### PR TITLE
ci: upgrade actions/setup-python to Node 22 (rf2-fc4nr)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f  # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
           cache: pip
@@ -129,4 +129,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f  # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Closes rf2-fc4nr. Clears the Node.js 20 deprecation warning.

## Changes

- `actions/setup-python` v5.4.0 (Node 20) → v5.6.0 (Node 22) in `docs.yml` and `test.yml`
- `actions/deploy-pages` v4.0.5 (Node 20) → v5.0.0 (Node 24) in `docs.yml` (swept up while sweeping for other Node 20 actions, per bead scope)

SHAs pinned with version comments, matching repo convention.

## Posture

Pre-alpha; workflow-syntactic update only; no behavioural change.

## Gates

- Workflows parse (validated via `yaml.safe_load`)
- All `actions/*` consumers now on Node 22+ (cache@v5.0.5, checkout@v6.0.2, deploy-pages@v5.0.0, setup-java@v5.2.0, setup-node@v6.4.0, setup-python@v5.6.0, upload-pages-artifact@v5.0.0)

Note: `softprops/action-gh-release@v1` still uses Node 16; out of scope for this bead (which is Node 20 → 22) but a candidate for a follow-up bead.