### PR TITLE
spec/docs(story): tutorial cluster — 6 rf2-l6jev follow-ons

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -160,7 +160,9 @@ Body:
 ```clojure
 {:doc       "..."
  :layout    :grid | :prose | :variants-grid | :tabs | :custom
- :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs
+ :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs (explicit list)
+ :for       <story-id>                            ; for :variants-grid only — auto-enumerate
+ :columns   <integer>                             ; for :grid / :variants-grid — column count
  :content   [{:type :prose :body "md..."} ...]    ; for :prose
  :render    <view-id>                              ; for :custom (a registered view)
  :modes     #{<mode-id> ...}                       ; future-reserved — see below
@@ -171,6 +173,41 @@ The `:variants-grid` layout (per Phase 2 SOTA refinement) renders
 every variant of a single parent story side-by-side; it differs from
 `:grid` (which renders an explicit `:variants` list) by enumerating
 variants from the registry.
+
+#### `:variants-grid` — explicit `:variants` vs auto-enumerated `:for` (rf2-pgccv)
+
+`:variants-grid` accepts the variant set via **one** of two slots —
+they are alternatives, not co-equals. Declaring both raises
+`:rf.error/workspace-shape` at registration.
+
+| Slot | Shape | Behaviour |
+|---|---|---|
+| `:variants` | `[<variant-id> ...]` (explicit vector) | Renders exactly the listed variants in declared order. Use when you want a curated subset, or to interleave variants from sibling stories. |
+| `:for` | `<story-id>` (single keyword) | Auto-enumerates every registered variant of the named parent story, in registration order. Use when you want "all variants of this story, no maintenance." New variants added to the story appear automatically without touching the workspace body. |
+
+Equivalent to the Storybook 8 contrast between an explicit `subcomponents`
+list and an auto-enumerated `*` glob — Story names the two paths
+explicitly so the authoring intent is in the body.
+
+```clojure
+;; Explicit list — cherry-pick three of the counter's eight variants:
+(story/reg-workspace :Workspace.counter/curated
+  {:layout   :variants-grid
+   :variants [:story.counter/empty
+              :story.counter/at-five
+              :story.counter/overflow]
+   :columns  3})
+
+;; Auto-enumerate — every variant of :story.counter, in registration order:
+(story/reg-workspace :Workspace.counter/auto-grid
+  {:layout  :variants-grid
+   :for     :story.counter
+   :columns 2})
+```
+
+Other layouts (`:grid`, `:tabs`) take `:variants` only — they have no
+single parent-story to enumerate against. `:prose` and `:custom`
+ignore both slots.
 
 #### Workspace `:modes` slot — future-reserved (v1) (rf2-q5e36)
 
@@ -291,6 +328,48 @@ unmount and §Loader teardown contract) is the better surface — the
 actor's `:exit` action captures the cleanup, and the state-machine
 runtime owns the destroy walk. `:teardown` on `:frame-setup` is the
 lightweight option for resources that need exactly one cancel event.
+
+#### Composition order — the `:fx-override` asymmetry (rf2-a6l59)
+
+A variant's effective decorator stack is the **story-level**
+decorators followed by the **variant-level** decorators (declared
+order in both cases). The three decorator kinds compose differently
+under that stack, and the asymmetry is deliberate but easy to trip
+on if you arrive expecting a single rule:
+
+| Kind | Composition rule | Intuition |
+|---|---|---|
+| `:hiccup` | **Outermost wraps innermost.** Story decorators are outer; variant decorators are inner. Walked LIFO so the *last* decorator declared on the variant ends up *closest* to the rendered view. | "Wrap" is geometric — story-level theme provider sits outside the variant-level layout-debug overlay. |
+| `:frame-setup` | **Declared order** (story decorators then variant decorators). Each runs its `:init` events / `:app-db-patch` against the variant's frame in turn; later writes overlay earlier ones at the same path. | First in, last write. Variant-level setup overrides story-level setup at the path level. |
+| `:fx-override` | **Declared order, but collisions on `:fx-id` resolve LAST-WINS.** Story decorators register first; variant decorators register second; if both target the same `:fx-id` the variant-level override wins. | The innermost decorator is closest to the variant's intent and should override outer stubs. |
+
+The asymmetry: `:hiccup` reads as **"outermost wraps innermost"**
+(story first, geometrically outside), while `:fx-override` reads as
+**"innermost overrides outermost"** (variant last, semantically wins).
+A reader who internalises the wrapping rule for `:hiccup` will be
+briefly surprised by `:fx-override`'s inversion. Both rules are the
+right call for their kind — wrapping nests, overrides last-write —
+but the inversion is worth naming because the same author can hit
+both in the same variant body.
+
+```clojure
+;; Story-level :fx-override registered first (the "base mock");
+;; variant-level :fx-override registered second wins on collision.
+(story/reg-story :story.checkout/flow
+  {:decorators [[:force-fx-stub :http/managed
+                 {:response {:status 200 :body {:items []}}}]]})
+
+(story/reg-variant :story.checkout/flow/server-error
+  {:decorators [[:force-fx-stub :http/managed                       ;; SAME :fx-id
+                 {:response {:status 500 :body :rf.http/failed}}]]})
+;;                                                  ^^^^^^^^^^^^
+;;                                                  variant-level wins
+```
+
+For collisions on `:hiccup` decorator ids the registry is keyed by
+id, so two decorators with the same id raise `:rf.error/decorator-id-collision`
+at registration — id collisions are an authoring bug, not a
+composition rule.
 
 ### `(reg-story-panel id metadata)`
 
@@ -418,6 +497,162 @@ variant). Each `(variant × mode)` cell has an independent
 `snapshot-identity` — see [`002-Runtime.md`](002-Runtime.md) §Snapshot
 identity.
 
+## Controls — schema-derived, zero-`:argtypes` (rf2-b87h2)
+
+The controls panel is **auto-derived** from the view's registered
+Malli schema. The schema-on-the-view IS the source of truth — the
+authoring story is "register your view with a schema; controls
+appear." Author-supplied `:argtypes` exists for the edge cases where
+the schema doesn't say enough; in most stories it is empty.
+
+This is the largest authoring win Story carries over Storybook: where
+Storybook authors write per-story `argTypes: { size: { control: {
+type: 'range', min: 0, max: 100 } } }`, Story authors write
+`[:int {:min 0 :max 100}]` once on the view and **all** stories of
+that view get the slider for free.
+
+### The mapping
+
+| Schema fragment | Auto-derived control | Notes |
+|---|---|---|
+| `:string` | text input | |
+| `:int` (optional `[:int {:min :max}]`) | number input or slider | Slider when both `:min` and `:max` are bounded. |
+| `:double` (optional `[:double {:min :max}]`) | number input or slider | As above. |
+| `:boolean` | toggle | |
+| `:keyword` | text input | Keyword-coercion at edit time. |
+| `[:enum a b c]` | select | Options are the enum members in declared order. |
+| `[:map [k1 s1] [k2 s2] ...]` | labelled group of nested rows | One row per key, recursive on each `s_i`. |
+| `[:vector X]` | repeater (rows + `[+]` / `[-]`) | Adds seed a default from `X` (text → "", number → 0, etc.). |
+| `[:set X]` | repeater (deduplicated) | As above; round-trips through `set`. |
+| `[:tuple X Y ...]` | fixed-arity row (no `[+]` / `[-]`) | One row per declared position. |
+
+The full collection-recursion contract — including how editing
+position `i` writes through to `[:cell-overrides variant-id arg-key i]`
+— lives in [§Schema-derivation pipeline](#schema-derivation-pipeline)
+below. That section is the technical reference; this one is what a
+new author needs to know to write their first controlled variant.
+
+### Worked example
+
+```clojure
+;; Author writes one schema on the view:
+(rf/reg-view :app.ui/button
+  [:map
+   [:label    :string]
+   [:variant  [:enum :primary :secondary :danger]]
+   [:size     [:int {:min 8 :max 64}]]
+   [:disabled? :boolean]]
+  (fn [args] [:button.btn {:class (str "btn-" (name (:variant args)))} (:label args)]))
+
+;; Every story of the view gets controls for free — no :argtypes:
+(story/reg-story :story.ui.button
+  {:doc       "Primary action button."
+   :component :app.ui/button
+   :args      {:label "Click me" :variant :primary :size 16 :disabled? false}})
+```
+
+The reader's controls panel shows:
+
+- `:label` → text input
+- `:variant` → select `[:primary :secondary :danger]`
+- `:size` → slider 8–64 (because both bounds are present)
+- `:disabled?` → toggle
+
+No `:argtypes` was written. Author-supplied `:argtypes` overrides the
+auto-derivation key-by-key when needed (e.g. force a free-form text
+input for a keyword-typed arg).
+
+### When to write `:argtypes` (the edge cases)
+
+`:argtypes` is for the cases the schema can't say enough:
+
+- The view has no registered schema (legacy code).
+- The author wants a different widget than the auto-derivation picks
+  (e.g. a stepper instead of a slider for a bounded `:int`).
+- The arg is computed from multiple schema fields and needs a custom
+  label / grouping.
+
+In all other cases, push the constraint up to the view's schema and
+let Story derive the control. The schema is the single source of
+truth; `:argtypes` is the override channel.
+
+See [§Schema-derivation pipeline](#schema-derivation-pipeline) for
+the full walker + override contract.
+
+## Stateful variants — every variant IS a frame (rf2-wqdq1)
+
+Stateful stories — "this variant shows the counter at 5" or "this
+variant shows the form mid-submission" — are the canonical case
+Storybook handles with `useArgs()` / `useState` inside a render fn,
+hitting the well-known hooks-inside-stories re-render limitation.
+Story's answer is structurally different: **every variant is mounted
+in its own isolated re-frame frame**, so there is no shared mutable
+state between variants and no hooks-inside-stories problem.
+
+This means "stateful variants" in Story is not a separate authoring
+mode — it's the default. You drive state with `:events` (setup) and
+`:play` (post-render), and you read it with subs (the canvas renders
+against the variant's frame) or assertions (which read through
+`:rf.assert/sub-equals` etc.).
+
+### The contract
+
+- **Per-variant frame allocation.** Every `(variant × mode × cell)`
+  triple is mounted in a unique frame; subs / events / fx within that
+  cell run against that frame's `app-db`. See
+  [`002-Runtime.md`](002-Runtime.md) §Per-variant frame allocation.
+- **No cross-cell bleed.** Two cells of the same variant in a
+  `:variants-grid` workspace each get their own frame. Incrementing
+  the counter in cell A does not affect cell B.
+- **No render fn, no hooks limitation.** The view is a registered
+  `reg-view`; the variant body is pure data. There is no place to
+  call a hook and no place for a hook to break.
+
+### Worked example — counter at three different states
+
+```clojure
+(rf/reg-view :app.ui/counter
+  (fn [_]
+    (let [n @(rf/subscribe [:counter/value])]
+      [:div
+       [:button {:on-click #(rf/dispatch [:counter/decrement])} "−"]
+       [:span.value n]
+       [:button {:on-click #(rf/dispatch [:counter/increment])} "+"]])))
+
+(story/reg-story :story.counter
+  {:component :app.ui/counter
+   :variants {:empty    {:events [[:counter/initialise]]}
+              :at-five  {:events [[:counter/initialise]
+                                  [:counter/set 5]]}
+              :driven   {:events [[:counter/initialise]]
+                         :play   [[:counter/increment]
+                                  [:counter/increment]
+                                  [:counter/increment]
+                                  [:rf.assert/sub-equals [:counter/value] 3]]}}})
+```
+
+Three variants, three independent app-dbs. Mount the
+`:Workspace.counter/auto-grid` workspace and all three render
+side-by-side, each cell starting fresh.
+
+### Storybook contrast
+
+| Storybook pattern | Story counterpart |
+|---|---|
+| `render: (args) => { const [a, setA] = useArgs(); ... }` | `:play` body dispatching events into the variant's frame |
+| `useState(...)` inside the render fn | The view's subs read from the per-variant frame's `app-db` |
+| Hooks-inside-stories re-render gotcha | None — there is no render fn |
+| One global app instance, decorator-wrapped per story | Per-variant frame; no global shared state |
+
+The structural win: **two cells of the same variant in a grid are
+independent by construction**, with no opt-in needed. The cost: the
+mental model is "frames, not hooks" — if you arrive from Storybook
+expecting a render fn, the first chapter to read is this one.
+
+See [`002-Runtime.md`](002-Runtime.md) §Per-variant frame allocation
+for the runtime contract, and the worked example in
+[§Play + assertions](#play--assertions) below for a full play body.
+
 ## Authoring grammar — worked examples
 
 Worked examples illustrating every aspect of the authoring grammar.
@@ -474,6 +709,9 @@ Story tool emits controls automatically:
 - `:disabled?` → `:boolean`
 
 Author writes zero `:argtypes` unless overriding the auto-derivation.
+See [§Controls — schema-derived, zero-`:argtypes`](#controls--schema-derived-zero-argtypes-rf2-b87h2)
+for the full schema → control mapping table and override-channel
+discussion.
 
 ### Decorators and `:args->events`
 

--- a/tools/story/spec/README.md
+++ b/tools/story/spec/README.md
@@ -22,6 +22,8 @@
 - **[Conventions.md](Conventions.md)** — Story-specific naming and structural conventions: reserved namespaces (`:story.*`, `:Workspace.*`, `:rf.story.*`), id grammars, the macro/`*`-fn split, the chrome-installer pair shape (canonical `install!`/`uninstall!`/`hydrate!`), the `*-id` Var pattern, token-banning rules, and the `reg-marks` re-export.
 - **[Principles.md](Principles.md)** — Story-specific non-negotiables — EDN-first first among them — the test new features pass against.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY each major call was made; the seven rf2-m6tu §6 decisions plus Phase-2 SOTA additions and IMPL-SPEC-emergent calls.
+- **[Tutorial-Playwright.md](Tutorial-Playwright.md)** — Tutorial-shaped Playwright e2e starter recipe: navigate to a variant by URL hash, wait for the canvas, assert against `[data-test=...]`, capture screenshots keyed by `snapshot-identity` (rf2-6qqry).
+- **[Tutorial-Embed.md](Tutorial-Embed.md)** — Tutorial-shaped embed recipe: `variant-share-url` + `?embed=1` chrome-hide flag → iframe-ready URLs for docs sites and READMEs. Local-SVG QR-share popover (no third-party egress, rf2-20w5i) (rf2-dafym).
 - **[findings/](findings/)** — Feature-set research and SOTA refinement working substrate; audit lineage, not normative.
 
 ## How to use

--- a/tools/story/spec/Tutorial-Embed.md
+++ b/tools/story/spec/Tutorial-Embed.md
@@ -1,0 +1,320 @@
+# Story — Tutorial: Embed-mode + variant share URLs (rf2-dafym)
+
+> A starter recipe for embedding a Story variant in a docs site,
+> README, or any third-party page as a clean iframe. Walks the
+> `variant-share-url` builder, the `?embed=1` chrome-hide flag, the
+> QR-share popover (local SVG, no third-party network egress), and
+> the three URL surfaces a reader generating embed code consults.
+
+## What "embed mode" buys you
+
+Story's chrome — sidebar, RHS Causa embed, toolbar — is great for
+authoring, but distracting when you want to drop a single variant
+into a docs page. The `?embed=1` query string elides the chrome and
+leaves the variant canvas alone, full-width, ready to iframe.
+
+Side-by-side:
+
+| Mode | Sidebar | RHS Causa | Toolbar | Canvas |
+|---|---|---|---|---|
+| Full shell (no flag) | visible | visible | visible | inset |
+| `?embed=1` (embed mode) | hidden | hidden | hidden | full width |
+
+The flag is hydrated once at shell mount (per
+[`API.md`](API.md) §URL surfaces) and never persisted to
+`localStorage`. A reader who clicks through to the full shell from
+an embedded view drops the flag at the address bar.
+
+## The three URL surfaces, briefly
+
+Story carries three URL surfaces (per
+[`API.md`](API.md) §URL surfaces). Knowing which one to reach for
+is the first step in writing embed code:
+
+| Surface | Source of truth | Encodes | Use case |
+|---|---|---|---|
+| `variant-share-url` | Args you pass in | Variant id + active modes + cell-overrides + substrate | Share popover; embed iframes; chat / bug-report links |
+| `url-from-state` | Live shell state | Workspace, mode tab, viewport, background, tag filter | Browser address bar during interactive use |
+| `embed-flag-from-current-url` | Current `?embed=1` query param | The `:embed?` chrome-state flag | The embed-mode toggle (this tutorial) |
+
+The recipe below stitches `variant-share-url` together with the
+`?embed=1` flag to produce iframe-ready URLs.
+
+## Audience and scope
+
+This recipe is for someone publishing docs, blog posts, READMEs, or
+any third-party page that wants to embed a Story variant as an
+iframe. The recipe covers:
+
+- Building the variant URL via `variant-share-url`.
+- Adding `?embed=1` for chrome-free presentation.
+- The iframe-attribute shape Story expects.
+- The QR-share popover and what's on the wire (nothing
+  third-party).
+- The hash-route shape (sharable across machines).
+- Common pitfalls and gotchas.
+
+What this recipe is **not**: a normative spec page. The normative
+contract lives in [`API.md`](API.md) §URL surfaces (rf2-zex19);
+this is the tutorial-shaped on-ramp.
+
+## Building a sharable variant URL
+
+`variant-share-url` is a pure URL builder — JVM-portable, CLJS-
+portable, no DOM access. Pass it a variant id and (optionally) the
+modes / overrides / substrate to encode.
+
+```clojure
+(require '[re-frame.story :as story])
+
+(story/variant-share-url :story.counter/at-five)
+;; => "?variant=%3Astory.counter%2Fat-five"
+
+(story/variant-share-url :story.counter/at-five
+  "https://myproject.day8.com.au/stories/"
+  {:active-modes #{:Mode.app/dark-desktop}
+   :cell-overrides {:label "Custom label"}
+   :substrate :reagent})
+;; => "https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five&modes=%3AMode.app%2Fdark-desktop&overrides=...&substrate=reagent"
+```
+
+The encoder:
+
+- URL-encodes every keyword (the leading `:` becomes `%3A`).
+- Omits empty parts (no `modes`, no `modes=` param in the output).
+- Preserves hash routes — if `base-url` ends in `#/stories/foo`,
+  params land *before* the hash so they remain readable via
+  `window.location.search`.
+
+## Adding the embed flag
+
+For an embed iframe, append `&embed=1` (or `?embed=1` if the URL
+has no other query params yet) to the share URL:
+
+```js
+// In your docs site's build step or template:
+function embedUrl(baseShareUrl) {
+  const u = new URL(baseShareUrl);
+  u.searchParams.set('embed', '1');
+  return u.toString();
+}
+
+const shareUrl = "https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five";
+const iframeSrc = embedUrl(shareUrl);
+// => "https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five&embed=1"
+```
+
+The flag is read once by `embed-flag-from-current-url` at shell
+mount and written to `[:chrome-visibility :embed?]` on the
+shell-state atom. Every chrome pane's visibility resolver gates on
+that slot — sidebar, toolbar, RHS Causa embed all drop out of the
+render tree, leaving the canvas alone.
+
+## The iframe
+
+Drop the embed URL into an `<iframe>` in your docs site:
+
+```html
+<iframe
+  src="https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five&embed=1"
+  title="Counter at five — Story variant"
+  loading="lazy"
+  width="100%"
+  height="320"
+  style="border: 0;"></iframe>
+```
+
+Notes on the attributes:
+
+- **`loading="lazy"`** — Story bundles aren't tiny; deferring the
+  fetch until the iframe scrolls into view keeps docs-page paint
+  budget intact.
+- **`title`** — accessible name for the iframe. Pick something
+  meaningful per embed.
+- **`width="100%"` + fixed `height`** — Story's canvas doesn't
+  auto-resize the iframe; you size it explicitly. For variable-
+  height canvases consider a fixed-aspect-ratio wrapper or the
+  [`iframe-resizer`](https://github.com/davidjbradshaw/iframe-resizer)
+  npm package (third-party; Story doesn't ship a postMessage
+  protocol for it).
+- **`border: 0`** — the variant canvas already carries its own
+  visual identity (per [`016-Design-Tokens.md`](016-Design-Tokens.md)).
+  An iframe border is double chrome.
+
+## The QR-share popover
+
+The Story shell's share affordance (top-right of the toolbar)
+opens a popover showing:
+
+1. The share URL (`variant-share-url` output for the active
+   variant + active modes + cell-overrides + substrate).
+2. A QR code rendered from that URL.
+
+The QR code is generated **locally** — `qrcode-generator` (npm,
+MIT, ~52 KB unpacked, zero deps) emits an inline SVG string that
+the popover splices via React's `dangerouslySetInnerHTML`. There
+is no third-party network request. The variant state + author-
+typed cell-overrides never leave the dev's machine.
+
+This is structurally better than Storybook's QR pattern (which
+proxies through `https://api.qrserver.com/...` and ships the full
+share URL as a query param to a third party). The audit lineage
+lives in `rf2-20w5i` (security audit, 2026-05-14); see
+[`005-SOTA-Features.md`](005-SOTA-Features.md) §Third-party
+network egress.
+
+To open the popover during authoring:
+
+- Click the QR / share glyph in the toolbar's `REC` cluster, or
+- Hit the `s` chrome hotkey, or
+- Command palette → "Share variant URL".
+
+The popover's "Copy URL" button writes to the system clipboard via
+`navigator.clipboard.writeText`. The "Copy as iframe" affordance
+(rf2-pucku follow-on) emits the iframe snippet shape from this
+tutorial — paste it directly into a docs page.
+
+## How embed mode and the chrome interact
+
+The embed flag is **one-shot at mount**. The chrome-visibility
+resolver consults `[:chrome-visibility :embed?]` (boolean) on the
+shell-state atom; the URL parser writes that slot once and never
+re-reads. This matters for two scenarios:
+
+| Scenario | Behaviour |
+|---|---|
+| Reader clicks a variant in the sidebar of an embedded shell | No-op — the sidebar isn't rendered. They follow the hash route. |
+| Reader navigates to a different variant via `window.history.pushState` (e.g. from a docs-page link) | The shell re-resolves the variant. The `:embed?` flag persists for the lifetime of the page (no localStorage round-trip, but no reset either). |
+| Reader reloads the iframe | `embed-flag-from-current-url` re-reads the query param. If the URL still has `&embed=1`, embed mode persists. |
+| Reader copies the iframe URL and opens it in a top-level tab | Embed mode persists in the new tab too. To drop it, edit the URL to remove `embed=1`. |
+
+The flag is **not sticky** in the sense that it doesn't persist to
+`localStorage` — the URL is the source of truth. This avoids the
+"every Story shell on this machine is in embed mode forever" bug
+that a localStorage-backed flag would carry.
+
+## Hash-route shape (for content-addressed embedding)
+
+If your shell is mounted under a hash route (`#/stories/...`),
+`variant-share-url` puts params *before* the hash:
+
+```
+https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five&embed=1#/stories/:story.counter/at-five
+```
+
+Both halves are read at mount:
+
+- `window.location.search` carries the query params (variant id,
+  modes, overrides, substrate, embed flag).
+- `window.location.hash` carries the canonical route for the
+  variant (consumed by the chrome's router).
+
+For a base URL with no hash route, the query params are
+sufficient — Story's URL parser handles both shapes.
+
+## Production-elided builds — embedding the static export
+
+For embeds that ship to production docs sites, use
+`npm run story:build` (per
+[`013-Static-Build.md`](013-Static-Build.md)) to produce a
+self-contained static HTML directory. The output:
+
+- Bundles the Story shell at `:advanced` optimisation.
+- Inlines the variant registry.
+- Carries the QR encoder + a11y opt-in surfaces (no
+  third-party fetches at runtime).
+- Drops the dev-time recorder, hot-reload, and live-validation
+  surfaces.
+
+Deploy the static directory to GitHub Pages, Netlify, Vercel, or
+raw S3, then point your iframes at the deployed URL. The embed
+flag and share-URL builder both ride the static build — no
+authoring-only dependency for end users.
+
+## Common pitfalls
+
+- **Forgetting to URL-encode the variant id when assembling URLs
+  by hand.** Variant ids like `:story.auth.login-form/happy-path`
+  carry both `:` and `/`; `variant-share-url` handles them, but a
+  hand-rolled URL string from a template will mis-parse. Use the
+  builder.
+- **Caching iframes on a CDN with stale variant bundles.** A docs
+  site that embeds a published Story shell must cache-bust the
+  iframe `src` when the underlying bundle changes — otherwise
+  CDN-cached iframes serve old variants. Versioned subdirectories
+  (`/stories/v1.2.3/`) are the safest pattern.
+- **Embedding from a dev shell into a production docs site.**
+  Don't iframe `http://localhost:8080` into your published docs.
+  Use the `story:build` output or a deployed shell.
+- **Mixing `?embed=1` with full-shell navigation.** Once a reader
+  clicks into the sidebar (which is hidden under `?embed=1`) the
+  flag has no UI to surface its state. If you want to offer a
+  "see this variant in the full shell" affordance, link out to a
+  separate `_blank` tab with the same URL minus the embed flag.
+- **Iframe `sandbox` attribute.** Story uses `localStorage` (for
+  the help-overlay seen-flag, RHS panel preferences, and a11y
+  CDN opt-in) and the clipboard API (for the share popover). A
+  fully-sandboxed iframe will break these surfaces. If you must
+  sandbox, allow at least `allow-scripts allow-same-origin`.
+- **CSP `frame-ancestors`.** If you publish the Story shell with
+  a Content-Security-Policy header, the `frame-ancestors`
+  directive must include the embedding origin or the iframe will
+  refuse to render. The static-build output ships no CSP by
+  default; if you add one, allow your docs-site origin.
+
+## End-to-end worked example
+
+A docs page embeds the counter's `:at-five` variant in dark mode:
+
+```html
+<!-- In your docs site's markdown or HTML template: -->
+<figure>
+  <iframe
+    src="https://myproject.day8.com.au/stories/?variant=%3Astory.counter%2Fat-five&modes=%3AMode.app%2Fdark-desktop&embed=1#/stories/:story.counter/at-five"
+    title="Counter at five (dark mode) — Story variant"
+    loading="lazy"
+    width="100%"
+    height="320"
+    style="border: 0;"></iframe>
+  <figcaption>The counter at 5, dark mode.</figcaption>
+</figure>
+```
+
+To produce the URL programmatically rather than hand-rolling it:
+
+```clojure
+(require '[re-frame.story :as story])
+
+(defn embed-iframe-src [variant-id base-url & {:keys [modes overrides substrate]}]
+  (str (story/variant-share-url variant-id base-url
+         (cond-> {}
+           modes      (assoc :active-modes modes)
+           overrides  (assoc :cell-overrides overrides)
+           substrate  (assoc :substrate substrate)))
+       "&embed=1"))
+
+(embed-iframe-src :story.counter/at-five
+                  "https://myproject.day8.com.au/stories/"
+                  :modes #{:Mode.app/dark-desktop})
+;; => "https://myproject.day8.com.au/stories/?variant=...&modes=...&embed=1"
+```
+
+The same builder runs JVM-side, CLJS-side, or in your docs site's
+build step.
+
+## Cross-references
+
+- [`API.md`](API.md) §URL surfaces — normative cluster table for
+  the three URL surfaces.
+- [`005-SOTA-Features.md`](005-SOTA-Features.md) §QR code in share
+  menu — the QR-share popover contract.
+- [`005-SOTA-Features.md`](005-SOTA-Features.md) §Third-party
+  network egress — the local-SVG decision (rf2-20w5i).
+- [`013-Static-Build.md`](013-Static-Build.md) — `story:build` for
+  production-deployable shells.
+- [`014-Chrome-Features.md`](014-Chrome-Features.md) §URL state —
+  hash-route hydration + the chrome-visibility model.
+- [`016-Design-Tokens.md`](016-Design-Tokens.md) — chrome identity
+  tokens; what the canvas carries when chrome is hidden.
+- [`Tutorial-Playwright.md`](Tutorial-Playwright.md) — the
+  companion recipe for e2e probing of Story variants.

--- a/tools/story/spec/Tutorial-Playwright.md
+++ b/tools/story/spec/Tutorial-Playwright.md
@@ -1,0 +1,302 @@
+# Story — Tutorial: Playwright e2e starter recipe (rf2-6qqry)
+
+> A minimum-viable Playwright probe for a Story-using app. Navigates
+> to `#/stories/<variant-id>`, waits for the canvas to mount, asserts
+> a `[data-test=...]` selector, captures a screenshot keyed by
+> `snapshot-identity`. Pair this with the production-quality gates in
+> [`tools/story/test/story_browser_scenarios.cjs`](../test/story_browser_scenarios.cjs)
+> and [`tools/story/test/story_feature_load.cjs`](../test/story_feature_load.cjs)
+> once you outgrow the starter shape.
+
+## Audience and scope
+
+This recipe is for a re-frame2 app that already mounts the Story
+shell via `re-frame.story/mount-shell!` and now wants to add a
+Playwright e2e probe of their own variants. The recipe covers:
+
+- Wiring Playwright to a shadow-cljs `npm run watch` (or a static
+  `story:build` output) URL.
+- Navigating to a variant via its URL hash route.
+- Waiting for the canvas to mount and Story's chrome to settle.
+- Asserting against a `[data-test=...]` selector in the variant's
+  rendered hiccup.
+- Capturing a screenshot keyed by `snapshot-identity` so a visual-
+  regression service (Chromatic, Percy, Argos, raw `pixelmatch`) can
+  diff stable cells across runs.
+
+What this recipe is **not**: a production e2e harness for Story's
+own QA. The shipped `story_browser_scenarios.cjs` and
+`story_feature_load.cjs` are gate-grade; this is the tutorial-shaped
+on-ramp.
+
+## Prerequisites
+
+- Story 0.x shell mounted at the page root via `mount-shell!`. The
+  variant URL hash route (`#/stories/<variant-id>`) MUST be wired
+  through `re-frame.story.ui.url-state/hydrate!` at boot (the
+  shell's standard install does this — see
+  [`014-Chrome-Features.md`](014-Chrome-Features.md) §URL state).
+- Variants of interest carry stable `[data-test=...]` selectors in
+  their rendered hiccup. The view, not the variant body, declares
+  these — they ride with the component into every variant of every
+  story that uses it.
+- Playwright installed in the consumer's repo (`npm i -D
+  @playwright/test`). The recipe assumes Playwright 1.40+; older
+  versions have a different `page.evaluate` signature but the
+  shape is unchanged.
+- A served Story shell. Three common shapes:
+  - `npm run watch` (shadow-cljs dev server) — fast iteration.
+  - `npm run story:build` + a static file server — closer to
+    production. See [`013-Static-Build.md`](013-Static-Build.md).
+  - A deployed `story:build` artefact on GitHub Pages / Netlify /
+    Vercel — for CI runs against a published shell.
+
+## The starter probe
+
+Create `e2e/story-probe.spec.js` in your repo (the path is
+arbitrary — Playwright globs whatever `playwright.config.js` points
+at). Adjust `BASE_URL` to wherever your Story shell is served.
+
+```js
+// e2e/story-probe.spec.js
+const { test, expect } = require('@playwright/test');
+
+const BASE_URL = process.env.STORY_BASE_URL || 'http://localhost:8080';
+
+/** Navigate to a Story variant via its URL hash route. */
+async function gotoVariant(page, variantId) {
+  await page.goto(`${BASE_URL}/#/stories/${encodeURIComponent(variantId)}`,
+    { waitUntil: 'load' });
+
+  // The shell mounts asynchronously; wait for the three landmark
+  // regions Story always renders.
+  await page.getByRole('navigation').waitFor({ state: 'visible', timeout: 10000 });
+  await page.getByRole('main').waitFor({ state: 'visible', timeout: 10000 });
+
+  // Dismiss the first-visit help overlay if present — it intercepts
+  // pointer events on a fresh localStorage.
+  const help = page.getByRole('dialog', { name: /Story playground help/i });
+  if (await help.isVisible().catch(() => false)) {
+    await help.getByRole('button', { name: /Got it/i }).click();
+  }
+
+  // The variant canvas carries a `data-test-variant` attribute set
+  // to the variant's id; wait for it.
+  await page.locator(`[data-test-variant="${variantId}"]`)
+    .waitFor({ state: 'visible', timeout: 10000 });
+}
+
+/** Read Story's snapshot-identity for the active variant from the canvas. */
+async function snapshotIdentity(page, variantId) {
+  return page.locator(`[data-test-variant="${variantId}"]`)
+    .getAttribute('data-snapshot-hash');
+}
+
+test('counter at-five renders the value 5', async ({ page }) => {
+  await gotoVariant(page, ':story.counter/at-five');
+
+  // The view declares `[data-test="counter-value"]`; assert on it.
+  await expect(page.locator('[data-test="counter-value"]')).toHaveText('5');
+
+  // Capture a screenshot keyed by snapshot-identity so a visual-
+  // regression diff is stable across runs.
+  const hash = await snapshotIdentity(page, ':story.counter/at-five');
+  await page.screenshot({ path: `screenshots/counter-at-five-${hash}.png` });
+});
+```
+
+That's the full minimum probe — three test-relevant steps (navigate,
+assert, screenshot) plus the canonical wait pattern.
+
+## How it works
+
+### URL hash routing
+
+Story's shell consumes `window.location.hash` to resolve which
+variant to mount. The hash format is `#/stories/<url-encoded
+variant-id>`. The fragment encoder is symmetric with
+`variant-share-url`'s output (per
+[`API.md`](API.md) §URL surfaces), so a URL pasted from the share
+popover navigates correctly.
+
+### Landmark waits
+
+Three semantic landmarks always render once the shell is up:
+
+| Landmark | Role | Purpose |
+|---|---|---|
+| `navigation` | `<nav>` | Sidebar with the variant tree |
+| `main` | `<main>` | Variant canvas |
+| `complementary` | `<aside>` | The RHS Causa embed |
+
+Waiting for `main` then for the canvas's `data-test-variant`
+selector is the correct gate — the canvas mounts only after the
+shell resolves the variant id from the URL hash.
+
+### The first-visit help overlay
+
+Story ships a one-shot first-visit help overlay (rf2-381i). On a
+fresh `localStorage` it covers the canvas with a modal dialog and
+intercepts pointer events. The recipe dismisses it if open; for CI
+runs that hit a persistent profile you can instead prime the
+"already-seen" key once at the start of the suite:
+
+```js
+test.beforeAll(async ({ browser }) => {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto(BASE_URL);
+  await page.evaluate(() => {
+    localStorage.setItem('re-frame.story/seen-help-v1', '1');
+  });
+  await ctx.close();
+});
+```
+
+### `data-test-variant` and `data-snapshot-hash`
+
+Story stamps two `data-*` attributes onto the canvas root:
+
+| Attribute | Value | Use |
+|---|---|---|
+| `data-test-variant` | The variant id (`:story.counter/at-five`) | Probe scope — assert "I'm looking at the right cell." |
+| `data-snapshot-hash` | The content-hash from `snapshot-identity` | Visual-regression key — name screenshots by hash so a stable variant produces a stable filename. |
+
+The hash includes `:variant-id`, `:active-modes`, `:substrate`, and
+`:content-hash` (the canvas's rendered hiccup). Changing any of
+those changes the hash; pixel-diffing then compares like-for-like.
+See [`002-Runtime.md`](002-Runtime.md) §Snapshot identity for the
+full hash recipe.
+
+### Author-side: declaring `[data-test=...]` selectors
+
+Selectors are the view's responsibility, not the variant body. The
+canonical pattern:
+
+```clojure
+(rf/reg-view :app.ui/counter
+  (fn [_]
+    (let [n @(rf/subscribe [:counter/value])]
+      [:div
+       [:button {:on-click  #(rf/dispatch [:counter/decrement])
+                 :data-test "counter-decrement"} "−"]
+       [:span {:data-test "counter-value"} n]
+       [:button {:on-click  #(rf/dispatch [:counter/increment])
+                 :data-test "counter-increment"} "+"]])))
+```
+
+Every variant of every story that mounts this view gets these
+selectors. The variant body stays pure data.
+
+## Driving state — Story's preferred path
+
+Playwright `userEvent.click(...)` works against Story canvases, but
+it is rarely the right tool for Story-driven probes. The variant
+body's `:play` slot is already a vector of events that drives the
+variant's frame; let Story dispatch them and use Playwright only to
+assert the final rendered state.
+
+```clojure
+;; Variant body declares the driving events:
+(story/reg-variant :story.counter/driven
+  {:events [[:counter/initialise]]
+   :play   [[:counter/increment]
+            [:counter/increment]
+            [:counter/increment]]})
+```
+
+```js
+// Playwright asserts the final state:
+test('counter driven by play body lands at 3', async ({ page }) => {
+  await gotoVariant(page, ':story.counter/driven');
+  await expect(page.locator('[data-test="counter-value"]')).toHaveText('3');
+});
+```
+
+Why prefer `:play` to Playwright clicks?
+
+- **Events round-trip with the share URL.** A URL copied from the
+  share popover reproduces the exact `:play` sequence on the
+  reader's machine; clicks in a Playwright file don't.
+- **EDN, not DOM.** The `:play` body is pure data — testable from
+  CLJS / JVM via `run-variant` without a browser at all.
+- **Record-don't-throw.** Story's `:rf.assert/*` events record into
+  `:assertions` and the sequence continues. Playwright's
+  `expect(...)` throws on first failure and stops.
+
+Use Playwright when you genuinely need a browser-only surface —
+real-pointer events, viewport sizing, file-upload dialogs,
+permissions prompts, multi-tab flows. Use `:play` for everything
+else.
+
+## Common pitfalls
+
+- **Forgetting to URL-encode the variant id.** A variant id like
+  `:story.auth.login-form/happy-path` carries a `/`; without
+  `encodeURIComponent` it breaks the hash route.
+- **Asserting before the canvas mounts.** The landmark waits are
+  not optional. The shell's internal nav-to-mount latency is a
+  few hundred ms on a warm dev server; without the wait the
+  selector resolves to an empty page.
+- **Screenshots keyed by variant id only, not snapshot-identity.**
+  Two cells of the same variant against different modes have
+  different pixels; the hash distinguishes them. A filename of
+  `counter-at-five.png` accumulates collisions across mode toggles.
+- **Hitting `:advanced`-compiled bundles.** Production-compiled
+  Story bundles elide all `reg-*` calls to `nil` (see
+  [`005-SOTA-Features.md`](005-SOTA-Features.md) §Production
+  elision). Run probes against the dev / `story:build` shell, not
+  against your application's production bundle.
+
+## Visual regression — the hash-keyed pattern
+
+If you ship a visual-regression service, the canonical pattern is:
+
+1. Per variant of interest, capture one screenshot per
+   `(variant × mode × substrate)` cell, naming it by the
+   `data-snapshot-hash` value.
+2. On the next run, capture again. If the hash matches a baseline,
+   pixel-diff against it. If the hash changed, treat it as a new
+   baseline candidate and surface for review.
+3. Cell churn (variant body / args / mode declaration changes)
+   produces a new hash automatically — you never diff apples to
+   oranges.
+
+The hash is content-derived, not timestamp-derived; identical
+declarations across machines produce identical hashes. Chromatic /
+Percy / Argos consume the screenshots; Story owns the keying.
+
+## Beyond the starter — when to graduate
+
+Once your suite outgrows the starter shape, reach for the
+production helpers shipped in `tools/story/test/`:
+
+- **`story_browser_scenarios.cjs`** — focused per-feature scenarios
+  with rich error context (`feature` / `phase` / `storyContext`
+  attached to thrown errors). The right shape for multi-step
+  workflows.
+- **`story_feature_load.cjs`** — wide gate-grade coverage of every
+  Story feature surface. The right shape for "does Story still
+  work in my app?" smoke runs.
+- **`examples/scripts/serve-and-run-story-play-scripts.cjs`** —
+  serves the shell and auto-drives every variant carrying a
+  `:play-script` body. The right shape for headless CI-as-test
+  runs over a corpus of variants.
+- **Multi-frame CLJS e2e** — for tests where you can avoid a real
+  browser entirely, see the `re-frame.story.test-helpers.e2e-multi-frame`
+  helpers and any of the `tools/story/test/re_frame/story/panels_e2e/`
+  test files. Sub-millisecond per case, no Playwright dependency.
+
+## Cross-references
+
+- [`002-Runtime.md`](002-Runtime.md) §Snapshot identity — the
+  content-hash recipe.
+- [`004-Assertions.md`](004-Assertions.md) — `:rf.assert/*`
+  events and the record-don't-throw contract.
+- [`013-Static-Build.md`](013-Static-Build.md) — `story:build`
+  output for CI against a static shell.
+- [`014-Chrome-Features.md`](014-Chrome-Features.md) §URL state —
+  hash-route hydration.
+- [`Tutorial-Embed.md`](Tutorial-Embed.md) — the companion recipe
+  for embedding variants as iframes in docs sites.
+- [`API.md`](API.md) §URL surfaces — the three URL axes Story carries.


### PR DESCRIPTION
## Summary
- 001-Authoring.md gains 4 new sections: Stateful variants (rf2-wqdq1) · Controls auto-derivation top-level promote (rf2-b87h2) · `:fx-override` last-wins asymmetry (rf2-a6l59) · `:for` slot on `reg-workspace` (rf2-pgccv)
- New Tutorial-Playwright.md (rf2-6qqry) — e2e starter recipe: navigate by URL hash, wait for canvas, assert against `[data-test=...]`, screenshot keyed by `snapshot-identity`
- New Tutorial-Embed.md (rf2-dafym) — `variant-share-url` + `?embed=1` chrome-hide flag → iframe-ready URLs for docs sites

## Beads
rf2-wqdq1, rf2-b87h2, rf2-6qqry, rf2-a6l59, rf2-dafym, rf2-pgccv (cluster-review bundle)

## Source
ai/findings/2026-05-20-story-tutorial-set.md F-4/F-5/F-6/F-7/F-8/F-9

## Acceptance
- mkdocs --strict clean (no new WARN/ERROR)
- All cross-refs resolve (`#schema-derivation-pipeline`, `#play--assertions`, `#controls--schema-derived-zero-argtypes-rf2-b87h2`, the two new Tutorial-*.md files cross-link each other and to API.md / 002-Runtime.md / 005-SOTA-Features.md / 013-Static-Build.md / 014-Chrome-Features.md / 016-Design-Tokens.md / Conventions.md)
- Voice preserved; no AI attribution

## Cross-worker coordination
- story-loader-gaps worker edits `tools/story/spec/002-Runtime.md` — distinct file
- story-MCP followons live in `tools/story-mcp/*` — distinct tree
- Other workers on impl + non-story-spec — distinct