### PR TITLE
feat(causa): settings — :epoch-history knob in General tab (rf2-3zyyx)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -759,6 +759,18 @@
     the bucket so downstream panels populate. Useful when debugging
     SSR / REPL / registry-time flows.
 
+  - `:epoch-history` (integer, default 50) — depth of the per-frame
+    epoch ring buffer (per rf2-3zyyx / spec/021 §10.7, §13). Maps 1:1
+    to `(rf/configure :epoch-history {:depth N})` — Causa's settings
+    write through to that runtime knob via `apply-epoch-history!` so
+    the live substrate ring resizes immediately on change AND the
+    persisted value is restored on next page-load BEFORE first paint.
+    The evicted-epoch placeholder text in every panel (spec/021 §10.7)
+    points at this knob — bumping it retains older epochs at a higher
+    heap cost. 50 matches `re-frame.epoch.state/default-depth`; lower
+    values save memory in long sessions, higher values retain more
+    time-travel coverage.
+
   ## :buffer section (rf2-ttnst — Settings popup v1 expansion)
 
   Buffer-depth tunables surfaced in the Buffer tab. All three are
@@ -779,6 +791,7 @@
                :show-tool-frames?      false
                :show-unchanged-subs?   false           ; rf2-wyvf2 Reactive-panel disclosure pin
                :show-ungrouped?        false           ; rf2-r9lyy opt-in pseudo-cascade surface
+               :epoch-history          50              ; rf2-3zyyx per-frame epoch ring depth
                :long-keyword-threshold 24
                ;; rf2-ybjkx — user-side override of the OS-level
                ;; `prefers-reduced-motion: reduce` media query. Three

--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -408,6 +408,45 @@
                       (str (long px) "px")))))
   nil)
 
