### PR TITLE
a11y(story): modal ARIA + controls inputs + arrow-key nav cluster (rf2-p1ai7 + u01y5 + 07m13)

### DIFF
--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -79,6 +79,7 @@
                    to the renderer."
   (:require [clojure.string :as str]
             #?(:cljs [reagent.core :as r])
+            #?(:cljs [re-frame.story.ui.a11y-dialog :as a11y-dialog])
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
 
@@ -418,48 +419,63 @@
      (when (:open? dialog-state)
        (let [draft-id     (:draft-id dialog-state)
              effective-id (or draft-id placeholder-id)
-             dtest        (fn [suffix] (str data-test-prefix "-" suffix))]
-         [:div {:style     (:modal-back styles)
-                :data-test (dtest "dialog")
-                :on-click  (fn [e]
-                             (when (= (.-target e) (.-currentTarget e))
-                               (on-close)))}
-          [:div {:style    (:modal styles)
-                 :on-click (fn [e] (.stopPropagation e))}
-           [:div {:style (:modal-title styles)} title]
-           (when hint
-             [:div {:style (:hint styles)} hint])
-           [:input
-            {:type          "text"
-             :style         (:id-input styles)
-             :data-test     (dtest "id-input")
-             :default-value (pr-str effective-id)
-             :on-change     (fn [e] (on-edit-id (.. e -target -value)))
-             :placeholder   placeholder-input}]
-           [:pre {:style     (:snippet styles)
-                  :data-test (dtest "snippet")}
-            snippet]
-           [:div {:style (:btn-row styles)}
-            (when on-discard
-              [:button
-               {:style     (:btn-muted styles)
-                :data-test (dtest "discard")
-                :on-click  (fn [_] (on-discard))}
-               "discard"])
-            (when on-export
-              [:button
-               {:style     (:btn-muted styles)
-                :data-test (dtest "export")
-                :title     "Export the recording as a :play-script (rich DSL)"
-                :on-click  (fn [_] (on-export))}
-               "export as :play-script"])
-            [:button
-             {:style     (:btn styles)
-              :data-test (dtest "copy")
-              :on-click  (fn [_] (on-copy))}
-             "copy to clipboard"]
-            [:button
-             {:style     (:btn-muted styles)
-              :data-test (dtest "close")
-              :on-click  (fn [_] (on-close))}
-             "close"]]]]))))
+             dtest        (fn [suffix] (str data-test-prefix "-" suffix))
+             title-id     (str data-test-prefix "-dialog-title")]
+         ;; rf2-p1ai7: wrap in a focus-trap so Escape closes, Tab cycles,
+         ;; focus moves in on mount, and focus returns to the trigger on
+         ;; close. The renderer is otherwise unchanged from the
+         ;; pre-fix shape — ARIA attrs (role / aria-modal / aria-labelledby)
+         ;; ride on the inner panel + the wrapper's on-click closes on
+         ;; backdrop tap as before. Hiccup is passed eagerly to the
+         ;; focus-trap so tests can string-traverse the full tree.
+         [a11y-dialog/focus-trap
+          {:on-close on-close}
+          [:div {:style     (:modal-back styles)
+                 :data-test (dtest "dialog")
+                 :on-click  (fn [e]
+                              (when (= (.-target e) (.-currentTarget e))
+                                (on-close)))}
+           [:div {:style          (:modal styles)
+                  :role           "dialog"
+                  :aria-modal     "true"
+                  :aria-labelledby title-id
+                  :on-click       (fn [e] (.stopPropagation e))}
+            [:div {:id    title-id
+                   :style (:modal-title styles)} title]
+            (when hint
+              [:div {:style (:hint styles)} hint])
+            [:input
+             {:type          "text"
+              :style         (:id-input styles)
+              :data-test     (dtest "id-input")
+              :aria-label    "New variant id"
+              :default-value (pr-str effective-id)
+              :on-change     (fn [e] (on-edit-id (.. e -target -value)))
+              :placeholder   placeholder-input}]
+            [:pre {:style     (:snippet styles)
+                   :data-test (dtest "snippet")}
+             snippet]
+            [:div {:style (:btn-row styles)}
+             (when on-discard
+               [:button
+                {:style     (:btn-muted styles)
+                 :data-test (dtest "discard")
+                 :on-click  (fn [_] (on-discard))}
+                "discard"])
+             (when on-export
+               [:button
+                {:style     (:btn-muted styles)
+                 :data-test (dtest "export")
+                 :title     "Export the recording as a :play-script (rich DSL)"
+                 :on-click  (fn [_] (on-export))}
+                "export as :play-script"])
+             [:button
+              {:style     (:btn styles)
+               :data-test (dtest "copy")
+               :on-click  (fn [_] (on-copy))}
+              "copy to clipboard"]
+             [:button
+              {:style     (:btn-muted styles)
+               :data-test (dtest "close")
+               :on-click  (fn [_] (on-close))}
+              "close"]]]]]))))

