### PR TITLE
feat(machines-viz): density variants (compact/regular/cosy) — rf2-32gw5

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -65,6 +65,7 @@ unrecognised keys at registration time).
 | `:direction` | no | `:tb` | Layout axis. `:tb` lays the chart top-to-bottom (rank flows down); `:lr` left-to-right (rank flows right). Promoted from an internal `chart.elk-layout/->elk-graph` arg to a top-level prop per rf2-ikdi3 so wide vs. narrow hosts can pick the axis without forking the file. |
 | `:layout-options` | no | `nil` | ELK `layoutOptions` overrides — a map of string → string keys that merge ON TOP of the canonical defaults (`chart.elk-layout/default-layout-options`). Hosts tighten / widen / swap individual knobs (`"elk.spacing.nodeNode"` for density, `"elk.layered.crossingMinimization.strategy"` for rank-order discipline, etc.) without re-stating the whole map. The `:direction` arg always wins for `"elk.direction"`. Per rf2-ikdi3. |
 | `:layout-engine` | no | `:auto` | Engine selector — `:auto` (cached ELK when available, layered fallback otherwise — the historical behaviour), `:elk` (cached ELK only; returns nothing when not ready so the host can choose 'wait + retry' over 'render the inferior engine'), `:layered` (force the layered fallback — useful for deterministic screenshot tests). Per rf2-ikdi3 — the two-engine reality (layered fallback + ELK) is now surfaced explicitly rather than hidden behind a single entry point. |
