### PR TITLE
feat(test-helpers): app-fixture + expect-text + wait-until (rf2-wy1ac P1)

### DIFF
--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -126,8 +126,28 @@
 
   ### Authoring
   - [[testid]] — build a `:data-testid`-carrying attrs map at the
-    view call site. Optional `extra` map merges additional attrs."
-  (:require [clojure.string :as str]))
+    view call site. Optional `extra` map merges additional attrs.
+
+  ### Single-frame e2e fixture (rf2-wy1ac)
+  - [[with-app-fixture]] — macro. Brackets `body` with a fresh frame
+    (created, bound as `*current-frame*`, destroyed on exit) and
+    optionally runs an `:install` hook and stashes a `:root-view`
+    for downstream `expect-text` / `wait-until` calls. Compresses the
+    five-line per-test fixture pattern to two lines (frame + body).
+  - [[expect-text]] — locate a `:data-testid` in the root-view's
+    rendered hiccup and assert on its text content via
+    `clojure.test/is`. 2-arity uses the fixture-stashed root view; the
+    3-arity accepts an explicit tree.
+  - [[wait-until]] — bounded-deadline poll for a condition. JVM is
+    synchronous; CLJS returns a `js/Promise` (composes with
+    `cljs.test/async`). Replaces incidental fixed-sleep waits when the
+    post-condition is observable in view-state or app-db."
+  (:require [clojure.string :as str]
+            [re-frame.frame :as frame]
+            #?(:clj  [clojure.test :as ctest]
+               :cljs [cljs.test :as ctest :include-macros true]))
+  #?(:cljs (:require-macros
+             [re-frame.test-helpers :refer [with-app-fixture]])))
 
 ;; ---------------------------------------------------------------------------
 ;; Hiccup-tree expansion
@@ -409,3 +429,326 @@
    {:data-testid id})
   ([id extra]
    (assoc extra :data-testid id)))
