### PR TITLE
feat(substrate): :rf/dispatch-origin tag on :event/dispatched (rf2-t1lxr)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -175,11 +175,20 @@
   `:trace-id`, `:origin`, `:source`. When `parent-envelope` is nil
   (caller did not thread one through — legacy routing-artefact callers
   or test fixtures), falls back to `{:frame frame-id}` so single-key
-  propagation still holds."
+  propagation still holds.
+
+  Per rf2-t1lxr: `:rf/dispatch-origin` is NOT inherited from the parent
+  — it's the *immediate* functional source of the dispatch, so the
+  child gets `:fx-emit` (this dispatch was emitted by the parent's
+  `:dispatch` / `:dispatch-later` fx-handler running in the do-fx
+  phase). Lineage is preserved via `:parent-dispatch-id`; the origin
+  tag answers \"who emitted THIS dispatch?\" not \"what initiated the
+  cascade?\"."
   [frame-id parent-envelope]
   (if parent-envelope
-    (select-keys parent-envelope inheritable-envelope-keys)
-    {:frame frame-id}))
+    (-> (select-keys parent-envelope inheritable-envelope-keys)
+        (assoc :rf/dispatch-origin :fx-emit))
+    {:frame frame-id :rf/dispatch-origin :fx-emit}))
 
 (def ^:private reserved-fx-handlers
   "Reserved fx-id → body-fn `(fn [frame-id parent-envelope args])`.

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -82,6 +82,12 @@
     :source             :ui :timer :http :repl :machine ...
     :origin             actor identity tag (:app default; :pair, :story,
                         :test, ... per Spec 002 §Dispatch origin tagging)
+    :rf/dispatch-origin closed-enum functional source per Causa A.5 /
+                        Spec 009 §Dispatch-origin tagging — one of
+                        :user :router :websocket :http :ssr :fx-emit
+                        :timer :test-harness :tool :internal. Defaults
+                        to :user. Distinct from :origin (actor identity)
+                        and :source (trigger kind). Per rf2-t1lxr.
     :dispatch-id        process-monotonic id allocated here per
                         Spec 009 §Dispatch correlation
     :parent-dispatch-id the in-flight dispatch's id when this dispatch is
@@ -137,6 +143,15 @@
              :trace-id               (:trace-id opts)
              :source                 (:source opts :ui)
              :origin                 (:origin opts :app)
+             ;; Per rf2-t1lxr: the closed-enum functional source per
+             ;; Causa A.5 / Spec 009 §Dispatch-origin tagging. The 10-value
+             ;; taxonomy (:user :router :websocket :http :ssr :fx-emit
+             ;; :timer :test-harness :tool :internal) classifies WHERE the
+             ;; dispatch came from. Defaults to :user; internal callers
+             ;; (router routing emits, fx `:dispatch` cascades, HTTP reply
+             ;; dispatches, machine timer fires, …) self-tag at their
+             ;; emit site to override the default.
+             :rf/dispatch-origin     (:rf/dispatch-origin opts :user)
              :dispatched-at          (interop/now-ms)}
       ;; Per rf2-ts1a: the macro form of `dispatch` / `dispatch-sync`
       ;; stamps an `:rf.trace/call-site` on the opts map. The read in
@@ -1232,8 +1247,11 @@
   "Emit the :event :event/dispatched trace event for this envelope. Per
   Spec 009 §Dispatch correlation, :dispatch-id and :parent-dispatch-id
   ride on :tags. Per Spec 002 §Dispatch origin tagging, :origin rides
-  on :tags too. Spec elision is automatic — trace/emit! short-circuits
-  when interop/debug-enabled? is false at compile time.
+  on :tags too. Per rf2-t1lxr, :rf/dispatch-origin (Causa A.5 closed-
+  enum functional source) also rides on :tags so Causa's L2 epoch
+  timeline can render the per-row origin tag. Spec elision is
+  automatic — trace/emit! short-circuits when interop/debug-enabled?
+  is false at compile time.
 
   Per rf2-qsjda: queue-time `:rf.trace/no-emit?` consideration. The
   `*handler-scope*` binding's `:no-emit?` slot doesn't exist yet at
