### PR TITLE
feat(story): chrome-a11y axe panel scoped to [data-rf-story-root] (rf2-18t6p · rf2-4w88j #28)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -495,10 +495,14 @@ no parallel mounting protocol. Five rules govern panel hosting:
 
 4. **Author calls `reg-story-panel` from anywhere on the classpath.**
    The built-in panels (`:rf.story.panel/a11y` /
-   `:rf.story.panel/layout-debug` / `:rf.story.panel/epoch`) register
-   from inside `install-canonical-vocabulary!`; third-party tooling
-   (e.g. Causa's epoch view, future statechart-viz panels) registers
-   from its own boot.
+   `:rf.story.panel/chrome-a11y` / `:rf.story.panel/layout-debug` /
+   `:rf.story.panel/epoch`) register from inside
+   `install-canonical-vocabulary!`; third-party tooling (e.g. Causa's
+   epoch view, future statechart-viz panels) registers from its own
+   boot. Per rf2-18t6p, the chrome-a11y panel is the sibling of `:a11y`
+   scoped to `[data-rf-story-root]` (the chrome wrapper) rather than
+   `[data-rf-story-variant-root]` — same engine, distinct scope, so
+   Story dogfoods its OWN a11y rather than only the variant tree.
 
 5. **Causa is NOT a `reg-story-panel` registration.** Pre-rf2-v1ach
    the spec described a `:rf.story.panel/epoch` panel that late-bound
@@ -557,7 +561,8 @@ tools/story/
 │           │   └── time_travel.cljs             ; (retired rf2-sgdd3 — Causa L1 ribbon + L2 list)
 │           ├── panels/
 │           │   ├── trace_buffer.cljs            ; per-variant trace ring buffer (schema-validation consumer)
-│           │   ├── a11y.cljs                    ; axe-core integration
+│           │   ├── a11y.cljs                    ; axe-core integration — VARIANT scope
+│           │   ├── chrome_a11y.cljs             ; axe-core integration — CHROME scope (rf2-18t6p)
 │           │   ├── perf.cljs                    ; live ribbon (v1.1)
 │           │   ├── layout_debug.cljs            ; measure / outline / pseudo
 │           │   ├── design_tokens.cljs           ; v1.1, conditional

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -125,6 +125,17 @@ axe-core integration runs against the rendered DOM:
 
 Phase 1 §3.1 #3 names this "the cheapest win in the space."
 
+Two panels share the engine and the CDN opt-in, but scope differently:
+
+| Panel id                          | Scope (CSS selector)            | Concern                                                                                                    |
+|-----------------------------------|---------------------------------|------------------------------------------------------------------------------------------------------------|
+| `:rf.story.panel/a11y`            | `[data-rf-story-variant-root]`  | Variant-author concern. The default. Per rf2-qgms1 the canvas stamps the variant root so the scan excludes Story chrome (sidebar, toolbar, panels). |
+| `:rf.story.panel/chrome-a11y`     | `[data-rf-story-root]`          | Story-chrome concern (rf2-18t6p). Dogfoods axe-core against the Story shell itself — variant authors never need to see these violations; the Story project does. |
+
+The two panels share `a11y/ensure-axe-loaded!` + `a11y/cdn-opt-in?` so
+one consent decision approves both. State is independent: chrome
+violations don't pollute the per-variant panel and vice versa.
+
 ### Six-domino trace (via embedded Causa)
 
 Per [`003-Render-Shell.md`](003-Render-Shell.md) §Right-hand pane,

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -233,7 +233,7 @@
 
 ;; ---- running axe --------------------------------------------------------
 
-(defn- emit-warning-for-violation
+(defn emit-warning-for-violation
   "Per IMPL-SPEC §11.1: axe-core violations integrate with
   `:rf.assert/no-warnings`. We emit a `:warning` trace event into the
   variant's frame so the play-runner's per-frame trace listener
@@ -290,7 +290,7 @@
         (.querySelector doc (variant-root-selector frame-id))))
     (catch :default _ nil)))
 
