### PR TITLE
ci: upgrade softprops/action-gh-release to Node 24 (rf2-ukhuf)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,7 +496,7 @@ jobs:
         # Mirrors re-frame v1's release-notes pattern — minimal body
         # with a link back to the CHANGELOG. Mike updates CHANGELOG.md
         # in the same release commit before tagging.
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
Closes rf2-ukhuf. Follow-on from rf2-fc4nr · clears Node 16 deprecation.

## Change
- `softprops/action-gh-release@v1` (Node 16) → `@v3.0.0` (Node 24), SHA-pinned in both `release.yml` and `template-release.yml`
- No schema change in the v1 → v3 jump affects our usage (`tag_name` + `name` + `body` only)

## Sweep
Audited every `uses:` line in `.github/workflows/*.yml`. The full distinct set after this PR:

| Action | Pinned version | Runtime |
| --- | --- | --- |
| `actions/cache` | v5.0.5 | Node 24 |
| `actions/checkout` | v6.0.2 | Node 24 |
| `actions/deploy-pages` | v5.0.0 | Node 24 |
| `actions/setup-java` | v5.2.0 | Node 24 |
| `actions/setup-node` | v6.4.0 | Node 24 |
| `actions/setup-python` | v5.6.0 | Node 20 |
| `actions/upload-pages-artifact` | v5.0.0 | Node 24 |
| `DeLaGuardo/setup-clojure` | 13.6.0 | Node 20 |
| `softprops/action-gh-release` | v3.0.0 | Node 24 |

No Node-16 actions remain.

## Gates
- `yaml.safe_load` clean for all six workflows