### PR TITLE
feat(causa): internal reg-l4-tab — declarative per-panel L4 tab registration (rf2-2moh1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
@@ -32,38 +32,38 @@
   reads from it. The list is small (~16 entries) and the
   duplication cost is negligible compared to the cycle-break."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.palette.sources :as sources]))
+            [day8.re-frame2-causa.palette.sources :as sources]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]))
 
 ;; ---- canonical panel list ------------------------------------------------
 ;;
-;; Single source of truth for the palette source aggregator. The ids
-;; mirror the 7 L3 tab ids in `shell.cljs` (per spec/018 §5); selecting
-;; a row dispatches `:rf.causa/select-tab` so the visible tab flips.
+;; Per rf2-2moh1 the palette reads its Runtime + Static panel inventory
+;; directly from the internal L4 tab registry. Adding a tab means a
+;; single `panel-registry/reg-l4-tab!` call in the panel's `install!`;
+;; the palette's source aggregator picks it up via the helpers below.
 ;;
-;; Routing added (rf2-nrbs9) — promoted from 'lives in App-db + Trace'
-;; to its own L3 lens tab. Per Mike's design call (2026-05-18):
-;; cohesive sub-domains earn their own tab rather than overloading
-;; App-db.
-(def palette-panels
-  [{:id :event    :label "Event"}
-   {:id :app-db   :label "App DB"}
-   {:id :views    :label "Views"}
-   {:id :trace    :label "Trace"}
-   {:id :machines :label "Machines"}
-   {:id :routing  :label "Routing"}
-   {:id :issues   :label "Issues"}])
+;; The previous cycle-break rationale (avoiding `palette → shell →
+;; palette` by duplicating the tab list) is moot because the registry
+;; has no shell / palette dependencies — `palette-subs → panel-registry`
+;; is a one-way edge.
 
