### PR TITLE
feat(substrate): DEBUG-gated handler source capture at reg-event-{db,fx,ctx} (rf2-xgfuy)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -175,23 +175,34 @@
 
 #?(:clj
    (do
-     (rm/defreg-macro reg-event-db events/reg-event-db
+     (rm/defreg-event-macro reg-event-db events/reg-event-db
        "Register a `(fn [db event-vec] new-db)` event handler under `id`.
-       Captures source-coords (Spec 001) at this call site. See
-       `re-frame.events/reg-event-db` for the full signature.")
+       Captures source-coords (Spec 001) at this call site. Additionally
+       captures the whole `(reg-event-db :id ...)` form as a string under
+       the handler's `:rf.handler/source` meta (Spec 009, rf2-xgfuy) —
+       DEBUG-gated, elided in CLJS `:advanced` + `goog.DEBUG=false`
+       production builds. See `re-frame.events/reg-event-db` for the
+       full signature.")
 
-     (rm/defreg-macro reg-event-fx events/reg-event-fx
+     (rm/defreg-event-macro reg-event-fx events/reg-event-fx
        "Register a `(fn [cofx event-vec] effect-map)` event handler under
        `id`. Effect-map is a closed shape: only `:db` and `:fx` at the
        top level. Captures source-coords (Spec 001) at this call site.
-       See `re-frame.events/reg-event-fx` for the full signature.")
+       Additionally captures the whole `(reg-event-fx :id ...)` form as
+       a string under the handler's `:rf.handler/source` meta (Spec 009,
+       rf2-xgfuy) — DEBUG-gated, elided in CLJS `:advanced` +
+       `goog.DEBUG=false` production builds. See
+       `re-frame.events/reg-event-fx` for the full signature.")
 
-     (rm/defreg-macro reg-event-ctx events/reg-event-ctx
+     (rm/defreg-event-macro reg-event-ctx events/reg-event-ctx
        "Register a `(fn [context] context)` full-context event handler
        under `id`. Advanced — most handlers want `reg-event-db` or
        `reg-event-fx` instead. Captures source-coords (Spec 001) at
-       this call site. See `re-frame.events/reg-event-ctx` for the
-       full signature.")
+       this call site. Additionally captures the whole `(reg-event-ctx
+       :id ...)` form as a string under the handler's `:rf.handler/
+       source` meta (Spec 009, rf2-xgfuy) — DEBUG-gated, elided in CLJS
+       `:advanced` + `goog.DEBUG=false` production builds. See
+       `re-frame.events/reg-event-ctx` for the full signature.")
 
      (rm/defreg-macro reg-sub subs/reg-sub
        "Register a subscription under `id`. Layer-1 subs read `app-db`

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -113,6 +113,72 @@
                             (symbol (str (ns-name ~'*ns*)))
                             (list* '~qualified args#))))))
 
+;; ---- defreg-event-macro --------------------------------------------------
+;;
+;; Per Spec 009 §`:rf.handler/source` and Causa Spec 021 §11.2 B.7
+;; stretch (rf2-xgfuy): `reg-event-db` / `reg-event-fx` / `reg-event-ctx`
+;; additionally capture the WHOLE `(reg-event-X :id ...)` form as a
+;; string under `:rf.handler/source` so Causa's Event panel can render
+;; the source inline.
+;;
+;; Scope decision (rf2-xgfuy): capture the WHOLE form (`(reg-event-X
+;; :id [interceptors] (fn ...))`), not just the handler-fn. The Causa
+;; Event panel mockup (Spec 021 §2.2) renders the macro name + id +
+;; full handler-fn body — the whole form gives the consumer everything
+;; in one slot rather than forcing it to re-derive the wrapping shape
+;; from `:event/kind` + `:handler-fn`.
+;;
+;; CLJS production elision: the emitted form binds
+;; `source-coords/*pending-form-source*` to
+;; `(if interop/debug-enabled? <pr-str-of-form> nil)` so Closure
+;; constant-folds the bound value to `nil` under `:advanced` +
+;; `goog.DEBUG=false` and DCEs the literal source-string bytes. JVM:
+;; the same expansion is emitted but `interop/debug-enabled?` is a
+;; runtime flag (dev-default `true`), so JVM/SSR/test builds carry the
+;; source string. The elision-probe asserts the production absence.
+
+#?(:clj
+   (defn with-form-source-form
+     "Wrap `body-form` in a binding of `source-coords/*pending-form-
+     source*` to the compile-time `pr-str` of `whole-form` (the entire
+     `(reg-event-X :id ...)` form as the user wrote it). Returns a
+     syntax-quote-safe form suitable for a reg-event-* defmacro to
+     emit. Per rf2-xgfuy.
+
+     The bound value rides an outer `(if interop/debug-enabled? <src>
+     nil)` gate so Closure DCEs the source-string literal under
+     `:advanced` + `goog.DEBUG=false`. JVM/SSR/test builds with
+     `interop/debug-enabled?` true carry the source string into the
+     registry meta via `events/merge-form-source`."
+     [whole-form body-form]
+     (let [src-string (pr-str whole-form)]
+       `(binding [re-frame.source-coords/*pending-form-source*
+                  (if re-frame.interop/debug-enabled? ~src-string nil)]
+          ~body-form))))
+
+#?(:clj
+   (defmacro defreg-event-macro
+     "Emits a `defmacro` for a `reg-event-{db,fx,ctx}` surface. Same
+     coord-capture skeleton as [[defreg-macro]] PLUS the form-source
+     capture per rf2-xgfuy: the emitted macro binds
+     `source-coords/*pending-form-source*` to a DEBUG-gated `pr-str`
+     of the whole user-written form so `re-frame.events/register-
+     event!` can stamp `:rf.handler/source` into the registry meta.
+
+     `delegate-sym` resolves through `re-frame.core`'s aliases at
+     `defreg-event-macro` expansion time (see
+     [[resolve-delegate-sym]])."
+     [macro-sym delegate-sym docstring & [attr-map]]
+     (let [qualified (resolve-delegate-sym delegate-sym)]
+       `(defmacro ~macro-sym
+          ~docstring
+          ~(or attr-map {})
+          [~'& args#]
+          (with-form-source-form ~'&form
+            (with-coords-form (meta ~'&form) ~'*file*
+                              (symbol (str (ns-name ~'*ns*)))
+                              (list* '~qualified args#)))))))
+
 ;; ---- reg-machine expansion (per-element coord stamping) ------------------
 ;;
 ;; The bespoke reg-* form (Spec 005 §Source-coord stamping; rf2-xbtj) —

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -17,7 +17,8 @@
   The marks are stashed in the per-(kind, id) marks table via
   `re-frame.marks/register-marks!` (called through the late-bind
   hook to keep events decoupled from the optional marks artefact)."
-  (:require [re-frame.registrar :as registrar]
+  (:require [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
@@ -291,6 +292,33 @@
              "reg-event-* arity error — expected (id handler), (id metadata handler), or (id metadata interceptors handler)"
              {:args args :count (count args)}))))
 
+(defn- merge-form-source
+  "Merge `*pending-form-source*` into `m` under `:rf.handler/source`
+  (Spec 009 §`:rf.handler/source`, Causa Spec 021 §11.2 B.7 stretch,
+  rf2-xgfuy). User-supplied `:rf.handler/source` overrides the auto-
+  captured value (mirrors `source-coords/merge-coords` semantics — so
+  tooling that synthesises registrations from another source can stamp
+  the original form-source). Returns `m` unchanged when no source is
+  pending (programmatic / REPL registrations that bypass the macro
+  path).
+
+  Per rf2-xgfuy §Production elision: the whole body is gated on
+  `interop/debug-enabled?`. Under `:advanced` + `goog.DEBUG=false`
+  Closure constant-folds the gate to `false` and DCEs the entire merge
+  — both the literal `:rf.handler/source` keyword's reachability from
+  this slot AND the dynamic-var lookup. Layered with the macro-emitted
+  `(if interop/debug-enabled? ~src-string nil)` gate on the bound
+  value, the source-string bytes themselves never reach the bundle.
+  JVM/SSR/test builds (where `interop/debug-enabled?` is true by
+  default) always capture."
+  [m]
+  (if-not interop/debug-enabled?
+    m
+    (let [src source-coords/*pending-form-source*]
+      (if (and src (not (contains? m :rf.handler/source)))
+        (assoc m :rf.handler/source src)
+        m))))
+
 (defn- register-event!
   "Common registration body for the three reg-event-* forms.
 
@@ -301,7 +329,9 @@
     3. wrap the user handler into the kind-appropriate interceptor via
        `wrap-event-handler` (see `kind-spec`);
     4. register under `:event` with `:event/kind` recording which form was
-       used and `:handler-fn` retained for tooling introspection;
+       used, `:handler-fn` retained for tooling introspection, and
+       `:rf.handler/source` carrying the macro-captured form-source
+       string when present (Spec 009, rf2-xgfuy);
     5. return the event id. Path-D schema-first privacy has no
        user-facing redaction interceptor to police at registration time.
 
@@ -319,7 +349,7 @@
     ;; dispatch in production.
     (reject-at-boundary-without-schema! reg-fn-name id meta interceptors)
     (registrar/register! :event id
-      (assoc (source-coords/merge-coords meta)
+      (assoc (-> meta source-coords/merge-coords merge-form-source)
              :event/kind   kind
              :handler-fn   handler-fn
              :interceptors (-> [] (into interceptors) (conj wrapped))))

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -61,6 +61,30 @@
   registrations that bypass the macro path)."
   nil)
 
+(def ^:dynamic *pending-form-source*
+  "Per-thread (per-call) handler form-source captured by `reg-event-{db,
+  fx,ctx}` macros and consumed by `re-frame.events/register-event!`. nil
+  outside a macro invocation.
+
+  Per Spec 009 §`:rf.handler/source` and Causa Spec 021 §11.2 B.7
+  stretch: the macros stamp the whole `(reg-event-X :id ...)` form as
+  a string into the handler's registry metadata under
+  `:rf.handler/source` so Causa's Event panel can render the source
+  inline (no need to leave the browser to read what code ran).
+
+  CLJS production elision: the macro emission wraps the binding-value
+  in an `(if interop/debug-enabled? <source-string> nil)` gate so
+  Closure constant-folds the gate to `nil` under `:advanced` +
+  `goog.DEBUG=false` and DCEs both the literal source string and the
+  `:rf.handler/source` keyword's reachability from this slot. The
+  elision probe asserts the absence; per-string DCE depends on no
+  other surface keeping the same byte sequence reachable.
+
+  JVM-side: always captured. The bundle-size argument doesn't apply on
+  the JVM; SSR / test / tooling builds can read
+  `(:rf.handler/source (rf/handler-meta :event id))` directly."
+  nil)
+
 (defn merge-coords
   "Merge `*pending-coords*` into `user-meta`. User-supplied :ns / :line
   / :file override auto-captured values per Spec 001. Returns user-meta

--- a/implementation/core/test/re_frame/handler_source_cljs_test.cljs
+++ b/implementation/core/test/re_frame/handler_source_cljs_test.cljs
@@ -1,0 +1,50 @@
+(ns re-frame.handler-source-cljs-test
+  "rf2-xgfuy — CLJS-side regression for DEBUG-gated handler form-source
+  capture at reg-event-{db,fx,ctx}.
+
+  The macros stamp the whole `(reg-event-X :id ...)` form as a string
+  into the handler's registry metadata under `:rf.handler/source`.
+  Under CLJS this test runs against the dev build (`goog.DEBUG=true`)
+  so capture is enabled. The production-elision verifier
+  (`scripts/check-elision.cjs`) asserts the absence in `goog.DEBUG=false`
+  bundles via the elision-probe namespace + sentinel grep — this CLJS
+  test pins the positive-presence side of the contract.
+
+  See `re-frame.handler-source-test` for the JVM-side counterpart and
+  `re-frame.core_reg_macros/defreg-event-macro` for the emission."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/reset-runtime-fixture-factory))
+
+(deftest reg-event-db-captures-form-source-cljs
+  (testing "rf2-xgfuy: CLJS reg-event-db stamps :rf.handler/source under DEBUG=true"
+    (rf/reg-event-db :rf2-xgfuy.cljs/event-db
+                     (fn [db _ev] db))
+    (let [m   (rf/handler-meta :event :rf2-xgfuy.cljs/event-db)
+          src (:rf.handler/source m)]
+      (is (string? src) ":rf.handler/source should be a string under DEBUG=true")
+      (is (str/includes? src "reg-event-db"))
+      (is (str/includes? src ":rf2-xgfuy.cljs/event-db"))
+      (is (str/includes? src "(fn [db _ev] db)")))))
+
+(deftest reg-event-fx-captures-form-source-cljs
+  (testing "rf2-xgfuy: CLJS reg-event-fx stamps :rf.handler/source under DEBUG=true"
+    (rf/reg-event-fx :rf2-xgfuy.cljs/event-fx
+                     (fn [_cofx _ev] {:db {:n 0}}))
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy.cljs/event-fx))]
+      (is (string? src))
+      (is (str/includes? src "reg-event-fx"))
+      (is (str/includes? src ":db {:n 0}")))))
+
+(deftest reg-event-ctx-captures-form-source-cljs
+  (testing "rf2-xgfuy: CLJS reg-event-ctx stamps :rf.handler/source under DEBUG=true"
+    (rf/reg-event-ctx :rf2-xgfuy.cljs/event-ctx
+                      (fn [ctx] ctx))
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy.cljs/event-ctx))]
+      (is (string? src))
+      (is (str/includes? src "reg-event-ctx")))))

--- a/implementation/core/test/re_frame/handler_source_test.clj
+++ b/implementation/core/test/re_frame/handler_source_test.clj
@@ -1,0 +1,138 @@
+(ns re-frame.handler-source-test
+  "rf2-xgfuy — DEBUG-gated handler form-source capture at reg-event-{db,
+  fx,ctx}. Per Spec 009 §`:rf.handler/source` and Causa Spec 021 §11.2
+  B.7 stretch.
+
+  The reg-event-* macros stamp the whole `(reg-event-X :id ...)` form
+  as a string into the handler's registry metadata under
+  `:rf.handler/source` so Causa's Event panel can render the source
+  inline. JVM-side is always-on (bundle-size argument doesn't apply);
+  CLJS-side is `goog.DEBUG`-gated so production bundles DCE the
+  literal source-string bytes. See `re-frame.core_reg_macros/defreg-
+  event-macro` for the emission and `re-frame.events/merge-form-
+  source` for the registrar-side merge."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.subs :as subs]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- shared assertions ----------------------------------------------------
+
+(defn- assert-source [kind id macro-name]
+  (let [m   (rf/handler-meta kind id)
+        src (:rf.handler/source m)]
+    (is (some? m) (str "handler-meta for " kind " " id " should be present"))
+    (is (string? src)
+        (str ":rf.handler/source should be a string for " kind " " id))
+    (is (str/includes? src macro-name)
+        (str ":rf.handler/source should include the macro name '" macro-name "'"))
+    (is (str/includes? src (pr-str id))
+        (str ":rf.handler/source should include the id literal '" (pr-str id) "'"))))
+
+;; ---- per-kind captures ----------------------------------------------------
+
+(deftest reg-event-db-captures-form-source
+  (testing "rf2-xgfuy: reg-event-db stamps :rf.handler/source on JVM"
+    (rf/reg-event-db :rf2-xgfuy/event-db-sample
+                     (fn [db _ev] db))
+    (assert-source :event :rf2-xgfuy/event-db-sample "reg-event-db")
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy/event-db-sample))]
+      ;; Whole-form capture: the handler-fn body must appear too, not
+      ;; just the surface. The Causa Event panel renders the body inline.
+      (is (str/includes? src "(fn [db _ev] db)")
+          ":rf.handler/source should include the handler-fn body"))))
+
+(deftest reg-event-fx-captures-form-source
+  (testing "rf2-xgfuy: reg-event-fx stamps :rf.handler/source on JVM"
+    (rf/reg-event-fx :rf2-xgfuy/event-fx-sample
+                     (fn [_cofx _ev] {:db {:n 0}}))
+    (assert-source :event :rf2-xgfuy/event-fx-sample "reg-event-fx")
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy/event-fx-sample))]
+      (is (str/includes? src ":db")
+          ":rf.handler/source should include the effect-map keyword"))))
+
+(deftest reg-event-ctx-captures-form-source
+  (testing "rf2-xgfuy: reg-event-ctx stamps :rf.handler/source on JVM"
+    (rf/reg-event-ctx :rf2-xgfuy/event-ctx-sample
+                      (fn [ctx] ctx))
+    (assert-source :event :rf2-xgfuy/event-ctx-sample "reg-event-ctx")))
+
+;; ---- middle slot: metadata-map / interceptor-vector ----------------------
+;;
+;; The reg-event-* surface accepts three shapes for the variadic tail
+;; (per re-frame.events/normalise-args). The form-source capture is
+;; mechanically `pr-str` of the WHOLE form, so all three shapes round-
+;; trip through the slot — no special-casing.
+
+(deftest captures-form-source-with-metadata-map
+  (testing "rf2-xgfuy: middle metadata-map round-trips into :rf.handler/source"
+    (rf/reg-event-db :rf2-xgfuy/event-with-meta
+                     {:doc "metadata-shape middle slot"}
+                     (fn [db _] db))
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy/event-with-meta))]
+      (is (string? src))
+      (is (str/includes? src ":doc"))
+      (is (str/includes? src "metadata-shape middle slot")))))
+
+(deftest captures-form-source-with-interceptor-vector
+  (testing "rf2-xgfuy: middle interceptor-vector round-trips into :rf.handler/source"
+    (rf/reg-event-fx :rf2-xgfuy/event-with-icpts
+                     [rf/unwrap]
+                     (fn [_cofx {:keys [v]}] {:db {:v v}}))
+    (let [src (:rf.handler/source
+               (rf/handler-meta :event :rf2-xgfuy/event-with-icpts))]
+      (is (string? src))
+      (is (str/includes? src "unwrap")))))
+
+;; ---- programmatic call (bypasses macro) ----------------------------------
+
+(deftest fn-form-call-skips-form-source
+  (testing "rf2-xgfuy: calling the underlying fn directly skips form-source capture
+  (so programmatic / fixture-synthesised registrations don't carry
+  poison strings from inside the framework)"
+    ((requiring-resolve 're-frame.events/reg-event-db)
+       :rf2-xgfuy/programmatic
+       (fn [db _] db))
+    (let [m (rf/handler-meta :event :rf2-xgfuy/programmatic)]
+      (is (some? m))
+      (is (not (contains? m :rf.handler/source))
+          ":rf.handler/source absent on direct fn call"))))
+
+;; ---- non-event reg-* macros DON'T carry :rf.handler/source ---------------
+
+(deftest reg-sub-does-not-capture-form-source
+  (testing "rf2-xgfuy: reg-sub is scoped to coord capture only — form-source
+  capture is explicit to reg-event-{db,fx,ctx} (Spec 009 §`:rf.handler/source`)"
+    (rf/reg-sub :rf2-xgfuy/sub-sample (fn [db _] db))
+    (let [m (rf/handler-meta :sub :rf2-xgfuy/sub-sample)]
+      (is (some? m))
+      (is (not (contains? m :rf.handler/source))
+          ":rf.handler/source absent on reg-sub"))))
+
+;; ---- user-supplied :rf.handler/source override ---------------------------
+
+(deftest user-supplied-source-wins
+  (testing "rf2-xgfuy: explicit :rf.handler/source in user metadata overrides
+  auto-capture (mirrors source-coords/merge-coords semantics so
+  tooling that synthesises registrations can stamp the original
+  source-string)"
+    (rf/reg-event-db :rf2-xgfuy/explicit-source
+                     {:rf.handler/source "(rf/reg-event-db :elsewhere ...)"
+                      :doc "hand-stamped source from a code-gen pass"}
+                     (fn [db _] db))
+    (let [m (rf/handler-meta :event :rf2-xgfuy/explicit-source)]
+      (is (= "(rf/reg-event-db :elsewhere ...)" (:rf.handler/source m))))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -272,7 +272,31 @@ const DEV_ONLY_SENTINELS = [
   // stamp branch DCEs. The `rf.trace/call-site` keyword's string
   // fragment must NOT survive in production bundles.
   { source: 're-frame.core/{dispatch,subscribe,inject-cofx} (rf.trace/call-site stamping)',
-    sentinel: 'rf.trace/call-site' }
+    sentinel: 'rf.trace/call-site' },
+  // re-frame.core/reg-event-{db,fx,ctx} — handler form-source capture
+  // (Spec 009 §`:rf.handler/source`, Causa Spec 021 §11.2 B.7 stretch,
+  // rf2-xgfuy). The defreg-event-macro emission wraps the bound source
+  // string in `(if interop/debug-enabled? ~src-string nil)` and the
+  // events/merge-form-source body is gated on `interop/debug-enabled?`.
+  // Under :advanced + goog.DEBUG=false, Closure constant-folds both
+  // gates to false and DCEs the keyword's reachability from the assoc
+  // slot AND the source-string bytes themselves. Two sentinels:
+  //
+  //   1. The slot keyword `rf.handler/source` — must NOT appear in
+  //      the prod bundle (the assoc branch DCEs, dropping the literal
+  //      from events.cljc's compiled output).
+  //   2. A distinctive source-string fragment minted in the elision-
+  //      probe. The probe registers
+  //        (rf/reg-event-db :probe/cs-event (fn [db _ev] db))
+  //      under DEBUG=true the captured form-source carries the byte
+  //      sequence `:probe/cs-event (fn [db _ev]`; under DEBUG=false
+  //      the macro-emitted `if interop/debug-enabled? ~src-string nil`
+  //      gate DCEs the source-string literal entirely. The fragment is
+  //      distinctive enough that a global grep is unambiguous.
+  { source: 're-frame.events/merge-form-source (rf.handler/source slot keyword)',
+    sentinel: 'rf.handler/source' },
+  { source: 're-frame.core/reg-event-db macro (form-source pr-str literal)',
+    sentinel: ':probe/cs-event (fn [db _ev]' }
   // Note (rf2-d3k3): re-frame.views/maybe-warn-plain-fn-under-non-
   // default-frame! emits :rf.warning/plain-fn-under-non-default-frame-
   // once gated on interop/debug-enabled?. We do NOT add a sentinel

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1072,6 +1072,33 @@ Shape and reservation:
 
 Production elision: the flag rides on a registry-meta surface (`handler-meta`) — not on a trace event — so the trace-surface DCE gate does not apply. The flag is one keyword + one boolean per registered event, lives in process memory only, and is consumed by dev tooling that itself does not ship to production (the framework's own dispatch path does not branch on it).
 
+#### `:rf.handler/source` — DEBUG-gated handler form-source capture (rf2-xgfuy)
+
+`reg-event-db` / `reg-event-fx` / `reg-event-ctx` each capture the WHOLE form the user wrote — `(reg-event-X :id ...)` — as a string at macro-expansion time and stamp it into the handler's registry metadata under `:rf.handler/source`. Tools (Causa's Event panel, the Event lens, IDE inspectors) render the captured source inline so the operator can read what code ran without leaving the browser to chase a `file:line` link. Per Causa Spec 021 §11.2 B.7 stretch (the Causa Event panel's §2.2 mockup renders the source inline immediately under step 3 "Handler invoked").
+
+Scope: the WHOLE form — macro name, id, optional middle slot (metadata-map or interceptor-vector), and the handler-fn body — rides under one slot. The capture is mechanically `pr-str` of `&form` at expansion time, so all documented `reg-event-*` shapes round-trip without special-casing.
+
+Consumer access:
+
+```clojure
+(->> (rf/handler-meta :event :my/event)
+     :rf.handler/source)                 ;; → string or nil
+```
+
+Shape and reservation:
+
+- Value is a string (the `pr-str` of the user-written form) or absent.
+- The keyword is owned by the framework under the `:rf.handler/*` reserved namespace (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)).
+- Absent on programmatic / REPL registrations that bypass the macro path (call `re-frame.events/reg-event-db` directly as a fn).
+- User-supplied `:rf.handler/source` in the registration metadata-map overrides auto-capture, mirroring the `:ns`/`:line`/`:file` override semantics of [Spec 001 §Source-coordinate capture](001-Registration.md#source-coordinate-capture-cljs-reference) so code-gen pipelines can stamp the originating source.
+- Coverage is scoped to `reg-event-{db,fx,ctx}` only. Other reg-* surfaces (`reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-route`, `reg-machine`, `reg-view`, `reg-app-schema`, `reg-error-projector`, `reg-head`, `reg-http-interceptor`) do not stamp the slot — their primary tooling surface today is `(:ns/:file/:line) → open-in-editor`. Widening to those surfaces is a follow-up; the Causa Event panel is the load-bearing consumer for the initial slice.
+
+Production elision (CLJS): **DEBUG-gated, two-layer**. The macro emission wraps the bound source-string in `(if interop/debug-enabled? <pr-str-of-form> nil)`; the registrar-side merge in `re-frame.events/merge-form-source` is wrapped in `(if-not interop/debug-enabled? m ...)`. Under `:advanced` + `goog.DEBUG=false` Closure constant-folds both gates and DCEs (a) the literal source-string bytes from the macro expansion, AND (b) the `:rf.handler/source` keyword's reachability from the merge `assoc` slot. The elision-probe (per [§Production builds](#production-builds-zero-overhead-zero-code) and `scripts/check-elision.cjs`) asserts both absences against the production bundle.
+
+Production elision (JVM): **always-on**. `re-frame.interop/debug-enabled?` is dev-default-true on the JVM; the bundle-size argument doesn't apply to SSR / test / tooling builds. The JVM-side macro emission carries the source string into the registry meta unconditionally — JVM `clojure -M:test` users can read `(:rf.handler/source (rf/handler-meta :event id))`. The `re-frame.debug=false` JVM property (per [§JVM builds](#jvm-builds)) flips the same gate and elides capture at registration time.
+
+The mechanism is "compile-time `pr-str` + dynamic-var thread + registrar merge." The macro produces a `pr-str` literal at compile time; the binding form publishes it on `re-frame.source-coords/*pending-form-source*` around the underlying `register-event!` call; `register-event!` reads the var via `merge-form-source` and `assoc`s it into the registered handler's metadata. No new namespace or registry slot beyond the registrar; consumer access is `(:rf.handler/source (rf/handler-meta :event id))`.
+
 ### Error namespace convention — five prefix shapes
 
 Error categories use **five distinct namespace prefixes**:


### PR DESCRIPTION
Closes rf2-xgfuy. Per spec/021 §11.2 B.7 stretch + spec/009 §`:rf.handler/source`.

## Summary

- New `defreg-event-macro` (sibling of `defreg-macro`) in `core_reg_macros.cljc` wraps the existing source-coord skeleton with a second binding: `*pending-form-source*` carries a `pr-str` of the WHOLE user-written form.
- `re-frame.events/register-event!` reads the var via a new `merge-form-source` helper and stamps `:rf.handler/source` into the registered handler''s metadata.
- The three reg-event-* shells in `re-frame.core` switch to `defreg-event-macro`; all other reg-* surfaces keep `defreg-macro` (unchanged behaviour).

## Captured-form scope decision

**Captured the WHOLE `(reg-event-X :id [interceptors] (fn ...))` form**, not just the handler-fn. The Causa Event panel §2.2 mockup renders the macro name + id + full handler-fn body in one block — passing the whole form through one slot is the simplest tooling shape and avoids forcing consumers to re-derive the wrapping from `:event/kind` + `:handler-fn`.

## DEBUG-gate / elision

Two-layer gate:

1. Macro emission: `(if interop/debug-enabled? ~src-string nil)` on the bound dynamic-var value. Under `:advanced` + `goog.DEBUG=false` Closure constant-folds the source-string literal to nil and DCEs the bytes.
2. Registrar-side merge: `(if-not interop/debug-enabled? m ...)` in `merge-form-source`. Under the same gate Closure DCEs the `:rf.handler/source` keyword''s reachability from the `assoc` slot.

JVM-side: always-on (bundle-size argument doesn''t apply). The same `interop/debug-enabled?` flag is dev-default-true on the JVM; `-Dre-frame.debug=false` flips it to off.

## Elision sentinels

`implementation/scripts/check-elision.cjs` extended with two new sentinels:

- `rf.handler/source` — the slot keyword, asserted absent in the prod bundle / present in the control bundle.
- `:probe/cs-event (fn [db _ev]` — a distinctive byte sequence from the elision-probe''s `(rf/reg-event-db :probe/cs-event (fn [db _ev] db))` — pins the source-string literal''s absence in prod / presence in control.

No new bundle-isolation sentinel needed; the keyword is framework-internal (not a tools-only surface) so the production-elision contract is the load-bearing assertion.

## Spec

`spec/009-Instrumentation.md` §`:rf.handler/source` documents the new metadata key (scope, shape, override semantics, two-layer elision contract, consumer access).

## Gates

- `npm run test:cljs` — 3691 tests / 10602 assertions / 0 failures
- `npm run test:elision` — production 34/34 sentinels absent; control 34/34 present
- `npm run test:bundle-isolation` — pass
- JVM `clojure -M:test -n re-frame.handler-source-test` — 8 tests / 24 assertions / pass
- JVM `clojure -M:test -n re-frame.source-coords-test` — 15 tests / 99 assertions / pass (no regression)
- JVM `clojure -M:test -n re-frame.events-test` — 16 tests / 97 assertions / pass (no regression)
- `python -m mkdocs build --strict` — exit 0