### PR TITLE
feat(causa): Routing panel — focused-epoch overlay shape (rf2-3kjlo)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-causa.panels.routing
-  "Routing tab — focused-event lens (rf2-o5f5f.3 narrows from rf2-lq0ef).
+  "Routing tab — topology-plus-overlay shape (rf2-3kjlo).
 
   ## Two verbs, two homes (Mike's decision, 2026-05-19)
 
@@ -9,52 +9,74 @@
     - **Static Routes** — browse-all + Simulate-URL + per-row inline
       expand + hermetic Simulate-navigation preview. Lives at
       `static/routes/panel.cljs`.
-    - **Runtime Routing** — focused-event lens. Surfaces the
-      routing-related slice of the focused event's cascade: FROM/TO
-      chips when the focused event triggered navigation; empty state
-      otherwise. THIS NAMESPACE.
+    - **Runtime Routing** — topology-plus-overlay (this ns) per
+      spec/021 §7. The full route tree is ALWAYS visible; the focused
+      epoch's nav activity overlays as a `:to` / `:from` / `:here`
+      marker on the relevant nodes. A 'This epoch' detail block below
+      the tree surfaces Phase / From / To / Match / Events.
 
-  Industry pattern (React Router / Tanstack / Vue Router / Next.js
-  Devtools): event-driven panels showcase the navigation cascade in
-  context; static catalogues live in their own browser. The
-  promote-narrow split mirrors that division.
+  ## Topology-plus-overlay shape (post-rf2-3kjlo reshape)
 
-  ## Lens surface (post-narrow)
+      ┌─ ROUTING · epoch #38 ────────────────────────── [◀ Prev] [Next ▶] ─┐
+      │ Stripe: yellow (:yellow)                                            │
+      │                                                                     │
+      │ Active route tree                                                   │
+      │  /                                                                  │
+      │  ├─ /cart      ◉  (active this epoch — :on-match)                   │
+      │  │  └─ /cart/:id                                                    │
+      │  ├─ /orders                                                         │
+      │  │  └─ /orders/:order-id                                            │
+      │  └─ /settings                                                       │
+      │                                                                     │
+      │ This epoch                                                          │
+      │   Phase     :on-match                                               │
+      │   From      /                                                       │
+      │   To        /cart                                                   │
+      │   Match     {:route :cart}                                          │
+      │   Events    [:rf/url-changed] [:cart/route-entered]                 │
+      │                                                                     │
+      │ Empty (no route activity this epoch):                               │
+      │   Shows tree with current active node highlighted; 'This epoch'     │
+      │   reads 'No route activity in this epoch.'                          │
+      └─────────────────────────────────────────────────────────────────────┘
 
-      ┌──────────────────────────────────────────────────┐
-      │ Routing — focused-event lens                     │
-      ├──────────────────────────────────────────────────┤
-      │ no nav?  →  'Focused event did not navigate.'    │
-      │           +  hint to open Static Routes for      │
-      │              registry browse.                    │
-      │ nav?     →  FROM chip · TO chip · TO id          │
-      │           +  params + query + fragment grid      │
-      └──────────────────────────────────────────────────┘
+  ## Per-epoch overlay markers
 
-  When the focused cascade carries a `:rf.route.nav-token/allocated`
-  trace event, FROM and TO chips render with the prior route + the
-  new route id. When the slice carries no navigation context (the
-  focused event was not a navigation event), the lens shows an
-  empty-orientation state — the user is reminded that BROWSE lives
-  on the Static surface.
+  The overlay paints inline alongside each topology row via
+  `routing-helpers/assign-markers`:
+
+    - `:to` (green stripe) — the focused cascade navigated TO this
+      route (the new HERE)
+    - `:from` (cyan stripe) — the focused cascade navigated AWAY from
+      this route
+    - `:here` (yellow dot) — the current active route when no
+      navigation happened this epoch
+
+  When the focused epoch has NO routing activity (`:activity` is nil)
+  the tree still renders with `:here` only; the 'This epoch' block
+  reads 'No route activity in this epoch.'
+
+  ## Focus contract (rf2-h0120 alignment)
+
+  The panel reads `:rf.causa/focus` per spec/018; that sub already
+  auto-resolves head-fallback via `spine/compose-focus` (when no user
+  focus is set, `:dispatch-id` snaps to the head focusable cascade).
+  No inline head-fallback needed at this layer — the spine sub IS the
+  head-fallback.
 
   ## Pure hiccup (rf2-tijr)
 
-  Same contract as every other Causa panel — the view is pure
-  hiccup, no Reagent / UIx / Helix references. Frame isolation comes
-  from the enclosing `[rf/frame-provider {:frame :rf/causa}]` in
-  `shell.cljs`. Every `subscribe` / `dispatch` here resolves to
-  `:rf/causa`.
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
+  Every `subscribe` / `dispatch` here resolves to `:rf/causa`.
 
   ## Helpers
 
-  Pure-data projection (`focused-cascade`,
-  `nav-token-allocated-in-cascade`, `from-to-from-cascade`) lives in
+  Pure-data projection (`project-topology`, `epoch-routing-activity`,
+  `project-topology-data`, plus the legacy lens helpers) lives in
   `routing_helpers.cljc` so the algebra runs under the JVM unit-test
-  target. The catalogue / search / Simulate-URL helpers
-  (`project-routes`, `filter-rows`, `simulate-url`) live there too
-  and now power the Static Routes panel — same shared primitives,
-  per the parent-epic findings §5.1."
+  target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
@@ -64,77 +86,218 @@
 
 ;; ---- visual primitives --------------------------------------------------
 
-(defn- marker-chip
-  "Render the `◆ FROM` / `◆ TO` marker chip. Returns nil when no
-  marker — used inline alongside the route-id."
+(defn- marker-glyph
+  "Resolve the marker glyph + colour for a topology row. Returns a
+  `{:glyph :colour :label}` map; nil when the row carries no marker.
+
+  Per spec/021 §7.2 + §17.1.5:
+    - `:to` → green `◉` dot (navigation destination)
+    - `:from` → cyan `◇` outline diamond (navigation origin)
+    - `:here` → yellow `●` (current active route, no nav this epoch)"
   [marker]
-  (when marker
-    (let [{:keys [label colour]}
-          (case marker
-            :from {:label "◆ FROM" :colour (:cyan tokens)}
-            :to   {:label "◆ TO"   :colour (:green tokens)}
-            nil)]
-      (when label
-        [:span {:data-testid (str "rf-causa-routing-marker-" (name marker))
-                :style       {:color          colour
-                              :font-weight    600
-                              :font-family    sans-stack
-                              :font-size      "11px"
-                              :letter-spacing "0.3px"
-                              :margin-right   "6px"
-                              :white-space    "nowrap"}}
-         label]))))
+  (case marker
+    :to   {:glyph "◉" :colour (:green tokens) :label "TO"}
+    :from {:glyph "◇" :colour (:cyan tokens)  :label "FROM"}
+    :here {:glyph "●" :colour (:yellow tokens) :label "HERE"}
+    nil))
 
