### PR TITLE
refactor(pair-mcp): 3 P3 follow-ons (rf2-suoj2 + l0isf + 41ce8)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -27,6 +27,29 @@
 ;;;;     probe can be a single bencode round-trip rather than a CLJS
 ;;;;     compile. A full page refresh wipes both — `discover-app`
 ;;;;     reports the missing preload with a structured setup hint.
+;;;;
+;;;; Naming surfaces — MCP vs runtime (rf2-41ce8, audit Finding #8).
+;;;;
+;;;;   re-frame2-pair-mcp deliberately carries TWO vocabularies for the
+;;;;   same logical surface: the MCP tool catalogue (operator-facing,
+;;;;   disciplined to the cross-MCP NAMING.md `list-<things>` verb
+;;;;   shape per rf2-4y595) and the runtime fn surface in THIS ns +
+;;;;   `re-frame.core` (historical names, kept as-is). Rename pairs:
+;;;;
+;;;;     | MCP tool name           | Runtime fn name             |
+;;;;     |-------------------------|-----------------------------|
+;;;;     | `list-subscriptions`    | `subscription-info`         |
+;;;;     | `list-handlers`         | `rf/registry-list`          |
+;;;;
+;;;;   An agent generating an eval form via `eval-cljs` uses the
+;;;;   right-hand column; the same agent calling the MCP tool surface
+;;;;   uses the left-hand column. The split was deliberate (rf2-4y595
+;;;;   stopped the rename at the MCP boundary — the runtime's audience
+;;;;   is smaller than the MCP surface, and a runtime rename ripples
+;;;;   into every eval-form caller). This paragraph documents the
+;;;;   asymmetry so it's discoverable rather than inherited-from-
+;;;;   history; see `spec/Principles.md` §"Tool verbs follow the
+;;;;   cross-MCP convention" for the policy rationale.
 
 (ns re-frame2-pair.runtime
   (:require [re-frame.core :as rf]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs
@@ -89,8 +89,10 @@
 ;; Four steps thread through `boundary-step/run-step-pipeline`. Each
 ;; step's `:run` receives the live context (carrying `:result` and
 ;; `:precheck-hash`) and returns a Promise of the next context. The
-;; `:short-circuit?` predicates encode the per-step skip rules
-;; declaratively — no inline conditionals in the orchestrator.
+;; `:skip-when?` predicates encode the per-step skip rules
+;; declaratively — no inline conditionals in the orchestrator
+;; (renamed from `:short-circuit?` per rf2-l0isf; the actual
+;; semantics are skip-this-step, not halt-the-chain).
 ;;
 ;; Adding a future step (request-level redaction, metrics, path-prefix
 ;; slicing, per-call elision toggle) is one map-entry addition here
@@ -103,7 +105,7 @@
   tools (cache enabled AND tool registers a precheck-target), fetches
   the runtime-side hash via one bencode round-trip and consults the
   cache. On a hit, writes the marker to `:result` (which trips
-  subsequent steps' `:short-circuit?` predicates). On a miss, records
+  subsequent steps' `:skip-when?` predicates). On a miss, records
   the fetched hash in `:precheck-hash` so `apply-cache` can attach
   it to the future entry."
   [{:keys [conn name args cache-opts] :as ctx}]
@@ -148,7 +150,7 @@
   "The four-step wire-boundary pipeline. Order matters — see step
   docstrings for the per-step semantics.
 
-  | Step              | When the step is skipped (`:short-circuit?`)        |
+  | Step              | When the step is skipped (`:skip-when?`)            |
   |-------------------|-----------------------------------------------------|
   | `:precheck`       | never — runs unconditionally; produces a marker     |
   |                   | result ONLY for eligible cacheable tools            |
@@ -162,19 +164,24 @@
   Cache before cap is the right order: a cache hit emits a sub-100-
   byte marker that's trivially under any reasonable cap, so flipping
   the order would never change behaviour but would waste a token
-  walk on the hit path."
-  [{:name           :precheck
-    :run            precheck-step}
-   {:name           :dispatch
-    :run            dispatch-step
-    :short-circuit? (fn [{:keys [result]}] (some? result))}
-   {:name           :apply-cache
-    :run            apply-cache-step
-    :short-circuit? (fn [{:keys [result]}]
-                      (or (isError? result) (wire/marker? result)))}
-   {:name           :apply-cap
-    :run            apply-cap-step
-    :short-circuit? (fn [{:keys [result]}] (wire/marker? result))}])
+  walk on the hit path.
+
+  `:skip-when?` is the per-step skip predicate (renamed from
+  `:short-circuit?` per rf2-l0isf — the prior name read as
+  halt-the-chain semantics; the actual semantics are skip-this-step
+  and continue to the next step's own predicate)."
+  [{:name       :precheck
+    :run        precheck-step}
+   {:name       :dispatch
+    :run        dispatch-step
+    :skip-when? (fn [{:keys [result]}] (some? result))}
+   {:name       :apply-cache
+    :run        apply-cache-step
+    :skip-when? (fn [{:keys [result]}]
+                  (or (isError? result) (wire/marker? result)))}
+   {:name       :apply-cap
+    :run        apply-cap-step
+    :skip-when? (fn [{:keys [result]}] (wire/marker? result))}])
 
 (defn invoke
   "Dispatch a `tools/call` invocation through the wire-boundary

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/boundary_step.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/boundary_step.cljs
@@ -21,19 +21,22 @@
   one level up. Each step is a map:
 
   ```clojure
-  {:name           :apply-cap
-   :run            (fn [ctx] Promise<ctx>)
-   :short-circuit? (fn [ctx] boolean)}
+  {:name       :apply-cap
+   :run        (fn [ctx] Promise<ctx>)
+   :skip-when? (fn [ctx] boolean)}
   ```
 
-  - `:name`           — namespaced for tracing / errors.
-  - `:run`            — receives the live context map and returns a
-                        Promise of the next context. Side-effects (LRU
-                        writes, nREPL round-trips) are the step's own.
-  - `:short-circuit?` — optional predicate over the post-`:run`
-                        context. When truthy, the rest of the pipeline
-                        is skipped — the current `:result` is the
-                        final response. Pure on the context; cheap.
+  - `:name`       — namespaced for tracing / errors.
+  - `:run`        — receives the live context map and returns a
+                    Promise of the next context. Side-effects (LRU
+                    writes, nREPL round-trips) are the step's own.
+  - `:skip-when?` — optional predicate over the pre-`:run` context.
+                    When truthy, THIS step is skipped (its `:run` is
+                    not called) and the pipeline continues to the
+                    next step. Pure on the context; cheap. Renamed
+                    from `:short-circuit?` (rf2-l0isf) — the prior
+                    name read as halt-the-chain semantics; the
+                    actual semantics are skip-this-step.
 
   ## Context shape
 
@@ -52,12 +55,13 @@
   `:precheck-hash` slot is the cheap-hash from rf2-36xod; the
   `apply-cache` step consumes it to record on a miss.
 
-  ## Short-circuit semantics
+  ## Skip-when semantics
 
-  Each step's `:short-circuit?` is checked BEFORE its `:run` — the
+  Each step's `:skip-when?` is checked BEFORE its `:run` — the
   predicate decides 'should I bother running'. When truthy, the
   step is skipped and the pipeline continues to the next step
-  (whose own predicate is then consulted).
+  (whose own predicate is then consulted). 'Skip' is per-step,
+  not chain-halting.
 
   `apply-cap`'s predicate fires on a `marker?` result (a cache-hit
   or overflow envelope is already a wire-bounded marker — capping
@@ -78,19 +82,19 @@
 
 (defn run-step-pipeline
   "Thread `ctx` through `steps` in order. Each step's `:run` returns a
-  Promise of the next `ctx`. After every step, the `:short-circuit?`
-  predicate is consulted — when truthy, the rest of the pipeline is
-  skipped and `ctx` is returned as-is.
+  Promise of the next `ctx`. Before every step, the `:skip-when?`
+  predicate is consulted — when truthy, THAT step's `:run` is not
+  called; the pipeline continues to the next step.
 
   Returns a Promise of the final `ctx`. Caller extracts `:result` for
   the MCP wire reply."
   [steps ctx]
   (reduce
-    (fn [pr {:keys [run short-circuit?] :as _step}]
+    (fn [pr {:keys [run skip-when?] :as _step}]
       (-> pr
           (.then
             (fn [ctx]
-              (if (and short-circuit? (short-circuit? ctx))
+              (if (and skip-when? (skip-when? ctx))
                 ctx
                 (run ctx))))))
     (js/Promise.resolve ctx)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
@@ -76,10 +76,10 @@
   `:rf.size/include-large?` is the *walker-facing* pass-through switch
   (true = no marker). The two are inverse views of the same Boolean.
   Pre-rf2-suoj2 the helper buried the inversion (`(not enabled?)`)
-  alongside `:include-sensitive?`'s pass-through parsing — sibling
-  opts with opposite parsing rules. The helper now treats both opts
-  uniformly (`(boolean ...)`); call sites compute
-  `(not elision?)` once and pass `:include-large?` in directly.
+  alongside the `include-sensitive?` arg's pass-through parsing —
+  sibling opts with opposite parsing rules. The helper now treats both
+  opts uniformly (`(boolean ...)`); call sites compute
+  `(not elision?)` once and pass `include-large?` in directly.
 
   Both knobs default off-box-safe per the Tool-Pair §Direct-read
   privacy posture contract — large slots elide, sensitive slots

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs
@@ -56,17 +56,30 @@
   "Render the elision opts map as an EDN string for inlining into a
   CLJS eval form sent over nREPL.
 
-  Knobs:
+  Knobs (rf2-suoj2 — both follow the walker-opt polarity so the helper
+  is symmetric across the two `:rf.size/*` opts):
 
-  - `enabled?`            — when true, `:rf.size/include-large?` is
-                            `false` so the walker emits markers; when
-                            false, `true` so values pass through
-                            unmodified.
+  - `include-large?`      — when true, `:rf.size/include-large?` is
+                            `true` so the walker passes large slots
+                            through unmodified; when false (the
+                            default for elision-enabled call sites),
+                            `false` so the walker substitutes the
+                            `:rf.size/large-elided` marker.
   - `include-sensitive?`  — when true, `:rf.size/include-sensitive?` is
                             `true` so the walker passes declared-
                             sensitive slots through unmodified; when
                             false (the default), `false` so the walker
                             substitutes the `:rf/redacted` sentinel.
+
+  Polarity note. The MCP arg `elision` is the *operator-facing* on/off
+  switch (true = apply the walker = emit markers). The walker opt
+  `:rf.size/include-large?` is the *walker-facing* pass-through switch
+  (true = no marker). The two are inverse views of the same Boolean.
+  Pre-rf2-suoj2 the helper buried the inversion (`(not enabled?)`)
+  alongside `:include-sensitive?`'s pass-through parsing — sibling
+  opts with opposite parsing rules. The helper now treats both opts
+  uniformly (`(boolean ...)`); call sites compute
+  `(not elision?)` once and pass `:include-large?` in directly.
 
   Both knobs default off-box-safe per the Tool-Pair §Direct-read
   privacy posture contract — large slots elide, sensitive slots
@@ -74,8 +87,8 @@
 
   Single-arity form retains the legacy default (`include-sensitive?`
   false) so legacy call-sites don't need to spell it out."
-  ([enabled?]
-   (elision-opts-edn enabled? false))
-  ([enabled? include-sensitive?]
-   (pr-str {base-vocab/include-large-opt     (not enabled?)
+  ([include-large?]
+   (elision-opts-edn include-large? false))
+  ([include-large? include-sensitive?]
+   (pr-str {base-vocab/include-large-opt     (boolean include-large?)
             base-vocab/include-sensitive-opt (boolean include-sensitive?)})))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -85,7 +85,10 @@
             frame-edn     (if frame
                             (pr-str frame)
                             (ef/emit (ef/rt-call 'current-frame)))
-            elision-opts  (elision/elision-opts-edn elision? incl?)
+            ;; rf2-suoj2 — `elision-opts-edn` takes walker-aligned
+            ;; `include-large?` polarity directly. MCP `elision` true =
+            ;; emit markers = `:include-large?` false; hence `(not elision?)`.
+            elision-opts  (elision/elision-opts-edn (not elision?) incl?)
             elide-call    (if elision?
                             (str "(re-frame.core/elide-wire-value v"
                                  "  (merge {:path path :frame " frame-edn "}"

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -77,7 +77,11 @@
         ;; `:sub-cache` slices (where elision fired) — it only
         ;; re-shapes `:epochs` — so the pre-dedup server count equals
         ;; the post-dedup client count.
-        elision-opts-form (elision/elision-opts-edn elision? incl?)
+        ;; rf2-suoj2 — `elision-opts-edn` now takes the walker-aligned
+        ;; `include-large?` polarity directly (no in-helper inversion).
+        ;; MCP arg `elision` true = emit markers = `:include-large?` false,
+        ;; hence the local `(not elision?)`.
+        elision-opts-form (elision/elision-opts-edn (not elision?) incl?)
         form     (if elision?
                    (ef/emit
                      (ef/rt-let

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -246,7 +246,11 @@
     (ef/emit
       (ef/rt-let
         ['drain (ef/rt-call 'drain-subscription! sub-id)
-         'opts  (ef/rt-raw (elision/elision-opts-edn true incl?))
+         ;; rf2-suoj2 — `elision-opts-edn` first arg is walker-aligned
+         ;; `include-large?` (subscribe always elides, so emit markers ⇒
+         ;; pass `false`). Pre-rf2-suoj2 this was `true` under the old
+         ;; "enabled?" polarity that the helper inverted internally.
+         'opts  (ef/rt-raw (elision/elision-opts-edn false incl?))
          'evts  (ef/rt-raw
                   (str "(mapv #(re-frame.core/elide-wire-value % opts)"
                        " (:events drain))"))]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/elision_test.cljs
@@ -32,32 +32,35 @@
 
 ;; ---------------------------------------------------------------------------
 ;; elision-opts-edn — EDN-render the walker's opts map for inlining.
+;;
+;; Post-rf2-suoj2: the helper takes walker-aligned `include-large?` /
+;; `include-sensitive?` polarities (both pass-through booleans — true
+;; ⇒ walker leaves the slot alone). Call sites convert from the MCP
+;; arg `elision` (operator-facing on/off) via `(not elision?)`.
 ;; ---------------------------------------------------------------------------
 
-(deftest elision-opts-edn-enabled-has-include-large-false
-  ;; When elision is on, we want the walker to ACTUALLY elide — so
-  ;; `:rf.size/include-large?` is `false`. The "include-large?" name
-  ;; is the walker's own switch (a `true` means pass through, a
-  ;; `false` means emit the marker — the keyword surfaces from the
-  ;; walker's API, not from our boolean).
-  (let [edn (elision/elision-opts-edn true)
+(deftest elision-opts-edn-include-large-false-emits-markers
+  ;; `:include-large?` false ⇒ walker emits the marker (the elision-ON
+  ;; call-site posture). The keyword surfaces from the walker's API:
+  ;; `true` means pass through, `false` means substitute the marker.
+  (let [edn (elision/elision-opts-edn false)
         parsed (cljs.reader/read-string edn)]
     (is (false? (:rf.size/include-large? parsed)))))
 
-(deftest elision-opts-edn-disabled-has-include-large-true
-  ;; When elision is disabled, `:rf.size/include-large?` is true so
-  ;; the walker passes the raw value through. (We also short-circuit
-  ;; the walk entirely in the eval form when disabled — see the
-  ;; snapshot-eval-form test below.)
-  (let [edn (elision/elision-opts-edn false)
+(deftest elision-opts-edn-include-large-true-passes-through
+  ;; `:include-large?` true ⇒ walker passes the raw value through (the
+  ;; elision-OFF call-site posture). The eval form also short-circuits
+  ;; the walk entirely when elision is disabled — see the snapshot-
+  ;; eval-form test below.
+  (let [edn (elision/elision-opts-edn true)
         parsed (cljs.reader/read-string edn)]
     (is (true? (:rf.size/include-large? parsed)))))
 
 (deftest elision-opts-edn-round-trips
   ;; The EDN we ship over nREPL must be readable on the other side.
   ;; pr-str + read-string round-trips for the structure we emit.
-  (doseq [enabled? [true false]]
-    (let [edn (elision/elision-opts-edn enabled?)
+  (doseq [include-large? [true false]]
+    (let [edn (elision/elision-opts-edn include-large?)
           parsed (cljs.reader/read-string edn)]
       (is (map? parsed))
       (is (contains? parsed :rf.size/include-large?)))))
@@ -90,7 +93,10 @@
   `:rf.size/include-sensitive?` opt."
   ([opts elision?] (build-snapshot-form opts elision? false))
   ([opts elision? include-sensitive?]
-   (let [elision-opts-form (elision/elision-opts-edn elision? include-sensitive?)]
+   ;; rf2-suoj2 — helper takes walker-aligned `include-large?`; flip
+   ;; from the MCP-arg `elision?` polarity here, mirroring the
+   ;; production call site in `tools/snapshot.cljs`.
+   (let [elision-opts-form (elision/elision-opts-edn (not elision?) include-sensitive?)]
      (if elision?
        (str "(let [snap (re-frame2-pair.runtime/snapshot-state "
             (pr-str opts) ")"
@@ -216,7 +222,10 @@
                          (str "(re-frame2-pair.runtime/snapshot " (pr-str frame) ")")
                          "(re-frame2-pair.runtime/snapshot)")
          frame-edn     (if frame (pr-str frame) "(re-frame2-pair.runtime/current-frame)")
-         elision-opts  (elision/elision-opts-edn elision? include-sensitive?)
+         ;; rf2-suoj2 — helper takes walker-aligned `include-large?`;
+         ;; flip from the MCP-arg `elision?` polarity here, mirroring
+         ;; the production call site in `tools/get_path.cljs`.
+         elision-opts  (elision/elision-opts-edn (not elision?) include-sensitive?)
          elide-call    (if elision?
                          (str "(re-frame.core/elide-wire-value v"
                               "  (merge {:path path :frame " frame-edn "}"
@@ -431,12 +440,14 @@
   ;; surface needs a co-ordinated update here.
   ;; Post-rf2-vflrg both opts ride the same map; assert against the
   ;; parsed form so map-key-order doesn't matter.
-  (let [parsed-on  (cljs.reader/read-string (elision/elision-opts-edn true))
-        parsed-off (cljs.reader/read-string (elision/elision-opts-edn false))]
-    (is (false? (:rf.size/include-large? parsed-on)))
-    (is (true?  (:rf.size/include-large? parsed-off)))
-    (is (false? (:rf.size/include-sensitive? parsed-on)))
-    (is (false? (:rf.size/include-sensitive? parsed-off)))))
+  ;; Post-rf2-suoj2 helper params are walker-aligned: `include-large?
+  ;; false` = emit markers (the elision-ON call-site posture).
+  (let [parsed-elide-on  (cljs.reader/read-string (elision/elision-opts-edn false))
+        parsed-elide-off (cljs.reader/read-string (elision/elision-opts-edn true))]
+    (is (false? (:rf.size/include-large? parsed-elide-on)))
+    (is (true?  (:rf.size/include-large? parsed-elide-off)))
+    (is (false? (:rf.size/include-sensitive? parsed-elide-on)))
+    (is (false? (:rf.size/include-sensitive? parsed-elide-off)))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-vflrg — `:include-sensitive?` threads through `elision-opts-edn`.
@@ -450,7 +461,7 @@
 (deftest elision-opts-edn-include-sensitive-defaults-false
   ;; The single-arity legacy form preserves the off-box-safe default:
   ;; sensitive slots redact unless the caller opts in explicitly.
-  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn true))]
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false))]
     (is (false? (:rf.size/include-sensitive? parsed))
         "single-arity ⇒ include-sensitive? false (the default per Tool-Pair §Direct-read privacy posture)")))
 
@@ -458,24 +469,23 @@
   ;; The documented opt-in flow: `:include-sensitive? true` flows into
   ;; the walker opt of the same shape. Sensitive slots then pass through
   ;; unmodified.
-  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn true true))]
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false true))]
     (is (true? (:rf.size/include-sensitive? parsed))
         "two-arity true ⇒ walker passes sensitive values through")))
 
 (deftest elision-opts-edn-include-sensitive-false-explicit
   ;; Explicit `false` matches the single-arity default.
-  (let [parsed-explicit (cljs.reader/read-string (elision/elision-opts-edn true false))
-        parsed-default  (cljs.reader/read-string (elision/elision-opts-edn true))]
+  (let [parsed-explicit (cljs.reader/read-string (elision/elision-opts-edn false false))
+        parsed-default  (cljs.reader/read-string (elision/elision-opts-edn false))]
     (is (= parsed-explicit parsed-default))))
 
-(deftest elision-opts-edn-include-sensitive-orthogonal-to-elision-switch
-  ;; The two knobs are orthogonal: elision-off + sensitive-on is a
-  ;; valid (if unusual) combo — the agent has explicitly opted into both
-  ;; raw values (`elision false`) and raw sensitive values
-  ;; (`include-sensitive? true`).
-  (doseq [enabled?           [true false]
+(deftest elision-opts-edn-include-sensitive-orthogonal-to-include-large
+  ;; rf2-suoj2 — the two knobs are orthogonal AND symmetric: both
+  ;; pass through to the walker via the same `(boolean ...)` parser.
+  ;; A test reader can read the args left-to-right with no inversion.
+  (doseq [include-large?     [true false]
           include-sensitive? [true false]]
     (let [parsed (cljs.reader/read-string
-                   (elision/elision-opts-edn enabled? include-sensitive?))]
-      (is (= (not enabled?) (:rf.size/include-large? parsed)))
+                   (elision/elision-opts-edn include-large? include-sensitive?))]
+      (is (= include-large?     (:rf.size/include-large? parsed)))
       (is (= include-sensitive? (:rf.size/include-sensitive? parsed))))))


### PR DESCRIPTION
## Summary

Three P3 follow-ons from the rf2-c8ohr re-frame2-pair-mcp wire-surface audit, bundled into a single PR since all three sit in `tools/re-frame2-pair-mcp/*` and are independent of in-flight workers.

- **rf2-suoj2** — unify `elision-opts-edn` polarity. The helper used to bury a `(not enabled?)` inversion on `:include-large?` while `:include-sensitive?` parsed via `(boolean ...)` — sibling walker opts with opposite parsing rules. Helper now accepts walker-aligned `include-large?` directly; both opts parse symmetrically. The MCP-arg-to-walker-opt polarity flip moves to the three call sites (`snapshot.cljs`, `get_path.cljs`, `subscribe.cljs`) where it reads locally as `(not elision?)`. Tests re-pinned against new arg-order semantics.
- **rf2-l0isf** — rename `:short-circuit?` → `:skip-when?` across the wire-boundary-pipeline step shape. The prior name implied halt-the-chain semantics; the actual semantics are skip-this-step (the pipeline continues to the next step's own predicate). One key rename in `boundary_step.cljs` + the four step defs in `tools.cljs`, plus surrounding docstrings. Pre-alpha posture; no back-compat shim.
- **rf2-41ce8** — document the runtime-vs-MCP naming bifurcation in the preload runtime ns docstring (`skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs`). The rf2-4y595 rename stopped at the MCP boundary (`list-subscriptions` / `list-handlers` on the wire; `subscription-info` / `rf/registry-list` in the runtime). Added a "Naming surfaces — MCP vs runtime" paragraph with the rename-pair table so the asymmetry is discoverable rather than inherited-from-history.

## Test plan

- [x] `npm run test:cljs` — 3585 tests, 10307 assertions, 0 failures, 0 errors
- [x] `mkdocs build --strict` — exit 0