### PR TITLE
story-mcp: 4 P2 follow-ons (rf2-pmwgn + 8h778 + zx0p0 + 76sf6)

### DIFF
--- a/skills/re-frame2-pair/references/stories.md
+++ b/skills/re-frame2-pair/references/stories.md
@@ -20,7 +20,7 @@ The `re-frame2-pair` skill's `allowed-tools` (per the SKILL.md frontmatter, land
 | `mcp__re-frame2-story-mcp__read-failures` | Diagnostic over the variant's `:rf.story/assertions` accumulator (no re-run) | Vector of `{:assertion :path :expected :actual :passed? :source}` |
 | `mcp__re-frame2-story-mcp__snapshot-identity` | Content hash of `(variant × args × decorators × loaders × substrate × modes)` | `{:identity <hash>}` — use to skip cells unchanged since a prior run |
 | `mcp__re-frame2-story-mcp__run-a11y` | axe-core results for the variant's rendered DOM | `{:violations [...]}` (JVM-standalone hosts return `[]` + a hint) |
-| `mcp__re-frame2-story-mcp__record-as-variant` | Records dispatches into the variant's frame for `:duration-ms`, returns a `(reg-variant ...)` snippet via `gen-play-snippet`; optional `:write-back?` re-registers | `{:snippet <string> :events <vector>}` |
+| `mcp__re-frame2-story-mcp__record-as-variant` | Records dispatches into the variant's frame for `:duration-ms`, returns a `(reg-variant ...)` snippet via `gen-play-snippet`; optional `:write-back` re-registers | `{:snippet <string> :events <vector>}` |
 
 `record-as-variant` is the only one whose read-only path is ungated; the write-back branch needs `re-frame.story-mcp.config/allow-writes?` truthy, same gate as `register-variant`. See `tools/story-mcp/spec/002-Tool-Registry.md` for full I/O schemas.
 
@@ -96,7 +96,7 @@ When the loop terminates, optionally call `record-as-variant` to capture the now
 - **`read-failures` does not re-run.** It reads the *last* `run-variant`'s `:rf.story/assertions` accumulator. After a manual re-frame2-pair dispatch, the accumulator is stale — re-run before reading.
 - **`run-a11y` needs the in-browser panel.** JVM-standalone story hosts return an empty list + a documented hint that axe-core requires the browser. If your session is browser-attached this works; if it's JVM-only, expect the no-op.
 - **`record-as-variant`'s filter layers are not free-form.** Filtering is inherited verbatim from `re-frame.story.recorder/recordable-event?` — op-type `:event/dispatched`, frame scope match against the target, internal-namespace skip (`:rf.assert/*`, `:rf.story/*`, `:re-frame.story.*`). You can't widen the filter via tool input.
-- **Write-back gate is per-server, not per-call.** `record-as-variant` with `:write-back? true` needs `--allow-writes` / `RF_STORY_MCP_ALLOW_WRITES=true` set on the story-mcp server start. The read-only path (snippet returned, no registration) needs no gate.
+- **Write-back gate is per-server, not per-call.** `record-as-variant` with `:write-back true` needs `--allow-writes` / `RF_STORY_MCP_ALLOW_WRITES=true` set on the story-mcp server start. The read-only path (snippet returned, no registration) needs no gate. Wire-key `:write-back` (no `?`) per rf2-pmwgn.
 
 ## Cross-references
 

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -76,6 +76,17 @@ Differs from `run-variant` in semantics: `preview-variant` is the
 "show me what this would look like" call; `run-variant` (in the
 Testing category) is the "execute and report pass/fail" call.
 
+**Annotation (rf2-8h778).** `preview-variant` carries
+`:destructiveHint true` — the same annotation as `run-variant`.
+Both tools invoke the same `(story/run-variant vk opts)` lifecycle
+under the covers; they dispatch events into the variant's frame
+and accumulate assertions. The semantic split (`preview-variant`
+returns the share URL; `run-variant` returns the `:passing?`
+boolean) does not change the side-effect surface, and the
+annotation must reflect that side-effect surface (agent hosts
+that auto-approve `readOnlyHint true` would otherwise auto-approve
+a call that mutates the frame).
+
 ### `list-substrates`
 
 Returns the set registered via
@@ -318,7 +329,7 @@ Three write tools. `register-variant` and `unregister-variant` are
 both gated behind `re-frame.story-mcp.config/allow-writes?` per
 [`003-Write-Surface-Gating.md`](003-Write-Surface-Gating.md);
 `record-as-variant` is ungated for the recording path and gated only
-when `:write-back?` is set.
+when `:write-back` is set.
 
 ### `register-variant`
 
@@ -349,11 +360,19 @@ contract per
 [`tools/story/spec/005-SOTA-Features.md`](../../story/spec/005-SOTA-Features.md)
 §Test Codegen.
 
-Optional `:write-back?` re-registers the source variant with
+Optional `:write-back` re-registers the source variant with
 `:play <captured-events>` via `reg-variant*` (preserving the
 existing `:component`, `:args`, `:decorators`, etc.). This branch is
 gated behind the same `allow-writes?` flag as `register-variant`; the
 read-only path (snippet only) needs no gate.
+
+Wire-key shape (rf2-pmwgn): the input-schema property key is
+`:write-back` (no `?`) — the same Anthropic `^[a-zA-Z0-9_.-]{1,64}$`
+constraint that mandates `:include-sensitive` (no `?`) applies here.
+The response-payload key `:written-back?` retains the `?`: response
+keys are NOT bound by the input-schema regex. The Clojure-idiomatic
+`?` belongs on predicates and on response data, not on input-schema
+property keys whose wire form disallows it.
 
 `:new-variant-id` lets the write-back land under a different id (the
 default is to overwrite the source). `:extends` defaults to the source

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -70,11 +70,54 @@ form disallows it.
 
 ## Docs tools
 
+### Pagination (rf2-76sf6)
+
+Every `list-*` tool accepts the cross-MCP pagination contract
+per spec/Principles.md §"Tight token budget":
+
+```clojure
+{:limit  integer (optional, default 25, max 200)
+ :cursor string  (optional opaque continuation token)}
+```
+
+The cursor is an opaque base64-encoded EDN map whose internal shape
+(today: `{:v 1 :offset N :total N :sig "<digest>"}`) is an
+implementation detail; agents pass the value back verbatim. The
+encoding lives in
+`tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc`.
+
+When the entry count fits on one page (≤ `:limit`), the response is
+the bare tool payload — no pagination metadata, byte-identical to
+the pre-rf2-76sf6 shape. When pagination kicks in, the response
+adds:
+
+```clojure
+{:total        integer    ; whole-set count at cursor-mint time
+ :limit        integer
+ :has-more?    boolean
+ :next-cursor  string | nil}  ; nil on the final page
+```
+
+If the underlying registry materially changes between cursor mint
+and cursor deref (e.g. a `register-variant` lands between two pages
+of `list-stories`), the server returns
+`{:isError true :structuredContent {:reason :rf.mcp/cursor-stale :tool "..."}}`
+— the same vocab pair-mcp uses for ring-rotation staleness. The
+agent restarts pagination from offset 0.
+
+The `get-*` / `<thing>->edn` tools are NOT paginated — their return
+is a single record bounded by the registered body's size, not a
+function of registry size. Wire-budget overruns are caught by the
+top-level cap via `:max-tokens` + the `:rf.mcp/overflow` marker.
+
 ### `list-stories`
 
-**Input.** `{:tags [keyword] (optional)}`.
+**Input.** `{:tags [keyword] (optional)
+                :limit integer (optional, default 25)
+                :cursor string (optional)}`.
 
-**Output.** `{:stories [{:id keyword :doc string ...}]}`.
+**Output.** `{:stories [{:id keyword :doc string ...}]}`, plus the
+pagination metadata when active (see "Pagination" above).
 
 **Spec.** [`002-Tool-Registry.md`](002-Tool-Registry.md) §Docs.
 
@@ -97,30 +140,43 @@ form disallows it.
 
 ### `list-tags`
 
-**Input.** `{}`.
+**Input.** `{:limit integer (optional) :cursor string (optional)}`.
 
-**Output.** `{:canonical [...] :project [...]}`.
+**Output.** `{:canonical [...] :custom [...] :all [...]}`. The
+`:canonical` set is the bounded 7-entry canonical-tag vector and
+is always returned in full. `:custom` (project-registered tags)
+and `:all` (the union) are paginated together per the contract
+above when the custom-tag count exceeds `:limit`.
 
 ### `list-modes`
 
-**Input.** `{}`.
+**Input.** `{:limit integer (optional) :cursor string (optional)}`.
 
-**Output.** `{:modes [{:id keyword :args map ...}]}`.
+**Output.** `{:modes [{:id keyword :args map ...}]}`, plus
+pagination metadata when active.
 
 ### `list-decorators` (rf2-mqp1u)
 
-**Input.** `{:kind "hiccup" | "frame-setup" | "fx-override" (optional)}`.
+**Input.** `{:kind "hiccup" | "frame-setup" | "fx-override" (optional)
+                :limit integer (optional) :cursor string (optional)}`.
 
