### PR TITLE
feat(causa): Machines topology — always-visible empty-state refinement (rf2-dbi87)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
@@ -346,10 +346,31 @@
                         (name ev*))))))
        set))
 
+(defn- to-path-from-trace
+  "Pull the `:to` state path off a `:rf.machine/transition` trace
+  event. Tolerant of three shapes:
+
+    1. Modern runtime: `:tags {:after {:state ...}}` (per
+       `lifecycle_fx/registration` `trace/emit!` of
+       `:rf.machine/transition`).
+    2. Legacy/test fixtures: top-level `:to` or `:tags :to`.
+    3. Pre-rf2-hwuki: `:payload :to`.
+
+  Returns the normalised path vector or nil."
+  [ev]
+  (let [after-state (get-in ev [:tags :after :state])
+        to          (or (get-in ev [:tags :to])
+                        (:to ev)
+                        (get-in ev [:payload :to]))]
+    (normalise-path (or after-state to))))
+
 (defn current-state-from-traces
   "Resolve the current-state path for `machine-id` from the
   `:rf.machine/transition` trace events vector. Returns the `:to`
-  path of the most recent matching trace, or nil. Pure."
+  path of the most recent matching trace, or nil. Pure.
+
+  Reads modern (`:tags :after :state`) + legacy (`:to`,
+  `:payload :to`) shapes — see `to-path-from-trace`."
   [trace-events machine-id]
   (let [matching (filter (fn [ev]
                            (and (= :rf.machine/transition (:operation ev))
@@ -357,5 +378,27 @@
                                     (= machine-id (get-in ev [:tags :machine-id])))))
                          (or trace-events []))]
     (when-let [last-ev (last matching)]
-      (normalise-path (or (:to last-ev)
-                          (get-in last-ev [:payload :to]))))))
+      (to-path-from-trace last-ev))))
+
+(defn current-state-from-epoch-history
+  "Walk `epoch-history` (a vector of epoch records, oldest-first per
+  `:rf/epoch-record`) backwards looking for the most recent
+  `:rf.machine/transition` trace for `machine-id`. Returns the `:to`
+  path of that transition, or nil if no transition for `machine-id`
+  appears anywhere in history.
+
+  Per spec/021 §6.3 (Queries / Per-frame state · current-state ●
+  annotation for case B): when the focused epoch has no transition,
+  the panel still renders topology with the most-recent-known state
+  annotated. This helper is the historical fallback caller — the view
+  layer composes it with `current-state-from-traces` (focused epoch)
+  + live snapshot `:state`.
+
+  Pure fn — JVM-runnable."
+  [epoch-history machine-id]
+  (let [history (vec (or epoch-history []))]
+    (loop [i (dec (count history))]
+      (when (>= i 0)
+        (let [events (get-in history [i :trace-events])
+              found  (current-state-from-traces events machine-id)]
+          (or found (recur (dec i))))))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
@@ -20,13 +20,24 @@
 
   ## current-state overlay
 
-  Two sources feed the `current-state-path` arg:
+  Four sources feed the `current-state-path` arg (precedence high → low):
 
-    1. Caller-supplied `:current-state-path` (highest priority).
+    1. Caller-supplied `:current-state-path` (explicit override).
     2. Caller-supplied `:trace-events` (the focused-epoch's
        `:rf.machine/transition` slice) — `topology/current-state-
        from-traces` resolves the `:to` of the most recent matching
        trace.
+    3. Caller-supplied `:epoch-history` (oldest-first vector of epoch
+       records) — `topology/current-state-from-epoch-history` walks
+       backward through prior epochs for the most recent transition
+       this machine took. This is the **case-B refinement** per
+       spec/021 §6.2 / §17.4.1 (rf2-dbi87): when the focused epoch
+       has no transition, the topology is STILL rendered and the
+       last-seen state is annotated as `:current`.
+    4. Caller-supplied `:snapshot-state` (the machine's live
+       `:state` keyword, off `(get-in app-db [:rf/machines <id>])`).
+       Used when the buffer carries no transition for this machine
+       at all — most-recent-known state from the live snapshot.
 
   ## Pure-hiccup contract
 
@@ -40,10 +51,25 @@
             [day8.re-frame2-causa.theme.tokens :as t :refer [tokens]]))
 
 (defn- resolve-current-state-path
-  "Per-spec precedence: explicit > traces > nil."
-  [machine-id current-state-path trace-events]
+  "Per-spec precedence (high → low): explicit > focused-epoch traces >
+  epoch-history walk-back > live snapshot `:state` > nil.
+
+  The walk-back + snapshot fallbacks are the case-B refinement per
+  spec/021 §6.2 / §17.4.1 (rf2-dbi87) — even when the focused epoch
+  has no transition, render the topology with the most-recent-known
+  state annotated as `:current`."
+  [machine-id current-state-path trace-events epoch-history snapshot-state]
   (or current-state-path
-      (topology/current-state-from-traces trace-events machine-id)))
+      (topology/current-state-from-traces trace-events machine-id)
+      (topology/current-state-from-epoch-history epoch-history machine-id)
+      ;; Live-snapshot fallback. The snapshot's `:state` slot is a
+      ;; bare keyword per Spec 005 §State; coerce to a path vector
+      ;; via `normalise-path` (vector / keyword / nil are all handled).
+      (when (some? snapshot-state)
+        (cond
+          (keyword? snapshot-state) [snapshot-state]
+          (vector? snapshot-state)  snapshot-state
+          :else                     nil))))
 
 (defn Topology
   "Render a machine's topology via xyflow. Args (map):
@@ -53,11 +79,22 @@
     :definition          — machine definition map (required; nil
                            renders the no-definition fallback).
     :current-state-path  — optional explicit current-state path (a
-                           vector of keywords). Overrides trace-
-                           derived current-state.
+                           vector of keywords). Highest-precedence
+                           current-state source.
     :trace-events        — optional vector of focused-epoch trace
                            events. Used to derive the current-state +
                            `fired-this-epoch` edge highlights.