@@ -1260,11 +1278,12 @@
     (when-not no-emit?
       (trace/with-call-site (:call-site envelope)
         (trace/emit! :event :event/dispatched
-                     (cond-> {:event    event
-                              :frame    (:frame envelope)
-                              :origin   (:origin envelope)
-                              :source   (:source envelope)
-                              :sync?    sync?}
+                     (cond-> {:event              event
+                              :frame              (:frame envelope)
+                              :origin             (:origin envelope)
+                              :rf/dispatch-origin (:rf/dispatch-origin envelope)
+                              :source             (:source envelope)
+                              :sync?              sync?}
                        (:dispatch-id envelope)
                        (assoc :dispatch-id (:dispatch-id envelope))
                        (:parent-dispatch-id envelope)

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -394,8 +394,14 @@
   ([events] (dispatch-sequence events {}))
   ([events {:keys [after-each] :as opts}]
    (let [frame-id (resolve-frame opts)
-         dispatch-opts (cond-> {:frame frame-id}
-                         (contains? opts :origin) (assoc :origin (:origin opts)))]
+         ;; Per rf2-t1lxr: test-fixture-driven dispatches default to
+         ;; :rf/dispatch-origin :test-harness so Causa's L2 timeline +
+         ;; per-origin filters can discriminate test-driven cascades
+         ;; from user-origin events. Caller may override.
+         dispatch-opts (cond-> {:frame frame-id :rf/dispatch-origin :test-harness}
+                         (contains? opts :origin) (assoc :origin (:origin opts))
+                         (contains? opts :rf/dispatch-origin)
+                         (assoc :rf/dispatch-origin (:rf/dispatch-origin opts)))]
      (doseq [ev events]
        (router/dispatch-sync! ev dispatch-opts)
        (when after-each

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -112,6 +112,13 @@
                      Origin tags the actor that issued the dispatch
                      (`:app` / `:pair` / `:story` / `:test` / ...) per
                      Spec 002 §Dispatch origin tagging.
+    :rf/dispatch-origin — keep only events whose `:tags :rf/dispatch-origin`
+                     matches the closed-enum value (one of `:user`,
+                     `:router`, `:websocket`, `:http`, `:ssr`,
+                     `:fx-emit`, `:timer`, `:test-harness`, `:tool`,
+                     `:internal`) per Spec 009 §Dispatch-origin tagging
+                     (rf2-t1lxr). Distinct from `:origin` (actor identity)
+                     and `:source` (trigger kind).
     :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
                      Cascade-wide post rf2-g6ih4 — every emit inside a
                      drain carries the in-flight cascade's dispatch-id.
@@ -140,6 +147,11 @@
                    severity event-id handler-id source origin
                    dispatch-id since-ms between pred]} opts
            sensitive-filter (:sensitive? opts)
+           ;; Per rf2-t1lxr: the closed-enum functional-source filter axis.
+           ;; Read directly via the namespaced key — `:keys` destructuring
+           ;; doesn't accept namespaced keys without `:as`-binding bulk so
+           ;; we lift it explicitly.
+           rf-dispatch-origin (:rf/dispatch-origin opts)
            [between-t0 between-t1] (when (and (sequential? between)
                                               (= 2 (count between)))
                                      between)
@@ -162,6 +174,9 @@
                                     (get-in ev [:tags :source]))))
                   (or (nil? origin)
                       (= origin (get-in ev [:tags :origin])))
+                  (or (nil? rf-dispatch-origin)
+                      (= rf-dispatch-origin
+                         (get-in ev [:tags :rf/dispatch-origin])))
                   (or (nil? dispatch-id)
                       (= dispatch-id (get-in ev [:tags :dispatch-id])))
                   (or (nil? since-ms)

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -417,3 +417,80 @@
       (is (= :pair (get-in ev [:tags :origin]))   ":origin lands under :tags :origin")
       ;; :source is hoisted to top-level by emit!, per the existing contract.
       (is (= :repl (:source ev))                  ":source is hoisted to top-level"))))
+
+;; ---- 4. :rf/dispatch-origin opt (rf2-t1lxr) -------------------------------
+
+(deftest dispatch-origin-defaults-to-user
+  (testing "no :rf/dispatch-origin opt → :tags :rf/dispatch-origin = :user"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping])
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :user (get-in ev [:tags :rf/dispatch-origin]))
+          "default :rf/dispatch-origin is :user per Spec 009 §Dispatch-origin tagging"))))
+
+(deftest dispatch-origin-opt-overrides-default
+  (testing ":rf/dispatch-origin :tool lands on the trace event"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool})
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :tool (get-in ev [:tags :rf/dispatch-origin]))
+          ":rf/dispatch-origin :tool lifted onto :tags :rf/dispatch-origin"))))
+
+(deftest dispatch-origin-distinct-from-origin-and-source
+  (testing ":rf/dispatch-origin / :origin / :source ride independently"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool
+                               :origin             :pair
+                               :source             :repl})
+    (let [ev (->> (rf/trace-buffer)
+                  dispatched-events
+                  (filter #(= [:ping] (get-in % [:tags :event])))
+                  first)]
+      (is ev)
+      (is (= :tool (get-in ev [:tags :rf/dispatch-origin])))
+      (is (= :pair (get-in ev [:tags :origin])))
+      (is (= :repl (:source ev))))))
+
+(deftest dispatch-origin-fx-emit-on-cascade
+  (testing "child dispatches emitted by :dispatch fx are tagged :fx-emit
+            regardless of the parent's :rf/dispatch-origin"
+    (rf/reg-event-fx :parent
+      (fn [_ _] {:fx [[:dispatch [:child]]]}))
+    (rf/reg-event-db :child (fn [db _] db))
+    (rf/dispatch-sync [:parent] {:rf/dispatch-origin :user})
+    (let [parent-ev (->> (rf/trace-buffer)
+                          dispatched-events
+                          (filter #(= [:parent] (get-in % [:tags :event])))
+                          first)
+          child-ev  (->> (rf/trace-buffer)
+                          dispatched-events
+                          (filter #(= [:child] (get-in % [:tags :event])))
+                          first)]
+      (is parent-ev)
+      (is child-ev)
+      (is (= :user (get-in parent-ev [:tags :rf/dispatch-origin]))
+          "parent carries the explicit :user opt")
+      (is (= :fx-emit (get-in child-ev [:tags :rf/dispatch-origin]))
+          "child overrides to :fx-emit — origin is the IMMEDIATE source,
+           lineage rides on :parent-dispatch-id"))))
+
+(deftest trace-buffer-filter-dispatch-origin
+  (testing ":rf/dispatch-origin filters by :tags :rf/dispatch-origin"
+    (rf/reg-event-db :ping (fn [db _] db))
+    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :tool})
+    (rf/dispatch-sync [:ping] {:rf/dispatch-origin :router})
+    (let [tool-evs (rf/trace-buffer {:rf/dispatch-origin :tool})]
+      (is (seq tool-evs))
+      (is (every? #(= :tool (get-in % [:tags :rf/dispatch-origin])) tool-evs)
+          ":rf/dispatch-origin :tool narrows to tool-issued cascades"))
+    (let [router-evs (rf/trace-buffer {:rf/dispatch-origin :router})]
+      (is (seq router-evs))
+      (is (every? #(= :router (get-in % [:tags :rf/dispatch-origin])) router-evs)))))

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -153,11 +153,16 @@
   `args` is the same map `build-reply-event` consumes; `frame` (optional)
   is threaded as `{:frame <id>}` onto the dispatch options when present.
   No-op when the registered router is absent or `build-reply-event`
-  returns nil (silenced reply)."
+  returns nil (silenced reply).
+
+  Per rf2-t1lxr: reply dispatches self-tag with
+  `:rf/dispatch-origin :http` so Causa's L2 timeline + tools can
+  discriminate HTTP-completion cascades from user-origin events."
   [args frame]
   (when-let [ev (build-reply-event args)]
     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-      (dispatch! ev (cond-> {} frame (assoc :frame frame))))))
+      (dispatch! ev (cond-> {:rf/dispatch-origin :http}
+                      frame (assoc :frame frame))))))
 
 (defn build-reply-event
   "Per Spec 014 §Reply addressing. Returns the event vector to dispatch,

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -239,10 +239,15 @@
     ;; [:rf.machine/spawned] so generic child machines can declare their
     ;; first transition out of an :initial state at spec-write time.
     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
-      (let [start (:start args)]
+      ;; Per rf2-t1lxr: machine-spawn :start dispatches are framework-
+      ;; internal lifecycle events — tag :rf/dispatch-origin :internal
+      ;; so Causa's L2 timeline can distinguish actor-bootstrap from
+      ;; user-origin events.
+      (let [start (:start args)
+            opts  {:frame frame-id :rf/dispatch-origin :internal}]
         (if (some? start)
-          (dispatch! [spawned-id start] {:frame frame-id})
-          (dispatch! [spawned-id [:rf.machine/spawned]] {:frame frame-id}))))
+          (dispatch! [spawned-id start] opts)
+          (dispatch! [spawned-id [:rf.machine/spawned]] opts))))
     spawned-id))
 
 ;; ---- :rf.machine/invoke-all-init -------------------------------------------

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -294,9 +294,13 @@
                 (interop/set-timeout!
                   (fn []
                     (when-let [dispatch! (late-bind/get-fn :router/dispatch!)]
+                      ;; Per rf2-t1lxr: machine :after timer firing tags
+                      ;; the resulting dispatch with :rf/dispatch-origin
+                      ;; :timer so Causa can prefix the L2 row + filter on
+                      ;; timer-origin epochs.
                       (dispatch! [parent-id [:rf.machine.timer/after-elapsed
                                               delay-key epoch]]
-                                 {:frame frame-id})))
+                                 {:frame frame-id :rf/dispatch-origin :timer})))
                   resolved-ms)
                 watch-key (when (= :sub delay-source)
                             [::after-watch frame-id parent-id invoke-id delay-key])]

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -981,10 +981,14 @@
                                                       (.getMessage ^Throwable exception))
                                                :cljs (some-> exception .-message))
                          :reason            "An :on-match event threw."}]
