### PR TITLE
a11y(machines-viz): role=img + aria-label on chart svg (rf2-rhtjp · rf2-w03x1 #9)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -521,12 +521,19 @@
               :overflow    "hidden"
               :background  (:bg-1 tokens)}}
      ;; Chart SVG — viewport-transform passes the user's zoom + pan.
+     ;; rf2-rhtjp — `:machine-id` carries the identity slug down to
+     ;; `mv-svg/render` so its `aria-label` reads as e.g. "State
+     ;; machine: auth with 4 states and 3 transitions." The
+     ;; surrounding wrapper div still owns the interactive
+     ;; `role="application"` + keyboard-shortcut affordance; the
+     ;; inner `<svg>` gets the per-chart descriptive label.
      (mv-svg/render
        positioned
        (cond-> {:from-highlight-id  from-highlight-id
                 :to-highlight-id    to-highlight-id
                 :on-state-click     on-state-click
                 :viewport-transform viewport
+                :machine-id         machine-id
                 :svg-attrs          {:style {:width  "100%"
                                              :height "100%"
                                              :display "block"}}}

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
@@ -706,6 +706,18 @@
                            interactive controls wrap the chart with
                            wheel-zoom / click-drag-pan / keyboard
                            handlers without forking `render`.
+    :machine-id          — rf2-rhtjp a11y. Optional keyword (or
+                           string) naming the machine the chart
+                           depicts. When present the root `<svg>`
+                           emits `role=\"img\"` + an
+                           `aria-label` of the form
+                           `\"State machine: <id> with N states and
+                           M transitions\"` so screen-reader users
+                           hear a meaningful description instead of
+                           an unlabelled graphic. Callers can
+                           still override either attribute via
+                           `:svg-attrs` (e.g. a host using the
+                           wrapping `role=\"application\"` pattern).
     :density             — rf2-32gw5. One of `:compact / :regular /
                            :cosy` (or `nil` ≡ `:regular`). Picks the
                            geometry + typography variant from
@@ -724,7 +736,7 @@
   ([{:keys [nodes edges width height] :as positioned}
     {:keys [highlight-id from-highlight-id to-highlight-id
             sim? on-state-click testid show-caption? caption
-            viewport-transform svg-attrs density]}]
+            viewport-transform svg-attrs density machine-id]}]
    ;; rf2-32gw5 — every helper destructures `vc/*chart*`; binding it
    ;; here per `:density` is the one-knob switch that propagates
    ;; through the whole render pass. All hiccup is eagerly realised
