### PR TITLE
feat(causa): Trace panel — focused-epoch scoping + film-strip navigation (rf2-7dyi8)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -84,11 +84,14 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.data-display.render :as data-display]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
+            [day8.re-frame2-causa.panels.shared.film-strip.header
+             :as film-strip]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -224,51 +227,96 @@
 
 ;; ---- header strip -------------------------------------------------------
 
+(defn- epoch-indicator
+  "Per spec/021 §5.2 — the film-strip header's middle slot reads
+  `epoch #N · X ops`. `epoch-id` is the focused cascade's settling
+  epoch (the canonical per-frame epoch primary key per spec/018 §6);
+  `rendered` is the post-filter row count (= 'X ops' visible right
+  now)."
+  [{:keys [epoch-id rendered]}]
+  (let [epoch-label (if (some? epoch-id)
+                      (str "epoch #" epoch-id)
+                      "no epoch focused")
+        ops-label   (str rendered " "
+                         (if (= 1 rendered) "op" "ops"))]
+    [:span {:data-testid "rf-causa-trace-epoch-indicator"
+            :style       {:color       (:text-tertiary tokens)
+                          :font-family mono-stack
+                          :font-size   "11px"}}
+     (str epoch-label " · " ops-label)]))
+
 (defn- header
-  "Panel header — title + counts + chip rows + clear-all."
-  [{:keys [total rendered distinct counts filters any-filter?]}]
-  [:header {:style {:padding       "12px 16px 6px 16px"
-                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-   [:div {:style {:display     "flex"
-                  :align-items "baseline"
-                  :gap         "12px"}}
-    ;; rf2-5kfxe.8 — domain-coloured accent stripe (:orange for Trace
-    ;; — events 'in flight'; orange is the firing/heat tone).
-    ;; rf2-5kfxe.9 — display face (Fraunces) for L4 title contrast.
-    [:h1 {:style (merge {:font-size   "20px"
-                         :font-family display-stack
-                         :font-weight 600
-                         :letter-spacing "-0.01em"
-                         :margin      0
-                         :color       (:text-primary tokens)}
-                        (t/accent-stripe-style :trace))}
-     "Trace"]
-    [:span {:data-testid "rf-causa-trace-counts"
-            :style {:font-size   "11px"
-                    :color       (:text-tertiary tokens)
-                    :font-family mono-stack}}
-     (str rendered " / " total " in view")]
-    (when any-filter?
-      [:button {:data-testid "rf-causa-trace-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
-                :style       {:margin-left "auto"
-                              :background  "transparent"
-                              :color       (:cyan tokens)
-                              :border      (str "1px solid " (:border-default tokens))
-                              :padding     "2px 8px"
-                              :border-radius "3px"
-                              :cursor      "pointer"
-                              :font-family sans-stack
-                              :font-size   "11px"}}
-       "Clear filters"])]
-   [:div {:style {:margin-top "8px"}}
-    (for [axis h/filter-axes]
-      ^{:key axis}
-      [axis-chip-row {:axis         axis
-                      :active-value (get filters axis)
-                      :distinct     (get distinct axis)
-                      :counts       (get counts axis)
-                      :axis-colour  (:accent-violet tokens)}])]])
+  "Panel header — film-strip + title + counts + chip rows + clear-all.
+
+  Per spec/021 §5.2 the Trace panel header carries:
+
+    - title `TRACE · epoch #N` (left)
+    - film-strip `[◀ Prev] [Next ▶]` (right)
+
+  The film-strip prev/next semantics per spec/021 §5.5 are
+  *chronological*: walk the L2 cascade list one epoch at a time
+  regardless of dispatch-origin. We delegate to the spine's
+  `:rf.causa/focus-cascade-prev` / `:rf.causa/focus-cascade-next`
+  handlers — the same surface the L1 ribbon nav uses — so prev/next
+  semantics live in ONE place and panels stay declarative."
+  [{:keys [total rendered distinct counts filters any-filter?
+           focus at-head? at-tail?]}]
+  (let [epoch-id (:epoch-id focus)]
+    [:header {:style {:padding       "12px 16px 6px 16px"
+                      :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:div {:style {:display     "flex"
+                    :align-items "baseline"
+                    :gap         "12px"}}
+      ;; rf2-5kfxe.8 — domain-coloured accent stripe (:orange for Trace
+      ;; — events 'in flight'; orange is the firing/heat tone).
+      ;; rf2-5kfxe.9 — display face (Fraunces) for L4 title contrast.
+      [:h1 {:style (merge {:font-size   "20px"
+                           :font-family display-stack
+                           :font-weight 600
+                           :letter-spacing "-0.01em"
+                           :margin      0
+                           :color       (:text-primary tokens)}
+                          (t/accent-stripe-style :trace))}
+       "Trace"]
+      [:span {:data-testid "rf-causa-trace-counts"
+              :style {:font-size   "11px"
+                      :color       (:text-tertiary tokens)
+                      :font-family mono-stack}}
+       (str rendered " / " total " in view")]
+      (when any-filter?
+        [:button {:data-testid "rf-causa-trace-clear-filters"
+                  :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
+                  :style       {:background  "transparent"
+                                :color       (:cyan tokens)
+                                :border      (str "1px solid " (:border-default tokens))
+                                :padding     "2px 8px"
+                                :border-radius "3px"
+                                :cursor      "pointer"
+                                :font-family sans-stack
+                                :font-size   "11px"}}
+         "Clear filters"])
+      ;; rf2-7dyi8 — film-strip header per spec/021 §5.2 + §5.5.
+      ;; Sits on the right edge of the title row; dispatches the
+      ;; canonical spine prev/next events so this panel's nav and the
+      ;; L1 ribbon's nav walk the same cascade vector with identical
+      ;; boundary semantics.
+      [:div {:style {:margin-left "auto"}}
+       (film-strip/header
+         {:panel-id  "trace"
+          :prev-fn   #(rf/dispatch [:rf.causa/focus-cascade-prev] {:frame :rf/causa})
+          :next-fn   #(rf/dispatch [:rf.causa/focus-cascade-next] {:frame :rf/causa})
+          :has-prev? (not at-tail?)
+          :has-next? (not at-head?)
+          :indicator (epoch-indicator {:epoch-id epoch-id
+                                       :rendered rendered})})]]
+     [:div {:style {:margin-top "8px"}}
+      (for [axis h/filter-axes]
+        ^{:key axis}
+        [axis-chip-row {:axis         axis
+                        :active-value (get filters axis)
+                        :distinct     (get distinct axis)
+                        :counts       (get counts axis)
+                        :axis-colour  (:accent-violet tokens)}])]]))
 
 ;; ---- per-row -------------------------------------------------------------
 
@@ -297,6 +345,30 @@
                             :margin-right  "4px"}}
      (format-axis-value value)]))
 
