### PR TITLE
spec(api): document configure-keys opts naming rule — namespaced for semantic, bare for ergonomic (rf2-yz80c)

### DIFF
--- a/spec/API.md
+++ b/spec/API.md
@@ -677,6 +677,19 @@ Runtime configuration is uniformly via `(rf/configure <key> <opts>)`. Every fram
 
 SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure` key — it is per-frame metadata on the frame's `:ssr` map (see [Conventions §Configuration surfaces](Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) bucket 3 and [011 §Server error projection](011-SSR.md#server-error-projection)). Different frames in the same process can carry different projector / dev-detail settings, so the natural lifetime is per-frame, not process-global.
 
+### Opts-key naming rule
+
+The opts map for any `configure` key mixes two shapes deliberately, and the choice is **not** stylistic — it encodes which contract owns the sub-key:
+
+- **Framework-owned semantic sub-keys use a namespaced keyword** under a reserved `:rf.<area>/*` sub-namespace (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)). The namespace identifies the cross-spec policy area the sub-key participates in — the same key shape appears verbatim wherever that policy is consumed, not only inside `configure`. Example: `:elision` carries `{:rf.size/threshold-bytes N}` because `:rf.size/threshold-bytes` is the same per-call policy key consumed by `rf/elide-wire-value` and the wire-elision walker (per [Conventions §Reserved namespaces — `:rf.size/*`](Conventions.md#the-single-root-reserved-set)). The namespaced form makes the cross-surface identity grep-visible and prevents collision with adjacent per-knob settings.
+- **Ergonomic per-knob sub-keys are unqualified bare keywords** (`:depth`, `:grace-period-ms`, `:trace-events-keep`, `:redact-fn`). These sub-keys are local to a single `configure` key's opts map — they do not appear elsewhere in the framework's vocabulary, so a framework-owned namespace would add noise without adding identity. The bare form is the default at this leaf position; reach for it whenever the knob is unique to one `configure` key.
+
+The discriminator is **whether the sub-key names a cross-surface policy slot or a one-off knob**. A sub-key earns a `:rf.<area>/*` namespace when it names a contract that lives in more than one place (`:rf.size/threshold-bytes` is read by `:elision`, by `elide-wire-value`, and by the MCP wire walker). A sub-key stays bare when it is local to its parent `configure` key (`:depth` under `:trace-buffer` has nothing to do with `:depth` under `:epoch-history` — same English word, separate knobs, no shared contract).
+
+New `configure` keys MUST apply the same rule: if a sub-key participates in a cross-spec policy area, qualify it under the area's reserved namespace; otherwise leave it bare. The rule is closed — there is no third shape (no `:configure/depth`, no `:rf.configure/*` prefix). A sub-key that would want a third shape is evidence the proposed knob is doing two things and should be split.
+
+### Fixed-and-additive
+
 The configure-keys vocabulary is fixed-and-additive (Spec-ulation): existing keys cannot be renamed or removed; new keys are added by extending the table. User code that wraps `configure` should pattern-match on known keys and ignore unknown ones.
 
 ---

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -439,6 +439,9 @@ For knobs that apply globally to the framework runtime, are addressed by a **key
 - `(rf/configure :epoch-history {:depth 50})` — ring-buffer depth for the Tool-Pair epoch surface
 - `(rf/configure :trace-buffer {:depth 200})` — ring-buffer depth for trace events
 - `(rf/configure :sub-cache {:grace-period-ms 50})` — deferred ref-counting grace period
+- `(rf/configure :elision {:rf.size/threshold-bytes 16384})` — wire-elision size threshold
+
+The opts-map sub-keys mix two shapes deliberately: cross-surface policy slots use a namespaced keyword under the area's reserved `:rf.<area>/*` sub-namespace (e.g. `:rf.size/threshold-bytes` — the same key the wire-elision walker reads); one-off per-knob settings stay bare (e.g. `:depth`, `:grace-period-ms`). The rule is closed and the discriminator is **whether the sub-key names a cross-spec policy slot or a one-off knob** — full statement at [API.md §Configure keys — Opts-key naming rule](API.md#opts-key-naming-rule).
 
 ### 2. `set-!` / `install-!` fns — adapter-pluggable hooks
 


### PR DESCRIPTION
## Summary

Bead **rf2-yz80c** — document the implicit opts-key naming rule for `configure` keys. The vocabulary mixes flat-bare and framework-namespaced keys without a stated rule:

- Flat-bare: `:depth`, `:grace-period-ms`, `:trace-events-keep`, `:redact-fn` (ergonomic per-knob)
- Framework-namespaced: `:rf.size/threshold-bytes` (semantic, framework-owned cross-surface policy slot)

This PR makes the implicit rule explicit:

- **API.md §Configure keys** — adds a new `### Opts-key naming rule` subsection between the SSR-not-a-configure-key note and the fixed-and-additive paragraph. States the rule, explains the discriminator (does the sub-key name a cross-surface policy slot or a one-off knob?), gives examples on both sides, and closes the set (no third shape).
- **Conventions.md §Configuration surfaces** — gains a one-paragraph cross-reference summarising the rule and pointing at the canonical statement in API.md. Also adds the `:elision` example to the bullet list (was missing the namespaced-sub-key exemplar).

Pre-alpha; explicit rule, not soft guidance.

Audit lineage: `ai/findings/2026-05-20-instrumentation-ssr-http-api-review.md §Finding 10`.

## Test plan

- [x] `mkdocs build --strict` from repo root passes (exit 0)