-(defn- nav-chip-row
-  "FROM → TO chip row rendered when the focused cascade triggered
-  navigation."
-  [{:keys [from-id to-id]}]
-  [:div {:data-testid "rf-causa-routing-nav-row"
-         :style       {:padding     "10px 16px"
-                       :display     "flex"
-                       :align-items "center"
-                       :gap         "8px"
-                       :font-family mono-stack
-                       :font-size   "13px"
-                       :color       (:text-primary tokens)}}
-   (when from-id
-     [:span {:data-testid "rf-causa-routing-from-cell"
-             :style       {:display     "inline-flex"
-                           :align-items "center"
-                           :padding     "4px 10px"
-                           :background  (:bg-2 tokens)
-                           :border-left (str "2px solid " (:cyan tokens))
-                           :border-radius "2px"
-                           :gap         "6px"}}
-      (marker-chip :from)
-      [:span {:style {:color (:text-primary tokens)}} (str from-id)]])
-   (when (and from-id to-id)
-     [:span {:style {:color       (:text-tertiary tokens)
-                     :font-family sans-stack}}
-      "→"])
-   (when to-id
-     [:span {:data-testid "rf-causa-routing-to-cell"
-             :style       {:display     "inline-flex"
-                           :align-items "center"
-                           :padding     "4px 10px"
-                           :background  (:bg-active tokens)
-                           :border-left (str "2px solid " (:green tokens))
-                           :border-radius "2px"
-                           :gap         "6px"}}
-      (marker-chip :to)
-      [:span {:style {:color (:text-primary tokens)}} (str to-id)]])])
+(defn- tree-prefix
+  "Compose the `├─ └─ │` prefix for a topology row at the given depth.
 
-;; ---- header / slice-detail / empty-state --------------------------------
+  Depth-0 rows render with no prefix; deeper rows render
+  `<spacer>(└─|├─) ` — `└─` for last-sibling rows, `├─` for non-last.
+  This is the same box-drawing scheme the spec mockup uses (§7.2).
+
+  Pragmatic v1: the inter-depth `│` continuation pipes are omitted —
+  routing trees are shallow (≤ 4 levels per spec §7.1) so the depth
+  indentation + branch glyphs alone read cleanly. A future bead can
+  refine the prefix once the inspector has live route topologies to
+  tune against."
+  [depth last-at-depth?]
+  (cond
+    (zero? depth) ""
+    :else         (let [indent (apply str (repeat (dec depth) "  "))
+                        branch (if last-at-depth? "└─ " "├─ ")]
+                    (str indent branch))))
+
+(defn- topology-row
+  "Render one route in the topology tree. The full row is mono so the
+  `├─ └─` glyphs line up; the marker (when present) renders to the
+  right of the path with its colour-coded glyph."
+  [{:keys [row depth last-at-depth?]}]
+  (let [{:keys [route-id path marker doc]} row
+        glyph (marker-glyph marker)
+        testid (str "rf-causa-routing-topology-row-"
+                    (when route-id (name route-id)))]
+    [:div {:data-testid testid
+           :data-route-id (when route-id (str route-id))
+           :data-marker   (when marker (name marker))
+           :style {:display      "flex"
+                   :align-items  "center"
+                   :gap          "8px"
+                   :padding      "2px 16px"
+                   :font-family  mono-stack
+                   :font-size    "12px"
+                   :color        (:text-primary tokens)
+                   :background   (when (= marker :to)
+                                   (:bg-active tokens))
+                   :border-left  (str "2px solid "
+                                      (if glyph
+                                        (:colour glyph)
+                                        "transparent"))
+                   :white-space  "pre"}}
+     [:span {:style {:color (:text-tertiary tokens)}}
+      (tree-prefix depth last-at-depth?)]
+     [:span {:style {:color       (:text-primary tokens)
+                     :font-weight (if (= marker :to) 600 400)}}
+      path]
+     (when glyph
+       [:span {:data-testid (str "rf-causa-routing-topology-marker-"
+                                 (name marker))
+               :style       {:color       (:colour glyph)
+                             :font-size   "11px"
+                             :font-weight 600
+                             :margin-left "8px"}}
+        (:glyph glyph) " " (:label glyph)])
+     (when (and (not marker) doc)
+       [:span {:style {:color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"
+                       :margin-left "8px"}}
+        doc])]))
+
+(defn- topology-tree
+  "Render the full topology — the always-visible base layer per
+  spec/021 §7.2. Empty topology vector ⇒ render nothing (the silent-
+  by-default contract per rf2-g3ghh; the surrounding panel renders
+  its empty section instead)."
+  [topology]
+  [:div {:data-testid "rf-causa-routing-topology"
+         :style       {:padding "8px 0"}}
+   [:div {:style {:padding        "0 16px 6px 16px"
+                  :color          (:text-tertiary tokens)
+                  :font-family    sans-stack
+                  :font-size      "10px"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"}}
+    "Active route tree"]
+   (into [:<>]
+         (for [entry topology]
+           ^{:key (str (-> entry :row :route-id))}
+           (topology-row entry)))])
+
+;; ---- "This epoch" detail block ------------------------------------------
+
+(defn- epoch-detail-row
+  "Render one `Label  value` row in the 'This epoch' grid."
+  [label value-hiccup label-testid value-testid]
+  [:<>
+   [:span {:data-testid label-testid
+           :style {:color       (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size   "11px"}}
+    label]
+   [:span {:data-testid value-testid
+           :style {:color       (:text-primary tokens)
+                   :font-family mono-stack
+                   :font-size   "12px"}}
+    value-hiccup]])
+
+(defn- this-epoch-block
+  "Render the 'This epoch' detail block per spec/021 §7.2.
+
+  When `:activity` is nil renders the empty-state caption (' No route
+  activity in this epoch. ') — the topology still renders above (per
+  the topology-plus-overlay contract).
+
+  When `:activity` is present surfaces Phase / From / To / Match /
+  Events using the topology-row marker colors so the overlay reads
+  consistently across the tree + this block."
+  [{:keys [activity from-id to-id current navigated?]}]
+  [:div {:data-testid "rf-causa-routing-this-epoch"
+         :style       {:border-top  (str "1px solid " (:border-subtle tokens))
+                       :padding     "10px 16px 12px 16px"
+                       :font-family sans-stack
+                       :font-size   "12px"}}
+   [:div {:style {:color          (:text-tertiary tokens)
+                  :font-size      "10px"
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"
+                  :margin-bottom  "6px"}}
+    "This epoch"]
+   (if (nil? activity)
+     [:div {:data-testid "rf-causa-routing-no-activity"
+            :style       {:color      (:text-tertiary tokens)
+                          :font-style "italic"
+                          :font-size  "12px"}}
+      "No route activity in this epoch."]
+     (let [{:keys [phase events match]} activity]
+       [:div {:style {:display               "grid"
+                      :grid-template-columns "80px 1fr"
+                      :row-gap               "4px"
+                      :column-gap            "12px"
+                      :align-items           "baseline"}}
+        (epoch-detail-row
+          "Phase"
+          [:span {:style {:color (:yellow tokens) :font-weight 600}}
+           (pr-str phase)]
+          "rf-causa-routing-detail-phase-label"
+          "rf-causa-routing-detail-phase")
+        (epoch-detail-row
+          "From"
+          (if from-id
+            [:span {:style {:color (:cyan tokens)}}
+             (str from-id)]
+            [:span {:style {:color (:text-tertiary tokens)}} "—"])
+          "rf-causa-routing-detail-from-label"
+          "rf-causa-routing-detail-from")
+        (epoch-detail-row
+          "To"
+          (if to-id
+            [:span {:style {:color (:green tokens) :font-weight 600}}
+             (str to-id)]
+            [:span {:style {:color (:text-tertiary tokens)}} "—"])
+          "rf-causa-routing-detail-to-label"
+          "rf-causa-routing-detail-to")
+        (epoch-detail-row
+          "Match"
+          (if (and navigated? (seq match))
+            [:span (pr-str match)]
+            [:span {:style {:color (:text-tertiary tokens)}}
+             (if (and navigated? current)
+               (pr-str (or (:params current) {}))
+               "—")])
+          "rf-causa-routing-detail-match-label"
+          "rf-causa-routing-detail-match")
+        (epoch-detail-row
+          "Events"
+          (if (seq events)
+            (into [:span {:style {:display "inline-flex" :gap "6px"
+                                  :flex-wrap "wrap"}}]
+                  (for [[idx ev] (map-indexed vector events)]
+                    ^{:key idx}
+                    [:span {:style {:color       (:accent-violet tokens)
+                                    :background  (:bg-1 tokens)
+                                    :padding     "1px 6px"
+                                    :border-radius "2px"
+                                    :font-size   "11px"}}
+                     (pr-str ev)]))
+            [:span {:style {:color (:text-tertiary tokens)}} "—"])
+          "rf-causa-routing-detail-events-label"
+          "rf-causa-routing-detail-events")]))])
+
+;; ---- header --------------------------------------------------------------
 
 (defn- header
-  [{:keys [navigated? to-id]}]
+  [{:keys [navigated? to-id silent?]}]
   [:div {:data-testid "rf-causa-routing-header"
-         :style       {:display       "flex"
-                       :align-items   "baseline"
+         :style       {:display         "flex"
+                       :align-items     "baseline"
                        :justify-content "space-between"
-                       :padding       "12px 16px 8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family   sans-stack}}
+                       :padding         "12px 16px 8px 16px"
+                       :border-bottom   (str "1px solid " (:border-subtle tokens))
+                       :font-family     sans-stack}}
    [:div
     ;; rf2-5kfxe.8 — domain-coloured accent stripe (:yellow for
     ;; Routing — side-channel attention tone, distinguished from
@@ -147,79 +310,60 @@
                          :color          (:text-primary tokens)}
                         (t/accent-stripe-style :routing))}
      "Routing"]
-    [:p {:style {:margin     "4px 0 0 0"
-                 :color      (:text-tertiary tokens)
-                 :font-size  "11px"
+    [:p {:style {:margin      "4px 0 0 0"
+                 :color       (:text-tertiary tokens)
+                 :font-size   "11px"
                  :line-height 1.4}}
-     "Focused-event lens — surfaces the navigation slice of the focused "
-     "event's cascade. "
-     [:span {:style {:color (:cyan tokens) :font-weight 600}} "◆ FROM"]
+     "Full topology of registered routes with focused-epoch overlay. "
+     [:span {:style {:color (:green tokens) :font-weight 600}} "◉ TO"]
      " / "
-     [:span {:style {:color (:green tokens) :font-weight 600}} "◆ TO"]
-     " mark the transition when the focused event triggered "
-     "navigation. For the full route catalogue browse + Simulate-URL "
-     "surface, switch to Static mode."]]
-   (when (and navigated? to-id)
+     [:span {:style {:color (:cyan tokens) :font-weight 600}} "◇ FROM"]
+     " / "
+     [:span {:style {:color (:yellow tokens) :font-weight 600}} "● HERE"]
+     " mark the per-epoch navigation overlay. For the full route catalogue browse + "
+     "Simulate-URL surface, switch to Static mode."]]
+   (when (and navigated? to-id (not silent?))
      [:span {:data-testid "rf-causa-routing-nav-summary"
              :style       {:color       (:green tokens)
                            :font-size   "11px"
                            :font-family mono-stack}}
       (str "→ " to-id)])])
 
-(defn- slice-detail
-  "Params / query / fragment breakdown for the route slice. Surfaces
-  when the focused event navigated — the `current` slice carries the
-  post-navigation params + query, and the user wants to see what
-  landed."
-  [{:keys [params query fragment] :as _current}]
-  [:div {:data-testid "rf-causa-routing-slice-detail"
-         :style       {:padding               "10px 16px"
-                       :border-top            (str "1px dotted " (:border-subtle tokens))
-                       :font-family           mono-stack
-                       :font-size             "12px"
-                       :color                 (:text-primary tokens)
-                       :display               "grid"
-                       :grid-template-columns "80px 1fr"
-                       :row-gap               "4px"
-                       :column-gap            "12px"}}
-   [:span {:style {:color (:text-tertiary tokens)}} "Params:"]
-   [:span (if (seq params) (pr-str params) "—")]
-   [:span {:style {:color (:text-tertiary tokens)}} "Query:"]
-   [:span (if (seq query) (pr-str query) "—")]
-   (when fragment
-     [:<>
-      [:span {:style {:color (:text-tertiary tokens)}} "Fragment:"]
-      [:span (pr-str fragment)]])])
+;; ---- empty (no routes registered) ---------------------------------------
 
-(defn- empty-state
-  "Renders when the focused event did NOT trigger navigation. The
-  lens is event-coupled — there is no 'current route' for browse;
-  that's the Static Routes verb."
+(defn- silent-state
+  "Renders when the host app has NO routes registered. Per
+  rf2-g3ghh silent-by-default: no placeholder rows, just a
+  single-line caption pointing to Static Routes for browse."
   []
-  [:div {:data-testid "rf-causa-routing-empty"
-         :style       {:padding     "16px"
-                       :display     "flex"
+  [:div {:data-testid "rf-causa-routing-silent"
+         :style       {:padding        "16px"
+                       :display        "flex"
                        :flex-direction "column"
-                       :gap         "8px"
-                       :color       (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size   "11px"}}
+                       :gap            "8px"
+                       :color          (:text-tertiary tokens)
+                       :font-family    sans-stack
+                       :font-size      "11px"}}
    [:span {:style {:font-style "italic"}}
-    "Focused event did not trigger navigation."]
+    "No routes registered in the host app."]
    [:span {:style {:color (:text-tertiary tokens)}}
-    "For browse + Simulate-URL, switch to "
-    [:strong {:style {:color (:cyan tokens)}} "Static"]
-    " mode (the Routes tab there lists every registered route)."]])
+    "Register routes via "
+    [:code {:style {:color       (:accent-violet tokens)
+                    :font-family mono-stack}}
+     "re-frame.routing/reg-route"]
+    " — the topology will render once the host installs them."]])
 
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Routing tab's root view — focused-event lens. Subscribes to
-  `:rf.causa/routing-tab-data` and renders FROM/TO chips + slice
-  detail when the focused cascade triggered navigation; otherwise
-  shows the empty orientation state pointing to Static Routes."
+  "The Routing tab's root view — topology-plus-overlay shape per
+  spec/021 §7. Subscribes to `:rf.causa/routing-tab-data` and renders
+  the full route topology with a per-epoch overlay; below the tree
+  the 'This epoch' block surfaces Phase / From / To / Match / Events
+  (or 'No route activity in this epoch.' when the focused cascade
+  carries no routing trace events)."
   []
-  (let [{:keys [from-id to-id navigated? current]
+  (let [{:keys [silent? topology activity from-id to-id navigated? current]
          :as _data}
         @(rf/subscribe [:rf.causa/routing-tab-data])]
     [:section {:data-testid "rf-causa-routing"
@@ -230,13 +374,16 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     (header {:navigated? navigated? :to-id to-id})
-     (if-not navigated?
-       (empty-state)
+     (header {:navigated? navigated? :to-id to-id :silent? silent?})
+     (if silent?
+       (silent-state)
        [:<>
-        (nav-chip-row {:from-id from-id :to-id to-id})
-        (when current
-          (slice-detail current))])]))
+        (topology-tree topology)
+        (this-epoch-block {:activity   activity
+                           :from-id    from-id
+                           :to-id      to-id
+                           :current    current
+                           :navigated? navigated?})])]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -249,9 +396,9 @@
       panel also reads this sub — process-global, frame-agnostic.
     - `:rf.causa/current-route-slice` — composite over the spine's
       target-frame app-db reading the `:rf/route` slice.
-    - `:rf.causa/routing-tab-data` — view-facing composite for the
-      Runtime Routing lens (focused-event scoped). Carries
-      `:from-id`, `:to-id`, `:navigated?`, `:current`.
+    - `:rf.causa/routing-tab-data` — view-facing topology-plus-overlay
+      composite (focused-epoch scoped). Carries `:silent?`, `:topology`,
+      `:activity`, `:from-id`, `:to-id`, `:navigated?`, `:current`.
     - `:rf.causa/set-registered-routes-override-for-test`,
       `:rf.causa/set-current-route-slice-override-for-test` —
       test-only override hooks.
@@ -303,20 +450,17 @@
         (map? target-db) (:rf/route target-db)
         :else            nil)))
 