--- a/tools/story/src/re_frame/story/ui/a11y_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y_dialog.cljs
@@ -1,0 +1,198 @@
+(ns re-frame.story.ui.a11y-dialog
+  "Shared a11y helpers for Story's modal dialogs (rf2-p1ai7).
+
+  Modal dialogs need a coherent a11y posture:
+
+  - role='dialog' + aria-modal='true' on the modal wrapper.
+  - Accessible name via aria-labelledby (preferred — visible label is
+    the title) or aria-label.
+  - Focus moves into the dialog on mount.
+  - Focus is trapped: Tab cycles forward to the first focusable on
+    overflow; Shift-Tab cycles back to the last on underflow.
+  - Escape closes the dialog.
+  - Focus returns to the element that opened the dialog on close.
+
+  Story's command palette and help overlay already do the role + aria
+  bits inline; this ns centralises the focus-trap + return-focus + key
+  handling so the three dialogs covered by rf2-p1ai7 (recorder
+  assertion picker, recorder save dialog, recorder export dialog,
+  save-variant dialog — all four since the save flows share
+  `review-dialog`) get the same posture without per-dialog drift.
+
+  Per the pre-alpha posture: each affordance is complete or not at all
+  — a focus trap without Escape, or without return-focus, is half-
+  shipped. This helper bundles all three so callers can't get it
+  partially right.
+
+  ## Surface
+
+  - `[focus-trap opts child-hiccup]` — a Reagent class-3 component
+    that wraps its child hiccup with:
+    - window-level keydown listener (Escape → on-close).
+    - capture-phase Tab listener on its root node (Tab cycles).
+    - focus-on-mount to the first focusable descendant (or
+      `:initial-focus-ref` when supplied).
+    - focus-return on unmount to the previously focused element.
+
+    `opts` is a map with `:on-close` (required, zero-arg fn) +
+    optional `:initial-focus-ref` (an atom/ref the dialog populates
+    with the element to focus on mount).
+
+    `child-hiccup` is the dialog's hiccup as-is — passed eagerly (not
+    via a thunk) so tests can string-traverse the rendered tree
+    without invoking the class component's render lifecycle.
+
+  ## Why a class-3 wrapper
+
+  We need the underlying DOM node post-mount to compute the focusable
+  set and install the capture-phase Tab handler. Function components
+  don't give us a stable ref handle without `r/with-let` + a manual
+  ref-callback, which a CLJS-side class wrapper handles more cleanly."
+  (:require [reagent.core :as r]))
+
+(def ^:private focusable-selector
+  "CSS selector matching elements that participate in the Tab order.
+  Excludes `[tabindex='-1']` so roving-focus list items don't trap the
+  cycle; explicitly includes `[tabindex='0']` for non-natively-focusable
+  elements that opt in."
+  (str "a[href], "
+       "button:not([disabled]), "
+       "input:not([disabled]), "
+       "select:not([disabled]), "
+       "textarea:not([disabled]), "
+       "[tabindex='0']"))
+
+(defn- focusable-descendants
+  "Return a JS array of focusable DOM nodes inside `root-el`. Order is
+  document order, matching the natural Tab traversal."
+  [^js root-el]
+  (when (and root-el (some? (.-querySelectorAll root-el)))
+    (let [nodes (.querySelectorAll root-el focusable-selector)]
+      (array-seq nodes))))
+
+(defn- focus-element!
+  "Focus `el` defensively — wrap in try/catch since hidden elements,
+  detached nodes, and JSDOM corner cases throw."
+  [^js el]
+  (when el
+    (try
+      (.focus el)
+      (catch :default _ nil))))
+
+(defn- handle-tab-cycle!
+  "Capture-phase Tab handler. When Tab fires on the last focusable
+  descendant, focus wraps to the first; Shift-Tab on the first wraps
+  to the last. The cycle is rooted at `root-el` so the dialog's tab
+  traversal never escapes its own subtree."
+  [^js root-el ^js evt]
+  (when (and (= "Tab" (.-key evt)) root-el)
+    (let [focusables (vec (focusable-descendants root-el))]
+      (when (seq focusables)
+        (let [first-el (first focusables)
+              last-el  (last focusables)
+              active   (.-activeElement js/document)
+              shift?   (.-shiftKey evt)]
+          (cond
+            (and shift? (or (= active first-el)
+                            (not (some #(= active %) focusables))))
+            (do
+              (.preventDefault evt)
+              (focus-element! last-el))
+
+            (and (not shift?) (or (= active last-el)
+                                  (not (some #(= active %) focusables))))
+            (do
+              (.preventDefault evt)
+              (focus-element! first-el))
+
+            :else nil))))))
+
+(defn focus-trap
+  "Reagent class-3 component that wraps a modal dialog's render output
+  with focus management:
+
+    - Captures the previously-focused element on mount; restores focus
+      to it on unmount.
+    - Focuses the first focusable descendant on mount (or
+      `:initial-focus-ref` if the caller populated it).
+    - Cycles Tab / Shift-Tab on the focusable descendants so focus
+      never leaves the dialog.
+    - Listens for Escape on window and invokes `:on-close`.
+
+  `opts`:
+    :on-close          — required zero-arg fn invoked on Escape.
+    :initial-focus-ref — optional atom; deref'd on mount and (when
+                         non-nil) focused in preference to the first
+                         tab-stop. Useful for the assertion-picker's
+                         vocabulary-list roving focus, where the
+                         currently-active list item is the right
+                         starting point.
+
+  `child-hiccup` — the dialog's hiccup vector, passed eagerly. The
+  child is spliced under the helper's wrapper div; the wrapper
+  carries no visual styling (display:contents) so callers retain
+  their own backdrop / panel layout."
+  [_opts _child-hiccup]
+  (let [root-ref     (atom nil)
+        prev-active  (atom nil)
+        key-handler  (atom nil)
+        tab-handler  (atom nil)]
+    (r/create-class
+      {:display-name "rf-story-a11y-focus-trap"
+
+       :component-did-mount
+       (fn [this]
+         (let [{:keys [on-close initial-focus-ref]} (-> this .-props .-argv second)]
+           ;; Snapshot the currently-focused element so we can restore on close.
+           (when (exists? js/document)
+             (reset! prev-active (.-activeElement js/document)))
+           ;; Window-level Escape handler. Use capture so we win over
+           ;; any in-dialog handler that might preventDefault first.
+           (let [f (fn [^js evt]
+                     (when (= "Escape" (.-key evt))
+                       (.preventDefault evt)
+                       (.stopPropagation evt)
+                       (on-close)))]
+             (reset! key-handler f)
+             (when (exists? js/window)
+               (.addEventListener js/window "keydown" f true)))
+           ;; Capture-phase Tab handler on the wrapper root. Capture so
+           ;; the cycle decision happens before any inner handler.
+           (let [f (fn [^js evt]
+                     (handle-tab-cycle! @root-ref evt))]
+             (reset! tab-handler f)
+             (when-let [root @root-ref]
+               (.addEventListener root "keydown" f true)))
+           ;; Initial focus — prefer the caller's nominated ref, else
+           ;; the first focusable descendant. Defer to a microtask so
+           ;; the dialog's render is in the DOM.
+           (when (exists? js/queueMicrotask)
+             (js/queueMicrotask
+               (fn []
+                 (let [explicit (when initial-focus-ref @initial-focus-ref)
+                       target   (or explicit
+                                    (first (focusable-descendants @root-ref)))]
+                   (focus-element! target)))))))
+
+       :component-will-unmount
+       (fn [_this]
+         (when-let [f @key-handler]
+           (when (exists? js/window)
+             (.removeEventListener js/window "keydown" f true)))
+         (when-let [f @tab-handler]
+           (when-let [root @root-ref]
+             (.removeEventListener root "keydown" f true)))
+         ;; Return focus to the element that opened the dialog. Defer
+         ;; to a microtask so React's unmount has settled.
+         (when (exists? js/queueMicrotask)
+           (let [target @prev-active]
+             (js/queueMicrotask (fn [] (focus-element! target))))))
+
+       :reagent-render
+       (fn [_opts child-hiccup]
+         [:div {:ref (fn [el] (reset! root-ref el))
+                ;; display:contents so the wrapper participates in flex /
+                ;; grid layouts identically to a fragment — the dialog's
+                ;; own backdrop / panel decides the visual frame.
+                :style {:display "contents"}}
+          child-hiccup])})))

--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -33,7 +33,8 @@
   disable-by-name routing through `resolve-decorators` is a future
   refinement when the decorator stack grows more complex; today the
   toggle is informational."
-  (:require [re-frame.story.registrar          :as registrar]
+  (:require [clojure.string                    :as str]
+            [re-frame.story.registrar          :as registrar]
             [re-frame.story.args               :as args]
             [re-frame.story.decorators         :as decorators]
             [re-frame.story.malli-schema-utils :as msu]
@@ -289,44 +290,69 @@
   [variant-id path]
   (fn [e] (on-change-at-path variant-id path (read-event-value e))))
 
+(defn- path-label
+  "Derive an accessible name for an input from its `path`. The path tail
+  is the user-visible label sibling (rendered in the `:label` span at
+  row level); we mirror it as `aria-label` so screen readers announce
+  the input by name. Per rf2-u01y5: the visible span is purely visual
+  — without this association screen readers announce 'edit, blank'.
+
+  Nested paths produce a slash-joined breadcrumb (`outer/inner`) so a
+  nested input under `:address.street` reads as 'address / street'."
+  [path]
+  (let [parts (mapv str path)]
+    (str/join " / " parts)))
+
 (defn- render-text [variant-id path value _]
-  [:input {:type      "text"
-           :style     (:input styles)
-           :value     (if (nil? value) "" (str value))
-           :on-change (on-string-change variant-id path)}])
+  [:input {:type       "text"
+           :style      (:input styles)
+           :aria-label (path-label path)
+           :value      (if (nil? value) "" (str value))
+           :on-change  (on-string-change variant-id path)}])
 
 (defn- render-textarea [variant-id path value _]
-  [:textarea {:style     (:textarea styles)
-              :value     (if (nil? value) "" (str value))
-              :on-change (on-string-change variant-id path)}])
+  [:textarea {:style      (:textarea styles)
+              :aria-label (path-label path)
+              :value      (if (nil? value) "" (str value))
+              :on-change  (on-string-change variant-id path)}])
 
 (defn- render-number [variant-id path value _]
-  [:input {:type      "number"
-           :style     (:input styles)
-           :value     (if (nil? value) "" value)
-           :on-change (fn [e]
-                        (let [s (read-event-value e)
-                              v (when (seq s) (js/parseFloat s))]
-                          (on-change-at-path variant-id path v)))}])
+  [:input {:type       "number"
+           :style      (:input styles)
+           :aria-label (path-label path)
+           :value      (if (nil? value) "" value)
+           :on-change  (fn [e]
+                         (let [s (read-event-value e)
+                               v (when (seq s) (js/parseFloat s))]
+                           (on-change-at-path variant-id path v)))}])
 
 (defn- render-boolean [variant-id path value _]
-  [:input {:type      "checkbox"
-           :checked   (boolean value)
-           :on-change (fn [e]
-                        (on-change-at-path variant-id path
-                                           (read-event-checked e)))}])
+  [:input {:type       "checkbox"
+           :aria-label (path-label path)
+           :checked    (boolean value)
+           :on-change  (fn [e]
+                         (on-change-at-path variant-id path
+                                            (read-event-checked e)))}])
 
 (defn- render-select [variant-id path value {:keys [options]}]
-  [:select {:value     (str value)
-            :style     (:input styles)
-            :on-change (on-string-change variant-id path)}
+  [:select {:value      (str value)
+            :style      (:input styles)
+            :aria-label (path-label path)
+            :on-change  (on-string-change variant-id path)}
    (for [opt options]
      ^{:key (str opt)}
      [:option {:value (str opt)} (str opt)])])
 
 (defn- render-radio [variant-id path value {:keys [options]}]
+  ;; rf2-u01y5: the radio-set wraps each input in a parent <label>, so
+  ;; the inner <input type="radio"> already inherits an accessible name
+  ;; from the wrapping label's text (the option's value). We add
+  ;; role="radiogroup" + aria-label on the container so screen readers
+  ;; announce the group's name (the path) before traversing options.
   (into [:div {:style (:radio-row styles)
-               :data-controls-radio-group (str (last path))}]
+               :data-controls-radio-group (str (last path))
+               :role       "radiogroup"
+               :aria-label (path-label path)}]
         (for [opt options]
           ^{:key (str opt)}
           [:label {:style (:radio-label styles)}
@@ -339,21 +365,23 @@
            (str opt)])))
 
 (defn- render-date [variant-id path value _]
-  [:input {:type      "date"
-           :style     (:input styles)
-           :value     (if (nil? value) "" (str value))
-           :on-change (fn [e]
-                        (let [s (read-event-value e)]
-                          (on-change-at-path variant-id path
-                                             (when (seq s) s))))}])
+  [:input {:type       "date"
+           :style      (:input styles)
+           :aria-label (path-label path)
+           :value      (if (nil? value) "" (str value))
+           :on-change  (fn [e]
+                         (let [s (read-event-value e)]
+                           (on-change-at-path variant-id path
+                                              (when (seq s) s))))}])
 
 (defn- render-color [variant-id path value _]
-  [:input {:type      "color"
-           :style     (:color-input styles)
-           :value     (if (and (string? value) (seq value))
-                        value
-                        "#000000")
-           :on-change (on-string-change variant-id path)}])
+  [:input {:type       "color"
+           :style      (:color-input styles)
+           :aria-label (path-label path)
+           :value      (if (and (string? value) (seq value))
+                         value
+                         "#000000")
+           :on-change  (on-string-change variant-id path)}])
 
 (def ^:private scalar-renderers
   "Closed scalar-widget vocabulary per spec/007-Stories.md §argtypes.

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -67,6 +67,7 @@
             [re-frame.story.recorder                     :as recorder]
             [re-frame.story.recorder.dom-capture         :as recorder-dom]
             [re-frame.story.review-dialog                :as review-dialog]
+            [re-frame.story.ui.a11y-dialog               :as a11y-dialog]
             [re-frame.story.ui.recorder-export-dialog    :as export-dialog]
             [re-frame.story.ui.state                     :as state]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
@@ -427,19 +428,32 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce ui-picker
-  (r/atom {:open?       false
-           :assertion   nil      ; the picked id, or nil while on phase 1
-           :field-text  {}       ; field-key → raw input string
-           :error       nil}))
+  (r/atom {:open?        false
+           :assertion    nil      ; the picked id, or nil while on phase 1
+           :field-text   {}       ; field-key → raw input string
+           :error        nil
+           :active-index 0}))     ; roving-focus cursor for phase-1 vocab list (rf2-07m13)
 
 (defn- open-picker! []
-  (reset! ui-picker {:open? true :assertion nil :field-text {} :error nil}))
+  (reset! ui-picker {:open? true :assertion nil :field-text {} :error nil :active-index 0}))
 
 (defn- close-picker! []
   (swap! ui-picker assoc :open? false))
 
 (defn- pick-assertion! [assertion-id]
   (swap! ui-picker assoc :assertion assertion-id :field-text {} :error nil))
