### PR TITLE
feat(causa): Machines panel xyflow integration adapter + topology (rf2-uwvyj)

### DIFF
--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -8,6 +8,7 @@
       "name": "re-frame2-tests",
       "version": "0.0.0-SNAPSHOT",
       "devDependencies": {
+        "@xyflow/react": "12.4.2",
         "http-server": "14.1.1",
         "playwright": "1.59.1",
         "qrcode-generator": "2.0.4",
@@ -16,6 +17,93 @@
         "shadow-cljs": "3.4.10",
         "todomvc-app-css": "2.4.3",
         "todomvc-common": "1.0.5"
+      }
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.4.2.tgz",
+      "integrity": "sha512-AFJKVc/fCPtgSOnRst3xdYJwiEcUN9lDY7EO/YiRvFHYCJGgfzg+jpvZjkTOnBLGyrMJre9378pRxAc3fsR06A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.50",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.50.tgz",
+      "integrity": "sha512-HVUZd4LlY88XAaldFh2nwVxDOcdIBxGpQ5txzwfJPf+CAjj2BfYug1fHs2p4yS7YO8H6A3EFJQovBE8YuHkAdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -162,6 +250,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -190,6 +285,120 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/debug": {
@@ -887,6 +1096,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
@@ -935,6 +1154,35 @@
           "optional": true
         },
         "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
           "optional": true
         }
       }

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -11,7 +11,8 @@
     "http-server": "14.1.1",
     "todomvc-app-css": "2.4.3",
     "todomvc-common": "1.0.5",