-  ;; View-facing composite (focused-event lens) ---------------------------
+  ;; View-facing composite (topology-plus-overlay shape, rf2-3kjlo) -------
 
   (rf/reg-sub :rf.causa/routing-tab-data
+    :<- [:rf.causa/registered-routes]
     :<- [:rf.causa/current-route-slice]
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/focus]
-    (fn [[slice cascades focus] _query]
+    (fn [[routes-map slice cascades focus] _query]
       (let [focused-cascade (h/focused-cascade cascades
-                                               (:dispatch-id focus))
-            nav             (h/from-to-from-cascade focused-cascade slice)]
-        {:from-id    (:from-id nav)
-         :to-id      (:to-id nav)
-         :navigated? (:navigated? nav)
-         :current    slice})))
+                                               (:dispatch-id focus))]
+        (h/project-topology-data routes-map slice focused-cascade))))
 
   ;; rf2-2moh1 — register the Runtime Routing tab with the internal L4
   ;; tab registry. Per rf2-nrbs9 Mike's design call (2026-05-18) Routing

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
@@ -436,6 +436,177 @@
      :sim-url       sim-url
      :sim-result    sim-result}))
 
+;; ---- topology projection (rf2-3kjlo) -----------------------------------
+;;
+;; The Routing panel renders a topology-plus-overlay shape per spec/021 §7:
+;; the FULL routing tree is always visible (registered routes nested by
+;; their `:parent` meta) and the focused epoch's nav-token activity
+;; overlays as a `:to` / `:from` / `:here` marker on the relevant nodes.
+;;
+;; The projection produces a vector of `{:row :depth :children}` entries
+;; suitable for textual `├─ └─ │` tree rendering (per §7.1 density note —
+;; most route trees are shallow ≤ 4 levels, so the textual tree is denser
+;; than xyflow). `:parent`-less routes become tree roots; orphaned
+;; `:parent` references (parent route-id not in the registrar) also
+;; become roots so the projection never drops a row.
+
+(defn- children-by-parent
+  "Group `rows` (already projected by `project-routes`) by their
+  `:parent` route-id. Returns `{<parent-id-or-nil> [row ...]}` with
+  children stable-sorted by `:path` so the tree renders deterministic."
+  [rows]
+  (->> rows
+       (group-by :parent)
+       (reduce-kv (fn [acc parent kids]
+                    (assoc acc parent (vec (sort-by :path kids))))
+                  {})))
+
+(defn- rooted?
+  "A row is a tree root when its `:parent` is nil OR when the parent
+  reference points to a route-id that is not in the registrar. The
+  second branch keeps orphaned children visible — the projection
+  promises every row appears exactly once."
+  [row registered-ids]
+  (or (nil? (:parent row))
+      (not (contains? registered-ids (:parent row)))))
+
+(defn project-topology
+  "Project the registered-routes map into a depth-decorated topology
+  vector — the data shape the Routing panel's tree-render consumes.
+
+  Returns `[{:row <row-from-project-routes>
+             :depth <int>           ;; 0 for roots, +1 per :parent hop
+             :last-at-depth? <bool> ;; true when this row is the last
+                                    ;; sibling at its depth (used by
+                                    ;; the view to pick `└─` vs `├─`)
+             } ...]`
+
+  Routes with `:parent` references that resolve to a registered
+  route-id nest beneath that route; routes without a parent (or with
+  an orphan parent) render at depth 0. Within each parent's children,
+  rows are sorted by `:path` so the topology is deterministic.
+
+  Cycles in the `:parent` graph (e.g. A → B → A) are protected against
+  via a `visited` set — a row that would re-enter the walk is skipped
+  at the second visit. The first visit wins; the second occurrence
+  drops out so the projection terminates and rows still appear exactly
+  once."
+  [routes-map]
+  (let [rows           (project-routes routes-map)
+        registered-ids (set (map :route-id rows))
+        kids           (children-by-parent rows)
+        roots          (->> rows
+                            (filter #(rooted? % registered-ids))
+                            (sort-by :path)
+                            vec)
+        walk (fn walk [row depth visited last-sibling?]
+               (let [id (:route-id row)]
+                 (if (contains? visited id)
+                   ;; Cycle protection — drop the re-entry.
+                   []
+                   (let [visited' (conj visited id)
+                         children (get kids id [])
+                         last-idx (dec (count children))
+                         child-rows
+                         (->> children
+                              (map-indexed
+                                (fn [i child]
+                                  (walk child (inc depth) visited'
+                                        (= i last-idx))))
+                              (reduce into []))]
+                     (into [{:row            row
+                             :depth          depth
+                             :last-at-depth? (boolean last-sibling?)}]
+                           child-rows)))))
+        last-root-idx (dec (count roots))]
+    (->> roots
+         (map-indexed
+           (fn [i root]
+             (walk root 0 #{} (= i last-root-idx))))
+         (reduce into []))))
+
+;; ---- per-epoch routing-activity projection (rf2-3kjlo) ------------------
+;;
+;; The "This epoch" block (per spec/021 §7.2) reads four short lines:
+;;
+;;     Phase     :on-match
+;;     From      /
+;;     To        /cart
+;;     Match     {:route :cart}
+;;     Events    [:rf/url-changed] [:cart/route-entered]
+;;
+;; The phase derives from the trace-event mix in the focused cascade:
+;;   - cascade carries :rf.route.nav-token/allocated → :on-match
+;;     (a navigation actually landed this epoch)
+;;   - cascade carries :rf.route/navigation-blocked → :navigation-blocked
+;;   - cascade carries :rf.route/fragment-changed → :fragment-changed
+;;   - otherwise → nil (no routing activity this epoch)
+;;
+;; The phase + from/to + matched-params + the event-vector list go into
+;; the "This epoch" block; when the projection returns nil for everything
+;; the view renders the "No route activity in this epoch." caption per
+;; spec §7.2 empty-state branch.
+
+(def ^:private routing-phase-ops
+  "Trace operations that indicate a routing-related phase. Order is
+  significant: nav-token/allocated wins (the actual on-match), then
+  navigation-blocked, then fragment-changed. The first match wins."
+  [[:rf.route.nav-token/allocated :on-match]
+   [:rf.route/navigation-blocked  :navigation-blocked]
+   [:rf.route/fragment-changed    :fragment-changed]])
+
+(defn- cascade-event-vectors
+  "Collect raw event vectors from a cascade. The cascade's top-level
+  `:event` slot is the root event; the `:effects` and `:other` buckets
+  may carry `:event/dispatched` trace records whose `:tags :event`
+  carries downstream event vectors. Returns a vector of event vectors
+  in insertion order, de-duplicated by identity."
+  [cascade]
+  (when cascade
+    (let [root       (:event cascade)
+          downstream (->> (cascade-trace-events cascade)
+                          (keep (fn [ev]
+                                  (when (and (map? ev)
+                                             (= :event/dispatched
+                                                (:operation ev)))
+                                    (get-in ev [:tags :event])))))
+          all        (cond->> downstream
+                       root (cons root))]
+      (->> all
+           (filter some?)
+           distinct
+           vec))))
+
+(defn epoch-routing-activity
+  "Derive a `{:phase :events :match}` map describing what the focused
+  cascade did to the route system this epoch. Returns nil when the
+  cascade is nil OR carries no routing-related trace events (the
+  view's 'No route activity' branch).
+
+  `:phase` is one of `#{:on-match :navigation-blocked :fragment-changed}`
+  per the trace-event mix.
+  `:events` is the cascade's event-vector list (root + downstream
+  dispatches), useful for the spec §7.2 'Events' row.
+  `:match` is the matched params map when phase is `:on-match` —
+  read off the framework's slice after the navigate handler wrote it.
+
+  The view layer renders this alongside the topology overlay; both
+  read off the same focused-cascade so they stay in sync."
+  [cascade current-slice]
+  (when cascade
+    (let [trace-evs (cascade-trace-events cascade)
+          phase    (some (fn [[op phase-kw]]
+                           (when (some #(and (map? %)
+                                             (= op (:operation %)))
+                                       trace-evs)
+                             phase-kw))
+                         routing-phase-ops)]
+      (when phase
+        {:phase  phase
+         :events (cascade-event-vectors cascade)
+         :match  (when (= :on-match phase)
+                   (:params current-slice))}))))
+
 ;; ---- composite projection ----------------------------------------------
 
 (defn project-data
@@ -473,3 +644,52 @@
       :query         query
       :sim-url       sim-url
       :sim-result    sim-result})))