+
+(defn- set-active-index!
+  "Clamp `idx` into `[0, n)` and stash on the picker state. The renderer
+  reads this to drive the roving-focus `tabindex` + `data-active`."
+  [idx]
+  (let [n (count recorder/assertion-vocabulary)]
+    (when (pos? n)
+      (let [clamped (cond
+                      (neg? idx) (dec n)         ; arrow-up wraps to last
+                      (>= idx n) 0               ; arrow-down wraps to first
+                      :else idx)]
+        (swap! ui-picker assoc :active-index clamped)))))
 
 (defn- set-field-text! [field-key s]
   (swap! ui-picker assoc-in [:field-text field-key] s))
@@ -495,88 +509,170 @@
         (close-picker!))
       (swap! ui-picker assoc :error detail))))
 
+(def ^:private picker-title-id
+  "Stable id stamped on the picker's visible title — referenced by
+  aria-labelledby so screen readers announce the dialog's name."
+  "story-recorder-picker-title")
+
+(defn- vocab-key-handler
+  "Phase-1 keyboard handler for the assertion-vocabulary list (rf2-07m13).
+
+  - ArrowDown / ArrowUp move the active cursor one row.
+  - Home / End jump to the first / last row.
+  - Enter / Space commit the active row (`pick-assertion!`).
+  - Escape closes the picker.
+
+  Focus is rolled via the `tabindex=0` / `tabindex=-1` pattern on the
+  row buttons; the renderer's `:ref` callback re-focuses the active
+  row when the cursor moves so screen-reader announcement follows.
+
+  `active-index` is the current cursor; `n` is the vocab length."
+  [active-index n]
+  (fn [^js evt]
+    (case (.-key evt)
+      "ArrowDown" (do (.preventDefault evt)
+                      (set-active-index! (inc active-index)))
+      "ArrowUp"   (do (.preventDefault evt)
+                      (set-active-index! (dec active-index)))
+      "Home"      (do (.preventDefault evt)
+                      (set-active-index! 0))
+      "End"       (do (.preventDefault evt)
+                      (set-active-index! (dec n)))
+      ("Enter" " ") (do
+                      (.preventDefault evt)
+                      (let [vocab (nth recorder/assertion-vocabulary active-index nil)]
+                        (when vocab
+                          (pick-assertion! (:id vocab)))))
+      nil)))
+
 (defn assertion-picker
   "Modal picker for mid-recording assertion insertion. Public so the
   shell can mount it alongside the recorder overlay (and so tests can
-  introspect the hiccup)."
+  introspect the hiccup).
+
+  rf2-p1ai7: ARIA role=dialog + aria-modal + aria-labelledby on the
+  picker panel; focus-trap wrapper handles Tab cycle, Escape, and
+  return-focus.
+
+  rf2-07m13: phase-1 vocabulary list implements the WAI-ARIA APG
+  menu pattern — role=menu on the container, role=menuitem on each
+  row, roving tabindex with ArrowUp/ArrowDown/Home/End/Enter handling."
   []
