### PR TITLE
feat(template): best-practice demos — error projector + app-db schema + HTTP failure matrix (rf2-48mij)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
@@ -15,6 +15,11 @@
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-helix      {:mvn/version "{{rf2-version}}"}
+         ;; Schema attachment — `reg-app-schema` + Malli adapter. The
+         ;; starter app's whole-app-db schema (see schema.cljs) needs
+         ;; this artefact for validation to actually fire; without it
+         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-causa-host] left layout column. Wired via
          ;; :devtools/preloads in shadow-cljs.edn.

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
@@ -16,6 +16,11 @@
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-reagent    {:mvn/version "{{rf2-version}}"}
+         ;; Schema attachment — `reg-app-schema` + Malli adapter. The
+         ;; starter app's whole-app-db schema (see schema.cljs) needs
+         ;; this artefact for validation to actually fire; without it
+         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-causa-host] left layout column. Wired via
          ;; :devtools/preloads in shadow-cljs.edn. Lockstep with

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
@@ -22,6 +22,11 @@
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-reagent    {:mvn/version "{{rf2-version}}"}
+         ;; Schema attachment — `reg-app-schema` + Malli adapter. The
+         ;; starter app's whole-app-db schema (see schema.cljs) needs
+         ;; this artefact for validation to actually fire; without it
+         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-causa-host] left layout column. Wired via
          ;; :devtools/preloads in shadow-cljs.edn. Lockstep with

--- a/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/events.cljs
@@ -3,7 +3,56 @@
 
    The handler is a pure function `(fn [db event] new-db)`. The runtime
    applies the returned db to the frame; views fan out from there."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            ;; The trace-listener surface (`register-trace-listener!`)
+            ;; lives in `re-frame.trace.tooling`, NOT `re-frame.core` —
+            ;; CLJS production bundles DCE the tooling namespace
+            ;; wholesale, so the `rf/...` alias for these fns is
+            ;; deliberately JVM-only (per rf2-qwm0a). Listener
+            ;; observability in `:advanced` + `goog.DEBUG=false`
+            ;; production builds is intentionally a no-op:
+            ;; `trace/emit!` is gated on `interop/debug-enabled?` and
+            ;; elides at compile time.
+            [re-frame.trace.tooling :as trace-tooling]
+            ;; Schema artefact — required as a side-effecting load so
+            ;; the late-bind hooks publish before {{namespace}}.schema
+            ;; runs its `reg-app-schema` registrations. Pulls in Malli
+            ;; via the schemas artefact's deps.
+            [re-frame.schemas]
+            [re-frame.schemas.malli]
+            ;; Schema registrations — loaded for the
+            ;; `(reg-app-schema [] CounterDb)` side-effect that wires
+            ;; the root app-db validator before any handler commits.
+            [{{namespace}}.schema]))
+
+;; --- Errors are events too -------------------------------------------------
+;;
+;; Per [Spec 009 §The listener API](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md#the-listener-api)
+;; every error inside the dispatch pipeline emits a structured trace
+;; event with `:op-type :error` — schema violations, handler exceptions,
+;; sub exceptions, fx exceptions, drain-depth exceeded, etc. The
+;; framework does NOT decide what the user sees; an app-level listener
+;; projects errors onto the UI.
+;;
+;; This default sink surfaces every error to the browser console so a
+;; silent regression (a handler that swallowed an exception, a schema
+;; that rejected a write, a fx that threw mid-cascade) is impossible
+;; to miss. Replace `js/console.error` with whatever your app does for
+;; user-visible error projection — toast, modal, error boundary, error
+;; reporter (Sentry / Rollbar / etc.).
+;;
+;; The listener key (`::error-sink`) is namespace-qualified — same-key
+;; re-registration replaces the previous callback atomically (per
+;; Spec 009 §Re-registration semantics), so hot-reload re-runs this
+;; form without leaking listeners.
+
+(trace-tooling/register-trace-listener!
+  ::error-sink
+  (fn [trace-event]
+    (when (= :error (:op-type trace-event))
+      (js/console.error "[{{namespace}}]"
+                        (:operation trace-event)
+                        (clj->js (:tags trace-event))))))
 
 ;; --- Initialisation --------------------------------------------------------
 ;;
@@ -26,3 +75,75 @@
   :counter/increment
   (fn [db _event]
     (update db :counter/value inc)))
