### PR TITLE
feat(causa): Static Machines Topology uses Chart adapter (rf2-md9oz)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -33,14 +33,35 @@
   static panel uses (`static/machines/topology.cljs` consumes the
   chart in static-read mode; this ns is its runtime peer).
 
-  ## Static-mode parity
+  ## Static-mode parity (rf2-md9oz)
 
   The static topology consumer (`static/machines/topology.cljs`)
-  is read-only and passes no `:highlight-id` / no
-  `:viewport-transform`. To give static users zoom + pan + fit
-  too, the same `Chart` view here can be embedded on the static
-  side in a follow-on bead — for v1 the static surface is
-  untouched."
+  is read-only and embeds this `Chart` view to get zoom + pan +
+  fit too. Static callers pass:
+
+    :show-view-mode-toggle? false  — Canvas/List toggle is a
+                                     Runtime concept; the Static
+                                     Machines panel already owns
+                                     a per-machine sub-mode pill
+                                     strip at L3, so the toggle
+                                     is meaningless on static.
+    :show-after-rings?      false  — after-rings overlay is a
+                                     Runtime focused-event lens;
+                                     no live focused event exists
+                                     on the static surface.
+    :testid                 \"rf-causa-static-machines-topology-svg\"
+                                   — overrides the inner SVG's
+                                     root data-testid so the
+                                     static-panel tests find it.
+    :show-controls-toolbar? true   — zoom/pan/fit toolbar still
+                                     useful on static; default
+                                     left on.
+
+  The per-machine viewport slot IS shared across Static and
+  Runtime — if the user pans/zooms a machine in either surface,
+  the other surface picks up the same viewport when it next
+  mounts. This matches the user model: 'this is the chart for
+  machine X, and I parked it in this view'."
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [day8.re-frame2-machines-viz.chart.controls :as ctl]
@@ -402,7 +423,7 @@
 
 (defn Chart
   "Render the interactive MachineChart inside the Runtime Machines
-  panel.
+  panel (or the Static Machines Topology body — rf2-md9oz).
 
   Args (map):
 
@@ -415,7 +436,25 @@
     :on-state-click   — click handler for state nodes.
     :show-after-rings? — when true (default) overlay
                         `[after-rings/AfterRingsOverlay positioned]`
-                        on top of the chart.
+                        on top of the chart. Runtime keeps true;
+                        Static passes false (no focused-event
+                        lens on static).
+    :show-view-mode-toggle? — when true (default) render the
+                        Canvas/List pill in the canvas's top-
+                        left. Runtime keeps true; Static passes
+                        false (the L3 sub-mode pills already
+                        own per-machine mode at the panel level).
+    :show-controls-toolbar? — when true (default) render the
+                        zoom/pan/fit controls toolbar in the
+                        canvas's top-right. Both Runtime and
+                        Static keep true.
+    :testid           — when present, forwarded to `mv-svg/render`
+                        as the inner SVG's root data-testid.
+                        Static passes
+                        `\"rf-causa-static-machines-topology-svg\"`
+                        so the existing static-panel tests still
+                        match. nil leaves the SVG with its
+                        default (`rf-mv-chart-svg`).
 
   Returns hiccup. Reads `:rf.causa.machine-canvas/viewport-for` so
   zoom/pan updates re-render the chart with a new
@@ -423,11 +462,14 @@
 
   The wrapper div carries the wheel/drag/keyboard handlers + sets
   `tabIndex=0` so the keyboard shortcuts work after the user
-  clicks on the canvas. The toolbar sits absolute-positioned in
-  the top-right corner."
+  clicks on the canvas. The controls toolbar sits absolute-
+  positioned in the top-right corner."
   [{:keys [positioned machine-id from-highlight-id to-highlight-id
-           on-state-click show-after-rings?]
-    :or   {show-after-rings? true}}]
+           on-state-click show-after-rings? show-view-mode-toggle?
+           show-controls-toolbar? testid]
+    :or   {show-after-rings?       true
+           show-view-mode-toggle?  true
+           show-controls-toolbar?  true}}]
   (let [viewport @(rf/subscribe
                     [:rf.causa.machine-canvas/viewport-for machine-id])
         content-dims {:width  (:width positioned)
@@ -481,13 +523,14 @@
      ;; Chart SVG — viewport-transform passes the user's zoom + pan.
      (mv-svg/render
        positioned
-       {:from-highlight-id  from-highlight-id
-        :to-highlight-id    to-highlight-id
-        :on-state-click     on-state-click
-        :viewport-transform viewport
-        :svg-attrs          {:style {:width  "100%"
-                                     :height "100%"
-                                     :display "block"}}})
+       (cond-> {:from-highlight-id  from-highlight-id
+                :to-highlight-id    to-highlight-id
+                :on-state-click     on-state-click
+                :viewport-transform viewport
+                :svg-attrs          {:style {:width  "100%"
+                                             :height "100%"
+                                             :display "block"}}}
+         (some? testid) (assoc :testid testid)))
      (when show-after-rings?
        ;; rf2-obp4z — the after-rings overlay receives the same
        ;; viewport-transform the chart applies. The overlay wraps
@@ -498,28 +541,30 @@
        [after-rings/AfterRingsOverlay
         positioned
         {:viewport-transform viewport}])
-     ;; Toolbar — absolute top-right, above the chart SVG.
-     [:div {:data-testid "rf-causa-machine-canvas-toolbar"
-            :style {:position "absolute"
-                    :top      "8px"
-                    :right    "8px"
-                    :z-index  2}}
-      (ctl/toolbar
-        {:viewport viewport
-         :on-action (fn [action]
-                      (dispatch-action machine-id action))
-         :testid-prefix (str "rf-causa-machine-canvas-controls-"
-                             (when machine-id
-                               (subs (str machine-id) 1)))
-         :compact? false})]
-     ;; View-mode toggle — absolute top-left.
-     [:div {:style {:position "absolute"
-                    :top      "8px"
-                    :left     "8px"
-                    :z-index  2}}
-      (let [mode @(rf/subscribe
-                    [:rf.causa.machine-canvas/view-mode-for machine-id])]
-        (view-mode-toggle {:machine-id machine-id :mode mode}))]]))
+     (when show-controls-toolbar?
+       ;; Toolbar — absolute top-right, above the chart SVG.
+       [:div {:data-testid "rf-causa-machine-canvas-toolbar"
+              :style {:position "absolute"
+                      :top      "8px"
+                      :right    "8px"
+                      :z-index  2}}
+        (ctl/toolbar
+          {:viewport viewport
+           :on-action (fn [action]
+                        (dispatch-action machine-id action))
+           :testid-prefix (str "rf-causa-machine-canvas-controls-"
+                               (when machine-id
+                                 (subs (str machine-id) 1)))
+           :compact? false})])
+     (when show-view-mode-toggle?
+       ;; View-mode toggle — absolute top-left.
+       [:div {:style {:position "absolute"
+                      :top      "8px"
+                      :left     "8px"
+                      :z-index  2}}
+        (let [mode @(rf/subscribe
+                      [:rf.causa.machine-canvas/view-mode-for machine-id])]
+          (view-mode-toggle {:machine-id machine-id :mode mode}))])]))
 
 ;; ---- install ------------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/topology.cljs
