### PR TITLE
docs(pair-mcp): cross-reference wire-pipeline + snapshot-pipeline split rationale (rf2-4dwpb)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot_pipeline.cljs
@@ -1,5 +1,6 @@
 (ns re-frame2-pair-mcp.tools.snapshot-pipeline
-  "Post-eval snapshot transforms.
+  "Post-eval snapshot transforms — specialised dispatchee for
+  `:kind :snapshot-map`.
 
   Three concerns are sequenced here:
 
@@ -24,7 +25,29 @@
        a bounded subtree). An empty path `[]` means \"explicit full\".
 
   `:app-db` is summarised inside `slice-app-db-in-snapshot`;
-  `summarise-other-slices-in-snapshot` skips it to avoid double-work."
+  `summarise-other-slices-in-snapshot` skips it to avoid double-work.
+
+  ## Role: specialised dispatchee (called from the orchestrator)
+
+  This ns is the `:kind :snapshot-map` arm of the wire pipeline. It
+  is NOT a top-level entry point; readers arriving via a wire
+  payload land first in `re-frame2-pair-mcp.tools.wire-pipeline`
+  (the general orchestrator that dispatches on `:kind`), which
+  delegates here for snapshot-map payloads.
+
+  ## Cross-file split (deliberate factoring)
+
+  Path-slicing + slice-mode resolution are markedly more elaborate
+  than other payload kinds need — `:epoch-vector` and
+  `:scalar-value` never touch app-db slices and never resolve a
+  mode. Hoisting that machinery into a dedicated namespace keeps
+  the orchestrator's cross-kind invariants (ordering, indicator
+  shape, envelope contract) uncluttered by concerns only one kind
+  cares about.
+
+  This is a deliberate factoring choice, not accidental drift:
+  see `re-frame2-pair-mcp.tools.wire-pipeline` for the orchestrator
+  + the other payload kinds (`:epoch-vector`, `:scalar-value`)."
   (:require [re-frame2-pair-mcp.tools.dedup :as dedup]
             [re-frame2-pair-mcp.tools.summary :as summary]))
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -76,7 +76,34 @@
   Tools call this once and splice the result through
   `wire/with-indicators` onto their envelope — the per-tool tail
   collapses from a 20-line `let` of intermediate names to a 5-line
-  pipeline call + envelope assembly."
+  pipeline call + envelope assembly.
+
+  ## Role: orchestrator (first stop on the wire)
+
+  This ns is the FIRST stop for any payload heading to or from the
+  nREPL bridge. It is a general orchestrator: it dispatches on
+  `:kind` and delegates the per-kind transforms. The orchestrator
+  itself owns only the cross-kind invariants (ordering, indicator
+  shape, envelope contract); per-kind elaboration lives elsewhere.
+
+  ## Cross-file split (deliberate factoring)
+
+  The `:snapshot-map` arm is intentionally factored out into
+  `re-frame2-pair-mcp.tools.snapshot-pipeline`. Path-slicing and
+  slice-mode resolution (per-slice `:modes` override · global
+  `:mode` arg · the `:path`-forces-`:path-sliced` rule for
+  `:app-db`) are markedly more elaborate than the other kinds
+  need — `:epoch-vector` and `:scalar-value` never touch app-db
+  slices and never resolve a mode. Inlining the snapshot-specific
+  machinery here would dwarf the orchestrator with concerns only
+  one kind cares about.
+
+  This is a deliberate factoring choice, not accidental drift:
+  see `re-frame2-pair-mcp.tools.snapshot-pipeline` for the
+  `:snapshot-map` specialisation (path-slicing + slice-mode
+  resolution). Readers tracing a `:kind :snapshot-map` payload
+  land here first (orchestrator + ordering invariant) and then
+  jump to `snapshot-pipeline` for the slice-level transforms."
   (:require [re-frame.mcp-base.elision :as base-elision]
             [re-frame2-pair-mcp.config :as config]
             [re-frame2-pair-mcp.tools.dedup :as dedup]


### PR DESCRIPTION
Closes rf2-4dwpb. Per rf2-c3hpi decision: keep the split, document via mutually-referenced ns docstrings. wire-pipeline = orchestrator (dispatches on :kind); snapshot-pipeline = specialised dispatchee for :kind :snapshot-map. Reader following :kind :snapshot-map sees the rationale at the first stop.