+          ;; Per rf2-t1lxr: routing-internal dispatches self-tag with
+          ;; :rf/dispatch-origin :router so Causa's L2 timeline + tools
+          ;; filter pills can discriminate framework-origin events from
+          ;; user-origin events.
           (router/dispatch! [:rf.route.internal/on-match-error
                              {:error     error-map
                               :nav-token nav-token}]
-                            {:frame frame}))))))
+                            {:frame frame :rf/dispatch-origin :router}))))))
 
 ;; Register the listener at ns-load. The listener id is namespaced under
 ;; :rf.route/* so accidental re-registration by another artefact is
@@ -1927,12 +1931,17 @@ unknown strategies as :preserve (no-op)."}
                               (when (and (not (.-defaultPrevented e))
                                          (plain-left-click? e))
                                 (.preventDefault e)
+                                ;; Per rf2-t1lxr: route-link click → :router
+                                ;; origin so the L2 epoch timeline tags the
+                                ;; resulting :rf/url-requested cascade as a
+                                ;; routing-substrate dispatch (not :user).
                                 (router/dispatch!
                                   [:rf/url-requested
                                    (cond-> {:url url :to to}
                                      (seq params)   (assoc :params params)
                                      (seq query)    (assoc :query  query)
-                                     fragment       (assoc :fragment fragment))])))))]
+                                     fragment       (assoc :fragment fragment))]
+                                  {:rf/dispatch-origin :router})))))]
        (into [:a attrs] children))))
 
 (defn route-link-render-ssr

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -84,6 +84,44 @@ When a tool (the pair tool, a story runner, the REPL, the SSR boot path) needs i
 
 `:origin` is **distinct from `:source`**: `:source` describes the *trigger kind* (`:ui` / `:timer` / `:http` / `:machine` / `:repl` / `:ssr-hydration`) and is essentially a "what woke the runtime?" axis; `:origin` describes the *actor identity* (which tool or app subsystem emitted the dispatch) and is used for filtering. Tools may set both.
 
+### Dispatch-origin tagging: `:rf/dispatch-origin`
+
+Every `:event/dispatched` trace event carries a closed-enum classifier under `:tags :rf/dispatch-origin` answering the question **"where, functionally, did this dispatch come from?"** Per the Causa A.5 taxonomy (and surfaced as the L2 epoch-timeline row prefix + Event-panel step 1 — see [tools/causa/spec/021 §1.5](../tools/causa/spec/021-Dynamic-Panel-Designs.md)):
+
+| Value | Set by | Meaning |
+|---|---|---|
+| `:user` | default (the macro / fn-form path supplies nothing else) | A user-emitted dispatch — a UI handler, a REPL call, a test body that did not opt into another tag. |
+| `:router` | `re-frame.routing` internal dispatches (the routing-error emit, `:route/link` click handler) | A routing-substrate dispatch — URL events, route-link clicks, on-match-error cascades. |
+| `:websocket` | application-level websocket adapters (the framework does not ship a websocket adapter) | A websocket-frame-arrived dispatch. The taxonomy slot is reserved; apps that wire websockets opt in via `{:rf/dispatch-origin :websocket}`. |
+| `:http` | `re-frame.http_encoding/dispatch-reply-via-late-bind!` (managed-request reply path) | An HTTP managed-request reply dispatch — `:on-success` / `:on-failure` cascade entry. |
+| `:ssr` | the user's hydration boot site (the framework does not auto-detect — see Spec 011) | The `:rf/hydrate` cascade or any other SSR-boot-time dispatch. |
+| `:fx-emit` | `re-frame.fx`'s `:dispatch` / `:dispatch-later` fx handlers (override-on-cascade — child dispatches are tagged `:fx-emit` regardless of parent's origin) | A dispatch emitted by the do-fx phase of another event handler. Lineage is preserved via `:parent-dispatch-id`; the origin tag answers "who emitted THIS dispatch?" |
+| `:timer` | `re-frame.machines.timer`'s `:after` fire site | A state-machine `:after` timer firing. (Application-level `setTimeout` / `setInterval` callers self-tag; the framework does not detect.) |
+| `:test-harness` | test fixtures that opt in (the framework does not auto-detect; see Spec 015 / `re-frame.test_support`) | Reserved slot for test bodies that want their dispatches discriminated. Application-level opt-in. |
+| `:tool` | tooling adapters (Causa controls, Story play scripts, the pair-MCP write surface) — they self-tag at their dispatch site | A tool-issued dispatch (operator clicking "step", a story-script driving the app). |
+| `:internal` | `re-frame.machines.lifecycle_fx/spawn` (`:start` event into newly-spawned actors) and other framework-internal lifecycle dispatches | A framework-substrate-internal dispatch (actor bootstrap, lifecycle cascade). |
+
+The default — for both the macro form (`(rf/dispatch event)` / `(rf/dispatch-sync event)`) and the fn form (`(rf/dispatch* event)`) — is `:user`. Internal callers thread `:rf/dispatch-origin` into the opts map at their emit site to override the default.
+
+```clojure
+;; user surface (default :user)
+(rf/dispatch [:cart/add {:sku "abc"}])
+
+;; explicit opt-in (per-call)
+(rf/dispatch [:order/submit] {:rf/dispatch-origin :tool})
+```
+
+`:rf/dispatch-origin` is **distinct from `:source` and `:origin`**:
+- `:source` (`:ui` / `:timer` / `:http` / `:machine` / `:repl` / `:ssr-hydration` / `:test` / `:other`) is the *trigger trio* — what woke the runtime — and predates the rf2-t1lxr addition.
+- `:origin` (`:app` / `:pair` / `:story` / `:test` / …) is the *actor identity* — which tool or app subsystem emitted the dispatch — and is **unconstrained** at the framework level.
+- `:rf/dispatch-origin` is the *closed-enum functional source* — the 10-value taxonomy above. Tools branch on it to render the L2 row prefix and per-origin filter pills.
+
+The closed enum is **closed** at the spec level. Adding a new value is a framework-level change with substrate-side consumer impact; it is not a per-app extension point. Tools and applications agree on the 10 values listed above.
+
+The dispatch envelope's `:rf/dispatch-origin` slot rides via the `:tags :rf/dispatch-origin` axis onto every `:event/dispatched` trace event. Production builds elide the trace surface entirely; the envelope's `:rf/dispatch-origin` slot remains in the production build (it is plain envelope data, not gated trace tooling) but consumers that read it sit on the dev-only trace stream and DCE alongside the rest of the trace machinery.
+
+Per rf2-t1lxr.
+
 ### `:op-type` vocabulary
 
 Core values: `:event`, `:sub/run`, `:sub/create`, `:event/do-fx`, `:fx`, `:view/render`, `:registry`, `:machine`, `:warning`, `:error`, `:info`.

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -101,6 +101,7 @@ Carried internally by every dispatch. User-facing event vector remains a vector;
    [:trace-id              {:optional true} :any]
    [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]] ;; trigger kind
    [:origin                {:optional true} :keyword]                      ;; actor identity (default :app) — per [002 §Dispatch origin tagging]
+   [:rf/dispatch-origin    {:optional true} [:enum :user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal]]  ;; closed-enum functional source (default :user) — per [009 §Dispatch-origin tagging]; per rf2-t1lxr
    [:dispatched-at         {:optional true} :any]])                        ;; CLJS reference may add an impl-specific timestamp; tools tolerate
 ```
 
@@ -121,7 +122,8 @@ The opts map a user passes to `(dispatch event opts)` / `(dispatch-sync event op
    [:interceptors          {:optional true} [:vector :any]]
    [:trace-id              {:optional true} :any]
    [:source                {:optional true} [:enum :ui :timer :http :machine :repl :ssr-hydration :test :other]]
-   [:origin                {:optional true} :keyword]])                     ;; actor identity tag — defaults to :app when omitted
+   [:origin                {:optional true} :keyword]                       ;; actor identity tag — defaults to :app when omitted
+   [:rf/dispatch-origin    {:optional true} [:enum :user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal]]])  ;; closed-enum functional source — defaults to :user when omitted (per rf2-t1lxr)
 ```
 
 The promotion is structural: `(dispatch event opts)` → envelope is `(merge {:event event :frame :rf/default :dispatched-at (now)} opts)`. The runtime asserts `:event` and `:frame` are present after the merge.


### PR DESCRIPTION
Closes rf2-t1lxr. Adds the 10-value closed-enum dispatch-origin schema + default `:user` + opts override + internal self-tagging at router/fx-emit/http/timer/internal sites. Unblocks Causa L2 epoch-timeline origin column per #1720 §12.

## What's new

- **Closed-enum schema** for `:rf/dispatch-origin` (added to `:rf/dispatch-envelope` and `:rf/dispatch-opts` in `spec/Spec-Schemas.md`): `:user · :router · :websocket · :http · :ssr · :fx-emit · :timer · :test-harness · :tool · :internal`.
- **Default origin** is `:user`. Opts override: `(rf/dispatch ev {:rf/dispatch-origin :tool})`.
- **Internal callers self-tag** at their emit sites:
  - `re-frame.routing` route-link click + on-match-error → `:router`
  - `re-frame.fx` `:dispatch` / `:dispatch-later` cascade-children → `:fx-emit` (overrides parent's origin; lineage rides on `:parent-dispatch-id`)
  - `re-frame.http-encoding/dispatch-reply-via-late-bind!` (managed-reply path) → `:http`
  - `re-frame.machines.timer` `:after` fire → `:timer`
  - `re-frame.machines.lifecycle_fx.spawn` `:start` event → `:internal`
  - `re-frame.test_support/dispatch-sequence` → `:test-harness` (caller-overridable)
- **Trace emission** — `:event/dispatched` op lifts `:rf/dispatch-origin` onto `:tags` alongside `:origin` and the existing fields.
- **Filter axis** — `rf/trace-buffer {:rf/dispatch-origin :tool}` filters by the new axis (extends the existing 13-key filter vocab).
- **Spec 009 §Dispatch-origin tagging** added — full taxonomy table + distinction-from `:source` / `:origin`.

## Deferred sub-tasks

- `:ssr` self-tagging — the `:rf/hydrate` boot dispatch lives in user code (the SSR boot snippet); the framework cannot auto-detect. Apps that opt in pass `{:rf/dispatch-origin :ssr}` at their boot dispatch.
- `:websocket` — no framework-shipped websocket adapter; the slot is reserved for application-level adapters that opt in.
- `:tool` self-tagging in Causa / Story / pair-MCP write surfaces — straightforward follow-on (each tool's dispatch site adds `{:rf/dispatch-origin :tool}`). Not in scope for this bead.

## Gates

- `npm run test:cljs` — 3688 tests / 10593 assertions, 0 failures
- `npm run test:bundle-isolation` — PASS (12 artefact entries, 27 sentinels absent)
- `mkdocs build --strict` — passes
- JVM core / routing / http / machines tests — all green
- New trace-buffer-test deftests (5) covering default `:user`, opt override, cross-field independence, `:fx-emit` cascade override, filter axis