@@ -1,19 +1,37 @@
 (ns day8.re-frame2-causa.static.machines.topology
   "Topology mode renderer — Static-read view of a machine's state graph
-  (rf2-o5f5f.2).
+  (rf2-o5f5f.2; rf2-md9oz upgrade to interactive Chart adapter).
 
   ## What it renders
 
-  The same `chart/svg` MachineChart primitive the Runtime panel uses
-  (per findings §5.1 — single implementation). **The Static-mode
-  rendering passes NO `:highlight-id`** — Topology in Static is a
-  static-read; there's no active state to spotlight.
+  The Static Topology body embeds `machine-canvas/Chart` — the same
+  interactive viewport adapter the Runtime Machines panel uses — so
+  Static users get zoom / pan / fit with the same gestures and the
+  same keyboard shortcuts (`+` / `-`, arrows, `f`, `0`). Stately and
+  XState's static / read-only chart views get the same affordances;
+  Causa's static surface should match.
 
-  Click on a state node fires `:rf.causa.static.machines/state-clicked`
-  with the clicked state's path; the right pane carries a metadata
-  rail showing incoming / outgoing edges + a source-coord chip (when
-  the definition lifts a coord onto the state). The chip degrades
-  gracefully when the coord is missing.
+  Static differs from Runtime in three respects:
+
+    1. NO focused-event lens — Static is a static-read; there's no
+       `:from-highlight-id` / `:to-highlight-id` to pass, and the
+       after-rings overlay is suppressed (`:show-after-rings?
+       false`).
+    2. NO Canvas/List view-mode toggle inside the canvas — the
+       Static Machines panel already owns a per-machine sub-mode
+       pill strip at L3 (Topology / Sim / Instances / Cascade); a
+       second toggle inside the canvas would be redundant noise.
+       (`:show-view-mode-toggle? false`.)
+    3. Click on a state node fires
+       `:rf.causa.static.machines/state-clicked` (with the clicked
+       state's path) — not the Runtime panel's inspector-lens
+       navigation event.
+
+  The per-machine viewport slot is shared with the Runtime Machine
+  Inspector — if the user pans / zooms in either surface, the other
+  picks up the same viewport when it next mounts. That matches the
+  user model: 'this is the chart for machine X, parked in this
+  view.'
 
   ## Empty states
 
@@ -21,8 +39,9 @@
     first row when one exists).
   - Machine has no definition (registrar returns nil from
     `machine-meta`) — render a hint pointing at `reg-machine`.
-  - Definition with no `:states` map (degenerate) — falls through to
-    `chart/svg/render`'s built-in 'no states' message.
+  - Definition with no `:states` map (degenerate) — falls through
+    to `mv-svg/render`'s built-in 'no states' message (rendered
+    inside the canvas host).
 
   ## Definition-stale post-reload
 