-;; rf2-ybjkx — Static-mode L3 tabs (5 entries; mirrors `static/shell.cljs/
-;; tabs`). The palette holds its own copy so Static-mode tab jumps land
-;; without forming a `palette → static.shell → palette` cycle. The list
-;; is small (5 entries) and stable — Static is a sealed enumeration per
-;; the parent epic (rf2-o5f5f.1).
-(def palette-static-tabs
-  [{:id :machines :label "Machines"}
-   {:id :routes   :label "Routes"}
-   {:id :schemas  :label "Schemas"}
-   {:id :views    :label "Views"}
-   {:id :events   :label "Events"}])
+(defn palette-panels
+  "Runtime-mode tab entries in the shape the palette source-aggregator
+  consumes — `[{:id :label} ...]`. Pulled at sub-recompute time so the
+  registry's runtime entries are the single source of truth.
+
+  Public so test fixtures + downstream tooling (story-mcp, pair-mcp)
+  can read the canonical Runtime tab inventory without reaching into
+  the panel registry directly."
+  []
+  (->> (panel-registry/tabs-for-mode :runtime)
+       (mapv (fn [{:keys [id label]}] {:id id :label label}))))
+
+(defn palette-static-tabs
+  "Static-mode tab entries in the same shape — see `palette-panels`."
+  []
+  (->> (panel-registry/tabs-for-mode :static)
+       (mapv (fn [{:keys [id label]}] {:id id :label label}))))
 
 (defn- handler-entries
   "Flat seq of `{:id :kind :doc :file :line}` rows from the framework
@@ -125,8 +125,8 @@
       ;; (a process-global atom) + the framework's frame registry
       ;; via the public rf wrappers.
       (sources/build-index
-        {:panels             palette-panels
-         :static-tabs        palette-static-tabs
+        {:panels             (palette-panels)
+         :static-tabs        (palette-static-tabs)
          :trace-buffer       buffer
          :frame-ids          (rf/frame-ids)
          :handlers           (handler-entries)

--- a/tools/causa/src/day8/re_frame2_causa/panel_registry.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panel_registry.cljc
@@ -1,0 +1,198 @@
+(ns day8.re-frame2-causa.panel-registry
+  "Internal L4-tab registry — `reg-l4-tab!` (rf2-2moh1).
+
+  ## The seam
+
+  Before this ns, `shell.cljs` carried a hard-coded vector of the 7
+  Runtime tabs + a parallel case-switch in `detail-panel`; `static/
+  shell.cljs` carried the same shape for the 6 Static tabs. Adding a
+  tab (e.g. promoting Routing to its own L3 lens per rf2-nrbs9)
+  required editing two files in lock-step — modify-shell coupling.
+
+  Per the audit finding `ai/findings/2026-05-20-tools-causa-api-review.md`
+  Finding #3: each panel's existing `(defn install! [] ...)` already
+  owns its subs / events / fxs. Threading the tab metadata through the
+  same install! call closes the loop — adding a tab now means:
+
+    (defn install! []
+      ...subs / events / fxs...
+      (registry/reg-l4-tab!
+        {:id    :foo
+         :label \"Foo\"
+         :mnem  \"f\"
+         :modes #{:runtime}
+         :order 6
+         :panel foo/Panel}))
+
+  …and the L3 tab bar + L4 detail panel pick it up automatically.
+
+  ## Public-API stance
+
+  v1 'no plugin registration API' (`spec/API.md` §The plugin
+  question) stays true. This is an INTERNAL seam — the registry atom
+  + the `reg-l4-tab!` fn are not re-exported through `re-frame.core`
+  nor any tool's public ns. Third parties cannot register tabs from
+  outside. The seam exists purely so per-panel registrations stay
+  colocated with the panel's other registrations.
+
+  ## Shape
+
+  Each tab entry carries:
+
+    :id     keyword — keyword that lands on `:rf.causa/selected-tab`
+            (Runtime) or `:rf.causa.static/selected-tab` (Static)
+            when the tab is selected.
+    :label  string — visible tab label.
+    :mnem   string — single-letter keyboard mnemonic.
+    :modes  set    — subset of #{:runtime :static}. Tabs registered
+                     against multiple modes appear in every matching
+                     tab bar.
+    :order  number — sort key for the tab bar render order. Lower
+                     comes first. The canonical 0..N integers reserve
+                     stable positions per spec/018 §5 (Runtime) +
+                     `tools/causa/spec/007-UX-IA.md` §Static mode
+                     (Static).
+    :panel  fn     — view function rendered when the tab is selected.
+                     Called with no args from a hiccup `[(:panel tab)]`
+                     vector so reg-view shapes resolve through their
+                     own React-context Provider.
+    :placeholder-bead opt string — sibling bead id when the tab still
+                                   renders a placeholder card (Static
+                                   tabs do this during the rf2-o5f5f
+                                   roll-out).
+
+  ## Idempotency
+
+  Re-registering a tab REPLACES the prior entry in place — same
+  posture as re-frame's registrar so shadow-cljs `:after-load`
+  cycles don't stack duplicates. The replace is silent (no warning)
+  because the per-panel install! sentinel above already guards the
+  hot-reload path; the registry's idempotency is just structural
+  insurance.
+
+  ## JVM-portable
+
+  `.cljc` so the JVM test corpus can exercise the pure-data
+  registry surface (registration shape, ordering, mode partition)
+  without spinning a CLJS runtime. Panel `:panel` views are CLJS-
+  only — JVM tests register stub `:panel` values (any value works;
+  the registry doesn't invoke `:panel`).")
+
+;; ---- registry atom ------------------------------------------------------
+
+(defonce ^{:doc "The L4 tab registry. Map of `[mode tab-id] → tab-entry`
+                 — composite key because the same `:id` may legitimately
+                 register against multiple modes (e.g. `:views` exists
+                 as both the Runtime Views tab — `panels/views.cljs` —
+                 and the Static Views catalogue tab — `static/views/
+                 panel.cljs`; same id, different content). Atom (not a
+                 defonce on a literal map) so per-panel `install!`
+                 mutations are visible to readers without re-loading
+                 this ns. Re-loading this ns under shadow-cljs
+                 `:after-load` preserves the atom's contents — `defonce`
+                 semantics.
+
+                 Tabs registered against multiple modes (a single tab
+                 entry with `:modes #{:runtime :static}`) materialise
+                 as ONE entry per `[mode id]` key — the registration
+                 mutation expands the `:modes` set across keys so
+                 lookup-by-mode is a constant-time `get`. Today every
+                 panel registers a single-mode entry so the expansion
+                 is the identity; the multi-mode pathway is structural
+                 insurance for the future routing/schemas-style verbs
+                 that might span modes."}
+  registry
+  (atom {}))
+
+;; ---- pure helpers (data-shape; JVM-portable) ----------------------------
+
+(defn tab-entries
+  "All registered tab entries as a seq. Order is undefined — use
+  `tabs-for-mode` for ordered render."
+  []
+  (vals @registry))
+
+(defn tabs-for-mode
+  "Ordered seq of tab entries registered against `mode`. Sorted by
+  `:order` (ascending; nil orders trail at +Inf so an unspecified
+  order doesn't crash the sort)."
+  [mode]
+  (->> @registry
+       (keep (fn [[[entry-mode _id] entry]]
+               (when (= entry-mode mode) entry)))
+       (sort-by #(or (:order %) ##Inf))
+       vec))
+
+(defn tab-by-id
+  "Lookup a tab entry by `mode` + `id`. Returns nil when no matching
+  tab is registered (the L4 detail panel renders an unknown-tab
+  stub in that case so a stale `:selected-tab` doesn't crash the
+  render)."
+  [mode id]
+  (get @registry [mode id]))
+
+(defn tab-ids-for-mode
+  "Set of tab ids registered for `mode`. Drives the
+  `:rf.causa.static/select-tab` event's contains? guard so unknown
+  ids land as no-ops."
+  [mode]
+  (into #{} (map :id) (tabs-for-mode mode)))
+
+(defn default-tab-for-mode
+  "First tab in `tabs-for-mode mode` order — the default landing tab
+  when `:selected-tab` is unset. Returns nil when no tabs are
+  registered for the mode (test-only state — production always has
+  the canonical inventory installed via `register-causa-handlers!`)."
+  [mode]
+  (:id (first (tabs-for-mode mode))))
+
+;; ---- mutation -----------------------------------------------------------
+
+(defn reg-l4-tab!
+  "Register an L4 tab entry. Idempotent — re-registering the same
+  `[mode id]` replaces the prior entry (same posture as re-frame's
+  registrar). Returns the registered entry.
+
+  Each panel's `(defn install! [] ...)` calls this alongside its
+  `reg-sub` / `reg-event-*` / `reg-fx` registrations so the tab
+  inventory is declarative-per-panel rather than hard-coded in
+  the shell.
+
+  Tabs registered against multiple modes (`:modes #{:runtime :static}`)
+  materialise as one entry per `[mode id]` key — every mode in the
+  set gets its own entry pointing at the same metadata. Today every
+  panel registers a single-mode entry; the multi-mode pathway is
+  insurance for cross-mode verbs that might land later."
+  [{:keys [id label mnem modes panel order placeholder-bead] :as tab}]
+  {:pre [(keyword? id)
+         (string? label)
+         (or (nil? mnem) (string? mnem))
+         (set? modes)
+         (seq modes)
+         (every? #{:runtime :static} modes)
+         (or (nil? order) (number? order))
+         (or (nil? placeholder-bead) (string? placeholder-bead))]}
+  (swap! registry
+         (fn [reg]
+           (reduce (fn [acc mode] (assoc acc [mode id] tab))
+                   reg
+                   modes)))
+  tab)
+
+(defn unreg-l4-tab!
+  "Test-only — drop tab entries for `id` (every mode). Production
+  never calls this; the per-panel install! pattern always replaces
+  in place."
+  [id]
+  (swap! registry
+         (fn [reg]
+           (into {} (remove (fn [[[_mode entry-id] _]] (= entry-id id))) reg)))
+  nil)
+
+(defn reset-for-test!
+  "Test-only — clear the registry so fixtures can drive a clean-slate
+  registration cycle. Paired with re-running the per-panel install!
+  fns (or `register-causa-handlers!` end-to-end) to repopulate."
+  []
+  (reset! registry {})
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -29,6 +29,7 @@
   root segment of any breadcrumb."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.diff.render :as diff-render]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.app-db-diff-events :as events]
             [day8.re-frame2-causa.panels.app-db-diff-sections
              :as sections]
@@ -116,4 +117,13 @@
   []
   (subs/install!)
   (events/install!)
+  ;; rf2-2moh1 — register the Runtime App DB tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :app-db
+     :label "App DB"
+     :mnem  "a"
+     :modes #{:runtime}
+     :order 1
+     :panel Panel})
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -65,6 +65,7 @@
     - tier-dot (reused in cascade-outcome + per-fx duration)"
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
@@ -1288,4 +1289,15 @@
                   :dispatch-id nil
                   :epoch-id    nil
                   :mode        :live
-                  :previewing? false)))))
+                  :previewing? false))))
+
+  ;; rf2-2moh1 — register the Runtime Event tab with the internal L4
+  ;; tab registry. The runtime shell's L3 tab bar + L4 detail panel
+  ;; pick the entry up by `tabs-for-mode :runtime`.
+  (panel-registry/reg-l4-tab!
+    {:id    :event
+     :label "Event"
+     :mnem  "e"
+     :modes #{:runtime}
+     :order 0
+     :panel Panel}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -52,6 +52,7 @@
   lives in `issues_ribbon_helpers.cljc` so the algebra runs under
   the JVM unit-test target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
@@ -584,4 +585,14 @@
       (-> db
           (dissoc :issues-active-severities)
           (dissoc :issues-active-prefixes)
-          (dissoc :issues-since-ms)))))
+          (dissoc :issues-since-ms))))
+
+  ;; rf2-2moh1 — register the Runtime Issues tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :issues
+     :label "Issues"
+     :mnem  "i"
+     :modes #{:runtime}
+     :order 6
+     :panel Panel}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -46,6 +46,7 @@
             [day8.re-frame2-causa.chart.layout :as chart-layout]
             [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
@@ -723,4 +724,14 @@
   (machine-canvas/install!)
 
   ;; ---- Share affordance (rf2-nqw0v) -----------------------------
-  (share/install!))
+  (share/install!)
+
+  ;; rf2-2moh1 — register the Runtime Machines tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :machines
+     :label "Machines"
+     :mnem  "m"
+     :modes #{:runtime}
+     :order 4
+     :panel Panel}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -56,6 +56,7 @@
   and now power the Static Routes panel — same shared primitives,
   per the parent-epic findings §5.1."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -316,5 +317,16 @@
          :to-id      (:to-id nav)
          :navigated? (:navigated? nav)
          :current    slice})))