+;; ---- payload renderer ---------------------------------------------------
+;;
+;; Per spec/021 §5 the per-row "expand payload" surface uses the shared
+;; data-display renderer (`day8.re-frame2-causa.data-display.render/
+;; render-tree`, rf2-jgip1, merged in #1739). The Trace panel passes
+;; the raw trace event as `:value`, with `:default-depth 2` per
+;; spec/021 §5.1 ("depth-2-expanded default").
+
+(defn- render-payload
+  "Per-row payload renderer. Wires the shared rf2-jgip1 data-display
+  renderer to the row's raw trace event. Each row gets its own
+  `:render-id` (`trace-row-<id>`) so the renderer's sticky expansion
+  state never collides across rows."
+  [{:keys [id raw] :as _row}]
+  [:div {:data-testid (str "rf-causa-trace-row-" id "-payload")
+         :style       {:padding "8px 16px 12px 110px"
+                       :background (:bg-1 tokens)
+                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   (data-display/render-tree
+     {:value        raw
+      :panel-id     :trace
+      :render-id    (str "trace-row-" id)
+      :default-depth 2})])
+
 (defn- trace-row
   "One row in the trace ribbon.
 
@@ -306,10 +378,19 @@
   new trace push shifted every visible row's index, so every key
   changed, and React unmounted+remounted the entire viewport on
   EVERY push. Same discipline class as rf2-kgn0c's `v:<variant-id>`
-  cell-keying in the story workspace."
+  cell-keying in the story workspace.
+
+  Per spec/021 §5.4 + rf2-7dyi8 the row-click behaviour is **inline
+  payload expansion** (NOT pivot to event-detail) — the Trace panel
+  is already scoped to the focused epoch (rf2-ycoct), so pivoting
+  would just navigate to the same cascade. Click toggles the row's
+  membership in `:rf.causa/trace-expanded-row-ids`; expanded rows
+  render the shared data-display renderer below the row inside the
+  same `<li>` so the React-key + scroll-anchoring discipline holds."
   [{:keys [id time op-type operation source origin frame description
            source-coord dispatch-id]
-    :as row}]
+    :as row}
+   {:keys [expanded?]}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
         dot-colour  (h/op-type-colour op-type)
         ;; rf2-59e7k — destroy-event rows surface a 'Show cancellation
@@ -319,16 +400,14 @@
         destroy?    (cch/destroy-event? {:operation operation})]
     [:li {:key         (h/row-key row)
           :data-testid row-test-id
+          :data-rf-causa-expanded (boolean expanded?)
           :on-click    (fn []
-                         (when dispatch-id
-                           (rf/dispatch [:rf.causa/select-dispatch-id
-                                         dispatch-id frame] {:frame :rf/causa})
-                           ;; Flip the visible tab to Event so the row
-                           ;; jump lands in event-detail. The legacy
-                           ;; `:rf.causa/select-panel` slot is no longer
-                           ;; read by the 4-layer shell (rf2-qy0nu).
-                           (rf/dispatch [:rf.causa/select-tab :event]
-                                        {:frame :rf/causa})))
+                         ;; rf2-7dyi8 — toggle inline payload expansion
+                         ;; rather than pivoting to event-detail (spec
+                         ;; §5.4: 'Row → expand payload · Inline in
+                         ;; panel (no nav)').
+                         (rf/dispatch [:rf.causa/toggle-trace-row-expand id]
+                                      {:frame :rf/causa}))
           :on-context-menu (when destroy?
                              (fn [e]
                                (.preventDefault e)
@@ -337,18 +416,26 @@
                                  [:rf.causa/cancellation-cascade-open
                                   {:kind :dispatch-id :id dispatch-id}]
                                  {:frame :rf/causa})))
-          :style       {:display       "grid"
-                        :grid-template-columns
-                        "84px 14px minmax(140px, 1fr) 2fr auto auto auto"
-                        :gap           "10px"
-                        :align-items   "center"
-                        :padding       "6px 16px"
-                        :border-bottom (str "1px solid " (:border-subtle tokens))
-                        :cursor        (if dispatch-id "pointer" "default")
-                        :color         (:text-primary tokens)
-                        :font-family   mono-stack
-                        :font-size     "12px"
-                        :line-height   1.35}}
+          :style       {:display        "block"
+                        :border-bottom  (str "1px solid "
+                                             (:border-subtle tokens))
+                        :background     (when expanded? (:bg-1 tokens))
+                        :cursor         "pointer"
+                        :color          (:text-primary tokens)
+                        :font-family    mono-stack
+                        :font-size      "12px"
+                        :line-height    1.35}}
+     ;; Row grid — the dense single-line summary per spec/021 §5.2.
+     ;; Held in an inner div so the optional payload can render as a
+     ;; sibling inside the same `<li>` without breaking the row's
+     ;; React-key stability discipline (rf2-z4fza).
+     [:div {:data-testid (str row-test-id "-summary")
+            :style       {:display       "grid"
+                          :grid-template-columns
+                          "84px 14px minmax(140px, 1fr) 2fr auto auto auto"
+                          :gap           "10px"
+                          :align-items   "center"
+                          :padding       "6px 16px"}}
      ;; Timestamp
      [:span {:data-testid (str row-test-id "-time")
              :style {:color (:text-tertiary tokens)
@@ -439,7 +526,10 @@
        [:span {:style {:color (:text-tertiary tokens)
                        :font-size "10px"
                        :min-width "10px"}}
-        ""])]))
+        ""])]
+     ;; rf2-7dyi8 — inline payload expansion. Consumes the shared
+     ;; rf2-jgip1 data-display renderer (#1739, landed in main).
+     (when expanded? (render-payload row))]))
 
 ;; ---- empty states -------------------------------------------------------
 
