### PR TITLE
docs(causa): cross-ref spec §012 to §021 Reactive panel (rf2-c6vfr)

### DIFF
--- a/tools/causa/spec/012-Views.md
+++ b/tools/causa/spec/012-Views.md
@@ -1,5 +1,7 @@
 # 012-Views
 
+> **See also**: [`021-Dynamic-Panel-Designs.md` §3](021-Dynamic-Panel-Designs.md#3-the-reactive-panel-reactive-perspective--steps-7-8) for the canonical Reactive (formerly "Views") panel content design. The L3 tab display label was renamed `Views` → `Reactive` per spec/021 §11.5; the tab key + spec doc continue to use `:views` / `012-Views.md` for stability. Per-panel content semantics moved to 021.
+
 ## Bug class
 
 **"Component re-rendered 50 times when I dispatched once — why?"** And:


### PR DESCRIPTION
Closes rf2-c6vfr. Per spec/021 §13 Doc-only beads. Final piece of the spec cross-ref trio (after #1736 §007 + #1737 §003+§004).