### PR TITLE
ci(gates): retire framework-testbeds Playwright gate — zero surfaces after migration waves (rf2-t5slp)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -35,7 +35,6 @@ cljs_prod=false
 bundle_isolation=false
 reagent_slim_bundle=false
 adapter_testbed_smokes=false
-framework_testbeds=false
 tools_jvm=false
 template_expensive=false
 mcp_conformance=false
@@ -51,7 +50,6 @@ mark_all() {
   bundle_isolation=true
   reagent_slim_bundle=true
   adapter_testbed_smokes=true
-  framework_testbeds=true
   tools_jvm=true
   template_expensive=true
   mcp_conformance=true
@@ -70,42 +68,12 @@ mark_all() {
 # tools/{story,causa}/testbeds/** legitimately drive the
 # story-feature-load + causa-feature-gate Playwright runners (their
 # variant graph IS what the gate exercises), so a runtime-extension
-# change there does fire the gate. The runtime-extension AND
-# allow-listed-subdir rule is symmetric with the framework-testbeds
-# split below — both gates filter by `.cljs|.cljc|.js|.cjs|.css|.scss`
-# under explicitly named subdirs, never by anything that grep-matches
-# the parent tool dir.
+# change there does fire the gate.
 is_story_causa_runtime_path() {
   case "$1" in
     tools/story/src/*|tools/causa/src/*|tools/story/testbeds/*|tools/causa/testbeds/*)
       case "$1" in
         *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss)
-          return 0 ;;
-        *)
-          return 1 ;;
-      esac
-      ;;
-    *)
-      return 1 ;;
-  esac
-}
-
-# rf2-9grp6 — predicate: does `$1` look like a framework-testbed
-# runtime source file (CLJS/CLJC/JS/CSS extension under
-# tools/causa/testbeds/** or top-level testbeds/**)? Returns 0 / 1.
-# The split between this gate and `adapter_testbed_smokes` is intentional
-# (rf2-cjp0i + this bead): adapter source changes fire the 3 adapter
-# smokes, framework-testbed source changes fire the 11 framework +
-# top-level testbeds; spec/Markdown changes fire neither. Story's own
-# testbeds (tools/story/testbeds/**) drive the Story/Causa browser gate
-# above, not this one — Causa-owned framework testbeds live under
-# tools/causa/testbeds/** plus the cross-cutting top-level testbeds/**
-# (SSR + framework-behaviour).
-is_framework_testbed_path() {
-  case "$1" in
-    tools/causa/testbeds/*|testbeds/*)
-      case "$1" in
-        *.cljs|*.cljc|*.js|*.cjs|*.css|*.scss|*.html|*.json)
           return 0 ;;
         *)
           return 1 ;;
@@ -126,18 +94,16 @@ else
         mark_all
         ;;
       implementation/core/*)
-        # rf2-8jz9t + rf2-k9ekz + rf2-9grp6 — adapter_testbed_smokes,
-        # framework_testbeds, and story_causa_browser are NOT fired
-        # here. The Playwright gates exist to catch surface-specific
-        # browser bugs (adapter mount lifecycle, Story variant boot,
-        # Causa panel layout, multi-frame isolation) — none of which
-        # are core regressions. Core renames are caught by node-test
-        # (consolidated CLJS unit + browser-test) which exercises every
-        # public re-frame.core fn, and by the always-on JVM core suite.
-        # A core rename that breaks an adapter mount, Story variant
-        # boot, or framework-testbed assertion silently is caught by
-        # the nightly cron + post-merge gate (both run the full matrix
-        # on main).
+        # rf2-8jz9t + rf2-k9ekz + rf2-t5slp — adapter_testbed_smokes
+        # and story_causa_browser are NOT fired here. The Playwright
+        # gates exist to catch surface-specific browser bugs (adapter
+        # mount lifecycle, Story variant boot, Causa panel layout) —
+        # none of which are core regressions. Core renames are caught
+        # by node-test (consolidated CLJS unit + browser-test) which
+        # exercises every public re-frame.core fn, and by the always-on
+        # JVM core suite. A core rename that breaks an adapter mount or
+        # Story variant boot silently is caught by the nightly cron +
+        # post-merge gate (both run the full matrix on main).
         implementation_jvm=true
         adapter_diagnostic=true
         cljs_browser=true
@@ -217,16 +183,15 @@ else
         cljs_prod=true
         ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
-        # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i + rf2-k9ekz + rf2-9grp6 —
-        # adapter_testbed_smokes, framework_testbeds, and
-        # story_causa_browser are NOT fired here. The Playwright gates
-        # are now triggered ONLY by direct source-tree changes (adapter
-        # source for adapter-testbed-smokes; tools/causa/testbeds/** +
-        # top-level testbeds/** for framework-testbeds;
-        # tools/{story,causa}/{src,testbeds}/** for the Story/Causa
-        # browser gate). A shadow-cljs.edn or implementation/scripts/
-        # change that breaks the build is caught by the nightly cron +
-        # post-merge gate (both run the full matrix on main).
+        # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i + rf2-k9ekz + rf2-t5slp —
+        # adapter_testbed_smokes and story_causa_browser are NOT fired
+        # here. The Playwright gates are triggered ONLY by direct
+        # source-tree changes (adapter source for adapter-testbed-
+        # smokes; tools/{story,causa}/{src,testbeds}/** for the Story/
+        # Causa browser gate). A shadow-cljs.edn or implementation/
+        # scripts/ change that breaks the build is caught by the
+        # nightly cron + post-merge gate (both run the full matrix on
+        # main).
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
@@ -241,21 +206,15 @@ else
         cljs_browser=true
         ;;
       testbeds/*)
-        # rf2-7vsfm + rf2-bxdk8 + rf2-cjp0i + rf2-9grp6 — Top-level
-        # testbeds/* are compiled + staged by the framework-testbeds
-        # orchestrator. Per rf2-cjp0i the adapter-testbed-smokes gate is
-        # scoped to the 3 adapter smokes themselves; per rf2-9grp6 the
-        # framework + top-level testbed Playwright surfaces are now
-        # covered by the split-out `framework-testbeds` gate, which
-        # fires on runtime-extension changes (.cljs/.cljc/.js/.cjs/.css/
-        # .scss/.html/.json) under this tree. Markdown/EDN-only diffs
-        # still skip the gate entirely. cljs_browser stays lit for CLJS-
+        # rf2-7vsfm + rf2-t5slp — Top-level testbeds/* surfaces are
+        # retained as Causa observation targets but no longer have a
+        # paired Playwright spec.cjs; all framework + top-level testbed
+        # specs migrated to CLJS/JVM unit tests under the four
+        # rf2-tglku waves and the split-out `framework-testbeds` gate
+        # was retired (rf2-t5slp). cljs_browser stays lit for CLJS-
         # source regressions in shared core/feature artefacts that the
         # testbed compiles transitively pull in.
         cljs_browser=true
-        if is_framework_testbed_path "$file"; then
-          framework_testbeds=true
-        fi
         ;;
       tools/template/*)
         # rf2-os0c1 — tools/template is a clj-new template that scaffolds
@@ -266,28 +225,24 @@ else
         template_expensive=true
         ;;
       tools/story/*|tools/causa/*)
-        # rf2-os0c1 + rf2-k9ekz + rf2-9grp6 — Story / Causa changes
+        # rf2-os0c1 + rf2-k9ekz + rf2-t5slp — Story / Causa changes
         # legitimately fan out to tools_jvm (per-artefact JVM unit tests
         # + sibling story-mcp consumer) and mcp_conformance (the MCP
-        # wrappers consume these artefacts). story_causa_browser is now
+        # wrappers consume these artefacts). story_causa_browser is
         # narrowed (rf2-k9ekz): it fires ONLY when the changed path is
         # under tools/{story,causa}/{src,testbeds}/** AND the file has a
         # runtime extension (.cljs/.cljc/.js/.cjs/.css/.scss). Markdown
         # specs under tools/{story,causa}/spec/**, JVM unit tests under
         # tools/{story,causa}/test/**, deps.edn, README.md, and *.txt
         # do NOT fire it — they cannot affect chrome and so cannot
-        # invalidate the Playwright gate. Per rf2-9grp6 the Causa-owned
-        # framework testbeds under tools/causa/testbeds/** also fire
-        # framework_testbeds (the split-out Playwright gate for the SSR
-        # + framework-behaviour surfaces). Story's own testbeds drive
-        # the story_causa_browser gate, not framework_testbeds.
+        # invalidate the Playwright gate. The split-out framework-
+        # testbeds gate (formerly rf2-9grp6) was retired in rf2-t5slp
+        # after all four rf2-tglku migration waves moved every Causa-
+        # owned testbed assertion to CLJS/JVM unit tests.
         tools_jvm=true
         mcp_conformance=true
         if is_story_causa_runtime_path "$file"; then
           story_causa_browser=true
-        fi
-        if is_framework_testbed_path "$file"; then
-          framework_testbeds=true
         fi
         ;;
       tools/story-mcp/*)
@@ -346,7 +301,6 @@ emit cljs_prod "$cljs_prod"
 emit bundle_isolation "$bundle_isolation"
 emit reagent_slim_bundle "$reagent_slim_bundle"
 emit adapter_testbed_smokes "$adapter_testbed_smokes"
-emit framework_testbeds "$framework_testbeds"
 emit tools_jvm "$tools_jvm"
 emit template_expensive "$template_expensive"
 emit mcp_conformance "$mcp_conformance"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
       bundle_isolation: ${{ steps.detect.outputs.bundle_isolation }}
       reagent_slim_bundle: ${{ steps.detect.outputs.reagent_slim_bundle }}
       adapter_testbed_smokes: ${{ steps.detect.outputs.adapter_testbed_smokes }}
-      framework_testbeds: ${{ steps.detect.outputs.framework_testbeds }}
       tools_jvm: ${{ steps.detect.outputs.tools_jvm }}
       template_expensive: ${{ steps.detect.outputs.template_expensive }}
       mcp_conformance: ${{ steps.detect.outputs.mcp_conformance }}
@@ -1039,108 +1038,18 @@ jobs:
       # comma-separated EXAMPLES_FILTER (substring OR-match against
       # shadow-cljs build ids). `adapters/` matches exactly the 3
       # adapter smokes (adapters/reagent-testbed, adapters/uix-testbed,
-      # adapters/helix-testbed); all other surfaces (framework testbeds
-      # under tools/causa/testbeds/* and top-level testbeds/*) skip
-      # compile/stage/spec-discovery. The split-out framework-testbeds
-      # job below carries that scope. Per rf2-8cevm the `examples/`
-      # tree is TEST-FREE.
+      # adapters/helix-testbed). Per rf2-8cevm the `examples/` tree
+      # is TEST-FREE. Per rf2-t5slp the framework-testbeds gate was
+      # retired — the four migration waves under rf2-tglku
+      # (rf2-4j0tb / rf2-lcg1z / rf2-pxb7t / rf2-e3j8l) migrated every
+      # framework + top-level testbed Playwright spec.cjs to CLJS/JVM
+      # unit tests, leaving zero surfaces for the split-out gate to run.
       #
       # NOT a required check on main initially — mirrors the rollout
       # pattern used for cljs-browser (rf2-zoem).
       - name: Compile adapter smokes, serve, and run Playwright specs
         env:
           EXAMPLES_FILTER: "adapters/"
-        run: npm run test:examples
-
-  framework-testbeds:
-    name: Framework testbeds (Playwright)
-    needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.framework_testbeds == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: implementation
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
-        with:
-          node-version: '24'
-          cache: npm
-          cache-dependency-path: implementation/package-lock.json
-
-      - name: Set up Clojure CLI
-        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
-        with:
-          cli: latest
-
-      - name: Cache Maven / gitlibs (shadow-cljs deps)
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.gitlibs
-          key: ${{ runner.os }}-cljs-framework-testbeds-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cljs-framework-testbeds-
-            ${{ runner.os }}-cljs-
-
-      - name: npm install
-        run: npm ci
-
-      - name: Install Playwright (Chromium + system deps)
-        run: npx playwright install --with-deps chromium
-
-      # rf2-9grp6 — framework + top-level testbed Playwright surfaces.
-      # Split out of `adapter-testbed-smokes` (rf2-cjp0i narrowed the
-      # adapter gate's trigger; this bead narrowed its scope to match).
-      # The EXAMPLES_FILTER pattern OR-matches the residual top-level
-      # testbed builds (testbeds/ssr-basic, testbeds/ssr-hydration-
-      # mismatch, testbeds/ssr-multi-frame) while excluding the 3
-      # adapter builds. RF2_CAUSA_RUN_GALLERY_SMOKES=1 (rf2-1w76p)
-      # additionally compiles + runs the panel-gallery stand-alone
-      # smokes (gate the rf2-kgn0c workspace-teardown regression) —
-      # those run AFTER the main spec sweep inside the same orchestrator
-      # invocation.
-      #
-      # (rf2-e3j8l, Wave 4) `examples/counter-perf` removed from this
-      # filter — the perf_counter Playwright assertions migrated to the
-      # CLJS nightly suite at
-      # `implementation/core/test/re_frame/performance_emit_nightly_test.cljs`.
-      # The shadow-cljs `examples/counter-perf` build target is retained
-      # for `npm run test:perf-bundle` (bundle-presence grep) but no
-      # longer has a Playwright spec.cjs to run.
-      #
-      # (rf2-lcg1z, Wave 2) `examples/parallel-frames` removed from
-      # this filter — the parallel_frames Playwright spec.cjs was
-      # deleted and its isolation assertions migrated to the CLJS
-      # node-test suite at
-      # `implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs`.
-      # The testbed surface itself stays in-tree as the canonical
-      # Causa-displayable multi-frame demo.
-      #
-      # (rf2-pxb7t, Wave 3) The 3 SSR testbed Playwright spec.cjs files
-      # (`ssr_basic`, `ssr_hydration_mismatch`, `ssr_multi_frame`)
-      # retired — assertions migrated to JVM tests at
-      # `implementation/ssr/test/re_frame/ssr_{hydration,hydration_mismatch,
-      # multi_frame_isolation}_test.clj` using `rf/subscribe-once`.
-      # Their `testbeds/ssr-*` shadow-cljs build targets are retained
-      # (Causa observation targets) but no longer have spec.cjs files
-      # to run; the orchestrator's EXAMPLES list was trimmed to drop the
-      # three SSR entries (no surface staged that nothing tests). The
-      # `testbeds/` filter pattern below remains the residual after-Wave-2
-      # shape; the SSR entries simply no longer match any EXAMPLES row.
-      - name: Compile framework + top-level testbeds, serve, and run Playwright specs
-        env:
-          EXAMPLES_FILTER: "testbeds/"
-          RF2_CAUSA_RUN_GALLERY_SMOKES: "1"
         run: npm run test:examples
 
   story-causa-browser:

--- a/TESTING.md
+++ b/TESTING.md
@@ -164,8 +164,7 @@ boolean GitHub-Actions outputs per surface:
 | `cljs_prod` | Surface that release-mode probes (`browser-test-prod-elision`, schemas boundary prod) cover changed. |
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
-| `adapter_testbed_smokes` | Adapter surface changed (`implementation/adapters/*`) or the orchestrator scripts that drive the smokes (`examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs`). Per rf2-bxdk8 + rf2-cjp0i + rf2-8cevm + rf2-9grp6: generic `examples/**` and `testbeds/**` paths no longer fire this gate (examples/ is test-free; testbed-source diffs fire `framework_testbeds` instead — see below). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs). |
-| `framework_testbeds` | Framework / top-level testbed source changed: `tools/causa/testbeds/**` (perf_counter, parallel_frames, feature_matrix, panel_gallery) or top-level `testbeds/**` (rf2-ik4io SSR + rf2-fe84r framework-behaviour). Fires only on runtime-extension changes (`.cljs`, `.cljc`, `.js`, `.cjs`, `.css`, `.scss`, `.html`, `.json`); Markdown / EDN-only diffs do not fire it. Per rf2-9grp6 this gate was split out of `adapter_testbed_smokes` after rf2-cjp0i narrowed the adapter gate to the 3 adapter smokes only — testbed-source diffs were silently uncovered at PR-time. |
+| `adapter_testbed_smokes` | Adapter surface changed (`implementation/adapters/*`) or the orchestrator scripts that drive the smokes (`examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs`). Per rf2-bxdk8 + rf2-cjp0i + rf2-8cevm + rf2-t5slp: generic `examples/**` and `testbeds/**` paths no longer fire this gate (examples/ is test-free; testbed surfaces stay as Causa observation targets with no paired Playwright spec.cjs — see the rf2-tglku migration waves). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs). |
 | `tools_jvm` | Story / Causa / Story-MCP / Causa-MCP / Pair2-MCP / MCP-base changed; gates the four per-tool JVM probes (`jvm-tools-{causa,story,story-mcp,mcp-base}`). Not set by `tools/template/*` or `tools/mcp-conformance/*` — those don't share runtime with the per-tool probes. |
 | `template_expensive` | `tools/template/*` changed; gates the template emitted-app smoke. |
 | `mcp_conformance` | Any MCP-server tool, `tools/mcp-base/*`, or `tools/mcp-conformance/*` changed. |
@@ -182,15 +181,14 @@ A few "blast-radius" inputs force the full sweep:
 - Changes under `implementation/core/*` fan out broadly (they touch
   almost every output) because core regressions can break every
   downstream substrate, tool, and bundle invariant. Exceptions: the
-  three Playwright gates (`adapter_testbed_smokes`,
-  `framework_testbeds`, `story_causa_browser`) are **not** fired by
-  `implementation/core/*` changes (rf2-8jz9t + rf2-k9ekz + rf2-9grp6).
-  The Playwright gates exist to catch surface-specific browser bugs
-  (adapter mount lifecycle, Story variant boot, Causa panel layout,
-  multi-frame isolation, framework-testbed contract) — none of which
-  are core regressions. Core renames are caught by `node-test`
-  (which exercises every public `re-frame.core` fn), and the nightly
-  cron + post-merge gate runs the full matrix on main.
+  two Playwright gates (`adapter_testbed_smokes` and
+  `story_causa_browser`) are **not** fired by `implementation/core/*`
+  changes (rf2-8jz9t + rf2-k9ekz). The Playwright gates exist to
+  catch surface-specific browser bugs (adapter mount lifecycle,
+  Story variant boot, Causa panel layout) — none of which are core
+  regressions. Core renames are caught by `node-test` (which
+  exercises every public `re-frame.core` fn), and the nightly cron +
+  post-merge gate runs the full matrix on main.
 
 **Adding a new artefact directory**: a new artefact (e.g. a new tool,
 new substrate, new SSR runtime) needs **two** matching changes:
@@ -243,37 +241,33 @@ hand-maintained against [`.github/scripts/report-changed-surfaces.sh`](.github/s
 condition changes (per the **Adding a new artefact directory** rule above).
 
 **Surface → output** — read this to verify "did my PR fire the right
-classifier outputs?" Rows are surface groups; columns are the 14
+classifier outputs?" Rows are surface groups; columns are the 13
 classifier outputs (exact names from the script). A `✓` means a change
 under that surface sets that output to `true`. The **blast-trigger row
 (S1)** is bold: any change to those four files calls `mark_all` and
 lights every output (defensive — anything that re-tiers the matrix
 must re-run the matrix).
 
-| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `adapter_testbed_smokes` | `framework_testbeds` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
-| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ |   |   |
-| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |   |
-| S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |   | ✓ | ✓ | ✓ | ✓ |   |   |
-| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
-| S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
-| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
-| S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
-| S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs` (orchestrator + runner + helpers — rf2-bxdk8 + rf2-cjp0i) |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |   |
-| S9 | `testbeds/*` (runtime-extension files — rf2-9grp6) |   |   | ✓ |   |   |   |   | ✓ |   |   |   |   |   |   |
-| S10 | `tools/template/*` |   |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |
-| S11 | `tools/story/{src,testbeds}/**`, `tools/causa/{src,testbeds}/**` (runtime-extension files — rf2-k9ekz) |   |   |   |   |   |   |   | ✓† | ✓ |   | ✓ |   | ✓ |   |
-| S11a | `tools/story/{spec,test,bench}/**`, `tools/causa/{spec,test}/**`, `tools/{story,causa}/{deps.edn,README.md}` (non-runtime under story/causa) |   |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
-| S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
-| S13 | `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*` |   |   |   |   |   |   |   |   | ✓ |   | ✓ | ✓ |   |   |
-| S14 | `tools/mcp-conformance/*` |   |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   |   |
-| S15 | `skills/re-frame2-pair/tests/fixture/*` |   |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   | ✓ |
-| S16 | `skills/re-frame2-pair/*` (other), `skills/shared/*` |   |   |   |   |   |   |   |   |   |   |   |   |   | ✓ |
-
-† Row S11 fires `framework_testbeds` only for paths under
-`tools/causa/testbeds/**` (Story's own testbeds drive
-`story_causa_browser`, not `framework_testbeds`).
+| # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `adapter_testbed_smokes` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
+| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ |   |   |
+| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |
+| S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
+| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
+| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |
+| S8 | `examples/*` (excluding the orchestrator scripts called out in S8a) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
+| S8a | `examples/scripts/{serve-and-run-examples-tests,run-examples-tests,spec-helpers}.cjs` (orchestrator + runner + helpers — rf2-bxdk8 + rf2-cjp0i) |   |   |   |   |   |   | ✓ |   |   |   |   |   |   |
+| S9 | `testbeds/*` (rf2-7vsfm — surfaces retained as Causa observation targets; rf2-t5slp retired the Playwright gate after all spec.cjs migrated to unit tests) |   |   | ✓ |   |   |   |   |   |   |   |   |   |   |
+| S10 | `tools/template/*` |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |
+| S11 | `tools/story/{src,testbeds}/**`, `tools/causa/{src,testbeds}/**` (runtime-extension files — rf2-k9ekz) |   |   |   |   |   |   |   | ✓ |   | ✓ |   | ✓ |   |
+| S11a | `tools/story/{spec,test,bench}/**`, `tools/causa/{spec,test}/**`, `tools/{story,causa}/{deps.edn,README.md}` (non-runtime under story/causa) |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
+| S12 | `tools/story-mcp/*` |   |   |   |   |   |   |   | ✓ |   | ✓ |   |   |   |
+| S13 | `tools/re-frame2-pair-mcp/*`, `tools/mcp-base/*` |   |   |   |   |   |   |   | ✓ |   | ✓ | ✓ |   |   |
+| S14 | `tools/mcp-conformance/*` |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   |   |
+| S15 | `skills/re-frame2-pair/tests/fixture/*` |   |   |   |   |   |   |   |   |   | ✓ | ✓ |   | ✓ |
+| S16 | `skills/re-frame2-pair/*` (other), `skills/shared/*` |   |   |   |   |   |   |   |   |   |   |   |   | ✓ |
 
 **Output → jobs** — read this to answer "if this output is `true`, what
 runs?" Job counts are grouped (the matrix expands to 30+ leaf jobs at
@@ -287,8 +281,7 @@ PR time; one row per output here so the table stays scannable).
 | `cljs_prod` | Release-mode probes ×3 (`browser-test-prod-elision`, schemas boundary prod, etc.) |
 | `bundle_isolation` | `bundle-isolation` |
 | `reagent_slim_bundle` | `reagent-slim-bundle-isolation` |
-| `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; the 3 adapter smokes only — rf2-9grp6 split out the framework + top-level testbeds into the `framework-testbeds` job below) |
-| `framework_testbeds` | `framework-testbeds` (Playwright; 2 Causa-owned framework testbeds at `tools/causa/testbeds/{perf_counter,parallel_frames}` + 9 top-level testbeds at `testbeds/{ssr_basic,ssr_hydration_mismatch,ssr_multi_frame,deliberate_throw,http_toggle,deep_machine,non_trivial_app_db,long_flow_w_failure,drain_depth_trigger}` + the panel-gallery smokes when `RF2_CAUSA_RUN_GALLERY_SMOKES=1`) |
+| `adapter_testbed_smokes` | `adapter-testbed-smokes` (Playwright; the 3 adapter smokes only — rf2-9grp6 split out the framework + top-level testbeds into a separate gate, which rf2-t5slp then retired after all four rf2-tglku migration waves moved every framework + top-level testbed assertion to CLJS/JVM unit tests) |
 | `tools_jvm` | Per-tool JVM probes ×4 (`jvm-tools-causa`, `jvm-tools-story`, `jvm-tools-story-mcp`, `jvm-tools-mcp-base`) |
 | `template_expensive` | `jvm-tools-template` (emitted-app smoke) |
 | `mcp_conformance` | MCP conformance ×4 (`mcp-conformance-{story,re-frame2-pair,wire-vocab,...}`) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ examples/
     process_monitor_helix/
 ```
 
-> **The `examples/` tree is test-free (rf2-8cevm, Mike directive 2026-05-19).** No `*.spec.cjs` may live under `examples/`. Browser smoke coverage is exactly 3 adapter-level smokes (Reagent / UIx / Helix) at [`implementation/adapters/<name>/testbed/spec.cjs`](../implementation/adapters/). Real-regression coverage lives in substrate contract tests (`npm run test:cljs`), the Causa feature-matrix gate (`npm run test:causa-feature-gate`), bundle-isolation (`npm run test:bundle-isolation`), the perf-bundle gate (`npm run test:perf-bundle`), and mcp-conformance. Framework testbeds at [`tools/causa/testbeds/`](../tools/causa/testbeds/) and the top-level [`testbeds/`](../testbeds/) carry their own non-adapter `spec.cjs` for cross-cutting surfaces (parallel-frames isolation, perf-API live counterpart, SSR, etc.).
+> **The `examples/` tree is test-free (rf2-8cevm, Mike directive 2026-05-19).** No `*.spec.cjs` may live under `examples/`. Browser smoke coverage is exactly 3 adapter-level smokes (Reagent / UIx / Helix) at [`implementation/adapters/<name>/testbed/spec.cjs`](../implementation/adapters/). Real-regression coverage lives in substrate contract tests (`npm run test:cljs`), the Causa feature-matrix gate (`npm run test:causa-feature-gate`), bundle-isolation (`npm run test:bundle-isolation`), the perf-bundle gate (`npm run test:perf-bundle`), and mcp-conformance. Framework testbeds at [`tools/causa/testbeds/`](../tools/causa/testbeds/) and the top-level [`testbeds/`](../testbeds/) stay in-tree as Causa observation targets but no longer carry paired Playwright `spec.cjs` files — the four rf2-tglku migration waves (rf2-4j0tb / rf2-lcg1z / rf2-pxb7t / rf2-e3j8l) moved their assertions to CLJS/JVM unit tests under `implementation/{core,epoch,flows,http,machines,ssr}/test/`, and rf2-t5slp retired the split-out framework-testbeds Playwright gate.
 
 The orchestrator and the runner consume `playwright` and `http-server` out of `implementation/node_modules/` — there is no separate `examples/package.json` by design; the implementation tree owns the npm dependency surface for the whole repo.
 
@@ -130,10 +130,10 @@ If you're building on UIx, read [`uix/counter_uix/`](uix/counter_uix/) and [`uix
 Per rf2-8cevm (Mike directive 2026-05-19) the `examples/` tree is **test-free** — no `*.spec.cjs` lives under `examples/`. The historic per-example Playwright sweep has been retired; real-regression coverage instead lives in:
 
 - **`npm run test:cljs`** — substrate contract tests (events, subs, handlers, machines, schemas) across every artefact under `npm run test:cljs`'s node-runtime CLJS suite.
-- **`npm run test:examples`** — adapter-level smokes only. Compiles + serves the 3 adapter testbeds (`implementation/adapters/<name>/testbed/`), the 2 Causa-owned framework testbeds (`tools/causa/testbeds/{parallel_frames,perf_counter}/`), and the top-level cross-cutting testbeds (`testbeds/<surface>/`), then runs their paired `spec.cjs`.
+- **`npm run test:examples`** — adapter-level smokes only. Compiles + serves the 3 adapter testbeds (`implementation/adapters/<name>/testbed/`) and runs their paired `spec.cjs`. Per rf2-t5slp the framework + top-level testbeds no longer carry Playwright specs (the rf2-tglku migration waves moved every assertion to CLJS/JVM unit tests).
 - **`npm run test:causa-feature-gate`** — 14-scenario Causa feature-matrix gate. The canonical browser sweep for cross-cutting feature regressions.
 - **`npm run test:bundle-isolation`** — production bundle grep contract for the per-feature artefact split.
-- **`npm run test:perf-bundle`** — static perf-flag bundle-isolation grep (complemented by the live `tools/causa/testbeds/perf_counter/spec.cjs`).
+- **`npm run test:perf-bundle`** — static perf-flag bundle-isolation grep (the live perf-API counterpart at `implementation/core/test/re_frame/performance_emit_nightly_test.cljs` runs in the nightly CLJS suite).
 - **`npm run test:story-feature-load`** — Story tool feature/load gate (occasional).
 
 ### Building examples interactively

--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -1,31 +1,22 @@
 #!/usr/bin/env node
 /*
- * Playwright runner for adapter smokes + framework testbeds.
+ * Playwright runner for the adapter smokes.
  *
  * Each surface is built by shadow-cljs into out/examples/<name>/main.js
  * and is paired with a hand-written index.html (staged into the same
  * directory by the orchestrator). This runner spins up a Chromium
  * browser and executes the spec.cjs files that sit alongside each
- * testbed under the SPEC_ROOTS below. Each spec navigates to the
- * surface's URL and asserts a user-visible behaviour (initial render +
- * an interaction + post-interaction state).
+ * adapter testbed under the SPEC_ROOTS below. Each spec navigates to
+ * the surface's URL and asserts a user-visible behaviour (initial
+ * render + an interaction + post-interaction state).
  *
- * Test surface inventory (post rf2-8cevm, Mike directive 2026-05-19 —
- * `examples/` tree is TEST-FREE):
+ * Test surface inventory (post rf2-8cevm + rf2-t5slp — `examples/`
+ * tree is TEST-FREE; the framework-testbeds Playwright gate was
+ * retired after the rf2-tglku migration waves moved every framework +
+ * top-level testbed assertion to CLJS/JVM unit tests):
  *
  *   - 3 adapter smokes   (implementation/adapters/<name>/testbed/spec.cjs)
  *     Reagent / UIx / Helix mount + dispatch + render.
- *
- *   - 0 framework testbeds under tools/causa/testbeds/. Both Causa-
- *     owned testbeds shed their Playwright specs in the rf2-tglku
- *     migration: perf_counter (Wave 4, rf2-e3j8l) and parallel_frames
- *     (Wave 2, rf2-lcg1z). Their data-layer contracts live as pure
- *     CLJS unit tests under implementation/core/test/re_frame/. The
- *     testbed surfaces themselves stay in-tree as the canonical
- *     Causa-displayable observation targets.
- *
- *   - top-level testbeds/  (testbeds/<surface>/spec.cjs)
- *     rf2-fe84r framework-behaviour cross-cutting + rf2-ik4io SSR.
  *
  * Real-regression coverage for everything else lives in: substrate
  * contract tests under `npm run test:cljs`, the Causa feature-matrix
@@ -75,8 +66,8 @@ const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8030';
 // empty) = the full sweep.
 //
 // rf2-9grp6 — comma-separated alternatives, OR-matched. Mirrors the
-// orchestrator's multi-pattern filter so the CI split (adapter smokes
-// vs framework testbeds) can pass a single shape through both stages.
+// orchestrator's multi-pattern filter so a single EXAMPLES_FILTER
+// shape gates compile/stage/spec selection identically.
 const FILTER = (process.env.EXAMPLES_FILTER || '').trim();
 function parseFilterPatterns(raw) {
   if (!raw) return [];
@@ -115,26 +106,15 @@ function matchesFilter(filePath) {
 //
 // Spec discovery (post rf2-8cevm, Mike directive 2026-05-19): the
 // `examples/` tree is TEST-FREE — no `*.spec.cjs` is permitted under
-// it. Discovery now scans only the spec-bearing roots:
+// it. Per rf2-t5slp the framework-testbeds Playwright gate was
+// retired after all four rf2-tglku migration waves moved every
+// framework + top-level testbed assertion to CLJS/JVM unit tests.
+// Discovery now scans only the per-adapter smoke root:
 //
-//   - tools/<tool>/testbeds/        — framework testbeds owned by Causa.
-//                                     Currently empty for Playwright
-//                                     specs — perf_counter (Wave 4)
-//                                     and parallel_frames (Wave 2) of
-//                                     the rf2-tglku migration both
-//                                     migrated their assertions to
-//                                     CLJS unit tests; the testbed
-//                                     dirs themselves stay in-tree
-//                                     as Causa-displayable demos.
-//   - testbeds/                     — top-level cross-cutting testbeds
-//                                     (rf2-fe84r framework-behaviour +
-//                                     rf2-ik4io SSR)
 //   - implementation/adapters/      — per-adapter end-to-end smokes
 //                                     (rf2-eceuv: Reagent/UIx/Helix)
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const SPEC_ROOTS = [
-  path.join(REPO_ROOT, 'tools'),
-  path.join(REPO_ROOT, 'testbeds'),
   path.join(REPO_ROOT, 'implementation', 'adapters'),
 ];
 const TIMEOUT_MS = parseInt(process.env.EXAMPLE_SPEC_TIMEOUT_MS || '30000', 10);
@@ -146,14 +126,11 @@ const { isVerboseTests } = require(path.join(
 ));
 const VERBOSE_TESTS = isVerboseTests();
 
-// Specs live alongside the example or testbed they exercise. Under
-// examples/ they sit two or three levels deep with file shape
-// `<name>.spec.cjs` (e.g. examples/reagent/counter/counter.spec.cjs).
-// Under tools/<tool>/testbeds/<scenario>/ the convention (rf2-p8f2s) is
-// the unprefixed `spec.cjs` — one spec per scenario directory, no name
-// repetition. Walk every root and pick up any file matching either
-// `*.spec.cjs` (legacy / examples convention) or exactly `spec.cjs`
-// (testbed convention).
+// Specs live alongside the adapter testbed they exercise: each adapter
+// (Reagent / UIx / Helix) ships `implementation/adapters/<name>/testbed/
+// spec.cjs` (the unprefixed-`spec.cjs` convention from rf2-p8f2s).
+// The walker also picks up `*.spec.cjs` for the historic examples shape,
+// though `examples/` is test-free today (rf2-8cevm).
 function isSpecFile(name) {
   return name === 'spec.cjs' || name.endsWith('.spec.cjs');
 }
@@ -161,7 +138,7 @@ function isSpecFile(name) {
 function listSpecFiles(roots) {
   const out = [];
   for (const root of roots) {
-    if (!fs.existsSync(root)) continue;       // testbeds/ is optional
+    if (!fs.existsSync(root)) continue;
     const stack = [root];
     while (stack.length > 0) {
       const dir = stack.pop();

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 /*
- * Orchestrator for the adapter-smoke + framework-testbed Playwright
- * suite (npm run test:examples). Per rf2-8cevm (Mike directive
- * 2026-05-19) the `examples/` tree is TEST-FREE — this orchestrator
- * compiles + stages only the surfaces paired with a `spec.cjs` under
- * the runner's SPEC_ROOTS (adapter smokes at
- * implementation/adapters/<name>/testbed/, framework testbeds at
- * tools/causa/testbeds/, and the top-level testbeds/ tree).
+ * Orchestrator for the adapter-smoke Playwright suite (npm run
+ * test:examples). Per rf2-8cevm (Mike directive 2026-05-19) the
+ * `examples/` tree is TEST-FREE — this orchestrator compiles +
+ * stages only the surfaces paired with a `spec.cjs` under the
+ * runner's SPEC_ROOTS, which is now just the three adapter smokes
+ * at implementation/adapters/<name>/testbed/.
  *
- * 1. Compiles each surface's shadow-cljs build (one per testbed).
+ * Per rf2-t5slp the framework-testbeds gate (formerly the second
+ * orchestrator invocation, scoped via EXAMPLES_FILTER=testbeds/)
+ * was retired after all four rf2-tglku migration waves moved every
+ * framework + top-level testbed Playwright spec.cjs to CLJS/JVM
+ * unit tests. The testbed surfaces themselves (tools/causa/testbeds/**
+ * and top-level testbeds/**) stay in-tree as Causa observation
+ * targets; they're no longer staged by this orchestrator.
+ *
+ * 1. Compiles each surface's shadow-cljs build (one per smoke).
  * 2. Stages each surface's hand-written index.html into its
  *    out/examples/<name>/ directory next to main.js.
  * 3. Spawns http-server over out/examples on port 8030.
@@ -17,7 +24,7 @@
  * 5. Always tears the server down.
  *
  * Build list, mount paths, and HTML sources are declared in EXAMPLES
- * below. Adding a new testbed: append an entry here ONLY when a
+ * below. Adding a new smoke: append an entry here ONLY when a
  * matching spec.cjs exists under SPEC_ROOTS; never stage a surface
  * that nothing tests.
  *
@@ -42,30 +49,22 @@ const {
 // supplied via either:
 //
 //   1. CLI flag (cross-platform; the recommended shape):
-//      node serve-and-run-examples-tests.cjs --filter realworld
+//      node serve-and-run-examples-tests.cjs --filter adapters
 //
 //   2. Env var (for CI / scripted use):
-//      EXAMPLES_FILTER=realworld node serve-and-run-examples-tests.cjs
+//      EXAMPLES_FILTER=adapters node serve-and-run-examples-tests.cjs
 //
 // rf2-9grp6 — multi-pattern filter. Comma separates alternatives, OR-
-// matched: `adapters/` matches only the 3 adapter smokes, while
-// `examples/counter-perf,examples/parallel-frames,testbeds/` matches
-// the 11 framework + top-level testbed builds. The CI split (rf2-9grp6)
-// drives this — `adapter-testbed-smokes` invokes the orchestrator with
-// the adapter pattern, `framework-testbeds` with the testbed patterns.
+// matched. The single CI invocation today (adapter-testbed-smokes)
+// passes `adapters/` to scope the runner to the 3 adapter smokes.
 // Single-pattern usage stays backwards-compatible.
 //
-// The packaged narrow shortcut lives in implementation/package.json
-// as `npm run test:examples:realworld`.
-//
 // The filter is substring-matched against the shadow-cljs build id
-// (`examples/<name>` or `testbeds/<name>`), giving a single knob that
-// composes with both the orchestrator's compile/stage loop and the
-// runner's spec walker. Live-SSR JVM server bring-up is skipped when
-// the filter excludes the `examples/ssr` build — keeps narrow runs
-// fast (~5s vs ~25s cold). Per Spec 008-Testing §Test surfaces — this
-// is the changed-surface CI tier for cross-artefact runtime changes
-// (the full sweep remains the local / nightly / release rigorous gate).
+// (`adapters/<name>-testbed`), giving a single knob that composes
+// with both the orchestrator's compile/stage loop and the runner's
+// spec walker. Per Spec 008-Testing §Test surfaces — this is the
+// changed-surface CI tier for adapter-mount regressions (the nightly
+// / release rigorous gate remains separate).
 function parseFilterFromArgs(argv) {
   // Accept `--filter <value>` or `--filter=<value>`. Ignore unknown
   // flags so future additions don't break — the orchestrator has no
@@ -113,17 +112,26 @@ cleanup.installSignalHandlers();
 // Playwright spec navigates to under http://127.0.0.1:PORT/.
 //
 // Policy (rf2-8cevm, Mike directive 2026-05-19): the `examples/` tree
-// is TEST-FREE. The runner orchestrates the three adapter smokes
-// (Reagent / UIx / Helix), the two framework testbeds owned by Causa
-// (perf-live + parallel-frames), and the cross-cutting top-level
-// `testbeds/` (rf2-ik4io SSR + rf2-fe84r framework-behaviour). Every
-// build below is paired with a `spec.cjs`; never add a build here
-// whose only purpose is "compile + stage with no spec to drive it"
-// (that's dead CI weight). Per-example smoke coverage that previously
-// lived under `examples/<substrate>/<name>/*.spec.cjs` has been
-// permanently retired — real regressions are caught by substrate
-// contract tests, the Causa feature-matrix gate, bundle-isolation,
-// the perf-bundle gate, and mcp-conformance.
+// is TEST-FREE. The orchestrator drives the three adapter smokes
+// (Reagent / UIx / Helix); every build below is paired with a
+// `spec.cjs`; never add a build here whose only purpose is "compile
+// + stage with no spec to drive it" (that's dead CI weight).
+//
+// Per-example smoke coverage that previously lived under
+// `examples/<substrate>/<name>/*.spec.cjs` has been permanently
+// retired — real regressions are caught by substrate contract tests,
+// the Causa feature-matrix gate, bundle-isolation, the perf-bundle
+// gate, and mcp-conformance.
+//
+// Per rf2-t5slp the framework-testbeds orchestrator invocation was
+// retired after all four rf2-tglku migration waves (rf2-4j0tb /
+// rf2-lcg1z / rf2-pxb7t / rf2-e3j8l) moved every framework + top-
+// level testbed assertion to CLJS/JVM unit tests under
+// `implementation/{core,epoch,flows,http,machines,ssr}/test/`. The
+// testbed surfaces themselves (`tools/causa/testbeds/**` +
+// `testbeds/**`) stay in-tree as Causa observation targets; the
+// build targets stay in `implementation/shadow-cljs.edn` but no
+// `EXAMPLES` row references them here.
 const EXAMPLES = [
   // ----- Adapter smokes (3 of 3) ----------------------------------------
   // rf2-eceuv — per-adapter end-to-end smoke. Each adapter (Reagent
@@ -150,54 +158,6 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'implementation', 'adapters', 'helix', 'testbed', 'index.html'),
     outDir: path.join(OUT_ROOT, 'adapter-testbeds', 'helix'),
   },
-
-  // ----- Framework testbeds (0) -----------------------------------------
-  // (Wave 4, rf2-e3j8l) The `examples/counter-perf` Playwright entry has
-  // been removed: `tools/causa/testbeds/perf_counter/spec.cjs` was
-  // deleted in favour of pure-CLJS User-Timing assertions at
-  // `implementation/core/test/re_frame/performance_emit_nightly_test.cljs`
-  // (nightly only, via the `:node-test-perf-nightly` shadow-cljs build).
-  // The `examples/counter-perf` shadow-cljs build target ITSELF is
-  // retained — `npm run test:perf-bundle` still uses it for the
-  // bundle-presence grep (scripts/check-perf-bundle.cjs).
-  //
-  // (Wave 2, rf2-lcg1z) The `examples/parallel-frames` Playwright entry
-  // has been removed: `tools/causa/testbeds/parallel_frames/spec.cjs`
-  // was deleted in favour of pure-CLJS multi-frame isolation
-  // assertions at
-  // `implementation/core/test/re_frame/multi_frame_isolation_cljs_test.cljs`
-  // (per-PR via the standard `:node-test` build). The testbed surface
-  // (`core.cljs`, `index.html`, `README.md`) stays in-tree as the
-  // canonical Causa-displayable multi-frame demo; only the Playwright
-  // spec.cjs retired.
-
-  // ----- Cross-cutting framework testbeds (rf2-fe84r / rf2-kzcim) -------
-  // Shared framework-behaviour testbed surfaces. These emit into
-  // `out/testbeds/<id>/` and the orchestrator copies the bundle into
-  // `OUT_ROOT/testbeds/<id>/` so http-server serves it under the same
-  // origin as the adapter smokes. The `bundleSrc` field opts a build
-  // into the bundle-copy step.
-  //
-  // Wave 1 of rf2-tglku (rf2-4j0tb) retired the Playwright spec.cjs files
-  // for six framework testbeds (`deliberate_throw`, `http_toggle`,
-  // `deep_machine`, `non_trivial_app_db`, `long_flow_w_failure`,
-  // `drain_depth_trigger`) — their assertions migrated to CLJS unit
-  // tests under `implementation/{core,epoch,flows,http,machines}/test/`.
-  // The testbed surfaces themselves stay in-tree as the canonical
-  // observation targets for Causa / Story / re-frame2-pair-mcp, but
-  // they no longer ship a spec.cjs, so they're dropped from the
-  // examples-orchestrator EXAMPLES list per the "never stage a surface
-  // that nothing tests" contract above.
-  //
-  // Wave 3 of rf2-tglku (rf2-pxb7t) retired the three SSR testbed
-  // Playwright spec.cjs files (`ssr_basic`, `ssr_hydration_mismatch`,
-  // `ssr_multi_frame`). Their assertions migrated to JVM tests under
-  // `implementation/ssr/test/re_frame/{ssr_hydration_test.clj,
-  // ssr_hydration_mismatch_test.clj, ssr_multi_frame_isolation_test.clj}`
-  // using `rf/subscribe-once` for the synchronous pre-/post-hydration
-  // reads. The testbed surfaces themselves (core.cljs + index.html +
-  // README.md) stay in-tree as Causa observation targets; their
-  // `testbeds/ssr-*` shadow-cljs build targets are retained.
 ];
 
 // rf2-h9ut9 — substring-match a build id against the filter. Empty
@@ -250,78 +210,11 @@ function compileAll() {
   }
 }
 
-// rf2-1w76p — panel-gallery smokes opt-in. The two scripts under
-// tools/causa/testbeds/panel_gallery/_smoke.cjs and
-// _workspace_switch_smoke.cjs are stand-alone (each spawns its own
-// http-server + Playwright) and don't fit the spec.cjs shape the
-// runner walks. They're gated behind RF2_CAUSA_RUN_GALLERY_SMOKES=1
-// (off in the fast PR loop, on in the rigorous browser job). When
-// enabled we compile :testbeds/panel-gallery, stage its index.html
-// next to the bundle, and invoke both smokes in sequence. A failure
-// in either smoke fails the whole `npm run test:examples` run.
-const GALLERY_SMOKES_ENABLED =
-  process.env.RF2_CAUSA_RUN_GALLERY_SMOKES === '1';
-
-function compileAndStagePanelGallery() {
-  const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['shadow-cljs', 'compile', 'testbeds/panel-gallery'];
-  const result = spawnSync(cmd, args, {
-    cwd: IMPL_ROOT,
-    stdio: 'inherit',
-    shell: isWin,
-  });
-  if (result.status !== 0) {
-    console.error(`> ${cmd} ${args.join(' ')}`);
-    throw new Error(
-      `shadow-cljs compile :testbeds/panel-gallery failed (exit ${result.status})`,
-    );
-  }
-  // Stage index.html next to the compiled bundle. The smokes serve
-  // implementation/out/testbeds/panel-gallery/ as the http-server
-  // root and request `/index.html`, so the file must live there.
-  const galleryHtmlSrc = path.join(
-    REPO_ROOT,
-    'tools', 'causa', 'testbeds', 'panel_gallery', 'index.html',
-  );
-  const galleryOutDir = path.join(
-    IMPL_ROOT, 'out', 'testbeds', 'panel-gallery',
-  );
-  if (!fs.existsSync(galleryOutDir)) {
-    throw new Error(`Panel-gallery bundle dir missing: ${galleryOutDir}`);
-  }
-  if (!fs.existsSync(galleryHtmlSrc)) {
-    throw new Error(`Panel-gallery index.html missing: ${galleryHtmlSrc}`);
-  }
-  fs.copyFileSync(galleryHtmlSrc, path.join(galleryOutDir, 'index.html'));
-}
-
-function runPanelGallerySmokes() {
-  const smokes = [
-    path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'panel_gallery', '_smoke.cjs'),
-    path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'panel_gallery', '_workspace_switch_smoke.cjs'),
-  ];
-  let anyFailed = false;
-  for (const smoke of smokes) {
-    console.log(`\n=== panel-gallery smoke: ${path.basename(smoke)} ===`);
-    const result = spawnSync(process.execPath, [smoke], {
-      stdio: 'inherit',
-      cwd: REPO_ROOT,
-    });
-    if (result.status !== 0) {
-      console.error(`FAIL panel-gallery smoke ${path.basename(smoke)} (exit ${result.status})`);
-      anyFailed = true;
-    }
-  }
-  return anyFailed ? 1 : 0;
-}
-
 function copyDirRecursive(src, dest) {
-  // Minimal recursive copy. Used only for `bundleSrc` — staging a
-  // shadow-cljs build whose `:output-dir` lives outside `OUT_ROOT`
-  // (testbed surfaces, rf2-fe84r) into the served tree. Each file
-  // overwrites the destination unconditionally so repeat runs pick up
-  // re-compiled bundles.
+  // Minimal recursive copy. Used by `stageShared` below to fan the
+  // `examples/_shared/` design-system tree into every staged smoke
+  // dir. Each file overwrites the destination unconditionally so
+  // repeat runs pick up re-compiled bundles.
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
     const s = path.join(src, entry.name);
@@ -353,19 +246,6 @@ function stageHtml() {
   // suppressed.  Errors still throw with the offending path.
   // rf2-h9ut9 — narrow EXAMPLES_FILTER: only stage selected entries.
   for (const ex of selectedExamples()) {
-    // rf2-fe84r — testbed surfaces ship their shadow-cljs `:output-dir`
-    // outside OUT_ROOT (per the per-surface `:testbeds/<name>` build's
-    // `out/testbeds/<name>` setting). Stage the compiled bundle into
-    // OUT_ROOT first so the static server picks it up under the
-    // expected URL path. Examples that emit straight into OUT_ROOT
-    // omit `bundleSrc` and skip this step.
-    if (ex.bundleSrc) {
-      if (!fs.existsSync(ex.bundleSrc)) {
-        throw new Error(`Bundle source missing: ${ex.bundleSrc}`);
-      }
-      copyDirRecursive(ex.bundleSrc, ex.outDir);
-    }
-
     if (!fs.existsSync(ex.outDir)) {
       throw new Error(`Build output dir missing: ${ex.outDir}`);
     }
@@ -431,28 +311,7 @@ async function main() {
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  let finalCode = code == null ? 1 : code;
-
-  // rf2-1w76p — opt-in panel-gallery smokes. Runs AFTER the main
-  // runner so the spec.cjs sweep + smokes share one wall-clock
-  // budget. The smokes spawn their own http-servers on ports
-  // 8766 / 8767 (distinct from the orchestrator's :8030) so there
-  // is no port collision with the still-running EXAMPLES server.
-  // Smoke failures fail the whole run; the orchestrator's server
-  // is still torn down via the cleanup hook in main()'s caller.
-  if (GALLERY_SMOKES_ENABLED) {
-    console.log('\nRF2_CAUSA_RUN_GALLERY_SMOKES=1 — running panel-gallery smokes');
-    try {
-      compileAndStagePanelGallery();
-      const smokeCode = runPanelGallerySmokes();
-      if (smokeCode !== 0) finalCode = smokeCode;
-    } catch (err) {
-      console.error('panel-gallery smokes failed to set up:', err.message);
-      finalCode = 1;
-    }
-  }
-
-  return finalCode;
+  return code == null ? 1 : code;
 }
 
 main().then(async (code) => {

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -101,65 +101,45 @@ test('targeted Story/Causa workflow runs the Story feature-load gate', () => {
   assert.match(workflow, /story-causa-browser:[\s\S]*npm run test:story-feature-load/);
 });
 
-// rf2-9grp6 — framework-testbeds gate split. Adapter source changes
-// fire `adapter_testbed_smokes` (existing). Testbed-source changes
-// under tools/causa/testbeds/** or top-level testbeds/** fire the
-// new `framework_testbeds` output. Spec/Markdown changes fire neither.
+// rf2-t5slp — the framework-testbeds gate was retired after all four
+// rf2-tglku migration waves moved every framework + top-level testbed
+// Playwright spec.cjs to CLJS/JVM unit tests. The classifier no longer
+// emits a `framework_testbeds` output; testbed source diffs only light
+// `cljs_browser` (for the transitive CLJS compile coverage).
 
-test('top-level testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
+test('framework_testbeds output is no longer emitted (rf2-t5slp)', () => {
   const result = classify('testbeds/ssr_basic/core.cljs');
-  assert.equal(result.framework_testbeds, 'true');
+  assert.equal(result.framework_testbeds, undefined);
 });
 
-test('top-level testbed .html changes trigger framework_testbeds (rf2-9grp6)', () => {
-  const result = classify('testbeds/ssr_basic/index.html');
-  assert.equal(result.framework_testbeds, 'true');
-});
-
-test('Causa perf_counter testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
-  const result = classify('tools/causa/testbeds/perf_counter/core.cljs');
-  assert.equal(result.framework_testbeds, 'true');
-});
-
-test('Causa parallel_frames testbed .cljs changes trigger framework_testbeds (rf2-9grp6)', () => {
-  const result = classify('tools/causa/testbeds/parallel_frames/core.cljs');
-  assert.equal(result.framework_testbeds, 'true');
-});
-
-test('top-level testbed README.md does NOT trigger framework_testbeds (rf2-9grp6)', () => {
-  const result = classify('testbeds/ssr_basic/README.md');
-  assert.equal(result.framework_testbeds, 'false');
-});
-
-test('Story src .cljs change does NOT trigger framework_testbeds (rf2-9grp6 — Story drives story_causa_browser, not this)', () => {
-  const result = classify('tools/story/src/foo.cljs');
-  assert.equal(result.framework_testbeds, 'false');
-});
-
-test('Adapter source change fires adapter_testbed_smokes but NOT framework_testbeds (rf2-9grp6)', () => {
-  const result = classify('implementation/adapters/reagent/testbed/core.cljs');
-  assert.equal(result.adapter_testbed_smokes, 'true');
-  assert.equal(result.framework_testbeds, 'false');
-});
-
-test('top-level testbed .cljs change fires framework_testbeds but NOT adapter_testbed_smokes (rf2-9grp6)', () => {
+test('top-level testbed .cljs change fires cljs_browser only (rf2-t5slp)', () => {
   const result = classify('testbeds/ssr_basic/core.cljs');
   assert.equal(result.adapter_testbed_smokes, 'false');
-  assert.equal(result.framework_testbeds, 'true');
+  assert.equal(result.cljs_browser, 'true');
 });
 
-test('framework-testbeds workflow job is gated by framework_testbeds output (rf2-9grp6)', () => {
-  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
-  assert.match(
-    workflow,
-    /framework-testbeds:[\s\S]*if:\s+needs\.detect_changed_surfaces\.outputs\.framework_testbeds\s*==\s*'true'/,
-  );
+test('Causa testbed .cljs change fires story_causa_browser only (rf2-t5slp)', () => {
+  const result = classify('tools/causa/testbeds/feature_matrix/core.cljs');
+  assert.equal(result.adapter_testbed_smokes, 'false');
+  assert.equal(result.story_causa_browser, 'true');
 });
 
-test('adapter-testbed-smokes workflow narrowed to EXAMPLES_FILTER=adapters/ (rf2-9grp6)', () => {
+test('Adapter source change fires adapter_testbed_smokes (rf2-t5slp regression guard)', () => {
+  const result = classify('implementation/adapters/reagent/testbed/core.cljs');
+  assert.equal(result.adapter_testbed_smokes, 'true');
+});
+
+test('framework-testbeds workflow job is removed (rf2-t5slp)', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
-  // Find the adapter-testbed-smokes job block and verify it passes the
-  // narrow adapters/ filter (so framework + top-level testbeds skip).
+  assert.doesNotMatch(workflow, /^\s*framework-testbeds:/m);
+  assert.doesNotMatch(workflow, /framework_testbeds/);
+});
+
+test('adapter-testbed-smokes workflow remains scoped to EXAMPLES_FILTER=adapters/ (rf2-t5slp)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  // Find the adapter-testbed-smokes job block and verify it still
+  // passes the narrow adapters/ filter — the only Playwright surface
+  // under the examples orchestrator after framework-testbeds retired.
   assert.match(
     workflow,
     /adapter-testbed-smokes:[\s\S]*EXAMPLES_FILTER:\s*"adapters\/"/,


### PR DESCRIPTION
## Summary

After all four rf2-tglku migration waves landed (#1692 Wave 1 / #1706 Wave 2 / #1710 Wave 3 / #1701 Wave 4), the framework-testbeds Playwright gate has zero surfaces — every framework + top-level testbed Playwright `spec.cjs` has been migrated to a CLJS/JVM unit test. #1710 demonstrated the empty-state failure mode (`EXAMPLES_FILTER='testbeds/' matched zero builds`) and was admin-merged because the failure was structurally irrelevant.

This PR retires the gate cleanly (pre-alpha posture — no skip-when-empty transitional).

### Surfaces touched

- `.github/workflows/test.yml` — drop `framework_testbeds` output + the `framework-testbeds` job; refresh `adapter-testbed-smokes` comment.
- `.github/scripts/report-changed-surfaces.sh` — drop the `framework_testbeds` output + emit + the `is_framework_testbed_path` predicate + the `testbeds/*` and `tools/{story,causa}/*` case-arm callers; refresh adjacent comments.
- `implementation/scripts/_changed-surfaces.test.cjs` — replace the six framework-testbeds cases (added in #1688) with rf2-t5slp regression guards (output absent, workflow job removed, classifier behaviour for `testbeds/` / Causa testbeds preserved on `cljs_browser` / `story_causa_browser`).
- `TESTING.md` — drop `framework_testbeds` row from the classifier output table; collapse the surface→output matrix from 14 to 13 columns; update the output→jobs table and the `implementation/core/*` fan-out note.
- `examples/scripts/serve-and-run-examples-tests.cjs` — drop dead `testbeds/` `EXAMPLES` entries (already empty after Wave 3), the `bundleSrc` field handling in `stageHtml`, and the `RF2_CAUSA_RUN_GALLERY_SMOKES` panel-gallery hooks (no CI driver remains).
- `examples/scripts/run-examples-tests.cjs` — narrow `SPEC_ROOTS` to `implementation/adapters/` only; refresh header comment.
- `examples/README.md` — update the `test:examples` blurb and the `testbeds/` note to reflect the retired gate.

### Out of scope

The rf2-1w76p panel-gallery stand-alone smokes (`_smoke.cjs`, `_workspace_switch_smoke.cjs`) lose their CI driver. They remain in tree under `tools/causa/testbeds/panel_gallery/` and can still be run locally. A follow-up bead can reallocate them to `story-causa-browser` if CI coverage of the rf2-kgn0c workspace-teardown regression should be preserved.

## Test plan

- [x] `node implementation/scripts/_changed-surfaces.test.cjs` — 18/18 pass (existing + new rf2-t5slp guards)
- [x] `python -c "import yaml; yaml.safe_load(open(''.github/workflows/test.yml''))"` — valid
- [x] `python -m mkdocs build --strict` — exit 0
- [x] `bash -n .github/scripts/report-changed-surfaces.sh` — exit 0
- [ ] CI on the PR: adapter-testbed-smokes + story-causa-browser still wire up; `framework-testbeds` job no longer in the matrix