-    "qrcode-generator": "2.0.4"
+    "qrcode-generator": "2.0.4",
+    "@xyflow/react": "12.4.2"
   },
   "scripts": {
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -363,6 +363,45 @@ const ARTEFACTS = [
     consumerAllowList: null,
     expectedAllowListHits: 0,
   },
+
+  // xyflow / @xyflow/react (rf2-uwvyj — Machines panel render-engine
+  // Path B per spec/021 §6.0 + §17.4). The xyflow library is a
+  // `devDependency` of `implementation/package.json` consumed only by
+  // tools/causa/src/day8/re_frame2_causa/panels/machines/
+  // xyflow_wrapper.cljs. Counter (and the UIx + Helix counter
+  // variants) MUST NOT pull xyflow into their production bundles —
+  // Causa is dev-only (gated by `:devtools/preloads` in shadow-cljs),
+  // and a host that doesn't install Causa should never pay for the
+  // ~50-80KB gzipped xyflow render engine.
+  //
+  // Sentinels are CSS class strings that survive `:advanced` because
+  // they appear as string literals in xyflow's source. The class
+  // `react-flow__pane` is xyflow's canvas-background DOM class —
+  // unique to the package; a global grep returns hits only when the
+  // xyflow module body is in the bundle. `@xyflow/react` is the npm
+  // package name as it appears in re-export keys; same posture.
+  //
+  // A non-zero hit means `@xyflow/react` got dragged into a
+  // production bundle (most likely a `:require` slipped from a
+  // tools/causa/* ns into an implementation/* ns, or the wrapper got
+  // moved out of the Causa preload-gated tree). Tools/causa MUST NOT
+  // be reachable from `implementation/` per the
+  // bundle-isolation contract in `tools/README.md`.
+  {
+    name: 'xyflow',
+    internalSentinels: [
+      // xyflow's canvas-pane CSS class. Distinctive substring;
+      // survives Closure :advanced (literal strings are not renamed).
+      { source: '@xyflow/react canvas pane CSS class (react-flow__pane)',
+        sentinel: 'react-flow__pane' },
+      // xyflow's node-renderer CSS class. Second sentinel guards
+      // against a future xyflow rename of one but not the other.
+      { source: '@xyflow/react node renderer CSS class (react-flow__node)',
+        sentinel: 'react-flow__node' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
@@ -1,0 +1,361 @@
+(ns day8.re-frame2-causa.panels.machines.topology
+  "Pure-data projector: re-frame2 machine definition → xyflow
+  nodes/edges (rf2-uwvyj · spec/021 §6 + §17.4).
+
+  ## Scope
+
+  One-way walker: takes a machine definition (the `{:initial :states
+  ...}` map registered via `rf/reg-machine`), an optional
+  current-state path (the `:to` of the most recent transition trace
+  in the focused epoch), and an optional set of `:fired-this-epoch`
+  edge-keys; returns `{:nodes [...] :edges [...]}` suitable for
+  handing to the xyflow wrapper.
+
+  ## Pure
+
+  No DOM, no React, no re-frame side effects. Every input is data;
+  every output is data. Tests live at
+  `tools/causa/test/day8/re_frame2_causa/panels/machines/
+  topology_cljs_test.cljs`.
+
+  ## Node kinds (per spec §17.4.2)
+
+    - `:current` — the state most recently entered (per the focused
+      epoch's `:rf.machine/transition` trace; `current-state-path`
+      arg).
+    - `:final`   — state with `:final? true` in the definition.
+    - `:standard` — every other state.
+    - `:region`  — reserved for parallel-region containers (not
+      surfaced in v1; layout walks the first region only — matches
+      the existing chart-layout posture).
+
+  ## Edge kinds (per spec §17.4.3)
+
+    - `:fired-this-epoch`     — edge keys in the `fired-edges` set
+                                are rendered with the animated violet
+                                stroke.
+    - `:registered-traversed` — edge keys in the `traversed-edges`
+                                set (most-recent traversal in the
+                                buffer, but NOT this epoch).
+    - `:registered`           — every other edge (registered, never
+                                traversed).
+
+  ## Layout posture
+
+  Initial v1 uses a deterministic top-to-bottom grid lift from the
+  existing `chart-layout/layout` (the SVG chart's pure-CLJS layout
+  fn) so the xyflow render's node positions visually align with the
+  legacy chart. xyflow's `dagre`-based `getLayoutedElements` helper
+  could ship as a follow-on bead (spec §17.4.4 calls for `rankdir:
+  LR` ultimately); for v1 the simple grid keeps the projection
+  self-contained + JVM-portable.
+
+  ## current-state-path resolution
+
+  Per spec §17.4.1, the `current ●` overlay marks the state node the
+  machine is currently in. Resolution priority (caller's
+  responsibility):
+
+    1. The `:to` of the most recent `:rf.machine/transition` trace
+       in the focused epoch.
+    2. The `:state` field of the machine's live snapshot map.
+    3. nil — no current-state overlay rendered."
+  (:require [clojure.string :as str]))
+
+;; ---- state walking ------------------------------------------------------
+
+(defn- normalise-path
+  "Coerce a path-spec into a path vector. Path-specs may be:
+
+    - a vector of keywords `[:populated]` or `[:level-1 :level-2]`
+    - a single keyword `:populated` (becomes `[:populated]`)
+    - nil (returns nil)
+    - any other shape (returns nil)"
+  [path]
+  (cond
+    (nil? path)       nil
+    (keyword? path)   [path]
+    (vector? path)    (when (every? keyword? path) path)
+    (seq? path)       (when (every? keyword? path) (vec path))
+    :else             nil))
+
+(defn- node-id-for-path
+  "Stable string id for a state path. Matches `chart-layout/node-id`'s
+  shape so node-ids resolve consistently across renderers."
+  [path]
+  (->> path
+       (map (fn [p]
+              (if (keyword? p)
+                (if-let [ns (namespace p)]
+                  (str ns "_" (name p))
+                  (name p))
+                (str p))))
+       (str/join "__")
+       (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
+
+(defn- walk-states
+  "Walk a `{state-id state-node}` map under `parent-path`; emit
+  `[{:path :final? :label} ...]`. Compound + parallel states are NOT
+  recursively flattened in v1 (parent is emitted as a single node;
+  children stay invisible). Same posture as the existing
+  chart-layout's `:depth 0` slice."
+  [parent-path state-map]
+  (when (map? state-map)
+    (mapv (fn [[state-id state-node]]
+            (let [path (conj (vec parent-path) state-id)]
+              {:path     path
+               :label    (name state-id)
+               :final?   (boolean (:final? state-node))
+               :initial? (boolean (:initial? state-node))}))
+          state-map)))
+
+(defn- collect-edges
+  "Walk a `{state-id state-node}` map; emit edges. Each edge is
+  `{:from :to :label :id}`. v1 reads `:on` map (event-id → target-
+  spec) on the immediate children of `:states`. Targets are coerced
+  to `[target-state-id]` paths (single-level). Self-transitions
+  (target = source) are emitted; the renderer can decide to render
+  or suppress."
+  [parent-path state-map]
+  (when (map? state-map)
+    (vec
+      (mapcat
+        (fn [[state-id state-node]]
+          (let [from-path (conj (vec parent-path) state-id)]
+            (when-let [on (:on state-node)]
+              (for [[event-id target-spec] on
+                    :let [target-id (cond
+                                      (keyword? target-spec) target-spec
+                                      (map? target-spec)     (:target target-spec)
+                                      :else                  nil)
+                          to-path   (when target-id [target-id])]
+                    :when to-path]
+                {:id    (str (node-id-for-path from-path)
+                             "__"
+                             (node-id-for-path to-path)
+                             "__"
+                             (name event-id))
+                 :from  from-path
+                 :to    to-path
+                 :label (name event-id)
+                 :event event-id}))))
+        state-map))))
+
+;; ---- definition → graph -------------------------------------------------
+
+(defn parse-definition
+  "Project a `definition` machine-spec map into a flat graph
+  `{:nodes [...] :edges [...] :initial-path ...}`. Mirrors the
+  existing `chart-layout/parse-definition`'s posture but is
+  self-contained (no machines-viz dep) so the xyflow path is fully
+  isolated from the SVG chart's evolution."
+  [definition]
+  (cond
+    (nil? definition)
+    {:nodes [] :edges [] :initial-path nil}
+
+    (= :parallel (:type definition))
+    ;; v1: project the first region only — matches chart-layout's
+    ;; existing posture. A follow-on bead surfaces full parallel
+    ;; rendering using xyflow's group/parent-node mechanic.
+    (let [[_region-id region] (first (:regions definition))]
+      (parse-definition region))
+
+    :else
+    (let [{:keys [initial states]} definition
+          nodes        (walk-states [] states)
+          initial-path (when initial [initial])
+          edges        (collect-edges [] states)]
+      {:nodes        (vec nodes)
+       :edges        edges
+       :initial-path initial-path})))
+
+;; ---- grid layout (pure) -------------------------------------------------
+
+(def ^:private grid-x-step 180)
+(def ^:private grid-y-step 90)
+(def ^:private grid-margin 40)
+
+(defn- grid-positions
+  "Deterministic top-to-bottom grid layout. Nodes from the same
+  level cluster horizontally; the initial state goes in row 0, all
+  reachable states in subsequent rows by BFS rank. Returns
+  `{path {:x :y}}`."
+  [nodes edges initial-path]
+  (let [adj (reduce (fn [m {:keys [from to]}]
+                      (update m from (fnil conj #{}) to))
+                    {}
+                    edges)
+        ;; BFS rank assignment
+        bfs (fn []
+              (loop [queue (if initial-path [[initial-path 0]] [])
+                     seen  (if initial-path {initial-path 0} {})]
+                (if-let [[path rank] (first queue)]
+                  (let [next-queue (subvec (vec queue) 1)
+                        children   (get adj path #{})
+                        new-items  (for [c children
+                                         :when (not (contains? seen c))]
+                                     [c (inc rank)])]
+                    (recur (into next-queue new-items)
+                           (merge seen (into {} new-items))))
+                  ;; Backfill unreached
+                  (reduce (fn [acc {:keys [path]}]
+                            (if (contains? acc path) acc (assoc acc path 0)))
+                          seen
+                          nodes))))
+        ranks (bfs)
+        ;; Group by rank, sort by stable id within rank
+        by-rank (->> nodes
+                     (sort-by #(node-id-for-path (:path %)))
+                     (group-by #(get ranks (:path %) 0))
+                     (into (sorted-map)))]
+    (reduce
+      (fn [acc [rank ranked-nodes]]
+        (let [y (+ grid-margin (* rank grid-y-step))]
+          (reduce
+            (fn [acc2 [idx n]]
+              (let [x (+ grid-margin (* idx grid-x-step))]
+                (assoc acc2 (:path n) {:x x :y y})))
+            acc
+            (map-indexed vector ranked-nodes))))
+      {}
+      by-rank)))
+
+;; ---- node-kind resolution (per spec §17.4.2) ----------------------------
+
+(defn node-kind
+  "Resolve the xyflow node kind for a node given the current-state
+  path. Precedence: `:current` > `:final` > `:standard`."
+  [{:keys [path final?]} current-state-path]
+  (let [cur (normalise-path current-state-path)]
+    (cond
+      (and cur (= cur path)) :current
+      final?                 :final
+      :else                  :standard)))
+
+;; ---- edge-kind resolution (per spec §17.4.3) ----------------------------
+
+(defn edge-kind
+  "Resolve the xyflow edge kind for an edge given the per-epoch
+  `fired-edge-ids` (edge ids fired in the focused epoch) +
+  `traversed-edge-ids` (edges traversed at some point in the
+  buffer's history, but NOT this epoch). Precedence:
+  `:fired-this-epoch` > `:registered-traversed` > `:registered`."
+  [{:keys [id]} fired-edge-ids traversed-edge-ids]
+  (cond
+    (contains? (or fired-edge-ids #{}) id)     :fired-this-epoch
+    (contains? (or traversed-edge-ids #{}) id) :registered-traversed
+    :else                                      :registered))
+
+;; ---- public projection --------------------------------------------------
+
+(defn project
+  "Project a machine definition (+ optional overlay context) into
+  xyflow `{:nodes [...] :edges [...]}`. Returns CLJS maps; the
+  wrapper's `coerce-nodes` / `coerce-edges` turn them into JS at the
+  React boundary.
+
+  Args (map):
+
+    :definition          — the machine definition map (required;
+                           `nil` returns an empty graph).
+    :current-state-path  — the path of the state the machine is
+                           currently in (optional; precedence rules
+                           in the ns docstring).
+    :fired-edge-ids      — set of edge-ids fired in the focused
+                           epoch (optional).
+    :traversed-edge-ids  — set of edge-ids traversed at some point
+                           in the buffer (optional).
+    :node-style-fn       — `(fn [kind] {style-map})`. Defaults to a
+                           no-op; the view layer typically passes
+                           `xyflow-style/node-style`.
+    :edge-style-fn       — `(fn [kind] {style-map})`. Defaults to
+                           no-op; view passes `xyflow-style/edge-
+                           style`.
+    :edge-animated-fn    — `(fn [kind] boolean)`. Defaults to no-op;
+                           view passes `xyflow-style/animated?`.
+
+  Style fns are injected (not called inline) so this ns stays pure
+  data — view-only deps live in the view ns."
+  [{:keys [definition current-state-path fired-edge-ids traversed-edge-ids
+           node-style-fn edge-style-fn edge-animated-fn]
+    :or   {node-style-fn    (fn [_kind] nil)
+           edge-style-fn    (fn [_kind] nil)
+           edge-animated-fn (fn [_kind] false)}}]
+  (let [{:keys [nodes edges]} (parse-definition definition)
+        positions             (grid-positions nodes edges
+                                              (some-> definition :initial vector))]
+    {:nodes
+     (mapv (fn [n]
+             (let [kind (node-kind n current-state-path)
+                   id   (node-id-for-path (:path n))
+                   pos  (get positions (:path n) {:x grid-margin :y grid-margin})]
+               {:id       id
+                :type     "default"
+                :position pos
+                :data     {:label (:label n)
+                           :kind  kind
+                           :path  (:path n)}
+                :style    (node-style-fn kind)
+                :draggable false
+                :selectable false}))
+           nodes)
+
+     :edges
+     (mapv (fn [e]
+             (let [kind (edge-kind e fired-edge-ids traversed-edge-ids)]
+               {:id       (:id e)
+                :source   (node-id-for-path (:from e))
+                :target   (node-id-for-path (:to e))
+                :label    (:label e)
+                :style    (edge-style-fn kind)
+                :animated (edge-animated-fn kind)
+                :data     {:kind  kind
+                           :event (:event e)}}))
+           edges)}))
+
+;; ---- focused-epoch overlay helpers --------------------------------------
+
+(defn extract-fired-edge-ids
+  "Given a vector of `:rf.machine/transition` trace events for the
+  focused epoch + the machine-id of interest, return the set of
+  edge-ids whose `(from → to via event)` matches a transition. Pure
+  fn. The match is loose — transitions that don't carry an explicit
+  event-id are excluded (they can't be matched to a `:on` edge)."
+  [trace-events machine-id]
+  (->> (or trace-events [])
+       (filter (fn [ev]
+                 (and (= :rf.machine/transition (:operation ev))
+                      (or (nil? machine-id)
+                          (= machine-id (get-in ev [:tags :machine-id]))))))
+       (keep (fn [ev]
+               (let [from  (or (:from ev) (get-in ev [:payload :from]))
+                     to    (or (:to ev)   (get-in ev [:payload :to]))
+                     event (or (:event ev) (get-in ev [:payload :event]))
+                     from* (normalise-path from)
+                     to*   (normalise-path to)
+                     ev*   (cond
+                             (keyword? event) event
+                             (vector? event)  (first event)
+                             :else            nil)]
+                 (when (and from* to* ev*)
+                   (str (node-id-for-path from*)
+                        "__"
+                        (node-id-for-path to*)
+                        "__"
+                        (name ev*))))))
+       set))
+
+(defn current-state-from-traces
+  "Resolve the current-state path for `machine-id` from the
+  `:rf.machine/transition` trace events vector. Returns the `:to`
+  path of the most recent matching trace, or nil. Pure."
+  [trace-events machine-id]
+  (let [matching (filter (fn [ev]
+                           (and (= :rf.machine/transition (:operation ev))
+                                (or (nil? machine-id)
+                                    (= machine-id (get-in ev [:tags :machine-id])))))
+                         (or trace-events []))]
+    (when-let [last-ev (last matching)]
+      (normalise-path (or (:to last-ev)
+                          (get-in last-ev [:payload :to]))))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
@@ -1,0 +1,119 @@
+(ns day8.re-frame2-causa.panels.machines.topology-view
+  "Reagent view ↔ xyflow projector composition (rf2-uwvyj · spec/021
+  §6 + §17.4).
+
+  This is the public consumer surface: the Machines Canvas panel
+  (or any other Causa panel rendering a single machine's topology)
+  mounts `[topology-view {:machine-id ... :definition ...}]` and
+  gets the styled xyflow canvas back.
+
+  ## Composition
+
+      machine-id + definition  ──→  topology/project   ──→  {:nodes :edges}
+                                          │
+                                          ▼ (xyflow-style/node-style + edge-style)
+                                          │
+                                          ▼ xyflow-wrapper/xyflow-canvas
+                                          │
+                                          ▼
+                                  <ReactFlow> in React tree
+
+  ## current-state overlay
+
+  Two sources feed the `current-state-path` arg:
+
+    1. Caller-supplied `:current-state-path` (highest priority).
+    2. Caller-supplied `:trace-events` (the focused-epoch's
+       `:rf.machine/transition` slice) — `topology/current-state-
+       from-traces` resolves the `:to` of the most recent matching
+       trace.
+
+  ## Pure-hiccup contract
+
+  This view returns hiccup; it does not subscribe to re-frame
+  directly — the parent panel is responsible for pulling the
+  definition + traces off the substrate and passing them in. Keeps
+  the view testable in isolation."
+  (:require [day8.re-frame2-causa.panels.machines.topology :as topology]
+            [day8.re-frame2-causa.panels.machines.xyflow-style :as xstyle]
+            [day8.re-frame2-causa.panels.machines.xyflow-wrapper :as wrapper]
+            [day8.re-frame2-causa.theme.tokens :as t :refer [tokens]]))
+
+(defn- resolve-current-state-path
+  "Per-spec precedence: explicit > traces > nil."
+  [machine-id current-state-path trace-events]
+  (or current-state-path
+      (topology/current-state-from-traces trace-events machine-id)))
+
+(defn Topology
+  "Render a machine's topology via xyflow. Args (map):
+
+    :machine-id          — keyword; used for testid stamping +
+                           trace-filter scoping.
+    :definition          — machine definition map (required; nil
+                           renders the no-definition fallback).
+    :current-state-path  — optional explicit current-state path (a
+                           vector of keywords). Overrides trace-
+                           derived current-state.
+    :trace-events        — optional vector of focused-epoch trace
+                           events. Used to derive the current-state +
+                           `fired-this-epoch` edge highlights.
+    :height              — outer wrapper height (default `'320px'`).
+                           xyflow requires a non-zero parent height.
+    :show-controls?      — pass-through to wrapper (default true).
+    :testid              — pass-through wrapper testid (default
+                           `'rf-causa-machines-topology'`).
+
+  Returns hiccup."
+  [{:keys [machine-id definition current-state-path trace-events
+           height show-controls? testid]
+    :or   {height          "320px"
+           show-controls?  true
+           testid          "rf-causa-machines-topology"}}]
+  (let [cur-path  (resolve-current-state-path machine-id
+                                              current-state-path
+                                              trace-events)
+        fired-ids (topology/extract-fired-edge-ids trace-events machine-id)
+        graph     (topology/project
+                    {:definition         definition
+                     :current-state-path cur-path
+                     :fired-edge-ids     fired-ids
+                     :node-style-fn      xstyle/node-style
+                     :edge-style-fn      xstyle/edge-style
+                     :edge-animated-fn   xstyle/animated?})]
+    (cond
+      (nil? definition)
+      [:div {:data-testid (str testid "-no-definition")
+             :data-machine-id (str machine-id)
+             :style {:padding "16px"
+                     :color (:text-tertiary tokens)
+                     :background (:bg-2 tokens)
+                     :border (str "1px dashed " (:border-default tokens))
+                     :border-radius "6px"}}
+       "Machine definition is not introspectable — no topology to render."]
+
+      (empty? (:nodes graph))
+      [:div {:data-testid (str testid "-empty")
+             :data-machine-id (str machine-id)
+             :style {:padding "16px"
+                     :color (:text-tertiary tokens)}}
+       "Machine has no states."]
+
+      :else
+      [:div {:data-testid testid
+             :data-machine-id (str machine-id)
+             :data-current-state (when cur-path (pr-str cur-path))
+             :data-node-count (str (count (:nodes graph)))
+             :data-edge-count (str (count (:edges graph)))
+             :style {:position "relative"
+                     :width  "100%"
+                     :height height
+                     :background (:bg-1 tokens)
+                     :border (str "1px solid " (:border-default tokens))
+                     :border-radius "6px"
+                     :overflow "hidden"}}
+       [wrapper/xyflow-canvas
+        {:nodes          (:nodes graph)
+         :edges          (:edges graph)
+         :show-controls? show-controls?
+         :testid         (str testid "-canvas")}]])))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
@@ -1,0 +1,113 @@
+(ns day8.re-frame2-causa.panels.machines.xyflow-style
+  "Causa-palette style props for xyflow nodes + edges (rf2-uwvyj ·
+  spec/021 §17.4.5 — the single source of truth for xyflow visual
+  props).
+
+  ## Why a separate ns
+
+  The wrapper (`xyflow_wrapper.cljs`) owns the React-class adapt + the
+  Reagent boundary; this ns owns the visual contract — node-shape
+  conventions (§17.4.2), edge-styles (§17.4.3), token mapping
+  (§17.4.5). The topology projector (`topology.cljs`) reads these
+  maps, never inlines hex literals.
+
+  ## Token integration
+
+  Reads from `theme/tokens` so a future palette swap (dark → light,
+  HCM remap, etc.) flows through unchanged. Per spec §17.4.5 the
+  catalogue covers:
+
+    - Node fill / border / radius per kind (`:standard`, `:final`,
+      `:current`, `:region`).
+    - Edge stroke / width / dash per kind (`:registered`,
+      `:registered-traversed`, `:fired-this-epoch`).
+    - Edge-label font, size, fill.
+
+  Pure-data only — no DOM / React side effects."
+  (:require [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack type-scale]]))
+
+;; ---- node-shape conventions (§17.4.2) -----------------------------------
+
+(defn node-style
+  "Resolve the xyflow `:style` map for a node of kind `kind`. Kinds
+  per spec §17.4.2:
+
+    :standard — rounded rect, 1px `:border-default` outline.
+    :final    — rounded rect + 2px `:green` outer (double-ring).
+    :current  — rounded rect + 2px `:green` + 1.2s pulse animation.
+    :region   — parallel-region container; dashed border.
+
+  Unknown kinds fall back to `:standard`."
+  [kind]
+  (let [base {:font-family   mono-stack
+              :font-size     (:body-tight type-scale)
+              :color         (:text-primary tokens)
+              :padding       "6px 10px"
+              :border-radius "6px"
+              :background    (:bg-2 tokens)}]
+    (case kind
+      :final    (assoc base
+                       :border      (str "2px solid " (:green tokens))
+                       :box-shadow  (str "inset 0 0 0 1px " (:bg-2 tokens)))
+      :current  (assoc base
+                       :border      (str "2px solid " (:green tokens))
+                       :animation   "rf-causa-machine-pulse 1.2s ease-in-out infinite")
+      :region   {:background    "transparent"
+                 :border        (str "1px dashed " (:border-default tokens))
+                 :border-radius "8px"}
+      ;; :standard + unknown fallback
+      (assoc base
+             :border (str "1px solid " (:border-default tokens))))))
+
+;; ---- edge styles (§17.4.3) ----------------------------------------------
+
+(defn edge-style
+  "Resolve the xyflow `:style` map for an edge of kind `kind`. Kinds
+  per spec §17.4.3:
+
+    :registered           — dashed `:text-tertiary` 1px (registered,
+                            not fired this epoch).
+    :registered-traversed — solid `:text-tertiary` 1px (most-recent
+                            traversal in the buffer; not fired this
+                            epoch).
+    :fired-this-epoch     — solid `:accent-violet` 2px. The
+                            `:animated true` xyflow prop is set
+                            alongside (see `topology.cljs`).
+
+  Unknown kinds fall back to `:registered`."
+  [kind]
+  (case kind
+    :registered-traversed {:stroke       (:text-tertiary tokens)
+                           :stroke-width 1}
+    :fired-this-epoch     {:stroke       (:accent-violet tokens)
+                           :stroke-width 2}
+    ;; :registered + unknown fallback
+    {:stroke           (:text-tertiary tokens)
+     :stroke-width     1
+     :stroke-dasharray "4 4"}))
+
+(defn animated?
+  "Whether the edge of kind `kind` should set xyflow's `:animated`
+  prop (the moving dashed-line affordance). Only `:fired-this-epoch`
+  animates per spec §17.4.3."
+  [kind]
+  (= kind :fired-this-epoch))
+
+;; ---- edge label (§17.4.3) -----------------------------------------------
+
+(def edge-label-style
+  "Style map for the xyflow `:label-style` prop — JetBrains Mono, the
+  `:micro` size, `:text-secondary` fill. Inline on the edge, not in a
+  side legend (spec §17.4.3)."
+  {:fill        (:text-secondary tokens)
+   :font-family mono-stack
+   :font-size   (:micro type-scale)})
+
+(def edge-label-bg-style
+  "Style for the small label rect xyflow renders behind edge labels
+  so they don't smear over the edge stroke. Matches the canvas
+  background so the label appears 'cut out' of the edge."
+  {:fill         (:bg-2 tokens)
+   :fill-opacity 0.9})

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_wrapper.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_wrapper.cljs
@@ -1,0 +1,187 @@
+(ns day8.re-frame2-causa.panels.machines.xyflow-wrapper
+  "Reagent/React interop wrapper around `@xyflow/react`'s `ReactFlow`
+  component (rf2-uwvyj · spec/021 §6.0 + §17.4 · 'Path B' locked).
+
+  ## What this owns
+
+  A thin shim — adapt-react-class around the npm-loaded `ReactFlow`
+  React component — so the rest of Causa can render the xyflow canvas
+  via pure Reagent hiccup:
+
+      [xyflow-canvas
+       {:nodes   [...]      ; vector of node maps (kw or string keys)
+        :edges   [...]      ; vector of edge maps
+        :style   {...}      ; outer wrapper :style map (passed through)
+        :testid  \"rf-causa-machine-xyflow\"}]
+
+  The wrapper is intentionally tiny: shape conversion (clj → JS) and
+  the `adapt-react-class` call. The Machines-panel topology projector
+  (`topology.cljs`) builds the `:nodes` + `:edges` vectors; this ns
+  only worries about handing them to React in the shape xyflow
+  expects.
+
+  ## Bundle isolation
+
+  `@xyflow/react` is a `devDependency` of `implementation/package.json`
+  — it is NEVER pulled into a production bundle. The
+  `check-bundle-isolation.cjs` sentinel (rf2-uwvyj) asserts that none
+  of the xyflow internal-symbol strings appear in `examples/counter`,
+  `examples/counter-uix`, or `examples/counter-helix` release blobs.
+  Causa is dev-only (gated by `:devtools/preloads` in shadow-cljs); a
+  consumer that doesn't install Causa never pays for xyflow.
+
+  ## Why a wrapper ns rather than inline interop
+
+  Three reasons (rf2-uwvyj acceptance):
+
+    1. **One throat for the React-class adapt.** xyflow is consumed in
+       multiple Causa surfaces (Machines panel Inspector, Machines
+       Canvas tab); a single shim lets future spec changes (xyflow
+       version bump, `<Background>` / `<Controls>` swap-in) land in
+       one file.
+    2. **CLJS-data → JS-prop boundary.** xyflow expects plain JS
+       arrays/objects for `nodes` / `edges`; converting at the wrapper
+       boundary keeps the projection layer (`topology.cljs`) pure
+       CLJS-data → CLJS-data — testable without DOM / React harness.
+    3. **Read-only render contract.** Per spec/021 §6.0 the integration
+       is read-only: drag-to-create-edge, multi-select, etc. are
+       disabled here at the wrapper level so the rest of Causa cannot
+       accidentally enable them.
+
+  ## Read-only render defaults
+
+  Per spec/021 §6.0 + §17.4.4 the wrapper applies these defaults:
+
+    - `nodes-draggable=false` · `nodes-connectable=false` ·
+      `elements-selectable=false` · `pan-on-drag=true` ·
+      `zoom-on-scroll=true` · `min-zoom=0.25` · `max-zoom=2`
+    - `fitView=true` · `fit-view-options={padding: 0.05}`"
+  (:require [reagent.core :as reagent]
+            ["@xyflow/react" :as xyflow]))
+
+;; ---- CSS note -----------------------------------------------------------
+
+;; xyflow ships a stylesheet at `@xyflow/react/dist/style.css` that
+;; provides the base node / edge / controls chrome. We deliberately do
+;; NOT import it via a `(:require ["@xyflow/react/dist/style.css"])`
+;; clause — shadow-cljs's npm-module resolver does not load `.css`
+;; via the require pipeline. Instead the Causa global stylesheet
+;; (`theme/global_styles`) inlines the minimum xyflow chrome rules
+;; we need (zoom/pan transform on `.react-flow__pane`; the
+;; `Controls` toolbar background); per-node + per-edge visual styling
+;; is applied via the `:style` props on the node/edge maps Causa
+;; emits (see `xyflow-style.cljs`).
+
+;; ---- React-class adaptation ---------------------------------------------
+
+(def ReactFlow
+  "Reagent-adapted xyflow `ReactFlow` React component. Use via the
+  `xyflow-canvas` Reagent fn below — direct use is fine when callers
+  want full prop control."
+  (reagent/adapt-react-class (.-ReactFlow xyflow)))
+
+(def Controls
+  "Reagent-adapted xyflow `Controls` React component. Renders the
+  zoom-in / zoom-out / fit-to-view chrome inside the ReactFlow
+  container. Re-styled via CSS variables — see
+  `theme/global_styles motion-css` for the Causa overrides."
+  (reagent/adapt-react-class (.-Controls xyflow)))
+
+(def Background
+  "Reagent-adapted xyflow `Background` React component. Optional dot
+  pattern in the canvas background — Causa enables only when the
+  caller sets `:show-background?` true."
+  (reagent/adapt-react-class (.-Background xyflow)))
+
+;; ---- clj → JS coercion --------------------------------------------------
+
+(defn- ->js
+  "Convert a CLJS map / vector to a fresh plain-JS object suitable for
+  handing to xyflow as a `node` / `edge` prop. Mirrors `clj->js` but
+  is documented at the boundary so future migrations (e.g. Helix-style
+  hash-arg conversion) land in one place."
+  [x]
+  (clj->js x))
+
+(defn coerce-nodes
+  "Coerce a vector of CLJS node maps into the JS array xyflow expects.
+  Exposed for direct callers; `xyflow-canvas` invokes it internally."
+  [nodes]
+  (->js (or nodes [])))
+
+(defn coerce-edges
+  "Coerce a vector of CLJS edge maps into the JS array xyflow expects."
+  [edges]
+  (->js (or edges [])))
+
+;; ---- public Reagent component -------------------------------------------
+
+(defn xyflow-canvas
+  "Reagent-friendly wrapper around xyflow's `ReactFlow` component.
+
+  Args (map):
+
+    :nodes               — vector of CLJS node maps. xyflow requires
+                           each node to have `:id`, `:position`
+                           `{:x :y}`, and `:data` `{:label ...}` at
+                           minimum. `:style` / `:className` /
+                           `:type` flow through unchanged.
+    :edges               — vector of CLJS edge maps. xyflow requires
+                           each edge to have `:id`, `:source`, and
+                           `:target` at minimum. `:label` / `:animated`
+                           / `:style` flow through.
+    :style               — outer wrapper `:style` map. Default
+                           `{:width \"100%\" :height \"100%\"}` so the
+                           canvas fills its parent — callers usually
+                           wrap in a flex container with an explicit
+                           height.
+    :show-controls?      — when true (default) render xyflow's built-in
+                           zoom/pan/fit Controls component. Per
+                           spec/021 §6.0 + §17.4.4 the `Fit` button
+                           re-runs `fitView`.
+    :show-background?    — when true (default false) render xyflow's
+                           Background dot pattern. Causa leaves false
+                           — the panel chrome already provides the
+                           dark surface; dots would add visual noise.
+    :fit-view?           — when true (default) `fitView` on mount with
+                           a small padding ratio. Per spec/021
+                           §17.4.4.
+    :min-zoom / :max-zoom — clamps (default 0.25 / 2 per
+                           spec/021 §17.4.4).
+    :testid              — outer wrapper `data-testid`. Defaults to
+                           `rf-causa-machine-xyflow`.
+
+  Returns hiccup. Caller is responsible for the surrounding flex /
+  height context — xyflow needs a non-zero parent height to render."
+  [{:keys [nodes edges style show-controls? show-background?
+           fit-view? min-zoom max-zoom testid]
+    :or   {show-controls?   true
+           show-background? false
+           fit-view?        true
+           min-zoom         0.25
+           max-zoom         2.0
+           testid           "rf-causa-machine-xyflow"}}]
+  (let [wrapper-style (merge {:width "100%" :height "100%"} style)
+        flow-props    {:nodes               (coerce-nodes nodes)
+                       :edges               (coerce-edges edges)
+                       :nodesDraggable      false
+                       :nodesConnectable    false
+                       :elementsSelectable  false
+                       :panOnDrag           true
+                       :zoomOnScroll        true
+                       :fitView             fit-view?
+                       :fitViewOptions      #js {:padding 0.05}
+                       :minZoom             min-zoom
+                       :maxZoom             max-zoom
+                       :proOptions          #js {:hideAttribution true}}]
+    [:div {:data-testid testid
+           :data-node-count (str (count nodes))
+           :data-edge-count (str (count edges))
+           :style wrapper-style}
+     (into [ReactFlow flow-props]
+           (cond-> []
+             show-background? (conj [Background])
+             show-controls?   (conj [Controls
+                                     {:showZoom true
+                                      :showFitView true
+                                      :showInteractive false}])))]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs
@@ -74,6 +74,7 @@
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
+            [day8.re-frame2-causa.panels.machines.topology-view :as topology-view]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens sans-stack mono-stack display-stack type-scale]]))
@@ -295,21 +296,41 @@
         "Machine definition is not introspectable. The chart cannot render."]
 
        :else
-       [machine-canvas/Chart
-        {:positioned             positioned
-         :machine-id             machine-id
-         ;; No focused-event lens on this tab — this is a
-         ;; spine-INDEPENDENT canvas browser. No from/to highlight,
-         ;; no after-rings overlay, no view-mode toggle (the toggle
-         ;; is a Runtime concept that belongs in the event-driven
-         ;; Machines Inspector tab).
-         :show-after-rings?      false
-         :show-view-mode-toggle? false
-         :on-state-click
-         (fn [path]
-           (rf/dispatch [:rf.causa.machines-canvas/state-clicked
-                         {:machine-id machine-id :path path}]
-                        {:frame :rf/causa}))}])]))
+       [:<>
+        [machine-canvas/Chart
+         {:positioned             positioned
+          :machine-id             machine-id
+          ;; No focused-event lens on this tab — this is a
+          ;; spine-INDEPENDENT canvas browser. No from/to highlight,
+          ;; no after-rings overlay, no view-mode toggle (the toggle
+          ;; is a Runtime concept that belongs in the event-driven
+          ;; Machines Inspector tab).
+          :show-after-rings?      false
+          :show-view-mode-toggle? false
+          :on-state-click
+          (fn [path]
+            (rf/dispatch [:rf.causa.machines-canvas/state-clicked
+                          {:machine-id machine-id :path path}]
+                         {:frame :rf/causa}))}]
+        ;; rf2-uwvyj — xyflow render (spec/021 §6.0 Path B). Sits
+        ;; alongside the legacy ELK SVG chart while the xyflow path
+        ;; proves out. Future bead can flip the legacy chart off; for
+        ;; now both surfaces render so the operator can compare.
+        [:div {:data-testid "rf-causa-machines-canvas-xyflow-section"
+               :style {:padding "8px 16px"
+                       :border-top (str "1px solid " (:border-subtle tokens))}}
+         [:div {:style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :margin "0 0 6px 0"}}
+          "xyflow (Path B)"]
+         [topology-view/Topology
+          {:machine-id machine-id
+           :definition definition
+           :height     "280px"
+           :testid     "rf-causa-machines-canvas-xyflow"}]]])]))
 
 ;; ---- public Panel view --------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
@@ -1,0 +1,246 @@
+(ns day8.re-frame2-causa.panels.machines.topology-cljs-test
+  "Pure-data tests for the xyflow topology projector (rf2-uwvyj ·
+  spec/021 §6 + §17.4). The projector is JS/React-free; tests run
+  under :node-test with zero DOM harness."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.panels.machines.topology :as topology]))
+
+(defn- toy-definition
+  "Minimal machine with three states + two transitions:
+
+    :empty -- :populate --> :populated -- :submit --> :submitting
+                                                            (final)"
+  []
+  {:initial :empty
+   :states  {:empty      {:on {:populate :populated}}
+             :populated  {:on {:submit :submitting}}
+             :submitting {:final? true}}})
+
+;; ---- parse-definition ---------------------------------------------------
+
+(deftest parse-definition-returns-empty-on-nil
+  (testing "nil definition → empty graph"
+    (let [g (topology/parse-definition nil)]
+      (is (= [] (:nodes g)))
+      (is (= [] (:edges g)))
+      (is (nil? (:initial-path g))))))
+
+(deftest parse-definition-emits-one-node-per-state
+  (let [g (topology/parse-definition (toy-definition))]
+    (testing "node count matches state count"
+      (is (= 3 (count (:nodes g)))))
+    (testing "each node carries label + final? + path"
+      (let [by-label (into {} (map (juxt :label identity) (:nodes g)))]
+        (is (= [:empty]      (-> by-label (get "empty") :path)))
+        (is (= [:populated]  (-> by-label (get "populated") :path)))
+        (is (= [:submitting] (-> by-label (get "submitting") :path)))
+        (is (true? (-> by-label (get "submitting") :final?))
+            ":final? carries through")
+        (is (false? (-> by-label (get "empty") :final?))
+            "non-final states have :final? false")))
+    (testing "initial path is captured"
+      (is (= [:empty] (:initial-path g))))))
+
+(deftest parse-definition-emits-edges-from-on-clauses
+  (let [g     (topology/parse-definition (toy-definition))
+        edges (:edges g)]
+    (testing "two edges (populate + submit)"
+      (is (= 2 (count edges))))
+    (testing "each edge carries from/to/label"
+      (let [by-label (into {} (map (juxt :label identity) edges))]
+        (is (= [:empty]     (-> by-label (get "populate") :from)))
+        (is (= [:populated] (-> by-label (get "populate") :to)))
+        (is (= [:populated]  (-> by-label (get "submit") :from)))
+        (is (= [:submitting] (-> by-label (get "submit") :to)))))))
+
+(deftest parse-definition-handles-map-target-spec
+  (testing "transition value may be a map {:target ... :guards ...}"
+    (let [def {:initial :a
+               :states  {:a {:on {:go {:target :b :guards [:always]}}}
+                         :b {:final? true}}}
+          g   (topology/parse-definition def)]
+      (is (= 1 (count (:edges g))))
+      (is (= [:a] (-> g :edges first :from)))
+      (is (= [:b] (-> g :edges first :to))))))
+
+(deftest parse-definition-handles-parallel-by-first-region
+  (testing "parallel definitions project the first region only (v1)"
+    (let [par {:type    :parallel
+               :regions {:r1 {:initial :a :states {:a {} :b {}}}
+                         :r2 {:initial :c :states {:c {}}}}}
+          g   (topology/parse-definition par)]
+      (is (= 2 (count (:nodes g)))
+          "first region's 2 states; second region not flattened"))))
+
+;; ---- node-kind ----------------------------------------------------------
+
+(deftest node-kind-precedence
+  (testing ":current wins over :final"
+    (is (= :current
+           (topology/node-kind {:path [:foo] :final? true} [:foo]))))
+  (testing ":final when not current"
+    (is (= :final
+           (topology/node-kind {:path [:foo] :final? true} [:bar]))))
+  (testing ":standard otherwise"
+    (is (= :standard
+           (topology/node-kind {:path [:foo] :final? false} nil)))
+    (is (= :standard
+           (topology/node-kind {:path [:foo] :final? false} [:bar])))))
+
+(deftest node-kind-accepts-keyword-or-vector-current
+  (testing "current-state-path may be a bare keyword"
+    (is (= :current
+           (topology/node-kind {:path [:foo] :final? false} :foo)))))
+
+;; ---- edge-kind ----------------------------------------------------------
+
+(deftest edge-kind-precedence
+  (testing ":fired-this-epoch when id in fired set"
+    (is (= :fired-this-epoch
+           (topology/edge-kind {:id "abc"} #{"abc"} #{}))))
+  (testing ":registered-traversed when id in traversed set"
+    (is (= :registered-traversed
+           (topology/edge-kind {:id "abc"} #{} #{"abc"}))))
+  (testing ":registered otherwise"
+    (is (= :registered
+           (topology/edge-kind {:id "abc"} #{} #{})))
+    (is (= :registered
+           (topology/edge-kind {:id "abc"} nil nil)))))
+
+;; ---- project ------------------------------------------------------------
+
+(deftest project-shape
+  (let [out (topology/project {:definition (toy-definition)})]
+    (testing "returns {:nodes :edges}"
+      (is (vector? (:nodes out)))
+      (is (vector? (:edges out)))
+      (is (= 3 (count (:nodes out))))
+      (is (= 2 (count (:edges out)))))
+    (testing "each xyflow node carries :id :position :data :type"
+      (let [n (first (:nodes out))]
+        (is (string? (:id n)))
+        (is (map? (:position n)))
+        (is (number? (-> n :position :x)))
+        (is (number? (-> n :position :y)))
+        (is (string? (-> n :data :label)))
+        (is (keyword? (-> n :data :kind)))))
+    (testing "each xyflow edge carries :id :source :target :label"
+      (let [e (first (:edges out))]
+        (is (string? (:id e)))
+        (is (string? (:source e)))
+        (is (string? (:target e)))
+        (is (string? (:label e)))
+        (is (keyword? (-> e :data :kind)))))))
+
+(deftest project-applies-current-state-overlay
+  (testing "current-state-path marks the matching node as :current"
+    (let [out      (topology/project
+                     {:definition         (toy-definition)
+                      :current-state-path [:populated]})
+          by-label (into {} (map (juxt #(-> % :data :label) identity)
+                                 (:nodes out)))]
+      (is (= :current  (-> by-label (get "populated") :data :kind)))
+      (is (= :standard (-> by-label (get "empty") :data :kind)))
+      (is (= :final    (-> by-label (get "submitting") :data :kind))
+          "final state stays final when not current"))))
+
+(deftest project-applies-fired-edge-overlay
+  (testing "fired-edge-ids set marks matching edges :fired-this-epoch"
+    (let [out         (topology/project {:definition (toy-definition)})
+          populate-id (some (fn [e]
+                              (when (= "populate" (:label e)) (:id e)))
+                            (:edges out))
+          out2        (topology/project
+                        {:definition     (toy-definition)
+                         :fired-edge-ids #{populate-id}})
+          edges-by-id (into {} (map (juxt :id identity) (:edges out2)))]
+      (is (string? populate-id))
+      (is (= :fired-this-epoch
+             (-> edges-by-id (get populate-id) :data :kind)))
+      ;; The other edge stays :registered.
+      (let [other-edge (some #(when (not= (:id %) populate-id) %)
+                             (:edges out2))]
+        (is (= :registered (-> other-edge :data :kind)))))))
+
+(deftest project-invokes-injected-style-fns
+  (testing "style fns are called per node/edge with the resolved kind"
+    (let [seen-node-kinds (atom [])
+          seen-edge-kinds (atom [])
+          out (topology/project
+                {:definition         (toy-definition)
+                 :current-state-path [:populated]
+                 :node-style-fn      (fn [k]
+                                       (swap! seen-node-kinds conj k)
+                                       {:test-marker (str "node-" (name k))})
+                 :edge-style-fn      (fn [k]
+                                       (swap! seen-edge-kinds conj k)
+                                       {:test-marker (str "edge-" (name k))})
+                 :edge-animated-fn   (fn [k] (= k :fired-this-epoch))})]
+      ;; Node style fn invoked once per node (3 nodes).
+      (is (= 3 (count @seen-node-kinds)))
+      (is (= #{:current :final :standard} (set @seen-node-kinds)))
+      ;; Edge style fn invoked once per edge (2 edges).
+      (is (= 2 (count @seen-edge-kinds)))
+      ;; Per-node :style carries the marker from the injected fn.
+      (let [marker-set (into #{} (map #(get-in % [:style :test-marker])
+                                      (:nodes out)))]
+        (is (contains? marker-set "node-current"))
+        (is (contains? marker-set "node-standard"))
+        (is (contains? marker-set "node-final"))))))
+
+(deftest project-handles-nil-definition
+  (testing "nil definition → empty graph (no exceptions)"
+    (let [out (topology/project {:definition nil})]
+      (is (= [] (:nodes out)))
+      (is (= [] (:edges out))))))
+
+;; ---- focused-epoch helpers ---------------------------------------------
+
+(deftest current-state-from-traces-resolves-latest
+  (testing "picks the :to of the LAST matching :rf.machine/transition"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      [:a] :to [:b] :event :go-b}
+                  {:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      [:b] :to [:c] :event :go-c}
+                  {:operation :something-else}]]
+      (is (= [:c] (topology/current-state-from-traces events :foo))))))
+
+(deftest current-state-from-traces-scopes-by-machine-id
+  (testing "ignores trace events belonging to other machines"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :other}
+                   :from      [:x] :to [:y] :event :wrong-machine}
+                  {:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      [:a] :to [:b] :event :ours}]]
+      (is (= [:b] (topology/current-state-from-traces events :foo))))))
+
+(deftest current-state-from-traces-returns-nil-when-no-match
+  (is (nil? (topology/current-state-from-traces [] :foo)))
+  (is (nil? (topology/current-state-from-traces nil :foo))))
+
+(deftest current-state-accepts-keyword-to
+  (testing ":to may be a bare keyword (per the normalise-path branch)"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      :a :to :b :event :go}]]
+      (is (= [:b] (topology/current-state-from-traces events :foo))))))
+
+(deftest extract-fired-edge-ids-shape
+  (testing "extracts edge-ids matching the from→to via event triple"
+    (let [graph       (topology/project {:definition (toy-definition)})
+          populate-id (some (fn [e] (when (= "populate" (:label e)) (:id e)))
+                            (:edges graph))
+          events      [{:operation :rf.machine/transition
+                        :tags      {:machine-id :cart}
+                        :from      [:empty] :to [:populated]
+                        :event     :populate}]
+          fired       (topology/extract-fired-edge-ids events :cart)]
+      (is (= #{populate-id} fired))))
+  (testing "events without a matching from/to/event don't contribute"
+    (is (= #{} (topology/extract-fired-edge-ids [] :cart)))
+    (is (= #{} (topology/extract-fired-edge-ids nil :cart)))
+    (is (= #{} (topology/extract-fired-edge-ids
+                 [{:operation :something-else}] :cart)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
@@ -1,0 +1,67 @@
+(ns day8.re-frame2-causa.panels.machines.xyflow-style-cljs-test
+  "Style-map tests for the xyflow per-node + per-edge style provider
+  (rf2-uwvyj · spec/021 §17.4.2 + §17.4.3 + §17.4.5)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.panels.machines.xyflow-style :as xstyle]
+            [day8.re-frame2-causa.theme.tokens :as t :refer [tokens]]))
+
+;; ---- node-style ---------------------------------------------------------
+
+(deftest node-style-standard-shape
+  (let [s (xstyle/node-style :standard)]
+    (is (= (:bg-2 tokens) (:background s)))
+    (is (= "6px" (:border-radius s)))
+    (is (= (str "1px solid " (:border-default tokens)) (:border s)))
+    (is (= (:text-primary tokens) (:color s)))))
+
+(deftest node-style-final-double-ring
+  (let [s (xstyle/node-style :final)]
+    (is (= (str "2px solid " (:green tokens)) (:border s)))
+    (is (some? (:box-shadow s))
+        "final state has the inner gap box-shadow (double-ring)")))
+
+(deftest node-style-current-applies-pulse-animation
+  (let [s (xstyle/node-style :current)]
+    (is (= (str "2px solid " (:green tokens)) (:border s)))
+    (is (some? (:animation s)))
+    (is (re-find #"rf-causa-machine-pulse" (str (:animation s)))
+        "uses the spec-named pulse keyframe")))
+
+(deftest node-style-region-is-dashed-transparent
+  (let [s (xstyle/node-style :region)]
+    (is (= "transparent" (:background s)))
+    (is (re-find #"dashed" (str (:border s))))))
+
+(deftest node-style-unknown-falls-back-to-standard
+  (is (= (xstyle/node-style :standard)
+         (xstyle/node-style :something-bogus))))
+
+;; ---- edge-style ---------------------------------------------------------
+
+(deftest edge-style-registered-is-dashed
+  (let [s (xstyle/edge-style :registered)]
+    (is (= (:text-tertiary tokens) (:stroke s)))
+    (is (= 1 (:stroke-width s)))
+    (is (= "4 4" (:stroke-dasharray s)))))
+
+(deftest edge-style-registered-traversed-is-solid
+  (let [s (xstyle/edge-style :registered-traversed)]
+    (is (= (:text-tertiary tokens) (:stroke s)))
+    (is (= 1 (:stroke-width s)))
+    (is (nil? (:stroke-dasharray s))
+        "traversed edges are solid, not dashed")))
+
+(deftest edge-style-fired-this-epoch-is-thick-violet
+  (let [s (xstyle/edge-style :fired-this-epoch)]
+    (is (= (:accent-violet tokens) (:stroke s)))
+    (is (= 2 (:stroke-width s)))))
+
+(deftest edge-animated-only-for-fired-this-epoch
+  (is (true?  (xstyle/animated? :fired-this-epoch)))
+  (is (false? (xstyle/animated? :registered)))
+  (is (false? (xstyle/animated? :registered-traversed))))
+
+;; ---- edge-label-style ---------------------------------------------------
+
+(deftest edge-label-style-uses-secondary-text-color
+  (is (= (:text-secondary tokens) (:fill xstyle/edge-label-style))))


### PR DESCRIPTION
Closes rf2-uwvyj. Per spec/021 §6 + §17.4. Super-prompt B.4.1 'Path B' (xyflow direct).

## Phases shipped (A + B + C)

- **A**: \`@xyflow/react@12.4.2\` devDep on \`implementation/package.json\` + Reagent/React wrapper (\`xyflow_wrapper.cljs\`) + bundle-isolation sentinels asserting xyflow is absent from production counter/uix/helix bundles.
- **B**: Per-spec node-shape conventions (\`:standard\` / \`:final\` / \`:current\` / \`:region\`) + edge styles (\`:registered\` / \`:registered-traversed\` / \`:fired-this-epoch\`) + Causa-palette token integration via \`xyflow_style.cljs\` (§17.4.5).
- **C**: Pure-data topology projector (\`topology.cljs\`) + Reagent view (\`topology_view.cljs\`) composing wrapper + style + projection + current-state overlay (§17.4.1). Wired into the Machines Canvas tab alongside the legacy ELK SVG chart so the new path can be compared visually while it proves out.

## Surface

NEW:
- \`tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_wrapper.cljs\` — Reagent \`adapt-react-class\` shim around xyflow's \`ReactFlow\` + \`Controls\` + \`Background\` components. Read-only render defaults (\`nodes-draggable=false\` etc.) per spec §6.0.
- \`tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs\` — Single source of truth for per-node + per-edge xyflow visual props (spec §17.4.5). Reads from \`theme/tokens\`; no hex literals.
- \`tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs\` — Pure-data projector: machine definition → \`{:nodes :edges}\` for xyflow. JVM-portable, fully unit-tested. \`extract-fired-edge-ids\` + \`current-state-from-traces\` derive overlay state from focused-epoch traces.
- \`tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs\` — Reagent view composing projector + style + wrapper.
- Tests: \`topology_cljs_test.cljs\` (22 deftest) + \`xyflow_style_cljs_test.cljs\` (10 deftest).

MODIFIED:
- \`implementation/package.json\` — \`@xyflow/react: 12.4.2\` devDependency.
- \`implementation/scripts/check-bundle-isolation.cjs\` — new \`xyflow\` artefact entry asserting \`react-flow__pane\` + \`react-flow__node\` sentinels are absent from prod bundles.
- \`tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs\` — single \`:require\` line + an additive xyflow-render section below the existing ELK SVG chart.

## Bundle isolation

xyflow MUST NOT leak into production bundles. The new sentinel artefact entry in \`check-bundle-isolation.cjs\` asserts \`react-flow__pane\` + \`react-flow__node\` (xyflow's CSS classes — distinctive substrings that survive \`:advanced\`) are absent from the counter / counter-uix / counter-helix release blobs. Gate enforced on every PR.

## Test plan

- [x] \`npm run test:cljs\` — 3660 tests, 10584 assertions, 0 failures, 0 errors
- [x] \`npm run test:bundle-isolation\` — 13 artefact entries; xyflow sentinels absent from all 3 production bundles
- [x] \`mkdocs build --strict\` — exit 0
- [x] Worktree guard passed (\`WORKTREE_ROOT=C:\Users\miket\code\re-frame2-worktrees\causa-machines-xyflow\`)