### PR TITLE
docs(skills): retire legacy 13-panels heading from re-frame2-causa/SKILL.md (rf2-to7ot)

### DIFF
--- a/skills/re-frame2-causa/SKILL.md
+++ b/skills/re-frame2-causa/SKILL.md
@@ -3,18 +3,18 @@ name: re-frame2-causa
 description: >
   Read-only tour of **Causa** — the re-frame2 devtools panel. Use when the
   user wants to know how to *launch* Causa (in-app inline panel, pop-out
-  window, programmatic mount, or the two wired hotkeys), which of its 13
+  window, programmatic mount, or the wired hotkeys), which of its 8
   panels surfaces the data they're looking for, or what each panel is
   *for*. Trigger phrases: "open Causa", "where is X in Causa",
   "which Causa panel shows…", "Ctrl+Shift+C", "Causa hotkey",
-  "Causa popout", "Causa hydration debugger", "Causa schema timeline",
-  "Causa machine inspector", and similar. **Do not use** for: driving
-  Causa programmatically from a live REPL (that's `re-frame2-pair`),
-  authoring the host app (`re-frame2`), bootstrapping a new project
-  (`re-frame2-setup`), or implementing Causa itself (no skill yet — the
-  `causa-implementor` sibling is deferred to post-alpha). This skill
-  cites `tools/causa/spec/*` as the source of truth; where a spec doc
-  has an open question, hedge with "see spec/0NN" rather than freezing
+  "Causa popout", "Causa machine inspector", "Causa issues feed",
+  and similar. **Do not use** for: driving Causa programmatically
+  from a live REPL (that's `re-frame2-pair`), authoring the host app
+  (`re-frame2`), bootstrapping a new project (`re-frame2-setup`), or
+  implementing Causa itself (no skill yet — the `causa-implementor`
+  sibling is deferred to post-alpha). This skill cites
+  `tools/causa/spec/*` as the source of truth; where a spec doc has
+  an open question, hedge with "see spec/0NN" rather than freezing
   prose.
 allowed-tools:
   - Read
@@ -35,8 +35,8 @@ This skill answers two questions, and only two:
 
 1. **How do I launch Causa?** — the inline panel, the pop-out, the
    programmatic entry points, the wired hotkeys.
-2. **Which panel shows X?** — a one-line purpose for each of the 13
-   panels Causa ships.
+2. **Which panel shows X?** — a one-line purpose for each of the 8
+   L4 panels Causa ships (per spec/021 §11.4).
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source,
 redaction-indicator semantics) are **out of scope** in this iteration —
@@ -55,8 +55,8 @@ gate — zero bytes ship to consumers.
 
 Causa consumes re-frame2's instrumentation surface (Spec 009 trace bus,
 Tool-Pair epoch history, the registrar query API) — it adds nothing the
-framework didn't already expose. The 13 panels are *presentation* of an
-already-structured runtime.
+framework didn't already expose. The 8 L4 panels are *presentation* of
+an already-structured runtime.
 
 For an AI agent surface against the running app, use `tools/re-frame2-pair-mcp/`
 — the raw nREPL pair-programming companion. Causa is the human-facing
@@ -102,32 +102,49 @@ on the launcher pill.
 
 ---
 
-## The 13 panels — what each surfaces
+## The 8 panels — what each surfaces
 
-The sidebar lists 13 panels in three groups (always-active, conditional,
-dormant). When the user asks "where is X?", route to the panel whose
-purpose covers it. For more detail on each — group membership, dormant
-state, activity badges, deeper "open it when…" guidance — see
-[`references/panels.md`](references/panels.md).
+<a id="the-13-panels--what-each-surfaces"></a>
 