+
+;; ---- topology-plus-overlay composite (rf2-3kjlo) -----------------------
+
+(defn project-topology-data
+  "The view-facing composite for the Routing panel's topology-plus-overlay
+  shape (per spec/021 §7).
+
+  Returns:
+
+      {:silent?    <bool>                 ;; true when no routes registered
+       :topology   [{:row :depth :last-at-depth? :marker} ...]
+                                          ;; the full route tree, depth-decorated
+       :current    <route-slice>          ;; the active :rf/route slice
+       :from-id    <route-id-or-nil>      ;; nav origin this epoch
+       :to-id      <route-id-or-nil>      ;; nav destination this epoch
+       :navigated? <bool>                 ;; true iff focused cascade navigated
+       :activity   <map-or-nil>}          ;; per-epoch routing activity
+                                          ;; (phase + events + match);
+                                          ;; nil ⇒ \"no route activity in this
+                                          ;; epoch\" branch per spec §7.2
+
+  The topology is always the FULL tree — overlays land via `:marker`
+  on the matching rows (`:to` for the destination, `:from` for the
+  origin, `:here` for the current route when no navigation happened
+  this epoch). The view paints the topology unconditionally so the
+  operator's mental map of the registered routes stays stable across
+  epoch focus changes."
+  [routes-map current-slice focused-cascade]
+  (let [topology       (project-topology routes-map)
+        silent?        (empty? topology)
+        nav            (from-to-from-cascade focused-cascade current-slice)
+        marker-input   (assoc nav :current-id (:id current-slice))
+        decorated      (mapv (fn [{:keys [row] :as entry}]
+                               (let [marked-row (first
+                                                  (assign-markers
+                                                    [row]
+                                                    marker-input))]
+                                 (assoc entry
+                                        :row    marked-row
+                                        :marker (:marker marked-row))))
+                             topology)
+        activity       (epoch-routing-activity focused-cascade current-slice)]
+    {:silent?    silent?
+     :topology   decorated
+     :current    current-slice
+     :from-id    (:from-id nav)
+     :to-id      (:to-id nav)
+     :navigated? (:navigated? nav)
+     :activity   activity}))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -1,32 +1,46 @@
 (ns day8.re-frame2-causa.panels.routing-cljs-test
   "CLJS-side wiring + view tests for Causa's Runtime Routing tab —
-  the focused-event lens (rf2-o5f5f.3 narrows from rf2-lq0ef).
+  the topology-plus-overlay shape (rf2-3kjlo, refining rf2-o5f5f.3).
 
-  ## Scope (post-narrow)
+  ## Scope (post-rf2-3kjlo)
 
-  Per Mike's two-verbs-two-homes decision (2026-05-19), the Runtime
-  Routing tab is a focused-event lens: it surfaces the routing slice
-  of the focused event's cascade — FROM/TO chips when navigation
-  fired; otherwise an empty state pointing to Static Routes for the
-  browse verb.
+  The Runtime Routing tab is a topology-plus-overlay surface per
+  spec/021 §7: the FULL routing tree is always visible (registered
+  routes nested by `:parent` meta); the focused epoch's nav activity
+  overlays as a `:to` / `:from` / `:here` marker on the relevant
+  nodes. A 'This epoch' detail block below the tree surfaces
+  Phase / From / To / Match / Events; when the focused cascade
+  carries no routing activity, the tree still renders with `:here`
+  only and the detail block reads 'No route activity in this epoch.'.
 
-  The browse + search + Simulate-URL surface was promoted to the
-  Static Routes panel (see
-  `static/routes/panel_cljs_test.cljs`).
+  The browse + search + Simulate-URL surface lives on the Static
+  Routes panel (see `static/routes/panel_cljs_test.cljs`).
 
   ## What's under test
 
-    1. **Registry wires the lens subs** — every sub the panel reads
-       gets installed by `register-causa-handlers!`. The promoted
-       browse / search / Simulate-URL slots (now under
+    1. **Registry wires the subs** — every sub the panel reads gets
+       installed by `register-causa-handlers!`. The promoted browse /
+       search / Simulate-URL slots (now under
        `:rf.causa.static.routes/*`) are NOT registered by
        `routing/install!` anymore.
 
-    2. **Empty / oriented states** — no-nav focused event renders the
-       empty state; nav-allocated focused cascade renders the FROM/TO
-       chip row + slice detail.
+    2. **Topology always renders** — when routes are registered, the
+       topology root + each route row render regardless of focused-
+       epoch activity.
 
-    3. **Frame isolation** — every read targets `:rf/causa`'s frame."
+    3. **Per-epoch overlay** — when the focused cascade carries a
+       `:rf.route.nav-token/allocated` emit, the destination row
+       gets a `:to` marker; the prior route (when distinct) gets a
+       `:from` marker; the 'This epoch' block surfaces the phase.
+
+    4. **No-activity branch** — when focused cascade has no routing
+       trace events, 'This epoch' reads the empty caption and the
+       topology still renders.
+
+    5. **Silent state** — when no routes registered, panel renders the
+       silent-by-default caption (no topology, no detail block).
+
+    6. **Frame isolation** — every read targets `:rf/causa`'s frame."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -76,6 +90,13 @@
             node))
         (hiccup-seq tree)))
 
