### PR TITLE
feat(machines-viz): AI-generate + SCXML round-trip (rf2-1bncf + rf2-6urjd)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -611,6 +611,24 @@ does **not** include:
   generalises; D2 + xstate-json are different output grammars over
   the same input). Per [Spec 005 §Future §Diagram export](../../../spec/005-StateMachines.md#diagram-export-from-transition-tables).
 
+### v1.1 shipped (rf2-1bncf + rf2-6urjd, 2026-05-21)
+
+- **SCXML import / export** (rf2-6urjd) — `(scxml/spec->scxml spec)`
+  + `(scxml/scxml->spec xml)` pure-data round-trip for non-CLJS
+  sharing (Erlang `gen_statem`, external workflow systems, the
+  xstate-visualizer). Per [`API.md`](./API.md) §SCXML import/export.
+  Promoted from "Out of scope (any version)" — the W3C standard
+  for statecharts is the interop floor for sharing machines with
+  non-Clojure tooling, and the round-trip implementation is small
+  and pure-data (no XML parser dep — string-based for the SCXML
+  subset we emit).
+- **AI-generate-a-machine** (rf2-1bncf) — `(ai-generate/generate-machine
+  user-prompt opts)` library fn with a pluggable `:resolver` seam.
+  Production callers inject an LLM bridge (Anthropic / OpenAI /
+  local Ollama / Causa's chat / re-frame2-pair-mcp); tests inject a
+  stub. Mirrors Stately Studio 2026's AI-generation feature. Per
+  [`API.md`](./API.md) §AI-generate-a-machine.
+
 ### Out of scope (any version)
 
 - A canvas-driven machine editor.
@@ -619,7 +637,6 @@ does **not** include:
   affordance; long-term storage is the user's problem).
 - Statechart-from-non-machine-code visualisation (Stately Studio
   2026 visualises Redux without XState; not Machines-Viz's lane).
-- SCXML import / export.
 - A Day8-hosted SaaS shell.
 
 ## Peer-product comparison (where the v1 ship-list lands)

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -683,6 +683,137 @@ and Causa 003 §Accessibility. v1.0 ships without it; the embedding
 host's transition-history ribbon + machine picker carry the
 accessible surface in the meantime.
 
+## SCXML import / export (v1.1, rf2-6urjd)
+
+SCXML is the W3C standard for statecharts. Round-tripping through
+SCXML lets re-frame2 machines be shared with non-CLJS tooling —
+external workflow systems, Erlang `gen_statem`-derived tools,
+Stately's importers, the xstate-visualizer. Same pure-data posture
+as the Mermaid emitter: a machine definition in, an XML string out;
+and the inverse on the read side.
+
+```clojure
+(:require [day8.re-frame2-machines-viz.scxml :as scxml])
+
+(scxml/spec->scxml machine-spec)
+;; => "<?xml version=\"1.0\" ...?>\n<scxml ...>...</scxml>"
+
+(scxml/scxml->spec scxml-string)
+;; => the parsed machine spec
+```
+
+### Round-trip
+
+```clojure
+(= machine-spec (-> machine-spec scxml/spec->scxml scxml/scxml->spec))
+```
+
+holds for the supported subset.
+
+### Supported grammar subset
+
+| Re-frame2 | SCXML mapping |
+|---|---|
+| `:initial`                            | `<scxml initial="...">` |
+| `:states` (flat)                      | `<state id="...">` |
+| `:states` (compound)                  | nested `<state>` with `initial` |
+| `:final? true`                        | `<final id="...">` |
+| `:on {:event :target}`                | `<transition event="event" target="target"/>` |
+| `:on {:event {:target ... :guard G}}` | `<transition cond="G" .../>` |
+| `:after {ms :target}`                 | `<transition event="after.ms" target="target"/>` |
+| `:always [...]`                       | `<transition target="..."/>` (eventless) |
+| `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
+| Namespaced ids (`:auth/login`)        | `auth.login` (dot-separated; SCXML id grammar) |
+| Vector-path targets                   | dot-joined `parent.child.grandchild` |
+
+### Not supported (lossy or omitted)
+
+- `:spawn-all` rows — omitted; the parent state renders without
+  spawn affordances.
+- `:tags` — re-frame2-specific; not part of W3C SCXML.
+- `:action`s and guard FN bodies — only the *names* survive
+  (SCXML `cond="name"` for guards; entry/exit `<script>` would
+  require evaluation context, so names are preserved as XML
+  comments on imports/exports).
+- Source-coord metadata — stripped at export time (same posture as
+  share-URL encoding; see [Principles §No session data in shares](./Principles.md)).
+
+### Error modes
+
+| `:reason` | Meaning |
+|---|---|
+| `:scxml/invalid-spec` | Input spec missing `:initial` / `:states` (or `:type :parallel` / `:regions`). |
+| `:scxml/parse-error`  | Input XML is malformed or missing the `<scxml>` root. |
+
+## AI-generate-a-machine (v1.1, rf2-1bncf)
+
+A pure library fn that takes a natural-language prompt and returns
+a normalised re-frame2 machine spec. The LLM call is pluggable —
+the fn accepts an injected `:resolver` so callers wire in whichever
+LLM bridge fits their environment (Anthropic API / OpenAI API /
+local Ollama / Causa's chat seam / re-frame2-pair-mcp).
+
+```clojure
+(:require [day8.re-frame2-machines-viz.ai-generate :as ai])
+
+(ai/generate-machine "a login flow with idle, loading, success and error states"
+                     {:resolver (fn [prompt] (call-anthropic prompt))})
+;; => {:initial :idle
+;;     :states  {:idle    {:on {:login :loading}}
+;;               :loading {:on {:ok :success :err :failed}}
+;;               :success {:final? true}
+;;               :failed  {:final? true}}}
+```
+
+### Contract
+
+- `(generate-machine user-prompt opts)` returns the validated spec
+  the same shape `reg-machine` accepts and `(rf/machine-meta id)`
+  returns.
+- `opts` recognises:
+  - `:resolver` — `(fn [prompt-string] llm-response-string)`. Required.
+    The namespace ships no default LLM bridge — production callers
+    inject one, tests inject a stub returning canned EDN.
+
+### Two-layer design
+
+The implementation separates the I/O boundary (the injected
+resolver) from the parse/validate step (this ns). The fn:
+
+1. Composes `system-prompt + user-prompt` into a single string via
+   `ai/build-prompt` (the canonical system prompt lives at
+   `ai/system-prompt`, exposed as a Var for audit / multi-turn
+   composition).
+2. Hands the prompt to `:resolver` and waits for a string response.
+3. Strips fenced code blocks (```clojure / ```edn / bare) tolerantly,
+   so the LLM may emit prose around the EDN form.
+4. Parses the EDN form and validates it carries `:initial` + non-
+   empty `:states` (or `:type :parallel` + non-empty `:regions`).
+
+### Reserved namespaces
+
+Generated machines use re-frame2's normal id conventions — feature-
+prefixed keywords (`:auth/idle`, `:cart/loading`), hyphenated bare
+names (`:idle`, `:loading-failed`). The system prompt asks the LLM
+to follow them; the parser does not enforce them (an LLM that
+emits `:loadingFailed` produces a working spec the caller can
+clean up or accept as-is).
+
+### Error modes
+
+| `:reason` | Meaning |
+|---|---|
+| `:ai-generate/no-resolver`  | `:resolver` opt was not provided. |
+| `:ai-generate/parse-failed` | Resolver output could not be parsed as EDN. |
+| `:ai-generate/invalid-spec` | Parsed value was not a valid machine shape. |
+
+### Determinism
+
+The fn itself is deterministic given a deterministic resolver. LLM
+resolvers are not deterministic by default; for reproducible tests
+inject a stub mapping known prompts to canned EDN responses (see
+the AI-generate test ns for examples).
+
 ## Public CLJS API surface — summary
 
 ```clojure
@@ -690,6 +821,11 @@ day8.re-frame2-machines-viz.chart/MachineChart    ; component
 day8.re-frame2-machines-viz.share/encode-share-url
 day8.re-frame2-machines-viz.share/decode-share-url
 day8.re-frame2-machines-viz.mermaid/emit          ; pure fn — definition → string
+day8.re-frame2-machines-viz.scxml/spec->scxml     ; v1.1 — pure fn
+day8.re-frame2-machines-viz.scxml/scxml->spec     ; v1.1 — pure fn
+day8.re-frame2-machines-viz.ai-generate/generate-machine ; v1.1 — pluggable LLM seam
+day8.re-frame2-machines-viz.ai-generate/build-prompt     ; v1.1 — prompt composer
+day8.re-frame2-machines-viz.ai-generate/system-prompt    ; v1.1 — Var
 day8.re-frame2-machines-viz.export/chart-as-png!
 day8.re-frame2-machines-viz.export/chart-as-svg
 day8.re-frame2-machines-viz.export/chart-as-mermaid
@@ -702,7 +838,8 @@ day8.re-frame2-machines-viz.export/copy-share-url-to-clipboard!
 
 No global state, no init function. The component is referentially
 transparent over its props; the share / export functions are pure
-(modulo the clipboard).
+(modulo the clipboard). The v1.1 SCXML + AI-generate surfaces are
+pure-data and JVM-callable.
 
 ## See also
 

--- a/tools/machines-viz/spec/README.md
+++ b/tools/machines-viz/spec/README.md
@@ -42,6 +42,21 @@ shipped surface is the Mermaid `stateDiagram-v2` exporter.
   composite states, parallel regions, transition labels, entry/exit
   actions, action/`do` labels, `invoke-all` row layout). JVM + CLJS
   test corpora cover the projection and the markdown-fence wrapping.
+- **SCXML import / export (v1.1)** — per
+  [rf2-6urjd](../../../.beads/) and
+  [`API.md`](API.md) §SCXML import/export. Implemented at
+  `src/day8/re_frame2_machines_viz/scxml.cljc`. Pure-data round-trip
+  `(= spec (-> spec spec->scxml scxml->spec))` for the supported
+  W3C SCXML subset (flat / compound / parallel, `:initial`, `:on`,
+  `:after`, `:always`, guards, `:final?`, namespaced ids). JVM +
+  CLJS test corpus pins the round-trip property + error modes.
+- **AI-generate-a-machine (v1.1)** — per
+  [rf2-1bncf](../../../.beads/) and
+  [`API.md`](API.md) §AI-generate-a-machine. Implemented at
+  `src/day8/re_frame2_machines_viz/ai_generate.cljc`. Pluggable
+  resolver seam (`:resolver`); the ns ships no default LLM bridge.
+  JVM + CLJS test corpus uses a stub resolver to pin the parse /
+  validate path; production callers wire their own LLM resolver in.
 
 ### Pending implementation
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -1,0 +1,272 @@
+(ns day8.re-frame2-machines-viz.ai-generate
+  "AI-generate-a-machine surface (rf2-1bncf · v1.1).
+
+  Stately Studio 2026 ships AI-generation: given a description,
+  generate a machine. This namespace hosts the re-frame2 equivalent:
+  a pure library fn that takes a natural-language prompt and returns
+  a normalised re-frame2 machine spec (the same shape `reg-machine`
+  consumes and `(rf/machine-meta id)` returns).
+
+  ## Two-layer design
+
+  The implementation separates two concerns:
+
+  1. **The prompt-resolver seam (`:resolver`).** A pluggable fn the
+     caller injects: `(fn [prompt-string] llm-response-string)`. This
+     fn is the I/O boundary — production callers wire in an
+     anthropic-API / OpenAI-API / local-LLM bridge here; tests
+     inject a stub returning canned EDN.
+
+     The resolver receives the full system+user prompt as a single
+     string and returns the LLM's response as a string. The
+     namespace knows nothing about HTTP, secrets, streaming, or
+     rate-limits — those live in the caller's resolver.
+
+  2. **The parse-and-validate step (this ns).** Walks the resolver's
+     string output, extracts the first EDN form (the LLM's response
+     may include prose before/after a fenced code block, which
+     authors and IDEs treat as commentary), and validates the
+     extracted spec against the same minimum shape `spec->scxml`
+     requires: `:initial` + non-empty `:states` (or `:type :parallel`
+     + non-empty `:regions`).
+
+  Round-trip is informational, not contractual: the LLM's
+  generations are non-deterministic by design. Callers wanting
+  determinism inject a deterministic resolver (e.g. a stub mapped
+  from `prompt` → `spec`).
+
+  ## Reserved namespaces
+
+  Generated machines use re-frame2's normal id conventions — feature-
+  prefixed keywords (`:auth/idle`, `:cart/loading`), hyphenated
+  bare names (`:idle`, `:loading-failed`). The system prompt asks the
+  LLM to follow these conventions; the parser doesn't enforce them
+  (an LLM that generates `:loadingFailed` produces a working spec
+  that the caller can ergonomic-cleanup or accept as-is).
+
+  ## Public API
+
+  - `(generate-machine prompt opts)` — Main entry point. Takes a
+    natural-language prompt and an opts map. Returns the parsed +
+    validated machine spec.
+  - `system-prompt` — The full system prompt as a string. Exposed so
+    callers can compose it into multi-turn chats, sandbox it for
+    quality testing, or audit it before shipping.
+
+  Per [`API.md`](../../spec/API.md) §AI-generate-a-machine."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])))
+
+;; ---------------------------------------------------------------------------
+;; System prompt
+
+(def system-prompt
+  "The canonical system prompt this namespace passes to the resolver.
+
+  Public Var so callers can audit the wording, compose multi-turn
+  chats around it, or fork it. Changes to this string are part of
+  the public contract — bumping the prompt's behaviour expectations
+  (\"always include `:final?` states for terminal outcomes\") is a
+  semver-relevant change."
+  (str/join "\n"
+    ["You are an assistant that generates re-frame2 state-machine specs."
+     ""
+     "A re-frame2 machine spec is a Clojure EDN map of the shape:"
+     ""
+     "  {:initial :idle"
+     "   :states  {:idle    {:on {:start :loading}}"
+     "             :loading {:on {:ok :success :err :failed}}"
+     "             :success {:final? true}"
+     "             :failed  {:final? true}}}"
+     ""
+     "Conventions:"
+     ""
+     "- State ids are keywords. Use bare keywords (:idle) for simple"
+     "  machines or namespaced keywords (:auth/idle, :cart/loading)"
+     "  when the machine belongs to a feature subdomain."
+     "- Event ids are keywords (:start, :submit, :rf/load)."
+     "- :initial names the starting state."
+     "- :states is a map of state-id → state-node. A state-node is a"
+     "  map with optional :on (event-id → transition), :final? true,"
+     "  :initial (for compound states), and :states (a child map)."
+     "- A transition value may be a target keyword (:loading) or a"
+     "  map with :target + optional :guard (:auth-ok?) and :action."
+     "- :final? true marks a terminal state."
+     "- For compound states, nest :states and provide a child"
+     "  :initial."
+     "- For parallel regions, use {:type :parallel :regions {...}}"
+     "  where each region carries its own :initial + :states."
+     ""
+     "Return ONLY the EDN spec inside a fenced code block:"
+     ""
+     "```clojure"
+     "{:initial :idle"
+     " :states  {...}}"
+     "```"
+     ""
+     "Do not include explanatory prose outside the fenced block."]))
+
+;; ---------------------------------------------------------------------------
+;; EDN extraction
+
+(defn- strip-fences
+  "If `s` contains a ```clojure / ``` fenced block, return the block's
+  body. Otherwise return `s` unchanged. Strips leading / trailing
+  whitespace either way.
+
+  Tolerates the LLM emitting:
+
+  - A bare EDN form with no fence.
+  - A ``` (untagged) fence.
+  - A ```clojure / ```edn / ```cljs fence.
+  - Surrounding prose."
+  [s]
+  (let [m (re-find #"(?s)```(?:clojure|cljs|edn)?\s*\n(.*?)```" s)]
+    (str/trim (if m (second m) s))))
+
+(defn- parse-edn
+  "Parse a string as one EDN form. Returns `[:ok form]` or
+  `[:err reason]`."
+  [s]
+  (try
+    [:ok (edn/read-string s)]
+    (catch #?(:clj Exception :cljs :default) e
+      [:err (ex-message e)])))
+
+;; ---------------------------------------------------------------------------
+;; Validation
+;;
+;; The minimum shape we enforce is what the rest of the substrate
+;; (`spec->scxml`, `mermaid/emit`, the chart renderer) requires:
+;; either {:initial K :states {non-empty}} or {:type :parallel
+;; :regions {non-empty maps each with :initial + :states}}.
+;;
+;; We deliberately don't validate beyond that — the LLM may emit
+;; perfectly-valid machine shapes the substrate hasn't formally
+;; described. Letting through "anything reg-machine accepts" matches
+;; the framework's "regularity over cleverness" posture better than
+;; coercing to a narrower subset.
+
+(defn- valid-state-tree? [{:keys [initial states]}]
+  (and (keyword? initial)
+       (map? states)
+       (seq states)))
+
+(defn- valid-parallel? [{:keys [regions] :as spec}]
+  (and (= :parallel (:type spec))
+       (map? regions)
+       (seq regions)
+       (every? valid-state-tree? (vals regions))))
+
+(defn- validate-spec
+  "Return `[:ok spec]` if `spec` is a recognised machine shape,
+  otherwise `[:err reason]`."
+  [spec]
+  (cond
+    (not (map? spec))
+    [:err "spec must be a map"]
+
+    (= :parallel (:type spec))
+    (if (valid-parallel? spec)
+      [:ok spec]
+      [:err "parallel spec must carry non-empty :regions; each region must carry :initial + non-empty :states"])
+
+    (valid-state-tree? spec)
+    [:ok spec]
+
+    :else
+    [:err "spec must carry :initial + non-empty :states (or :type :parallel + :regions)"]))
+
+;; ---------------------------------------------------------------------------
+;; Default resolver
+;;
+;; Refuses-by-default. Production callers MUST inject a resolver fn;
+;; tests inject a stub. We do NOT ship a default that calls an
+;; external LLM because (a) it'd make this namespace depend on
+;; network I/O, (b) it'd require shipping API keys / secret-handling,
+;; and (c) the principal use case is the IDE-side AI pair (Causa's
+;; chat / re-frame2-pair-mcp) which already has an LLM seam.
+
+(defn- default-resolver [_prompt]
+  (throw (ex-info
+           (str "ai-generate/generate-machine called without a :resolver opt. "
+                "Inject a resolver fn (string -> string) that bridges to "
+                "your LLM of choice; see the ns docstring for the contract.")
+           {:reason :ai-generate/no-resolver})))
+
+;; ---------------------------------------------------------------------------
+;; Public API
+
+(defn build-prompt
+  "Construct the full prompt string the resolver receives.
+
+  Pure-data — composable from the public Vars `system-prompt` and
+  the caller's `user-prompt`. Exposed so tests can assert prompt
+  shape without invoking the resolver."
+  [user-prompt]
+  (str system-prompt
+       "\n\n"
+       "User request:\n"
+       user-prompt))
+
+(defn generate-machine
+  "Generate a re-frame2 machine spec from a natural-language prompt.
+
+  ## Arguments
+
+  - `user-prompt` — a natural-language description of the desired
+    machine, e.g. `\"a machine for a login flow with idle, loading,
+    success, and error states\"`.
+  - `opts` — a map. Recognised keys:
+    - `:resolver` (required) — `(fn [prompt-string] llm-response-string)`.
+      Bridges to the caller's LLM. Tests inject a stub.
+
+  ## Returns
+
+  The parsed + validated machine spec — the same shape `reg-machine`
+  accepts and `(rf/machine-meta id)` returns.
+
+  ## Throws
+
+  `(ex-info ... {:reason :ai-generate/<kw>})` for:
+
+  - `:ai-generate/no-resolver` — `:resolver` was not provided.
+  - `:ai-generate/parse-failed` — the resolver's output could not
+    be parsed as EDN.
+  - `:ai-generate/invalid-spec` — the parsed value was not a valid
+    machine shape.
+
+  ## Determinism
+
+  The fn itself is deterministic given a deterministic resolver. LLM
+  resolvers are not deterministic by default; for reproducible tests
+  inject a stub resolver that returns canned EDN per known prompt."
+  ([user-prompt] (generate-machine user-prompt {}))
+  ([user-prompt {:keys [resolver] :as _opts}]
+   (let [resolver-fn   (or resolver default-resolver)
+         full-prompt   (build-prompt user-prompt)
+         response      (resolver-fn full-prompt)
+         _             (when-not (string? response)
+                         (throw (ex-info
+                                  "resolver must return a string"
+                                  {:reason   :ai-generate/parse-failed
+                                   :response response})))
+         stripped      (strip-fences response)
+         [stage spec-or-reason] (parse-edn stripped)]
+     (cond
+       (= :err stage)
+       (throw (ex-info (str "could not parse resolver output as EDN: " spec-or-reason)
+                       {:reason   :ai-generate/parse-failed
+                        :response response
+                        :stripped stripped}))
+
+       :else
+       (let [[stage2 ok-or-reason] (validate-spec spec-or-reason)]
+         (if (= :ok stage2)
+           ok-or-reason
+           (throw (ex-info (str "resolver output was not a valid machine spec: "
+                                ok-or-reason)
+                           {:reason   :ai-generate/invalid-spec
+                            :response response
+                            :spec     spec-or-reason}))))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -1,0 +1,670 @@
+(ns day8.re-frame2-machines-viz.scxml
+  "SCXML (W3C State Chart XML) import/export for re-frame2 machine
+  definitions (rf2-6urjd · v1.1).
+
+  SCXML is the W3C standard for statecharts. Round-tripping through
+  SCXML lets re-frame2 machines be shared with non-CLJS tooling —
+  external workflow systems, Erlang `gen_statem`-derived tools,
+  Stately's importers, the xstate-visualizer. Same pure-data posture
+  as `mermaid.cljc`: a machine definition in, an XML string out;
+  and the inverse on the read side.
+
+  ## Input / output
+
+  Two public fns:
+
+  - `(spec->scxml machine-spec)` — produces an SCXML XML string for
+    the given normalised machine definition (the same shape
+    `(rf/machine-meta id)` returns).
+  - `(scxml->spec scxml-string)` — parses an SCXML XML string into a
+    re-frame machine spec.
+
+  Round-trip is exact for the supported subset:
+
+  ```clojure
+  (= machine-spec (-> machine-spec spec->scxml scxml->spec))
+  ```
+
+  ## Supported subset
+
+  The SCXML mapping intentionally covers the static topology that
+  has a direct SCXML equivalent. Other features (timer countdowns,
+  `:spawn-all` rows, microstep semantics) survive as labelled edges
+  but lose their runtime affordance — the same lossy-by-design
+  posture the Mermaid emitter takes.
+
+  | Re-frame2 | SCXML mapping |
+  |---|---|
+  | `:initial`                            | `<scxml initial=\"...\">` |
+  | `:states` (flat)                      | `<state id=\"...\">` |
+  | `:states` (compound)                  | nested `<state>` with `initial` |
+  | `:final? true`                        | `<final id=\"...\">` |
+  | `:on {:event :target}`                | `<transition event=\"event\" target=\"target\"/>` |
+  | `:on {:event {:target ... :guard G}}` | `<transition cond=\"G\" .../>` |
+  | `:after {ms :target}`                 | `<transition event=\"after.ms\" target=\"target\"/>` |
+  | `:always [...]`                       | `<transition target=\"...\"/>` (eventless) |
+  | `{:type :parallel :regions ...}`      | `<parallel>` containing region `<state>`s |
+  | Namespaced ids (`:auth/login`)        | `auth.login` (dot-separated; SCXML id allows `.`) |
+  | Vector-path targets                   | dot-joined `parent.child.grandchild` |
+
+  ## Not supported (lossy or omitted)
+
+  - `:spawn-all` rows — omitted; the parent state renders without
+    spawn affordances.
+  - `:tags` — re-frame2-specific; not part of W3C SCXML.
+  - `:action`s and guard FN bodies — only the *names* survive
+    (SCXML `cond=\"name\"` for guards; entry/exit `<script>` would
+    require evaluation context, so names are preserved as XML
+    comments on imports/exports).
+  - Source-coord metadata — stripped at export time (same posture as
+    share-URL encoding; see `Principles.md` §No session data in shares).
+
+  Round-trip failure modes throw `(ex-info ... {:reason :scxml/...})`
+  with a `:reason` keyword for programmatic dispatch.
+
+  Per [`API.md`](../../spec/API.md) §SCXML import/export."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Id mapping
+;;
+;; Re-frame2 ids are typically keywords (`:idle`, `:auth/login-flow`)
+;; or vector paths (`[:authenticated :browsing]`). SCXML state ids
+;; are strings; the W3C grammar (XML Name) accepts `.` `_` `-` and
+;; alphanumerics. We map: `:auth/login` → `"auth.login"`, hyphens
+;; preserved, vector paths dot-joined.
+
+(defn- keyword->id-string
+  "Map a single keyword to its SCXML id string."
+  [k]
+  (if-let [ns (namespace k)]
+    (str ns "." (name k))
+    (name k)))
+
+(defn- path->id-string
+  "Map a re-frame2 id (keyword or vector path) to a single SCXML id
+  string. Path separator is `.` — distinct from the `.` used inside a
+  namespaced keyword because path components are full-segment-joined.
+  Decoders disambiguate by walking the registered state hierarchy
+  from the root, not by counting dots."
+  [id]
+  (cond
+    (keyword? id) (keyword->id-string id)
+    (vector? id)  (str/join "." (map keyword->id-string id))
+    (string? id)  id
+    :else         (str id)))
+
+(defn- id-string->keyword
+  "Inverse of `keyword->id-string`. Recovers `:ns/name` from
+  `\"ns.name\"`; bare `\"name\"` round-trips to `:name`."
+  [s]
+  (when s
+    (let [parts (str/split s #"\.")]
+      (if (= 1 (count parts))
+        (keyword s)
+        (keyword (first parts) (str/join "." (rest parts)))))))
+
+;; ---------------------------------------------------------------------------
+;; XML emit — string-based, no external library
+
+(defn- escape-xml-attr
+  "Escape a string for safe inclusion inside an XML attribute value."
+  [s]
+  (-> s
+      (str/replace "&"  "&amp;")
+      (str/replace "<"  "&lt;")
+      (str/replace ">"  "&gt;")
+      (str/replace "\"" "&quot;")
+      (str/replace "'"  "&apos;")))
+
+(defn- indent-str
+  [depth]
+  (apply str (repeat depth "  ")))
+
+(defn- transition-candidates
+  "Normalise a transition spec to candidate maps. Same grammar
+  walker as `mermaid.cljc/transition-candidates`."
+  [spec]
+  (cond
+    (keyword? spec) [{:target spec}]
+    (vector? spec)  (if (every? keyword? spec)
+                      [{:target spec}]
+                      (mapcat transition-candidates spec))
+    (map? spec)     [spec]
+    :else           []))
+
+(defn- emit-transition
+  "Emit a `<transition>` line for one candidate."
+  [event-name {:keys [target guard action]} depth]
+  (let [parts (cond-> []
+                event-name (conj (str "event=\"" (escape-xml-attr event-name) "\""))
+                target     (conj (str "target=\"" (escape-xml-attr (path->id-string target)) "\""))
+                guard      (conj (str "cond=\"" (escape-xml-attr (keyword->id-string guard)) "\"")))
+        attrs (str/join " " parts)
+        self-close? (nil? action)]
+    (str (indent-str depth)
+         (if self-close?
+           (str "<transition " attrs "/>")
+           (str "<transition " attrs ">"
+                "<!-- action: " (escape-xml-attr (keyword->id-string action)) " -->"
+                "</transition>")))))
+
+(defn- emit-transitions-for-on
+  [on-map depth]
+  (mapcat (fn [[event spec]]
+            (map #(emit-transition (keyword->id-string event) % depth)
+                 (transition-candidates spec)))
+          on-map))
+
+(defn- emit-transitions-for-after
+  [after-map depth]
+  (mapcat (fn [[delay spec]]
+            (map #(emit-transition (str "after." (if (keyword? delay)
+                                                  (keyword->id-string delay)
+                                                  delay))
+                                   % depth)
+                 (transition-candidates spec)))
+          after-map))
+
+(defn- emit-transitions-for-always
+  [always depth]
+  (->> (transition-candidates always)
+       (map #(emit-transition nil % depth))))
+
+(defn- emit-state
+  "Emit a `<state>` (or `<final>`) block for one state-node."
+  [state-id state-node depth]
+  (let [{:keys [final? initial states on after always]} state-node
+        id-str (path->id-string state-id)
+        tag    (if final? "final" "state")
+        attrs  (cond-> (str "id=\"" (escape-xml-attr id-str) "\"")
+                 (and (not final?) initial)
+                 (str " initial=\"" (escape-xml-attr (path->id-string initial)) "\""))
+        children
+        (concat
+          (emit-transitions-for-on on (inc depth))
+          (emit-transitions-for-after after (inc depth))
+          (emit-transitions-for-always always (inc depth))
+          (mapcat (fn [[child-id child-node]]
+                    (emit-state child-id child-node (inc depth)))
+                  states))]
+    (if (seq children)
+      (concat [(str (indent-str depth) "<" tag " " attrs ">")]
+              children
+              [(str (indent-str depth) "</" tag ">")])
+      [(str (indent-str depth) "<" tag " " attrs "/>")])))
+
+(defn- emit-flat-or-compound
+  [{:keys [initial states]} depth]
+  (concat
+    [(str (indent-str depth)
+          "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\""
+          " version=\"1.0\""
+          " initial=\"" (escape-xml-attr (path->id-string initial)) "\">")]
+    (mapcat (fn [[child-id child-node]]
+              (emit-state child-id child-node (inc depth)))
+            states)
+    [(str (indent-str depth) "</scxml>")]))
+
+(defn- emit-parallel
+  [{:keys [regions]} depth]
+  (concat
+    [(str (indent-str depth)
+          "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\""
+          " version=\"1.0\">")
+     (str (indent-str (inc depth)) "<parallel id=\"rf2_parallel_root\">")]
+    (mapcat (fn [[region-id region-node]]
+              ;; Each region is a state with its own initial + states.
+              (emit-state region-id region-node (+ depth 2)))
+            regions)
+    [(str (indent-str (inc depth)) "</parallel>")
+     (str (indent-str depth) "</scxml>")]))
+
+;; ---------------------------------------------------------------------------
+;; Public emit fn
+
+(defn spec->scxml
+  "Convert a re-frame2 machine spec to an SCXML XML string.
+
+  `machine-spec` is the normalised definition shape `(rf/machine-meta
+  id)` returns (per Spec 005 §Transition table grammar):
+
+  ```clojure
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :success :err :failed}}
+             :success {:final? true}
+             :failed  {:final? true}}}
+  ```
+
+  Or a parallel definition:
+
+  ```clojure
+  {:type :parallel
+   :regions {:data { ... } :form { ... }}}
+  ```
+
+  Throws `(ex-info ... {:reason :scxml/invalid-spec})` if the spec
+  is missing required keys.
+
+  Round-trips through `scxml->spec`:
+
+  ```clojure
+  (= machine-spec (-> machine-spec spec->scxml scxml->spec))
+  ```
+
+  for the supported subset documented in the ns docstring."
+  [machine-spec]
+  (cond
+    (= :parallel (:type machine-spec))
+    (let [{:keys [regions]} machine-spec]
+      (when-not (and (map? regions) (seq regions))
+        (throw (ex-info "parallel spec requires non-empty :regions"
+                        {:reason :scxml/invalid-spec :spec machine-spec})))
+      (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+           (str/join "\n" (emit-parallel machine-spec 0))))
+
+    (and (:initial machine-spec) (map? (:states machine-spec)) (seq (:states machine-spec)))
+    (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+         (str/join "\n" (emit-flat-or-compound machine-spec 0)))
+
+    :else
+    (throw (ex-info "spec must carry :initial + non-empty :states, or :type :parallel + :regions"
+                    {:reason :scxml/invalid-spec :spec machine-spec}))))
+
+;; ---------------------------------------------------------------------------
+;; XML parse — minimal regex-based reader for the SCXML subset we
+;; emit. This deliberately doesn't try to be a full XML parser; it
+;; round-trips our own output and consumes the common SCXML shapes
+;; external tools emit (single-line tags, attribute order is free,
+;; whitespace tolerated). For unsupported XML constructs (CDATA,
+;; namespaces beyond the default scxml ns, processing instructions
+;; other than the leading `<?xml ... ?>`) the parser is best-effort
+;; and may throw.
+
+(defn- strip-prolog
+  "Drop the leading `<?xml ... ?>` declaration if present."
+  [s]
+  (str/replace s #"(?s)^\s*<\?xml[^?]*\?>\s*" ""))
+
+(defn- strip-comments
+  "Drop `<!-- ... -->` comments. Used by the parser to discard the
+  action-name comments the emitter injects on transitions with
+  actions (the action survives the round-trip as a comment because
+  SCXML proper has no action-id-on-transition slot)."
+  [s]
+  (str/replace s #"(?s)<!--.*?-->" ""))
+
+(defn- parse-attrs
+  "Parse a space-separated attribute string from a start-tag into a
+  map of string keys to unescaped string values. Tolerant of any
+  attribute order; recognises both single and double quotes."
+  [^String attr-string]
+  (let [pattern #"(\w+)\s*=\s*\"([^\"]*)\""
+        matches (re-seq pattern attr-string)]
+    (into {}
+          (map (fn [[_ k v]]
+                 [k (-> v
+                        (str/replace "&apos;" "'")
+                        (str/replace "&quot;" "\"")
+                        (str/replace "&gt;"   ">")
+                        (str/replace "&lt;"   "<")
+                        (str/replace "&amp;"  "&"))]))
+          matches)))
+
+(defn- event-name->keyword
+  "Convert an SCXML transition `event` attribute (e.g. `\"rf.load\"`)
+  to a re-frame2 event keyword (`:rf/load`). Single dot ⇒ namespaced
+  keyword; no dot ⇒ bare keyword. Multi-dot event names are kept as
+  single keywords (`:a.b.c`) — they're not paths."
+  [event-string]
+  (when event-string
+    (let [parts (str/split event-string #"\.")]
+      (case (count parts)
+        1 (keyword event-string)
+        2 (keyword (first parts) (second parts))
+        (keyword event-string)))))
+
+(defn- unescape-id-string
+  "Convert a SCXML id string back to a re-frame2 keyword (or vector
+  path when the id has more than one logical segment).
+
+  We can't distinguish `\"auth.login\"` (one namespaced keyword) from
+  `\"auth.login\"` (a two-segment compound path) at the string level.
+  The convention is: ids the encoder produces from compound paths use
+  dot-joined segments where each segment is either bare (`name`) or
+  namespaced (`ns.name`). Since the encoder only round-trips its own
+  output structurally, we map back via the simplest unambiguous rule:
+  a single dot = namespaced keyword; multi-dot = vector path."
+  [s]
+  (let [dot-count (count (filter #(= % \.) s))]
+    (cond
+      (= 0 dot-count) (keyword s)
+      (= 1 dot-count) (id-string->keyword s)
+      :else
+      (let [parts (str/split s #"\.")]
+        (mapv keyword parts)))))
+
+(defn- tokenize
+  "Walk an XML string and return a flat seq of token maps:
+  `{:kind :start :tag t :attrs {}}`, `{:kind :end :tag t}`,
+  `{:kind :self :tag t :attrs {}}`. Discards whitespace and text
+  (this subset has no text content)."
+  [^String xml]
+  (let [tag-re #"(?s)<(/?)\s*([A-Za-z][A-Za-z0-9_:-]*)\s*([^>]*?)(/?)>"]
+    (->> (re-seq tag-re xml)
+         (map (fn [[_ closing tag attrs self-close]]
+                (cond
+                  (= "/" closing) {:kind :end :tag tag}
+                  (= "/" self-close) {:kind :self :tag tag :attrs (parse-attrs attrs)}
+                  :else {:kind :start :tag tag :attrs (parse-attrs attrs)}))))))
+
+(defn- direct-transitions
+  "From a flat seq of tokens that compose one state's body, return
+  only those `<transition>` tokens that are *direct* children — i.e.
+  not nested inside a deeper `<state>` / `<final>` / `<parallel>`.
+  Self-closing transitions don't contribute to depth."
+  [tokens]
+  (loop [remaining tokens
+         depth     0
+         acc       []]
+    (if (empty? remaining)
+      acc
+      (let [t (first remaining)]
+        (cond
+          (= :self (:kind t))
+          (recur (rest remaining)
+                 depth
+                 (if (and (zero? depth)
+                          (= "transition" (:tag t)))
+                   (conj acc t)
+                   acc))
+
+          (and (= :start (:kind t)) (= "transition" (:tag t)))
+          ;; Non-self-closing transition (we emit them self-closing
+          ;; for clean output, but be tolerant on the parse side).
+          ;; We treat its content as not affecting state-block depth.
+          (recur (rest remaining)
+                 depth
+                 (if (zero? depth) (conj acc t) acc))
+
+          (and (= :end (:kind t)) (= "transition" (:tag t)))
+          (recur (rest remaining) depth acc)
+
+          (= :start (:kind t))
+          (recur (rest remaining) (inc depth) acc)
+
+          (= :end (:kind t))
+          (recur (rest remaining) (dec depth) acc)
+
+          :else
+          (recur (rest remaining) depth acc))))))
+
+(defn- consume-transitions
+  "Walk an open `<state>` body's tokens and split out direct-child
+  transitions vs the rest (which group-children-by-state will turn
+  into nested state blocks). Returns `{:on ... :after ... :always
+  [...] :children-tokens [...]}`."
+  [child-tokens]
+  (let [ts              (direct-transitions child-tokens)
+        ;; The remaining stream still contains the nested-state
+        ;; tokens AND the direct-transition tokens (we filter the
+        ;; latter out of children-tokens so they don't end up walked
+        ;; as states).
+        ts-set          (set ts)
+        non-transitions (remove (fn [t]
+                                  (or (ts-set t)
+                                      ;; Drop the trailing </transition>
+                                      ;; if a non-self-closing form was used.
+                                      (and (= :end (:kind t))
+                                           (= "transition" (:tag t)))))
+                                child-tokens)
+        coll
+        (reduce
+          (fn [acc t]
+            (let [attrs    (:attrs t)
+                  event    (get attrs "event")
+                  target   (get attrs "target")
+                  guard-s  (get attrs "cond")
+                  cand-map (cond-> {}
+                             target  (assoc :target (unescape-id-string target))
+                             guard-s (assoc :guard (keyword guard-s)))
+                  ;; Canonical shorthand: when a transition carries
+                  ;; *only* :target, write it as the bare keyword/path
+                  ;; in `:on` and `:after` maps. :always keeps the
+                  ;; full candidate-map form so the vector-of-maps
+                  ;; grammar lines up with `(transition-candidates ...)`.
+                  simple-cand (if (= [:target] (keys cand-map))
+                                (:target cand-map)
+                                cand-map)]
+              (cond
+                (and event (str/starts-with? event "after."))
+                (let [d-str (subs event 6)
+                      d     (try
+                              #?(:clj  (Long/parseLong d-str)
+                                 :cljs (let [n (js/parseInt d-str 10)]
+                                         (if (js/isNaN n) nil n)))
+                              (catch #?(:clj Exception :cljs :default) _ nil))
+                      k     (or d (keyword d-str))]
+                  (update-in acc [:after k]
+                             (fn [existing]
+                               (if existing
+                                 (if (vector? existing)
+                                   (conj existing simple-cand)
+                                   [existing simple-cand])
+                                 simple-cand))))
+
+                (nil? event)
+                (update acc :always (fnil conj []) cand-map)
+
+                :else
+                (update-in acc [:on (unescape-id-string event)]
+                           (fn [existing]
+                             (if existing
+                               (if (vector? existing)
+                                 (conj existing simple-cand)
+                                 [existing simple-cand])
+                               simple-cand))))))
+          {}
+          ts)]
+    (assoc coll :children-tokens non-transitions)))
+
+(declare parse-state-block)
+
+(defn- group-children-by-state
+  "Given a flat seq of tokens that sit inside one `<state>` body
+  (already excluding transitions), pair every `<state>` /
+  `<final>` open token with its matching close + interior tokens.
+  Returns a seq of `{:start ... :body ... :self? bool}` maps."
+  [tokens]
+  (loop [remaining tokens
+         acc       []]
+    (if (empty? remaining)
+      acc
+      (let [t (first remaining)]
+        (cond
+          ;; Transitions are not state blocks — skip them at this
+          ;; level. consume-transitions picks up the direct
+          ;; transitions before group-children-by-state is called
+          ;; on the children-tokens.
+          (and (= "transition" (:tag t))
+               (or (= :self (:kind t))
+                   (= :start (:kind t))
+                   (= :end (:kind t))))
+          (recur (rest remaining) acc)
+
+          (= :self (:kind t))
+          (recur (rest remaining)
+                 (conj acc {:start t :body [] :self? true}))
+
+          (= :start (:kind t))
+          (let [tag (:tag t)
+                [body rest-tokens] (loop [body []
+                                          depth 1
+                                          rs (rest remaining)]
+                                     (cond
+                                       (empty? rs)
+                                       (throw (ex-info (str "unclosed <" tag ">")
+                                                       {:reason :scxml/parse-error
+                                                        :tag    tag}))
+
+                                       (and (= :end (:kind (first rs)))
+                                            (= tag (:tag (first rs)))
+                                            (= 1 depth))
+                                       [body (rest rs)]
+
+                                       (and (= :start (:kind (first rs)))
+                                            (= tag (:tag (first rs))))
+                                       (recur (conj body (first rs)) (inc depth) (rest rs))
+
+                                       (and (= :end (:kind (first rs)))
+                                            (= tag (:tag (first rs))))
+                                       (recur (conj body (first rs)) (dec depth) (rest rs))
+
+                                       :else
+                                       (recur (conj body (first rs)) depth (rest rs))))]
+            (recur rest-tokens
+                   (conj acc {:start t :body body :self? false})))
+
+          :else
+          (recur (rest remaining) acc))))))
+
+(defn- parse-state-block
+  "Parse one `<state>` / `<final>` block into a `[state-id state-node]`
+  pair. `self?` indicates a self-closing tag with no children."
+  [{:keys [start body self?]}]
+  (let [tag        (:tag start)
+        attrs      (:attrs start)
+        id-str     (get attrs "id")
+        initial-str (get attrs "initial")
+        state-id   (unescape-id-string id-str)
+        base       (cond-> {}
+                     (= "final" tag) (assoc :final? true)
+                     initial-str     (assoc :initial (unescape-id-string initial-str)))]
+    (if (or self? (empty? body))
+      [state-id base]
+      (let [{:keys [on after always children-tokens]} (consume-transitions body)
+            child-blocks (group-children-by-state children-tokens)
+            child-states (when (seq child-blocks)
+                           (into {}
+                                 (map parse-state-block child-blocks)))
+            node (cond-> base
+                   (seq on)           (assoc :on on)
+                   (seq after)        (assoc :after after)
+                   (seq always)       (assoc :always always)
+                   (seq child-states) (assoc :states child-states))]
+        [state-id node]))))
+
+(defn- parse-parallel-body
+  "Parse the children of a `<parallel>` element into a `:regions`
+  map. `group-children-by-state` already filters transition tokens
+  at this depth."
+  [parallel-body]
+  (let [region-blocks (group-children-by-state parallel-body)]
+    (into {}
+          (map (fn [{:keys [start body self?]}]
+                 (let [region-id (unescape-id-string (get (:attrs start) "id"))
+                       [_ region-node] (parse-state-block {:start start :body body :self? self?})]
+                   ;; Strip :final? off the region top-level — regions are
+                   ;; not final states even when their own children are.
+                   [region-id (dissoc region-node :final?)])))
+          region-blocks)))
+
+(defn scxml->spec
+  "Parse an SCXML XML string into a re-frame2 machine spec.
+
+  Inverse of `spec->scxml`:
+
+  ```clojure
+  (= machine-spec (-> machine-spec spec->scxml scxml->spec))
+  ```
+
+  for the supported subset documented in the ns docstring.
+
+  Throws `(ex-info ... {:reason :scxml/parse-error})` when the input
+  is not a valid SCXML document our parser recognises (missing root
+  `<scxml>`, unclosed tags, etc.). Throws `:scxml/invalid-spec` if
+  the parsed structure is missing required keys (no `:initial`, no
+  `:states`)."
+  [scxml-string]
+  (when-not (string? scxml-string)
+    (throw (ex-info "scxml->spec expects a string"
+                    {:reason :scxml/parse-error :input scxml-string})))
+  (let [tokens (-> scxml-string strip-prolog strip-comments tokenize vec)
+        root-start (first (filter #(= "scxml" (:tag %)) tokens))]
+    (when-not root-start
+      (throw (ex-info "no <scxml> root element found"
+                      {:reason :scxml/parse-error})))
+    (let [token-vec (vec tokens)
+          start-idx (some (fn [i] (when (identical? (nth token-vec i) root-start) i))
+                          (range (count token-vec)))
+          root-body
+          (let [;; Walk to the matching </scxml>
+                tail (subvec token-vec (inc start-idx))
+                end-idx (loop [i 0 depth 1]
+                          (cond
+                            (>= i (count tail))
+                            (throw (ex-info "unclosed <scxml>"
+                                            {:reason :scxml/parse-error}))
+
+                            (and (= :start (:kind (nth tail i)))
+                                 (= "scxml" (:tag (nth tail i))))
+                            (recur (inc i) (inc depth))
+
+                            (and (= :end (:kind (nth tail i)))
+                                 (= "scxml" (:tag (nth tail i))))
+                            (if (= 1 depth)
+                              i
+                              (recur (inc i) (dec depth)))
+
+                            :else
+                            (recur (inc i) depth)))]
+            (subvec tail 0 end-idx))
+
+          parallel-token
+          (first (filter #(and (= "parallel" (:tag %))
+                               (= :start (:kind %)))
+                         root-body))]
+      (if parallel-token
+        ;; Parallel definition
+        (let [p-start-idx (some (fn [i] (when (identical? (nth root-body i) parallel-token) i))
+                                (range (count root-body)))
+              tail (subvec root-body (inc p-start-idx))
+              end-idx (loop [i 0 depth 1]
+                        (cond
+                          (>= i (count tail))
+                          (throw (ex-info "unclosed <parallel>"
+                                          {:reason :scxml/parse-error}))
+
+                          (and (= :start (:kind (nth tail i)))
+                               (= "parallel" (:tag (nth tail i))))
+                          (recur (inc i) (inc depth))
+
+                          (and (= :end (:kind (nth tail i)))
+                               (= "parallel" (:tag (nth tail i))))
+                          (if (= 1 depth)
+                            i
+                            (recur (inc i) (dec depth)))
+
+                          :else
+                          (recur (inc i) depth)))
+              parallel-body (subvec tail 0 end-idx)]
+          {:type    :parallel
+           :regions (parse-parallel-body parallel-body)})
+
+        ;; Flat / compound definition
+        (let [initial-str (get-in root-start [:attrs "initial"])
+              ;; group-children-by-state itself skips <transition>
+              ;; tokens at the current depth — so root-level
+              ;; transitions are dropped (we have no slot for them
+              ;; in our spec grammar) and nested transitions stay
+              ;; inside their owning state's body for
+              ;; consume-transitions to pick up.
+              top-state-blocks (group-children-by-state root-body)
+              states (into {}
+                           (map parse-state-block top-state-blocks))]
+          (when (empty? states)
+            (throw (ex-info "scxml document has no <state> or <final> elements"
+                            {:reason :scxml/invalid-spec})))
+          (cond-> {:states states}
+            initial-str (assoc :initial (unescape-id-string initial-str))))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
@@ -1,0 +1,193 @@
+(ns day8.re-frame2-machines-viz.ai-generate-cljs-test
+  "Pure-data tests for the AI-generate surface (rf2-1bncf · v1.1).
+
+  Coverage:
+
+  - `build-prompt` composes the system prompt and the user request
+    into a single string.
+  - `generate-machine` with a stub resolver returns the parsed spec
+    for canned responses (the LLM seam is the injected resolver;
+    tests inject a deterministic stub).
+  - `generate-machine` handles fenced (```clojure / ```edn / bare)
+    and unfenced responses.
+  - Error modes throw `ex-info` with `:reason :ai-generate/<kw>`.
+  - Generated specs are usable by sibling exporters (`scxml->spec`
+    round-trip + `mermaid/emit`), so the AI-generate path connects
+    end-to-end with the rest of the substrate."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.ai-generate :as ai]
+            [day8.re-frame2-machines-viz.scxml :as scxml]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+
+(def login-flow-spec
+  {:initial :idle
+   :states  {:idle    {:on {:login :loading}}
+             :loading {:on {:ok :authenticated :err :failed}}
+             :authenticated {:final? true}
+             :failed  {:final? true}}})
+
+(def parallel-form-spec
+  {:type    :parallel
+   :regions {:net  {:initial :idle
+                    :states  {:idle    {:on {:fetch :loading}}
+                              :loading {}}}
+             :form {:initial :empty
+                    :states  {:empty    {:on {:type :composing}}
+                              :composing {}}}}})
+
+(defn- stub-resolver
+  "Build a deterministic resolver that returns `response` regardless
+  of the prompt it receives. Mimics an LLM with a fixed answer."
+  [response]
+  (fn [_prompt] response))
+
+(defn- fence-clojure
+  "Wrap an EDN string in a ```clojure fence (the system prompt asks
+  the LLM to emit this shape)."
+  [edn-str]
+  (str "Here's the spec:\n\n```clojure\n" edn-str "\n```\n\n"
+       "Use this as a starting point — feel free to refine."))
+
+;; ---------------------------------------------------------------------------
+;; build-prompt
+
+(deftest build-prompt-embeds-system-prompt
+  (testing "the full prompt includes the system prompt"
+    (let [out (ai/build-prompt "a login flow")]
+      (is (str/includes? out ai/system-prompt)))))
+
+(deftest build-prompt-includes-user-request
+  (testing "the user request appears after the system prompt"
+    (let [out (ai/build-prompt "a login flow")]
+      (is (str/includes? out "a login flow"))
+      ;; The system prompt comes first; the user request second.
+      (is (< (str/index-of out ai/system-prompt)
+             (str/index-of out "a login flow"))))))
+
+(deftest system-prompt-mentions-key-conventions
+  (testing "system-prompt names the load-bearing convention surfaces
+            so the LLM has the right vocabulary"
+    (is (str/includes? ai/system-prompt ":initial"))
+    (is (str/includes? ai/system-prompt ":states"))
+    (is (str/includes? ai/system-prompt ":on"))
+    (is (str/includes? ai/system-prompt ":final?"))
+    (is (str/includes? ai/system-prompt ":parallel"))
+    (is (str/includes? ai/system-prompt ":regions"))))
+
+;; ---------------------------------------------------------------------------
+;; generate-machine — happy paths
+
+(deftest generate-with-fenced-clojure-response-returns-spec
+  (testing "a ```clojure fenced EDN response parses to the spec"
+    (let [resp (fence-clojure (pr-str login-flow-spec))
+          out  (ai/generate-machine "a login flow"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= login-flow-spec out)))))
+
+(deftest generate-with-bare-edn-response-returns-spec
+  (testing "a bare EDN response (no fence) also parses"
+    (let [resp (pr-str login-flow-spec)
+          out  (ai/generate-machine "a login flow"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= login-flow-spec out)))))
+
+(deftest generate-with-edn-fence-returns-spec
+  (testing "a ```edn-fenced response parses"
+    (let [resp (str "```edn\n" (pr-str login-flow-spec) "\n```")
+          out  (ai/generate-machine "a login flow"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= login-flow-spec out)))))
+
+(deftest generate-tolerates-surrounding-prose
+  (testing "prose around the fenced block is stripped"
+    (let [resp (str "Sure, here's a login flow machine:\n\n"
+                    "```clojure\n" (pr-str login-flow-spec) "\n```\n\n"
+                    "Let me know if you want to adjust the transitions.")
+          out  (ai/generate-machine "a login flow"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= login-flow-spec out)))))
+
+(deftest generate-handles-parallel-spec
+  (testing "parallel machines parse and validate"
+    (let [resp (fence-clojure (pr-str parallel-form-spec))
+          out  (ai/generate-machine "a parallel net + form machine"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= parallel-form-spec out)))))
+
+;; ---------------------------------------------------------------------------
+;; generate-machine — error modes
+
+(deftest generate-without-resolver-throws-no-resolver
+  (testing "missing :resolver throws :ai-generate/no-resolver"
+    (let [ex (try
+               (ai/generate-machine "a login flow")
+               nil
+               (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is ex)
+      (is (= :ai-generate/no-resolver (:reason (ex-data ex)))))))
+
+(deftest generate-with-non-string-resolver-response-throws-parse-failed
+  (testing "resolver returning a non-string throws :parse-failed"
+    (let [resolver (fn [_] 42)
+          ex (try
+               (ai/generate-machine "x" {:resolver resolver})
+               nil
+               (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is ex)
+      (is (= :ai-generate/parse-failed (:reason (ex-data ex)))))))
+
+(deftest generate-with-unparseable-edn-throws-parse-failed
+  (testing "resolver returning malformed EDN throws :parse-failed"
+    (let [resolver (stub-resolver "```clojure\n{{{ not-edn }}}\n```")
+          ex (try
+               (ai/generate-machine "x" {:resolver resolver})
+               nil
+               (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is ex)
+      (is (= :ai-generate/parse-failed (:reason (ex-data ex)))))))
+
+(deftest generate-with-non-machine-spec-throws-invalid-spec
+  (testing "resolver returning valid EDN that isn't a machine shape
+            throws :invalid-spec"
+    (let [resolver (stub-resolver "{:not-a-machine 42}")
+          ex (try
+               (ai/generate-machine "x" {:resolver resolver})
+               nil
+               (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is ex)
+      (is (= :ai-generate/invalid-spec (:reason (ex-data ex)))))))
+
+(deftest generate-with-non-map-spec-throws-invalid-spec
+  (testing "resolver returning a vector / number / string throws :invalid-spec"
+    (doseq [bad ["[]" "42" "\"hello\"" ":keyword"]]
+      (let [resolver (stub-resolver bad)
+            ex (try
+                 (ai/generate-machine "x" {:resolver resolver})
+                 nil
+                 (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+        (is ex (str "expected ex for " bad))
+        (is (= :ai-generate/invalid-spec (:reason (ex-data ex))))))))
+
+(deftest generate-rejects-parallel-without-regions
+  (testing ":type :parallel without :regions throws :invalid-spec"
+    (let [resolver (stub-resolver "{:type :parallel}")
+          ex (try
+               (ai/generate-machine "x" {:resolver resolver})
+               nil
+               (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+      (is ex)
+      (is (= :ai-generate/invalid-spec (:reason (ex-data ex)))))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end — generated specs work with the rest of the substrate
+
+(deftest generated-spec-round-trips-through-scxml
+  (testing "a spec from generate-machine survives the scxml round-trip"
+    (let [resp (fence-clojure (pr-str login-flow-spec))
+          out  (ai/generate-machine "a login flow"
+                                    {:resolver (stub-resolver resp)})]
+      (is (= out (-> out scxml/spec->scxml scxml/scxml->spec))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -1,0 +1,245 @@
+(ns day8.re-frame2-machines-viz.scxml-cljs-test
+  "Pure-data tests for SCXML import/export (rf2-6urjd · v1.1).
+
+  Mirrors the structure of `mermaid_cljs_test.cljc`. Coverage:
+
+  - `spec->scxml` emits a valid SCXML XML string for the supported
+    grammar subset (flat, compound, parallel, namespaced ids, final
+    states, guards, `:after`, `:always`).
+  - `scxml->spec` parses our own output back to the original spec
+    structure.
+  - Round-trip property: `(= spec (-> spec spec->scxml scxml->spec))`
+    holds for every supported fixture.
+  - Error cases throw `ex-info` with a `:reason :scxml/*` key."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.scxml :as scxml]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — small, hand-curated machine definitions per Spec 005
+;; §Transition table grammar. Mirror the fixtures in
+;; `mermaid_cljs_test.cljc` so the two emitters cover the same
+;; topology surface.
+
+(def idle-loading-success-error
+  "The canonical small machine: idle → loading → success / error."
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :success :err :failed}}
+             :success {:final? true}
+             :failed  {:final? true}}})
+
+(def compound-machine
+  "A compound machine with one nested region."
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(def namespaced-machine
+  "Machine using namespaced and hyphenated ids — exercises the
+  keyword<->id-string mapping."
+  {:initial :auth/idle
+   :states  {:auth/idle    {:on {:rf/load :auth/loading}}
+             :auth/loading {:on {:done :auth/idle}}}})
+
+(def guarded-machine
+  "Machine with a guarded transition — exercises `cond=` on
+  `<transition>`."
+  {:initial :checking
+   :states  {:checking {:on {:check {:target :ready :guard :ready?}}}
+             :ready    {:final? true}}})
+
+(def after-machine
+  "Machine with an `:after` timer transition. `:after` is lossy at
+  the SCXML level (no countdown ring vocabulary) — the timer
+  survives as an `event=\"after.5000\"` transition."
+  {:initial :loading
+   :states  {:loading {:after {5000 :timeout}
+                       :on    {:loaded :done}}
+             :timeout {}
+             :done    {}}})
+
+(def always-machine
+  "Machine with an `:always` (eventless) transition."
+  {:initial :checking
+   :states  {:checking {:always [{:target :ready :guard :ready?}
+                                 {:target :blocked}]}
+             :ready    {}
+             :blocked  {}}})
+
+(def parallel-machine
+  "A `:type :parallel` machine with two regions."
+  {:type    :parallel
+   :regions {:data {:initial :nothing
+                    :states  {:nothing {:on {:fetch :loading}}
+                              :loading {}}}
+             :form {:initial :neutral
+                    :states  {:neutral {:on {:submit :correct}}
+                              :correct {:final? true}}}}})
+
+;; ---------------------------------------------------------------------------
+;; Emit shape
+
+(deftest emit-starts-with-xml-prolog
+  (testing "emitted SCXML always carries the <?xml ... ?> prolog"
+    (let [out (scxml/spec->scxml idle-loading-success-error)]
+      (is (str/starts-with? out "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")))))
+
+(deftest emit-includes-scxml-root-with-namespace
+  (testing "emit produces a <scxml xmlns=...> root with the W3C ns"
+    (let [out (scxml/spec->scxml idle-loading-success-error)]
+      (is (str/includes? out "<scxml"))
+      (is (str/includes? out "xmlns=\"http://www.w3.org/2005/07/scxml\""))
+      (is (str/includes? out "version=\"1.0\""))
+      (is (str/includes? out "</scxml>")))))
+
+(deftest emit-flat-machine-includes-initial-and-final-states
+  (testing "<scxml initial=...> and <final id=...> render"
+    (let [out (scxml/spec->scxml idle-loading-success-error)]
+      (is (str/includes? out "initial=\"idle\""))
+      (is (str/includes? out "<state id=\"idle\""))
+      (is (str/includes? out "<state id=\"loading\""))
+      (is (str/includes? out "<final id=\"success\""))
+      (is (str/includes? out "<final id=\"failed\"")))))
+
+(deftest emit-renders-transition-events
+  (testing "transitions render with event= and target= attrs"
+    (let [out (scxml/spec->scxml idle-loading-success-error)]
+      (is (str/includes? out "event=\"start\""))
+      (is (str/includes? out "target=\"loading\""))
+      (is (str/includes? out "event=\"ok\""))
+      (is (str/includes? out "target=\"success\"")))))
+
+(deftest emit-compound-machine-nests-states
+  (testing "compound states emit nested <state> blocks with initial="
+    (let [out (scxml/spec->scxml compound-machine)]
+      (is (str/includes? out "<state id=\"authenticated\" initial=\"browsing\""))
+      (is (str/includes? out "<state id=\"browsing\""))
+      (is (str/includes? out "<state id=\"paying\"")))))
+
+(deftest emit-namespaced-ids-use-dot-separator
+  (testing ":auth/idle → id=\"auth.idle\""
+    (let [out (scxml/spec->scxml namespaced-machine)]
+      (is (str/includes? out "initial=\"auth.idle\""))
+      (is (str/includes? out "<state id=\"auth.idle\""))
+      (is (str/includes? out "<state id=\"auth.loading\""))
+      (is (str/includes? out "event=\"rf.load\"")))))
+
+(deftest emit-guards-render-as-cond-attribute
+  (testing "guarded transitions render with cond= on <transition>"
+    (let [out (scxml/spec->scxml guarded-machine)]
+      (is (str/includes? out "cond=\"ready?\"")))))
+
+(deftest emit-after-transitions-encode-delay-in-event-name
+  (testing ":after {5000 :timeout} → event=\"after.5000\""
+    (let [out (scxml/spec->scxml after-machine)]
+      (is (str/includes? out "event=\"after.5000\""))
+      (is (str/includes? out "target=\"timeout\"")))))
+
+(deftest emit-always-transitions-omit-event-attribute
+  (testing ":always candidates render as eventless <transition>s
+            (no event= attribute; target= + optional cond= only)"
+    (let [out (scxml/spec->scxml always-machine)]
+      ;; Both attribute orders are equally valid SCXML; assert
+      ;; semantic content, not lexical order.
+      (is (str/includes? out "target=\"ready\""))
+      (is (str/includes? out "cond=\"ready?\""))
+      (is (str/includes? out "<transition target=\"blocked\"/>"))
+      ;; Eventless transitions must not carry event= — confirm by
+      ;; searching for the malformed combination.
+      (is (not (re-find #"event=\"\"" out))))))
+
+(deftest emit-parallel-machine-uses-parallel-element
+  (testing ":type :parallel emits a <parallel> wrapper with region children"
+    (let [out (scxml/spec->scxml parallel-machine)]
+      (is (str/includes? out "<parallel id=\"rf2_parallel_root\""))
+      (is (str/includes? out "<state id=\"data\" initial=\"nothing\""))
+      (is (str/includes? out "<state id=\"form\" initial=\"neutral\""))
+      (is (str/includes? out "</parallel>")))))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip property
+
+(defn- round-trips? [spec]
+  (= spec (-> spec scxml/spec->scxml scxml/scxml->spec)))
+
+(deftest round-trip-flat-machine
+  (testing "idle-loading-success-error round-trips through SCXML"
+    (is (round-trips? idle-loading-success-error))))
+
+(deftest round-trip-compound-machine
+  (testing "compound machine with nested states round-trips"
+    (is (round-trips? compound-machine))))
+
+(deftest round-trip-namespaced-machine
+  (testing "namespaced ids round-trip via dot-separation"
+    (is (round-trips? namespaced-machine))))
+
+(deftest round-trip-guarded-machine
+  (testing "guards round-trip via cond= attribute"
+    (is (round-trips? guarded-machine))))
+
+(deftest round-trip-after-machine
+  (testing ":after timers round-trip via event=\"after.<ms>\""
+    (is (round-trips? after-machine))))
+
+(deftest round-trip-always-machine
+  (testing ":always eventless transitions round-trip"
+    (is (round-trips? always-machine))))
+
+(deftest round-trip-parallel-machine
+  (testing ":type :parallel + :regions round-trips through <parallel>"
+    (is (round-trips? parallel-machine))))
+
+;; ---------------------------------------------------------------------------
+;; Error cases
+
+(deftest spec->scxml-rejects-invalid-spec
+  (testing "missing :initial throws :scxml/invalid-spec"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/spec->scxml {:states {:idle {}}}))))
+  (testing "missing :states throws :scxml/invalid-spec"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/spec->scxml {:initial :idle}))))
+  (testing "parallel without :regions throws"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/spec->scxml {:type :parallel})))))
+
+(deftest scxml->spec-rejects-non-string
+  (testing "non-string input throws :scxml/parse-error"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/scxml->spec nil)))
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/scxml->spec 42)))))
+
+(deftest scxml->spec-rejects-missing-root
+  (testing "input without <scxml> throws :scxml/parse-error"
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs js/Error)
+                 (scxml/scxml->spec "<not-scxml/>")))))
+
+;; ---------------------------------------------------------------------------
+;; Documentation of lossy features
+;;
+;; These tests don't assert error behaviour — they document, via
+;; canonical fixtures, which features *don't* survive the round-trip
+;; bit-for-bit. The current list is empty (every fixture above round-
+;; trips) — the comment is the contract. If a future fixture is
+;; added here that doesn't round-trip, name the loss explicitly.
+
+(deftest round-trip-property-pinned-on-supported-subset
+  (testing "every fixture in this ns round-trips through SCXML —
+            extend with explicit-loss tests when adding lossy
+            features (e.g. :spawn-all rows)"
+    (doseq [[name spec] [["idle-loading-success-error" idle-loading-success-error]
+                         ["compound-machine"            compound-machine]
+                         ["namespaced-machine"          namespaced-machine]
+                         ["guarded-machine"             guarded-machine]
+                         ["after-machine"               after-machine]
+                         ["always-machine"              always-machine]
+                         ["parallel-machine"            parallel-machine]]]
+      (testing name
+        (is (= spec (-> spec scxml/spec->scxml scxml/scxml->spec)))))))


### PR DESCRIPTION
Closes rf2-1bncf (AI-generate-a-machine surface) + rf2-6urjd (SCXML import/export). v1.1 features pulled forward per Mike 2026-05-21.

## Summary

- **rf2-1bncf** — `day8.re-frame2-machines-viz.ai-generate/generate-machine` library fn with pluggable `:resolver` seam for LLM bridges. Pure data; tests inject a stub.
- **rf2-6urjd** — `day8.re-frame2-machines-viz.scxml/{spec->scxml,scxml->spec}` pure-data round-trip for non-CLJS sharing. SCXML promoted from "Out of scope (any version)" → v1.1 shipped.

Both surfaces are isolated to `tools/machines-viz/` — no parallel-edit conflict with the audit-rename bundle (which lives in `spec/*` + `implementation/machines`) or the audit#17 classification work (`ai/findings/` only).

## Implementation notes

- SCXML implementation is string-based — no external XML library dep. Round-trip property `(= spec (-> spec spec->scxml scxml->spec))` holds for the supported subset (flat / compound / parallel, `:initial`, `:on`, `:after`, `:always`, guards, `:final?`, namespaced ids).
- AI-generate ships **no default LLM bridge**: production callers inject one (Anthropic / OpenAI / Ollama / Causa chat / re-frame2-pair-mcp), tests inject a stub. The fn itself is deterministic given a deterministic resolver.
- Spec updates: `API.md` gains §SCXML import/export + §AI-generate-a-machine; `000-Vision.md` moves SCXML out of "Out of scope" + adds v1.1 shipped section; `README.md` lists the new surfaces.

## Test plan

- [x] `clojure -M:test` from `tools/machines-viz/` — 187 tests / 449 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 3856 tests / 11172 assertions / 0 failures
- [ ] mkdocs build --strict (CI gate; no mkdocs nav changes in this PR)