-**Output.** `{:decorators [{:id keyword :kind keyword :doc string ...}]}`.
-Per-kind slots: `:has-wrap?` (hiccup, never the closure itself);
-`:init` + `:app-db-patch` (frame-setup); `:fx-id` + `:response`
-(fx-override).
+**Output.** `{:decorators [{:id keyword :kind keyword :doc string ...}]}`,
+plus pagination metadata when active. Per-kind slots: `:has-wrap?`
+(hiccup, never the closure itself); `:init` + `:app-db-patch`
+(frame-setup); `:fx-id` + `:response` (fx-override).
+
+When a `:kind` filter is applied, the cursor's fingerprint is over
+the filtered id-set — so a kind-filter change between pages reads
+as a stale cursor (different fingerprint).
 
 ### `list-assertions`
 
-**Input.** `{}`.
+**Input.** `{:limit integer (optional) :cursor string (optional)}`.
 
-**Output.** `{:assertions [{:id keyword :arity ... :semantics "..."}]}`.
+**Output.** `{:canonical [{:id :payload :semantics}] :registered [keyword ...]}`.
+The `:canonical` doc vector (the 7-assertion documentation) is
+bounded and always returned in full. `:registered` (the live
+registered-assertion ids) is paginated per the contract above.
 
 ### `get-docs-markdown` (rf2-i0kyy)
 
@@ -212,11 +268,34 @@ hosts return `{:violations [] :hint "axe-core requires the in-browser panel."}`.
  :include-sensitive boolean (optional, gated — see `preview-variant`)}
 ```
 
-**Output.** `{:assertions [map] :passing? boolean}`. No re-run.
+**Output.**
+
+```clojure
+{:variant-id keyword            ; the frame the failures came from
+ :total      integer            ; total assertion records seen post-scrub
+ :failures   [{:assertion :passed? ...}]
+                                ; records where :passed? is NOT true
+ :passing?   boolean}           ; vacuous pass when :total is 0
+```
+
+No re-run. The `:failures` slot is filtered to records where
+`:passed?` is not `true` — the wire-budget optimisation per
+`tools/testing.cljc:147–151`; agents wanting the full assertion
+vec read it via `run-variant`'s `:assertions` slot. `:total` is
+the count of all records (including passed) so an agent can
+distinguish "we have records and they're all green" from "no
+assertions ran" without re-running. Pinned by the end-to-end
+conformance harness at
+`tools/mcp-conformance/test/end-to-end-story.cjs` (asserts on the
+`:total` + `:failures` slots, locking the shape — rf2-zx0p0).
 
 `:include-sensitive` follows the same `--allow-sensitive-reads`
 boot gate as `preview-variant` / `run-variant`. Assertion records
-stamped `:sensitive? true` are dropped at egress by default.
+stamped `:sensitive? true` are dropped at egress by default; the
+`:passing?` predicate runs against the SCRUBBED vec so an
+agent's view of green/red is consistent with the records it
+actually sees (a dropped sensitive failure does not quietly flip
+`:passing?` to true).
 
 ## Write tools (gated)
 
@@ -283,9 +362,16 @@ Bridges `re-frame.story`'s recorder primitives (per
  :doc            string  (optional)                ; embedded in snippet
  :extends        keyword (optional)                ; defaults to :variant-id
  :alias          string  (optional, default "story")
- :write-back?    boolean (optional, default false) ; re-register with :play <captured>
+ :write-back     boolean (optional, default false) ; re-register with :play <captured>
 }
 ```
+
+The input-schema property key is `:write-back` (no `?`) per the
+Anthropic `^[a-zA-Z0-9_.-]{1,64}$` regex on tool input-property
+names (rf2-pmwgn) — the same wire-key rule that motivates
+`:include-sensitive` (no `?`). Response-payload keys are not bound
+by the regex; the structuredContent slot `:written-back?` retains
+the `?` per Clojure idiom.
 
 **Output.**
 
@@ -301,7 +387,7 @@ Bridges `re-frame.story`'s recorder primitives (per
 
 **Errors.**
 - `isError: true` when the source `:variant-id` is not registered.
-- `isError: true` when `:write-back?` is true but the gate is closed
+- `isError: true` when `:write-back` is true but the gate is closed
   (`{:gated true}` in `structuredContent`).
 - `isError: true` when the write-back `reg-variant*` call fails (shape
   validation, unresolved `:extends`, etc.).

--- a/tools/story-mcp/spec/Principles.md
+++ b/tools/story-mcp/spec/Principles.md
@@ -194,12 +194,20 @@ budget the agent needs for the next ten ops.
 The discipline applies across three axes:
 
 - **Pagination / cursor for unbounded surfaces.**