+(defn- all-by-testid [tree testid]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (= testid (:data-testid (second node)))))
+          (hiccup-seq tree)))
+
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {}))
@@ -85,7 +106,8 @@
 (def cart-routes
   {:route/cart      {:path "/cart"      :doc "cart"}
    :route/checkout  {:path "/checkout"  :doc "checkout"}
-   :route/payment   {:path "/checkout/payment"}
+   :route/payment   {:path "/checkout/payment"
+                     :parent :route/checkout}
    :route/confirm   {:path "/checkout/confirm"
                      :parent :route/checkout
                      :on-match [:confirm/load]}})
@@ -98,8 +120,8 @@
 
 ;; ---- (1) registry wiring + tab inventory --------------------------------
 
-(deftest registry-installs-routing-lens-subs
-  (testing "register-causa-handlers! installs the focused-event lens subs"
+(deftest registry-installs-routing-subs
+  (testing "register-causa-handlers! installs the topology-plus-overlay subs"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/registered-routes))
         ":rf.causa/registered-routes sub registered (shared with Static)")
@@ -110,7 +132,7 @@
     (is (some? (registrar/handler :sub :rf.causa/current-route-slice-override))
         "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.causa/routing-tab-data))
-        "view-facing focused-event-lens composite sub registered")
+        "view-facing topology-plus-overlay composite sub registered")
     (is (some? (registrar/handler :event :rf.causa/set-registered-routes-override-for-test))
         "test-only override event registered")
     (is (some? (registrar/handler :event :rf.causa/set-current-route-slice-override-for-test))
@@ -139,10 +161,10 @@
       (is (= 9 (count panels))
           "exactly 9 entries — Event / App DB / Views / Trace / Machines / Machines Canvas / Routing / Issues / Chrome A11y (rf2-mkpnb + rf2-5r2yj)"))))
 
