### PR TITLE
ci(gates): rename + narrow Examples → Adapter testbed smokes (rf2-bxdk8 + rf2-cjp0i)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -34,7 +34,7 @@ cljs_browser=false
 cljs_prod=false
 bundle_isolation=false
 reagent_slim_bundle=false
-examples_browser=false
+adapter_testbed_smokes=false
 tools_jvm=false
 template_expensive=false
 mcp_conformance=false
@@ -49,7 +49,7 @@ mark_all() {
   cljs_prod=true
   bundle_isolation=true
   reagent_slim_bundle=true
-  examples_browser=true
+  adapter_testbed_smokes=true
   tools_jvm=true
   template_expensive=true
   mcp_conformance=true
@@ -68,9 +68,9 @@ else
         mark_all
         ;;
       implementation/core/*)
-        # rf2-8jz9t — examples_browser NOT fired here. The
-        # examples-browser job exercises the 3 adapter-level smokes
-        # (Reagent/UIx/Helix at implementation/adapters/<name>/testbed/)
+        # rf2-8jz9t — adapter_testbed_smokes NOT fired here. The
+        # adapter-testbed-smokes job exercises the 3 adapter-level
+        # smokes (Reagent/UIx/Helix at implementation/adapters/<name>/testbed/)
         # which catch adapter-specific bugs (createRoot lifecycle,
         # hydration, real concurrent scheduling) — not core regressions.
         # Core renames are caught by node-test (CLJS unit + browser-test)
@@ -92,7 +92,7 @@ else
         # rf2-8cevm — the examples/ tree is test-free. counter_slim_and_fast
         # used to ship a paired spec.cjs but the bundle-isolation contract
         # at scripts/check-reagent-slim-bundle-isolation.cjs is the
-        # canonical gate; examples_browser is no longer fired here.
+        # canonical gate; adapter_testbed_smokes is no longer fired here.
         implementation_jvm=true
         adapter_diagnostic=true
         cljs_browser=true
@@ -100,25 +100,38 @@ else
         reagent_slim_bundle=true
         ;;
       implementation/adapters/*)
+        # rf2-bxdk8 + rf2-cjp0i — the adapter-testbed-smokes gate is
+        # scoped to the 3 adapter smokes at
+        # implementation/adapters/<reagent|uix|helix>/testbed/. Adapter
+        # source changes are the canonical trigger; orchestrator-script
+        # changes are caught by the harness-script case below.
         implementation_jvm=true
         adapter_diagnostic=true
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
-        examples_browser=true
+        adapter_testbed_smokes=true
         tools_jvm=true
         template_expensive=true
         mcp_conformance=true
         mcp_live=true
         ;;
+      examples/scripts/serve-and-run-examples-tests.cjs|examples/scripts/run-examples-tests.cjs|examples/scripts/spec-helpers.cjs)
+        # rf2-bxdk8 + rf2-cjp0i — the orchestrator + runner + helpers
+        # under examples/scripts/ drive the adapter-testbed-smokes job
+        # (via `npm run test:examples`). They are the *only* paths
+        # under examples/ that fire this gate; the rest of examples/**
+        # is test-free per rf2-8cevm.
+        adapter_testbed_smokes=true
+        ;;
       implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/deps.edn)
-        # rf2-8jz9t — examples_browser NOT fired here. Per-feature
+        # rf2-8jz9t — adapter_testbed_smokes NOT fired here. Per-feature
         # artefact changes are covered by their own JVM + CLJS unit
         # suites (implementation_jvm, cljs_browser, cljs_prod) and by
-        # bundle_isolation; the adapter smokes under examples-browser
-        # only catch adapter-mount-specific bugs (createRoot lifecycle,
-        # hydration, real concurrent scheduling). Nightly + post-merge
-        # gate runs the full matrix.
+        # bundle_isolation; the adapter smokes under
+        # adapter-testbed-smokes only catch adapter-mount-specific bugs
+        # (createRoot lifecycle, hydration, real concurrent scheduling).
+        # Nightly + post-merge gate runs the full matrix.
         implementation_jvm=true
         cljs_browser=true
         cljs_prod=true
@@ -144,12 +157,14 @@ else
         cljs_prod=true
         ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
-        # rf2-8jz9t — examples_browser NOT fired here. The examples-browser
-        # job is now triggered ONLY by direct adapter/example/testbed
-        # surface changes (implementation/adapters/*, examples/*,
-        # testbeds/*). A shadow-cljs.edn or scripts/ change that breaks
-        # the examples-browser build is caught by the nightly cron +
-        # post-merge gate (both run the full matrix on main).
+        # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i — adapter_testbed_smokes NOT
+        # fired here. The adapter-testbed-smokes job is now triggered
+        # ONLY by direct adapter surface changes
+        # (implementation/adapters/*) or by changes to the orchestrator
+        # scripts under examples/scripts/. A shadow-cljs.edn or
+        # implementation/scripts/ change that breaks the build is
+        # caught by the nightly cron + post-merge gate (both run the
+        # full matrix on main).
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
@@ -157,19 +172,22 @@ else
         story_causa_browser=true
         ;;
       examples/*)
+        # rf2-bxdk8 + rf2-cjp0i + rf2-8cevm — examples/** is test-free.
+        # adapter_testbed_smokes is NOT fired by generic examples/**
+        # paths; only the orchestrator scripts under examples/scripts/
+        # (matched above) fire it. The cljs_browser gate covers
+        # CLJS-source regressions touched by examples/.
         cljs_browser=true
-        examples_browser=true
         ;;
       testbeds/*)
-        # rf2-7vsfm — Top-level testbeds/* is mounted by
-        # examples/scripts/serve-and-run-examples-tests.cjs (ssr_basic,
-        # ssr_hydration_mismatch, ssr_multi_frame, deliberate_throw,
-        # http_toggle, deep_machine, non_trivial_app_db,
-        # long_flow_w_failure, drain_depth_trigger, …) and consumed by
-        # `npm run test:examples` -> the examples-browser job. A
-        # testbed-only PR must trigger both surfaces.
+        # rf2-7vsfm + rf2-bxdk8 + rf2-cjp0i — Top-level testbeds/* are
+        # compiled + staged by the orchestrator at
+        # examples/scripts/serve-and-run-examples-tests.cjs, but per
+        # rf2-cjp0i the adapter-testbed-smokes gate is scoped to the
+        # adapter smokes themselves; testbed-only diffs no longer fire
+        # adapter_testbed_smokes. cljs_browser still covers CLJS-source
+        # regressions; nightly + post-merge gate runs the full matrix.
         cljs_browser=true
-        examples_browser=true
         ;;
       tools/template/*)
         # rf2-os0c1 — tools/template is a clj-new template that scaffolds
@@ -243,7 +261,7 @@ emit cljs_browser "$cljs_browser"
 emit cljs_prod "$cljs_prod"
 emit bundle_isolation "$bundle_isolation"
 emit reagent_slim_bundle "$reagent_slim_bundle"
-emit examples_browser "$examples_browser"
+emit adapter_testbed_smokes "$adapter_testbed_smokes"
 emit tools_jvm "$tools_jvm"
 emit template_expensive "$template_expensive"
 emit mcp_conformance "$mcp_conformance"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       cljs_prod: ${{ steps.detect.outputs.cljs_prod }}
       bundle_isolation: ${{ steps.detect.outputs.bundle_isolation }}
       reagent_slim_bundle: ${{ steps.detect.outputs.reagent_slim_bundle }}
-      examples_browser: ${{ steps.detect.outputs.examples_browser }}
+      adapter_testbed_smokes: ${{ steps.detect.outputs.adapter_testbed_smokes }}
       tools_jvm: ${{ steps.detect.outputs.tools_jvm }}
       template_expensive: ${{ steps.detect.outputs.template_expensive }}
       mcp_conformance: ${{ steps.detect.outputs.mcp_conformance }}
@@ -260,7 +260,7 @@ jobs:
       # returns 0 when there are no test namespaces matching its
       # pattern. Per rf2-3yij Decision 7 the substrate's smoke-test
       # surface is the browser-side counter + login specs — see the
-      # examples-browser job below.
+      # adapter-testbed-smokes job below.
       - name: Run JVM tests (uix artefact, classpath probe)
         run: clojure -M:test || echo "no JVM-runnable tests in uix artefact (expected)"
 
@@ -305,7 +305,7 @@ jobs:
       # test-runner returns 0 when there are no test namespaces
       # matching its pattern. Per rf2-2qit Decision 7 the substrate's
       # smoke-test surface is the browser-side counter + login specs —
-      # see the examples-browser job below.
+      # see the adapter-testbed-smokes job below.
       - name: Run JVM tests (helix artefact, classpath probe)
         run: clojure -M:test || echo "no JVM-runnable tests in helix artefact (expected)"
 
@@ -987,10 +987,10 @@ jobs:
       - name: Verify counter bundle isolates every per-feature artefact
         run: npm run test:bundle-isolation
 
-  examples-browser:
-    name: Examples (browser, headless Chromium, rf2-lyj0)
+  adapter-testbed-smokes:
+    name: Adapter testbed smokes (browser, headless Chromium)
     needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.examples_browser == 'true'
+    if: needs.detect_changed_surfaces.outputs.adapter_testbed_smokes == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/TESTING.md
+++ b/TESTING.md
@@ -164,7 +164,7 @@ boolean GitHub-Actions outputs per surface:
 | `cljs_prod` | Surface that release-mode probes (`browser-test-prod-elision`, schemas boundary prod) cover changed. |
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
-| `examples_browser` | Direct examples / adapter / top-level testbed surface changed (`implementation/adapters/*`, `examples/*`, `testbeds/*`). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs; nightly + post-merge gate runs the full matrix on main). |
+| `adapter_testbed_smokes` | Adapter surface changed (`implementation/adapters/*`) or the orchestrator scripts that drive the smokes (`examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs`). Per rf2-bxdk8 + rf2-cjp0i + rf2-8cevm: generic `examples/**` and `testbeds/**` paths no longer fire this gate (examples/ is test-free; testbed-only diffs are caught by `cljs_browser` and the nightly + post-merge full matrix). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs). |
 | `tools_jvm` | Story / Causa / Story-MCP / Causa-MCP / Pair2-MCP / MCP-base changed; gates the four per-tool JVM probes (`jvm-tools-{causa,story,story-mcp,mcp-base}`). Not set by `tools/template/*` or `tools/mcp-conformance/*` — those don't share runtime with the per-tool probes. |
 | `template_expensive` | `tools/template/*` changed; gates the template emitted-app smoke. |
 | `mcp_conformance` | Any MCP-server tool, `tools/mcp-base/*`, or `tools/mcp-conformance/*` changed. |
@@ -181,8 +181,8 @@ A few "blast-radius" inputs force the full sweep:
 - Changes under `implementation/core/*` fan out broadly (they touch
   almost every output) because core regressions can break every
   downstream substrate, tool, and bundle invariant. Exception:
-  `examples_browser` is **not** fired by `implementation/core/*`
-  changes (rf2-8jz9t). The adapter smokes under examples-browser
+  `adapter_testbed_smokes` is **not** fired by `implementation/core/*`
+  changes (rf2-8jz9t). The adapter smokes under adapter-testbed-smokes
   only catch adapter-mount-specific bugs (createRoot lifecycle,
   hydration, real concurrent scheduling); core renames are caught
   by `node-test` (which exercises every public `re-frame.core`
@@ -247,7 +247,7 @@ under that surface sets that output to `true`. The **blast-trigger row
 lights every output (defensive — anything that re-tiers the matrix
 must re-run the matrix).
 
-| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `examples_browser` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
+| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `adapter_testbed_smokes` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
 | S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |
@@ -256,8 +256,9 @@ must re-run the matrix).
 | S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
 | S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   | ✓ |   |
-| S8 | `examples/*` |   |   | ✓ |   |   |   | ✓ |   |   |   |   |   |   |
-| S9 | `testbeds/*` |   |   | ✓ |   |   |   | ✓ |   |   |   |   |   |   |
+| S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
+| S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs` (orchestrator + runner + helpers — rf2-bxdk8 + rf2-cjp0i) |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |
+| S9 | `testbeds/*` |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
 | S10 | `tools/template/*` |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |
 | S11 | `tools/story/*`, `tools/causa/*` |   |   |   |   |   |   |   | ✓ |   | ✓ |   | ✓ |   |
 | S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
@@ -278,7 +279,7 @@ PR time; one row per output here so the table stays scannable).
 | `cljs_prod` | Release-mode probes ×3 (`browser-test-prod-elision`, schemas boundary prod, etc.) |
 | `bundle_isolation` | `bundle-isolation` |
 | `reagent_slim_bundle` | `reagent-slim-bundle-isolation` |
-| `examples_browser` | `examples-browser` (Playwright, testbeds + examples) |
+| `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; 3 adapter smokes + the framework + top-level testbeds the orchestrator compiles) |
 | `tools_jvm` | Per-tool JVM probes ×4 (`jvm-tools-causa`, `jvm-tools-story`, `jvm-tools-story-mcp`, `jvm-tools-mcp-base`) |
 | `template_expensive` | `jvm-tools-template` (emitted-app smoke) |
 | `mcp_conformance` | MCP conformance ×4 (`mcp-conformance-{story,re-frame2-pair,wire-vocab,...}`) |
@@ -296,7 +297,7 @@ actually does today:
 
 | Gate | Workflow job | Why skip-ok |
 |---|---|---|
-| Adapter JVM classpath probes (Reagent / Reagent Slim / UIx / Helix) | `jvm-reagent`, `jvm-reagent-slim`, `jvm-uix`, `jvm-helix` | Adapter namespaces are `:cljs-only`. The job runs `clojure -M:test` with an `or-echo` fallback so a zero-test alias still proves the artefact's deps + classpath wiring stay green. Real adapter coverage is the browser counter + login specs (rf2-3yij / rf2-2qit Decision 7) under the examples-browser job, and per-adapter CLJS unit tests under the consolidated `node-test` build. |
+| Adapter JVM classpath probes (Reagent / Reagent Slim / UIx / Helix) | `jvm-reagent`, `jvm-reagent-slim`, `jvm-uix`, `jvm-helix` | Adapter namespaces are `:cljs-only`. The job runs `clojure -M:test` with an `or-echo` fallback so a zero-test alias still proves the artefact's deps + classpath wiring stay green. Real adapter coverage is the browser counter + login specs (rf2-3yij / rf2-2qit Decision 7) under the adapter-testbed-smokes job, and per-adapter CLJS unit tests under the consolidated `node-test` build. |
 | `tools/causa` JVM probe | `jvm-tools-causa` | Causa ships two JVM tests today (`config_test.clj`, `trace_bus_test.clj`); an `or-echo` fallback keeps the job green if that set shrinks to zero on an intermediate cut. The CLJS surface is already covered by the consolidated `node-test` build (shadow-cljs.edn lists `tools/causa/test` as a source path). |
 | Pair2 live-overflow without nREPL | `mcp-conformance-re-frame2-pair` — step `Run re-frame2-pair-mcp live-overflow conformance (SKIPPED without nREPL)` | The step runs `npm run test:re-frame2-pair-live-overflow` (no env). The script exits 0 with a SKIP marker when `$SHADOW_CLJS_NREPL_PORT` is unset — so the SKIP path is exercised on every CI run (a regression that broke the SKIP, e.g. crashing on missing env, surfaces here). Real live coverage is the hermetic step that follows: `npm run test:re-frame2-pair-live-overflow-hermetic` (which spawns shadow-cljs + Chromium against `skills/re-frame2-pair/tests/fixture/`, sets `SHADOW_CLJS_NREPL_PORT`, and runs the same script). |
 

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -8,7 +8,7 @@
  *   4. Snapshot console errors         — none beyond the expected.
  *
  * Wired into CI behind the RF2_CAUSA_RUN_GALLERY_SMOKES=1 opt-in
- * (rf2-1w76p): the examples-browser job sets the flag and the
+ * (rf2-1w76p): the adapter-testbed-smokes job sets the flag and the
  * orchestrator at examples/scripts/serve-and-run-examples-tests.cjs
  * compiles :testbeds/panel-gallery, stages index.html alongside the
  * bundle, and invokes this script after the main spec sweep. Run

--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -17,7 +17,7 @@
  * clicking from `event-detail/all` to `app-db-diff/all`.
  *
  * Wired into CI behind the RF2_CAUSA_RUN_GALLERY_SMOKES=1 opt-in
- * (rf2-1w76p, mirrors `_smoke.cjs`'s posture): the examples-browser
+ * (rf2-1w76p, mirrors `_smoke.cjs`'s posture): the adapter-testbed-smokes
  * job sets the flag and the orchestrator at
  * examples/scripts/serve-and-run-examples-tests.cjs invokes this
  * script after the main spec sweep. Run manually post-compile to


### PR DESCRIPTION
## Summary

The CI gate at `.github/workflows/test.yml` previously named
`Examples (browser, headless Chromium, rf2-lyj0)` misdescribed what
it actually tests. Per rf2-8cevm (the **examples/** tree is test-free
lock, 2026-05-19) the canonical surface for this gate is the 3 adapter
testbed smokes at `implementation/adapters/<reagent|uix|helix>/testbed/spec.cjs`.
Bundles **rf2-bxdk8** (rename) + **rf2-cjp0i** (narrow path filter).

### Renames (no soft aliases — pre-alpha posture)

| Surface | Before | After |
|---|---|---|
| Job key | `examples-browser` | `adapter-testbed-smokes` |
| Output key | `examples_browser` | `adapter_testbed_smokes` |
| Display name | `Examples (browser, headless Chromium, rf2-lyj0)` | `Adapter testbed smokes (browser, headless Chromium)` |

### Path-filter narrowing (`.github/scripts/report-changed-surfaces.sh`)

The renamed gate now fires ONLY on:

- `implementation/adapters/*` (adapter sources / smokes)
- `examples/scripts/serve-and-run-examples-tests.cjs` (orchestrator)
- `examples/scripts/run-examples-tests.cjs` (runner)
- `examples/scripts/spec-helpers.cjs` (helpers)
- Blast-trigger files (workflow / classifier / TESTING.md → `mark_all`)

**Removed** from the trigger:

- `examples/**` — examples/ is test-free per rf2-8cevm. `cljs_browser`
  still covers CLJS-source regressions.
- `testbeds/**` — top-level testbed-only diffs no longer fire this
  gate; `cljs_browser` still covers source regressions, and the
  nightly + post-merge full matrix re-runs the orchestrator on main.

### Consequence to surface

The orchestrator at `examples/scripts/serve-and-run-examples-tests.cjs`
**continues** to compile + run the framework testbeds (perf-counter,
parallel-frames) and the top-level `testbeds/**` Playwright specs when
the gate IS triggered — the job content is unchanged. Only the
**trigger** is narrowed. A PR that only touches `testbeds/ssr_basic/index.html`
(or any other top-level testbed) will not fire this gate at PR-time;
nightly + post-merge full-matrix runs still cover it. If you want
those testbeds covered at PR-time on testbed-only diffs, that's a
follow-on (and conflicts with the rf2-cjp0i constraint as written —
file a fresh bead if the policy needs revisiting).

### Files changed

- `.github/workflows/test.yml` — job key / output key / display name + 2 comment refs
- `.github/scripts/report-changed-surfaces.sh` — variable rename, new orchestrator case, removed examples/** + testbeds/** triggers
- `TESTING.md` — output-table row, blast-trigger prose, surface→output matrix (S8/S8a/S9), output→jobs table
- `tools/causa/testbeds/panel_gallery/_smoke.cjs` — comment ref
- `tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` — comment ref

## Test plan

- [x] `bash report-changed-surfaces.sh implementation/adapters/reagent/testbed/spec.cjs` → `adapter_testbed_smokes=true`
- [x] `bash report-changed-surfaces.sh examples/reagent/some.cljs` → `adapter_testbed_smokes=false`
- [x] `bash report-changed-surfaces.sh testbeds/ssr_basic/index.html` → `adapter_testbed_smokes=false`
- [x] `bash report-changed-surfaces.sh examples/scripts/serve-and-run-examples-tests.cjs` → `adapter_testbed_smokes=true`
- [x] `bash report-changed-surfaces.sh --all` → renamed key in mark_all output
- [x] `node implementation/scripts/_changed-surfaces.test.cjs` → 4 passed
- [x] `python -m mkdocs build --strict` → OK (pre-existing `the-mayor-method` warning unrelated)
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → YAML valid
- [ ] CI: this PR itself triggers `mark_all` (touches `.github/workflows/test.yml` + `report-changed-surfaces.sh` + `TESTING.md`) so the full matrix runs, including the renamed `adapter-testbed-smokes` job.