### PR TITLE
feat(causa): per-cascade structured export (rf2-0us27 · v1.1 pulled forward)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/export/cascade.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/export/cascade.cljc
@@ -1,0 +1,292 @@
+(ns day8.re-frame2-causa.export.cascade
+  "Per-cascade structured export (rf2-0us27, v1.1 pulled forward).
+
+  ## Why this ns exists
+
+  Lock 4 (`ai/findings/causa-sota-alternatives-2026-05-13.md` §10)
+  decided no whole-session export at v1.0 — serialisation, redaction,
+  and version-skew risk make the share unit too coarse to round-trip
+  cleanly across teams. The pressure-test (Reactime / Replay.io /
+  fulcro-inspect) confirmed the lock but also surfaced a genuinely
+  narrower share-unit that v1.0 doesn't address: ONE focused cascade.
+
+  v1.1 explores per-cascade export — the user picks a cascade in
+  Causa's L2 list, clicks 'Export this epoch', and gets a single
+  EDN document carrying everything needed to triage that cascade in
+  isolation. No replay, no time-travel: a structured artefact a
+  teammate (or an AI) can read end-to-end without booting the app.
+
+  ## Output shape
+
+  `project-cascade` returns a single map shaped:
+
+      {:rf.causa.export/version    1
+       :exported-at                <iso-string|nil>
+       :epoch-id                   <epoch-id|nil>
+       :dispatch-id                <opaque-id|nil>
+       :frame                      <frame-id|nil>
+       :event                      <event-vec|nil>
+       :dispatched                 <trace-event|nil>   ;; full :event/dispatched
+       :handler                    <trace-event|nil>   ;; :event/run-end (last wins)
+       :fx                         <trace-event|nil>   ;; :event/do-fx
+       :coeffects                  <coeffect-map|nil>  ;; hoisted from handler
+       :effects                    [<trace-event> ...] ;; :op-type :fx
+       :subs                       [<trace-event> ...] ;; :sub/run + :sub/create
+       :renders                    [<trace-event> ...] ;; :view/render
+       :other                      [<trace-event> ...] ;; errors, flows, …
+       :timing                     {:started-ms <n|nil>
+                                    :ended-ms   <n|nil>
+                                    :duration-ms <n|nil>
+                                    :event-count <int>}
+       :app-db                     {:before <db|nil>
+                                    :after  <db|nil>
+                                    :diff   [<triple> ...]}
+       :trace-events               [<trace-event> ...] ;; raw, oldest-first
+       :issues                     [<issue> ...]}      ;; warnings/errors
+
+  The map is plain Clojure data — vectors, maps, keywords. JSON
+  conversion is a one-liner (`cheshire`/`js->clj` on the caller's
+  side) because every key/value is a primitive or a nested
+  collection thereof. EDN serialisation roundtrips via the standard
+  `pr-str` / `clojure.edn/read-string` pair.
+
+  ## What is NOT exported
+
+  - **Reagent/React render trees.** `:view/render` trace events
+    capture the render call (component name, frame, dispatch-id);
+    the rendered VDOM is intentionally absent. Lock 4's serialisation
+    argument holds at the React-tree level — VDOM is non-portable
+    across substrate versions.
+
+  - **Sensitive data.** This ns is pure projection over the cascade
+    record + the trace events the buffer holds; redaction lives
+    upstream (Spec 009 §Privacy — `:sensitive?` events are stripped
+    at ingest by `trace-bus/collect-trace!`). An exported cascade is
+    no more sensitive than what Causa already shows on screen.
+
+  - **Cross-cascade context.** The export is INTENTIONALLY narrow —
+    one cascade, its db-before/after, its trace events. No prior /
+    subsequent cascades, no full epoch history, no machine timelines
+    spanning sibling cascades. The narrow share unit is the whole
+    point per the v1.1 design: triage one cascade in isolation.
+
+  ## Round-trip discipline
+
+  `project-cascade` is pure-data + JVM-runnable + idempotent. The
+  output map's keys are stable; consumers may rely on key presence
+  even when the value is nil (so a teammate's tool can detect
+  'this cascade had no handler' vs 'this field was never exported').
+  Schema additions are MINOR-version bumps to `:rf.causa.export/
+  version`; field removals / shape changes are MAJOR.
+
+  ## Caller contract
+
+  Callers supply:
+
+    - `cascade`    — a `:rf.causa/cascades`-shaped map (the
+                     `re-frame.trace.projection/group-cascades`
+                     output entry).
+    - `epoch`      — optional `:rf/epoch-record` from
+                     `:rf.causa/epoch-history` matching the cascade.
+                     When absent, `:app-db` shows nils.
+    - `opts`       — `{:exported-at <iso-string-or-nil>}`. The
+                     exported-at slot is caller-supplied so the
+                     pure projection stays JVM-time-deterministic;
+                     CLJS callers pass `(js/Date.).toISOString()`.
+
+  The projection is tolerant: nil cascade returns a minimal envelope
+  with `:dispatch-id nil` so downstream consumers can detect 'nothing
+  to export'."
+  (:require [clojure.set :as set]
+            [clojure.string :as str]))
+
+;; ---- schema version -----------------------------------------------------
+
+(def schema-version
+  "Bumped on additive schema changes; carried in `:rf.causa.export/
+  version` so downstream tools can fall back gracefully for
+  v(future)+. Start at 1; bump on additions / shape changes."
+  1)
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- trace-event-time
+  "Pull `:time` off a trace event. Trace envelopes carry `:time`
+  top-level when emitted via `re-frame.trace/emit!`. Returns nil for
+  events without a time (e.g. fixtures)."
+  [ev]
+  (when (map? ev) (:time ev)))
+
+(defn- collect-event-times
+  "Walk the cascade record's trace event slots and return a vector of
+  every `:time` we can find. Used to compute the timing envelope."
+  [{:keys [dispatched handler fx effects subs renders other]}]
+  (let [evs (concat [dispatched handler fx] effects subs renders other)]
+    (into [] (keep trace-event-time) evs)))
+
+(defn- compute-timing
+  "Derive `{:started-ms :ended-ms :duration-ms :event-count}` from the
+  cascade's trace events. Returns a map with nil values when no times
+  resolve (e.g. JVM-only fixtures). `:event-count` is the total trace
+  events folded across all domino slots."
+  [cascade]
+  (let [times (collect-event-times cascade)
+        n     (+ (count (:effects cascade))
+                 (count (:subs cascade))
+                 (count (:renders cascade))
+                 (count (:other cascade))
+                 (if (:dispatched cascade) 1 0)
+                 (if (:handler cascade) 1 0)
+                 (if (:fx cascade) 1 0))]
+    (if (seq times)
+      (let [t0 (apply min times)
+            t1 (apply max times)]
+        {:started-ms  t0
+         :ended-ms    t1
+         :duration-ms (- t1 t0)
+         :event-count n})
+      {:started-ms  nil
+       :ended-ms    nil
+       :duration-ms nil
+       :event-count n})))
+
+(defn- extract-coeffects
+  "The framework's handler trace event carries the resolved coeffect
+  map on the `:event/run-end` envelope under `:coeffects` (Spec 009
+  §Handler envelopes). Pull it out as a top-level slot so the export
+  reader doesn't have to know the trace event's internal layout."
+  [handler-event]
+  (when (map? handler-event)
+    (or (:coeffects handler-event)
+        (get-in handler-event [:tags :coeffects]))))
+
+(defn- diff-triples
+  "Diff the epoch's `:db-before` / `:db-after`. Lifted from
+  `panels.app-db-diff-helpers/diff-paths` in spirit — but kept inline
+  + simpler here so the export ns has no dep on panel internals
+  (production wiring uses the panel helper; the inline form keeps
+  this ns standalone-callable from MCP / JVM contexts where the
+  panel ns is not on the classpath).
+
+  Returns a vector of triples `[{:op :added|:modified|:removed
+  :path [...] :before _ :after _}]` covering paths whose value
+  differs between `before` and `after`. Operates at the top-map
+  level — nested values surface as MODIFIED on their parent path
+  (good enough for export; the panel's deeper structural diff is a
+  rendering concern)."
+  [before after]
+  (cond
+    (and (nil? before) (nil? after)) []
+    (and (map? before) (map? after))
+    (let [ks-b   (set (keys before))
+          ks-a   (set (keys after))
+          added  (mapv (fn [k] {:op :added :path [k] :before nil :after (get after k)})
+                       (sort (set/difference ks-a ks-b)))
+          removed (mapv (fn [k] {:op :removed :path [k] :before (get before k) :after nil})
+                        (sort (set/difference ks-b ks-a)))
+          changed (mapv (fn [k] {:op :modified :path [k]
+                                 :before (get before k)
+                                 :after  (get after k)})
+                        (sort (filter (fn [k]
+                                        (and (contains? ks-b k)
+                                             (contains? ks-a k)
+                                             (not= (get before k) (get after k))))
+                                      ks-a)))]
+      (into [] cat [added changed removed]))
+    (not= before after)
+    [{:op :modified :path [] :before before :after after}]
+    :else
+    []))
+
+(defn- extract-issues
+  "Surface errors / warnings out of the cascade's `:other` bucket as
+  a flat issue vector. Trace events with `:op-type :error` or
+  `:warning` are issues; the renderer (e.g. an AI agent triaging the
+  export) reads them off the top-level `:issues` slot rather than
+  walking `:other` itself."
+  [{:keys [other]}]
+  (into []
+        (comp (filter map?)
+              (filter #(contains? #{:error :warning} (:op-type %)))
+              (map (fn [ev]
+                     {:severity (:op-type ev)
+                      :message  (or (:message ev)
+                                    (get-in ev [:tags :message])
+                                    (:operation ev))
+                      :event    ev})))
+        other))
+
+(defn project-cascade
+  "Pure data → structured export map. See ns docstring for the
+  output shape + caller contract.
+
+  - `cascade`  — `:rf.causa/cascades`-shaped entry (or nil).
+  - `opts`     — `{:epoch       <epoch-record-or-nil>
+                   :exported-at <iso-string-or-nil>}`.
+
+  JVM + CLJS. Idempotent. Stable key set."
+  ([cascade]
+   (project-cascade cascade nil))
+  ([cascade {:keys [epoch exported-at] :as _opts}]
+   (let [{:keys [dispatch-id frame event dispatched handler
+                 fx effects subs renders other]} (or cascade {})
+         timing      (compute-timing cascade)
+         issues      (extract-issues cascade)
+         coeffects   (extract-coeffects handler)
+         db-before   (:db-before epoch)
+         db-after    (:db-after epoch)
+         epoch-id    (or (:epoch-id epoch))
+         raw-trace   (or (:trace-events epoch) [])]
+     {:rf.causa.export/version schema-version
+      :exported-at             exported-at
+      :epoch-id                epoch-id
+      :dispatch-id             dispatch-id
+      :frame                   frame
+      :event                   event
+      :dispatched              dispatched
+      :handler                 handler
+      :fx                      fx
+      :coeffects               coeffects
+      :effects                 (vec (or effects []))
+      :subs                    (vec (or subs []))
+      :renders                 (vec (or renders []))
+      :other                   (vec (or other []))
+      :timing                  timing
+      :app-db                  {:before db-before
+                                :after  db-after
+                                :diff   (diff-triples db-before db-after)}
+      :trace-events            (vec raw-trace)
+      :issues                  issues})))
+
+;; ---- serialisation ------------------------------------------------------
+
+(defn to-edn-string
+  "Render an export map to an EDN string via `pr-str`. The export map
+  is pure-data so `pr-str` is sufficient — every value is either a
+  primitive, a keyword, a vector/map of same, or a fully-printable
+  Clojure datatype. Tests and the share-modal copy path both go
+  through here so the wire shape stays in one place."
+  [export-map]
+  (binding [*print-length* nil
+            *print-level*  nil]
+    (pr-str export-map)))
+
+(defn suggested-filename
+  "Derive a filesystem-safe filename for a download. Combines a
+  short `:dispatch-id` excerpt with the exported-at timestamp. JVM
+  + CLJS. Pure fn."
+  [{:keys [dispatch-id exported-at]}]
+  (let [id-str (cond
+                 (number? dispatch-id) (str dispatch-id)
+                 (some? dispatch-id)   (str dispatch-id)
+                 :else                 "cascade")
+        clean  (-> id-str
+                   (str/replace #"[^A-Za-z0-9._-]+" "-")
+                   (str/replace #"^-+|-+$" ""))
+        ts     (when exported-at
+                 (-> exported-at
+                     (str/replace #"[:.]" "-")))]
+    (str "causa-cascade-"
+         (if (seq clean) clean "unknown")
+         (when (seq ts) (str "-" ts))
+         ".edn")))

--- a/tools/causa/src/day8/re_frame2_causa/share.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share.cljs
@@ -57,7 +57,8 @@
   reg-fx replacement."
   (:require [cljs.reader :as reader]
             [clojure.string :as str]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.export.cascade :as export-cascade]))
 
 ;; ---- encode / decode ----------------------------------------------------
 
@@ -273,7 +274,56 @@
   ;; copy button's label off this slot ("Copy" → "Copied!" → reset).
   (rf/reg-sub :rf.causa/share-copy-status
     (fn [db _query]
-      (get db :share/copy-status :idle))))
+      (get db :share/copy-status :idle)))
+
+  ;; ---- per-cascade structured export (rf2-0us27) -----------------------
+  ;;
+  ;; The export is a pure projection of the currently-focused cascade
+  ;; into a JVM-serialisable EDN map (`day8.re-frame2-causa.export.
+  ;; cascade/project-cascade`). It rides the same modal as the share-
+  ;; URL because conceptually both are "share a snapshot of my Causa
+  ;; context"; the modal renders the URL + an export button row.
+  ;;
+  ;; The composite picks the focused cascade by `:dispatch-id` /
+  ;; `:frame` off the spine (`:rf.causa/focus`), pairs it with the
+  ;; matching epoch record from `:rf.causa/epoch-history`, and feeds
+  ;; both into the pure projection. Pre-focus / empty-buffer returns
+  ;; nil; the modal toggles its export buttons off in that state.
+  (rf/reg-sub :rf.causa/cascade-export
+    :<- [:rf.causa/event-detail]
+    :<- [:rf.causa/epoch-history]
+    :<- [:rf.causa/focus]
+    (fn [[event-detail history focus] _query]
+      (let [{:keys [selected-cascade selected-dispatch-id]} event-detail
+            epoch-id (:epoch-id focus)
+            epoch    (when epoch-id
+                       (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
+                             history))]
+        (when (and selected-cascade selected-dispatch-id)
+          (export-cascade/project-cascade
+            selected-cascade
+            {:epoch epoch})))))
+
+  ;; The EDN string the modal exposes — pre-rendered so the modal can
+  ;; show a preview / size hint live. nil when no cascade is focused.
+  (rf/reg-sub :rf.causa/cascade-export-edn
+    :<- [:rf.causa/cascade-export]
+    (fn [export _query]
+      (when export
+        (export-cascade/to-edn-string export))))
+
+  ;; Convenience: is there anything to export right now? Drives the
+  ;; export-button's `:disabled` slot in the modal.
+  (rf/reg-sub :rf.causa/cascade-export-available?
+    :<- [:rf.causa/cascade-export]
+    (fn [export _query]
+      (boolean export)))
+
+  ;; Export-action status — `:idle | :copied | :downloaded | :failed`.
+  ;; Mirrors `:share-copy-status` but for the cascade-export buttons.
+  (rf/reg-sub :rf.causa/cascade-export-status
+    (fn [db _query]
+      (get db :share/cascade-export-status :idle))))
 
 ;; ---- effects ------------------------------------------------------------
 
@@ -291,10 +341,31 @@
   (when (and js/navigator (.-clipboard js/navigator))
     (.writeText (.-clipboard js/navigator) (str text))))
 
+(defn download-text-file!
+  "Browser-side text-file download via a Blob + transient <a> click.
+  CLJS-only. Tests `with-redefs` this to capture the (filename, text)
+  pair without touching the DOM. Returns true on a successful
+  best-effort dispatch, false otherwise."
+  [filename text]
+  (try
+    (when (and js/document js/window)
+      (let [blob (js/Blob. #js [(str text)] #js {:type "text/plain;charset=utf-8"})
+            url  (.createObjectURL (.-URL js/window) blob)
+            a    (.createElement js/document "a")]
+        (set! (.-href a) url)
+        (set! (.-download a) (str filename))
+        (.appendChild (.-body js/document) a)
+        (.click a)
+        (.removeChild (.-body js/document) a)
+        (.revokeObjectURL (.-URL js/window) url)
+        true))
+    (catch :default _ false)))
+
 (defn install-fxs!
   "Register the share-specific fxs. The clipboard fx itself reuses
   the shared `:rf.causa.fx/copy-to-clipboard` fx already registered
-  by app_db_diff_events.cljs; this install only adds the new-tab fx."
+  by app_db_diff_events.cljs; this install only adds the new-tab +
+  download fxs."
   []
   ;; Open a URL in a new browser tab. Wrapped as an fx so the test
   ;; rig can stub `:rf.causa.fx/open-in-new-tab` instead of touching
@@ -302,7 +373,14 @@
   (rf/reg-fx :rf.causa.fx/open-in-new-tab
     (fn [url]
       (when (and url js/window)
-        (.open js/window (str url) "_blank")))))
+        (.open js/window (str url) "_blank"))))
+
+  ;; Save a text payload to disk via a transient anchor + Blob URL.
+  ;; rf2-0us27 — used by the cascade-export download button.
+  ;; Wrapped as an fx so tests can stub the side-effect.
+  (rf/reg-fx :rf.causa.fx/download-text-file
+    (fn [{:keys [filename text]}]
+      (download-text-file! filename text))))
 
 ;; ---- events -------------------------------------------------------------
 
@@ -378,6 +456,81 @@
                       (some? position)    (assoc :position position)))
             url   (current-share-url state)]
         {:fx [[:rf.causa.fx/open-in-new-tab url]]})))
+
+  ;; ---- per-cascade structured export events (rf2-0us27) -------------
+  ;;
+  ;; Two surfaces against the same projection: copy the EDN to clipboard
+  ;; or download it as a file. Both fire-and-forget; the status slot
+  ;; flips on success / failure and resets to `:idle` after a short
+  ;; delay so the button label reverts.
+  (rf/reg-event-db :rf.causa/cascade-export-status
+    (fn [db [_ status]]
+      (assoc db :share/cascade-export-status (or status :idle))))
+
+  ;; rf2-0us27 — Copy the focused cascade's export EDN to clipboard.
+  ;; Reads the composite the same way share-url does: subscribe-at-fire
+  ;; rather than rely on the modal's in-flight render. Stashes the
+  ;; rendered EDN under `:share/last-cascade-export` for test inspection
+  ;; and flips `:share/cascade-export-status` to drive the button label.
+  (rf/reg-event-fx :rf.causa/copy-cascade-export-to-clipboard
+    (fn [{:keys [db]} _event]
+      (let [;; Build the export by reading the same sub the modal does.
+            ;; The sub is layer-2 over `:rf.causa/event-detail` /
+            ;; `:rf.causa/epoch-history` / `:rf.causa/focus` so the
+            ;; value is the same value the modal renders.
+            export @(rf/subscribe [:rf.causa/cascade-export])
+            edn    (when export (export-cascade/to-edn-string export))]
+        (if (not edn)
+          {:db (assoc db :share/cascade-export-status :failed)}
+          (let [p (copy-to-clipboard! edn)]
+            (when p
+              (.then p
+                     (fn [_]
+                       (rf/dispatch [:rf.causa/cascade-export-status :copied]
+                                    {:frame :rf/causa})
+                       (js/setTimeout
+                         (fn []
+                           (rf/dispatch [:rf.causa/cascade-export-status :idle]
+                                        {:frame :rf/causa}))
+                         1500))
+                     (fn [_]
+                       (rf/dispatch [:rf.causa/cascade-export-status :failed]
+                                    {:frame :rf/causa}))))
+            {:db (assoc db :share/last-cascade-export edn)})))))
+
+  ;; rf2-0us27 — Download the focused cascade's export EDN as a file.
+  ;; Routes through the `:rf.causa.fx/download-text-file` fx so tests
+  ;; can `with-redefs` the side effect away. Same status-slot wiring as
+  ;; the copy event so the button reverts to idle on resolve.
+  (rf/reg-event-fx :rf.causa/download-cascade-export
+    (fn [{:keys [db]} _event]
+      (let [export   @(rf/subscribe [:rf.causa/cascade-export])
+            edn      (when export (export-cascade/to-edn-string export))
+            ts       (try (.toISOString (js/Date.)) (catch :default _ nil))
+            filename (when export
+                       (export-cascade/suggested-filename
+                         {:dispatch-id (:dispatch-id export)
+                          :exported-at ts}))]
+        (if (or (not edn) (not filename))
+          {:db (assoc db :share/cascade-export-status :failed)}
+          (do
+            ;; Status flip rides setTimeouts (mirroring the copy-URL path)
+            ;; so the button reverts after the user has seen "Downloaded!".
+            (js/setTimeout
+              (fn []
+                (rf/dispatch [:rf.causa/cascade-export-status :downloaded]
+                             {:frame :rf/causa}))
+              0)
+            (js/setTimeout
+              (fn []
+                (rf/dispatch [:rf.causa/cascade-export-status :idle]
+                             {:frame :rf/causa}))
+              1500)
+            {:db (assoc db
+                        :share/last-cascade-export      edn
+                        :share/last-cascade-export-name filename)
+             :fx [[:rf.causa.fx/download-text-file
+                   {:filename filename :text edn}]]})))))
 
   ;; Restore Causa state from a decoded share-state map. Drives the
   ;; per-slot reducers so the same code-paths that handle interactive

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -168,6 +168,75 @@
                   :cursor "pointer"}}
    "Open in new tab"])
 
+;; ---- per-cascade structured export (rf2-0us27) -----------------------
+;;
+;; Two action buttons against the same projection — `:rf.causa/
+;; cascade-export`. Both short-circuit (rendered grey + disabled) when
+;; no cascade is focused. Status labels mirror the URL-copy buttons
+;; so the modal's affordances feel consistent.
+
+(defn- cascade-export-copy-button
+  [available? status]
+  (let [copied?     (= :copied status)
+        failed?     (= :failed status)
+        downloaded? (= :downloaded status)
+        label       (cond
+                      copied?     "Copied!"
+                      downloaded? "Downloaded!"
+                      failed?     "Export failed"
+                      :else       "Copy cascade EDN")
+        tone        (cond
+                      copied?     (:green tokens)
+                      downloaded? (:green tokens)
+                      failed?     (:red tokens)
+                      (not available?) (:bg-2 tokens)
+                      :else       (:accent-violet tokens))]
+    [:button
+     {:data-testid "rf-causa-share-modal-export-cascade-copy"
+      :data-status (name (or status :idle))
+      :disabled    (not available?)
+      :title       (if available?
+                     "Copy the focused cascade as a structured EDN document"
+                     "Focus a cascade in the L2 list to enable export")
+      :on-click    (fn [_]
+                     (when available?
+                       (rf/dispatch
+                         [:rf.causa/copy-cascade-export-to-clipboard]
+                         {:frame :rf/causa})))
+      :style       {:background tone
+                    :border "none"
+                    :color (if available? (:bg-0 tokens) (:text-tertiary tokens))
+                    :font-family sans-stack
+                    :font-size "12px"
+                    :font-weight 600
+                    :padding "8px 16px"
+                    :border-radius "4px"
+                    :cursor (if available? "pointer" "not-allowed")
+                    :min-width "160px"}}
+     label]))
+
+(defn- cascade-export-download-button
+  [available?]
+  [:button
+   {:data-testid "rf-causa-share-modal-export-cascade-download"
+    :disabled    (not available?)
+    :title       (if available?
+                   "Save the focused cascade EDN to disk"
+                   "Focus a cascade in the L2 list to enable export")
+    :on-click    (fn [_]
+                   (when available?
+                     (rf/dispatch [:rf.causa/download-cascade-export]
+                                  {:frame :rf/causa})))
+    :style       {:background "transparent"
+                  :border (str "1px solid " (:border-default tokens))
+                  :color (if available? (:text-primary tokens) (:text-tertiary tokens))
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :padding "8px 14px"
+                  :border-radius "4px"
+                  :cursor (if available? "pointer" "not-allowed")}}
+   "Download .edn"])
+
 (defn- reset-button
   []
   [:button
@@ -231,9 +300,11 @@
 (defn share-dialog
   "The Share dialog body. Pure hiccup."
   []
-  (let [share-state @(rf/subscribe [:rf.causa/share-state])
-        share-url   @(rf/subscribe [:rf.causa/share-url])
-        copy-status @(rf/subscribe [:rf.causa/share-copy-status])]
+  (let [share-state    @(rf/subscribe [:rf.causa/share-state])
+        share-url      @(rf/subscribe [:rf.causa/share-url])
+        copy-status    @(rf/subscribe [:rf.causa/share-copy-status])
+        export-avail?  @(rf/subscribe [:rf.causa/cascade-export-available?])
+        export-status  @(rf/subscribe [:rf.causa/cascade-export-status])]
     [:div (merge
             ;; rf2-7389r — WAI-ARIA dialog contract + focus capture on
             ;; mount so keyboard users land inside the modal (audit
@@ -258,7 +329,25 @@
                     :flex-wrap "wrap"}}
       (copy-button copy-status)
       (open-in-new-tab-button)
-      (reset-button)]]))
+      (reset-button)]
+     ;; rf2-0us27 — per-cascade structured export row. Sits below the
+     ;; URL-share row because conceptually it's a separate share unit
+     ;; (a snapshot of the focused cascade vs the current Causa view).
+     [:div {:data-testid "rf-causa-share-modal-export-cascade-row"
+            :style {:display "flex"
+                    :align-items "center"
+                    :gap "8px"
+                    :flex-wrap "wrap"
+                    :margin-top "4px"
+                    :padding-top "10px"
+                    :border-top (str "1px solid " (:border-subtle tokens))}}
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-family mono-stack
+                      :font-size "11px"
+                      :margin-right "4px"}}
+       "Per-cascade export"]
+      (cascade-export-copy-button export-avail? export-status)
+      (cascade-export-download-button export-avail?)]]))
 
 (rf/reg-view Modal
   "The Share modal. Renders only when `:rf.causa/share-modal-open?`

--- a/tools/causa/test/day8/re_frame2_causa/export/cascade_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/export/cascade_cljs_test.cljc
@@ -1,0 +1,277 @@
+(ns day8.re-frame2-causa.export.cascade-cljs-test
+  "Pure-data tests for per-cascade structured export (rf2-0us27,
+  v1.1).
+
+  Covers:
+
+    1. Schema envelope — version + stable key set surfaces every
+       documented slot even when the cascade is nil / empty.
+    2. Domino projection — dispatched / handler / fx / effects / subs
+       / renders / other carry through verbatim.
+    3. Coeffects hoist — pulled out of the handler trace event onto
+       the top-level `:coeffects` slot.
+    4. Timing envelope — started/ended/duration computed from trace
+       event `:time` slots; nil-times case yields nil bounds + a
+       non-nil event-count.
+    5. App-DB block — `:before` / `:after` / `:diff` populated from
+       the supplied epoch record; diff covers added / removed /
+       modified at the top map level.
+    6. Issues hoist — `:error` / `:warning` op-types in `:other`
+       surface as a flat `:issues` vector.
+    7. `to-edn-string` round-trips via `pr-str`.
+    8. `suggested-filename` sanitises the dispatch-id + timestamp.
+
+  CLJC — `cascade/project-cascade` is JVM-runnable, so the test runs
+  under both `clojure -M:test` and `npm run test:cljs`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as reader])
+            [day8.re-frame2-causa.export.cascade :as export]))
+
+(defn- read-edn [s]
+  #?(:clj (edn/read-string s)
+     :cljs (reader/read-string s)))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def sample-dispatched
+  {:op-type :event :operation :event/dispatched
+   :id 10 :time 100
+   :tags {:event [:cart/add-item :sku-1]
+          :dispatch-id 7 :frame :rf/default}})
+
+(def sample-handler
+  {:op-type :event :operation :event/run-end
+   :id 11 :time 110
+   :coeffects {:event [:cart/add-item :sku-1]
+               :db {:cart {:items []}}}
+   :tags {:event-id :cart/add-item :handler-id :cart/add-item-handler}})
+
+(def sample-fx
+  {:op-type :event :operation :event/do-fx
+   :id 12 :time 115
+   :tags {:dispatch-id 7}})
+
+(def sample-effect
+  {:op-type :fx :operation :db
+   :id 13 :time 116
+   :tags {:fx-id :db :dispatch-id 7}})
+
+(def sample-sub
+  {:op-type :sub :operation :sub/run
+   :id 14 :time 120
+   :tags {:query [:cart/total] :dispatch-id 7}})
+
+(def sample-render
+  {:op-type :view :operation :view/render
+   :id 15 :time 122
+   :tags {:component :cart/Item :dispatch-id 7}})
+
+(def sample-error
+  {:op-type :error :operation :handler/threw
+   :id 16 :time 125
+   :message "boom"
+   :tags {:dispatch-id 7}})
+
+(def sample-cascade
+  {:dispatch-id 7
+   :frame       :rf/default
+   :event       [:cart/add-item :sku-1]
+   :dispatched  sample-dispatched
+   :handler     sample-handler
+   :fx          sample-fx
+   :effects     [sample-effect]
+   :subs        [sample-sub]
+   :renders     [sample-render]
+   :other       [sample-error]})
+
+(def sample-epoch
+  {:epoch-id  :epoch-42
+   :db-before {:cart {:items []}}
+   :db-after  {:cart {:items [:sku-1]}
+               :ui   {:flash "Added"}}
+   :trace-events [sample-dispatched sample-handler sample-fx
+                  sample-effect sample-sub sample-render]})
+
+;; ---- 1. schema envelope -------------------------------------------------
+
+(deftest schema-version-present
+  (let [out (export/project-cascade nil)]
+    (is (= 1 (:rf.causa.export/version out))
+        "version is always present")))
+
+(deftest nil-cascade-still-produces-stable-key-set
+  (let [out (export/project-cascade nil)
+        expected-keys #{:rf.causa.export/version
+                        :exported-at :epoch-id :dispatch-id :frame
+                        :event :dispatched :handler :fx :coeffects
+                        :effects :subs :renders :other :timing
+                        :app-db :trace-events :issues}]
+    (doseq [k expected-keys]
+      (is (contains? out k) (str "expected key " k " in export map")))))
+
+(deftest exported-at-passes-through-from-opts
+  (let [out (export/project-cascade sample-cascade
+                                    {:exported-at "2026-05-21T01:23:45.000Z"})]
+    (is (= "2026-05-21T01:23:45.000Z" (:exported-at out)))))
+
+;; ---- 2. domino projection -----------------------------------------------
+
+(deftest dispatch-id-and-frame-flow-through
+  (let [out (export/project-cascade sample-cascade)]
+    (is (= 7 (:dispatch-id out)))
+    (is (= :rf/default (:frame out)))
+    (is (= [:cart/add-item :sku-1] (:event out)))))
+
+(deftest domino-slots-preserved-verbatim
+  (let [out (export/project-cascade sample-cascade)]
+    (is (= sample-dispatched (:dispatched out)))
+    (is (= sample-handler    (:handler out)))
+    (is (= sample-fx         (:fx out)))
+    (is (= [sample-effect]   (:effects out)))
+    (is (= [sample-sub]      (:subs out)))
+    (is (= [sample-render]   (:renders out)))
+    (is (= [sample-error]    (:other out)))))
+
+(deftest empty-domino-slots-default-to-empty-vec
+  (let [out (export/project-cascade {:dispatch-id 1 :event [:x]})]
+    (is (= [] (:effects out)))
+    (is (= [] (:subs out)))
+    (is (= [] (:renders out)))
+    (is (= [] (:other out)))
+    (is (= [] (:trace-events out)))))
+
+;; ---- 3. coeffects hoist -------------------------------------------------
+
+(deftest coeffects-hoisted-from-handler
+  (let [out (export/project-cascade sample-cascade)]
+    (is (= {:event [:cart/add-item :sku-1]
+            :db {:cart {:items []}}}
+           (:coeffects out)))))
+
+(deftest coeffects-nil-when-handler-absent
+  (let [out (export/project-cascade (dissoc sample-cascade :handler))]
+    (is (nil? (:coeffects out)))))
+
+;; ---- 4. timing envelope -------------------------------------------------
+
+(deftest timing-spans-min-to-max-event-time
+  (let [out (export/project-cascade sample-cascade)
+        t   (:timing out)]
+    (is (= 100 (:started-ms t)))
+    (is (= 125 (:ended-ms t)))
+    (is (= 25  (:duration-ms t)))
+    (is (pos? (:event-count t)))))
+
+(deftest timing-event-count-folds-every-slot
+  (let [out (export/project-cascade sample-cascade)]
+    ;; 1 dispatched + 1 handler + 1 fx + 1 effect + 1 sub + 1 render + 1 other = 7
+    (is (= 7 (get-in out [:timing :event-count])))))
+
+(deftest timing-nil-when-no-event-times
+  (let [out (export/project-cascade {:dispatch-id 1})
+        t   (:timing out)]
+    (is (nil? (:started-ms t)))
+    (is (nil? (:ended-ms t)))
+    (is (nil? (:duration-ms t)))
+    (is (zero? (:event-count t)))))
+
+;; ---- 5. app-db block ----------------------------------------------------
+
+(deftest app-db-uses-epoch-before-and-after
+  (let [out (export/project-cascade sample-cascade {:epoch sample-epoch})]
+    (is (= {:cart {:items []}} (get-in out [:app-db :before])))
+    (is (= {:cart {:items [:sku-1]} :ui {:flash "Added"}}
+           (get-in out [:app-db :after])))
+    (is (= :epoch-42 (:epoch-id out)))))
+
+(deftest app-db-diff-detects-added-modified-removed
+  (let [epoch {:epoch-id :e1
+               :db-before {:a 1 :b 2 :c 3}
+               :db-after  {:a 1 :b 99 :d 4}}
+        out (export/project-cascade {:dispatch-id 1} {:epoch epoch})
+        diff (get-in out [:app-db :diff])
+        by-op (group-by :op diff)]
+    (is (some #(= [:b] (:path %)) (:modified by-op)) ":b modified")
+    (is (some #(= [:c] (:path %)) (:removed by-op))  ":c removed")
+    (is (some #(= [:d] (:path %)) (:added by-op))    ":d added")))
+
+(deftest app-db-diff-empty-when-before-equals-after
+  (let [epoch {:epoch-id :e1
+               :db-before {:a 1}
+               :db-after  {:a 1}}
+        out (export/project-cascade {:dispatch-id 1} {:epoch epoch})]
+    (is (= [] (get-in out [:app-db :diff])))))
+
+(deftest app-db-nil-when-no-epoch-supplied
+  (let [out (export/project-cascade sample-cascade)]
+    (is (nil? (get-in out [:app-db :before])))
+    (is (nil? (get-in out [:app-db :after])))
+    (is (= [] (get-in out [:app-db :diff])))))
+
+(deftest trace-events-pulled-from-epoch
+  (let [out (export/project-cascade sample-cascade {:epoch sample-epoch})]
+    (is (= 6 (count (:trace-events out)))
+        "all six raw trace events on the epoch flow through")))
+
+;; ---- 6. issues hoist ----------------------------------------------------
+
+(deftest issues-surface-errors-and-warnings
+  (let [warn  {:op-type :warning :operation :flow/circular
+               :id 20 :message "circular" :tags {:dispatch-id 7}}
+        cascade (assoc sample-cascade :other [sample-error warn])
+        out (export/project-cascade cascade)
+        issues (:issues out)]
+    (is (= 2 (count issues)))
+    (is (= #{:error :warning} (set (map :severity issues))))
+    (is (some #(= "boom" (:message %)) issues))))
+
+(deftest issues-empty-when-no-errors
+  (let [out (export/project-cascade (assoc sample-cascade :other []))]
+    (is (= [] (:issues out)))))
+
+;; ---- 7. EDN round-trip --------------------------------------------------
+
+(deftest to-edn-string-roundtrips
+  (let [out (export/project-cascade sample-cascade {:epoch sample-epoch
+                                                    :exported-at "2026-05-21T00:00:00.000Z"})
+        s   (export/to-edn-string out)
+        back (read-edn s)]
+    (is (string? s))
+    (is (= (:dispatch-id out) (:dispatch-id back)))
+    (is (= (:event out)       (:event back)))
+    (is (= (:rf.causa.export/version out)
+           (:rf.causa.export/version back)))))
+
+(deftest to-edn-string-does-not-truncate
+  ;; pr-str under non-bound *print-length* would truncate deep colls;
+  ;; the export's binding lifts that limit.
+  (let [big-cascade {:dispatch-id 1
+                     :effects (vec (repeat 200 sample-effect))}
+        out (export/project-cascade big-cascade)
+        s   (export/to-edn-string out)
+        back (read-edn s)]
+    (is (= 200 (count (:effects back))))))
+
+;; ---- 8. filename sanitisation ------------------------------------------
+
+(deftest suggested-filename-uses-dispatch-id-and-timestamp
+  (let [name (export/suggested-filename
+               {:dispatch-id 42
+                :exported-at "2026-05-21T01:23:45.000Z"})]
+    (is (clojure.string/starts-with? name "causa-cascade-42-"))
+    (is (clojure.string/ends-with?   name ".edn"))))
+
+(deftest suggested-filename-strips-illegal-chars
+  (let [name (export/suggested-filename
+               {:dispatch-id "abc/def:ghi"
+                :exported-at nil})]
+    (is (not (clojure.string/includes? name "/")))
+    (is (not (clojure.string/includes? name ":")))
+    (is (clojure.string/ends-with? name ".edn"))))
+
+(deftest suggested-filename-handles-nil-dispatch-id
+  (let [name (export/suggested-filename {:dispatch-id nil :exported-at nil})]
+    (is (clojure.string/includes? name "cascade"))
+    (is (clojure.string/ends-with? name ".edn"))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -324,6 +324,12 @@
    :rf.causa/share-modal-open?
    :rf.causa/share-state
    :rf.causa/share-url
+   ;; rf2-0us27 — Per-cascade structured export subs. Co-located with
+   ;; the share/* family — same modal, same install! call.
+   :rf.causa/cascade-export
+   :rf.causa/cascade-export-available?
+   :rf.causa/cascade-export-edn
+   :rf.causa/cascade-export-status
    :rf.causa/suppressed-sensitive-count
    :rf.causa/target-frame
    :rf.causa/target-frame-db
@@ -581,6 +587,11 @@
    :rf.causa/share-copy-status
    :rf.causa/share-modal-close
    :rf.causa/share-modal-open
+   ;; rf2-0us27 — Per-cascade structured export events. Lives under
+   ;; the share/* family because it rides the same modal as URL share.
+   :rf.causa/cascade-export-status
+   :rf.causa/copy-cascade-export-to-clipboard
+   :rf.causa/download-cascade-export
    ;; rf2-r4nao — Static Machines Sim sub-mode events (rehost from
    ;; rf2-v869p Phase 2; ns moved from :rf.causa/sim-* to
    ;; :rf.causa.static.machines/sim-*).
@@ -615,6 +626,8 @@
    :rf.causa.fx/copy-to-clipboard
    ;; rf2-nqw0v Phase 5 — Share affordance: new-tab open fx.
    :rf.causa.fx/open-in-new-tab
+   ;; rf2-0us27 — Per-cascade structured export: text-file download fx.
+   :rf.causa.fx/download-text-file
    ;; rf2-ak4ms — auto-filter persistence side-effect. Lives under the
    ;; filter-specific prefix because the localStorage write is bound
    ;; to the filter-mutating events (add-filter / remove-filter /

--- a/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
@@ -335,3 +335,95 @@
         (is (< (:z-index style) 1000))
         (is (= "absolute"
                (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+;; ---- per-cascade structured export (rf2-0us27) -------------------------
+;;
+;; The share/install! family also registers the cascade-export surface:
+;; a sub family that projects `:rf.causa/event-detail` →
+;; `day8.re-frame2-causa.export.cascade/project-cascade`, an event-fx
+;; for clipboard copy, and an event-fx + fx for file download.
+;;
+;; These tests prove the wiring exists and short-circuits cleanly when
+;; no cascade is focused. The pure projection itself has dedicated
+;; coverage in `export.cascade-cljs-test.cljc`.
+
+(deftest install-registers-cascade-export-handlers
+  (testing "register-causa-handlers! installs every rf2-0us27 cascade-
+            export handler"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/cascade-export)))
+    (is (some? (registrar/handler :sub :rf.causa/cascade-export-edn)))
+    (is (some? (registrar/handler :sub :rf.causa/cascade-export-available?)))
+    (is (some? (registrar/handler :sub :rf.causa/cascade-export-status)))
+    (is (some? (registrar/handler :event :rf.causa/cascade-export-status)))
+    (is (some? (registrar/handler :event :rf.causa/copy-cascade-export-to-clipboard)))
+    (is (some? (registrar/handler :event :rf.causa/download-cascade-export)))
+    (is (some? (registrar/handler :fx :rf.causa.fx/download-text-file)))))
+
+(deftest cascade-export-unavailable-when-no-cascade-focused
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (is (false? @(rf/subscribe [:rf.causa/cascade-export-available?]))
+        "with an empty trace buffer there is no cascade to export")
+    (is (nil? @(rf/subscribe [:rf.causa/cascade-export]))
+        "the projection is nil when no cascade is selected")
+    (is (nil? @(rf/subscribe [:rf.causa/cascade-export-edn]))
+        "the EDN string is nil when no cascade is selected")))
+
+(deftest copy-cascade-export-no-op-without-cascade
+  (testing "the copy event flips status to :failed (rather than
+            throwing) when no cascade is focused"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [captured (atom :unset)]
+        (with-redefs [share/copy-to-clipboard! (fn [t] (reset! captured t) nil)]
+          (rf/dispatch-sync [:rf.causa/copy-cascade-export-to-clipboard]))
+        (is (= :unset @captured)
+            "no clipboard call when nothing to export")
+        (is (= :failed @(rf/subscribe [:rf.causa/cascade-export-status]))
+            "status flips to :failed so the modal can show the user")))))
+
+(deftest download-cascade-export-no-op-without-cascade
+  (testing "the download event flips status to :failed without
+            firing the file-save fx"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [captured (atom :unset)]
+        (with-redefs [share/download-text-file! (fn [_ _] (reset! captured :fired))]
+          (rf/dispatch-sync [:rf.causa/download-cascade-export]))
+        (is (= :unset @captured)
+            "the download fx does not fire when nothing to export")
+        (is (= :failed @(rf/subscribe [:rf.causa/cascade-export-status])))))))
+
+(deftest cascade-export-status-transitions
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (is (= :idle @(rf/subscribe [:rf.causa/cascade-export-status]))
+        "default status is :idle")
+    (rf/dispatch-sync [:rf.causa/cascade-export-status :copied])
+    (is (= :copied @(rf/subscribe [:rf.causa/cascade-export-status])))
+    (rf/dispatch-sync [:rf.causa/cascade-export-status :downloaded])
+    (is (= :downloaded @(rf/subscribe [:rf.causa/cascade-export-status])))
+    (rf/dispatch-sync [:rf.causa/cascade-export-status :idle])
+    (is (= :idle @(rf/subscribe [:rf.causa/cascade-export-status])))))
+
+(deftest cascade-export-row-renders-in-share-modal
+  (testing "the modal body renders the per-cascade export row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/share-modal-open]))
+    (rf/with-frame :rf/causa
+      (let [tree (share-modal/Modal)
+            row  (find-by-testid tree "rf-causa-share-modal-export-cascade-row")
+            copy (find-by-testid tree "rf-causa-share-modal-export-cascade-copy")
+            dl   (find-by-testid tree "rf-causa-share-modal-export-cascade-download")]
+        (is (some? row)
+            "export row mounts inside the share dialog")
+        (is (some? copy)
+            "the cascade-copy button is in the tree")
+        (is (some? dl)
+            "the cascade-download button is in the tree")
+        (is (true? (:disabled (second copy)))
+            "the copy button is disabled when no cascade is available")
+        (is (true? (:disabled (second dl)))
+            "the download button is disabled when no cascade is available")))))


### PR DESCRIPTION
## Summary

- v1.1 exploration from the Lock 4 pressure-test followup. Lock 4 holds at the whole-session level (no full session-state export); per-cascade export is the narrower share unit that survives the round-trip: one cascade, its db-before/after diff, its raw trace events.
- New ns `day8.re-frame2-causa.export.cascade` (CLJC, JVM-runnable, pure-data) projects a `:rf.causa/cascades`-shaped record + the matching epoch into an EDN-serialisable map: `:event` · `:coeffects` · `:effects` · `:subs` · `:renders` · `:other` · `:timing` · `:app-db {:before :after :diff}` · `:trace-events` · `:issues`.
- Share modal grows a second action row — **Copy cascade EDN** + **Download .edn** — alongside the existing URL share buttons. Both short-circuit (disabled + grey) when no cascade is focused.
- Schema version slot (`:rf.causa.export/version 1`) so downstream tools can detect additive bumps.
- VDOM and `:sensitive?` data are intentionally absent — Spec 009 §Privacy already strips sensitive events at ingest; React render trees are non-portable across substrate versions (Lock 4 holds at that level).

## Test plan

- [x] `npm run test:cljs` — 3849 tests, 11196 assertions, 0 failures (registry snapshot updated to cover the 3 new events / 4 new subs / 1 new fx; share modal smoke proves the export row + disabled buttons mount).
- [x] `npm run test:bundle-isolation` — counter / counter-uix / counter-helix all green.
- [x] `npm run test:reagent-slim:bundle-isolation` — 3 contracts passed.
- [x] `mkdocs build --strict` — exit 0.
- [x] JVM unit tests — 23 deftests in `export.cascade-cljs-test` cover schema envelope, domino projection, coeffects hoist, timing, app-db diff, issues hoist, EDN round-trip, filename sanitisation.

Closes rf2-0us27.