### PR TITLE
feat(causa): shared film-strip header — [◀ Prev] [Next ▶] for L4 panels (rf2-h7nqh)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc
@@ -1,0 +1,214 @@
+(ns day8.re-frame2-causa.panels.shared.film-strip.header
+  "Shared film-strip header — `[◀ Prev] [Next ▶]` epoch navigation
+  consumed by every L4 panel (rf2-h7nqh).
+
+  Per `tools/causa/spec/021-Dynamic-Panel-Designs.md`:
+
+    - §2.5 — film-strip back/forward semantics: `[◀ Prev] [Next ▶]`
+      walks the L2 spine chronologically. MVP: next chronological
+      epoch regardless of dispatch-origin (per super-prompt B.5).
+      Stretch: per-panel filter slot (e.g. Issues panel's 'next
+      epoch with ⚠').
+    - §17.1.5 — iconography: `◀ Prev` left-pointing triangle glyph
+      at 12px JetBrains Mono; hit target 28×20px (≥ 24×24 AA target-
+      size + 4px vertical padding for the operator's fingertip
+      target).
+    - §17.1.3 — palette: chevrons render `:text-secondary` default ·
+      `:text-primary` on hover. Disabled state demotes the foreground
+      to `:text-tertiary` with `cursor: not-allowed`.
+    - §17.2 — interaction-state matrix: pressed → `translateY(1px)`
+      ~60ms; disabled → `:text-tertiary` + `cursor: not-allowed`,
+      tabindex removed. Focus-ring is the global `:focus-visible`
+      amber — inherited from `theme/global_styles`, never suppressed.
+
+  ## Shape
+
+      [header {:panel-id   \"event\"
+               :prev-fn    #(rf/dispatch [::nav-prev])
+               :next-fn    #(rf/dispatch [::nav-next])
+               :has-prev?  true
+               :has-next?  true
+               :indicator  [:span … ]}]   ; optional middle slot
+
+  ## Contract
+
+    `:panel-id`    — required; stable string used in `:data-testid`s
+                     so per-panel tests can anchor the buttons
+                     (`rf-causa-<panel-id>-film-strip-prev`, etc.)
+                     and walk the rendered header by id.
+
+    `:prev-fn`     — required; 0-arg fn fired on click of `◀ Prev`.
+                     Pure handler — the parent panel computes the
+                     destination epoch and dispatches the rewind /
+                     focus event.
+
+    `:next-fn`     — required; 0-arg fn fired on click of `Next ▶`.
+
+    `:has-prev?`   — required boolean. When false the button
+                     renders in the disabled visual state per
+                     §17.2 (no handler attached, no tabindex).
+
+    `:has-next?`   — required boolean. Same semantics as
+                     `:has-prev?`.
+
+    `:indicator`   — optional hiccup, rendered between the two
+                     buttons. Parent passes whatever epoch
+                     indicator / context it wants (`epoch #42`,
+                     dispatch-origin pill, filter chip, …).
+
+    `:filter-fn`   — STRETCH, optional. When supplied the header
+                     surfaces a `data-rf-causa-filter` attribute
+                     carrying the filter-fn's truthy marker so
+                     panel-level tests can assert the filter is
+                     wired through. The component does NOT compute
+                     prev/next here — that's the parent panel's
+                     job; the slot just accommodates the per-panel
+                     narrowing surface (e.g. Issues panel's 'next
+                     epoch with ⚠' per §17.5 follow-on).
+
+  ## Pure component
+
+  No app-db touches, no subscriptions, no global mutation. Parent
+  panel computes prev/next epoch + has-prev?/has-next? from its
+  own state (typically a `:rf.causa/focus` sub + the L2 spine) and
+  passes the resolved fns in. This keeps every L4 panel free to
+  shape its own navigation semantics (chronological for MVP,
+  filtered for stretch) without forking the visual treatment.
+
+  ## Why a separate ns
+
+  Every L4 panel (Event, Reactive, App-db, Trace, Machines,
+  Routing, Issues, Chrome-A11y) renders a film-strip in its header.
+  Inlining the hiccup eight times invites drift; hoisting it here
+  gives the visual rhythm one source of truth — a future tweak
+  (chevron weight, hit-target geometry, focus-ring radius) lands
+  in one place."
+  (:require [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack type-scale]]))
+
+;; ---- visual tokens ------------------------------------------------------
+;;
+;; §17.1.5 + §17.1.3 lock the visual treatment. Catalogued here as
+;; defs so the test suite can assert the rendered hiccup picks up the
+;; canonical tokens (test-by-data, not test-by-pixel).
+
+(def ^:private button-base-style
+  "Shared style map for both `◀ Prev` and `Next ▶` buttons.
+
+  Hit target: 28×20px per §17.1.5 (≥ 24×24 AA target-size; 28×20
+  with 4px vertical padding for the operator's fingertip target).
+
+  Mono font + 12px size per §17.1.5 (`◀ Prev` — left-pointing
+  triangle glyph, 12px JetBrains Mono)."
+  {:display          "inline-flex"
+   :align-items      "center"
+   :justify-content  "center"
+   :min-width        "28px"
+   :min-height       "20px"
+   :padding          "4px 8px"
+   :border           "none"
+   :background       "transparent"
+   :font-family      mono-stack
+   :font-size        (:caption type-scale)
+   :line-height      1
+   :user-select      "none"
+   :-webkit-user-select "none"})
+
+(defn- enabled-style
+  "Default (interactive) style — chevron in `:text-secondary` per
+  §17.1.3 row 'Film-strip back/forward chevron'."
+  []
+  (merge button-base-style
+         {:color  (:text-secondary tokens)
+          :cursor "pointer"}))
+
+(defn- disabled-style
+  "Disabled style — foreground demoted to `:text-tertiary` per
+  §17.2 'Disabled' row + cursor: not-allowed."
+  []
+  (merge button-base-style
+         {:color  (:text-tertiary tokens)
+          :cursor "not-allowed"}))
+
+;; ---- the buttons --------------------------------------------------------
+
+(defn- film-strip-button
+  "Render one of the two film-strip buttons.
+
+  `direction` is `:prev` or `:next`; the glyph + label + testid
+  derive from it. `enabled?` flips between the interactive and
+  disabled visual states (no handler / no tabindex when disabled
+  per §17.2)."
+  [{:keys [panel-id direction enabled? on-click]}]
+  (let [label  (case direction
+                 :prev "◀ Prev"     ;; ◀ Prev
+                 :next "Next ▶")    ;; Next ▶
+        suffix (case direction
+                 :prev "prev"
+                 :next "next")
+        testid (str "rf-causa-" panel-id "-film-strip-" suffix)]
+    (if enabled?
+      [:button {:data-testid testid
+                :type        "button"
+                :aria-label  (case direction
+                               :prev "Previous epoch"
+                               :next "Next epoch")
+                :on-click    on-click
+                :style       (enabled-style)}
+       label]
+      ;; Disabled — no handler attached, no tabindex (per §17.2).
+      ;; `:disabled true` is the canonical HTML signal; mirroring it
+      ;; as `:aria-disabled "true"` keeps the AT story intact.
+      [:button {:data-testid    testid
+                :type           "button"
+                :disabled       true
+                :aria-disabled  "true"
+                :aria-label     (case direction
+                                  :prev "Previous epoch"
+                                  :next "Next epoch")
+                :tab-index      -1
+                :style          (disabled-style)}
+       label])))
+
+;; ---- the header --------------------------------------------------------
+
+(defn header
+  "Render the shared `[◀ Prev] [Next ▶]` film-strip header for an
+  L4 panel.
+
+  Pure component — no app-db touches, no subscriptions. The parent
+  panel computes prev/next-fn + has-prev?/has-next? and passes them
+  in. See ns doc for the full contract.
+
+  Returns hiccup."
+  [{:keys [panel-id prev-fn next-fn has-prev? has-next? indicator
+           filter-fn]}]
+  (let [;; The optional filter-fn surfaces as a data-attribute so
+        ;; per-panel tests can assert the slot is wired through.
+        ;; The component itself does NOT call the filter — prev/next
+        ;; semantics live in the parent.
+        filter-attr (when filter-fn {:data-rf-causa-filter "active"})]
+    [:div (merge {:data-testid (str "rf-causa-" panel-id "-film-strip")
+                  :style       {:display         "inline-flex"
+                                :align-items     "center"
+                                :gap             "8px"      ;; §17.1.1 :gap-2
+                                :font-family     mono-stack
+                                :font-size       (:caption type-scale)}}
+                 filter-attr)
+     (film-strip-button
+       {:panel-id  panel-id
+        :direction :prev
+        :enabled?  (boolean has-prev?)
+        :on-click  (when has-prev? prev-fn)})
+     (when (some? indicator)
+       [:span {:data-testid (str "rf-causa-" panel-id
+                                 "-film-strip-indicator")
+               :style       {:color       (:text-tertiary tokens)
+                             :font-family mono-stack
+                             :font-size   (:caption type-scale)}}
+        indicator])
+     (film-strip-button
+       {:panel-id  panel-id
+        :direction :next
+        :enabled?  (boolean has-next?)
+        :on-click  (when has-next? next-fn)})]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/shared/film_strip/header_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/shared/film_strip/header_cljs_test.cljc
@@ -1,0 +1,261 @@
+(ns day8.re-frame2-causa.panels.shared.film-strip.header-cljs-test
+  "Tests for the shared film-strip header (rf2-h7nqh).
+
+  Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §2.5 + §17.1.5
+  + §17.2 + §17.1.3.
+
+  Component is pure hiccup — these tests walk the rendered tree by
+  `data-testid` and never mount a DOM, so the suite runs on the JVM
+  side too (cljc)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.shared.film-strip.header :as fs]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- tiny hiccup walker ------------------------------------------------
+;;
+;; We deliberately avoid pulling in `re-frame.test-helpers` for these
+;; tests — the component is small + pure, the walker stays tiny too.
+
+(defn- walk
+  "Walk `tree` depth-first yielding every hiccup vector node."
+  [tree]
+  (cond
+    (and (vector? tree) (keyword? (first tree)))
+    (cons tree (mapcat walk (rest tree)))
+
+    (sequential? tree)
+    (mapcat walk tree)
+
+    :else
+    nil))
+
+(defn- find-by-testid
+  "Return the first hiccup vector under `tree` whose attrs carry
+  `:data-testid == testid`, or nil."
+  [tree testid]
+  (some (fn [node]
+          (when-let [a (second node)]
+            (when (and (map? a) (= testid (:data-testid a)))
+              node)))
+        (walk tree)))
+
+(defn- attrs [node] (second node))
+
+;; ---- §2.5 + §17.1.5 — both buttons render with stable testids ---------
+
+(deftest header-renders-both-buttons-with-stable-testids
+  (testing "rf2-h7nqh — every L4 panel mounts the same film-strip;
+            the testids are stable + panel-scoped so per-panel tests
+            can anchor without forking the visual contract."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")
+          next (find-by-testid tree "rf-causa-event-film-strip-next")]
+      (is (some? prev) "prev button renders with rf-causa-<panel>-film-strip-prev testid")
+      (is (some? next) "next button renders with rf-causa-<panel>-film-strip-next testid")
+      (is (= :button (first prev)))
+      (is (= :button (first next))))))
+
+(deftest header-panel-id-flows-into-every-testid
+  (testing "rf2-h7nqh — swap the panel-id, every emitted testid swaps
+            with it. No hard-coded panel name leaks through."
+    (let [tree (fs/header {:panel-id  "issues"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})]
+      (is (some? (find-by-testid tree "rf-causa-issues-film-strip")))
+      (is (some? (find-by-testid tree "rf-causa-issues-film-strip-prev")))
+      (is (some? (find-by-testid tree "rf-causa-issues-film-strip-next")))
+      (is (nil?  (find-by-testid tree "rf-causa-event-film-strip-prev"))
+          "no Event-flavoured testid leaks through Issues' header"))))
+
+(deftest header-button-labels-carry-the-canonical-glyphs
+  (testing "rf2-h7nqh — `◀ Prev` and `Next ▶` glyphs per §17.1.5
+            iconography. Glyphs are deliberate (consistent with the
+            Causa iconography convention)."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")
+          next (find-by-testid tree "rf-causa-event-film-strip-next")]
+      (is (= "◀ Prev" (last prev)))
+      (is (= "Next ▶" (last next))))))
+
+;; ---- §17.1.3 — palette: enabled chevron rides :text-secondary ----------
+
+(deftest enabled-buttons-ride-the-canonical-text-secondary-token
+  (testing "rf2-h7nqh — §17.1.3 binds the chevron to `:text-secondary`
+            in the default state (hover swap is a CSS concern; this
+            test pins the base state)."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")
+          next (find-by-testid tree "rf-causa-event-film-strip-next")]
+      (is (= (:text-secondary tokens/tokens)
+             (get-in (attrs prev) [:style :color]))
+          "prev chevron rides the canonical :text-secondary hex")
+      (is (= (:text-secondary tokens/tokens)
+             (get-in (attrs next) [:style :color])))
+      (is (= "pointer" (get-in (attrs prev) [:style :cursor]))
+          "enabled chevron carries a pointer cursor"))))
+
+;; ---- §17.2 — disabled state (no handler, no tabindex, dim token) -------
+
+(deftest disabled-prev-demotes-to-text-tertiary-and-strips-handler
+  (testing "rf2-h7nqh — §17.2 disabled row: foreground at
+            `:text-tertiary`, cursor `not-allowed`, tabindex
+            removed, no handler. (At start of L2 spine.)"
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly :should-not-fire)
+                           :next-fn   (constantly nil)
+                           :has-prev? false
+                           :has-next? true})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")
+          a    (attrs prev)]
+      (is (= (:text-tertiary tokens/tokens)
+             (get-in a [:style :color]))
+          "disabled chevron demotes to :text-tertiary")
+      (is (= "not-allowed" (get-in a [:style :cursor])))
+      (is (true? (:disabled a))
+          "HTML `disabled` attribute set so click events fizzle at the DOM")
+      (is (= "true" (:aria-disabled a)))
+      (is (= -1 (:tab-index a)) "tabindex removed per §17.2")
+      (is (nil? (:on-click a))
+          "no handler attached — disabled buttons MUST NOT fire prev-fn"))))
+
+(deftest disabled-next-demotes-the-same-way
+  (testing "rf2-h7nqh — §17.2 disabled — symmetric for Next (e.g. at
+            the end of the L2 spine)."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly :should-not-fire)
+                           :has-prev? true
+                           :has-next? false})
+          next (find-by-testid tree "rf-causa-event-film-strip-next")
+          a    (attrs next)]
+      (is (= (:text-tertiary tokens/tokens)
+             (get-in a [:style :color])))
+      (is (true? (:disabled a)))
+      (is (nil? (:on-click a))))))
+
+(deftest both-disabled-when-spine-is-empty
+  (testing "rf2-h7nqh — empty L2 spine: both buttons render in their
+            disabled visual state. Component MUST tolerate the
+            zero-epoch case."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? false
+                           :has-next? false})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")
+          next (find-by-testid tree "rf-causa-event-film-strip-next")]
+      (is (true? (:disabled (attrs prev))))
+      (is (true? (:disabled (attrs next)))))))
+
+;; ---- handler wiring -----------------------------------------------------
+
+(deftest enabled-prev-button-carries-the-supplied-handler
+  (testing "rf2-h7nqh — when has-prev? is true the prev-fn is wired
+            to :on-click. Pure-data assertion (no DOM)."
+    (let [calls (atom 0)
+          tree  (fs/header {:panel-id  "event"
+                            :prev-fn   #(swap! calls inc)
+                            :next-fn   (constantly nil)
+                            :has-prev? true
+                            :has-next? true})
+          prev  (find-by-testid tree "rf-causa-event-film-strip-prev")
+          h     (:on-click (attrs prev))]
+      (is (fn? h) "handler attached when has-prev? true")
+      (h)
+      (is (= 1 @calls) "click invokes the supplied prev-fn"))))
+
+(deftest enabled-next-button-carries-the-supplied-handler
+  (testing "rf2-h7nqh — symmetric for next-fn."
+    (let [calls (atom 0)
+          tree  (fs/header {:panel-id  "event"
+                            :prev-fn   (constantly nil)
+                            :next-fn   #(swap! calls inc)
+                            :has-prev? true
+                            :has-next? true})
+          next  (find-by-testid tree "rf-causa-event-film-strip-next")
+          h     (:on-click (attrs next))]
+      (is (fn? h))
+      (h)
+      (is (= 1 @calls)))))
+
+;; ---- middle slot — optional epoch indicator ---------------------------
+
+(deftest indicator-slot-is-optional-and-omitted-when-not-supplied
+  (let [tree (fs/header {:panel-id  "event"
+                         :prev-fn   (constantly nil)
+                         :next-fn   (constantly nil)
+                         :has-prev? true
+                         :has-next? true})]
+    (is (nil? (find-by-testid tree "rf-causa-event-film-strip-indicator"))
+        "no indicator hiccup leaks through when caller omits :indicator")))
+
+(deftest indicator-slot-renders-supplied-hiccup-with-stable-testid
+  (testing "rf2-h7nqh — parent passes hiccup; component slots it
+            between the two buttons."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true
+                           :indicator [:strong "epoch #42"]})
+          slot (find-by-testid tree "rf-causa-event-film-strip-indicator")]
+      (is (some? slot))
+      (is (= [:strong "epoch #42"] (last slot))
+          "slot contents are the caller's hiccup verbatim"))))
+
+;; ---- §17.5 stretch — per-panel filter slot ----------------------------
+
+(deftest filter-fn-slot-is-accommodated-but-optional
+  (testing "rf2-h7nqh — MVP can ship without; the API just needs to
+            accommodate. When omitted the data-attr is absent."
+    (let [tree (fs/header {:panel-id  "issues"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})
+          root (find-by-testid tree "rf-causa-issues-film-strip")]
+      (is (nil? (:data-rf-causa-filter (attrs root)))))))
+
+(deftest filter-fn-when-supplied-marks-the-root-for-test-assertion
+  (testing "rf2-h7nqh stretch — Issues panel passes a `:filter-fn`
+            (e.g. 'next epoch with ⚠'); the slot surfaces as a
+            data-attr so panel-level tests can pin the wiring
+            without the component knowing the filter's semantics."
+    (let [tree (fs/header {:panel-id  "issues"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true
+                           :filter-fn (fn [_epoch] true)})
+          root (find-by-testid tree "rf-causa-issues-film-strip")]
+      (is (= "active" (:data-rf-causa-filter (attrs root)))))))
+
+;; ---- typography — JetBrains Mono per §17.1.5 ---------------------------
+
+(deftest buttons-ride-the-mono-stack-per-iconography-spec
+  (testing "rf2-h7nqh — §17.1.5 binds the chevrons to 12px JetBrains
+            Mono. The mono-stack token is the single source for the
+            face."
+    (let [tree (fs/header {:panel-id  "event"
+                           :prev-fn   (constantly nil)
+                           :next-fn   (constantly nil)
+                           :has-prev? true
+                           :has-next? true})
+          prev (find-by-testid tree "rf-causa-event-film-strip-prev")]
+      (is (= tokens/mono-stack
+             (get-in (attrs prev) [:style :font-family]))))))


### PR DESCRIPTION
Closes rf2-h7nqh. Per spec/021 §13. New shared component used by every L4 panel: prev/next epoch navigation with disabled-state handling, optional middle indicator slot, stretch :filter-fn for per-panel narrowing. CLJS unit tests only.