@@ -626,7 +716,28 @@
         focused-id     (:dispatch-id focus)
         focused-cascade (when focused-id
                           (some #(when (= focused-id (:dispatch-id %)) %)
-                                cascades))]
+                                cascades))
+        ;; rf2-7dyi8 — film-strip nav boundaries. We walk the same
+        ;; cascade list the L1 ribbon walks (`cascades` already passes
+        ;; through `trace-bus/causa-internal-cascade?` in the registry
+        ;; sub) so prev/next semantics match exactly. Empty cascade
+        ;; list → both buttons disabled.
+        cascade-ids    (mapv :dispatch-id cascades)
+        at-head?       (or (empty? cascade-ids)
+                           (= focused-id (last cascade-ids))
+                           (nil? focused-id))
+        at-tail?       (or (empty? cascade-ids)
+                           (= focused-id (first cascade-ids)))
+        ;; rf2-7dyi8 — per-row inline payload expansion set. The
+        ;; trace-row hiccup reads `expanded?` from the closure built
+        ;; here so the row-fn keeps the single-arg shape `overflow/
+        ;; capped-list` requires.
+        expanded-ids   @(rf/subscribe [:rf.causa/trace-expanded-row-ids])
+        row-with-state (fn [row]
+                         (trace-row row
+                                    {:expanded?
+                                     (contains? (or expanded-ids #{})
+                                                (:id row))}))]
     [:section {:data-testid "rf-causa-trace"
                :style       {:height         "100%"
                              :display        "flex"
@@ -640,7 +751,10 @@
               :distinct    distinct
               :counts      counts
               :filters     filters
-              :any-filter? any-filter?})
+              :any-filter? any-filter?
+              :focus       focus
+              :at-head?    at-head?
+              :at-tail?    at-tail?})
      ;; rf2-b76v4 — cascade-status timeline bar. Renders only when a
      ;; cascade is in focus and the ribbon has rows; the empty-state
      ;; branches don't carry a 'focused cascade' surface to colour.
