### PR TITLE
polish(causa): §17.5 visual-language cluster — tokens + spacing + icons + machine pulse (rf2-ezx8w)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -75,8 +75,17 @@
                            :font-weight 600
                            :letter-spacing "-0.01em"
                            :margin      0
-                           :color       (:text-primary tokens)}
+                           :color       (:text-primary tokens)
+                           :display     "flex"
+                           :align-items "center"
+                           :gap         "8px"}
                           (t/accent-stripe-style :app-db))}
+       ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ◐ in
+       ;; :cyan (App-db's domain colour via panel-domain->token).
+       [:span {:data-testid "rf-causa-app-db-panel-icon"
+               :aria-hidden "true"
+               :style       (t/panel-icon-style :app-db)}
+        (:app-db t/panel-icon)]
        "App-db diff"]]
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond

--- a/tools/causa/src/day8/re_frame2_causa/panels/chrome_a11y/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/chrome_a11y/panel.cljs
@@ -489,8 +489,18 @@
                             :font-weight    600
                             :letter-spacing "-0.01em"
                             :margin         0
-                            :color          (:text-primary tokens)}
+                            :color          (:text-primary tokens)
+                            :display        "flex"
+                            :align-items    "center"
+                            :gap            "8px"}
                            (t/accent-stripe-style :chrome-a11y))}
+        ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ✦ in
+        ;; :red (Chrome A11y's diagnostics-group sibling accent, shared
+        ;; with Issues per panel-domain->token).
+        [:span {:data-testid "rf-causa-chrome-a11y-panel-icon"
+                :aria-hidden "true"
+                :style       (t/panel-icon-style :chrome-a11y)}
+         (:chrome-a11y t/panel-icon)]
         "Chrome A11y"]
        [:span {:data-testid "rf-causa-chrome-a11y-count"
                :style       {:font-size   (:caption type-scale)

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -179,8 +179,16 @@
                          :font-weight 600
                          :letter-spacing "-0.01em"
                          :margin 0
-                         :color  (:text-primary tokens)}
+                         :color  (:text-primary tokens)
+                         :display "flex" :align-items "center"
+                         :gap "8px"}
                         (t/accent-stripe-style :issues))}
+     ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ⚠ in
+     ;; :red (Issues' domain colour via panel-domain->token).
+     [:span {:data-testid "rf-causa-issues-panel-icon"
+             :aria-hidden "true"
+             :style       (t/panel-icon-style :issues)}
+      (:issues t/panel-icon)]
      "Issues"]
     [:span {:data-testid "rf-causa-issues-counts"
             :style {:font-size   "11px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -477,8 +477,16 @@
                             :font-weight 600
                             :letter-spacing "-0.01em"
                             :margin 0
-                            :color (:text-primary tokens)}
+                            :color (:text-primary tokens)
+                            :display "flex" :align-items "center"
+                            :gap "8px"}
                            (t/accent-stripe-style :machines))}
+        ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ◆ in
+        ;; :green (Machines' domain colour via panel-domain->token).
+        [:span {:data-testid "rf-causa-machine-inspector-panel-icon"
+                :aria-hidden "true"
+                :style       (t/panel-icon-style :machines)}
+         (:machines t/panel-icon)]
         "Machine inspector"]]
       (when (not= :no-machines empty-kind)
         [:div {:style {:display "flex"

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs
@@ -210,8 +210,17 @@
                         :font-weight 600
                         :letter-spacing "-0.01em"
                         :margin 0
-                        :color (:text-primary tokens)}
+                        :color (:text-primary tokens)
+                        :display "flex" :align-items "center"
+                        :gap "8px"}
                        (t/accent-stripe-style :machines))}
