### PR TITLE
a11y(causa): @media (forced-colors: active) overrides using system tokens (rf2-wxepo · rf2-4w88j #20)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -468,6 +468,147 @@
     "  outline: 2px solid #FBBF24;\n"
     "  outline-offset: 2px;\n"
     "  border-radius: 3px;\n"
+    "}\n"
+    ;; rf2-wxepo — Windows High Contrast Mode (forced-colors). The UA
+    ;; strips inline `:background` and `:color` declarations and forces
+    ;; its own palette (Canvas / CanvasText / Highlight / …), which
+    ;; collapses every author-encoded signal across the Causa chrome:
+    ;;
+    ;;   - L1 ribbon mode stripe (violet/cyan accent on the left edge)
+    ;;   - L2 row focused border (cyan)
+    ;;   - L2 row status accent (the 2px inset box-shadow on the
+    ;;     trailing edge — box-shadow itself is also dropped in HCM)
+    ;;   - L2 row gutter causal-chain thread (1px violet inset)
+    ;;   - L4 panel-domain accent stripes (3px left border in each
+    ;;     panel's hue — violet/cyan/orange/green/yellow/red)
+    ;;   - Focus-visible amber outline (the #FBBF24 hex above; the UA
+    ;;     forces this to its own Highlight regardless of author intent)
+    ;;   - Secondary / tertiary text (drifted greys collapse to a
+    ;;     single CanvasText hue)
+    ;;
+    ;; The remedy is to map each signal onto a CSS *system colour
+    ;; keyword* inside `@media (forced-colors: active)`. System tokens
+    ;; are the ONE class of colour the UA accepts and honours in HCM
+    ;; — every other hex is overridden. Each rule is `!important` so
+    ;; the per-element inline-style declarations are beaten on
+    ;; specificity (inline style normally wins over external CSS;
+    ;; `!important` in CSS reverses that).
+    ;;
+    ;; Token mapping:
+    ;;   Highlight    — focus ring, focused row, mode stripe, gutter
+    ;;                  thread, focus markers (the user's "what's
+    ;;                  selected/active" hue under their HCM theme)
+    ;;   CanvasText   — primary text + neutral border accents (the
+    ;;                  default ink colour of the HCM theme)
+    ;;   Mark         — status-relevant emphasis (errored row accent;
+    ;;                  semantically the "important emphasis" system
+    ;;                  hue, distinct from Highlight so the operator
+    ;;                  can still tell "error" from "selected")
+    ;;   GrayText     — secondary / tertiary text + stale / paused
+    ;;                  state (the HCM theme's "disabled / muted" hue)
+    ;;   ButtonText   — interactive button/icon ink (chevrons, ✕,
+    ;;                  ribbon icons) so they read as actionable
+    ;;   LinkText     — hyperlink ink (only sparingly used in Causa
+    ;;                  chrome, but covered for completeness)
+    ;;
+    ;; Signal preservation is the criterion: under HCM the operator
+    ;; must still distinguish focused-vs-not, error-vs-success,
+    ;; in-flight-vs-stale, primary-vs-secondary text. The mapping
+    ;; below preserves those distinctions even when every author hex
+    ;; is forced.
+    "@media (forced-colors: active) {\n"
+    ;; Focus-visible amber → Highlight. The UA already forces the
+    ;; outline colour, but writing it explicitly guarantees the
+    ;; correct semantic system-token is requested (some UAs honour
+    ;; author-specified system colours and skip the forced override).
+    "  [data-testid=\"rf-causa-shell\"] *:focus-visible,\n"
+    "  [data-testid=\"rf-causa-static-shell\"] *:focus-visible,\n"
+    "  [data-testid=\"rf-causa-palette-backdrop\"] *:focus-visible {\n"
+    "    outline-color: Highlight !important;\n"
+    "  }\n"
+    ;; L1 ribbon mode stripe (violet runtime / cyan static) → Highlight.
+    ;; The 2px left border is the operator's "which mode am I in"
+    ;; signal; preserve it as the user's selected-emphasis hue.
+    "  [data-testid=\"rf-causa-ribbon\"] {\n"
+    "    border-left-color: Highlight !important;\n"
+    "  }\n"
+    ;; L2 focused event row — `aria-pressed=\"true\"` rides on the
+    ;; focused row's `<li>`. The 1px solid cyan border becomes a
+    ;; Highlight outline (outline composes over the existing border
+    ;; without disturbing layout; HCM strips inline background, so
+    ;; the row's fill becomes Canvas + the Highlight outline reads
+    ;; as the selection signal).
+    "  [data-testid^=\"rf-causa-event-row-\"][aria-pressed=\"true\"] {\n"
+    "    outline: 2px solid Highlight !important;\n"
+    "    outline-offset: -1px !important;\n"
+    "  }\n"
+    ;; L2 row status accents — read off `data-rf-causa-status`. The
+    ;; box-shadow inset that paints the trailing-edge stripe is
+    ;; dropped by HCM, so we re-introduce the signal as a right-edge
+    ;; outline-ish border via box-shadow with a system colour (which
+    ;; HCM honours). `Mark` reads as 'important emphasis' and is the
+    ;; idiomatic token for error / warning accents distinct from
+    ;; selection (Highlight).
+    "  [data-rf-causa-status=\"settled-error\"] {\n"
+    "    box-shadow: inset -2px 0 0 0 Mark !important;\n"
+    "  }\n"
+    ;; In-flight (still running) → Highlight (it's the 'active' row).
+    "  [data-rf-causa-status=\"in-flight\"] {\n"
+    "    box-shadow: inset -2px 0 0 0 Highlight !important;\n"
+    "  }\n"
+    ;; Settled-success → CanvasText (neutral; success is the absence
+    ;; of an alarm, so a quiet ink-coloured stripe reads as 'done,
+    ;; no problem'). Distinguishable from in-flight + error because
+    ;; the system tokens render differently under every HCM theme.
+    "  [data-rf-causa-status=\"settled-success\"] {\n"
+    "    box-shadow: inset -2px 0 0 0 CanvasText !important;\n"
+    "  }\n"
+    ;; Stale / paused-by-tool → GrayText. Both states are the 'muted /
+    ;; not-currently-live' family; the disabled-text system hue is
+    ;; the canonical match.
+    "  [data-rf-causa-status=\"stale\"],\n"
+    "  [data-rf-causa-status=\"paused-by-tool\"] {\n"
+    "    box-shadow: inset -2px 0 0 0 GrayText !important;\n"
+    "  }\n"
+    ;; L2 row gutter — the 1px causal-chain thread (violet) and the
+    ;; focus markers (⦿ / ◌) need a system-token landing. The gutter
+    ;; <span> doesn't carry a testid hook, so we target the
+    ;; row-gutter testid pattern. The inset box-shadow becomes
+    ;; Highlight; the marker colour becomes Highlight too so the
+    ;; focus-set anchor reads at a glance.
+    "  [data-testid^=\"rf-causa-row-gutter-\"] {\n"
+    "    box-shadow: inset 1px 0 0 0 Highlight !important;\n"
+    "    color: Highlight !important;\n"
+    "  }\n"
+    ;; L4 panel domain accent stripes (3px left border on the panel
+    ;; <h1>) — every panel hue (violet/cyan/orange/green/yellow/red)
+    ;; collapses to CanvasText so the stripe still paints as a
+    ;; visible left edge. Panels remain visually distinguishable by
+    ;; their L3 tab label and their content; the stripe drops its
+    ;; per-panel colour information but keeps its presence as a
+    ;; rhythm marker. We target the `<h1>` elements inside the L4
+    ;; panel slot via the `rf-causa-detail-panel-*` testid prefix.
+    "  [data-testid^=\"rf-causa-detail-panel-\"] h1 {\n"
+    "    border-left-color: CanvasText !important;\n"
+    "  }\n"
+    ;; Ribbon icons + close-X — keep them as ButtonText so they
+    ;; read as actionable. The Settings ✕ accent + the right-cluster
+    ;; icons inherit through this rule.
+    "  [data-testid=\"rf-causa-icon-settings\"],\n"
+    "  [data-testid=\"rf-causa-icon-close\"],\n"
+    "  [data-testid=\"rf-causa-nav-prev\"],\n"
+    "  [data-testid=\"rf-causa-nav-next\"],\n"
+    "  [data-testid=\"rf-causa-nav-head\"],\n"
+    "  [data-testid=\"rf-causa-focus-chip-clear\"] {\n"
+    "    color: ButtonText !important;\n"
+    "  }\n"
+    ;; Hyperlinks inside Causa chrome → LinkText. Sparingly used
+    ;; (open-in-editor anchors, doc links) but covered so every
+    ;; HCM-relevant interactive surface has a system-token landing.
+    "  [data-testid=\"rf-causa-shell\"] a,\n"
+    "  [data-testid=\"rf-causa-static-shell\"] a {\n"
+    "    color: LinkText !important;\n"
+    "  }\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -178,6 +178,151 @@
       (is (re-find #"outline-offset:\s*2px" css)
           "2px outline-offset so the ring doesn't graze the element"))))
 
+;; ---- rf2-wxepo — forced-colors (Windows High Contrast Mode) ------------
+;;
+;; Windows HCM forces the UA palette onto every element — inline
+;; `:background` + `:color` declarations are overridden and box-shadow
+;; is dropped, which collapses every author-encoded signal across the
+;; Causa chrome. `@media (forced-colors: active)` re-introduces the
+;; signals using CSS system colour keywords (Canvas / CanvasText /
+;; Highlight / Mark / GrayText / ButtonText / LinkText) which the UA
+;; accepts and honours.
+;;
+;; Signal-preservation criterion: under HCM the operator must still
+;; distinguish focused-vs-not, error-vs-success, in-flight-vs-stale,
+;; primary-vs-secondary text. Each test below asserts one of those
+;; signals has a system-token landing inside the forced-colors block.
+
+(deftest motion-css-declares-forced-colors-block
+  (testing "rf2-wxepo — the motion stylesheet ships a
+            `@media (forced-colors: active)` block so HCM users get a
+            chrome that preserves the author-encoded signals via
+            system colour tokens."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"@media\s*\(forced-colors:\s*active\)" css)
+          "forced-colors media query is present"))))
+
+(deftest motion-css-forced-colors-maps-focus-ring-to-highlight
+  (testing "rf2-wxepo — the global :focus-visible amber outline
+            (#FBBF24) overrides to `Highlight` under HCM so keyboard-
+            only users see the user's selected-emphasis hue rather
+            than the UA's forced override of the amber hex."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"outline-color:\s*Highlight" css)
+          "focus-visible outline-color is Highlight inside the block"))))
+
+(deftest motion-css-forced-colors-maps-ribbon-stripe-to-highlight
+  (testing "rf2-wxepo — the L1 ribbon's 2px left-edge mode stripe
+            (runtime violet / static cyan) maps to `Highlight` so the
+            mode signal is preserved under HCM."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"\[data-testid=\"rf-causa-ribbon\"\]\s*\{[^}]*border-left-color:\s*Highlight"
+                   css)
+          "ribbon border-left-color is Highlight"))))
+
+(deftest motion-css-forced-colors-distinguishes-status-accents
+  (testing "rf2-wxepo — the four lifecycle-status accents map onto
+            DISTINCT system tokens so the operator still tells error
+            from success from in-flight from stale/paused under HCM.
+            Highlight (in-flight = active), Mark (error = important
+            emphasis), CanvasText (success = quiet ink), GrayText
+            (stale / paused = muted)."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"data-rf-causa-status=\"settled-error\"[^}]*Mark" css)
+          "settled-error → Mark")
+      (is (re-find #"data-rf-causa-status=\"in-flight\"[^}]*Highlight" css)
+          "in-flight → Highlight")
+      (is (re-find #"data-rf-causa-status=\"settled-success\"[^}]*CanvasText" css)
+          "settled-success → CanvasText")
+      (is (re-find #"data-rf-causa-status=\"stale\"" css)
+          "stale rule present")
+      (is (re-find #"data-rf-causa-status=\"paused-by-tool\"" css)
+          "paused-by-tool rule present")
+      (is (re-find #"data-rf-causa-status=\"stale\"[^{]*\{[^}]*GrayText"
+                   (or (re-find #"data-rf-causa-status=\"stale\"[\s\S]*?\}" css)
+                       ""))
+          "stale → GrayText"))))
+
+(deftest motion-css-forced-colors-maps-focused-row-to-highlight
+  (testing "rf2-wxepo — the focused L2 event row (aria-pressed=\"true\")
+            picks up a Highlight outline under HCM so the selection
+            signal is preserved when the cyan border is stripped."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"aria-pressed=\"true\"[^}]*outline:[^}]*Highlight" css)
+          "focused row outline uses Highlight"))))
+
+(deftest motion-css-forced-colors-maps-gutter-thread-to-highlight
+  (testing "rf2-wxepo — the L2 row gutter's 1px causal-chain thread
+            (violet inset box-shadow) and focus markers map to
+            Highlight under HCM so the spine's vertical thread + the
+            focus-set anchors stay visible."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"data-testid\^=\"rf-causa-row-gutter-\"[^}]*Highlight"
+                   css)
+          "gutter rule uses Highlight"))))
+
+(deftest motion-css-forced-colors-maps-panel-accent-stripe-to-canvastext
+  (testing "rf2-wxepo — every L4 panel-domain accent stripe
+            (violet/cyan/orange/green/yellow/red) collapses to
+            CanvasText under HCM. Panels remain distinguishable by
+            their tab label + content; the stripe keeps its presence
+            as a rhythm marker without colour information."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"data-testid\^=\"rf-causa-detail-panel-\"[^}]*border-left-color:\s*CanvasText"
+                   css)
+          "panel <h1> border-left-color is CanvasText"))))
+
+(deftest motion-css-forced-colors-maps-interactive-icons-to-buttontext
+  (testing "rf2-wxepo — the ribbon icons (settings ✕, close ✕,
+            nav chevrons, focus-chip clear) map to ButtonText under
+            HCM so they read as actionable controls in the HCM
+            theme's interactive-ink hue."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"data-testid=\"rf-causa-icon-settings\"" css))
+      (is (re-find #"data-testid=\"rf-causa-icon-close\"" css))
+      (is (re-find #"data-testid=\"rf-causa-nav-prev\"" css))
+      (is (re-find #"data-testid=\"rf-causa-nav-next\"" css))
+      (is (re-find #"data-testid=\"rf-causa-focus-chip-clear\"" css))
+      (is (re-find #"ButtonText" css)
+          "ButtonText system token is used"))))
+
+(deftest motion-css-forced-colors-maps-anchors-to-linktext
+  (testing "rf2-wxepo — hyperlinks inside the Causa shell roots
+            map to LinkText under HCM so the hyperlink-ink hue is
+            picked up from the HCM theme."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"\[data-testid=\"rf-causa-shell\"\]\s*a[^}]*LinkText"
+                   css)
+          "anchor rule under runtime shell uses LinkText")
+      (is (re-find #"\[data-testid=\"rf-causa-static-shell\"\]\s*a[^}]*LinkText"
+                   css)
+          "anchor rule under static shell uses LinkText"))))
+
+(deftest motion-css-forced-colors-uses-important-to-beat-inline-styles
+  (testing "rf2-wxepo — every rule inside the forced-colors block
+            uses `!important` so the per-element inline-style
+            declarations (the 357 call sites that paint background /
+            color / border directly) are beaten on specificity.
+            Inline style normally wins over external CSS; !important
+            in the external CSS reverses that. A spot-check on a
+            handful of declarations is enough — the block author
+            convention is uniform."
+    (let [css @#'gs/motion-css
+          ;; Extract just the forced-colors block so we don't pick up
+          ;; !important from elsewhere (there shouldn't be any, but
+          ;; defensive).
+          block (re-find #"@media\s*\(forced-colors:\s*active\)[\s\S]*?\n\}\n"
+                        css)]
+      (is (some? block)
+          "forced-colors block found")
+      (when block
+        (is (re-find #"Highlight\s*!important" block)
+            "Highlight rule carries !important")
+        (is (re-find #"CanvasText\s*!important" block)
+            "CanvasText rule carries !important")
+        (is (re-find #"Mark\s*!important" block)
+            "Mark rule carries !important")))))
+
 ;; ---- rf2-5kfxe.6 — light theme CSS variables ---------------------------
 
 (deftest themes-css-publishes-root-defaults


### PR DESCRIPTION
## Summary

Windows High Contrast Mode (HCM) forces the UA palette onto every element — inline `:background` + `:color` declarations are overridden and `box-shadow` is dropped, which collapses every author-encoded signal across Causa's chrome:

- L1 ribbon mode stripe (violet runtime / cyan static)
- L2 event row focused border (cyan)
- L2 row status accent (the 2px inset box-shadow on the trailing edge)
- L2 row gutter causal-chain thread (1px violet inset)
- L4 panel-domain accent stripes (3px left border in each panel's hue)
- Focus-visible amber outline (#FBBF24)
- Secondary / tertiary text

Add a `@media (forced-colors: active)` block to `theme/global_styles/motion-css` that re-introduces each signal via CSS **system colour keywords** — the one class of colour HCM accepts and honours:

| Token | Use |
|---|---|
| `Highlight` | focus ring, focused row outline, ribbon mode stripe, gutter thread, focus markers, in-flight status |
| `CanvasText` | primary text, panel-domain accent stripes (collapse to neutral ink), settled-success status |
| `Mark` | settled-error status accent (important emphasis, distinct from selection) |
| `GrayText` | stale + paused-by-tool status accents (muted family) |
| `ButtonText` | ribbon icons (settings, close, nav chevrons, focus-chip clear) |
| `LinkText` | hyperlinks under both shell roots |

Every rule carries `!important` so the per-element inline-style declarations are beaten on specificity (inline style normally wins over external CSS).

**Signal preservation criterion**: under HCM the operator still distinguishes focused-vs-not, error-vs-success, in-flight-vs-stale, primary-vs-secondary text. The four lifecycle-status states (`settled-error` / `in-flight` / `settled-success` / `stale|paused-by-tool`) map onto four DISTINCT system tokens (`Mark` / `Highlight` / `CanvasText` / `GrayText`).

**No palette tokens were modified** — only the `@media (forced-colors: active)` block was added — so the palette-drift gate (rf2-z7ms8) does not apply.

## Test plan

- [x] `npm run test:cljs` — 3644 tests / 10447 assertions / 0 failures / 0 errors
- [x] `mkdocs build --strict` — clean (exit 0)
- [x] 10 new deftests in `global_styles_cljs_test.cljs` cover the forced-colors block, focus ring, ribbon stripe, four distinct status-accent tokens, focused row, gutter thread, panel accent, interactive icons, hyperlinks, and `!important` specificity
- [ ] (manual, post-merge) verify Causa renders in Windows HCM with status signals preserved