@@ -659,7 +773,7 @@
                                   :style       {:list-style "none"
                                                 :margin     0
                                                 :padding    0}}
-                       :row-fn   trace-row}))]]))
+                       :row-fn   row-with-state}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -775,6 +889,31 @@
   (rf/reg-event-db :rf.causa/clear-trace-filters
     (fn [db _event]
       (dissoc db :trace-filters)))
+
+  ;; ---- rf2-7dyi8 — per-row inline payload expansion ------------------
+  ;;
+  ;; Per spec/021 §5.4 clicking a row expands its payload inline (no
+  ;; nav). The expanded set lives in app-db so the toggle survives
+  ;; sub-recomputes. The shared rf2-jgip1 renderer owns deeper-than-2
+  ;; expansion state under its own `:rf.causa/data-display-expansion`
+  ;; slot; this set gates whether the renderer is mounted for a row
+  ;; at all.
+
+  (rf/reg-sub :rf.causa/trace-expanded-row-ids
+    (fn [db _query]
+      (get db :trace-expanded-row-ids #{})))
+
+  (rf/reg-event-db :rf.causa/toggle-trace-row-expand
+    (fn [db [_ row-id]]
+      (let [current (get db :trace-expanded-row-ids #{})]
+        (assoc db :trace-expanded-row-ids
+               (if (contains? current row-id)
+                 (disj current row-id)
+                 (conj current row-id))))))
+
+  (rf/reg-event-db :rf.causa/clear-trace-expand
+    (fn [db _event]
+      (dissoc db :trace-expanded-row-ids)))
 
   ;; rf2-2moh1 — register the Runtime Trace tab with the internal L4
   ;; tab registry.

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -363,11 +363,11 @@
 
 ;; ---- (6) row interactions -----------------------------------------------
 
-(deftest row-click-pivots-to-event-tab-when-dispatch-id-present
-  (testing "clicking a row whose event carries a :dispatch-id dispatches
-            :rf.causa/select-dispatch-id + :rf.causa/select-tab :event
-            (rf2-qy0nu — the legacy :select-panel slot is no longer
-            read by the 4-layer shell)"
+(deftest row-click-toggles-inline-payload-expansion
+  (testing "rf2-7dyi8 — clicking a row dispatches
+            :rf.causa/toggle-trace-row-expand with the row's :id rather
+            than pivoting to event-detail. Per spec/021 §5.4 the Trace
+            panel surfaces row payloads inline; no nav."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 7 :op-type :event :operation :event/dispatched
@@ -382,14 +382,65 @@
             (is (some? row) "row node present")
             (is (some? handler) "row carries an :on-click handler")
             (when handler (handler))))
-        (is (some #(= [:rf.causa/select-dispatch-id 42 :rf/default] %) @dispatches)
-            "select-dispatch-id fired with the row's dispatch-id and frame")
-        (is (some #(= [:rf.causa/select-tab :event] %) @dispatches)
-            "select-tab fired to flip the visible tab")))))
+        (is (some #(= [:rf.causa/toggle-trace-row-expand 7] %) @dispatches)
+            ":rf.causa/toggle-trace-row-expand fired with the row's :id")
+        (is (not-any? #(and (vector? %)
+                            (= :rf.causa/select-dispatch-id (first %)))
+                      @dispatches)
+            "the legacy pivot is gone — no select-dispatch-id fired")
+        (is (not-any? #(and (vector? %)
+                            (= :rf.causa/select-tab (first %)))
+                      @dispatches)
+            "no select-tab fired (no nav per spec/021 §5.4)")))))
+
+(deftest toggle-trace-row-expand-event-mutates-set
+  (testing "rf2-7dyi8 — :rf.causa/toggle-trace-row-expand toggles row
+            membership in :trace-expanded-row-ids set."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-trace-row-expand 11])
+      (is (= #{11} @(rf/subscribe [:rf.causa/trace-expanded-row-ids]))
+          "first toggle adds the id")
+      (rf/dispatch-sync [:rf.causa/toggle-trace-row-expand 22])
+      (is (= #{11 22} @(rf/subscribe [:rf.causa/trace-expanded-row-ids]))
+          "second toggle on a different id appends")
+      (rf/dispatch-sync [:rf.causa/toggle-trace-row-expand 11])
+      (is (= #{22} @(rf/subscribe [:rf.causa/trace-expanded-row-ids]))
+          "toggling an already-expanded row removes it")
+      (rf/dispatch-sync [:rf.causa/clear-trace-expand])
+      (is (= #{} @(rf/subscribe [:rf.causa/trace-expanded-row-ids]))
+          ":rf.causa/clear-trace-expand drops every expanded id"))))
+
+(deftest expanded-row-renders-data-display-payload
+  (testing "rf2-7dyi8 — when a row's :id is in the expanded set, the
+            shared rf2-jgip1 data-display renderer mounts below the row."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-trace {:id 13 :op-type :event :operation :event/dispatched
+                              :dispatch-id 1 :source :ui :origin :app}))
+      ;; Pre-expansion — no payload.
+      (let [tree (trace/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-13-payload"))
+            "payload block absent when row is not in expanded set"))
+      ;; Toggle expand → payload renders.
+      (rf/dispatch-sync [:rf.causa/toggle-trace-row-expand 13])
+      (let [tree    (trace/Panel)
+            payload (find-by-testid tree "rf-causa-trace-row-13-payload")]
+        (is (some? payload) "payload block renders when row is expanded")
+        ;; rf2-jgip1's render-tree always renders a wrapper div with
+        ;; data-testid `rf-causa-data-display-trace-<render-id>`; pin
+        ;; that the panel's render-id wiring lands in the canonical
+        ;; per-row slot so two adjacent expansions don't collide on
+        ;; sticky expansion state.
+        (is (some? (find-by-testid tree
+                                   "rf-causa-data-display-trace-trace-row-13"))
+            "shared rf2-jgip1 renderer mounted with per-row render-id")))))
 
 (deftest source-coord-click-fires-open-in-editor
   (testing "clicking the source-coord chip fires :rf.causa/open-in-editor;
-            stopPropagation prevents the row's pivot from also firing"
+            stopPropagation prevents the row's expand-toggle from also
+            firing (rf2-7dyi8 — the row click toggles inline expansion
+            now, the source-coord button bubbles must not toggle it)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push a trace whose :rf.trace/trigger-handler carries a source-coord.
@@ -921,3 +972,121 @@
             "LIVE auto-snap → focus has :dispatch-id 100 → no :no-focus")
         (is (= 100 (:cascade-dispatch-id feed))
             "scope landed on the head cascade automatically")))))
