### PR TITLE
chore(mcp-conformance): cluster — error-code union + count-rule + alias shape (rf2-lku2q + rf2-2akdw + rf2-if13b)

### DIFF
--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -77,7 +77,12 @@ the post-rename state — pair-mcp's two former deviations
 follow-on C5). The convention is the lock for **any future extension**
 to re-frame2-pair-mcp / story-mcp.
 
-### re-frame2-pair-mcp (14 tools)
+### re-frame2-pair-mcp
+
+(Live tool count: see
+[`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
+— the canonical count site per §"Single source of truth for tool
+counts" below.)
 
 | Tool | Verb shape | Notes |
 |---|---|---|
@@ -95,7 +100,12 @@ to re-frame2-pair-mcp / story-mcp.
 | `list-handlers` | `list-` | Conformant — renamed from `registry-list` per rf2-4y595 (NAMING.md follow-on). The `<noun>-list` suffix was flagged as rejected in §"What's NOT a locked verb" above; `list-<things>` prefix is the catalogued shape. The runtime's `(rf/registry-list kind)` accessor keeps its name (separate naming surface). Added by rf2-pctf8. |
 | `get-re-frame2-pair-instructions` | `get-` | Conformant — single-record read of the agent-onboarding instructions blob (rf2-fnpqg). Mirrors story-mcp's `get-story-instructions`. |
 
-### Story-mcp (19 tools)
+### Story-mcp
+
+(Live tool count: see
+[`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md)
+— the canonical count site per §"Single source of truth for tool
+counts" below.)
 
 | Tool | Verb shape | Notes |
 |---|---|---|
@@ -150,11 +160,13 @@ The convention for per-server tool-catalogue docs:
   it or convert it to a count-free link. The cross-MCP audit walks the
   triplet once per release looking for the pattern; until that audit is
   automated, the discipline lives here.
-- **`Server alignment today` (above)** carries explicit counts because the
-  audit table is the canonical comparison — those counts WILL drift unless
-  this NAMING.md is itself updated when the catalogues are. The table's
-  counts are pinned **to this doc's last audit pass**, not asserted as
-  always-current; the catalogue is always the live source.
+- **`Server alignment today` (above) carries no integer counts in its
+  headings.** Per-server subsections link to the catalogue for the live
+  count rather than pinning an integer that would silently age past the
+  next add/remove. The audit table itself enumerates the verb-conformance
+  judgement for each tool by name — a tool added after this doc's last
+  audit pass simply isn't in the table yet, which is the correct signal
+  ("re-audit needed") rather than a contradicted count.
 
 This is the same single-source-of-truth principle that governs the verb
 table above — the table is the lock, the per-server catalogues are the
@@ -181,6 +193,45 @@ markers (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`,
 `:rf.mcp/diff-from`, `:rf.mcp/cache-hit`, `:rf.size/large-elided`,
 `:rf.elision/at`) — see [`wire-vocab/README.md`](./wire-vocab/README.md)
 for the shape contract and the conformance gate.
+
+### JSON-RPC error codes
+
+Underneath the `:reason` keyword layer above sits the **JSON-RPC 2.0
+numeric error-code** layer — the codes the SDK / framework return
+when a request is malformed at the protocol level rather than failing
+in tool-result space. Per JSON-RPC §5.1 and MCP's reuse, the same
+numeric codes apply across the triplet; the canonical home for every
+code constant is
+[`tools/mcp-base/src/re_frame/mcp_base/vocab.cljc`](../mcp-base/src/re_frame/mcp_base/vocab.cljc)
+(see the `code-*` defs).
+
+The conformance contract pins:
+
+- **`-32601 MethodNotFound`** — the canonical code for an unknown
+  JSON-RPC method. Pinned by `mcp-base/vocab.cljc/code-method-not-found`.
+  Every server in the triplet MUST yield this code for an unrecognised
+  method name; the conformance harness asserts the exact value (see
+  `tools/mcp-conformance/test/_runner.cjs/assertJsonRpcErrorCodes`).
+- **`-32602 InvalidParams` / `-32603 InternalError`** — both are
+  conformant today for a malformed `tools/call` request (e.g. one
+  missing the `:name` slot). JSON-RPC §5.1's plain reading says
+  `-32602`; the npm MCP SDK in practice wraps the underlying zod
+  parse failure as `-32603`. Both are pinned by `mcp-base/vocab.cljc`
+  (`code-invalid-params` / `code-internal-error`). The conformance
+  gate accepts the **union** — either code passes
+  `assertJsonRpcErrorCodes` — so an SDK tightening that flips the
+  emit from one to the other does not break the contract. A future
+  bead may collapse to a single code if upstream converges; until
+  then the union is the locked surface.
+
+Note the relationship to MCP tool-result errors: tool-execution
+failures (a `dispatch` that throws, a `run-variant` that asserts) do
+NOT use these JSON-RPC codes. They surface via the MCP tool-result
+shape (`isError: true` plus the `:reason` keyword vocabulary above)
+so the agent host can present the failure to the LLM without
+aborting the conversation. JSON-RPC codes are reserved for
+protocol-level failures the SDK detects before (or instead of)
+dispatching a tool.
 
 ## How to extend this table
 

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -69,7 +69,7 @@ on the server side surfaces as an SDK parse-error.
   under a real over-budget eval. **Gated on `$SHADOW_CLJS_NREPL_PORT`**:
   unset = clean SKIP (degraded mode can't trip the cap naturally),
   set = full live-runtime cap-trigger conformance against the
-  canonical `OverflowBody` schema pinned by `wire-vocab/`.
+  canonical `ReFrame2PairOverflowBody` schema pinned by `wire-vocab/`.
 - `test/live-re-frame2-pair-subscribe.cjs` — re-frame2-pair-mcp **live**-runtime variant
   (rf2-zb5z6) that exercises the `notifications/progress` streaming
   wire surface. Subscribes to `:trace`, dispatches a known event,
@@ -137,8 +137,8 @@ SKIP. When attached:
 3. SDK's `CallToolResultSchema` accepts the envelope; `isError` is
    `false` (overflow is a signal, not an error).
 4. Response text carries `:rf.mcp/overflow`.
-5. Marker body validates against canonical `OverflowBody` schema
-   pinned by `wire-vocab/`: `:limit :reached`, integer `:cap-tokens`
+5. Marker body validates against canonical `ReFrame2PairOverflowBody`
+   schema pinned by `wire-vocab/`: `:limit :reached`, integer `:cap-tokens`
    and `:token-count` with `:token-count > :cap-tokens`, string
    `:tool` and `:hint`.
 6. Pin per-tool facts: `:cap-tokens = 5000` (default), `:tool =

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -267,7 +267,7 @@ runWithWatchdog(
     console.log('OK   response text carries :rf.mcp/overflow marker key');
 
     // 5. Schema-validate the marker body against the canonical
-    // OverflowBody shape pinned by wire-vocab. This is the
+    // ReFrame2PairOverflowBody shape pinned by wire-vocab. This is the
     // cross-server vocabulary assertion: re-frame2-pair-mcp's wire emission
     // MUST satisfy the same shape as the wire-vocab fixture.
     const body = parseOverflowMarker(text);
@@ -279,7 +279,7 @@ runWithWatchdog(
       );
     }
     assertOverflowBody(body, 'eval-cljs live overflow');
-    console.log('OK   marker body validates against canonical OverflowBody schema');
+    console.log('OK   marker body validates against canonical ReFrame2PairOverflowBody schema');
 
     // 6. Pin the load-bearing semantic facts about the marker:
     //   - :cap-tokens MUST equal the documented default (5000).

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -109,7 +109,17 @@
   `mcp-base/overflow.cljc/overflow-payload`). Every emit carries
   `:cap-tokens` + `:token-count` + `:tool` + `:hint` plus the `:limit
   :reached` sentinel. Required-not-optional — an emit missing any of
-  these is a contract break, not a degenerate but tolerated marker."
+  these is a contract break, not a degenerate but tolerated marker.
+
+  Single-emitter today; the per-server name IS the canonical name.
+  Pinned cross-server as a re-frame2-pair-mcp-only shape; if a future
+  MCP server ships an `:rf.mcp/overflow` emit, the wrapper's body
+  slot below becomes `[:or ReFrame2PairOverflowBody PairXOverflowBody]`
+  rather than a one-arm canonical alias. (Same posture as
+  `ReFrame2PairProgressNotificationParams`.) Cap renames (`cap-tokens`
+  vs `cap_tokens`), field renames (`hint` vs `next-step`), or empty
+  bodies all trip the schema. Per rf2-kn8cj (refactor-audit r2 of
+  rf2-azk9c §F-VOCAB-2)."
   [:map
    {:closed false}
    [:limit       [:enum :reached]]
@@ -118,31 +128,9 @@
    [:token-count :int]
    [:hint        [:or :string :keyword]]])
 