+
+  ;; rf2-2moh1 — register the Runtime Routing tab with the internal L4
+  ;; tab registry. Per rf2-nrbs9 Mike's design call (2026-05-18) Routing
+  ;; earns its own L3 lens tab between Machines and Issues.
+  (panel-registry/reg-l4-tab!
+    {:id    :routing
+     :label "Routing"
+     :mnem  "r"
+     :modes #{:runtime}
+     :order 5
+     :panel Panel})
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -84,6 +84,7 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
@@ -773,4 +774,14 @@
   ;; 'Clear filters' button + the no-matches empty state.
   (rf/reg-event-db :rf.causa/clear-trace-filters
     (fn [db _event]
-      (dissoc db :trace-filters))))
+      (dissoc db :trace-filters)))
+
+  ;; rf2-2moh1 — register the Runtime Trace tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :trace
+     :label "Trace"
+     :mnem  "t"
+     :modes #{:runtime}
+     :order 3
+     :panel Panel}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views.cljs
@@ -28,6 +28,7 @@
   delegation and the rf2-043uz lesson documented in the legacy
   `subscriptions.cljs`."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.views-events :as events]
             [day8.re-frame2-causa.panels.views-sub-diff-subs :as sub-diff-subs]
             [day8.re-frame2-causa.panels.views-subs :as subs]