-  `list-variants`, `list-modes`, `list-assertions`, and any
-  read tool whose return size is a function of registry size
-  MUST accept a `:limit` argument and return a `:cursor` for
-  continuation. The default `:limit` MUST keep the response
-  under the cap. No unbounded list responses; no "best-effort"
-  omission of pagination.
+  `list-stories`, `list-modes`, `list-decorators`,
+  `list-assertions`, `list-tags`, and any read tool whose return
+  size is a function of registry size MUST accept a `:limit`
+  argument and return a `:cursor` for continuation. The default
+  `:limit` MUST keep the response under the cap. No unbounded
+  list responses; no "best-effort" omission of pagination.
+
+  Implemented per rf2-76sf6 (default `:limit` 25, max 200,
+  base64-encoded opaque cursor with whole-set fingerprint for
+  staleness detection); see
+  `tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc`. The
+  `get-*` / `<thing>->edn` tools are exempt — their return is a
+  single record bounded by the body size, not a function of
+  registry size; the wire-boundary cap catches overruns there.
 - **Summarisation modes for rich payloads.** Ops with rich
   per-item shape (`run-variant`, `snapshot-identity`,
   `variant->edn`) MUST expose a `:mode` argument with at

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -1,0 +1,239 @@
+(ns re-frame.story-mcp.tools.cursor
+  "Cursor pagination for the Docs `list-*` tools (rf2-76sf6).
+
+  Implements the spec/Principles.md §'Tight token budget' pagination
+  MUST: every read tool whose return size is a function of registry
+  size MUST accept a `:limit` argument and return a `:cursor` for
+  continuation. The default `:limit` MUST keep the response under the
+  cap (5,000 tokens).
+
+  ## Why story-mcp's cursor differs from pair-mcp's
+
+  Pair-MCP's cursors (`tools/re-frame2-pair-mcp/tools/cursor.cljs`) carry
+  an `:after-id` epoch-id because epochs live in a bounded ring buffer
+  — staleness matters: when enough new epochs land between calls that
+  the ring rotates past the cursor's id, the server returns
+  `:rf.mcp/cursor-stale` so the agent can recover. The cursor is opaque
+  base64-encoded EDN to keep the encoding implementation-detail.
+
+  Story-MCP's registries (`stories`, `tags`, `modes`, `decorators`,
+  `assertions`) are append-mostly stable structures — no ring rotation,
+  no buffer eviction. A stable sort over the id-set + integer offset
+  is sufficient. We still wrap the offset in an opaque base64 cursor
+  so the wire shape matches pair-mcp's contract — an agent that
+  learned `:cursor`/`:next-cursor` on pair-mcp uses the same slot here.
+
+  ## Cursor shape
+
+  Opaque base64 of a pr-str'd EDN map:
+
+      {:v 1
+       :offset N             ; 0-based index into the stable-sorted seq
+       :total  N             ; total count at the time the cursor was minted
+       :sig    \"<digest>\"} ; cheap whole-set fingerprint
+
+  The `:sig` slot lets us detect a registry that materially changed
+  between calls (e.g. a new `register-variant` landed between the
+  first list-stories page and the second). When the live signature
+  doesn't match the cursor's, we return `:rf.mcp/cursor-stale` —
+  same vocab as pair-mcp's ring-rotation case. The agent restarts.
+
+  ## When pagination kicks in
+
+  The default `:limit` is sized per tool's `:typicalTokens` budget so
+  small registries return everything in one call (no cursor in the
+  response). Pagination only activates when the entry count exceeds
+  the limit. The response shape:
+
+      ;; small set, no pagination needed:
+      {:stories [...]}
+
+      ;; large set, paginated:
+      {:stories [...]                       ; <= :limit entries
+       :total 137                           ; whole-set count
+       :limit 25
+       :has-more? true
+       :next-cursor \"<base64>\"}
+
+      ;; final page:
+      {:stories [...]
+       :total 137
+       :limit 25
+       :has-more? false
+       :next-cursor nil}"
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [re-frame.mcp-base.args :as args]
+            [re-frame.mcp-base.vocab :as vocab]
+            [re-frame.story-mcp.tools.helpers :as h])
+  #?(:clj (:import (java.util Base64))))
+
+(def ^:const default-limit
+  "Default page size for the Docs `list-*` tools. Sized to keep the
+  response under the 5K-token cap for typical registry shapes
+  (`{:id ... :doc ... :tags [...]}`-style entries — ~150-300 chars per
+  entry pretty-printed). At 25 entries we leave headroom for the
+  envelope + per-entry padding; agents that have explicit budget
+  headroom raise via the `:limit` arg."
+  25)
+
+(def ^:const max-limit
+  "Hard ceiling on `:limit` (rf2-76sf6). The wire-boundary cap will
+  catch oversize responses regardless, but we clamp the arg at the
+  tool surface so the agent gets a deterministic per-page count rather
+  than a `:rf.mcp/overflow` fallback. 200 is well past what any
+  registry should need on a single page."
+  200)
+
+(defn- b64-encode
+  "Base64-encode a UTF-8 string. JVM-only (story-mcp's canonical
+  deploy)."
+  [^String s]
+  #?(:clj  (-> (Base64/getEncoder)
+               (.encodeToString (.getBytes s "UTF-8")))
+     :cljs (-> (js/Buffer.from s "utf8")
+               (.toString "base64"))))
+
+(defn- b64-decode
+  "Decode a base64 string back to UTF-8."
+  [^String s]
+  #?(:clj  (String. (.decode (Base64/getDecoder) s) "UTF-8")
+     :cljs (-> (js/Buffer.from s "base64")
+               (.toString "utf8"))))
+
+(defn- fingerprint
+  "Cheap whole-set fingerprint — a sorted-hash of the id-set. We use
+  this to detect a registry that materially changed between cursor
+  mint and dereference. The sort is required for determinism (sets
+  don't order); the hash is the JVM `hash` over the sorted seq.
+
+  Pure data computation (no salt, no secrets) — the fingerprint is a
+  drift detector, not a security token."
+  [ids]
+  (str (hash (vec (sort-by str ids)))))
+
+(defn parse-limit-arg
+  "Normalise the `:limit` MCP arg into an integer in
+  `[1, max-limit]`. Default `default-limit`. Caller-supplied values
+  above `max-limit` clamp DOWN (the same posture as `run-variant`'s
+  `:timeout-ms` ceiling — a legitimate large request still works,
+  just capped)."
+  [raw]
+  (min max-limit (args/parse-positive-int raw default-limit)))
+
+(defn encode-cursor
+  "Encode a cursor payload as a base64 string. Returns nil when there
+  are no more entries — the absence-of-cursor IS the end-of-pagination
+  signal."
+  [{:keys [offset total sig]}]
+  (when (and (integer? offset) (< offset total))
+    (b64-encode (pr-str {:v 1 :offset offset :total total :sig sig}))))
+
+(defn decode-cursor
+  "Decode a base64 cursor back to its EDN payload. Returns:
+    - `nil` if the cursor arg is absent or blank.
+    - `::malformed` if the cursor exists but doesn't decode to a
+      well-formed payload map. Callers treat `::malformed` the same as
+      `::stale` — the agent must drop the cursor and restart.
+
+  Hardened against the same EDN-reader posture as `register-variant`'s
+  body slot (`tools/write.cljc`): the `:default` reader handler throws
+  on any custom tagged literal; the input is decoded only once.
+  Cursors are short opaque tokens — anything longer than 1 KB is
+  rejected before parsing."
+  [s]
+  (cond
+    (or (nil? s) (and (string? s) (str/blank? s))) nil
+    (not (string? s)) ::malformed
+    (> (count s) 1024) ::malformed
+    :else
+    (try
+      (let [edn (b64-decode s)
+            v   (edn/read-string {:default (fn [_t _v] (throw (ex-info "bad tag" {})))} edn)]
+        (if (and (map? v)
+                 (= 1 (:v v))
+                 (integer? (:offset v))
+                 (integer? (:total v))
+                 (string? (:sig v)))
+          v
+          ::malformed))
+      (catch #?(:clj Throwable :cljs :default) _ ::malformed))))
+
+(defn cursor-stale-result
+  "Structured cursor-stale error result. Uses the cross-MCP vocab
+  `:rf.mcp/cursor-stale` (`re-frame.mcp-base.vocab/cursor-stale-reason`)
+  — same vocab pair-mcp uses for ring-rotation staleness, so an agent
+  that learned the recovery path on pair-mcp reuses it here.
+
+  In story-mcp's case staleness means the underlying id-set changed
+  between cursor-mint and cursor-deref (e.g. a `register-variant`
+  landed between two pages of `list-stories`). The agent restarts;
+  there is no recovery via wider window — the registry is the source
+  of truth."
+  [tool]
+  (h/error-result
+    (str "Cursor stale: the registry changed between pages. Drop the "
+         "cursor and restart `" tool "`.")
+    {:ok?    false
+     :reason vocab/cursor-stale-reason
+     :tool   tool
+     :hint   "Drop :cursor and re-request from offset 0."}))
+
+(defn page
+  "Apply pagination to a sorted seq of entries.
+
+  Inputs:
+    - `entries`     — the full sorted vector of entries to paginate.
+                      (Sort externally; this fn assumes a stable
+                      caller-determined ordering.)
+    - `ids`         — the underlying id set used to compute the
+                      fingerprint. Pass the same source the entries
+                      were derived from so cursor-deref can validate.
+    - `arguments`   — the MCP tool arg map (`:limit`, `:cursor`).
+    - `tool-name`   — used for the stale-cursor error message.
+
+  Returns either:
+    - `[:ok page-vec page-metadata]` — happy path. `page-vec` is the
+      sliced entries; `page-metadata` is a map of `:total :limit
+      :has-more? :next-cursor` slots the caller merges into their
+      payload.
+    - `[:err error-result]` — cursor was malformed or stale; the
+      caller returns this result directly.
+
+  The caller assembles the final payload by merging the page-metadata
+  into the tool's normal response shape (the metadata slots only land
+  when pagination actually kicked in — small registries that fit on
+  one page return `[:ok entries {}]`)."
+  [entries ids arguments tool-name]
+  (let [limit         (parse-limit-arg (:limit arguments))
+        cursor        (decode-cursor (:cursor arguments))
+        total         (count entries)
+        live-sig      (fingerprint ids)]
+    (cond
+      ;; Malformed or stale cursor — same recovery (drop + restart).
+      (= cursor ::malformed)
+      [:err (cursor-stale-result tool-name)]
+
+      ;; Cursor present but the underlying set changed between mint
+      ;; and deref. Agent restarts.
+      (and cursor (not= (:sig cursor) live-sig))
+      [:err (cursor-stale-result tool-name)]
+
+      :else
+      (let [offset    (or (:offset cursor) 0)
+            end       (min total (+ offset limit))
+            page-vec  (subvec (vec entries) (min offset total) end)
+            has-more? (< end total)
+            next-c    (when has-more?
+                        (encode-cursor {:offset end :total total :sig live-sig}))
+            ;; The pagination-metadata slots only land when pagination
+            ;; actually kicked in — a small registry that fits on one
+            ;; page returns the bare entries without `:total` etc., so
+            ;; the small-registry common case is unchanged on the wire.
+            meta-map  (if (or cursor has-more?)
+                        {:total       total
+                         :limit       limit
+                         :has-more?   has-more?
+                         :next-cursor next-c}
+                        {})]
+        [:ok page-vec meta-map]))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -169,7 +169,16 @@
                   :required ["variant-id"]
                   :additionalProperties false}
     :outputSchema s/default-output-schema
-    :annotations  s/read-only-annotations
+    ;; rf2-8h778 — `preview-variant` invokes the same `story/run-variant`
+    ;; pipeline as `run-variant`: it dispatches events into the variant's
+    ;; frame, accumulates assertions, and mutates the runtime. The audit
+    ;; (rf2-3pn6c Finding #2) caught the asymmetry — `read-only-annotations`
+    ;; here would have allowed agent hosts to auto-approve a call that
+    ;; mutates the frame. The semantic distinction between the two tools
+    ;; (`preview-variant` returns the share URL too; `run-variant` returns
+    ;; the `:passing?` boolean) is real but doesn't change the destructive
+    ;; nature of the underlying lifecycle run.
+    :annotations  s/run-variant-annotations
     :handler     tool-preview-variant}
 
    {:name           "list-substrates"

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -2,10 +2,21 @@
   "Docs-category tool handlers — introspection over the Story
   registry. Per IMPL-SPEC §7.2 these are the pure-read surfaces:
   `list-stories`, `get-story`, `get-variant`, `list-tags`,
-  `list-modes`, `list-assertions`, `variant->edn`."
+  `list-modes`, `list-assertions`, `variant->edn`.
+
+  ## Pagination (rf2-76sf6)
+
+  Per spec/Principles.md §'Tight token budget' MUST, every `list-*`
+  tool accepts `:limit` + `:cursor`. Small registries fit on one
+  page and never see the pagination metadata; large registries get
+  `:total`, `:limit`, `:has-more?`, `:next-cursor` slots alongside
+  the normal payload. The `get-*` / `<thing>->edn` tools are NOT
+  paginated — their return is a single record bounded by the
+  registered body's size, not a function of registry size."
   (:require [clojure.set :as set]
             [re-frame.mcp-base.args :as args]
             [re-frame.story :as story]
+            [re-frame.story-mcp.tools.cursor :as cursor]
             [re-frame.story-mcp.tools.helpers :as h]
             [re-frame.story-mcp.tools.schemas :as s]))
 
@@ -13,8 +24,10 @@
   "Docs: all registered stories (with optional tag filters).
 
   `args`:
-    :tags — vector of tag ids (strings or `:keyword` forms); narrows
-            the result to stories whose `:tags` set intersects this.
+    :tags    — vector of tag ids (strings or `:keyword` forms); narrows
+               the result to stories whose `:tags` set intersects this.
+    :limit   — optional, default 25. Per-page entry count (rf2-76sf6).
+    :cursor  — optional opaque continuation token from a previous call.
 
   HOT PATH (rf2-d3iso): agents spam this tool. The variant-id slot per
   story is read from `story/variants-by-story` — a single O(V) pass
@@ -24,7 +37,12 @@
   rf2-lqjbk: caller-supplied `:tags` entries route through
   `args/safe-keyword` against the registered-tag set — unknown tag
   ids skip the intersection rather than interning a fresh JVM
-  keyword."
+  keyword.
+
+  rf2-76sf6: pagination via `cursor/page`. The stable-sort key is the
+  story id (string projection). Small registries return the bare
+  `{:stories [...]}` payload; once entries exceed `:limit` the
+  response adds `:total :limit :has-more? :next-cursor`."
   [args]
   (let [stories  (story/registrations :story)
         tag-set  (story/list-tags)
@@ -37,12 +55,22 @@
                          stories)
                    stories)
         index    (story/variants-by-story)
-        payload  {:stories (vec (for [[sid body] filtered]
-                                  {:id   sid
-                                   :doc  (:doc body)
-                                   :tags (vec (:tags body))
-                                   :variants (sort (get index sid #{}))}))}]
-    (h/text-result (h/pr-edn payload) payload)))
+        ;; Build the full sorted entry vec FIRST; pagination slices it.
+        ;; The sort is on string projection of the id for stable cross-
+        ;; page ordering — the fingerprint depends on it.
+        sorted   (sort-by (comp str key) filtered)
+        all-ids  (keys filtered)
+        entries  (mapv (fn [[sid body]]
+                         {:id   sid
+                          :doc  (:doc body)
+                          :tags (vec (:tags body))
+                          :variants (sort (get index sid #{}))})
+                       sorted)]
+    (let [[res page meta] (cursor/page entries all-ids args "list-stories")]
+      (if (= res :err)
+        page
+        (let [payload (merge {:stories page} meta)]
+          (h/text-result (h/pr-edn payload) payload))))))
 
 (defn tool-get-story
   "Docs: one story's full body.
@@ -68,24 +96,48 @@
         (h/text-result (h/pr-edn payload) payload)))))
 
 (defn tool-list-tags
-  "Docs: canonical tags + custom tags."
-  [_args]
+  "Docs: canonical tags + custom tags.
+
+  rf2-76sf6: the bifurcated `{:canonical :custom :all}` shape is
+  retained; `:canonical` is always the full 7-tag set (it is bounded
+  and not a function of registry size, so the pagination MUST does not
+  apply). `:custom` (project-registered tags) and `:all` (their union)
+  are paginated when the count exceeds `:limit`. Small registries see
+  no pagination metadata."
+  [args]
   (let [registered (story/list-tags)
-        canonical  story/canonical-tags
-        custom     (set/difference (set registered) (set canonical))
-        payload    {:canonical (vec (sort-by str canonical))
-                    :custom    (vec (sort-by str custom))
-                    :all       (vec (sort-by str registered))}]
-    (h/text-result (h/pr-edn payload) payload)))
+        canonical  (vec (sort-by str story/canonical-tags))
+        custom-set (set/difference (set registered) (set canonical))
+        custom     (vec (sort-by str custom-set))
+        [res page meta] (cursor/page custom custom-set args "list-tags")]
+    (if (= res :err)
+      page
+      (let [;; :all is the union of :canonical + the (page-sliced) :custom.
+            ;; When no pagination kicks in (small registry) the result is
+            ;; byte-identical to the pre-rf2-76sf6 shape.
+            all-page (vec (sort-by str (into canonical page)))
+            payload  (merge {:canonical canonical
+                             :custom    page
+                             :all       all-page}
+                            meta)]
+        (h/text-result (h/pr-edn payload) payload)))))
 
 (defn tool-list-modes
   "Docs: registered modes (from `reg-mode`). Returns each mode's id +
-  body so agents can see the `:args` saved tuple."
-  [_args]
+  body so agents can see the `:args` saved tuple.
+
+  rf2-76sf6: paginated per spec/Principles.md §'Tight token budget'."
+  [args]
   (let [modes   (story/registrations :mode)
-        payload {:modes (vec (for [[mid body] modes]
-                               {:id mid :doc (:doc body) :args (:args body)}))}]
-    (h/text-result (h/pr-edn payload) payload)))
+        sorted  (sort-by (comp str key) modes)
+        all-ids (keys modes)
+        entries (mapv (fn [[mid body]] {:id mid :doc (:doc body) :args (:args body)})
+                      sorted)
+        [res page meta] (cursor/page entries all-ids args "list-modes")]
+    (if (= res :err)
+      page
+      (let [payload (merge {:modes page} meta)]
+        (h/text-result (h/pr-edn payload) payload)))))
 
 (defn- decorator-summary
   "Project one decorator body to the EDN-safe shape — id, kind, doc,
@@ -127,15 +179,26 @@
   - `:kind` (string, optional) — narrow to one decorator kind. One
     of `\"hiccup\"`, `\"frame-setup\"`, `\"fx-override\"`. Resolved
     through `args/safe-keyword` against the bounded `decorator-kinds`
-    set (rf2-lqjbk); unrecognised values are treated as no filter."
+    set (rf2-lqjbk); unrecognised values are treated as no filter.
+
+  rf2-76sf6: pagination via `:limit` / `:cursor`. The filtered+sorted
+  entry vec is paged; the cursor's fingerprint is over the FILTERED
+  id-set so a kind-filter change between pages reads as a stale
+  cursor (different sig)."
   [args]
   (let [kind-filter (some-> (:kind args) (args/safe-keyword decorator-kinds))
         decorators  (story/registrations :decorator)
-        entries     (cond->> (for [[did body] decorators]
-                               (decorator-summary did body))
-                      kind-filter (filter #(= kind-filter (:kind %))))
-        payload     {:decorators (vec entries)}]
-    (h/text-result (h/pr-edn payload) payload)))
+        filtered    (cond->> decorators
+                      kind-filter (into {} (filter (fn [[_ body]]
+                                                     (= kind-filter (:kind body))))))
+        sorted      (sort-by (comp str key) filtered)
+        all-ids     (keys filtered)
+        entries     (mapv (fn [[did body]] (decorator-summary did body)) sorted)
+        [res page meta] (cursor/page entries all-ids args "list-decorators")]
+    (if (= res :err)
+      page
+      (let [payload (merge {:decorators page} meta)]
+        (h/text-result (h/pr-edn payload) payload)))))
 
 (def canonical-assertion-docs
   "Per spec/007 line 304 + IMPL-SPEC §3.5 the canonical seven
@@ -163,12 +226,23 @@
     :semantics "fx-id emitted during play?"}])
 
 (defn tool-list-assertions
-  "Docs: the `:rf.assert/*` canonical vocabulary + arity docs."
-  [_args]
-  (let [registered (story/canonical-assertion-ids)
-        payload    {:canonical canonical-assertion-docs
-                    :registered (vec (sort-by str registered))}]
-    (h/text-result (h/pr-edn payload) payload)))
+  "Docs: the `:rf.assert/*` canonical vocabulary + arity docs.
+
+  rf2-76sf6: the bifurcated `{:canonical :registered}` shape is
+  retained; `:canonical` is the full 7-assertion doc vector (bounded
+  and constant, so the pagination MUST does not apply). `:registered`
+  (project-registered + canonical ids) is paginated when the count
+  exceeds `:limit`. Small registries see no pagination metadata."
+  [args]
+  (let [registered (sort-by str (story/canonical-assertion-ids))
+        reg-vec    (vec registered)
+        [res page meta] (cursor/page reg-vec (set reg-vec) args "list-assertions")]
+    (if (= res :err)
+      page
+      (let [payload (merge {:canonical  canonical-assertion-docs
+                            :registered page}
+                           meta)]
+        (h/text-result (h/pr-edn payload) payload)))))
 
 (defn tool-variant->edn
   "Docs: round-trippable EDN of a registered variant. Identical payload
@@ -266,7 +340,7 @@
   "Docs-category descriptors, in IMPL-SPEC §7.2 order."
   [{:name           "list-stories"
     :category       :docs
-    :description    (str "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids. "
+    :description    (str "All registered stories, optionally filtered by tags. Each entry carries id, doc, tags, and child variant ids. Paginated per rf2-76sf6 (`:limit` default 25, optional `:cursor` continuation). "
                          "Examples: "
                          "1. All stories: {} -> {:stories [{:id :story.cart :doc \"...\" :tags [:dev :docs] :variants [:story.cart/empty :story.cart/full]} ...]}. "
                          "2. Filter by tag: {:tags [\":docs\"]} -> {:stories [...]} — only stories whose :tags intersect the requested set. "
@@ -274,8 +348,9 @@
     :typicalTokens  1500
     :inputSchema {:type "object"
                   :properties (s/with-max-tokens
-                                {:tags {:type "array" :items s/kw-or-string
-                                        :description "Optional tag filter; story `:tags` set must intersect."}})
+                                (s/with-pagination
+                                  {:tags {:type "array" :items s/kw-or-string
+                                          :description "Optional tag filter; story `:tags` set must intersect."}}))
                   :additionalProperties false}
     :outputSchema s/default-output-schema
     :annotations  s/read-only-annotations
@@ -315,26 +390,32 @@
 
    {:name           "list-tags"
     :category       :docs
-    :description    (str "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project. "
+    :description    (str "Canonical tags (`:dev :docs :test :screenshot :experimental :internal :agent`) + any custom tags registered by the project. Paginated per rf2-76sf6 — `:canonical` stays full (bounded 7); `:custom` and `:all` slice per `:limit` / `:cursor`. "
                          "Examples: "
                          "1. Fresh registry: {} -> {:canonical [:agent :dev :docs :experimental :internal :screenshot :test] :custom [] :all [:agent :dev :docs ...]}. "
                          "2. Project with custom tags: {} -> {:canonical [...] :custom [:mobile :rtl] :all [:agent :dev :docs ... :mobile :rtl]}. "
-                         "3. Pair with list-stories: call this first, then list-stories with :tags to filter the catalogue.")
+                         "3. Pair with list-stories: call this first, then list-stories with :tags to filter the catalogue. "
+                         "4. Large custom set — paginated: {:limit 25} -> {:canonical [...7...] :custom [...25...] :all [...32...] :total 50 :limit 25 :has-more? true :next-cursor \"<base64>\"}.")
     :typicalTokens  100
-    :inputSchema    {:type "object" :properties (s/with-max-tokens {}) :additionalProperties false}
+    :inputSchema    {:type "object"
+                     :properties (s/with-max-tokens (s/with-pagination {}))
+                     :additionalProperties false}
     :outputSchema   s/default-output-schema
     :annotations    s/read-only-annotations
     :handler        tool-list-tags}
 
    {:name           "list-modes"
     :category       :docs
-    :description    (str "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`. "
+    :description    (str "Registered modes (Chromatic-style saved tuples of args). Each entry is `{:id :doc :args}`. Paginated per rf2-76sf6 (`:limit` default 25, optional `:cursor`). "
                          "Examples: "
                          "1. Project with modes: {} -> {:modes [{:id :mode/dark :doc \"Dark theme\" :args {:theme :dark}} {:id :mode/mobile :doc \"...\" :args {:viewport :mobile}}]}. "
                          "2. Fresh registry (no project modes): {} -> {:modes []}. "
-                         "3. Use with preview-variant: pass {:active-modes [\":mode/dark\"]} on a preview-variant call to render the variant under that mode.")
+                         "3. Use with preview-variant: pass {:active-modes [\":mode/dark\"]} on a preview-variant call to render the variant under that mode. "
+                         "4. Large mode set — paginated: {:limit 10} -> {:modes [...10...] :total 47 :limit 10 :has-more? true :next-cursor \"<base64>\"}.")
     :typicalTokens  200
-    :inputSchema    {:type "object" :properties (s/with-max-tokens {}) :additionalProperties false}
+    :inputSchema    {:type "object"
+                     :properties (s/with-max-tokens (s/with-pagination {}))
+                     :additionalProperties false}
     :outputSchema   s/default-output-schema
     :annotations    s/read-only-annotations
     :handler        tool-list-modes}
@@ -348,17 +429,20 @@
                          "for `:fx-override`. The read-only peer of the deferred `register-decorator` "
                          "write surface — closures don't transport, so the write side stays out of "
                          "scope, but the read side is cheap. Optional `:kind` arg narrows to one "
-                         "decorator kind. "
+                         "decorator kind. Paginated per rf2-76sf6 (`:limit` default 25, optional "
+                         "`:cursor`). "
                          "Examples: "
                          "1. All decorators: {} -> {:decorators [{:id :with-router :kind :hiccup :doc \"...\" :has-wrap? true} {:id :seed-cart :kind :frame-setup :doc \"...\" :init [...] :app-db-patch {...}} {:id :stub-http :kind :fx-override :fx-id :http :response {...}}]}. "
                          "2. Filter to one kind: {:kind \"fx-override\"} -> {:decorators [{:id :stub-http :kind :fx-override ...}]}. "
-                         "3. Empty registry: {} -> {:decorators []}.")
+                         "3. Empty registry: {} -> {:decorators []}. "
+                         "4. Paginated: {:limit 10} -> {:decorators [...10...] :total 23 :limit 10 :has-more? true :next-cursor \"<base64>\"}.")
     :typicalTokens  500
     :inputSchema {:type "object"
                   :properties (s/with-max-tokens
-                                {:kind {:type "string"
-                                        :description "Optional filter — only return decorators of this kind."
-                                        :enum ["hiccup" "frame-setup" "fx-override"]}})
+                                (s/with-pagination
+                                  {:kind {:type "string"
+                                          :description "Optional filter — only return decorators of this kind."
+                                          :enum ["hiccup" "frame-setup" "fx-override"]}}))
                   :additionalProperties false}
     :outputSchema s/default-output-schema
     :annotations  s/read-only-annotations
@@ -366,13 +450,16 @@
 
    {:name           "list-assertions"
     :category       :docs
-    :description    (str "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids. "
+    :description    (str "The seven canonical `:rf.assert/*` events with payload arity + semantics, plus any project-registered assertion ids. Paginated per rf2-76sf6 — `:canonical` (the 7-entry doc vector) stays full; `:registered` slices per `:limit` / `:cursor`. "
                          "Examples: "
                          "1. Default: {} -> {:canonical [{:id :rf.assert/path-equals :payload \"[path expected]\" :semantics \"(= (get-in @app-db path) expected)\"} ...] :registered [:rf.assert/dispatched? :rf.assert/effect-emitted ...]}. "
                          "2. With budget knob: {:max-tokens 1000} -> same shape, tighter cap. "
-                         "3. Pair with run-variant: discover the assertion vocab here, then write :play sequences referencing those event ids.")
+                         "3. Pair with run-variant: discover the assertion vocab here, then write :play sequences referencing those event ids. "
+                         "4. Paginated: {:limit 5} -> {:canonical [...7...] :registered [...5...] :total 14 :limit 5 :has-more? true :next-cursor \"<base64>\"}.")
     :typicalTokens  500
-    :inputSchema    {:type "object" :properties (s/with-max-tokens {}) :additionalProperties false}
+    :inputSchema    {:type "object"
+                     :properties (s/with-max-tokens (s/with-pagination {}))
+                     :additionalProperties false}
     :outputSchema   s/default-output-schema
     :annotations    s/read-only-annotations
     :handler        tool-list-assertions}

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -11,11 +11,23 @@
   filter work (op-type :event/dispatched, frame scope, internal-ns
   suppression) — see `re-frame.story.recorder/recordable-event?`.
 
-  Optional `:write-back?` re-registers the source variant with the
+  Optional `:write-back` re-registers the source variant with the
   captured `:play` slot — gated by the same `allow-writes?` flag as
   `register-variant` (`tools.write/assert-writes-allowed`). This is
   the self-healing-loop hook the spec mentions: agent drives canvas →
-  tool returns snippet AND patches the variant in place."
+  tool returns snippet AND patches the variant in place.
+
+  ## Wire-key shape (rf2-pmwgn)
+
+  The wire-arg key is `:write-back` (no `?`) to satisfy Anthropic's
+  `^[a-zA-Z0-9_.-]{1,64}$` constraint on tool input-schema property
+  keys — the same rationale as `:include-sensitive`. The structured-
+  content response key `:written-back?` keeps the `?` because response-
+  payload keys are NOT bound by that regex (per
+  `schemas.cljc` §wire-key shape). The predicate function
+  `write-back?` in scope retains the `?` per the Clojure predicate
+  idiom — the `?` belongs on predicates and on response data, not on
+  the input-schema property whose wire form disallows it."
   (:require [re-frame.mcp-base.args :as args]
             [re-frame.story :as story]
             [re-frame.story-mcp.config :as config]
@@ -77,7 +89,7 @@
                                           [:rf.error :explain]))))))
 
 (defn tool-record-as-variant
-  "Dev (or Write when `:write-back?` is true): bridge the recorder's
+  "Dev (or Write when `:write-back` is true): bridge the recorder's
   start → capture → snippet pipeline across the MCP boundary.
 
   Args:
@@ -95,7 +107,7 @@
                               threaded; durations above the ceiling are
                               rejected with a structured error
                               (rf2-4yuhi).
-    :new-variant-id optional — when `:write-back?` is true, register the
+    :new-variant-id optional — when `:write-back` is true, register the
                               captured `:play` body as a NEW variant
                               with this id. Defaults to the source
                               `:variant-id` (overwrites in place).
@@ -106,10 +118,12 @@
                               canvas it ran against).
     :alias         optional — short ns alias in the rendered form
                               (default `\"story\"`).
