### PR TITLE
feat(spec): transducer-shaped event router (rf2-cl8me . v1.1 design pass)

### DIFF
--- a/implementation/core/src/re_frame/router_transducer.cljc
+++ b/implementation/core/src/re_frame/router_transducer.cljc
@@ -1,0 +1,313 @@
+(ns re-frame.router-transducer
+  "Phase-1 reference scaffold for the v1.1 transducer-shaped router design
+  (rf2-cl8me). Non-normative: this namespace is NOT wired into the live
+  runtime. It exists so the design in spec/Design-TransducerRouter.md is
+  exercisable from the REPL and pinned by a CLJS/CLJ unit-test surface.
+
+  The design intent:
+   - `frame-transducer-factory` returns a transducer that maps dispatch
+     envelopes to step-results. The xforms own per-event work (resolve
+     handler, run pipeline, compute new state); they do not commit and do
+     not schedule.
+   - Three reducing-function presets (`sync-rf`, `queued-rf`, `batch-rf`)
+     decide how successive states are accumulated and when they are
+     committed. The reducing function is what differentiates v1's drain
+     loop from a synchronous transduce from a batched cascade-settle
+     commit.
+   - The scaffold ships a `manual-driver` only — enough to exercise the
+     reducing functions deterministically in tests. Real drivers
+     (microtask / raf / virtual-time) are Phase 2.
+
+  Substrate-agnostic boundary: nothing in this namespace touches the
+  rendering substrate or the live frame registry. The 'frame' value
+  passed in is a plain map carrying a `:handlers` lookup (event-id ->
+  handler-fn) and the current `:db` value. Real wiring resolves these
+  against `re-frame.frame` / `re-frame.events`; the scaffold keeps them
+  injectable so the unit tests are pure.
+
+  See spec/Design-TransducerRouter.md for the full contract."
+  (:require [re-frame.interop :as interop]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- the per-event xforms -------------------------------------------------
+;;
+;; Each xform takes (and returns) a step-result map per the design. The
+;; transducer itself is `(comp xf-resolve-handler xf-validate-event
+;; xf-run-handler xf-stage-effects xf-tag-step)`. All five are pure: no
+;; container writes, no scheduling, no trace side-effects (the design has
+;; trace emit-sites here but the scaffold elides them — the trace surface
+;; is tested elsewhere and the scaffold's purpose is the reducing-function
+;; story, not the trace projection).
+
+(defn xf-resolve-handler
+  "Map step: look up the event-id's handler in the envelope's frame and
+  attach it as `:handler`. When the handler is missing, tag the step
+  `:rf/step :no-handler` and stop further xforms from touching it."
+  []
+  (map (fn [{:keys [envelope] :as step}]
+         (let [event    (:event envelope)
+               event-id (first event)
+               handlers (get-in envelope [:frame :handlers])
+               handler  (get handlers event-id)]
+           (if handler
+             (assoc step :handler handler :event event :event-id event-id)
+             (assoc step
+                    :event     event
+                    :event-id  event-id
+                    :rf/step   :no-handler
+                    :db-after  (:db-before step)
+                    :effects   {}))))))
+
+(defn xf-validate-event
+  "Map step: when the envelope carries `:validate-event` (a predicate
+  fn), invoke it. Failed validation short-circuits with
+  `:rf/step :validation`. No-op when absent. This is the per-step seam
+  for Spec 010 §Per-step recovery row 1."
+  []
+  (map (fn [{:keys [envelope event] :as step}]
+         (let [validator (:validate-event envelope)]
+           (cond
+             (= (:rf/step step) :no-handler)
+             step
+
+             (and validator (not (validator event)))
+             (assoc step
+                    :rf/step  :validation
+                    :db-after (:db-before step)
+                    :effects  {})
+
+             :else
+             step)))))
+
+(defn xf-run-handler
+  "Map step: when the step is still `:ok`, invoke the handler against
+  `:db-before` and the event. The handler signature is
+  `(fn [db event] -> effects-map)` where effects-map is at minimum
+  `{:db new-db}`; effects without `:db` carry the previous db through.
+
+  Handler exceptions are caught and surfaced as `:rf/step :handler-throw`
+  with the structured error attached. The pre-cascade `:db` is preserved
+  on `:db-after` so a downstream `batch-rf` can decide whether to roll
+  back or commit-with-error."
+  []
+  (map (fn [{:keys [handler event db-before] :as step}]
+         (if (#{:no-handler :validation} (:rf/step step))
+           step
+           (try
+             (let [effects  (handler db-before event)
+                   db-after (if (contains? effects :db)
+                              (:db effects)
+                              db-before)]
+               (assoc step
+                      :rf/step  :ok
+                      :db-after db-after
+                      :effects  effects))
+             (catch #?(:clj Throwable :cljs :default) ex
+               (assoc step
+                      :rf/step  :handler-throw
+                      :db-after db-before
+                      :effects  {}
+                      :error    {:operation :rf.error/handler-throw
+                                 :event     event
+                                 :ex        ex})))))))
+
+(defn xf-stage-effects
+  "Map step: extract non-:db effects into a flat `:fx` seq so the
+  reducing function can apply them in a single walk. v1's `do-fx`
+  walks `:fx` in source order; the scaffold preserves that contract.
+
+  An effects-map like `{:db ... :fx [[:dispatch [:x]] [:http {...}]]}`
+  yields `:fx [[:dispatch [:x]] [:http {...}]]`. A non-`:fx`-shaped
+  effects-map like `{:db ... :dispatch [:x]}` is normalised into the
+  same seq form so reducing fns don't need to know about the legacy
+  shape."
+  []
+  (map (fn [{:keys [effects] :as step}]
+         (let [fx-vec    (vec (:fx effects))
+               extras    (for [[k v] (dissoc effects :db :fx)
+                               :when (some? v)]
+                           [k v])
+               staged    (into fx-vec extras)]
+           (assoc step :fx staged)))))
+
+(defn xf-tag-step
+  "Map step: normalise `:rf/step` to `:ok` when no earlier xform has
+  tagged the step. Reducing functions key off this to decide commit
+  vs. rollback vs. emit-error-and-continue."
+  []
+  (map (fn [step]
+         (cond-> step
+           (nil? (:rf/step step)) (assoc :rf/step :ok)))))
+
+(defn frame-transducer
+  "The composed transducer: envelope -> step-result. Stateless; reusable
+  across many envelopes and many reducing functions. Closes over no
+  per-frame state — the frame is carried inside each envelope so the
+  same transducer instance can route across frames if a host wants."
+  []
+  (comp
+    (map (fn [envelope]
+           {:envelope  envelope
+            :db-before (get-in envelope [:frame :db])
+            :event     (:event envelope)}))
+    (xf-resolve-handler)
+    (xf-validate-event)
+    (xf-run-handler)
+    (xf-stage-effects)
+    (xf-tag-step)))
+
+(defn frame-transducer-factory
+  "Per the design's public surface. Returns a transducer that maps
+  envelopes onto step-results for `frame`.
+
+  The factory exists for symmetry with the design's public API. The
+  frame is currently carried inside each envelope (so one transducer
+  instance can service many frames); the factory is the future seam
+  for per-frame customisations (e.g. interceptor-override pre-bound
+  into the transducer)."
+  [_frame]
+  (frame-transducer))
+
+;; ---- reducing-function presets -------------------------------------------
+;;
+;; Each reducing function closes over a frame-record-like atom holding
+;; `{:db <current-db> :events-applied <count> :fx-applied <vec>
+;;   :errors <vec>}`. The reducing function receives step-results from
+;; the transducer and decides how to fold them into the accumulator.
+
+(defn- apply-fx-eager
+  "Apply the staged `:fx` seq immediately. The scaffold's fx-apply is a
+  no-op shape — real wiring would dispatch into `re-frame.fx`. Returns
+  the input acc with `:fx-applied` extended for test observability."
+  [acc fx]
+  (update acc :fx-applied into fx))
+
+(defn sync-rf
+  "Reducing function: every step commits eagerly. `:db-after` is written
+  into the accumulator's `:db` slot, `:fx` is applied inline. This is
+  the equivalent of v1's `dispatch-sync` — synchronous, fixed-point on
+  return.
+
+  The returned accumulator carries the final db plus a trace of every
+  step under `:steps` for test observability. Production wiring would
+  drop `:steps` and write through to the substrate container."
+  []
+  (fn
+    ([] {:db nil :steps [] :fx-applied [] :errors []})
+    ([acc] acc)                          ;; completing arity
+    ([acc step]
+     (let [{:keys [rf/step db-after fx error]} step]
+       (cond-> acc
+         true            (assoc :db db-after)
+         true            (update :steps conj step)
+         (seq fx)        (apply-fx-eager fx)
+         (some? error)   (update :errors conj error)
+         (= step :ok)    identity)))))
+
+(defn queued-rf
+  "Reducing function: commits eagerly per step (same as `sync-rf` for
+  the accumulator surface), but `:fx [[:dispatch ...]]` entries are
+  *enqueued* on the accumulator's `:queue` rather than applied inline.
+  This is the v1 drain shape — the driver pumps the queue between
+  outer transduce calls.
+
+  A real wiring's driver (microtask / raf) re-enters the transduce
+  with the dequeued envelope; the scaffold just exposes the queue for
+  tests to drain manually via `manual-driver`."
+  []
+  (fn
+    ([] {:db nil :steps [] :queue interop/empty-queue
+         :fx-applied [] :errors []})
+    ([acc] acc)
+    ([acc step]
+     (let [{:keys [rf/step db-after fx error]} step
+           [dispatches non-dispatches] ((juxt filter remove)
+                                        (fn [[k _]] (= k :dispatch))
+                                        (or fx []))]
+       (cond-> acc
+         true                    (assoc :db db-after)
+         true                    (update :steps conj step)
+         (seq non-dispatches)    (apply-fx-eager (vec non-dispatches))
+         (seq dispatches)        (update :queue into (map second dispatches))
+         (some? error)           (update :errors conj error))))))
+
+(defn batch-rf
+  "Reducing function: defers the commit until the completing arity.
+  Intermediate `:db-after` values are folded onto the accumulator's
+  `:db` but `:fx` is NOT applied until completing. The completing
+  arity then walks the staged-fx vector once.
+
+  This is the natural fit for cascades that touch `:db` N times but
+  should pay one commit + one fx-walk at cascade boundary (Spec 005
+  `:always`, SSR loader fan-in)."
+  []
+  (fn
+    ([] {:db nil :staged-fx [] :steps [] :fx-applied [] :errors []
+         :committed? false})
+    ([acc]
+     (-> acc
+         (apply-fx-eager (:staged-fx acc))
+         (assoc :committed? true
+                :staged-fx [])))
+    ([acc step]
+     (let [{:keys [rf/step db-after fx error]} step]
+       (cond-> acc
+         true            (assoc :db db-after)
+         true            (update :steps conj step)
+         (seq fx)        (update :staged-fx into fx)
+         (some? error)   (update :errors conj error))))))
+
+;; ---- manual driver --------------------------------------------------------
+;;
+;; The simplest driver: tests construct it, push envelopes, and tick the
+;; pump explicitly. Real drivers wrap the same shape around the host's
+;; microtask / raf / virtual-time scheduler.
+
+(defn manual-driver
+  "Construct a manual-pump driver. Returns a handle map with three
+  closures over a single mutable cell:
+    :push!  (push! envelope) — enqueue an envelope
+    :tick!  (tick! frame rf) — pop one envelope and transduce it,
+                               returning the new accumulator
+    :drain! (drain! frame rf) — tick! to fixed point; returns the
+                               final accumulator after the queue empties"
+  []
+  (let [state (atom {:queue interop/empty-queue :acc nil})]
+    {:push!  (fn [envelope]
+               (swap! state update :queue conj envelope))
+     :tick!  (fn [frame rf]
+               (let [{:keys [queue acc]} @state]
+                 (if (empty? queue)
+                   acc
+                   (let [envelope (peek queue)
+                         next-acc (transduce
+                                    (frame-transducer-factory frame)
+                                    (fn
+                                      ([] (or acc (rf)))
+                                      ([a] (rf a))
+                                      ([a step] (rf a step)))
+                                    [envelope])]
+                     (swap! state assoc :queue (pop queue) :acc next-acc)
+                     next-acc))))
+     :drain! (fn [frame rf]
+               (loop []
+                 (let [{:keys [queue]} @state]
+                   (if (empty? queue)
+                     (:acc @state)
+                     (do
+                       (let [envelope (peek queue)
+                             cur-acc  (or (:acc @state) (rf))
+                             next-acc (transduce
+                                        (frame-transducer-factory frame)
+                                        (fn
+                                          ([] cur-acc)
+                                          ([a] a)
+                                          ([a step] (rf a step)))
+                                        cur-acc
+                                        [envelope])]
+                         (swap! state assoc
+                                :queue (pop queue)
+                                :acc next-acc))
+                       (recur))))))
+     :peek   (fn [] @state)}))

--- a/implementation/core/test/re_frame/router_transducer_test.cljc
+++ b/implementation/core/test/re_frame/router_transducer_test.cljc
@@ -1,0 +1,189 @@
+(ns re-frame.router-transducer-test
+  "Unit coverage for the v1.1 transducer-router Phase-1 scaffold
+  (rf2-cl8me). Non-normative — these tests pin the scaffold's pure-fn
+  surface so the design at spec/Design-TransducerRouter.md is exercisable.
+
+  The scaffold does not touch the live runtime; these tests construct
+  ad-hoc envelopes + frames and walk them through the transducer +
+  reducing functions directly. No registrar / no router / no substrate."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.router-transducer :as rt]))
+
+;; ---- test-only helpers ----------------------------------------------------
+
+(defn- envelope
+  "Construct a minimal dispatch envelope. The frame here is a plain map
+  carrying `:handlers` + `:db`; real wiring would point at the live
+  frame record."
+  [event handlers db & {:as extras}]
+  (merge {:event event
+          :frame {:handlers handlers
+                  :db       db}}
+         extras))
+
+(defn- transduce-one
+  "Drive one envelope through (factory frame) + rf. Returns the final acc."
+  [envelope rf]
+  (let [tdx (rt/frame-transducer-factory (:frame envelope))]
+    (transduce tdx rf [envelope])))
+
+;; ---- transducer / step-result coverage -----------------------------------
+
+(deftest step-result-shape
+  (testing "happy path produces a fully-tagged step-result"
+    (let [handlers {:inc (fn [db _] {:db (update db :n inc)})}
+          e        (envelope [:inc] handlers {:n 0})
+          steps    (into [] (rt/frame-transducer-factory (:frame e)) [e])]
+      (is (= 1 (count steps)))
+      (let [step (first steps)]
+        (is (= :ok (:rf/step step)))
+        (is (= {:n 0} (:db-before step)))
+        (is (= {:n 1} (:db-after step)))
+        (is (= {:db {:n 1}} (:effects step)))
+        (is (= [] (:fx step)))))))
+
+(deftest no-handler-step-tag
+  (testing "missing handler short-circuits with :rf/step :no-handler"
+    (let [e     (envelope [:missing] {} {:n 0})
+          steps (into [] (rt/frame-transducer-factory (:frame e)) [e])
+          step  (first steps)]
+      (is (= :no-handler (:rf/step step)))
+      (is (= {:n 0} (:db-after step)) "db preserved on no-handler"))))
+
+(deftest handler-throw-tags-error
+  (testing "handler exception is caught and surfaced as :handler-throw"
+    (let [handlers {:boom (fn [_ _] (throw (ex-info "boom" {})))}
+          e        (envelope [:boom] handlers {:n 0})
+          steps    (into [] (rt/frame-transducer-factory (:frame e)) [e])
+          step     (first steps)]
+      (is (= :handler-throw (:rf/step step)))
+      (is (= {:n 0} (:db-after step)) "db rolled back on throw")
+      (is (some? (:error step)))
+      (is (= :rf.error/handler-throw (get-in step [:error :operation]))))))
+
+(deftest validate-event-short-circuits
+  (testing "failed :validate-event fence short-circuits before run"
+    (let [seen (atom false)
+          handlers {:x (fn [_ _] (reset! seen true) {:db {:n 1}})}
+          e (envelope [:x] handlers {:n 0}
+                      :validate-event (fn [ev] (= ev [:y]))) ;; fails
+          steps (into [] (rt/frame-transducer-factory (:frame e)) [e])
+          step  (first steps)]
+      (is (= :validation (:rf/step step)))
+      (is (false? @seen) "handler never invoked when validation fails")
+      (is (= {:n 0} (:db-after step))))))
+
+(deftest fx-staging
+  (testing "non-:db effects are normalised into a flat :fx seq"
+    (let [handlers {:multi (fn [_ _]
+                             {:db {:n 1}
+                              :fx [[:dispatch [:next]]]
+                              :http {:url "/x"}})}
+          e        (envelope [:multi] handlers {:n 0})
+          steps    (into [] (rt/frame-transducer-factory (:frame e)) [e])
+          step     (first steps)]
+      (is (= :ok (:rf/step step)))
+      (is (= {:n 1} (:db-after step)))
+      (is (= [[:dispatch [:next]] [:http {:url "/x"}]] (:fx step))
+          "extras after :fx in source order"))))
+
+;; ---- reducing-function coverage ------------------------------------------
+
+(deftest sync-rf-commits-eagerly
+  (testing "sync-rf folds db-after onto :db and walks fx inline"
+    (let [handlers {:inc (fn [db _] {:db (update db :n inc)
+                                     :fx [[:log :did-inc]]})}
+          rf (rt/sync-rf)
+          acc (transduce-one (envelope [:inc] handlers {:n 0}) rf)]
+      (is (= {:n 1} (:db acc)))
+      (is (= [[:log :did-inc]] (:fx-applied acc)))
+      (is (= 1 (count (:steps acc))))
+      (is (= [] (:errors acc))))))
+
+(deftest sync-rf-folds-multiple-envelopes
+  (testing "sync-rf applied across multiple envelopes accumulates db"
+    (let [handlers {:inc (fn [db _] {:db (update db :n inc)})}
+          frame    {:handlers handlers :db {:n 0}}
+          ;; Each envelope sees the SAME :db (the frame snapshot) because
+          ;; the scaffold does not thread acc->frame; real wiring would
+          ;; rebind the frame's :db slot via the substrate container.
+          envs     [(envelope [:inc] handlers {:n 0})
+                    (envelope [:inc] handlers {:n 1})
+                    (envelope [:inc] handlers {:n 2})]
+          tdx      (rt/frame-transducer-factory frame)
+          acc      (transduce tdx (rt/sync-rf) envs)]
+      (is (= {:n 3} (:db acc)) "last db-after wins")
+      (is (= 3 (count (:steps acc)))))))
+
+(deftest queued-rf-routes-dispatches-to-queue
+  (testing "queued-rf segregates :dispatch fx from other fx"
+    (let [handlers {:start (fn [_ _]
+                             {:db {:n 1}
+                              :fx [[:dispatch [:next]]
+                                   [:log :started]
+                                   [:dispatch [:also-next]]]})}
+          rf  (rt/queued-rf)
+          acc (transduce-one (envelope [:start] handlers {:n 0}) rf)]
+      (is (= {:n 1} (:db acc)))
+      (is (= [[:log :started]] (:fx-applied acc))
+          ":dispatch entries do NOT land in :fx-applied")
+      (is (= [[:next] [:also-next]] (vec (:queue acc)))
+          ":dispatch entries land on :queue in source order"))))
+
+(deftest batch-rf-defers-fx-until-completing
+  (testing "batch-rf accumulates fx but applies them only on completing arity"
+    (let [handlers {:a (fn [_ _] {:db {:n 1} :fx [[:log :a]]})
+                    :b (fn [_ _] {:db {:n 2} :fx [[:log :b]]})}
+          frame    {:handlers handlers :db {:n 0}}
+          envs     [(envelope [:a] handlers {:n 0})
+                    (envelope [:b] handlers {:n 1})]
+          tdx      (rt/frame-transducer-factory frame)
+          ;; transduce calls the completing arity automatically
+          acc      (transduce tdx (rt/batch-rf) envs)]
+      (is (= {:n 2} (:db acc)) "last db wins")
+      (is (true? (:committed? acc)) "completing arity stamps :committed?")
+      (is (= [[:log :a] [:log :b]] (:fx-applied acc))
+          "both fx applied at completing")
+      (is (= [] (:staged-fx acc)) "staged buffer cleared after commit"))))
+
+(deftest batch-rf-skips-fx-without-completing
+  (testing "fx are NOT applied when only the step arity runs (no completing)"
+    (let [handlers {:a (fn [_ _] {:db {:n 1} :fx [[:log :a]]})}
+          rf       (rt/batch-rf)
+          init     (rf)
+          step1    (first (into []
+                                (rt/frame-transducer-factory
+                                  {:handlers handlers :db {:n 0}})
+                                [(envelope [:a] handlers {:n 0})]))
+          acc      (rf init step1)]
+      (is (= {:n 1} (:db acc)))
+      (is (= [[:log :a]] (:staged-fx acc)) "fx staged, not applied")
+      (is (= [] (:fx-applied acc)) "no fx applied yet")
+      (is (false? (:committed? acc))))))
+
+;; ---- driver coverage ------------------------------------------------------
+
+(deftest manual-driver-tick-one-at-a-time
+  (testing "manual driver pumps one envelope per tick!"
+    (let [handlers {:inc (fn [db _] {:db (update db :n inc)})}
+          frame    {:handlers handlers :db {:n 0}}
+          {:keys [push! tick!]} (rt/manual-driver)]
+      (push! (envelope [:inc] handlers {:n 0}))
+      (push! (envelope [:inc] handlers {:n 0}))
+      (let [acc1 (tick! frame (rt/sync-rf))]
+        (is (= {:n 1} (:db acc1))))
+      (let [acc2 (tick! frame (rt/sync-rf))]
+        (is (= {:n 1} (:db acc2)) "second tick processes second envelope")
+        (is (= 2 (count (:steps acc2)))
+            "steps accumulate across ticks")))))
+
+(deftest manual-driver-drain-to-fixed-point
+  (testing "drain! processes everything until queue empties"
+    (let [handlers {:inc (fn [db _] {:db (update db :n inc)})}
+          frame    {:handlers handlers :db {:n 0}}
+          {:keys [push! drain!]} (rt/manual-driver)]
+      (dotimes [_ 5] (push! (envelope [:inc] handlers {:n 0})))
+      (let [acc (drain! frame (rt/sync-rf))]
+        (is (= 5 (count (:steps acc))))
+        (is (= {:n 1} (:db acc))
+            "frame-db is constant across envelopes in the scaffold")))))

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -1250,11 +1250,11 @@ When `destroy-frame!` runs, every cached reactive needs its `dispose!`-equivalen
 
 ### Transducer-shaped event processing (substrate-agnostic router)
 
-> **Status: post-v1 deferred.** v1 ships the existing drain loop; the Spec-level design pass on a transducer-shaped router is deferred to v1.1 to keep v1 scope tight and avoid coupling the router redesign to other v1-critical work. Tracked in rf2-cl8me.
+> **Status: post-v1 deferred — v1.1 design pass landed.** v1 ships the existing drain loop; the Spec-level design pass on a transducer-shaped router lives at [Design-TransducerRouter.md](Design-TransducerRouter.md) with a Phase-1 reference scaffold at `implementation/core/src/re_frame/router_transducer.cljc`. The design is non-normative for v1 — the runtime does **not** consume the scaffold yet. Tracked in rf2-cl8me.
 
-pure-frame implements event processing as a transducer parameterised by the frame: `(frame-transducer-factory frame) → transducer`, with the reducing function determining how state flows (sync, queued, batch). The transducer captures the per-event step (resolve handler → run interceptor pipeline → produce new state); the reducing function decides how successive states are accumulated and committed.
+pure-frame implements event processing as a transducer parameterised by the frame: `(frame-transducer-factory frame) → transducer`, with the reducing function determining how state flows (sync, queued, batch). The transducer captures the per-event step (resolve handler → run interceptor pipeline → produce new state); the reducing function decides how successive states are accumulated and committed. The full v1.1 design — primitive contract, reducing-function presets (`sync-rf` / `queued-rf` / `batch-rf`), driver model, two-stage compatibility plan with the v1 drain loop, and interactions with Specs 005 / 009 / 011 / 012 — lives at [Design-TransducerRouter.md](Design-TransducerRouter.md).
 
-Originally flagged as worth considering for v1. A transducer-shaped router is reusable, testable, and extensible without exposing rendering or scheduling primitives at the public API — but the design pass is non-trivial and overlaps with the router work in [012-Routing.md](012-Routing.md), so the call for v1 is to keep the drain loop and revisit the transducer formulation post-v1.
+Originally flagged as worth considering for v1. A transducer-shaped router is reusable, testable, and extensible without exposing rendering or scheduling primitives at the public API — but the design pass is non-trivial, so the call for v1 was to keep the drain loop and revisit the transducer formulation post-v1. On the v1.1 re-examination, the suspected overlap with [012-Routing.md](012-Routing.md) (URL routing) was non-existent — the two specs live on orthogonal axes.
 
 ## Resolved decisions
 

--- a/spec/Design-TransducerRouter.md
+++ b/spec/Design-TransducerRouter.md
@@ -1,0 +1,296 @@
+> **Type:** Design (post-v1 / v1.1 design pass)
+> Status: deferred from v1; design-only pass tracked by rf2-cl8me.
+
+# Design — Transducer-shaped event router (substrate-agnostic)
+
+This document is the **v1.1 design pass** for re-frame2's event-processing pipeline as a transducer.
+It is **non-normative** for v1: the v1 runtime ships the existing drain loop owned by
+[002-Frames §Run-to-completion dispatch](002-Frames.md#run-to-completion-dispatch-drain-semantics).
+This file specifies the *shape* a v1.1 router would take and the reference primitives that
+accompany it. A small scaffold ships at `implementation/core/src/re_frame/router_transducer.cljc`
+with CLJS/CLJ unit-test coverage so the design can be exercised in the REPL — the runtime
+does **not** consume it yet.
+
+The doc has four sections:
+
+1. **Motivation** — why a transducer shape is worth pulling forward.
+2. **Contract** — `frame-transducer-factory`, the three reducing-function presets, and the
+   substrate-agnostic boundary.
+3. **Compatibility with v1's drain loop** — additive-then-replacement story; what stays, what
+   moves, what disappears.
+4. **Interactions** — with Spec 005 machines, Spec 011 SSR, Spec 012 URL routing, and Spec 009
+   instrumentation.
+
+Pointer back: [002-Frames §Transducer-shaped event processing](002-Frames.md#transducer-shaped-event-processing-substrate-agnostic-router)
+is the deferred-status anchor in the normative spec; this document is what it points to.
+
+---
+
+## 1. Motivation
+
+The v1 router (`re-frame.router/drain-loop!`) bakes three concerns into one piece of code:
+
+- **Per-event step** — resolve handler, run the interceptor pipeline, produce a new state, apply
+  effects. This is *reusable*: SSR runs the same step, test harnesses run the same step, a
+  pair-tool replay runs the same step.
+- **State accumulation** — how successive new-state values are committed: synchronously into the
+  app-db container (v1), into a batched commit at the end of the cascade (an open question
+  raised by 005's `:always` transitions), or into a derived list of states (for time-travel
+  replay).
+- **Scheduling** — when the next event runs: synchronously under `dispatch-sync` (v1), under
+  the drain pump on the host's microtask queue (v1's default), or under an externally-driven
+  pump (test harness, SSR loader fan-in).
+
+A transducer cleanly separates concern 1 (the transducer `xf`) from concerns 2-and-3 (the
+reducing function and the driver). The same transducer pipes through:
+
+- **`sync`** — a reducing function that commits every state synchronously. Equivalent to
+  `dispatch-sync`.
+- **`queued`** — a reducing function that drains a queue to fixed point per Spec 002's
+  run-to-completion rules.
+- **`batch`** — a reducing function that accumulates intermediate states and commits *once* at
+  cascade-settle. Useful when a cascade fires N events that each touch app-db and the host can
+  defer paint to the cascade boundary (Spec 005's `:always` is the motivating case).
+
+The driver (when does the next event arrive?) is a third axis, orthogonal to the
+reducing function. v1 ships one driver, the host-microtask pump; a v1.1 transducer formulation
+makes the driver a parameter.
+
+---
+
+## 2. Contract
+
+### 2.1 Primitive: `frame-transducer-factory`
+
+```clojure
+(frame-transducer-factory frame) → transducer
+```
+
+Given a `frame` record (per [002 §What lives in a frame](002-Frames.md#what-lives-in-a-frame)),
+return a stateless transducer that maps **dispatch envelopes** (per
+[002 §Routing: the dispatch envelope](002-Frames.md#routing-the-dispatch-envelope)) to
+**step-results**. A step-result is the closed map:
+
+```clojure
+{:db-before  <value>           ;; app-db before the step
+ :db-after   <value>           ;; app-db after the step (= db-before on no-op)
+ :event      <event-vector>    ;; the user-facing event
+ :envelope   <envelope>        ;; the full envelope (passes through for tracing)
+ :effects    <effects-map>     ;; the effects map produced by the handler
+ :error      <error-or-nil>    ;; structured error per Spec 009 §Error contract; nil on success
+ :rf/step    :ok | :no-handler | :frame-destroyed | :validation | :handler-throw}
+```
+
+The transducer itself is a single `comp` of pure mapping/filtering xforms, each owning one phase
+of the v1 `process-event*` cascade:
+
+```clojure
+(comp
+  (xf-resolve-handler  registry)   ;; envelope -> envelope with :handler resolved
+  (xf-validate-event   registry)   ;; gated by :spec; tags :validation step on fail
+  (xf-run-interceptors)             ;; runs the pipeline; reads cofx, produces effects
+  (xf-commit-app-db    container)   ;; computes :db-after; does NOT write
+  (xf-apply-fx         fx-registry) ;; pulls non-:db effects out for the reducing fn
+  (xf-emit-trace))                  ;; tags trace events per Spec 009; pure side-effect-free
+                                    ;; — actual emit happens in the reducing fn's commit step
+```
+
+**Substrate-agnostic boundary.** None of these xforms call into the rendering substrate. The
+transducer produces a step-result; the **reducing function** decides whether to write
+`:db-after` into the substrate container, whether to flush `:effects`, and when to schedule the
+next event. This is what makes the transducer reusable across all three substrates (Reagent /
+UIx / Helix), under JVM (no substrate), and inside a tool-pair replay (rewrites the reducing
+function to capture a trace instead of committing).
+
+### 2.2 Reducing-function presets
+
+Three preset reducing functions ship with v1.1:
+
+**`sync-rf`** — fully synchronous. Each step commits `:db-after` into the substrate container
+and runs `:effects` inline. Cascade dispatches are pushed onto a thread-local queue and drained
+to fixed point before `sync-rf` returns. Equivalent to v1's `dispatch-sync`.
+
+```clojure
+(transduce (frame-transducer-factory frame) sync-rf init-state envelope-seq)
+;; => final state; substrate container holds the post-cascade db
+```
+
+**`queued-rf`** — the v1 drain shape. Commits `:db-after` on every step; the driver pump runs
+the next envelope on the host's microtask queue. Cascade dispatches are appended to the frame's
+FIFO. Equivalent to v1's `dispatch`.
+
+**`batch-rf`** — accumulator. Steps update an in-memory `db` value without writing through to
+the container. The reducing function commits the final accumulated value in a single
+`replace-container!` call at cascade-settle. Effects are deferred to the same boundary. Useful
+when:
+
+- Spec 005 `:always` fires N intermediate transitions and the host can pay one commit for the
+  whole cascade.
+- A test harness wants to inspect every intermediate state without paying a substrate write.
+- An SSR loader fan-in waits for all child fetches to settle before any view re-renders.
+
+`batch-rf` is *not* a default — surfaces that need it opt in per-cascade via a per-call hint on
+the envelope (`:rf/commit :batch` vs. `:eager` / `:sync`).
+
+### 2.3 The driver
+
+A driver is a function `(driver pump-fn) → driver-handle`. The driver decides *when* `pump-fn`
+runs and returns a handle the runtime can use to schedule, pause, and tear down.
+
+- **`microtask-driver`** — v1's behaviour. `pump-fn` runs under `js/queueMicrotask` (CLJS) or
+  inline (JVM). Default.
+- **`raf-driver`** — `pump-fn` runs under `requestAnimationFrame`. For frame-locked cascades.
+- **`manual-driver`** — test harness drives `pump-fn` explicitly via `(tick handle)`. Used by
+  the conformance corpus and SSR loaders.
+- **`virtual-time-driver`** — a debug driver that advances under a controlled clock. Time-travel
+  replay can use this to step through a recorded envelope-seq deterministically.
+
+The driver is per-frame, set at `reg-frame` time via `:driver` (default `:microtask`). Frame
+presets (per [002 §Frame presets](002-Frames.md#frame-presets--capability-bundles-for-common-configurations))
+fix the driver: `:default` → `:microtask`, `:test` → `:manual`, `:ssr-server` → `:manual`,
+`:story` → `:microtask`.
+
+### 2.4 Public surface
+
+Only three functions are exposed at the public substrate API:
+
+```clojure
+;; The primitive itself — used by the runtime, the test harness, and tools.
+(re-frame.core/frame-transducer-factory frame) → transducer
+
+;; Reducing-function constructors. Each closes over the frame; the transducer is reusable.
+(re-frame.core/sync-rf       frame) → reducing-fn
+(re-frame.core/queued-rf     frame) → reducing-fn
+(re-frame.core/batch-rf      frame) → reducing-fn
+
+;; Driver constructors (opaque handles).
+(re-frame.core/microtask-driver) → driver
+(re-frame.core/manual-driver)    → driver
+```
+
+`dispatch`, `dispatch-sync`, and `subscribe` retain their v1 signatures. They become *thin
+wrappers* over the transducer-driver composition: `dispatch-sync` is `(transduce (factory frame)
+(sync-rf frame) ...)`; `dispatch` enqueues onto the driver's pump. **No user-facing breakage** —
+the transducer is an internal refactor that surfaces three new opt-in primitives for advanced
+use.
+
+---
+
+## 3. Compatibility with v1's drain loop
+
+The migration is **two staged**, not a flag-day:
+
+**Stage A (v1.1 minor)** — additive. Ship `frame-transducer-factory`, the three reducing-fn
+presets, and the driver primitives **alongside** the existing drain loop. The drain loop still
+owns the default code path; the transducer primitives are a new surface for tools, tests, and
+SSR loaders to consume. No runtime-internal call changes.
+
+**Stage B (v2.0 major)** — replacement. The drain loop becomes a thin shim that constructs the
+transducer + `queued-rf` + `microtask-driver` and runs them. The v1 `drain-loop!` /
+`process-event!` decomposition disappears from the supported surface; its internals are
+re-expressed in transducer terms. No user-facing API change — `dispatch` / `dispatch-sync`
+behaviour is preserved bit-exact against the conformance corpus.
+
+**What disappears.** `re-frame.router/drain-depth-default`, `mark-drainer!`, `clear-drainer!`,
+`take-event!`, `run-one-pass!`, `force-release-on-halt!`, `try-release-on-empty!` — all are
+specific to the v1 queue-pump shape. Under Stage B they collapse into a single `queued-rf` +
+`microtask-driver` definition.
+
+**What stays.** Spec 002's normative behaviour is unchanged: run-to-completion, FIFO ordering
+within a frame, depth-exceeded rollback, `:dispatch-sync` reentrancy guard, frame-destroy
+mid-drain semantics. Each is a property of the *reducing function* under Stage B, not of
+ad-hoc drain code.
+
+**Atomic rollback.** v1's depth-exceeded path (`handle-depth-exceeded!`) restores the
+pre-cascade `:db` and emits a `:halted-depth` epoch. Under Stage B this becomes the
+**transducer's `completing` arity**: when the reducing function detects depth exhaustion it
+short-circuits via `reduced` carrying the rollback marker, and the completing arity emits the
+epoch record. Pure, testable, no flag.
+
+---
+
+## 4. Interactions
+
+### 4.1 Spec 005 — State machines
+
+Machines-as-event-handlers (per [005 §Machines as event handlers](005-StateMachines.md)) sit
+inside the transducer as just-another-handler. A machine transition that fires N `:always`
+events from `:on-entry` enqueues N envelopes which the same transducer drains. `batch-rf` is
+the natural home for `:always`-heavy cascades — N intermediate transitions, one commit.
+
+### 4.2 Spec 011 — SSR
+
+SSR's frame-per-request model wants `batch-rf` + `manual-driver`. A loader fan-in dispatches
+N `:rf.server/fetch` events, the manual driver pumps them under the SSR runtime's
+`render-to-string` orchestration, and `batch-rf` commits the final db once before the hiccup
+tree is materialised. This is currently implemented ad-hoc in `re-frame.ssr`; the v1.1 spec
+folds the ad-hoc code into the transducer + reducing-fn + driver triple.
+
+### 4.3 Spec 012 — URL routing
+
+Spec 012 governs URL ↔ frame state. Routing dispatches `:rf.route/navigate` and standard
+runtime events; those events flow through the transducer like any other. The transducer
+formulation does not interact with Spec 012's normative surface — they live on different
+axes. The v1 deferral worried about an overlap; on re-examination there is none.
+
+### 4.4 Spec 009 — Instrumentation
+
+Each xform in the transducer's `comp` is the natural seam for a trace event:
+`xf-resolve-handler` emits `:rf.handler/resolved`, `xf-run-interceptors` emits per-interceptor
+`:rf.interceptor/before` and `:rf.interceptor/after`, `xf-commit-app-db` emits `:rf.db/replaced`
+on a real diff, `xf-apply-fx` emits `:rf.fx/handled` per fx. The trace surface stays exactly
+what Spec 009 defines; the transducer formulation just makes the emit-sites lexically obvious.
+
+### 4.5 Tool-Pair
+
+A pair-tool replay rewrites the reducing function. The transducer (the xforms) stays bit-exact;
+the reducing function commits to a **trace-buffer** instead of to the substrate container. This
+is how time-travel replay can stay deterministic across hot-reloads — the per-step xform is
+re-evaluated under the new code, but the envelope-seq is replayed verbatim.
+
+---
+
+## 5. Implementation roadmap
+
+**Phase 1 — scaffold (this bead, rf2-cl8me).**
+- `implementation/core/src/re_frame/router_transducer.cljc` — pure functions: the
+  `frame-transducer-factory` stub, the three reducing-fn presets, the manual-driver shape.
+  No wiring into the live runtime. CLJS/CLJ-unit-test-covered.
+
+**Phase 2 — v1.1 additive (separate bead).**
+- Wire `manual-driver` + `batch-rf` to the SSR loader fan-in and replace the ad-hoc code in
+  `re-frame.ssr`. Single isolated change; no behavioural impact outside SSR.
+- Publish the transducer + driver primitives at `re-frame.core`. Document as opt-in.
+
+**Phase 3 — v2.0 replacement (separate bead, post-v1.1).**
+- Re-express `re-frame.router/drain-loop!` as `(queued-rf + microtask-driver)`. Run the full
+  conformance corpus on the rewrite; require bit-exact equivalence on trace event order,
+  app-db value sequence, and epoch record shape. Remove the v1 drain-loop ad-hoc code.
+
+---
+
+## Open questions (deferred to Phase 2)
+
+- **Driver ↔ frame coupling.** Should the driver be per-frame (current sketch) or
+  per-process? A per-process driver simplifies multi-frame coordination; per-frame allows
+  Story / SSR / Pair drivers to coexist in one process. Lean per-frame — the multi-process
+  per-frame story already exists for routers and queues.
+- **Step-result vocabulary.** The `:rf/step` enum (`:ok`, `:no-handler`, …) overlaps with
+  Spec 009's `:rf.handler/...` trace event family. Reconcile before Phase 2: probably collapse
+  `:rf/step` to a flat `:rf.step/*` keyword set under Conventions §Reserved namespaces.
+- **Cancellation semantics.** A long-running cascade under `manual-driver` may want
+  cancellation. v1's drain has no notion of mid-cascade cancel (it short-circuits only on
+  depth-exceeded and frame-destroy). Decision: defer to Phase 2 unless a Tool-Pair surface
+  forces it sooner.
+
+---
+
+## Cross-references
+
+- [002-Frames §Run-to-completion dispatch](002-Frames.md#run-to-completion-dispatch-drain-semantics) — v1 normative behaviour preserved across both stages.
+- [002-Frames §Transducer-shaped event processing](002-Frames.md#transducer-shaped-event-processing-substrate-agnostic-router) — the deferred-status anchor that points here.
+- [005-StateMachines](005-StateMachines.md) — `:always` cascades motivating `batch-rf`.
+- [011-SSR](011-SSR.md) — frame-per-request + loader fan-in motivating `manual-driver`.
+- [009-Instrumentation](009-Instrumentation.md) — trace-emission sites become the transducer's xform boundaries.
+- `implementation/core/src/re_frame/router_transducer.cljc` — Phase-1 reference scaffold.
+- `implementation/core/test/re_frame/router_transducer_test.cljc` — scaffold unit tests.


### PR DESCRIPTION
Closes rf2-cl8me. Pulled forward from v1.1 deferred per Mike 2026-05-20.

## Summary

Lands the v1.1 design pass for re-frame2's event-processing pipeline as a transducer, plus a Phase-1 reference scaffold. The runtime is unchanged — the scaffold is opt-in and not consumed by the live drain loop.

- **`spec/Design-TransducerRouter.md`** — full design: `frame-transducer-factory` primitive returning a stateless transducer of envelopes to step-results; three reducing-function presets (`sync-rf` / `queued-rf` / `batch-rf`) covering the synchronous, queue-drain, and batched-commit cases; per-frame driver model (microtask / raf / manual / virtual-time); two-stage compatibility plan (Stage A v1.1 additive, Stage B v2.0 replacement); interactions with Specs 005 / 009 / 011 / 012; three-phase implementation roadmap.
- **`spec/002-Frames.md`** — update the deferred-status pointer to link to the new design doc; note the suspected Spec 012 overlap was non-existent on re-examination.
- **`implementation/core/src/re_frame/router_transducer.cljc`** — Phase-1 reference scaffold. Composed transducer (resolve / validate / run / stage-fx / tag-step), three reducing-fn presets, manual driver. Pure functions, no runtime wiring.
- **`implementation/core/test/re_frame/router_transducer_test.cljc`** — 12 tests / 40 assertions covering step-result shape, no-handler / handler-throw / validation tagging, fx staging normalisation, all three reducing functions (eager commit, queue routing, deferred commit on completing arity), manual-driver tick + drain.

## Test plan

- [x] `npm run test:cljs` — 3793 tests / 11001 assertions / 0 failures (new scaffold included)
- [x] `clojure -M:test` from `implementation/core/` — 12 tests / 40 assertions / 0 failures
- [x] `mkdocs build --strict` — exit 0; new `Design-TransducerRouter.md` picked up

## Notes

The scaffold is intentionally not wired into the live runtime — that is Phase 2 (per the roadmap in the design doc). This PR is the design-doc-plus-exercisable-skeleton landing; the additive Phase-2 wiring (SSR loader fan-in re-expressed via `batch-rf` + `manual-driver`) and the eventual Phase-3 replacement of `drain-loop!` are separate beads to be filed later.

Scope per the bead's "lean toward (c)": design doc + minimal scaffold.