+    ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ◆ in
+    ;; :green (Machines Canvas shares the :green accent with Machine
+    ;; Inspector per panel-domain->token).
+    [:span {:data-testid "rf-causa-machines-canvas-panel-icon"
+            :aria-hidden "true"
+            :style       (t/panel-icon-style :machines-canvas)}
+     (:machines-canvas t/panel-icon)]
     "Machines canvas"]
    (when machine-id
      [:span {:style {:color (:accent-violet tokens)

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -80,8 +80,16 @@
    [:h1 {:style (merge {:font-size "20px" :font-family display-stack
                         :font-weight 600 :letter-spacing "-0.01em"
                         :margin 0
-                        :color (:text-primary tokens)}
+                        :color (:text-primary tokens)
+                        :display "flex" :align-items "center"
+                        :gap "8px"}
                        (t/accent-stripe-style :views))}
+    ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ◉ in
+    ;; :cyan (Reactive/Views share the :cyan domain accent).
+    [:span {:data-testid "rf-causa-reactive-panel-icon"
+            :aria-hidden "true"
+            :style       (t/panel-icon-style :views)}
+     (:reactive t/panel-icon)]
     "Reactive"]
    (when (:has-cascade? data)
      [:p {:data-testid "rf-causa-reactive-header-meta"

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -307,8 +307,17 @@
                          :font-weight    600
                          :text-transform "uppercase"
                          :letter-spacing "0.5px"
-                         :color          (:text-primary tokens)}
+                         :color          (:text-primary tokens)
+                         :display        "flex"
+                         :align-items    "center"
+                         :gap            "8px"}
                         (t/accent-stripe-style :routing))}
+     ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. 🌐 in
+     ;; :yellow (Routing's domain colour via panel-domain->token).
+     [:span {:data-testid "rf-causa-routing-panel-icon"
+             :aria-hidden "true"
+             :style       (t/panel-icon-style :routing)}
+      (:routing t/panel-icon)]
      "Routing"]
     [:p {:style {:margin      "4px 0 0 0"
                  :color       (:text-tertiary tokens)

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -275,8 +275,17 @@
                            :font-weight 600
                            :letter-spacing "-0.01em"
                            :margin      0
-                           :color       (:text-primary tokens)}
+                           :color       (:text-primary tokens)
+                           :display     "flex"
+                           :align-items "center"
+                           :gap         "8px"}
                           (t/accent-stripe-style :trace))}
+       ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. ⬢ in
+       ;; :orange (Trace's domain colour via panel-domain->token).
+       [:span {:data-testid "rf-causa-trace-panel-icon"
+               :aria-hidden "true"
+               :style       (t/panel-icon-style :trace)}
+        (:trace t/panel-icon)]
        "Trace"]
       [:span {:data-testid "rf-causa-trace-counts"
               :style {:font-size   "11px"

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -444,6 +444,35 @@
     "  from { opacity: 0; transform: translateY(2px); }\n"
     "  to   { opacity: 1; transform: translateY(0); }\n"
     "}\n"
+    ;; rf2-ezx8w — machine-state pulse (spec/021 §17.4.2 + §17.4.5).
+    ;; The xyflow `:current` node (most recent visit per per-epoch
+    ;; transition trace) carries `:animation rf-causa-machine-pulse
+    ;; 1.2s ease-in-out infinite` per `panels/machines/xyflow_style`.
+    ;; The keyframe alternates `box-shadow` + `opacity` so the green
+    ;; outer ring gently breathes — subtle scale-less pulse that reads
+    ;; as "this is the live state" without becoming a strobe across
+    ;; multi-machine canvases.
+    ;;
+    ;; The 1.2s duration is documented in §17.2 (interaction-state
+    ;; matrix → animation timings) as the machine-state current-state
+    ;; pulse cadence. It runs through `--rf-causa-motion-scale` like
+    ;; every other Causa animation, so the `prefers-reduced-motion:
+    ;; reduce` seam (+ the rf2-ybjkx user override) collapses it to
+    ;; a single resolve frame.
+    ;;
+    ;; `0%` and `100%` carry the resting frame; the midpoint adds a
+    ;; faint green glow + a 0.85 opacity dip. The xyflow node's base
+    ;; rectangle stays painted at full opacity — only the box-shadow
+    ;; halo around it pulses (alternate-style breath rather than the
+    ;; node itself flickering).
+    "@keyframes rf-causa-machine-pulse {\n"
+    "  0%, 100% {\n"
+    "    box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.45);\n"
+    "  }\n"
+    "  50% {\n"
+    "    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0);\n"
+    "  }\n"
+    "}\n"
     ;; rf2-fxde5 — global `:focus-visible` focus ring. Causa-wide
     ;; keyboard-only focus indicator scoped to descendants of the
     ;; shell roots (`[data-testid="rf-causa-shell"]` for Runtime,

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -452,3 +452,88 @@
   [tab]
   {:border-left   (str "3px solid " (panel-accent tab))
    :padding-left  "10px"})
+
+;; ---- spacing scale (rf2-ezx8w · spec/021 §17.1.1) -----------------------
+
+(def spacing
+  "Causa's 4-px-base spacing scale per spec/021 §17.1.1. Density is
+  binding (§0); spacing reinforces it. Every gap / pad value across
+  the panels is a multiple of 4 — this map catalogues the canonical
+  steps so per-panel implementations stop guessing.
+
+  | Key      | Pixels | Use                                                |
+  |----------|--------|----------------------------------------------------|
+  | `:gap-0` | 0      | Adjacent inline glyphs (e.g. diff-glyph + value)   |
+  | `:gap-1` | 4px    | Tight inline gap (icon → label inside a chip)      |
+  | `:gap-2` | 8px    | Between sibling rows in dense tables               |
+  | `:gap-3` | 12px   | Between major sections inside a panel              |
+  | `:gap-4` | 16px   | Panel inner padding (top/right/bottom/left)        |
+  | `:gap-5` | 20px   | Between distinct cards / canvases                  |
+  | `:gap-6` | 24px   | Between zones inside a panel                       |
+
+  Values are CSS strings so call sites drop them straight into inline
+  `:style` maps (e.g. `:padding (:gap-4 spacing)` for the canonical
+  16px panel pad). Pure data; JVM-portable.
+
+  Padding inside cards (the canvas frame around each per-machine
+  xyflow render) is `:gap-3` (12px) — workstation density, not
+  consumer breathing room."
+  {:gap-0 "0"
+   :gap-1 "4px"
+   :gap-2 "8px"
+   :gap-3 "12px"
+   :gap-4 "16px"
+   :gap-5 "20px"
+   :gap-6 "24px"})
+
+;; ---- per-panel header icons (rf2-ezx8w · spec/021 §17.1.5) --------------
+
+(def panel-icon
+  "Per-panel header glyph map per spec/021 §17.1.5 iconography. Each
+  L4 tab carries a Unicode glyph rendered to the LEFT of the panel
+  `<h1>` (or its inline-stripe header equivalent). Colour resolves
+  through `panel-domain->token` so the glyph rides the panel's domain
+  hue — a visual tie between the accent stripe and the icon.
+
+  | Tab           | Glyph |
+  |---------------|-------|
+  | `:event`      | ⚡    |
+  | `:reactive`   | ◉    |
+  | `:views`      | ◉    |
+  | `:app-db`     | ◐    |
+  | `:trace`      | ⬢    |
+  | `:machines`   | ◆    |
+  | `:machines-canvas` | ◆ |
+  | `:routing`    | 🌐    |
+  | `:issues`     | ⚠    |
+  | `:chrome-a11y` | ✦    |
+
+  Emoji glyphs are deliberate — consistent with existing Causa
+  convention (the L2-row badges + the Routing 🌐 affordance already
+  ship emoji). Under HCM the @media (forced-colors: active) block
+  strips the color; the glyph alone carries the signal — colour is
+  never alone (§007)."
+  {:event           "⚡"
+   :reactive        "◉"
+   :views           "◉"
+   :app-db          "◐"
+   :trace           "⬢"
+   :machines        "◆"
+   :machines-canvas "◆"
+   :routing         "🌐"
+   :issues          "⚠"
+   :chrome-a11y     "✦"})
+
+(defn panel-icon-style
+  "Build an inline-style map for the panel header icon span. Resolves
+  the panel's domain colour through `panel-accent` so the glyph rides
+  the same hue as the 3px accent stripe. Caller adds an 8px right
+  margin (or `:gap` from a flex parent) so the icon sits to the LEFT
+  of the panel's title per §17.1.5.
+
+  Returns a map merge-able into an existing `:style`."
+  [tab]
+  {:color       (panel-accent tab)
+   :font-weight 600
+   :font-size   "14px"
+   :line-height 1})

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -540,7 +540,10 @@
       (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-empty"))
             "empty-state container present")
-        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-slices")))))))
+        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-slices")))
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-app-db-panel-icon"))
+            "panel header icon (◐ in :cyan) present")))))
 
 (deftest sections-render-when-diff-present
   (testing "with history populated, the panel renders the sections-per-

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -157,7 +157,10 @@
         (is (some? (find-by-testid tree "rf-causa-issues-severity-chips"))
             "severity chip row present")
         (is (some? (find-by-testid tree "rf-causa-issues-since-input"))
-            "since-ms input present")))))
+            "since-ms input present")
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-issues-panel-icon"))
+            "panel header icon (⚠ in :red) present")))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -129,7 +129,10 @@
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-empty"))
-            "empty-state container present")))))
+            "empty-state container present")
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-panel-icon"))
+            "panel header icon (◆ in :green) present")))))
 
 ;; ---- (3) blank state (event has no machine activity) ------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines_canvas_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines_canvas_view_cljs_test.cljs
