### PR TITLE
feat(causa): L2 epoch timeline — dispatch-origin prefix + activity badges (rf2-gf58j)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
@@ -1,0 +1,271 @@
+(ns day8.re-frame2-causa.panels.l2-timeline
+  "Pure-fn helpers for the L2 epoch-timeline row chrome (rf2-gf58j).
+
+  Two concerns live here, both pure-data + JVM/CLJS portable so the
+  shape is testable from `clojure -M:test` without a CLJS runtime:
+
+    1. **Dispatch-origin prefix** — per `tools/causa/spec/021-Dynamic-
+       Panel-Designs.md` §17.1.5 + `spec/009-Instrumentation.md`
+       §Dispatch-origin tagging (closed-enum, landed in #1735). Each
+       L2 row carries a short glyph / chip prefix denoting the
+       functional origin of the dispatch (`:user` is silent — the
+       common case shouldn't clutter the row).
+
+    2. **Activity badges** — per spec/021 §1 + §17.1.5. Each row
+       summarises what the epoch's cascade actually DID via a
+       compact badge cluster (issues / machine transitions / HTTP
+       activity / fx-emit child dispatches / timer fires).
+
+  ## Why a dedicated namespace
+
+  `shell.cljs` is the hot-zone surface other workers (rf2-wyvf2's
+  tab inventory; rf2-2moh1's L4 tab registry) iterate on; pulling
+  the pure logic out keeps shell.cljs's `event-row` body stable and
+  lets these helpers be tested as plain data. The shell touches one
+  `:require` line and one hiccup-insertion site — the rest of the
+  L2 row's structure (gutter, event-id, time chip) is unchanged.
+
+  ## Cascade record shape consumed
+
+  `cascade` is the per-dispatch projection record (per
+  `re-frame.trace.projection/group-cascades`):
+
+      {:dispatch-id <id>
+       :event       <event-vector>
+       :dispatched  <:event/dispatched trace event>  ;; carries :tags :rf/dispatch-origin
+       :handler     <:event/run-end trace event>
+       :fx          <:event/do-fx trace event>
+       :effects     [...]                            ;; :op-type :fx
+       :subs        [...]                            ;; :sub/run + :sub/create
+       :renders     [...]                            ;; :view/render
+       :other       [...]                            ;; errors, warnings,
+       :errors      [...]}                           ;; existing :errors slot
+
+  Reads are defence-in-depth nil-safe so synthetic test fixtures
+  that omit slots (e.g. cascades constructed by JVM tests) do not
+  blow up.
+
+  ## Closed-enum origin → glyph mapping (spec/021 §17.1.5)
+
+  | `:rf/dispatch-origin` | Render        | Notes                                  |
+  |-----------------------|---------------|----------------------------------------|
+  | `:user`               | (nothing)     | Default. Silent so the common case     |
+  |                       |               | doesn't clutter the row.               |
+  | `:router`             | `R` chip      | re-frame.routing internal dispatches.  |
+  | `:http`               | `🌐` glyph    | Managed-HTTP settle / response.        |
+  | `:ssr`                | `💧` glyph    | Hydration boot / SSR-time dispatches.  |
+  | `:fx-emit`            | `⚡` glyph    | Dispatched from a parent's do-fx.      |
+  | `:timer`              | `⏲` glyph    | Timer-fired dispatch.                  |
+  | `:test-harness`       | `T` chip      | Opt-in test fixture dispatches.        |
+  | `:tool`               | `🔧` glyph    | Tool dispatches (pair / story / REPL). |
+  | `:internal`           | `i` chip      | Framework-internal dispatches.         |
+  | `:websocket`          | `🌊` glyph    | App websocket adapters (reserved).     |
+  | unknown / nil         | (nothing)     | Defence-in-depth — never throws.       |"
+  (:require [clojure.string :as str]))
+
+;; ---- 1. dispatch-origin prefix ------------------------------------------
+
+(def origin-glyphs
+  "Closed-enum origin → display-glyph map per spec/021 §17.1.5. `:user`
+  is `nil` because the common case is silent. Unknown / nil origins
+  also resolve to `nil` so the renderer omits the prefix.
+
+  Pure-data so a test can iterate the mapping without touching the
+  view layer."
+  {:user         nil
+   :router       "R"
+   :http         "🌐"   ; 🌐
+   :ssr          "💧"   ; 💧
+   :fx-emit      "⚡"         ; ⚡
+   :timer        "⏲"         ; ⏲
+   :test-harness "T"
+   :tool         "🔧"   ; 🔧
+   :internal     "i"
+   :websocket    "🌊"}) ; 🌊
+
+(def origin-titles
+  "Hover-title text per origin. Surfaces the closed-enum value to the
+  operator on hover; the glyph is the at-a-glance affordance, the
+  title is the disambiguation."
+  {:user         "Dispatch origin: :user (default — app code)"
+   :router       "Dispatch origin: :router (routing-substrate dispatch)"
+   :http         "Dispatch origin: :http (managed-HTTP settle)"
+   :ssr          "Dispatch origin: :ssr (hydration boot)"
+   :fx-emit      "Dispatch origin: :fx-emit (child of a parent's do-fx)"
+   :timer        "Dispatch origin: :timer (timer-fired dispatch)"
+   :test-harness "Dispatch origin: :test-harness (test-fixture opt-in)"
+   :tool         "Dispatch origin: :tool (tool / REPL / story)"
+   :internal     "Dispatch origin: :internal (framework-internal)"
+   :websocket    "Dispatch origin: :websocket (app websocket adapter)"})
+
+(defn dispatch-origin-of
+  "Read the `:rf/dispatch-origin` tag from a cascade's `:dispatched`
+  trace event. Returns the closed-enum keyword or nil when absent
+  (synthetic fixtures, cascades projected from older traces that
+  predate rf2-t1lxr). Pure data; nil-safe at every level."
+  [cascade]
+  (when (map? cascade)
+    (get-in cascade [:dispatched :tags :rf/dispatch-origin])))
+
+(defn origin-prefix-glyph
+  "Pure-data version of the per-origin prefix. Returns the glyph
+  string or nil when the origin should render no prefix (:user,
+  unknown, nil). Tests assert this without touching hiccup."
+  [origin]
+  (get origin-glyphs origin))
+
+(defn origin-prefix-title
+  "Hover-title text for a given origin, or nil when the origin has
+  no prefix to title."
+  [origin]
+  (when (origin-prefix-glyph origin)
+    (get origin-titles origin)))
+
+;; ---- 2. activity badges -------------------------------------------------
+;;
+;; The cascade's `:other` slot collects every non-domino trace event
+;; (errors / warnings / machine transitions / http settles / timer
+;; fires / fx-emit child dispatches). We classify the cluster ONCE
+;; into a small flag map and the renderer reads the flags — cheaper
+;; than walking the slot per badge and more testable.
+
+(defn- str-of [x]
+  (when (some? x) (str x)))
+
+(defn- op-namespace
+  "Return the namespace string of a keyword `:operation` value, or nil
+  when the operation is not a keyword. Defence-in-depth — synthetic
+  fixtures occasionally carry string operations."
+  [op]
+  (when (keyword? op) (namespace op)))
+
+(defn- has-error-op?
+  "True when any event in `events` is a `:rf.error/*` or has
+  `:op-type :error`. Per Spec 009 the canonical error-prefix is
+  `:rf.error/` (`:operation` namespaced under it); `:op-type :error`
+  is the secondary axis used by trace consumers that don't branch on
+  the namespaced operation."
+  [events]
+  (boolean
+   (some (fn [ev]
+           (or (= :error (:op-type ev))
+               (= "rf.error" (op-namespace (:operation ev)))))
+         events)))
+
+(defn- has-machine-op?
+  "True when any event in `events` is a `:rf.machine/*` trace —
+  state-machine transition / spawn / despawn."
+  [events]
+  (boolean
+   (some (fn [ev]
+           (= "rf.machine" (op-namespace (:operation ev))))
+         events)))
+
+(defn- has-http-op?
+  "True when any event in `events` is a `:rf.http/*` or `:http/*`
+  trace. Both namespaces are surfaced by the managed-HTTP substrate
+  (`:rf.http/` is the canonical Spec 009 prefix; `:http/` is the
+  legacy alias still in use by some adapters)."
+  [events]
+  (boolean
+   (some (fn [ev]
+           (let [ns (op-namespace (:operation ev))]
+             (or (= "rf.http" ns)
+                 (= "http" ns))))
+         events)))
+
+(defn- has-timer-op?
+  "True when any event in `events` is a `:rf.timer/*` trace."
+  [events]
+  (boolean
+   (some (fn [ev]
+           (= "rf.timer" (op-namespace (:operation ev))))
+         events)))
+
+(defn cascade-activity-flags
+  "Walk the cascade's `:other` events ONCE and return a small flag
+  map summarising the activity classes the row's badge cluster
+  surfaces. Pure-data; nil-safe on missing slots.
+
+  Returned shape:
+
+      {:error?    bool   ;; :rf.error/* or :op-type :error present
+       :machine?  bool   ;; :rf.machine/* transition present
+       :http?     bool   ;; :rf.http/* or :http/* settle present
+       :timer?    bool   ;; :rf.timer/* fire present
+       :fx-emit?  bool}  ;; cascade itself dispatched via :fx-emit
+                         ;; (a CHILD epoch — origin tag on this cascade
+                         ;; says `:fx-emit`)
+
+  The `:fx-emit?` flag is read from the CASCADE's own origin tag
+  rather than from `:other` events; per Spec 009 §Dispatch-origin
+  tagging, a cascade whose origin is `:fx-emit` is itself the child
+  of another cascade's do-fx phase — rendering the badge on the
+  CHILD row surfaces 'this dispatch was triggered by a parent's
+  do-fx'. (We expose the flag on every row regardless of origin so
+  the renderer can compose; the prefix layer is what surfaces the
+  origin per-row.)
+
+  Errors are ALSO read from `:errors` (the cascade's existing
+  pre-rf2-gf58j slot used by `shell/gutter-glyph`) so an
+  error-bearing cascade flags the warn badge whether the trace
+  surfaced as a `:rf.error/*` op or as a populated `:errors` vector."
+  [cascade]
+  (let [others (when (map? cascade) (:other cascade))
+        errors (when (map? cascade) (:errors cascade))
+        origin (dispatch-origin-of cascade)]
+    {:error?   (or (boolean (seq errors)) (has-error-op? others))
+     :machine? (has-machine-op? others)
+     :http?    (has-http-op? others)
+     :timer?   (or (has-timer-op? others) (= :timer origin))
+     :fx-emit? (= :fx-emit origin)}))
+
+(def activity-badge-glyphs
+  "Pure-data badge map. Render order is fixed — issues first (the
+  attention-grabbing red), then machine, then HTTP, then fx-emit,
+  then timer. Tests iterate this map to assert the canonical
+  mapping."
+  {:error?   "⚠"         ; ⚠
+   :machine? "◆"         ; ◆
+   :http?    "🌐"   ; 🌐
+   :fx-emit? "⚡"         ; ⚡
+   :timer?   "⏲"})       ; ⏲
+
+(def ^:private activity-badge-order
+  "Render order (left → right) per spec/021 §17.1.5 — issues lead,
+  machine + HTTP next (cascade-shape signals), fx-emit + timer last
+  (origin-derived signals)."
+  [:error? :machine? :http? :fx-emit? :timer?])
+
+(defn activity-badges
+  "Project a cascade onto an ordered vector of badge glyphs. Pure
+  data; returns `[]` when the cascade has no detected activity. The
+  view layer renders one `:span` per glyph.
+
+  Render order matches `activity-badge-order`; absent flags are
+  skipped so the cluster compresses to the present badges. The
+  `^{:key}` metadata the view layer attaches is the glyph itself
+  (stable per badge class within one row)."
+  [cascade]
+  (let [flags (cascade-activity-flags cascade)]
+    (into []
+          (keep (fn [k]
+                  (when (get flags k)
+                    (get activity-badge-glyphs k))))
+          activity-badge-order)))
+
+(defn activity-badges-tooltip
+  "Build the row's `:title` text describing which activity badges
+  are present. Returns nil when no badges to title (so the caller
+  can decide whether to attach the tooltip at all). Pure-data;
+  consumed by the view layer's badge-cluster span."
+  [cascade]
+  (let [flags (cascade-activity-flags cascade)
+        parts (cond-> []
+                (:error?   flags) (conj "issues raised")
+                (:machine? flags) (conj "machine transition")
+                (:http?    flags) (conj "HTTP activity")
+                (:fx-emit? flags) (conj "fx-emit child")
+                (:timer?   flags) (conj "timer fired"))]
+    (when (seq parts)
+      (str "Activity: " (str/join " · " parts)))))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -124,6 +124,11 @@
             ;; the ribbon's :rf.causa/event-detail subscribers consume).
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
+            ;; rf2-gf58j — L2 epoch-timeline dispatch-origin prefix +
+            ;; activity badges. Pure-fn helpers live in `panels/l2-
+            ;; timeline.cljc` so the shape is JVM-testable; the shell
+            ;; consumes them in `event-row` (single insertion site).
+            [day8.re-frame2-causa.panels.l2-timeline :as l2-timeline]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.resize-handle :as resize-handle]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
@@ -930,7 +935,15 @@
         ;; signal "this is a pseudo-cascade outside any dispatch".
         ungrouped?  (ungrouped-cascade? cascade)
         glyph       (gutter-glyph cascade focused-id)
-        badges      (row-badges cascade)
+        ;; rf2-gf58j — L2 row chrome: per-origin prefix + per-cascade
+        ;; activity badges. Both pulled from the cascade record;
+        ;; helpers live in `panels.l2-timeline` so the projection is
+        ;; pure-data and JVM-testable.
+        origin         (l2-timeline/dispatch-origin-of cascade)
+        origin-prefix  (l2-timeline/origin-prefix-glyph origin)
+        origin-title   (l2-timeline/origin-prefix-title origin)
+        badges         (l2-timeline/activity-badges cascade)
+        badges-tooltip (l2-timeline/activity-badges-tooltip cascade)
         ev-id       (event-id-of-cascade cascade)
         event-vec   (:event cascade)
         ;; rf2-b76v4 — canonical event-lifecycle status colour. ONE
@@ -1195,6 +1208,23 @@
               gutter-click (assoc :on-click gutter-click))
       (or focus-marker
           [:span {:style {:color glyph-col}} glyph])]
+     ;; rf2-gf58j — dispatch-origin prefix. Renders a per-origin
+     ;; glyph (`R` / `🌐` / `💧` / `⚡` / `⏲` / `T` / `🔧` / `i` /
+     ;; `🌊`) before the event-id when the origin is non-`:user`;
+     ;; `:user` stays silent so the common case doesn't clutter the
+     ;; row. The `:title` carries the closed-enum value as a hover
+     ;; affordance. Suppressed for the `:ungrouped` pseudo-cascade
+     ;; (no real dispatch envelope, no origin tag to surface).
+     (when (and origin-prefix (not ungrouped?))
+       [:span {:data-testid (str "rf-causa-row-origin-" (name origin))
+               :data-rf-causa-origin (name origin)
+               :title origin-title
+               :style {:flex-shrink 0
+                       :color (:accent-violet tokens)
+                       :font-size (:caption type-scale)
+                       :min-width "12px"
+                       :text-align "center"}}
+        origin-prefix])
      ;; Round-3 rf2-cmtkw — minimal default row renders ONLY the
      ;; bare event-id keyword (e.g. `:cart/add-item`). The full event
      ;; vector with args moves to the row's hover tooltip + the L4
@@ -1216,10 +1246,16 @@
          ":ungrouped (pseudo-cascade)"]
         (render-event-id-only event-vec))]
      (when (seq badges)
-       [:span {:data-testid "rf-causa-row-badges"
-               :style {:display "flex" :gap "4px" :flex-shrink 0
-                       :color (:yellow tokens)
-                       :font-size (:caption type-scale)}}
+       ;; rf2-gf58j — activity-badge cluster sourced from
+       ;; `panels.l2-timeline/activity-badges`. Render order matches
+       ;; the spec/021 §17.1.5 canonical sequence (⚠ ◆ 🌐 ⚡ ⏲);
+       ;; the tooltip names the present classes so the operator can
+       ;; read what the cluster means without leaving L2.
+       [:span (cond-> {:data-testid "rf-causa-row-badges"
+                       :style {:display "flex" :gap "4px" :flex-shrink 0
+                               :color (:yellow tokens)
+                               :font-size (:caption type-scale)}}
+                badges-tooltip (assoc :title badges-tooltip))
         (for [b badges]
           ^{:key b} [:span b])])
      ;; Relative-time chip (rf2-vbbq0). Right-aligned per Mike's design

--- a/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
@@ -1,0 +1,260 @@
+(ns day8.re-frame2-causa.panels.l2-timeline-cljs-test
+  "Pure-data tests for the L2 epoch-timeline helpers (rf2-gf58j).
+
+  ## What's under test
+
+    1. **dispatch-origin extraction** — `dispatch-origin-of` reads
+       `[:dispatched :tags :rf/dispatch-origin]` and nil-safes every
+       step.
+    2. **origin → glyph mapping** — every closed-enum value renders
+       the right glyph; `:user` is silent; unknown / nil return nil.
+    3. **origin → title text** — present only when a glyph is
+       present.
+    4. **cascade activity flags** — per-class detection from `:other`
+       events + the cascade's origin tag + the `:errors` slot.
+    5. **activity-badges projection** — ordered, compressed, glyph-
+       matched against the canonical mapping.
+    6. **activity tooltip** — nil-safe + human-readable.
+
+  Pure-fn shape — input cascade-aggregate map → expected output
+  glyph string / hiccup-ready vector. No CLJS runtime touched."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.l2-timeline :as l2]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- cascade-with-origin
+  "Build a synthetic cascade record whose `:dispatched` carries the
+  given dispatch-origin tag. Mirrors the shape produced by
+  `re-frame.trace.projection/group-cascades`."
+  [origin]
+  {:dispatch-id 42
+   :event       [:cart/add-item {:id 99}]
+   :dispatched  {:operation :event/dispatched
+                 :op-type   :event
+                 :tags      {:rf/dispatch-origin origin
+                             :dispatch-id        42}}
+   :other       []
+   :errors      []})
+
+(defn- ev
+  "Build a synthetic trace event with the given operation."
+  [operation & {:keys [op-type tags] :or {op-type nil tags {}}}]
+  (cond-> {:operation operation :tags tags}
+    op-type (assoc :op-type op-type)))
+
+;; ---- 1. dispatch-origin extraction --------------------------------------
+
+(deftest dispatch-origin-of-test
+  (testing "reads :rf/dispatch-origin from :dispatched :tags"
+    (is (= :tool   (l2/dispatch-origin-of (cascade-with-origin :tool))))
+    (is (= :router (l2/dispatch-origin-of (cascade-with-origin :router))))
+    (is (= :user   (l2/dispatch-origin-of (cascade-with-origin :user)))))
+
+  (testing "nil-safe on missing slots"
+    (is (nil? (l2/dispatch-origin-of nil)))
+    (is (nil? (l2/dispatch-origin-of {})))
+    (is (nil? (l2/dispatch-origin-of {:dispatched nil})))
+    (is (nil? (l2/dispatch-origin-of {:dispatched {}})))
+    (is (nil? (l2/dispatch-origin-of {:dispatched {:tags {}}}))))
+
+  (testing "non-map input returns nil"
+    (is (nil? (l2/dispatch-origin-of "not a cascade")))
+    (is (nil? (l2/dispatch-origin-of 42)))))
+
+;; ---- 2. origin → glyph mapping ------------------------------------------
+
+(deftest origin-prefix-glyph-test
+  (testing ":user is silent (no prefix) — the common case stays clutter-free"
+    (is (nil? (l2/origin-prefix-glyph :user))))
+
+  (testing "every non-user closed-enum value renders a glyph"
+    (is (= "R"    (l2/origin-prefix-glyph :router)))
+    (is (= "🌐"   (l2/origin-prefix-glyph :http)))     ; 🌐
+    (is (= "💧"   (l2/origin-prefix-glyph :ssr)))      ; 💧
+    (is (= "⚡"     (l2/origin-prefix-glyph :fx-emit)))  ; ⚡
+    (is (= "⏲"     (l2/origin-prefix-glyph :timer)))    ; ⏲
+    (is (= "T"    (l2/origin-prefix-glyph :test-harness)))
+    (is (= "🔧"   (l2/origin-prefix-glyph :tool)))     ; 🔧
+    (is (= "i"    (l2/origin-prefix-glyph :internal)))
+    (is (= "🌊"   (l2/origin-prefix-glyph :websocket)))) ; 🌊
+
+  (testing "unknown / nil → nil (defence-in-depth, never throws)"
+    (is (nil? (l2/origin-prefix-glyph nil)))
+    (is (nil? (l2/origin-prefix-glyph :unknown-axis)))
+    (is (nil? (l2/origin-prefix-glyph "string"))))
+
+  (testing "the mapping covers exactly the closed enum (Spec 009 / Causa A.5)"
+    (is (= #{:user :router :http :ssr :fx-emit :timer
+             :test-harness :tool :internal :websocket}
+           (set (keys l2/origin-glyphs))))))
+
+;; ---- 3. origin → title text ---------------------------------------------
+
+(deftest origin-prefix-title-test
+  (testing "title text present only when the glyph is present"
+    (is (nil?              (l2/origin-prefix-title :user)))
+    (is (nil?              (l2/origin-prefix-title nil)))
+    (is (some?             (l2/origin-prefix-title :router)))
+    (is (some?             (l2/origin-prefix-title :tool)))
+    (is (some?             (l2/origin-prefix-title :http))))
+
+  (testing "title carries the keyword name so the operator can read the closed-enum value"
+    (is (re-find #":router"      (l2/origin-prefix-title :router)))
+    (is (re-find #":fx-emit"     (l2/origin-prefix-title :fx-emit)))
+    (is (re-find #":websocket"   (l2/origin-prefix-title :websocket)))))
+
+;; ---- 4. cascade activity flags ------------------------------------------
+
+(deftest cascade-activity-flags-defaults-test
+  (testing "an empty cascade yields all-false flags"
+    (let [flags (l2/cascade-activity-flags {})]
+      (is (= {:error? false :machine? false :http? false
+              :timer? false :fx-emit? false}
+             flags))))
+
+  (testing "nil cascade is safe — returns all-false flags"
+    (let [flags (l2/cascade-activity-flags nil)]
+      (is (= {:error? false :machine? false :http? false
+              :timer? false :fx-emit? false}
+             flags)))))
+
+(deftest cascade-activity-flags-error-test
+  (testing ":errors slot populated → error? true (legacy axis)"
+    (let [flags (l2/cascade-activity-flags
+                 {:errors [{:operation :rf.error/handler-throw}]})]
+      (is (true? (:error? flags)))))
+
+  (testing ":op-type :error on :other → error? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.error/handler-throw :op-type :error)]})]
+      (is (true? (:error? flags)))))
+
+  (testing ":rf.error/* operation on :other (no :op-type) → error? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.error/bad-fx)]})]
+      (is (true? (:error? flags))))))
+
+(deftest cascade-activity-flags-machine-test
+  (testing ":rf.machine/* operation → machine? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.machine/transition)]})]
+      (is (true? (:machine? flags))))
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.machine/spawn)
+                          (ev :rf.machine/despawn)]})]
+      (is (true? (:machine? flags))))))
+
+(deftest cascade-activity-flags-http-test
+  (testing ":rf.http/* operation → http? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.http/managed-request-settle)]})]
+      (is (true? (:http? flags)))))
+
+  (testing ":http/* legacy operation → http? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :http/request-success)]})]
+      (is (true? (:http? flags))))))
+
+(deftest cascade-activity-flags-timer-test
+  (testing ":rf.timer/* operation → timer? true"
+    (let [flags (l2/cascade-activity-flags
+                 {:other [(ev :rf.timer/fired)]})]
+      (is (true? (:timer? flags)))))
+
+  (testing "cascade origin :timer alone (no :rf.timer trace) → timer? true"
+    ;; The runtime stamps origin-on-dispatch; some timer dispatches
+    ;; don't carry a separate :rf.timer/fired trace event but the
+    ;; origin tag still tells the story.
+    (let [flags (l2/cascade-activity-flags (cascade-with-origin :timer))]
+      (is (true? (:timer? flags))))))
+
+(deftest cascade-activity-flags-fx-emit-test
+  (testing "cascade origin :fx-emit → fx-emit? true"
+    (let [flags (l2/cascade-activity-flags (cascade-with-origin :fx-emit))]
+      (is (true? (:fx-emit? flags)))))
+
+  (testing "cascade origin :user → fx-emit? false"
+    (let [flags (l2/cascade-activity-flags (cascade-with-origin :user))]
+      (is (false? (:fx-emit? flags))))))
+
+(deftest cascade-activity-flags-mixed-test
+  (testing "multiple activity classes light up independently"
+    (let [c (-> (cascade-with-origin :fx-emit)
+                (assoc :other [(ev :rf.machine/transition)
+                               (ev :rf.http/managed-request-settle)
+                               (ev :rf.error/handler-throw :op-type :error)]))
+          flags (l2/cascade-activity-flags c)]
+      (is (= {:error? true :machine? true :http? true
+              :timer? false :fx-emit? true}
+             flags)))))
+
+;; ---- 5. activity-badges projection --------------------------------------
+
+(deftest activity-badges-empty-test
+  (testing "a quiet cascade yields []"
+    (is (= [] (l2/activity-badges {})))
+    (is (= [] (l2/activity-badges nil)))
+    (is (= [] (l2/activity-badges (cascade-with-origin :user))))))
+
+(deftest activity-badges-single-test
+  (testing "one flag → one badge"
+    (is (= ["⚠"]
+           (l2/activity-badges {:errors [{:operation :rf.error/throw}]})))
+    (is (= ["◆"]
+           (l2/activity-badges {:other [(ev :rf.machine/transition)]})))
+    (is (= ["🌐"]
+           (l2/activity-badges {:other [(ev :rf.http/managed-request-settle)]})))
+    (is (= ["⚡"]
+           (l2/activity-badges (cascade-with-origin :fx-emit))))
+    (is (= ["⏲"]
+           (l2/activity-badges (cascade-with-origin :timer))))))
+
+(deftest activity-badges-ordered-test
+  (testing "badges render in the canonical order ⚠ ◆ 🌐 ⚡ ⏲"
+    (let [c (-> (cascade-with-origin :fx-emit)
+                (assoc :other [(ev :rf.timer/fired)
+                               (ev :rf.http/managed-request-settle)
+                               (ev :rf.machine/transition)
+                               (ev :rf.error/handler-throw :op-type :error)]))]
+      (is (= ["⚠" "◆" "🌐" "⚡" "⏲"]
+             (l2/activity-badges c))))))
+
+(deftest activity-badges-glyph-mapping-test
+  (testing "every flag maps to its canonical glyph"
+    (is (= "⚠" (get l2/activity-badge-glyphs :error?)))
+    (is (= "◆" (get l2/activity-badge-glyphs :machine?)))
+    (is (= "🌐" (get l2/activity-badge-glyphs :http?)))
+    (is (= "⚡" (get l2/activity-badge-glyphs :fx-emit?)))
+    (is (= "⏲" (get l2/activity-badge-glyphs :timer?))))
+
+  (testing "the mapping covers exactly the five activity flags"
+    (is (= #{:error? :machine? :http? :fx-emit? :timer?}
+           (set (keys l2/activity-badge-glyphs))))))
+
+;; ---- 6. activity tooltip ------------------------------------------------
+
+(deftest activity-badges-tooltip-test
+  (testing "nil when no badges are present"
+    (is (nil? (l2/activity-badges-tooltip {})))
+    (is (nil? (l2/activity-badges-tooltip nil)))
+    (is (nil? (l2/activity-badges-tooltip (cascade-with-origin :user)))))
+
+  (testing "human-readable cluster description"
+    (let [c (-> (cascade-with-origin :fx-emit)
+                (assoc :other [(ev :rf.machine/transition)
+                               (ev :rf.http/managed-request-settle)
+                               (ev :rf.error/handler-throw :op-type :error)]))
+          tip (l2/activity-badges-tooltip c)]
+      (is (string? tip))
+      (is (re-find #"^Activity:" tip))
+      (is (re-find #"issues raised" tip))
+      (is (re-find #"machine transition" tip))
+      (is (re-find #"HTTP activity" tip))
+      (is (re-find #"fx-emit child" tip))))
+
+  (testing "single-badge tooltip"
+    (is (= "Activity: issues raised"
+           (l2/activity-badges-tooltip
+            {:errors [{:operation :rf.error/throw}]})))))


### PR DESCRIPTION
Closes rf2-gf58j. Per spec/021 §1 + §17.1.5. Substrate deps landed (#1729 cascade-captured · #1735 dispatch-origin).

Each L2 row gets:
- Per-origin glyph/chip prefix (R · 🌐 · 💧 · ⚡ · ⏲ · T · 🔧 · i · 🌊). :user is silent (don't clutter common case).
- Activity badge cluster (⚠ ◆ 🌐 ⚡ ⏲) from cascade activity (errors / machine / http / fx-emit / timer).

Pure-fn helpers live in `tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc` so the projection is JVM-testable; `shell.cljs` touches one require line + one hiccup-insertion site in `event-row`.

CLJS unit tests only · no Playwright.