### PR TITLE
ci(gates): tighten Story/Causa Playwright trigger + split testbed Playwright gate (rf2-k9ekz + rf2-9grp6)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -35,6 +35,7 @@ cljs_prod=false
 bundle_isolation=false
 reagent_slim_bundle=false
 adapter_testbed_smokes=false
+framework_testbeds=false
 tools_jvm=false
 template_expensive=false
 mcp_conformance=false
@@ -50,12 +51,69 @@ mark_all() {
   bundle_isolation=true
   reagent_slim_bundle=true
   adapter_testbed_smokes=true
+  framework_testbeds=true
   tools_jvm=true
   template_expensive=true
   mcp_conformance=true
   mcp_live=true
   story_causa_browser=true
   skills_structural=true
+}
+
+# rf2-k9ekz — predicate: does `$1` look like a Story/Causa runtime
+# source file (CLJS/CLJC/JS/CSS extension under tools/{story,causa}/src/**
+# or tools/{story,causa}/testbeds/**)? Returns 0 (yes) / 1 (no). The
+# Story/Causa browser gate only fires on a runtime-relevant extension
+# under one of those two trees — Markdown specs, EDN config, and JVM
+# unit tests under tools/{story,causa}/{spec,test,bench}/** do not
+# affect chrome and so do not fire the gate. Testbeds under
+# tools/{story,causa}/testbeds/** legitimately drive the
+# story-feature-load + causa-feature-gate Playwright runners (their
+# variant graph IS what the gate exercises), so a runtime-extension
+# change there does fire the gate. The runtime-extension AND
+# allow-listed-subdir rule is symmetric with the framework-testbeds
+# split below — both gates filter by `.cljs|.cljc|.js|.cjs|.css|.scss`
+# under explicitly named subdirs, never by anything that grep-matches
+# the parent tool dir.
+is_story_causa_runtime_path() {
+  case "$1" in
+    tools/story/src/*|tools/causa/src/*|tools/story/testbeds/*|tools/causa/testbeds/*)
+      case "$1" in
+        *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss)
+          return 0 ;;
+        *)
+          return 1 ;;
+      esac
+      ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# rf2-9grp6 — predicate: does `$1` look like a framework-testbed
+# runtime source file (CLJS/CLJC/JS/CSS extension under
+# tools/causa/testbeds/** or top-level testbeds/**)? Returns 0 / 1.
+# The split between this gate and `adapter_testbed_smokes` is intentional
+# (rf2-cjp0i + this bead): adapter source changes fire the 3 adapter
+# smokes, framework-testbed source changes fire the 11 framework +
+# top-level testbeds; spec/Markdown changes fire neither. Story's own
+# testbeds (tools/story/testbeds/**) drive the Story/Causa browser gate
+# above, not this one — Causa-owned framework testbeds live under
+# tools/causa/testbeds/** plus the cross-cutting top-level testbeds/**
+# (SSR + framework-behaviour).
+is_framework_testbed_path() {
+  case "$1" in
+    tools/causa/testbeds/*|testbeds/*)
+      case "$1" in
+        *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss|*.html|*.json)
+          return 0 ;;
+        *)
+          return 1 ;;
+      esac
+      ;;
+    *)
+      return 1 ;;
+  esac
 }
 
 if [ "$files" = "__ALL__" ]; then
@@ -68,15 +126,18 @@ else
         mark_all
         ;;
       implementation/core/*)
-        # rf2-8jz9t — adapter_testbed_smokes NOT fired here. The
-        # adapter-testbed-smokes job exercises the 3 adapter-level
-        # smokes (Reagent/UIx/Helix at implementation/adapters/<name>/testbed/)
-        # which catch adapter-specific bugs (createRoot lifecycle,
-        # hydration, real concurrent scheduling) — not core regressions.
-        # Core renames are caught by node-test (CLJS unit + browser-test)
-        # which exercises every public re-frame.core fn. A core rename
-        # that breaks adapter mount silently is caught by the nightly
-        # cron + post-merge gate (both run the full matrix on main).
+        # rf2-8jz9t + rf2-k9ekz + rf2-9grp6 — adapter_testbed_smokes,
+        # framework_testbeds, and story_causa_browser are NOT fired
+        # here. The Playwright gates exist to catch surface-specific
+        # browser bugs (adapter mount lifecycle, Story variant boot,
+        # Causa panel layout, multi-frame isolation) — none of which
+        # are core regressions. Core renames are caught by node-test
+        # (consolidated CLJS unit + browser-test) which exercises every
+        # public re-frame.core fn, and by the always-on JVM core suite.
+        # A core rename that breaks an adapter mount, Story variant
+        # boot, or framework-testbed assertion silently is caught by
+        # the nightly cron + post-merge gate (both run the full matrix
+        # on main).
         implementation_jvm=true
         adapter_diagnostic=true
         cljs_browser=true
@@ -86,7 +147,6 @@ else
         template_expensive=true
         mcp_conformance=true
         mcp_live=true
-        story_causa_browser=true
         ;;
       implementation/adapters/reagent-slim/*|examples/reagent/counter_slim_and_fast/*|implementation/scripts/check-reagent-slim-bundle-isolation.cjs)
         # rf2-8cevm — the examples/ tree is test-free. counter_slim_and_fast
@@ -157,19 +217,20 @@ else
         cljs_prod=true
         ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
-        # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i — adapter_testbed_smokes NOT
-        # fired here. The adapter-testbed-smokes job is now triggered
-        # ONLY by direct adapter surface changes
-        # (implementation/adapters/*) or by changes to the orchestrator
-        # scripts under examples/scripts/. A shadow-cljs.edn or
-        # implementation/scripts/ change that breaks the build is
-        # caught by the nightly cron + post-merge gate (both run the
-        # full matrix on main).
+        # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i + rf2-k9ekz + rf2-9grp6 —
+        # adapter_testbed_smokes, framework_testbeds, and
+        # story_causa_browser are NOT fired here. The Playwright gates
+        # are now triggered ONLY by direct source-tree changes (adapter
+        # source for adapter-testbed-smokes; tools/causa/testbeds/** +
+        # top-level testbeds/** for framework-testbeds;
+        # tools/{story,causa}/{src,testbeds}/** for the Story/Causa
+        # browser gate). A shadow-cljs.edn or implementation/scripts/
+        # change that breaks the build is caught by the nightly cron +
+        # post-merge gate (both run the full matrix on main).
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
         reagent_slim_bundle=true
-        story_causa_browser=true
         ;;
       examples/*)
         # rf2-bxdk8 + rf2-cjp0i + rf2-8cevm — examples/** is test-free.
@@ -180,14 +241,21 @@ else
         cljs_browser=true
         ;;
       testbeds/*)
-        # rf2-7vsfm + rf2-bxdk8 + rf2-cjp0i — Top-level testbeds/* are
-        # compiled + staged by the orchestrator at
-        # examples/scripts/serve-and-run-examples-tests.cjs, but per
-        # rf2-cjp0i the adapter-testbed-smokes gate is scoped to the
-        # adapter smokes themselves; testbed-only diffs no longer fire
-        # adapter_testbed_smokes. cljs_browser still covers CLJS-source
-        # regressions; nightly + post-merge gate runs the full matrix.
+        # rf2-7vsfm + rf2-bxdk8 + rf2-cjp0i + rf2-9grp6 — Top-level
+        # testbeds/* are compiled + staged by the framework-testbeds
+        # orchestrator. Per rf2-cjp0i the adapter-testbed-smokes gate is
+        # scoped to the 3 adapter smokes themselves; per rf2-9grp6 the
+        # framework + top-level testbed Playwright surfaces are now
+        # covered by the split-out `framework-testbeds` gate, which
+        # fires on runtime-extension changes (.cljs/.cljc/.js/.cjs/.css/
+        # .scss/.html/.json) under this tree. Markdown/EDN-only diffs
+        # still skip the gate entirely. cljs_browser stays lit for CLJS-
+        # source regressions in shared core/feature artefacts that the
+        # testbed compiles transitively pull in.
         cljs_browser=true
+        if is_framework_testbed_path "$file"; then
+          framework_testbeds=true
+        fi
         ;;
       tools/template/*)
         # rf2-os0c1 — tools/template is a clj-new template that scaffolds
@@ -198,13 +266,29 @@ else
         template_expensive=true
         ;;
       tools/story/*|tools/causa/*)
-        # rf2-os0c1 — Story / Causa runtime changes legitimately fan out
-        # to story-causa-browser (Playwright feature gates), tools_jvm
-        # (per-artefact JVM unit tests + sibling story-mcp consumer), and
-        # mcp_conformance (the MCP wrappers consume these artefacts).
+        # rf2-os0c1 + rf2-k9ekz + rf2-9grp6 — Story / Causa changes
+        # legitimately fan out to tools_jvm (per-artefact JVM unit tests
+        # + sibling story-mcp consumer) and mcp_conformance (the MCP
+        # wrappers consume these artefacts). story_causa_browser is now
+        # narrowed (rf2-k9ekz): it fires ONLY when the changed path is
+        # under tools/{story,causa}/{src,testbeds}/** AND the file has a
+        # runtime extension (.cljs/.cljc/.js/.cjs/.css/.scss). Markdown
+        # specs under tools/{story,causa}/spec/**, JVM unit tests under
+        # tools/{story,causa}/test/**, deps.edn, README.md, and *.txt
+        # do NOT fire it — they cannot affect chrome and so cannot
+        # invalidate the Playwright gate. Per rf2-9grp6 the Causa-owned
+        # framework testbeds under tools/causa/testbeds/** also fire
+        # framework_testbeds (the split-out Playwright gate for the SSR
+        # + framework-behaviour surfaces). Story's own testbeds drive
+        # the story_causa_browser gate, not framework_testbeds.
         tools_jvm=true
         mcp_conformance=true
-        story_causa_browser=true
+        if is_story_causa_runtime_path "$file"; then
+          story_causa_browser=true
+        fi
+        if is_framework_testbed_path "$file"; then
+          framework_testbeds=true
+        fi
         ;;
       tools/story-mcp/*)
         # rf2-os0c1 — MCP wrappers don't run in a browser; story-causa-browser
@@ -262,6 +346,7 @@ emit cljs_prod "$cljs_prod"
 emit bundle_isolation "$bundle_isolation"
 emit reagent_slim_bundle "$reagent_slim_bundle"
 emit adapter_testbed_smokes "$adapter_testbed_smokes"
+emit framework_testbeds "$framework_testbeds"
 emit tools_jvm "$tools_jvm"
 emit template_expensive "$template_expensive"
 emit mcp_conformance "$mcp_conformance"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
       bundle_isolation: ${{ steps.detect.outputs.bundle_isolation }}
       reagent_slim_bundle: ${{ steps.detect.outputs.reagent_slim_bundle }}
       adapter_testbed_smokes: ${{ steps.detect.outputs.adapter_testbed_smokes }}
+      framework_testbeds: ${{ steps.detect.outputs.framework_testbeds }}
       tools_jvm: ${{ steps.detect.outputs.tools_jvm }}
       template_expensive: ${{ steps.detect.outputs.template_expensive }}
       mcp_conformance: ${{ steps.detect.outputs.mcp_conformance }}
@@ -1033,27 +1034,86 @@ jobs:
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
-      # Compile the adapter-smoke + framework-testbed shadow-cljs builds
-      # (each paired with a spec.cjs under tools/, testbeds/, and
-      # implementation/adapters/), stage their index.html alongside the
-      # bundles, serve out/examples on :8030, and run the Playwright
-      # specs. Per rf2-8cevm the `examples/` tree is TEST-FREE — only
-      # the 3 adapter smokes (Reagent/UIx/Helix), 2 Causa-owned
-      # framework testbeds (parallel-frames, perf-counter), and the
-      # top-level testbeds/ specs (rf2-fe84r + rf2-ik4io SSR) are
-      # exercised here.
-      #
-      # RF2_CAUSA_RUN_GALLERY_SMOKES=1 (rf2-1w76p) opts in to the two
-      # panel-gallery stand-alone smokes (_smoke.cjs +
-      # _workspace_switch_smoke.cjs) which boot the gallery testbed
-      # end-to-end and gate the rf2-kgn0c workspace-teardown
-      # regression. They run AFTER the main spec sweep inside the
-      # same orchestrator invocation.
+      # rf2-9grp6 — narrow scope. The orchestrator at
+      # examples/scripts/serve-and-run-examples-tests.cjs supports a
+      # comma-separated EXAMPLES_FILTER (substring OR-match against
+      # shadow-cljs build ids). `adapters/` matches exactly the 3
+      # adapter smokes (adapters/reagent-testbed, adapters/uix-testbed,
+      # adapters/helix-testbed); all other surfaces (framework testbeds
+      # under tools/causa/testbeds/* and top-level testbeds/*) skip
+      # compile/stage/spec-discovery. The split-out framework-testbeds
+      # job below carries that scope. Per rf2-8cevm the `examples/`
+      # tree is TEST-FREE.
       #
       # NOT a required check on main initially — mirrors the rollout
       # pattern used for cljs-browser (rf2-zoem).
-      - name: Compile adapter smokes + testbeds, serve, and run Playwright specs
+      - name: Compile adapter smokes, serve, and run Playwright specs
         env:
+          EXAMPLES_FILTER: "adapters/"
+        run: npm run test:examples
+
+  framework-testbeds:
+    name: Framework testbeds (Playwright)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.framework_testbeds == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-framework-testbeds-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-framework-testbeds-
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      # rf2-9grp6 — framework + top-level testbed Playwright surfaces.
+      # Split out of `adapter-testbed-smokes` (rf2-cjp0i narrowed the
+      # adapter gate's trigger; this bead narrowed its scope to match).
+      # The EXAMPLES_FILTER pattern OR-matches the 11 framework / SSR
+      # builds (2 Causa-owned: counter-perf + parallel-frames; 9 top-
+      # level: ssr-basic, ssr-hydration-mismatch, ssr-multi-frame,
+      # deliberate-throw, http-toggle, deep-machine, non-trivial-app-db,
+      # long-flow-w-failure, drain-depth-trigger) while excluding the 3
+      # adapter builds. RF2_CAUSA_RUN_GALLERY_SMOKES=1 (rf2-1w76p)
+      # additionally compiles + runs the panel-gallery stand-alone
+      # smokes (gate the rf2-kgn0c workspace-teardown regression) —
+      # those run AFTER the main spec sweep inside the same orchestrator
+      # invocation.
+      - name: Compile framework + top-level testbeds, serve, and run Playwright specs
+        env:
+          EXAMPLES_FILTER: "examples/counter-perf,examples/parallel-frames,testbeds/"
           RF2_CAUSA_RUN_GALLERY_SMOKES: "1"
         run: npm run test:examples
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -164,12 +164,13 @@ boolean GitHub-Actions outputs per surface:
 | `cljs_prod` | Surface that release-mode probes (`browser-test-prod-elision`, schemas boundary prod) cover changed. |
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
-| `adapter_testbed_smokes` | Adapter surface changed (`implementation/adapters/*`) or the orchestrator scripts that drive the smokes (`examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs`). Per rf2-bxdk8 + rf2-cjp0i + rf2-8cevm: generic `examples/**` and `testbeds/**` paths no longer fire this gate (examples/ is test-free; testbed-only diffs are caught by `cljs_browser` and the nightly + post-merge full matrix). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs). |
+| `adapter_testbed_smokes` | Adapter surface changed (`implementation/adapters/*`) or the orchestrator scripts that drive the smokes (`examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs`). Per rf2-bxdk8 + rf2-cjp0i + rf2-8cevm + rf2-9grp6: generic `examples/**` and `testbeds/**` paths no longer fire this gate (examples/ is test-free; testbed-source diffs fire `framework_testbeds` instead — see below). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs). |
+| `framework_testbeds` | Framework / top-level testbed source changed: `tools/causa/testbeds/**` (perf_counter, parallel_frames, feature_matrix, panel_gallery) or top-level `testbeds/**` (rf2-ik4io SSR + rf2-fe84r framework-behaviour). Fires only on runtime-extension changes (`.cljs`, `.cljc`, `.js`, `.cjs`, `.css`, `.scss`, `.html`, `.json`); Markdown / EDN-only diffs do not fire it. Per rf2-9grp6 this gate was split out of `adapter_testbed_smokes` after rf2-cjp0i narrowed the adapter gate to the 3 adapter smokes only — testbed-source diffs were silently uncovered at PR-time. |
 | `tools_jvm` | Story / Causa / Story-MCP / Causa-MCP / Pair2-MCP / MCP-base changed; gates the four per-tool JVM probes (`jvm-tools-{causa,story,story-mcp,mcp-base}`). Not set by `tools/template/*` or `tools/mcp-conformance/*` — those don't share runtime with the per-tool probes. |
 | `template_expensive` | `tools/template/*` changed; gates the template emitted-app smoke. |
 | `mcp_conformance` | Any MCP-server tool, `tools/mcp-base/*`, or `tools/mcp-conformance/*` changed. |
 | `mcp_live` | re-frame2-pair-mcp / mcp-base / mcp-conformance changed; gates the live MCP coverage. |
-| `story_causa_browser` | `tools/story/*` or `tools/causa/*` runtime changed. Not set by the `-mcp` wrappers (they don't run in a browser). |
+| `story_causa_browser` | Story / Causa runtime source changed under `tools/{story,causa}/{src,testbeds}/**` AND the changed file has a runtime extension (`.cljs`, `.cljc`, `.js`, `.cjs`, `.css`, `.scss`). Per rf2-k9ekz the trigger is narrowed: Markdown specs under `tools/{story,causa}/spec/**`, JVM unit tests under `tools/{story,causa}/test/**`, `deps.edn`, `README.md`, and `*.txt` do NOT fire it — they cannot affect chrome and so cannot invalidate the Playwright gate. Not set by the `-mcp` wrappers (they don't run in a browser). |
 | `skills_structural` | `skills/re-frame2-pair/*` or `skills/shared/*` changed. |
 
 A few "blast-radius" inputs force the full sweep:
@@ -180,14 +181,16 @@ A few "blast-radius" inputs force the full sweep:
   full matrix).
 - Changes under `implementation/core/*` fan out broadly (they touch
   almost every output) because core regressions can break every
-  downstream substrate, tool, and bundle invariant. Exception:
-  `adapter_testbed_smokes` is **not** fired by `implementation/core/*`
-  changes (rf2-8jz9t). The adapter smokes under adapter-testbed-smokes
-  only catch adapter-mount-specific bugs (createRoot lifecycle,
-  hydration, real concurrent scheduling); core renames are caught
-  by `node-test` (which exercises every public `re-frame.core`
-  fn), and the nightly cron + post-merge gate runs the full matrix
-  on main.
+  downstream substrate, tool, and bundle invariant. Exceptions: the
+  three Playwright gates (`adapter_testbed_smokes`,
+  `framework_testbeds`, `story_causa_browser`) are **not** fired by
+  `implementation/core/*` changes (rf2-8jz9t + rf2-k9ekz + rf2-9grp6).
+  The Playwright gates exist to catch surface-specific browser bugs
+  (adapter mount lifecycle, Story variant boot, Causa panel layout,
+  multi-frame isolation, framework-testbed contract) — none of which
+  are core regressions. Core renames are caught by `node-test`
+  (which exercises every public `re-frame.core` fn), and the nightly
+  cron + post-merge gate runs the full matrix on main.
 
 **Adding a new artefact directory**: a new artefact (e.g. a new tool,
 new substrate, new SSR runtime) needs **two** matching changes:
@@ -240,32 +243,37 @@ hand-maintained against [`.github/scripts/report-changed-surfaces.sh`](.github/s
 condition changes (per the **Adding a new artefact directory** rule above).
 
 **Surface → output** — read this to verify "did my PR fire the right
-classifier outputs?" Rows are surface groups; columns are the 13
+classifier outputs?" Rows are surface groups; columns are the 14
 classifier outputs (exact names from the script). A `✓` means a change
 under that surface sets that output to `true`. The **blast-trigger row
 (S1)** is bold: any change to those four files calls `mark_all` and
 lights every output (defensive — anything that re-tiers the matrix
 must re-run the matrix).
 
-| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `adapter_testbed_smokes` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
-| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |
-| S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
-| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
-| S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
-| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   | ✓ |   |
-| S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
-| S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs` (orchestrator + runner + helpers — rf2-bxdk8 + rf2-cjp0i) |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |
-| S9 | `testbeds/*` |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
-| S10 | `tools/template/*` |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |
-| S11 | `tools/story/*`, `tools/causa/*` |   |   |   |   |   |   |   | ✓ |   | ✓ |   | ✓ |   |
-| S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
-| S13 | `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*` |   |   |   |   |   |   |   | ✓ |   | ✓ | ✓ |   |   |
-| S14 | `tools/mcp-conformance/*` |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   |   |
-| S15 | `skills/re-frame2-pair/tests/fixture/*` |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   | ✓ |
-| S16 | `skills/re-frame2-pair/*` (other), `skills/shared/*` |   |   |   |   |   |   |   |   |   |   |   |   | ✓ |
+| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `adapter_testbed_smokes` | `framework_testbeds` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
+| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ |   |   |
+| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |   |
+| S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ | ✓ | ✓ | ✓ |   |   |
+| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
+| S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
+| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
+| S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs` (orchestrator + runner + helpers — rf2-bxdk8 + rf2-cjp0i) |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |   |
+| S9 | `testbeds/*` (runtime-extension files — rf2-9grp6) |   |   | ✓ |   |   |   |   | ✓ |   |   |   |   |   |   |
+| S10 | `tools/template/*` |   |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |
+| S11 | `tools/story/{src,testbeds}/**`, `tools/causa/{src,testbeds}/**` (runtime-extension files — rf2-k9ekz) |   |   |   |   |   |   |   | ✓† | ✓ |   | ✓ |   | ✓ |   |
+| S11a | `tools/story/{spec,test,bench}/**`, `tools/causa/{spec,test}/**`, `tools/{story,causa}/{deps.edn,README.md}` (non-runtime under story/causa) |   |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
+| S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
+| S13 | `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ | ✓ |   |   |
+| S14 | `tools/mcp-conformance/*` |   |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   |   |
+| S15 | `skills/re-frame2-pair/tests/fixture/*` |   |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   | ✓ |
+| S16 | `skills/re-frame2-pair/*` (other), `skills/shared/*` |   |   |   |   |   |   |   |   |   |   |   |   |   | ✓ |
+
+† Row S11 fires `framework_testbeds` only for paths under
+`tools/causa/testbeds/**` (Story's own testbeds drive
+`story_causa_browser`, not `framework_testbeds`).
 
 **Output → jobs** — read this to answer "if this output is `true`, what
 runs?" Job counts are grouped (the matrix expands to 30+ leaf jobs at
@@ -279,12 +287,13 @@ PR time; one row per output here so the table stays scannable).
 | `cljs_prod` | Release-mode probes ×3 (`browser-test-prod-elision`, schemas boundary prod, etc.) |
 | `bundle_isolation` | `bundle-isolation` |
 | `reagent_slim_bundle` | `reagent-slim-bundle-isolation` |
-| `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; 3 adapter smokes + the framework + top-level testbeds the orchestrator compiles) |
+| `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; the 3 adapter smokes only — rf2-9grp6 split out the framework + top-level testbeds into the `framework-testbeds` job below) |
+| `framework_testbeds` | `framework-testbeds` (Playwright; 2 Causa-owned framework testbeds at `tools/causa/testbeds/{perf_counter,parallel_frames}` + 9 top-level testbeds at `testbeds/{ssr_basic,ssr_hydration_mismatch,ssr_multi_frame,deliberate_throw,http_toggle,deep_machine,non_trivial_app_db,long_flow_w_failure,drain_depth_trigger}` + the panel-gallery smokes when `RF2_CAUSA_RUN_GALLERY_SMOKES=1`) |
 | `tools_jvm` | Per-tool JVM probes ×4 (`jvm-tools-causa`, `jvm-tools-story`, `jvm-tools-story-mcp`, `jvm-tools-mcp-base`) |
 | `template_expensive` | `jvm-tools-template` (emitted-app smoke) |
 | `mcp_conformance` | MCP conformance ×4 (`mcp-conformance-{story,re-frame2-pair,wire-vocab,...}`) |
 | `mcp_live` | `mcp-conformance-re-frame2-pair` (live + hermetic) |
-| `story_causa_browser` | `story-causa-browser` (feature gates, Playwright) |
+| `story_causa_browser` | `story-causa-browser` (feature gates, Playwright — Causa feature-matrix + Story static + Story feature-load + Story play-scripts) |
 | `skills_structural` | `skills-structural` |
 
 

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -70,7 +70,16 @@ const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8030';
 // the spec file's absolute path, so values like `realworld` match
 // `examples/reagent/realworld/realworld.spec.cjs` cleanly. Unset (or
 // empty) = the full sweep.
+//
+// rf2-9grp6 — comma-separated alternatives, OR-matched. Mirrors the
+// orchestrator's multi-pattern filter so the CI split (adapter smokes
+// vs framework testbeds) can pass a single shape through both stages.
 const FILTER = (process.env.EXAMPLES_FILTER || '').trim();
+function parseFilterPatterns(raw) {
+  if (!raw) return [];
+  return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+const FILTER_PATTERNS = parseFilterPatterns(FILTER);
 // rf2-mpa3x — normalize before substring-matching. Two cosmetic
 // conventions diverge between build ids and spec paths:
 //
@@ -94,8 +103,9 @@ function normalizeForFilter(s) {
   return s.replace(/_/g, '-').replace(/\\/g, '/');
 }
 function matchesFilter(filePath) {
-  if (FILTER === '') return true;
-  return normalizeForFilter(filePath).includes(normalizeForFilter(FILTER));
+  if (FILTER_PATTERNS.length === 0) return true;
+  const normalized = normalizeForFilter(filePath);
+  return FILTER_PATTERNS.some((p) => normalized.includes(normalizeForFilter(p)));
 }
 // __dirname is <repo>/examples/scripts; the example tree sits at
 // <repo>/examples (one level up).

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -35,17 +35,25 @@ const {
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 // rf2-h9ut9 — narrow filter. When set, only the EXAMPLES entries
-// whose `build` id includes the substring are compiled + staged, and
-// the value is propagated to the Playwright runner via the
-// `EXAMPLES_FILTER` env-var so the runner only executes matching
-// specs. Unset (or empty) = the full sweep. The filter is supplied
-// via either:
+// whose `build` id includes any one of the comma-separated substrings
+// are compiled + staged, and the value is propagated to the Playwright
+// runner via the `EXAMPLES_FILTER` env-var so the runner only executes
+// matching specs. Unset (or empty) = the full sweep. The filter is
+// supplied via either:
 //
 //   1. CLI flag (cross-platform; the recommended shape):
 //      node serve-and-run-examples-tests.cjs --filter realworld
 //
 //   2. Env var (for CI / scripted use):
 //      EXAMPLES_FILTER=realworld node serve-and-run-examples-tests.cjs
+//
+// rf2-9grp6 — multi-pattern filter. Comma separates alternatives, OR-
+// matched: `adapters/` matches only the 3 adapter smokes, while
+// `examples/counter-perf,examples/parallel-frames,testbeds/` matches
+// the 11 framework + top-level testbed builds. The CI split (rf2-9grp6)
+// drives this — `adapter-testbed-smokes` invokes the orchestrator with
+// the adapter pattern, `framework-testbeds` with the testbed patterns.
+// Single-pattern usage stays backwards-compatible.
 //
 // The packaged narrow shortcut lives in implementation/package.json
 // as `npm run test:examples:realworld`.
@@ -71,6 +79,14 @@ function parseFilterFromArgs(argv) {
 }
 const FILTER = parseFilterFromArgs(process.argv)
             || (process.env.EXAMPLES_FILTER || '').trim();
+// rf2-9grp6 — split a comma-separated filter into the list of
+// substrings. Empty filter returns an empty array (meaning
+// "pass-through everything" — see `selectedExample` below).
+function parseFilterPatterns(raw) {
+  if (!raw) return [];
+  return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+const FILTER_PATTERNS = parseFilterPatterns(FILTER);
 // rf2-043cm — `EXAMPLES_PORT` env-var override defaults to 8030. Lets
 // parallel workers / contended dev sessions (e.g. a long-running
 // `shadow-cljs watch` on the parallel-frames testbed at 8030)
@@ -247,8 +263,9 @@ function normalizeForFilter(s) {
   return s.replace(/_/g, '-').replace(/\\/g, '/');
 }
 function selectedExample(ex) {
-  if (FILTER === '') return true;
-  return normalizeForFilter(ex.build).includes(normalizeForFilter(FILTER));
+  if (FILTER_PATTERNS.length === 0) return true;
+  const normalized = normalizeForFilter(ex.build);
+  return FILTER_PATTERNS.some((p) => normalized.includes(normalizeForFilter(p)));
 }
 
 function selectedExamples() {

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -36,24 +36,134 @@ function classify(...files) {
   );
 }
 
-test('Story feature-load runner changes trigger targeted Story/Causa browser CI', () => {
-  const result = classify('tools/story/test/story_feature_load.cjs');
+// rf2-k9ekz — Story/Causa browser Playwright gate trigger is narrowed
+// to runtime-source changes under tools/{story,causa}/{src,testbeds}/**
+// AND a runtime-extension (.cljs/.cljc/.js/.cjs/.css/.scss). Spec /
+// test / EDN / deps / Markdown changes do not fire it.
+
+test('Story src .cljs changes trigger story_causa_browser', () => {
+  const result = classify('tools/story/src/foo.cljs');
   assert.equal(result.story_causa_browser, 'true');
 });
 
-test('Story browser scenario changes trigger targeted Story/Causa browser CI', () => {
-  const result = classify('tools/story/test/story_browser_scenarios.cjs');
+test('Causa src .cljs changes trigger story_causa_browser', () => {
+  const result = classify('tools/causa/src/foo.cljs');
   assert.equal(result.story_causa_browser, 'true');
 });
 
-test('Story feature-load testbed changes trigger targeted Story/Causa browser CI', () => {
+test('Story testbed .cljs changes trigger story_causa_browser (gate runs the testbed)', () => {
   const result = classify('tools/story/testbeds/counter_with_stories/stories.cljs');
+  assert.equal(result.story_causa_browser, 'true');
+});
+
+test('Causa feature_matrix testbed .cljs changes trigger story_causa_browser', () => {
+  const result = classify('tools/causa/testbeds/feature_matrix/core.cljs');
+  assert.equal(result.story_causa_browser, 'true');
+});
+
+test('Story spec-only .md changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/story/spec/Spec.md');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Causa spec-only .md changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/causa/spec/017-Test-Coverage-Matrix.md');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Story test-only changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/story/test/story_feature_load.cjs');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Causa test-only changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/causa/test/some_test.clj');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Story deps.edn changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/story/deps.edn');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Story README.md changes do NOT trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/story/README.md');
+  assert.equal(result.story_causa_browser, 'false');
+});
+
+test('Mixed Story src + spec change DOES trigger story_causa_browser (rf2-k9ekz)', () => {
+  const result = classify('tools/story/src/foo.cljs', 'tools/story/spec/bar.md');
   assert.equal(result.story_causa_browser, 'true');
 });
 
 test('targeted Story/Causa workflow runs the Story feature-load gate', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
   assert.match(workflow, /story-causa-browser:[\s\S]*npm run test:story-feature-load/);
+});
+
+// rf2-9grp6 — framework-testbeds gate split. Adapter source changes
+// fire `adapter_testbed_smokes` (existing). Testbed-source changes
+// under tools/causa/testbeds/** or top-level testbeds/** fire the
+// new `framework_testbeds` output. Spec/Markdown changes fire neither.
+
+test('top-level testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('testbeds/ssr_basic/core.cljs');
+  assert.equal(result.framework_testbeds, 'true');
+});
+
+test('top-level testbed .html changes trigger framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('testbeds/ssr_basic/index.html');
+  assert.equal(result.framework_testbeds, 'true');
+});
+
+test('Causa perf_counter testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('tools/causa/testbeds/perf_counter/core.cljs');
+  assert.equal(result.framework_testbeds, 'true');
+});
+
+test('Causa parallel_frames testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('tools/causa/testbeds/parallel_frames/core.cljs');
+  assert.equal(result.framework_testbeds, 'true');
+});
+
+test('top-level testbed README.md does NOT trigger framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('testbeds/ssr_basic/README.md');
+  assert.equal(result.framework_testbeds, 'false');
+});
+
+test('Story src .cljs change does NOT trigger framework_testbeds (rf2-9grp6 — Story drives story_causa_browser, not this)', () => {
+  const result = classify('tools/story/src/foo.cljs');
+  assert.equal(result.framework_testbeds, 'false');
+});
+
+test('Adapter source change fires adapter_testbed_smokes but NOT framework_testbeds (rf2-9grp6)', () => {
+  const result = classify('implementation/adapters/reagent/testbed/core.cljs');
+  assert.equal(result.adapter_testbed_smokes, 'true');
+  assert.equal(result.framework_testbeds, 'false');
+});
+
+test('top-level testbed .cljs change fires framework_testbeds but NOT adapter_testbed_smokes (rf2-9grp6)', () => {
+  const result = classify('testbeds/ssr_basic/core.cljs');
+  assert.equal(result.adapter_testbed_smokes, 'false');
+  assert.equal(result.framework_testbeds, 'true');
+});
+
+test('framework-testbeds workflow job is gated by framework_testbeds output (rf2-9grp6)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  assert.match(
+    workflow,
+    /framework-testbeds:[\s\S]*if:\s+needs\.detect_changed_surfaces\.outputs\.framework_testbeds\s*==\s*'true'/,
+  );
+});
+
+test('adapter-testbed-smokes workflow narrowed to EXAMPLES_FILTER=adapters/ (rf2-9grp6)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  // Find the adapter-testbed-smokes job block and verify it passes the
+  // narrow adapters/ filter (so framework + top-level testbeds skip).
+  assert.match(
+    workflow,
+    /adapter-testbed-smokes:[\s\S]*EXAMPLES_FILTER:\s*"adapters\/"/,
+  );
 });
 
 let failed = 0;


### PR DESCRIPTION
## Summary

- **rf2-k9ekz** — Narrow `story_causa_browser` trigger to runtime-source changes under `tools/{story,causa}/{src,testbeds}/**` with a runtime extension (`.cljs|.cljc|.js|.cjs|.css|.scss`). Spec Markdown, JVM tests, `deps.edn`, `README.md`, and `*.txt` no longer fire the ~3-min Playwright gate. `implementation/core/*` and `implementation/shadow-cljs.edn` also stop firing it (Playwright gates target surface-specific bugs, not core regressions; nightly + post-merge full matrix catches transitive breakage).
- **rf2-9grp6** — Split `adapter-testbed-smokes` (which still ran ~13 surfaces despite its narrowed trigger). New `framework-testbeds` Playwright job gated on a new `framework_testbeds` classifier output (fires on `tools/causa/testbeds/**` or top-level `testbeds/**` with a runtime extension). Existing `adapter-testbed-smokes` job now passes `EXAMPLES_FILTER=adapters/` to keep its scope to the 3 adapter smokes only. Closes the rf2-cjp0i side-effect coverage gap: testbed-only diffs fire `framework_testbeds` at PR-time again.
- Orchestrator + runner extended with comma-separated multi-pattern `EXAMPLES_FILTER` (substring OR-match) so both jobs share one `npm run test:examples` entrypoint. Backwards-compatible with single-pattern usage.

## Behaviour matrix

| Diff type | adapter-testbed-smokes | framework-testbeds | story-causa-browser |
|---|---|---|---|
| `implementation/adapters/<reagent>/*` | yes | no | no |
| `testbeds/ssr_basic/core.cljs` | no | yes | no |
| `tools/causa/testbeds/perf_counter/core.cljs` | no | yes | yes (causa src/testbeds also fire it) |
| `tools/story/src/foo.cljs` | no | no | yes |
| `tools/story/spec/Spec.md` | no | no | no |
| `tools/story/test/*.cjs` | no | no | no |
| `tools/story/deps.edn` | no | no | no |
| `implementation/core/foo.cljc` | no | no | no |

## Surfaces touched

- `.github/scripts/report-changed-surfaces.sh` — new `is_story_causa_runtime_path` + `is_framework_testbed_path` predicates, narrowed `tools/{story,causa}/*` rule, removed Playwright triggers from `implementation/core/*` + `implementation/shadow-cljs.edn`, new `framework_testbeds` output.
- `.github/workflows/test.yml` — new `framework-testbeds` job; `adapter-testbed-smokes` step gets `EXAMPLES_FILTER=adapters/`; `detect_changed_surfaces` exposes `framework_testbeds`.
- `examples/scripts/{serve-and-run-examples-tests,run-examples-tests}.cjs` — comma-separated multi-pattern filter parser.
- `TESTING.md` — output table entries for both gates; surface-matrix S9/S11/S11a rows; output→jobs row for `framework_testbeds`; blast-trigger note now lists all three Playwright gates as core-exempt.
- `implementation/scripts/_changed-surfaces.test.cjs` — 22 tests (was 4) covering rf2-k9ekz exclusions + rf2-9grp6 split + workflow wiring.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML loads
- [x] `python -m mkdocs build --strict` — clean
- [x] `node implementation/scripts/_changed-surfaces.test.cjs` — 22/22 pass
- [x] `cd implementation && npm run test:script-policy` — green
- [x] Manual sanity sweep of 19 filter combinations across both EXAMPLES_FILTER patterns
- [ ] CI must show: doc-only / spec-only / test-only / deps-only PRs touching `tools/{story,causa}` skip both Playwright gates; testbed-source PRs fire only `framework-testbeds`; adapter-source PRs fire only `adapter-testbed-smokes`.