@@ -76,7 +76,10 @@
         (is (some? (find-by-testid tree "rf-causa-machines-canvas-no-selection"))
             "canvas pane shows no-selection state")
         (is (nil? (find-by-testid tree "rf-causa-machines-canvas-picker-rows"))
-            "picker rows container NOT rendered when empty")))))
+            "picker rows container NOT rendered when empty")
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-machines-canvas-panel-icon"))
+            "panel header icon (◆ in :green) present")))))
 
 ;; ---- 2. populated state ------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -34,3 +34,13 @@
     (let [tree (view/reactive-panel)]
       (is (has-testid? tree "rf-causa-reactive-empty")
           "empty-state surfaces when no cascade exists"))))
+
+(deftest reactive-panel-header-icon-present
+  (testing "rf2-ezx8w · spec/021 §17.1.5 — the Reactive panel header
+            carries a ◉ glyph in :cyan via theme.tokens/panel-icon
+            to the left of the title."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (let [tree (view/reactive-panel)
+          icon (th/find-by-testid tree "rf-causa-reactive-panel-icon")]
+      (is (some? icon) "panel icon span present"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -177,6 +177,9 @@
             "panel root present")
         (is (some? (find-by-testid tree "rf-causa-routing-header"))
             "header always renders")
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-routing-panel-icon"))
+            "panel header icon (🌐 in :yellow) present")
         (is (some? (find-by-testid tree "rf-causa-routing-topology"))
             "topology always renders when routes are registered")
         ;; Each route gets a topology-row entry.

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -169,7 +169,10 @@
         (is (some? (find-by-testid tree "rf-causa-trace"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-trace-counts"))
-            "counts span present")))))
+            "counts span present")
+        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
+        (is (some? (find-by-testid tree "rf-causa-trace-panel-icon"))
+            "panel header icon (⬢ in :orange) present")))))
 
 (deftest feed-list-renders-when-events-present
   (testing "with events in the buffer the panel renders the <ul> feed

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -112,6 +112,36 @@
           "the initial state lifts 2px below final → the new tab rises
            into place rather than appearing statically"))))
 
+;; ---- rf2-ezx8w — machine-state pulse keyframe --------------------------
+
+(deftest motion-css-declares-machine-pulse-keyframes
+  (testing "rf2-ezx8w — the xyflow `:current` node references
+            `rf-causa-machine-pulse` (see panels/machines/xyflow_style
+            `:current` kind). The keyframe MUST be declared in the
+            injected motion stylesheet so the animation resolves at
+            paint time rather than no-op'ing."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"@keyframes\s+rf-causa-machine-pulse" css)
+          "keyframes block named rf-causa-machine-pulse exists"))))
+
+(deftest motion-css-machine-pulse-uses-green-halo
+  (testing "rf2-ezx8w / spec/021 §17.4 — the pulse halo rides the
+            `:green` token (rgba 74, 222, 128) — Causa's 'final / live
+            state' hue. The 0% / 100% resting frame is the inner ring;
+            the midpoint expands the box-shadow halo + dips alpha so
+            the green ring gently breathes. Subtle box-shadow pulse
+            rather than a scale or full-opacity flicker so multi-
+            machine canvases don't strobe."
+    (let [css @#'gs/motion-css]
+      ;; Resting frame — the halo at rest is solid green at moderate alpha.
+      (is (re-find #"0%,\s*100%\s*\{\s*box-shadow:\s*0\s+0\s+0\s+0\s+rgba\(74,\s*222,\s*128"
+                   css)
+          "resting box-shadow uses the :green token rgba")
+      ;; Midpoint — the halo expands + alpha drops toward zero.
+      (is (re-find #"50%\s*\{\s*box-shadow:\s*0\s+0\s+0\s+4px\s+rgba\(74,\s*222,\s*128,\s*0\)"
+                   css)
+          "midpoint box-shadow expands to 4px halo with 0 alpha"))))
+
 ;; ---- rf2-5kfxe.5 — prefers-reduced-motion seam --------------------------
 
 (deftest motion-css-declares-root-motion-scale-default

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -20,6 +20,7 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [clojure.set :as set]
+            [clojure.string :as string]
             [day8.re-frame2-causa.theme.tokens :as t]
             [day8.re-frame2-machines-viz.theme.tokens :as mv]))
 