-;; ---- (2) empty state ---------------------------------------------------
+;; ---- (2) topology base layer (always visible) ---------------------------
 
-(deftest panel-renders-empty-state-without-nav-cascade
-  (testing "no focused-event nav → empty orientation pointing to Static Routes"
+(deftest panel-renders-topology-when-routes-registered
+  (testing "topology base layer renders for every registered route"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -155,22 +177,60 @@
             "panel root present")
         (is (some? (find-by-testid tree "rf-causa-routing-header"))
             "header always renders")
-        (is (some? (find-by-testid tree "rf-causa-routing-empty"))
-            "empty orientation rendered when focused event did not navigate")
-        (is (nil? (find-by-testid tree "rf-causa-routing-nav-row"))
-            "FROM/TO row NOT rendered without nav cascade")
-        ;; Promoted browse surfaces MUST NOT be present anymore
-        (is (nil? (find-by-testid tree "rf-causa-routing-list"))
-            "flat list NOT rendered (promoted to Static Routes)")
-        (is (nil? (find-by-testid tree "rf-causa-routing-search"))
-            "search NOT rendered (promoted to Static Routes)")
-        (is (nil? (find-by-testid tree "rf-causa-routing-sim"))
-            "Simulate-URL NOT rendered (promoted to Static Routes)")))))
+        (is (some? (find-by-testid tree "rf-causa-routing-topology"))
+            "topology always renders when routes are registered")
+        ;; Each route gets a topology-row entry.
+        (doseq [rid (keys cart-routes)]
+          (is (some? (find-by-testid tree
+                       (str "rf-causa-routing-topology-row-" (name rid))))
+              (str "topology row rendered for " rid)))
+        (is (some? (find-by-testid tree "rf-causa-routing-this-epoch"))
+            "'This epoch' detail block always renders")))))
 
-;; ---- (3) FROM / TO chip row when focused cascade navigated -------------
+(deftest panel-renders-silent-when-no-routes
+  (testing "no routes registered → silent caption + no topology"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing"))
+            "panel root present")
+        (is (some? (find-by-testid tree "rf-causa-routing-header"))
+            "header still renders")
+        (is (some? (find-by-testid tree "rf-causa-routing-silent"))
+            "silent caption rendered for empty registrar")
+        (is (nil? (find-by-testid tree "rf-causa-routing-topology"))
+            "topology NOT rendered when no routes registered")
+        (is (nil? (find-by-testid tree "rf-causa-routing-this-epoch"))
+            "'This epoch' block NOT rendered when silent")))))
 
-(deftest panel-renders-from-to-when-cascade-navigated
-  (testing "focused cascade with nav-token emit → FROM + TO chip row + slice detail"
+;; ---- (3) no-activity branch (focused epoch with no routing trace) -------
+
+(deftest panel-renders-no-activity-when-cascade-has-no-routing
+  (testing "focused cascade with no routing trace events → topology renders + 'No route activity'"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-topology"))
+            "topology renders unconditionally")
+        (is (some? (find-by-testid tree "rf-causa-routing-no-activity"))
+            "'No route activity' caption rendered")
+        ;; current-route highlight as `:here`
+        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-here"))
+            "current route gets :here marker when no nav this epoch")
+        (is (nil? (find-by-testid tree "rf-causa-routing-detail-phase"))
+            "phase detail NOT rendered when no activity")))))
+
+;; ---- (4) per-epoch overlay (focused cascade with nav-token emit) --------
+
+(deftest panel-paints-to-marker-when-cascade-navigated
+  (testing "focused cascade with nav-token emit → :to marker + Phase :on-match"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -190,30 +250,29 @@
                           {:frame :rf/causa})
         (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
       (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-nav-row"))
-            "FROM/TO chip row rendered")
-        ;; FROM cell does NOT render here — no prior slice id distinct
-        ;; from confirm, so from-to-from-cascade collapses :from-id.
-        ;; The TO cell + nav marker chips MUST render.
-        (is (some? (find-by-testid tree "rf-causa-routing-to-cell"))
-            "TO cell rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-marker-to"))
-            "TO marker chip text rendered")
+        ;; Topology still renders.
+        (is (some? (find-by-testid tree "rf-causa-routing-topology")))
+        ;; :to marker present on the destination row.
+        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-to"))
+            ":to marker rendered on destination route in the topology")
+        ;; Header summary surfaces the TO id.
         (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
-            "header nav summary surfaces the TO id")
-        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
-            "slice detail grid rendered alongside nav row")
-        (is (nil? (find-by-testid tree "rf-causa-routing-empty"))
-            "empty state NOT rendered when navigation triggered")))))
+            "header carries → TO summary chip")
+        ;; This-epoch detail block surfaces Phase :on-match.
+        (is (some? (find-by-testid tree "rf-causa-routing-detail-phase"))
+            "'Phase' value rendered in This-epoch block")
+        (is (some? (find-by-testid tree "rf-causa-routing-detail-to"))
+            "'To' value rendered in This-epoch block")
+        (is (nil? (find-by-testid tree "rf-causa-routing-no-activity"))
+            "empty-state caption NOT rendered when activity present")))))
 
