### PR TITLE
spec(causa): shrink 008-Embedding-Contract to full-shell-only · remove unused Panel props (rf2-s45jq · resolves rf2-6yuos)

### DIFF
--- a/skills/re-frame2/references/tooling/causa.md
+++ b/skills/re-frame2/references/tooling/causa.md
@@ -9,7 +9,7 @@
 - Resizing the inline panel via the `--rf-causa-inline-width` CSS variable.
 - Suppressing the page-load auto-open on a tool-only canvas (Story-only build, internal dev page).
 - Reaching the pop-out from CLJS or a devtools console.
-- Choosing between inline / popout / declarative embedding (per Spec 008) / MCP-only access.
+- Choosing between inline / popout / full-shell embedding (per Spec 008) / MCP-only access.
 
 Do **not** load this leaf to learn what Causa is — load `tools/causa/README.md` for the panel inventory and Spec 011 for the full launch-mode treatment.
 
@@ -50,7 +50,7 @@ Most apps use **inline (default)**. Reach for the others only when the trigger f
 | Local development; want devtools in the app window | **Inline (default)** | Add the preload + the `[data-rf-causa-host]` host. Causa auto-mounts. |
 | Want a second monitor for Causa | **Inline + pop-out** | Inline mount as above, then `(causa/popout!)` from CLJS or `window.day8.re_frame2_causa.popout_BANG_()` from a devtools console. Same JS realm via `window.opener`. |
 | Tool-only page that can't reserve right-column real estate (Story-only canvas, internal config UI) | **Suppress auto-open** | `(causa-config/configure! {:rf.causa/auto-open? false})` before `rf/init!`. Causa stays installed; explicit `open!` still works and still warns on missing host. |