@@ -34,9 +53,9 @@
   (the `machine-definitions` sub fires on framework hot-reload), so
   the data shown is always live."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.static.machines.helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -55,8 +74,19 @@
 ;; ---- chart wrapper ------------------------------------------------------
 
 (defn- chart
-  "Render the chart SVG for `definition`. NO highlight — Static
-  Topology is a static-read."
+  "Render the interactive MachineChart canvas for `definition`. NO
+  highlight + NO after-rings — Static Topology is a static-read.
+
+  rf2-md9oz — delegates to `machine-canvas/Chart` (same adapter the
+  Runtime Machines panel uses) so the user gets zoom / pan / fit
+  + keyboard shortcuts on the Static surface too. The static-
+  flavoured opts are:
+
+    :show-view-mode-toggle? false  — Static panel owns sub-mode at L3.
+    :show-after-rings?      false  — no focused-event lens on static.
+    :testid                        — overrides the inner SVG testid
+                                     so the existing static-panel
+                                     tests still match."
   [{:keys [definition machine-id]}]
   (let [direction  :tb
         positioned (elk-layout/layout-or-fallback definition direction)
@@ -81,16 +111,23 @@
            :data-layout-engine engine
            :style {:padding    "12px"
                    :background (:bg-1 tokens)
-                   :overflow   "auto"
-                   :position   "relative"}}
-     (chart-svg/render
-       positioned
-       {:testid         "rf-causa-static-machines-topology-svg"
-        :on-state-click
-        (fn [path]
-          (rf/dispatch [:rf.causa.static.machines/state-clicked
-                        {:machine-id machine-id :path path}]
-                       {:frame :rf/causa}))})]))
+                   :overflow   "hidden"
+                   :position   "relative"
+                   ;; The canvas-host fills this wrapper — must give it
+                   ;; vertical room so the chart isn't clipped to 0px.
+                   :flex       "1 1 auto"
+                   :min-height "260px"}}
+     [machine-canvas/Chart
+      {:positioned             positioned
+       :machine-id             machine-id
+       :show-after-rings?      false
+       :show-view-mode-toggle? false
+       :testid                 "rf-causa-static-machines-topology-svg"
+       :on-state-click
+       (fn [path]
+         (rf/dispatch [:rf.causa.static.machines/state-clicked
+                       {:machine-id machine-id :path path}]
+                      {:frame :rf/causa}))}]]))
 
 ;; ---- chart toolbar (open in popout) -------------------------------------
 
@@ -148,8 +185,11 @@
   "Render Topology mode for `machine-id`. `definition` is the
   registrar's spec map; `source-coord` is its lifted coord (or nil).
 
