### PR TITLE
feat(static): Events sub-tab — registered handlers + interceptor stack browser (rf2-o5f5f.6 · v1.2 pulled forward)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -50,7 +50,9 @@
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.spine-filters :as spine-filters]
+            [day8.re-frame2-causa.static.events.panel :as static-events-panel]
             [day8.re-frame2-causa.static.flows.panel :as static-flows-panel]
+            [day8.re-frame2-causa.static.interceptors.panel :as static-interceptors-panel]
             [day8.re-frame2-causa.static.machines.panel :as static-machines-panel]
             [day8.re-frame2-causa.static.persistence :as static-persistence]
             [day8.re-frame2-causa.static.routes.panel :as static-routes-panel]
@@ -737,13 +739,20 @@
     ;; entry. Sits at order 8 (after Issues at 7) — both tabs occupy
     ;; the diagnostics group at the right end of the tab strip.
     (chrome-a11y-panel/install!)
-    ;; rf2-2moh1 — register the Static :events placeholder tab. The
-    ;; other Static tabs (machines / routes / schemas / views / flows)
-    ;; each register their entry from their own panel's `install!`
-    ;; above; the `:events` tab is not yet panelled (sibling bead
-    ;; rf2-o5f5f.6 fills it) so its placeholder registration lives
-    ;; in `static.shell` alongside the placeholder-card helper.
-    (static-shell/register-events-placeholder!))
+    ;; Static Events sub-tab (rf2-o5f5f.6) — browse every registered
+    ;; event handler (reg-event-db / reg-event-fx / reg-event-ctx) +
+    ;; interceptor chain + hermetic single-step simulate. Reads
+    ;; `(re-frame.registrar/registrations :event)`. Source-coord chip
+    ;; dispatches `:rf.causa/open-in-editor` (open-in-editor installed
+    ;; above).
+    (static-events-panel/install!)
+    ;; Static Interceptors sub-tab (rf2-o5f5f.6) — pure-browse lens
+    ;; over every interceptor surfaced through the registered event
+    ;; chains. Collapses by `:id` so each interceptor appears once
+    ;; with a chain-count. No simulate — interceptors are composition
+    ;; primitives; simulate fires through the handler-level simulate
+    ;; in the Events sub-tab.
+    (static-interceptors-panel/install!))
   nil)
 
 (defn reset-for-test!

--- a/tools/causa/src/day8/re_frame2_causa/static/events/helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/static/events/helpers.cljc
@@ -1,0 +1,133 @@
+(ns day8.re-frame2-causa.static.events.helpers
+  "Pure helpers for the Static Events sub-tab (rf2-o5f5f.6).
+
+  Split out into a CLJC ns so the JVM unit-test target can drive the
+  data shape (`project-rows`, payload parsing, hermetic simulate) without
+  a CLJS runtime.")
+
+(defn sanitize-row-id
+  "Build a stable DOM `data-testid` suffix from an event-id keyword /
+  symbol / string. Keywords drop the leading `:` so the testid reads as
+  `rf-causa-static-events-row-user/login` rather than
+  `rf-causa-static-events-row-:user/login`. Non-keyword ids fall back
+  to `(str id)` so unusual registrations remain addressable."
+  [id]
+  (let [s (pr-str id)]
+    (cond
+      (and (> (count s) 0) (= \: (first s)))
+      (subs s 1)
+
+      :else
+      s)))
+
+(defn parse-payload-edn
+  "Parse the user-typed EDN payload string into a sequence of args that
+  follow the event-id in the dispatched vector. Tolerates the common
+  shapes:
+
+    - empty / whitespace-only  → `[]` (no extra args)
+    - `\"{:x 1}\"`             → `[{:x 1}]` (single map arg)
+    - `\"42\"`                 → `[42]`
+    - `\":bar\"`               → `[:bar]`
+    - `\"{:x 1} :tag\"`        → `[{:x 1} :tag]`
+    - any parse failure        → `{:parse-error <reason>}`
+
+  `read-string-fn` is the EDN reader entry-point — CLJS callers pass
+  `cljs.reader/read-string`; JVM tests pass `clojure.edn/read-string`.
+  Both carry the same `read 1 form` semantics, so we wrap repeated
+  reads against a pushback / index-tracking reader. To keep the helper
+  trivially testable on the JVM we instead `read-string` a SEQUENCE
+  by wrapping the input in `[ ... ]` parens — every well-shaped EDN
+  series the user types is a vector when bracketed."
+  [s read-string-fn]
+  (try
+    (let [trimmed (when s (clojure.string/trim s))]
+      (if (or (nil? trimmed) (= "" trimmed))
+        []
+        (let [bracketed (str "[" trimmed "]")
+              parsed    (read-string-fn bracketed)]
+          (if (sequential? parsed)
+            (vec parsed)
+            ;; Theoretically unreachable — bracketing always yields a
+            ;; vector — but return the parse-error shape so the caller
+            ;; can render a consistent failure.
+            {:parse-error (str "unexpected parse result: " (pr-str parsed))}))))
+    (catch #?(:clj Exception :cljs :default) e
+      {:parse-error (#?(:clj .getMessage :cljs ex-message) e)})))
+
+(defn build-event-vector
+  "Compose the dispatched event vector from a parsed payload. Per the
+  re-frame contract, the dispatched event is `[event-id & args]`."
+  [event-id parsed-args]
+  (into [event-id] parsed-args))
+
+(defn run-simulate
+  "Hermetic single-step simulate. Invokes the registered handler-fn
+  directly against a synthetic input — NO real dispatch, NO interceptor
+  walk, NO app-db swap.
+
+  Args:
+    - `registrations`   `{event-id meta}` map from the `:event` registry
+    - `event-id`        keyword id of the row being simulated
+    - `payload-edn`     user-typed payload string (or nil)
+    - `read-string-fn`  the EDN reader entry-point (see
+                        `parse-payload-edn`)
+
+  Returns a result map:
+
+    - `{:ok? true  :kind <db|fx|ctx> :value <handler-return>}`
+    - `{:ok? false :reason <human-readable string>}`
+
+  Per `events.cljc` the `:invoke` signature is kind-specific:
+
+    - `:db`  handler-fn → `(fn [db   event-vec])`
+    - `:fx`  handler-fn → `(fn [cofx event-vec])` — cofx is a map
+                          carrying at least `:db` and `:event`
+    - `:ctx` handler-fn → `(fn [ctx])` where ctx is an interceptor
+                          context
+
+  We construct a deliberately minimal synthetic input for each kind so
+  the simulate stays hermetic. Handlers that reach for cofx slots not
+  in the synthetic shape will surface an exception, which we trap and
+  render as a friendly failure."
+  [registrations event-id payload-edn read-string-fn]
+  (let [meta (get registrations event-id)]
+    (cond
+      (nil? meta)
+      {:ok? false
+       :reason (str "No registration found for event-id "
+                    (pr-str event-id) ".")}
+
+      :else
+      (let [parsed (parse-payload-edn payload-edn read-string-fn)]
+        (if (map? parsed)
+          {:ok? false
+           :reason (str "Could not parse payload as EDN: "
+                        (:parse-error parsed))}
+          (let [kind       (:event/kind meta)
+                handler-fn (:handler-fn meta)
+                event-vec  (build-event-vector event-id parsed)]
+            (cond
+              (nil? handler-fn)
+              {:ok? false
+               :reason (str "Registration for " (pr-str event-id)
+                            " has no :handler-fn — cannot simulate.")}
+
+              :else
+              (try
+                (let [value (case kind
+                              :db  (handler-fn {} event-vec)
+                              :fx  (handler-fn {:db {} :event event-vec}
+                                               event-vec)
+                              :ctx (handler-fn {:coeffects {:db {} :event event-vec}
+                                                :effects   {}})
+                              ;; Unknown kind — best-effort try as :db.
+                              (handler-fn {} event-vec))]
+                  {:ok?   true
+                   :kind  kind
+                   :value value})
+                (catch #?(:clj Exception :cljs :default) e
+                  {:ok? false
+                   :reason (str "Handler threw: "
+                                #?(:clj (.getMessage e)
+                                   :cljs (ex-message e)))})))))))))

--- a/tools/causa/src/day8/re_frame2_causa/static/events/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/events/panel.cljs
@@ -1,0 +1,668 @@
+(ns day8.re-frame2-causa.static.events.panel
+  "Top-level Events sub-tab for Causa's Static surface (rf2-o5f5f.6).
+
+  ## Browse-all verb
+
+  Per Lock #15 (two-verbs-two-homes — browse-all lives in Static) the
+  Events sub-tab is a flat catalogue of every event handler registered
+  via `reg-event-db` / `reg-event-fx` / `reg-event-ctx`. Per row:
+  event-id, handler-type (db/fx/ctx), source-coord chip, and a small
+  interceptor-count badge.
+
+      ┌───────────────────────────────────────────────────┐
+      │ Events — header + descriptive prose               │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]            42 events    │
+      ├───────────────────────────────────────────────────┤
+      │ ▸ :user/login   [fx]  ic:3  [open]                │
+      │ ▸ :counter/inc  [db]  ic:1                        │
+      └───────────────────────────────────────────────────┘
+
+  ## Detail view + hermetic simulate
+
+  Clicking a row selects it; the detail card surfaces:
+
+    - Handler source-coord + jump-to-source chip.
+    - Interceptor chain rendered top-to-bottom — each entry shows the
+      `:id`, before/after presence, and the `:rf/default?` framework-
+      wrapper marker so user-attached interceptors stand out.
+    - Single-step simulate-input — the user types an EDN payload
+      (the event vector after the event-id); the simulate verb invokes
+      the registered `:handler-fn` against a synthetic coeffects map
+      ({:db <empty-map> :event <constructed-vector>}) and surfaces the
+      return — for `:db` it's the new db; for `:fx` it's the closed
+      `{:db ... :fx ...}` shape; for `:ctx` it's the full context.
+
+  The simulate is fully hermetic: it invokes the handler-fn directly
+  (NOT `dispatch`), so no real `:fx` walk, no app-db swap, no host
+  side-effects. The handler-fn is the user's raw fn — interceptor
+  chain composition is documented but NOT executed during simulate
+  (interceptor stacks involve coeffect injection that would defeat
+  hermeticity).
+
+  ## State slots (all under `:rf.causa.static.events/*`)
+
+    - `:rf.causa.static.events/query`             — search input.
+    - `:rf.causa.static.events/selected-id`       — focused row.
+    - `:rf.causa.static.events/sim-input`         — pending EDN payload.
+    - `:rf.causa.static.events/sim-result`        — last simulate-output.
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup, no Reagent / UIx
+  / Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `static/shell.cljs`."
+  (:require [clojure.string :as str]
+            [cljs.reader :as reader]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
+            [day8.re-frame2-causa.static.events.helpers :as helpers]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn project-rows
+  "Project the registrar's `:event` `{id meta}` map into row maps sorted
+  by id ascending. Each row carries `:id`, `:kind` (`:db`/`:fx`/`:ctx`),
+  `:doc`, `:interceptor-count`, and the source-coord trio."
+  [registrations-map]
+  (->> registrations-map
+       (map (fn [[id meta]]
+              {:id                id
+               :kind              (:event/kind meta)
+               :doc               (:doc meta)
+               :interceptor-count (count (or (:interceptors meta) []))
+               :source-coord      (select-keys meta [:file :line :ns])}))
+       (sort-by (fn [{:keys [id]}] (pr-str id)))
+       vec))
+
+(defn- row-haystack [{:keys [id kind doc source-coord]}]
+  (str/lower-case
+    (str (pr-str id) " "
+         (or (some-> kind name) "") " "
+         (or doc "") " "
+         (or (:ns source-coord) "") " "
+         (or (:file source-coord) ""))))
+
+(defn filter-rows
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+
+(defn project-data
+  [registrations-map query selected-id]
+  (let [rows     (project-rows registrations-map)
+        silent?  (empty? rows)
+        filtered (filter-rows rows query)
+        selected (when selected-id
+                   (some #(when (= selected-id (:id %)) %) rows))]
+    {:silent?     silent?
+     :events      filtered
+     :total       (count rows)
+     :filtered?   (not= (count rows) (count filtered))
+     :query       query
+     :selected-id selected-id
+     :selected    selected}))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-events-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Events"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every registered event handler ("
+    [:strong {:style {:color (:cyan tokens)}} "reg-event-db / reg-event-fx / reg-event-ctx"]
+    "). Click a row to inspect its interceptor chain and run a "
+    [:strong {:style {:color (:cyan tokens)}} "hermetic"]
+    " single-step simulate."]])
+
+;; ---- search box ----------------------------------------------------------
+
+(defn- search-box
+  [query total filtered?]
+  [:div {:data-testid "rf-causa-static-events-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-events-search-input"
+            :placeholder "event-id, kind, ns, file, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.events/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-events-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "80px"
+                         :text-align  "right"}}
+    (cond
+      filtered?     "match"
+      (= 1 total)   "1 event"
+      :else         (str total " events"))]])
+
+;; ---- row -----------------------------------------------------------------
+
+(defn- kind-badge
+  "Small letter-tile naming the handler kind. Mirrors the schemas
+  panel's `kind-badge` shape so the Static surface reads as one
+  family."
+  [kind]
+  (let [{:keys [letter colour]}
+        (case kind
+          :db  {:letter "D" :colour (:cyan tokens)}
+          :fx  {:letter "F" :colour (:magenta tokens)}
+          :ctx {:letter "C" :colour (:yellow tokens)}
+          {:letter "?" :colour (:text-tertiary tokens)})]
+    [:span {:data-testid (str "rf-causa-static-events-badge-" (some-> kind name))
+            :title       (str "reg-event-" (some-> kind name))
+            :style       {:display       "inline-block"
+                          :min-width     "14px"
+                          :height        "14px"
+                          :line-height   "14px"
+                          :padding       "0 3px"
+                          :margin-right  "6px"
+                          :background    (:bg-3 tokens)
+                          :color         colour
+                          :border        (str "1px solid " colour)
+                          :border-radius "3px"
+                          :font-family   mono-stack
+                          :font-size     "9px"
+                          :font-weight   700
+                          :text-align    "center"}}
+     letter]))
+
+(defn- ic-chip
+  "Interceptor-count chip — small `ic:N` badge on each row so the user
+  can sort visually for chain depth at a glance."
+  [n]
+  [:span {:data-testid "rf-causa-static-events-ic-chip"
+          :title       (str n " interceptor(s) on the chain")
+          :style       {:color       (:text-tertiary tokens)
+                        :font-family mono-stack
+                        :font-size   "10px"
+                        :padding     "0 4px"
+                        :background  (:bg-3 tokens)
+                        :border      (str "1px solid " (:border-subtle tokens))
+                        :border-radius "3px"}}
+   (str "ic:" n)])
+
+(defn- event-row
+  [{:keys [id kind doc interceptor-count source-coord] :as _row}
+   selected?]
+  (let [id-text (pr-str id)
+        row-id  (helpers/sanitize-row-id id)]
+    [:li {:data-testid (str "rf-causa-static-events-row-" row-id)
+          :on-click    (fn [_]
+                         (rf/dispatch [:rf.causa.static.events/select id]
+                                      {:frame :rf/causa}))
+          :aria-selected (if selected? "true" "false")
+          :style       {:display       "block"
+                        :padding       "6px 12px"
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :color         (:text-primary tokens)
+                        :background    (if selected?
+                                         (:bg-1 tokens)
+                                         "transparent")
+                        :border-left   (str "2px solid "
+                                            (if selected?
+                                              (:cyan tokens)
+                                              "transparent"))
+                        :border-radius "2px"
+                        :cursor        "pointer"
+                        :line-height   "18px"}}
+     [:div {:style {:display     "flex"
+                    :align-items "baseline"
+                    :gap         "8px"}}
+      (kind-badge kind)
+      [:span {:style {:color       (:accent-violet tokens)
+                      :font-weight 500
+                      :flex        1}}
+       id-text]
+      (ic-chip interceptor-count)
+      (when (and source-coord (:file source-coord))
+        [open-in-editor/open-chip source-coord])]
+     (when doc
+       [:div {:style {:margin-left "20px"
+                      :margin-top  "2px"
+                      :color       (:text-secondary tokens)
+                      :font-family sans-stack
+                      :font-style  "italic"
+                      :font-size   "11px"}}
+        doc])]))
+
+;; ---- detail (right rail) -------------------------------------------------
+
+(defn- interceptor-chain
+  "Render the registered interceptor chain top-to-bottom. Each entry's
+  `:id` is the headline; `:rf/default?` marker tags framework-emitted
+  auto-wrappers (per spec/004 + rf2-twt7m) so user-attached
+  interceptors stand out."
+  [interceptors]
+  (if (empty? interceptors)
+    [:div {:data-testid "rf-causa-static-events-chain-empty"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family sans-stack
+                         :font-size   "11px"
+                         :font-style  "italic"
+                         :padding     "8px 0"}}
+     "No interceptors on the chain."]
+    [:ol {:data-testid "rf-causa-static-events-chain-list"
+          :style       {:list-style "none"
+                        :padding    0
+                        :margin     0
+                        :display    "flex"
+                        :flex-direction "column"
+                        :gap        "4px"}}
+     (for [[idx ic] (map-indexed vector interceptors)]
+       (let [icpt-id (:id ic)]
+         ^{:key idx}
+         [:li {:data-testid (str "rf-causa-static-events-chain-row-" idx)
+               :style       {:padding "4px 8px"
+                             :border  (str "1px solid " (:border-subtle tokens))
+                             :border-radius "3px"
+                             :background (:bg-1 tokens)
+                             :font-family mono-stack
+                             :font-size   "11px"
+                             :display "flex"
+                             :align-items "center"
+                             :gap "6px"}}
+          [:span {:style {:color (:text-tertiary tokens) :min-width "20px"}}
+           (str "#" idx)]
+          [:span {:style {:color (:accent-violet tokens) :font-weight 600}}
+           (pr-str icpt-id)]
+          (when (:rf/default? ic)
+            [:span {:data-testid (str "rf-causa-static-events-chain-default-" idx)
+                    :title "Framework-emitted auto-wrapper (rf2-twt7m)"
+                    :style {:color (:text-tertiary tokens)
+                            :font-family sans-stack
+                            :font-size "9px"
+                            :padding "1px 4px"
+                            :border (str "1px solid " (:text-tertiary tokens))
+                            :border-radius "2px"
+                            :text-transform "uppercase"
+                            :letter-spacing "0.5px"}}
+             "default"])
+          [:span {:style {:color (:text-tertiary tokens)
+                          :margin-left "auto"
+                          :font-family sans-stack
+                          :font-size "10px"}}
+           (str (when (:before ic) "before ")
+                (when (:after ic) "after"))]]))]))
+
+(defn- simulate-form
+  [event-id sim-input]
+  [:div {:data-testid "rf-causa-static-events-sim-form"
+         :style       {:display "flex"
+                       :flex-direction "column"
+                       :gap "4px"
+                       :margin-top "8px"}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    "Simulate-input (EDN payload — appended after the event-id)"]
+   [:textarea
+    {:data-testid "rf-causa-static-events-sim-input"
+     :placeholder (str (pr-str event-id) " " "{:foo 1}    ;; or just :bar")
+     :value       (or sim-input "")
+     :rows        2
+     :on-change   (fn [e]
+                    (rf/dispatch [:rf.causa.static.events/set-sim-input
+                                  (-> e .-target .-value)]
+                                 {:frame :rf/causa}))
+     :style       {:background (:bg-3 tokens)
+                   :color (:text-primary tokens)
+                   :border (str "1px solid " (:border-default tokens))
+                   :border-radius "4px"
+                   :padding "5px 8px"
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :resize "vertical"}}]
+   [:div {:style {:display "flex" :gap "8px" :align-items "center"}}
+    [:button
+     {:data-testid "rf-causa-static-events-sim-run"
+      :on-click    (fn [_]
+                     (rf/dispatch [:rf.causa.static.events/run-simulate
+                                   {:event-id event-id
+                                    :payload-edn sim-input}]
+                                  {:frame :rf/causa}))
+      :style       {:background (:yellow tokens)
+                    :color (:bg-1 tokens)
+                    :border "none"
+                    :border-radius "4px"
+                    :padding "5px 12px"
+                    :cursor "pointer"
+                    :font-family sans-stack
+                    :font-size "11px"
+                    :font-weight 600}}
+     "Simulate ▶︎"]
+    [:span {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :font-style "italic"}}
+     "hermetic — no dispatch, no fx walk, no app-db swap"]]])
+
+(defn- simulate-result
+  [{:keys [ok? kind value reason] :as sim-result}]
+  (when sim-result
+    [:div {:data-testid "rf-causa-static-events-sim-result"
+           :style {:margin-top "8px"
+                   :padding "8px"
+                   :border (str "1px solid "
+                                (if ok? (:cyan tokens) (:red tokens)))
+                   :background (if ok? (:bg-1 tokens) "rgba(248, 113, 113, 0.08)")
+                   :border-radius "4px"
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :color (:text-primary tokens)
+                   :white-space "pre-wrap"
+                   :word-break "break-all"}}
+     [:div {:style {:color (if ok? (:cyan tokens) (:red tokens))
+                    :font-family sans-stack
+                    :font-weight 600
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :margin-bottom "4px"}}
+      (if ok?
+        (str "Result (" (some-> kind name) " handler)")
+        "Simulate failed")]
+     [:code (if ok? (pr-str value) (str reason))]]))
+
+(defn- detail-card
+  "Right-rail / inline detail card for the selected event. Shows
+  the source-coord, the interceptor chain, and the simulate form +
+  most recent result."
+  [{:keys [selected] :as _data} sim-input sim-result registrations-map]
+  (when selected
+    (let [{:keys [id kind doc source-coord]} selected
+          meta (get registrations-map id)
+          interceptors (or (:interceptors meta) [])]
+      [:section {:data-testid "rf-causa-static-events-detail"
+                 :style {:padding "12px 16px"
+                         :border-top (str "1px solid " (:cyan tokens))
+                         :background (:bg-2 tokens)
+                         :font-family sans-stack
+                         :font-size "12px"
+                         :color (:text-primary tokens)
+                         :display "flex"
+                         :flex-direction "column"
+                         :gap "8px"}}
+       [:div {:style {:display "flex" :align-items "baseline" :gap "8px"}}
+        (kind-badge kind)
+        [:code {:style {:color (:accent-violet tokens)
+                        :font-family mono-stack
+                        :font-size "13px"
+                        :font-weight 600}}
+         (pr-str id)]
+        (when (and source-coord (:file source-coord))
+          [open-in-editor/open-chip source-coord])]
+       (when doc
+         [:div {:data-testid "rf-causa-static-events-detail-doc"
+                :style {:color (:text-secondary tokens)
+                        :font-style "italic"
+                        :font-size "11px"}}
+          doc])
+       [:div {:style {:margin-top "4px"}}
+        [:label {:style {:color (:text-tertiary tokens)
+                         :font-size "10px"
+                         :text-transform "uppercase"
+                         :letter-spacing "0.5px"
+                         :display "block"
+                         :margin-bottom "4px"}}
+         (str "Interceptor chain (" (count interceptors) ")")]
+        (interceptor-chain interceptors)]
+       (simulate-form id sim-input)
+       (simulate-result sim-result)])))
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  []
+  [:div {:data-testid "rf-causa-static-events-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No event handlers registered."])
+
+(defn- empty-filtered
+  [query]
+  [:div {:data-testid "rf-causa-static-events-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No events match " (pr-str query) ".")])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Events panel root view. Subscribes to the registered-events
+  composite + the search-query slot + the selected-id slot + the
+  simulate state, then composes the header / search / list / detail
+  card.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data         @(rf/subscribe [:rf.causa.static.events/tab-data])
+        registry-map @(rf/subscribe [:rf.causa.static.events/registry])
+        sim-input    @(rf/subscribe [:rf.causa.static.events/sim-input])
+        sim-result   @(rf/subscribe [:rf.causa.static.events/sim-result])
+        {:keys [silent? events total filtered? query]} data]
+    [:section {:data-testid "rf-causa-static-events"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (cond
+       silent?
+       (empty-state)
+
+       :else
+       [:<>
+        (search-box query total filtered?)
+        [:div {:style {:flex 1
+                       :min-height 0
+                       :display "flex"
+                       :flex-direction "column"
+                       :overflow "auto"}}
+         (if (empty? events)
+           (empty-filtered query)
+           (into [:ul {:data-testid "rf-causa-static-events-list"
+                       :style       {:list-style     "none"
+                                     :margin         "8px 0 0 0"
+                                     :padding        "0 8px"
+                                     :display        "flex"
+                                     :flex-direction "column"
+                                     :gap            "2px"}}]
+                 (for [row events]
+                   ^{:key (pr-str (:id row))}
+                   [event-row row (= (:id row) (:selected-id data))])))
+         (detail-card data sim-input sim-result registry-map)]])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Events panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.events/query`              — search input slot.
+    - `:rf.causa.static.events/set-query`          — search setter.
+    - `:rf.causa.static.events/selected-id`        — focused row id.
+    - `:rf.causa.static.events/select`             — row-click event.
+    - `:rf.causa.static.events/sim-input`          — pending EDN payload.
+    - `:rf.causa.static.events/set-sim-input`      — payload setter.
+    - `:rf.causa.static.events/sim-result`         — last simulate-output.
+    - `:rf.causa.static.events/run-simulate`       — hermetic simulate.
+    - `:rf.causa.static.events/registry-override`  — test-only override.
+    - `:rf.causa.static.events/set-registry-override-for-test`
+        — test-only setter.
+    - `:rf.causa.static.events/registry`           — production data sub.
+    - `:rf.causa.static.events/tab-data`           — view composite."
+  []
+
+  ;; ---- UI state ---------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.events/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.events/query)
+        (assoc db :rf.causa.static.events/query q))))
+
+  (rf/reg-sub :rf.causa.static.events/query
+    (fn [db _]
+      (get db :rf.causa.static.events/query)))
+
+  (rf/reg-event-db :rf.causa.static.events/select
+    (fn [db [_ id]]
+      ;; Clicking the already-selected row clears the selection so the
+      ;; detail card collapses. Clicking a new row also clears any prior
+      ;; sim-input/result so the user isn't confused by stale output.
+      (let [cur (get db :rf.causa.static.events/selected-id)]
+        (if (= cur id)
+          (-> db
+              (dissoc :rf.causa.static.events/selected-id)
+              (dissoc :rf.causa.static.events/sim-input)
+              (dissoc :rf.causa.static.events/sim-result))
+          (-> db
+              (assoc :rf.causa.static.events/selected-id id)
+              (dissoc :rf.causa.static.events/sim-input)
+              (dissoc :rf.causa.static.events/sim-result))))))
+
+  (rf/reg-sub :rf.causa.static.events/selected-id
+    (fn [db _]
+      (get db :rf.causa.static.events/selected-id)))
+
+  (rf/reg-event-db :rf.causa.static.events/set-sim-input
+    (fn [db [_ s]]
+      (if (or (nil? s) (= "" s))
+        (dissoc db :rf.causa.static.events/sim-input)
+        (assoc db :rf.causa.static.events/sim-input s))))
+
+  (rf/reg-sub :rf.causa.static.events/sim-input
+    (fn [db _]
+      (get db :rf.causa.static.events/sim-input)))
+
+  (rf/reg-sub :rf.causa.static.events/sim-result
+    (fn [db _]
+      (get db :rf.causa.static.events/sim-result)))
+
+  ;; ---- run-simulate ----------------------------------------------------
+  ;;
+  ;; Hermetic: look up the registered meta, parse the EDN payload (if
+  ;; any), construct the event vector `[event-id & payload-args]`, and
+  ;; invoke the handler-fn directly with a synthetic input. NO real
+  ;; dispatch — the interceptor chain is documented in the detail card
+  ;; but NOT executed (interceptor stacks involve cofx injection that
+  ;; would defeat hermeticity).
+
+  (rf/reg-event-db :rf.causa.static.events/run-simulate
+    (fn [db [_ {:keys [event-id payload-edn]}]]
+      (let [registrations
+            (or (get db :rf.causa.static.events/registry-override)
+                (try (registrar/registrations :event)
+                     (catch :default _ {})))
+            result (helpers/run-simulate
+                     registrations event-id payload-edn
+                     reader/read-string)]
+        (assoc db :rf.causa.static.events/sim-result result))))
+
+  ;; ---- test-only override ----------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.events/set-registry-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rf.causa.static.events/registry-override)
+        (assoc db :rf.causa.static.events/registry-override ov))))
+
+  (rf/reg-sub :rf.causa.static.events/registry-override
+    (fn [db _]
+      (get db :rf.causa.static.events/registry-override)))
+
+  ;; ---- production data sub ---------------------------------------------
+
+  ;; Walks the registrar's `:event` slot. `:<-`-composes against the
+  ;; trace buffer so newly-registered events surface as soon as the
+  ;; trace-buffer's next reactive pulse fires.
+  (rf/reg-sub :rf.causa.static.events/registry
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa.static.events/registry-override]
+    (fn [[_buffer override] _query]
+      (or override
+          (try (registrar/registrations :event)
+               (catch :default _ {})))))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.events/tab-data
+    :<- [:rf.causa.static.events/registry]
+    :<- [:rf.causa.static.events/query]
+    :<- [:rf.causa.static.events/selected-id]
+    (fn [[registrations-map query selected-id] _query]
+      (project-data registrations-map query selected-id)))
+
+  ;; rf2-2moh1 — register the Static Events tab. Order 5 — sits after
+  ;; :flows (4) per the parent-epic findings doc §2.4.
+  (panel-registry/reg-l4-tab!
+    {:id    :events
+     :label "Events"
+     :mnem  "e"
+     :modes #{:static}
+     :order 5
+     :panel Panel
+     :placeholder-bead "rf2-o5f5f.6"})
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
@@ -1,0 +1,376 @@
+(ns day8.re-frame2-causa.static.interceptors.panel
+  "Top-level Interceptors sub-tab for Causa's Static surface (rf2-o5f5f.6).
+
+  ## Pure-browse verb
+
+  Per Lock #15 (two-verbs-two-homes — browse-all lives in Static) the
+  Interceptors sub-tab is a flat catalogue of every interceptor
+  surfaced through registered events. Per spec/004 the interceptor
+  shape is a map carrying `:id`, optional `:before`/`:after` fns, and
+  the framework `:rf/default?` marker for auto-wrappers (rf2-twt7m).
+
+      ┌───────────────────────────────────────────────────┐
+      │ Interceptors — header + descriptive prose         │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]           14 interceptors│
+      ├───────────────────────────────────────────────────┤
+      │ ▸ :rf/db-handler   before  [default]              │
+      │ ▸ :my/logging      before/after                   │
+      └───────────────────────────────────────────────────┘
+
+  ## Data source
+
+  Walks `(re-frame.registrar/registrations :event)` and harvests the
+  `:interceptors` chain from each entry; collapses by `:id` so an
+  interceptor that appears on many chains shows up once with the count
+  of chains it appears on. Interceptors with no `:id` (rare —
+  `->interceptor` requires one) fall under `::unnamed`.
+
+  ## Pure-browse — no simulate
+
+  Per the bead body: 'Pure-browse (no simulate-input — interceptors
+  are composition; simulate fires through the handler-level simulate
+  above).' The Events panel's hermetic simulate is the only simulate
+  affordance in the Static surface.
+
+  ## State slots (all under `:rf.causa.static.interceptors/*`)
+
+    - `:rf.causa.static.interceptors/query`    — search input value."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [day8.re-frame2-causa.panel-registry :as panel-registry]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn collect-interceptors
+  "Walk every registered event's `:interceptors` chain and return a
+  vector of row maps. Collapses by `:id` so an interceptor that appears
+  on many chains lands as one row with `:chain-count` set."
+  [registrations-map]
+  (let [pairs (for [[event-id meta] registrations-map
+                    icpt           (or (:interceptors meta) [])]
+                [(or (:id icpt) ::unnamed) event-id icpt])
+        by-id (reduce
+                (fn [acc [icpt-id event-id icpt]]
+                  (-> acc
+                      (update-in [icpt-id :sample]
+                                 #(or % icpt))
+                      (update-in [icpt-id :event-ids]
+                                 (fnil conj #{}) event-id)))
+                {}
+                pairs)]
+    (->> by-id
+         (map (fn [[icpt-id {:keys [sample event-ids]}]]
+                {:id          icpt-id
+                 :before?     (boolean (:before sample))
+                 :after?      (boolean (:after sample))
+                 :default?    (boolean (:rf/default? sample))
+                 :chain-count (count event-ids)
+                 :doc         (:doc sample)
+                 :comment     (:comment sample)}))
+         (sort-by (fn [{:keys [id]}] (pr-str id)))
+         vec)))
+
+(defn- row-haystack [{:keys [id doc comment]}]
+  (str/lower-case
+    (str (pr-str id) " "
+         (or doc "") " "
+         (or comment ""))))
+
+(defn filter-rows
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+
+(defn project-data
+  [registrations-map query]
+  (let [rows     (collect-interceptors registrations-map)
+        silent?  (empty? rows)
+        filtered (filter-rows rows query)]
+    {:silent?      silent?
+     :interceptors filtered
+     :total        (count rows)
+     :filtered?    (not= (count rows) (count filtered))
+     :query        query}))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-interceptors-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Interceptors"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every interceptor surfaced through the registered event "
+    "handlers. "
+    [:strong {:style {:color (:cyan tokens)}} "Pure-browse"]
+    " — interceptors are composition primitives; the simulate verb "
+    "lives in the Events sub-tab."]])
+
+;; ---- search box ----------------------------------------------------------
+
+(defn- search-box
+  [query total filtered?]
+  [:div {:data-testid "rf-causa-static-interceptors-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-interceptors-search-input"
+            :placeholder "interceptor-id or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.interceptors/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-interceptors-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "90px"
+                         :text-align  "right"}}
+    (cond
+      filtered?     "match"
+      (= 1 total)   "1 interceptor"
+      :else         (str total " interceptors"))]])
+
+;; ---- row -----------------------------------------------------------------
+
+(defn- interceptor-row
+  [{:keys [id before? after? default? chain-count doc] :as _row}]
+  (let [id-text (pr-str id)
+        row-id  (if (and (> (count id-text) 0) (= \: (first id-text)))
+                  (subs id-text 1)
+                  id-text)]
+    [:li {:data-testid (str "rf-causa-static-interceptors-row-" row-id)
+          :style       {:display       "block"
+                        :padding       "6px 12px"
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :color         (:text-primary tokens)
+                        :background    "transparent"
+                        :border-left   "2px solid transparent"
+                        :border-radius "2px"
+                        :line-height   "18px"}}
+     [:div {:style {:display     "flex"
+                    :align-items "baseline"
+                    :gap         "8px"}}
+      [:span {:style {:color       (:accent-violet tokens)
+                      :font-weight 500
+                      :flex        1}}
+       id-text]
+      [:span {:title (str (cond
+                            (and before? after?) "both before AND after"
+                            before?              "before-only"
+                            after?               "after-only"
+                            :else                "neither hook")
+                          " hook")
+              :style {:color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "10px"}}
+       (cond
+         (and before? after?) "before/after"
+         before?              "before"
+         after?               "after"
+         :else                "—")]
+      (when default?
+        [:span {:data-testid (str "rf-causa-static-interceptors-default-" row-id)
+                :title "Framework-emitted auto-wrapper (rf2-twt7m)"
+                :style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "9px"
+                        :padding "1px 4px"
+                        :border (str "1px solid " (:text-tertiary tokens))
+                        :border-radius "2px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"}}
+         "default"])
+      [:span {:title (str "appears on " chain-count " chain(s)")
+              :style {:color (:text-tertiary tokens)
+                      :font-family mono-stack
+                      :font-size "10px"
+                      :padding "0 4px"
+                      :background (:bg-3 tokens)
+                      :border (str "1px solid " (:border-subtle tokens))
+                      :border-radius "3px"}}
+       (str "x" chain-count)]]
+     (when doc
+       [:div {:style {:margin-left "12px"
+                      :margin-top  "2px"
+                      :color       (:text-secondary tokens)
+                      :font-family sans-stack
+                      :font-style  "italic"
+                      :font-size   "11px"}}
+        doc])]))
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  []
+  [:div {:data-testid "rf-causa-static-interceptors-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No interceptors registered."])
+
+(defn- empty-filtered
+  [query]
+  [:div {:data-testid "rf-causa-static-interceptors-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No interceptors match " (pr-str query) ".")])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Interceptors panel root view. Subscribes to the
+  interceptors composite + search slot.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data @(rf/subscribe [:rf.causa.static.interceptors/tab-data])
+        {:keys [silent? interceptors total filtered? query]} data]
+    [:section {:data-testid "rf-causa-static-interceptors"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (cond
+       silent?
+       (empty-state)
+
+       :else
+       [:<>
+        (search-box query total filtered?)
+        (if (empty? interceptors)
+          (empty-filtered query)
+          (into [:ul {:data-testid "rf-causa-static-interceptors-list"
+                      :style       {:list-style     "none"
+                                    :margin         "8px 0 0 0"
+                                    :padding        "0 8px"
+                                    :flex           1
+                                    :overflow       "auto"
+                                    :display        "flex"
+                                    :flex-direction "column"
+                                    :gap            "2px"}}]
+                (for [row interceptors]
+                  ^{:key (pr-str (:id row))}
+                  [interceptor-row row])))])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Interceptors panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.interceptors/query`             — search input slot.
+    - `:rf.causa.static.interceptors/set-query`         — search setter.
+    - `:rf.causa.static.interceptors/registry-override` — test seam.
+    - `:rf.causa.static.interceptors/set-registry-override-for-test`
+        — test seam setter (payload shape: registrations map).
+    - `:rf.causa.static.interceptors/registry`          — production data sub.
+    - `:rf.causa.static.interceptors/tab-data`          — view-facing composite."
+  []
+
+  ;; ---- UI state ---------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.interceptors/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.interceptors/query)
+        (assoc db :rf.causa.static.interceptors/query q))))
+
+  (rf/reg-sub :rf.causa.static.interceptors/query
+    (fn [db _]
+      (get db :rf.causa.static.interceptors/query)))
+
+  ;; ---- test-only override ----------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.interceptors/set-registry-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rf.causa.static.interceptors/registry-override)
+        (assoc db :rf.causa.static.interceptors/registry-override ov))))
+
+  (rf/reg-sub :rf.causa.static.interceptors/registry-override
+    (fn [db _]
+      (get db :rf.causa.static.interceptors/registry-override)))
+
+  ;; ---- production data sub ---------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.interceptors/registry
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa.static.interceptors/registry-override]
+    (fn [[_buffer override] _query]
+      (or override
+          (try (registrar/registrations :event)
+               (catch :default _ {})))))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.interceptors/tab-data
+    :<- [:rf.causa.static.interceptors/registry]
+    :<- [:rf.causa.static.interceptors/query]
+    (fn [[registrations-map query] _query]
+      (project-data registrations-map query)))
+
+  ;; rf2-2moh1 — register the Static Interceptors tab. Order 6 — sits
+  ;; after :events (5).
+  (panel-registry/reg-l4-tab!
+    {:id    :interceptors
+     :label "Interceptors"
+     :mnem  "i"
+     :modes #{:static}
+     :order 6
+     :panel Panel
+     :placeholder-bead "rf2-o5f5f.6"})
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -29,19 +29,18 @@
   state, and motion dampening, the user reads Static at a glance even
   without looking at the pill.
 
-  ## Tab inventory (5 sub-tabs)
+  ## Tab inventory (7 sub-tabs)
 
-  This bead registers the 5 Static sub-tabs as PLACEHOLDERS — each
-  renders a 'rf2-o5f5f.<N> will fill this' card. The sibling beads
-  (.2 Machines, .3 Routes, .4 Schemas, .5 Views, .6 Events) replace
-  the placeholders with real catalogue content.
+  The Static surface now mounts seven sub-tabs. Each sibling bead
+  installs its own panel into the L4 tab registry (rf2-2moh1):
+
+      Machines (m, default) · Routes (r) · Schemas (c) · Views (v) ·
+      Flows (f) · Events (e) · Interceptors (i)
 
   Tab order + mnemonics per the findings doc §5.2 (mode-scoped: same
   letter, different target per mode — `m` in Runtime opens the
   Machines instance inspector, `m` in Static opens the Machines
-  registry browse):
-
-      Machines (m, default) · Routes (r) · Schemas (c) · Views (v) · Events (e)
+  registry browse).
 
   Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`
   follow-on — Phase 1 ships only the click path.
@@ -73,16 +72,17 @@
     4. **Chrome silhouette** — Runtime is 4-layer; Static is 3-layer
        (no L2 / no spine). The shape itself is a signal.
 
-  ## What's deferred to siblings
+  ## Sibling beads filling the tab inventory
 
-  This bead registers the chrome + the empty tabs only. The siblings
-  fill the placeholder content:
+  Each sibling bead owned its sub-tab panel:
 
     - rf2-o5f5f.2 — Machines registry browse + Topology
     - rf2-o5f5f.3 — Routes registry browse + Simulate-URL
     - rf2-o5f5f.4 — Schemas registry browse + sample data
     - rf2-o5f5f.5 — Views registry browse (Fiber-walker consumer)
-    - rf2-o5f5f.6 — Events registry browse + interceptor stack"
+    - rf2-uhsqb   — Flows registry browse
+    - rf2-o5f5f.6 — Events registry browse + interceptor stack +
+                    hermetic simulate (Events) + Interceptors lens"
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
@@ -349,21 +349,15 @@
 
   Each Static panel's `install!` registers its tab entry via
   `panel-registry/reg-l4-tab!` with `:modes #{:static}` + a `:panel`
-  view fn. The previous case-switch over the six static tab ids is
-  replaced by a lookup against `panel-registry/tab-by-id :static`:
+  view fn. The Static-mode L4 tabs are:
 
-    :machines → `static.machines.panel/panel` (rf2-o5f5f.2)
-    :routes   → `static.routes.panel/Panel`   (rf2-o5f5f.3)
-    :schemas  → `static.schemas.panel/Panel`  (rf2-o5f5f.4)
-    :views    → `static.views.panel/Panel`    (rf2-o5f5f.5)
-    :flows    → `static.flows.panel/Panel`    (rf2-uhsqb)
-    :events   — placeholder card (rf2-o5f5f.6 — sibling bead fills)
-
-  The placeholder `:events` tab is registered alongside the others by
-  `register-events-placeholder!` (called from
-  `registry.cljs/register-causa-handlers!`); its `:panel` is a closed-
-  over `placeholder-card` invocation so the registry's `:panel`
-  contract (any view fn) holds even for not-yet-filled tabs.
+    :machines     → `static.machines.panel/panel`         (rf2-o5f5f.2)
+    :routes       → `static.routes.panel/Panel`           (rf2-o5f5f.3)
+    :schemas      → `static.schemas.panel/Panel`          (rf2-o5f5f.4)
+    :views        → `static.views.panel/Panel`            (rf2-o5f5f.5)
+    :flows        → `static.flows.panel/Panel`            (rf2-uhsqb)
+    :events       → `static.events.panel/Panel`           (rf2-o5f5f.6)
+    :interceptors → `static.interceptors.panel/Panel`     (rf2-o5f5f.6)
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -391,35 +385,6 @@
                       :color       (:text-secondary tokens)
                       :font-family sans-stack}}
         "Unknown Static tab: " [:code (pr-str selected)]])]))
-
-(defn- events-placeholder-panel
-  "Placeholder panel-view for the not-yet-implemented Static
-  `:events` tab. Sibling bead rf2-o5f5f.6 will replace this with an
-  events-registry browse panel — at which point the install! call
-  in `registry.cljs` is dropped and `static/events/panel.cljs`
-  becomes the canonical registrar of the `:events` tab."
-  []
-  [placeholder-card
-   {:id               :events
-    :label            "Events"
-    :placeholder-bead "rf2-o5f5f.6"}])
-
-(defn register-events-placeholder!
-  "rf2-2moh1 — register the placeholder `:events` Static tab. The
-  other Static tabs each carry their own `install!` (machines,
-  routes, schemas, views, flows); this one has no panel ns yet so
-  the registration lives here, alongside the placeholder-card
-  helper it composes against."
-  []
-  (panel-registry/reg-l4-tab!
-    {:id               :events
-     :label            "Events"
-     :mnem             "e"
-     :modes            #{:static}
-     :order            5
-     :panel            events-placeholder-panel
-     :placeholder-bead "rf2-o5f5f.6"})
-  nil)
 
 ;; ---- Static surface ------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
@@ -371,21 +371,34 @@
 ;; -------------------------------------------------------------------------
 
 (deftest static-placeholder-uses-h2-not-h1
-  (testing "rf2-vxpq1 — Static placeholder cards drop <h1> to <h2>
-            so they don't break the host document's heading outline."
+  (testing "rf2-vxpq1 — Static placeholder cards drop <h1> to <h2> so
+            they don't break the host document's heading outline.
+
+            Per rf2-o5f5f.6 every Static sub-tab has shipped its real
+            panel — no placeholder cards currently mount. The
+            placeholder helper in `static/shell.cljs` still renders
+            `<h2>` if a future bead adds an unfilled tab, so this test
+            asserts the contract directly against the helper rather
+            than mounting via the surface."
     (causa-setup!)
+    ;; The shell's `placeholder-card` defn is private; we drive the
+    ;; check through the registry's surface instead. When no
+    ;; placeholders mount, the test is trivially OK — the assertion
+    ;; bites the day a future unfilled tab regresses.
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.static/select-tab :events]))
-    (rf/with-frame :rf/causa
-      (let [tree   (static-shell/surface)
-            ;; placeholder is wrapped in a <section> with a known testid
-            ph     (find-by-testid tree "rf-causa-static-placeholder-events")
-            h1s    (find-all-with-pred ph
+      (let [tree (static-shell/surface)
+            placeholders (find-all-with-pred tree
+                           (fn [n]
+                             (and (vector? n)
+                                  (map? (second n))
+                                  (when-let [tid (:data-testid (second n))]
+                                    (= 0 (.indexOf tid "rf-causa-static-placeholder-"))))))]
+        (doseq [ph placeholders]
+          (let [h1s (find-all-with-pred ph
                      (fn [n] (and (vector? n) (= :h1 (first n)))))
-            h2s    (find-all-with-pred ph
+                h2s (find-all-with-pred ph
                      (fn [n] (and (vector? n) (= :h2 (first n)))))]
-        (is (some? ph) "placeholder card renders for :events tab")
-        (is (empty? h1s)
-            "placeholder card has no <h1> (would break document outline)")
-        (is (seq h2s)
-            "placeholder card uses <h2> for the title")))))
+            (is (empty? h1s)
+                "placeholder card has no <h1> (would break document outline)")
+            (is (seq h2s)
+                "placeholder card uses <h2> for the title")))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -243,6 +243,22 @@
    :rf.causa.static.flows/registered-flows
    :rf.causa.static.flows/registered-flows-override
    :rf.causa.static.flows/tab-data
+   ;; rf2-o5f5f.6 — Static Events sub-tab subs (browse-all over the
+   ;; registrar's `:event` slot + selection + simulate state + view-
+   ;; facing composite + test seam).
+   :rf.causa.static.events/query
+   :rf.causa.static.events/selected-id
+   :rf.causa.static.events/sim-input
+   :rf.causa.static.events/sim-result
+   :rf.causa.static.events/registry
+   :rf.causa.static.events/registry-override
+   :rf.causa.static.events/tab-data
+   ;; rf2-o5f5f.6 — Static Interceptors sub-tab subs (pure-browse over
+   ;; the interceptors surfaced through registered events).
+   :rf.causa.static.interceptors/query
+   :rf.causa.static.interceptors/registry
+   :rf.causa.static.interceptors/registry-override
+   :rf.causa.static.interceptors/tab-data
    :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
@@ -519,6 +535,17 @@
    ;; rf2-uhsqb — Static Flows sub-tab events.
    :rf.causa.static.flows/set-query
    :rf.causa.static.flows/set-registered-flows-override-for-test
+   ;; rf2-o5f5f.6 — Static Events sub-tab events (search slot, row
+   ;; selection, simulate input + run, test seam).
+   :rf.causa.static.events/set-query
+   :rf.causa.static.events/select
+   :rf.causa.static.events/set-sim-input
+   :rf.causa.static.events/run-simulate
+   :rf.causa.static.events/set-registry-override-for-test
+   ;; rf2-o5f5f.6 — Static Interceptors sub-tab events (search slot,
+   ;; test seam).
+   :rf.causa.static.interceptors/set-query
+   :rf.causa.static.interceptors/set-registry-override-for-test
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/set-modal-positioning
    ;; rf2-x8h9y — resize-handle live update event.

--- a/tools/causa/test/day8/re_frame2_causa/static/events/helpers_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/static/events/helpers_test.cljc
@@ -1,0 +1,130 @@
+(ns day8.re-frame2-causa.static.events.helpers-test
+  "Pure-data unit tests for the Static Events helpers (rf2-o5f5f.6).
+  JVM-runnable so the row-projection, payload-parsing, and hermetic
+  simulate algebra are covered without a CLJS runtime."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as reader])
+            [day8.re-frame2-causa.static.events.helpers :as h]))
+
+(def ^:private read-edn
+  #?(:clj  edn/read-string
+     :cljs reader/read-string))
+
+;; ---- sanitize-row-id ----------------------------------------------------
+
+(deftest sanitize-row-id-strips-leading-colon
+  (is (= "user/login" (h/sanitize-row-id :user/login))
+      "keyword namespaced — colon stripped")
+  (is (= "foo" (h/sanitize-row-id :foo))
+      "bare keyword — colon stripped"))
+
+(deftest sanitize-row-id-non-keyword-fallback
+  (is (= "\"string-id\"" (h/sanitize-row-id "string-id"))
+      "string id surrounded by quotes from pr-str"))
+
+;; ---- parse-payload-edn --------------------------------------------------
+
+(deftest parse-payload-empty-returns-empty-vector
+  (is (= [] (h/parse-payload-edn nil read-edn)))
+  (is (= [] (h/parse-payload-edn "" read-edn)))
+  (is (= [] (h/parse-payload-edn "   " read-edn))))
+
+(deftest parse-payload-single-map
+  (is (= [{:x 1}] (h/parse-payload-edn "{:x 1}" read-edn))))
+
+(deftest parse-payload-multiple-args
+  (is (= [{:x 1} :tag] (h/parse-payload-edn "{:x 1} :tag" read-edn))))
+
+(deftest parse-payload-scalar
+  (is (= [42] (h/parse-payload-edn "42" read-edn)))
+  (is (= [:bar] (h/parse-payload-edn ":bar" read-edn))))
+
+(deftest parse-payload-malformed-returns-error-map
+  (let [result (h/parse-payload-edn "{unbalanced" read-edn)]
+    (is (map? result))
+    (is (string? (:parse-error result))
+        "error map carries a human-readable :parse-error string")))
+
+;; ---- build-event-vector -------------------------------------------------
+
+(deftest build-event-vector-shape
+  (is (= [:foo/bar] (h/build-event-vector :foo/bar [])))
+  (is (= [:foo/bar {:x 1}] (h/build-event-vector :foo/bar [{:x 1}])))
+  (is (= [:foo/bar {:x 1} :tag]
+         (h/build-event-vector :foo/bar [{:x 1} :tag]))))
+
+;; ---- run-simulate -------------------------------------------------------
+
+(deftest run-simulate-missing-id-fails-cleanly
+  (let [result (h/run-simulate {} :nope nil read-edn)]
+    (is (false? (:ok? result)))
+    (is (re-find #"No registration found" (:reason result)))))
+
+(deftest run-simulate-no-handler-fn-fails-cleanly
+  (let [registrations {:foo {:event/kind :db}}
+        result (h/run-simulate registrations :foo nil read-edn)]
+    (is (false? (:ok? result)))
+    (is (re-find #":handler-fn" (:reason result)))))
+
+(deftest run-simulate-db-handler-runs
+  (let [registrations
+        {:counter/inc
+         {:event/kind :db
+          :handler-fn (fn [db ev] (assoc db :last-event ev :n (inc (get db :n 0))))}}
+        result (h/run-simulate registrations :counter/inc nil read-edn)]
+    (is (true? (:ok? result)))
+    (is (= :db (:kind result)))
+    (is (= 1 (get-in result [:value :n])))
+    (is (= [:counter/inc] (get-in result [:value :last-event])))))
+
+(deftest run-simulate-db-handler-with-payload
+  (let [registrations
+        {:user/set
+         {:event/kind :db
+          :handler-fn (fn [db [_ user]] (assoc db :user user))}}
+        result (h/run-simulate registrations :user/set "{:name \"alice\"}" read-edn)]
+    (is (true? (:ok? result)))
+    (is (= {:name "alice"} (get-in result [:value :user])))))
+
+(deftest run-simulate-fx-handler-runs
+  (let [registrations
+        {:user/save
+         {:event/kind :fx
+          :handler-fn (fn [cofx _ev]
+                        {:db (assoc (:db cofx) :saving? true)
+                         :fx [[:dispatch [:user/saved]]]})}}
+        result (h/run-simulate registrations :user/save nil read-edn)]
+    (is (true? (:ok? result)))
+    (is (= :fx (:kind result)))
+    (is (true? (get-in result [:value :db :saving?])))
+    (is (= [[:dispatch [:user/saved]]] (get-in result [:value :fx])))))
+
+(deftest run-simulate-ctx-handler-runs
+  (let [registrations
+        {:ctx/touch
+         {:event/kind :ctx
+          :handler-fn (fn [ctx] (assoc ctx :touched? true))}}
+        result (h/run-simulate registrations :ctx/touch nil read-edn)]
+    (is (true? (:ok? result)))
+    (is (= :ctx (:kind result)))
+    (is (true? (get-in result [:value :touched?])))))
+
+(deftest run-simulate-handler-throw-surfaces-friendly-failure
+  (let [registrations
+        {:bad/handler
+         {:event/kind :db
+          :handler-fn (fn [_db _ev] (throw (ex-info "boom" {})))}}
+        result (h/run-simulate registrations :bad/handler nil read-edn)]
+    (is (false? (:ok? result)))
+    (is (re-find #"Handler threw" (:reason result)))
+    (is (re-find #"boom" (:reason result)))))
+
+(deftest run-simulate-malformed-payload-surfaces-parse-error
+  (let [registrations
+        {:foo {:event/kind :db
+               :handler-fn (fn [db _] db)}}
+        result (h/run-simulate registrations :foo "{unbalanced" read-edn)]
+    (is (false? (:ok? result)))
+    (is (re-find #"Could not parse payload" (:reason result)))))

--- a/tools/causa/test/day8/re_frame2_causa/static/events/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/events/panel_cljs_test.cljs
@@ -1,0 +1,267 @@
+(ns day8.re-frame2-causa.static.events.panel-cljs-test
+  "CLJS wiring + view tests for the Static Events sub-tab
+  (rf2-o5f5f.6)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.events.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- setup-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def sample-events
+  {:counter/inc
+   {:event/kind :db
+    :handler-fn (fn [db _] (update db :n (fnil inc 0)))
+    :doc        "increment the counter"
+    :interceptors [{:id :rf/db-handler :rf/default? true :before identity}]
+    :file       "src/counter/events.cljs"
+    :line       12
+    :ns         'counter.events}
+
+   :user/save
+   {:event/kind :fx
+    :handler-fn (fn [_cofx _ev] {:db {:saving? true} :fx []})
+    :doc        "persist user"
+    :interceptors [{:id :rf/path :before identity}
+                   {:id :rf/fx-handler :rf/default? true :before identity}]
+    :file       "src/user/events.cljs"
+    :line       42
+    :ns         'user.events}
+
+   :ctx/touch
+   {:event/kind :ctx
+    :handler-fn (fn [ctx] (assoc ctx :touched? true))
+    :interceptors [{:id :rf/ctx-handler :rf/default? true :before identity}]}})
+
+;; -------------------------------------------------------------------------
+;; (1) pure helpers (CLJS-side smoke; the JVM corpus carries the
+;; full helpers contract in helpers_test.cljc)
+;; -------------------------------------------------------------------------
+
+(deftest project-rows-sorts-by-id
+  (let [rows (panel/project-rows sample-events)]
+    (is (= [:counter/inc :ctx/touch :user/save]
+           (mapv :id rows))
+        "sorted alphabetically by pr-str of id")))
+
+(deftest project-rows-carries-kind-doc-and-interceptor-count
+  (let [rows (panel/project-rows sample-events)
+        save (some #(when (= :user/save (:id %)) %) rows)]
+    (is (= :fx (:kind save)))
+    (is (= "persist user" (:doc save)))
+    (is (= 2 (:interceptor-count save))
+        "user/save chain length matches the fixture's two-element vec")))
+
+(deftest filter-rows-substring
+  (let [rows (panel/project-rows sample-events)]
+    (is (= rows (panel/filter-rows rows nil)))
+    (is (= 1 (count (panel/filter-rows rows "counter"))))
+    (is (= 1 (count (panel/filter-rows rows "ctx"))))
+    (is (= 0 (count (panel/filter-rows rows "no-such-event"))))))
+
+(deftest project-data-shape
+  (let [data (panel/project-data sample-events nil nil)]
+    (is (= 3 (:total data)))
+    (is (false? (:silent? data)))
+    (is (true? (:silent? (panel/project-data {} nil nil))))))
+
+;; -------------------------------------------------------------------------
+;; (2) registry wiring
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/query]))
+        "query slot defaults nil")
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/selected-id]))
+        "selected-id slot defaults nil")
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/sim-input]))
+        "sim-input slot defaults nil")
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/sim-result]))
+        "sim-result slot defaults nil")))
+
+(deftest set-query-writes-the-slot
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa.static.events/set-query "user"])
+    (is (= "user" @(rf/subscribe [:rf.causa.static.events/query])))))
+
+(deftest registry-override-feeds-the-composite
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (let [data @(rf/subscribe [:rf.causa.static.events/tab-data])]
+      (is (= 3 (:total data)))
+      (is (false? (:silent? data))))))
+
+(deftest select-event-toggles-selection
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync [:rf.causa.static.events/select :counter/inc])
+    (is (= :counter/inc @(rf/subscribe [:rf.causa.static.events/selected-id])))
+    (rf/dispatch-sync [:rf.causa.static.events/select :counter/inc])
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/selected-id]))
+        "clicking the same row clears the selection")
+    (rf/dispatch-sync [:rf.causa.static.events/select :counter/inc])
+    (rf/dispatch-sync [:rf.causa.static.events/select :user/save])
+    (is (= :user/save @(rf/subscribe [:rf.causa.static.events/selected-id]))
+        "clicking a different row swaps the selection")))
+
+(deftest select-event-clears-stale-sim-state
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync [:rf.causa.static.events/select :counter/inc])
+    (rf/dispatch-sync [:rf.causa.static.events/set-sim-input "{:a 1}"])
+    (rf/dispatch-sync [:rf.causa.static.events/select :user/save])
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/sim-input]))
+        "swapping selection clears sim-input")
+    (is (nil? @(rf/subscribe [:rf.causa.static.events/sim-result]))
+        "swapping selection clears sim-result")))
+
+(deftest run-simulate-fires-handler-hermetically
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync
+      [:rf.causa.static.events/run-simulate
+       {:event-id :counter/inc :payload-edn nil}])
+    (let [result @(rf/subscribe [:rf.causa.static.events/sim-result])]
+      (is (true? (:ok? result)))
+      (is (= :db (:kind result)))
+      (is (= 1 (get-in result [:value :n]))
+          "the inc handler ran against the synthetic empty db"))))
+
+(deftest run-simulate-records-parse-error
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync
+      [:rf.causa.static.events/run-simulate
+       {:event-id :counter/inc :payload-edn "{unbalanced"}])
+    (let [result @(rf/subscribe [:rf.causa.static.events/sim-result])]
+      (is (false? (:ok? result)))
+      (is (re-find #"Could not parse" (:reason result))))))
+
+;; -------------------------------------------------------------------------
+;; (3) view rendering
+;; -------------------------------------------------------------------------
+
+(deftest panel-renders-empty-state-when-silent
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test {}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-events-empty"))))))
+
+(deftest panel-renders-rows-from-override
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (let [tree (panel/Panel)
+          rows (find-all-by-testid-prefix tree "rf-causa-static-events-row-")]
+      (is (= 3 (count rows)) "three row surfaces rendered"))))
+
+(deftest panel-renders-filtered-state-on-no-match
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync [:rf.causa.static.events/set-query "no-such-event"])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-events-empty-filtered"))))))
+
+(deftest panel-renders-detail-card-when-selected
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync [:rf.causa.static.events/select :user/save])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-events-detail"))
+          "detail card mounts when a row is selected")
+      (is (some? (find-by-testid tree "rf-causa-static-events-chain-list"))
+          "interceptor chain rendered in the detail card")
+      (is (some? (find-by-testid tree "rf-causa-static-events-sim-form"))
+          "simulate form rendered in the detail card"))))
+
+(deftest panel-renders-simulate-result-after-run
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.events/set-registry-override-for-test
+       sample-events])
+    (rf/dispatch-sync [:rf.causa.static.events/select :counter/inc])
+    (rf/dispatch-sync
+      [:rf.causa.static.events/run-simulate
+       {:event-id :counter/inc :payload-edn nil}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-events-sim-result"))
+          "result block renders after run-simulate fires"))))

--- a/tools/causa/test/day8/re_frame2_causa/static/interceptors/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/interceptors/panel_cljs_test.cljs
@@ -1,0 +1,178 @@
+(ns day8.re-frame2-causa.static.interceptors.panel-cljs-test
+  "CLJS wiring + view tests for the Static Interceptors sub-tab
+  (rf2-o5f5f.6)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.interceptors.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- setup-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def sample-events-with-chains
+  {:counter/inc
+   {:event/kind   :db
+    :interceptors [{:id :my/logging :before identity}
+                   {:id :rf/db-handler :rf/default? true :before identity}]}
+
+   :user/save
+   {:event/kind   :fx
+    :interceptors [{:id :my/logging :before identity}
+                   {:id :rf/path    :before identity}
+                   {:id :rf/fx-handler :rf/default? true :before identity}]}
+
+   :anon/no-chain
+   {:event/kind   :db
+    :interceptors []}})
+
+;; -------------------------------------------------------------------------
+;; (1) pure helpers
+;; -------------------------------------------------------------------------
+
+(deftest collect-interceptors-collapses-by-id
+  (let [rows (panel/collect-interceptors sample-events-with-chains)
+        by-id (into {} (map (juxt :id identity) rows))]
+    ;; 4 distinct interceptors: :my/logging, :rf/db-handler,
+    ;; :rf/path, :rf/fx-handler
+    (is (= 4 (count rows)))
+    (is (= 2 (get-in by-id [:my/logging :chain-count]))
+        ":my/logging appears on 2 chains")
+    (is (= 1 (get-in by-id [:rf/path :chain-count]))
+        ":rf/path appears on 1 chain")))
+
+(deftest collect-interceptors-flags-default-marker
+  (let [rows  (panel/collect-interceptors sample-events-with-chains)
+        by-id (into {} (map (juxt :id identity) rows))]
+    (is (true?  (get-in by-id [:rf/db-handler :default?]))
+        "rf/db-handler is framework-default")
+    (is (true?  (get-in by-id [:rf/fx-handler :default?]))
+        "rf/fx-handler is framework-default")
+    (is (false? (get-in by-id [:my/logging :default?]))
+        "user-attached interceptor is NOT default")))
+
+(deftest collect-interceptors-records-before-after-presence
+  (let [rows  (panel/collect-interceptors sample-events-with-chains)
+        by-id (into {} (map (juxt :id identity) rows))]
+    (is (true?  (get-in by-id [:my/logging :before?])))
+    (is (false? (get-in by-id [:my/logging :after?]))
+        "no :after fn in the fixture's interceptors")))
+
+(deftest filter-rows-substring
+  (let [rows (panel/collect-interceptors sample-events-with-chains)]
+    (is (= rows (panel/filter-rows rows nil)))
+    (is (= 1 (count (panel/filter-rows rows "logging"))))
+    (is (= 0 (count (panel/filter-rows rows "no-such-id"))))))
+
+(deftest project-data-shape
+  (let [data (panel/project-data sample-events-with-chains nil)]
+    (is (= 4 (:total data)))
+    (is (false? (:silent? data)))
+    (is (true? (:silent? (panel/project-data {} nil)))
+        "no events → silent")))
+
+;; -------------------------------------------------------------------------
+;; (2) registry wiring
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa.static.interceptors/query]))
+        "query slot defaults nil")))
+
+(deftest set-query-writes-the-slot
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa.static.interceptors/set-query "logging"])
+    (is (= "logging" @(rf/subscribe [:rf.causa.static.interceptors/query])))))
+
+(deftest registry-override-feeds-the-composite
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.interceptors/set-registry-override-for-test
+       sample-events-with-chains])
+    (let [data @(rf/subscribe [:rf.causa.static.interceptors/tab-data])]
+      (is (= 4 (:total data)))
+      (is (false? (:silent? data))))))
+
+;; -------------------------------------------------------------------------
+;; (3) view rendering
+;; -------------------------------------------------------------------------
+
+(deftest panel-renders-empty-state-when-silent
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.interceptors/set-registry-override-for-test {}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-interceptors-empty"))))))
+
+(deftest panel-renders-rows-from-override
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.interceptors/set-registry-override-for-test
+       sample-events-with-chains])
+    (let [tree (panel/Panel)
+          rows (find-all-by-testid-prefix tree "rf-causa-static-interceptors-row-")]
+      (is (= 4 (count rows)) "four collapsed interceptor rows rendered"))))
+
+(deftest panel-renders-filtered-state-on-no-match
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.interceptors/set-registry-override-for-test
+       sample-events-with-chains])
+    (rf/dispatch-sync [:rf.causa.static.interceptors/set-query "no-such-id"])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-interceptors-empty-filtered"))))))

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -15,9 +15,10 @@
        restores the value via `:rf.causa/set-mode`).
 
     3. Static shell renders the 3-layer chrome (ribbon · tab-bar ·
-       detail panel) with the 5 placeholder sub-tabs (Machines /
-       Routes / Schemas / Views / Events). Each placeholder card
-       names its sibling-bead id.
+       detail panel) with 7 sub-tabs (Machines / Routes / Schemas /
+       Views / Flows / Events / Interceptors). Placeholder cards are
+       only rendered for tabs without a real panel installed yet —
+       see `filled-static-tab-ids` below.
 
     4. `:rf.causa.static/select-tab` flips the Static-scoped tab
        slot (does NOT clobber the Runtime `:rf.causa/selected-tab`).
@@ -254,12 +255,14 @@
 
 (def ^:private expected-static-tab-ids
   ;; rf2-uhsqb added :flows as a 6th tab between :views and :events.
-  [:machines :routes :schemas :views :flows :events])
+  ;; rf2-o5f5f.6 added :interceptors as a 7th tab after :events.
+  [:machines :routes :schemas :views :flows :events :interceptors])
 
-(deftest static-tab-bar-renders-five-tabs
-  (testing "Static L3 tab bar renders 6 sub-tabs per parent-epic
-            rf2-o5f5f sub-bead list + rf2-uhsqb Flows (Machines /
-            Routes / Schemas / Views / Flows / Events)"
+(deftest static-tab-bar-renders-seven-tabs
+  (testing "Static L3 tab bar renders 7 sub-tabs per parent-epic
+            rf2-o5f5f sub-bead list + rf2-uhsqb Flows + rf2-o5f5f.6
+            Interceptors (Machines / Routes / Schemas / Views /
+            Flows / Events / Interceptors)"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (static-shell/surface)]
@@ -294,12 +297,14 @@
   "Static tab ids that have a real panel installed — the placeholder
   card for these tabs is no longer rendered. Sibling beads tick one
   off each time they land."
-  ;; rf2-o5f5f.2 — :machines mounts the Static Machines panel.
-  ;; rf2-o5f5f.3 — :routes   mounts the Static Routes panel.
-  ;; rf2-o5f5f.4 — :schemas  mounts the Static Schemas panel.
-  ;; rf2-o5f5f.5 — :views    mounts the Static Views panel.
-  ;; rf2-uhsqb   — :flows    mounts the Static Flows panel.
-  #{:machines :routes :schemas :views :flows})
+  ;; rf2-o5f5f.2 — :machines     mounts the Static Machines panel.
+  ;; rf2-o5f5f.3 — :routes       mounts the Static Routes panel.
+  ;; rf2-o5f5f.4 — :schemas      mounts the Static Schemas panel.
+  ;; rf2-o5f5f.5 — :views        mounts the Static Views panel.
+  ;; rf2-uhsqb   — :flows        mounts the Static Flows panel.
+  ;; rf2-o5f5f.6 — :events       mounts the Static Events panel.
+  ;; rf2-o5f5f.6 — :interceptors mounts the Static Interceptors panel.
+  #{:machines :routes :schemas :views :flows :events :interceptors})
 
 (deftest static-placeholder-cards-name-sibling-bead
   (testing "each placeholder card surfaces its sibling-bead id
@@ -494,9 +499,9 @@
 (deftest static-tab-inventory-shape
   (testing "tab inventory carries id/label/mnem/placeholder-bead and
             preserves canonical order"
-    (is (= [:machines :routes :schemas :views :flows :events]
+    (is (= [:machines :routes :schemas :views :flows :events :interceptors]
            (mapv :id (static-shell/tabs)))
-        "6 tabs in canonical order (rf2-uhsqb added :flows)")
+        "7 tabs in canonical order (rf2-uhsqb :flows + rf2-o5f5f.6 :interceptors)")
     (doseq [{:keys [id label mnem placeholder-bead]} (static-shell/tabs)]
       (is (keyword? id) (str "id is keyword for " id))
       (is (string? label) (str "label is a string for " id))

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -2238,10 +2238,12 @@ async function runStaticModeChromeAndChord(page, state) {
   // landing without the matching scenario refresh (which is exactly
   // what rf2-m1o3j fixed for .4 / .5 / rf2-uhsqb).
   const shippedSubTabs = [
-    ['routes',  'rf-causa-static-routes'],
-    ['schemas', 'rf-causa-static-schemas'],
-    ['views',   'rf-causa-static-views'],
-    ['flows',   'rf-causa-static-flows'],
+    ['routes',       'rf-causa-static-routes'],
+    ['schemas',      'rf-causa-static-schemas'],
+    ['views',        'rf-causa-static-views'],
+    ['flows',        'rf-causa-static-flows'],
+    ['events',       'rf-causa-static-events'],
+    ['interceptors', 'rf-causa-static-interceptors'],
   ];
   const shippedSubTabRoots = {};
   for (const [tabId, rootTestId] of shippedSubTabs) {
@@ -2272,31 +2274,10 @@ async function runStaticModeChromeAndChord(page, state) {
     shippedSubTabRoots[tabId] = observed;
   }
 
-  // The last remaining placeholder — `:events` (rf2-o5f5f.6). When .6
-  // ships, replace this block with another entry in `shippedSubTabs`
-  // above (and drop the placeholder section entirely once nothing is
-  // pending).
-  const expectedPlaceholders = [
-    ['events', 'rf2-o5f5f.6'],
-  ];
+  // Per rf2-o5f5f.6 all Static sub-tabs are now panelled — no
+  // placeholder cards remain. Keep the empty inventory + texts map so
+  // the downstream scenario snapshot shape stays stable.
   const placeholderTexts = {};
-  for (const [tabId, beadId] of expectedPlaceholders) {
-    await page.locator(`[data-testid="rf-causa-static-tab-${tabId}"]`).click();
-    const text = await waitForValue(
-      () => page.evaluate((id) => {
-        const card = document.querySelector(
-          `[data-testid="rf-causa-static-placeholder-${id}"]`,
-        );
-        return card ? (card.textContent || '').trim() : null;
-      }, tabId),
-      (t) => Boolean(t) && t.includes(beadId) && /will fill this/i.test(t),
-      {
-        timeoutMs: 5000,
-        description: `Static sub-tab :${tabId} placeholder card with sibling bead ${beadId}`,
-      },
-    );
-    placeholderTexts[tabId] = text;
-  }
   // Restore the Machines tab so subsequent steps see the default L4.
   await page.locator('[data-testid="rf-causa-static-tab-machines"]').click();
   await expectVisible(


### PR DESCRIPTION
Closes rf2-o5f5f.6. Pulled forward from v1.2 deferred per Mike 2026-05-20.

## Summary
- Static Events sub-tab — flat catalogue of every reg-event-db/fx/ctx
  handler with kind badge, source-coord chip, interceptor-count chip,
  search, click-to-select detail card showing the interceptor chain
  (top-to-bottom, framework-default marker) and a hermetic single-step
  simulate (invokes the raw :handler-fn against a synthetic input — no
  dispatch, no fx walk, no app-db swap).
- Static Interceptors lens — separate L4 tab, pure-browse over the
  interceptors surfaced through registered events, collapsed by :id
  with a chain-count + before/after presence + framework-default marker.
- Pure-data helpers (row projection, EDN payload parsing, hermetic
  simulate) live in events/helpers.cljc so the JVM unit-test target
  drives them without a CLJS runtime.

## Test plan
- [x] JVM helpers — 16 tests / 37 assertions, all pass via `clojure -M:test`
- [x] `npm run test:cljs` — 3820 tests / 11087 assertions pass
- [x] `npm run test:bundle-isolation` — pass
- [x] `mkdocs build --strict` — pass