### PR TITLE
fix(causa): finish :rf.causa/* rename — 5 stragglers exposed post-#1705

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1099,7 +1099,7 @@ panel may inline its own URI assembly.
 
 - The user picks the editor via the **Settings** popup (`,`) → View.
   Stored under the `:rf.causa/editor` config key.
-- The boot-time entry is `(causa-config/configure! {:editor …})` per
+- The boot-time entry is `(causa-config/configure! {:rf.causa/editor …})` per
   [`015-Configuration.md`](./015-Configuration.md) §`:rf.causa/editor`.
 - Default: `:vscode` — the most-installed editor in 2026.
 - The preference is **session-scoped**, persisted via the same Causa

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -502,8 +502,8 @@ MAY assign them semantics.
   per-localStorage paths.
 
 Note: `:theme` is **no longer reserved** — it now lives inside the
-`:settings` map (see above) and is reachable via the Settings popup's
-Theme tab or `(configure! {:settings {:theme :light}})`.
+`:rf.causa/settings` map (see above) and is reachable via the Settings
+popup's Theme tab or `(configure! {:rf.causa/settings {:theme :light}})`.
 
 ## Vision — full configure! key inventory (30+ keys)
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -1049,13 +1049,13 @@ The popup's "Match scope" checkboxes — `event-id` / `event-args` / `source-coo
 
 Ribbon pills persist via localStorage per host-app under a Causa-namespaced key. **v1 storage key:** `"re-frame2.causa.filters.v1"` (versioned so future schema changes can ignore stale payloads). Configurable via `(causa-config/configure! {:rf.causa/filters-storage-key "<key>"})` per [`015-Configuration.md`](015-Configuration.md) — hosts that run multiple Causa instances in the same browser session (Story testbeds) override so each instance keeps its own pill state.
 
-Host-supplied seed via `(causa-config/configure! {:filters {:in […] :out […]}})` lands ONLY on first install when localStorage is empty — the seed never clobbers a user's hand-tuned set. Per the [`Empty defaults`](#empty-defaults--recommended-quick-add) policy above, Causa itself ships with `nil` seed (first-session honesty).
+Host-supplied seed via `(causa-config/configure! {:rf.causa/filters {:in […] :out […]}})` lands ONLY on first install when localStorage is empty — the seed never clobbers a user's hand-tuned set. Per the [`Empty defaults`](#empty-defaults--recommended-quick-add) policy above, Causa itself ships with `nil` seed (first-session honesty).
 
 The Settings popup §9 exposes the pill set + Recommended quick-add + factory-reset (the §9 Filters tab in v1 is a pointer into the ribbon pill UI — full per-pill management surface lives in the ribbon per spec §3; see [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Settings popup — v1 ships).
 
 ### Error overrides
 
-When a filtered event raises an exception, surface it anyway (`:filters/auto-hide-error-overrides?` config key, default `true`). The row appears with both `⚠` and `▽` (filter-bypass) gutter; user knows "this would normally be hidden, but it errored."
+When a filtered event raises an exception, surface it anyway (`:rf.causa/filters-auto-hide-error-overrides?` config key, default `true`). The row appears with both `⚠` and `▽` (filter-bypass) gutter; user knows "this would normally be hidden, but it errored."
 
 ### Data-layer filtering
 
@@ -1233,10 +1233,9 @@ ribbon and re-implementing it in two places would invite drift.
 
 Every Settings popup field maps to a `(causa-config/configure! {…})` key. See [`015-Configuration.md`](015-Configuration.md) for the full enumeration. New keys this spec adds:
 
-- `:filters/in` — vec of `{:pattern :scope}` IN pills.
-- `:filters/out` — vec of `{:pattern :scope}` OUT pills.
-- `:filters/auto-hide-error-overrides?` — bool, default `true`.
-- `:picker/show-tool-frames?` — bool, default `false`.
+- `:rf.causa/filters` `{:in […] :out […]}` — IN/OUT pill seeds.
+- `:rf.causa/filters-auto-hide-error-overrides?` — bool, default `true`.
+- `:rf.causa/picker-show-tool-frames?` — bool, default `false`.
 
 ---
 

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -140,7 +140,7 @@
 ;; editor with a classpath-relative path
 ;; ("panel_gallery/event_detail_stories.cljs:115:3") that the editor's
 ;; filesystem resolver could not find. The Causa config now exposes
-;; `:project-root` — set once at boot via `causa-config/configure!` — and
+;; `:rf.causa/project-root` — set once at boot via `causa-config/configure!` — and
 ;; `resolve-uri` (which both the chip and the `:rf.editor/open` fx share)
 ;; prepends it before the URI ships. Mirror of Story's rf2-zfy1e matrix.
 
@@ -165,7 +165,7 @@
 (deftest open-chip-project-root-regression-rf2-5m5n2
   (testing "regression: the panel-gallery testbed's failure case now
             resolves to an absolute on-disk URI when the host has
-            plumbed :project-root through causa-config/configure!"
+            plumbed :rf.causa/project-root through causa-config/configure!"
     (config/set-project-root!
       "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
     (let [hiccup (open-in-editor/open-chip

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -117,10 +117,10 @@
   ;; collectors/API/keybinding installed but skip the default panel
   ;; launch; app pages that want Causa inline still provide the normal
   ;; `[data-rf-causa-host]` contract.
-  (causa-config/configure! {:launch/auto-open? false})
+  (causa-config/configure! {:rf.causa/auto-open? false})
   (rf/init! reagent-adapter/adapter)
   (story/install-canonical-vocabulary!)
-  ;; rf2-r1uod — `:project-root` plumbed through Story; the
+  ;; rf2-r1uod — `:rf.story/project-root` plumbed through Story; the
   ;; `causa-preset` bridge propagates it into Causa's slot so the
   ;; Causa-as-RHS open-in-editor chips resolve absolute on-disk paths.
   (story/configure! {:rf.story/project-root (resolve-project-root)})


### PR DESCRIPTION
## Summary

PR #1705 (`:rf.causa/*` rename, merged via the parallel-worker `59a22b94` chain) missed five bare-key call sites that newer PRs had introduced or that the original rename pass had skipped in spec prose. The unknown keys are silently ignored by `configure!` per the forward-compat rule — the `login_form` testbed in particular would leave Causa's auto-open default ON and trip the layout-host-selector runtime error in the Story/Causa browser gate, mirroring exactly the bug `09728a77` fixed for `counter_with_stories`.

Five renames:

- `tools/causa/spec/007-UX-IA.md` — `{:editor …}` → `{:rf.causa/editor …}` in the boot-time `(causa-config/configure! …)` example
- `tools/causa/spec/015-Configuration.md` — `(configure! {:settings {:theme :light}})` → `(configure! {:rf.causa/settings {:theme :light}})`
- `tools/causa/spec/018-Event-Spine.md` — `:filters/in` / `:filters/out` / `:filters/auto-hide-error-overrides?` / `:picker/show-tool-frames?` in the "New keys this spec adds" table + prose → `:rf.causa/*` equivalents (kept the `:rf.causa/filters {:in […] :out […]}` map shape that 015 reserves)
- `tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs` — two prose comments: `:project-root` → `:rf.causa/project-root`
- `tools/story/testbeds/login_form/core.cljs` — `(causa-config/configure! {:launch/auto-open? false})` → `{:rf.causa/auto-open? false}` (added in #1709 with the legacy key; same class of bug as `09728a77`'s counter_with_stories fix)

Pre-alpha posture preserved: hard rename, no fallback paths.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 775 tests, 0 failures, 0 errors (validated during the original rebase attempt)
- [x] `mkdocs build --strict` — passes
- [ ] CI gates (CLJS / browser / docs / bundle-isolation) — green on push