### PR TITLE
feat(causa): chrome-a11y axe panel scoped to [data-rf-causa-root] (rf2-5r2yj · rf2-4w88j #28)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -16,6 +16,7 @@ event**:
 | **Machines** (`m`) | "What did this event do to my machines?" — transitions, cancellation cascade, `:after` rings. **Event-driven only post-rf2-y9xmf** (no picker, no Mode A/B/C; BLANK when the focused event has no machine activity; per-machine prev/next nav walks the spine). |
 | **Machines Canvas** (`c`) | "What does this machine LOOK like?" — spine-INDEPENDENT canvas browser. Picker on the left, interactive Chart adapter on the right (zoom / pan / fit + keyboard shortcuts). No focused-event lens — the canvas always shows the picked machine's full topology. Earned its own tab per the cohesive-sub-domain rule (rf2-mkpnb). |
 | **Issues** (`i`) | "What's wrong here?" — errors · warnings · schema violations · hydration mismatches · advisories. |
+| **Chrome A11y** (`y`) | "Is Causa's OWN chrome accessible?" — spine-INDEPENDENT dogfood (rf2-5r2yj). Runs axe-core scoped to `#rf-causa-root` — the Causa mount node — so a11y regressions in the L1 ribbon, L2 event list, L3 tab bar, L4 detail panels, modals, and resize handle surface during dev. Mirrors Story's `chrome-a11y` panel (PR #1695). axe-core loads opt-in via CDN with an SRI hash pinned; consent click lives inline in the panel. |
 
 Plus popovers (`r` nav-token timeline · `f` wire-trace
 + `h` hydration bisector, future). Every popover is invokable from any
@@ -59,7 +60,7 @@ the left because normal layout owns the relationship.
 ├─────────────────────────────────────────────────────────────────────────┤
 │ LAYER 2  Event list (8 rows default; resizable; min 2)                  │  the spine / timeline
 ├─────────────────────────────────────────────────────────────────────────┤
-│ LAYER 3  Tab bar (40px) — 8 tabs                                        │  projection selector
+│ LAYER 3  Tab bar (40px) — 9 tabs                                        │  projection selector
 ├─────────────────────────────────────────────────────────────────────────┤
 │ LAYER 4  Detail panel (fills remaining canvas)                          │  per-tab content
 └─────────────────────────────────────────────────────────────────────────┘
@@ -80,7 +81,7 @@ Wireframe at default (800px popout, "cosy" density):
 │ ● :cart/recalculate                                                     │
 │ ◉ :order/retry                                      🌐  ← head/sel      │
 ├═════════════════════════════════════════════════════════════════════════┤   drag handle (L2/L3)
-│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 │   L3 — 8 tabs
+│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 ○Chrome-A11y │   L3 — 9 tabs
 ├─────────────────────────────────────────────────────────────────────────┤
 │ — Event tab content for the focused event —                             │   L4 — fills the rest
 └─────────────────────────────────────────────────────────────────────────┘
@@ -99,12 +100,14 @@ The four layers, top to bottom:
    decorated by gutter glyph (`● ◉ x ▥ ↺`) + right-aligned badges (`⚠`
    `🌐` `🤖`) + trailing redaction marker (`[● REDACTED N]`). The
    spine sub `:rf.causa/focus` reads from this layer.
-3. **L3 — Tab bar (40px).** Eight tabs: Event / App-db / Views / Trace /
-   Machines / Machines Canvas / Routing / Issues. Letter mnemonics:
-   `e` `a` `v` `t` `m` `c` `r` `i`. Count badges (`Views 8`) update
-   with focused cascade. Routing was promoted to its own L3 tab in
-   rf2-nrbs9; Machines Canvas was promoted in rf2-mkpnb — both follow
-   the cohesive-sub-domain rule (sub-domains earn their own lens tab).
+3. **L3 — Tab bar (40px).** Nine tabs: Event / App-db / Views / Trace /
+   Machines / Machines Canvas / Routing / Issues / Chrome A11y. Letter
+   mnemonics: `e` `a` `v` `t` `m` `c` `r` `i` `y`. Count badges
+   (`Views 8`) update with focused cascade. Routing was promoted to its
+   own L3 tab in rf2-nrbs9; Machines Canvas was promoted in rf2-mkpnb —
+   both follow the cohesive-sub-domain rule (sub-domains earn their own
+   lens tab). Chrome A11y was added in rf2-5r2yj as the diagnostics-
+   group dogfood — mirror of Story's `chrome-a11y` panel (#1695).
 4. **L4 — Detail panel.** Fills remaining canvas (60% default;
    resizable via L2/L3 drag handle). Per-tab content; all values
    rendered via the cljs-devtools-shaped renderer (see §Detail panel
@@ -758,6 +761,7 @@ restructuring the header chrome. The mapping
 | `:machines` | green | `:green` (machine state lands green for "final") |
 | `:routing` | yellow | `:yellow` (side-channel attention tone) |
 | `:issues` | red | `:red` (errors; semantic red) |
+| `:chrome-a11y` | red | `:red` (diagnostics group sibling to `:issues`; both surface "what's wrong here?" content — rf2-5r2yj) |
 
 The helper `theme/tokens/accent-stripe-style` emits the inline-style
 map (`:border-left "3px solid <hex>"` + `:padding-left "10px"`); per-

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -38,7 +38,7 @@ Every selection event passes through a single spine sub — `:rf.causa/focus` �
 ├─────────────────────────────────────────────────────────────────────────┤
 │ LAYER 2  Event list (8 rows default; resizable; min 2)                  │  the spine / timeline
 ├─────────────────────────────────────────────────────────────────────────┤
-│ LAYER 3  Tab bar (40px) — 8 tabs                                        │  projection selector
+│ LAYER 3  Tab bar (40px) — 9 tabs                                        │  projection selector
 ├─────────────────────────────────────────────────────────────────────────┤
 │ LAYER 4  Detail panel (fills remaining canvas)                          │  per-tab content
 └─────────────────────────────────────────────────────────────────────────┘
@@ -418,11 +418,11 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 
 ## §5 Tab bar + detail panel (Layers 3 + 4)
 
-### The 8 tabs
+### The 9 tabs
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────────────────┐
-│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ○Canvas  ○Routing  ⚠Issues 1         │   L3
+│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 ○Chrome-A11y   │   L3
 └──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -436,6 +436,7 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 | 6 | **Machines Canvas** | `c` | **Spine-INDEPENDENT canvas browser** (rf2-mkpnb). Master-detail — picker on the left (one row per registered machine, sorted by name), interactive Chart adapter on the right (zoom / pan / fit + keyboard shortcuts). No focused-event lens — the canvas always shows the picked machine's full topology. Promoted to its own L4 tab per the cohesive-sub-domain rule; sibling to the event-driven Machines Inspector at order 5. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Interactive Machines canvas (rf2-y3l8z) + [`007-UX-IA.md`](007-UX-IA.md) §Layout |
 | 7 | **Routing** | `r` | **FLAT focused-event lens** (rf2-lq0ef): current matched route + params/query/fragment + **Simulate-URL** input ranking every registered route via the 6-rule `:rf.route/rank` tuple with the rank explainer inline; per-focused-event glyphs `◆ HERE` / `◆ FROM` / `◆ TO`. Silent when no routes registered. | this doc §5.6 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab |
 | 8 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns | this doc §5.4 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon |
+| 9 | **Chrome A11y** | `y` | **Spine-INDEPENDENT dogfood** (rf2-5r2yj). Runs axe-core scoped to `#rf-causa-root` — Causa's own chrome — so a11y regressions in the tool's L1 ribbon, L2 event list, L3 tab bar, L4 detail panels, modals, and resize handle surface during dev. Mirrors Story's `chrome-a11y` panel (PR #1695). axe-core is loaded opt-in via CDN with an SRI hash pinned (no Settings toggle — pre-alpha posture: explicit consent click in the panel). | [`007-UX-IA.md`](../tools/causa/spec/007-UX-IA.md) §Layout |
 
 **Effects is folded into Event** — the "fx handlers that ran" block under Event tab covers it.
 
@@ -447,7 +448,7 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────────────────────┐
-│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ○Canvas  ○Routing  ⚠Issues 1         │
+│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 ○Chrome-A11y   │
 └──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -458,7 +459,7 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 - **Dormant tab:** `text-disabled` + `○`; clickable → empty state.
 - **Count flash on LIVE update:** count flashes violet 200ms then settles. No continuous spinner.
 
-Single-row at all widths. Below 800px labels truncate to 3 chars (`Eve App Vie Tra Mac Can Rou Iss`); counts always full. Below 560px the strip scrolls horizontally.
+Single-row at all widths. Below 800px labels truncate to 3 chars (`Eve App Vie Tra Mac Can Rou Iss A11`); counts always full. Below 560px the strip scrolls horizontally.
 
 ### Tab strip ARIA
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/chrome_a11y/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/chrome_a11y/panel.cljs
@@ -1,0 +1,606 @@
+(ns day8.re-frame2-causa.panels.chrome-a11y.panel
+  "Chrome accessibility (axe-core) panel — Runtime L4 tab (rf2-5r2yj,
+  parent rf2-4w88j #28).
+
+  ## Why a separate tab
+
+  Causa is itself a complex interactive surface — tablist, modals,
+  drag handles, palette, settings popup, filter pills. Like every
+  dev tool it earns the same a11y discipline it expects of host apps.
+  This panel dogfoods axe-core against Causa's OWN chrome (the
+  `#rf-causa-root` mount node + everything inside it), surfacing
+  regressions during dev without depending on the host app to scan
+  the tool's chrome.
+
+  Story shipped the equivalent panel in PR #1695 (`re-frame.story.ui.
+  chrome-a11y`). This panel mirrors that pattern: same axe-core engine
+  (loaded via CDN with explicit opt-in + SRI hash pin), same panel
+  shape, scoped to Causa's chrome root rather than Story's.
+
+  ## Relationship to host-app a11y
+
+  Causa does NOT scan host-app DOM. The host app may have its own
+  a11y tooling (Story's variant-a11y panel, browser extension, axe-
+  core run from the console, etc.) — Causa's chrome-a11y panel is
+  strictly self-scoped. The scan root is `#rf-causa-root` (the mount
+  node `mount.cljs` allocates and ids); axe-core walks every
+  descendant — the L1 ribbon, L2 event list, L3 tab bar, L4 panels,
+  the resize handle, every modal that's currently open. Host-app
+  chrome is excluded by construction.
+
+  ## CDN opt-in (mirrors rf2-20w5i)
+
+  Per Story's security audit (rf2-20w5i): axe-core is **opt-in only**.
+  Running a scan loads `axe-core@4.10.0` from a public CDN
+  (cdn.jsdelivr.net) with an SRI integrity hash pinned so a
+  compromised mirror fails closed. The dev's first scan is gated on
+  an explicit consent click; subsequent scans re-use the persisted
+  opt-in. Pre-alpha posture: no Settings toggle, no in-shell
+  config — the consent prompt lives inline in the panel.
+
+  Why not vendor axe-core directly? Same Closure :advanced UMD
+  parser issue Story documented — axe-core's UMD wrapper trips
+  `Block-scoped variable _typeof declared more than once` under
+  shadow-cljs's pinned Closure. Until shadow-cljs upgrades Closure
+  (or axe-core ships an ESM build), opt-in CDN is the pragmatic path.
+
+  ## Pre-alpha posture
+
+  No toggle to opt out — the panel is always available as an L4 tab,
+  runs on demand via the 'run' button. Production builds where the
+  Causa shell is gone (Closure DCE drops the entire tool surface
+  under `:advanced` when the preload isn't required) never reach
+  this ns.
+
+  ## State
+
+  `violations` + `run-state` are single atoms (not per-frame). There's
+  exactly one chrome surface per Causa mount, so a per-frame map
+  would be over-structured. Mirror of Story's chrome-a11y.
+
+  ## Pure hiccup discipline (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references at the panel boundary. Frame
+  isolation comes from the enclosing `[rf/frame-provider {:frame
+  :rf/causa}]` in `shell.cljs`. The `r/atom`s for violations / run-
+  state are local component state (the panel re-renders by Reagent's
+  reactive-deref on @-reads inside `Panel`), not Causa app-db slots —
+  the data has no other consumer and survives only as long as the
+  shell is mounted."
+  (:require [reagent.core :as r]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack display-stack type-scale]]))
+
+;; ---- chrome root selector ------------------------------------------------
+
+(def ^:const chrome-root-id
+  "The DOM id `mount.cljs` stamps on the Causa mount root. The shell
+  body lives inside this node; axe-core scans every descendant."
+  "rf-causa-root")
+
+(def ^:const chrome-root-selector
+  "CSS selector resolving to the Causa chrome root. Single-instance:
+  `mount.cljs` allocates exactly one `#rf-causa-root` per page so
+  this selector resolves to at most one element."
+  (str "#" chrome-root-id))
+
+(defn find-chrome-root
+  "Resolve the DOM element marked as the Causa chrome root, or nil if
+  Causa isn't mounted (e.g. node-runtime tests, or before
+  `mount.cljs/open!`).
+
+  Wrapped in try/catch so node-runtime callers receive nil rather
+  than a ReferenceError on `js/document`."
+  []
+  (try
+    (let [doc (.-document js/globalThis)]
+      (when doc
+        (or (.getElementById doc chrome-root-id)
+            (.querySelector doc chrome-root-selector))))
+    (catch :default _ nil)))
+
+;; ---- axe-core CDN load (opt-in, mirrors Story rf2-20w5i) ----------------
+
+(def ^:const axe-cdn-url
+  "Pinned axe-core CDN URL. SRI hash below ensures byte-level
+  integrity (a compromised mirror fails closed at the browser's
+  hash-verification gate)."
+  "https://cdn.jsdelivr.net/npm/axe-core@4.10.0/axe.min.js")
+
+(def ^:const axe-cdn-integrity
+  "Subresource Integrity hash for `axe-cdn-url`'s 4.10.0 axe.min.js.
+  Identical to Story's pin (rf2-20w5i)."
+  "sha384-hU7+BBSOB5dIfLKxLW/kXBTPxNWTSmiQ8F4jiCU0++kNwNoOt7zVkEum1ZqDhASc")
+
+(def ^:const cdn-opt-in-key
+  "localStorage key under which the Causa-side CDN opt-in lives.
+  Distinct from Story's `rf.story.a11y/cdn-opt-in` — Causa and Story
+  approvals are independent (a dev may opt in to Causa's scanner
+  without approving Story's)."
+  "rf.causa.chrome-a11y/cdn-opt-in")
+
+(defonce
+  ^{:doc "In-memory mirror of the persisted opt-in. Initialised from
+         `localStorage` on first read; falls back to this when the
+         host environment lacks `localStorage`. Wrapped in an
+         `r/atom` so the panel re-renders when the opt-in flips."}
+  cdn-opt-in-atom
+  (r/atom false))
+
+(defonce ^:private cdn-opt-in-bootstrapped? (atom false))
+
+(defn- read-storage-opt-in
+  "Best-effort read from `localStorage`. Returns true iff the key
+  exists with value `\"true\"`; nil on any error so the in-memory
+  atom stays authoritative when storage is blocked."
+  []
+  (try
+    (let [ls (.-localStorage js/globalThis)]
+      (when ls
+        (= "true" (.getItem ls cdn-opt-in-key))))
+    (catch :default _ nil)))
+
+(defn- write-storage-opt-in!
+  "Best-effort write to `localStorage`. Silent no-op when storage is
+  unavailable. The in-memory atom is always written by the caller;
+  this is purely for persistence across reloads."
+  [approve?]
+  (try
+    (let [ls (.-localStorage js/globalThis)]
+      (when ls
+        (if approve?
+          (.setItem ls cdn-opt-in-key "true")
+          (.removeItem ls cdn-opt-in-key))))
+    (catch :default _ nil))
+  nil)
+
+(defn cdn-opt-in?
+  "Read the dev's CDN opt-in. Bootstraps from `localStorage` on first
+  call so a prior session's approval survives a reload."
+  []
+  (when-not @cdn-opt-in-bootstrapped?
+    (when-let [stored (read-storage-opt-in)]
+      (reset! cdn-opt-in-atom stored))
+    (reset! cdn-opt-in-bootstrapped? true))
+  @cdn-opt-in-atom)
+
+(defn set-cdn-opt-in!
+  "Persist the dev's opt-in decision. `approve?` true approves; false
+  retracts. The in-memory atom always reflects the choice; the
+  `localStorage` write is best-effort."
+  [approve?]
+  (let [v (boolean approve?)]
+    (reset! cdn-opt-in-atom v)
+    (reset! cdn-opt-in-bootstrapped? true)
+    (write-storage-opt-in! v))
+  nil)
+
+(defonce
+  ^{:doc "True once axe-core's `<script>` tag has been injected and
+         `js/axe` is available. Idempotent loader."}
+  axe-loaded?
+  (atom false))
+
+(defn ensure-axe-loaded!
+  "Inject the axe-core `<script>` tag if not already present. Returns
+  a `js/Promise` resolving to `js/axe` once available.
+
+  The injection only fires when the dev has opted in via
+  `set-cdn-opt-in!`. Without the opt-in the returned promise rejects
+  with `:rf.causa.chrome-a11y/cdn-not-opted-in` so callers surface
+  the consent prompt rather than silently loading remote code.
+
+  The injected `<script>` carries an SRI `integrity` attribute pinning
+  the expected hash + `crossorigin=\"anonymous\"` so the browser
+  enforces hash verification."
+  []
+  (js/Promise.
+    (fn [resolve reject]
+      (cond
+        @axe-loaded?
+        (resolve (.-axe js/window))
+
+        (some? (.-axe js/window))
+        (do (reset! axe-loaded? true)
+            (resolve (.-axe js/window)))
+
+        (not (cdn-opt-in?))
+        (reject (js/Error. "rf.causa.chrome-a11y/cdn-not-opted-in"))
+
+        :else
+        (let [script (.createElement js/document "script")]
+          (set! (.-src script) axe-cdn-url)
+          (set! (.-async script) true)
+          (.setAttribute script "integrity" axe-cdn-integrity)
+          (.setAttribute script "crossorigin" "anonymous")
+          (set! (.-onload script)
+                (fn [_]
+                  (reset! axe-loaded? true)
+                  (resolve (.-axe js/window))))
+          (set! (.-onerror script)
+                (fn [_]
+                  (reject (js/Error. "rf.causa.chrome-a11y/cdn-load-failed"))))
+          (.appendChild (.-head js/document) script))))))
+
+;; ---- violations stylesheet ----------------------------------------------
+
+(def ^:const violations-stylesheet
+  "Inline outline for any element axe-core flagged. Mirrors Story's
+  `[data-rf-a11y-violation]` overlay so devs running both tools see
+  the same red outline shape."
+  (str
+    "[data-rf-causa-a11y-violation] { outline: 2px solid #f04; }"
+    "[data-rf-causa-a11y-violation='critical'] { outline-color: #ff0040; }"
+    "[data-rf-causa-a11y-violation='serious']  { outline-color: #ff8000; }"
+    "[data-rf-causa-a11y-violation='moderate'] { outline-color: #f1c40f; }"
+    "[data-rf-causa-a11y-violation='minor']    { outline-color: #888; }"))
+
+(defonce ^:private stylesheet-injected? (atom false))
+
+(defn ensure-stylesheet!
+  "Inject the violations stylesheet exactly once per page. Idempotent."
+  []
+  (when (and (not @stylesheet-injected?)
+             (exists? js/document))
+    (let [style (.createElement js/document "style")]
+      (set! (.-textContent style) violations-stylesheet)
+      (.setAttribute style "data-rf-causa-chrome-a11y" "true")
+      (.appendChild (.-head js/document) style)
+      (reset! stylesheet-injected? true))
+    nil))
+
+;; ---- state --------------------------------------------------------------
+
+(defonce
+  ^{:doc "Latest chrome-scan violations as a vector. Single atom — one
+         chrome surface per Causa mount."}
+  violations
+  (r/atom []))
+
+(defonce
+  ^{:doc "Run state: :idle|:loading|:running|:done|:error|:no-root|:no-consent.
+         Drives the panel's button label + status line."}
+  run-state
+  (r/atom :idle))
+
+(defn reset-state!
+  "Test-fixture helper. Clears violations + resets run-state. The CDN
+  opt-in is NOT cleared (persisted user decision)."
+  []
+  (reset! violations [])
+  (reset! run-state :idle)
+  nil)
+
+;; ---- running axe --------------------------------------------------------
+
+(defn record-violation-overlay!
+  "Stamp `data-rf-causa-a11y-violation` on every DOM node axe-core
+  flagged. Selectors are scoped to `scope-el` so the overlay never
+  decorates host-app nodes outside the Causa chrome root.
+
+  Best-effort: a selector that doesn't match (DOM mutated since the
+  scan) is silently skipped."
+  [scope-el ^js violation]
+  (let [nodes (.-nodes violation)
+        root  (or scope-el js/document)]
+    (doseq [node (array-seq nodes)]
+      (doseq [target (array-seq (.-target node))]
+        (try
+          (let [el (.querySelector root target)]
+            (when el
+              (.setAttribute el "data-rf-causa-a11y-violation"
+                             (or (.-impact violation) "moderate"))))
+          (catch :default _ nil))))))
+
+(defn run-axe!
+  "Run axe-core against the Causa chrome root and store violations.
+  Returns a `js/Promise` resolving to the violations vector — or nil
+  when the chrome root cannot be resolved.
+
+  Reuses the same CDN opt-in gate Story documents in rf2-20w5i: the
+  first run prompts for consent; subsequent runs re-use the persisted
+  decision."
+  ([] (run-axe! (find-chrome-root)))
+  ([context]
+   (cond
+     (nil? context)
+     (do
+       (reset! run-state :no-root)
+       (js/console.warn
+         "[causa.chrome-a11y] no chrome root found"
+         "— the Causa shell does not appear to be mounted.")
+       (js/Promise.resolve nil))
+
+     (not (cdn-opt-in?))
+     (do
+       (reset! run-state :no-consent)
+       (js/Promise.resolve nil))
+
+     :else
+     (do
+       (reset! run-state :loading)
+       (-> (ensure-axe-loaded!)
+           (.then
+             (fn [^js axe]
+               (reset! run-state :running)
+               (.run axe context)))
+           (.then
+             (fn [^js results]
+               (let [vs       (.-violations results)
+                     scope-el (when (and (some? context)
+                                         (some? (.-nodeType context)))
+                                context)]
+                 (reset! violations (vec (array-seq vs)))
+                 (doseq [v (array-seq vs)]
+                   (record-violation-overlay! scope-el v))
+                 (reset! run-state :done)
+                 vs)))
+           (.catch
+             (fn [e]
+               (reset! run-state :error)
+               (js/console.error "[causa.chrome-a11y]" e)
+               nil)))))))
+
+;; ---- per-violation render -----------------------------------------------
+
+(defn- impact-style
+  "Inline-style map for the violation row's left border + colour.
+  `impact` is axe-core's string (`critical` / `serious` / `moderate` /
+  `minor`); unknown values fall back to `moderate`."
+  [impact]
+  (case impact
+    "critical" {:border-left-color "#ff4040" :color (:red tokens)}
+    "serious"  {:border-left-color "#ff8000" :color "#fed"}
+    "moderate" {:border-left-color "#f1c40f" :color "#ffd"}
+    "minor"    {:border-left-color "#888"    :color "#ccc"}
+    {:border-left-color "#f1c40f" :color "#ffd"}))
+
+(defn- violation-row
+  "One axe-core violation, rendered as a stripe-bordered row. Hiccup
+  only; no Reagent imports."
+  [^js v]
+  (let [impact       (.-impact v)
+        nodes        (.-nodes v)
+        first-target (when (and nodes (pos? (.-length nodes)))
+                       (let [n0      (aget nodes 0)
+                             targets (.-target n0)]
+                         (when (and targets (pos? (.-length targets)))
+                           (aget targets 0))))]
+    [:div {:data-testid      "rf-causa-chrome-a11y-violation"
+           :data-a11y-id     (.-id v)
+           :data-a11y-impact (or impact "")
+           :style            (merge {:padding       "6px 8px"
+                                     :margin        "4px 0"
+                                     :border-left   "3px solid"
+                                     :background    (:bg-3 tokens)
+                                     :border-radius "3px"
+                                     :font-family   mono-stack
+                                     :font-size     (:caption type-scale)}
+                                    (impact-style impact))}
+     [:div {:style {:font-weight 700 :margin-bottom "2px"}}
+      (.-help v)]
+     [:div {:style {:color (:text-secondary tokens)
+                    :font-size (:micro type-scale)}}
+      (.-description v)]
+     (when first-target
+       [:div {:style {:color       (:cyan tokens)
+                      :font-family mono-stack
+                      :font-size   (:micro type-scale)
+                      :margin-top  "2px"}}
+        (str "→ " first-target)])
+     [:div {:style {:color     (:text-tertiary tokens)
+                    :font-size (:micro type-scale)}}
+      (str ":" (.-id v) " · " (or impact "moderate"))]]))
+
+;; ---- consent prompt -----------------------------------------------------
+
+(defn- consent-prompt
+  "Inline consent UI shown when the dev hasn't opted in to the CDN
+  load. Text describes the egress in plain words so the dev can
+  decide whether their environment permits it."
+  []
+  [:div {:data-testid "rf-causa-chrome-a11y-consent"
+         :style       {:padding     "12px"
+                       :border-top  (str "1px dashed " (:border-default tokens))
+                       :margin-top  "4px"
+                       :font-family sans-stack
+                       :color       (:text-primary tokens)}}
+   [:div {:style {:font-weight 700
+                  :color       (:red tokens)
+                  :margin-bottom "6px"
+                  :font-size   (:caption type-scale)}}
+    "axe-core not loaded"]
+   [:div {:style {:font-size   (:micro type-scale)
+                  :line-height "1.4"
+                  :color       (:text-secondary tokens)
+                  :margin-bottom "6px"}}
+    "Running an a11y scan loads "
+    [:code {:style {:color (:cyan tokens) :font-family mono-stack}} "axe-core@4.10.0"]
+    " from a public CDN ("
+    [:code {:style {:color (:cyan tokens) :font-family mono-stack}} "cdn.jsdelivr.net"]
+    "). The remote JS gets full DOM access to this page; an SRI hash "
+    "pinned in the loader detects tampering, but the dependency itself "
+    "is a trust call. Causa's app state never leaves the browser."]
+   [:div {:style {:font-size (:micro type-scale)
+                  :color     (:text-secondary tokens)
+                  :margin-bottom "10px"}}
+    "Approve once per browser; the opt-in is remembered in "
+    [:code {:style {:color (:cyan tokens) :font-family mono-stack}} "localStorage"]
+    " under "
+    [:code {:style {:color (:cyan tokens) :font-family mono-stack}} cdn-opt-in-key]
+    "."]
+   [:button {:data-testid "rf-causa-chrome-a11y-approve"
+             :on-click    (fn [_]
+                            (set-cdn-opt-in! true)
+                            (run-axe!))
+             :style       {:background    (:accent-violet tokens)
+                           :color         "white"
+                           :border        "none"
+                           :border-radius "3px"
+                           :padding       "4px 12px"
+                           :cursor        "pointer"
+                           :font-family   sans-stack
+                           :font-size     (:caption type-scale)}}
+    "enable axe-core + scan"]])
+
+;; ---- public Panel view --------------------------------------------------
+
+(rf/reg-view Panel
+  "The Chrome A11y tab's root view. Mirrors Story's chrome-a11y
+  panel — header strip with title + run button, status line, and
+  the per-violation feed below.
+
+  Per rf2-in6l2 `reg-view`-registered so any subs the panel reads
+  resolve through the enclosing `[rf/frame-provider {:frame
+  :rf/causa}]` in `shell.cljs`. Today the panel reads no Causa
+  app-db slots — its state lives in the module-level r/atoms — but
+  the reg-view discipline keeps the door open for future
+  reactive surfaces (e.g. surfacing the violation count on the L3
+  tab badge)."
+  []
+  (ensure-stylesheet!)
+  (let [vs    @violations
+        state @run-state
+        busy? (or (= state :loading) (= state :running))]
+    [:section {:data-testid "rf-causa-chrome-a11y"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     [:header {:style {:padding       "12px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+      [:div {:style {:display     "flex"
+                     :align-items "center"
+                     :gap         "12px"}}
+       ;; rf2-5kfxe.8 — domain-coloured accent stripe. Chrome a11y
+       ;; sits in the diagnostics group alongside Issues — the
+       ;; `:chrome-a11y` entry in `theme.tokens/panel-domain->token`
+       ;; maps to `:red` so the two tabs read as one family at the
+       ;; right edge of the tab strip.
+       [:h1 {:style (merge {:font-size      "20px"
+                            :font-family    display-stack
+                            :font-weight    600
+                            :letter-spacing "-0.01em"
+                            :margin         0
+                            :color          (:text-primary tokens)}
+                           (t/accent-stripe-style :chrome-a11y))}
+        "Chrome A11y"]
+       [:span {:data-testid "rf-causa-chrome-a11y-count"
+               :style       {:font-size   (:caption type-scale)
+                             :color       (:text-tertiary tokens)
+                             :font-family mono-stack}}
+        (cond
+          (= state :done) (str (count vs) " violation"
+                               (when (not= 1 (count vs)) "s"))
+          (= state :idle) "axe-core · click run"
+          :else           "")]
+       [:button {:data-testid "rf-causa-chrome-a11y-run"
+                 :disabled    busy?
+                 :on-click    (fn [_] (when-not busy? (run-axe!)))
+                 :style       {:margin-left   "auto"
+                               :background    (if busy?
+                                                (:bg-3 tokens)
+                                                (:accent-violet tokens))
+                               :color         "white"
+                               :border        "none"
+                               :border-radius "3px"
+                               :padding       "4px 12px"
+                               :cursor        (if busy? "wait" "pointer")
+                               :font-family   sans-stack
+                               :font-size     (:caption type-scale)}}
+        (case state
+          :loading    "loading…"
+          :running    "running…"
+          :error      "retry"
+          :no-root    "retry"
+          :no-consent "approve…"
+          :idle       "run"
+          "re-run")]]
+      [:div {:data-testid "rf-causa-chrome-a11y-status"
+             :style       {:color       (:text-secondary tokens)
+                           :font-size   (:micro type-scale)
+                           :font-family sans-stack
+                           :margin-top  "6px"}}
+       (case state
+         :idle       "click run to scan the Causa chrome at #rf-causa-root"
+         :loading    "fetching axe-core from CDN…"
+         :running    "scanning Causa chrome…"
+         :error      "axe-core failed to load (offline, CSP, or SRI mismatch)"
+         :no-root    "Causa shell not mounted — open it (Ctrl+Shift+C) and retry"
+         :no-consent "axe-core load needs your approval (see below)"
+         :done       (let [n (count vs)]
+                       (cond
+                         (zero? n) "no violations in the Causa chrome"
+                         (= 1 n)   "1 violation found in the Causa chrome"
+                         :else     (str n " violations found in the Causa chrome"))))]]
+     [:div {:style {:flex 1 :overflow "auto" :padding "8px 16px"}}
+      (cond
+        (= state :no-consent)
+        [consent-prompt]
+
+        (= state :idle)
+        [:div {:data-testid "rf-causa-chrome-a11y-idle"
+               :style       {:color       (:text-tertiary tokens)
+                             :font-style  "italic"
+                             :font-family sans-stack
+                             :font-size   (:caption type-scale)
+                             :padding     "12px 0"}}
+         "Click run to scan the Causa chrome. The scan is scoped to "
+         [:code {:style {:font-family mono-stack
+                         :color (:cyan tokens)}}
+          chrome-root-selector]
+         " — host-app DOM is excluded."]
+
+        (empty? vs)
+        [:div {:data-testid "rf-causa-chrome-a11y-empty"
+               :style       {:padding     "12px 0"
+                             :font-family sans-stack
+                             :font-size   (:caption type-scale)
+                             :color       (:text-secondary tokens)}}
+         [:span {:style {:color       (:green tokens)
+                         :font-size   "16px"
+                         :font-weight 700
+                         :margin-right "8px"}}
+          "✓"]
+         "No violations."]
+
+        :else
+        (into [:div {:data-testid "rf-causa-chrome-a11y-violations"}]
+              (for [[i v] (map-indexed vector vs)]
+                ^{:key i} [violation-row v])))]]))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Chrome A11y tab's Causa-side
+  registrations. Registers the Runtime L4 tab under
+  `:id :chrome-a11y`, `:mnem y` (for a11Y — `a` / `c` / `i` are taken
+  by App-db / Machines Canvas / Issues respectively), `:modes
+  #{:runtime}`, `:order 8` (sits after Issues at order 7 — both tabs
+  occupy the diagnostics group at the right end of the tab strip).
+
+  Today the panel has no Causa app-db registrations — its state lives
+  in module-level r/atoms (`violations`, `run-state`, `cdn-opt-in-
+  atom`) because the data has no other consumer. Future iterations
+  that surface the violation count on the L3 tab badge would register
+  a `:rf.causa.chrome-a11y/violation-count` sub here.
+
+  The `:panel` value resolves through the `reg-view`-registered
+  `Panel` above so subscriptions inside the panel resolve through
+  the shell's `[rf/frame-provider {:frame :rf/causa}]`."
+  []
+  (panel-registry/reg-l4-tab!
+    {:id    :chrome-a11y
+     :label "Chrome A11y"
+     :mnem  "y"
+     :modes #{:runtime}
+     :order 8
+     :panel Panel})
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -55,6 +55,7 @@
             [day8.re-frame2-causa.panels.app-db-segment-inspector
              :as app-db-segment-inspector]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-causa.panels.chrome-a11y.panel :as chrome-a11y-panel]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
@@ -721,6 +722,14 @@
     (static-flows-panel/install!)
     (views/install!)
     (trace/install!)
+    ;; Chrome A11y tab (rf2-5r2yj) — Runtime L4 tab that runs axe-core
+    ;; scoped to `#rf-causa-root` (Causa's own chrome). Mirror of
+    ;; Story's chrome-a11y panel (PR #1695). No app-db registrations —
+    ;; the panel's state lives in module-level `r/atom`s because the
+    ;; data has no other consumer; the install! only adds the L4 tab
+    ;; entry. Sits at order 8 (after Issues at 7) — both tabs occupy
+    ;; the diagnostics group at the right end of the tab strip.
+    (chrome-a11y-panel/install!)
     ;; rf2-2moh1 — register the Static :events placeholder tab. The
     ;; other Static tabs (machines / routes / schemas / views / flows)
     ;; each register their entry from their own panel's `install!`

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -413,6 +413,12 @@
                                   attention tone — distinguishes
                                   from app-db's main colour)
     :issues    → :red            (issues = errors; semantic red)
+    :chrome-a11y → :red          (rf2-5r2yj — diagnostics-group
+                                  sibling to :issues; both surface
+                                  \"what's wrong here?\" content, so
+                                  the red accent reads them as one
+                                  family at the right edge of the
+                                  tab strip)
 
   JVM-portable pure data → keyword. Call sites do
   `(get tokens (panel-domain->token tab))` to materialise the hex."
@@ -423,7 +429,8 @@
    :machines        :green
    :machines-canvas :green
    :routing         :yellow
-   :issues          :red})
+   :issues          :red
+   :chrome-a11y     :red})
 
 (defn panel-accent
   "Resolve the L4 panel's accent hex from the canonical

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -136,8 +136,8 @@
     (let [panels (palette-subs/palette-panels)
           ids    (set (map :id panels))]
       (is (contains? ids :routing) ":routing in palette-panels")
-      (is (= 8 (count panels))
-          "exactly 8 entries — Event / App DB / Views / Trace / Machines / Machines Canvas / Routing / Issues (rf2-mkpnb)"))))
+      (is (= 9 (count panels))
+          "exactly 9 entries — Event / App DB / Views / Trace / Machines / Machines Canvas / Routing / Issues / Chrome A11y (rf2-mkpnb + rf2-5r2yj)"))))
 
 ;; ---- (2) empty state ---------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -264,23 +264,26 @@
 (def ^:private expected-tab-ids
   "Authoritative tab inventory per spec/018 §5 The 8 tabs (Routing
   promoted to its own L3 tab per rf2-nrbs9; Machines Canvas promoted
-  per rf2-mkpnb)."
-  [:event :app-db :views :trace :machines :machines-canvas :routing :issues])
+  per rf2-mkpnb; Chrome A11y added per rf2-5r2yj — the dogfood axe-
+  core panel mirrors Story's chrome-a11y from #1695 and sits in the
+  diagnostics group at the right end of the strip)."
+  [:event :app-db :views :trace :machines :machines-canvas :routing :issues :chrome-a11y])
 
 (deftest tab-bar-renders-seven-tabs
-  (testing "spec/018 §5 — eight tabs (Event / App-db / Views / Trace /
-            Machines / Machines Canvas / Routing / Issues)"
+  (testing "spec/018 §5 + rf2-5r2yj — nine tabs (Event / App-db / Views /
+            Trace / Machines / Machines Canvas / Routing / Issues /
+            Chrome A11y)"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             tabs (find-all-by-testid-prefix tree "rf-causa-tab-")]
         ;; Need to filter out the L4 detail panel and tab-bar root.
-        (is (= 8 (count (filter (fn [n]
+        (is (= 9 (count (filter (fn [n]
                                   (let [t (:data-testid (second n))]
                                     (some #(= t (str "rf-causa-tab-" (name %)))
                                           expected-tab-ids)))
                                 tabs)))
-            "8 tab buttons render")
+            "9 tab buttons render")
         (doseq [tab-id expected-tab-ids]
           (is (some? (find-by-testid tree (str "rf-causa-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -123,13 +123,14 @@
 ;; ---- panel domain colours (rf2-5kfxe.8) --------------------------------
 
 (deftest panel-domain-map-covers-every-l4-tab
-  (testing "rf2-5kfxe.8 — the 8 L4 tabs each get a domain colour, so
+  (testing "rf2-5kfxe.8 — the 9 L4 tabs each get a domain colour, so
             panels are distinguishable at a glance via the 3px left
             border on their header. Machines Canvas (rf2-mkpnb)
             shares :green with Machines (the two are sibling
-            sub-domain tabs)."
+            sub-domain tabs); Chrome A11y (rf2-5r2yj) shares :red
+            with Issues (the diagnostics group sibling)."
     (let [tabs #{:event :app-db :views :trace :machines :machines-canvas
-                 :routing :issues}]
+                 :routing :issues :chrome-a11y}]
       (is (= tabs (set (keys t/panel-domain->token)))))))
 
 (deftest panel-accent-resolves-through-tokens


### PR DESCRIPTION
## Summary

Dogfood axe-core against Causa's own chrome — mirror of Story's `chrome-a11y` panel from #1695. New Runtime L4 tab `:chrome-a11y` (mnem `y`, order 8), bumping the tab inventory 8 → 9. Scan is scoped to `#rf-causa-root` (Causa's mount node), so axe-core walks every Causa surface without touching host-app DOM.

## What landed

- New panel module: `tools/causa/src/day8/re_frame2_causa/panels/chrome_a11y/panel.cljs` — `Panel` view via `reg-view`, `install!` that calls `panel-registry/reg-l4-tab!`, axe-core CDN loader (opt-in, SRI-pinned), violation-row hiccup, consent prompt, violations stylesheet (`[data-rf-causa-a11y-violation]`).
- Engine reuse: Causa had no axe-core engine before, so the loader is local to this panel (Story owns its own copy too — same SRI hash, independent opt-in keys so Causa and Story approvals are separate).
- Registration: one new line in `registry.cljs/install-canonical-panels!` calling `chrome-a11y-panel/install!` after `trace/install!`.
- Domain colour: `panel-domain->token` gains `:chrome-a11y → :red` so the accent stripe reads as one family with Issues (diagnostics group).
- Spec sweeps: `007-UX-IA.md` (bug-class table + L3 prose + wireframe + domain-colour table) and `018-Event-Spine.md` (§5 The 9 tabs table + both wireframes + L1 wireframe).
- Test sweeps: `shell-tab-bar-renders-seven-tabs` (8 → 9), `palette-includes-routing` (8 → 9 entries), `panel-domain-map-covers-every-l4-tab` (8 → 9 L4 tabs).

## Why the scope is `#rf-causa-root`

`mount.cljs` stamps `id="rf-causa-root"` on the mount node it allocates; the shell body lives inside it. The bead's title proposed `[data-rf-causa-root]` but the actual selector is `#rf-causa-root` — same element, more idiomatic given the existing stamping discipline.

## Pre-alpha posture

No Settings toggle, no in-shell config; CDN opt-in lives inline in the panel and persists to `localStorage` under `rf.causa.chrome-a11y/cdn-opt-in`. The panel runs on demand via its run button.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 775 tests, 2346 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 3634 tests, 10430 assertions, 0 failures
- [x] `cd implementation && npm run test:bundle-isolation` — both gates pass (axe-core CDN loader stays Causa-internal; no bundle leak)
- [x] `mkdocs build --strict` from repo root — clean