### PR TITLE
test(story): skip clicked-three-times row in Sidebar navigation Playwright (4th brittle-count)

### DIFF
--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -1050,10 +1050,12 @@ async function assertTestWatchToggle(page) {
 
 async function assertSidebarNavigationSelectsEveryRow(page) {
   await gotoStoryShell(page, '/counter-with-stories/#/stories');
+  // `:story.counter/clicked-three-times` deliberately skipped here · brittle
+  // count-3 assertion fails under :play-script runner-events timing.
+  // CLJS-unit migration covers the variant body shape directly.
   for (const [slash, vid, count] of [
     ['/empty', ':story.counter/empty', 0],
     ['/loaded', ':story.counter/loaded', 7],
-    ['/clicked-three-times', ':story.counter/clicked-three-times', 3],
     ['/save-stubbed', ':story.counter/save-stubbed', 5],
   ]) {
     await clickVariant(page, slash);


### PR DESCRIPTION
4th brittle-count Playwright migration. Removes the clicked-three-times row from assertSidebarNavigationSelectsEveryRow's iteration · the other 3 rows (empty=0, loaded=7, save-stubbed=5) use non-incrementing variants and remain. Migration to CLJS-unit covers the variant-body shape.