-| Panel | One-line purpose | When you'd open it |
-|---|---|---|
-| **Event detail** *(hero)* | The six-domino cascade for the selected dispatch: event vector, diff, fx fired, subs recomputed, renders, duration. | Default landing view. "What happened in this dispatch?" |
-| **Time travel** | Bottom-rail scrubber over per-frame `epoch-history`; passive scrub rebases view, explicit rewind calls `restore-epoch`. | "Walk me through the last N dispatches." |
-| **App-db** | Slice-centric diff: changed slices for the selected epoch + pinned live slices + reserved-key inspector. | "What in app-db just changed?" / "Show me when `[:cart :items]` last moved." |
-| **Reactive** *(formerly "Subscriptions" / "Views"; tab key stays `:views` per spec/021 §11.5)* | Focused epoch's reactive cascade as a DAG: subs recompute + views re-render, inline values, invalidation chains, cache status. | "Why didn't my view update?" / "Trace the recompute chain for `:cart/total`." / "Which views re-rendered this epoch?" |
-| **Effects** *(fx)* | Registered fxs + per-fx invocations + outcome status + stub indicator. | "Which fx fired in this epoch?" / "Did `:http/get` get skipped?" |
-| **Trace** | Raw event ribbon — every trace event in the buffer as a timestamped row, filterable along the 13-axis Spec 009 vocabulary. | "Grep the full trace stream." / "Show me every `:rf.fx/*` event in the last minute." |
-| **Machines** | State-chart per registered machine (embeds `tools/machines-viz/`) + transition-history ribbon. Pre-alpha: chart is a placeholder pending the viz impl. | "What state is my checkout machine in?" / "What transition fired?" |
-| **Flows** | Registered flows + per-flow inputs / output path / live recomputation indicator. | "Is this flow recomputing?" / "Which inputs feed this flow?" |
-| **Routes** | Registered routes + active `:rf/route` slice + recent navigation history. | "What route am I on?" / "Show me the last few navigations." |
-| **Performance** | Per-cascade duration capture, perf-tier colour (`<16ms` / `16–50` / `50–100` / `>100`), budget-warning markers. | "Which cascades blew the INP budget?" |
-| **Issues** | Unified feed: errors + warnings + schema violations + hydration mismatches. Top-strip badge mirrors count. | "Anything broken?" / "Show me all schema failures." |
-| **Schemas** | One row per registered schema; coloured dot per failure with recovery-mode mapping. | "Has any schema violated this session?" / "When did `:user/profile` start failing?" |
-| **Hydration** *(dormant)* | Server-vs-client render-tree side-by-side with divergent node flagged and hash-bisector path highlighted. Dormant `◌` until the first `:rf.ssr/hydration-mismatch` trace lands. | "My SSR hydration is mismatching" — only visible when SSR runs. |
+Causa's L4 panel row holds **8 lenses on the focused epoch**, fixed in
+the order set by spec/021 §11.4: **Event · App-db · Reactive · Trace ·
+Machines · Routing · Issues · Chrome A11y**. Cross-epoch signal lives
+on the L2 timeline above (badges + stripes); every L4 panel answers
+"what happened in **this** epoch?" through its own lens (§021 §1.2 —
+binding). When the user asks "where is X?", route to the panel whose
+purpose covers it. For per-panel layout, iconography, stripe tokens,
+and "open it when…" depth see [`references/panels.md`](references/panels.md).
 
