### PR TITLE
ci(template): re-evaluate ci.yml cut for v1.1 (rf2-k2z79)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
+++ b/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+# {{name}} — CI
+#
+# Minimal CI for a fresh re-frame2 scaffold:
+#   - JDK 21 + Clojure CLI (matches re-frame2's reference build)
+#   - Node 22 LTS + npm
+#   - Maven / gitlibs + npm caches keyed by deps files
+#   - `npm install` then `npm test` — runs the :node-test build per
+#     shadow-cljs.edn (no browser; pure cljs.test under Node).
+#
+# Add steps as your project grows:
+#   - `clojure -M:cljfmt check` (the scaffold ships .cljfmt.edn)
+#   - clj-kondo (the scaffold ships .clj-kondo/config.edn)
+#   - `npx shadow-cljs release app` to gate the release bundle
+#
+# Action pins use SHA + version-comment per GitHub's hardening
+# guidance. Bump them in lockstep with Dependabot or by hand.
+
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (JVM + Node)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Set up Node 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-${{ hashFiles('deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-
+
+      - name: Cache npm
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
+      - name: Install npm deps
+        # `npm install` (not `npm ci`) — the scaffold ships without a
+        # package-lock.json. Commit your lockfile and switch to `npm ci`
+        # for fully reproducible builds.
+        run: npm install
+
+      - name: Run tests (shadow-cljs :node-test)
+        run: npm test

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -181,6 +181,8 @@ related error, that's the fix.
 │   └── config.edn           ; linter config (empty by default)
 ├── .cljfmt.edn              ; cljfmt formatter config — `clojure -M:cljfmt check` / `fix`
 ├── lefthook.yml             ; pre-commit format + lint hook (see lefthook.dev/installation)
+├── .github/workflows/
+│   └── ci.yml               ; baseline GitHub Actions CI — JDK 21 + Clojure CLI + Node 22 + `npm test`
 ├── resources/public/
 │   ├── index.html           ; host page; loads shadow-cljs's compiled output
 │   └── css/app.css          ; minimal plain CSS — body / button / h1

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -20,6 +20,8 @@ my-app/
 │   └── config.edn            empty default; lint rules slot in here
 ├── .cljfmt.edn               cljfmt formatter config — `clojure -M:cljfmt check` / `fix`
 ├── lefthook.yml              pre-commit format + lint hook (see lefthook.dev/installation)
+├── .github/workflows/
+│   └── ci.yml                baseline CI — JDK 21 + Clojure CLI + Node 22 + `npm test`
 ├── resources/public/
 │   ├── index.html            host page; loads /js/main.js + /css/app.css
 │   └── css/app.css           three-rule plain stylesheet
@@ -87,6 +89,7 @@ tools/template/
     ├── root/                             ; bulk-copied, default placement
     │   ├── README.md
     │   ├── lefthook.yml
+    │   ├── .github/workflows/ci.yml      ; baseline CI workflow (rf2-k2z79)
     │   ├── dev/{user.clj, scratch.cljs}
     │   └── resources/public/{index.html, css/app.css}
     ├── _shared/                          ; substrate-agnostic; renamed at emit

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -121,6 +121,8 @@
    ".cljfmt.edn"
    ;; Git pre-commit hook config (rf2-s8xee).
    "lefthook.yml"
+   ;; Baseline CI workflow (rf2-k2z79).
+   ".github/workflows/ci.yml"
    "dev/user.clj"
    "dev/scratch.cljs"
    "resources/public/index.html"
@@ -274,6 +276,28 @@
               "README ships the per-substrate badge")
           (is (.contains readme-text "License-MIT")
               "README ships a License badge"))
+
+        ;; -- Baseline CI workflow (rf2-k2z79) --
+        (let [ci-text (slurp (io/file root ".github/workflows/ci.yml"))]
+          (is (.contains ci-text "name: ci")
+              ".github/workflows/ci.yml declares the ci workflow")
+          (is (.contains ci-text "node-version: '22'")
+              "ci.yml pins Node 22 LTS")
+          (is (.contains ci-text "java-version: '21'")
+              "ci.yml pins JDK 21 (matches re-frame2 reference build)")
+          (is (.contains ci-text "actions/checkout@")
+              "ci.yml uses actions/checkout with a SHA pin")
+          (is (.contains ci-text "actions/setup-java@")
+              "ci.yml uses actions/setup-java with a SHA pin")
+          (is (.contains ci-text "actions/setup-node@")
+              "ci.yml uses actions/setup-node with a SHA pin")
+          (is (.contains ci-text "DeLaGuardo/setup-clojure@")
+              "ci.yml uses DeLaGuardo/setup-clojure with a SHA pin")
+          (is (.contains ci-text "npm test")
+              "ci.yml runs `npm test` (delegates to shadow-cljs :node-test
+               per the emitted package.json)")
+          (is (.contains ci-text "# acme/my-app")
+              "ci.yml header substitutes {{name}}"))
 
         ;; -- Security baseline (rf2-sh3l8) --
         (let [index-text  (slurp (io/file root "resources/public/index.html"))


### PR DESCRIPTION
Closes rf2-k2z79. Pulled forward from v1.1 deferred per Mike 2026-05-20.

## Summary
- Adds a minimal baseline `.github/workflows/ci.yml` to the deps-new template (lands at `root/.github/workflows/ci.yml`, bulk-copied by deps-new; `{{name}}` substitutes into the header comment).
- Workflow shape: JDK 21 + Clojure CLI + Node 22 LTS + Maven/gitlibs/npm caches + `npm install` then `npm test` (delegates to shadow-cljs `:node-test` per the emitted `package.json`). Single job on ubuntu-latest.
- All action pins use SHA + version-comment, mirroring the re-frame2 monorepo: `actions/checkout` v6.0.2, `actions/setup-java` v5.2.0, `DeLaGuardo/setup-clojure` 13.6.0, `actions/setup-node` v6.4.0, `actions/cache` v5.0.5 — all Node-22 runners (no `actions/setup-python`, so sidesteps rf2-fc4nr's deprecation work).
- Test surface — `template_test.clj` adds `.github/workflows/ci.yml` to `common-files` so all three substrates assert emission, plus a new content-shape block asserting Node 22, JDK 21, SHA-pinned actions, `npm test`, and the `{{name}}` substitution.
- Docs — `tools/template/spec/002-Generated-Shape.md` updates both the generated and template-side tree maps; `root/README.md` updates the project layout block.

## Test plan
- [x] `clojure -M:test` from `tools/template/` — 19 tests / 346 assertions / 0 failures, 0 errors
- [x] `mkdocs build --strict` — clean (exit 0)
- [x] Smoke: `clojure -Tnew create :template day8/re-frame2-template :name acme/my-app` produces `.github/workflows/ci.yml` with header `# acme/my-app — CI`