-  Pure-ish — reads no subscribes (the panel feeds the props). The
-  embedded `chart-svg/render` is pure hiccup."
+  The embedded `machine-canvas/Chart` (rf2-md9oz) subscribes to
+  `:rf.causa.machine-canvas/viewport-for` internally so zoom / pan
+  state lives in app-db — the body function itself is still pure
+  hiccup; the subscribe lands one level down in the canvas
+  adapter."
   [{:keys [machine-id definition source-coord] :as args}]
   (cond
     (nil? definition)

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_canvas_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_canvas_cljs_test.cljs
@@ -228,3 +228,52 @@
     (let [positioned {:nodes [] :edges [] :width 100 :height 50 :initial-id nil}
           tree (mc/Chart {:positioned positioned :machine-id :m})]
       (is (some? (find-by-testid tree "rf-causa-machine-canvas-view-mode-toggle"))))))
+
+;; ---- 7. Static-mode opt-out knobs (rf2-md9oz) --------------------------
+
+(deftest chart-view-omits-view-mode-toggle-when-knob-false
+  (testing "rf2-md9oz — Static Topology consumer passes
+            :show-view-mode-toggle? false to suppress the Canvas/List
+            pill (Static panel owns sub-mode at L3)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [positioned {:nodes [] :edges [] :width 100 :height 50 :initial-id nil}
+            tree (mc/Chart {:positioned positioned
+                            :machine-id :m
+                            :show-view-mode-toggle? false})]
+        (is (some? (find-by-testid tree "rf-causa-machine-canvas-host"))
+            "canvas host still mounts")
+        (is (nil? (find-by-testid tree "rf-causa-machine-canvas-view-mode-toggle"))
+            "view-mode toggle is suppressed")))))
+
+(deftest chart-view-omits-controls-toolbar-when-knob-false
+  (testing "Optional escape hatch — callers can suppress the controls
+            toolbar without forking the adapter. Default-on (covered
+            in chart-view-emits-canvas-host)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [positioned {:nodes [] :edges [] :width 100 :height 50 :initial-id nil}
+            tree (mc/Chart {:positioned positioned
+                            :machine-id :m
+                            :show-controls-toolbar? false})]
+        (is (nil? (find-by-testid tree "rf-causa-machine-canvas-toolbar"))
+            "controls toolbar suppressed when knob is false")))))
+
+(deftest chart-view-forwards-testid-to-inner-svg
+  (testing "rf2-md9oz — the static panel needs to override the inner
+            SVG's data-testid so existing static-panel selectors keep
+            matching. Chart forwards :testid to mv-svg/render."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [positioned {:nodes [{:node-id :a :x 0 :y 0
+                                 :width 40 :height 20
+                                 :path [:a] :label "a"}]
+                        :edges []
+                        :width 200 :height 100
+                        :initial-id nil}
+            tree (mc/Chart {:positioned positioned
+                            :machine-id :m
+                            :testid     "rf-causa-static-machines-topology-svg"})]
+        (is (some? (find-by-testid tree
+                                   "rf-causa-static-machines-topology-svg"))
+            "inner SVG carries the overridden testid")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
@@ -430,6 +430,62 @@
                                  "rf-causa-static-machines-topology-no-definition"))))))
 
 ;; -------------------------------------------------------------------------
