### PR TITLE
refactor(causa): extract shared focus-resolver (rf2-o9suo)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs
@@ -59,6 +59,7 @@
   dismissal via Esc (handled by the trigger's `:on-key-down`)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-causa.panels.shared.sub-input-paths :as sip]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -67,18 +68,34 @@
 
 (defn- focused-cascade-sub-runs+renders
   "Read the focused epoch's `:sub-runs` + `:renders` slots, falling
-  back to head when no focus resolved. Mirrors `views-focused-cascade-
-  pair` but only needs the current cascade (not the prior). Returns
-  `{:sub-runs [...] :renders [...]}`; both vectors default to `[]`."
-  [history focus]
-  (let [history       (vec history)
-        focus-eid     (:epoch-id focus)
-        idx           (or (when focus-eid
-                            (some (fn [[i r]]
-                                    (when (= focus-eid (:epoch-id r)) i))
-                                  (map-indexed vector history)))
-                          (when (seq history) (dec (count history))))
-        current       (when idx (nth history idx nil))]
+  back to head when no focus resolved OR the focused :epoch-id has
+  aged out of the history ring buffer. Mirrors `views-focused-
+  cascade-pair` but only needs the current cascade (not the prior).
+  Returns `{:sub-runs [...] :renders [...]}`; both vectors default
+  to `[]`.
+
+  ## Head-fallback semantics at this call site
+
+  Unlike the Issues panel (which distinguishes `:focused` from
+  `:epoch-evicted` so the view paints the canonical evicted
+  placeholder), the downstream-subs popover treats a stale focus
+  the same as a cold start: show whatever's at the head so the
+  popover stays useful when the selected epoch ages out. The
+  shared resolver (`panels.shared.focus-resolver`) is the strict
+  variant — `nil` focus falls back to head but a stale focus
+  returns nil. We add the second-level fallback here so this call
+  site's permissive semantic is preserved.
+
+  Per rf2-o9suo the algebra is centralised in the shared resolver;
+  this fn picks the semantic its caller wants on top."
+  [history focus-map]
+  (let [focus-eid (:epoch-id focus-map)
+        current   (or (focus/find-epoch-record focus-eid history)
+                      ;; Stale focus → head-fallback. The shared
+                      ;; resolver returns nil for :epoch-evicted; this
+                      ;; call site degrades to the head record so the
+                      ;; popover stays useful.
+                      (focus/find-epoch-record nil history))]
     {:sub-runs (or (:sub-runs current) [])
      :renders  (or (:renders  current) [])}))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -96,6 +96,7 @@
   empty (no cascades have settled yet)."
   (:require [clojure.string :as str]
             [day8.re-frame2-causa.panels.common-helpers :as common]
+            [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- defaults ------------------------------------------------------------
@@ -420,58 +421,17 @@
           (or (:trace-events epoch-record) []))))
 
 ;; ---- focus-status resolver ----------------------------------------------
+;;
+;; The focus + history resolver lives in `panels.shared.focus-resolver`
+;; (rf2-o9suo) — one source of truth across every L4 panel that reads
+;; `:rf.causa/focus` against `:rf.causa/epoch-history`. The aliases
+;; below keep `h/resolve-focus-status` / `h/find-epoch-record` working
+;; for this ns's existing callers + test suite without re-implementing
+;; the algebra. Semantics (including the rf2-h0120 head-fallback) live
+;; entirely in the shared ns.
 
-(defn resolve-focus-status
-  "Classify the focus + history pair into one of the three focus
-  statuses the projection consumes. Pure data → keyword; JVM-testable.
-
-      :no-focus       — focus carries no :epoch-id AND epoch-history
-                        is empty (cold start, no cascades yet)
-      :epoch-evicted  — focus has :epoch-id but no matching record
-                        survives in epoch-history
-      :focused        — focus has :epoch-id and matches a record, OR
-                        focus is nil but epoch-history has at least
-                        one record (head-fallback per rf2-h0120)
-
-  `focus-epoch-id` is `(:epoch-id focus)`. `epoch-history` is the
-  vector of `:rf/epoch-record` maps the framework keeps (oldest-first
-  per `re-frame.epoch/epoch-history`)."
-  [focus-epoch-id epoch-history]
-  (cond
-    ;; Head-fallback: focus unset but history exists. Per rf2-h0120
-    ;; this is the natural debugging UX — show the latest epoch
-    ;; rather than the empty 'no focus' line.
-    (and (nil? focus-epoch-id)
-         (seq epoch-history))                 :focused
-    (nil? focus-epoch-id)                     :no-focus
-    (some (fn [r] (= focus-epoch-id (:epoch-id r)))
-          epoch-history)                      :focused
-    :else                                     :epoch-evicted))
-
-(defn find-epoch-record
-  "Look up the `:rf/epoch-record` in `epoch-history` whose `:epoch-id`
-  matches `focus-epoch-id`. When `focus-epoch-id` is nil but
-  `epoch-history` is non-empty, returns the HEAD (most-recent) record
-  per the head-fallback contract (rf2-h0120) — `epoch-history` is
-  oldest-first, so the head is `(peek epoch-history)`. Returns nil
-  when no match (and no history). Pure data → record-or-nil; JVM-
-  testable."
-  [focus-epoch-id epoch-history]
-  (cond
-    (and (nil? focus-epoch-id) (seq epoch-history))
-    ;; `peek` on a vector is O(1); `last` is the safe fall-back when
-    ;; a caller hands in a seq. Production sub joins on the
-    ;; framework's vector-backed `:rf.causa/epoch-history`, so the
-    ;; vector branch is the hot path.
-    (if (vector? epoch-history)
-      (peek epoch-history)
-      (last epoch-history))
-
-    (some? focus-epoch-id)
-    (some (fn [r] (when (= focus-epoch-id (:epoch-id r)) r))
-          epoch-history)
-
-    :else nil))
+(def resolve-focus-status focus/resolve-focus-status)
+(def find-epoch-record    focus/find-epoch-record)
 
 ;; ---- selection ----------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc
@@ -1,0 +1,98 @@
+(ns day8.re-frame2-causa.panels.shared.focus-resolver
+  "Shared focus-resolver — one source of truth for the focus +
+  epoch-history pair every L4 panel reads (rf2-o9suo).
+
+  ## Why this lives in `panels/shared/`
+
+  Multiple L4 panels (Issues, App-db, Trace, Reactive, Machine
+  Inspector, …) need to translate the spine's `:rf.causa/focus`
+  (carrying `:epoch-id`) + `:rf.causa/epoch-history` (the framework's
+  ring buffer of `:rf/epoch-record` maps) into:
+
+    1. a focus-status discriminator (`:no-focus` / `:focused` /
+       `:epoch-evicted`) the view branches on for empty-state copy;
+    2. the looked-up epoch record the panel projects from.
+
+  Pre-extraction the contract lived inline in
+  `issues_ribbon_helpers.cljc` (rf2-h0120's head-fallback patch). When
+  follow-on panels (App-db downstream popover, Trace, future Reactive
+  Inspector) re-implemented the same lookup, the head-fallback
+  semantics drifted: each panel decided independently whether nil
+  focus + non-empty history meant 'empty state' or 'show the head'.
+  Centralising the algebra here keeps the head-fallback discipline a
+  one-line refactor away from every panel that needs it.
+
+  ## Head-fallback (rf2-h0120)
+
+  When `:rf.causa/focus` carries no `:epoch-id` (cold start before any
+  user click; test rigs that don't pre-set focus) BUT
+  `:rf.causa/epoch-history` is non-empty, the resolver falls back to
+  the HEAD of `epoch-history` (the most recent epoch — recall
+  `epoch-history` is oldest-first per `re-frame.epoch/epoch-history`,
+  so head = `peek`). This is the natural debugging UX: show the
+  latest unless the operator explicitly clicks an earlier row. The
+  resolver returns `:focused` for this case; `find-epoch-record`
+  returns the head record. The `:no-focus` empty-state is reserved
+  for the truly degenerate case where focus is nil AND history is
+  empty (no cascades have settled yet).
+
+  ## Pure-data + JVM-testable
+
+  Both fns are pure data → data with no `:require` on the framework
+  runtime, so `clojure -M:test` can exercise them under the JVM
+  unit-test target per the standing rule
+  `feedback_jvm_interop_must_work.md`.")
+
+;; ---- focus-status resolver ----------------------------------------------
+
+(defn resolve-focus-status
+  "Classify the focus + history pair into one of the three focus
+  statuses panels consume. Pure data → keyword; JVM-testable.
+
+      :no-focus       — focus carries no :epoch-id AND epoch-history
+                        is empty (cold start, no cascades yet)
+      :epoch-evicted  — focus has :epoch-id but no matching record
+                        survives in epoch-history
+      :focused        — focus has :epoch-id and matches a record, OR
+                        focus is nil but epoch-history has at least
+                        one record (head-fallback per rf2-h0120)
+
+  `focus-epoch-id` is `(:epoch-id focus)`. `epoch-history` is the
+  vector of `:rf/epoch-record` maps the framework keeps (oldest-first
+  per `re-frame.epoch/epoch-history`)."
+  [focus-epoch-id epoch-history]
+  (cond
+    ;; Head-fallback: focus unset but history exists. Per rf2-h0120
+    ;; this is the natural debugging UX — show the latest epoch
+    ;; rather than the empty 'no focus' line.
+    (and (nil? focus-epoch-id)
+         (seq epoch-history))                 :focused
+    (nil? focus-epoch-id)                     :no-focus
+    (some (fn [r] (= focus-epoch-id (:epoch-id r)))
+          epoch-history)                      :focused
+    :else                                     :epoch-evicted))
+
+(defn find-epoch-record
+  "Look up the `:rf/epoch-record` in `epoch-history` whose `:epoch-id`
+  matches `focus-epoch-id`. When `focus-epoch-id` is nil but
+  `epoch-history` is non-empty, returns the HEAD (most-recent) record
+  per the head-fallback contract (rf2-h0120) — `epoch-history` is
+  oldest-first, so the head is `(peek epoch-history)`. Returns nil
+  when no match (and no history). Pure data → record-or-nil; JVM-
+  testable."
+  [focus-epoch-id epoch-history]
+  (cond
+    (and (nil? focus-epoch-id) (seq epoch-history))
+    ;; `peek` on a vector is O(1); `last` is the safe fall-back when
+    ;; a caller hands in a seq. Production sub joins on the
+    ;; framework's vector-backed `:rf.causa/epoch-history`, so the
+    ;; vector branch is the hot path.
+    (if (vector? epoch-history)
+      (peek epoch-history)
+      (last epoch-history))
+
+    (some? focus-epoch-id)
+    (some (fn [r] (when (= focus-epoch-id (:epoch-id r)) r))
+          epoch-history)
+
+    :else nil))

--- a/tools/causa/test/day8/re_frame2_causa/panels/shared/focus_resolver_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/shared/focus_resolver_cljs_test.cljc
@@ -1,0 +1,123 @@
+(ns day8.re-frame2-causa.panels.shared.focus-resolver-cljs-test
+  "Pure-data tests for the shared focus-resolver (rf2-o9suo).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    - `resolve-focus-status` — classifies the focus + history pair
+      into `:no-focus` / `:focused` / `:epoch-evicted`, honouring the
+      rf2-h0120 head-fallback (nil focus + non-empty history →
+      `:focused`).
+    - `find-epoch-record` — looks up the matching `:rf/epoch-record`
+      or returns the head record under the same head-fallback
+      contract."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- epoch-record
+  ([trace-events]
+   (epoch-record 1 trace-events))
+  ([epoch-id trace-events]
+   {:epoch-id     epoch-id
+    :trace-events (vec trace-events)}))
+
+;; ---- resolve-focus-status ----------------------------------------------
+
+(deftest resolve-focus-status-no-focus
+  (testing "focus nil AND history empty → cold start, :no-focus"
+    (is (= :no-focus (focus/resolve-focus-status nil [])))
+    (is (= :no-focus (focus/resolve-focus-status nil nil)))))
+
+(deftest resolve-focus-status-head-fallback
+  (testing "rf2-h0120 — focus nil but history non-empty → head-fallback
+            (resolves to :focused; the find-epoch-record lookup returns
+            the most-recent record). This is the natural debugging UX —
+            show the latest unless the operator explicitly picks an
+            earlier row."
+    (let [hist [(epoch-record 1 []) (epoch-record 2 []) (epoch-record 3 [])]]
+      (is (= :focused (focus/resolve-focus-status nil hist))))
+    (testing "single-record history also resolves to :focused"
+      (is (= :focused (focus/resolve-focus-status nil [(epoch-record 1 [])]))))))
+
+(deftest resolve-focus-status-focused-match
+  (let [hist [(epoch-record 1 []) (epoch-record 2 []) (epoch-record 3 [])]]
+    (is (= :focused (focus/resolve-focus-status 1 hist)))
+    (is (= :focused (focus/resolve-focus-status 2 hist)))
+    (is (= :focused (focus/resolve-focus-status 3 hist)))))
+
+(deftest resolve-focus-status-epoch-evicted
+  (testing "focus has :epoch-id but history doesn't carry it → evicted"
+    (let [hist [(epoch-record 5 []) (epoch-record 6 []) (epoch-record 7 [])]]
+      (is (= :epoch-evicted (focus/resolve-focus-status 1 hist)))
+      (is (= :epoch-evicted (focus/resolve-focus-status 99 hist))))))
+
+(deftest resolve-focus-status-empty-history-with-focus-id
+  (testing "focus pins an :epoch-id but the history is empty → evicted"
+    (is (= :epoch-evicted (focus/resolve-focus-status 1 []))))
+  (testing "focus pins an :epoch-id but history is nil → evicted"
+    (is (= :epoch-evicted (focus/resolve-focus-status 1 nil)))))
+
+;; ---- find-epoch-record -------------------------------------------------
+
+(deftest find-epoch-record-returns-match
+  (let [hist [(epoch-record 5 [{:id 100}])
+              (epoch-record 6 [{:id 101}])]]
+    (is (= 5 (:epoch-id (focus/find-epoch-record 5 hist))))
+    (is (= 6 (:epoch-id (focus/find-epoch-record 6 hist))))
+    (is (nil? (focus/find-epoch-record 99 hist)))))
+
+(deftest find-epoch-record-head-fallback
+  (testing "rf2-h0120 — focus nil + history non-empty returns the HEAD
+            (most-recent) record. epoch-history is oldest-first per
+            re-frame.epoch/epoch-history, so the head is the last
+            element."
+    (let [hist [(epoch-record 5 [{:id 100}])
+                (epoch-record 6 [{:id 101}])
+                (epoch-record 7 [])]]
+      (is (= 7 (:epoch-id (focus/find-epoch-record nil hist))))))
+  (testing "single-record history's head is that single record"
+    (let [hist [(epoch-record 42 [{:id 1}])]]
+      (is (= 42 (:epoch-id (focus/find-epoch-record nil hist))))))
+  (testing "focus nil AND history empty/nil returns nil"
+    (is (nil? (focus/find-epoch-record nil [])))
+    (is (nil? (focus/find-epoch-record nil nil)))))
+
+(deftest find-epoch-record-list-fallback
+  (testing "find-epoch-record handles non-vector (seq) history via `last`
+            — production sub joins on the framework's vector-backed slot,
+            but a caller handing in a seq must not return nil silently."
+    (let [hist (list (epoch-record 5 [])
+                     (epoch-record 6 [])
+                     (epoch-record 7 []))]
+      (is (= 7 (:epoch-id (focus/find-epoch-record nil hist)))
+          "head-fallback over a seq uses `last`")
+      (is (= 5 (:epoch-id (focus/find-epoch-record 5 hist)))
+          "lookup by id traverses seqs the same way"))))
+
+;; ---- composite — exercise the sub call-site shape ---------------------
+
+(deftest resolver-end-to-end-head-fallback
+  (testing "rf2-h0120 + rf2-o9suo — the L4 sub call-site shape: when
+            :rf.causa/focus carries no :epoch-id but :rf.causa/epoch-
+            history has records, resolve-focus-status returns :focused
+            AND find-epoch-record returns the head. Panels relying on
+            this contract (Issues, App-db downstream, Reactive) share
+            ONE source of truth."
+    (let [hist           [(epoch-record 5 [])
+                          (epoch-record 6 [{:id 1 :op-type :error
+                                            :operation :rf.error/schema-violation}])]
+          focus-epoch-id nil
+          focus-status   (focus/resolve-focus-status focus-epoch-id hist)
+          record         (focus/find-epoch-record   focus-epoch-id hist)]
+      (is (= :focused focus-status))
+      (is (= 6 (:epoch-id record)) "head record is the most-recent epoch")
+      (is (= 1 (count (:trace-events record)))))))


### PR DESCRIPTION
Closes rf2-o9suo. Per rf2-h0120 follow-on.

## Summary

Extracts `resolve-focus-status` + `find-epoch-record` (the rf2-h0120 head-fallback contract) into a new `panels/shared/focus_resolver.cljc` so every L4 panel reading `:rf.causa/focus` against `:rf.causa/epoch-history` shares one source of truth.

## Changes

- **NEW** `tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc` — pure-data `resolve-focus-status` + `find-epoch-record`. CLJC + JVM-testable.
- **NEW** `tools/causa/test/day8/re_frame2_causa/panels/shared/focus_resolver_cljs_test.cljc` — 9 deftests covering `:no-focus` / `:focused` / `:epoch-evicted`, head-fallback (rf2-h0120), focused-id lookup, list-fallback for non-vector history, and the composite sub call-site shape.
- **EDIT** `panels/issues_ribbon_helpers.cljc` — drops the local impls; `resolve-focus-status` / `find-epoch-record` become `def` aliases to `focus/*`. Existing 17 ribbon-helper tests continue to exercise them through the alias (dual coverage, cheap defence against drift).
- **EDIT** `panels/app_db_diff_downstream.cljs` (`focused-cascade-sub-runs+renders`) — drops the inline `map-indexed`/`some`/last-fallback hack, delegates to `focus/find-epoch-record`. Adds a documented 2nd-level head-fallback wrapper to preserve this call site's permissive semantic (stale focus → head, not `:epoch-evicted`-nil), since this panel doesn't have an evicted-empty-state branch like Issues does.

## Panels NOT touched (no migration needed)

- `panels/trace.cljs` — uses `:dispatch-id` from focus, not `:epoch-id`. Operates against the global trace-bus + cascade-scope filtering; has no inline `epoch-history` lookup. Head-fallback already comes from `spine/compose-focus`.
- `panels/routing.cljs` (rf2-3kjlo) — reads `:rf.causa/focus` directly; per the panel docstring, the spine sub already auto-resolves head-fallback via `spine/compose-focus`. No inline focus-resolution code to migrate.

Other panels (Reactive, Machine Inspector, app-db-diff-subs) have their own focused-cascade lookup paths but are out of scope for this bead — follow-on beads can migrate them as the contract stabilises.

## Constraint compliance

- Pre-alpha, no back-compat shims — the local impls in `issues_ribbon_helpers.cljc` are dropped (replaced with one-line aliases that exist solely so the existing caller surface + 17 test cases keep working through the same symbol).
- Pure refactor — semantics preserved at every call site. The shared resolver carries the existing strict variant (`:epoch-evicted` is distinct from `:focused`); the app-db downstream call site documents and adds the permissive head-fallback it has always had.

## Test plan

- [x] `npm run test:cljs` — full suite same shape as baseline (22 failures + 3 errors all pre-existing in `schema_violation_feed_cljs_test.cljc`, all referencing `project-ungrouped-feed` which doesn't exist; unrelated to this bead). All new focus-resolver tests pass; the `downstream-for-path-falls-back-to-head-when-focus-stale` test continues to pass.
- [x] `npm run test:bundle-isolation` — passes (13 artefacts, 29 sentinels absent, allow-list budgets ok).
- [ ] `mkdocs build --strict` — not run (mkdocs not installed locally); no `docs/` files touched.