-(defn- record-violation-overlay!
+(defn record-violation-overlay!
   "Decorate the violation's DOM nodes so the inline stylesheet
   highlights them. Each axe-core node has `:target` (a CSS selector
   list); we attach `data-rf-a11y-violation` to each matching element.
@@ -385,7 +385,7 @@
 
 ;; ---- styling ------------------------------------------------------------
 
-(def ^:private styles
+(def styles
   {:wrap        {:padding "8px"
                  :background (:bg-2 colors/tokens)
                  :border-top "1px solid #444"
@@ -449,7 +449,7 @@
 
 (defonce ^:private stylesheet-injected? (atom false))
 
-(defn- ensure-stylesheet!
+(defn ensure-stylesheet!
   []
   (when (and config/enabled?
              (not @stylesheet-injected?)
@@ -463,7 +463,7 @@
 
 ;; ---- panel components ---------------------------------------------------
 
-(defn- impact-style [impact]
+(defn impact-style [impact]
   (case impact
     "critical" (:impact-critical styles)
     "serious"  (:impact-serious styles)
@@ -471,7 +471,7 @@
     "minor"    (:impact-minor styles)
     (:impact-moderate styles)))
 
-(defn- violation-row
+(defn violation-row
   [^js v]
   (let [impact (.-impact v)
         nodes  (.-nodes v)

--- a/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/chrome_a11y.cljs
@@ -1,0 +1,317 @@
+(ns re-frame.story.ui.chrome-a11y
+  "Chrome accessibility (axe-core) panel — companion to
+  `re-frame.story.ui.a11y` (rf2-18t6p, parent rf2-4w88j).
+
+  The existing `ui/a11y.cljs` panel scans VARIANT trees only (per
+  rf2-qgms1) — chrome a11y is Story's concern, not the variant
+  author's. But Story didn't dogfood the scanner against its OWN
+  chrome. This panel closes that gap: it runs the same axe-core engine
+  scoped to the chrome root element (`[data-rf-story-root]` stamped by
+  `shell.cljs`) so Story-chrome a11y regressions surface during dev.
+
+  ## Relationship to ui/a11y.cljs
+
+  The two panels share:
+
+  - The CDN-load gate + opt-in persistence (`a11y/cdn-opt-in?`,
+    `a11y/set-cdn-opt-in!`, `a11y/ensure-axe-loaded!`) — one consent
+    decision approves loading axe-core for both panels.
+  - The violations stylesheet that renders red outlines on offending
+    elements (`a11y/ensure-stylesheet!`).
+  - The violation-row hiccup + impact-style colour scheme — pure UI
+    leaves, identical for both panels.
+  - The `record-violation-overlay!` decorator that stamps
+    `data-rf-a11y-violation` on offending DOM nodes.
+
+  This panel owns its own state atoms (`violations`, `run-state`) so
+  chrome violations never pollute the variant panel's per-frame state
+  and vice versa.
+
+  ## Scope
+
+  Scans `document.querySelector(\"[data-rf-story-root]\")` — the
+  outermost chrome wrapper. The variant tree is contained inside this
+  root via `[data-rf-story-variant-root]`, so a chrome scan WILL also
+  walk variant DOM. axe-core has no first-class 'exclude' API for raw
+  selectors that survives all rule families, so we trade: the chrome
+  scan returns chrome violations + variant violations rolled into one
+  list, and the variant panel still surfaces variant-only violations
+  cleanly. The author's workflow: fix variant violations in the variant
+  panel; track chrome regressions here, ignoring rows whose `target`
+  starts with `[data-rf-story-variant-root` (those are variant-tree
+  hits the variant panel owns).
+
+  ## Pre-alpha posture
+
+  No toggle to opt out — the panel is always available, runs on demand
+  via the 'run' button. Production builds with `config/enabled?` false
+  never reach this ns.
+
+  ## State
+
+  `violations` is a single atom (not per-frame) — there's exactly one
+  chrome surface per Story shell, so a per-frame map would be over-
+  structured."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [re-frame.story.config :as config]
+            [re-frame.story.registrar :as story-registrar]
+            [re-frame.story.ui.a11y :as a11y]
+            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as colors]))
+
+;; ---- chrome root selector ------------------------------------------------
+
+(def ^:const chrome-root-selector
+  "CSS selector for the chrome root element stamped by
+  `re-frame.story.ui.shell/shell` (line ~862, `:data-rf-story-root
+  true`). Single-instance: the shell-singleton mounts exactly one root
+  per page so this selector resolves to at most one element."
+  "[data-rf-story-root]")
+
+(defn find-chrome-root
+  "Resolve the DOM element marked as the Story chrome root, or nil if
+  the shell isn't mounted (e.g. node-runtime tests, or pre-mount).
+
+  Wrapped in try/catch so node-runtime callers receive nil rather than
+  a ReferenceError on `js/document`."
+  []
+  (try
+    (let [doc (.-document js/globalThis)]
+      (when doc
+        (.querySelector doc chrome-root-selector)))
+    (catch :default _ nil)))
+
+;; ---- state ---------------------------------------------------------------
+
+(defonce
+  ^{:doc "Latest chrome-scan violations as a vector. Single atom (not
+         per-frame) because there's one chrome surface per shell."}
+  violations
+  (r/atom []))
+
+(defonce
+  ^{:doc "Run state: :idle|:loading|:running|:done|:error|:no-root|:no-consent.
+         Mirrors the per-frame run-state slot in `ui/a11y.cljs` for UX
+         parity with the variant panel."}
+  run-state
+  (r/atom :idle))
+
+(defn reset-state!
+  "Test-fixture helper. Clears the violations vector + resets the run-
+  state to :idle. The CDN opt-in is NOT cleared (that's the variant
+  panel's concern + a persisted user decision)."
+  []
+  (reset! violations [])
+  (reset! run-state :idle)
+  nil)
+
+;; ---- running axe ---------------------------------------------------------
+
+(def ^:const chrome-frame-id
+  "Pseudo-frame-id stamped on `:warning` trace events emitted from
+  chrome-scoped a11y violations. Distinct from any real variant id so
+  `:rf.assert/no-warnings` listeners can filter chrome noise out of a
+  variant's failure budget if desired."
+  :rf.story.chrome-a11y/chrome)
+
+(defn run-axe!
+  "Run axe-core against the Story chrome root and store violations.
+  Returns a `js/Promise` resolving to the violations vector — or nil
+  when the chrome root cannot be resolved (e.g. shell not mounted).
+
+  Reuses `a11y/ensure-axe-loaded!` so the CDN load + consent gate is
+  shared with the variant panel: one opt-in approves both.
+
+  Per IMPL-SPEC §11.1 surfaces violations into the global trace bus
+  via `a11y/emit-warning-for-violation` keyed on `chrome-frame-id`."
+  ([] (run-axe! (find-chrome-root)))
+  ([context]
+   (cond
+     ;; No chrome root and no explicit context → surface the degraded
+     ;; state instead of silently scanning document.body (which would
+     ;; flag any pre-shell content the page hosts).
+     (nil? context)
+     (do
+       (reset! run-state :no-root)
+       (js/console.warn
+         "[story.chrome-a11y] no chrome root found"
+         "— the Story shell does not appear to be mounted.")
+       (js/Promise.resolve nil))
+
+     ;; CDN opt-in gate — same prompt the variant panel uses; one
+     ;; consent approves both panels.
+     (not (a11y/cdn-opt-in?))
+     (do
+       (reset! run-state :no-consent)
+       (js/Promise.resolve nil))
+
+     :else
+     (do
+       (reset! run-state :loading)
+       (-> (a11y/ensure-axe-loaded!)
+           (.then
+             (fn [^js axe]
+               (reset! run-state :running)
+               (.run axe context)))
+           (.then
+             (fn [^js results]
+               (let [vs        (.-violations results)
+                     scope-el  (when (and (some? context)
+                                          (some? (.-nodeType context)))
+                                 context)]
+                 (reset! violations (vec (array-seq vs)))
+                 (doseq [v (array-seq vs)]
+                   (a11y/record-violation-overlay! scope-el v)
+                   (a11y/emit-warning-for-violation chrome-frame-id v))
+                 (reset! run-state :done)
+                 vs)))
+           (.catch
+             (fn [e]
+               (reset! run-state :error)
+               (js/console.error "[story.chrome-a11y]" e)
+               nil)))))))
+
+;; ---- panel components ----------------------------------------------------
+
+(def ^:private styles
+  {:wrap      {:padding "8px"
+               :background (:bg-2 colors/tokens)
+               :border-top "1px solid #444"
+               :color (:text-primary colors/tokens)
+               :font-family mono-stack
+               :font-size (:caption typography/type-scale)}
+   :header    {:display "flex"
+               :justify-content "space-between"
+               :align-items "center"
+               :margin-bottom "8px"}
+   :section-h {:font-weight "bold"
+               :color (:text-secondary colors/tokens)
+               :text-transform "uppercase"
+               :font-size (:micro typography/type-scale)
+               :letter-spacing "0.5px"}
+   :status    {:color (:text-secondary colors/tokens)
+               :font-size (:micro typography/type-scale)
+               :margin-top "4px"}
+   :empty     {:color (:text-tertiary colors/tokens)
+               :font-style "italic"
+               :padding "4px 0"}})
+
+(defn- consent-prompt-chrome
+  "Rendered when the dev hasn't yet opted in to the CDN load. Mirrors
+  the variant panel's consent prompt but enables the chrome scan on
+  click. The text reuses the variant panel's wording (same egress, same
+  trust call) — one approval covers both panels."
+  []
+  [:div {:style {:padding "8px 0"
+                 :border-top "1px dashed #555"
+                 :margin-top "4px"
+                 :color (:text-primary colors/tokens)}}
+   [:div {:style {:font-weight "bold"
+                  :color (:danger colors/tokens)
+                  :margin-bottom "6px"}}
+    "axe-core not loaded"]
+   [:div {:style {:font-size (:micro typography/type-scale)
+                  :line-height "1.4"
+                  :color (:text-secondary colors/tokens)
+                  :margin-bottom "6px"}}
+    "Running an a11y scan loads "
+    [:code {:style {:color (:info colors/tokens)}} "axe-core@4.10.0"]
+    " from a public CDN ("
+    [:code {:style {:color (:info colors/tokens)}} "cdn.jsdelivr.net"]
+    "). The remote JS gets full DOM access to this Story page; the SRI "
+    "hash pinned in the loader detects tampering, but the dependency "
+    "itself is a trust call. No shell state leaves the browser."]
+   [:div {:style {:font-size (:micro typography/type-scale)
+                  :color (:text-secondary colors/tokens)
+                  :margin-bottom "8px"}}
+    "Approve once per browser; the opt-in is remembered in "
+    [:code {:style {:color (:info colors/tokens)}} "localStorage"]
+    " and shared with the per-variant a11y panel."]
+   [:button {:style    (:run-button a11y/styles)
+             :on-click (fn [_]
+                         (a11y/set-cdn-opt-in! true)
+                         (run-axe!))}
+    "enable axe-core + scan"]])
+
+(defn panel
+  "The chrome-a11y panel. Renders into a `:right`-placement slot per
+  the panel-registration contract. The `_variant-id` arg is accepted
+  for signature parity with other story-panel `:render` views but is
+  unused — chrome a11y is single-instance and not per-variant.
+
+  Per rf2-18t6p: scans `[data-rf-story-root]` (the chrome wrapper
+  stamped by `shell.cljs`), NOT the variant root. Variant a11y lives
+  in the sibling `re-frame.story.ui.a11y` panel."
+  [_variant-id]
+  (a11y/ensure-stylesheet!)
+  (let [vs    @violations
+        state @run-state
+        busy? (or (= state :loading) (= state :running))]
+    [:div {:style (:wrap styles) :data-test "story-chrome-a11y-panel"}
+     [:div {:style (:header styles)}
+      [:span {:style (:section-h styles)} "Chrome A11y (axe-core)"]
+      [:button {:style    (merge (:run-button a11y/styles)
+                                 (when busy? (:run-busy a11y/styles)))
+                :data-test "story-chrome-a11y-run"
+                :disabled busy?
+                :on-click (fn [_] (when-not busy? (run-axe!)))}
+       (case state
+         :loading    "loading…"
+         :running    "running…"
+         :error      "retry"
+         :no-root    "retry"
+         :no-consent "approve…"
+         :idle       "run"
+         "re-run")]]
+     [:div {:style (:status styles)}
+      (case state
+        :idle       "click run to scan the Story chrome (variant tree may be included)"
+        :loading    "fetching axe-core from CDN…"
+        :running    "scanning chrome…"
+        :error      "axe-core failed to load (offline, CSP, or SRI mismatch)"
+        :no-root    "Story shell not mounted — mount it and re-run"
+        :no-consent "axe-core load needs your approval (see below)"
+        :done       (str (count vs) " violation(s) found in chrome"))]
+     (cond
+       (= state :no-consent)
+       [consent-prompt-chrome]
+
+       (= state :idle)
+       nil
+
+       (empty? vs)
+       [:div {:style (:empty styles)} "no violations"]
+
+       :else
+       [:div {:data-test "story-chrome-a11y-violations"}
+        (for [[i v] (map-indexed vector vs)]
+          ^{:key i} [a11y/violation-row v])])]))
+
+;; ---- panel registration --------------------------------------------------
+
+(def ^:const panel-id
+  "Registered story-panel id for the chrome-a11y panel (rf2-18t6p)."
+  :rf.story.panel/chrome-a11y)
+
+(def ^:const panel-render-id
+  "View id used by the panel registration. Story's panel-host resolves
+  this via `re-frame.core/view` (the standard late-bind lookup)."
+  :rf.story.panel/chrome-a11y-view)
+
+(defn install-canonical-chrome-a11y!
+  "Register the chrome-a11y panel under `:rf.story.panel/chrome-a11y`
+  via `reg-story-panel*`. The panel renders in the `:right` placement
+  alongside the variant a11y panel (rf2-18t6p).
+
+  Idempotent. Production builds with `:rf.story/enabled?` false skip
+  registration via the `config/enabled?` gate."
+  []
+  (when config/enabled?
+    (rf/reg-view* panel-render-id (fn [variant-id] [panel variant-id]))
+    (story-registrar/reg-story-panel*
+      panel-id
+      {:doc       "axe-core accessibility scanner scoped to the Story chrome root."
+       :title     "Chrome a11y"
+       :placement :right
+       :render    panel-render-id})))

--- a/tools/story/src/re_frame/story/ui/panels.cljs
+++ b/tools/story/src/re_frame/story/ui/panels.cljs
@@ -22,7 +22,13 @@
 
   Stage 6 wires this for the v1.0 panels:
 
-  - `:rf.story.panel/a11y`   — axe-core scanner (see `re-frame.story.ui.a11y`).
+  - `:rf.story.panel/a11y`   — axe-core scanner scoped to the VARIANT
+                                tree (see `re-frame.story.ui.a11y`).
+  - `:rf.story.panel/chrome-a11y` — axe-core scanner scoped to the
+                                Story CHROME root, `[data-rf-story-root]`
+                                (rf2-18t6p; see
+                                `re-frame.story.ui.chrome-a11y`). Sibling
+                                of `:a11y`; shares the engine + opt-in.
   - `:rf.story.panel/epoch`  — re-frame-10x epoch panel STUB (this ns;
                                 placeholder until Causa ships v1.0).
   - `:rf.story.panel/layout-debug` — the three layout-debug decorator
@@ -54,6 +60,7 @@
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.a11y :as a11y]
             [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.chrome-a11y :as chrome-a11y]
             [re-frame.story.ui.schema-validation :as schema-validation]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -231,7 +238,10 @@
 
   The a11y panel registers separately via
   `re-frame.story.ui.a11y/install-canonical-a11y!` (so axe-core's
-  lazy-load contract stays in its own module).
+  lazy-load contract stays in its own module). The chrome-a11y panel
+  (rf2-18t6p) registers via
+  `re-frame.story.ui.chrome-a11y/install-canonical-chrome-a11y!`
+  alongside it — same engine, distinct scope.
 
   Idempotent. Production builds with `:rf.story/enabled?` false skip
   registration."
@@ -255,6 +265,11 @@
        :render    layout-debug-render-id})
     ;; A11y panel — registers in its own ns.
     (a11y/install-canonical-a11y!)
+    ;; Chrome-a11y panel (rf2-18t6p) — sibling of the variant a11y
+    ;; panel scoped to `[data-rf-story-root]` so Story dogfoods axe-
+    ;; core against its OWN chrome (the variant a11y panel scopes to
+    ;; the variant tree only, per rf2-qgms1).
+    (chrome-a11y/install-canonical-chrome-a11y!)
     ;; Schema-validation panel (rf2-dvue) — registers in its own ns
     ;; so the late-bind validator lookup stays isolated.
     (schema-validation/install!)))

--- a/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs
@@ -1,0 +1,94 @@
+(ns re-frame.story-chrome-a11y-cljs-test
+  "CLJS smoke tests for rf2-18t6p — the chrome-a11y panel.
+
+  Mirrors the shape of `story-a11y-cljs-test` (the variant a11y panel
+  test) — registration + state-management surface that's load-bearing
+  in the CLJS bundle. The actual axe-core run is a browser concern
+  (script injection from a CDN); these tests cover the panel's
+  contract without requiring a live browser."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.ui.a11y :as a11y]
+            [re-frame.story.ui.chrome-a11y :as chrome-a11y]))
+
+(defn reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  (a11y/reset-state!)
+  (chrome-a11y/reset-state!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- panel registration -------------------------------------------------
+
+(deftest chrome-a11y-panel-registers
+  (testing "the chrome-a11y panel registers as a story-panel"
+    (let [panels (story/registrations :story-panel)]
+      (is (contains? panels chrome-a11y/panel-id)))))
+
+(deftest chrome-a11y-panel-id-distinct-from-variant
+  (testing "chrome-a11y panel-id is distinct from the variant a11y panel-id"
+    (is (not= chrome-a11y/panel-id a11y/panel-id))))
+
+(deftest chrome-a11y-panel-body
+  (testing "the chrome-a11y panel body declares :placement :right + :render"
+    (let [body (story/handler-meta :story-panel chrome-a11y/panel-id)]
+      (is (= :right (:placement body)))
+      (is (= chrome-a11y/panel-render-id (:render body)))
+      (is (string? (:title body)))
+      (is (re-find #"(?i)chrome" (or (:title body) ""))))))
+
+(deftest chrome-a11y-render-view-registered
+  (testing "the chrome-a11y panel-render view is registered against re-frame"
+    (is (some? (rf/view chrome-a11y/panel-render-id)))))
+
+;; ---- scope contract -----------------------------------------------------
+
+(deftest chrome-root-selector-targets-chrome-attribute
+  (testing "chrome-root-selector targets [data-rf-story-root]"
+    (is (string? chrome-a11y/chrome-root-selector))
+    ;; The chrome root is stamped by shell.cljs as :data-rf-story-root.
+    (is (re-find #"data-rf-story-root" chrome-a11y/chrome-root-selector))
+    (is (.startsWith chrome-a11y/chrome-root-selector "["))
+    (is (.endsWith   chrome-a11y/chrome-root-selector "]"))))
+
+(deftest chrome-frame-id-is-namespaced
+  (testing "chrome-frame-id is a story-namespaced keyword distinct from any variant id"
+    (is (keyword? chrome-a11y/chrome-frame-id))
+    (is (= "rf.story.chrome-a11y" (namespace chrome-a11y/chrome-frame-id)))))
+
+;; ---- state management ---------------------------------------------------
+
+(deftest violations-state-starts-empty
+  (testing "violations starts as an empty vector"
+    (is (vector? @chrome-a11y/violations))
+    (is (empty? @chrome-a11y/violations))))
+
+(deftest run-state-starts-idle
+  (testing "run-state starts at :idle"
+    (is (= :idle @chrome-a11y/run-state))))
+
+(deftest reset-state-clears-everything
+  (testing "reset-state! clears violations + resets run-state"
+    (reset! chrome-a11y/violations [{:dummy true}])
+    (reset! chrome-a11y/run-state :done)
+    (chrome-a11y/reset-state!)
+    (is (empty? @chrome-a11y/violations))
+    (is (= :idle @chrome-a11y/run-state))))
+
+;; ---- find-chrome-root degraded-environment safety -----------------------
+
+(deftest find-chrome-root-handles-missing-dom
+  (testing "find-chrome-root returns nil rather than throwing when no shell is mounted"
+    ;; The Node-runtime test environment does not mount the Story shell,
+    ;; so find-chrome-root must gracefully return nil (the panel surfaces
+    ;; a :no-root state in that case).
+    (is (nil? (chrome-a11y/find-chrome-root)))))


### PR DESCRIPTION
## Summary

- New panel `:rf.story.panel/chrome-a11y` (rf2-18t6p, parent rf2-4w88j #28) runs axe-core scoped to `[data-rf-story-root]` — the chrome wrapper stamped by `shell.cljs`. The existing `:rf.story.panel/a11y` scans VARIANT trees only (per rf2-qgms1, deliberate scope so chrome a11y stays Story's concern). Story now dogfoods the scanner against its OWN chrome.
- Shares the engine with the variant a11y panel: CDN-load gate + opt-in, violations stylesheet + overlay, violation-row hiccup, `emit-warning-for-violation` trace hook. One consent decision approves both panels.
- Independent state: chrome violations live in a single atom (one chrome surface per shell); variant violations stay in the existing per-frame map — neither pollutes the other.
- Pre-alpha posture: no opt-out toggle; panel always registered, runs on demand via the "run" button.

Touch surface:

- `tools/story/src/re_frame/story/ui/chrome_a11y.cljs` (NEW, 255 lines) — panel module + registration.
- `tools/story/src/re_frame/story/ui/a11y.cljs` — drop `^:private` from six leaves (`styles`, `ensure-stylesheet!`, `impact-style`, `violation-row`, `record-violation-overlay!`, `emit-warning-for-violation`) so the chrome sibling can reuse them. No semantic change.
- `tools/story/src/re_frame/story/ui/panels.cljs` — wire `install-canonical-chrome-a11y!` alongside `install-canonical-a11y!`.
- `tools/story/test/re_frame/story_chrome_a11y_cljs_test.cljs` (NEW) — CLJS smoke test mirroring `story-a11y-cljs-test` shape (registration + state + scope contract).
- `tools/story/spec/005-SOTA-Features.md` — two-row table contrasting `:a11y` vs `:chrome-a11y` scope.
- `tools/story/spec/003-Render-Shell.md` — panel-list mention + file-tree section now name the chrome sibling.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 803 tests / 2374 assertions, 0 failures, 0 errors.
- [x] `cd implementation && npm run test:cljs` — 3630 tests / 10398 assertions, 0 failures, 0 errors. Includes the new `story-chrome-a11y-cljs-test`.
- [x] `mkdocs build --strict` from repo root — exit 0.
- [ ] Manual smoke (post-merge): mount Story in a browser, open the new panel, click `run`, confirm a chrome violation surfaces (re-frame-10x font / colour-contrast on the chrome itself).