### PR TITLE
docs(causa): cross-ref spec §003 + §004 to §021 canonical per-panel design (rf2-z0i59)

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -1,5 +1,7 @@
 # 003-Machine-Inspector
 
+> **See also**: [`021-Dynamic-Panel-Designs.md` §6](021-Dynamic-Panel-Designs.md#6-the-machines-panel-topology--overlay) for the canonical content design layered onto the topology view.
+
 > **2026-05-19 collapse note (rf2-y9xmf):** the Runtime Machines panel
 > is now **event-driven only**. The panel is BLANK when the currently
 > focused event triggered no machine transitions; it renders one

--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -1,5 +1,7 @@
 # 004-App-DB-Diff
 
+> **See also**: [`021-Dynamic-Panel-Designs.md` §4](021-Dynamic-Panel-Designs.md#4-the-app-db-panel-state-bridge) for the canonical content design including downstream-subs overlay.
+
 ## Bug class
 
 **"What part of app-db actually changed when I dispatched this event?"**


### PR DESCRIPTION
Closes rf2-z0i59. Per spec/021 §13 Doc-only beads.

003 → 021 §6 (Machines panel, topology + overlay)
004 → 021 §4 (App-db panel, state bridge — includes downstream-subs overlay)

Gates: `python scripts/check_doc_slugs.py` exit 0; `python -m mkdocs build --strict` exit 0.