### PR TITLE
feat(causa): registry-side sub input-paths walk · path-filtered downstream-subs (rf2-gblq6)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
@@ -1,5 +1,5 @@
 (ns day8.re-frame2-causa.panels.app-db-diff-downstream
-  "App-DB panel — downstream-subs overlay (rf2-op9v2).
+  "App-DB panel — downstream-subs overlay (rf2-op9v2 → rf2-gblq6).
 
   Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §4.4 — hover (or
   click) any changed app-db path → popover lists subs and views
@@ -8,21 +8,20 @@
   navigates to the Reactive panel (tab key `:views`, rebadged
   'Reactive' per rf2-wyvf2 / PR #1741).
 
-  ## MVP (rf2-op9v2)
+  ## Path-filtering (rf2-gblq6)
 
-  The cascade aggregate `:rf.cascade/captured` (#1729) carries
-  per-cascade `:subs-recomputed` / `:subs-skipped` / `:views-rendered`
-  vectors but does NOT yet carry per-sub `:input-paths` attribution.
-  Without that, filtering 'subs depending on path X' surgically is not
-  possible from the trace stream alone — the registry-side input-paths
-  lookup would be needed.
+  rf2-op9v2 (PR #1747) shipped the popover as MVP — full cascade, no
+  path filter. rf2-gblq6 (this rev) adds the registry-side walk
+  (`panels.shared.sub-input-paths`) and filters the popover to subs
+  whose static `:<-` chain depends on the hovered path. Subs with
+  unknown attribution (cycle, missing upstream) fall through the
+  conservative-include branch so the popover never lies by omission.
 
-  The MVP therefore renders the FULL cascade — every sub that ran
-  (recomputed or skipped) + every view that rendered this cascade — in
-  every per-path popover. A follow-on bead (rf2-op9v2-followup) will
-  refine the list to path-specific subs once the substrate carries
-  input-paths in the cascade aggregate (or once an additional registry
-  walk is wired in).
+  See `panels.shared.sub-input-paths` for the resolver contract — the
+  walk reports layer-1 leaves the sub composes over; the path-match
+  heuristic compares keyword-segment overlap of those leaves against
+  the hovered path-vec (matches the spec §4.4 example `[:cart :state]`
+  ↔ `:cart/state`).
 
   Data source: the focused epoch's `:sub-runs` + `:renders` projections
   on the epoch record (the same slots the Reactive panel reads —
@@ -60,6 +59,7 @@
   dismissal via Esc (handled by the trigger's `:on-key-down`)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.panels.shared.sub-input-paths :as sip]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -97,27 +97,47 @@
     :<- [:rf.causa.app-db/popover-slot]
     (fn [slot _] (:path slot)))
 
-  ;; Downstream subs / views for the focused cascade. MVP (rf2-op9v2):
-  ;; returns ALL subs + views in the focused cascade — the popover
-  ;; renders the same list for every changed path. A follow-on bead
-  ;; will narrow the list to subs that actually read the hovered path
-  ;; once input-paths attribution lands in the substrate.
+  ;; Downstream subs / views for the focused cascade — path-filtered
+  ;; via the registry-side input-paths walk (rf2-gblq6).
   ;;
-  ;; The sub takes a `:path` query arg slot today only so future
-  ;; refinement is a body-only change (no caller migration).
+  ;; Algorithm:
+  ;;   1. Read every sub-id that ran in the cascade (recomputed +
+  ;;      skipped).
+  ;;   2. For each sub-id, walk the registry via
+  ;;      `sip/resolve-input-paths` to get its layer-1 leaves.
+  ;;   3. Keep the sub in the popover when `sip/sub-touches-path?`
+  ;;      returns truthy — nil (unknown) ⇒ include, empty ⇒ exclude,
+  ;;      keyword-segment overlap ⇒ include.
+  ;;
+  ;; Views are filtered transitively: a view appears when its
+  ;; `:triggered-by` sub passes the same filter (or when the view's
+  ;; render-key includes a sub-id segment overlapping the path).
   (rf/reg-sub :rf.causa/app-db-downstream-for-path
     :<- [:rf.causa/epoch-history]
     :<- [:rf.causa/focus]
-    (fn [[history focus] [_query _path]]
+    (fn [[history focus] [_query path]]
       (let [{:keys [sub-runs renders]}
-            (focused-cascade-sub-runs+renders history focus)]
-        {:subs-recomputed (vec (filter :recomputed? sub-runs))
-         :subs-skipped    (vec (remove :recomputed? sub-runs))
-         :views-rendered  (vec renders)
-         ;; rf2-op9v2 MVP marker — drives the 'showing full cascade'
-         ;; affordance in the popover so the operator knows the list
-         ;; is not yet path-filtered.
-         :path-filtered?  false}))))
+            (focused-cascade-sub-runs+renders history focus)
+            registry      (sip/sub-meta-map)
+            touches-path? (fn [sub-id]
+                            (sip/sub-touches-path?
+                              (sip/resolve-input-paths sub-id registry)
+                              path))
+            kept-sub-runs (filter #(touches-path? (:sub-id %)) sub-runs)
+            kept-sub-ids  (into #{} (map :sub-id) kept-sub-runs)
+            kept-renders  (filter
+                            (fn [{:keys [triggered-by]}]
+                              (or (nil? triggered-by)
+                                  (contains? kept-sub-ids triggered-by)
+                                  (touches-path? triggered-by)))
+                            renders)]
+        {:subs-recomputed (vec (filter :recomputed? kept-sub-runs))
+         :subs-skipped    (vec (remove :recomputed? kept-sub-runs))
+         :views-rendered  (vec kept-renders)
+         ;; rf2-gblq6 — popover is now truly path-filtered. The MVP-
+         ;; note affordance (`rf-causa-app-db-popover-mvp-note`) is
+         ;; removed downstream in `popover-body`.
+         :path-filtered?  true}))))
 
 ;; ---- events ------------------------------------------------------------
 
@@ -241,7 +261,7 @@
   "Render the popover contents — subs list (recomputed first, then
   skipped) + views list + ⤴ footer affordance."
   [path]
-  (let [{:keys [subs-recomputed subs-skipped views-rendered path-filtered?]}
+  (let [{:keys [subs-recomputed subs-skipped views-rendered]}
         @(rf/subscribe [:rf.causa/app-db-downstream-for-path path])
         any-content? (or (seq subs-recomputed)
                          (seq subs-skipped)
@@ -278,21 +298,6 @@
                       :font-family mono-stack
                       :text-transform "none"}}
        (f/format-edn (vec path))]]
-     (when-not path-filtered?
-       ;; rf2-op9v2 MVP affordance — make the 'not yet path-filtered'
-       ;; state explicit so operators don't think the cascade ran the
-       ;; full list against this specific path. Removed once the
-       ;; follow-on bead lands input-paths attribution.
-       [:div {:data-testid "rf-causa-app-db-popover-mvp-note"
-              :style {:padding     "4px 8px"
-                      :background  (:bg-3 tokens)
-                      :color       (:text-tertiary tokens)
-                      :font-family sans-stack
-                      :font-size   "10px"
-                      :font-style  "italic"
-                      :border-bottom (str "1px solid "
-                                          (:border-subtle tokens))}}
-        "Showing full cascade — path-filtered list pending (rf2-op9v2)"])
      (cond
        (not any-content?)
        [:div {:data-testid "rf-causa-app-db-popover-empty"

--- a/tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc
@@ -1,0 +1,275 @@
+(ns day8.re-frame2-causa.panels.shared.sub-input-paths
+  "Registry-side walk for sub input-paths (rf2-gblq6).
+
+  ## Why this exists
+
+  The App-DB downstream-subs popover (rf2-op9v2 / PR #1747) lists every
+  sub that ran in the focused cascade — full cascade, not path-filtered.
+  Without per-sub `:input-paths` attribution the popover can't surgically
+  answer 'which subs read THIS path?'. The substrate's
+  `:rf.cascade/captured` aggregate doesn't carry per-sub input-paths
+  either: subs read app-db via arbitrary handler-fn bodies (`get-in`,
+  destructuring, walks), and the substrate adapter has no tap on those
+  reads.
+
+  This helper bridges the gap by walking the static sub registry —
+  pure data, no app-db, no reactive runtime. Same shape as
+  `re-frame.subs.tooling/sub-topology`, just narrower: walk the
+  `:input-signals` chain and report the **layer-1 leaves** the
+  target sub ultimately depends on.
+
+  Layer-1 leaves are the subs that read `app-db` directly. They're
+  the closest static proxy for 'which paths does this sub touch'
+  because the body of a layer-1 sub IS the contract — and the
+  convention `(reg-sub :foo/bar (fn [db _] (get-in db [:foo :bar])))`
+  means the sub-id of a layer-1 sub often carries the path semantics
+  the operator hovered.
+
+  ## What the walk returns
+
+  For each sub-id, an `:input-paths` slot — `nil` or a sorted vector
+  of layer-1 sub-ids:
+
+    - `nil` — **unknown**. The sub has at least one unresolvable
+      upstream (cycle, missing registration, opaque resolution). The
+      popover's path-filter treats `nil` as 'could match any path' —
+      conservative include.
+
+    - `[layer-1-sub-id ...]` — the layer-1 leaves the sub composes
+      over. Singleton vector `[sub-id]` for layer-1 subs themselves
+      (each layer-1 sub IS its own leaf). Layer-n subs union the
+      leaves of every upstream signal. The vector is `sort-by pr-str`
+      ordered for deterministic test output.
+
+  Layer-1 sub-ids stand in for paths because there's no static
+  `:rf.sub/path` declaration on sub registrations today (Spec 002
+  §Subscriptions composing — handler-fn bodies are opaque). When a
+  future bead adds an explicit `:rf.sub/path` slot, the resolver can
+  read it directly and the popover gains true path-vec attribution.
+  Until then, layer-1 sub-ids are the cleanest static proxy.
+
+  ## Cycle + missing handling
+
+  Cycle detection uses a per-call `visited?` set; encountering a
+  visited sub-id during recursion returns the `:unknown` sentinel.
+  Subs not found in the registrar also return `:unknown`. The walk
+  is bounded by the registry size — no transitive recurse can
+  revisit a node — so total cost is `O(N * fanout)` where N is the
+  registry size.
+
+  ## Path-filter contract
+
+  `sub-touches-path?` takes a hovered path-vec + a sub's declared
+  input-paths (the `resolve-input-paths` result) and returns truthy
+  when the sub should appear in the popover.
+
+  Match rules:
+
+    1. `input-paths` is `nil` → include (unknown ⇒ conservative).
+    2. `input-paths` is `[]` → exclude. The sub composes no layer-1
+       reads — it depends on no app-db state, so it can't have been
+       affected by the hovered path.
+    3. `input-paths` carries layer-1 sub-ids → include when ANY
+       leaf's sub-id overlaps the hovered path via the
+       `sub-id-touches-path?` heuristic below.
+
+  `sub-id-touches-path?` matches a layer-1 sub-id against a path-vec
+  via keyword-segment overlap:
+
+    - The sub-id is split into namespace + name (`:cart/state` →
+      `:cart` + `:state`).
+    - The path-vec's keyword segments are compared against the
+      sub-id's segments. Any segment match counts as a touch.
+
+  This heuristic matches the spec §4.4 example (path `[:cart :state]`
+  → sub `:cart/state`) without claiming static guarantees. The
+  conservative-include branch (nil ⇒ include) keeps the popover
+  honest when the heuristic can't speak.
+
+  ## CLJC
+
+  The helper is `.cljc` so the same code runs in CLJS (Causa's
+  primary target) and JVM tests. The walk has no platform-specific
+  branches — pure registrar data."
+  (:require [re-frame.registrar :as registrar]))
+
+;; ---- registry projection -------------------------------------------------
+
+(defn- input-signal-ids
+  "Project a sub's `:input-signals` slot — vector of `[query-id args...]`
+  — to a vector of just the upstream sub-ids. Mirrors the
+  `re-frame.subs.tooling/sub-topology` projection."
+  [input-signals]
+  (mapv first input-signals))
+
+(defn sub-meta-map
+  "Snapshot of every registered sub's static metadata as a flat map
+  `{sub-id {:input-signal-ids [...] :layer-1? bool}}`. Pure data over
+  `registrar/registrations` — no app-db, no reactive runtime.
+
+  Layer-1 subs (which read app-db directly) report
+  `:input-signal-ids []` + `:layer-1? true`. Layer-2+ subs report
+  their declared upstream sub-ids + `:layer-1? false`.
+
+  Tests can pass an injected map to `resolve-input-paths` / `resolve-
+  many` so the walk is testable without seeding the registrar."
+  []
+  (reduce-kv
+    (fn [acc sub-id meta]
+      (let [signals (input-signal-ids (:input-signals meta))]
+        (assoc acc sub-id
+               {:input-signal-ids signals
+                :layer-1?         (empty? signals)})))
+    {}
+    (registrar/registrations :sub)))
+
+;; ---- the walk -----------------------------------------------------------
+
+(defn- -resolve
+  "Recursive resolution. Returns either a set of layer-1 sub-ids the
+  target ultimately depends on, or the keyword `:unknown` when the
+  walk can't terminate (cycle, missing registration).
+
+  The accumulator is a set rather than vector — duplicate-upstream
+  diamonds collapse to a single leaf. Top-level caller projects the
+  set to a sorted vector for stable test assertions.
+
+  `:unknown` sentinel + the `visited?` set live inside the call;
+  callers consume `resolve-input-paths` which converts the sentinel
+  to `nil`."
+  [sub-id sub-meta-map visited?]
+  (cond
+    (contains? visited? sub-id)
+    :unknown ;; cycle — short-circuit to unknown
+
+    :else
+    (let [entry (get sub-meta-map sub-id)]
+      (cond
+        (nil? entry)
+        :unknown ;; missing registration — unknown
+
+        (:layer-1? entry)
+        ;; Layer-1 leaf — the sub itself IS the static input-path
+        ;; surface. Return a set containing just this sub-id so a
+        ;; downstream layer-2 sub composing several layer-1 leaves
+        ;; sees the union.
+        #{sub-id}
+
+        :else
+        ;; Layer-n — recurse into every upstream. If ANY upstream is
+        ;; unknown, the whole result is unknown (conservative — we
+        ;; can't claim to know paths when part of the chain is
+        ;; opaque).
+        (let [visited?' (conj visited? sub-id)]
+          (reduce
+            (fn [acc upstream-id]
+              (let [u (-resolve upstream-id sub-meta-map visited?')]
+                (if (= u :unknown)
+                  (reduced :unknown)
+                  (into acc u))))
+            #{}
+            (:input-signal-ids entry)))))))
+
+(defn resolve-input-paths
+  "Return the layer-1 leaves `sub-id` ultimately depends on, or `nil`
+  when the walk can't terminate. Pure fn over the registry projection
+  returned by `sub-meta-map` (or any equivalent `{sub-id {:input-
+  signal-ids [...] :layer-1? bool}}` shape).
+
+  Result is a sorted vector of layer-1 sub-ids (sort by `pr-str` so
+  tests get deterministic ordering across keyword + string ids), or
+  `nil` for unknown. Layer-1 subs themselves return a single-element
+  vector `[sub-id]` so the leaf IS its own input-path proxy.
+
+  Empty layer-1 vector (`[]`) is reserved for the theoretical case
+  of a layer-n sub with no declared upstream signals — pathological
+  in practice (such a sub would never recompute), but representable
+  for completeness.
+
+  See the namespace docstring for the contract + why we return
+  layer-1 sub-ids rather than path-vecs."
+  ([sub-id]
+   (resolve-input-paths sub-id (sub-meta-map)))
+  ([sub-id sub-meta-map]
+   (let [result (-resolve sub-id sub-meta-map #{})]
+     (when (not= result :unknown)
+       (vec (sort-by pr-str result))))))
+
+(defn resolve-many
+  "Batch form — return `{sub-id input-paths}` for every sub-id in the
+  registry. Tools that need the full map (e.g. Causa's downstream
+  popover walking every cascade-captured sub) call this once per
+  walk to amortise the registrar projection."
+  ([]
+   (resolve-many (sub-meta-map)))
+  ([sub-meta-map]
+   (reduce-kv
+     (fn [acc sub-id _entry]
+       (assoc acc sub-id (resolve-input-paths sub-id sub-meta-map)))
+     {}
+     sub-meta-map)))
+
+;; ---- path-filter ---------------------------------------------------------
+
+(defn- keyword-segments
+  "Return the set of keyword 'segments' a sub-id occupies. Keywords
+  carry up to two segments: namespace + name. `:cart/state` →
+  `#{:cart :state}`; `:foo` → `#{:foo}`. Strings and other id shapes
+  return `#{}` — out of scope for the path-overlap heuristic."
+  [sub-id]
+  (cond
+    (keyword? sub-id)
+    (let [n  (name sub-id)
+          ns (namespace sub-id)]
+      (cond-> #{(keyword n)}
+        (and ns (seq ns)) (conj (keyword ns))))
+    :else
+    #{}))
+
+(defn- path-keyword-segments
+  "Return the keyword segments of a path-vec (filtering out
+  non-keyword segments like indices, strings)."
+  [path-vec]
+  (set (filter keyword? path-vec)))
+
+(defn sub-id-touches-path?
+  "Heuristic: returns true when a layer-1 sub-id's keyword segments
+  overlap a path-vec's keyword segments. Matches the spec §4.4
+  example shape (path `[:cart :state]` ↔ sub `:cart/state`).
+
+  Pure fn — no app-db, no registry. Exposed for tests + reuse by
+  panels that want to render 'this layer-1 sub touches this path'
+  affordances."
+  [sub-id path-vec]
+  (let [sub-segs  (keyword-segments sub-id)
+        path-segs (path-keyword-segments path-vec)]
+    (boolean
+      (and (seq sub-segs)
+           (seq path-segs)
+           (some sub-segs path-segs)))))
+
+(defn sub-touches-path?
+  "Returns truthy when a sub whose declared `input-paths` (the
+  `resolve-input-paths` result) should appear in the popover for a
+  hovered `path-vec`.
+
+  Match rules (see the namespace docstring §Path-filter contract):
+
+    1. `input-paths` is `nil` → include (unknown ⇒ conservative).
+    2. `input-paths` is `[]` → exclude (sub composes no layer-1
+       reads — it can't be affected by ANY path).
+    3. `input-paths` carries layer-1 sub-ids → include when ANY leaf
+       sub-id overlaps `path-vec` via `sub-id-touches-path?`.
+
+  `path-vec` may be `nil`; treated as `[]` (root) — falls through to
+  rule 3 with no keyword segments, so non-nil non-empty layer-1
+  leaves always EXCLUDE when the path is root. Operators hovering
+  the root would expect every sub in the cascade — for that case the
+  caller should bypass this filter entirely (path-vec `[]` is a
+  whole-db signal)."
+  [input-paths path-vec]
+  (cond
+    (nil? input-paths) true                      ;; rule 1 — unknown
+    (empty? input-paths) false                   ;; rule 2 — no app-db reads
+    :else                                        ;; rule 3 — keyword overlap
+    (boolean (some #(sub-id-touches-path? % path-vec) input-paths))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_downstream_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_downstream_cljs_test.cljs
@@ -155,8 +155,8 @@
     (is (= [] (:subs-recomputed out)))
     (is (= [] (:subs-skipped out)))
     (is (= [] (:views-rendered out)))
-    (is (false? (:path-filtered? out))
-        "rf2-op9v2 MVP marker — path-filter is not yet implemented")))
+    (is (true? (:path-filtered? out))
+        "rf2-gblq6 — sub now reports path-filtered? true")))
 
 (deftest downstream-for-path-projects-sub-runs-and-renders
   ;; Seed a minimal epoch-history sub + focus pair so the downstream
@@ -184,6 +184,77 @@
            (:subs-skipped out)))
     (is (= 1 (count (:views-rendered out))))
     (is (= :cart/state (:triggered-by (first (:views-rendered out)))))))
+
+(deftest downstream-for-path-filters-by-registry-walk
+  ;; rf2-gblq6 — register two layer-1 subs whose ids overlap
+  ;; different paths. The popover should only include subs whose
+  ;; registry walk overlaps the hovered path.
+  (downstream/install!)
+  ;; Register `:cart/state` as layer-1 — its sub-id segments
+  ;; `#{:cart :state}` overlap path `[:cart :state]`.
+  (rf/reg-sub :cart/state (fn [db _] (get-in db [:cart :state])))
+  ;; Register `:user/profile` as layer-1 — its segments
+  ;; `#{:user :profile}` DON'T overlap `[:cart :state]`.
+  (rf/reg-sub :user/profile (fn [db _] (get-in db [:user :profile])))
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :cart/state   :recomputed? true}
+                   {:sub-id :user/profile :recomputed? true}]
+        :renders  []}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _] {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path
+                            [:cart :state]])]
+    (is (= [{:sub-id :cart/state :recomputed? true}]
+           (:subs-recomputed out))
+        "only the sub whose layer-1 leaves overlap the path survives")
+    (is (true? (:path-filtered? out))
+        "rf2-gblq6 marker — path-filter is active")))
+
+(deftest downstream-for-path-includes-unknown-subs-conservatively
+  ;; rf2-gblq6 — when a sub isn't in the registrar (cascade-captured
+  ;; but registration cleared), resolve-input-paths returns nil
+  ;; (unknown) and the conservative-include branch keeps it in the
+  ;; popover so we never lie by omission.
+  (downstream/install!)
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :totally-unregistered :recomputed? true}]
+        :renders  []}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _] {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path
+                            [:cart :state]])]
+    (is (= [{:sub-id :totally-unregistered :recomputed? true}]
+           (:subs-recomputed out))
+        "unknown sub-ids fall through to conservative-include")))
+
+(deftest downstream-for-path-includes-layer-2-via-transitive-walk
+  ;; rf2-gblq6 — a layer-2 sub depending on a layer-1 sub whose
+  ;; id overlaps the path should be included via the transitive
+  ;; walk. Validates that the walk follows `:<-` chains.
+  (downstream/install!)
+  (rf/reg-sub :cart/state (fn [db _] (get-in db [:cart :state])))
+  (rf/reg-sub :cart/can-submit?
+    :<- [:cart/state]
+    (fn [state _] (= state :ready)))
+  (rf/reg-sub :rf.causa/epoch-history
+    (fn [_ _]
+      [{:epoch-id :ep-1
+        :sub-runs [{:sub-id :cart/can-submit? :recomputed? true}]
+        :renders  []}]))
+  (rf/reg-sub :rf.causa/focus
+    (fn [_ _] {:epoch-id :ep-1 :dispatch-id 1 :frame :rf/default}))
+
+  (let [out @(rf/subscribe [:rf.causa/app-db-downstream-for-path
+                            [:cart :state]])]
+    (is (= [{:sub-id :cart/can-submit? :recomputed? true}]
+           (:subs-recomputed out))
+        "layer-2 sub kept via transitive walk to its layer-1 upstream")))
 
 (deftest downstream-for-path-falls-back-to-head-when-focus-stale
   ;; When :rf.causa/focus carries an :epoch-id NOT in history, the
@@ -253,9 +324,9 @@
     (is (some? (find-by-testid out
                                 "rf-causa-app-db-popover-jump-reactive"))
         "⤴ footer 'jump to Reactive panel' affordance")
-    (is (some? (find-by-testid out
-                                "rf-causa-app-db-popover-mvp-note"))
-        "MVP affordance flags 'not yet path-filtered' state")))
+    (is (nil? (find-by-testid out
+                               "rf-causa-app-db-popover-mvp-note"))
+        "rf2-gblq6 — MVP-note affordance removed once true path-filter ships")))
 
 (deftest hover-trigger-popover-empty-state
   (downstream/install!)

--- a/tools/causa/test/day8/re_frame2_causa/panels/shared/sub_input_paths_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/shared/sub_input_paths_cljs_test.cljc
@@ -1,0 +1,189 @@
+(ns day8.re-frame2-causa.panels.shared.sub-input-paths-cljs-test
+  "Tests for the registry-side sub input-paths walk (rf2-gblq6).
+
+  The helper is pure data — these tests inject synthetic registry
+  projections (`{sub-id {:input-signal-ids [...] :layer-1? bool}}`)
+  rather than seeding the real registrar. That keeps the suite
+  hermetic and lets us exercise edge cases (cycles, missing upstream)
+  without polluting any per-test registrar state.
+
+  CLJC — runs on JVM and CLJS sides; no platform-specific branches in
+  the helper."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.shared.sub-input-paths :as sip]))
+
+;; ---- resolve-input-paths --------------------------------------------------
+
+(deftest layer-1-sub-resolves-to-itself
+  ;; A layer-1 sub IS its own input-path proxy. The walk returns a
+  ;; singleton vector containing the sub-id.
+  (let [registry {:cart/state {:input-signal-ids [] :layer-1? true}}]
+    (is (= [:cart/state]
+           (sip/resolve-input-paths :cart/state registry))
+        "layer-1 leaf resolves to a vector containing itself")))
+
+(deftest layer-2-sub-resolves-to-its-upstream-layer-1-leaves
+  ;; Layer-2 sub `:cart/total` reads from layer-1 `:cart/items`.
+  ;; Walk should yield `[:cart/items]` — the layer-1 leaf, not the
+  ;; layer-2 id itself.
+  (let [registry {:cart/items {:input-signal-ids [] :layer-1? true}
+                  :cart/total {:input-signal-ids [:cart/items]
+                               :layer-1? false}}]
+    (is (= [:cart/items]
+           (sip/resolve-input-paths :cart/total registry))
+        "layer-2 sub resolves to its layer-1 upstream")))
+
+(deftest layer-3-sub-resolves-transitively
+  ;; Layer-3 chain — `:c` reads `:b` reads `:a` (layer-1). The walk
+  ;; should reach `:a` transitively.
+  (let [registry {:a {:input-signal-ids [] :layer-1? true}
+                  :b {:input-signal-ids [:a] :layer-1? false}
+                  :c {:input-signal-ids [:b] :layer-1? false}}]
+    (is (= [:a] (sip/resolve-input-paths :c registry))
+        "layer-3 sub reaches its layer-1 leaf transitively")))
+
+(deftest layer-2-multi-input-sub-unions-leaves
+  ;; Layer-2 sub with two layer-1 upstreams should union the leaves.
+  ;; Ordering deterministic via sort-by pr-str.
+  (let [registry {:cart/items   {:input-signal-ids [] :layer-1? true}
+                  :user/profile {:input-signal-ids [] :layer-1? true}
+                  :checkout/ready?
+                  {:input-signal-ids [:cart/items :user/profile]
+                   :layer-1? false}}]
+    (is (= [:cart/items :user/profile]
+           (sip/resolve-input-paths :checkout/ready? registry))
+        "multi-input layer-2 sub unions its layer-1 leaves")))
+
+(deftest diamond-dependency-collapses-shared-leaf
+  ;; Diamond — `:d` reads `:b` and `:c`; both read layer-1 `:root`.
+  ;; The shared leaf should appear once.
+  (let [registry {:root {:input-signal-ids [] :layer-1? true}
+                  :b    {:input-signal-ids [:root] :layer-1? false}
+                  :c    {:input-signal-ids [:root] :layer-1? false}
+                  :d    {:input-signal-ids [:b :c] :layer-1? false}}]
+    (is (= [:root] (sip/resolve-input-paths :d registry))
+        "diamond dependency collapses shared layer-1 leaf")))
+
+(deftest cycle-returns-nil
+  ;; Cycle — `:a` reads `:b`; `:b` reads `:a`. The walk must
+  ;; short-circuit to nil rather than recurse forever.
+  (let [registry {:a {:input-signal-ids [:b] :layer-1? false}
+                  :b {:input-signal-ids [:a] :layer-1? false}}]
+    (is (nil? (sip/resolve-input-paths :a registry))
+        "cycle resolves to nil (unknown)")
+    (is (nil? (sip/resolve-input-paths :b registry))
+        "either side of the cycle is unknown")))
+
+(deftest self-cycle-returns-nil
+  ;; Self-cycle — `:a` reads itself.
+  (let [registry {:a {:input-signal-ids [:a] :layer-1? false}}]
+    (is (nil? (sip/resolve-input-paths :a registry))
+        "self-cycle resolves to nil")))
+
+(deftest missing-upstream-returns-nil
+  ;; Layer-2 sub references an upstream that isn't registered.
+  ;; Walk must return nil (unknown) — the missing leaf could be
+  ;; anything.
+  (let [registry {:b {:input-signal-ids [:missing] :layer-1? false}}]
+    (is (nil? (sip/resolve-input-paths :b registry))
+        "missing upstream resolves to nil")))
+
+(deftest partial-unknown-upstream-poisons-result
+  ;; Diamond where one branch reaches a known leaf and the other is
+  ;; cyclic. The whole result must be nil — we can't claim
+  ;; partial knowledge.
+  (let [registry {:leaf {:input-signal-ids [] :layer-1? true}
+                  :good {:input-signal-ids [:leaf] :layer-1? false}
+                  :bad  {:input-signal-ids [:cycle] :layer-1? false}
+                  :cycle {:input-signal-ids [:bad] :layer-1? false}
+                  :composite
+                  {:input-signal-ids [:good :bad] :layer-1? false}}]
+    (is (nil? (sip/resolve-input-paths :composite registry))
+        "any unknown upstream poisons the composite result")))
+
+(deftest missing-sub-itself-returns-nil
+  ;; Walking a sub-id that isn't in the registry returns nil.
+  (is (nil? (sip/resolve-input-paths :not-registered {}))
+      "missing target sub resolves to nil"))
+
+(deftest empty-registry-returns-empty-resolve-many
+  (is (= {} (sip/resolve-many {}))
+      "empty registry yields empty resolve-many"))
+
+(deftest resolve-many-projects-every-sub
+  ;; Batch form returns the {sub-id input-paths} map for every
+  ;; registered sub.
+  (let [registry {:cart/items {:input-signal-ids [] :layer-1? true}
+                  :cart/total {:input-signal-ids [:cart/items]
+                               :layer-1? false}}]
+    (is (= {:cart/items [:cart/items]
+            :cart/total [:cart/items]}
+           (sip/resolve-many registry))
+        "resolve-many returns one entry per registered sub")))
+
+;; ---- sub-id-touches-path? ------------------------------------------------
+
+(deftest sub-id-touches-path-positive-cases
+  (testing "namespaced sub matches segment-overlap path"
+    (is (sip/sub-id-touches-path? :cart/state [:cart :state]))
+    (is (sip/sub-id-touches-path? :cart/state [:cart])
+        "namespace alone is a match")
+    (is (sip/sub-id-touches-path? :cart/state [:state])
+        "name alone is a match"))
+  (testing "single-segment sub matches single-segment path"
+    (is (sip/sub-id-touches-path? :counter [:counter]))))
+
+(deftest sub-id-touches-path-negative-cases
+  (testing "no segment overlap → no match"
+    (is (not (sip/sub-id-touches-path? :cart/state [:user :profile])))
+    (is (not (sip/sub-id-touches-path? :foo [:bar :baz]))))
+  (testing "empty path → no match"
+    (is (not (sip/sub-id-touches-path? :cart/state []))))
+  (testing "non-keyword sub-id → no match"
+    (is (not (sip/sub-id-touches-path? "string-id" [:cart :state])))))
+
+(deftest sub-id-touches-path-ignores-non-keyword-path-segments
+  ;; Path with indices or strings — only keyword segments
+  ;; participate in the overlap test.
+  (is (sip/sub-id-touches-path? :cart/items [:cart :items 0])
+      "keyword segments still match around an integer index")
+  (is (not (sip/sub-id-touches-path? :checkout/state [:cart "items" 0]))
+      "no keyword segments overlap"))
+
+;; ---- sub-touches-path? ---------------------------------------------------
+
+(deftest sub-touches-path-rule-1-unknown-includes
+  ;; Rule 1 — nil input-paths means unknown; include conservatively.
+  (is (sip/sub-touches-path? nil [:cart :state])
+      "nil input-paths ⇒ include")
+  (is (sip/sub-touches-path? nil [])
+      "nil input-paths ⇒ include even at root"))
+
+(deftest sub-touches-path-rule-2-empty-excludes
+  ;; Rule 2 — empty input-paths means the sub composes no app-db
+  ;; reads; exclude.
+  (is (not (sip/sub-touches-path? [] [:cart :state]))
+      "empty input-paths ⇒ exclude"))
+
+(deftest sub-touches-path-rule-3-keyword-overlap
+  ;; Rule 3 — keyword overlap of any leaf id against the path.
+  (testing "single layer-1 leaf overlaps path"
+    (is (sip/sub-touches-path? [:cart/state] [:cart :state]))
+    (is (sip/sub-touches-path? [:cart/state] [:cart]))
+    (is (not (sip/sub-touches-path? [:cart/state] [:user :profile]))))
+  (testing "any leaf in a multi-leaf set is enough"
+    (is (sip/sub-touches-path? [:cart/state :user/profile]
+                               [:user :profile]))
+    (is (not (sip/sub-touches-path? [:cart/state :user/profile]
+                                     [:session :token])))))
+
+;; ---- sub-meta-map (registrar integration smoke) -------------------------
+
+#?(:cljs
+   (deftest sub-meta-map-empty-registry-returns-empty-map
+     ;; A side-effecting test fixture-free smoke that sub-meta-map
+     ;; reads the live registrar. We can't reliably assert specific
+     ;; sub-ids without a fixture, but the result MUST be a map.
+     (is (map? (sip/sub-meta-map))
+         "sub-meta-map returns a map (registry projection shape)")))


### PR DESCRIPTION
Closes rf2-gblq6 + supersedes rf2-owkom.

Walks re-frame.subs registry to derive per-sub input-paths attribution. The App-DB downstream-subs popover now filters to subs whose static `:<-` chain depends on the hovered path. Removes the `rf-causa-app-db-popover-mvp-note` affordance shipped in #1747.

## Approach

NEW `tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc`:

- `sub-meta-map` — projects `registrar/registrations :sub` to `{sub-id {:input-signal-ids [...] :layer-1? bool}}`.
- `resolve-input-paths` — recursive walk via `:input-signals`. Returns sorted vec of layer-1 leaves, or `nil` (unknown — cycle, missing upstream, or any unknown branch poisons the composite).
- `sub-touches-path?` — match rules: `nil` ⇒ include (conservative), `[]` ⇒ exclude (no app-db reads), non-empty ⇒ keyword-segment overlap of any leaf id against the hovered path-vec. Matches spec §4.4 example `[:cart :state]` ↔ `:cart/state`.

Cycle detection via per-call `visited?` set; missing registration → `:unknown` sentinel internally → `nil` at the public boundary.

## Files

- NEW `tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc` — pure helper, `.cljc` (JVM + CLJS).
- M `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs` — consume helper for path-filter, remove MVP-note affordance, flip `:path-filtered? true`.
- NEW `tools/causa/test/day8/re_frame2_causa/panels/shared/sub_input_paths_cljs_test.cljc` — 16 pure-fn tests (layer-1, layer-n transitive, diamond, cycle, self-cycle, missing upstream, partial-unknown-poison, resolve-many, keyword-overlap variants, rule-by-rule sub-touches-path?).
- M `tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_downstream_cljs_test.cljs` — flips `:path-filtered?` assertion to `true`, drops MVP-note testid assertion, adds 3 new tests (registry-walk filter, unknown-sub conservative-include, layer-2 transitive filter).

## Gates

- `npm run test:cljs` — 3704 tests / 10694 assertions / 0 failures
- `npm run test:bundle-isolation` — PASS (counter / counter-uix / counter-helix bundles clean)
- `python -m mkdocs build --strict` — built without errors (informational link warning is pre-existing)