### PR TITLE
docs: fix 4 mkdocs link-check failures inherited from #1720 + #1724

### DIFF
--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -9,9 +9,9 @@ Co-drafted by Mike + mayor; this doc is the implementer's reference
 for the **per-panel content layout**, **shared data-display renderer**,
 **locked decisions**, and **substrate gaps** that the redesign implies.
 
-Canonical foundation: [`ai/prompts/causa-interface-adjustments.md`](../../../ai/prompts/causa-interface-adjustments.md)
-(local-only working doc). The framing in §1 below is a synthesis — the
-super-prompt remains the authoritative statement of intent.
+Canonical foundation: `ai/prompts/causa-interface-adjustments.md`
+(local-only working doc; not in repo). The framing in §1 below is a
+synthesis — the super-prompt remains the authoritative statement of intent.
 
 Cross-refs:
 - [`000-Vision.md`](000-Vision.md) — the five canonical questions

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -337,7 +337,7 @@ The inverse — strict on input shape, forgiving on value set
 delivers the Reagent variant instead of the requested UIx, and
 the user finds out at `shadow-cljs watch app` time.
 
-## Retired §clj-new-over-deps-new
+## Retired — clj-new-over-deps-new
 
 > This was the v1 decision (through 2026-05). Superseded by §1 above
 > on 2026-05-12 per Mike's template walkthrough Q2 lock (rf2-dolpf).
@@ -364,7 +364,7 @@ fit. The git-coord distribution decision is independent of
 deps-new-vs-clj-new but was bundled into the same migration for
 release-machinery simplification.
 
-## Retired §`:edn-args`-not-top-level
+## Retired — `:edn-args`-not-top-level
 
 > This was a v1 implementation finding (clj-new era). Superseded by
 > deps-new's native top-level k/v args (see §1 / API.md §Top-level


### PR DESCRIPTION
Quick docs-only fix. Unblocks mkdocs gate for all open PRs (currently failing #1730 / #1731 / pending PRs).

## Fixes

**#1720 leftover** — `tools/causa/spec/021-Dynamic-Panel-Designs.md:12` linked to `ai/prompts/causa-interface-adjustments.md` (gitignored / local-only). Replaced with prose mention.

**#1724 leftover** — `tools/template/spec/DESIGN-RATIONALE.md` had two Retired headings using `§` which generated single-hyphen slugs, but in-body links expected double-hyphen slugs. Renamed to em-dash to match.

`python scripts/check_doc_slugs.py` exits clean locally.