-    :write-back?   optional — when true, also re-register the variant
+    :write-back    optional — when true, also re-register the variant
                               via `reg-variant*` with `:play <captured>`.
                               Requires `allow-writes?` (same gate as
-                              `register-variant`).
+                              `register-variant`). Wire-key shape per
+                              rf2-pmwgn: no `?` — Anthropic's input-
+                              schema property-name regex rejects it.
 
   Output:
     `{:variant-id <source>
@@ -123,8 +137,8 @@
 
   Errors:
     - Source `:variant-id` is not registered.
-    - `:write-back?` true but `allow-writes?` is false.
-    - `:write-back?` true and the underlying `reg-variant*` fails (shape
+    - `:write-back` true but `allow-writes?` is false.
+    - `:write-back` true and the underlying `reg-variant*` fails (shape
       validation, unknown extends, etc.).
 
   Filter layers are inherited from the recorder verbatim (op-type
@@ -134,7 +148,7 @@
   [arguments]
   (h/with-variant arguments
     (fn [vk body]
-      (let [write-back? (args/parse-boolean (:write-back? arguments) false)
+      (let [write-back? (args/parse-boolean (:write-back arguments) false)
             duration-ms (args/parse-non-negative-int (:duration-ms arguments) 0)]
         (or (when write-back? (write/assert-writes-allowed "record-as-variant"))
             (when (> duration-ms max-duration-ms)
@@ -163,10 +177,10 @@
             ;;   interning. Defaults to the source `vk` when omitted.
             ;;
             ;; - `:new-variant-id` is the write-back target. When
-            ;;   `:write-back?` is true we DO need a fresh keyword
+            ;;   `:write-back` is true we DO need a fresh keyword
             ;;   (the registrar's gate is `--allow-writes`; the
             ;;   operator chose to grow the registry). When
-            ;;   `:write-back?` is false the slot exists only for the
+            ;;   `:write-back` is false the slot exists only for the
             ;;   rendered snippet's first-line `:variant-id` literal —
             ;;   we render the caller's string as `:<string>` via
             ;;   `read-string` ONLY when the existing variant-id grammar
@@ -232,10 +246,10 @@
   per IMPL-SPEC §7.3."
   [{:name           "record-as-variant"
     :category       :write
-    :description    (str "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back?` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`). "
+    :description    (str "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`). Wire-key shape per rf2-pmwgn: input-schema property keys MUST omit the trailing `?` (Anthropic regex); the response key `:written-back?` is not bound by the same rule. "
                          "Examples: "
                          "1. Snippet-only record (no write-back): {:variant-id \":story.cart/full\" :duration-ms 2000} -> {:variant-id :story.cart/full :play-snippet \"(story/reg-variant :story.cart/full {:extends :story.cart/full :play [[:cart/add ...]]})\" :recorded-event-count 4 :duration-ms 2012 :captured [[:cart/add ...]] :written-back? false}. "