@@ -53,4 +54,13 @@
   (subs/install!)
   (sub-diff-subs/install!)
   (events/install!)
+  ;; rf2-2moh1 — register the Runtime Views tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :views
+     :label "Views"
+     :mnem  "v"
+     :modes #{:runtime}
+     :order 2
+     :panel Panel})
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -364,7 +364,7 @@
 
     (rf/reg-event-db :rf.causa.static/select-tab
       (fn [db [_ tab-id]]
-        (if (contains? static-shell/tab-ids tab-id)
+        (if (contains? (static-shell/tab-ids) tab-id)
           (assoc db :rf.causa.static/selected-tab tab-id)
           db)))
 
@@ -710,7 +710,14 @@
     ;; row vector for the view.
     (static-flows-panel/install!)
     (views/install!)
-    (trace/install!))
+    (trace/install!)
+    ;; rf2-2moh1 — register the Static :events placeholder tab. The
+    ;; other Static tabs (machines / routes / schemas / views / flows)
+    ;; each register their entry from their own panel's `install!`
+    ;; above; the `:events` tab is not yet panelled (sibling bead
+    ;; rf2-o5f5f.6 fills it) so its placeholder registration lives
+    ;; in `static.shell` alongside the placeholder-card helper.
+    (static-shell/register-events-placeholder!))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -106,17 +106,21 @@
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
             [day8.re-frame2-causa.frame-switcher :as frame-switcher]
-            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.app-db-segment-inspector
              :as app-db-segment-inspector]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
