### PR TITLE
feat(story): :teardown slot on :frame-setup decorators — rf2-dg2uh

### DIFF
--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -48,7 +48,14 @@
             [re-frame.story.decorators :as decorators]
             [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.loaders    :as loaders]
-            [re-frame.story.registrar  :as registrar]))
+            [re-frame.story.registrar  :as registrar]
+            ;; rf2-dg2uh — trace-listener pattern for the teardown
+            ;; exception-projection path: re-frame's interceptor chain
+            ;; catches handler exceptions internally and emits
+            ;; `:rf.error/handler-exception` trace events rather than
+            ;; re-throwing (per `runtime/capture-phase-errors` —
+            ;; the same listener pattern is used here for phase-teardown).
+            [re-frame.trace.tooling    :as trace-tooling]))
 
 ;; ---- fx-override-stub registration ---------------------------------------
 ;;
@@ -158,9 +165,139 @@
       (doseq [ev init-events]
         (rf/dispatch-sync ev {:frame frame-id})))))
 
+;; ---- :frame-setup decorator teardown -------------------------------------
+
+(defn- teardown-exception-record
+  "Build the `:rf.error/exception` assertion record projected when a
+  `:teardown` event throws. Per `002-Runtime.md` §Error projection and
+  §Loader teardown contract — phase is `:phase-teardown`, the record
+  lands in `:rf.story/assertions` so the variant's last result-map
+  surfaces the failure (the play / variant pane renders it inline)."
+  [variant-id event err]
+  {:assertion  :rf.error/exception
+   :variant-id variant-id
+   :phase      :phase-teardown
+   :event      event
+   :error      {:message #?(:clj  (.getMessage ^Throwable err)
+                            :cljs (str err))
+                :stack   #?(:clj  (with-out-str (.printStackTrace ^Throwable err))
+                            :cljs (.-stack err))
+                :data    (when (instance? #?(:clj clojure.lang.ExceptionInfo
+                                             :cljs ExceptionInfo) err)
+                           (ex-data err))}
+   :passed?    false})
+
+(defonce ^:private teardown-capture-counter (atom 0))
+
+(defn- with-teardown-trace-listener
+  "Register `listener` against a fresh capture id, run `body-fn` (a
+  0-arg thunk), then remove the listener in a `finally`. Returns
+  `body-fn`'s return value.
+
+  Mirrors `re-frame.story.runtime/with-trace-listener` — that helper is
+  private to runtime.cljc; replicating it here keeps the
+  `frames → runtime` arrow unidirectional (frames is leaf-level)."
+  [listener body-fn]
+  (let [cb-id (keyword "re-frame.story.frames"
+                       (str "teardown-capture-"
+                            (swap! teardown-capture-counter inc)))]
+    (trace-tooling/register-trace-cb! cb-id listener)
+    (try (body-fn)
+      (finally (trace-tooling/remove-trace-cb! cb-id)))))
+
+(defn- apply-frame-teardown!
+  "Walk the resolved `:frame-setup` decorators IN REVERSE-DECLARATION
+  ORDER and dispatch-sync each decorator's `:teardown` events against
+  the variant's frame. Per `001-Authoring.md` §`:teardown` — symmetric
+  counterpart of `:init` and `002-Runtime.md` §Loader teardown contract
+  step 3.
+
+  Composition order. Innermost (variant-level) teardowns fire BEFORE
+  outermost (story-level / global) teardowns — mirrors function-scope
+  cleanup conventions. The resolver concatenates
+  `(global → story → variant)` in declared order; reversing the stack
+  walks innermost → outermost.
+
+  Inside each decorator the declared `:teardown` events fire in
+  declared order — symmetric to `:init` (which fires events in
+  declared order too).
+
+  Exception handling. re-frame's interceptor chain catches handler
+  exceptions internally and emits a `:rf.error/handler-exception`
+  trace event rather than re-throwing (per spec/009 §Error trace).
+  We register a trace listener for the duration of the walk that
+  collects each captured exception, then project them onto the
+  variant frame's `[:rf.story/assertions]` as `:rf.error/exception`
+  records with `:phase :phase-teardown`. The walk continues —
+  teardown never aborts `destroy-frame!`. Synchronous throws (from
+  outside the interceptor chain — rare) are also caught directly via
+  the wrapping `try/catch`."
+  [variant-id frame-setup-decorators]
+  (let [pending  (atom [])
+        drain!   (fn []
+                   ;; Drain pending captured exceptions into the
+                   ;; variant frame's [:rf.story/assertions] BEFORE the
+                   ;; next teardown dispatch — so a later teardown event
+                   ;; (e.g. an outer decorator's :teardown) reading the
+                   ;; assertions slot sees earlier failures already
+                   ;; projected. Mirrors the spec's "land in the
+                   ;; variant's last :rf.story/assertions record"
+                   ;; contract for in-order observability.
+                   (when-let [evs (seq @pending)]
+                     (reset! pending [])
+                     (doseq [tev evs]
+                       (let [orig-event (get-in tev [:tags :event])
+                             err        (get-in tev [:tags :exception])
+                             record     (teardown-exception-record
+                                          variant-id orig-event err)]
+                         (try
+                           (rf/dispatch-sync [::append-teardown-assertion record]
+                                             {:frame variant-id})
+                           (catch #?(:clj Throwable :cljs :default) _ nil))))))
+        listener (fn [ev]
+                   (when (and (= :rf.error/handler-exception (:operation ev))
+                              (= variant-id (get-in ev [:tags :frame])))
+                     (swap! pending conj ev)))]
+    (with-teardown-trace-listener
+      listener
+      (fn []
+        (doseq [r (reverse frame-setup-decorators)]
+          (let [body            (:body r)
+                teardown-events (:teardown body)]
+            (doseq [ev teardown-events]
+              (try
+                (rf/dispatch-sync ev {:frame variant-id})
+                (catch #?(:clj Throwable :cljs :default) err
+                  ;; Synchronous throw (outside the interceptor chain).
+                  ;; Project directly. The trace-listener path covers
+                  ;; in-handler throws that the interceptor chain catches.
+                  (let [record (teardown-exception-record variant-id ev err)]
+                    (try
+                      (rf/dispatch-sync [::append-teardown-assertion record]
+                                        {:frame variant-id})
+                      (catch #?(:clj Throwable :cljs :default) _ nil)))))
+              ;; Drain after every teardown dispatch so the next
+              ;; teardown event sees the projected record.
+              (drain!))))))
+    ;; Final drain — catch any trace events that arrived after the last
+    ;; dispatch inside the listener-bound region. (Shouldn't happen for
+    ;; dispatch-sync, but the belt-and-braces drain costs nothing.)
+    (let [collected @pending]
+      (reset! pending [])
+      (doseq [tev collected]
+        (let [orig-event (get-in tev [:tags :event])
+              err        (get-in tev [:tags :exception])
+              record     (teardown-exception-record variant-id orig-event err)]
+          (try
+            (rf/dispatch-sync [::append-teardown-assertion record]
+                              {:frame variant-id})
+            (catch #?(:clj Throwable :cljs :default) _ nil)))))))
+
 (defn install-helpers!
   "Register Story-internal helper events: `::apply-app-db-patch` for
-  `:frame-setup` decorators' `:app-db-patch` slot. Idempotent."
+  `:frame-setup` decorators' `:app-db-patch` slot, and
+  `::append-teardown-assertion` for the `:teardown` exception
+  projection path. Idempotent."
   []
   (when config/enabled?
     (rf/reg-event-db
@@ -170,7 +307,11 @@
           (fn [d path v]
             (assoc-in d (if (vector? path) path [path]) v))
           db
-          patch)))))
+          patch)))
+    (rf/reg-event-db
+      ::append-teardown-assertion
+      (fn [db [_ record]]
+        (update db :rf.story/assertions (fnil conj []) record)))))
 
 ;; ---- allocation -----------------------------------------------------------
 
@@ -249,15 +390,37 @@
 ;; ---- destruction ----------------------------------------------------------
 
 (defn destroy!
-  "Tear down a variant frame. Clears the lifecycle watcher table for
-  the frame, drops per-frame assertion + stub accumulators, then
-  calls `rf/destroy-frame!`. Returns nil."
+  "Tear down a variant frame. Per `002-Runtime.md` §Loader teardown
+  contract — §What the runtime guarantees the destroy walk is:
+
+  1. Drop per-variant assertion accumulators (`drop-assertion-accumulators`
+     late-bind shim) + per-frame stub-call log.
+  2. Clear lifecycle watchers (`loaders/clear-watchers!`).
+  3. Dispatch-sync the variant's `:frame-setup` decorator `:teardown`
+     events in reverse-declaration order. Exceptions are caught and
+     projected into the variant frame's `:rf.story/assertions` as
+     `:rf.error/exception` records with `:phase :phase-teardown`. The
+     walk never aborts.
+  4. Machines spawned into the variant frame receive
+     `:rf.machine/destroy` (existing spec/005 contract, executed
+     inside `rf/destroy-frame!`).
+  5. `rf/destroy-frame!` runs the frame's own teardown walk.
+
+  Returns nil."
   [variant-id]
   (when config/enabled?
     (loaders/clear-watchers! variant-id)
     (clear-stub-call-log! variant-id)
     (when-let [drop (late-bind/get-fn :drop-assertion-accumulators)]
       (try (drop variant-id) (catch #?(:clj Throwable :cljs :default) _ nil)))
+    ;; Run `:frame-setup` decorator `:teardown` events. Resolve the
+    ;; decorator stack here (rather than carrying it through the
+    ;; destroy! signature) so the caller surface stays unchanged —
+    ;; `destroy-variant!` takes only a variant-id.
+    (try
+      (let [stack (decorators/resolve-decorators variant-id)]
+        (apply-frame-teardown! variant-id (:frame-setup stack)))
+      (catch #?(:clj Throwable :cljs :default) _ nil))
     (rf/destroy-frame! variant-id)
     nil))
 

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -599,17 +599,26 @@
 (def DecoratorFrameSetup
   "`:frame-setup`-kind decorator — declares pre-render setup. Either an
   ordered list of events to dispatch into the variant's frame
-  (`:init`), or a static app-db patch (`:app-db-patch`), or both."
+  (`:init`), or a static app-db patch (`:app-db-patch`), or both.
+
+  Optionally carries a `:teardown` vector of events — the symmetric
+  counterpart to `:init` — dispatch-sync'd into the variant's frame at
+  destroy time. Per `001-Authoring.md` §`:teardown` — symmetric
+  counterpart of `:init` and `002-Runtime.md` §Loader teardown contract.
+  Composition order at destroy is reverse-declaration: innermost
+  decorator's `:teardown` runs first. The slot is optional; only `:init`,
+  `:app-db-patch`, or `:teardown` need be present (any combination)."
   [:and
    [:map
     [:doc          {:optional true} :string]
     [:kind         [:= :frame-setup]]
     [:init         {:optional true} [:vector EventVector]]
+    [:teardown     {:optional true} [:vector EventVector]]
     [:app-db-patch {:optional true} [:map-of :any :any]]]
    [:fn {:error/message
-         "frame-setup decorator needs at least one of :init / :app-db-patch"}
-    (fn [{:keys [init app-db-patch]}]
-      (or (some? init) (some? app-db-patch)))]])
+         "frame-setup decorator needs at least one of :init / :app-db-patch / :teardown"}
+    (fn [{:keys [init app-db-patch teardown]}]
+      (or (some? init) (some? app-db-patch) (some? teardown)))]])
 
 (def DecoratorFxOverride
   "`:fx-override`-kind decorator — stubs an fx for the lifetime of the

--- a/tools/story/test/re_frame/story_teardown_test.clj
+++ b/tools/story/test/re_frame/story_teardown_test.clj
@@ -1,0 +1,304 @@
+(ns re-frame.story-teardown-test
+  "JVM tests for the `:teardown` slot on `:frame-setup` decorators.
+
+  Spec coverage (rf2-dg2uh):
+    - `tools/story/spec/001-Authoring.md` §`:teardown` — symmetric
+      counterpart of `:init`.
+    - `tools/story/spec/002-Runtime.md`   §Loader teardown contract,
+      §What the runtime guarantees.
+
+  The `:teardown` slot is the lightweight cleanup path symmetric with
+  `:init`. On `destroy-variant!` the runtime walks the resolved
+  `:frame-setup` decorator stack IN REVERSE-DECLARATION ORDER and
+  dispatch-syncs each decorator's `:teardown` events into the variant
+  frame. Exceptions thrown by teardown events are caught and projected
+  into the variant frame's `[:rf.story/assertions]` as
+  `:rf.error/exception` records with `:phase :phase-teardown`. The walk
+  never aborts `rf/destroy-frame!`.
+
+  Test surface (minimum-viable contract):
+
+  - **fires** — a single-decorator teardown actually runs on destroy.
+  - **reverse-order composition** — innermost (variant-level) before
+    outermost (story-level). Mirrors function-scope cleanup.
+  - **exception caught** — a throwing teardown event does not propagate;
+    `destroy-frame!` still completes.
+  - **assertion record** — a thrown teardown lands as
+    `:rf.error/exception` with `:phase :phase-teardown` in the variant
+    frame's `[:rf.story/assertions]`.
+  - **schema accepts the optional slot** — `reg-decorator` rejects a
+    `:frame-setup` body that omits all of `:init` / `:app-db-patch` /
+    `:teardown`, but accepts `{:teardown [...]}` standalone."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core             :as rf]
+            [re-frame.frame            :as frame]
+            [re-frame.machines         :as machines]
+            [re-frame.registrar        :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story            :as story]
+            [re-frame.story.async      :as async]
+            [re-frame.story.config     :as config]
+            [re-frame.story.frames     :as frames]
+            [re-frame.story.loaders    :as loaders]
+            [re-frame.story.schemas    :as schemas]
+            [malli.core                :as m]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-all [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (require 're-frame.machines :reload)
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (config/set-global-args! {})
+  (reset! frames/stub-call-log {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (test-fn))
+
+(use-fixtures :each reset-all)
+
+;; ===========================================================================
+;; SCHEMA — `:teardown` is an optional slot on `:frame-setup` bodies
+;; ===========================================================================
+
+(deftest schema-accepts-frame-setup-with-only-teardown
+  (testing "a :frame-setup decorator body carrying only :teardown is valid
+            — the schema's at-least-one-of guard counts :teardown as a
+            satisfying slot. Symmetric with :init / :app-db-patch."
+    (is (m/validate schemas/Decorator
+                    {:kind :frame-setup :teardown [[:noop]]}))
+    (is (m/validate schemas/Decorator
+                    {:kind :frame-setup :init [[:setup]] :teardown [[:cleanup]]}))
+    (is (m/validate schemas/Decorator
+                    {:kind :frame-setup :app-db-patch {:x 1} :teardown [[:cleanup]]}))))
+
+(deftest schema-rejects-empty-frame-setup-body
+  (testing "a :frame-setup body with NONE of :init / :app-db-patch /
+            :teardown still fails — the at-least-one-of guard holds."
+    (is (not (m/validate schemas/Decorator {:kind :frame-setup})))))
+
+(deftest schema-rejects-non-vector-teardown
+  (testing ":teardown must be a vector of event vectors — a bare keyword
+            or a single event vector at the top level is invalid."
+    (is (not (m/validate schemas/Decorator
+                         {:kind :frame-setup :teardown :not-a-vector})))
+    (is (not (m/validate schemas/Decorator
+                         {:kind :frame-setup :teardown [:not-a-vector-of-vectors]})))))
+
+;; ===========================================================================
+;; FIRES — a single-decorator teardown actually runs at destroy
+;; ===========================================================================
+
+(deftest teardown-events-fire-on-destroy
+  (testing ":teardown events dispatched at destroy reach the variant
+            frame's event handlers"
+    (let [fired (atom [])]
+      (rf/reg-event-db :feed/close-socket
+        (fn [db _] (swap! fired conj :feed/close-socket) db))
+      (story/reg-decorator :feed/live-subscription
+        {:kind     :frame-setup
+         :init     [[:feed/noop-init]]
+         :teardown [[:feed/close-socket]]})
+      (rf/reg-event-db :feed/noop-init (fn [db _] db))
+      (story/reg-variant :story.feed/teardown-fires
+        {:decorators [[:feed/live-subscription]]
+         :events     []})
+      ;; Allocate + destroy. The single :frame-setup decorator's
+      ;; :teardown event must fire on destroy.
+      (async/deref-blocking
+        (story/run-variant :story.feed/teardown-fires) 5000)
+      (is (= [] @fired)
+          "teardown has NOT fired yet — the variant is still live")
+      (story/destroy-variant! :story.feed/teardown-fires)
+      (is (= [:feed/close-socket] @fired)
+          "teardown fired exactly once on destroy"))))
+
+(deftest teardown-events-fire-in-declared-order-within-a-decorator
+  (testing "within a single decorator's :teardown vector, events fire
+            in declared order — symmetric with :init"
+    (let [fired (atom [])]
+      (rf/reg-event-db :step/one
+        (fn [db _] (swap! fired conj :one) db))
+      (rf/reg-event-db :step/two
+        (fn [db _] (swap! fired conj :two) db))
+      (rf/reg-event-db :step/three
+        (fn [db _] (swap! fired conj :three) db))
+      (story/reg-decorator :multi-step-teardown
+        {:kind     :frame-setup
+         :init     [[:step/noop]]
+         :teardown [[:step/one] [:step/two] [:step/three]]})
+      (rf/reg-event-db :step/noop (fn [db _] db))
+      (story/reg-variant :story.feed/multi-step
+        {:decorators [[:multi-step-teardown]]
+         :events     []})
+      (async/deref-blocking
+        (story/run-variant :story.feed/multi-step) 5000)
+      (story/destroy-variant! :story.feed/multi-step)
+      (is (= [:one :two :three] @fired)
+          "within one decorator, teardown events run in declared order"))))
+
+;; ===========================================================================
+;; REVERSE-ORDER COMPOSITION — innermost (variant) fires BEFORE outermost
+;; (story). Per 001-Authoring.md §Composition order.
+;; ===========================================================================
+
+(deftest teardown-composes-in-reverse-declaration-order
+  (testing "a stack of two :frame-setup decorators (one at story level,
+            one at variant level) tears down innermost-first: the
+            variant-level decorator's :teardown runs BEFORE the story-
+            level decorator's :teardown. Mirrors function-scope cleanup."
+    (let [fired (atom [])]
+      (rf/reg-event-db :outer/cleanup
+        (fn [db _] (swap! fired conj :outer) db))
+      (rf/reg-event-db :inner/cleanup
+        (fn [db _] (swap! fired conj :inner) db))
+      (story/reg-decorator :outer-dec
+        {:kind :frame-setup :init [[:outer/noop]] :teardown [[:outer/cleanup]]})
+      (story/reg-decorator :inner-dec
+        {:kind :frame-setup :init [[:inner/noop]] :teardown [[:inner/cleanup]]})
+      (rf/reg-event-db :outer/noop (fn [db _] db))
+      (rf/reg-event-db :inner/noop (fn [db _] db))
+      (story/reg-story :story.teardown.order
+        {:decorators [[:outer-dec]]})
+      (story/reg-variant :story.teardown.order/v
+        {:decorators [[:inner-dec]]
+         :events     []})
+      (async/deref-blocking
+        (story/run-variant :story.teardown.order/v) 5000)
+      (story/destroy-variant! :story.teardown.order/v)
+      (is (= [:inner :outer] @fired)
+          "reverse-declaration: innermost (variant-level :inner-dec)
+           tears down BEFORE outermost (story-level :outer-dec).
+           spec/002 §Loader teardown contract step 3."))))
+
+(deftest teardown-composes-reverse-within-a-single-level
+  (testing "two decorators declared at the SAME level (variant) still
+            tear down in reverse-declaration order — the resolved
+            :frame-setup vector reversed is the walk order"
+    (let [fired (atom [])]
+      (rf/reg-event-db :dec-a/cleanup
+        (fn [db _] (swap! fired conj :a) db))
+      (rf/reg-event-db :dec-b/cleanup
+        (fn [db _] (swap! fired conj :b) db))
+      (story/reg-decorator :dec-a
+        {:kind :frame-setup :init [[:dec-a/noop]] :teardown [[:dec-a/cleanup]]})
+      (story/reg-decorator :dec-b
+        {:kind :frame-setup :init [[:dec-b/noop]] :teardown [[:dec-b/cleanup]]})
+      (rf/reg-event-db :dec-a/noop (fn [db _] db))
+      (rf/reg-event-db :dec-b/noop (fn [db _] db))
+      (story/reg-variant :story.teardown.same-level/v
+        {:decorators [[:dec-a] [:dec-b]]
+         :events     []})
+      (async/deref-blocking
+        (story/run-variant :story.teardown.same-level/v) 5000)
+      (story/destroy-variant! :story.teardown.same-level/v)
+      (is (= [:b :a] @fired)
+          "later-declared :dec-b tears down before earlier-declared :dec-a"))))
+
+;; ===========================================================================
+;; EXCEPTION HANDLING — throwing teardown caught; record projected
+;; ===========================================================================
+
+(deftest throwing-teardown-event-does-not-abort-destroy
+  (testing "a teardown event that throws is caught by the runtime —
+            destroy-frame! still runs. spec/002 §Loader teardown
+            contract: teardown never aborts destroy-frame!"
+    (rf/reg-event-db :boom/cleanup
+      (fn [_ _] (throw (ex-info "teardown boom" {:why :test}))))
+    (story/reg-decorator :boom-dec
+      {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
+    (rf/reg-event-db :boom/noop (fn [db _] db))
+    (story/reg-variant :story.teardown.boom/v
+      {:decorators [[:boom-dec]]
+       :events     []})
+    (async/deref-blocking
+      (story/run-variant :story.teardown.boom/v) 5000)
+    ;; The destroy walk catches the exception. After destroy, the
+    ;; variant frame is gone (rf/destroy-frame! ran).
+    (is (nil? (story/destroy-variant! :story.teardown.boom/v))
+        "destroy-variant! returns nil — exception caught, walk completed")
+    (is (not (contains? (story/variant-frames) :story.teardown.boom/v))
+        "the frame is destroyed despite the teardown throw")))
+
+(deftest throwing-teardown-records-exception-assertion
+  (testing "a teardown event that throws is projected into the variant
+            frame's [:rf.story/assertions] as an :rf.error/exception
+            record with :phase :phase-teardown. spec/002 §Error
+            projection + §Loader teardown contract.
+
+            Capture strategy: a probe decorator at the STORY level fires
+            its :teardown LAST (reverse-order walk: variant-level boom
+            first, story-level probe last). The probe reads
+            [:rf.story/assertions] off the variant frame's app-db and
+            copies it to a side-atom, so the test can inspect the record
+            after destroy-frame! evicts the frame."
+    (let [captured (atom nil)]
+      (rf/reg-event-db :boom/cleanup
+        (fn [_ _] (throw (ex-info "teardown boom" {:why :test}))))
+      (rf/reg-event-db :boom/noop (fn [db _] db))
+      (rf/reg-event-db ::probe-snapshot
+        (fn [db _]
+          (reset! captured (:rf.story/assertions db))
+          db))
+      (story/reg-decorator :boom-dec
+        {:kind :frame-setup :init [[:boom/noop]] :teardown [[:boom/cleanup]]})
+      (story/reg-decorator :probe-dec
+        {:kind :frame-setup
+         :init [[:boom/noop]]
+         :teardown [[::probe-snapshot]]})
+      ;; Story-level decorator runs OUTERMOST. Reverse-order at destroy
+      ;; means variant-level :boom-dec fires first; story-level
+      ;; :probe-dec fires last — AFTER the boom's exception record has
+      ;; landed on [:rf.story/assertions].
+      (story/reg-story :story.teardown.record
+        {:decorators [[:probe-dec]]})
+      (story/reg-variant :story.teardown.record/v
+        {:decorators [[:boom-dec]]
+         :events     []})
+      (async/deref-blocking
+        (story/run-variant :story.teardown.record/v) 5000)
+      (story/destroy-variant! :story.teardown.record/v)
+      (let [asserts @captured
+            err     (first (filter #(= :rf.error/exception (:assertion %))
+                                   asserts))]
+        (is (some? err)
+            "an :rf.error/exception record landed in [:rf.story/assertions]
+             before destroy-frame! evicted the variant frame")
+        (is (= :phase-teardown (:phase err))
+            ":phase :phase-teardown carried on the record")
+        (is (false? (:passed? err))
+            ":passed? false — error records never pass")
+        (is (= [:boom/cleanup] (:event err))
+            ":event slot carries the throwing event vector")
+        (is (= :story.teardown.record/v (:variant-id err))
+            ":variant-id carries the variant id")
+        (is (string? (:message (:error err)))
+            ":error :message is the thrown exception's message")
+        (is (= {:why :test} (:data (:error err)))
+            ":error :data carries the ex-info data map")))))
+
+;; ===========================================================================
+;; UNAFFECTED SHAPES — decorators without :teardown still work
+;; ===========================================================================
+
+(deftest decorator-without-teardown-is-untouched
+  (testing "a :frame-setup decorator that declares no :teardown still
+            tears down cleanly — the walk is a no-op for that decorator"
+    (rf/reg-event-db :seed/init
+      (fn [db _] (assoc db :seeded? true)))
+    (story/reg-decorator :seed-only
+      {:kind :frame-setup :init [[:seed/init]]})
+    (story/reg-variant :story.teardown.none/v
+      {:decorators [[:seed-only]]
+       :events     []})
+    (async/deref-blocking
+      (story/run-variant :story.teardown.none/v) 5000)
+    (is (nil? (story/destroy-variant! :story.teardown.none/v))
+        "destroy returns nil — no-op teardown walk completes cleanly")
+    (is (not (contains? (story/variant-frames) :story.teardown.none/v))
+        "frame still destroyed")))


### PR DESCRIPTION
## Summary

Wires the impl side of the loader-teardown contract specced in #1668 (rf2-dg2uh):

- `tools/story/src/re_frame/story/schemas.cljc` — `DecoratorFrameSetup` accepts optional `:teardown [event ...]`; the at-least-one-of guard now counts `:teardown` alongside `:init` / `:app-db-patch`.
- `tools/story/src/re_frame/story/frames.cljc` — `apply-frame-teardown!` walks the resolved `:frame-setup` decorator stack in REVERSE-DECLARATION ORDER and dispatch-syncs each decorator's `:teardown` events into the variant frame, sitting in `destroy!` between drop-accumulators/clear-watchers and `rf/destroy-frame!`. Uses the same trace-listener pattern `runtime/capture-phase-errors` uses for phase-1/2 errors: `:rf.error/handler-exception` trace events targeting the variant frame are projected onto the frame's `[:rf.story/assertions]` as `:rf.error/exception` records with `:phase :phase-teardown`. Pending records drain after each teardown dispatch so a later teardown (e.g. an outer decorator's `:teardown`) observes earlier failures.
- `tools/story/test/re_frame/story_teardown_test.clj` — schema acceptance/rejection; teardown fires on destroy; declared-order within a decorator; reverse-order composition across story/variant levels and within a single level; throwing teardown does not abort `destroy-frame!`; exception record shape (`:phase :phase-teardown`, `:variant-id`, `:event`, `:error {:message :data}`, `:passed? false`); decorators without `:teardown` remain a no-op.

## Bead

- rf2-dg2uh — impl(story): wire `:teardown` on `:frame-setup` decorators (P2 follow-on to rf2-jqrbc).

## Spec match

Implements the contract locked in #1668:
- `001-Authoring.md` §`:teardown` — symmetric counterpart of `:init`
- `002-Runtime.md` §Loader teardown contract → §What the runtime guarantees steps 3 (teardown) and the §Error projection shape

## Test plan

- [x] `tools/story` `clojure -M:test` — 803 tests, 2374 assertions, 0 failures/errors
- [x] `implementation/` `npm run test:cljs` — 3603 tests, 10345 assertions, 0 failures/errors
- [x] `mkdocs build --strict` — exit 0