+;; (11b) Topology mode — interactive canvas adapter (rf2-md9oz)
+;; -------------------------------------------------------------------------
+
+(deftest topology-mode-wraps-chart-in-canvas-host
+  (testing "rf2-md9oz — Static Topology body delegates to
+            machine-canvas/Chart so users get zoom / pan / fit."
+    (causa-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a {:initial :idle
+                              :states  {:idle {} :done {}}}})
+    (rf/with-frame :rf/causa
+      (let [tree (panel/panel)]
+        (is (some? (find-by-testid tree "rf-causa-machine-canvas-host"))
+            "the chart is now wrapped in the interactive canvas-host")
+        (is (some? (find-by-testid tree "rf-causa-machine-canvas-toolbar"))
+            "controls toolbar (zoom / pan / fit) is present on static too")
+        ;; The inner SVG testid still resolves so existing static-panel
+        ;; selectors keep working.
+        (is (some? (find-by-testid tree "rf-causa-static-machines-topology-svg"))
+            ":testid forwards through Chart to the SVG primitive")))))
+
+(deftest topology-mode-omits-view-mode-toggle-on-static
+  (testing "rf2-md9oz — Static surface already owns the per-machine
+            sub-mode pill strip at L3; the canvas's Canvas/List toggle
+            is meaningless on static and must NOT mount."
+    (causa-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a {:initial :idle
+                              :states  {:idle {} :done {}}}})
+    (rf/with-frame :rf/causa
+      (let [tree (panel/panel)]
+        (is (nil? (find-by-testid tree
+                                  "rf-causa-machine-canvas-view-mode-toggle"))
+            "view-mode toggle is suppressed on static via
+             :show-view-mode-toggle? false")))))
+
+(deftest topology-mode-keeps-popout-and-source-coord-affordances
+  (testing "The Static panel's existing 'open in popout' affordance +
+            source-coord chip still live in the chart-toolbar ABOVE
+            the canvas — they did not absorb into the canvas's own
+            controls toolbar."
+    (causa-setup!)
+    (seed-machines! [:m/a])
+    (seed-definitions! {:m/a {:initial :idle
+                              :states  {:idle {} :done {}}
+                              :source-coord {:file "src/m_a.cljs" :line 12}}})
+    (rf/with-frame :rf/causa
+      (let [tree (panel/panel)]
+        (is (some? (find-by-testid tree
+                                   "rf-causa-static-machines-topology-toolbar"))
+            "static chart-toolbar still mounts above the canvas")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-static-machines-topology-popout"))
+            "Pop-out affordance still present")))))
+
+;; -------------------------------------------------------------------------
 ;; (12) Public install — install-fx + hydrate
 ;; -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Static Machines Topology body now uses the interactive `machine-canvas/Chart` view (zoom/pan/fit + keyboard shortcuts) instead of the v1 read-only `chart-svg/render` path.
- `Chart` gains three new knobs so a single adapter can serve both surfaces:
  - `:show-view-mode-toggle?` (default `true`) — Static passes `false`; the L3 sub-mode pill strip already owns per-machine mode on the static panel.
  - `:show-controls-toolbar?` (default `true`) — kept on for Static too (zoom/pan/fit still useful).
  - `:testid` — forwarded to `mv-svg/render` so existing static-panel selectors (`rf-causa-static-machines-topology-svg`) keep matching.
- `:show-after-rings?` (existing) passed as `false` from Static — no focused-event lens on the static surface.
- Per-machine viewport slot is shared across Static and Runtime — pan/zoom a machine in either surface and the other picks up the same viewport.
- Reduced-motion seam preserved (handled inside `mv-svg/render`'s `inline-stylesheet`).
- Existing static chart-toolbar (Pop-out + source-coord chip) stays above the canvas — the canvas's own zoom/pan/fit toolbar sits absolute-positioned inside the canvas.
- Parity with Stately / XState's read-only chart views.

## Bead
rf2-md9oz (P3, rf2-y3l8z follow-on)

## Acceptance
- `npm run test:cljs` — 3591 tests, 0 failures, 0 errors
- `mkdocs build --strict` — clean (exit 0)
- New tests:
  - `topology-mode-wraps-chart-in-canvas-host` — Static Topology mounts `rf-causa-machine-canvas-host` + `rf-causa-machine-canvas-toolbar`; the `:testid` knob still routes the inner SVG testid through.
  - `topology-mode-omits-view-mode-toggle-on-static` — Canvas/List toggle is suppressed on Static.
  - `topology-mode-keeps-popout-and-source-coord-affordances` — Pop-out + source-coord chip still mount above the canvas.
  - `chart-view-omits-view-mode-toggle-when-knob-false` — `:show-view-mode-toggle? false` opt-out wired correctly.
  - `chart-view-omits-controls-toolbar-when-knob-false` — `:show-controls-toolbar? false` opt-out wired correctly.
  - `chart-view-forwards-testid-to-inner-svg` — `:testid` flows through `Chart` into `mv-svg/render`.

## Decisions taken
- **View-mode toggle on static:** OFF (Static panel already owns sub-mode at L3; a second toggle inside the canvas would be redundant noise).
- **Viewport slot scope:** Static and Runtime share the per-machine viewport — visual continuity matches the user model 'this is the chart for machine X, parked in this view'.
- **Static chart-toolbar:** Stays above the canvas (does not absorb into the canvas's controls toolbar). Pop-out + source-coord live with the panel header; zoom/pan/fit live with the canvas.
- **`on-state-click`:** Static dispatches `:rf.causa.static.machines/state-clicked`; Runtime keeps its existing inspector lens — the callback shape is per-caller.