+            ;; Panel views (Event / App DB / Views / Trace / Machines /
+            ;; Routing / Issues) are pulled in via the L4 tab registry —
+            ;; each panel's `install!` registers `{:panel <view-fn>}`
+            ;; with `panel-registry/reg-l4-tab!` (rf2-2moh1) and
+            ;; `detail-panel` reaches the entry through
+            ;; `panel-registry/tab-by-id`. The shell no longer requires
+            ;; those panel nses directly; the event-detail ns is the
+            ;; one exception (kept for the inline cascade-outcome helpers
+            ;; the ribbon's :rf.causa/event-detail subscribers consume).
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
-            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
-            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
-            [day8.re-frame2-causa.panels.routing :as routing]
-            [day8.re-frame2-causa.panels.views :as views]
-            [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.resize-handle :as resize-handle]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
@@ -131,36 +135,44 @@
 
 ;; ---- tab inventory ------------------------------------------------------
 ;;
-;; Frame-switcher concerns (the internal-frames filter set, distinct-frames
-;; helper, ribbon picker view) live in `frame_switcher.cljs` per rf2-iwwou
-;; — the L1 ribbon's frame slot is a single contractually-anchored surface
-;; every frame-aware feature reaches through. The ribbon's `[frame-
-;; switcher/frame-switcher-view]` is the only call site here.
+;; Per rf2-2moh1 the L3 tab inventory now lives in the internal
+;; `panel-registry` — each panel's `install!` registers its own tab
+;; metadata declaratively (`reg-l4-tab!`), and the L3 tab-bar +
+;; L4 detail-panel read the registry via `tabs-for-mode :runtime`
+;; (driven by the `:modes` set on each entry).
+;;
+;; The seven Runtime tabs registered against `#{:runtime}` retain the
+;; canonical left-to-right order via `:order` (0..6) — spec/018 §5
+;; ordering is preserved as registration metadata rather than a literal
+;; vector in this ns.
+;;
+;; Labels use spaces (`App DB` not `App-db`) so the rendered text
+;; carries no `-` glyphs — Playwright's `getByRole('button', {name:
+;; '-'})` accessible-name matching is substring-based and would
+;; otherwise lasso our tab buttons in any host whose app exposes
+;; `-`-named buttons (counter `+ / -`).
+;;
+;; Frame-switcher concerns (the internal-frames filter set, distinct-
+;; frames helper, ribbon picker view) live in `frame_switcher.cljs` per
+;; rf2-iwwou — the L1 ribbon's frame slot is a single contractually-
+;; anchored surface every frame-aware feature reaches through. The
+;; ribbon's `[frame-switcher/frame-switcher-view]` is the only call
+;; site here.
 
-(def ^:private tabs
-  "The seven L3 tabs per spec/018 §5 The 7 tabs. Order is the canonical
-  left-to-right ribbon order; the `:mnem` letter is the keyboard
-  mnemonic (spec/018 §11).
+(defn- runtime-tabs
+  "Ordered Runtime tab entries — reads the panel registry. Pulled
+  through a fn (not a def) so re-`install!`-driven registrations
+  during shadow-cljs `:after-load` are picked up by the tab bar
+  without a manual reload of this ns."
+  []
+  (panel-registry/tabs-for-mode :runtime))
 
-  Per rf2-nrbs9 Routing was promoted from 'lives in App-db + Trace' to
-  its own L3 tab — cohesive sub-domains earn their own lens tab rather
-  than overloading App-db. The tab sits between Machines and Issues
-  (alphabetical adjacency keeps the ribbon scannable).
-
-  Labels use spaces (`App DB` not `App-db`) so the rendered text
-  carries no `-` glyphs — Playwright's `getByRole('button', {name:
-  '-'})` accessible-name matching is substring-based and would
-  otherwise lasso our tab buttons in any host whose app exposes
-  `-`-named buttons (counter `+ / -`)."
-  [{:id :event    :label "Event"    :mnem "e"}
-   {:id :app-db   :label "App DB"   :mnem "a"}
-   {:id :views    :label "Views"    :mnem "v"}
-   {:id :trace    :label "Trace"    :mnem "t"}
-   {:id :machines :label "Machines" :mnem "m"}
-   {:id :routing  :label "Routing"  :mnem "r"}
-   {:id :issues   :label "Issues"   :mnem "i"}])
-
-(def ^:private default-tab :event)
+(def ^:private default-tab
+  "Default landing tab for Runtime mode per spec/018 §5 — the Event
+  lens. Registry-derived defaults (the first tab in `runtime-tabs`)
+  would land here too, but pinning the keyword keeps the documented
+  default explicit (spec/018 §5 is normative on the landing tab)."
+  :event)
 
 ;; ---- helpers (pure, exported for tests) ---------------------------------
 
@@ -1415,7 +1427,9 @@
                    :background    (:bg-1 tokens)
                    :border-top    (str "1px solid " (:border-subtle tokens))
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     (for [{:keys [id] :as tab} tabs]
+     ;; rf2-2moh1 — iterate `runtime-tabs` (registry-derived) rather
+     ;; than a literal vector. Tab order follows each entry's `:order`.
+     (for [{:keys [id] :as tab} (runtime-tabs)]
        ^{:key id}
        [tab-button (assoc tab :active? (= id selected))])]))
 
@@ -1493,23 +1507,17 @@
                     :animation  (str "rf-causa-fade-in "
                                      (t/duration-css (:fade-duration-ms t/motion))
                                      " ease-out forwards")}}
-      (case selected
-        :event    [event-detail/Panel]
-        :app-db   [app-db-diff/Panel]
-        ;; Views tab — full Views panel per spec/012-Views.md (rf2-21ob3
-        ;; replaced the legacy Subscriptions panel with Views; the 4-
-        ;; layer chrome surfaces it as the L3 `:views` tab rather than a
-        ;; sidebar entry).
-        :views    [views/Panel]
-        :trace    [trace/Panel]
-        :machines [machine-inspector/Panel]
-        ;; Routing tab (rf2-nrbs9) — 7th L3 tab; lens on the focused
-        ;; event over the registered-routes tree per spec/016 §Routing
-        ;; tab content. Mike's design call (2026-05-18): cohesive sub-
-        ;; domains earn their own lens tab rather than overloading
-        ;; App-db.
-        :routing  [routing/Panel]
-        :issues   [issues-ribbon/Panel]
+      ;; rf2-2moh1 — registry-driven panel mount. Each tab's per-panel
+      ;; `install!` declares `:panel <view-fn>` via
+      ;; `panel-registry/reg-l4-tab!`; the previous case-switch over
+      ;; `{:event :app-db :views :trace :machines :routing :issues}` is
+      ;; replaced by a lookup against `tab-by-id :runtime`. The seven
+      ;; tabs and their per-panel view fns each live colocated with
+      ;; the panel's own subs / events / fxs in `panels/<panel>.cljs`
+      ;; rather than the panel-cum-shell coupling the literal case-
+      ;; switch encoded.
+      (if-let [tab (panel-registry/tab-by-id :runtime selected)]
+        [(:panel tab)]
         [unknown-tab-stub selected])]]))
 
 ;; ---- Runtime / Static surface composer (rf2-o5f5f.1) --------------------

--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -43,6 +43,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.flows.registry :as flows-registry]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale mono-stack sans-stack]]))
@@ -360,5 +361,17 @@
     :<- [:rf.causa.static.flows/query]
     (fn [[registry-snapshot query] _query]
       (project-data registry-snapshot query)))
+
+  ;; rf2-2moh1 — register the Static Flows tab with the internal L4
+  ;; tab registry. Order 4 sits between :views (3) and :events (5)
+  ;; per the parent epic findings doc §2.4.
+  (panel-registry/reg-l4-tab!
+    {:id    :flows
+     :label "Flows"
+     :mnem  "l"
+     :modes #{:static}
+     :order 4
+     :panel Panel
+     :placeholder-bead "rf2-uhsqb"})
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/panel.cljs
@@ -57,6 +57,7 @@
   `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs` scopes
   subscribes / dispatches to Causa's frame."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.static.machines.browse-list :as browse-list]
             [day8.re-frame2-causa.static.machines.definition-detail
              :as definition-detail]
@@ -249,4 +250,14 @@
   ;; Hydrate from localStorage. The persistence ns guards storage
   ;; availability internally so the JVM test path is a no-op.
   (persistence/hydrate!)
+  ;; rf2-2moh1 — register the Static Machines tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :machines
+     :label "Machines"
+     :mnem  "m"
+     :modes #{:static}
+     :order 0
+     :panel panel
+     :placeholder-bead "rf2-o5f5f.2"})
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs
@@ -58,6 +58,7 @@
   / Helix references. Frame isolation comes from the enclosing
   `[rf/frame-provider {:frame :rf/causa}]` in `static/shell.cljs`."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
             [day8.re-frame2-causa.static.routes.browse-list :as browse-list]
             [day8.re-frame2-causa.static.routes.simulate-url :as simulate-url]
@@ -216,5 +217,16 @@
     :<- [:rf.causa.static.routes/sim-url]
     (fn [[routes-map query sim-url] _query]
       (h/project-static-data routes-map query sim-url)))
+
+  ;; rf2-2moh1 — register the Static Routes tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :routes
+     :label "Routes"
+     :mnem  "r"
+     :modes #{:static}
+     :order 1
+     :panel Panel
+     :placeholder-bead "rf2-o5f5f.3"})
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -53,6 +53,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas.storage :as schemas-storage]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale mono-stack sans-stack]]))
@@ -414,5 +415,16 @@
     :<- [:rf.causa.static.schemas/query]
     (fn [[{:keys [schemas-by-frame events subs]} query] _query]
       (project-data schemas-by-frame events subs query)))
+
+  ;; rf2-2moh1 — register the Static Schemas tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :schemas
+     :label "Schemas"
+     :mnem  "c"
+     :modes #{:static}
+     :order 2
+     :panel Panel
+     :placeholder-bead "rf2-o5f5f.4"})
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -84,46 +84,60 @@
     - rf2-o5f5f.5 — Views registry browse (Fiber-walker consumer)
     - rf2-o5f5f.6 — Events registry browse + interceptor stack"
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.static.flows.panel :as flows-panel]
-            [day8.re-frame2-causa.static.machines.panel :as static-machines]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
-            [day8.re-frame2-causa.static.routes.panel :as routes-panel]
-            [day8.re-frame2-causa.static.schemas.panel :as schemas-panel]
-            [day8.re-frame2-causa.static.views.panel :as views-panel]
+            ;; Static panel views (Machines / Routes / Schemas / Views /
+            ;; Flows) are pulled in via the L4 tab registry — each
+            ;; panel's `install!` registers `{:panel <view-fn>}` with
+            ;; `panel-registry/reg-l4-tab!` (rf2-2moh1) and
+            ;; `detail-panel` reaches the entry through
+            ;; `panel-registry/tab-by-id :static`. The shell no longer
+            ;; requires those panel nses directly.
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale layout sans-stack]]))
 
 ;; ---- tab inventory ------------------------------------------------------
+;;
+;; Per rf2-2moh1 the Static-mode L3 tab inventory now lives in the
+;; internal `panel-registry`. Each Static panel's `install!` registers
+;; its own tab metadata (`{:modes #{:static} :order ...}`); the
+;; helpers below read the registry so external callers (registry.cljs
+;; for `:rf.causa.static/select-tab`'s contains? guard, tests asserting
+;; the canonical order) see one source of truth.
 
-(def tabs
-  "The five L3 tabs Static mode exposes per the findings doc
-  `2026-05-19-causa-explorer-mode.md` §2.4 + parent-epic rf2-o5f5f
-  sub-bead list. Each entry carries:
+(defn tabs
+  "Ordered Static-mode tab entries. Each entry carries `:id`,
+  `:label`, `:mnem`, `:modes`, `:order`, `:panel`, and (for tabs
+  awaiting their sibling-bead content) `:placeholder-bead`. Order
+  matches the parent-epic findings doc
+  `2026-05-19-causa-explorer-mode.md` §2.4 — machines, routes,
+  schemas, views, flows, events.
 
-    - `:id`     — keyword that lands on `:rf.causa.static/selected-tab`
-                  when the tab is selected.
-    - `:label`  — visible tab label.
-    - `:mnem`   — keyboard mnemonic letter (rendered in the tab's
-                  `title`; follow-on bead wires the actual keybinding).
-    - `:placeholder-bead` — the sibling bead id that fills the tab.
+  Default landing tab is `:machines` per Mike's call (the densest
+  Static surface; opening Static on a fresh slate should land on the
+  highest-value tab) — see `default-tab` below.
 
-  Order matches the findings doc. Default is `:machines` per Mike's
-  call (the Machines registry is the densest Static surface; opening
-  Static on a fresh slate should land on the highest-value tab)."
-  [{:id :machines :label "Machines" :mnem "m" :placeholder-bead "rf2-o5f5f.2"}
-   {:id :routes   :label "Routes"   :mnem "r" :placeholder-bead "rf2-o5f5f.3"}
-   {:id :schemas  :label "Schemas"  :mnem "c" :placeholder-bead "rf2-o5f5f.4"}
-   {:id :views    :label "Views"    :mnem "v" :placeholder-bead "rf2-o5f5f.5"}
-   {:id :flows    :label "Flows"    :mnem "l" :placeholder-bead "rf2-uhsqb"}
-   {:id :events   :label "Events"   :mnem "e" :placeholder-bead "rf2-o5f5f.6"}])
+  Per rf2-2moh1 this changed shape from a literal `def` vector to a
+  zero-arg `defn` reading the registry. Callers must invoke
+  `(static-shell/tabs)` not bare `static-shell/tabs` — `:no-back-
+  compat` pre-alpha posture."
+  []
+  (panel-registry/tabs-for-mode :static))
 