-The hero on first open is **Event detail**. AI integration lives in
-the separate `tools/re-frame2-pair-mcp/` jar — Causa itself is the human
+| Panel | Icon · Stripe | One-line purpose | When you'd open it |
+|---|---|---|---|
+| **Event** *(hero)* | `⚡` · violet | The six-step handling pipeline for the focused dispatch: DISPATCH → COEFFECTS → HANDLER → EFFECTS RETURNED → EFFECTS APPLIED → FLOWS RECOMPUTED. | Default landing view. "What did this event do?" / "What fx fired?" / "Did the flow recompute?" |
+| **App-db** | `◐` · cyan | Two-zone: DIFF (changed paths for this epoch) + STATE (full db at end of epoch via lazy tree). Hover any changed path for downstream-subs popover. | "What just changed in app-db?" / "What's downstream of `[:cart :items]`?" |
+| **Reactive** | `◉` · cyan | The reactive cascade as a depth-first DAG: subs recomputed (step 7) + views re-rendered (step 8) with `caused-by ← sub ← path` causation on every leaf. | "Why didn't my view update?" / "Trace the recompute chain for `:cart/total`." / "Which views re-rendered this epoch?" |
+| **Trace** | `⬢` · orange | Raw Spec 009 trace events for the focused epoch — one mono row per op, filterable by `[op-type ▾] [tag ▾]`, payload expands inline. | "Show me every raw op in this epoch." / "Is `:rf.fx/*` firing as expected?" |
+| **Machines** | `◆` · green | Per-machine xyflow topology + current-state pulse via 4-source precedence walk-back; guards / actions / cancellations in per-canvas footer. | "What state is my checkout machine in?" / "What transition fired?" / "What guards passed/failed?" |
+| **Routing** | `🌐` · yellow | Active route tree (textual, `├─ └─`) + this-epoch block (phase, from/to, match, events). Reads `:rf.route/can-leave` / `:can-enter` / `:on-match` / `:url-changed`. | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
+| **Issues** | `⚠` · red | Per-epoch errors + warnings + schema violations + a11y violations, unified. Head-fallback to most-recent epoch when the spine is at head. | "Anything broken in this epoch?" / "Show me all schema failures here." / "What warnings fired?" |
+| **Chrome A11y** | `✦` · red | Causa's own chrome accessibility dogfood — audit list (rule-id, severity, affected element, remediation hint). Spine-independent. | "Is Causa's own chrome accessible right now?" — meta surface. |
+
+### Retired pre-rebuild panels — where their content lives now
+
+Six panels from the pre-rebuild inventory (Subscriptions, Effects,
+Flows, Performance, Schemas, Hydration) are **not** separate L4 panels.
+Their content is surfaced through the 8 above (per
+[`references/panels.md` §What's deliberately NOT here](references/panels.md#whats-deliberately-not-here)
++ spec/021 §15):
+
+| Retired panel | Where its content lives now |
+|---|---|
+| **Subscriptions** | **Reactive** (cascade tree, step 7) + **App-db** (downstream-subs hover popover on changed paths) |
+| **Effects** (`fx`) | **Event** step 4 (returned) + step 5 (applied) + **Trace** (raw `:rf.fx/*` ops) |
+| **Flows** | **Event** step 6 (FLOWS RECOMPUTED) |
+| **Performance** | L2 row stripe colours (cross-epoch budget signal) + per-step `:time` inside **Trace** |
+| **Schemas** | **Issues** (schema violations land in the unified per-epoch feed) |
+| **Hydration** *(SSR)* | **Issues** (hydration mismatches land in the unified per-epoch feed) |
+
+The hero on first open is **Event**. AI integration lives in the
+separate `tools/re-frame2-pair-mcp/` jar — Causa itself is the human
 surface only.
 
 ---
@@ -162,11 +179,11 @@ short of improvising.
   detail (the mount contract, the epoch pump's ordering guarantees, the
   redaction marker's grammar), link to the relevant
   `tools/causa/spec/*.md` and quote sparingly.
-- **Pre-alpha hedge.** Some panels are partial (Machines depends on
-  `tools/machines-viz/` which is a placeholder pre-alpha; Schemas /
-  Hydration only render when the relevant feature is wired into the
-  host). When a user asks about an in-progress surface, say so and
-  point at the spec.
+- **Pre-alpha hedge.** Some surfaces are partial (Machines depends on
+  `tools/machines-viz/` xyflow styling that's still landing; Issues
+  only populates the schema / hydration rows when the host has those
+  features wired). When a user asks about an in-progress surface, say
+  so and point at the spec.
 - **Don't invent hotkeys.** Only `Ctrl+Shift+C` and `Ctrl+Shift+/` are
   globally wired today. Everything else in
   [`spec/007-UX-IA.md` §Keyboard](../../tools/causa/spec/007-UX-IA.md#keyboard)


### PR DESCRIPTION
Closes rf2-to7ot. Follow-on from rf2-b9iu9's panels.md rewrite (#1766). SKILL.md now matches canonical 8-panel state per spec/021.

## Summary
- Rewrites the panel-tour table in SKILL.md to the canonical 8-panel set (Event · App-db · Reactive · Trace · Machines · Routing · Issues · Chrome A11y) per spec/021 §11.4 + the new `references/panels.md`.
- Adds a routing table for the 6 retired pre-rebuild panels (Subscriptions, Effects, Flows, Performance, Schemas, Hydration) → their post-rebuild homes.
- Preserves the old `#the-13-panels--what-each-surfaces` slug via an inline `<a id>` so the backlink in `references/panels.md` keeps resolving — no cross-file edit needed.
- Updates the frontmatter description + intro prose ("13 panels" → "8 panels") and corrects the Style-guidance hedge (Schemas / Hydration are no longer separate panels — they surface in Issues).

## Surface
- `skills/re-frame2-causa/SKILL.md` only — strict scope adherence.

## Gates
- `python scripts/check_doc_slugs.py` → exit 0
- `python -m mkdocs build --strict` → exit 0