+    :epoch-history       — optional oldest-first vector of epoch
+                           records. Walked backwards for the most-
+                           recent-known transition for this machine
+                           when the focused epoch has none (case B
+                           per spec/021 §6.2).
+    :snapshot-state      — optional live snapshot state (a keyword or
+                           a path vector — per Spec 005 §State).
+                           Used as the final fallback for the
+                           current-state ● annotation when neither the
+                           focused epoch nor the history buffer carries
+                           a transition for this machine.
     :height              — outer wrapper height (default `'320px'`).
                            xyflow requires a non-zero parent height.
     :show-controls?      — pass-through to wrapper (default true).
@@ -66,14 +103,22 @@
 
   Returns hiccup."
   [{:keys [machine-id definition current-state-path trace-events
-           height show-controls? testid]
+           epoch-history snapshot-state height show-controls? testid]
     :or   {height          "320px"
            show-controls?  true
            testid          "rf-causa-machines-topology"}}]
   (let [cur-path  (resolve-current-state-path machine-id
                                               current-state-path
-                                              trace-events)
+                                              trace-events
+                                              epoch-history
+                                              snapshot-state)
         fired-ids (topology/extract-fired-edge-ids trace-events machine-id)
+        ;; Case-B detection (rf2-dbi87 / spec/021 §6.2): the focused
+        ;; epoch fired no transitions for this machine. The view STILL
+        ;; renders the topology — only the fired-this-epoch overlay is
+        ;; absent. Surfaces as a data attribute so tests + downstream
+        ;; views can assert the empty-state shape.
+        no-transition-this-epoch? (empty? fired-ids)
         graph     (topology/project
                     {:definition         definition
                      :current-state-path cur-path
@@ -105,6 +150,15 @@
              :data-current-state (when cur-path (pr-str cur-path))
              :data-node-count (str (count (:nodes graph)))
              :data-edge-count (str (count (:edges graph)))
+             :data-no-transition-this-epoch (str no-transition-this-epoch?)
+             :data-current-state-source (cond
+                                          current-state-path "explicit"
+                                          (topology/current-state-from-traces
+                                            trace-events machine-id) "trace-events"
+                                          (topology/current-state-from-epoch-history
+                                            epoch-history machine-id) "epoch-history"
+                                          (some? snapshot-state) "snapshot"
+                                          :else "none")
              :style {:position "relative"
                      :width  "100%"
                      :height height

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
@@ -244,3 +244,123 @@
     (is (= #{} (topology/extract-fired-edge-ids nil :cart)))
     (is (= #{} (topology/extract-fired-edge-ids
                  [{:operation :something-else}] :cart)))))
+
+;; ---- rf2-dbi87: always-visible empty-state (Case B) --------------------
+;;
+;; Per spec/021 §6.2 Case B + §17.4.1 — when the focused epoch has NO
+;; machine transition, the topology MUST still render with the most-
+;; recent-known state annotated as :current. The projector keeps emitting
+;; the full topology unchanged (Case B is a render-layer concern); these
+;; tests pin the helpers that resolve "most-recent-known" from sources
+;; OUTSIDE the focused epoch (epoch-history walk-back + runtime trace
+;; shapes).
+
+(deftest project-emits-full-graph-with-no-fired-edges
+  (testing "case-B render: full topology + current-state overlay, no fired"
+    (let [out         (topology/project
+                        {:definition         (toy-definition)
+                         :current-state-path [:populated]
+                         :fired-edge-ids     #{}})
+          edges-kinds (into #{} (map #(-> % :data :kind) (:edges out)))
+          nodes-by-lb (into {} (map (juxt #(-> % :data :label) identity)
+                                    (:nodes out)))]
+      (is (= 3 (count (:nodes out)))
+          "all states still emit")
+      (is (= 2 (count (:edges out)))
+          "all transitions still emit (no overlay arrows added)")
+      (is (= #{:registered} edges-kinds)
+          "no edge is :fired-this-epoch when fired-edge-ids is empty")
+      (is (= :current (-> nodes-by-lb (get "populated") :data :kind))
+          "current-state overlay still annotates the matching node"))))
+
+(deftest current-state-from-traces-reads-tags-after-state
+  (testing "modern runtime shape: :tags {:after {:state ...}}"
+    ;; Per lifecycle_fx/registration the runtime stamps
+    ;;   {:tags {:after  {:state <to-kw> ...}
+    ;;           :before {:state <from-kw> ...}
+    ;;           :machine-id <id>}}
+    ;; The legacy top-level :to slot still works (existing tests pin it).
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :cart
+                               :after      {:state :populated}}}]]
+      (is (= [:populated]
+             (topology/current-state-from-traces events :cart))))))
+
+(deftest current-state-from-traces-prefers-modern-shape-over-legacy
+  (testing "when both :after :state AND legacy :to are present, modern wins"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :cart
+                               :after      {:state :populated}
+                               :to         :should-be-ignored}}]]
+      ;; Per to-path-from-trace: `(or after-state to)` — `after-state`
+      ;; wins when present.
+      (is (= [:populated]
+             (topology/current-state-from-traces events :cart))))))
+
+(deftest current-state-from-epoch-history-walks-back
+  (testing "walks epoch-history newest→oldest, returns most-recent :to"
+    (let [history [{:epoch-id 1
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :cart}
+                                    :from [:empty] :to [:populated]
+                                    :event :populate}]}
+                   {:epoch-id 2
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :cart}
+                                    :from [:populated] :to [:submitting]
+                                    :event :submit}]}
+                   ;; Epoch 3 has no machine activity — the walk
+                   ;; back skips it and picks epoch 2's :submitting.
+                   {:epoch-id 3
+                    :trace-events [{:operation :something-else}]}]]
+      (is (= [:submitting]
+             (topology/current-state-from-epoch-history history :cart))))))
+
+(deftest current-state-from-epoch-history-empty-cases
+  (testing "nil history → nil"
+    (is (nil? (topology/current-state-from-epoch-history nil :cart))))
+  (testing "empty history → nil"
+    (is (nil? (topology/current-state-from-epoch-history [] :cart))))
+  (testing "history with no transition for this machine → nil"
+    (let [history [{:epoch-id 1 :trace-events []}
+                   {:epoch-id 2 :trace-events [{:operation :something-else}]}]]
+      (is (nil? (topology/current-state-from-epoch-history history :cart))))))
+
+(deftest current-state-from-epoch-history-scopes-by-machine-id
+  (testing "ignores transitions belonging to other machines"
+    (let [history [{:epoch-id 1
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :other}
+                                    :from [:x] :to [:y]
+                                    :event :wrong-machine}]}
+                   {:epoch-id 2
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :cart}
+                                    :from [:empty] :to [:populated]
+                                    :event :populate}]}]]
+      (is (= [:populated]
+             (topology/current-state-from-epoch-history history :cart))))))
+
+(deftest current-state-from-epoch-history-reads-modern-shape
+  (testing "epoch-history walk-back honours the modern :tags :after :state shape"
+    (let [history [{:epoch-id 1
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :cart
+                                           :after {:state :authing}}}]}]]
+      (is (= [:authing]
+             (topology/current-state-from-epoch-history history :cart))))))
+
+(deftest current-state-from-epoch-history-picks-latest-within-epoch
+  (testing "within an epoch's trace-events, the LAST matching transition wins"
+    (let [history [{:epoch-id 1
+                    :trace-events [{:operation :rf.machine/transition
+                                    :tags {:machine-id :cart}
+                                    :from [:empty] :to [:populated]
+                                    :event :populate}
+                                   ;; Microstep after — should be picked.
+                                   {:operation :rf.machine/transition
+                                    :tags {:machine-id :cart}
+                                    :from [:populated] :to [:submitting]
+                                    :event :submit}]}]]
+      (is (= [:submitting]
+             (topology/current-state-from-epoch-history history :cart))))))


