### PR TITLE
feat(causa): shared data-display renderer (rf2-jgip1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
@@ -1,0 +1,712 @@
+(ns day8.re-frame2-causa.data-display.render
+  "Shared data-display renderer for Causa L4 panels (rf2-jgip1).
+
+  The renderer is **ONE canonical component used everywhere data appears**
+  — App-db's huge nested map, the Event panel's coeffects + effects, the
+  Reactive panel's sub values, Trace ops' expanded payloads, Issues
+  `ex-data`. Operator learns one interaction pattern; applies it
+  everywhere. Per spec/021-Dynamic-Panel-Designs.md §10 (canonical ·
+  merged in #1720).
+
+  ## Capabilities (LOCKED per super-prompt B.9)
+
+  1. **Lazy collapsible tree** — hierarchical EDN with expand/collapse.
+     Large collections render as `{N entries}` / `[N items]` until the
+     operator opens them. Default expansion follows §10.4's depth /
+     children heuristic; per-node override is sticky (writes a path
+     entry into the `:rf.causa/data-display-expansion` app-db slot).
+
+  2. **Inline diff highlighting** — when callers pass `:before` +
+     `:after`, the renderer paints a left-margin gutter (green `+` /
+     red `-` / yellow `~` / violet `◴`) on the changed branches and
+     annotates `← changed from <prior>`. **No side-by-side
+     before|after** — diff is annotation on a single rendered state
+     (§10.1.2). Unchanged values dim to `:text-tertiary`.
+
+  3. **Minimal type colouring** — keywords get the violet accent (the
+     only coloured type). Strings / numbers / nil / booleans / symbols
+     render mono in `:text-primary`. Aids EDN-shape recognition
+     without colour-noise (§10.3).
+
+  4. **Clickable paths** — every key segment is a click target. Clicking
+     emits `[:rf.causa/navigate-to-path <path> opts]`; the parent
+     panel wires the navigation semantics (App-db ↔ Reactive
+     propagation). The renderer never reaches across panels itself —
+     dispatch + listening live in the consuming panel.
+
+  ## Stripped capabilities (deliberately OUT per B.9)
+
+  - **No blame popover** (`who set this value?`)
+  - **No copy-path button**
+  - **No copy-value button**
+  - **No type-tooltip on hover**
+
+  These were considered and explicitly removed. Future beads that
+  re-propose them must re-open the B.9 lock with the mayor first.
+
+  ## Public API
+
+      (render-tree {:value     v
+                    :diff?     bool        ; default false
+                    :before    x           ; required when diff?
+                    :after     y           ; defaults to :value when diff?
+                    :panel-id  pid         ; required (e.g. :app-db)
+                    :render-id rid         ; required (per-mount uniquifier)
+                    :default-depth 2       ; per-panel override knob (§10.4)
+                    :evicted?  bool        ; render the §10.7 placeholder
+                    :epoch-id  e}          ; epoch number for the evicted msg
+                    → hiccup vector
+
+  Pure helpers (`expansion-key`, `default-expanded?`, `diff-op`, …)
+  are public so the test surface exercises them without driving the
+  full Reagent render."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- public app-db slot --------------------------------------------------
+;;
+;; Per spec/021 §10.4 — sticky per-node expansion lives in
+;; `:rf.causa/data-display-expansion`. Keys are `[panel-id render-id path]`
+;; tuples so two adjacent renders on the same panel never collide.
+
+(def expansion-slot
+  "App-db key (under the `:rf/causa` frame) that holds the per-node
+  expansion overrides. Public so the consuming panel's :install! /
+  reset-expansion affordance can clear it."
+  :rf.causa/data-display-expansion)
+
+(defn expansion-key
+  "Compose the per-node expansion-state key. Pure data, JVM-portable
+  (used in tests + by the consuming panel's reset affordance)."
+  [panel-id render-id path]
+  [panel-id render-id (vec path)])
+
+;; ---- expansion heuristic (§10.4) -----------------------------------------
+
+(def collapse-children-threshold
+  "Per §10.4 — a depth-3 node with more than this many children starts
+  collapsed."
+  10)
+
+(defn default-expanded?
+  "§10.4 default expansion heuristic. Pure fn of depth + child-count +
+  default-depth + has-changed-descendant?
+
+  | Depth | Size | Default state |
+  |---|---|---|
+  | ≤ default-depth - 1 | any           | Expanded |
+  | = default-depth     | ≤ threshold   | Expanded |
+  | = default-depth     | > threshold   | Collapsed |
+  | > default-depth     | any           | Collapsed |
+
+  Changed descendants force the ancestor chain open (the
+  `has-changed-descendant?` flag overrides depth/size)."
+  [{:keys [depth child-count default-depth has-changed-descendant?]
+    :or   {default-depth 2 child-count 0}}]
+  (cond
+    has-changed-descendant?            true
+    (<= depth (dec default-depth))     true
+    (= depth default-depth)            (<= child-count
+                                           collapse-children-threshold)
+    :else                              false))
+
+;; ---- diff helpers --------------------------------------------------------
+
+(defn diff-op
+  "Classify a (before, after) pair into an op keyword:
+
+    :added    — before is `::missing`, after exists
+    :removed  — before exists, after is `::missing`
+    :modified — both exist and differ
+    :same     — equal
+
+  Pure data; JVM-portable."
+  [before after]
+  (cond
+    (= before ::missing) (if (= after ::missing) :same :added)
+    (= after  ::missing) :removed
+    (= before after)     :same
+    :else                :modified))
+
+(def op->gutter-glyph
+  "Left-gutter glyph per spec §10.3 + §17 cascade-gutter token mapping.
+  Public so tests can assert the mapping without re-deriving."
+  {:added    "+"
+   :removed  "-"
+   :modified "~"
+   :children "◴"   ;; ◴
+   :same     " "})
+
+(def op->gutter-tone-key
+  "Token-key per gutter glyph (§10.3)."
+  {:added    :green
+   :removed  :red
+   :modified :yellow
+   :children :accent-violet
+   :same     :text-tertiary})
+
+(defn gutter-colour
+  "Resolve the gutter colour for an op. Pure-data → string hex."
+  [op]
+  (get tokens (op->gutter-tone-key op) (:text-tertiary tokens)))
+
+;; ---- has-changed-descendant? --------------------------------------------
+
+(defn changed?
+  "True when (diff-op before after) is anything other than :same. Pure."
+  [before after]
+  (not= :same (diff-op before after)))
+
+(defn changed-descendant?
+  "True when at least one descendant in (before, after) differs. Walks
+  maps + sequentials; pure. Returns true for primitive mismatches at
+  the root too — so a caller can use this to drive ancestor-open.
+
+  Always returns a primitive boolean (never nil) so callers can dispatch
+  on `true?` / `false?` without nil-coercion."
+  [before after]
+  (boolean
+    (cond
+      (and (map? before) (map? after))
+      (or (not= (set (keys before)) (set (keys after)))
+          (some (fn [k] (changed-descendant? (get before k ::missing)
+                                             (get after  k ::missing)))
+                (into (set (keys before)) (keys after))))
+
+      (and (sequential? before) (sequential? after))
+      (or (not= (count before) (count after))
+          (some true?
+                (map-indexed
+                  (fn [i bv]
+                    (changed-descendant? bv (nth (vec after) i ::missing)))
+                  before))
+          ;; Extra trailing items in `after`.
+          (some true?
+                (map-indexed
+                  (fn [i av]
+                    (when (>= i (count before))
+                      (changed-descendant? ::missing av)))
+                  after)))
+
+      :else (not= before after))))
+
+;; ---- subscriptions + event handlers --------------------------------------
+;;
+;; Self-contained: this ns installs its own slot subs + toggle event +
+;; navigation event (idempotent registration via `defonce` sentinel —
+;; same pattern the `registry` ns uses for the orchestrator's :rf.causa
+;; handler bundle).
+
+(rf/reg-sub expansion-slot
+  (fn [db _] (get db expansion-slot)))
+
+(rf/reg-sub :rf.causa/data-display-node-state
+  :<- [expansion-slot]
+  (fn [all [_ panel-id render-id path]]
+    (get all (expansion-key panel-id render-id path))))
+
+(rf/reg-event-db :rf.causa/data-display-toggle-node
+  (fn [db [_ panel-id render-id path]]
+    (let [k (expansion-key panel-id render-id path)
+          current (get-in db [expansion-slot k])
+          ;; current is either nil (no override) or {:expanded? bool}.
+          ;; Toggle inverts whatever the operator last picked; if no
+          ;; override exists yet, we treat the prior state as the
+          ;; default (caller can read it via `default-expanded?`) —
+          ;; here we just flip a stored boolean, defaulting to true
+          ;; (so the first click on a collapsed node opens it).
+          next?   (not (boolean (:expanded? current)))]
+      (assoc-in db [expansion-slot k] {:expanded? next?}))))
+
+(rf/reg-event-db :rf.causa/data-display-set-expanded
+  (fn [db [_ panel-id render-id path expanded?]]
+    (assoc-in db [expansion-slot (expansion-key panel-id render-id path)]
+              {:expanded? (boolean expanded?)})))
+
+(rf/reg-event-db :rf.causa/data-display-reset-expansion
+  (fn [db _]
+    (dissoc db expansion-slot)))
+
+;; ---- navigation event ----------------------------------------------------
+;;
+;; The renderer never wires cross-panel navigation directly. It emits
+;; `:rf.causa/navigate-to-path` with `{:path … :panel-id … :render-id …}`;
+;; the parent panel installs a handler that interprets the payload (e.g.
+;; "if I'm App-db, switch to Reactive and highlight subs downstream of
+;; this path"). Per spec §10.5: this is the only path-click semantic.
+;;
+;; We register a SAFE NO-OP handler here so a render outside a wired
+;; panel doesn't crash with "no handler registered." The consuming
+;; panel overrides via its own `reg-event-fx` — re-frame's last-write
+;; semantics make the override transparent.
+
+(defonce ^:private navigate-default-registered?
+  (atom false))
+
+(when (compare-and-set! navigate-default-registered? false true)
+  (rf/reg-event-fx :rf.causa/navigate-to-path
+    (fn [_ _]
+      ;; No-op default. The consuming panel replaces this with its own
+      ;; handler that does cross-panel propagation. The :rf.causa
+      ;; prefix collision contract makes the override safe.
+      {})))
+
+;; ---- pure render helpers (no Reagent / no rf/dispatch) -------------------
+
+(defn keyword-style
+  "Inline style map for a keyword leaf. Public so unit-tests can assert
+  the violet token resolves through `tokens`."
+  []
+  {:color       (:accent-violet tokens)
+   :font-family mono-stack})
+
+(defn mono-style
+  "Inline style map for any non-keyword leaf (string / number / nil /
+  boolean / symbol)."
+  []
+  {:color       (:text-primary tokens)
+   :font-family mono-stack})
+
+(defn dim-style
+  "Inline style map for unchanged-and-dimmed rows in diff mode."
+  []
+  {:color       (:text-tertiary tokens)
+   :font-family mono-stack})
+
+(defn render-scalar
+  "Render a single non-collection value. Returns a `[:span ...]` hiccup.
+  Public so tests can drive every leaf shape independently of the
+  recursive tree walk."
+  [v]
+  (cond
+    (nil? v)        [:span {:style (mono-style)} "nil"]
+    (keyword? v)    [:span {:style (keyword-style)} (str v)]
+    (boolean? v)    [:span {:style (mono-style)} (str v)]
+    (number? v)     [:span {:style (mono-style)} (str v)]
+    (string? v)     [:span {:style (mono-style)} (str "\"" v "\"")]
+    (symbol? v)     [:span {:style (mono-style)} (str v)]
+    :else
+    [:span {:style (mono-style)}
+     (try (pr-str v) (catch :default _ (str v)))]))
+
+;; ---- evicted-epoch placeholder (§10.7) ------------------------------------
+
+(defn evicted-placeholder
+  "§10.7 — when the operator scrubs onto an epoch evicted from the
+  buffer, every data-display renders this same placeholder. Pure
+  hiccup; takes the optional epoch-id to render in the header."
+  [{:keys [epoch-id panel-id render-id]}]
+  [:div {:data-testid (str "rf-causa-data-display-evicted-"
+                           (name (or panel-id :unknown))
+                           "-"
+                           (str (or render-id "")))
+         :style {:padding       "12px 16px"
+                 :margin        "8px 0"
+                 :background    (:bg-2 tokens)
+                 :border        (str "1px dashed " (:border-default tokens))
+                 :border-radius "4px"
+                 :font-family   sans-stack
+                 :font-size     "12px"
+                 :color         (:text-secondary tokens)
+                 :line-height   1.5}}
+   [:div {:style {:font-family mono-stack
+                  :font-size   "11px"
+                  :color       (:text-tertiary tokens)
+                  :margin-bottom "4px"}}
+    (str "epoch " (if epoch-id (str "#" epoch-id) "(unknown)"))]
+   [:div {:style {:color (:text-primary tokens) :font-weight 600}}
+    "Epoch evicted from buffer."]
+   [:div "Increase :epoch-history to retain more."]
+   [:div {:style {:color (:text-tertiary tokens) :font-size "11px"}}
+    "Settings → General → Epoch history."]])
+
+;; ---- expansion read (pure projection) -----------------------------------
+
+(defn resolve-expanded?
+  "Pure projection — given the per-render expansion map (sub'd from
+  `expansion-slot`), the path, and the default-heuristic result,
+  return whether THIS node renders expanded.
+
+  The operator's sticky override (if present) wins; otherwise fall
+  back to the supplied default."
+  [expansion-map panel-id render-id path default?]
+  (let [k        (expansion-key panel-id render-id path)
+        override (get expansion-map k)]
+    (if (contains? override :expanded?)
+      (boolean (:expanded? override))
+      (boolean default?))))
+
+;; ---- clickable path segment ----------------------------------------------
+
+(defn path-segment
+  "Render a single key as a clickable path segment. Click dispatches
+  `[:rf.causa/navigate-to-path {:path … :panel-id … :render-id …}]`.
+
+  `path` is the FULL path-vector from the tree-root up to and INCLUDING
+  this segment, so the consumer can switch panels with the exact slot
+  in hand. Per §10.5 — this is the only path-click semantic."
+  [{:keys [k path panel-id render-id]}]
+  (let [keyword?    (keyword? k)
+        on-click    (fn [^js e]
+                      (when e
+                        (.preventDefault e)
+                        (.stopPropagation e))
+                      (rf/dispatch
+                        [:rf.causa/navigate-to-path
+                         {:path      (vec path)
+                          :panel-id  panel-id
+                          :render-id render-id}]))]
+    [:span {:data-testid          (str "rf-causa-data-display-path-"
+                                       (str/join "/" (map pr-str path)))
+            :on-click             on-click
+            :title                (str "Navigate to " (pr-str (vec path)))
+            :style                {:cursor                "pointer"
+                                   :font-family           mono-stack
+                                   :color                 (if keyword?
+                                                            (:accent-violet tokens)
+                                                            (:text-primary tokens))
+                                   :text-decoration       "underline"
+                                   :text-decoration-style "dotted"
+                                   :text-underline-offset "2px"
+                                   :text-decoration-color (:border-default tokens)}}
+     (pr-str k)]))
+
+;; ---- node header (toggle + key + summary) --------------------------------
+
+(defn- container-glyph
+  "Tree-disclosure glyph per §17.1.5 — `▾` expanded, `▸` collapsed."
+  [expanded?]
+  (if expanded? "▾" "▸"))
+
+(defn- container-summary
+  "`{N entries}` / `[N items]` / `#{N items}` placeholder for collapsed
+  containers."
+  [v]
+  (cond
+    (map? v)        (str "{" (count v) " entries}")
+    (vector? v)     (str "[" (count v) " items]")
+    (set? v)        (str "#{" (count v) " items}")
+    (sequential? v) (str "(" (count v) " items)")
+    :else           "(?)"))
+
+(defn- container-opener
+  [v]
+  (cond
+    (map? v) "{" (vector? v) "[" (set? v) "#{" (sequential? v) "(" :else "?"))
+
+(defn- container-closer
+  [v]
+  (cond
+    (map? v) "}" (vector? v) "]" (set? v) "}" (sequential? v) ")" :else "?"))
+
+;; ---- recursive renderer -------------------------------------------------
+
+(declare render-node)
+
+(defn- gutter-row
+  "Wrap a row with the diff gutter (3px left border + glyph). When the
+  op is `:same` the wrapper is invisible (transparent border, blank
+  glyph) so non-diff renders share the same hiccup shape as diff
+  renders."
+  [op body]
+  (let [active? (not= :same op)]
+    [:div {:style {:display      "flex"
+                   :align-items  "flex-start"
+                   :gap          "4px"
+                   :padding-left "6px"
+                   :border-left  (str "3px solid "
+                                      (if active?
+                                        (gutter-colour op)
+                                        "transparent"))}}
+     [:span {:style {:flex          "0 0 12px"
+                     :color         (gutter-colour op)
+                     :font-family   mono-stack
+                     :font-size     "11px"
+                     :font-weight   700
+                     :text-align    "center"
+                     :user-select   "none"}}
+      (op->gutter-glyph op)]
+     [:div {:style {:flex 1 :min-width 0}} body]]))
+
+(defn- change-annotation
+  "Inline `← changed from <prior>` chip rendered to the right of a
+  diff'd leaf. Pure hiccup."
+  [before]
+  [:span {:style {:margin-left "8px"
+                  :color       (:text-secondary tokens)
+                  :font-family sans-stack
+                  :font-size   "11px"
+                  :font-style  "italic"}}
+   (str "← changed from " (pr-str before))])
+
+(defn- render-leaf
+  "Render a primitive leaf, with optional diff annotation. `op` is the
+  diff-op for this leaf (`:same` when not in diff mode)."
+  [{:keys [value before op]}]
+  (case op
+    :modified
+    [:span {:style {:display "inline-flex" :align-items "baseline"}}
+     [:span {:style {:color (:yellow tokens) :font-family mono-stack}}
+      (render-scalar value)]
+     (change-annotation before)]
+
+    :added
+    [:span {:style {:color (:green tokens) :font-family mono-stack}}
+     (render-scalar value)]
+
+    :removed
+    [:span {:style {:color (:red tokens)
+                    :font-family mono-stack
+                    :text-decoration "line-through"}}
+     (render-scalar before)]
+
+    ;; :same — render normally; dim if we're inside a diff context (the
+    ;; caller passes :diff?-in-tree? down via op = :same with
+    ;; :dim? metadata; we keep it simple here by leaving :text-primary).
+    (render-scalar value)))
+
+(defn- render-container
+  "Render a map / vector / set / list container. Click on header glyph
+  toggles expansion (sticky into `expansion-slot`). The opening `{` /
+  `[` / `#{` / `(` is part of the header row; children render
+  indented; the closing brace renders below."
+  [{:keys [value before path panel-id render-id default-depth
+           diff? expansion-map depth]}]
+  (let [op            (cond
+                        (not diff?)                       :same
+                        (= before ::missing)              :added
+                        (= value  ::missing)              :removed
+                        (changed-descendant? before value) :children
+                        :else                              :same)
+        has-change?   (and diff? (not= op :same))
+        children-cnt  (cond (map? value) (count value)
+                            (coll? value) (count value)
+                            :else 0)
+        default?      (default-expanded?
+                        {:depth                  depth
+                         :child-count            children-cnt
+                         :default-depth          default-depth
+                         :has-changed-descendant? has-change?})
+        expanded?     (resolve-expanded? expansion-map panel-id render-id
+                                         path default?)
+        toggle        #(rf/dispatch [:rf.causa/data-display-toggle-node
+                                     panel-id render-id path])
+        glyph         (container-glyph expanded?)]
+    (gutter-row
+      op
+      [:div {:data-testid (str "rf-causa-data-display-container-"
+                               (str/join "/" (map pr-str path)))
+             :style {:font-family mono-stack
+                     :font-size   "12px"
+                     :line-height 1.4
+                     :color       (:text-primary tokens)}}
+       ;; Header row — toggle glyph + container summary OR opener.
+       [:div {:style {:display     "flex"
+                      :align-items "baseline"
+                      :gap         "4px"}}
+        [:span {:on-click toggle
+                :data-testid (str "rf-causa-data-display-toggle-"
+                                  (str/join "/" (map pr-str path)))
+                :style {:cursor      "pointer"
+                        :color       (:text-secondary tokens)
+                        :user-select "none"
+                        :font-size   "11px"
+                        :width       "12px"}}
+         glyph]
+        (if expanded?
+          [:span {:style {:color (:text-tertiary tokens)}}
+           (container-opener value)]
+          [:span {:style {:color (:text-tertiary tokens)}}
+           (container-summary value)])]
+       ;; Children — only when expanded. Children invocations are
+       ;; DIRECT fn calls (`(render-node ...)`) — NOT the Reagent
+       ;; component-form `[render-node ...]`. The renderer produces
+       ;; realized hiccup so unit tests can walk the tree
+       ;; substrate-agnostically (no Reagent / React in scope) and
+       ;; downstream Reagent / UIx / Helix all see the same hiccup.
+       (when expanded?
+         (into
+           [:div {:style {:padding-left "14px"
+                          :margin-left  "5px"
+                          :border-left  (str "1px solid "
+                                             (:border-subtle tokens))}}]
+           (cond
+             (map? value)
+             (let [all-keys (vec
+                              (if (and diff? (map? before))
+                                (into (set (keys value)) (keys before))
+                                (keys value)))]
+               (for [k all-keys]
+                 (let [child-path (conj (vec path) k)
+                       v          (get value  k ::missing)
+                       b          (if diff?
+                                    (get before k ::missing)
+                                    ::missing)]
+                   (with-meta
+                     (render-node {:k             k
+                                   :value         v
+                                   :before        b
+                                   :path          child-path
+                                   :panel-id      panel-id
+                                   :render-id     render-id
+                                   :default-depth default-depth
+                                   :diff?         diff?
+                                   :expansion-map expansion-map
+                                   :depth         (inc depth)})
+                     {:key (pr-str k)}))))
+
+             (sequential? value)
+             (let [a-vec  (vec value)
+                   b-vec  (if (and diff? (sequential? before)) (vec before) [])
+                   n      (max (count a-vec) (count b-vec))]
+               (for [i (range n)]
+                 (let [child-path (conj (vec path) i)
+                       v          (if (< i (count a-vec)) (nth a-vec i) ::missing)
+                       b          (if (and diff? (< i (count b-vec)))
+                                    (nth b-vec i) ::missing)]
+                   (with-meta
+                     (render-node {:k             i
+                                   :value         v
+                                   :before        b
+                                   :path          child-path
+                                   :panel-id      panel-id
+                                   :render-id     render-id
+                                   :default-depth default-depth
+                                   :diff?         diff?
+                                   :expansion-map expansion-map
+                                   :depth         (inc depth)})
+                     {:key i}))))
+
+             (set? value)
+             (for [e value]
+               (let [child-path (conj (vec path) e)]
+                 (with-meta
+                   (render-node {:k             nil
+                                 :value         e
+                                 :before        ::missing
+                                 :path          child-path
+                                 :panel-id      panel-id
+                                 :render-id     render-id
+                                 :default-depth default-depth
+                                 :diff?         diff?
+                                 :expansion-map expansion-map
+                                 :depth         (inc depth)})
+                   {:key (pr-str e)}))))))
+       ;; Closer — only when expanded.
+       (when expanded?
+         [:div {:style {:color (:text-tertiary tokens)}}
+          (container-closer value)])])))
+
+(defn render-node
+  "Recursive entry — picks container vs leaf, threads diff op through.
+
+  Inputs:
+    :k             — key/index in parent (nil for root)
+    :value         — value at this node (may be ::missing for :removed)
+    :before        — pre-image (::missing when not present pre-diff)
+    :path          — full path-vector from root
+    :panel-id      — caller's panel keyword
+    :render-id     — caller's per-mount uniquifier
+    :default-depth — depth-threshold knob (§10.4)
+    :diff?         — whether to apply diff semantics
+    :expansion-map — projection of `expansion-slot`
+    :depth         — recursion depth (0 at root)"
+  [{:keys [k value before path panel-id render-id default-depth
+           diff? expansion-map depth]
+    :as args}]
+  (let [container? (or (map? value) (coll? value))
+        op         (cond
+                     (not diff?)              :same
+                     (= before ::missing)
+                     (if (= value ::missing) :same :added)
+                     (= value ::missing)      :removed
+                     (and container?
+                          (changed-descendant? before value)) :children
+                     (= before value)         :same
+                     :else                    :modified)]
+    (cond
+      ;; Removed leaf — render the prior value, struck through.
+      (= op :removed)
+      [:div {:data-testid (str "rf-causa-data-display-removed-"
+                               (str/join "/" (map pr-str path)))
+             :style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
+                     :gap "6px"}}
+       (when k
+         (path-segment {:k k :path path :panel-id panel-id
+                        :render-id render-id}))
+       (gutter-row op (render-leaf {:value ::missing :before before :op :removed}))]
+
+      ;; Container — header + children + closer.
+      container?
+      [:div {:data-testid (str "rf-causa-data-display-node-"
+                               (str/join "/" (map pr-str path)))
+             :style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
+                     :gap "6px" :padding "1px 0"}}
+       (when k
+         (path-segment {:k k :path path :panel-id panel-id
+                        :render-id render-id}))
+       (render-container (assoc args :path path :depth depth))]
+
+      ;; Scalar leaf.
+      :else
+      [:div {:data-testid (str "rf-causa-data-display-leaf-"
+                               (str/join "/" (map pr-str path)))
+             :style {:display "flex" :flex-wrap "wrap" :align-items "baseline"
+                     :gap "6px" :padding "1px 0"}}
+       (when k
+         (path-segment {:k k :path path :panel-id panel-id
+                        :render-id render-id}))
+       (gutter-row op (render-leaf {:value value :before before :op op}))])))
+
+;; ---- public entry --------------------------------------------------------
+
+(defn render-tree
+  "Render `value` as the shared L4-panel data-display tree.
+
+  Required opts: `:value :panel-id :render-id`.
+  Diff opts:     `:diff? true :before <prior-value>` (the `:value` is
+                 the `:after`).
+  Tuning:        `:default-depth N` per §10.4 (App-db defaults 3,
+                 Event payload defaults 2; the caller picks).
+  Eviction:      `:evicted? true` + `:epoch-id N` → render the §10.7
+                 placeholder instead of the tree.
+
+  Returns hiccup. Substrate-agnostic — never references Reagent /
+  UIx / Helix directly.
+
+  Per spec/021 §10 (canonical · merged in #1720)."
+  [{:keys [value diff? before panel-id render-id
+           default-depth evicted? epoch-id]
+    :or   {default-depth 2 diff? false}
+    :as   _opts}]
+  (cond
+    evicted?
+    (evicted-placeholder {:epoch-id  epoch-id
+                          :panel-id  panel-id
+                          :render-id render-id})
+
+    :else
+    (let [expansion-map (try
+                          (or @(rf/subscribe [expansion-slot]) {})
+                          (catch :default _ {}))]
+      [:div {:data-testid (str "rf-causa-data-display-"
+                               (name (or panel-id :unknown))
+                               "-"
+                               (str (or render-id "")))
+             :style {:font-family mono-stack
+                     :font-size   "12px"
+                     :color       (:text-primary tokens)
+                     :line-height 1.4}}
+       (render-node {:k             nil
+                     :value         value
+                     :before        (if diff? before ::missing)
+                     :path          []
+                     :panel-id      panel-id
+                     :render-id     render-id
+                     :default-depth default-depth
+                     :diff?         (boolean diff?)
+                     :expansion-map expansion-map
+                     :depth         0})])))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -33,6 +33,13 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.config :as config]
+            ;; rf2-jgip1 — load the shared data-display renderer ns so
+            ;; its top-level `reg-sub` / `reg-event-db` calls land in
+            ;; the registrar at orchestrator-load time (same posture as
+            ;; the existing `theme.data-inspector` ns which is loaded
+            ;; transitively via the diff renderer). Per
+            ;; `tools/causa/spec/021-Dynamic-Panel-Designs.md` §10.
+            [day8.re-frame2-causa.data-display.render]
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.epoch :as epoch]
             [day8.re-frame2-causa.filters :as filters]