+
+;; ---------------------------------------------------------------------------
+;; Single-frame e2e fixture (rf2-wy1ac)
+;;
+;; The trio below — `with-app-fixture`, `expect-text`, `wait-until` —
+;; compresses the dominant single-frame e2e test pattern from five
+;; lines of fixture boilerplate to two. Multi-frame setups (Causa,
+;; Story) keep using `rf/with-frame` + the lower-level primitives
+;; directly; this fixture is for the common app-developer case.
+;;
+;; The shape:
+;;
+;;     (deftest counter-increments
+;;       (th/with-app-fixture {:install  counter/install!
+;;                             :root-view counter/main}
+;;                            :test-app
+;;         (rf/dispatch-sync [:counter/inc])
+;;         (rf/dispatch-sync [:counter/inc])
+;;         (th/expect-text :counter-display \"2\")))
+;;
+;; `with-app-fixture` creates the frame, pins it as `*current-frame*`,
+;; calls the `:install` fn inside that scope (so any `reg-event-db` /
+;; `reg-sub` etc. land while the frame is active), then runs `body`
+;; with the root view stashed for `expect-text`. On exit (success or
+;; exception) the frame is destroyed.
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *current-root-view*
+  "Root-view fn stashed by [[with-app-fixture]] for the body's dynamic
+  extent. [[expect-text]] and [[wait-until]]'s 2-arity testid form read
+  this var to know which view-fn to call when assembling the hiccup
+  tree. `nil` outside a fixture body; callers that want to operate on
+  an explicit tree use the 3-arity shapes instead."
+  nil)
+
+(def ^:dynamic *current-root-view-args*
+  "Args vector passed to `*current-root-view*` when rendering the
+  tree. Defaults to `[]` (the common Reagent-style zero-arg view).
+  [[with-app-fixture]] sets this from the fixture opts' `:root-view-args`
+  key — callers whose root view takes arguments (e.g. a props map)
+  supply them once at the fixture site, not at every `expect-text`
+  call."
+  [])
+
+#?(:clj
+   (defmacro with-app-fixture
+     "Bracket `body` with a fresh single-frame fixture — the dominant
+     shape for app-developer e2e tests (rf2-wy1ac).
+
+     Two call shapes — first arg is the discriminator:
+
+       (with-app-fixture opts-map frame-id body+)
+       (with-app-fixture opts-map           body+)   ; anonymous gensym'd id
+
+     `opts-map` (all keys optional):
+
+       :install         zero-arg fn called *inside* the frame's dynamic
+                        extent, after the frame is created. Typical
+                        body: `(reg-event-db ...)` / `(reg-sub ...)` /
+                        `(reg-view ...)` calls that the test relies on.
+                        Registrations land in the global registrar; pair
+                        this fixture with `re-frame.test-support/reset-runtime-fixture`
+                        (or `with-fresh-registrar`) to roll them back
+                        between tests.
+       :root-view       view fn (a hiccup-returning function). Stashed in
+                        `*current-root-view*` for the body so [[expect-text]]
+                        and [[wait-until]]'s testid forms can find it
+                        without an explicit tree argument.
+       :root-view-args  args vector passed to `:root-view` when rendering
+                        the tree. Defaults to `[]`. Use when the view fn
+                        takes a props map or similar.
+       :frame-config    extra map merged into the frame's config map
+                        (passed to `make-frame` / `reg-frame`). Use for
+                        `:on-create`, `:fx-overrides`, `:interceptor-overrides`,
+                        `:interceptors` and the rest of the frame-shape
+                        contract per Spec 002.
+
+     The macro:
+       1. Creates the frame (anonymous gensym'd id, or the supplied
+          `frame-id`).
+       2. Binds `re-frame.frame/*current-frame*` to that id for the
+          dynamic extent of `body`.
+       3. Calls `:install` (if supplied) — zero-arg, with the frame
+          already bound.
+       4. Binds `*current-root-view*` / `*current-root-view-args*` from
+          the opts (if `:root-view` is supplied).
+       5. Runs `body`.
+       6. In a `finally`, calls `(destroy-frame! id)` so the frame is
+          released regardless of whether `body` returned normally.
+
+     Per Spec 008 §Test fixture lifecycle patterns — this is the
+     ergonomic shorthand over the Pattern 1 / Pattern 2 long forms."
+     {:arglists '([opts-map frame-id body+] [opts-map body+])}
+     [opts & more]
+     (let [[frame-id body] (if (and (seq more) (keyword? (first more)))
+                             [(first more) (rest more)]
+                             [nil more])
+           opts-sym       (gensym "opts")
+           install-sym    (gensym "install")
+           root-view-sym  (gensym "root-view")
+           root-args-sym  (gensym "root-args")
+           frame-cfg-sym  (gensym "frame-config")
+           id-sym         (gensym "frame-id")
+           create-form    (if frame-id
+                            `(re-frame.frame/reg-frame ~frame-id ~frame-cfg-sym)
+                            `(re-frame.frame/make-frame ~frame-cfg-sym))]
+       `(let [~opts-sym       ~opts
+              ~install-sym    (:install      ~opts-sym)
+              ~root-view-sym  (:root-view    ~opts-sym)
+              ~root-args-sym  (or (:root-view-args ~opts-sym) [])
+              ~frame-cfg-sym  (or (:frame-config   ~opts-sym) {})
+              ~id-sym         ~create-form]
+          (try
+            (binding [re-frame.frame/*current-frame*                 ~id-sym
+                      re-frame.test-helpers/*current-root-view*      ~root-view-sym
+                      re-frame.test-helpers/*current-root-view-args* ~root-args-sym]
+              (when ~install-sym (~install-sym))
+              ~@body)
+            (finally
+              (re-frame.frame/destroy-frame! ~id-sym)))))))
+
+(defn- render-current-root
+  "Render the fixture-stashed root view to a hiccup tree, or throw
+  with a helpful message when no `:root-view` was supplied."
+  []
+  (if-let [view *current-root-view*]
+    (apply view *current-root-view-args*)
+    (throw (ex-info
+             (str "expect-text / wait-until called outside a "
+                  "`with-app-fixture` body, OR the fixture did not "
+                  "supply :root-view. Pass an explicit tree as the "
+                  "first arg, or set :root-view in the fixture opts.")
+             {:rf.test-helpers/error :no-root-view}))))
+
+(defn- coerce-testid-string
+  "Allow testids supplied as keywords (`:counter-display`) at the call
+  site, while the underlying hiccup-walk keys on the string form. A
+  string testid passes through; anything else (`nil`, a number) is an
+  argument error."
+  [testid]
+  (cond
+    (keyword? testid) (name testid)
+    (string?  testid) testid
+    :else
+    (throw (ex-info (str "testid must be a keyword or string, got "
+                         (pr-str testid))
+                    {:rf.test-helpers/error :bad-testid
+                     :testid                testid}))))
+
+(defn expect-text
+  "Assert that the hiccup node carrying `:data-testid testid` has
+  `text-content` equal to `expected`. Reports via `clojure.test/is`
+  — failure carries the actual text in the diagnostic.
+
+  Two call shapes:
+
+    (expect-text testid expected)
+      Uses the fixture-stashed root view from `*current-root-view*`
+      (set by [[with-app-fixture]]). The view fn is called with
+      `*current-root-view-args*` to assemble the tree.
+
+    (expect-text tree testid expected)
+      Walks the supplied `tree` directly — no fixture required.
+
+  `testid` may be a string (`\"counter-display\"`) or a keyword
+  (`:counter-display`); keywords are coerced via `name`.
+
+  Returns `true` on pass, `false` on fail — the `clojure.test`
+  failure has already been reported in either case, so callers
+  rarely care about the boolean.
+
+  Per Spec 008 §Single-frame e2e fixture (rf2-wy1ac)."
+  ([testid expected]
+   (expect-text (render-current-root) testid expected))
+  ([tree testid expected]
+   (let [testid-str (coerce-testid-string testid)
+         node       (find-by-testid tree testid-str)
+         actual     (when node (text-content node))
+         pass?      (= expected actual)]
+     (ctest/do-report
+       {:type     (if pass? :pass :fail)
+        :message  (cond
+                    (nil? node)
+                    (str "expect-text: no node with :data-testid "
+                         (pr-str testid-str)
+                         " found in tree")
+                    :else
+                    (str "expect-text: text mismatch at :data-testid "
+                         (pr-str testid-str)))
+        :expected expected
+        :actual   actual})
+     pass?)))
+
+;; ---------------------------------------------------------------------------
+;; wait-until — bounded-deadline poll for async-stable assertions
+;;
+;; The view-test counterpart to `re-frame.test-support/poll-until`:
+;; same shape (JVM-sync / CLJS-Promise), tuned for the hiccup-walk
+;; pattern. The 1-arity (predicate) is a thin alias on poll-until
+;; semantics; the testid-form (`(wait-until testid expected)`) polls
+;; the fixture-stashed root view until its `:data-testid` node's text
+;; matches `expected`, or the deadline elapses.
+;;
+;; Use this when an event cascade is async (HTTP, dispatched
+;; machine transition, scheduled event via `dispatch`) and the
+;; post-condition is observable in the rendered view. For sync
+;; cascades, `expect-text` after `dispatch-sync` is sufficient.
+;; ---------------------------------------------------------------------------
+
+(defn- wait-timeout-error
+  "Shared timeout-error constructor so test code can pattern-match on
+  `:rf.test-helpers/wait-timeout` regardless of runtime."
+  [label elapsed-ms]
+  (ex-info (str "wait-until timed out"
+                (when label (str " — " label)))
+           {:rf.test-helpers/wait-timeout true
+            :elapsed-ms                   elapsed-ms
+            :label                        label}))
+
+#?(:clj
+   (defn- jvm-wait-until-pred
+     [pred {:keys [timeout-ms interval-ms label]
+            :or   {timeout-ms 2000 interval-ms 5}}]
+     (let [start    (System/currentTimeMillis)
+           deadline (+ start timeout-ms)]
+       (loop []
+         (let [v (try (pred) (catch Throwable _ false))]
+           (cond
+             v v
+             (>= (System/currentTimeMillis) deadline)
+             (throw (wait-timeout-error
+                      label (- (System/currentTimeMillis) start)))
+             :else (do (Thread/sleep ^long interval-ms) (recur))))))))
+
+#?(:cljs
+   (defn- cljs-wait-until-pred
+     [pred {:keys [timeout-ms interval-ms label]
+            :or   {timeout-ms 2000 interval-ms 5}}]
+     (let [start    (.now js/Date)
+           deadline (+ start timeout-ms)]
+       (js/Promise.
+         (fn [resolve reject]
+           (letfn [(settle [v]
+                     (cond
+                       v (resolve v)
+                       (>= (.now js/Date) deadline)
+                       (reject (wait-timeout-error
+                                 label (- (.now js/Date) start)))
+                       :else (js/setTimeout tick interval-ms)))
+                   (tick []
+                     (let [raw (try (pred)
+                                    (catch :default _ false))]
+                       (if (instance? js/Promise raw)
+                         (-> ^js/Promise raw
+                             (.then settle)
+                             (.catch (fn [_] (settle false))))
+                         (settle raw))))]
+             (tick)))))))
+
+(defn wait-until
+  "Bounded-deadline poll until a condition is truthy. The view-test
+  counterpart to `re-frame.test-support/poll-until`.
+
+  Two call shapes:
+
+    (wait-until pred)
+    (wait-until pred opts)
+      Poll `(pred)` until truthy or the deadline elapses.
+
+    (wait-until testid expected)
+    (wait-until testid expected opts)
+      Poll the fixture-stashed root view (`*current-root-view*`)
+      until `(text-content (find-by-testid tree testid)) = expected`,
+      or the deadline elapses. Equivalent to:
+        (wait-until #(= expected
+                        (text-content
+                          (find-by-testid (render-root) testid))))
+
+  `opts` (all optional):
+    :timeout-ms   default 2000 — overall deadline.
+    :interval-ms  default 5    — gap (ms) between probes.
+    :label        string/keyword used in the timeout message.
+
+  Per-platform shape (matching `poll-until`):
+    JVM:  synchronous — returns the truthy value, throws `ex-info`
+                        with `:rf.test-helpers/wait-timeout` `true` on
+                        timeout.
+    CLJS: async       — returns a `js/Promise`. Resolves with the
+                        truthy value, rejects with an `ex-info`-style
+                        error on timeout. Compose with `cljs.test/async`.
+
+  Use for async event flows (HTTP, scheduled events, machine `:after`
+  transitions) that need to drain past `dispatch-sync`. Not a
+  substitute for timer-semantics sleeps (grace-period elapse,
+  throttle/debounce window) — those should keep their explicit sleep
+  and annotate the intent locally.
+
+  Per Spec 008 §Single-frame e2e fixture (rf2-wy1ac)."
+  ([pred-or-testid]
+   (wait-until pred-or-testid nil))
+  ([pred-or-testid opts-or-expected]
+   (cond
+     (fn? pred-or-testid)
+     #?(:clj  (jvm-wait-until-pred  pred-or-testid (or opts-or-expected {}))
+        :cljs (cljs-wait-until-pred pred-or-testid (or opts-or-expected {})))
+
+     ;; (wait-until testid expected) — testid form, default opts.
+     :else
+     (wait-until pred-or-testid opts-or-expected nil)))
+  ([testid expected opts]
+   (let [testid-str (coerce-testid-string testid)
+         label      (or (:label opts)
+                        (str "text under :data-testid " (pr-str testid-str)
+                             " = " (pr-str expected)))
+         opts*      (assoc (or opts {}) :label label)
+         probe      (fn []
+                      (let [node (find-by-testid (render-current-root)
+                                                 testid-str)
+                            actual (when node (text-content node))]
+                        (when (= expected actual)
+                          actual)))]
+     #?(:clj  (jvm-wait-until-pred  probe opts*)
+        :cljs (cljs-wait-until-pred probe opts*)))))

