### PR TITLE
docs(template): rf2-dolpf §4 — docs sweep + repo-split migration scaffolding (rf2-7jgkv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ tools/                         CLJS dev/inspection tools that consume re-frame2'
                                it — bundle-isolated from production builds.
   template/                    day8/re-frame2-template — deps-new template for new re-frame2
                                apps; the v1 re-frame-template's v2 successor. Build-time scaffold.
+                               Permanent home: github.com/day8/re-frame2-template (lives here while
+                               the rebuild settles; see tools/template/spec/005-Repo-Split.md).
   story/                       day8/re-frame2-story — Storybook-flavoured playground
   story-mcp/                   day8/re-frame2-story-mcp — MCP agent surface for story
   re-frame2-pair-mcp/                   day8/re-frame2-re-frame2-pair-mcp — MCP agent surface for the re-frame2-pair

--- a/migration/from-clj-new-template/README.md
+++ b/migration/from-clj-new-template/README.md
@@ -1,0 +1,189 @@
+# Migration — clj-new template → deps-new template
+
+> **Type:** Migration
+> A user-facing migration note for developers who scaffolded a
+> previous-generation re-frame2 app via the retired
+> `clojure -X:project/new :template re-frame2` invocation
+> (`day8/clj-template.re-frame2` on Clojars). The current template
+> is `day8/re-frame2-template` — a deps-new template distributed as
+> a git-coord on
+> [`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
+
+## TL;DR
+
+| Phase | Invocation |
+|---|---|
+| **Old** (clj-new + Clojars; retired at rf2-dolpf §2.5 on 2026-05-20) | `clojure -X:project/new :template re-frame2 :name acme/my-app` |
+| **New** (deps-new + git-coord) | `clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app` |
+
+No action is required on **existing** scaffolded apps — the
+template's role ends at emit time, so the source tree it generated
+for you has no compile-time or runtime knowledge of the template
+artefact. Apps scaffolded under the clj-new template continue to
+build and run unchanged.
+
+This doc is for the next time you reach for the template — to
+scaffold a new app, or to remind yourself what shape the template
+emits. The invocation surface changed.
+
+## What changed
+
+### The template framework
+
+[**clj-new**](https://github.com/seancorfield/clj-new) →
+[**deps-new**](https://github.com/seancorfield/deps-new). Both
+maintained by sean-corfield; deps-new is the current-generation
+Clojure scaffolder. The template's programmatic body
+(`data-fn` / `template-fn` / `post-process-fn`) replaces the
+clj-new-era Mustache-only substitution shape.
+
+### The distribution channel
+
+**Clojars → git-coord.** The published artefact is no longer
+`day8/clj-template.re-frame2` on Clojars; it is a tagged commit on
+[`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
+`clojure -Tnew create` resolves the template via deps-new's
+git-coord lookup (`io.github.*` triggers an auto-git-clone of the
+named GitHub repo).
+
+The old Clojars artefact (`day8/clj-template.re-frame2`) is frozen
+at its last clj-new release. Older versions remain resolvable for
+legacy users — we just stop pushing new versions. New work uses the
+git-coord shape.
+
+### The invocation form
+
+The substrate selector + the feature flags move from `:edn-args` to
+top-level k/v pairs:
+
+```bash
+# OLD — clj-new + :edn-args
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix :include-story? true]'
+
+# NEW — deps-new + top-level k/v
+clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app \
+        :substrate :uix \
+        :include-story? true
+```
+
+deps-new takes top-level args directly. The clj-new-era
+`:edn-args` pass-through bag was a clj-new harness constraint
+(`create` stripped unknown top-level args before invoking the
+template); deps-new has no analogous behaviour, so the indirection
+retires.
+
+## The locked-three-flags rule
+
+Under the v1-era clj-new template the supported flag set was
+`:substrate` plus the gated `:include-story?` exception. Under the
+deps-new rebuild, the **locked v1 set is exactly three flags**:
+
+| Flag | Type | Default | Meaning |
+|---|---|---|---|
+| `:include-story?` | boolean | `false` | When `true`, scaffolds the Story playground alongside the live app (Reagent only in v1). |
+| `:css` | keyword (`:plain` / `:tailwind`) | `:plain` | When `:tailwind`, scaffolds Tailwind v4 in place of the default plain-CSS `app.css`. Gated on rf2-gthro. |
+| `:include-ssr?` | boolean | `false` | When `true`, scaffolds the SSR build (Spec 011). Gated on rf2-0m5ea. |
+
+Plus the substrate selector:
+
+| Arg | Values | Default |
+|---|---|---|
+| `:substrate` | `:reagent` / `:uix` / `:helix` | `:reagent` |
+
+No other branching flags ship in v1. Every new flag requires
+explicit DESIGN-RATIONALE justification (see
+[tools/template/spec/DESIGN-RATIONALE.md](../../tools/template/spec/DESIGN-RATIONALE.md)).
+
+## Per-flag delta (clj-new → deps-new)
+
+For each flag, the move from `:edn-args '[...]'` to top-level k/v:
+
+```bash
+# Substrate
+# OLD
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix]'
+# NEW
+clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app \
+        :substrate :uix
+
+# Include Story
+# OLD
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:include-story? true]'
+# NEW
+clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app \
+        :include-story? true
+
+# Combined
+# OLD
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:substrate :uix :include-story? true]'
+# NEW
+clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app \
+        :substrate :uix \
+        :include-story? true
+```
+
+## What didn't change
+
+- **The substrate set.** Reagent (default) / UIx / Helix. Adding a
+  new substrate is still the same shape: drop a sub-tree under
+  `_<substrate>/`, add a `case` clause in `template-fn`, ship the
+  per-substrate test.
+- **The substrate-agnostic shell.** `events.cljs`, `subs.cljs`,
+  host HTML, `.gitignore`, `dev/` tree, `.editorconfig`,
+  `lefthook.yml` — emitted identically across all three
+  substrates.
+- **The counter throughline.** Every variant emits a working
+  counter, mirroring [Guide chapter 03 — Your first
+  app](https://github.com/day8/re-frame2/blob/main/docs/guide/03-your-first-app.md)
+  and the canonical `examples/<substrate>/counter*/` apps.
+- **Pin lockstep.** `:rf2-version`, `:shadow-version`,
+  `:react-version` continue to track
+  `implementation/package.json` and the re-frame2 alpha release
+  cadence.
+
+## Tag-pinning
+
+deps-new's git-coord supports tag-pinning out of the box. To
+scaffold against a specific template release:
+
+```bash
+clojure -Tnew create :template io.github.day8/re-frame2-template#template-v0.0.1.alpha :name acme/my-app
+```
+
+(The `template-v…` prefix matches the template's tag-on-release CI;
+see [tools/template/spec/003-DepsNew-Rebuild-Plan.md §3.1](../../tools/template/spec/003-DepsNew-Rebuild-Plan.md).)
+
+Tag-pinning is the recommended shape for reproducible scaffolds —
+the team gets the same emitted tree every time, independent of any
+later template releases.
+
+## Get the `-Tnew` tool
+
+If you don't have deps-new's `-Tnew` tool installed globally:
+
+```bash
+clojure -Ttools install-latest :lib io.github.seancorfield/deps-new :as new
+```
+
+See [deps-new's README](https://github.com/seancorfield/deps-new#installation)
+for the full install reference.
+
+## Cross-references
+
+- [tools/template/spec/000-Vision.md](../../tools/template/spec/000-Vision.md)
+  — what the template is for; lineage from v1.
+- [tools/template/spec/API.md](../../tools/template/spec/API.md)
+  — the consolidated public invocation surface.
+- [tools/template/spec/003-DepsNew-Rebuild-Plan.md](../../tools/template/spec/003-DepsNew-Rebuild-Plan.md)
+  — the normative migration plan (rf2-dolpf).
+- [tools/template/spec/005-Repo-Split.md](../../tools/template/spec/005-Repo-Split.md)
+  — the monorepo → external repo migration procedure.
+- [tools/template/spec/DESIGN-RATIONALE.md](../../tools/template/spec/DESIGN-RATIONALE.md)
+  — WHY deps-new + git-coord over clj-new + Clojars.
+- [migration/from-re-frame-v1/README.md](../from-re-frame-v1/README.md)
+  — the framework-level migration note (re-frame v1.x → re-frame2);
+  separate concern from the template invocation surface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
     - "async-flow-fx → reg-machine": migration/from-re-frame-v1/async-flow-fx-to-reg-machine.md
     - "http-fx → managed HTTP": migration/from-re-frame-v1/http-fx-to-managed-http.md
     - "Observability logging sweep": migration/from-re-frame-v1/observability-logging-sweep.md
+    - "clj-new → deps-new template": migration/from-clj-new-template/README.md
 
 markdown_extensions:
   - meta

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,10 +32,10 @@ re-frame2 ships **seven** skills, grouped by the situation they cover:
   directory to a working `shadow-cljs watch` counter via the canonical
   seven-step path. Complementary to the generator template under
   [`tools/template/`](../tools/template/): use the template
-  (`clojure -X:project/new :template re-frame2 :name acme/my-app`) when
-  you want a one-shot scaffold; reach for this skill when you're adding
-  re-frame2 to an existing CLJS project, or when you want to understand
-  each step the template performs.
+  (`clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app`)
+  when you want a one-shot scaffold; reach for this skill when you're
+  adding re-frame2 to an existing CLJS project, or when you want to
+  understand each step the template performs.
 
 - **[`re-frame-migration/`](./re-frame-migration/)** — migrate an existing
   re-frame v1.x ClojureScript codebase to re-frame2. Drives the

--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -13,10 +13,13 @@ Once the counter mounts, the author switches to the main `re-frame2` skill (for 
 
 ## Relationship to the generator template
 
-re-frame2 also ships a one-command project generator under
-[`tools/template/`](../../tools/template/) (`clojure -X:project/new
-:template re-frame2 :name acme/my-app`). The two routes are complementary,
-not redundant:
+re-frame2 also ships a one-command project generator —
+`day8/re-frame2-template`, a [deps-new](https://github.com/seancorfield/deps-new)
+template living under [`tools/template/`](../../tools/template/) in
+the monorepo today (final home:
+[`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template)).
+Invoke as `clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app`.
+The two routes are complementary, not redundant:
 
 | Use the **template** when… | Use this **skill** when… |
 |---|---|

--- a/tools/shadow-cljs.edn
+++ b/tools/shadow-cljs.edn
@@ -36,12 +36,13 @@
 ;;
 ;; ## Why template is invisible here
 ;;
-;; `tools/template/` is JVM-only (clj-new template) — its `src/` tree
-;; contains placeholder-bearing `.cljs` template files that are NOT
-;; valid ClojureScript. The template dep is excluded from
-;; tools/deps.edn's base `:deps` map for that reason (see the comment
-;; block in tools/deps.edn). With `:deps true` active, shadow-cljs only
-;; sees what the base `:deps` map exposes, so the template's
+;; `tools/template/` is JVM-only (deps-new template) — its
+;; `resources/day8/re_frame2_template/` tree contains
+;; placeholder-bearing `.cljs` template files that are NOT valid
+;; ClojureScript. The template dep is excluded from tools/deps.edn's
+;; base `:deps` map for that reason (see the comment block in
+;; tools/deps.edn). With `:deps true` active, shadow-cljs only sees
+;; what the base `:deps` map exposes, so the template's
 ;; placeholder-bearing files never reach the shadow-cljs reader.
 {:deps true
 

--- a/tools/template/README.md
+++ b/tools/template/README.md
@@ -18,6 +18,16 @@
 > cuts a GitHub Release on every `template-v<VERSION>` tag push;
 > [`VERSION`](./VERSION) carries the template's own version sequence
 > (independent of the framework-wide repo-root `VERSION`).
+>
+> **Repo home:** the template's permanent home is
+> [`github.com/day8/re-frame2-template`](https://github.com/day8/re-frame2-template).
+> It lives under `tools/template/` in the re-frame2 monorepo while the
+> rebuild settles (rf2-dolpf §4); the split out to the external repo is
+> a Mike-operator handoff. The deps-new coord shifts from
+> `day8/re-frame2-template` (current `:local/root` shape, monorepo) to
+> `io.github.day8/re-frame2-template` (git-coord, external repo) once
+> the split completes — see [`spec/005-Repo-Split.md`](./spec/005-Repo-Split.md)
+> for the migration procedure.
 
 This tool generates a fresh re-frame2 application skeleton. It is the
 front door for new users: one command and you have a working CLJS app
@@ -108,9 +118,11 @@ The normative contract lives under [`spec/`](./spec/):
 | [`spec/001-Substrate-Variants.md`](./spec/001-Substrate-Variants.md) | Reagent / UIx / Helix variants; the top-level k/v invocation form; substrate coercion. |
 | [`spec/002-Generated-Shape.md`](./spec/002-Generated-Shape.md) | The file tree emitted; the resource tree; substitution variables. |
 | [`spec/003-DepsNew-Rebuild-Plan.md`](./spec/003-DepsNew-Rebuild-Plan.md) | Migration plan from clj-new + Clojars to deps-new + git-coord (rf2-dolpf). |
+| [`spec/004-SSR-Validation-Report.md`](./spec/004-SSR-Validation-Report.md) | SSR reference-impl validation report (rf2-0m5ea); gates the `:include-ssr?` flag work. |
+| [`spec/005-Repo-Split.md`](./spec/005-Repo-Split.md) | Migration procedure for the monorepo → external repo split (rf2-dolpf §4 / rf2-7jgkv). |
 | [`spec/Principles.md`](./spec/Principles.md) | The design principles (build-time only, counter as canonical example, substrate-agnostic shell, top-level k/v selection). |
 | [`spec/API.md`](./spec/API.md) | The consolidated public invocation surface. |
-| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | WHY each major decision (deps-new vs clj-new vs CLI, top-level k/v plumbing, three substrates in v1, counter as example, no-Story-yet, pin lockstep). |
+| [`spec/DESIGN-RATIONALE.md`](./spec/DESIGN-RATIONALE.md) | WHY each major decision (deps-new + git-coord over clj-new + Clojars, top-level k/v plumbing, three substrates in v1, counter as example, no-Story-yet, pin lockstep). |
 
 ## Cross-references
 

--- a/tools/template/spec/003-DepsNew-Rebuild-Plan.md
+++ b/tools/template/spec/003-DepsNew-Rebuild-Plan.md
@@ -408,28 +408,44 @@ Goal: tag-based release replaces the Clojars publish pipeline.
 - ✓ `tools/template/spec/README.md` — index entries reflect the
   new shape.
 
-## §4 Stage 4 — Docs + migration for existing template users
+## §4 Stage 4 — Docs + migration for existing template users (rf2-7jgkv — IN-FLIGHT 2026-05-20)
 
-Goal: existing clj-new template users have a clean upgrade path.
+Goal: existing clj-new template users have a clean upgrade path;
+the template's permanent home moves to the dedicated
+`github.com/day8/re-frame2-template` repo.
 
-Suggested commit decomposition:
+Status: docs sweep landed at rf2-h0w5y §3.2 (#1724); migration note
++ repo-split scaffolding landed at rf2-7jgkv. The actual external
+repo creation + initial push is a Mike-operator handoff (see
+[005-Repo-Split.md](005-Repo-Split.md)).
 
-### §4.1 — Repo split: extract to `day8/re-frame2-template` (rf2 follow-on bead)
+### §4.1 — Skill / repo-root docs residue sweep (DONE 2026-05-20)
 
-- Move `tools/template/` to the dedicated `day8/re-frame2-template`
-  repo (git-history preserved via `git subtree split` or filter-repo).
-- Update `tools/README.md` to point at the external repo.
-- Update the top-level repo `README.md` "Project layout" section.
-- All cross-references in the wider re-frame2 spec
-  (`docs/guide/03-your-first-app.md`, top-level README, blog-post-ish
-  copy under `docs/`) sweep through.
+The rf2-h0w5y §3.2 sweep covered the template's own spec/ tree +
+`tools/template/README.md`. The residue swept under rf2-7jgkv:
 
-### §4.2 — Migration note for existing users (rf2 follow-on bead)
+- ✓ `tools/shadow-cljs.edn` — "JVM-only (clj-new template)" comment
+  flipped to "(deps-new template)" + path under
+  `resources/day8/re_frame2_template/`.
+- ✓ `skills/README.md` — re-frame2-setup index entry's template
+  invocation example flipped to `clojure -Tnew create
+  :template io.github.day8/re-frame2-template`.
+- ✓ `skills/re-frame2-setup/README.md` — Relationship-to-the-
+  generator-template section rewritten against the deps-new shape;
+  external-repo home called out.
+- ✓ Repo-root `README.md` — Project Layout entry annotated with
+  the eventual external repo home + cross-ref to 005-Repo-Split.md.
+- ✓ `tools/template/README.md` — Spec table entry corrected
+  ("deps-new vs clj-new vs CLI" → "deps-new + git-coord over
+  clj-new + Clojars"); added entries for the new 004 + 005 specs;
+  repo-home callout block added.
+- ✓ `tools/template/spec/README.md` — index entries added for
+  004 + 005.
 
-- Add `migration/from-clj-new-template/README.md` (or wherever the
-  existing migration tree lives — `migration/from-re-frame-v1/`
-  is the precedent).
-- One-liner change for the user:
+### §4.2 — Migration note for existing users (DONE 2026-05-20)
+
+- ✓ Added [`migration/from-clj-new-template/README.md`](../../../migration/from-clj-new-template/README.md).
+  One-liner change for the user:
   ```
   # OLD
   clojure -X:project/new :template re-frame2 :name acme/my-app
@@ -437,7 +453,38 @@ Suggested commit decomposition:
   # NEW
   clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app
   ```
-- Surface the locked-three-flags rule + the v1 flag set.
+- ✓ Surfaces the locked-three-flags rule + the v1 flag set
+  (`:include-story?`, `:css`, `:include-ssr?`).
+- ✓ Lists the per-flag deltas (each `:edn-args '[...]'` flag now
+  rides as a top-level k/v pair).
+- ✓ Added the migration note to `mkdocs.yml`'s Migration nav.
+
+### §4.3 — Repo split (SCAFFOLDING DONE 2026-05-20; operator-handoff pending)
+
+- ✓ [`tools/template/spec/005-Repo-Split.md`](005-Repo-Split.md)
+  documents the full migration procedure (what to copy out, how to
+  retarget the deps-new coord, the cutover sequence). Numbered 005
+  because 004 is taken by the SSR Validation Report (rf2-0m5ea).
+- ✓ `tools/template/README.md` flags the future external location
+  prominently; cross-refs to 005-Repo-Split.md.
+- ⚠ **Operator action required** (Mike-side):
+  - Create `github.com/day8/re-frame2-template` repo.
+  - Run `git subtree split` from this monorepo to seed the
+    external repo's history.
+  - Push initial commits + first release tag.
+  - Move `.github/workflows/template-release.yml` to the
+    external repo (the workflow lives in the external repo
+    post-split; it's the template's own CI surface).
+  - Update the in-monorepo `tools/template/` to a "see external
+    repo" stub (or delete; the deps-new coord
+    `io.github.day8/re-frame2-template` resolves against the
+    external repo from that point on).
+  - File a follow-on bead to retire the in-monorepo
+    `tools/template/` resource tree once the external repo's CI
+    is green and at least one release tag exists.
+
+Once §4.3's operator handoff completes, the EPIC bead rf2-dolpf can
+be closed.
 
 ## §5 Cross-references to locked v1 emit spec
 

--- a/tools/template/spec/005-Repo-Split.md
+++ b/tools/template/spec/005-Repo-Split.md
@@ -1,0 +1,301 @@
+# Template — Repo Split (Monorepo → External Repo)
+
+> **Normative procedure for moving `tools/template/` out of the
+> re-frame2 monorepo to its permanent home at
+> `github.com/day8/re-frame2-template`** (rf2-dolpf §4 / rf2-7jgkv).
+>
+> Scope: this doc owns the migration sequence + the deps-new coord
+> retarget. The steady-state spec of the template lives in 000 / 001
+> / 002 / API / Principles / DESIGN-RATIONALE; this doc retires once
+> the external repo is live and the in-monorepo `tools/template/` is
+> stubbed or deleted.
+
+## §1 Why split
+
+The template's published invocation surface is `clojure -Tnew create
+:template io.github.day8/re-frame2-template`. The `io.github.*`
+prefix triggers deps-new's auto-git-clone path
+(`tools.deps.extensions.git`'s `auto-git-url`) — deps-new clones the
+named GitHub repo and resolves the template body inside the cloned
+tree. For that to work end-to-end, **the template body must live at
+the root of a standalone GitHub repo**, not nested under
+`tools/template/` in a monorepo. A monorepo-nested template can be
+exercised via `:local/root` for development, but cannot be the
+published production-invocation target — deps-new clones the named
+repo, not a subdirectory of it.
+
+Secondary benefits:
+
+- **Release cadence independence.** Template releases tag on the
+  template repo, not the monorepo. The two trees ship at their own
+  pace. The `tools/template/VERSION` file (added at rf2-h0w5y §3.1)
+  is already independent of the framework-wide repo-root `VERSION`,
+  in anticipation.
+- **Smaller clone footprint** for `clojure -Tnew` consumers — they
+  get the template's own commits, not the full re-frame2 monorepo
+  (which is heavy: 22 K-line spec, full implementation tree, multiple
+  tool surfaces, etc.).
+- **Cleaner CI surface.** The template repo owns its
+  `template-release.yml` workflow + tag-on-release pipeline
+  (rf2-h0w5y §3.1); the monorepo's CI doesn't need to know about
+  template publishes post-split.
+
+## §2 What lives where after the split
+
+```
+github.com/day8/re-frame2-template/        ; external repo (NEW)
+├── README.md                              ; invocation + quick start (copy of tools/template/README.md)
+├── deps.edn                               ; the template's own deps (test-time only)
+├── VERSION                                ; the template's own version (e.g. 0.0.1.alpha)
+├── template.edn                           ; deps-new declarative config (placeholder)
+├── src/day8/re_frame2_template/
+│   └── hooks.clj                          ; :data-fn / :template-fn / :post-process-fn
+├── resources/day8/re_frame2_template/
+│   ├── template.edn                       ; the in-tree template config (resource-side)
+│   ├── root/                              ; bulk-copied content (README, lefthook, dev/, resources/public/)
+│   ├── _shared/                           ; renamed content (dotfiles, src/test sources)
+│   ├── _reagent/                          ; Reagent-specific
+│   ├── _uix/                              ; UIx-specific
+│   └── _helix/                            ; Helix-specific
+├── spec/                                  ; the spec/ tree (000-Vision, 001-Substrate-Variants, ...)
+├── test/day8/re_frame2_template/
+│   ├── template_test.clj
+│   ├── template_emission_test.clj
+│   └── emitted_test_run_test.clj
+└── .github/workflows/
+    └── template-release.yml               ; tag-on-release CI (moved from re-frame2 monorepo)
+
+github.com/day8/re-frame2/                 ; monorepo (current)
+└── tools/template/                        ; STUB or DELETED after the split (see §6)
+```
+
+The on-disk path inside the external repo is **identical** to the
+in-monorepo path under `tools/template/`. deps-new's `find-root`
+resolves `:template io.github.day8/re-frame2-template` against the
+cloned external repo's `resources/day8/re_frame2_template/`
+directory; the on-disk shape doesn't need to change.
+
+## §3 Migration sequence (operator-side)
+
+This is the **operator-handoff sequence**. The scaffolding (this
+doc, the migration note, the cross-ref sweep) landed under
+rf2-7jgkv; the steps below are Mike-side actions that complete the
+split.
+
+### §3.1 Seed the external repo
+
+Use `git subtree split` to extract `tools/template/`'s history from
+the monorepo into a new branch:
+
+```bash
+# In the re-frame2 monorepo
+cd /path/to/re-frame2
+git subtree split --prefix=tools/template -b template-split-export
+```
+
+This produces a `template-split-export` branch whose history is the
+subset of monorepo commits that touched `tools/template/`, rewritten
+to look like a standalone repo (`tools/template/` becomes the new
+repo root).
+
+Then create the external repo and push:
+
+```bash
+# Create the new repo on github.com/day8/re-frame2-template (empty)
+# via the GitHub web UI or gh repo create.
+
+# Push the extracted history
+git remote add template-repo git@github.com:day8/re-frame2-template.git
+git push template-repo template-split-export:main
+```
+
+### §3.2 Move the release workflow
+
+The template-release workflow (`.github/workflows/template-release.yml`,
+landed at rf2-h0w5y §3.1) currently lives in the re-frame2 monorepo.
+Move it to the external repo:
+
+```bash
+# In the external repo
+cp /path/to/re-frame2/.github/workflows/template-release.yml \
+   .github/workflows/template-release.yml
+git add .github/workflows/template-release.yml
+git commit -m "ci: tag-on-release workflow (moved from monorepo)"
+git push template-repo main
+```
+
+The workflow's checkout step + path references (`tools/template/...`)
+need adjusting against the external repo's root layout (the template
+now lives at the repo root, not under `tools/template/`). Concrete
+edits:
+
+- Drop the `tools/template/` prefix from path references:
+  `tools/template/VERSION` → `VERSION`,
+  `tools/template/test/` → `test/`, etc.
+- The `clojure -M:test` invocation runs from the repo root.
+- The `paths:` filter on the `push:` trigger drops the
+  `tools/template/**` prefix (every change in the external repo
+  touches the template).
+
+### §3.3 Pin the initial release tag
+
+The git-coord distribution (rf2-h0w5y §3.1) cuts a tag per release.
+The first tag on the external repo establishes the initial release
+that `clojure -Tnew create :template io.github.day8/re-frame2-template`
+can resolve:
+
+```bash
+# In the external repo (or via gh release create)
+cd /path/to/external-repo
+git tag template-v0.0.1.alpha
+git push template-repo template-v0.0.1.alpha
+```
+
+(The `template-v…` prefix matches the workflow's trigger filter; see
+rf2-h0w5y §3.1.)
+
+### §3.4 Verify the published invocation works
+
+From any directory (not inside either repo):
+
+```bash
+cd $(mktemp -d)
+clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app
+cd my-app
+cat deps.edn  # should reference re-frame2 alpha coords
+```
+
+If deps-new resolves the template via the git-coord and the
+generated tree matches the in-monorepo template's emit set, the
+external repo is live.
+
+### §3.5 Retire the in-monorepo `tools/template/`
+
+Once §3.4 is green, the in-monorepo `tools/template/` becomes
+redundant. Two options:
+
+**Option A — Stub.** Replace `tools/template/` with a one-file
+README pointing at the external repo. Cheap and discoverable for
+anyone who lands at the old path. Keep enough of the original
+README to redirect:
+
+```markdown
+# tools/template/ — moved
+
+The re-frame2 template moved to its own repo:
+**[github.com/day8/re-frame2-template](https://github.com/day8/re-frame2-template)**.
+
+Invocation:
+
+    clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app
+
+See the external repo for the full spec, source, and CI.
+```
+
+**Option B — Delete.** Remove `tools/template/` entirely; rely on
+the repo-root README's "Project layout" entry and this doc's history
+to point readers at the external repo.
+
+The bead reviewing this decision should weigh discoverability (A is
+friendlier for anyone who clones the monorepo expecting the template
+there) against repo hygiene (B is cleaner; the template's history
+already migrated). File a follow-on bead for the stub-vs-delete
+call.
+
+### §3.6 Sweep remaining monorepo cross-refs
+
+After §3.5, sweep the monorepo for any remaining `tools/template/`
+references that survived the docs sweep and either:
+
+- Point at the external repo (`https://github.com/day8/re-frame2-template`).
+- Delete if the reference is now meaningless.
+
+`tools/deps.edn`'s `:local/root "template"` entry retires (the
+testbed / cross-tool tests no longer link the template; the
+template's tests run in its own CI on the external repo). The
+`tools/shadow-cljs.edn` "JVM-only" exclusion comment retires —
+the template is no longer part of the tools/ classpath at all.
+
+The repo-root README's Project Layout entry retires (replace the
+`template/` row with a one-line "see github.com/day8/re-frame2-template"
+note, or drop entirely).
+
+## §4 Deps-new coord retarget
+
+The deps-new coord used to invoke the template changes shape across
+the split:
+
+| Phase | Coord | Resolution |
+|---|---|---|
+| Pre-split (development) | `day8/re-frame2-template` | `:local/root "tools/template"` in the consuming `deps.edn`. Used by tests + manual smoke. Does NOT trigger deps-new's auto-git-clone. |
+| Pre-split (via published-shape coord) | `io.github.day8/re-frame2-template` | deps-new clones the **re-frame2 monorepo** (because the `day8/re-frame2-template` GitHub repo doesn't exist yet), then fails to find `resources/day8/re_frame2_template/template.edn` at the cloned repo root (it's under `tools/template/` in the monorepo). Not a viable production path; only `:local/root` works pre-split. |
+| Post-split (published) | `io.github.day8/re-frame2-template` | deps-new clones from `https://github.com/day8/re-frame2-template.git` via `auto-git-url`, then resolves the template body inside the cloned tree at `resources/day8/re_frame2_template/`. |
+| Post-split (pinned to tag) | `io.github.day8/re-frame2-template#template-v<version>` | Same as above, but pinned to a specific git tag (matches the `template-v…` tag space from rf2-h0w5y §3.1). |
+
+The local-dev fallback (`:local/root` against a checkout of the
+external repo) continues to work post-split:
+
+```bash
+git clone https://github.com/day8/re-frame2-template.git
+cd /path/to/consumer
+clojure -Sdeps '{:deps {day8/re-frame2-template
+                        {:local/root "/path/to/re-frame2-template"}}}' \
+        -Tnew create :template day8/re-frame2-template :name acme/my-app
+```
+
+(Note: `day8/re-frame2-template`, not `io.github.day8/re-frame2-template`,
+for the `:local/root` path — the `io.github.*` prefix triggers
+auto-clone before classpath lookup, which loses the local override.)
+
+## §5 CI workflow (lives in the external repo post-split)
+
+The `template-release.yml` workflow (from rf2-h0w5y §3.1) currently
+lives in the re-frame2 monorepo at
+`.github/workflows/template-release.yml`. Post-split it lives **in
+the external repo**, not the monorepo.
+
+Shape (unchanged across the split, modulo path adjustments per §3.2):
+
+- Trigger: push of a tag matching
+  `template-v[0-9]+.[0-9]+.[0-9]+*`.
+- Steps:
+  1. `clojure -M:test` — runs the template's own JVM test suite.
+  2. Read the `VERSION` file.
+  3. Verify the tag matches `template-v<VERSION>`.
+  4. Cut a GitHub Release pointing at the tagged commit.
+- Secrets needed: `GITHUB_TOKEN` (default; for push-tag permission).
+  **No Clojars credentials** — git-coord distribution has no
+  artefact-upload step.
+
+The monorepo's CI doesn't carry any template-publish hooks post-split;
+the template owns its own release cadence end-to-end.
+
+## §6 Decision: stub vs. delete the in-monorepo tools/template/
+
+Open question for the operator handoff. See §3.5 above. File a
+follow-on bead once the external repo is live; resolve the question
+based on whether the monorepo discoverability gain (Option A) or
+the repo-hygiene gain (Option B) wins.
+
+Pre-alpha posture: hard rename, no transitional carry-over of the
+template source. The template's history lives in the external repo
+post-split; the monorepo carries a pointer at most.
+
+## §7 Cross-references
+
+- [003-DepsNew-Rebuild-Plan.md](003-DepsNew-Rebuild-Plan.md) §4 —
+  the parent migration plan; this doc owns §4.3.
+- [`tools/template/README.md`](../README.md) — the template's
+  user-facing README, updated to reference the future external
+  location.
+- [`tools/template/spec/000-Vision.md`](000-Vision.md) — Lineage
+  section enumerates the Clojars → git-coord shift.
+- [`tools/template/spec/DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)
+  §1 — WHY deps-new + git-coord over clj-new + Clojars.
+- [`migration/from-clj-new-template/README.md`](../../../migration/from-clj-new-template/README.md)
+  — user-facing migration note for existing clj-new template users.
+- rf2-dolpf — EPIC umbrella; closes once §4.3 operator handoff lands.
+- rf2-7jgkv — this scaffolding + cross-ref sweep.
+- rf2-h0w5y — git-coord release pipeline (the
+  `template-release.yml` workflow, which moves into the external
+  repo as part of the split).

--- a/tools/template/spec/README.md
+++ b/tools/template/spec/README.md
@@ -6,6 +6,8 @@
 - **[001-Substrate-Variants.md](001-Substrate-Variants.md)** — The three substrate variants (`:reagent` default, `:uix`, `:helix`); top-level k/v invocation form; substrate coercion.
 - **[002-Generated-Shape.md](002-Generated-Shape.md)** — File layout the template emits; deps-new resource tree (`root/` + `_shared/` + per-substrate); substitution variables.
 - **[003-DepsNew-Rebuild-Plan.md](003-DepsNew-Rebuild-Plan.md)** — Normative migration plan for the deps-new rebuild (rf2-dolpf): final shape, Stage 2-4 decomposition, cross-references to the v1 emit-spec locks.
+- **[004-SSR-Validation-Report.md](004-SSR-Validation-Report.md)** — SSR reference-impl validation report (rf2-0m5ea); gates the `:include-ssr?` flag work.
+- **[005-Repo-Split.md](005-Repo-Split.md)** — Migration procedure for splitting `tools/template/` out of the monorepo into `github.com/day8/re-frame2-template` (rf2-dolpf §4 / rf2-7jgkv).
 - **[API.md](API.md)** — Consolidated public surface: every invocation form, every argument, every supported flag.
 - **[Principles.md](Principles.md)** — Template-specific design principles (build-time only, never on consumer classpath); WHY for the major decisions lives in DESIGN-RATIONALE.
 - **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — WHY behind 000 / 001 / 002 / Principles / API; deps-new over clj-new + git-coord over Clojars; beads referenced as rf2-xxxx.
@@ -13,4 +15,4 @@
 
 ## How to use
 
-This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor scope (deps-new template, build-time-only, alpha-channel `day8/re-frame2-*` coords, git-coord distribution); the capability docs (001–002) are normative — they own the substrate-variants matrix and the generated file shape. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated invocation reference. [`003-DepsNew-Rebuild-Plan.md`](003-DepsNew-Rebuild-Plan.md) is the migration record (§2-3 landed; §4 outstanding). `findings/` preserves the audit lineage and is never normative.
+This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor scope (deps-new template, build-time-only, alpha-channel `day8/re-frame2-*` coords, git-coord distribution); the capability docs (001–002) are normative — they own the substrate-variants matrix and the generated file shape. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated invocation reference. [`003-DepsNew-Rebuild-Plan.md`](003-DepsNew-Rebuild-Plan.md) is the migration record (§2-3 landed; §4 docs-sweep + scaffolding landed at rf2-7jgkv; §4 repo-split is operator-handoff per [`005-Repo-Split.md`](005-Repo-Split.md)). `findings/` preserves the audit lineage and is never normative.


### PR DESCRIPTION
## Summary

Closes out rf2-dolpf §4 in the deps-new template rebuild epic.

- **§4.1 — Docs sweep residue.** rf2-h0w5y §3.2 covered the template's own spec/ tree + `tools/template/README.md`. This PR sweeps the remaining `clojure -X:project/new` / `clj-new` residue in `tools/shadow-cljs.edn`, `skills/README.md`, `skills/re-frame2-setup/README.md`, and the repo-root `README.md`. Also corrects the "deps-new vs clj-new vs CLI" line in `tools/template/README.md`'s spec table and adds entries for the two new specs (004-SSR-Validation-Report.md and the new 005-Repo-Split.md).
- **§4.2 — Migration note.** Adds `migration/from-clj-new-template/README.md` for users who scaffolded under the retired clj-new template. Covers the invocation change, the locked-three-flags rule (`:include-story?` / `:css` / `:include-ssr?`), per-flag deltas, the no-action-needed posture for existing scaffolded apps, and tag-pinning via the `template-v…` tag space. Added to `mkdocs.yml`'s Migration nav.
- **§4.3 — Repo-split scaffolding (operator-handoff pending).** Adds `tools/template/spec/005-Repo-Split.md` (numbered 005 because 004 is taken by SSR Validation Report rf2-0m5ea). Documents the full migration procedure for splitting `tools/template/` out into `github.com/day8/re-frame2-template`: `git subtree split` sequence, workflow move from monorepo to external repo, deps-new coord retarget table, post-split stub-vs-delete question. The actual external-repo creation + initial push is a Mike-operator handoff, flagged explicitly in `003-DepsNew-Rebuild-Plan.md` §4.

Out of scope (explicit operator-handoff for Mike):
- Creating the `day8/re-frame2-template` GitHub repo.
- Pushing initial commits + first release tag.
- Moving `.github/workflows/template-release.yml` into the external repo.
- The post-split `tools/template/` stub-vs-delete decision.

## Test plan

- [x] `cd tools/template && clojure -M:test` → 19 tests / 318 assertions / 0 failures.
- [x] `python -m mkdocs build --strict` → clean (no warnings, exit 0).
- [x] All clj-new / `:edn-args` / `clojure -X:project/new` references swept from skill docs, repo-root README, and `tools/shadow-cljs.edn`. Historical references retained inside DESIGN-RATIONALE.md §Retired and the migration note's "what changed" narrative.