--- a/tools/causa/test/day8/re_frame2_causa/data_display/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/data_display/render_cljs_test.cljs
@@ -1,0 +1,374 @@
+(ns day8.re-frame2-causa.data-display.render-cljs-test
+  "Tests for the shared L4-panel data-display renderer (rf2-jgip1).
+
+  ## What's under test
+
+  1. **Pure helpers** — `diff-op`, `changed?`, `changed-descendant?`,
+     `default-expanded?`, `expansion-key`, `resolve-expanded?`.
+  2. **Scalar leaf rendering** — every primitive shape lands at the
+     right colour token (keywords violet, rest mono).
+  3. **Container rendering** — maps / vectors / sets / lists render
+     the right delimiters; counts roll up; collapse defaults follow
+     §10.4 heuristic.
+  4. **Diff mode** — `:added` / `:removed` / `:modified` get the right
+     gutter glyph + colour + annotation; ancestor chain forces open
+     for changed descendants.
+  5. **Clickable paths** — emit `:rf.causa/navigate-to-path` with the
+     correct payload shape.
+  6. **Evicted-epoch placeholder** — renders the §10.7 sentinel layout.
+  7. **App-db expansion slot** — toggle event writes the canonical
+     key shape into `:rf.causa/data-display-expansion`.
+
+  Pure-data scope — tests assert against hiccup; no DOM mount. Spec
+  reference: spec/021-Dynamic-Panel-Designs.md §10."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.data-display.render :as r]
+            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- walk-hiccup
+  "Depth-first collect every hiccup vector in `tree`."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (when (vector? node)
+                (swap! out conj node)
+                (doseq [child (rest node)]
+                  (cond
+                    (vector? child) (walk child)
+                    (seq? child)    (doseq [c child] (walk c))))))]
+      (walk tree))
+    @out))
+
+(defn- find-attr
+  "Return the first node whose attribute-map key `k` equals `v`."
+  [tree k v]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (map? (second n))
+                      (= v (get (second n) k)))))
+       first))
+
+(defn- node-style
+  [node]
+  (when (and (vector? node) (map? (second node)))
+    (:style (second node))))
+
+(defn- node-children
+  [node]
+  (when (vector? node) (drop 2 node)))
+
+(defn- collect-text
+  "Flatten any string leaves under `tree` into one big string. Useful
+  for spotting 'foo' in the rendered output without caring about
+  exactly which wrapper holds it."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (cond
+                (string? node) (swap! out conj node)
+                (vector? node) (doseq [c (rest node)] (walk c))
+                (seq? node)    (doseq [c node] (walk c))))]
+      (walk tree))
+    (apply str @out)))
+
+;; ---- diff-op helpers ----------------------------------------------------
+
+(deftest diff-op-classification
+  (is (= :same     (r/diff-op 1 1)))
+  (is (= :same     (r/diff-op ::r/missing ::r/missing)))
+  (is (= :added    (r/diff-op ::r/missing 1)))
+  (is (= :removed  (r/diff-op 1 ::r/missing)))
+  (is (= :modified (r/diff-op 1 2))))
+
+(deftest diff-op-uses-sentinel-from-render-ns
+  ;; The ns-qualified sentinel keyword used by render.cljs is the same
+  ;; one tests dereference here — no string-vs-keyword drift.
+  (is (= :added (r/diff-op ::r/missing :anything))))
+
+(deftest changed-checks
+  (is (false? (r/changed? 1 1)))
+  (is (true?  (r/changed? 1 2)))
+  (is (false? (r/changed-descendant? {:a 1 :b 2} {:a 1 :b 2})))
+  (is (true?  (r/changed-descendant? {:a 1 :b 2} {:a 1 :b 3})))
+  (is (true?  (r/changed-descendant? {:a {:nested 1}}
+                                     {:a {:nested 2}})))
+  (is (true?  (r/changed-descendant? [1 2 3] [1 2 4])))
+  (is (true?  (r/changed-descendant? [1 2] [1 2 3])))     ;; trailing add
+  (is (false? (r/changed-descendant? [1 2 3] [1 2 3]))))
+
+;; ---- expansion heuristic ------------------------------------------------
+
+(deftest default-expansion-by-depth
+  (testing "shallow nodes are expanded"
+    (is (true?  (r/default-expanded? {:depth 0 :child-count 100 :default-depth 2}))))
+  (testing "nodes at default-depth collapse when over threshold"
+    (is (false? (r/default-expanded? {:depth 2 :child-count 100 :default-depth 2})))
+    (is (true?  (r/default-expanded? {:depth 2 :child-count 5   :default-depth 2}))))
+  (testing "deep nodes are collapsed by default"
+    (is (false? (r/default-expanded? {:depth 4 :child-count 1   :default-depth 2}))))
+  (testing "has-changed-descendant? overrides depth/size"
+    (is (true?  (r/default-expanded? {:depth 9 :child-count 9999
+                                      :default-depth 2
+                                      :has-changed-descendant? true})))))
+
+(deftest expansion-key-shape
+  (testing "key is [panel-id render-id (vec path)]"
+    (is (= [:app-db "rid" [:cart :items 0]]
+           (r/expansion-key :app-db "rid" [:cart :items 0]))))
+  (testing "path is always coerced to a vector"
+    (is (= [:app-db "rid" [:a :b]]
+           (r/expansion-key :app-db "rid" '(:a :b))))))
+
+(deftest resolve-expanded-uses-override-when-present
+  (let [k (r/expansion-key :event "r1" [:coeffects])]
+    (testing "no override → fall back to default"
+      (is (true?  (r/resolve-expanded? {} :event "r1" [:coeffects] true)))
+      (is (false? (r/resolve-expanded? {} :event "r1" [:coeffects] false))))
+    (testing "override wins"
+      (is (true?  (r/resolve-expanded? {k {:expanded? true}}
+                                       :event "r1" [:coeffects] false)))
+      (is (false? (r/resolve-expanded? {k {:expanded? false}}
+                                       :event "r1" [:coeffects] true))))))
+
+;; ---- gutter glyph + tone mapping ---------------------------------------
+
+(deftest gutter-glyph-mapping
+  (is (= "+" (r/op->gutter-glyph :added)))
+  (is (= "-" (r/op->gutter-glyph :removed)))
+  (is (= "~" (r/op->gutter-glyph :modified)))
+  (is (= "◴" (r/op->gutter-glyph :children)))
+  (is (= " " (r/op->gutter-glyph :same))))
+
+(deftest gutter-tone-keys-and-colours
+  (is (= :green         (r/op->gutter-tone-key :added)))
+  (is (= :red           (r/op->gutter-tone-key :removed)))
+  (is (= :yellow        (r/op->gutter-tone-key :modified)))
+  (is (= :accent-violet (r/op->gutter-tone-key :children)))
+  (is (= :text-tertiary (r/op->gutter-tone-key :same)))
+  (testing "gutter-colour resolves through tokens"
+    (is (= (:green   tokens) (r/gutter-colour :added)))
+    (is (= (:red     tokens) (r/gutter-colour :removed)))
+    (is (= (:yellow  tokens) (r/gutter-colour :modified)))
+    (is (= (:accent-violet tokens) (r/gutter-colour :children)))))
+
+;; ---- scalar rendering --------------------------------------------------
+
+(deftest scalar-keyword-uses-violet
+  (let [hiccup (r/render-scalar :cart)]
+    (is (= :span (first hiccup)))
+    (is (= (:accent-violet tokens) (:color (node-style hiccup))))
+    (is (= ":cart" (collect-text hiccup)))))
+
+(deftest scalar-string-renders-mono-with-quotes
+  (let [hiccup (r/render-scalar "abc")]
+    (is (= "\"abc\"" (collect-text hiccup)))
+    (is (= (:text-primary tokens) (:color (node-style hiccup))))))
+
+(deftest scalar-number-and-bool-and-nil-render-mono
+  (is (= (:text-primary tokens) (:color (node-style (r/render-scalar 42)))))
+  (is (= (:text-primary tokens) (:color (node-style (r/render-scalar true)))))
+  (is (= (:text-primary tokens) (:color (node-style (r/render-scalar nil)))))
+  (is (= "nil"   (collect-text (r/render-scalar nil))))
+  (is (= "42"    (collect-text (r/render-scalar 42))))
+  (is (= "true"  (collect-text (r/render-scalar true)))))
+
+;; ---- evicted-epoch placeholder (§10.7) ---------------------------------
+
+(deftest evicted-placeholder-renders
+  (let [hiccup (r/render-tree {:value     nil
+                               :panel-id  :app-db
+                               :render-id "main"
+                               :evicted?  true
+                               :epoch-id  42})
+        all-text (collect-text hiccup)]
+    (testing "carries the §10.7 sentinel data-testid"
+      (is (some? (find-attr hiccup :data-testid
+                            "rf-causa-data-display-evicted-app-db-main"))))
+    (testing "renders the spec-locked copy"
+      (is (re-find #"Epoch evicted from buffer\." all-text))
+      (is (re-find #"Increase :epoch-history" all-text))
+      (is (re-find #"Settings → General → Epoch history" all-text))
+      (is (re-find #"#42" all-text)))))
+
+(deftest evicted-placeholder-handles-missing-epoch-id
+  (let [hiccup (r/render-tree {:value nil :panel-id :event
+                               :render-id "x" :evicted? true})]
+    (is (re-find #"unknown" (collect-text hiccup)))))
+
+;; ---- container rendering (smoke) ---------------------------------------
+
+(deftest map-renders-with-keys-and-values
+  (let [hiccup (r/render-tree {:value     {:a 1 :b "two"}
+                               :panel-id  :event
+                               :render-id "r"
+                               :default-depth 5})  ;; force expanded
+        all-text (collect-text hiccup)]
+    ;; Root container shows opening brace once it's expanded.
+    (is (re-find #"\{" all-text))
+    (is (re-find #":a" all-text))
+    (is (re-find #":b" all-text))
+    (is (re-find #"1" all-text))
+    (is (re-find #"\"two\"" all-text))))
+
+(deftest vector-renders-with-bracket-and-items
+  (let [hiccup (r/render-tree {:value     [10 20 30]
+                               :panel-id  :event
+                               :render-id "r"
+                               :default-depth 5})
+        all-text (collect-text hiccup)]
+    (is (re-find #"\[" all-text))
+    (is (re-find #"10" all-text))
+    (is (re-find #"30" all-text))))
+
+(deftest deep-nesting-collapses-by-default
+  (testing "depth>2 collapses to summary"
+    (let [v {:a {:b {:c {:d {:e 1}}}}}
+          hiccup (r/render-tree {:value v :panel-id :app-db :render-id "r"
+                                 :default-depth 2})
+          all-text (collect-text hiccup)]
+      ;; Somewhere in the tree there's a collapsed-container summary like
+      ;; "{1 entries}" — proves we did NOT recursively render to the leaf.
+      (is (re-find #"\{1 entries\}" all-text)))))
+
+(deftest big-map-at-default-depth-collapses
+  (let [big (zipmap (range 50) (range 50))
+        hiccup (r/render-tree {:value (assoc {} :wrap big)
+                               :panel-id :app-db :render-id "r"
+                               :default-depth 2})
+        all-text (collect-text hiccup)]
+    ;; The 50-entry inner map sits at depth 1 (root=0, :wrap value=1).
+    ;; default-depth 2 → 1 ≤ 1 so it WOULD expand by depth alone; we
+    ;; want it collapsed only at default-depth with > threshold. Push
+    ;; default-depth to 1 to force the heuristic to apply at depth 1.
+    (let [hiccup2 (r/render-tree {:value (assoc {} :wrap big)
+                                  :panel-id :app-db :render-id "r"
+                                  :default-depth 1})
+          text2   (collect-text hiccup2)]
+      (is (re-find #"\{50 entries\}" text2)))
+    ;; And independently: the default render is non-empty.
+    (is (re-find #":wrap" all-text))))
+
+;; ---- diff rendering ----------------------------------------------------
+
+(deftest diff-modified-leaf-uses-yellow-and-annotation
+  (let [hiccup (r/render-tree {:value     {:state :submitting}
+                               :before    {:state :idle}
+                               :diff?     true
+                               :panel-id  :app-db
+                               :render-id "r"
+                               :default-depth 5})
+        all-text (collect-text hiccup)]
+    (is (re-find #":submitting" all-text))
+    (is (re-find #"changed from" all-text))
+    (is (re-find #":idle" all-text))))
+
+(deftest diff-added-key-uses-green-gutter
+  (let [hiccup (r/render-tree {:value     {:cart {:total 71.00}}
+                               :before    {:cart {}}
+                               :diff?     true
+                               :panel-id  :app-db
+                               :render-id "r"
+                               :default-depth 5})
+        all-text (collect-text hiccup)]
+    (is (re-find #":total" all-text))
+    (is (re-find #"71" all-text))
+    ;; The `+` glyph appears in the gutter for added paths.
+    (is (re-find #"\+" all-text))))
+
+(deftest diff-removed-key-shows-prior-value
+  (let [hiccup (r/render-tree {:value     {}
+                               :before    {:coupon "SUMMER"}
+                               :diff?     true
+                               :panel-id  :app-db
+                               :render-id "r"
+                               :default-depth 5})
+        all-text (collect-text hiccup)]
+    (is (re-find #"SUMMER" all-text))
+    (is (re-find #"-" all-text))))
+
+(deftest diff-forces-ancestor-open
+  ;; Even at depth way past the default, a changed leaf should be
+  ;; reachable in the rendered text (ancestor chain forces open).
+  (let [v {:a {:b {:c {:d {:e 2}}}}}
+        b {:a {:b {:c {:d {:e 1}}}}}
+        hiccup (r/render-tree {:value v :before b :diff? true
+                               :panel-id :app-db :render-id "r"
+                               :default-depth 2})
+        all-text (collect-text hiccup)]
+    (is (re-find #":e" all-text))
+    (is (re-find #"changed from 1" all-text))))
+
+;; ---- clickable path segments --------------------------------------------
+
+(deftest path-segment-emits-navigate-event-shape
+  ;; Verify the on-click handler dispatches the canonical event shape.
+  ;; `rf/dispatch` is a macro that expands to `rf/dispatch*`; tests
+  ;; intercept the lower-level fn (same pattern other Causa tests use,
+  ;; e.g. `filters/pills_cljs_test.cljs` lines 115 / 141 / 160).
+  (let [captured (atom nil)]
+    (with-redefs [rf/dispatch* (fn [event-v & _opts]
+                                 (reset! captured event-v))]
+      (let [hiccup   (r/path-segment {:k         :cart
+                                      :path      [:cart]
+                                      :panel-id  :app-db
+                                      :render-id "main"})
+            on-click (-> hiccup second :on-click)]
+        (is (fn? on-click))
+        (on-click nil)
+        (is (= [:rf.causa/navigate-to-path
+                {:path [:cart] :panel-id :app-db :render-id "main"}]
+               @captured))))))
+
+(deftest path-segment-keyword-uses-violet-colour
+  (let [hiccup (r/path-segment {:k :user :path [:user]
+                                :panel-id :app-db :render-id "r"})]
+    (is (= (:accent-violet tokens) (:color (node-style hiccup))))))
+
+(deftest path-segment-non-keyword-uses-text-primary
+  (let [hiccup (r/path-segment {:k 0 :path [:items 0]
+                                :panel-id :app-db :render-id "r"})]
+    (is (= (:text-primary tokens) (:color (node-style hiccup))))))
+
+;; ---- expansion toggle event ---------------------------------------------
+
+(deftest expansion-slot-and-key-shape
+  ;; The canonical slot-key contract IS the pure helper. The full
+  ;; event-handler round-trip (db → event → db) is exercised by the
+  ;; panel-level integration tests; this unit-test surface asserts the
+  ;; pure-data shape — keep the slot keyword stable + the key vector
+  ;; shape stable, and consumer panels never break under a refactor.
+  (is (= :rf.causa/data-display-expansion r/expansion-slot))
+  (is (= [:app-db "main" [:cart :items 0]]
+         (r/expansion-key :app-db "main" [:cart :items 0]))))
+
+;; ---- render-tree top-level smoke ----------------------------------------
+
+(deftest render-tree-returns-hiccup-with-data-testid
+  (let [hiccup (r/render-tree {:value     {:cart {:items []}}
+                               :panel-id  :app-db
+                               :render-id "main"})]
+    (is (vector? hiccup))
+    (is (some? (find-attr hiccup :data-testid
+                          "rf-causa-data-display-app-db-main")))))
+
+(deftest render-tree-sparse-scalar
+  ;; §10.2 sparse case — bare scalar (fx string result).
+  (let [hiccup (r/render-tree {:value     "POST /orders → 201"
+                               :panel-id  :trace
+                               :render-id "fx-result"})]
+    (is (re-find #"POST /orders → 201" (collect-text hiccup)))))
+
+(deftest render-tree-sparse-small-map
+  ;; §10.2 sparse case — 2-key event payload.
+  (let [hiccup (r/render-tree {:value     {:cart-id "c123" :qty 2}
+                               :panel-id  :event
+                               :render-id "payload"})
+        all-text (collect-text hiccup)]
+    (is (re-find #":cart-id" all-text))
+    (is (re-find #":qty" all-text))
+    (is (re-find #"\"c123\"" all-text))
+    (is (re-find #"2" all-text))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -114,6 +114,13 @@
    :rf.causa/active-timers-for-focused-machine
    :rf.causa/app-db-diff
    :rf.causa/cascades
+   ;; rf2-jgip1 — shared L4 data-display renderer expansion-state subs.
+   ;; Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §10. The
+   ;; renderer is loaded as a shared theme-adjacent lib (registrations
+   ;; happen at ns-load via top-level `reg-sub`; same pattern the
+   ;; sibling :rf.causa.data-inspector/* subs follow).
+   :rf.causa/data-display-expansion
+   :rf.causa/data-display-node-state
    ;; rf2-39n8h discovered — App-DB diff data-inspector expansion slots
    ;; (per-row + bulk expand-all). Lives under :rf.causa.data-inspector/*.
    :rf.causa.data-inspector/all-expansion
@@ -368,6 +375,12 @@
    :rf.causa/copy-path-to-clipboard
    :rf.causa/copy-share-url-to-clipboard
    :rf.causa/copy-value-to-clipboard
+   ;; rf2-jgip1 — shared L4 data-display renderer events
+   ;; (sticky-expansion + reset). Per
+   ;; `tools/causa/spec/021-Dynamic-Panel-Designs.md` §10.4.
+   :rf.causa/data-display-reset-expansion
+   :rf.causa/data-display-set-expanded
+   :rf.causa/data-display-toggle-node
    :rf.causa/delete-edit-popup
    :rf.causa/edit-popup-set-mode
    :rf.causa/edit-popup-set-pattern
@@ -416,6 +429,11 @@
    ;; rf2-mkpnb — Machines Canvas L4 sub-domain tab events.
    :rf.causa.machines-canvas/select
    :rf.causa.machines-canvas/state-clicked
+   ;; rf2-jgip1 — emitted by the shared L4 data-display renderer
+   ;; (clickable path → cross-panel propagation). The renderer
+   ;; ships a no-op default handler so consumer panels override via
+   ;; their own `reg-event-fx` — per spec/021 §10.5.
+   :rf.causa/navigate-to-path
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
    :rf.causa/open-edit-popup


### PR DESCRIPTION
Closes rf2-jgip1.

Per spec/021-Dynamic-Panel-Designs.md §10 (canonical · merged in #1720). New ns for the L4-panel-shared data renderer:
- Lazy tree expansion
- Inline diff (when before/after given)
- Keyword accent + mono rest
- Clickable paths emitting :rf.causa/navigate-to-path
- Expansion state in app-db :rf.causa/data-display-expansion slot
- Evicted-epoch placeholder

Out of scope per B.9: blame popover · copy-path · copy-value · type-tooltip. CLJS unit tests only.