-(def default-tab :machines)
+(def default-tab
+  "Default landing tab when `:rf.causa.static/selected-tab` is unset.
+  Pinned to `:machines` per the parent-epic findings doc — the densest
+  Static surface is the highest-value landing."
+  :machines)
 
-(def tab-ids
-  "Set of valid tab ids — used by `:rf.causa.static/select-tab` to
-  reject unknown values from the dispatch arg. JVM-portable pure data."
-  (into #{} (map :id) tabs))
+(defn tab-ids
+  "Set of valid Static tab ids — used by `:rf.causa.static/select-tab`
+  to reject unknown values from the dispatch arg. Reads through the
+  registry so a new `reg-l4-tab!` is picked up without modifying this
+  ns."
+  []
+  (panel-registry/tab-ids-for-mode :static))
 
 ;; ---- mode signal #2 — left-edge stripe colour ---------------------------
 
@@ -284,7 +298,8 @@
                    :background    (:bg-1 tokens)
                    :border-top    (str "1px solid " (:border-subtle tokens))
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     (for [{:keys [id] :as tab} tabs]
+     ;; rf2-2moh1 — iterate the registry's static-mode entries.
+     (for [{:keys [id] :as tab} (tabs)]
        ^{:key id}
        [tab-button (assoc tab :active? (= id selected))])]))
 