--- a/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
@@ -1,0 +1,275 @@
+(ns re-frame.test-helpers-app-fixture-cljs-test
+  "Coverage for `re-frame.test-helpers/with-app-fixture` + the
+  `expect-text` / `wait-until` trio (rf2-wy1ac).
+
+  Dual-runtime: the file is named `*_cljs_test.cljc` so both the JVM
+  test runner and the shadow-cljs `:node-test` build pick it up. The
+  hiccup-walk helpers run identically under both runtimes; the
+  `wait-until`-CLJS-promise branch is gated under a reader-conditional
+  and exercised on Node only."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures async]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-helpers :as th]
+            [re-frame.test-support :as ts]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — fresh registrar + plain-atom adapter per test.
+;;
+;; with-app-fixture creates / destroys frames; the snapshot/restore
+;; pattern rolls back any reg-event-db calls the test's :install hook
+;; makes.
+;;
+;; Per cljs.test: async tests in this ns (the wait-until CLJS Promise
+;; coverage) require fixtures supplied as `{:before ... :after ...}`
+;; — the fn-form fixture doesn't suspend across the async body. Mirror
+;; the pattern in re-frame.dispatch-frame-capture-cljs-test.
+;; ---------------------------------------------------------------------------
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (ts/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (ts/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {}))
+
+;; clojure.test/use-fixtures takes only the fn-form; cljs.test/use-fixtures
+;; also takes a {:before :after} map (needed for async tests, which the
+;; fn-form cannot suspend across). Branch by runtime.
+#?(:clj
+   (use-fixtures :each
+     (fn [t]
+       (before!)
+       (try (t) (finally (after!))))))
+
+#?(:cljs
+   (use-fixtures :each
+     {:before before! :after after!}))
+
+;; ---------------------------------------------------------------------------
+;; Test view fns + install hooks
+;; ---------------------------------------------------------------------------
+
+(defn- counter-install!
+  "Tiny app — :counter/inc bumps :n; :counter/init seeds to zero."
+  []
+  (rf/reg-event-db ::counter-init (fn [db _]   (assoc db :n 0)))
+  (rf/reg-event-db ::counter-inc  (fn [db _]   (update db :n inc)))
+  (rf/dispatch-sync [::counter-init]))
+
+(defn- counter-view
+  "Form-1 view that reads `:n` straight off `app-db` via
+  `get-frame-db` — keeps the test self-contained without reaching
+  for `subscribe` / reactive caches."
+  []
+  (let [n (:n (rf/get-frame-db (rf/current-frame)))]
+    [:div {:data-testid "counter-root"}
+     [:span {:data-testid "counter-display"} (str n)]]))
+
+;; ---------------------------------------------------------------------------
+;; with-app-fixture — Shape 1 (named frame-id)
+;; ---------------------------------------------------------------------------
+
+(deftest with-app-fixture-creates-named-frame-and-binds-it
+  (testing "Shape 1: explicit :test-app frame-id is created, pinned as
+            *current-frame* for the body, and destroyed on exit"
+    (let [seen-frame (atom nil)]
+      (th/with-app-fixture {:install counter-install!} :test-app
+        (reset! seen-frame (rf/current-frame))
+        (is (= :test-app @seen-frame)
+            "with-frame binding kicks in for the body")
+        (is (= 0 (:n (rf/get-frame-db :test-app)))
+            ":install ran inside the frame and dispatched :counter-init"))
+      (is (= :test-app @seen-frame))
+      (is (nil? (get @frame/frames :test-app))
+          "frame is destroyed when the body exits"))))
+
+(deftest with-app-fixture-without-install-still-creates-frame
+  (testing "Shape 1 with no :install — fixture creates / binds / destroys
+            the frame even when the opts map is empty"
+    (th/with-app-fixture {} :test-no-install
+      (is (= :test-no-install (rf/current-frame))))
+    (is (nil? (get @frame/frames :test-no-install)))))
+
+(deftest with-app-fixture-destroys-frame-on-exception
+  (testing "Shape 1: body throwing does NOT leak the frame — try/finally
+            in the macro expansion ensures destroy-frame!"
+    (let [thrown (atom nil)]
+      (try
+        (th/with-app-fixture {:install counter-install!} :test-throws
+          (throw (ex-info "boom" {:rf/test :expected})))
+        (catch #?(:clj Throwable :cljs :default) e
+          (reset! thrown e)))
+      (is (some? @thrown) "the body's exception propagated")
+      (is (nil? (get @frame/frames :test-throws))
+          "even though body threw, the frame was destroyed"))))
+
+;; ---------------------------------------------------------------------------
+;; with-app-fixture — Shape 2 (anonymous gensym'd frame-id)
+;; ---------------------------------------------------------------------------
+
+(deftest with-app-fixture-anonymous-frame-id
+  (testing "Shape 2: omitting the frame-id gensym's an anonymous id
+            under :rf.frame/* and uses it for the body"
+    (let [seen-frame (atom nil)]
+      (th/with-app-fixture {:install counter-install!}
+        (reset! seen-frame (rf/current-frame))
+        (is (keyword? @seen-frame))
+        (is (= "rf.frame" (namespace @seen-frame))
+            "anonymous id sits in the framework's :rf.frame/* namespace"))
+      (is (nil? (get @frame/frames @seen-frame))
+          "anonymous frame is destroyed on exit"))))
+
+;; ---------------------------------------------------------------------------
+;; with-app-fixture — :root-view stash for expect-text
+;; ---------------------------------------------------------------------------
+
+(deftest with-app-fixture-stashes-root-view
+  (testing ":root-view in the opts is bound in *current-root-view* for
+            the body's dynamic extent"
+    (th/with-app-fixture {:install   counter-install!
+                          :root-view counter-view}
+                         :test-root-view
+      (is (= counter-view th/*current-root-view*)
+          ":root-view is reachable from the body")
+      (is (= [] th/*current-root-view-args*)
+          ":root-view-args defaults to empty"))
+    (is (nil? th/*current-root-view*)
+        "*current-root-view* is unbound after the body")))
+
+(deftest with-app-fixture-passes-root-view-args
+  (testing ":root-view-args, when supplied, ride into the bound view-args slot"
+    (let [view-fn (fn [props] [:div {:data-testid "argy"} (:label props)])]
+      (th/with-app-fixture {:root-view      view-fn
+                            :root-view-args [{:label "hi"}]}
+                           :test-view-args
+        (is (= [{:label "hi"}] th/*current-root-view-args*)
+            ":root-view-args is bound for the body")))))
+
+;; ---------------------------------------------------------------------------
+;; expect-text
+;; ---------------------------------------------------------------------------
+
+(deftest expect-text-asserts-on-fixture-root-view
+  (testing "the 2-arity (testid expected) reads the fixture-stashed
+            root view, renders, and asserts text"
+    (th/with-app-fixture {:install   counter-install!
+                          :root-view counter-view}
+                         :test-expect
+      (rf/dispatch-sync [::counter-inc])
+      (rf/dispatch-sync [::counter-inc])
+      (is (true? (th/expect-text :counter-display "2"))
+          "expect-text returned true and reported a pass"))))
+
+(deftest expect-text-three-arity-walks-explicit-tree
+  (testing "the 3-arity (tree testid expected) form accepts an explicit
+            hiccup tree — useful for view-only tests that don't need a
+            full fixture"
+    (let [tree [:div [:span {:data-testid "label"} "hello"]]]
+      (is (true? (th/expect-text tree "label" "hello"))))))
+
+(deftest expect-text-string-and-keyword-testids
+  (testing "testid may be a keyword (sugar) or a string (raw)"
+    (let [tree [:span {:data-testid "tag"} "x"]]
+      (is (true? (th/expect-text tree :tag "x")))
+      (is (true? (th/expect-text tree "tag" "x"))))))
+
+(deftest expect-text-throws-without-fixture-when-no-tree
+  (testing "calling 2-arity expect-text outside a with-app-fixture body
+            (and without a :root-view) raises a clear error — not a
+            mysterious NPE"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
+                 (th/expect-text :anything "x")))))
+
+#?(:clj
+   (deftest expect-text-fails-loudly-on-missing-testid
+     (testing "no node matching the testid → reports :fail via do-report
+               and returns false. Capture the report so this unit test
+               does not itself fail when the diagnostic fires. JVM-only
+               because `with-redefs` on `clojure.test/report` is the
+               idiomatic capture path (matches re-frame.test-support's
+               own test suite)."
+       (let [tree     [:div]
+             recorded (atom [])
+             result   (with-redefs [clojure.test/report
+                                    (fn [m] (swap! recorded conj (:type m)))]
+                        (th/expect-text tree :missing "x"))]
+         (is (false? result)
+             "missing testid → expect-text returned false")
+         (is (some #(= :fail %) @recorded)
+             "a :fail report was emitted by expect-text")))))
+
+;; ---------------------------------------------------------------------------
+;; wait-until — predicate form
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest wait-until-pred-returns-truthy-value
+     (testing "JVM: a pred that goes truthy synchronously is returned"
+       (is (= :ok (th/wait-until (constantly :ok) {:timeout-ms 200}))))))
+
+#?(:clj
+   (deftest wait-until-pred-throws-on-timeout
+     (testing "JVM: pred that never goes truthy throws ex-info with
+               :rf.test-helpers/wait-timeout true"
+       (let [e (try (th/wait-until (constantly false)
+                                   {:timeout-ms 30 :interval-ms 5
+                                    :label "never"})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+         (is (some? e) "timeout threw")
+         (is (true? (:rf.test-helpers/wait-timeout (ex-data e))))
+         (is (= "never" (:label (ex-data e))))))))
+
+#?(:clj
+   (deftest wait-until-testid-form-asserts-text
+     (testing "JVM: (wait-until testid expected) under a fixture polls
+               the root view until the text matches"
+       (th/with-app-fixture {:install   counter-install!
+                             :root-view counter-view}
+                            :test-wait-jvm
+         (rf/dispatch-sync [::counter-inc])
+         (is (= "1" (th/wait-until :counter-display "1"
+                                   {:timeout-ms 200})))))))
+
+#?(:cljs
+   (deftest wait-until-pred-returns-promise
+     (testing "CLJS: wait-until on a fn returns a js/Promise that
+               resolves with the truthy value"
+       (async done
+         (-> (th/wait-until (constantly :ok) {:timeout-ms 200})
+             (.then (fn [v]
+                      (is (= :ok v))
+                      (done)))
+             (.catch (fn [e]
+                       (is false (str "unexpected reject: "
+                                      (#?(:cljs .-message :clj nil) e)))
+                       (done))))))))
+
+#?(:cljs
+   (deftest wait-until-pred-rejects-on-timeout
+     (testing "CLJS: wait-until rejects with :rf.test-helpers/wait-timeout
+               on deadline elapse"
+       (async done
+         (-> (th/wait-until (constantly false)
+                            {:timeout-ms 20 :interval-ms 5
+                             :label "never"})
+             (.then (fn [v]
+                      (is false (str "unexpected resolve: " v))
+                      (done)))
+             (.catch (fn [e]
+                       (let [data (ex-data e)]
+                         (is (true? (:rf.test-helpers/wait-timeout data)))
+                         (is (= "never" (:label data))))
+                       (done))))))))

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -18,7 +18,7 @@ The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runti
 |---|---|---|
 | `re-frame.core` | Production primitives, also the testing entry points | `make-frame`, `destroy-frame!`, `reset-frame!`, `with-frame`, `dispatch-sync`, `with-fx-overrides`, `get-frame-db`, `snapshot-of`, `sub-topology`, `compute-sub`, `machine-transition` |
 | `re-frame.test-support` | Test-only fixture machinery + test-flavoured helpers | `snapshot-registrar`, `restore-registrar!`, `with-fresh-registrar`, `reset-runtime-fixture`, `dispatch-sequence`, `assert-state`, `poll-until` |
-| `re-frame.test-helpers` | View-assertion helpers (hiccup-walk + `testid` authoring) | `expand-tree`, `find-by-attr` / `find-all-by-attr` / `find-by-attr-prefix`, `find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix`, `attrs`, `children`, `text-content`, `extract-handler`, `invoke-handler`, `testid` |
+| `re-frame.test-helpers` | View-assertion helpers (hiccup-walk + `testid` authoring) + single-frame e2e fixture (rf2-wy1ac) | `expand-tree`, `find-by-attr` / `find-all-by-attr` / `find-by-attr-prefix`, `find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix`, `attrs`, `children`, `text-content`, `extract-handler`, `invoke-handler`, `testid`, `with-app-fixture`, `expect-text`, `wait-until` |
 
 `re-frame.test-support` does **not** re-export from `re-frame.core` — a test file requires both namespaces (`[re-frame.core :as rf]` for primitives, `[re-frame.test-support :as ts]` for fixture machinery and helpers). View-assertion test files additionally `:require [re-frame.test-helpers :as th]`. The split is deliberate: `re-frame.core` carries surfaces that compose into production code paths as well as tests; `re-frame.test-support` is a require-gated test-only convenience surface; `re-frame.test-helpers` is the view-assertion surface used only by tests (per [§View-assertion helpers](#view-assertion-helpers-re-frametest-helpers)).
 
@@ -38,6 +38,7 @@ The concrete API for testing, satisfying [Goal 11 (Deterministic, testable runti
 | Static sub-graph inspection | `(rf/sub-topology)` |
 | Sub computation against an `app-db` | `(rf/compute-sub query-v db)` — query-v is `[:sub-id arg1 arg2]`, JVM-runnable |
 | Test-flavoured helpers | `(ts/dispatch-sequence events)` — chained `dispatch-sync`; `(ts/assert-state path expected)` — clojure.test-aware assertion. Both ship with `re-frame.test-support`. |
+| Single-frame e2e fixture | `(th/with-app-fixture {:install f :root-view v} :frame-id body...)` — create + bind frame, run `:install`, stash `:root-view`, destroy on exit. Pair with `(th/expect-text testid expected)` and `(th/wait-until pred-or-testid expected)` for the two-line single-frame test pattern (rf2-wy1ac). |
 
 ### `with-frame` call shapes
 
@@ -155,6 +156,41 @@ For testing state machine transitions, skip the frame entirely:
 ```
 
 `machine-transition` is a pure function — no frame, no `app-db`, no router. Test the logic in isolation; integration tests cover the wiring. See [005 §Testing](005-StateMachines.md#testing) for the full three-level test pyramid (pure `machine-transition`, unregistered handler fn from `create-machine-handler`, registered in test frame).
+
+### Pattern 5 — single-frame e2e fixture (rf2-wy1ac)
+
+The dominant shape for app-developer end-to-end tests: one frame, one install hook (the app's `install!` fn that registers events / subs / views), one root view, and an assertion that the rendered text matches after dispatching. Patterns 1–3 carry the long-form fixture; `with-app-fixture` is the two-line shorthand:
+
+```clojure
+(deftest counter-increments
+  (th/with-app-fixture {:install   counter/install!
+                        :root-view counter/main}
+                       :test-app
+    (rf/dispatch-sync [:counter/inc])
+    (rf/dispatch-sync [:counter/inc])
+    (th/expect-text :counter-display "2")))
+```
+
+The macro:
+
+1. Creates the named frame (or gensym's an anonymous `:rf.frame/*` id when the frame-id positional arg is omitted).
+2. Binds `*current-frame*` to that frame for the body's dynamic extent — `dispatch-sync` and `subscribe` inside the body resolve to it without any explicit `{:frame ...}` opt.
+3. Calls the `:install` fn (zero-arg) inside the frame's scope. Typical body: `reg-event-db` / `reg-sub` / `reg-view` calls that the test relies on. Registrations land in the global registrar; pair with `re-frame.test-support/reset-runtime-fixture` (or `with-fresh-registrar`) to roll them back between tests.
+4. Stashes the `:root-view` fn in `*current-root-view*` so `expect-text` / `wait-until`'s testid form can find it without an explicit tree argument. `:root-view-args` (default `[]`) rides into `*current-root-view-args*` for views that take a props map.
+5. Runs `body`.
+6. In a `finally`, destroys the frame regardless of whether `body` returned normally or threw — no leaked frames across tests.
+
+`opts-map` keys (all optional): `:install`, `:root-view`, `:root-view-args`, `:frame-config` (passed through to `make-frame` / `reg-frame` — `:on-create`, `:fx-overrides`, `:interceptor-overrides`, `:interceptors` and the rest of the frame-shape contract per [Spec 002 §`reg-frame`](002-Frames.md#reg-frame--atomic-create-and-register-and-the-canonical-metadata-grammar)).
+
+The companion helpers:
+
+- **`(th/expect-text testid expected)`** — 2-arity: render the fixture-stashed root view, walk for `:data-testid testid`, assert `(text-content node) = expected`. Reports `:pass` / `:fail` via `clojure.test/is`. The 3-arity `(expect-text tree testid expected)` takes an explicit hiccup tree — useful for view-only tests that don't need a full fixture. `testid` may be a keyword (`:counter-display`, coerced via `name`) or a string.
+- **`(th/wait-until pred-or-testid)`** / **`(th/wait-until testid expected)`** / **`(th/wait-until pred opts)`** / **`(th/wait-until testid expected opts)`** — bounded-deadline poll for async-stable assertions. The view-test counterpart to `re-frame.test-support/poll-until`: same per-platform shape (JVM-synchronous returning the truthy value; CLJS-async returning a `js/Promise` that resolves on success and rejects on timeout). The testid form polls the fixture-stashed root view until the text matches; the predicate form polls an arbitrary fn. `opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`. Use for async event flows (HTTP, scheduled events, machine `:after` transitions) that drain past `dispatch-sync`. Timer-semantics sleeps (grace-period elapse, throttle/debounce window) keep their explicit sleep and annotate the intent locally — `wait-until` is for *settles*, not *windows*.
+
+When NOT to use Pattern 5:
+
+- **Multi-frame setups** (Causa, Story, cross-frame tests) — Pattern 1 / 2 with explicit `rf/with-frame` calls each frame is clearer; the fixture stash is single-slot by design.
+- **Tests that don't render** — the install + frame lifecycle of Pattern 5 is overkill for pure-event tests. Reach for `(rf/with-frame [f (rf/make-frame opts)] ...)` and skip the view-stash entirely.
 
 ## Per-test stubbing patterns
 
@@ -299,7 +335,7 @@ Both are JVM-runnable and require no DOM. Reach for `render-to-string` when the 
 
 ### Normative surface — `re-frame.test-helpers`
 
-Thirteen public defs, organised by role. Every entry is JVM-runnable; the namespace requires only `clojure.string` and stays classpath-clean for callers that don't pull React or Reagent.
+Sixteen public defs, organised by role. Every entry except `with-app-fixture` (which threads through `re-frame.frame/reg-frame` and `destroy-frame!`) is JVM-runnable purely against `clojure.string`; the namespace pulls `re-frame.frame` for the fixture-macro expansion and `clojure.test` / `cljs.test` for `expect-text`'s `do-report` path.
 
 | Helper | Form | Signature | Purpose |
 |---|---|---|---|
@@ -316,6 +352,9 @@ Thirteen public defs, organised by role. Every entry is JVM-runnable; the namesp
 | `find-by-testid-prefix` | Fn | `(find-by-testid-prefix tree prefix) → vector` | Every node whose `:data-testid` STARTS with `prefix`. Equivalent to `(find-by-attr-prefix tree :data-testid prefix)`. |
 | `invoke-handler` | Fn | `(invoke-handler node event-key & args) → any` | Find the handler under `event-key` on `node` and call it. Returns the handler's return value (typically `nil` for `dispatch`-side-effecting `:on-click`s). **Throws** when `node` is not a hiccup vector, the node has no attrs map, or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug, not a passing case). |
 | `testid` | Fn | `(testid id)` / `(testid id extra) → map` | Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Use at the view call site: `[:button (testid "counter-inc" {:on-click ...}) "+"]`. |
+| `with-app-fixture` | Macro | `(with-app-fixture opts-map frame-id body+)` / `(with-app-fixture opts-map body+)` | Single-frame e2e fixture (rf2-wy1ac). Creates the frame, binds `*current-frame*` for the body's dynamic extent, calls `:install` (zero-arg) inside the scope, stashes `:root-view` / `:root-view-args` for `expect-text` / `wait-until`, and destroys the frame on exit (success or exception). Frame-id is positional and optional; omitting it gensym's an anonymous `:rf.frame/*` id. Opts keys: `:install`, `:root-view`, `:root-view-args`, `:frame-config` (passed through to `make-frame` / `reg-frame`). See [§Pattern 5 — single-frame e2e fixture](#pattern-5--single-frame-e2e-fixture-rf2-wy1ac). |
+| `expect-text` | Fn | `(expect-text testid expected)` / `(expect-text tree testid expected) → bool?` | Locate `:data-testid testid` in the (fixture-stashed) root view's rendered hiccup and assert `(text-content node) = expected` via `clojure.test/is` (`do-report`). `testid` accepts a keyword (coerced via `name`) or a string. The 2-arity reads the fixture-stashed root view from `*current-root-view*`; the 3-arity walks an explicit tree. Throws (with a clear `ex-info` message) if neither a fixture nor an explicit tree is present. |
+| `wait-until` | Fn | `(wait-until pred)` / `(wait-until pred opts)` / `(wait-until testid expected)` / `(wait-until testid expected opts)` | Bounded-deadline poll for async-stable assertions. JVM: synchronous — returns the truthy value, throws `ex-info` with `:rf.test-helpers/wait-timeout true` on timeout. CLJS: returns a `js/Promise` that resolves with the truthy value or rejects on timeout. The testid form polls the fixture-stashed root view until `(text-content (find-by-testid tree testid)) = expected`; the predicate form polls an arbitrary fn. `opts`: `:timeout-ms` (2000), `:interval-ms` (5), `:label`. Sister of `re-frame.test-support/poll-until` — same shape, tuned for the hiccup-walk pattern. |
 
 ### Function-component expansion
 
@@ -367,7 +406,7 @@ Authoring side — emit a testid at the view call site:
 
 ### JVM-runnable boundary for hiccup-walk
 
-Every helper in `re-frame.test-helpers` is JVM-runnable — the namespace requires only `clojure.string`. The reagent-slim Form-3 detection uses a reader-conditional (`#?(:cljs ...)`) that's a no-op on the JVM (the JVM has no `.-cljsReagentClass` property access on plain fns), so Form-3 expansion is a CLJS-only optimisation and JVM tests see the same hiccup tree.
+Every helper in `re-frame.test-helpers` is JVM-runnable. The hiccup-walk core (everything pre-rf2-wy1ac) is classpath-clean against `clojure.string` alone; the fixture trio (`with-app-fixture` / `expect-text` / `wait-until`) additionally reaches `re-frame.frame` (for `reg-frame` / `make-frame` / `destroy-frame!` / `*current-frame*`) and `clojure.test` / `cljs.test` (for `expect-text`'s `do-report` failure path). The fixture deps are framework-internal — they do not pull React, Reagent, or any substrate adapter into the classpath. The reagent-slim Form-3 detection uses a reader-conditional (`#?(:cljs ...)`) that's a no-op on the JVM (the JVM has no `.-cljsReagentClass` property access on plain fns), so Form-3 expansion is a CLJS-only optimisation and JVM tests see the same hiccup tree. `wait-until`'s per-platform shape is reader-conditional (JVM synchronous; CLJS `js/Promise`) per [§Pattern 5](#pattern-5--single-frame-e2e-fixture-rf2-wy1ac).
 
 This complements the JVM-runnable list in [§Normative surface §JVM-runnable boundary](#jvm-runnable-boundary-authoritative): hiccup-walk joins `render-to-string` as a JVM-runnable view-test path.
 
@@ -555,6 +594,7 @@ The canonical helper inventory is the union of three namespaces:
 | `poll-until` | `re-frame.test-support` (rf2-ka3n6 / rf2-fun38) | `(poll-until pred)` / `(poll-until pred opts)` — bounded-deadline poll for `(pred)` to be truthy. JVM returns the truthy value synchronously (throws `ex-info` with `:rf.test/poll-timeout true` on timeout); CLJS returns a `js/Promise` that resolves with the truthy value or rejects on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label` (string/keyword for the timeout message). Replaces incidental fixed `Thread/sleep N` / `js/setTimeout` whose intent is "wait for an observable state change" — NOT for timer-semantics tests (grace-period elapse, throttle/debounce window, "prove a thing did NOT happen within window N"); those should keep their sleep and annotate that intent locally. |
 | `snapshot-registrar`, `restore-registrar!`, `with-fresh-registrar`, `reset-runtime-fixture` | `re-frame.test-support` | Snapshot/restore the registrar (and per-process state — frames, flows, schemas, trace listeners) around a test or fixture. The standard `:each` fixture for re-frame2 test suites. |
 | `expand-tree`, `find-by-attr` / `find-all-by-attr` / `find-by-attr-prefix`, `find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix`, `attrs`, `children`, `text-content`, `extract-handler`, `invoke-handler`, `testid` | `re-frame.test-helpers` | Hiccup-walk view-assertion surface — call the view-fn directly, walk the returned hiccup, assert on content or invoke a handler. JVM-runnable; no JSDOM, no React, no `act()`. Full inventory and contract: [§View-assertion helpers](#view-assertion-helpers-re-frametest-helpers). |
+| `with-app-fixture`, `expect-text`, `wait-until` | `re-frame.test-helpers` (rf2-wy1ac) | Single-frame e2e fixture trio. `with-app-fixture` brackets a body with a fresh frame + `:install` hook + `:root-view` stash; `expect-text` walks the stashed view for a testid'd node and asserts text content; `wait-until` polls a condition or a testid's text until a deadline elapses (JVM-sync / CLJS-Promise). Compresses the 5-line single-frame e2e pattern to 2 lines. See [§Pattern 5 — single-frame e2e fixture](#pattern-5--single-frame-e2e-fixture-rf2-wy1ac). |
 
 This is the full surface. Anything else a test needs is composed from `dispatch-sync` / `get-frame-db` / `compute-sub` / `machine-transition` directly — there is no hidden helper layer.
 


### PR DESCRIPTION
## Summary
- New macro `re-frame.test-helpers/with-app-fixture` — single-line wrapper for single-frame e2e tests. Creates + binds a frame, calls user's `:install` hook inside the scope, stashes `:root-view` for downstream helpers, destroys the frame on exit.
- New helper `expect-text` — combines `find-by-testid` + `text-content` + `clojure.test/is`-style assertion. 2-arity uses the fixture-stashed root view; 3-arity walks an explicit tree.
- New helper `wait-until` — bounded-deadline poll for async-stable assertions. JVM-sync / CLJS-Promise per-platform shape, mirroring `re-frame.test-support/poll-until`. Two forms: predicate or `(testid expected)`.
- Spec 008 documents the canonical 2-line pattern as Pattern 5, updates the `re-frame.test-helpers` inventory (16 public defs), and refreshes the JVM-runnable boundary text.

Compresses the 5-line e2e pattern Mike asked about:

```clojure
(deftest counter-increments
  (th/with-app-fixture {:install   counter/install!
                        :root-view counter/main}
                       :test-app
    (rf/dispatch-sync [:counter/inc])
    (rf/dispatch-sync [:counter/inc])
    (th/expect-text :counter-display "2")))
```

## Bead
rf2-wy1ac (P1)

## Acceptance
- 14 new deftests (`implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc`) covering both fixture shapes (named + anonymous frame id), `:install` hook execution, `:root-view` stashing, exception-safe teardown, `expect-text` 2-arity / 3-arity / keyword-vs-string testids / missing-testid `:fail` path, and `wait-until` predicate-form + testid-form on both JVM (sync) and CLJS (Promise).
- Full JVM suite: `clojure -M:test` → 650 tests, 0 failures.
- Full CLJS suite: `npm run test:cljs` → 3597 tests, 0 failures.
- `python -m mkdocs build --strict` → clean.