### PR TITLE
fix(template): emit lefthook.yml (no dot) — rf2-kqsdt

### DIFF
--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -19,7 +19,7 @@ my-app/
 ├── .clj-kondo/
 │   └── config.edn            empty default; lint rules slot in here
 ├── .cljfmt.edn               cljfmt formatter config — `clojure -M:cljfmt check` / `fix`
-├── .lefthook.yml             pre-commit format + lint hook (see lefthook.dev/installation)
+├── lefthook.yml              pre-commit format + lint hook (see lefthook.dev/installation)
 ├── resources/public/
 │   ├── index.html            host page; loads /js/main.js + /css/app.css
 │   └── css/app.css           three-rule plain stylesheet
@@ -88,7 +88,7 @@ tools/template/
         │   ├── clj-kondo/
         │   │   └── config.edn            ; emitted under .clj-kondo/
         │   ├── cljfmt.edn                ; emitted as .cljfmt.edn
-        │   ├── lefthook.yml              ; emitted as .lefthook.yml
+        │   ├── lefthook.yml              ; emitted as lefthook.yml
         │   ├── events.cljs
         │   ├── events_test.cljs
         │   ├── subs.cljs

--- a/tools/template/spec/003-DepsNew-Rebuild-Plan.md
+++ b/tools/template/spec/003-DepsNew-Rebuild-Plan.md
@@ -48,7 +48,7 @@ day8/re-frame2-template/                ; eventually its own repo
 │   │   ├── editorconfig                (→ .editorconfig)
 │   │   ├── clj-kondo/config.edn        (→ .clj-kondo/config.edn)
 │   │   ├── cljfmt.edn                  (→ .cljfmt.edn)
-│   │   ├── lefthook.yml                (→ .lefthook.yml)
+│   │   ├── lefthook.yml                (→ lefthook.yml)
 │   │   ├── events.cljs · subs.cljs · events_test.cljs
 │   │   ├── index.html · resources/public/css/app.css
 │   │   └── dev/{user.clj, scratch.cljs}

--- a/tools/template/src/clj/new/re_frame2.clj
+++ b/tools/template/src/clj/new/re_frame2.clj
@@ -201,7 +201,7 @@
              ;; cljfmt config — `clojure -M:cljfmt check` / `fix`.
              [".cljfmt.edn"     (sub-render "shared/cljfmt.edn")]
              ;; lefthook — pre-commit format + lint gate.
-             [".lefthook.yml"   (sub-render "shared/lefthook.yml")]
+             ["lefthook.yml"    (sub-render "shared/lefthook.yml")]
              ;; -- src tree --
              ;;
              ;; `core.cljs` swaps to the hash-routing with-stories variant

--- a/tools/template/src/clj/new/re_frame2/shared/README.md
+++ b/tools/template/src/clj/new/re_frame2/shared/README.md
@@ -180,7 +180,7 @@ related error, that's the fix.
 ├── .clj-kondo/
 │   └── config.edn           ; linter config (empty by default)
 ├── .cljfmt.edn              ; cljfmt formatter config — `clojure -M:cljfmt check` / `fix`
-├── .lefthook.yml            ; pre-commit format + lint hook (see lefthook.dev/installation)
+├── lefthook.yml             ; pre-commit format + lint hook (see lefthook.dev/installation)
 ├── resources/public/
 │   ├── index.html           ; host page; loads shadow-cljs's compiled output
 │   └── css/app.css          ; minimal plain CSS — body / button / h1

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -136,7 +136,7 @@
    ;; Formatter config (rf2-5ecqj).
    ".cljfmt.edn"
    ;; Git pre-commit hook config (rf2-s8xee).
-   ".lefthook.yml"
+   "lefthook.yml"
    "dev/user.clj"
    "dev/scratch.cljs"
    "resources/public/index.html"


### PR DESCRIPTION
## Summary

Per audit `rf2-whit9` Finding #5 (major): lefthook's documented canonical
config filename is `lefthook.yml` (no leading dot). The dotted variant is
recognised by lefthook but is not canonical per
[lefthook.dev/configuration](https://lefthook.dev/configuration/) — users
copy-pasting from upstream docs hit naming friction.

This PR changes the template emit name from `.lefthook.yml` to
`lefthook.yml`:

- `tools/template/src/clj/new/re_frame2.clj` — emit-site rename
- `tools/template/spec/002-Generated-Shape.md` — tree diagrams
- `tools/template/src/clj/new/re_frame2/shared/README.md` — layout block
- `tools/template/test/clj/new/re_frame2_test.clj` — `common-files` list
- `tools/template/spec/003-DepsNew-Rebuild-Plan.md` — rebuild plan

The source resource at `shared/lefthook.yml` already matched and is
unchanged. Pre-alpha: strict rename, no dual-name fallback.

Closes rf2-kqsdt.

## Test plan

- [x] `cd tools/template && clojure -M:test` — 19 tests, 261 assertions, 0 failures, 0 errors
- [x] `mkdocs build --strict` — exit 0