### PR TITLE
feat(causa): App-db panel — downstream-subs overlay (rf2-op9v2)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -308,10 +308,16 @@
   omitted (older test callers that pass `[path child-summary]` or
   `[path child-summary subtree-value]` still work)."
   ([section-path child-summary]
-   (breadcrumb section-path child-summary nil nil))
+   (breadcrumb section-path child-summary nil nil nil))
   ([section-path child-summary subtree-value]
-   (breadcrumb section-path child-summary subtree-value nil))
+   (breadcrumb section-path child-summary subtree-value nil nil))
   ([section-path child-summary subtree-value origin-tag]
+   (breadcrumb section-path child-summary subtree-value origin-tag nil))
+  ;; rf2-op9v2 — 5-arg arity accepts an `extra-affordance` hiccup that
+  ;; renders between the origin-tag chip and the standard affordance
+  ;; row. The App-db panel injects its downstream-subs hover trigger
+  ;; via this slot. Nil → legacy layout preserved.
+  ([section-path child-summary subtree-value origin-tag extra-affordance]
    (let [{:keys [added removed modified children]
           :or   {added 0 removed 0 modified 0 children 0}} child-summary
          total-changes (+ added removed modified children)
@@ -340,6 +346,13 @@
       ;; preserving the legacy hiccup shape.
       (when origin-tag
         (origin-tag-chip section-path origin-tag))
+      ;; rf2-op9v2 — App-db panel's downstream-subs hover trigger (or
+      ;; any future caller's per-section affordance) renders between
+      ;; the origin chip and the standard affordance row so the
+      ;; trigger sits next to the path/writer attribution where the
+      ;; operator is already looking.
+      (when extra-affordance
+        extra-affordance)
       ;; Affordance row — Show-me-when / Copy path / Copy value.
       ;; Pin was dropped under rf2-e9tb0 when pinned-watches was
       ;; superseded by the clickable-segment inspector popup.
@@ -646,9 +659,13 @@
   `prefers-reduced-motion: reduce`. The `:animation-fill-mode forwards`
   pins the end state (transparent) so the row settles at `bg-3` once
   the wash decays."
-  ([s surface] (section s surface nil false))
-  ([s surface origin-tag] (section s surface origin-tag false))
-  ([{:keys [path subtree]} surface origin-tag flash?]
+  ([s surface] (section s surface nil false nil))
+  ([s surface origin-tag] (section s surface origin-tag false nil))
+  ([s surface origin-tag flash?] (section s surface origin-tag flash? nil))
+  ;; rf2-op9v2 — 5-arg arity threads an `extra-affordance` hiccup into
+  ;; the breadcrumb. Used by the App-db panel to inject its
+  ;; downstream-subs hover trigger per-section.
+  ([{:keys [path subtree]} surface origin-tag flash? extra-affordance]
    (let [child-summary (if (= :children (at/op-of subtree))
                          (:child-summary subtree)
                          nil)
@@ -675,7 +692,7 @@
      [:section {:data-testid (str "rf-causa-diff-section-"
                                   (pr-str path))
                 :style (merge base-style flash-style)}
-      (breadcrumb path child-summary after-value origin-tag)
+      (breadcrumb path child-summary after-value origin-tag extra-affordance)
       [:div {:style {:padding "8px 12px"
                      :font-family mono-stack
                      :font-size "12px"
@@ -703,7 +720,8 @@
   When `opts` is omitted (older callers, test rigs), no origin chip
   renders and no flash plays — the legacy hiccup shape is preserved."
   ([sections surface] (render-sections sections surface nil))
-  ([sections surface {:keys [flow-writes diff-triples epoch-id] :as _opts}]
+  ([sections surface {:keys [flow-writes diff-triples epoch-id
+                             extra-affordance-fn] :as _opts}]
    (if (empty? sections)
      [:div {:data-testid "rf-causa-diff-empty"
             :style {:padding "12px"
@@ -720,7 +738,14 @@
            ;; supplied (the caller is the live panel). Test rigs that
            ;; omit `:epoch-id` get the legacy no-flash render so the
            ;; hiccup-walking tests stay deterministic.
-           flash?     (some? epoch-id)]
+           flash?     (some? epoch-id)
+           ;; rf2-op9v2 — per-section caller-supplied affordance hook
+           ;; (e.g. App-db panel's downstream-subs hover trigger).
+           ;; `extra-affordance-fn` is `(fn [path] hiccup-or-nil)`.
+           ;; Omitting it preserves the legacy hiccup shape.
+           extra-for  (fn [section-path]
+                        (when extra-affordance-fn
+                          (extra-affordance-fn section-path)))]
        (into [:div {:data-testid "rf-causa-diff-sections"}]
              (for [s sections]
                ;; React key combines epoch-id + section path so a new
@@ -738,6 +763,7 @@
                ;; `with-meta` on the returned vector is the correct
                ;; surface.
                (with-meta
-                 (section s surface (origin-for (:path s)) flash?)
+                 (section s surface (origin-for (:path s))
+                          flash? (extra-for (:path s)))
                  {:key (str (when epoch-id (str epoch-id "/"))
                             (pr-str (:path s)))})))))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -30,6 +30,8 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.diff.render :as diff-render]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
+            [day8.re-frame2-causa.panels.app-db-diff-downstream
+             :as downstream]
             [day8.re-frame2-causa.panels.app-db-diff-events :as events]
             [day8.re-frame2-causa.panels.app-db-diff-sections
              :as sections]
@@ -105,10 +107,19 @@
          ;; React mount per section and the diff-flash keyframes
          ;; auto-play (yellow wash decaying to transparent over 400ms,
          ;; scaled by the `--rf-causa-motion-scale` seam).
+         ;; rf2-op9v2 — `:extra-affordance-fn` lets us inject the
+         ;; downstream-subs hover trigger into every section's
+         ;; breadcrumb. The trigger renders its own popover when
+         ;; hovered/focused; only one popover is open at a time per
+         ;; `:rf.causa.app-db/popover-slot`.
          (diff-render/render-sections changed-sections "app-db-diff"
                                        {:flow-writes  flow-writes
                                         :diff-triples diff-triples
-                                        :epoch-id     selected-epoch-id})
+                                        :epoch-id     selected-epoch-id
+                                        :extra-affordance-fn
+                                        (fn [section-path]
+                                          [downstream/hover-trigger
+                                           section-path])})
          (sections/reserved-group changed-reserved)])]]))
 
 (defn install!
@@ -117,6 +128,9 @@
   []
   (subs/install!)
   (events/install!)
+  ;; rf2-op9v2 — downstream-subs overlay subs + events (the hover
+  ;; popover that lists subs/views downstream of each changed path).
+  (downstream/install!)
   ;; rf2-2moh1 — register the Runtime App DB tab with the internal L4
   ;; tab registry.
   (panel-registry/reg-l4-tab!

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
@@ -1,0 +1,456 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-downstream
+  "App-DB panel — downstream-subs overlay (rf2-op9v2).
+
+  Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §4.4 — hover (or
+  click) any changed app-db path → popover lists subs and views
+  downstream of that path (subs that recomputed/skipped and views that
+  rendered in this cascade). Each downstream sub has a ⤴ button that
+  navigates to the Reactive panel (tab key `:views`, rebadged
+  'Reactive' per rf2-wyvf2 / PR #1741).
+
+  ## MVP (rf2-op9v2)
+
+  The cascade aggregate `:rf.cascade/captured` (#1729) carries
+  per-cascade `:subs-recomputed` / `:subs-skipped` / `:views-rendered`
+  vectors but does NOT yet carry per-sub `:input-paths` attribution.
+  Without that, filtering 'subs depending on path X' surgically is not
+  possible from the trace stream alone — the registry-side input-paths
+  lookup would be needed.
+
+  The MVP therefore renders the FULL cascade — every sub that ran
+  (recomputed or skipped) + every view that rendered this cascade — in
+  every per-path popover. A follow-on bead (rf2-op9v2-followup) will
+  refine the list to path-specific subs once the substrate carries
+  input-paths in the cascade aggregate (or once an additional registry
+  walk is wired in).
+
+  Data source: the focused epoch's `:sub-runs` + `:renders` projections
+  on the epoch record (the same slots the Reactive panel reads —
+  `views_subs.cljs` §:rf.causa/views-focused-cascade-pair). These
+  exist on every epoch record per `spec/Spec-Schemas.md
+  §:rf/epoch-record`; reading them does NOT require the cascade-
+  captured aggregate to be focus-gated (the aggregate adds bounded
+  capture + view-render entries which we don't strictly need for the
+  popover list).
+
+  ## Navigation event
+
+  `:rf.causa/navigate-to-panel` is registered here as a thin handler
+  that:
+
+    1. Writes the target `:sub-id` + `:query-v` into a `:rf.causa.app-
+       db/nav-cursor` slot. The Reactive panel (rf2-wyvf2 / PR #1741)
+       reads this slot to auto-scroll/highlight on mount.
+    2. Dispatches `:rf.causa/select-tab` with the target tab id.
+
+  When rf2-wyvf2 lands without auto-scroll wiring, the tab swap still
+  works and the cursor sits in app-db harmlessly (a follow-on PR can
+  hook the Reactive panel to it).
+
+  ## Popover lifecycle
+
+  Open/close state lives on `:rf.causa.app-db/popover` in Causa's
+  app-db — `nil` when closed, `{:path <vec>}` when open at a path.
+  Hover-in opens, hover-out (after the dispatch round-trip) closes.
+  The popover body is mounted inside the hover trigger so its hover
+  area connects to the trigger (no flicker between them).
+
+  Per the §4.4 'Causa-owned component' guidance the popover is not a
+  browser `title=` tooltip; it's a real DOM panel with keyboard
+  dismissal via Esc (handled by the trigger's `:on-key-down`)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- subs --------------------------------------------------------------
+
+(defn- focused-cascade-sub-runs+renders
+  "Read the focused epoch's `:sub-runs` + `:renders` slots, falling
+  back to head when no focus resolved. Mirrors `views-focused-cascade-
+  pair` but only needs the current cascade (not the prior). Returns
+  `{:sub-runs [...] :renders [...]}`; both vectors default to `[]`."
+  [history focus]
+  (let [history       (vec history)
+        focus-eid     (:epoch-id focus)
+        idx           (or (when focus-eid
+                            (some (fn [[i r]]
+                                    (when (= focus-eid (:epoch-id r)) i))
+                                  (map-indexed vector history)))
+                          (when (seq history) (dec (count history))))
+        current       (when idx (nth history idx nil))]
+    {:sub-runs (or (:sub-runs current) [])
+     :renders  (or (:renders  current) [])}))
+
+(defn install-subs!
+  []
+  ;; Popover open/close state — nil when closed, `{:path <vec>}` open.
+  (rf/reg-sub :rf.causa.app-db/popover-slot
+    (fn [db _]
+      (get-in db [:app-db :popover])))
+
+  (rf/reg-sub :rf.causa.app-db/popover-open?
+    :<- [:rf.causa.app-db/popover-slot]
+    (fn [slot _] (some? slot)))
+
+  (rf/reg-sub :rf.causa.app-db/popover-path
+    :<- [:rf.causa.app-db/popover-slot]
+    (fn [slot _] (:path slot)))
+
+  ;; Downstream subs / views for the focused cascade. MVP (rf2-op9v2):
+  ;; returns ALL subs + views in the focused cascade — the popover
+  ;; renders the same list for every changed path. A follow-on bead
+  ;; will narrow the list to subs that actually read the hovered path
+  ;; once input-paths attribution lands in the substrate.
+  ;;
+  ;; The sub takes a `:path` query arg slot today only so future
+  ;; refinement is a body-only change (no caller migration).
+  (rf/reg-sub :rf.causa/app-db-downstream-for-path
+    :<- [:rf.causa/epoch-history]
+    :<- [:rf.causa/focus]
+    (fn [[history focus] [_query _path]]
+      (let [{:keys [sub-runs renders]}
+            (focused-cascade-sub-runs+renders history focus)]
+        {:subs-recomputed (vec (filter :recomputed? sub-runs))
+         :subs-skipped    (vec (remove :recomputed? sub-runs))
+         :views-rendered  (vec renders)
+         ;; rf2-op9v2 MVP marker — drives the 'showing full cascade'
+         ;; affordance in the popover so the operator knows the list
+         ;; is not yet path-filtered.
+         :path-filtered?  false}))))
+
+;; ---- events ------------------------------------------------------------
+
+(defn install-events!
+  []
+  (rf/reg-event-db :rf.causa.app-db/show-downstream
+    (fn [db [_ path]]
+      (assoc-in db [:app-db :popover] {:path (vec path)})))
+
+  (rf/reg-event-db :rf.causa.app-db/hide-downstream
+    (fn [db _]
+      (update db :app-db dissoc :popover)))
+
+  ;; `:rf.causa/navigate-to-panel` — fire-and-forget cross-panel
+  ;; navigation. Per rf2-op9v2 the immediate caller is the popover's
+  ;; ⤴ button; the handler also accepts a free-form `:sub-id` /
+  ;; `:query-v` payload that lands in `:rf.causa.app-db/nav-cursor`
+  ;; for the Reactive panel (rf2-wyvf2 / PR #1741) to auto-scroll to.
+  ;;
+  ;; When rf2-wyvf2 lands the cursor slot is consumed there; today
+  ;; the cursor sits in app-db harmlessly.
+  (rf/reg-event-fx :rf.causa/navigate-to-panel
+    (fn [{:keys [db]} [_ {:keys [target sub-id query-v]}]]
+      (let [target (or target :views)]
+        {:db (-> db
+                 (update :app-db dissoc :popover)
+                 (cond->
+                   (or sub-id query-v)
+                   (assoc-in [:app-db :nav-cursor]
+                             {:target  target
+                              :sub-id  sub-id
+                              :query-v query-v})))
+         :fx [[:dispatch [:rf.causa/select-tab target]]]}))))
+
+;; ---- view --------------------------------------------------------------
+
+(defn- sub-row
+  "One row in the popover's subs list. Carries the ⤴ jump button."
+  [{:keys [sub-id query-v recomputed?]}]
+  (let [label-suffix (if recomputed? "(recomputed)" "(skipped)")]
+    [:li {:data-testid (str "rf-causa-app-db-popover-sub-"
+                            (pr-str sub-id))
+          :style {:display         "flex"
+                  :align-items     "center"
+                  :justify-content "space-between"
+                  :gap             "8px"
+                  :padding         "3px 8px"
+                  :font-family     mono-stack
+                  :font-size       "11px"
+                  :color           (:text-primary tokens)
+                  :border-bottom   (str "1px solid "
+                                        (:border-subtle tokens))}}
+     [:span {:style {:overflow      "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space   "nowrap"
+                     :flex          1}}
+      [:span {:style {:color (:accent-violet tokens) :font-weight 600}}
+       (pr-str sub-id)]
+      (when (seq query-v)
+        [:span {:style {:color (:text-tertiary tokens) :margin-left "4px"}}
+         (f/truncate (f/format-edn (vec query-v)) 24)])
+      [:span {:style {:color (:text-tertiary tokens)
+                      :margin-left "6px"
+                      :font-family sans-stack
+                      :font-size "10px"}}
+       label-suffix]]
+     [:button
+      {:data-testid (str "rf-causa-app-db-popover-jump-"
+                         (pr-str sub-id))
+       :title       "Jump to this sub in the Reactive panel"
+       :aria-label  "Jump to this sub in the Reactive panel"
+       :on-click    (fn [^js e]
+                      (.preventDefault e)
+                      (.stopPropagation e)
+                      (rf/dispatch
+                        [:rf.causa/navigate-to-panel
+                         {:target  :views
+                          :sub-id  sub-id
+                          :query-v query-v}]
+                        {:frame :rf/causa}))
+       :style       {:flex          "0 0 auto"
+                     :background    "transparent"
+                     :border        (str "1px solid "
+                                         (:border-default tokens))
+                     :border-radius "3px"
+                     :color         (:accent-violet tokens)
+                     :font-family   mono-stack
+                     :font-size     "11px"
+                     :cursor        "pointer"
+                     :padding       "0 6px"
+                     :line-height   "16px"}}
+      "⤴"]]))
+
+(defn- view-row
+  "One row in the popover's views list. No ⤴ button (the Reactive
+  panel ⤴ jump is per-sub, since the popover's primary affordance is
+  'jump to the sub that drives this render'). Views are listed for
+  context — operator sees 'rendering CheckoutButton because of this
+  path's cascade'."
+  [{:keys [render-key triggered-by] :as render}]
+  (let [view-id    (when (vector? render-key) (first render-key))
+        view-label (or view-id render-key)]
+    [:li {:data-testid (str "rf-causa-app-db-popover-view-"
+                            (pr-str view-label))
+          :style {:padding       "3px 8px"
+                  :font-family   mono-stack
+                  :font-size     "11px"
+                  :color         (:text-primary tokens)
+                  :border-bottom (str "1px solid "
+                                      (:border-subtle tokens))}}
+     [:span {:style {:color (:accent-violet tokens) :font-weight 600}}
+      (pr-str view-label)]
+     (when triggered-by
+       [:span {:style {:color (:text-tertiary tokens)
+                       :margin-left "6px"
+                       :font-family sans-stack
+                       :font-size "10px"}}
+        (str "← " (pr-str triggered-by))])]))
+
+(defn- popover-body
+  "Render the popover contents — subs list (recomputed first, then
+  skipped) + views list + ⤴ footer affordance."
+  [path]
+  (let [{:keys [subs-recomputed subs-skipped views-rendered path-filtered?]}
+        @(rf/subscribe [:rf.causa/app-db-downstream-for-path path])
+        any-content? (or (seq subs-recomputed)
+                         (seq subs-skipped)
+                         (seq views-rendered))]
+    [:div {:data-testid "rf-causa-app-db-popover-body"
+           :role        "dialog"
+           :aria-label  (str "Downstream subs for path " (pr-str path))
+           :on-click    #(.stopPropagation %)
+           :style {:position       "absolute"
+                   :left           0
+                   :top            "100%"
+                   :margin-top     "4px"
+                   :z-index        20
+                   :min-width      "280px"
+                   :max-width      "420px"
+                   :background     (:bg-2 tokens)
+                   :border         (str "1px solid "
+                                        (:border-default tokens))
+                   :border-radius  "4px"
+                   :box-shadow     "0 4px 12px rgba(0,0,0,0.4)"
+                   :overflow       "hidden"
+                   :font-family    sans-stack}}
+     [:header {:style {:padding "6px 8px"
+                       :background (:bg-3 tokens)
+                       :border-bottom (str "1px solid "
+                                           (:border-subtle tokens))
+                       :font-size "11px"
+                       :color (:text-secondary tokens)
+                       :font-family sans-stack
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"}}
+      "Downstream of "
+      [:code {:style {:color (:accent-violet tokens)
+                      :font-family mono-stack
+                      :text-transform "none"}}
+       (f/format-edn (vec path))]]
+     (when-not path-filtered?
+       ;; rf2-op9v2 MVP affordance — make the 'not yet path-filtered'
+       ;; state explicit so operators don't think the cascade ran the
+       ;; full list against this specific path. Removed once the
+       ;; follow-on bead lands input-paths attribution.
+       [:div {:data-testid "rf-causa-app-db-popover-mvp-note"
+              :style {:padding     "4px 8px"
+                      :background  (:bg-3 tokens)
+                      :color       (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size   "10px"
+                      :font-style  "italic"
+                      :border-bottom (str "1px solid "
+                                          (:border-subtle tokens))}}
+        "Showing full cascade — path-filtered list pending (rf2-op9v2)"])
+     (cond
+       (not any-content?)
+       [:div {:data-testid "rf-causa-app-db-popover-empty"
+              :style {:padding "8px"
+                      :font-size "11px"
+                      :color (:text-tertiary tokens)
+                      :font-style "italic"
+                      :font-family sans-stack}}
+        "No subs ran in this cascade."]
+
+       :else
+       [:<>
+        (when (seq subs-recomputed)
+          [:section {:data-testid "rf-causa-app-db-popover-subs-recomputed"}
+           [:h4 {:style {:margin "0"
+                         :padding "4px 8px"
+                         :font-size "10px"
+                         :font-family sans-stack
+                         :text-transform "uppercase"
+                         :letter-spacing "0.5px"
+                         :color (:text-secondary tokens)
+                         :background (:bg-3 tokens)
+                         :font-weight 600}}
+            "Subs depending on this path"]
+           (into [:ul {:style {:margin 0 :padding 0 :list-style "none"}}]
+                 (for [sr subs-recomputed]
+                   (with-meta (sub-row (assoc sr :recomputed? true))
+                              {:key (pr-str [(:sub-id sr) (:query-v sr)])})))])
+        (when (seq subs-skipped)
+          [:section {:data-testid "rf-causa-app-db-popover-subs-skipped"}
+           [:h4 {:style {:margin "0"
+                         :padding "4px 8px"
+                         :font-size "10px"
+                         :font-family sans-stack
+                         :text-transform "uppercase"
+                         :letter-spacing "0.5px"
+                         :color (:text-secondary tokens)
+                         :background (:bg-3 tokens)
+                         :font-weight 600}}
+            "Subs skipped (cache hit)"]
+           (into [:ul {:style {:margin 0 :padding 0 :list-style "none"}}]
+                 (for [sr subs-skipped]
+                   (with-meta (sub-row (assoc sr :recomputed? false))
+                              {:key (pr-str [(:sub-id sr) (:query-v sr)])})))])
+        (when (seq views-rendered)
+          [:section {:data-testid "rf-causa-app-db-popover-views"}
+           [:h4 {:style {:margin "0"
+                         :padding "4px 8px"
+                         :font-size "10px"
+                         :font-family sans-stack
+                         :text-transform "uppercase"
+                         :letter-spacing "0.5px"
+                         :color (:text-secondary tokens)
+                         :background (:bg-3 tokens)
+                         :font-weight 600}}
+            "Views rendered"]
+           (into [:ul {:style {:margin 0 :padding 0 :list-style "none"}}]
+                 (for [r views-rendered]
+                   (with-meta (view-row r)
+                              {:key (pr-str (:render-key r))})))])])
+     ;; ⤴ footer affordance — jumps to the Reactive panel without a
+     ;; specific sub focus (the operator can scrub from there). Mirrors
+     ;; the spec §4.4 footer line '⤴ jump to Reactive panel'.
+     [:div {:style {:padding "4px 8px"
+                    :border-top (str "1px solid "
+                                     (:border-subtle tokens))
+                    :background (:bg-3 tokens)
+                    :text-align "right"}}
+      [:button
+       {:data-testid "rf-causa-app-db-popover-jump-reactive"
+        :on-click    (fn [^js e]
+                       (.preventDefault e)
+                       (.stopPropagation e)
+                       (rf/dispatch
+                         [:rf.causa/navigate-to-panel {:target :views}]
+                         {:frame :rf/causa}))
+        :style       {:background    "transparent"
+                      :border        (str "1px solid "
+                                          (:border-default tokens))
+                      :border-radius "3px"
+                      :color         (:accent-violet tokens)
+                      :font-family   sans-stack
+                      :font-size     "10px"
+                      :cursor        "pointer"
+                      :padding       "1px 6px"}}
+       "⤴ jump to Reactive panel"]]]))
+
+(defn hover-trigger
+  "Inline trigger element placed in a section's breadcrumb. On hover
+  (or click / keyboard activation) opens the downstream-subs popover
+  anchored to this trigger. The trigger reads the popover slot to
+  decide whether to render the body — only the popover whose path
+  matches this trigger renders, so multiple section triggers don't
+  spawn overlapping popovers.
+
+  `path` is the section's app-db path."
+  [path]
+  (let [open-path @(rf/subscribe [:rf.causa.app-db/popover-path])
+        active?   (= (vec path) (vec (or open-path [])))
+        open      (fn [^js e]
+                    (.preventDefault e)
+                    (.stopPropagation e)
+                    (rf/dispatch [:rf.causa.app-db/show-downstream path]
+                                 {:frame :rf/causa}))
+        close     (fn [_e]
+                    (rf/dispatch [:rf.causa.app-db/hide-downstream]
+                                 {:frame :rf/causa}))]
+    [:span {:data-testid (str "rf-causa-app-db-downstream-trigger-"
+                              (pr-str path))
+            :tab-index   0
+            :role        "button"
+            :aria-haspopup "dialog"
+            :aria-expanded (if active? "true" "false")
+            :aria-label  (str "Show subs and views downstream of "
+                              (pr-str path))
+            :title       (str "Hover or click to see subs/views downstream of "
+                              (pr-str path))
+            :on-mouse-enter open
+            :on-mouse-leave close
+            :on-focus       open
+            :on-blur        close
+            :on-click       open
+            :on-key-down    (fn [^js e]
+                              (case (.-key e)
+                                ("Escape" "Esc")
+                                (do (.preventDefault e) (close e))
+                                ("Enter" " ")
+                                (do (.preventDefault e) (open e))
+                                nil))
+            :style {:position      "relative"
+                    :display       "inline-flex"
+                    :align-items   "center"
+                    :gap           "2px"
+                    :padding       "1px 6px"
+                    :margin-left   "4px"
+                    :background    (if active?
+                                     (:bg-active tokens)
+                                     (:bg-2 tokens))
+                    :border        (str "1px solid "
+                                        (:border-default tokens))
+                    :border-radius "3px"
+                    :color         (:accent-violet tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"
+                    :cursor        "pointer"
+                    :user-select   "none"
+                    :line-height   "14px"}}
+     "⤴ subs"
+     (when active?
+       (popover-body path))]))
+
+;; ---- install! ----------------------------------------------------------
+
+(defn install!
+  "Idempotent install — subs + events for the downstream-subs overlay.
+  The trigger view is mounted by the App-DB panel directly from
+  `app-db-diff.cljs`."
+  []
+  (install-subs!)
+  (install-events!)
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_downstream_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_downstream_cljs_test.cljs
@@ -1,0 +1,289 @@
+(ns day8.re-frame2-causa.panels.app-db-diff-downstream-cljs-test
+  "CLJS unit tests for the App-DB panel's downstream-subs overlay
+  (rf2-op9v2).
+
+  Three test groups:
+
+    1. **Subs install** — the leaf's `install-subs!` registers the
+       three popover-state subs (`-slot`, `-open?`, `-path`) and the
+       per-path downstream-subs query.
+
+    2. **Events install + behaviour** — `:rf.causa.app-db/show-
+       downstream` + `:rf.causa.app-db/hide-downstream` toggle the
+       popover slot; `:rf.causa/navigate-to-panel` writes the
+       `:nav-cursor` slot and dispatches `:rf.causa/select-tab`.
+
+    3. **View shape** — the hover-trigger renders an inert chip when
+       no popover is open; rendering becomes active when the slot
+       matches the trigger's path; the popover body lists subs +
+       views from the focused cascade's `:sub-runs` / `:renders`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.app-db-diff-downstream
+             :as downstream]
+            [day8.re-frame2-causa.panels.app-db-diff-subs
+             :as app-db-subs]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter plain-atom/adapter
+     :init-fn (fn []
+                (reset! app-db-subs/diff-cache {})
+                (reset! app-db-subs/annotated-tree-cache {})
+                (reset! app-db-subs/redacted-modified-cache {})
+                (reset! app-db-subs/flow-writes-cache {}))}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- find-hiccup
+  "Walk a hiccup tree depth-first; return the first vector whose
+  attribute map has `[:data-testid testid]` (or whose attribute map
+  contains a `:data-testid` key matching the predicate `pred`)."
+  [tree pred]
+  (cond
+    (and (vector? tree)
+         (map? (second tree))
+         (pred (:data-testid (second tree))))
+    tree
+
+    (vector? tree)
+    (some #(find-hiccup % pred) (rest tree))
+
+    (seq? tree)
+    (some #(find-hiccup % pred) tree)
+
+    :else nil))
+
+(defn- find-by-testid [tree testid]
+  (find-hiccup tree #(= testid %)))
+
+;; ---- subs install ---------------------------------------------------------
+
+(deftest install-subs-registers-popover-state-subs
+  (downstream/install-subs!)
+  (is (some? (registrar/handler :sub :rf.causa.app-db/popover-slot)))
+  (is (some? (registrar/handler :sub :rf.causa.app-db/popover-open?)))
+  (is (some? (registrar/handler :sub :rf.causa.app-db/popover-path)))
+  (is (some? (registrar/handler :sub :rf.causa/app-db-downstream-for-path))))
+
+;; ---- events install -------------------------------------------------------
+
+(deftest install-events-registers-show-hide-and-navigate
+  (downstream/install-events!)
+  (is (some? (registrar/handler :event :rf.causa.app-db/show-downstream)))
+  (is (some? (registrar/handler :event :rf.causa.app-db/hide-downstream)))
+  (is (some? (registrar/handler :event :rf.causa/navigate-to-panel))))
+
+;; ---- show / hide event behaviour ------------------------------------------
+
+(deftest show-downstream-writes-popover-slot
+  (downstream/install!)
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:cart :state]])
+  (is (= [:cart :state]
+         @(rf/subscribe [:rf.causa.app-db/popover-path]))
+      "popover-path subscribe reads the path the show event wrote")
+  (is @(rf/subscribe [:rf.causa.app-db/popover-open?])
+      "popover-open? becomes true when slot is non-nil"))
+
+(deftest hide-downstream-clears-the-slot
+  (downstream/install!)
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:cart :state]])
+  (rf/dispatch-sync [:rf.causa.app-db/hide-downstream])
+  (is (nil? @(rf/subscribe [:rf.causa.app-db/popover-path])))
+  (is (false? @(rf/subscribe [:rf.causa.app-db/popover-open?]))))
+
+;; ---- navigate-to-panel ----------------------------------------------------
+
+(deftest navigate-to-panel-dispatches-select-tab-and-writes-cursor
+  ;; The chained dispatch lands on the substrate's `:rf.causa/select-
+  ;; tab` event — register a capture so we can assert the chain. We
+  ;; don't stub `:dispatch` because re-frame's built-in `:dispatch`
+  ;; fx routes through the registrar's own seam; the simplest
+  ;; assertion is that the target event ran and wrote the
+  ;; `:selected-tab` slot in app-db.
+  (downstream/install!)
+  (rf/reg-event-db :rf.causa/select-tab
+    (fn [db [_ tab-id]]
+      (assoc db ::captured-tab tab-id)))
+  (rf/dispatch-sync [:rf.causa/navigate-to-panel
+                     {:target  :views
+                      :sub-id  :cart/state
+                      :query-v [:cart/state]}])
+  (rf/reg-sub ::captured-tab (fn [db _] (::captured-tab db)))
+  (is (= :views @(rf/subscribe [::captured-tab]))
+      "navigate-to-panel chains :rf.causa/select-tab via :fx")
+  ;; nav-cursor was written for the Reactive panel (rf2-wyvf2 / PR
+  ;; #1741) to consume when scrolling.
+  (rf/reg-sub ::nav-cursor (fn [db _] (get-in db [:app-db :nav-cursor])))
+  (is (= {:target :views :sub-id :cart/state :query-v [:cart/state]}
+         @(rf/subscribe [::nav-cursor]))
+      ":nav-cursor slot carries the sub-id + query-v + target"))
+
+(deftest navigate-to-panel-defaults-target-to-views
+  (downstream/install!)
+  (rf/reg-event-db :rf.causa/select-tab
+    (fn [db [_ tab-id]]
+      (assoc db ::captured-tab tab-id)))
+  (rf/dispatch-sync [:rf.causa/navigate-to-panel {}])
+  (rf/reg-sub ::captured-tab (fn [db _] (::captured-tab db)))
+  (is (= :views @(rf/subscribe [::captured-tab]))
+      "default target is :views"))
+
+(deftest navigate-to-panel-closes-open-popover
+  (downstream/install!)
+  ;; Stub select-tab so the chained dispatch does NOT fall through to
+  ;; the substrate's real handler (which isn't registered in this leaf
+  ;; test).
+  (rf/reg-event-db :rf.causa/select-tab (fn [db _] db))
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:cart :state]])
+  (rf/dispatch-sync [:rf.causa/navigate-to-panel
+                     {:target  :views
+                      :sub-id  :cart/state
+                      :query-v [:cart/state]}])
+  (is (nil? @(rf/subscribe [:rf.causa.app-db/popover-path]))
+      "navigation dismisses any open popover (no orphan tooltip)"))
+
+;; ---- downstream-for-path sub ----------------------------------------------
+
+(deftest downstream-for-path-defaults-when-no-history
+  (downstream/install!)
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path
+                            [:cart :state]])]
+    (is (= [] (:subs-recomputed out)))
+    (is (= [] (:subs-skipped out)))
+    (is (= [] (:views-rendered out)))
+    (is (false? (:path-filtered? out))
+        "rf2-op9v2 MVP marker — path-filter is not yet implemented")))
+
+(deftest downstream-for-path-projects-sub-runs-and-renders
+  ;; Seed a minimal epoch-history sub + focus pair so the downstream
+  ;; sub has something to project. The focus-eid is matched against
+  ;; the seeded record's :epoch-id so the projection picks the right
+  ;; cascade.
+  (downstream/install!)
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs  [{:sub-id :cart/state    :recomputed? true}
+                    {:sub-id :cart/items    :recomputed? false}]
+        :renders   [{:render-key  [:checkout-button "t1"]
+                     :triggered-by :cart/state
+                     :elapsed-ms  0.4}]}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _]
+      {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path
+                            [:cart :state]])]
+    (is (= [{:sub-id :cart/state :recomputed? true}]
+           (:subs-recomputed out)))
+    (is (= [{:sub-id :cart/items :recomputed? false}]
+           (:subs-skipped out)))
+    (is (= 1 (count (:views-rendered out))))
+    (is (= :cart/state (:triggered-by (first (:views-rendered out)))))))
+
+(deftest downstream-for-path-falls-back-to-head-when-focus-stale
+  ;; When :rf.causa/focus carries an :epoch-id NOT in history, the
+  ;; sub falls back to the head record (last entry). Mirrors the
+  ;; views_subs.cljs fallback so the popover stays useful when the
+  ;; selected epoch ages out of the ring buffer.
+  (downstream/install!)
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :stale  :recomputed? true}]
+        :renders  []}
+       {:epoch-id :ep-2
+        :sub-runs [{:sub-id :head/sub :recomputed? true}]
+        :renders  []}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _]
+      {:epoch-id :missing-from-history :dispatch-id 99 :frame :rf/default}))
+
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path [:any]])]
+    (is (= [{:sub-id :head/sub :recomputed? true}]
+           (:subs-recomputed out))
+        "head record is the fallback when focus epoch is missing")))
+
+;; ---- hover-trigger render shape ------------------------------------------
+
+(deftest hover-trigger-renders-with-stable-testid
+  (downstream/install!)
+  (let [hiccup [downstream/hover-trigger [:cart :state]]
+        ;; Drive the reagent component fn directly (it returns hiccup
+        ;; for the current subscribe values without a React mount).
+        out    (downstream/hover-trigger [:cart :state])]
+    (is (vector? out))
+    (is (some? (find-by-testid
+                 out
+                 "rf-causa-app-db-downstream-trigger-[:cart :state]"))
+        "trigger carries a path-keyed testid")))
+
+(deftest hover-trigger-omits-popover-body-when-inactive
+  (downstream/install!)
+  (let [out (downstream/hover-trigger [:cart :state])]
+    (is (nil? (find-by-testid out "rf-causa-app-db-popover-body"))
+        "no popover body when the slot is closed")))
+
+(deftest hover-trigger-renders-popover-body-when-path-active
+  ;; Seed a focused cascade so the popover-body sub returns content
+  ;; and the popover renders the subs section.
+  (downstream/install!)
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :cart/state :recomputed? true}]
+        :renders  [{:render-key [:checkout-button "t1"]
+                    :triggered-by :cart/state
+                    :elapsed-ms 0.1}]}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _] {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:cart :state]])
+
+  (let [out (downstream/hover-trigger [:cart :state])]
+    (is (some? (find-by-testid out "rf-causa-app-db-popover-body"))
+        "body renders when this trigger's path matches the open slot")
+    (is (some? (find-by-testid out
+                                "rf-causa-app-db-popover-jump-:cart/state"))
+        "⤴ jump button per recomputed sub")
+    (is (some? (find-by-testid out
+                                "rf-causa-app-db-popover-jump-reactive"))
+        "⤴ footer 'jump to Reactive panel' affordance")
+    (is (some? (find-by-testid out
+                                "rf-causa-app-db-popover-mvp-note"))
+        "MVP affordance flags 'not yet path-filtered' state")))
+
+(deftest hover-trigger-popover-empty-state
+  (downstream/install!)
+  ;; No epoch-history → empty cascade → popover renders the empty
+  ;; state instead of the subs/views lists.
+  (rf/reg-sub :rf.causa/epoch-history (fn [_ _] []))
+  (rf/reg-sub :rf.causa/focus (fn [_ _] nil))
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:cart :state]])
+  (let [out (downstream/hover-trigger [:cart :state])]
+    (is (some? (find-by-testid out "rf-causa-app-db-popover-empty")))))
+
+(deftest hover-trigger-other-paths-do-not-render-overlapping-popovers
+  ;; Two simultaneous triggers (paths A + B); only the trigger whose
+  ;; path matches the open slot renders its body. Ensures the global
+  ;; slot serialises the popover — clicking from one section to
+  ;; another swaps the popover without leaking ghosts.
+  (downstream/install!)
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :s :recomputed? true}]
+        :renders  []}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _] {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+  (rf/dispatch-sync [:rf.causa.app-db/show-downstream [:a]])
+
+  (let [active   (downstream/hover-trigger [:a])
+        inactive (downstream/hover-trigger [:b])]
+    (is (some? (find-by-testid active   "rf-causa-app-db-popover-body")))
+    (is (nil?  (find-by-testid inactive "rf-causa-app-db-popover-body"))
+        "only the matching-path trigger renders its body")))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -113,6 +113,13 @@
    ;; rf2-7hwwe — Machine Inspector `:after` countdown rings.
    :rf.causa/active-timers-for-focused-machine
    :rf.causa/app-db-diff
+   ;; rf2-op9v2 — App-db panel downstream-subs overlay (per-path hover
+   ;; popover listing subs/views downstream of each changed path).
+   ;; Three popover-state subs + one per-path downstream query.
+   :rf.causa.app-db/popover-slot
+   :rf.causa.app-db/popover-open?
+   :rf.causa.app-db/popover-path
+   :rf.causa/app-db-downstream-for-path
    :rf.causa/cascades
    ;; rf2-jgip1 — shared L4 data-display renderer expansion-state subs.
    ;; Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §10. The
@@ -335,6 +342,11 @@
   `:rf.causa.<panel>/*` convention codified in
   `tools/causa/spec/014-Registry-Catalogue.md` §Naming convention."
   (sorted-set
+   ;; rf2-op9v2 — App-db downstream-subs overlay events (popover
+   ;; show/hide + cross-panel navigation to the Reactive panel).
+   :rf.causa.app-db/show-downstream
+   :rf.causa.app-db/hide-downstream
+   :rf.causa/navigate-to-panel
    ;; rf2-39n8h discovered — App-DB diff data-inspector events:
    ;; per-row toggle/set + large-value confirmation flow (request +
    ;; confirm). Lives under :rf.causa.data-inspector/*.


### PR DESCRIPTION
Closes rf2-op9v2. Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §4.4 (App-db panel · downstream-subs overlay).

## What changed

Each changed-app-db-path row in the App-db panel now carries a `⤴ subs` hover trigger in its section breadcrumb. Hovering (or clicking / keyboard-activating) the trigger opens a Causa-owned popover listing:

  - **Subs depending on this path** — subs recomputed this cascade, with per-sub `⤴` jump buttons that dispatch `:rf.causa/navigate-to-panel {:target :views :sub-id ... :query-v ...}`.
  - **Subs skipped (cache hit)** — subs whose `:recomputed?` came back false.
  - **Views rendered** — view-render rows with the triggering sub annotation.

The popover footer carries the spec-mandated `⤴ jump to Reactive panel` affordance (target-less navigation).

## MVP scope — full cascade listing

The cascade-captured aggregate (#1729) carries `:subs-recomputed` + `:subs-skipped` per cascade but does **not** yet carry per-sub `:input-paths` attribution, so we cannot filter the popover list to *just* subs that read the hovered path. Per the bead's fallback plan we ship the full-cascade list and surface that explicitly via a small `Showing full cascade — path-filtered list pending (rf2-op9v2)` chip inside every popover. A follow-on bead (rf2-op9v2-followup) will refine to true path-filtering once the substrate carries input-paths attribution OR a registry-side walk wires in.

The sub `:rf.causa/app-db-downstream-for-path` already takes a path argument so the refinement is a body-only change with no caller migration.

## Data sourcing

Read straight from the focused epoch record's `:sub-runs` + `:renders` slots (same surface the Reactive panel reads via `views_subs.cljs/:rf.causa/views-focused-cascade-pair`). Falls back to head when the focused epoch is missing from the ring buffer — mirrors the existing app-db-diff fallback so the popover stays useful through history evictions.

## `:rf.causa/navigate-to-panel` handler

Registered here as a thin handler that writes `:rf.causa.app-db/nav-cursor` (`{:target :sub-id :query-v}`) into Causa's app-db and chains `:rf.causa/select-tab` via `:fx`. When PR #1741 (rf2-wyvf2 Reactive panel) lands, the cursor slot can be picked up by the Reactive panel to auto-scroll/highlight the target sub. Today the tab swap still happens; the cursor sits in app-db harmlessly until consumed.

## Shared renderer seam

`diff/render.cljs` learnt one new opt — `:extra-affordance-fn (fn [path] hiccup)` — so the App-db panel can inject its hover trigger into every section breadcrumb without duplicating render code. All existing arities preserved (test fixtures pass nil for both new positional args). Reactive panel's sub-output drilldown (which also calls `render-sections`) is unaffected.

## Tests

`tools/causa/test/.../panels/app_db_diff_downstream_cljs_test.cljs` — 13 CLJS unit tests covering:
  - Subs + events install registers the expected handlers
  - Popover show/hide event flow round-trips through app-db
  - `:rf.causa/navigate-to-panel` chains `:rf.causa/select-tab`, writes the nav-cursor, defaults target to `:views`, and dismisses any open popover
  - Downstream-for-path sub projects `:sub-runs` (recomputed vs skipped) + `:renders` from the focused cascade, with the head fallback when focus is stale
  - Hover-trigger renders inert chip when slot is closed
  - Hover-trigger renders popover body + per-sub jump buttons + ⤴ footer + MVP affordance when slot's path matches
  - Two simultaneous triggers do not overlap (global popover slot serialises)
  - Empty-cascade state renders the empty popover

Plus the `registry_cljs_test.cljs` snapshot bumps for the four new subs (`:rf.causa.app-db/popover-{slot,open?,path}` + `:rf.causa/app-db-downstream-for-path`) and three new events (`:rf.causa.app-db/{show,hide}-downstream` + `:rf.causa/navigate-to-panel`).

## Gates

- `npm run test:cljs` — 3647 tests, 10539 assertions, 0 failures
- `npm run test:bundle-isolation` — PASS (the downstream overlay lives entirely under the existing Causa namespace so the production bundles stay clean)
- `mkdocs build --strict` — the existing `the-mayor-method.md → ./the-mayor-method/` warning is preexisting on `main` and not in scope here

## Posture

Pre-alpha · no back-compat shims · CLJS unit tests only.