+
+;; ---- (10) film-strip header — rf2-7dyi8 --------------------------------
+;;
+;; Per spec/021 §5.2 the Trace panel header carries a `[◀ Prev] [Next ▶]`
+;; film-strip on the right. Per §5.5 prev/next semantics are chronological
+;; — the shared component delegates to the spine's
+;; `:rf.causa/focus-cascade-prev` / `:rf.causa/focus-cascade-next` events.
+
+(deftest film-strip-header-renders-in-trace-panel
+  (testing "the film-strip header sits in the Trace panel header with
+            the canonical panel-id testid prefix"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 1}))
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-trace-film-strip"))
+            "film-strip wrapper present")
+        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-prev"))
+            "prev button present")
+        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-next"))
+            "next button present")
+        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-indicator"))
+            "indicator slot present")
+        (is (some? (find-by-testid tree "rf-causa-trace-epoch-indicator"))
+            "indicator carries the 'epoch #N · X ops' content")))))
+
+(deftest film-strip-prev-dispatches-focus-cascade-prev
+  (testing "rf2-7dyi8 — clicking the film-strip prev button dispatches
+            :rf.causa/focus-cascade-prev (the canonical spine prev
+            event the L1 ribbon also uses). Requires at least two
+            cascades so the boundary doesn't disable the button."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Two cascades + focus on the head — prev should be enabled.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                             :dispatch-id 2}))
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/Panel)
+                btn     (find-by-testid tree "rf-causa-trace-film-strip-prev")
+                handler (:on-click (second btn))]
+            (is (some? btn) "prev button found")
+            (is (some? handler)
+                "prev button is enabled (two cascades, focused on head)")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/focus-cascade-prev] %) @dispatches)
+            ":rf.causa/focus-cascade-prev fired on prev click")))))
+
+(deftest film-strip-next-dispatches-focus-cascade-next
+  (testing "rf2-7dyi8 — clicking the film-strip next button dispatches
+            :rf.causa/focus-cascade-next. Pin focus to the tail so
+            next is enabled."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                             :dispatch-id 2}))
+      ;; Step focus to the tail (cascade 1) so next is enabled.
+      (rf/dispatch-sync [:rf.causa/focus-cascade 1])
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/Panel)
+                btn     (find-by-testid tree "rf-causa-trace-film-strip-next")
+                handler (:on-click (second btn))]
+            (is (some? btn) "next button found")
+            (is (some? handler)
+                "next button is enabled (focused on tail with newer cascade)")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/focus-cascade-next] %) @dispatches)
+            ":rf.causa/focus-cascade-next fired on next click")))))
+
+(deftest film-strip-prev-disabled-at-tail
+  (testing "rf2-7dyi8 — when focused on the tail cascade (oldest), the
+            prev button renders in the disabled visual state with no
+            on-click handler attached."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                             :dispatch-id 2}))
+      (rf/dispatch-sync [:rf.causa/focus-cascade 1])  ;; tail
+      (let [tree    (trace/Panel)
+            btn     (find-by-testid tree "rf-causa-trace-film-strip-prev")
+            handler (:on-click (second btn))]
+        (is (some? btn) "prev button still rendered (in disabled state)")
+        (is (nil? handler)
+            "prev button has no on-click when at the tail boundary")
+        (is (true? (:disabled (second btn)))
+            "prev button carries the HTML disabled attribute")))))
+
+(deftest film-strip-next-disabled-at-head
+  (testing "rf2-7dyi8 — when focused on the head cascade (newest), the
+            next button renders in the disabled visual state with no
+            on-click handler attached."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                             :dispatch-id 2}))
+      ;; LIVE auto-snap puts focus on the head (dispatch-id 2).
+      (let [tree    (trace/Panel)
+            btn     (find-by-testid tree "rf-causa-trace-film-strip-next")
+            handler (:on-click (second btn))]
+        (is (some? btn) "next button still rendered (in disabled state)")
+        (is (nil? handler)
+            "next button has no on-click when at the head boundary")
+        (is (true? (:disabled (second btn)))
+            "next button carries the HTML disabled attribute")))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -311,6 +311,8 @@
    ;; rf2-7hwwe — `:after` countdown ring hover slot (rich tooltip lifecycle).
    :rf.causa/timer-hover
    :rf.causa/trace-buffer
+   ;; rf2-7dyi8 — per-row inline payload expansion state (spec/021 §5.4).
+   :rf.causa/trace-expanded-row-ids
    :rf.causa/trace-feed
    ;; rf2-39n8h discovered — trace-feed UI-state slot (selection /
    ;; expansion state shared by the Trace panel).
@@ -362,6 +364,8 @@
    :rf.causa/clear-trace-buffer
    ;; rf2-e9tb0 — App-DB segment-inspector popup close event.
    :rf.causa/close-segment-inspector
+   ;; rf2-7dyi8 — drop every expanded trace-row id in one shot.
+   :rf.causa/clear-trace-expand
    :rf.causa/clear-trace-filters
    :rf.causa/close-edit-popup
    :rf.causa/close-shell
@@ -561,6 +565,9 @@
    :rf.causa/timer-hover
    :rf.causa/timer-tick
    :rf.causa/toggle-live-pause
+   ;; rf2-7dyi8 — toggle the inline payload expansion for one trace row
+   ;; (per spec/021 §5.4 — Row → expand payload · Inline in panel).
+   :rf.causa/toggle-trace-row-expand
    ;; Reactive panel events (rf2-wyvf2 · spec/021 §3 · renamed from
    ;; Views per §11.5; tab key stays `:views`).
    :rf.causa/reactive-set-unchanged


### PR DESCRIPTION
Closes rf2-7dyi8. Per spec/021 §5.

## Summary

- **Film-strip header** (spec/021 §5.2 + §5.5) — consumes the shared `panels.shared.film-strip.header` component (rf2-h7nqh, #1738). Dispatches the canonical `:rf.causa/focus-cascade-prev` / `:rf.causa/focus-cascade-next` spine events so this panel's nav and the L1 ribbon's nav walk the same cascade vector with identical boundary semantics. Indicator slot shows `epoch #N · X ops`.
- **Re-scope to focused epoch** — already in place via the rf2-ycoct cascade-scope wiring (`:rf.causa/focus` → `project-feed-from-state`'s `:cascade-dispatch-id` arg). No aggregate-across-epochs view.
- **Row click → inline payload expansion** (spec/021 §5.4) — replaces the legacy pivot-to-event-detail behaviour (per pre-alpha "no back-compat shims"). Click toggles `:rf.causa/trace-expanded-row-ids`; expanded rows render the **shared rf2-jgip1 data-display renderer** (#1739, landed in main before this PR) below the row inside the same `<li>` so React-key stability holds.

## Test plan

- [x] `npm run test:cljs` — 3639 tests, 0 failures (8 new tests for film-strip + expand toggle + data-display wiring; pivot test retired)
- [x] `npm run test:bundle-isolation` — PASS
- [x] `mkdocs build --strict` — clean

## Surface

- `tools/causa/src/day8/re_frame2_causa/panels/trace.cljs` — film-strip header, inline-expand row-click, data-display payload renderer
- `tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs` — 7 new tests, 1 test rewritten (pivot → toggle-expand)
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — snapshot: +1 sub (`:rf.causa/trace-expanded-row-ids`), +2 events (`:rf.causa/toggle-trace-row-expand`, `:rf.causa/clear-trace-expand`)