@@ -329,35 +344,33 @@
     "Static mode is event-INDEPENDENT — this tab will browse what's "
     "registered, not what just fired. See parent epic rf2-o5f5f."]])
 
-(defn- tab-by-id
-  "Pure helper. Look up a tab map by `:id`. Returns nil when the id is
-  not in the inventory (the L4 panel falls back to a generic 'unknown'
-  card)."
-  [id]
-  (some #(when (= id (:id %)) %) tabs))
-
 (rf/reg-view detail-panel
-  "L4 detail panel — case-switch on `:rf.causa.static/selected-tab`.
-  Phase 1 (rf2-o5f5f.1) landed placeholder cards for every tab; sibling
-  beads (.2 / .3 / .4 / .5 / .6) progressively replace each placeholder
-  with real catalogue content.
+  "L4 detail panel — registry-driven mount (rf2-2moh1).
 
-  Live mounts:
+  Each Static panel's `install!` registers its tab entry via
+  `panel-registry/reg-l4-tab!` with `:modes #{:static}` + a `:panel`
+  view fn. The previous case-switch over the six static tab ids is
+  replaced by a lookup against `panel-registry/tab-by-id :static`:
+
     :machines → `static.machines.panel/panel` (rf2-o5f5f.2)
     :routes   → `static.routes.panel/Panel`   (rf2-o5f5f.3)
     :schemas  → `static.schemas.panel/Panel`  (rf2-o5f5f.4)
     :views    → `static.views.panel/Panel`    (rf2-o5f5f.5)
     :flows    → `static.flows.panel/Panel`    (rf2-uhsqb)
+    :events   — placeholder card (rf2-o5f5f.6 — sibling bead fills)
 
-  Placeholder still-pending (the sibling-bead card):
-    :events
+  The placeholder `:events` tab is registered alongside the others by
+  `register-events-placeholder!` (called from
+  `registry.cljs/register-causa-handlers!`); its `:panel` is a closed-
+  over `placeholder-card` invocation so the registry's `:panel`
+  contract (any view fn) holds even for not-yet-filled tabs.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
   []
   (let [selected (or @(rf/subscribe [:rf.causa.static/selected-tab])
                      default-tab)
-        tab      (tab-by-id selected)]
+        tab      (panel-registry/tab-by-id :static selected)]
     [:div {:data-testid (str "rf-causa-static-detail-panel-" (name selected))
            ;; rf2-plajx — Static L4 closes the tab/tabpanel loop.
            ;; Pairs with the per-tab `id` set by `tab-button` so
@@ -371,31 +384,42 @@
                    :overflow    "auto"
                    :background  (:bg-2 tokens)
                    :color       (:text-primary tokens)}}
-     (cond
-       (= selected :machines)
-       [static-machines/panel]
-
-       (= selected :routes)
-       [routes-panel/Panel]
-
-       (= selected :schemas)
-       [schemas-panel/Panel]
-
-       (= selected :views)
-       [views-panel/Panel]
-
-       (= selected :flows)
-       [flows-panel/Panel]
-
-       tab
-       [placeholder-card tab]
-
-       :else
+     (if tab
+       [(:panel tab)]
        [:div {:data-testid "rf-causa-static-tab-unknown"
               :style {:padding     "16px"
                       :color       (:text-secondary tokens)
                       :font-family sans-stack}}
         "Unknown Static tab: " [:code (pr-str selected)]])]))
+
+(defn- events-placeholder-panel
+  "Placeholder panel-view for the not-yet-implemented Static
+  `:events` tab. Sibling bead rf2-o5f5f.6 will replace this with an
+  events-registry browse panel — at which point the install! call
+  in `registry.cljs` is dropped and `static/events/panel.cljs`
+  becomes the canonical registrar of the `:events` tab."
+  []
+  [placeholder-card
+   {:id               :events
+    :label            "Events"
+    :placeholder-bead "rf2-o5f5f.6"}])
+
+(defn register-events-placeholder!
+  "rf2-2moh1 — register the placeholder `:events` Static tab. The
+  other Static tabs each carry their own `install!` (machines,
+  routes, schemas, views, flows); this one has no panel ns yet so
+  the registration lives here, alongside the placeholder-card
+  helper it composes against."
+  []
+  (panel-registry/reg-l4-tab!
+    {:id               :events
+     :label            "Events"
+     :mnem             "e"
+     :modes            #{:static}
+     :order            5
+     :panel            events-placeholder-panel
+     :placeholder-bead "rf2-o5f5f.6"})
+  nil)
 
 ;; ---- Static surface ------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/static/views/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/views/panel.cljs
@@ -55,6 +55,7 @@
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale mono-stack sans-stack]]))
@@ -338,5 +339,16 @@
     :<- [:rf.causa.static.views/query]
     (fn [[registrations-map query] _query]
       (project-data registrations-map query)))