### PR DESCRIPTION
Closes rf2-dbi87. Extends #1748 (rf2-uwvyj xyflow Phase C).

Per spec/021 §6.2 Case B + §17.4.1, when the focused epoch has no machine transition the Machines panel should still render the full topology with the most-recent-known state annotated as `:current` — not a blank surface.

## Surface

* `tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs`
  - `to-path-from-trace` (new private): tolerate modern (`:tags :after :state`), legacy (`:to` / `:tags :to`), and pre-rf2-hwuki (`:payload :to`) shapes.
  - `current-state-from-traces`: read modern `:tags :after :state` shape (back-compatible with the legacy `:to` slot the existing tests pin).
  - `current-state-from-epoch-history` (new public): walk an oldest-first vector of epoch records newest→oldest and return the `:to` path of the most-recent `:rf.machine/transition` for a machine-id. Pure; JVM-runnable.

* `tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs`
  - `resolve-current-state-path` precedence extended to 4 sources: explicit > focused-epoch traces > epoch-history walk-back > live snapshot `:state`.
  - `Topology` accepts new `:epoch-history` + `:snapshot-state` args.
  - Root div carries `:data-no-transition-this-epoch` + `:data-current-state-source` attributes so tests / downstream callers can assert the case-B shape.

* `tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs`
  - +9 new tests (one Case-B render assertion + one modern-shape variant on the existing helper + 7 history walk-back coverage tests).

## current-state lookup precedence

1. Caller-supplied `:current-state-path` (explicit override).
2. Focused-epoch `:trace-events` (most-recent transition `:to`).
3. **`:epoch-history` walk-back** (rf2-dbi87 — the new fallback).
4. Live `:snapshot-state` keyword/path (Spec 005 §State).
5. nil.

The xyflow wrapper from #1748 is unchanged — only the projection + view-layer resolution surfaces gain the new fallbacks.

## Gates

* `npm run test:cljs` — 3690 tests / 10671 assertions, 0 failures.
* `npm run test:bundle-isolation` — PASS, 13 artefact entries, 29 sentinels absent, 3 allow-list budgets ok.
* `mkdocs build --strict` — exit 0.

## Out of scope

The Machine Inspector `blank-state` integration (`machine_inspector.cljs`) — which would actually surface case-B topology in the running panel — is a separate follow-on bead. This PR delivers the always-visible projection + resolution primitive; the panel integration uses these helpers when filed.