-(deftest panel-renders-from-and-to-when-prior-slice-differs
-  (testing "focused cascade with nav-token emit + distinct prior slice → FROM + TO"
+(deftest panel-paints-from-and-to-when-prior-slice-differs
+  (testing "focused cascade with distinct prior slice → both :from and :to markers"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/causa})
-      ;; Prior slice = :route/cart (will be the FROM after the nav lands on
-      ;; :route/confirm).
+      ;; Prior slice = :route/cart; navigate to :route/confirm.
       (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
                          {:id :route/cart :params {} :query {}}]
                         {:frame :rf/causa})
@@ -227,11 +286,9 @@
                           {:frame :rf/causa})
         (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
       (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-from-cell"))
-            "FROM cell rendered (prior slice = :route/cart)")
-        (is (some? (find-by-testid tree "rf-causa-routing-marker-from"))
-            "FROM marker chip rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-to-cell"))
-            "TO cell rendered (nav destination = :route/confirm)")
-        (is (some? (find-by-testid tree "rf-causa-routing-marker-to"))
-            "TO marker chip rendered")))))
+        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-from"))
+            ":from marker rendered on origin route")
+        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-to"))
+            ":to marker rendered on destination route")
+        (is (some? (find-by-testid tree "rf-causa-routing-detail-from"))
+            "'From' value rendered in This-epoch block")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
@@ -451,3 +451,227 @@
       ;; Slot shape still carries path (registered) but no params (no match).
       (is (= "/cart" (:path pv)))
       (is (not (contains? (:slot-shape pv) :params))))))