+| `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Picks the geometry + typography map from `visual-constants/chart-for-density`; the chart's `corner-radius` lock (rf2-g6cig) is invariant across every density so the chart's visual character stays consistent — only quantity scales. Per [§Density](#density) and rf2-32gw5. |
 
 The four `:on-*` callback shapes are mirrored from
 [Causa 003 §Source-coord integration](../../causa/spec/003-Machine-Inspector.md#source-coord-integration);
@@ -127,6 +128,74 @@ introduce new registries.
 
 Source: lifted from
 [Causa 003 §Data sources](../../causa/spec/003-Machine-Inspector.md#data-sources).
+
+## Density
+
+The chart ships **three named density variants**. Hosts pick one via
+the `:density` prop on `MachineChart`; the same machine renders at
+different physical sizes without forking the renderer.
+
+| Density | When to pick it |
+|---|---|
+| `:compact` | Story's 50-chart panel grid; thumbnail listings; any surface where the chart is one of many and the user is scanning the grid for shape rather than reading individual labels. Walks the typography back to the spec/007-UX-IA refused-floor (state 11px / edge 9px) — the refused-floor was set for dense data-grid surfaces, and this density IS that surface. Geometry tightens ~25% (paddings, dot-grid spacing, pill height). |
+| `:regular` | The default. Causa's machines tab; the read-only viewer page; any embedded host that picks no density at all. Typography sits at the chart-floor (state 13px / edge 11px per rf2-gg7ws). The constants in `visual-constants/chart-regular` are the same constants `visual-constants/chart` aliases. |
+| `:cosy` | Single-chart presentation displays — Causa's machines tab on a wide monitor, a standalone viewer on a projector, an editor's docs-page screenshot. Walks the typography up to state 15px / edge 13px. Geometry loosens ~25%. |
+
+### Identity vs. quantity
+
+Density scales **quantity**, not **identity**. The same chart at all
+three densities reads as the same chart — the rounded-rect 'data, not
+product' character (rf2-g6cig) holds. Specifically:
+
+- **`corner-radius` is locked at 6 across every density** per the
+  rf2-g6cig lock. A 'compact' chart with `corner-radius 4` would
+  read as a different chart, not a smaller one; a 'cosy' chart with
+  `corner-radius 10` would read as 'product chrome'. The lock means
+  the chart's silhouette is the same at every scale.
+- **`edge-label-backplate-opacity` is invariant** across densities
+  (rf2-gg7ws collision-avoidance v1 — the backplate's contrast
+  budget doesn't scale with type size).
+- **`dot-grid-alpha` is invariant** — the backdrop's subtlety
+  doesn't track density.
+
+Every other geometry / typography knob (`stroke-width`, paddings,
+pill geometry, every `*-px` font size, the dot-grid `spacing-px` /
+`radius-px`) tracks the density axis monotonically: `:compact <
+:regular < :cosy`. The three named maps in `visual-constants` share
+the SAME key set (asserted by `visual-constants-cljs-test`).
+
+### Resolution rules
+
+- `:density nil` or unspecified ≡ `:regular`.
+- `:density` ∈ `:compact` / `:regular` / `:cosy` resolves to the
+  matching named map via `visual-constants/chart-for-density`.
+- Any other value throws an `ex-info` at render time — picking an
+  unknown density is a programmer error, not a runtime fallback.
+- The resolved density surfaces on the root `<svg>` element as
+  `data-density="<compact|regular|cosy>"` so hosts and tests can
+  read the active density without re-reading the bound prop.
+
+### Implementation notes
+
+- The render entry-point (`chart.svg/render`) rebinds the dynamic
+  Var `visual-constants/*chart*` to the chosen density's map for
+  the duration of the call. Helpers destructure off `vc/*chart*`,
+  not off the namespace-level `vc/chart` alias.
+- Hiccup construction is eager (`into` over `for`) so every density-
+  resolved constant is captured in the returned data structure;
+  the dynamic binding unwinds before the hiccup is handed to
+  React.
+- Direct hiccup-walking tests that want a non-default density can
+  `binding [vc/*chart* (vc/chart-for-density :compact)] ...` and
+  call helpers directly; production code always goes through the
+  `:density` prop.
+
+Per rf2-32gw5 (resolves the `visual-constants.cljc` doc-string's
+'a future density toggle (compact / cosy / comfy) a one-knob change'
+forward-promise; naming settled on compact / regular / cosy per the
+bead title — `regular` is the load-bearing default name now that the
+chart-floor lift (rf2-gg7ws) put the previous-default size at the
+floor of three rungs rather than the only rung).
 
 ## Performance invariants
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
@@ -61,29 +61,21 @@
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
-;; ---- visual constants (delegated to vc/chart) ---------------------------
-
-(def ^:private corner-radius           (:corner-radius vc/chart))
-(def ^:private stroke-width            (:stroke-width vc/chart))
-(def ^:private highlight-stroke-width  (:stroke-width-emphasis vc/chart))
-(def ^:private compound-pad-x          (:compound-pad-x vc/chart))
-(def ^:private compound-pad-y          (:compound-pad-y vc/chart))
-(def ^:private state-label-px          (:state-label-px vc/chart))
-(def ^:private edge-label-px           (:edge-label-px vc/chart))
-(def ^:private edge-label-backplate-opacity
-  (:edge-label-backplate-opacity vc/chart))
-(def ^:private final-glyph-px          (:final-glyph-px vc/chart))
-(def ^:private compound-title-px       (:compound-title-px vc/chart))
-(def ^:private caption-strip-px        (:caption-strip-px vc/chart))
-(def ^:private caption-text-px         (:caption-text-px vc/chart))
-(def ^:private tag-pill-height         (:tag-pill-height vc/chart))
-(def ^:private tag-pill-pad-x          (:tag-pill-pad-x vc/chart))
-(def ^:private tag-pill-px             (:tag-pill-px vc/chart))
-(def ^:private tag-pill-gap            (:tag-pill-gap vc/chart))
-(def ^:private tag-pill-row-gap        (:tag-pill-row-gap vc/chart))
-(def ^:private dot-grid-spacing-px     (:dot-grid-spacing-px vc/chart))
-(def ^:private dot-grid-radius-px      (:dot-grid-radius-px vc/chart))
-(def ^:private dot-grid-alpha          (:dot-grid-alpha vc/chart))
+;; ---- visual constants (read from vc/*chart* per render) ----------------
+;;
+;; rf2-32gw5 — the chart's geometry + typography are no longer
+;; namespace-level `def ^:private` aliases of `vc/chart`. Instead each
+;; helper destructures from the dynamic Var `vc/*chart*`, which the
+;; render entry-point rebinds per call from `:density` ∈
+;; #{:compact :regular :cosy}. The default value of `vc/*chart*` is
+;; `vc/chart-regular`, so helpers called outside `render` (the
+;; `compound-containers` public fn, tests that invoke a helper
+;; directly) see the same constants they always have. A density-
+;; aware render path nests its hiccup construction inside
+;; `(binding [vc/*chart* (vc/chart-for-density density)] ...)`; all
+;; hiccup is eagerly realised (`into` over `for`) before the binding
+;; unwinds, so the values are captured in the returned data
+;; structure, not deferred to lookup at React-mount time.
 
 (def ^:private mono-font-stack
   "Mono stack used for chart node + edge labels — payload surface.
@@ -175,7 +167,8 @@
   When the compound parent itself has no children in the projected
   graph (e.g. an empty `:states {}`) the container is dropped."
   [nodes]
-  (let [compound-parents (filter :compound? nodes)
+  (let [{:keys [compound-pad-x compound-pad-y]} vc/*chart*
+        compound-parents (filter :compound? nodes)
         ;; Group every node by the prefix-paths of its ancestors so we
         ;; can do a single pass instead of scanning per-parent.
         by-parent-path
@@ -226,26 +219,27 @@
   grouping CHROME, not data; sans reads as 'section heading' where
   mono would read as 'identifier value'."
   [{:keys [x y width height label node-id]}]
-  [:g {:data-testid (str "rf-mv-chart-compound-" node-id)
-       :data-node-id node-id}
-   [:rect {:x x :y y :width width :height height
-           :rx 10
-           :fill (tokens/with-alpha :accent-violet 0.06)
-           :stroke (:accent-violet tokens/tokens)
-           :stroke-width 1
-           :stroke-dasharray (:compound-stroke-dash vc/chart)
-           :pointer-events "none"}]
-   ;; Title strip — small label flushed top-left so the parent state's
-   ;; name reads as a "section heading" above its children.
-   (when label
-     [:text {:x (+ x 10)
-             :y (+ y 14)
-             :font-family tokens/sans-stack
-             :font-size compound-title-px
-             :font-weight 600
-             :fill (:accent-violet tokens/tokens)
-             :pointer-events "none"}
-      label])])
+  (let [{:keys [compound-stroke-dash compound-title-px]} vc/*chart*]
+    [:g {:data-testid (str "rf-mv-chart-compound-" node-id)
+         :data-node-id node-id}
+     [:rect {:x x :y y :width width :height height
+             :rx 10
+             :fill (tokens/with-alpha :accent-violet 0.06)
+             :stroke (:accent-violet tokens/tokens)
+             :stroke-width 1
+             :stroke-dasharray compound-stroke-dash
+             :pointer-events "none"}]
+     ;; Title strip — small label flushed top-left so the parent state's
+     ;; name reads as a "section heading" above its children.
+     (when label
+       [:text {:x (+ x 10)
+               :y (+ y 14)
+               :font-family tokens/sans-stack
+               :font-size compound-title-px
+               :font-weight 600
+               :fill (:accent-violet tokens/tokens)
+               :pointer-events "none"}
+        label])]))
 
 (defn- dot-grid-pattern
   "rf2-m4nj4 — define an SVG `<pattern>` painting a single tinted dot
@@ -260,21 +254,24 @@
   painted FIRST in the render order so every chart element sits
   above it."
   []
-  [:pattern {:id "rf-mv-chart-dot-grid"
-             :data-testid "rf-mv-chart-dot-grid"
-             :x 0 :y 0
-             :width dot-grid-spacing-px
-             :height dot-grid-spacing-px
-             :patternUnits "userSpaceOnUse"}
-   [:circle {:cx (/ dot-grid-spacing-px 2)
-             :cy (/ dot-grid-spacing-px 2)
-             :r dot-grid-radius-px
-             :fill (tokens/with-alpha :accent-violet dot-grid-alpha)}]])
+  (let [{:keys [dot-grid-spacing-px dot-grid-radius-px dot-grid-alpha]}
+        vc/*chart*]
+    [:pattern {:id "rf-mv-chart-dot-grid"
+               :data-testid "rf-mv-chart-dot-grid"
+               :x 0 :y 0
+               :width dot-grid-spacing-px
+               :height dot-grid-spacing-px
+               :patternUnits "userSpaceOnUse"}
+     [:circle {:cx (/ dot-grid-spacing-px 2)
+               :cy (/ dot-grid-spacing-px 2)
+               :r dot-grid-radius-px
+               :fill (tokens/with-alpha :accent-violet dot-grid-alpha)}]]))
 
 (defn- render-initial-marker
   [initial-node]
   (when initial-node
-    (let [cx (- (:x initial-node) 16)
+    (let [{:keys [stroke-width]} vc/*chart*
+          cx (- (:x initial-node) 16)
           cy (+ (:y initial-node) (quot (:height initial-node) 2))
           nx (:x initial-node)
           ny cy]
@@ -300,7 +297,9 @@
   it transforms with the node (no separate positioning logic).
   Empty / nil `tags` produces nil so the renderer can `(when ...)` it."
   [{:keys [x y width tags]}]
-  (let [pills (sort (vec tags))]
+  (let [{:keys [tag-pill-height tag-pill-pad-x tag-pill-px
+                tag-pill-gap tag-pill-row-gap]} vc/*chart*
+        pills (sort (vec tags))]
     (when (seq pills)
       (let [pill-w (fn [t]
                      (let [s (if (keyword? t) (name t) (str t))]
@@ -351,7 +350,10 @@
   [{:keys [x y width height label final? compound? node-id path]
     :as n}
    {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
-  (let [active?         (= node-id highlight-id)
+  (let [{:keys [corner-radius stroke-width compound-stroke-dash
+                state-label-px final-glyph-px]
+         highlight-stroke-width :stroke-width-emphasis} vc/*chart*
+        active?         (= node-id highlight-id)
         from-highlight? (= node-id from-highlight-id)
         to-highlight?   (= node-id to-highlight-id)
         ;; rf2-2sez0 — the previous heartbeat-pulse animation was
@@ -395,7 +397,7 @@
                :fill "none"
                :stroke (:border-subtle tokens/tokens)
                :stroke-width 1
-               :stroke-dasharray (:compound-stroke-dash vc/chart)}])
+               :stroke-dasharray compound-stroke-dash}])
      ;; Final states get a double-ring
      (when final?
        [:rect {:x (- x 3) :y (- y 3)
@@ -494,7 +496,9 @@
   [{:keys [event-label points guard action from-id to-id]
     :as _edge}
    {:keys [highlight-id from-highlight-id to-highlight-id]}]
-  (let [active?         (or (= from-id highlight-id)
+  (let [{:keys [stroke-width edge-label-px edge-label-backplate-opacity]
+         highlight-stroke-width :stroke-width-emphasis} vc/*chart*
+        active?         (or (= from-id highlight-id)
                             (= to-id   highlight-id))
         focused-edge?   (and (some? from-highlight-id)
                              (some? to-highlight-id)
@@ -605,56 +609,57 @@
   down by `caption-strip-px` when this is rendered."
   [{:keys [machine-id current-state reached-count total-count chart-width]}]
   (when (or machine-id current-state)
-    [:g {:data-testid "rf-mv-chart-caption-strip"
-         :data-machine-id (str machine-id)
-         :data-current-state (str current-state)}
-     [:rect {:x 0 :y 0
-             :width chart-width
-             :height caption-strip-px
-             :fill (tokens/with-alpha :bg-2 0.6)
-             :stroke (:border-subtle tokens/tokens)
-             :stroke-width 0.5}]
-     ;; machine-id (mono, primary)
-     (when machine-id
-       [:text {:x 12 :y (- caption-strip-px 10)
-               :font-family mono-font-stack
-               :font-size caption-text-px
-               :font-weight 600
-               :fill (:accent-violet tokens/tokens)}
-        (format-state-label machine-id)])
-     ;; separator + current-state (mono, italic, cyan)
-     (when (and machine-id current-state)
-       [:text {:x (+ 12
-                     ;; rough mono char-width estimate so the cursor
-                     ;; lands past the machine-id without measuring
-                     ;; the DOM. The strip uses sans-stack for chrome
-                     ;; punctuation between the two payload mono
-                     ;; slugs.
-                     (long (* 7 (count (format-state-label machine-id)))))
-               :y (- caption-strip-px 10)
-               :font-family tokens/sans-stack
-               :font-size caption-text-px
-               :fill (:text-tertiary tokens/tokens)}
-        " · current "])
-     (when current-state
-       [:text {:x (+ 12
-                     (long (* 7 (count (format-state-label machine-id))))
-                     ;; sans " · current " ~64px at 11px
-                     64)
-               :y (- caption-strip-px 10)
-               :font-family mono-font-stack
-               :font-size caption-text-px
-               :font-style "italic"
-               :fill (:cyan tokens/tokens)}
-        (format-state-label current-state)])
-     ;; reached/total — right-aligned (sans micro)
-     (when (and (integer? reached-count) (integer? total-count))
-       [:text {:x (- chart-width 12) :y (- caption-strip-px 10)
-               :font-family tokens/sans-stack
-               :font-size caption-text-px
-               :text-anchor "end"
-               :fill (:text-tertiary tokens/tokens)}
-        (str reached-count "/" total-count " states reached")])]))
+    (let [{:keys [caption-strip-px caption-text-px]} vc/*chart*]
+      [:g {:data-testid "rf-mv-chart-caption-strip"
+           :data-machine-id (str machine-id)
+           :data-current-state (str current-state)}
+       [:rect {:x 0 :y 0
+               :width chart-width
+               :height caption-strip-px
+               :fill (tokens/with-alpha :bg-2 0.6)
+               :stroke (:border-subtle tokens/tokens)
+               :stroke-width 0.5}]
+       ;; machine-id (mono, primary)
+       (when machine-id
+         [:text {:x 12 :y (- caption-strip-px 10)
+                 :font-family mono-font-stack
+                 :font-size caption-text-px
+                 :font-weight 600
+                 :fill (:accent-violet tokens/tokens)}
+          (format-state-label machine-id)])
+       ;; separator + current-state (mono, italic, cyan)
+       (when (and machine-id current-state)
+         [:text {:x (+ 12
+                       ;; rough mono char-width estimate so the cursor
+                       ;; lands past the machine-id without measuring
+                       ;; the DOM. The strip uses sans-stack for chrome
+                       ;; punctuation between the two payload mono
+                       ;; slugs.
+                       (long (* 7 (count (format-state-label machine-id)))))
+                 :y (- caption-strip-px 10)
+                 :font-family tokens/sans-stack
+                 :font-size caption-text-px
+                 :fill (:text-tertiary tokens/tokens)}
+          " · current "])
+       (when current-state
+         [:text {:x (+ 12
+                       (long (* 7 (count (format-state-label machine-id))))
+                       ;; sans " · current " ~64px at 11px
+                       64)
+                 :y (- caption-strip-px 10)
+                 :font-family mono-font-stack
+                 :font-size caption-text-px
+                 :font-style "italic"
+                 :fill (:cyan tokens/tokens)}
+          (format-state-label current-state)])
+       ;; reached/total — right-aligned (sans micro)
+       (when (and (integer? reached-count) (integer? total-count))
+         [:text {:x (- chart-width 12) :y (- caption-strip-px 10)
+                 :font-family tokens/sans-stack
+                 :font-size caption-text-px
+                 :text-anchor "end"
+                 :fill (:text-tertiary tokens/tokens)}
+          (str reached-count "/" total-count " states reached")])])))
 
 ;; ---- public entry -------------------------------------------------------
 
@@ -701,6 +706,17 @@
                            interactive controls wrap the chart with
                            wheel-zoom / click-drag-pan / keyboard
                            handlers without forking `render`.
+    :density             — rf2-32gw5. One of `:compact / :regular /
+                           :cosy` (or `nil` ≡ `:regular`). Picks the
+                           geometry + typography variant from
+                           `visual-constants/chart-for-density` and
+                           binds it on `vc/*chart*` for the duration
+                           of this render. Hosts pick `:compact` for
+                           thumbnail-grid displays (Story's 50-chart
+                           panel), `:regular` for the chart-floor
+                           default (Causa's machines tab), `:cosy`
+                           for single-chart presentation displays.
+                           An unknown keyword throws.
 
   Returns a stable hiccup form. Empty graphs (no nodes) render an
   inline note so the panel never sees an empty SVG container."
@@ -708,9 +724,17 @@
   ([{:keys [nodes edges width height] :as positioned}
     {:keys [highlight-id from-highlight-id to-highlight-id
             sim? on-state-click testid show-caption? caption
-            viewport-transform svg-attrs]}]
+            viewport-transform svg-attrs density]}]
+   ;; rf2-32gw5 — every helper destructures `vc/*chart*`; binding it
+   ;; here per `:density` is the one-knob switch that propagates
+   ;; through the whole render pass. All hiccup is eagerly realised
+   ;; (every `into` over `for` walks its seq before returning) so the
+   ;; constants are captured in the returned data structure, not
+   ;; deferred to React-mount time.
+   (binding [vc/*chart* (vc/chart-for-density density)]
    (if (empty? nodes)
      [:div {:data-testid (or testid "rf-mv-chart-empty")
+            :data-density (name (or density :regular))
             :style {:padding "16px"
                     ;; rf2-trorn — sans-stack token rather than the
                     ;; previous `'Inter, system-ui, ...'` literal.
@@ -718,7 +742,8 @@
                     :font-size "12px"
                     :color (:text-tertiary tokens/tokens)}}
       "Machine has no states to render."]
-     (let [initial-node (some (fn [n]
+     (let [{:keys [caption-strip-px]} vc/*chart*
+           initial-node (some (fn [n]
                                 (when (and (:initial? n)
                                            (= 0 (:depth n))) n))
                               nodes)
@@ -752,6 +777,10 @@
                            :data-from-highlight-id (or from-highlight-id "")
                            :data-to-highlight-id (or to-highlight-id "")
                            :data-has-caption (str (boolean show-caption?))
+                           ;; rf2-32gw5 — surface the resolved density
+                           ;; so tests + hosts can inspect it without
+                           ;; re-reading the bound prop.
+                           :data-density (name (or density :regular))
                            :data-viewport-scale (str scale)
                            :data-viewport-tx (str tx)
                            :data-viewport-ty (str ty)
@@ -834,7 +863,7 @@
                                 :from-highlight-id from-highlight-id
                                 :to-highlight-id   to-highlight-id
                                 :sim?              sim?
-                                :on-state-click    on-state-click})))]]]))))
+                                :on-state-click    on-state-click})))]]])))))
 
 (defn render-from-definition
   "Convenience: lay out + render in one call. Useful for the panel

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -5,22 +5,36 @@
   rf2-g6cig — the chart was previously sprinkled with magic numbers
   (`corner-radius 8`, `stroke-width 1.5`, `pad-x 16`, font sizes 9 / 7,
   etc.). Lifting them into one map keeps the chart's visual character
-  legible at a glance and makes a future density toggle (compact /
-  cosy / comfy) a one-knob change.
+  legible at a glance.
 
-  rf2-cd053 / rf2-gg7ws — state-label + edge-label font sizes
-  walked up from the previous spec/007-UX-IA refused-floor (11 / 9)
-  to a chart-appropriate 13 / 11 per the 2026-05-20 visual-quality
-  lift. The refused-floor was set for dense data-grid surfaces;
-  applying it to a chart that competes with xstate-stately's
-  typography was a category error (see audit Finding #2). Node
-  geometry adapts via wider nodes (`:node-width-px` in
-  `chart.layout`).
+  rf2-32gw5 — the chart ships THREE density variants:
+  `chart-compact`, `chart-regular`, `chart-cosy`. The previous
+  docstring 'a future density toggle (compact / cosy / comfy)' was a
+  forward-promise that has now landed. The naming settled on
+  `compact / regular / cosy` (per bead title); `regular` is the
+  load-bearing chart-floor floor (per rf2-gg7ws) and the default
+  every consumer gets when `:density` is unspecified or `nil`.
+  `compact` shrinks geometry + typography proportionally for grid
+  layouts (Story's 50-chart panel grid); `cosy` widens both for the
+  single-chart-display case (Causa's machines tab on a wide
+  monitor). Hosts pick one via the chart's `:density` prop. The
+  three maps share the SAME key set (asserted by
+  `visual-constants-cljs-test`); a key in one is a key in all.
 
-  rf2-g6cig — corner-radius locked at 6px. The React Flow default
-  (8) reads as 'product chrome'; brutalist (0) reads as 'wireframe';
-  6 is the sweet spot — soft enough to feel finished, sharp enough
-  to read as 'data, not product'. Locked 2026-05-19.
+  rf2-cd053 / rf2-gg7ws — `chart-regular` state-label + edge-label
+  font sizes walked up from the previous spec/007-UX-IA refused-floor
+  (11 / 9) to a chart-appropriate 13 / 11 per the 2026-05-20 visual-
+  quality lift. The refused-floor was set for dense data-grid
+  surfaces; applying it to a chart that competes with xstate-stately's
+  typography was a category error. `chart-compact` deliberately walks
+  back to 11/9 since the compact density IS the dense-grid surface
+  the original floor existed for; `chart-cosy` walks up to 15/13.
+
+  rf2-g6cig — corner-radius locked at 6px across every density. The
+  React Flow default (8) reads as 'product chrome'; brutalist (0)
+  reads as 'wireframe'; 6 is the sweet spot — soft enough to feel
+  finished, sharp enough to read as 'data, not product'. Locked
+  2026-05-19. Density does not unlock this.
 
   rf2-2sez0 — heartbeat-pulse animation removed 2026-05-20. The
   active state's static affordance (cyan tint + emphasised stroke)
@@ -29,11 +43,14 @@
   cueing. `:pulse-stroke-width-add` retired with the animation."
   {:no-doc true})
 
-(def chart
-  "Chart visual constants. Keys:
+(def chart-regular
+  "Chart visual constants — REGULAR density (the default).
+
+  Keys:
 
     :corner-radius            — node rounded-corner radius in px
-                                (rf2-g6cig lock: 6)
+                                (rf2-g6cig lock: 6 across every
+                                density)
     :stroke-width             — default node + edge stroke width
     :stroke-width-emphasis    — emphasised node/edge stroke width
                                 (active / focused-event lens)
@@ -43,9 +60,9 @@
                                 leaves room for the title strip)
     :compound-stroke-dash     — dashed pattern for compound borders
     :state-label-px           — state node label font-size
-                                (rf2-gg7ws lift — 13)
+                                (rf2-gg7ws lift — regular: 13)
     :edge-label-px            — edge label font-size
-                                (rf2-gg7ws lift — 11)
+                                (rf2-gg7ws lift — regular: 11)
     :edge-label-backplate-opacity
                               — opacity of the small white rect
                                 painted behind each edge label so
@@ -75,7 +92,7 @@
    :compound-pad-y         24
    :compound-stroke-dash   "4 3"
 
-   ;; ── typography (rf2-gg7ws — lifted from 11/9 to 13/11) ───────
+   ;; ── typography (rf2-gg7ws — chart-regular floor 13/11) ───────
    :state-label-px         13
    :edge-label-px          11
    :edge-label-backplate-opacity 0.85
@@ -95,3 +112,156 @@
    :dot-grid-spacing-px    16
    :dot-grid-radius-px     1.0
    :dot-grid-alpha         0.06})
+
+(def chart-compact
+  "Chart visual constants — COMPACT density.
+
+  Smaller nodes, smaller type, tighter gaps. Targets the 50-chart
+  Story grid where each chart is a thumbnail and the user's eye
+  scans the grid for shape rather than reading individual labels.
+
+  Walks the typography back to the spec/007-UX-IA refused-floor
+  (11 / 9) — the refused-floor was set for dense data-grid surfaces,
+  and the compact density IS the dense-grid surface it existed for.
+
+  Geometry is pulled in by ~25% (paddings, pill height, dot-grid
+  spacing); corner-radius is unchanged because the rf2-g6cig lock
+  applies across every density (a wireframe-looking thumbnail is
+  still wrong).
+
+  Shares the SAME key set as `chart-regular` (asserted by
+  visual-constants-cljs-test rf2-32gw5)."
+  {;; ── geometry (~25% tighter) ──────────────────────────────────
+   :corner-radius          6           ;; rf2-g6cig lock — same in every density
+   :stroke-width           1.0
+   :stroke-width-emphasis  2.0
+   :compound-pad-x         10
+   :compound-pad-y         18
+   :compound-stroke-dash   "3 2"
+
+   ;; ── typography (rf2-gg7ws refused-floor revisited for thumbnails)
+   :state-label-px         11
+   :edge-label-px          9
+   :edge-label-backplate-opacity 0.85
+   :final-glyph-px         11
+   :compound-title-px      11
+   :caption-strip-px       22
+   :caption-text-px        9
+
+   ;; ── state-tag pills ──────────────────────────────────────────
+   :tag-pill-height        10
+   :tag-pill-pad-x         4
+   :tag-pill-px            7
+   :tag-pill-gap           2
+   :tag-pill-row-gap       3
+
+   ;; ── dot-grid background ──────────────────────────────────────
+   :dot-grid-spacing-px    12
+   :dot-grid-radius-px     0.85
+   :dot-grid-alpha         0.06})
+
+(def chart-cosy
+  "Chart visual constants — COSY density.
+
+  Larger nodes, larger type, more breathing room. Targets the
+  single-chart-display case — Causa's machines tab on a wide monitor
+  or a presentation-mode standalone viewer. The user is reading the
+  chart, not scanning a grid; labels are payload, not decoration.
+
+  Walks the typography up to 15 / 13. Geometry widens by ~25%
+  (paddings, pill height, dot-grid spacing). Corner-radius is
+  unchanged per the rf2-g6cig lock — the chart's visual character
+  must read consistently across densities; only quantity scales,
+  not identity.
+
+  Shares the SAME key set as `chart-regular` (asserted by
+  visual-constants-cljs-test rf2-32gw5)."
+  {;; ── geometry (~25% looser) ───────────────────────────────────
+   :corner-radius          6           ;; rf2-g6cig lock — same in every density
+   :stroke-width           1.75
+   :stroke-width-emphasis  3.0
+   :compound-pad-x         20
+   :compound-pad-y         30
+   :compound-stroke-dash   "5 4"
+
+   ;; ── typography (walked up one notch from the regular floor) ──
+   :state-label-px         15
+   :edge-label-px          13
+   :edge-label-backplate-opacity 0.85
+   :final-glyph-px         15
+   :compound-title-px      15
+   :caption-strip-px       34
+   :caption-text-px        13
+
+   ;; ── state-tag pills ──────────────────────────────────────────
+   :tag-pill-height        14
+   :tag-pill-pad-x         6
+   :tag-pill-px            10
+   :tag-pill-gap           4
+   :tag-pill-row-gap       5
+
+   ;; ── dot-grid background ──────────────────────────────────────
+   :dot-grid-spacing-px    20
+   :dot-grid-radius-px     1.15
+   :dot-grid-alpha         0.06})
+
+(def chart
+  "Default chart visual constants — alias for `chart-regular`.
+
+  Direct consumers may continue to reference `vc/chart` for the
+  regular-density map. The `MachineChart` component's `:density`
+  prop (per `tools/machines-viz/spec/API.md` §Density) picks one of
+  the three named maps at render time; this Var is the resolved
+  value when `:density` is unspecified."
+  chart-regular)
+
+(def ^:dynamic *chart*
+  "The currently-resolved chart visual-constants map. Defaults to
+  `chart-regular`. The `MachineChart` render entry (`chart.svg/render`)
+  rebinds this for the duration of a single render pass to the
+  density picked by `:density`; helpers inside the renderer read
+  their geometry / typography off this dynamic Var instead of off
+  the namespace-level `chart` Var so a single chart instance can
+  render at compact, regular, or cosy without re-wiring the helper
+  graph.
+
+  Test-only, non-public consumers may rebind this directly via
+  `binding`; production callers go through the `:density` prop. Per
+  rf2-32gw5."
+  chart-regular)
+
+(def densities
+  "The complete catalogue of density keywords accepted by
+  `chart-for-density` (and, transitively, the `MachineChart`
+  `:density` prop). Exposed as a Var so hosts that want to render a
+  picker UI can enumerate the choices without hardcoding."
+  [:compact :regular :cosy])
+
+(def ^:private density->chart-map
+  {:compact chart-compact
+   :regular chart-regular
+   :cosy    chart-cosy})
+
+(defn chart-for-density
+  "Resolve a density keyword to its chart visual-constants map.
+
+  - `:compact`  → `chart-compact`  (thumbnail-grid density)
+  - `:regular`  → `chart-regular`  (default — chart-appropriate floor)
+  - `:cosy`     → `chart-cosy`     (presentation density)
+  - `nil`       → `chart-regular`  (the implicit default)
+  - any other → throws `ex-info` with the offending value; an
+                unrecognised density is a programmer error, not a
+                runtime fallback (per rf2-32gw5: hosts pick from the
+                closed set or the chart rejects).
+
+  Pure fn — JVM-runnable. The MachineChart component calls this once
+  per render, then threads the resolved map through every helper."
+  [density]
+  (cond
+    (nil? density) chart-regular
+    (contains? density->chart-map density) (get density->chart-map density)
+    :else
+    (throw (ex-info (str "Unknown chart density: " (pr-str density)
+                         ". Expected one of " (pr-str densities) ".")
+                    {:density   density
+                     :expected  densities}))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
@@ -698,3 +698,91 @@
             (str "no `[` in event-only label: " l))
         (is (not (str/includes? l "/"))
             (str "no `/` in event-only label: " l))))))
+
+;; ---- rf2-32gw5 — density variants --------------------------------------
+;;
+;; `:density ∈ #{:compact :regular :cosy}` picks one of three named maps
+;; in `visual-constants`. The renderer binds `vc/*chart*` for the
+;; duration of the render pass; helpers destructure off the dynamic Var.
+;; Tests assert (a) the density surfaces on the root `<svg>` as a
+;; `data-density` attr (so hosts / tests can read it back), (b) the
+;; helper-emitted font-size + geometry tracks the chosen density, and
+;; (c) unknown densities throw.
+
+(defn- node-text-font-sizes
+  "Collect every `:font-size` value from `<text>` nodes inside the
+  chart's `rf-mv-chart-nodes` group. Used to assert state-label-px
+  threads through to the rendered hiccup per density."
+  [tree]
+  (let [nodes-g (find-by-testid tree "rf-mv-chart-nodes")]
+    (->> (hiccup-seq nodes-g)
+         (keep (fn [n]
+                 (when (and (vector? n)
+                            (= :text (first n))
+                            (map? (second n)))
+                   (:font-size (second n)))))
+         (filter number?)
+         set)))
+
+(deftest render-density-defaults-to-regular
+  (testing "rf2-32gw5 — no :density option ≡ :regular. The root svg
+            surfaces `data-density=regular`; node label font-sizes
+            match `vc/chart-regular`'s `:state-label-px`."
+    (let [tree (chart-svg/render-from-definition small-machine)
+          [_ root-attrs] tree
+          sizes (node-text-font-sizes tree)]
+      (is (= "regular" (:data-density root-attrs)))
+      (is (contains? sizes (:state-label-px vc/chart-regular))
+          "regular density propagates state-label-px=13"))))
+
+(deftest render-density-compact-data-attr
+  (testing "rf2-32gw5 — :density :compact surfaces on the root svg
+            and the node labels render at the compact font size"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine {:density :compact})
+          [_ root-attrs] tree
+          sizes (node-text-font-sizes tree)]
+      (is (= "compact" (:data-density root-attrs)))
+      (is (contains? sizes (:state-label-px vc/chart-compact))
+          "compact density propagates state-label-px=11")
+      (is (not (contains? sizes (:state-label-px vc/chart-cosy)))
+          "compact does NOT leak cosy's state-label-px"))))
+
+(deftest render-density-cosy-data-attr
+  (testing "rf2-32gw5 — :density :cosy surfaces on the root svg and
+            the node labels render at the cosy font size"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine {:density :cosy})
+          [_ root-attrs] tree
+          sizes (node-text-font-sizes tree)]
+      (is (= "cosy" (:data-density root-attrs)))
+      (is (contains? sizes (:state-label-px vc/chart-cosy))
+          "cosy density propagates state-label-px=15"))))
+
+(deftest render-density-nil-is-regular
+  (testing "rf2-32gw5 — explicit :density nil ≡ unspecified ≡ regular"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine {:density nil})
+          [_ root-attrs] tree]
+      (is (= "regular" (:data-density root-attrs))))))
+
+(deftest render-density-rejects-unknown
+  (testing "rf2-32gw5 — an unrecognised density throws at render
+            time. Hosts pick from the closed set or the chart
+            refuses to render — no silent fallback."
+    (is (thrown? #?(:clj  Exception
+                    :cljs js/Error)
+                 (chart-svg/render-from-definition
+                   small-machine {:density :spacious})))))
+
+(deftest render-density-binding-unwinds
+  (testing "rf2-32gw5 — after a non-default density render, the
+            namespace-level `vc/*chart*` Var resets to its default
+            (chart-regular). The `binding` form must unwind even
+            when hiccup is eagerly realised inside it."
+    (chart-svg/render-from-definition small-machine {:density :compact})
+    (is (= vc/chart-regular vc/*chart*)
+        "vc/*chart* returns to chart-regular after a :compact render")
+    (chart-svg/render-from-definition small-machine {:density :cosy})
+    (is (= vc/chart-regular vc/*chart*)
+        "vc/*chart* returns to chart-regular after a :cosy render")))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -15,6 +15,12 @@
   value (that's `visual_constants.cljc` itself, deliberately literal
   so a code review can spot drift).
 
+  rf2-32gw5 — pins extended to the three density variants
+  (`chart-compact / chart-regular / chart-cosy`): each density has
+  the SAME key set as the others, the corner-radius lock (rf2-g6cig)
+  holds across every density, and `chart-for-density` resolves the
+  closed catalogue + throws on unknown densities.
+
   Cites audit Gap-4."
   (:require
     #?(:clj  [clojure.test :refer [deftest is testing]]
@@ -126,3 +132,106 @@
     (let [a (:dot-grid-alpha vc/chart)]
       (is (pos? a))
       (is (< a 1.0)))))
+
+;; ---- density variants (rf2-32gw5) --------------------------------------
+;;
+;; The three density variants share the SAME key set as the regular map;
+;; a typo / accidental dissoc in one variant would surface as a runtime
+;; nil through the renderer's destructure. Pin the equality directly.
+
+(deftest chart-default-is-regular
+  (testing "rf2-32gw5 — `vc/chart` is the regular-density alias. A
+            consumer reaching for `vc/chart` gets exactly the
+            regular map; the chart-floor (rf2-gg7ws) lift was set at
+            the regular density and that's the default identity."
+    (is (= vc/chart vc/chart-regular))))
+
+(deftest density-variants-share-key-set
+  (testing "rf2-32gw5 — every density carries the same key set as
+            `chart-regular`. A key in one is a key in all; a density
+            that diverged would surface as a runtime nil from a
+            helper destructure that's perfectly correct for the
+            regular density."
+    (is (= expected-chart-keys (set (keys vc/chart-compact))))
+    (is (= expected-chart-keys (set (keys vc/chart-regular))))
+    (is (= expected-chart-keys (set (keys vc/chart-cosy))))))
+
+(deftest density-variants-have-no-nil-values
+  (testing "rf2-32gw5 — no entry in any density resolves to nil"
+    (is (every? some? (vals vc/chart-compact)))
+    (is (every? some? (vals vc/chart-regular)))
+    (is (every? some? (vals vc/chart-cosy)))))
+
+(deftest density-variants-respect-corner-radius-lock
+  (testing "rf2-g6cig — corner-radius is locked at 6 across every
+            density. Density scales QUANTITY (type size, padding,
+            stroke); it must not alter the chart's visual IDENTITY.
+            The rounded-rect 'data, not product' character holds."
+    (is (= 6 (:corner-radius vc/chart-compact)))
+    (is (= 6 (:corner-radius vc/chart-regular)))
+    (is (= 6 (:corner-radius vc/chart-cosy)))))
+
+(deftest density-typography-monotonic
+  (testing "rf2-32gw5 — `state-label-px` is monotonic across the
+            density axis: compact < regular < cosy. If a density's
+            type walks back or up unexpectedly the picker UI would
+            ship a 'cosy' value that's actually tighter than
+            'regular' — a labelling bug. Same monotonicity holds for
+            edge labels."
+    (is (< (:state-label-px vc/chart-compact)
+           (:state-label-px vc/chart-regular)
+           (:state-label-px vc/chart-cosy)))
+    (is (< (:edge-label-px vc/chart-compact)
+           (:edge-label-px vc/chart-regular)
+           (:edge-label-px vc/chart-cosy)))))
+
+(deftest density-geometry-monotonic
+  (testing "rf2-32gw5 — compound padding + dot-grid spacing are also
+            monotonic. Compact tightens; cosy loosens. Density is
+            ONE knob — every quantity that should track it does."
+    (is (< (:compound-pad-x vc/chart-compact)
+           (:compound-pad-x vc/chart-regular)
+           (:compound-pad-x vc/chart-cosy)))
+    (is (< (:dot-grid-spacing-px vc/chart-compact)
+           (:dot-grid-spacing-px vc/chart-regular)
+           (:dot-grid-spacing-px vc/chart-cosy)))))
+
+(deftest densities-catalogue-is-closed
+  (testing "rf2-32gw5 — the `densities` Var enumerates the closed
+            choice set hosts pick from. Three entries, no more, no
+            less. New densities require a deliberate spec amendment."
+    (is (= [:compact :regular :cosy] vc/densities))))
+
+(deftest chart-for-density-resolves-named-densities
+  (testing "rf2-32gw5 — every named density resolves to its map"
+    (is (= vc/chart-compact (vc/chart-for-density :compact)))
+    (is (= vc/chart-regular (vc/chart-for-density :regular)))
+    (is (= vc/chart-cosy    (vc/chart-for-density :cosy)))))
+
+(deftest chart-for-density-nil-is-regular
+  (testing "rf2-32gw5 — nil (the implicit default; `:density` prop
+            omitted) resolves to `chart-regular`. Hosts that never
+            pass `:density` get exactly the pre-rf2-32gw5 chart."
+    (is (= vc/chart-regular (vc/chart-for-density nil)))))
+
+(deftest chart-for-density-unknown-throws
+  (testing "rf2-32gw5 — an unrecognised density is a programmer
+            error, not a silent fallback. The host either picks
+            from the closed set or the chart refuses to render."
+    (is (thrown? #?(:clj  Exception
+                    :cljs js/Error)
+                 (vc/chart-for-density :spacious)))
+    (is (thrown? #?(:clj  Exception
+                    :cljs js/Error)
+                 (vc/chart-for-density :super-compact)))
+    (is (thrown? #?(:clj  Exception
+                    :cljs js/Error)
+                 (vc/chart-for-density "regular"))))) ;; string, not kw
+
+(deftest dynamic-chart-default-is-regular
+  (testing "rf2-32gw5 — `vc/*chart*` defaults to `chart-regular`
+            outside any `binding`. Helpers that destructure off
+            `vc/*chart*` outside the renderer's binding scope see
+            the same constants the namespace-level alias provided
+            before rf2-32gw5."
+    (is (= vc/chart-regular vc/*chart*))))


### PR DESCRIPTION
## Summary

Resolves the `visual_constants.cljc` doc-string's forward-promise — "a future density toggle (compact / cosy / comfy) a one-knob change" — by shipping three named density variants for the MachineChart. Naming settled on **compact / regular / cosy** (per the bead title — `regular` is the chart-floor default now that the rf2-gg7ws lift put the previous-default size at the floor of three rungs rather than the only rung).

- **`chart-compact`** — state-label 11 / edge-label 9; geometry tightened ~25%. Targets Story's 50-chart panel grid + thumbnail listings.
- **`chart-regular`** — state-label 13 / edge-label 11 (the existing rf2-gg7ws chart-floor). Default when `:density` is unspecified.
- **`chart-cosy`** — state-label 15 / edge-label 13; geometry loosened ~25%. Targets Causa's single-chart presentation displays.

Hosts pick one via `:density` on `MachineChart` (and `chart.svg/render`). The render entry rebinds a new dynamic Var `visual-constants/*chart*` for the duration of the call; every helper inside `chart.svg` destructures off `vc/*chart*` instead of namespace-level `def ^:private` aliases. A single chart instance can render at any density without forking the helper graph. The resolved density surfaces on the root `<svg>` as `data-density`.

### Invariants preserved (identity, not quantity)

- `:corner-radius` is locked at **6** across every density per the rf2-g6cig lock — density scales QUANTITY, not IDENTITY.
- `:edge-label-backplate-opacity` + `:dot-grid-alpha` are invariant per their original rationales.
- Every other geometry/typography knob (`stroke-width`, paddings, pill geometry, `*-px` font sizes, dot-grid spacing/radius) tracks the density axis monotonically: `compact < regular < cosy`. Tests assert the monotonicity directly so a future swap that breaks the ordering fails CI.

### No back-compat shims (pre-alpha)

- `chart-for-density` throws on unknown densities — no silent fallback.
- The legacy `vc/chart` Var continues as an alias for `chart-regular` (the default identity); it is NOT a deprecation shim — it remains the canonical handle for the regular-density map.

### Spec + tests

- `tools/machines-viz/spec/API.md` gains a §Density section and a `:density` row in the prop table.
- `visual-constants-cljs-test` pins the shared key set across variants, the corner-radius lock, the monotonicity contract, and the unknown-density throw.
- `chart/svg_cljs_test` pins that `:density` surfaces on `data-density`, the chosen density's `state-label-px` propagates through to the rendered hiccup, and the binding form unwinds cleanly after `render` returns.

Bead: rf2-32gw5 (P3, machines-viz density variants).
Disjoint from open PRs (#1670 story spec, #1672 impl/core strip, #1673 spec/Privacy.md, #1674 template lefthook).

## Test plan

- [x] `cd implementation && npm run test:cljs` — 3620 tests / 10379 assertions / 0 failures
- [x] `mkdocs build --strict` — passes
- [ ] CI re-runs the same gates plus bundle-isolation, perf-bundle, mcp-conformance.