-(def OverflowBody
-  "`{:rf.mcp/overflow {...}}` body — the token-budget overflow marker.
-
-  Per re-frame2-pair-mcp `mcp-base/overflow.cljc/overflow-payload`. The shape
-  pins required fields:
-
-  - **re-frame2-pair-mcp shape:** `:limit :reached` + `:cap-tokens` +
-    `:token-count` + `:tool` + `:hint`. Hyphen-separated child names;
-    `:cap-tokens` is the cap, `:token-count` is the over-budget count.
-
-  An emit shaped as `{:rf.mcp/overflow {:limit :reached}}` alone is
-  NOT conformant — every required field MUST be present. Cap renames
-  (`cap-tokens` vs `cap_tokens`), field renames (`hint` vs `next-step`),
-  or empty bodies all trip the schema. Per rf2-kn8cj (refactor-audit r2
-  of rf2-azk9c §F-VOCAB-2).
-
-  When a second MCP server (re-)adopts the cross-MCP overflow shape
-  with a different field name set, extend this as `[:or Pair2Body
-  OtherBody]` (the historical pattern from when causa-mcp was an MCP
-  server, dropped in rf2-bu21t)."
-  ReFrame2PairOverflowBody)
-
 (def Overflow
-  "`{:rf.mcp/overflow OverflowBody}` — the wrapper shape."
-  [:map [:rf.mcp/overflow OverflowBody]])
+  "`{:rf.mcp/overflow ReFrame2PairOverflowBody}` — the wrapper shape."
+  [:map [:rf.mcp/overflow ReFrame2PairOverflowBody]])
 
 (def SummaryBody
   "`{:rf.mcp/summary {...}}` body — the lazy tree-summary marker.
@@ -297,7 +285,7 @@
   Pinned cross-server today as a re-frame2-pair-mcp-only shape; if a future
   MCP server ships a `subscribe`/`unsubscribe` pair (per NAMING.md),
   its emit MUST satisfy this schema or extend it as a `[:or ...]`
-  (same posture as OverflowBody)."
+  (same posture as `ReFrame2PairOverflowBody`)."
   [:map
    {:closed false}
    [:progressToken :any]                          ;; opaque per MCP spec
@@ -552,12 +540,13 @@
 
 (deftest overflow-empty-body-is-rejected
   ;; rf2-kn8cj (refactor-audit r2 of rf2-azk9c §F-VOCAB-2): the previous
-  ;; `OverflowBody` schema marked every slot except `:limit` `{:optional
-  ;; true}`, so an emit shaped as `{:rf.mcp/overflow {:limit :reached}}`
-  ;; alone validated. That under-constrained the cross-server contract:
-  ;; an emit MUST carry re-frame2-pair-mcp's shape (`:cap-tokens` + `:token-count`
-  ;; + `:tool` + `:hint`). The schema now requires every field; this
-  ;; gate pins the regression directly.
+  ;; `ReFrame2PairOverflowBody` schema marked every slot except `:limit`
+  ;; `{:optional true}`, so an emit shaped as
+  ;; `{:rf.mcp/overflow {:limit :reached}}` alone validated. That
+  ;; under-constrained the cross-server contract: an emit MUST carry
+  ;; re-frame2-pair-mcp's shape (`:cap-tokens` + `:token-count` + `:tool` +
+  ;; `:hint`). The schema now requires every field; this gate pins the
+  ;; regression directly.
   (testing "empty body (only :limit :reached) fails validation"
     (is (not (m/validate Overflow {:rf.mcp/overflow {:limit :reached}}))
         "Overflow schema must reject an emit with only :limit :reached — the re-frame2-pair shape requires more fields."))
@@ -758,7 +747,7 @@
                "form is " (marker-key->literal key))))))
 
 ;; ---------------------------------------------------------------------------