+
+  ;; rf2-2moh1 — register the Static Views tab with the internal L4
+  ;; tab registry.
+  (panel-registry/reg-l4-tab!
+    {:id    :views
+     :label "Views"
+     :mnem  "v"
+     :modes #{:static}
+     :order 3
+     :panel Panel
+     :placeholder-bead "rf2-o5f5f.5"})
 
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -133,9 +133,10 @@
 
 (deftest palette-includes-routing
   (testing "the palette's canonical panel list carries the :routing entry"
-    (let [ids (set (map :id palette-subs/palette-panels))]
+    (let [panels (palette-subs/palette-panels)
+          ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 7 (count palette-subs/palette-panels))
+      (is (= 7 (count panels))
           "exactly 7 entries — Event / App DB / Views / Trace / Machines / Routing / Issues"))))
 
 ;; ---- (2) empty state ---------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
@@ -507,5 +507,5 @@
             placeholder is replaced by the live panel"
     (is (= "rf2-o5f5f.2"
            (-> (some #(when (= :machines (:id %)) %)
-                     static-shell/tabs)
+                     (static-shell/tabs))
                :placeholder-bead)))))

--- a/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
@@ -330,7 +330,7 @@
 
 (deftest static-shell-routes-tab-is-in-inventory
   (testing ":routes is in the Static tab inventory + the shell can render it"
-    (is (contains? (set (map :id static-shell/tabs)) :routes)
+    (is (contains? (set (map :id (static-shell/tabs))) :routes)
         ":routes is in the Static tab inventory")
     (setup-causa-frame!)
     (rf/with-frame :rf/causa

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -495,9 +495,9 @@
   (testing "tab inventory carries id/label/mnem/placeholder-bead and
             preserves canonical order"
     (is (= [:machines :routes :schemas :views :flows :events]
-           (mapv :id static-shell/tabs))
+           (mapv :id (static-shell/tabs)))
         "6 tabs in canonical order (rf2-uhsqb added :flows)")
-    (doseq [{:keys [id label mnem placeholder-bead]} static-shell/tabs]
+    (doseq [{:keys [id label mnem placeholder-bead]} (static-shell/tabs)]
       (is (keyword? id) (str "id is keyword for " id))
       (is (string? label) (str "label is a string for " id))
       (is (and (string? mnem) (= 1 (count mnem)))


### PR DESCRIPTION
## Summary

Per audit Finding #3 ([2026-05-20-tools-causa-api-review.md](../blob/main/ai/findings/2026-05-20-tools-causa-api-review.md)) — introduce an internal `panel-registry/reg-l4-tab!` so per-panel `install!` calls register their L4 tab declaratively rather than the shell hardcoding two parallel structures (tabs vector + case-switch). Adding a tab now means adding one `reg-l4-tab!` call in the panel's own `install!`.

- **New `panel_registry.cljc`** — JVM-portable internal registry with `reg-l4-tab!` / `tabs-for-mode` / `tab-by-id` / `tab-ids-for-mode`. Keyed by `[mode id]` so the `:views` tab can register against both `:runtime` (lens) and `:static` (catalogue) without collision.
- **Each panel's `install!`** (7 Runtime + 5 Static + a placeholder `:events` registration in static/shell) now declares its tab metadata via `reg-l4-tab!`.
- **`shell.cljs` + `static/shell.cljs`** — literal tab vectors + case-switches removed; tab-bar iterates `(runtime-tabs)` / `(tabs)`, detail-panel reads `tab-by-id`. `static-shell/tabs` changed from `def` → `defn` (pre-alpha posture, no back-compat shim).
- **`palette/subs.cljs`** — `palette-panels` / `palette-static-tabs` now read through the registry, collapsing the third duplicate source of truth.

v1 'no plugin registration API' (spec/API.md) stays true — this is an internal seam, not a re-exported public surface.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 3603 tests, 0 failures
- [x] `cd tools/causa && clojure -M:test` — 775 tests, 0 failures
- [x] `cd implementation && npm run test:bundle-isolation` — bundle isolation + reagent-free sentinels both PASS
- [x] `python -m mkdocs build --strict` from repo root — builds clean