-| Want to embed a single Causa panel inside the app's own layout (e.g. an embedded epoch scrubber in a debug screen) | **Declarative embedding via Spec 008** | See `tools/causa/spec/008-Embedding-Contract.md` for the `Panel` component shape. Not for "I want the whole panel"; only for "I want one slice of Causa as an app component." |
+| Want to mount the full Causa shell inside another host (Story is the canonical example) | **Full-shell embed via Spec 008** | See `tools/causa/spec/008-Embedding-Contract.md` §Full-shell embed contract. The host surrenders the global chord (`:rf.causa/keybinding-enabled? false`) so its own keybindings reach their handlers. Single-panel embedding is NOT a v1.0 host-facing affordance. |
 | Want an AI agent to read / time-travel the running re-frame2 app programmatically | **re-frame2-pair-mcp** | Configure the `tools/re-frame2-pair-mcp/` server in the agent host (`re-frame2-pair-mcp`). Raw nREPL pair-programming companion. UI may or may not be open in the browser. |
 
 Cross-machine debugging and mobile launch are out of scope at v1.0 (see Spec 011 §Default summary, locks #5 and #9).
@@ -97,7 +97,7 @@ Set `(causa-config/configure! {:rf.causa/auto-open? false})` before `rf/init!` o
 
 - Story-only browser-test canvases (the page is a test harness; no human reads Causa).
 - Internal dev pages whose layout can't accommodate a right column.
-- Embed-via-Spec-008 pages where the app composes specific Causa panels into its own layout, not the whole shell.
+- Full-shell-embed pages (per Spec 008) where the host owns shell mount lifecycle — the host's own boot, not Causa's preload-auto-open, drives mount timing.
 
 Suppression only blocks the default page-load open. Explicit `open!`, `toggle!`, and the keybinding still work — and if no host exists when they fire, Causa still emits the missing-host diagnostic. App dev pages should leave auto-open at its `true` default and provide `[data-rf-causa-host]`.
 
@@ -120,5 +120,5 @@ Causa's shell wraps in `[rf/frame-provider {:frame :rf/causa} ...]`. Every `subs
 - `tools/causa/README.md` — panel inventory, headline experiences, file layout.
 - `tools/causa/spec/011-Launch-Modes.md` — normative launch-mode contract, full popout handling.
 - `tools/causa/spec/007-UX-IA.md` — five-region layout, keyboard map, density model.
-- `tools/causa/spec/008-Embedding-Contract.md` — the declarative `Panel` shape for embedding one panel inside the app.
+- `tools/causa/spec/008-Embedding-Contract.md` — the full-shell embed contract (Story mounts Causa with `:rf.causa/keybinding-enabled? false`).
 - `skills/re-frame-migration/references/causa-replaces-10x.md` — the 10x → Causa migration view, including the keybinding-parity caveat.

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -188,7 +188,7 @@ that the tool could be one-shotted from it.
 | [`spec/005-Schema-Timeline.md`](./spec/005-Schema-Timeline.md) | Per-schema timeline; recovery-mode colouring. |
 | [`spec/006-Hydration-Debugger.md`](./spec/006-Hydration-Debugger.md) | SSR render-tree diff; divergent-node surfacing. |
 | [`spec/007-UX-IA.md`](./spec/007-UX-IA.md) | Layout, interaction, visual language (typography, colour, motion). |
-| [`spec/008-Embedding-Contract.md`](./spec/008-Embedding-Contract.md) | Story-embed contract; the `Panel` component shape. |
+| [`spec/008-Embedding-Contract.md`](./spec/008-Embedding-Contract.md) | Full-shell embed contract (Causa-as-Story-RHS); state isolation via the `:rf/causa` frame-provider. |
 | [`spec/011-Launch-Modes.md`](./spec/011-Launch-Modes.md) | In-app true-inline host + standalone-via-MCP for remote-attach. |
 | [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles (read-only, observation-only, etc.). |
 | [`spec/API.md`](./spec/API.md) | User-facing surface (`init!`, panel mount, MCP tool list). |

--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -158,8 +158,8 @@ who want Causa's panel chrome get the chart transitively via Causa.
   Causa → machines-viz → implementation/ dependency arrow at the
   whole-tool level.
 - [`008-Embedding-Contract.md`](008-Embedding-Contract.md) — the
-  embed surface for the chart (depend on `tools/machines-viz/`
-  directly when you don't need the panel chrome).
+  full-shell embed contract. Hosts that want only the chart skip
+  Causa entirely and depend on `tools/machines-viz/` directly.
 
 ## Tab placement
 

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1554,8 +1554,9 @@ the placeholder Static sub-tabs (a separate decision).
 ### See also
 
 - [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — the
-  embedding contract for Story / first-party embeds (the `:compact?`
-  / `:scope` / `:on-event` props the panel views consume).
+  full-shell embedding contract for Story / first-party embeds (Story
+  mounts the full Causa shell with `:rf.causa/keybinding-enabled?
+  false`).
 - [`011-Launch-Modes.md`](./011-Launch-Modes.md) — the default
   in-app shell-mount path via `[data-rf-causa-host]`.
 - [`Conventions.md`](./Conventions.md) §Panel facade + leaf split —

--- a/tools/causa/spec/008-Embedding-Contract.md
+++ b/tools/causa/spec/008-Embedding-Contract.md
@@ -1,61 +1,28 @@
 # 008-Embedding-Contract
 
-Causa's default full-shell integration is an app-provided true-inline
-layout host (`[data-rf-causa-host]`) described in
-[`011-Launch-Modes.md`](./011-Launch-Modes.md). This file covers the
-separate embedded-panel contract.
+Causa's default integration is an app-provided true-inline layout host
+(`[data-rf-causa-host]`) described in
+[`011-Launch-Modes.md`](./011-Launch-Modes.md). This doc covers the
+**full-shell embed contract** — the canonical shape Story (per
+[`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) §RHS) uses to mount
+the entire 4-layer Causa shell as its right-hand-side observability
+surface.
 
-Causa is consumed by Story (per `spec/007-Stories.md` §6.7) as a
-per-variant observability ribbon. This doc specifies the contract:
-every Causa panel exports a React component (or hiccup-fn equivalent)
-that can be embedded outside Causa's own chrome.
+Single-panel embedding as a host-facing affordance is **not part of
+the v1.0 contract**. Hosts that want per-panel mount fns reach for
+the `day8.re-frame2-causa.panels/mount-<panel>!` surface enumerated in
+[`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract — that
+surface is internal-but-stable (the shell composes panels through it;
+tests mount panels through it) rather than a host-facing embed
+contract with its own props vocabulary.
 
-## The contract
+## Full-shell embed contract (Causa-as-Story-RHS)
 
-Every panel exposes a public `Panel` component that accepts a props
-map:
-
-```clojure
-{:frame    :story.auth/login         ;; which frame to observe
- :compact? true                      ;; reduced chrome — no sidebar, no header
- :height   320                       ;; in pixels (optional; default flex)
- :scope    {:dispatch-id-prefix ...} ;; optional filter to restrict the observation window
- :on-event #(...)}                   ;; optional callback when the panel emits an event (e.g. click-to-source)
-```
-
-### Props
-
-| Prop | Required | Default | Meaning |
-|---|---|---|---|
-| `:frame` | yes | n/a | The frame-id this panel observes. The panel does not switch frames; the host owns frame selection. |
-| `:compact?` | no | `false` | If true: no sidebar, no top strip, no bottom rail. The panel renders as a self-contained card. |
-| `:height` | no | `nil` (flex) | Fixed height in pixels. Useful for Story variants that want a uniform ribbon height. |
-| `:scope` | no | `nil` | A filter map narrowing what the panel observes. See §Scoping below. |
-| `:on-event` | no | `nil` | A callback `(fn [event-map])` invoked when the panel emits a host-meaningful event (source-coord click, re-dispatch request, etc.). |
-
-### Embedded posture
-
-When embedded (`:compact? true`), the panel:
-
-- Does **not** claim `Ctrl+Shift+C`.
-- Does **not** open its own pop-out window.
-- Does **not** show a "close" button.
-- Does **not** render the sidebar, top strip, or bottom rail.
-- **Does** render its own content area identically to the
-  non-embedded version.
-- **Does** respect the user's density / theme / keybinding preferences
-  (the same localStorage settings drive both modes).
-
-The panel **knows it's embedded** via the `:compact?` flag.
-
-### Full-shell embed contract (Causa-as-Story-RHS)
-
-When a host mounts the **full Causa shell** (not a single panel) as
-its right-hand-side observability surface — Story does this per
-[`spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) §RHS —
-the host MUST surrender Causa's global keybinding capture so its own
-shortcuts (typically `Cmd/Ctrl+K` for the host's command palette) are
-not swallowed by Causa's capture-phase listener:
+When a host mounts the **full Causa shell** as its right-hand-side
+observability surface, the host MUST surrender Causa's global
+keybinding capture so its own shortcuts (typically `Cmd/Ctrl+K` for
+the host's command palette) are not swallowed by Causa's capture-phase
+listener:
 
 ```clojure
 (causa-config/configure! {:rf.causa/keybinding-enabled? false})
@@ -91,158 +58,76 @@ posture stays on `js/document` and continues consuming keypresses.
 The full API contract for `detach!` is documented in
 [`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!`.
 
-## Scoping
+## Embed props inventory
 
-The `:scope` prop narrows the observation window:
+The full-shell embed exposes exactly two host-visible props:
 
-```clojure
-{:scope {:dispatch-id-prefix "story-variant-7c2-"  ;; observe only dispatches in this Story variant
-         :since-time         <ms>                  ;; observe only events newer than this
-         :only-origins       #{:app :story}        ;; filter by :origin axis
-         :include-children?  true}}                ;; if true, also observe child cascades
-```
+| Prop | Required | Default | Meaning |
+|---|---|---|---|
+| `:frame` | no | `:rf/causa` (Causa-internal default) | The frame the shell's frame-provider wraps. Hosts that need the embedded shell to read a non-default Causa-internal frame pass this through `mount-shell!`'s `opts`; in practice the default is what every shipped host uses. The shell's frame-picker UI is the canonical way to choose which *host* frame Causa observes — that selection lives in `:rf.causa/target-frame` inside `:rf/causa`'s db. |
+| `:height` | no | host-CSS owned | Causa does not read a height prop. The host's stylesheet sizes the mount-point container (typically via `--rf-causa-inline-width` for inline-host width and the host's flex / grid rules for height). Listed here because hosts often think of "height" as part of the embed contract; the contract is "the host owns it". |
 
-Scoping rules:
-
-- All scope keys are **optional**; absent means "no filter on this
-  axis."
-- Multiple scope keys are **AND-combined**.
-- Scope applies to the panel's data feed: an embedded event-detail
-  panel with `:dispatch-id-prefix "story-variant-..."` only shows
-  events whose `:dispatch-id` starts with that prefix.
-- Scope does **not** filter the trace bus itself — other Causa
-  instances and other consumers see all events. The framework's
-  emission is unchanged.
-
-### Why scoping exists
-
-Story renders multiple variants on one page. Each variant runs in
-its own frame and emits its own dispatches; the embedded ribbon for
-variant A must not show variant B's events. Scoping is the
-mechanism.
-
-## What ships embedded at v1.0
-
-| Panel | v1.0 embeddable? |
-|---|---|
-| **Event detail** | Yes (the primary embed target for Story). |
-| **App-db inspector** | Yes (compact-mode renders the slice-centric view only; no full-tree escape). |
-| **Issues ribbon** | Yes. |
-| **Performance ribbon** | Yes. |
-| Machine inspector | v1.0 — depends on `tools/machines-viz/` (its own tool jar; per rf2-o9arp / PR #1570). Causa re-exports the public chart API via thin shims so embedders that want the chart alone can depend on `tools/machines-viz/` directly without bringing in Causa's panel chrome. See also 003 §Architectural posture (H1) and 000 §Dependency arrows (H6). |
-| Subscription graph | v1.1. |
-| Schema timeline | v1.1. |
-| Hydration debugger | Not embeddable (the panel is contextual to a specific hydration; doesn't compose). |
-| Settings | Not embeddable. |
-
-The v1.0 embed set covers Story's needs (per `spec/007-Stories.md`
-§6.7 — Story embeds the **epoch panel** at v1.0). The wider v1.1
-embed set covers Story's planned ribbon expansions.
-
-## How Story wires it in
-
-Per `tools/story/` (when it lands):
-
-```clojure
-(ns day8.story.variants
-  (:require [re-frame.story :as story]
-            [day8.re-frame2-causa.panels.event-detail :as causa-event]))
-
-(story/reg-story-panel :story.auth/login
-  {:panels
-   [{:title  "Login form"
-     :render (fn [variant-data] [login-form variant-data])}
-    {:title  "Causa: events"
-     :render (fn [variant-data]
-               [causa-event/Panel
-                {:frame    (:frame variant-data)
-                 :compact? true
-                 :height   320
-                 :scope    {:dispatch-id-prefix (:scope-prefix variant-data)
-                            :include-children?  true}}])}]})
-```
-
-The host (Story) controls layout; Causa supplies the content.
-
-## Hook-style integration
-
-For React-only hosts that don't render Reagent, Causa exposes a
-plain-React surface:
-
-```javascript
-import {EventDetailPanel} from '@day8/re-frame2-causa/panels';
-
-function StoryVariant() {
-  return (
-    <EventDetailPanel
-      frame=":story.auth/login"
-      compact
-      height={320}
-      scope={{dispatchIdPrefix: 'story-variant-7c2-'}}
-    />
-  );
-}
-```
-
-The JS API kebab-cases / camelCases the props (`compact` for
-`:compact?`, `dispatchIdPrefix` for `:dispatch-id-prefix`).
-
-Internally the JS surface delegates to the same Reagent components;
-the JS wrapper is a thin adapter.
+Both props are honoured by the **frame-provider convention** (the
+`mount-<panel>!` surface from [`007-UX-IA.md`](./007-UX-IA.md)
+§Mountable panel contract: every mount fn opens with
+`[rf/frame-provider {:frame ...} ...]` and renders into the
+host-supplied mount-point — Causa never sizes its own container). No
+other host-facing props exist.
 
 ## What the host owns
 
-When embedded, the host (Story) owns:
+When Causa is embedded full-shell, the host (Story) owns:
 
-- **Frame selection.** The `:frame` prop is fixed by the host; Causa
-  never re-binds it from inside the embedded panel.
-- **Layout.** Where the embed goes on the page, its surrounding
+- **Layout.** Where the Causa shell goes on the page, its surrounding
   chrome, its size.
-- **Lifecycle.** Mount / unmount on variant change. Causa's panels
-  are pure with respect to their props; they tear down cleanly on
-  unmount.
-- **Event routing.** The host's `:on-event` callback decides what
-  to do with embed-emitted events (open a side panel, log,
-  ignore).
+- **Lifecycle.** Mount / unmount of the shell. Causa's mount fn
+  returns an unmount fn so the host owns teardown.
+- **Frame selection.** The host selects which host frame Causa
+  observes via Causa's own frame-picker UI; the host does not
+  re-bind the frame from outside.
+- **Keybinding capture.** Per the contract above, the host owns
+  global keystrokes; Causa's chord listener is detached.
 
 What Causa owns:
 
-- **The panel's content.** What's rendered inside the embed.
-- **Internal state** (selected slice, scroll position, expand/collapse
-  state) — local to the panel instance, not persisted.
-- **Live updates** from the trace bus / epoch history, scoped by the
-  `:scope` prop.
+- **Shell contents.** The 4-layer chrome and every panel inside it.
+- **Internal state** (selected tab, scrubber position, expand /
+  collapse state, filter settings) — local to the shell instance,
+  persisted via Causa's own localStorage slots.
+- **Live updates** from the trace bus / epoch history.
 
 ## State isolation (Option-C frame-provider)
 
-Causa's panels mount **inside the host's React tree** so embedding is
-zero-config — drop a `[Panel ...]` into Story / your own layout and it
-renders. But Causa's *state* must never bleed into the host's app-db,
-its subs, or its dispatch queue. That isolation is achieved by an
-internal frame-provider wrapper; see [`011-Launch-Modes.md`](./011-Launch-Modes.md)
-for the in-app overlay context and [`007-UX-IA.md`](./007-UX-IA.md)
-for shell layout. The mechanism, locked under rf2-tijr (2026-05-12):
+Causa's shell mounts **inside the host's React tree** so embedding is
+zero-config — drop a `mount-shell!` call into Story / your own layout
+and it renders. But Causa's *state* must never bleed into the host's
+app-db, its subs, or its dispatch queue. That isolation is achieved
+by an internal frame-provider wrapper; see
+[`011-Launch-Modes.md`](./011-Launch-Modes.md) for the in-app overlay
+context and [`007-UX-IA.md`](./007-UX-IA.md) for shell layout. The
+mechanism, locked under rf2-tijr (2026-05-12):
 
-### Frame-provider wraps every panel
+### Frame-provider wraps the shell
 
-Each public `Panel` component opens with an internal
-`[rf/frame-provider {:frame :rf/causa} ...]`. Descendant subscriptions
-and dispatches re-anchor to the `:rf/causa` frame, *not* the host's
-`:rf/default` (or whatever frame the host's tree is providing).
-Consequences:
+Every Causa mount fn (the master `mount-shell!` and every per-panel
+`mount-<panel>!` per [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel
+contract) opens with an internal `[rf/frame-provider {:frame
+:rf/causa} ...]`. Descendant subscriptions and dispatches re-anchor
+to the `:rf/causa` frame, *not* the host's `:rf/default` (or whatever
+frame the host's tree is providing). Consequences:
 
 - **App-db isolated.** `:rf.causa/buffer-cleared` writes touch
   `:rf/causa`'s db; the host app-db is untouched.
 - **Subs isolated.** A panel sub like `:rf.causa/trace-buffer` reads
   `:rf/causa`'s db.
-- **Dispatches isolated.** Events fired from inside the panel run on
+- **Dispatches isolated.** Events fired from inside the shell run on
   `:rf/causa`'s event queue and interceptor chain.
 - **Machines isolated.** Causa's machines live in `:rf/causa` and
   don't share state with host machines.
 
 Host code never sees `:rf/causa`; the wrapper is an implementation
-detail of `Panel`. Story (and any other host) embeds Causa with no
-awareness of the frame split.
+detail of the mount-fn surface. Story (and any other host) embeds
+Causa with no awareness of the frame split.
 
 ### Registry-key isolation via `:rf.causa/*` prefix
 
@@ -270,16 +155,20 @@ that needs it, not in a central shim layer.
 
 ## What this doesn't do
 
+- **No host-facing per-panel props vocabulary.** Hosts mount the full
+  shell; the shell composes panels internally. The
+  `mount-<panel>!` aggregator surface is documented at
+  [`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract for
+  internal use (shell composition, tests, future tools); it carries
+  one `opts` key — `:frame` — and is not a host-facing embed contract.
 - **No two-way binding.** The host doesn't push state into Causa
-  beyond the props; Causa doesn't push state back beyond
-  `:on-event` callbacks.
-- **No cross-embed coordination.** Two embedded panels on the same
-  page do not share state. Each panel reads the trace bus
-  independently. (The trace bus emits once; multiple subscribers see
-  the same event — the per-panel scope filters happen client-side.)
-- **No standalone styling overrides.** Embedded panels use Causa's
-  theme tokens. The host can wrap them in a container that overrides
-  CSS variables but cannot patch panel internals.
+  beyond the configure! slots; Causa doesn't push state back to the
+  host.
+- **No standalone styling overrides.** The embedded shell uses
+  Causa's theme tokens. The host can wrap the shell in a container
+  that overrides CSS variables (`--rf-causa-font-size`,
+  `--rf-causa-accent`, `--rf-causa-inline-width`, …) but cannot
+  patch shell internals.
 - **No security boundary.** Causa runs in the host page's JS realm.
   If the host is untrusted, do not embed Causa.
 
@@ -289,13 +178,14 @@ v1.0 is **first-party panels only.** No plugin API, no panel registry.
 Third-party-extensible panels are a v2.0 design discussion.
 
 The current contract leaves room: every panel is already a
-self-contained component with a props-only interface. A future
-plugin registry would `:require` a third-party namespace and register
-it under a new sidebar entry with the same `Panel` shape.
+self-contained component with a `Panel` reg-view + `install!` shape
+(per [`Conventions.md`](./Conventions.md) §Panel facade + leaf split).
+A future plugin registry would `:require` a third-party namespace and
+register it under a new sidebar entry with the same `Panel` shape.
 
-No commitment is made about the third-party plugin surface
-shape — the embedding contract above is for the **canonical
-first-party panels**, not for any future third-party kind.
+No commitment is made about the third-party plugin surface shape —
+the embedding contract above is for the **canonical first-party
+shell**, not for any future third-party kind.
 
 ## Vision — Story ↔ Causa preset round-tripping
 
@@ -303,8 +193,8 @@ first-party panels**, not for any future third-party kind.
 debugging posture (filters set, tab selected, pinned epoch); when
 someone else opens that story, they should land in the same posture."
 
-The Story embedding contract (above) covers the **structural** props
-the host passes to a panel. The next-step affordance is **deep preset
+The full-shell embed contract above covers the **structural** wiring
+Story uses to mount Causa. The next-step affordance is **deep preset
 round-tripping**: when a Story variant declares `{:causa/preset {…}}`,
 Causa restores **the full visible state** on mount:
 

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -297,8 +297,8 @@ Remove the `:preloads` entry, or:
 Per `rf2-sbfb7` the body-padding dock surface (`dock!` / `undock!`) and
 the imperative inline-panel surface (`mount-inline-panel!` /
 `unmount-inline-panel!`) were removed. The true-inline default and the
-`popout!` window cover the dock use case; declarative panel embedding
-is the surface enumerated in
+`popout!` window cover the dock use case; full-shell embedding (e.g.
+Causa-as-Story-RHS) is enumerated in
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md).
 
 ### Closed state
@@ -477,9 +477,10 @@ singletons, not just the in-app shell:
 
 (The third pre-existing singleton — `inline-mounts` for the
 imperative `mount-inline-panel!` debug API — went away under
-`rf2-sbfb7` together with the debug API itself; declarative panel
-embedding under [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
-replaces it and does not touch the mount singleton surface.)
+`rf2-sbfb7` together with the debug API itself; full-shell embedding
+under [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)
+covers the remaining host use cases and does not touch the mount
+singleton surface.)
 
 **Popout external-close cleanup.** Per `rf2-yudol` `popout!` MUST
 register `pagehide` / `unload` listeners on the popout window so

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -233,9 +233,8 @@ facade:
 
 ### Panel reg-views
 
-Each panel namespace exports a single public `Panel` component for
-embedding (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)).
-The canonical symbol list:
+Each panel namespace exports a single public `Panel` component. The
+canonical symbol list:
 
 ```clojure
 day8.re-frame2-causa.panels.event-detail/Panel
@@ -252,16 +251,14 @@ violation-timeline`, `hydration-debugger`, and `mcp-server`. The
 4-layer shell switches over the 6 L3 tab ids in `spec/018-Event-
 Spine.md` §5 — these six are the surviving `Panel` exports.)
 
-Each accepts the props map specified in
-[`008-Embedding-Contract.md`](./008-Embedding-Contract.md):
-
-```clojure
-{:frame    :app/main          ;; frame to observe (required)
- :compact? false              ;; reduced chrome (optional)
- :height   nil                ;; pixels (optional)
- :scope    {...}              ;; filter (optional)
- :on-event #(...)}            ;; emit-event callback (optional)
-```
+These `Panel` components are the leaves the shell composes — they
+are NOT a host-facing single-panel embed surface. Hosts that want to
+mount Causa embed the **full shell** per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Full-shell
+embed contract. The `mount-<panel>!` aggregator surface enumerated in
+[`007-UX-IA.md`](./007-UX-IA.md) §Mountable panel contract is
+internal-but-stable (used by shell composition and tests); it accepts
+one `opts` key — `:frame` — defaulting to `:rf/causa`.
 
 ## Public JS API
 
@@ -269,7 +266,6 @@ For React-only hosts (a JS Story consumer, a non-Reagent app):
 
 ```javascript
 import {init, open, close, toggle, popout} from '@day8/re-frame2-causa';
-import {EventDetailPanel, /* ... */} from '@day8/re-frame2-causa/panels';
 
 init({defaultFrame: ':app/main', theme: 'dark', density: 'cosy'});
 
@@ -277,19 +273,14 @@ open();
 close();
 toggle();
 popout();
-
-// Embedded panel
-<EventDetailPanel
-  frame=":app/main"
-  compact
-  height={320}
-  scope={{dispatchIdPrefix: 'story-variant-7c2-', includeChildren: true}}
-  onEvent={(evt) => console.log(evt)}
-/>
 ```
 
-The JS surface is a thin adapter over the Reagent components; props
-camelCase what the Reagent surface kebab-cases.
+The JS surface is a thin adapter over the canonical CLJS facade
+(§Canonical: `day8.re-frame2-causa.core`); props camelCase what the
+CLJS surface kebab-cases. There is no host-facing single-panel embed
+surface — full-shell embedding via
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md) is the
+canonical shape.
 
 ## Trace / epoch surfaces (consumed, not exposed)
 
@@ -747,11 +738,11 @@ major bumps with it.
   `rf2-sbfb7` (Mike's pre-alpha decision "A — delete both"); the
   true-inline default and `popout!` cover the dock use case.
 - **No imperative `mount-inline-panel!` / `unmount-inline-panel!`.**
-  Removed per `rf2-sbfb7`; declarative panel embedding lives at
+  Removed per `rf2-sbfb7`; full-shell embedding lives at
   [`008-Embedding-Contract.md`](./008-Embedding-Contract.md).
 
 ## Resolved decisions
 
 | Decision | Bead | Outcome |
 |---|---|---|
-| Keep or delete `dock!` / `undock!` / `mount-inline-panel!` / `unmount-inline-panel!` debug surfaces | `rf2-sbfb7` | "A — delete both" (Mike, 2026-05-17). Pre-alpha posture: no back-compat shims; the true-inline default + `popout!` cover the dock use case, declarative `Panel` (008-Embedding-Contract) covers the embedded-panel use case. |
+| Keep or delete `dock!` / `undock!` / `mount-inline-panel!` / `unmount-inline-panel!` debug surfaces | `rf2-sbfb7` | "A — delete both" (Mike, 2026-05-17). Pre-alpha posture: no back-compat shims; the true-inline default + `popout!` cover the dock use case, full-shell embedding (008-Embedding-Contract) covers Causa-as-Story-RHS. |

--- a/tools/causa/spec/README.md
+++ b/tools/causa/spec/README.md
@@ -56,9 +56,10 @@ main read**.
 - **[007-UX-IA.md](007-UX-IA.md)** — Typography, colour tokens, animation
   timings, keyboard maps, density gradients — the pixels-that-feel-right
   reference.
-- **[008-Embedding-Contract.md](008-Embedding-Contract.md)** — Per-panel
-  `Panel` component contract so Story (and others) can embed Causa
-  surfaces outside Causa's own chrome.
+- **[008-Embedding-Contract.md](008-Embedding-Contract.md)** — Full-shell
+  embed contract so Story (and others) can mount the entire Causa
+  shell as a right-hand-side observability surface; state isolation
+  via the `:rf/causa` frame-provider.
 - **[011-Launch-Modes.md](011-Launch-Modes.md)** — In-app true-inline
   host and standalone-via-MCP remote-attach.
 - **[012-Views.md](012-Views.md)** — Views tab: three-group layout

--- a/tools/causa/testbeds/feature_matrix/README.md
+++ b/tools/causa/testbeds/feature_matrix/README.md
@@ -36,7 +36,7 @@ re-check. It now exercises the follow-up surfaces directly:
   (laid out to the left of Causa) clickable and that `popout!` renders a same-origin second-window
   Causa shell sharing the opener's runtime. (Per `rf2-sbfb7`, the dock /
   docked-overlay and `mount-inline-panel!` debug surfaces were removed;
-  declarative embedding lands under 008-Embedding-Contract.)
+  full-shell embedding lands under 008-Embedding-Contract.)
 - Schema recovery: the schema testbed loads the Malli adapter so browser runs
   assert rollback, skipped handlers, skipped fx, and the Causa schema panel's
   current row/empty-state projection.


### PR DESCRIPTION
## Summary

- Rewrites `tools/causa/spec/008-Embedding-Contract.md` as **full-shell-only**: keeps the canonical §Full-shell embed contract (Causa-as-Story-RHS), state isolation via the `:rf/causa` frame-provider, `:rf.causa/*` registry-key isolation, and adapter resolution. Removes the single-panel-embed contract, the Panel props table where `:scope` / `:compact?` / `:on-event` appeared, §Embedded posture, §Scoping, §What ships embedded at v1.0, §How Story wires it in, and §Hook-style integration.
- Documents `:frame` + `:height` as the only host-visible props (honoured by the frame-provider convention).
- Updates cross-references in `007-UX-IA.md`, `API.md`, `003-Machine-Inspector.md`, `011-Launch-Modes.md`, `tools/causa/README.md`, `tools/causa/spec/README.md`, `tools/causa/testbeds/feature_matrix/README.md`, and `skills/re-frame2/references/tooling/causa.md`. Removes the now-incorrect "embedded panel" Panel-props code-block from API.md (CLJS Panel reg-views + JS API sections).
- Resolves the spec/impl drift recorded by audit Finding #6 (rf2-6j2lr) and the decision in rf2-6yuos (decided 2026-05-20: shrink the contract — pre-alpha posture, no aspirational specs with zero consumers).
- No `tools/causa/src/` changes — the props weren't wired anyway; nothing to migrate or remove.

## Test plan

- [x] `mkdocs build --strict` from repo root — clean (no warnings, no broken links introduced by this PR)
- [x] `:scope` / `:compact?` / `:on-event` no longer appear as Panel props anywhere in `tools/causa/spec/`, `skills/`, or `docs/` (findings/ historical drafts left as-is by design — they are research-anchor docs, not normative spec, and aren't in mkdocs nav)
- [x] `:frame` + `:height` documented as the only Panel props in the new §Embed props inventory
- [x] §Full-shell embed contract retained verbatim (Story mounts the full Causa shell with `:rf.causa/keybinding-enabled? false`; `detach!` lifecycle for after-preload mounts)