+;; ---- epoch history (rf2-3zyyx — spec/021 §10.7, §13) -------------------
+;;
+;; The Epoch history slider in Settings → General writes through to the
+;; substrate's per-frame ring depth via `(rf/configure :epoch-history
+;; {:depth N})` — the same runtime knob `re-frame.epoch.state/merge-config!`
+;; gates on. The substrate reads the depth on every `record!` so the new
+;; cap takes effect on the next drain settle; existing oversize histories
+;; are NOT retroactively trimmed (pre-alpha posture — the substrate
+;; comment on `elide-just-crossed-trace-events` documents this exactly).
+;;
+;; ## Why route through `rf/configure` rather than reach into epoch.state
+;;
+;; `re-frame.core/configure` is the published API (per spec/Tool-Pair
+;; §Bounded history + Conventions §Configure keys). Reaching directly
+;; into `re-frame.epoch.state/merge-config!` would couple Causa to an
+;; internal seam; the `configure` fn late-binds through the hook table
+;; so production builds that DCE the epoch artefact silently no-op.
+;;
+;; Non-positive values are clamped to 1 at the substrate boundary
+;; (`merge-config!`'s `non-neg-int?` predicate accepts 0, but a 0 ring
+;; would defeat Causa's reason for existing). The slider's min is 10 so
+;; the boundary case is mostly defensive.
+
+(defn apply-epoch-history!
+  "Write `n` (the epoch-history depth) through to the substrate's
+  per-frame ring buffer via `(rf/configure :epoch-history {:depth N})`.
+  No-op when `n` is non-numeric (a malformed persisted payload survives
+  into here as `nil`; the substrate ignores the slot rather than
+  resetting to default). Failures (epoch artefact not loaded, late-bind
+  hook unresolved) degrade silently — the persisted value still lives
+  in the settings atom and the next configure call (if the artefact
+  loads later) will land cleanly."
+  [n]
+  (when (and (number? n) (pos? n))
+    (try
+      (rf/configure :epoch-history {:depth (long n)})
+      (catch :default _ nil)))
+  nil)
+
 ;; ---- panel position -----------------------------------------------------
 
 (defn apply-panel-position!
@@ -566,6 +605,13 @@
     ;; mounted yet; the host pickup happens at next paint via the
     ;; var cascade).
     (apply-panel-width! (get-in s [:general :panel-width-px]))
+    ;; rf2-3zyyx — restore the persisted epoch-history depth so the
+    ;; substrate's per-frame ring buffer matches the user's saved
+    ;; capacity BEFORE the first dispatch settles into it. No-op-safe
+    ;; when the epoch artefact isn't loaded (the late-bind hook in
+    ;; `re-frame.core/configure` returns nil so the call is a tap-only
+    ;; no-op).
+    (apply-epoch-history! (get-in s [:general :epoch-history]))
     ;; Panel-position is intentionally NOT applied at boot — the
     ;; preload's auto-open already handles the default `:right-rail`
     ;; case, and reopening into the saved position would surprise a

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -134,6 +134,15 @@
         (and (= section :general) (= key :use-system-colors?))
         (effects/apply-use-system-colors! value)
 
+        ;; rf2-3zyyx — Epoch history slider. Writes through to the
+        ;; substrate's per-frame ring depth via
+        ;; `(rf/configure :epoch-history {:depth N})`. See
+        ;; `settings/effects.cljs §apply-epoch-history!` for the
+        ;; late-bind contract; non-positive values are dropped at the
+        ;; effect boundary.
+        (and (= section :general) (= key :epoch-history))
+        (effects/apply-epoch-history! value)
+
         ;; Auto-open-on-error toggle — install the sub-watcher on
         ;; flip-on, detach on flip-off. The install is also attempted
         ;; from `mount/ensure-causa-frame!` so the persisted-true case

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -262,7 +262,8 @@
         long-kw-thresh  @(rf/subscribe [:rf.causa/long-keyword-threshold])
         show-tool?      @(rf/subscribe [:rf.causa/show-tool-frames?])
         show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
-        show-unchanged-subs? @(rf/subscribe [:rf.causa/setting :general :show-unchanged-subs?])]
+        show-unchanged-subs? @(rf/subscribe [:rf.causa/setting :general :show-unchanged-subs?])
+        epoch-history   @(rf/subscribe [:rf.causa/setting :general :epoch-history])]
     [:div {:data-testid "rf-causa-settings-section-general"}
      [:h2 {:style (section-heading-style)} "General"]
 
@@ -430,6 +431,49 @@
                               :font-family  mono-stack}}]]
       [:p {:style (hint-style)}
        "Fully-qualified keywords longer than this elide in compact list cells."]]
+
+     ;; ── Epoch history slider (rf2-3zyyx — spec/021 §10.7, §13) ──
+     ;;
+     ;; Depth of the per-frame epoch ring buffer. Writes through to
+     ;; the substrate via `(rf/configure :epoch-history {:depth N})`
+     ;; (see settings/effects.cljs §apply-epoch-history!). The
+     ;; "Epoch evicted from buffer" placeholder text in every panel
+     ;; (spec/021 §10.7) points the operator here — bumping the knob
+     ;; retains more time-travel coverage at a higher heap cost.
+     ;; Slider range 10–500 brackets the default 50 with one decade
+     ;; in either direction.
+     [:div {:style (field-style)}
+      [:label {:html-for "rf-causa-settings-epoch-history-input"
+               :style    (label-style)} "Epoch history"]
+      [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
+       [:input {:data-testid "rf-causa-settings-epoch-history-input"
+                :id          "rf-causa-settings-epoch-history-input"
+                :type        "range"
+                :min         "10"
+                :max         "500"
+                :step        "10"
+                :value       (str (or epoch-history 50))
+                :on-change   (fn [^js e]
+                               (let [n (js/parseInt (.. e -target -value) 10)]
+                                 (when-not (js/isNaN n)
+                                   (rf/dispatch
+                                     [:rf.causa/settings-update
+                                      :general :epoch-history n]
+                                     {:frame :rf/causa}))))
+                :style       {:flex 1}}]
+       [:span {:data-testid "rf-causa-settings-epoch-history-value"
+               :style       {:font-family mono-stack
+                             :color       (:text-secondary tokens)
+                             :min-width   "48px"
+                             :text-align  "right"}}
+        (str (or epoch-history 50))]]
+      [:p {:style (hint-style)}
+       "Number of epochs Causa retains per frame for time-travel "
+       "inspection. Older epochs evict when the buffer fills; the "
+       [:code {:style {:font-family mono-stack
+                       :color (:text-tertiary tokens)}}
+        "Epoch evicted from buffer"]
+       " placeholder points here. Default 50."]]
 
      ;; ── Power user divider + show-tool-frames toggle (rf2-ttnst) ─
      ;;

--- a/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
@@ -19,6 +19,7 @@
   subscription value transition."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.epoch.state :as epoch-state]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -228,6 +229,62 @@
   (when-let [el (shell-root)]
     (is (= "12px" (.getPropertyValue (.-style el) "--rf-causa-text-size")))
     (is (true? (.contains (.-classList el) "rf-causa-theme-light")))))
+
+;; ---- epoch-history (rf2-3zyyx) -----------------------------------------
+
+(deftest apply-epoch-history-writes-substrate-depth
+  (testing "rf2-3zyyx — apply-epoch-history! routes through
+            `(rf/configure :epoch-history {:depth N})` so the
+            substrate's per-frame ring buffer matches the user's
+            saved capacity. Reads the live depth from
+            `re-frame.epoch.state` to assert the wire actually landed."
+    ;; Capture original depth so the fixture doesn't leak the bump.
+    (let [orig (epoch-state/depth)]
+      (try
+        (effects/apply-epoch-history! 123)
+        (is (= 123 (epoch-state/depth))
+            "substrate depth picks up the new value")
+        ;; Defensive: nil / non-numeric is a no-op so a malformed
+        ;; persisted payload never zeros the ring.
+        (effects/apply-epoch-history! nil)
+        (is (= 123 (epoch-state/depth))
+            "nil input is a no-op; substrate depth unchanged")
+        (effects/apply-epoch-history! 0)
+        (is (= 123 (epoch-state/depth))
+            "zero input is dropped at the effect boundary; substrate
+             depth unchanged (the slider's min is 10 anyway)")
+        (finally
+          (rf/configure :epoch-history {:depth orig}))))))
+
+(deftest update-event-applies-epoch-history-effect
+  (testing "rf2-3zyyx — dispatching `:rf.causa/settings-update :general
+            :epoch-history N` writes through to the substrate via the
+            matching effect."
+    (setup!)
+    (let [orig (epoch-state/depth)]
+      (try
+        (rf/with-frame :rf/causa
+          (rf/dispatch-sync [:rf.causa/settings-update
+                             :general :epoch-history 150]))
+        (is (= 150 (config/get-setting :general :epoch-history))
+            "config slot carries the new value")
+        (is (= 150 (epoch-state/depth))
+            "substrate ring depth follows the dispatch")
+        (finally
+          (rf/configure :epoch-history {:depth orig}))))))
+
+(deftest apply-all-restores-epoch-history
+  (testing "rf2-3zyyx — the boot path re-applies the persisted depth
+            so the substrate ring matches the user's saved capacity
+            BEFORE first dispatch."
+    (let [orig (epoch-state/depth)]
+      (try
+        (config/update-setting! :general :epoch-history 88)
+        (effects/apply-all!)
+        (is (= 88 (epoch-state/depth))
+            "apply-all! routes the persisted value to the substrate")
+        (finally
+          (rf/configure :epoch-history {:depth orig}))))))
 
 ;; ---- panel width (rf2-x8h9y) -------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
@@ -37,7 +37,11 @@
     (is (= :right-rail
               (config/get-setting :general :panel-position)))
     (is (= false  (config/get-setting :general :auto-open-on-error?)))
-    (is (= :dark  (config/get-setting :theme nil)))))
+    (is (= :dark  (config/get-setting :theme nil)))
+    ;; rf2-3zyyx — epoch-history default matches the substrate's
+    ;; `re-frame.epoch.state/default-depth` so a fresh install carries
+    ;; the same ring depth Causa observed before the knob was surfaced.
+    (is (= 50 (config/get-setting :general :epoch-history)))))
 
 ;; ---- per-setting round-trip --------------------------------------------
 
@@ -73,6 +77,20 @@
   (reset! config/settings config/default-settings)
   (config/load-settings-from-storage!)
   (is (= :light (config/get-setting :theme nil))))
+
+(deftest epoch-history-round-trips
+  ;; rf2-3zyyx — the Epoch history slider persists the depth through
+  ;; the same localStorage path every other :general knob uses; on
+  ;; reload the substrate cap is restored via `apply-epoch-history!`
+  ;; (separate test in effects_cljs_test).
+  (config/update-setting! :general :epoch-history 200)
+  (is (= 200 (config/get-setting :general :epoch-history)))
+  (reset! config/settings config/default-settings)
+  (is (= 50 (config/get-setting :general :epoch-history))
+      "atom-only reset returns to default")
+  (config/load-settings-from-storage!)
+  (is (= 200 (config/get-setting :general :epoch-history))
+      "reload from localStorage restores 200"))
 
 (deftest legacy-telemetry-key-is-silently-dropped
   ;; rf2-jh9ws: settings persisted from prior sessions with a

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
@@ -106,7 +106,13 @@
       (is (find-by-testid rendered "rf-causa-settings-section-general"))
       (is (find-by-testid rendered "rf-causa-settings-text-size-input"))
       (is (find-by-testid rendered "rf-causa-settings-panel-position-right-rail"))
-      (is (find-by-testid rendered "rf-causa-settings-auto-open-on-error")))))
+      (is (find-by-testid rendered "rf-causa-settings-auto-open-on-error"))
+      ;; rf2-3zyyx — Epoch history slider renders in General with its
+      ;; numeric readout sibling.
+      (is (find-by-testid rendered "rf-causa-settings-epoch-history-input")
+          "Epoch history slider renders in General")
+      (is (find-by-testid rendered "rf-causa-settings-epoch-history-value")
+          "Epoch history numeric readout renders alongside the slider"))))
 
 (deftest filters-section-renders
   (setup!)


### PR DESCRIPTION
Closes rf2-3zyyx. Per spec/021 §10.7 + §13.

## Summary

- New `:epoch-history` slot in `:general` (default `50`, matching `re-frame.epoch.state/default-depth`)
- Range slider in Settings → General (range 10–500, step 10) with numeric readout sibling
- `apply-epoch-history!` writes through to the substrate via `(rf/configure :epoch-history {:depth N})` so the per-frame ring resizes live AND is restored at boot via `apply-all!` BEFORE first paint
- Mirrors the `:show-unchanged-subs?` pattern landed by rf2-wyvf2 (#1741)

## Tests (CLJS unit only)

- `persistence_cljs_test`: default 50, localStorage round-trip
- `effects_cljs_test`: `apply-epoch-history!` writes substrate depth; nil/zero no-op; dispatch propagates; `apply-all!` restores at boot
- `popup_cljs_test`: slider + numeric readout render in General

## Gates

- `npm run test:cljs` — 3696 tests, 0 failures
- `npm run test:bundle-isolation` — pass
- `mkdocs build --strict` — pass (exit 0)