+
+;; --- HTTP failure matrix (commented exemplar) ------------------------------
+;;
+;; The shape below is the canonical `:rf.http/managed` call-site (per
+;; [Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md)).
+;; Adopt it as-is when your app starts talking to an HTTP backend:
+;;
+;;   1. Require `[re-frame.http-managed]` at app boot — that's the load-
+;;      time side-effect that registers the `:rf.http/managed` fx and
+;;      publishes the call-site helpers. Without it, dispatching the fx
+;;      below would raise `:rf.error/no-such-fx`.
+;;   2. Add `day8/re-frame2-http {:mvn/version "{{rf2-version}}"}` to
+;;      your `deps.edn` (the artefact is split out so apps that don't
+;;      talk HTTP don't pay for it).
+;;   3. Uncomment the handler below.
+;;
+;; The closed `:retry :on` set is drawn from the **retryable subset** of
+;; the `:rf.http/*` failure-category vocabulary (Spec 014 §Failure
+;; categories): `:rf.http/transport` (network/DNS/connection-refused),
+;; `:rf.http/http-5xx` (server-side; the canonical retryable case), and
+;; `:rf.http/timeout` (per-attempt). The other categories
+;; (`:rf.http/cors`, `:rf.http/decode-failure`, `:rf.http/http-4xx`,
+;; `:rf.http/aborted`, `:rf.http/accept-failure`) are **non-retryable
+;; by construction** and the framework rejects them in `:retry :on` at
+;; fx-call time with `:rf.error/http-bad-retry-on`.
+;;
+;; The single `:on-failure` branch sees the resolved failure category
+;; via `(:kind (:failure reply))` — branch on the keyword to project
+;; each error case onto the UI shape your app wants. Body-conditional
+;; retry (e.g. "the server sent `:retry-after`, wait that long") is
+;; **out of scope** for `:retry`; lift those into a state machine per
+;; Spec 014 §Boundary — transport vs semantic retry.
+;;
+#_(rf/reg-event-fx
+    :counter/load
+    (fn [{:keys [db]} [_ msg]]
+      (cond
+        ;; Success branch — server returned `{"delta": N}` (decoded
+        ;; per :decode :auto).
+        (some-> msg :rf/reply :kind (= :success))
+        {:db (-> db
+                 (update :counter/value + (:delta (:value (:rf/reply msg))))
+                 (assoc :counter/status :idle))}
+
+        ;; Failure branch — exactly one dispatch per request, even
+        ;; with retry, per Spec 014 §Retry × :on-failure semantics.
+        ;; Project each :rf.http/* category onto a UI-facing message.
+        (some-> msg :rf/reply :kind (= :failure))
+        (let [failure (:failure (:rf/reply msg))]
+          {:db (assoc db :counter/status :error
+                         :counter/error
+                         (case (:kind failure)
+                           :rf.http/transport      "Network unavailable."
+                           :rf.http/cors           "Misconfigured CORS — check the server."
+                           :rf.http/timeout        "Server took too long to respond."
+                           :rf.http/http-4xx       "Client error — request rejected."
+                           :rf.http/http-5xx       "Server error — try again later."
+                           :rf.http/decode-failure "Bad response from server."
+                           :rf.http/aborted        "Request cancelled."
+                           "Something went wrong."))})
+
+        ;; Initial branch — issue the request.
+        :else
+        {:db (assoc db :counter/status :loading :counter/error nil)
+         :fx [[:rf.http/managed
+               {:request {:method :get :url "/api/counter"}
+                :decode  :auto
+                :retry   {:on           #{:rf.http/transport
+                                          :rf.http/http-5xx
+                                          :rf.http/timeout}
+                          :max-attempts 3
+                          :backoff      [200 1000 3000]}}]]})))

--- a/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
+++ b/tools/template/resources/day8/re_frame2_template/_shared/schema.cljs
@@ -1,0 +1,41 @@
+(ns {{namespace}}.schema
+  "App-db schema — typed-at-boundaries posture (Spec 010).
+
+   re-frame2 attaches schemas at paths. The framework validates writes
+   against every registered path-schema after each handler completes a
+   state mutation. A non-conforming write rolls back the `:db` effect
+   and emits a structured `:rf.error/schema-validation-failure` trace —
+   the runtime treats it as a failed dispatch (flows don't evaluate,
+   `:fx` doesn't walk), but the queue continues to drain.
+
+   The starter app registers ONE schema at the empty path `[]` — the
+   whole-app-db form (`get-in`/`assoc-in` semantics: `[]` means \"the
+   whole map\"). For multi-feature apps, split per-feature schemas at
+   their prefix paths (`[:cart]`, `[:auth]`, ...) per
+   [Spec 010 §`app-db` schemas — path-based](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md#app-db-schemas--path-based)
+   and the [Feature-modularity prefix
+   convention](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md#feature-modularity-prefix-convention).
+
+   The schemas artefact (`day8/re-frame2-schemas`) and the Malli adapter
+   (`re-frame.schemas.malli`) are loaded as side-effects in events.cljs
+   — that publishes Malli's `validate` and `explain` into the framework's
+   late-bind hook table before any `reg-app-schema` call runs.
+
+   Schemas validate **in dev** (and on JVM unless production-hardened);
+   the validation check elides automatically under `:advanced`
+   `goog.DEBUG=false` builds — schema attachments stay in source but
+   cost nothing in production hot paths."
+  (:require [re-frame.core :as rf]))
+
+;; --- Whole-app-db schema ---------------------------------------------------
+;;
+;; A closed map: a typo like `:countr/value` (one missing `e`) is caught
+;; at the boundary instead of producing a silent `nil` downstream. Open
+;; vs closed is a team decision — open admits new keys mid-development;
+;; closed catches typos. Best practice for a starter scaffold: closed.
+
+(def CounterDb
+  [:map {:closed true}
+   [:counter/value :int]])
+
+(rf/reg-app-schema [] CounterDb)

--- a/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
@@ -16,6 +16,11 @@
 
          day8/re-frame2            {:mvn/version "{{rf2-version}}"}
          day8/re-frame2-uix        {:mvn/version "{{rf2-version}}"}
+         ;; Schema attachment — `reg-app-schema` + Malli adapter. The
+         ;; starter app's whole-app-db schema (see schema.cljs) needs
+         ;; this artefact for validation to actually fire; without it
+         ;; CLJS soft-passes per Spec 010 §Recommended soft-pass.
+         day8/re-frame2-schemas    {:mvn/version "{{rf2-version}}"}
          ;; In-app devtools panel — auto-opens into the app-provided
          ;; [data-rf-causa-host] left layout column. Wired via
          ;; :devtools/preloads in shadow-cljs.edn.

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -187,6 +187,7 @@ related error, that's the fix.
 ├── src/{{nested-dirs}}/
 │   ├── core.cljs            ; entry point — mounts the root view
 │   ├── events.cljs          ; `:counter/initialise`, `:counter/increment` handlers
+│   ├── schema.cljs          ; whole-app-db Malli schema + `reg-app-schema`
 │   ├── subs.cljs            ; `:counter/value` subscription
 │   └── views.cljs           ; the counter view ({{substrate}})
 ├── test/{{nested-dirs}}/
@@ -211,6 +212,165 @@ This is the same counter walked through in
 the state key is intentionally feature-scoped (`:counter/value`, not a
 bare `:count`) so generated applications start with AI-readable,
 non-colliding app-db slices.
+
+## Best practices baked into the scaffold
+
+re-frame2 ships with distinctive postures on **error visibility**,
+**typed boundaries**, and **HTTP failure handling**. The starter app
+demonstrates each one inline so new apps inherit the conventions
+without ceremony.
+
+### Errors are events too
+
+Every error inside the dispatch pipeline — schema violation, handler
+exception, sub exception, fx exception, drain-depth overflow — emits a
+structured trace event with `:op-type :error` (per
+[Spec 009 §Error contract](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md)).
+The framework does NOT decide what the user sees; an **app-level
+listener projects errors onto the UI**.
+
+The scaffold registers a default error sink at the top of `events.cljs`:
+
+```clojure
+(trace-tooling/register-trace-listener!
+  ::error-sink
+  (fn [trace-event]
+    (when (= :error (:op-type trace-event))
+      (js/console.error "[your-app]"
+                        (:operation trace-event)
+                        (clj->js (:tags trace-event))))))
+```
+
+(The listener API lives in `re-frame.trace.tooling`, not `re-frame.core`
+— CLJS production bundles DCE the tooling namespace wholesale, so the
+`rf/...` alias for these fns is JVM-only. Per Spec 009 §JVM-only
+aliases — rf2-qwm0a.)
+
+The sink surfaces every error to the console — silent regressions are
+impossible to miss. Replace `js/console.error` with whatever your app
+does for user-visible errors (toast, error boundary, Sentry / Rollbar /
+etc.).
+
+The same-key registration form means hot-reload re-runs without
+leaking listeners; the listener registry elides in production builds
+(per [Spec 009 §`register-trace-listener!`](https://github.com/day8/re-frame2/blob/main/spec/009-Instrumentation.md#the-listener-api)).
+
+Note: re-frame2 also ships `reg-error-projector` for **server-side
+rendering** (SSR), where the projector maps internal trace events to
+HTTP-response shapes. That projector is a separate surface from the
+client-side error sink above — see
+[Spec 011 §SSR](https://github.com/day8/re-frame2/blob/main/spec/011-SSR.md)
+if you're rendering server-side.
+
+### Typed app-db boundaries
+
+`schema.cljs` registers a **whole-app-db schema** at the empty path
+`[]`. The framework validates every write against the registered
+schemas; a non-conforming write rolls back the `:db` effect and emits
+`:rf.error/schema-validation-failure`. The error then flows through
+the error sink above — wrong writes are caught at the boundary, not
+N renders downstream.
+
+```clojure
+(def CounterDb
+  [:map {:closed true}
+   [:counter/value :int]])
+
+(rf/reg-app-schema [] CounterDb)
+```
+
+Closed maps catch typos (`:countr/value` → schema rejection); open
+maps admit new keys during development. The starter uses closed —
+flip to `{:closed false}` if you want laxer registration while you
+sketch.
+
+For multi-feature apps, register **per-feature schemas at their
+prefix path** rather than one giant root schema:
+
+```clojure
+(rf/reg-app-schemas
+  {[:cart]                  CartSlice
+   [:cart :items]           [:vector CartItem]
+   [:auth]                  AuthSlice
+   [:auth :login-form]      FormSlice})
+```
+
+Per-feature schemas compose with the root schema; both validate. Full
+detail: [Spec 010 §`app-db` schemas — path-based](https://github.com/day8/re-frame2/blob/main/spec/010-Schemas.md#app-db-schemas--path-based).
+
+Schema validation elides automatically under `:advanced`
+`goog.DEBUG=false` builds — registrations stay in source but cost
+nothing in production hot paths.
+
+### HTTP — closed failure-category set and a single `:on-failure` branch
+
+`events.cljs` ships a commented-out `:rf.http/managed` handler showing
+the canonical call shape per
+[Spec 014 §`:rf.http/managed`](https://github.com/day8/re-frame2/blob/main/spec/014-HTTPRequests.md).
+Uncomment and adapt when your app starts talking to a backend.
+
+Two distinctive postures land in the example:
+
+1. **Closed `:retry :on` set.** Only the *retryable* subset of the
+   `:rf.http/*` failure-category vocabulary is admissible:
+   `:rf.http/transport`, `:rf.http/http-5xx`, `:rf.http/timeout`. The
+   non-retryable categories (`:rf.http/cors`,
+   `:rf.http/decode-failure`, `:rf.http/http-4xx`, `:rf.http/aborted`,
+   `:rf.http/accept-failure`) are rejected at fx-call time with
+   `:rf.error/http-bad-retry-on` — misuse fails fast at the dispatch
+   site, not silently across the request's lifetime.
+
+2. **Single `:on-failure` branch, project on the kind.** Exactly one
+   `:on-failure` dispatch fires per request (even with retry — per
+   Spec 014 §Retry × `:on-failure` semantics). Branch on
+   `(:kind (:failure reply))` to project each `:rf.http/*` category
+   onto the UI-facing message:
+
+   ```clojure
+   (case (:kind failure)
+     :rf.http/transport      "Network unavailable."
+     :rf.http/http-5xx       "Server error — try again later."
+     :rf.http/timeout        "Server took too long to respond."
+     :rf.http/decode-failure "Bad response from server."
+     ...)
+   ```
+
+   Body-conditional retry (e.g. honour a `:retry-after` header) is
+   **out of scope** for `:retry` — that's semantic, not transport.
+   Lift it into a state machine per Spec 014 §Boundary — transport vs
+   semantic retry.
+
+To enable HTTP, add `day8/re-frame2-http` to `deps.edn` and require
+`[re-frame.http-managed]` at app boot (the side-effecting load that
+registers `:rf.http/managed`).
+
+### Naming conventions
+
+The scaffold follows the **`:domain/action` keyword shape** throughout
+— `:counter/value` for the app-db slice, `:counter/initialise` and
+`:counter/increment` for events, `:counter/value` for the sub. Same
+shape for views and fx; the **id prefix identifies the feature**.
+
+Two rules cover most of the surface:
+
+- **Reserved namespaces are framework-owned.** Anything under `:rf/*`,
+  `:rf.<area>/*` (e.g. `:rf.http/*`, `:rf.machine/*`), and
+  `:rf.error/*` belongs to the framework. App ids live under your own
+  domain prefix — never `:rf` / `:rf.*`.
+
+- **Per-feature `:rf.<area>/*` patterns for fx.** A feature with
+  prefix `:cart` namespaces its events under `:cart/...` and
+  `:cart.<area>/...`; its subs under `:cart/...`; its app-db slice at
+  `[:cart]`; its schemas under `[:cart]` paths; its private fx under
+  `:cart.<sub-area>/...` (e.g. `:cart.persistence/save`). A feature
+  does NOT reach into another feature's slice directly — it goes
+  through the other feature's subs (to read) and dispatches the other
+  feature's events (to write).
+
+Full normative catalogue:
+[spec/Conventions.md](https://github.com/day8/re-frame2/blob/main/spec/Conventions.md)
+— reserved namespaces, fx-id sub-namespaces, reserved app-db keys,
+and the feature-modularity prefix convention.
 
 ## Next steps
 

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -254,6 +254,7 @@
                                 ;; path.
                                 "events.cljs"          (str "src/" nested "/events.cljs")
                                 "subs.cljs"            (str "src/" nested "/subs.cljs")
+                                "schema.cljs"          (str "src/" nested "/schema.cljs")
                                 "events_test.cljs"     (str "test/" nested "/events_test.cljs")}
                          ;; Story scaffolding lands under
                          ;; `src/<nested>/stories.cljs` when the flag

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -152,7 +152,9 @@
             (assoc-in [:deps adapter-coord]
                       {:local/root (rel-of (str "implementation/adapters/" (name substrate)))})
             (assoc-in [:deps 'day8/re-frame2-causa]
-                      {:local/root (rel-of "tools/causa")}))]
+                      {:local/root (rel-of "tools/causa")})
+            (assoc-in [:deps 'day8/re-frame2-schemas]
+                      {:local/root (rel-of "implementation/schemas")}))]
     (spit deps-file (with-out-str (clojure.pprint/pprint rewritten)))))
 
 ;; --- node_modules symlink --------------------------------------------------

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -461,6 +461,7 @@
         (assert-scratch-with-frame-shape! substrate proj)
         (doseq [rel ["test/acme/my_app/events_test.cljs"
                      "src/acme/my_app/events.cljs"
+                     "src/acme/my_app/schema.cljs"
                      "src/acme/my_app/subs.cljs"
                      "src/acme/my_app/views.cljs"
                      "dev/scratch.cljs"]]

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -132,6 +132,7 @@
   ;; "acme/my_app".
   ["src/acme/my_app/core.cljs"
    "src/acme/my_app/events.cljs"
+   "src/acme/my_app/schema.cljs"
    "src/acme/my_app/subs.cljs"
    "src/acme/my_app/views.cljs"
    "test/acme/my_app/events_test.cljs"])
@@ -190,6 +191,59 @@
           (is (= "0.0.1.alpha"
                  (get-in deps [:deps 'day8/re-frame2-causa :mvn/version]))
               "Causa coord lockstep with core version"))
+
+        ;; -- Schemas coord in deps.edn (rf2-48mij) --
+        (let [deps (read-edn (io/file root "deps.edn"))]
+          (is (contains? (:deps deps) 'day8/re-frame2-schemas)
+              "deps.edn references day8/re-frame2-schemas (best-practice
+               whole-app-db schema needs the artefact on the classpath
+               for CLJS validation to fire)")
+          (is (= "0.0.1.alpha"
+                 (get-in deps [:deps 'day8/re-frame2-schemas :mvn/version]))
+              "schemas coord lockstep with core version"))
+
+        ;; -- Best-practice surface in events.cljs + schema.cljs (rf2-48mij) --
+        (let [events-text (slurp (io/file root "src/acme/my_app/events.cljs"))
+              schema-text (slurp (io/file root "src/acme/my_app/schema.cljs"))]
+          (is (.contains events-text "register-trace-listener!")
+              "events.cljs registers an error-sink trace listener
+               (errors-are-events-too best-practice)")
+          (is (.contains events-text "re-frame.trace.tooling")
+              "events.cljs uses the re-frame.trace.tooling/register-trace-listener!
+               surface — CLJS-only (the rf/... alias is JVM-only,
+               per rf2-qwm0a)")
+          (is (.contains events-text "re-frame.schemas")
+              "events.cljs side-effect-loads re-frame.schemas so Malli
+               publishes into the late-bind hook table before any
+               reg-app-schema runs")
+          (is (.contains events-text "re-frame.schemas.malli")
+              "events.cljs also loads the Malli adapter (without it the
+               default validator soft-passes per Spec 010)")
+          (is (.contains events-text ":rf.http/managed")
+              "events.cljs ships the commented HTTP failure-matrix
+               exemplar so users see the canonical call shape")
+          (is (.contains events-text ":rf.http/http-5xx")
+              "events.cljs's HTTP exemplar uses the closed
+               :rf.http/* category set in :retry :on")
+          (is (.contains schema-text "reg-app-schema")
+              "schema.cljs registers a whole-app-db schema")
+          (is (.contains schema-text "CounterDb")
+              "schema.cljs ships the CounterDb Malli schema"))
+
+        ;; -- README best-practice + naming sections (rf2-48mij) --
+        (let [readme-text (slurp (io/file root "README.md"))]
+          (is (.contains readme-text "Best practices baked into the scaffold")
+              "README has a Best practices section")
+          (is (.contains readme-text "Errors are events too")
+              "README documents the errors-are-events-too posture")
+          (is (.contains readme-text "Typed app-db boundaries")
+              "README documents the typed-at-boundaries posture")
+          (is (.contains readme-text "closed failure-category set")
+              "README documents the closed :rf.http/* failure-category set")
+          (is (.contains readme-text "Naming conventions")
+              "README documents the naming-conventions rules")
+          (is (.contains readme-text "spec/Conventions.md")
+              "README links to spec/Conventions.md for the normative catalogue"))
 
         ;; -- package.json sanity --
         (let [pj-text (slurp (io/file root "package.json"))]


### PR DESCRIPTION
## Summary

Per Mike walkthrough 2026-05-13 (bead rf2-48mij), the deps-new template now ships the distinctive re-frame2 postures inline so generated apps inherit best-practice without ceremony.

- **Errors are events too.** `events.cljs` registers a default error sink via `re-frame.trace.tooling/register-trace-listener!` filtering on `:op-type :error`. Every error inside the dispatch pipeline (schema violation, handler exception, sub exception, fx exception, drain overflow) surfaces to the console — silent regressions impossible to miss. Users swap `js/console.error` for whatever their UI does (toast / error boundary / Sentry).
- **Typed app-db boundaries.** New `schema.cljs` registers a whole-app-db Malli schema (`[:map {:closed true} [:counter/value :int]]`) at the empty path per Spec 010. Closed-map catches typos at the boundary, not N renders downstream. `day8/re-frame2-schemas` added to every deps.edn variant so CLJS validation actually fires.
- **HTTP failure matrix.** `events.cljs` carries a commented-out `:rf.http/managed` handler showing the canonical call shape: closed `:retry :on` set drawn from the retryable subset of `:rf.http/*` failure categories (`:rf.http/transport`, `:rf.http/http-5xx`, `:rf.http/timeout`); single `:on-failure` branch switching on `(:kind (:failure reply))` to project each `:rf.http/*` category onto a UI message.
- **Naming conventions.** README's new "Best practices baked into the scaffold" section covers reserved framework namespaces (`:rf/*`, `:rf.<area>/*`), the `:domain/action` keyword shape, and the per-feature `:rf.<sub-area>/*` fx convention — with a pointer to `spec/Conventions.md` for the normative catalogue.

## Note on the bead's "error projector" terminology

The bead description says "error projector" but `reg-error-projector` (Spec 011 §SSR) is the **server-side response-shape projector** — it maps internal trace events to HTTP-response shapes for SSR. The bead's intent ("default projector surfaces errors visibly") is the **client-side** error pattern: `register-trace-listener!` filtering on `:op-type :error` per Spec 009. We use the spec-correct client-side surface and call out the SSR projector separately in the README so future audits don't trip over the terminology.

## Coordination with rf2-40vmd

This PR touches `tools/template/resources/day8/re_frame2_template/_shared/`, `_reagent/`, `_uix/`, `_helix/`, `root/README.md`, and the test suite — all content surfaces. rf2-40vmd is structural (delete clj-new tree + add publish setup) and shouldn't overlap at file level. Sequence whichever lands first; the second rebases.

## Test plan

- [x] `cd tools/template && clojure -M:test` — 38 tests, 579 assertions, 0 failures / errors
- [x] `mkdocs build --strict` from repo root — clean
- [ ] Manual smoke (post-merge): `clojure -Sdeps '{:deps {day8/re-frame2-template {:local/root "./tools/template"}}}' -Tnew create :template day8/re-frame2-template :name acme/my-app` produces an app with the error sink wired, schema registered, and HTTP exemplar inline
- [ ] Optional: `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 cd tools/template && clojure -M:test` (emitted-test-run smoke; opt-in by env)

Refs: rf2-48mij (this bead), rf2-c2770 (deps-new full body, parent), rf2-dolpf (deps-new rebuild epic).