-  (let [{:keys [open? assertion field-text error] :as picker} @ui-picker]
+  (let [{:keys [open? assertion field-text error active-index] :as picker} @ui-picker
+        vocab recorder/assertion-vocabulary
+        n     (count vocab)
+        ;; Clamp the cursor against the live vocabulary length so the
+        ;; renderer never receives an out-of-range index (defensive
+        ;; against the open-picker! seed of 0 vs. an empty vocabulary).
+        idx   (cond
+                (zero? n)            0
+                (or (nil? active-index) (neg? active-index)) 0
+                (>= active-index n)  (dec n)
+                :else                active-index)
+        active-row-ref (atom nil)]
     (when open?
-      [:div
-       {:style    (:picker-back styles)
-        :data-test "story-recorder-picker"
-        :on-click (fn [e]
-                    (when (= (.-target e) (.-currentTarget e))
-                      (close-picker!)))}
-       [:div {:style (:picker styles)
-              :on-click (fn [e] (.stopPropagation e))}
-        [:div {:style (:picker-title styles)}
-         (if assertion
-           (str "Add assertion — " (pr-str assertion))
-           "Add assertion — pick from the canonical vocabulary")]
+      [a11y-dialog/focus-trap
+       {:on-close          close-picker!
+        ;; In phase 1, the menu's active row is the natural starting
+        ;; focus. In phase 2 we leave the helper to pick the first
+        ;; focusable (the back button or the first field input).
+        :initial-focus-ref (when (nil? assertion) active-row-ref)}
+       [:div
+        {:style    (:picker-back styles)
+         :data-test "story-recorder-picker"
+         :on-click (fn [e]
+                     (when (= (.-target e) (.-currentTarget e))
+                       (close-picker!)))}
+        [:div {:style          (:picker styles)
+               :role           "dialog"
+               :aria-modal     "true"
+               :aria-labelledby picker-title-id
+               :on-click       (fn [e] (.stopPropagation e))}
+         [:div {:id    picker-title-id
+                :style (:picker-title styles)}
+          (if assertion
+            (str "Add assertion — " (pr-str assertion))
+            "Add assertion — pick from the canonical vocabulary")]
 
-        (if (nil? assertion)
-          ;; Phase 1: vocabulary list.
-          [:div {:style (:picker-grid styles)
-                 :data-test "story-recorder-picker-vocab"}
-           (for [{:keys [id label hint]} recorder/assertion-vocabulary]
-             ^{:key id}
-             [:button
-              {:style      (:picker-row styles)
-               :data-test  (str "story-recorder-picker-id-"
-                                (namespace id) "-" (name id))
-               :on-click   (fn [_] (pick-assertion! id))}
-              [:span {:style (:picker-row-id styles)} (pr-str id)]
-              [:span {:style (:picker-row-hint styles)} hint]])]
+         (if (nil? assertion)
+           ;; Phase 1: vocabulary list — role=menu + roving tabindex.
+           [:div {:style       (:picker-grid styles)
+                  :data-test   "story-recorder-picker-vocab"
+                  :role        "menu"
+                  :aria-label  "Assertion vocabulary"
+                  :on-key-down (vocab-key-handler idx n)}
+            (doall
+              (map-indexed
+                (fn [i {:keys [id label hint]}]
+                  (let [active? (= i idx)]
+                    ^{:key id}
+                    [:button
+                     {:style      (:picker-row styles)
+                      :data-test  (str "story-recorder-picker-id-"
+                                       (namespace id) "-" (name id))
+                      :data-active (if active? "true" "false")
+                      :role       "menuitem"
+                      :tab-index  (if active? 0 -1)
+                      :aria-label (or label (pr-str id))
+                      :ref        (fn [el]
+                                    (when (and active? el)
+                                      (reset! active-row-ref el)))
+                      :on-click   (fn [_] (pick-assertion! id))
+                      :on-focus   (fn [_] (set-active-index! i))}
+                     [:span {:style (:picker-row-id styles)} (pr-str id)]
+                     [:span {:style (:picker-row-hint styles)} hint]]))
+                vocab))]
 
-          ;; Phase 2: field entry + preview.
-          (let [{:keys [fields hint]} (recorder/vocabulary-entry assertion)
-                preview (preview-event picker)]
-            [:div {:style {:display "flex" :flex-direction "column" :gap "10px"}
-                   :data-test "story-recorder-picker-fields"}
-             [:div {:style (:hint styles)} hint]
-             (for [{:keys [key prompt placeholder]} fields]
-               ^{:key key}
-               [:label {:style (:field-row styles)}
-                [:span {:style (:field-label styles)} prompt]
-                [:input
-                 {:type        "text"
-                  :style       (:field-input styles)
-                  :data-test   (str "story-recorder-picker-field-" (name key))
-                  :placeholder placeholder
-                  :value       (get field-text key "")
-                  :on-change   (fn [e] (set-field-text! key (.. e -target -value)))}]
-                (when (and error (= (:field error) key))
-                  [:span {:style (:field-error styles)
-                          :data-test "story-recorder-picker-error"}
-                   "EDN didn't parse — " (pr-str (:raw error))])])
-             (when (seq fields)
-               [:div {:style {:font-size (:micro typography/type-scale) :color (:text-tertiary colors/tokens)}}
-                "preview:"])
-             (when preview
-               [:pre {:style     (:preview styles)
-                      :data-test "story-recorder-picker-preview"}
-                (pr-str preview)])
-             [:div {:style (:btn-row styles)}
-              [:button
-               {:style    (:btn-muted styles)
-                :data-test "story-recorder-picker-back"
-                :on-click (fn [_] (swap! ui-picker assoc
-                                         :assertion nil
-                                         :field-text {}
-                                         :error nil))}
-               "← back"]
-              [:button
-               {:style    (:btn-muted styles)
-                :data-test "story-recorder-picker-cancel"
-                :on-click (fn [_] (close-picker!))}
-               "cancel"]
-              [:button
-               {:style     (:btn styles)
-                :data-test "story-recorder-picker-insert"
-                :disabled  (some? error)
-                :on-click  (fn [_] (insert!))}
-               "insert"]]]))]])))
+           ;; Phase 2: field entry + preview.
+           (let [{:keys [fields hint]} (recorder/vocabulary-entry assertion)
+                 preview (preview-event picker)]
+             [:div {:style {:display "flex" :flex-direction "column" :gap "10px"}
+                    :data-test "story-recorder-picker-fields"}
+              [:div {:style (:hint styles)} hint]
+              (for [{:keys [key prompt placeholder]} fields]
+                ^{:key key}
+                [:label {:style (:field-row styles)}
+                 [:span {:style (:field-label styles)} prompt]
+                 [:input
+                  {:type        "text"
+                   :style       (:field-input styles)
+                   :data-test   (str "story-recorder-picker-field-" (name key))
+                   :placeholder placeholder
+                   :aria-label  prompt
+                   :value       (get field-text key "")
+                   :on-change   (fn [e] (set-field-text! key (.. e -target -value)))}]
+                 (when (and error (= (:field error) key))
+                   [:span {:style (:field-error styles)
+                           :data-test "story-recorder-picker-error"}
+                    "EDN didn't parse — " (pr-str (:raw error))])])
+              (when (seq fields)
+                [:div {:style {:font-size (:micro typography/type-scale) :color (:text-tertiary colors/tokens)}}
+                 "preview:"])
+              (when preview
+                [:pre {:style     (:preview styles)
+                       :data-test "story-recorder-picker-preview"}
+                 (pr-str preview)])
+              [:div {:style (:btn-row styles)}
+               [:button
+                {:style    (:btn-muted styles)
+                 :data-test "story-recorder-picker-back"
+                 :on-click (fn [_] (swap! ui-picker assoc
+                                          :assertion nil
+                                          :field-text {}
+                                          :error nil
+                                          :active-index 0))}
+                "← back"]
+               [:button
+                {:style    (:btn-muted styles)
+                 :data-test "story-recorder-picker-cancel"
+                 :on-click (fn [_] (close-picker!))}
+                "cancel"]
+               [:button
+                {:style     (:btn styles)
+                 :data-test "story-recorder-picker-insert"
+                 :disabled  (some? error)
+                 :on-click  (fn [_] (insert!))}
+                "insert"]]]))]]])))
 
 ;; rf2-d5u89: Reagent-mirror of the DOM-capture enabled flag so the
 ;; overlay chip re-renders when the user toggles capture. The flag

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -52,6 +52,7 @@
             [re-frame.story.recorder.play-export          :as export]
             [re-frame.story.recorder.play-export-events   :as export-events]
             [re-frame.story.review-dialog                 :as review-dialog]