-;; JS-vs-Malli `OverflowBody` cross-encoding sanity (rf2-0zqox).
+;; JS-vs-Malli `ReFrame2PairOverflowBody` cross-encoding sanity (rf2-0zqox).
 ;;
 ;; `test/live-re-frame2-pair-overflow.cjs` hand-rolls `assertOverflowBody` as a JS
 ;; re-encoding of `ReFrame2PairOverflowBody`. The two encodings must agree on
@@ -1234,7 +1223,7 @@
 ;;   - `live-re-frame2-pair-overflow.cjs` only exercised `eval-cljs`.
 ;;   - No test observed a real `notifications/progress` frame.
 ;;
-;; The pin shape mirrors the OverflowBody cross-encoding posture above:
+;; The pin shape mirrors the ReFrame2PairOverflowBody cross-encoding posture above:
 ;;
 ;;   1. fixture validates against `ReFrame2PairProgressNotificationParams`.
 ;;   2. literal `"notifications/progress"` appears in re-frame2-pair-mcp's emit
@@ -1323,15 +1312,15 @@
 
 (def ^:private live-re-frame2-pair-subscribe-js-rel
   "Relative path to the hand-rolled JS `notifications/progress`
-  assertion. Mirrors `live-re-frame2-pair-overflow-js-rel` for the OverflowBody
-  cross-encoding gate."
+  assertion. Mirrors `live-re-frame2-pair-overflow-js-rel` for the
+  ReFrame2PairOverflowBody cross-encoding gate."
   "tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs")
 
 (def ^:private re-frame2-pair-progress-js-required-grep-markers
   "Substrings the JS `assertProgressParams` MUST contain to pin every
   required field on `ReFrame2PairProgressNotificationParams`. Each entry is
   `[malli-path js-substring]` — the path for error reporting, the
-  substring as the grep target. Mirrors the OverflowBody table above:
+  substring as the grep target. Mirrors the ReFrame2PairOverflowBody table above:
   a field added to the Malli schema MUST add a row here; a field
   removed MUST remove a row."
   [[":progressToken"
@@ -1353,7 +1342,7 @@
 
 (deftest js-assertProgressParams-pins-every-re-frame2-pair-progress-required-field
   ;; Cross-encoding sanity gate (rf2-i3ffz F-GAP-1, mirrors rf2-0zqox
-  ;; for OverflowBody). For every required field on the Malli
+  ;; for ReFrame2PairOverflowBody). For every required field on the Malli
   ;; `ReFrame2PairProgressNotificationParams` schema, the JS
   ;; `assertProgressParams` function MUST carry a substring that
   ;; asserts the same shape. Missing fields trip this gate with the


### PR DESCRIPTION
## Summary

3-bead audit-followon cluster on the `tools/mcp-conformance/` surface. All three originate from rf2-li7dw's API review; they share `NAMING.md` + `wire-vocab/test/.../wire_vocab_test.clj` so they're sequenced as one PR (parallel workers would conflict).

- **rf2-lku2q (F5)** — `NAMING.md` §Error-vocabulary alignment now carries a "JSON-RPC error codes" sub-section documenting the cross-MCP code contract: `-32601 MethodNotFound` canonical for unknown method; `-32602 InvalidParams` / `-32603 InternalError` both conformant for malformed `tools/call` (the conformance gate accepts the union to absorb SDK behaviour drift). Cross-links `mcp-base/vocab.cljc` as the canonical code-constant home. Clarifies the relationship to MCP tool-result errors — protocol-level failures use the JSON-RPC codes, tool-execution failures stay in `:reason`-keyword + `isError: true` space.
- **rf2-2akdw (F4)** — `NAMING.md` §Server alignment headings shed their integer tool counts (`### re-frame2-pair-mcp (14 tools)` → `### re-frame2-pair-mcp`). Each subsection links to the catalogue file as the canonical count site, removing the self-violation of the doc's own §"Single source of truth for tool counts" rule. The single-source-of-truth section's "audit table is an exception" bullet is rewritten to record the new no-counts posture.
- **rf2-if13b (F1)** — wire-vocab test schemas unified under the per-server-name-is-canonical convention. Drops the one-arm `OverflowBody = ReFrame2PairOverflowBody` alias; folds its docstring guidance into `ReFrame2PairOverflowBody` and updates `Overflow` to point at the per-server name directly. Both `ReFrame2PairOverflowBody` and `ReFrame2PairProgressNotificationParams` now share the same shape: "single-emitter today; per-server name IS canonical; if a second server adopts, the wrapper body slot becomes `[:or ...]`". Downstream references in test comments, the README, and `live-re-frame2-pair-overflow.cjs` updated in lockstep.

## Gates

- `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — 38 tests / 468 assertions, 0 failures, 0 errors (both before and after the alias drop)
- `python -m mkdocs build --strict` — clean (NAMING.md is not in nav; the strict pass exercises link/spec hygiene anyway)
- No `implementation/package.json` script for `test:mcp-conformance` — skipped per bundle instructions.

## Notes

Two commits (one per logical surface — wire-vocab + NAMING.md), one PR. Pre-alpha; no deprecated-alias placeholders left behind.

## Test plan

- [ ] Wire-vocab JVM test passes in CI
- [ ] mkdocs strict build passes in CI
- [ ] No stale `OverflowBody` bare-name references remain anywhere in the repo