### PR TITLE
a11y(causa): aria-label on Runtime ribbon ✕ + Settings ✕ close buttons (rf2-a0psm · rf2-w03x1 #14)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -100,6 +100,8 @@
      (h/cascade-summary cascade)]]
    (when close-fn
      [:button {:data-testid "rf-causa-cancellation-cascade-close"
+               :aria-label  "Close cancellation cascade"
+               :title       "Close"
                :on-click    close-fn
                :style       {:background  "transparent"
                              :border      "none"

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -623,6 +623,7 @@
       "⚙"]
      [:button {:data-testid "rf-causa-icon-close"
                :title       "Close (Ctrl+Shift+C)"
+               :aria-label  "Close Causa"
                :on-click    #(rf/dispatch [:rf.causa/close-shell] {:frame :rf/causa})
                :style       icon-style}
       "✕"]]))


### PR DESCRIPTION
## Summary

- Runtime ribbon ✕ close (`shell.cljs:624`) now carries `aria-label="Close Causa"`, matching the Static-shell sibling's contract. Screen readers previously announced only the literal "X" glyph.
- Cancellation-cascade close (`panels/cancellation_cascade.cljs:102`) now carries `aria-label="Close cancellation cascade"` plus a `:title`. It was bare before.
- Settings popup close (`settings/view.cljs:1086`) was flagged by the audit but already carries `aria-label="Close settings"` in tree — verified, no change needed.

Other ✕ / × close affordances surveyed and confirmed already labeled: Static shell ribbon close, app-db segment-inspector close, share modal, spine_filters mute-manager, filters/edit_popup, filters/pills (remove pill).

Audit reference: `ai/findings/2026-05-20-causa-story-a11y-audit.md` #14. Part of the `rf2-k6xyr` a11y campaign.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 775 tests / 2346 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 3665 tests / 10515 assertions / 0 failures
- [x] `python -m mkdocs build --strict` — exit 0
- [ ] Manual: open Causa Runtime ribbon, run `chrome-a11y` panel (PR #1702), confirm no axe-core violations on the close affordances

Closes rf2-a0psm.