+            [re-frame.story.ui.a11y-dialog                :as a11y-dialog]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
 
@@ -282,6 +283,12 @@
 ;; The dialog itself
 ;; ---------------------------------------------------------------------------
 
+(def ^:private title-id
+  "Stable id stamped on the dialog's visible title so the modal's
+  aria-labelledby pointer resolves. Constant — only one export dialog
+  is mounted at a time."
+  "story-recorder-export-dialog-title")
+
 (defn export-dialog
   "Render the export dialog. Returns nil when `:open?` is false on
   `@ui-dialog` so the caller can mount it unconditionally next to the
@@ -292,81 +299,96 @@
       (let [{:keys [spec rendered]} (build-export-from-dialog state)
             {:keys [name source-id variant-id auto-assert?
                     replay-status replay-failure-msg]} state]
-        [:div
-         {:style     (:back styles)
-          :data-test "story-recorder-export-dialog"
-          :on-click  (fn [e]
-                       (when (= (.-target e) (.-currentTarget e))
-                         (close-dialog!)))}
-         [:div {:style    (:modal styles)
-                :on-click (fn [e] (.stopPropagation e))}
-          [:div {:style (:title styles)}
-           "Recorder → :play-script export"
-           (replay-pill replay-status replay-failure-msg)]
-          [:div {:style (:hint styles)}
-           (str "Generated from " (count (:events state))
-                " captured event" (when (not= 1 (count (:events state))) "s")
-                " against " (pr-str source-id)
-                ". Tweak the options, then copy + paste into your stories ns.")]
+        ;; rf2-p1ai7: focus-trap wrapper — Escape closes, Tab cycles,
+        ;; focus moves into the dialog on mount, focus returns to the
+        ;; trigger on close. The dialog hiccup is passed eagerly so
+        ;; tests can string-traverse the full tree without invoking
+        ;; the class component's render lifecycle.
+        [a11y-dialog/focus-trap
+         {:on-close close-dialog!}
+         [:div
+          {:style     (:back styles)
+           :data-test "story-recorder-export-dialog"
+           :on-click  (fn [e]
+                        (when (= (.-target e) (.-currentTarget e))
+                          (close-dialog!)))}
+          [:div {:style          (:modal styles)
+                 :role           "dialog"
+                 :aria-modal     "true"
+                 :aria-labelledby title-id
+                 :on-click       (fn [e] (.stopPropagation e))}
+           [:div {:id    title-id
+                  :style (:title styles)}
+            "Recorder → :play-script export"
+            (replay-pill replay-status replay-failure-msg)]
+           [:div {:style (:hint styles)}
+            (str "Generated from " (count (:events state))
+                 " captured event" (when (not= 1 (count (:events state))) "s")
+                 " against " (pr-str source-id)
+                 ". Tweak the options, then copy + paste into your stories ns.")]
 
-          ;; ---- Name ---------------------------------------------------------
-          [:div {:style (:row styles)}
-           [:label {:style (:label styles)} "Name"]
-           [:input
-            {:type        "text"
-             :style       (:input styles)
-             :data-test   "story-recorder-export-name-input"
-             :placeholder "happy path"
-             :value       name
-             :on-change   (fn [e] (set-name! (.. e -target -value)))}]]
+           ;; ---- Name ---------------------------------------------------------
+           [:div {:style (:row styles)}
+            [:label {:style (:label styles)
+                     :html-for "story-recorder-export-name-input-el"} "Name"]
+            [:input
+             {:type        "text"
+              :id          "story-recorder-export-name-input-el"
+              :style       (:input styles)
+              :data-test   "story-recorder-export-name-input"
+              :placeholder "happy path"
+              :value       name
+              :on-change   (fn [e] (set-name! (.. e -target -value)))}]]
 
-          ;; ---- Variant id ---------------------------------------------------
-          [:div {:style (:row styles)}
-           [:label {:style (:label styles)} "Variant id"]
-           [:input
-            {:type          "text"
-             :style         (:input styles)
-             :data-test     "story-recorder-export-variant-id-input"
-             :placeholder   ":story.your/recorded-flow"
-             :default-value (pr-str variant-id)
-             :on-change     (fn [e] (set-variant-id! (.. e -target -value)))}]]
+           ;; ---- Variant id ---------------------------------------------------
+           [:div {:style (:row styles)}
+            [:label {:style (:label styles)
+                     :html-for "story-recorder-export-variant-id-input-el"} "Variant id"]
+            [:input
+             {:type          "text"
+              :id            "story-recorder-export-variant-id-input-el"
+              :style         (:input styles)
+              :data-test     "story-recorder-export-variant-id-input"
+              :placeholder   ":story.your/recorded-flow"
+              :default-value (pr-str variant-id)
+              :on-change     (fn [e] (set-variant-id! (.. e -target -value)))}]]
 
-          ;; ---- Auto-assert toggle ------------------------------------------
-          [:label
-           {:style     (:checkbox-row styles)
-            :data-test "story-recorder-export-auto-assert"}
-           [:input
-            {:type      "checkbox"
-             :data-test "story-recorder-export-auto-assert-checkbox"
-             :checked   auto-assert?
-             :on-change (fn [_] (toggle-auto-assert!))}]
-           [:span {:style (:label styles)} "Auto-assert app-db at end"]
-           [:span {:style (:hint styles)}
-            (str "(top-" export/default-max-auto-assertions
-                 " changed paths; trim manually after pasting)")]]
+           ;; ---- Auto-assert toggle ------------------------------------------
+           [:label
+            {:style     (:checkbox-row styles)
+             :data-test "story-recorder-export-auto-assert"}
+            [:input
+             {:type      "checkbox"
+              :data-test "story-recorder-export-auto-assert-checkbox"
+              :checked   auto-assert?
+              :on-change (fn [_] (toggle-auto-assert!))}]
+            [:span {:style (:label styles)} "Auto-assert app-db at end"]
+            [:span {:style (:hint styles)}
+             (str "(top-" export/default-max-auto-assertions
+                  " changed paths; trim manually after pasting)")]]
 
-          ;; ---- Snippet preview ---------------------------------------------
-          [:pre {:style     (:snippet styles)
-                 :data-test "story-recorder-export-snippet"}
-           rendered]
+           ;; ---- Snippet preview ---------------------------------------------
+           [:pre {:style     (:snippet styles)
+                  :data-test "story-recorder-export-snippet"}
+            rendered]
 
-          ;; ---- Button row --------------------------------------------------
-          [:div {:style (:btn-row styles)}
-           [:button
-            {:style    (:btn-muted styles)
-             :data-test "story-recorder-export-replay"
-             :on-click (fn [_] (run-replay! state spec))}
-            "replay in this story"]
-           [:button
-            {:style    (:btn styles)
-             :data-test "story-recorder-export-copy"
-             :on-click (fn [_] (review-dialog/copy-to-clipboard! rendered))}
-            "copy to clipboard"]
-           [:button
-            {:style    (:btn-muted styles)
-             :data-test "story-recorder-export-close"
-             :on-click (fn [_] (close-dialog!))}
-            "close"]]]]))))
+           ;; ---- Button row --------------------------------------------------
+           [:div {:style (:btn-row styles)}
+            [:button
+             {:style    (:btn-muted styles)
+              :data-test "story-recorder-export-replay"
+              :on-click (fn [_] (run-replay! state spec))}
+             "replay in this story"]
+            [:button
+             {:style    (:btn styles)
+              :data-test "story-recorder-export-copy"
+              :on-click (fn [_] (review-dialog/copy-to-clipboard! rendered))}
+             "copy to clipboard"]
+            [:button
+             {:style    (:btn-muted styles)
+              :data-test "story-recorder-export-close"
+              :on-click (fn [_] (close-dialog!))}
+             "close"]]]]]))))
 
 ;; ---------------------------------------------------------------------------
 ;; Public open-from-recorder helper