-                         "2. With write-back (gate must be open): {:variant-id \":story.cart/full\" :duration-ms 1000 :write-back? true :new-variant-id \":story.cart/recorded\"} -> {... :written-back? true :new-variant-id :story.cart/recorded}. "
+                         "2. With write-back (gate must be open): {:variant-id \":story.cart/full\" :duration-ms 1000 :write-back true :new-variant-id \":story.cart/recorded\"} -> {... :written-back? true :new-variant-id :story.cart/recorded}. "
                          "3. Duration too long: {:variant-id \":story.cart/full\" :duration-ms 60000} -> {:isError true :content [{:text \":duration-ms 60000 exceeds ceiling 30000ms...\"}] :structuredContent {:rf.error :rf.story-mcp/duration-ms-too-large :duration-ms 60000 :max-allowed 30000}}.")
     :typicalTokens  1500
     :inputSchema {:type "object"
@@ -246,15 +260,16 @@
                                                                     "Hard ceiling " max-duration-ms "ms — the MCP server's request loop is single-threaded so "
                                                                     "this call blocks unrelated tools for the full window; abusive durations are rejected (rf2-4yuhi).")}
                                  :new-variant-id (assoc s/kw-or-string
-                                                   :description "When `:write-back?` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
+                                                   :description "When `:write-back` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
                                  :doc            {:type "string"
                                                   :description "Optional docstring embedded in the rendered snippet."}
                                  :extends        (assoc s/kw-or-string
                                                    :description "Variant id embedded as `:extends` in the snippet. Defaults to the source `:variant-id`.")
                                  :alias          {:type "string"
                                                   :description "Short ns alias for the rendered form (default \"story\")."}
-                                 :write-back?    {:type "boolean"
-                                                  :description "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`."}})
+                                 :write-back     {:type "boolean"
+                                                  :description (str "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`. "
+                                                                    "Wire-key shape: no `?` per Anthropic's `^[a-zA-Z0-9_.-]{1,64}$` input-schema property-name regex (rf2-pmwgn).")}})
                   :required ["variant-id"]
                   :additionalProperties false}
     :outputSchema s/write-gated-output-schema

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -39,7 +39,15 @@
   for booleans is rejected at the host, so the wire form drops it. The
   predicate FUNCTION `helpers/include-sensitive?` retains the `?` (the
   Clojure idiom belongs on the predicate, not on the data key whose
-  wire form disallows it)."
+  wire form disallows it).
+
+  This is the canonical rule for the **input-schema property side**
+  (rf2-pmwgn): every boolean tool input property MUST omit the
+  trailing `?` (today: `:include-sensitive` and `:write-back`).
+  Response-payload keys (in `structuredContent`) are NOT bound by the
+  Anthropic regex and retain the Clojure-idiomatic `?` — that's why
+  `:passing?`, `:registered?`, `:unregistered?`, `:written-back?`,
+  `:has-wrap?` survive on the response side."
   {:type "boolean"
    :description (str "Opt in to forwarding sensitive `:app-db` slots and "
                      "assertion records. Default false (declared-sensitive paths "
@@ -53,6 +61,58 @@
   tool inherits the slot so the cap is uniformly overrideable per call."
   [props]
   (assoc props :max-tokens max-tokens-schema))
+
+;; ---------------------------------------------------------------------------
+;; Pagination schema fragments (rf2-76sf6)
+;;
+;; spec/Principles.md §'Tight token budget' MUST: every read tool whose
+;; return size is a function of registry size MUST accept `:limit` and
+;; return a `:cursor` for continuation. The Docs `list-*` tools share
+;; the same pagination contract — define the schema fragments once
+;; here and inject via `with-pagination`.
+;; ---------------------------------------------------------------------------
+
+(def limit-schema
+  "Recurring fragment — `list-*` tools accept a `:limit` arg to bound
+  the per-page entry count. Default 25 per
+  `re-frame.story-mcp.tools.cursor/default-limit`; clamped to 200 per
+  `max-limit`."
+  {:type "integer" :minimum 1 :maximum 200
+   :description (str "Per-page entry count. Default 25; clamped to 200. "
+                     "Pair with `:cursor` for continuation across pages. "
+                     "Per spec/Principles.md §'Tight token budget' the "
+                     "default keeps the response under the wire cap.")})
+
+(def cursor-schema
+  "Recurring fragment — `list-*` tools accept an opaque `:cursor`
+  string for continuation. The agent passes the response's
+  `:next-cursor` value back verbatim on the next call; the encoding is
+  an implementation detail (today: base64 of an EDN map; subject to
+  change). When the underlying registry changes between cursor mint
+  and deref, the server returns `:rf.mcp/cursor-stale` and the agent
+  must drop the cursor + restart."
+  {:type "string"
+   :description (str "Opaque continuation token from a previous list-* call's "
+                     ":next-cursor slot. Agents pass the value back verbatim. "
+                     "On registry change between pages the server returns "
+                     ":rf.mcp/cursor-stale; drop the cursor and restart.")})
+
+(defn with-pagination
+  "Inject `:limit` and `:cursor` slots into a tool's `:properties`
+  map. Used by every Docs `list-*` tool per spec/Principles.md
+  §'Tight token budget' (rf2-76sf6).
+
+  The `get-*` tools (`get-story`, `get-variant`, `get-docs-markdown`,
+  `variant->edn`) are NOT paginated — their return is a single record
+  bounded by the registered body's size, not a function of registry
+  size. Per the Principles MUST: 'any read tool whose return size is
+  a function of registry size' — single-record reads are bounded
+  separately by the wire-boundary cap (`:max-tokens` + the
+  `:rf.mcp/overflow` marker)."
+  [props]
+  (assoc props
+         :limit  limit-schema
+         :cursor cursor-schema))
 
 (defn with-include-sensitive
   "Inject the `:include-sensitive` slot into a tool's `:properties`
@@ -122,15 +182,17 @@
 ;; `destructiveHint`, `idempotentHint`, `openWorldHint` — per
 ;; mcp_best_practices.md.
 ;;
-;; Story-mcp matrix (per the bead rf2-94p8q):
+;; Story-mcp matrix (per the bead rf2-94p8q, refined per rf2-8h778):
 ;;
-;;   - READ-ONLY tools: get-story-instructions, preview-variant,
-;;     list-substrates, list-stories, get-story, get-variant, list-tags,
-;;     list-modes, list-decorators, list-assertions, get-docs-markdown,
-;;     variant->edn, snapshot-identity, run-a11y, read-failures.
+;;   - READ-ONLY tools: get-story-instructions, list-substrates,
+;;     list-stories, get-story, get-variant, list-tags, list-modes,
+;;     list-decorators, list-assertions, get-docs-markdown, variant->edn,
+;;     snapshot-identity, run-a11y, read-failures.
 ;;
-;;   - DESTRUCTIVE tools: run-variant (dispatches events into a story
-;;     frame), register-variant, unregister-variant, record-as-variant.
+;;   - DESTRUCTIVE tools: preview-variant (dispatches events into a
+;;     variant's frame via the same `story/run-variant` lifecycle as
+;;     run-variant — rf2-8h778), run-variant, register-variant,
+;;     unregister-variant, record-as-variant.
 ;; ---------------------------------------------------------------------------
 
 (def read-only-annotations
@@ -151,17 +213,25 @@
    :openWorldHint   false})
 
 (def run-variant-annotations
-  "Annotations for `run-variant` — executes a variant's four-phase
-  lifecycle which dispatches events into the variant's frame. Per
+  "Annotations for the variant-lifecycle tools (`run-variant` and
+  `preview-variant`) — both execute a variant's four-phase lifecycle
+  which dispatches events into the variant's frame. Per
   spec/Tool-Pair.md §Direct-read privacy posture the run is a write
   to the runtime, so `:destructiveHint true`. The events fire inside
-  the JVM process — `:openWorldHint false`."
+  the JVM process — `:openWorldHint false`.
+
+  rf2-8h778: `preview-variant` originally shipped with
+  `read-only-annotations`; the audit (rf2-3pn6c Finding #2) caught
+  the asymmetry — both tools call `(story/run-variant vk opts)` and
+  derive their result from the lifecycle outcome. The annotations
+  must match the side-effect surface, not the verb gloss
+  (`preview-variant`'s rendered URL output) at the wire."
   {:destructiveHint true
    :openWorldHint   false})
 
 (def write-gated-output-schema
   "outputSchema for write-surface tools (`register-variant`,
-  `unregister-variant`, `record-as-variant` with `:write-back? true`).
+  `unregister-variant`, `record-as-variant` with `:write-back true`).
   Includes the gated-error shape — when the operator-only
   `--allow-writes` flag is closed, the tool returns
   `{:isError true :structuredContent {:gated true :tool \"<name>\"}}`.

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -194,7 +194,7 @@
       (is (every? #(map? (:annotations %)) ds))))
   (testing "matrix: read-only tools have readOnlyHint"
     (let [by-name (into {} (map (juxt :name identity)) registry/tool-registry)
-          ro-tools ["get-story-instructions" "preview-variant" "list-substrates"
+          ro-tools ["get-story-instructions" "list-substrates"
                     "list-stories" "get-story" "get-variant" "list-tags"
                     "list-modes" "list-decorators" "list-assertions"
                     "get-docs-markdown" "variant->edn" "snapshot-identity"
@@ -202,10 +202,16 @@
       (doseq [n ro-tools]
         (is (true? (get-in (by-name n) [:annotations :readOnlyHint]))
             (str n " should have readOnlyHint true (rf2-94p8q matrix)")))))
+  ;; rf2-8h778: preview-variant moves to the destructive list. It dispatches
+  ;; events into the variant's frame via the same `story/run-variant`
+  ;; lifecycle as `run-variant`; the original `read-only-annotations`
+  ;; marking was a wire-mismatch with the actual side-effect surface and
+  ;; would have let agent-host auto-approval skip the destructive-write
+  ;; ceremony.
   (testing "matrix: destructive tools have destructiveHint"
     (let [by-name (into {} (map (juxt :name identity)) registry/tool-registry)
-          dest-tools ["run-variant" "register-variant" "unregister-variant"
-                      "record-as-variant"]]
+          dest-tools ["preview-variant" "run-variant" "register-variant"
+                      "unregister-variant" "record-as-variant"]]
       (doseq [n dest-tools]
         (is (true? (get-in (by-name n) [:annotations :destructiveHint]))
             (str n " should have destructiveHint true (rf2-94p8q matrix)"))))))
@@ -443,6 +449,153 @@
   (let [r (invoke "get-docs-markdown" {})]
     (is (error? r))
     (is (re-find #"story-id" (-> r :content first :text)))))
+
+;; ---------------------------------------------------------------------------
+;; Pagination on the Docs `list-*` tools (rf2-76sf6)
+;;
+;; spec/Principles.md §'Tight token budget' MUST: every read tool whose
+;; return size is a function of registry size MUST accept `:limit` +
+;; `:cursor`. These tests pin:
+;;   - small registries return the bare shape (no pagination metadata)
+;;     — the pre-rf2-76sf6 wire shape is preserved
+;;   - large registries (>= :limit) return :total :limit :has-more?
+;;     :next-cursor
+;;   - cursor round-trips across pages
+;;   - a stale cursor (registry mutated between pages) returns
+;;     :rf.mcp/cursor-stale
+;;   - `:limit` is clamped to the documented ceiling
+;; ---------------------------------------------------------------------------
+
+(deftest list-stories-small-registry-no-pagination-metadata
+  (testing "single-story fixture fits on one page — no :total / :next-cursor"
+    (let [r (invoke "list-stories" {})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (vector? (:stories s)))
+      (is (not (contains? s :total))
+          "small registry MUST NOT carry pagination metadata (wire shape unchanged)")
+      (is (not (contains? s :next-cursor))))))
+
+(deftest list-stories-paginates-when-over-limit
+  (testing "with many stories + :limit smaller than total, response is paginated"
+    ;; Register additional stories so total > :limit. The fixture leaves
+    ;; one story; adding 4 more + :limit 2 produces a 5-entry total.
+    (doseq [n (range 4)]
+      (story/reg-story (keyword (str "story.pager" n))
+        {:doc (str "Pager story " n) :component :app/x :tags #{:dev}}))
+    (let [r (invoke "list-stories" {:limit 2})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 2 (count (:stories s))) "first page honours :limit")
+      (is (= 5 (:total s)) "five stories total (fixture + 4)")
+      (is (= 2 (:limit s)))
+      (is (true? (:has-more? s)))
+      (is (string? (:next-cursor s)))
+      ;; Round-trip the cursor: passing :next-cursor returns the next page.
+      (let [r2 (invoke "list-stories" {:limit 2 :cursor (:next-cursor s)})
+            s2 (:structuredContent r2)]
+        (is (success? r2))
+        (is (= 2 (count (:stories s2))) "second page also 2 entries")
+        (is (true? (:has-more? s2)))
+        (is (string? (:next-cursor s2)))
+        ;; Final page: one entry, has-more? false, next-cursor nil.
+        (let [r3 (invoke "list-stories" {:limit 2 :cursor (:next-cursor s2)})
+              s3 (:structuredContent r3)]
+          (is (success? r3))
+          (is (= 1 (count (:stories s3))) "final page has the remaining entry")
+          (is (false? (:has-more? s3)))
+          (is (nil? (:next-cursor s3))))))))
+
+(deftest list-stories-stale-cursor-returns-error
+  (testing "a registry mutation between pages stales the cursor"
+    (doseq [n (range 3)]
+      (story/reg-story (keyword (str "story.stale" n))
+        {:doc (str "Stale " n) :component :app/x :tags #{:dev}}))
+    (let [r1     (invoke "list-stories" {:limit 1})
+          cursor (-> r1 :structuredContent :next-cursor)]
+      (is (string? cursor))
+      ;; Mutate the registry: register one more story before deref.
+      (story/reg-story :story.intruder
+        {:doc "Landed mid-pagination" :component :app/x :tags #{:dev}})
+      (let [r2 (invoke "list-stories" {:limit 1 :cursor cursor})
+            s2 (:structuredContent r2)]
+        (is (error? r2))
+        (is (= :rf.mcp/cursor-stale (:reason s2)))
+        (is (= "list-stories" (:tool s2)))))))
+
+(deftest list-stories-limit-clamped-to-max
+  (testing ":limit above the ceiling clamps DOWN to max-limit"
+    (let [r (invoke "list-stories" {:limit 99999})
+          s (:structuredContent r)]
+      (is (success? r))
+      ;; With 1 fixture story, no pagination kicks in — but if it did,
+      ;; the :limit slot would be 200 (max-limit), not 99999. We verify
+      ;; this by registering enough stories to force pagination.
+      (doseq [n (range 250)]
+        (story/reg-story (keyword (str "story.clamp" n))
+          {:doc "" :component :app/x :tags #{:dev}}))
+      (let [r2 (invoke "list-stories" {:limit 99999})
+            s2 (:structuredContent r2)]
+        (is (success? r2))
+        ;; Total is fixture + 250 = 251; with :limit clamped to 200,
+        ;; first page is 200 entries and :has-more? true.
+        (is (<= (count (:stories s2)) 200)
+            "first page MUST NOT exceed max-limit 200")))))
+
+(deftest list-stories-malformed-cursor-reads-as-stale
+  (testing "a malformed :cursor (bad base64 / wrong shape) returns the stale error"
+    (let [r (invoke "list-stories" {:cursor "not-a-valid-cursor!!!"})
+          s (:structuredContent r)]
+      (is (error? r))
+      (is (= :rf.mcp/cursor-stale (:reason s))))))
+
+(deftest list-modes-paginates
+  (testing "list-modes honours :limit + :cursor"
+    (doseq [n (range 35)]
+      ;; Mode ids per spec/007 grammar: `:Mode.<path>/<name>`.
+      (story/reg-mode (keyword "Mode.pager" (str "m" n))
+        {:doc "" :args {}}))
+    (let [r (invoke "list-modes" {:limit 10})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 10 (count (:modes s))))
+      (is (true? (:has-more? s)))
+      (is (string? (:next-cursor s))))))
+
+(deftest list-decorators-pagination-preserves-kind-filter
+  (testing ":kind filter narrows the paginated entry set"
+    ;; Build enough hiccup decorators to force pagination of a kind filter.
+    (doseq [n (range 30)]
+      (story/reg-decorator (keyword (str "dec.page/h" n))
+        {:kind :hiccup :doc "" :wrap (fn [child] child)}))
+    (let [r (invoke "list-decorators" {:kind "hiccup" :limit 5})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 5 (count (:decorators s))))
+      (is (every? #(= :hiccup (:kind %)) (:decorators s)))
+      (is (true? (:has-more? s))))))
+
+(deftest list-tags-canonical-stays-full-under-pagination
+  (testing "the canonical-tag slot is bounded (7) so it never paginates"
+    ;; Register lots of custom tags.
+    (doseq [n (range 50)]
+      (story/reg-tag (keyword (str "tag/pager" n)) {:doc ""}))
+    (let [r (invoke "list-tags" {:limit 5})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 7 (count (:canonical s)))
+          "the 7-entry canonical set always lands in full")
+      (is (= 5 (count (:custom s))) ":custom honours :limit")
+      (is (true? (:has-more? s))))))
+
+(deftest list-assertions-canonical-doc-stays-full
+  (testing "the canonical assertion-doc vector is bounded (7) so it never paginates"
+    (let [r (invoke "list-assertions" {:limit 3})
+          s (:structuredContent r)]
+      (is (success? r))
+      (is (= 7 (count (:canonical s)))
+          "the canonical-doc vec is the bounded reference; not subject to pagination")
+      (is (<= (count (:registered s)) 3) ":registered honours :limit"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Testing tools
@@ -763,7 +916,7 @@
       (is (true? (-> r :structuredContent :gated)))
       (is (= "unregister-variant" (-> r :structuredContent :tool))))
     (let [r (invoke "record-as-variant" {:variant-id  "story.button/primary"
-                                         :write-back? true})]
+                                         :write-back  true})]
       (is (error? r))
       (is (true? (-> r :structuredContent :gated)))
       (is (= "record-as-variant" (-> r :structuredContent :tool))))))
@@ -858,22 +1011,22 @@
       (is (re-find #":counter/by 7" (:play-snippet s))))))
 
 (deftest record-as-variant-write-back-gated-by-default
-  (testing "write-back? true with allow-writes? false ⇒ gated error"
+  (testing "write-back true with allow-writes? false ⇒ gated error"
     (is (false? (config/writes-allowed?)))
     (let [r (invoke "record-as-variant" {:variant-id  "story.button/primary"
-                                         :write-back? true})]
+                                         :write-back  true})]
       (is (error? r))
       (is (re-find #"Write surface disabled" (-> r :content first :text)))
       (is (true? (-> r :structuredContent :gated))))))
 
 (deftest record-as-variant-write-back-overwrites-source
-  (testing "write-back? true with gate open re-registers the source variant"
+  (testing "write-back true with gate open re-registers the source variant"
     (config/set-allow-writes! true)
     (drive-events-during-recording [[:counter/inc] [:counter/inc]])
     (let [r (invoke "record-as-variant"
                     {:variant-id  "story.button/primary"
                      :duration-ms 100
-                     :write-back? true})
+                     :write-back  true})
           s (:structuredContent r)]
       (is (success? r))
       (is (true? (:written-back? s)))
@@ -892,7 +1045,7 @@
                     {:variant-id     "story.button/primary"
                      :new-variant-id "story.button/recorded"
                      :duration-ms    100
-                     :write-back?    true})
+                     :write-back     true})
           s (:structuredContent r)]
       (is (success? r))
       (is (true? (:written-back? s)))
@@ -974,7 +1127,7 @@
     (let [r    (invoke "record-as-variant"
                        {:variant-id  "story.button/primary"
                         :duration-ms 100
-                        :write-back? true})
+                        :write-back  true})
           body (story/variant->edn :story.button/primary)]
       (is (success? r))
       (is (true? (-> r :structuredContent :written-back?)))
@@ -992,13 +1145,13 @@
                        {:variant-id     "story.button/primary"
                         :new-variant-id "story.button/origin-recorded"
                         :duration-ms    100
-                        :write-back?    true})
+                        :write-back     true})
           body (story/variant->edn :story.button/origin-recorded)]
       (is (success? r))
       (is (= :story-mcp (:origin body))))))
 
 (deftest record-as-variant-without-write-back-does-not-touch-source
-  (testing "without :write-back? the source variant is untouched (no :origin landed)"
+  (testing "without :write-back the source variant is untouched (no :origin landed)"
     ;; This pins the contract: the write happens only on the write-back
     ;; branch. The :origin stamp is the marker of a write — its absence
     ;; on a non-write-back call is the marker of a no-write.
@@ -1696,7 +1849,7 @@
                     {:variant-id     "story.button/primary"
                      :new-variant-id "garbage-id-no-namespace"  ; not :story.x/y
                      :duration-ms    50
-                     :write-back?    true})]
+                     :write-back     true})]
       (is (error? r) "write-back against a malformed target id must fail")
       (is (re-find #"(?i)Write-back failed" (-> r :content first :text))
           "the error text names the failure surface — agents pattern-match on this")

--- a/tools/story-mcp/test/stdio-roundtrip.js
+++ b/tools/story-mcp/test/stdio-roundtrip.js
@@ -162,11 +162,12 @@ function run() {
 
       // 2d. Verify the record-as-variant descriptor (rf2-luhdu landing):
       // required `variant-id`; optional duration-ms / new-variant-id / doc
-      // / extends / alias / write-back?.
+      // / extends / alias / write-back. (Wire-key `write-back` — no `?` per
+      // Anthropic's input-schema property-name regex; rf2-pmwgn.)
       const recDesc = (list.result?.tools || []).find((t) => t.name === 'record-as-variant');
       if (!recDesc) throw new Error('record-as-variant descriptor missing from tools/list');
       const recProps = recDesc.inputSchema?.properties || {};
-      for (const k of ['variant-id', 'duration-ms', 'new-variant-id', 'doc', 'extends', 'alias', 'write-back?']) {
+      for (const k of ['variant-id', 'duration-ms', 'new-variant-id', 'doc', 'extends', 'alias', 'write-back']) {
         if (!(k in recProps)) {
           throw new Error('record-as-variant inputSchema missing property: ' + k);
         }
@@ -174,7 +175,7 @@ function run() {
       if (!recDesc.inputSchema?.required?.includes('variant-id')) {
         throw new Error('record-as-variant.inputSchema missing required: variant-id');
       }
-      console.log('OK   record-as-variant descriptor -> variant-id (required) + duration-ms/new-variant-id/doc/extends/alias/write-back?');
+      console.log('OK   record-as-variant descriptor -> variant-id (required) + duration-ms/new-variant-id/doc/extends/alias/write-back');
 
       // 3. tools/call list-tags — read-side smoke; the canonical seven
       // tags must be present (loaded by `install-canonical-vocabulary!` in


### PR DESCRIPTION
## Summary
- :write-back? wire-key rule clarified (rf2-pmwgn)
- preview-variant annotation reconciled (rf2-8h778)
- read-failures spec aligned with impl reality (rf2-zx0p0)
- :limit + :cursor pagination added to Docs list-*/get-* tools (rf2-76sf6)

Alpha posture: no back-compat shims; renames are renames.

## Beads
rf2-pmwgn, rf2-8h778, rf2-zx0p0, rf2-76sf6 (all P2)

## Source
ai/findings/2026-05-20-tools-story-mcp-api-review.md

## Acceptance
- test:cljs + JVM clean
- mkdocs --strict clean