@@ -732,9 +744,35 @@
    ;; constants are captured in the returned data structure, not
    ;; deferred to React-mount time.
    (binding [vc/*chart* (vc/chart-for-density density)]
+   (let [;; rf2-rhtjp — a11y. Compute a screen-reader description
+         ;; from the model the chart already receives. Reads as a
+         ;; complete sentence: "State machine: foo with 4 states and
+         ;; 5 transitions." When `:machine-id` is not supplied the
+         ;; identity slot is omitted ("State machine with N states
+         ;; and M transitions."). The label is stable + deterministic
+         ;; — pure fn of the positioned graph + the caller's id.
+         n-states      (count nodes)
+         n-transitions (count edges)
+         id-fragment   (when (some? machine-id)
+                         (str ": " (if (keyword? machine-id)
+                                     (str (symbol machine-id))
+                                     (str machine-id))))
+         aria-label    (str "State machine"
+                            id-fragment
+                            " with "
+                            n-states " "
+                            (if (= 1 n-states) "state" "states")
+                            " and "
+                            n-transitions " "
+                            (if (= 1 n-transitions) "transition" "transitions")
+                            ".")]
    (if (empty? nodes)
      [:div {:data-testid (or testid "rf-mv-chart-empty")
             :data-density (name (or density :regular))
+            :role        "img"
+            :aria-label  (str "State machine"
+                              id-fragment
+                              " has no states to render.")
             :style {:padding "16px"
                     ;; rf2-trorn — sans-stack token rather than the
                     ;; previous `'Inter, system-ui, ...'` literal.
@@ -784,6 +822,16 @@
                            :data-viewport-scale (str scale)
                            :data-viewport-tx (str tx)
                            :data-viewport-ty (str ty)
+                           ;; rf2-rhtjp — a11y. `role=\"img\"` so the
+                           ;; SVG is announced as a single image
+                           ;; (not its child <text> tokens) and
+                           ;; `aria-label` so the user hears the
+                           ;; machine identity + topology summary.
+                           ;; Both are overridable via `:svg-attrs`
+                           ;; (e.g. a host wrapping with
+                           ;; `role=\"application\"`).
+                           :role "img"
+                           :aria-label aria-label
                            :viewBox (str "0 0 " width " " total-h)
                            :width "100%"
                            :preserveAspectRatio "xMidYMin meet"
@@ -863,7 +911,7 @@
                                 :from-highlight-id from-highlight-id
                                 :to-highlight-id   to-highlight-id
                                 :sim?              sim?
-                                :on-state-click    on-state-click})))]]])))))
+                                :on-state-click    on-state-click})))]]]))))))
 
 (defn render-from-definition
   "Convenience: lay out + render in one call. Useful for the panel
@@ -969,9 +1017,18 @@
     :height  (default 16)
     :stroke              — line colour (default `:cyan` token)
     :testid              — overrides the root data-testid
-    :max-sample          — pin the y-axis ceiling"
+    :max-sample          — pin the y-axis ceiling
+    :label               — rf2-rhtjp a11y. Overrides the default
+                           `aria-label`. Hosts that render the
+                           sparkline next to a textual count (the
+                           cluster-row already shows the rate
+                           value in text) MAY pass `:aria-hidden`
+                           via `:label \"\"` to suppress the
+                           announcement; otherwise the default
+                           label reads as
+                           `\"Sparkline of N samples, peak P.\"`"
   ([samples] (sparkline samples {}))
-  ([samples {:keys [width height stroke testid max-sample]
+  ([samples {:keys [width height stroke testid max-sample label]
              :or   {width  60
                     height 16
                     stroke (:cyan tokens/tokens)
@@ -997,14 +1054,27 @@
                                              (* ratio inner-h)))]
                               [x y]))
                           (range n)
-                          samples))]
-     [:svg {:data-testid testid
-            :data-samples (pr-str samples)
-            :width  width
-            :height height
-            :viewBox (str "0 0 " width " " height)
-            :style {:display "inline-block"
-                    :vertical-align "middle"}}
+                          samples))
+         ;; rf2-rhtjp — a11y. Default screen-reader label describes
+         ;; the data the glyph encodes; empty string lets a host
+         ;; mark it `aria-hidden` (decorative next to text).
+         aria-label (cond
+                      (= "" label)  nil
+                      (some? label) label
+                      (zero? n)     "Sparkline (no samples)."
+                      :else         (str "Sparkline of " n " "
+                                         (if (= 1 n) "sample" "samples")
+                                         ", peak " max-v "."))]
+     [:svg (cond-> {:data-testid testid
+                    :data-samples (pr-str samples)
+                    :width  width
+                    :height height
+                    :viewBox (str "0 0 " width " " height)
+                    :style {:display "inline-block"
+                            :vertical-align "middle"}}
+             aria-label       (assoc :role "img"
+                                     :aria-label aria-label)
+             (nil? aria-label) (assoc :aria-hidden "true"))
       [:line {:x1 0 :y1 baseline :x2 width :y2 baseline
               :stroke (:border-subtle tokens/tokens)
               :stroke-width 0.5}]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
@@ -100,6 +100,65 @@
     (is (some? (find-by-testid tree "rf-mv-chart-svg"))
         "root SVG present")))
 
+;; ---- a11y: role + aria-label on the root <svg> (rf2-rhtjp) -------------
+;;
+;; Audit rf2-w03x1 #9 — Screen-reader users encountering the chart heard
+;; nothing because the root `<svg>` carried no `role` + no accessible
+;; name. The renderer now emits `role="img"` plus an `aria-label`
+;; derived from the machine identity (when known) and the topology
+;; summary (state + transition counts) so the chart announces itself
+;; as a meaningful image instead of an unlabelled graphic.
+
+(deftest render-svg-root-has-role-img
+  (let [tree (chart-svg/render-from-definition small-machine)
+        [_ root-attrs] tree]
+    (is (= "img" (:role root-attrs))
+        "root SVG carries role=\"img\" for screen-reader announcement")))
+
+(deftest render-svg-root-aria-label-includes-counts
+  (testing "aria-label conveys topology summary without a machine-id"
+    (let [tree (chart-svg/render-from-definition small-machine)
+          [_ root-attrs] tree
+          label (:aria-label root-attrs)]
+      (is (string? label))
+      (is (not (str/blank? label)))
+      (is (str/includes? label "State machine"))
+      (is (str/includes? label "4 states")
+          "small-machine has 4 states (:idle :loading :success :failed)")
+      (is (str/includes? label "3 transitions")
+          "small-machine has 3 transitions (:start :ok :err)"))))
+
+(deftest render-svg-root-aria-label-names-the-machine
+  (testing "aria-label includes the machine identity when :machine-id is passed"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine
+                 {:machine-id :user-flow})
+          [_ root-attrs] tree
+          label (:aria-label root-attrs)]
+      (is (str/includes? label "user-flow")
+          "machine-id appears in the screen-reader label"))))
+
+(deftest render-empty-fallback-carries-role-img-and-aria-label
+  (testing "empty graph fallback is announced as a labelled image too"
+    (let [tree (chart-svg/render-from-definition nil {:machine-id :empty-m})
+          attrs (second tree)]
+      (is (= "img" (:role attrs))
+          "empty fallback carries role=\"img\"")
+      (is (string? (:aria-label attrs)))
+      (is (str/includes? (:aria-label attrs) "empty-m")
+          "aria-label names the machine even in the empty state"))))
+
+(deftest render-svg-attrs-can-override-role-and-aria-label
+  (testing "callers can override the a11y attrs via :svg-attrs (back-compat)"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine
+                 {:machine-id :m
+                  :svg-attrs  {:role       "application"
+                               :aria-label "custom"}})
+          [_ root-attrs] tree]
+      (is (= "application" (:role root-attrs)))
+      (is (= "custom" (:aria-label root-attrs))))))
+
 (deftest render-emits-one-node-per-state
   (let [tree    (chart-svg/render-from-definition small-machine)
         nodes   (find-all-by-testid-prefix tree "rf-mv-chart-node-")]
@@ -182,6 +241,32 @@
 (deftest sparkline-honours-custom-testid
   (let [svg (chart-svg/sparkline [1 2 3] {:testid "rf-cluster-rate-1"})]
     (is (= "rf-cluster-rate-1" (:data-testid (second svg))))))
+
+;; ---- a11y on the sparkline (rf2-rhtjp) ---------------------------------
+
+(deftest sparkline-default-emits-role-img-with-data-label
+  (testing "the sparkline announces itself as an image with a sample summary"
+    (let [svg   (chart-svg/sparkline [1 5 3])
+          attrs (second svg)]
+      (is (= "img" (:role attrs)))
+      (is (string? (:aria-label attrs)))
+      (is (str/includes? (:aria-label attrs) "3 samples"))
+      (is (str/includes? (:aria-label attrs) "peak 5")))))
+
+(deftest sparkline-empty-label-marks-decorative
+  (testing "passing :label \"\" suppresses the label for hosts that already announce the data textually"
+    (let [svg   (chart-svg/sparkline [1 2 3] {:label ""})
+          attrs (second svg)]
+      (is (nil? (:role attrs)))
+      (is (nil? (:aria-label attrs)))
+      (is (= "true" (:aria-hidden attrs))
+          "decorative sparklines next to text should be aria-hidden"))))
+
+(deftest sparkline-custom-label-overrides-default
+  (let [svg   (chart-svg/sparkline [1 2 3] {:label "Rate of state changes"})
+        attrs (second svg)]
+    (is (= "img" (:role attrs)))
+    (is (= "Rate of state changes" (:aria-label attrs)))))
 
 ;; ---- compound containers (rf2-m7co9 Phase 4) -------------------------
 


### PR DESCRIPTION
## Summary

Audit rf2-w03x1 #9 flagged the machines-viz `<svg>` chart — the central content of Causa's Runtime Machines tab and Static Machines Topology panel — as an unlabelled graphic blob to screen readers. No `role`, no `aria-label`, no `<title>`/`<desc>`. The inline cluster-row sparkline had the same problem. This PR fixes both surfaces.

### Changes

- `tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc`
  - `render` accepts a new `:machine-id` opt; emits `role="img"` + a deterministic `aria-label` derived from the positioned model: `"State machine: <id> with N states and M transitions."`
  - Empty-graph fallback `<div>` carries `role="img"` + a matching label so the "no states to render" surface is announced too.
  - `sparkline` accepts a new `:label` opt; default reads `"Sparkline of N samples, peak P."`. Hosts that already announce the underlying value textually pass `:label ""` to mark the glyph `aria-hidden="true"`.
  - `:svg-attrs` still wins on collision — hosts that wrap with `role="application"` keep their escape hatch (covered by an explicit override test).

- `tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs`
  - `machine-canvas/Chart` pipes its existing `:machine-id` arg through to `mv-svg/render`. Runtime + Static Topology both flow through this adapter (rf2-md9oz), so both surfaces light up with one wire-up.

- `tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc`
  - Asserts role + label on the chart root, empty fallback, machine-id slug, `:svg-attrs` override path, and the sparkline default / decorative / custom-label paths.

### Refs

- Audit: rf2-w03x1 #9 (`ai/findings/2026-05-20-causa-story-a11y-audit.md`)
- Bead: rf2-rhtjp
- Wrapper precedent: `tools/causa/src/.../panels/machine_canvas.cljs:486-489` already wraps with `role="application"` + a navigation label; this change adds the per-chart descriptive label on the SVG itself.

## Test plan

- [x] `cd implementation && npm run test:cljs` (3652 tests, 10475 assertions, 0 failures, 0 errors)
- [x] New deftests:
  - [x] `render-svg-root-has-role-img`
  - [x] `render-svg-root-aria-label-includes-counts`
  - [x] `render-svg-root-aria-label-names-the-machine`
  - [x] `render-empty-fallback-carries-role-img-and-aria-label`
  - [x] `render-svg-attrs-can-override-role-and-aria-label`
  - [x] `sparkline-default-emits-role-img-with-data-label`
  - [x] `sparkline-empty-label-marks-decorative`
  - [x] `sparkline-custom-label-overrides-default`
- [ ] mkdocs build --strict (no docs touched; not run locally)