--- a/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
@@ -279,3 +279,54 @@
            ;; — the trailing element is the widget-spec map, ensuring the
            ;; dispatch carried our :widget tag through.
            (is (= w (:widget sub-spec))))))))
+
+;; ---- aria-label on every scalar widget (rf2-u01y5) ----------------------
+;;
+;; Every scalar widget MUST carry an :aria-label derived from its path tail
+;; — without this the visible <span> label sibling has no programmatic
+;; association with the input and screen readers announce 'edit, blank'.
+
+#?(:cljs
+   (deftest each-scalar-widget-carries-aria-label
+     (testing "rf2-u01y5: every scalar widget renders with an :aria-label
+               derived from its path tail so screen readers announce the
+               input by name rather than 'edit, blank'."
+       (doseq [[w expected-tag]
+               [[{:widget :text}                              :input]
+                [{:widget :textarea}                          :textarea]
+                [{:widget :number}                            :input]
+                [{:widget :boolean}                           :input]
+                [{:widget :select :options [:a :b]}           :select]
+                [{:widget :date}                              :input]
+                [{:widget :color}                             :input]]]
+         (let [tree (controls/scalar-widget
+                      :story.x/v [:username] "x" w)]
+           (is (= expected-tag (first tree))
+               (str (:widget w) " renders the right tag"))
+           (is (some? (-> tree second :aria-label))
+               (str (:widget w) " carries an :aria-label"))
+           (is (re-find #"username" (-> tree second :aria-label))
+               (str (:widget w) " :aria-label includes the path tail")))))))
+
+#?(:cljs
+   (deftest radio-widget-radiogroup-has-aria-label
+     (testing "rf2-u01y5: the :radio container is a role=radiogroup with
+               an aria-label — the inner inputs inherit a name from their
+               wrapping <label> so they don't need their own aria-label."
+       (let [tree (controls/scalar-widget
+                    :story.x/v [:variant] :primary
+                    {:widget :radio :options [:primary :secondary]})]
+         (is (= :div (first tree)))
+         (is (= "radiogroup" (-> tree second :role)))
+         (is (some? (-> tree second :aria-label)))
+         (is (re-find #"variant" (-> tree second :aria-label)))))))
+
+#?(:cljs
+   (deftest nested-path-aria-label-is-breadcrumb
+     (testing "rf2-u01y5: nested path produces a slash-joined breadcrumb
+               so a nested input is announced as 'address / street'
+               rather than just 'street'."
+       (let [tree (controls/scalar-widget
+                    :story.x/v [:address :street] "Main St" {:widget :text})]
+         (is (re-find #"address" (-> tree second :aria-label)))
+         (is (re-find #"street"  (-> tree second :aria-label)))))))

--- a/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
@@ -146,3 +146,63 @@
            (is (not (str/includes? flat ":auth/login"))
                "B's freshly-captured events do NOT bleed into the snippet")
            (is (not (str/includes? flat ":auth/logout"))))))))
+
+;; ---- CLJS-only: assertion picker ARIA + arrow-key nav (rf2-p1ai7 + 07m13)
+
+#?(:cljs
+   (defn- open-picker-for-test! []
+     (reset! ui-rec/ui-picker {:open?        true
+                               :assertion    nil
+                               :field-text   {}
+                               :error        nil
+                               :active-index 0})))
+
+#?(:cljs
+   (deftest assertion-picker-stamps-modal-aria
+     (testing "rf2-p1ai7: the assertion picker carries role=dialog +
+              aria-modal + aria-labelledby on its panel"
+       (open-picker-for-test!)
+       (let [flat (str (ui-rec/assertion-picker))]
+         (is (str/includes? flat "dialog")     "role=dialog appears")
+         (is (str/includes? flat "aria-modal") "aria-modal flag is stamped")
+         (is (str/includes? flat "aria-labelledby")
+             "aria-labelledby points at the panel's visible title")
+         (is (str/includes? flat "story-recorder-picker-title")
+             "the title carries the id referenced by aria-labelledby")))))
+
+#?(:cljs
+   (deftest assertion-picker-vocabulary-is-a-menu
+     (testing "rf2-07m13: phase-1 vocabulary list renders role=menu with
+              menuitem rows + a roving tabindex (only the active row
+              has tabindex=0)."
+       (open-picker-for-test!)
+       (let [flat (str (ui-rec/assertion-picker))]
+         (is (str/includes? flat "menu")
+             "role=menu identifies the vocab container")
+         (is (str/includes? flat "menuitem")
+             "role=menuitem identifies each row")
+         (is (str/includes? flat "Assertion vocabulary")
+             "the menu carries an aria-label for the group")
+         ;; Roving tabindex: with active-index=0 the first row should
+         ;; show tab-index 0 and the rest -1. We check both are present
+         ;; somewhere in the tree.
+         (is (re-find #"tab-index" flat)
+             "tabindex is stamped on the rows")))))
+
+#?(:cljs
+   (deftest assertion-picker-active-index-moves
+     (testing "rf2-07m13: set-active-index! clamps + wraps the cursor
+              across the vocabulary length."
+       (open-picker-for-test!)
+       (let [n (count recorder/assertion-vocabulary)]
+         ;; Step forward through bounds.
+         (#'ui-rec/set-active-index! 0)
+         (is (= 0 (:active-index @ui-rec/ui-picker)))
+         (#'ui-rec/set-active-index! 1)
+         (is (= 1 (:active-index @ui-rec/ui-picker)))
+         ;; Past the end wraps to 0.
+         (#'ui-rec/set-active-index! (+ n 5))
+         (is (= 0 (:active-index @ui-rec/ui-picker)))
+         ;; Negative wraps to the last index.
+         (#'ui-rec/set-active-index! -1)
+         (is (= (dec n) (:active-index @ui-rec/ui-picker)))))))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -199,3 +199,41 @@
     (is (= (pred/indent-after "   :play [")
            (pred/indent-after "   :args {"))
         "both flows' prefixes collapse to the same indent")))
+
+;; ---- ARIA: modal a11y posture (rf2-p1ai7) -------------------------------
+
+(deftest renderer-stamps-role-dialog-and-aria-modal
+  (testing "rf2-p1ai7: the rendered modal carries role=dialog + aria-modal=true"
+    (let [flat (str (review-dialog/review-dialog
+                      (opened-state)
+                      {:title             "Save"
+                       :snippet           "(snippet)"
+                       :placeholder-id    :story.x/example
+                       :placeholder-input ":story.x/sample"
+                       :on-edit-id        (fn [_])
+                       :on-copy           (fn [])
+                       :on-close          (fn [])
+                       :data-test-prefix  "test"}))]
+      (is (str/includes? flat "dialog")
+          "role=dialog appears in the rendered tree")
+      (is (str/includes? flat "aria-modal")
+          "aria-modal flag is stamped on the modal panel")
+      (is (str/includes? flat "aria-labelledby")
+          "aria-labelledby threads the title id into the modal panel")
+      (is (str/includes? flat "test-dialog-title")
+          "the title's id matches the data-test-prefix derived id"))))
+
+(deftest renderer-id-input-carries-aria-label
+  (testing "rf2-u01y5: the variant-id input has an accessible name"
+    (let [flat (str (review-dialog/review-dialog
+                      (opened-state)
+                      {:title             "Save"
+                       :snippet           "(snippet)"
+                       :placeholder-id    :story.x/example
+                       :placeholder-input ":story.x/sample"
+                       :on-edit-id        (fn [_])
+                       :on-copy           (fn [])
+                       :on-close          (fn [])
+                       :data-test-prefix  "test"}))]
+      (is (str/includes? flat "aria-label")
+          "the input carries an aria-label so it's not announced as 'edit, blank'"))))


### PR DESCRIPTION
## Summary

Three a11y-themed Story beads from the rf2-w03x1 audit / rf2-k6xyr campaign — bundled because they share the surface (`tools/story/src/re_frame/story/ui/...`) and are uniformly small.

- **rf2-p1ai7 (P2)** — Modal ARIA on three dialogs (recorder assertion picker, recorder export dialog, save-variant + recorder save dialogs via the shared `review_dialog.cljc` renderer). Each now carries `role='dialog'` + `aria-modal='true'` + `aria-labelledby`; a new shared `ui/a11y_dialog.cljs` focus-trap component handles Escape/Tab cycle/focus-on-mount/focus-return-on-unmount.
- **rf2-u01y5 (P2)** — Every scalar widget in the controls panel (`text/textarea/number/boolean/select/radio/date/color`) now carries an `:aria-label` derived from the path tail. The radio container is `role='radiogroup'` with a path-derived label. Nested paths produce a slash-joined breadcrumb (`address / street`).
- **rf2-07m13 (P3)** — Recorder picker phase-1 vocabulary list is now `role='menu'` + `role='menuitem'` with the WAI-ARIA APG roving-tabindex pattern. ArrowUp/Down (with wrap), Home/End (clamp), Enter/Space (commit) all work; only the active row has `tabindex=0`.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 803 tests / 2374 assertions / **0 failures**
- [x] `cd implementation && npm run test:cljs` — 3642 tests / 10467 assertions / **0 failures** (up 8 tests from baseline 3634, all my new assertions pass)
- [x] 8 new tests added covering: dialog ARIA posture (role/aria-modal/aria-labelledby), input `:aria-label` across all 7 scalar widgets + nested-path breadcrumb + radiogroup label, picker `role=menu` / `menuitem` / `tabindex` + active-index wrap/clamp.
- [ ] Smoke-check on a running Story shell — Escape closes each dialog, Tab cycles, focus returns to trigger, arrow keys move the picker cursor.

WORKTREE_ROOT: `C:\Users\miket\code\re-frame2-worktrees\story-a11y-bundle`