+
+;; ---- project-topology (rf2-3kjlo) ---------------------------------------
+
+(def parented-routes
+  "Registrar with explicit `:parent` references so the topology
+  projection can build a non-trivial tree. /checkout has two child
+  routes; the rest sit at depth 0."
+  {:route/root      (route "/")
+   :route/cart      (route "/cart")
+   :route/checkout  (route "/checkout")
+   :route/payment   (route "/checkout/payment"
+                           :parent :route/checkout)
+   :route/confirm   (route "/checkout/confirm"
+                           :parent :route/checkout)
+   :route/admin     (route "/admin")})
+
+(deftest project-topology-empty-test
+  (testing "empty registrar yields []"
+    (is (= [] (h/project-topology {})))))
+
+(deftest project-topology-depth-and-shape-test
+  (testing "every registered route appears exactly once in the projection"
+    (let [topology (h/project-topology parented-routes)
+          by-id    (group-by #(-> % :row :route-id) topology)]
+      (is (= (count parented-routes) (count topology))
+          "topology row count equals registrar size")
+      (doseq [rid (keys parented-routes)]
+        (is (= 1 (count (get by-id rid)))
+            (str rid " appears exactly once in the projection")))))
+
+  (testing "parented children land at depth = parent depth + 1"
+    (let [topology (h/project-topology parented-routes)
+          by-id    (into {} (map (juxt #(-> % :row :route-id) :depth))
+                         topology)]
+      (is (= 0 (get by-id :route/checkout))
+          ":route/checkout sits at depth 0 (no parent)")
+      (is (= 1 (get by-id :route/payment))
+          ":route/payment sits at depth 1 under :route/checkout")
+      (is (= 1 (get by-id :route/confirm))
+          ":route/confirm sits at depth 1 under :route/checkout")
+      (is (= 0 (get by-id :route/admin)) ":route/admin stays at depth 0")))
+
+  (testing "children appear after their parent (DFS order)"
+    (let [topology (h/project-topology parented-routes)
+          ids      (mapv #(-> % :row :route-id) topology)
+          ck-idx   (.indexOf ids :route/checkout)
+          pay-idx  (.indexOf ids :route/payment)
+          conf-idx (.indexOf ids :route/confirm)]
+      (is (< ck-idx pay-idx) ":route/checkout precedes :route/payment")
+      (is (< ck-idx conf-idx) ":route/checkout precedes :route/confirm")))
+
+  (testing "last-at-depth? flag marks last sibling at each depth"
+    (let [topology (h/project-topology parented-routes)
+          last-by-id (into {} (map (juxt #(-> % :row :route-id) :last-at-depth?))
+                           topology)]
+      ;; Within :route/checkout's children paths sort lexicographically:
+      ;; "/checkout/confirm" < "/checkout/payment", so :route/payment is
+      ;; the last child at depth 1.
+      (is (true? (get last-by-id :route/payment))
+          ":route/payment is the last sibling at depth 1 under /checkout")
+      (is (false? (get last-by-id :route/confirm))
+          ":route/confirm is not the last sibling at depth 1"))))
+
+(deftest project-topology-orphan-parent-test
+  (testing "rows whose :parent points to an unregistered route become roots"
+    (let [orphan-routes {:route/orphan
+                         (route "/orphan" :parent :route/missing)
+                         :route/root (route "/")}
+          topology (h/project-topology orphan-routes)
+          orphan-entry (some #(when (= :route/orphan (-> % :row :route-id)) %)
+                             topology)]
+      (is (some? orphan-entry) "orphan still appears in topology")
+      (is (= 0 (:depth orphan-entry))
+          "orphan rendered at depth 0 (parent reference broken)"))))
+
+(deftest project-topology-cycle-protection-test
+  (testing "a cycle in the :parent graph does not loop"
+    ;; A → B → A. Neither has a nil parent; both should still appear
+    ;; (the rooted? predicate treats them as roots since neither's
+    ;; parent points to nil, BUT the registered-ids set DOES contain
+    ;; both ids — so they're NOT rooted via the orphan branch. They
+    ;; ARE rooted only when their parent isn't in registered-ids.
+    ;; With both parents registered they wouldn't be roots — which
+    ;; means the walk-from-roots never includes them. Test the milder
+    ;; cycle case: a self-cycle.
+    (let [self-cycle {:route/self
+                      (route "/self" :parent :route/self)
+                      :route/root (route "/")}
+          topology (h/project-topology self-cycle)
+          ids      (mapv #(-> % :row :route-id) topology)]
+      ;; :route/root appears; :route/self may or may not (it's a self-
+      ;; root via the cycle-protection branch). Critically, the call
+      ;; must terminate and return a vector.
+      (is (vector? topology) "projection terminates on self-cycle")
+      (is (contains? (set ids) :route/root)
+          "non-cycling routes still appear"))))
+
+;; ---- epoch-routing-activity (rf2-3kjlo) ---------------------------------
+
+(deftest epoch-routing-activity-no-cascade-test
+  (testing "nil cascade → nil activity"
+    (is (nil? (h/epoch-routing-activity nil nil)))
+    (is (nil? (h/epoch-routing-activity nil {:id :route/cart})))))
+
+(deftest epoch-routing-activity-no-routing-trace-test
+  (testing "cascade with no routing trace events → nil (no activity)"
+    (let [c (cascade 1 [:counter/inc])]
+      (is (nil? (h/epoch-routing-activity c {:id :route/cart}))))))
+
+(deftest epoch-routing-activity-on-match-test
+  (testing "nav-token-allocated emit → phase :on-match + match params"
+    (let [c (cascade 7 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-1")])
+          activity (h/epoch-routing-activity c {:id :route/confirm
+                                                :params {:order-id "x"}})]
+      (is (some? activity))
+      (is (= :on-match (:phase activity)))
+      (is (= {:order-id "x"} (:match activity))
+          "match surfaces the slice's params when phase is :on-match"))))
+
+(deftest epoch-routing-activity-events-test
+  (testing "events list carries root event vector + downstream dispatches"
+    (let [downstream {:id 8 :op-type :event :operation :event/dispatched
+                      :tags {:event [:cart/route-entered]}}
+          c (cascade 7 [:rf.route/navigate :route/cart]
+              :other [(nav-allocated-trace :route/cart "nav-1")
+                      downstream])
+          activity (h/epoch-routing-activity c {:id :route/cart})]
+      (is (= [[:rf.route/navigate :route/cart]
+              [:cart/route-entered]]
+             (:events activity))))))
+
+(deftest epoch-routing-activity-navigation-blocked-test
+  (testing "navigation-blocked emit → phase :navigation-blocked + nil match"
+    (let [blocked-ev {:id 1 :op-type :event
+                      :operation :rf.route/navigation-blocked
+                      :tags {:route-id :route/admin}}
+          c (cascade 1 [:rf.route/navigate :route/admin]
+              :other [blocked-ev])
+          activity (h/epoch-routing-activity c {:id :route/cart})]
+      (is (= :navigation-blocked (:phase activity)))
+      (is (nil? (:match activity))
+          "match is only surfaced when phase is :on-match"))))
+
+(deftest epoch-routing-activity-fragment-changed-test
+  (testing "fragment-changed emit → phase :fragment-changed"
+    (let [frag-ev {:id 1 :op-type :event
+                   :operation :rf.route/fragment-changed
+                   :tags {:fragment "step-2"}}
+          c (cascade 1 [:foo] :other [frag-ev])
+          activity (h/epoch-routing-activity c {:id :route/cart})]
+      (is (= :fragment-changed (:phase activity))))))
+
+;; ---- project-topology-data composite (rf2-3kjlo) ------------------------
+
+(deftest project-topology-data-silent-test
+  (testing "no routes registered → silent? true, empty topology, nil activity"
+    (let [data (h/project-topology-data {} {:id :route/cart} nil)]
+      (is (true? (:silent? data)))
+      (is (= [] (:topology data)))
+      (is (nil? (:activity data)))
+      (is (false? (:navigated? data))))))
+
+(deftest project-topology-data-topology-shape-test
+  (testing "topology vector mirrors project-topology + carries marker"
+    (let [data (h/project-topology-data parented-routes
+                                        {:id :route/cart}
+                                        nil)
+          ids  (mapv #(-> % :row :route-id) (:topology data))]
+      (is (false? (:silent? data)))
+      (is (= (count parented-routes) (count (:topology data))))
+      (is (contains? (set ids) :route/cart))
+      ;; No focused cascade ⇒ no activity; current slice ⇒ HERE marker
+      ;; on :route/cart only.
+      (let [marker-by-id (into {}
+                               (map (juxt #(-> % :row :route-id) :marker))
+                               (:topology data))]
+        (is (= :here (get marker-by-id :route/cart))
+            ":route/cart carries :here marker (current slice id)")
+        (is (nil? (get marker-by-id :route/admin))
+            "non-current routes carry no marker")))))
+
+(deftest project-topology-data-overlay-test
+  (testing "focused cascade caused navigation → :to overlay + :on-match phase"
+    (let [c (cascade 42 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-9" 42)])
+          data (h/project-topology-data parented-routes
+                                        {:id :route/confirm
+                                         :params {:x 1}}
+                                        c)
+          marker-by-id (into {}
+                             (map (juxt #(-> % :row :route-id) :marker))
+                             (:topology data))]
+      (is (true? (:navigated? data)))
+      (is (= :route/confirm (:to-id data)))
+      (is (= :to (get marker-by-id :route/confirm)))
+      (is (some? (:activity data)))
+      (is (= :on-match (-> data :activity :phase)))
+      (is (= {:x 1} (-> data :activity :match)))))
+
+  (testing "focused cascade with distinct prior slice paints both :from and :to"
+    (let [c (cascade 1 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-3")])
+          data (h/project-topology-data parented-routes {:id :route/cart} c)
+          marker-by-id (into {}
+                             (map (juxt #(-> % :row :route-id) :marker))
+                             (:topology data))]
+      (is (= :from (get marker-by-id :route/cart)))
+      (is (= :to   (get marker-by-id :route/confirm))))))
+
+(deftest project-topology-data-no-activity-test
+  (testing "focused cascade has no routing trace events → activity nil; HERE still paints"
+    (let [c (cascade 9 [:counter/inc])
+          data (h/project-topology-data parented-routes
+                                        {:id :route/cart}
+                                        c)
+          marker-by-id (into {}
+                             (map (juxt #(-> % :row :route-id) :marker))
+                             (:topology data))]
+      (is (false? (:navigated? data)))
+      (is (nil? (:activity data))
+          "activity is nil when cascade has no routing trace events")
+      (is (= :here (get marker-by-id :route/cart))
+          "current route still gets :here marker"))))


### PR DESCRIPTION
Closes rf2-3kjlo. Per spec/021 §7.

Topology-plus-overlay: full routing tree always visible; focused-epoch transition highlighted on top. Head-fallback for nil focus is inherited from `:rf.causa/focus` (spine's `compose-focus` already resolves head when no user focus set).

## What changed

- `tools/causa/src/.../panels/routing.cljs` — rewritten to topology+overlay:
  - Always-visible `Active route tree` (depth-decorated tree of registered routes nested by `:parent` meta, with `├─ └─` box-drawing prefixes per spec §7.2)
  - Per-epoch overlay markers on the relevant rows: `:to` green ◉ (destination), `:from` cyan ◇ (origin), `:here` yellow ● (current active when no nav this epoch)
  - `This epoch` detail block underneath — Phase / From / To / Match / Events (or 'No route activity in this epoch.' caption when focused cascade carries no routing trace)
  - Silent state when no routes registered (no topology, no detail block)
- `tools/causa/src/.../panels/routing_helpers.cljc` — additive helpers:
  - `project-topology` — registrar map → depth-decorated tree vector; orphan-parent + self-cycle protection
  - `epoch-routing-activity` — detects `:on-match` / `:navigation-blocked` / `:fragment-changed` phases from cascade trace events; surfaces event-vector list
  - `project-topology-data` — composite folding topology + overlay + activity
- `:rf.causa/routing-tab-data` sub rewired to `project-topology-data` (new shape: `:silent? :topology :activity :from-id :to-id :navigated? :current`)
- CLJS unit tests covering topology projection, activity detection, composite shape, panel render branches (silent / no-activity / overlay)

## Surface

Clean on `tools/causa/src/.../panels/routing.{cljs,helpers}` (did NOT touch `shell.cljs` per rf2-h0120 worker boundary).

## Gates

- `npm run test:cljs` — 3708 tests / 10746 assertions, 0 failures, 0 errors
- `npm run test:bundle-isolation` — PASS
- `mkdocs build --strict` — PASS

CLJS unit tests only.