@@ -429,6 +430,92 @@
             (str "light-palette drift on " k
                  ": causa=" (pr-str (get t/light-palette k))
                  " vs machines-viz=" (pr-str (get mv/light-palette k))))))))
+
+;; ---- rf2-ezx8w — spacing scale (spec/021 §17.1.1) ----------------------
+
+(deftest spacing-scale-covers-canonical-steps
+  (testing "rf2-ezx8w — `spacing` exposes :gap-0 through :gap-6 per
+            spec/021 §17.1.1. Density is binding (§0); the 4-px base
+            grid is the canonical scale every panel reads."
+    (let [expected #{:gap-0 :gap-1 :gap-2 :gap-3 :gap-4 :gap-5 :gap-6}]
+      (is (= expected (set (keys t/spacing)))))))
+
+(deftest spacing-scale-emits-px-strings
+  (testing "rf2-ezx8w — every spacing entry is a CSS string callers can
+            drop into inline `:style` maps. `:gap-0` is the literal
+            `0` (no unit); the rest are px-suffixed multiples of 4."
+    (is (= "0"    (:gap-0 t/spacing)))
+    (is (= "4px"  (:gap-1 t/spacing)))
+    (is (= "8px"  (:gap-2 t/spacing)))
+    (is (= "12px" (:gap-3 t/spacing)))
+    (is (= "16px" (:gap-4 t/spacing)))
+    (is (= "20px" (:gap-5 t/spacing)))
+    (is (= "24px" (:gap-6 t/spacing)))))
+
+(deftest spacing-scale-monotone-increasing
+  (testing "rf2-ezx8w — the spacing scale is monotone increasing in
+            pixel value. Guards against accidental re-ordering when
+            adding intermediate steps later."
+    (let [px (fn [k]
+               (let [v (get t/spacing k)]
+                 (if (= v "0")
+                   0
+                   #?(:clj  (Long/parseLong (string/replace v "px" ""))
+                      :cljs (js/parseInt v 10)))))
+          ks [:gap-0 :gap-1 :gap-2 :gap-3 :gap-4 :gap-5 :gap-6]]
+      (doseq [[a b] (partition 2 1 ks)]
+        (is (< (px a) (px b))
+            (str a " (" (get t/spacing a) ") < "
+                 b " (" (get t/spacing b) ")"))))))
+
+;; ---- rf2-ezx8w — per-panel header icons (spec/021 §17.1.5) -------------
+
+(deftest panel-icon-map-covers-every-l4-tab
+  (testing "rf2-ezx8w — every L4 tab has a header-icon glyph per
+            spec/021 §17.1.5. Mirrors `panel-domain->token` so the
+            icon and the accent stripe address the same tab keys."
+    (let [tabs #{:event :reactive :views :app-db :trace :machines
+                 :machines-canvas :routing :issues :chrome-a11y}]
+      (is (= tabs (set (keys t/panel-icon)))))))
+
+(deftest panel-icon-glyphs-are-strings
+  (testing "rf2-ezx8w — every glyph value is a non-empty string.
+            Catches accidental keyword / nil drop-outs."
+    (doseq [[tab glyph] t/panel-icon]
+      (is (string? glyph) (str tab " glyph is a string"))
+      (is (seq glyph)     (str tab " glyph is non-empty")))))
+
+(deftest panel-icon-spec-glyphs
+  (testing "rf2-ezx8w — the canonical glyphs per spec/021 §17.1.5
+            iconography table. Drift here breaks the visual contract."
+    (is (= "⚡" (:event           t/panel-icon)))
+    (is (= "◉" (:reactive        t/panel-icon)))
+    (is (= "◉" (:views           t/panel-icon)))
+    (is (= "◐" (:app-db          t/panel-icon)))
+    (is (= "⬢" (:trace           t/panel-icon)))
+    (is (= "◆" (:machines        t/panel-icon)))
+    (is (= "◆" (:machines-canvas t/panel-icon)))
+    (is (= "🌐" (:routing         t/panel-icon)))
+    (is (= "⚠" (:issues          t/panel-icon)))
+    (is (= "✦" (:chrome-a11y     t/panel-icon)))))
+
+(deftest panel-icon-style-rides-panel-accent
+  (testing "rf2-ezx8w — `panel-icon-style` resolves the glyph colour
+            through `panel-accent` so the icon hue tracks the same
+            domain token as the 3px stripe."
+    (doseq [tab (keys t/panel-icon)]
+      (let [s (t/panel-icon-style tab)]
+        (is (= (t/panel-accent tab) (:color s))
+            (str tab " icon colour = accent hex"))
+        (is (string? (:font-size s)))
+        (is (= 600 (:font-weight s)))))))
+
+(deftest panel-icon-style-falls-back-for-unknown
+  (testing "unknown tab → :accent-violet (same fallback as panel-
+            accent). The icon always paints rather than dropping to a
+            colourless stroke."
+    (is (= (:accent-violet t/tokens)
+           (:color (t/panel-icon-style :unknown-tab-kw))))))
 
 (deftest causa-and-machines-viz-mono-and-sans-stacks-match
   (testing "rf2-z7ms8 — the font stacks are part of the shared visual


### PR DESCRIPTION
Closes rf2-ezx8w. Per spec/021 §17.5 critic recommendations (canonical · #1720 design doc).

## Four bundled items

**1. HCM token coverage audit.** All Causa src hexes resolve through `theme/tokens` except the axe-core impact-severity tints in `panels/chrome_a11y/panel.cljs` (`#ff4040 / #ff8000 / #f1c40f / #888 / #fed / #ffd / #ccc` — 5 inline literals scoped to axe's `critical/serious/moderate/minor` ink choices). Those are axe-specific severity colours, not part of §17 visual language. Documented as a gap; left untouched.

**2. Spacing-scale tokens.** Added `spacing` map in `theme/tokens.cljc` with `:gap-0` through `:gap-6` per §17.1.1 (0 / 4px / 8px / 12px / 16px / 20px / 24px). 3 new CLJS unit tests assert: key-set coverage, exact px-string values, monotone ordering.

**3. Per-panel header icons.** New `panel-icon` map + `panel-icon-style` helper in `theme/tokens.cljc`. One icon glyph per L4 panel per §17.1.5 iconography, each rendered to the LEFT of the `<h1>` and coloured through `panel-accent`:

  - Event ⚡ (rf2-zv9r9 / #1744 — already shipped, untouched)
  - Reactive ◉ (:cyan) — `panels/reactive_panel_view.cljs`
  - App-db ◐ (:cyan) — `panels/app_db_diff.cljs`
  - Trace ⬢ (:orange) — `panels/trace.cljs`
  - Machines ◆ (:green) — `panels/machine_inspector.cljs`
  - Machines canvas ◆ (:green) — `panels/machines_canvas/panel.cljs`
  - Routing 🌐 (:yellow) — `panels/routing.cljs`
  - Issues ⚠ (:red) — `panels/issues_ribbon.cljs`
  - Chrome A11y ✦ (:red) — `panels/chrome_a11y/panel.cljs`

  Testid pattern matches Event panel's already-shipped `rf-causa-event-detail-panel-icon` convention: `rf-causa-<panel>-panel-icon`. Each panel view-test now asserts the icon span is present (7 new assertions across 7 view-test files).

**4. Machine-state pulse keyframe.** Added `rf-causa-machine-pulse` keyframe to `theme/global_styles motion-css` next to the existing `rf-causa-diff-flash` + `rf-causa-fade-in` keyframes. Subtle 1.2s box-shadow halo pulse on the xyflow `:current` node (rgba green at 0%/100%, expands to 4px halo with 0 alpha at 50%). Already referenced from `panels/machines/xyflow_style.cljs :current` — the keyframe definition closes the missing link. 2 new CLJS unit tests assert: keyframes block present + green halo rgba.

## Surface

- `theme/tokens.cljc` — `spacing` + `panel-icon` + `panel-icon-style`
- `theme/global_styles.cljs` — `rf-causa-machine-pulse` keyframe
- `panels/{app_db_diff,reactive_panel_view,trace,issues_ribbon,machine_inspector,routing,chrome_a11y/panel,machines_canvas/panel}.cljs` — 8 panel header icon insertions
- Tests: 8 new deftests in `theme/tokens_cljs_test.cljc` + 2 in `theme/global_styles_cljs_test.cljs` + 1 deftest / inline assertion per view-test

## Gates

- `npm run test:cljs` — 3753 tests / 10895 assertions / 0 failures
- `npm run test:bundle-isolation` — green (counter / counter-uix / counter-helix bundles all pass)
- `mkdocs build --strict` — green (no warnings)