### PR TITLE
feat(causa): View hierarchy fallback — data-attribute tagging per substrate adapter (rf2-01il5)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_view_id_attr_cljs_test.cljs
@@ -1,0 +1,97 @@
+(ns re-frame.adapter.helix-view-id-attr-cljs-test
+  "Per Spec 006 §View tagging contract (rf2-01il5): the Helix adapter's
+  wrap-view MUST inject `data-rf-view=\"<id>\"` on the rendered root
+  React element ALONGSIDE `data-rf2-source-coord`. The injection rides
+  the same React.cloneElement call, the same `interop/debug-enabled?`
+  gate, and the same exemption for non-DOM roots.
+
+  This file is the Helix-side counterpart to
+  `re-frame.view-id-attr-cljs-test` (Reagent path) and
+  `re-frame.adapter.uix-view-id-attr-cljs-test` (UIx path)."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter helix-adapter/adapter}))
+
+(defn- react-element-view-attr
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf-view")))
+
+(defn- react-element-source-coord
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf2-source-coord")))
+
+;; ---- DOM-tag root: both attrs injected ------------------------------------
+
+(deftest reg-view-tags-dom-root-with-data-rf-view-helix
+  (testing "Per rf2-01il5: a programmatic reg-view* under the Helix adapter
+            routes the render-fn through (adapter/wrap-view ...) so the
+            rendered React element carries BOTH data-rf-view AND
+            data-rf2-source-coord on the root element."
+    (let [user-fn (fn []
+                    (React/createElement "span" #js {} "hi"))]
+      (rf/reg-view* :rf.helix-view-id-test/dom-root user-fn)
+      (let [render (rf/view :rf.helix-view-id-test/dom-root)
+            out    (render)]
+        (is (some? out))
+        (is (= "span" (.-type out)))
+        (let [view  (react-element-view-attr out)
+              coord (react-element-source-coord out)]
+          (is (string? view))
+          (is (= ":rf.helix-view-id-test/dom-root" view))
+          (is (string? coord)))))))
+
+;; ---- Fragment exemption ---------------------------------------------------
+
+(deftest reg-view-fragment-root-is-exempt-for-view-id-helix
+  (testing "Fragment root is exempt — no attribute lands on Fragment props."
+    (let [Frag    (.-Fragment React)
+          user-fn (fn []
+                    (React/createElement Frag nil
+                                         (React/createElement "p" nil "a")
+                                         (React/createElement "p" nil "b")))]
+      (rf/reg-view* :rf.helix-view-id-test/fragment-root user-fn)
+      (let [render (rf/view :rf.helix-view-id-test/fragment-root)
+            out    (render)]
+        (is (some? out))
+        (is (identical? Frag (.-type out)))
+        (is (nil? (react-element-view-attr out)))
+        (is (nil? (react-element-source-coord out)))))))
+
+;; ---- user-supplied attr wins ----------------------------------------------
+
+(deftest reg-view-preserves-user-supplied-view-id-helix
+  (testing "User-supplied data-rf-view survives the wrap-view pass."
+    (let [user-attr "stamped:by-user"
+          user-fn   (fn []
+                      (React/createElement "div"
+                        #js {"data-rf-view" user-attr}
+                        "hi"))]
+      (rf/reg-view* :rf.helix-view-id-test/user-attr-root user-fn)
+      (let [render (rf/view :rf.helix-view-id-test/user-attr-root)
+            out    (render)]
+        (is (some? out))
+        (is (= user-attr (react-element-view-attr out)))))))
+
+;; ---- wrap-view direct exercise --------------------------------------------
+
+(deftest wrap-view-coexists-with-data-rf-view-helix
+  (testing "wrap-view returns a fn; calling it on a real React element
+            yields output carrying data-rf-view alongside data-rf2-source-coord"
+    (let [out-from-fn (atom nil)
+          wrapped     (helix-adapter/wrap-view :rf.helix-view-id-test/sample
+                                               {:line 42 :column 7}
+                                               (fn []
+                                                 (reset! out-from-fn :ran)
+                                                 (React/createElement "div" #js {} "x")))]
+      (is (fn? wrapped))
+      (let [out (wrapped)]
+        (is (= :ran @out-from-fn))
+        (is (= ":rf.helix-view-id-test/sample" (react-element-view-attr out)))))))

--- a/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_id_attr_cljs_test.cljs
@@ -1,0 +1,185 @@
+(ns re-frame.view-id-attr-cljs-test
+  "Per Spec 006 §View tagging contract (rf2-01il5): when
+  `interop/debug-enabled?` is true, the Reagent substrate adapter MUST
+  also inject `data-rf-view=\"<id>\"` on the rendered root DOM element
+  of every registered view — ALONGSIDE `data-rf2-source-coord`. The
+  view-id attribute is the FALLBACK data source for the runtime
+  view-hierarchy walker when the Fiber-walker primary path (rf2-mxkq7)
+  is unavailable.
+
+  Coverage (mirrors `source_coord_dom_cljs_test.cljs` shape):
+
+    - DOM-keyword root with no attrs map: the wrapper splices an attrs
+      map carrying BOTH data-rf2-source-coord AND data-rf-view.
+    - DOM-keyword root WITH an existing attrs map: both attributes are
+      merged in alongside the user's attrs.
+    - User-supplied data-rf-view wins (don't overwrite).
+    - Form-2 (render-fn returns a fn): inner-fn output gets BOTH attrs.
+    - React Fragment root: exempt; no attribute injected; one-shot
+      warning emitted (same exemption as source-coord).
+    - Format: the attribute value is `(str id)` — i.e. `\":ns/sym\"`
+      for a namespaced keyword id.
+
+  Production elision (interop/debug-enabled? = false at build time) is
+  verified separately by the elision-probe build via the
+  `data-rf-view` sentinel registered in `scripts/check-elision.cjs`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- root-view-attr
+  "Pull the :data-rf-view value from the root attrs map of a hiccup
+  vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf-view (second hiccup))))
+
+(defn- root-coord-attr
+  "Pull the :data-rf2-source-coord value from the root attrs map of a
+  hiccup vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf2-source-coord (second hiccup))))
+
+;; ---- DOM-keyword root, no existing attrs map ------------------------------
+
+(deftest tags-dom-root-without-attrs
+  (testing "a reg-view'd component with [:tag children…] gets BOTH
+            :data-rf2-source-coord AND :data-rf-view spliced in"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/no-attrs} no-attrs-view []
+      [:span "hi"])
+    (let [render (rf/view :rf.view-id-test/no-attrs)
+          out    (render)
+          view   (root-view-attr out)
+          coord  (root-coord-attr out)]
+      (is (vector? out))
+      (is (= :span (first out)) "root tag preserved")
+      (is (string? view) ":data-rf-view present alongside :data-rf2-source-coord")
+      (is (string? coord) ":data-rf2-source-coord present (parity)")
+      (is (= ":rf.view-id-test/no-attrs" view)
+          "view attribute value is (str id) — leading-colon preserved"))))
+
+;; ---- DOM-keyword root with attrs map --------------------------------------
+
+(deftest tags-dom-root-with-existing-attrs
+  (testing "a reg-view'd component with [:tag {:class …} children…] has
+            :data-rf-view merged into the existing attrs map alongside
+            user attrs (without disturbing them)"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/with-attrs} with-attrs-view []
+      [:div {:class "card" :id "x"} "body"])
+    (let [render (rf/view :rf.view-id-test/with-attrs)
+          out    (render)
+          attrs  (second out)]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (is (map? attrs))
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (= "x"    (:id    attrs)) "user :id preserved")
+      (is (= ":rf.view-id-test/with-attrs" (:data-rf-view attrs))
+          ":data-rf-view merged in alongside user attrs")
+      (is (string? (:data-rf2-source-coord attrs))
+          ":data-rf2-source-coord still merged in (parity)"))))
+
+;; ---- user-supplied data-rf-view wins --------------------------------------
+
+(deftest user-supplied-data-rf-view-wins
+  (testing "a render-fn that already set :data-rf-view is not overwritten
+            — composability with hand-stamped tools (e.g. for tests that
+            inject a synthetic view-id)"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/user-stamped} user-stamped-view []
+      [:p {:data-rf-view "stamped:by-user"} "ok"])
+    (let [render (rf/view :rf.view-id-test/user-stamped)
+          out    (render)]
+      (is (= "stamped:by-user" (:data-rf-view (second out)))
+          "user-supplied attribute survives the wrapper's merge"))))
+
+;; ---- Form-2: render-fn returns a fn --------------------------------------
+
+(deftest tags-form-2-inner-output
+  (testing "Form-2 render-fns return a fn; the wrapper recurses on the
+            inner fn's output so :data-rf-view lands on the eventual
+            rendered DOM root, not the outer fn"
+    (rf/reg-view* :rf.view-id-test/form-2
+      (fn []
+        (fn inner-render []
+          [:section.f2 "form-2 body"])))
+    (let [wrapper (rf/view :rf.view-id-test/form-2)
+          out     (wrapper)]
+      (is (fn? out) "outer wrapper returns a fn (Form-2 shape preserved)")
+      (let [inner-out (out)]
+        (is (vector? inner-out) "inner fn returns hiccup")
+        (is (= :section.f2 (first inner-out)))
+        (is (= ":rf.view-id-test/form-2" (root-view-attr inner-out))
+            ":data-rf-view landed on the inner output's root")))))
+
+;; ---- React Fragment / non-DOM root: skip ----------------------------------
+
+(deftest fragment-root-is-exempt-for-view-id
+  (testing "a render-fn that returns a React Fragment :<> at the root is
+            exempt for :data-rf-view (same exemption as source-coord);
+            the walker falls back to the Fiber-walker primary path for
+            fragments per Spec 006 §View tagging contract §Documented
+            edge cases"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/fragment} fragment-view []
+      [:<> [:p "a"] [:p "b"]])
+    (let [render (rf/view :rf.view-id-test/fragment)
+          out    (render)]
+      (is (= :<> (first out)) "fragment marker preserved")
+      (is (not (and (map? (second out))
+                    (contains? (second out) :data-rf-view)))
+          "no :data-rf-view on fragment root"))))
+
+(deftest interop-react-component-root-is-exempt-for-view-id
+  (testing "a render-fn whose root is a React-component head (`[:> Cmp …]`)
+            is exempt for :data-rf-view — pair tools fall back per the
+            documented edge cases"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/interop-root} interop-view []
+      [:> "div" {} "body"])
+    (let [render (rf/view :rf.view-id-test/interop-root)
+          out    (render)]
+      (is (= :> (first out)))
+      (is (not (contains? (second out) :data-rf-view))
+          "no :data-rf-view merged into the interop props map"))))
+
+;; ---- attribute format -----------------------------------------------------
+
+(deftest attribute-format-is-str-id
+  (testing "the :data-rf-view value is exactly (str id) — preserving the
+            leading colon so a walker can disambiguate keyword ids from
+            raw strings"
+    (rf/reg-view ^{:rf/id :rf.view-id-test/format-check} format-check-view []
+      [:i "x"])
+    (let [out  ((rf/view :rf.view-id-test/format-check))
+          attr (root-view-attr out)]
+      (is (string? attr))
+      (is (= ":rf.view-id-test/format-check" attr)
+          "format is (str :ns/sym) — leading-colon preserved")
+      ;; A consumer reads back via (keyword (subs s 1)).
+      (is (= :rf.view-id-test/format-check
+             (keyword (subs attr 1)))
+          "walker round-trips ':<ns>/<sym>' → keyword cleanly"))))
+
+;; ---- id derived from call-site symbol (no override) ----------------------
+
+(deftest tagging-uses-auto-derived-id
+  (testing "without an :rf/id override, the auto-derived id (from
+            (keyword (str *ns*) (str sym))) drives the :data-rf-view value"
+    (rf/reg-view auto-view []
+      [:em "hi"])
+    (let [render (rf/view :re-frame.view-id-attr-cljs-test/auto-view)
+          out    (render)
+          attr   (root-view-attr out)]
+      (is (string? attr))
+      (is (= ":re-frame.view-id-attr-cljs-test/auto-view" attr)
+          "auto-derived id drives :data-rf-view via (str id)"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_view_id_attr_cljs_test.cljs
@@ -1,0 +1,112 @@
+(ns re-frame.adapter.uix-view-id-attr-cljs-test
+  "Per Spec 006 §View tagging contract (rf2-01il5): the UIx adapter's
+  wrap-view MUST inject `data-rf-view=\"<id>\"` on the rendered root
+  React element ALONGSIDE `data-rf2-source-coord`. The injection rides
+  the same React.cloneElement call, the same `interop/debug-enabled?`
+  gate, and the same exemption for non-DOM roots.
+
+  This file is the UIx-side counterpart to
+  `re-frame.view-id-attr-cljs-test` (Reagent path). Same shape; the
+  React-element output replaces the hiccup vector."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture-factory
+    {:adapter uix-adapter/adapter}))
+
+(defn- react-element-view-attr
+  "Pull `data-rf-view` off a React element's `.-props`, or nil."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf-view")))
+
+(defn- react-element-source-coord
+  "Pull `data-rf2-source-coord` off a React element's `.-props`, or nil."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf2-source-coord")))
+
+;; ---- DOM-tag root: both attrs injected ------------------------------------
+
+(deftest reg-view-tags-dom-root-with-data-rf-view-uix
+  (testing "Per rf2-01il5: a programmatic reg-view* under the UIx adapter
+            routes the render-fn through (adapter/wrap-view ...) so the
+            rendered React element carries BOTH data-rf-view AND
+            data-rf2-source-coord on the root element."
+    (let [user-fn (fn []
+                    (React/createElement "span" #js {} "hi"))]
+      (rf/reg-view* :rf.uix-view-id-test/dom-root user-fn)
+      (let [render (rf/view :rf.uix-view-id-test/dom-root)
+            out    (render)]
+        (is (some? out))
+        (is (= "span" (.-type out)) "root element type preserved")
+        (let [view  (react-element-view-attr out)
+              coord (react-element-source-coord out)]
+          (is (string? view)
+              "data-rf-view present on the root React element")
+          (is (= ":rf.uix-view-id-test/dom-root" view)
+              "view attribute value is (str id) — leading-colon preserved")
+          (is (string? coord)
+              "data-rf2-source-coord still present (parity contract)"))))))
+
+;; ---- Fragment exemption ---------------------------------------------------
+
+(deftest reg-view-fragment-root-is-exempt-for-view-id-uix
+  (testing "A React.Fragment root is exempt — cloneElement is skipped,
+            so neither attribute lands on the props of the Fragment."
+    (let [Frag    (.-Fragment React)
+          user-fn (fn []
+                    (React/createElement Frag nil
+                                         (React/createElement "p" nil "a")
+                                         (React/createElement "p" nil "b")))]
+      (rf/reg-view* :rf.uix-view-id-test/fragment-root user-fn)
+      (let [render (rf/view :rf.uix-view-id-test/fragment-root)
+            out    (render)]
+        (is (some? out))
+        (is (identical? Frag (.-type out)))
+        (is (nil? (react-element-view-attr out))
+            "no data-rf-view on Fragment root (exempt; walker falls back)")
+        (is (nil? (react-element-source-coord out))
+            "no data-rf2-source-coord on Fragment root (parity)")))))
+
+;; ---- user-supplied attr wins ----------------------------------------------
+
+(deftest reg-view-preserves-user-supplied-view-id-uix
+  (testing "When the user component's root element already carries
+            `data-rf-view`, the wrapper passes it through unchanged —
+            no cloneElement clobber. Guards the existing-attr
+            short-circuit in `inject-source-coord-attr`."
+    (let [user-attr "stamped:by-user"
+          user-fn   (fn []
+                      (React/createElement "div"
+                        #js {"data-rf-view" user-attr}
+                        "hi"))]
+      (rf/reg-view* :rf.uix-view-id-test/user-attr-root user-fn)
+      (let [render (rf/view :rf.uix-view-id-test/user-attr-root)
+            out    (render)]
+        (is (some? out))
+        (is (= user-attr (react-element-view-attr out))
+            "user-supplied data-rf-view survives the wrap-view pass")))))
+
+;; ---- format helper --------------------------------------------------------
+
+(deftest wrap-view-coexists-with-data-rf-view-uix
+  (testing "wrap-view returns a fn; calling it on a real React element
+            yields output carrying data-rf-view alongside data-rf2-source-coord"
+    (let [out-from-fn (atom nil)
+          wrapped     (uix-adapter/wrap-view :rf.uix-view-id-test/sample
+                                             {:line 42 :column 7}
+                                             (fn []
+                                               (reset! out-from-fn :ran)
+                                               (React/createElement "div" #js {} "x")))]
+      (is (fn? wrapped))
+      (let [out (wrapped)]
+        (is (= :ran @out-from-fn))
+        (is (some? out))
+        (let [view (react-element-view-attr out)]
+          (is (= ":rf.uix-view-id-test/sample" view)
+              "wrap-view's React.cloneElement injected data-rf-view"))))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -563,6 +563,16 @@
          ":"
          (if col (str col) "?"))))
 
+(defn format-view-id
+  "Render the registry id keyword as the `:data-rf-view` attribute
+  value. Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The
+  walker reads it back via `(keyword (subs s 1))` when the leading `:`
+  is present. Per Spec 006 §View tagging contract (rf2-01il5).
+  Mirrors re-frame.views.source-coord-annotation/format-view-id so
+  the attribute value is identical across substrates."
+  [id]
+  (str id))
+
 (defn make-warn-once-cache
   "Return an `(atom #{})` for tracking per-id warn-once emission. Each
   adapter owns its own cache so multiple adapters can coexist in test
@@ -608,18 +618,34 @@
 
 (defn- inject-source-coord-attr
   "Wrap `out` (the user component's React element output) with a
-  cloneElement call that adds `:data-rf2-source-coord`. Non-element
-  outputs (nil, fragment, function-component head) emit a one-shot
-  warning per id and pass through unchanged. Per Spec 006 §Source-coord
-  annotation."
-  [warn-fn id coord-attr out]
+  cloneElement call that adds both `data-rf2-source-coord` (Spec 006
+  §Source-coord annotation, rf2-z7f7) and `data-rf-view` (Spec 006
+  §View tagging contract, rf2-01il5). Non-element outputs (nil,
+  fragment, function-component head) emit a one-shot warning per id
+  and pass through unchanged — pair tools fall back to `:rf/id` for
+  source-coord; the view-walker falls back to the Fiber-walker primary
+  path for hierarchy capture.
+
+  CRITICAL: cloneElement returns a new element with the SAME `type` and
+  `key` slots — it does NOT wrap the original. Wrapping with a
+  synthetic host element (the `[:div]` shape rejected by Spec 006
+  §View tagging contract) would break flexbox / CSS Grid / table
+  layouts / `:nth-child` selectors / positioning ancestors / stacking
+  contexts / CSS containment."
+  [warn-fn id coord-attr view-attr out]
   (cond
     (dom-element? out)
-    (let [props    (.-props out)
-          existing (when props (aget props "data-rf2-source-coord"))]
-      (if existing
+    (let [props             (.-props out)
+          existing-coord    (when props (aget props "data-rf2-source-coord"))
+          existing-view     (when props (aget props "data-rf-view"))
+          patch             #js {}]
+      (when-not existing-coord
+        (aset patch "data-rf2-source-coord" coord-attr))
+      (when-not existing-view
+        (aset patch "data-rf-view" view-attr))
+      (if (and existing-coord existing-view)
         out
-        (React/cloneElement out #js {"data-rf2-source-coord" coord-attr})))
+        (React/cloneElement out patch)))
 
     :else
     (do
@@ -632,16 +658,19 @@
   `warn-fn` (typically built via `make-warn-non-dom-root-fn`). The
   returned fn has the standard 3-arg shape `(id metadata user-fn) ->
   wrapped-user-fn` and produces a function component that injects
-  `data-rf2-source-coord` on the rendered root DOM element when
-  `interop/debug-enabled?` is true. Production builds elide via
-  `interop/debug-enabled?` per Spec 009 §Production builds."
+  both `data-rf2-source-coord` (Spec 006 §Source-coord annotation) and
+  `data-rf-view` (Spec 006 §View tagging contract) on the rendered
+  root DOM element when `interop/debug-enabled?` is true. Production
+  builds elide via `interop/debug-enabled?` per Spec 009 §Production
+  builds."
   [warn-fn]
   (fn wrap-view [id metadata user-fn]
     (if interop/debug-enabled?
-      (let [coord-attr (format-source-coord id metadata)]
+      (let [coord-attr (format-source-coord id metadata)
+            view-attr  (format-view-id id)]
         (fn wrapped-user-fn [& args]
           (let [out (apply user-fn args)]
-            (inject-source-coord-attr warn-fn id coord-attr out))))
+            (inject-source-coord-attr warn-fn id coord-attr view-attr out))))
       user-fn)))
 
 (defn install-clear-warn-once-step!

--- a/implementation/core/src/re_frame/views/source_coord_annotation.cljs
+++ b/implementation/core/src/re_frame/views/source_coord_annotation.cljs
@@ -1,8 +1,8 @@
 (ns re-frame.views.source-coord-annotation
-  "Source-coord DOM annotation walk for the Reagent-side views ns. Per
-  rf2-lh7p — split out of `re-frame.views` so the views file stays
-  focused on registration orchestration. Re-frame.views re-exports the
-  `format-source-coord` helper so the existing test that references
+  "Source-coord + view-id DOM annotation walk for the Reagent-side views
+  ns. Per rf2-lh7p — split out of `re-frame.views` so the views file
+  stays focused on registration orchestration. Re-frame.views re-exports
+  the `format-source-coord` helper so the existing test that references
   `#'re-frame.views/format-source-coord` continues to resolve.
 
   Per Spec 006 §Source-coord annotation (rf2-z7f7 / rf2-z9n1) the
@@ -13,24 +13,35 @@
   jump-to-source) map a clicked DOM node back to the reg-view call
   site.
 
+  Per Spec 006 §View tagging contract (rf2-01il5) the same wrapper also
+  stamps `data-rf-view=\"<ns>/<sym>\"` on the same root element — the
+  fallback for the runtime view-hierarchy walker when the Fiber-reading
+  primary path (Spec View-Hierarchy-Capture, rf2-mxkq7) is unavailable.
+  Both attributes ride the same wrapper, the same hiccup walk, and the
+  same `interop/debug-enabled?` elision gate.
+
   Contract details:
 
     - The id is a registry keyword `<ns>/<sym>`. Combined with the
       captured `:line` / `:column` (from `(meta &form)` at reg-view
-      macro-expansion time), the attribute value is
+      macro-expansion time), the source-coord attribute value is
       `<ns>:<sym>:<line>:<col>`. `<col>` is `?` when the column was
-      not captured (the column-key is optional per Spec 001).
+      not captured (the column-key is optional per Spec 001). The
+      view-id attribute value is `(str id)` — i.e. `:rf.foo/bar` for a
+      namespaced keyword id; the walker reads it back via
+      `(keyword (subs s 1))`.
 
     - The wrapper inspects the user's render-fn output:
-        * `[:tag {...attrs} & children]` → merge :data-rf2-source-coord
-          into attrs.
-        * `[:tag & children]` (no attrs map)            → splice an attrs
-          map in.
+        * `[:tag {...attrs} & children]` → merge both attrs into the
+          existing map.
+        * `[:tag & children]` (no attrs map) → splice an attrs map in
+          carrying both attributes.
         * `[fn-or-component-or-fragment …]` (head is a fn / class / `:>`
           / React-fragment marker) → SKIP and emit a one-shot warning
           per id. Pair-tool consumers fall back to the registry's
-          `:rf/id` for these cases (per Spec 006 §Source-coord
-          annotation, documented Fragment exemption).
+          `:rf/id` for source-coord; the view-walker falls back to the
+          Fiber-walker primary path (or treats the view as invisible to
+          the hierarchy capture — documented edge case).
         * Form-2: when the render-fn returns a fn (`(fn [args] body)`),
           we recurse on the inner-fn's output the next time the wrapper
           is called — Reagent invokes the inner fn during the SAME
@@ -39,10 +50,20 @@
           is to wrap the returned fn so the inner output gets walked
           too.
 
+    - CRITICAL constraint (rf2-01il5 Comment 5): the wrapper MUST
+      mutate the existing first element's attribute map. NEVER wrap
+      with a synthetic `[:div]`. Wrapping breaks flexbox, CSS Grid,
+      table layouts, `:nth-child` selectors, positioning ancestors,
+      stacking contexts, and CSS containment. The wrap-with-div
+      approach is a non-starter.
+
     - Production elision: every annotation site sits inside
       `(when interop/debug-enabled? ...)` so the closure compiler
       constant-folds the entire branch under `:advanced` +
-      `goog.DEBUG=false`. Per Spec 009 §Production builds."
+      `goog.DEBUG=false`. Per Spec 009 §Production builds. Both
+      `data-rf2-source-coord` and `data-rf-view` literals are part of
+      the production-bundle elision sentinel set (see
+      `scripts/check-elision.cjs`)."
   (:require [re-frame.views.warn-once :as warn-once]))
 
 (defn format-source-coord
@@ -70,12 +91,27 @@
        (not= :<> head)
        (not= :> head)))
 
+(defn format-view-id
+  "Render the registry id keyword as the `:data-rf-view` attribute
+  value. Returns `(str id)` so `:rf.foo/bar` → `\":rf.foo/bar\"`. The
+  walker reads it back via `(keyword (subs s 1))` when the leading `:`
+  is present. Per Spec 006 §View tagging contract (rf2-01il5)."
+  [id]
+  (str id))
+
 (defn inject-source-coord-attr
-  "Walk the user's render-fn output and merge :data-rf2-source-coord
-  into the root element's attrs map. Called from inside the wrapper
-  (gated on interop/debug-enabled?). Returns the (possibly rewritten)
+  "Walk the user's render-fn output and merge both
+  `:data-rf2-source-coord` (Spec 006 §Source-coord annotation, rf2-z7f7)
+  and `:data-rf-view` (Spec 006 §View tagging contract, rf2-01il5) into
+  the root element's attrs map. Called from inside the wrapper (gated
+  on `interop/debug-enabled?`). Returns the (possibly rewritten)
   hiccup. Non-DOM roots are returned unchanged after a one-shot
   warning per Spec 006 §Source-coord annotation.
+
+  CRITICAL: this fn MUST mutate the existing first element's attrs.
+  NEVER wrap with a synthetic `[:div]` — wrapping breaks flexbox /
+  CSS Grid / table layouts / `:nth-child` selectors / positioning
+  ancestors / stacking contexts / CSS containment.
 
   Form-2: when `out` is a fn, return a fn that recurses on the inner
   output — Reagent's renderer will call our returned fn just like
@@ -90,20 +126,25 @@
 
     ;; Hiccup vector with a DOM-tag keyword head. Annotate the root.
     (and (vector? out) (dom-tag? (first out)))
-    (let [head     (first out)
-          maybe-attrs (second out)]
+    (let [head        (first out)
+          maybe-attrs (second out)
+          view-attr   (format-view-id id)]
       (if (map? maybe-attrs)
         ;; Existing attrs map — merge in (don't overwrite if user
-        ;; already set it for some reason).
-        (let [merged (if (contains? maybe-attrs :data-rf2-source-coord)
-                       maybe-attrs
-                       (assoc maybe-attrs :data-rf2-source-coord coord-attr))]
+        ;; already set either attribute for some reason).
+        (let [merged (cond-> maybe-attrs
+                       (not (contains? maybe-attrs :data-rf2-source-coord))
+                       (assoc :data-rf2-source-coord coord-attr)
+                       (not (contains? maybe-attrs :data-rf-view))
+                       (assoc :data-rf-view view-attr))]
           (into [head merged] (drop 2 out)))
         ;; No attrs map — splice one in between head and children.
-        (into [head {:data-rf2-source-coord coord-attr}] (rest out))))
+        (into [head {:data-rf2-source-coord coord-attr
+                     :data-rf-view          view-attr}] (rest out))))
 
     ;; Non-DOM root (fn-component head, fragment, lazy-seq, nil). Skip
-    ;; with a one-shot warning. Pair tools fall back to :rf/id.
+    ;; with a one-shot warning. Pair tools fall back to :rf/id;
+    ;; view-walker falls back to the Fiber-walker primary path.
     :else
     (do
       (when (vector? out)

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -254,6 +254,17 @@ const DEV_ONLY_SENTINELS = [
   // must NOT appear in :advanced + goog.DEBUG=false bundles.
   { source: 're-frame.views/reg-view* (data-rf2-source-coord injection)',
     sentinel: 'data-rf2-source-coord' },
+  // re-frame.views — view-id DOM annotation (Spec 006 §View tagging
+  // contract, rf2-01il5). The reg-view* wrapper ALSO merges
+  // `:data-rf-view` onto the rendered root DOM element when
+  // `interop/debug-enabled?` is true — the fallback path for runtime
+  // view-hierarchy capture when the Fiber-walker primary path
+  // (rf2-mxkq7) is unavailable. The injection rides the SAME gate as
+  // data-rf2-source-coord (no separate code path or elision branch);
+  // the literal "data-rf-view" string fragment must NOT appear in
+  // :advanced + goog.DEBUG=false bundles.
+  { source: 're-frame.views/reg-view* (data-rf-view injection)',
+    sentinel: 'data-rf-view' },
   // re-frame.core/reg-machine — per-element source-coord stamping
   // (Spec 005 §Source-coord stamping, rf2-8bp3). The reg-machine macro
   // emits an `(if interop/debug-enabled? (assoc spec :rf.machine/

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -328,6 +328,78 @@ The view-side annotation above is one half of the tool-pair source-mapping contr
 
 Both surfaces share the production-elision contract: the stamping branch is gated on `interop/debug-enabled?`, so under `:advanced` + `goog.DEBUG=false` the closure compiler folds it away. The `rf.machine/source-coords` keyword is part of the standard `scripts/check-elision.cjs` sentinel set (verified ABSENT in the production bundle, PRESENT in the control bundle).
 
+## View tagging contract (fallback; rf2-01il5)
+
+> **Status: fallback safety-net only.** The primary path for runtime view-hierarchy capture is the **Fiber-walker** documented in [View-Hierarchy-Capture.md](View-Hierarchy-Capture.md) (rf2-mxkq7). This section pins the per-adapter fallback path that activates only if Fiber-reading breaks on a future React-version regression, or if a non-React substrate is ever wired in. Both paths can coexist; the fallback adds a single attribute per registered view and costs ~zero in production (elision-gated).
+
+The same per-render wrapper that injects `data-rf2-source-coord` (§Source-coord annotation above) also injects `data-rf-view="<id>"` on the rendered root DOM element when `interop/debug-enabled?` is true. The two attributes ride the same wrapper, the same walk, and the same production-elision gate — there is no separate code path or separate elision contract.
+
+### Attribute value format
+
+```
+data-rf-view="<id>"
+```
+
+`<id>` is the registry id keyword stringified verbatim — `(str id)`. For a namespaced keyword id `:rf.foo/bar` the attribute value is `":rf.foo/bar"` (leading colon preserved). The walker reads it back via `(keyword (subs s 1))` when the leading `:` is present, falling back to the raw string for non-keyword ids.
+
+The committed public contract is `:rf/view-id-attr` (see [Spec-Schemas](Spec-Schemas.md)); the on-attribute representation matches the registry handler-id, not the call-site symbol — symmetric to how `data-rf2-source-coord` carries the registry id portion.
+
+### Injection rules
+
+The wrapper inspects the user render-fn's output and mutates the **first concrete element's existing attribute map** (the SAME element that carries `data-rf2-source-coord`). The injection rules:
+
+- `[:tag {…attrs} & children]` — merge `:data-rf-view` into the existing attrs map (alongside `:data-rf2-source-coord`).
+- `[:tag & children]` (no attrs map) — splice an attrs map in between head and children carrying both attributes.
+- `[fragment / interop-head / fn-component …]` — SKIP (see §Documented edge cases below).
+- React-element output (UIx, Helix): `React.cloneElement` with `{"data-rf-view": <id>}` on the same call that adds `data-rf2-source-coord`.
+- Form-2: when the render-fn returns a fn, the wrapper recurses on the inner fn's output (same machinery as the source-coord walk).
+
+### CRITICAL constraint: mutate, do not wrap
+
+> Adapters MUST mutate the existing first element's attribute map. Adapters MUST NOT wrap the rendered tree with a synthetic host element (e.g. `[:div {:data-rf-view …} <user-tree>]`).
+
+Wrapping is a non-starter — it breaks every layout idiom that depends on the DOM tree shape:
+
+- **Flexbox + CSS Grid** — `display: flex` / `display: grid` parents lay out their *direct* children. A synthetic wrapper would make every reg-view'd component a single grid/flex item regardless of what its render-fn produced.
+- **Table layouts** — `<table>` / `<tr>` / `<td>` is a fixed DOM contract; an interposed `<div>` between `<table>` and `<tr>` is invalid HTML and breaks the browser's table-anonymous-box generation.
+- **`:nth-child` and sibling selectors** — `:nth-child(2n+1)`, `+ sibling`, `~ general-sibling` all count DOM positions. A wrapper would shift every child's index by one and break striping / first-row callouts / form-row separators.
+- **Positioning ancestors** — `position: absolute` looks for the nearest `position: !static` ancestor. A wrapper that inadvertently inherits the user's `position: relative` would silently capture every descendant's absolute positioning.
+- **Stacking contexts** — `z-index` resolves against the nearest stacking-context ancestor; a wrapper with `opacity < 1` or `transform` would create a new stacking context the user didn't author.
+- **CSS containment** — `contain: layout / paint` boundaries depend on element identity; an interposed wrapper would either shift the boundary or invalidate the optimisation.
+
+The mutate-existing-attrs strategy avoids every one of these failure modes — the rendered DOM tree is structurally identical to the un-instrumented version, modulo two extra attributes on the root element of each registered view.
+
+### Documented edge cases (fidelity gaps)
+
+The fallback is a **lossy approximation** of the Fiber-walker's hierarchy capture. These shapes are exempt from `data-rf-view` annotation (the wrapper SKIPs with a one-shot warning per id, same as the source-coord exemption):
+
+1. **React Fragment root (`:<>` / `<Fragment>`)** — a fragment has no DOM element to annotate. The fallback walker treats the component as invisible to hierarchy capture (its children become orphans of the next-up tagged ancestor). The Fiber-walker primary path handles fragments correctly via the `child` slot.
+
+2. **Nil / conditional root (`(when cond …)` returning nil)** — when the render-fn returns nil, no DOM element exists. Same fidelity gap as fragments: the view is invisible on the render that returned nil; subsequent re-renders that produce a DOM element are tagged correctly.
+
+3. **Component-returning-component head (`[other-view …]`)** — when a reg-view'd component's root is another reg-view'd component, the wrapper SKIPs (the head is a fn, not a DOM-tag keyword). The inner component will tag *its own* root; the outer view is invisible to the hierarchy capture and its children become orphans of the inner tagged element. Pair tools can chase the wrapping via `(rf/handler-meta :view id)`.
+
+4. **Portals (`React.createPortal`)** — portals teleport the rendered subtree to a different DOM location. The walker's DOM-containment inference will associate portal children with the portal target's ancestor chain, not with the portal-rendering component's ancestor chain. The Fiber-walker primary path handles portals correctly because Fiber `return` pointers follow the logical parent, not the DOM parent.
+
+5. **`display: none` subtrees** — elements with `display: none` are present in the DOM tree (and so are walkable by `querySelectorAll`) but are not laid out. The walker reports them; consumers (Causa Views panel) may choose to filter them out. This is a known fidelity gap, not a correctness bug.
+
+6. **Interop component head (`:>` in Reagent)** — `[:> Cmp {…props}]` hands the props map straight to React's component, which may not be a DOM-tag (and certainly should not have framework-derived strings inserted into its props). The wrapper SKIPs and emits the same warning as the source-coord exemption.
+
+### Production elision (mandatory)
+
+`data-rf-view` MUST elide under `:advanced` + `goog.DEBUG=false` via the SAME `(when interop/debug-enabled? …)` gate that elides `data-rf2-source-coord`. The literal `data-rf-view` string fragment is part of the standard `scripts/check-elision.cjs` sentinel set.
+
+### Walker contract (fallback path)
+
+When the fallback is consuming the tagged DOM, the walker:
+
+1. Calls `document.querySelectorAll('[data-rf-view]')` to enumerate every tagged element in document order.
+2. For each tagged element, reads `data-rf-view` and `data-rf2-source-coord` off the DOM node.
+3. Infers parent-child by DOM containment: element B is a child of element A iff A is the nearest tagged ancestor of B (via `.contains()` walks).
+4. Produces the same output shape as the Fiber-walker (per [View-Hierarchy-Capture.md §Output shape](View-Hierarchy-Capture.md#output-shape)) so consumer code is path-agnostic.
+
+The walker implementation lives at `tools/causa/src/day8/re_frame2_causa/views/view_walker.cljs` (alongside the Fiber-walker per the spec's Ownership table). Both walkers are bundle-isolated from production builds.
+
 ## Subscription cache — contract and operational semantics
 
 A subscription's value lives in the per-frame **sub-cache**. This section defines the contract: the cache shape, the lookup algorithm, the invalidation algorithm, the ref-counting and disposal rules, the layer-1/2/3 sub semantics, and the lifetime contract that ties them together. The contract is host-agnostic; the [Reagent reference adapter §Sub-cache wiring](#sub-cache-wiring-reagent-realisation) shows the CLJS realisation.

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -427,6 +427,29 @@ Consumers parse the four segments pragmatically (split on `:` from the right twi
 
 The string format is committed as a public contract (rf2-q7r0): pair-shaped tools, conformance harnesses, and CDP-driven test runners all parse it directly. Future extensions are additive — additional trailing segments may appear; consumers MUST handle the 4-segment shape and tolerate (ignore) trailing segments they do not recognise.
 
+### `:rf/view-id-attr`
+
+> **Layer:** Public
+> **Owner:** [006-ReactiveSubstrate §View tagging contract](006-ReactiveSubstrate.md#view-tagging-contract-fallback-rf2-01il5)
+> **Status:** v1-required (fallback path; primary path is the Fiber walker per [View-Hierarchy-Capture.md](View-Hierarchy-Capture.md))
+
+The DOM-attribute string contract emitted by Reagent / UIx / Helix adapters as the value of `data-rf-view` on rendered view roots (per [Spec 006 §View tagging contract](006-ReactiveSubstrate.md#view-tagging-contract-fallback-rf2-01il5)). The stringified registry id keyword:
+
+```
+<id-as-str>          ;; e.g. ":my.app/header" for the keyword :my.app/header
+```
+
+For a namespaced keyword id, the attribute value is `(str id)` — the leading `:` is preserved so the walker can distinguish `(keyword (subs s 1))` from a non-keyword id. For a non-keyword id (unusual but legal at the registrar layer) the attribute carries the raw string repr.
+
+```clojure
+(def ViewIdAttr
+  [:re #"^:?[^/]+(?:/.+)?$"])                                                  ;; permissive; consumers prefer (keyword (subs s 1)) when leading-colon
+```
+
+Consumers (the fallback `view-walker`) read the attribute and call `(keyword (subs s 1))` when the string starts with `:`; otherwise the raw string is used as the id.
+
+The view-id attribute pairs with `data-rf2-source-coord` (`:rf/source-coord-attr` above) — both attributes land on the same root element of every registered view, ride the same `interop/debug-enabled?` elision gate, and elide together under `:advanced` + `goog.DEBUG=false`. Per Spec 006 §View tagging contract: `data-rf-view` is the FALLBACK; the primary path for runtime view-hierarchy capture is the Fiber walker.
+
 ### `:rf/effect-map`
 
 > **Layer:** Runtime

--- a/spec/View-Hierarchy-Capture.md
+++ b/spec/View-Hierarchy-Capture.md
@@ -47,7 +47,7 @@ The walker is also dev-only by classpath: Causa's preload is `:devtools/preloads
 1. **Ship a fix** — update the walker to the new Fiber slot names / shape. This is the expected path when React renames a slot but keeps the structural model.
 2. **Fall back to data-attribute tagging** — switch the consuming tool to the fallback in bead `rf2-01il5`. Each `reg-view` mutates its first element's attribute map to include `data-rf-view="<name>"`; the walker queries `document.querySelectorAll('[data-rf-view]')` and infers parent ⊃ children by DOM containment. This is the React-version-independent escape hatch.
 
-The fallback is documented in `rf2-01il5` and in the findings doc §12.1 — it is the second-best option *only* (fragments invisible, portals teleport-broken, requires per-adapter cost). The default ship is the Fiber walker.
+The fallback is **shipped and dormant** — the tagging is wired into every adapter's render-time wrapper (Reagent via the inline hiccup walk, UIx + Helix via the spine's React.cloneElement wrapper); the contract pins the attribute format and the documented edge cases at [Spec 006 §View tagging contract](006-ReactiveSubstrate.md#view-tagging-contract-fallback-rf2-01il5). It is the second-best option (fragments invisible, portals teleport-broken, requires per-adapter wrap-view cost in dev builds) and consumers should default to the Fiber walker.
 
 ## View-id tagging convention
 

--- a/tools/causa/src/day8/re_frame2_causa/views/view_walker.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/view_walker.cljs
@@ -1,0 +1,205 @@
+(ns day8.re-frame2-causa.views.view-walker
+  "Fallback runtime view-hierarchy walker — `data-rf-view` attribute path
+  (rf2-01il5).
+
+  ## Status: FALLBACK SAFETY NET only
+
+  The primary path for runtime view-hierarchy capture is the Fiber-walker
+  (rf2-mxkq7) — see [View-Hierarchy-Capture.md](../../../../../spec/View-Hierarchy-Capture.md).
+  This namespace ships the **data-attribute fallback**:
+
+      - Each re-frame2 adapter (Reagent / UIx / Helix) tags the rendered
+        root DOM element of every registered view with
+        `data-rf-view=\"<id>\"`. The tagging is wired in at adapter
+        ns-load via the source-coord wrapper (Spec 006 §View tagging
+        contract).
+      - This walker queries `document.querySelectorAll('[data-rf-view]')`
+        and reconstructs parent ⊃ children purely from DOM containment.
+        No React internals; no Fiber slot reads; no version-coupling.
+
+  Activate this walker when:
+
+      1. A future React-version regression breaks the Fiber-walker.
+      2. A non-React substrate is ever wired in (none today — Reagent,
+         UIx, and Helix all mount through React, so the data-attribute
+         path is dormant under the canonical install).
+
+  ## Fidelity gaps (documented edge cases)
+
+  The fallback is a **lossy approximation** of the Fiber-walker. Per
+  Spec 006 §View tagging contract §Documented edge cases:
+
+      - Fragment root (`:<>`) — invisible to the walker (no DOM
+        element to tag); its children become orphans of the next-up
+        tagged ancestor.
+      - Nil / conditional root — invisible on the render that returned
+        nil; subsequent re-renders that emit a DOM element are tagged.
+      - Component-returning-component head — outer view invisible; the
+        inner reg-view'd component tags its own root.
+      - Portals — DOM containment associates portal children with the
+        portal target, not the portal-rendering component.
+      - `display: none` subtrees — present in the walk; consumers may
+        filter them out.
+
+  ## Production DCE
+
+  This namespace lives under `tools/causa/`, which is bundle-isolated
+  from production bundles (per the bundle-isolation contract — see
+  `implementation/scripts/check-bundle-isolation.cjs`). Every public
+  fn in this file is also gated on `interop/debug-enabled?` as a
+  second line of defence against accidental requires from a non-dev
+  entry point — per Spec 006 §Production elision and Spec 009
+  §Production builds.
+
+  ## Output shape
+
+  The walker produces a depth-first vector of:
+
+      {:view-id   <keyword | string | nil>   ;; resolved from data-rf-view
+       :depth     <non-negative integer>     ;; 0 = root tagged element
+       :node-key  <integer>}                 ;; stable hash of the DOM node
+
+  In document order — mirrors the Fiber-walker's output shape per
+  [View-Hierarchy-Capture.md §Output shape](../../../../../spec/View-Hierarchy-Capture.md#output-shape)
+  so consumer code is path-agnostic. `:node-key` substitutes for the
+  Fiber-walker's `:fiber-key` — same role (stable React key for tree-row
+  rendering across re-walks)."
+  (:require [re-frame.interop :as interop]))
+
+;; ---- attribute parsing -----------------------------------------------------
+
+(defn parse-view-id
+  "Parse a `data-rf-view` attribute value back into the registry id.
+
+      \":rf.foo/bar\"  → :rf.foo/bar         ;; namespaced kw
+      \":bare\"        → :bare               ;; unqualified kw (legal at registrar)
+      \"raw-string\"   → \"raw-string\"      ;; non-kw id (unusual)
+
+  Per Spec 006 §View tagging contract §Attribute value format and
+  Spec-Schemas §`:rf/view-id-attr`."
+  [s]
+  (cond
+    (or (nil? s) (not (string? s)))
+    nil
+
+    ;; Leading colon → keyword. Splits on the first `/` to recover ns/name.
+    (and (pos? (count s)) (= ":" (subs s 0 1)))
+    (let [body (subs s 1)
+          slash (.indexOf body "/")]
+      (if (neg? slash)
+        (keyword body)
+        (keyword (subs body 0 slash) (subs body (inc slash)))))
+
+    :else
+    s))
+
+;; ---- DOM walk --------------------------------------------------------------
+;;
+;; Build the parent ⊃ children tree from DOM containment.
+;;
+;; Algorithm: collect every `[data-rf-view]` element in document order.
+;; For each tagged element, walk up its DOM `parentNode` chain looking
+;; for the nearest ancestor that is ALSO tagged — that ancestor is its
+;; logical parent. Elements with no tagged ancestor are roots (depth 0).
+;;
+;; `Element.contains` is documented across IE6+ and every modern engine
+;; (per MDN, baseline-2003) so the containment check is portable. The
+;; `parentNode` walk is O(depth) per tagged element; total O(N * D) for
+;; N tagged elements at depth D. In practice the tagged-element count is
+;; bounded by the registered-views count and D is the DOM depth — well
+;; under 1ms for the dashboards we ship.
+;;
+;; The walk also tolerates a tagged element with NO `data-rf-view`
+;; attribute on its DOM node — this can happen during a re-render where
+;; the adapter wrapper's annotation hasn't landed yet. Those elements
+;; are skipped (not rooted, not parented).
+
+(defn- node-key
+  "Stable integer key for a DOM node. We use `hash` on the underlying
+  JS object — `hash` is identity-stable for the JS object's lifetime,
+  so two consecutive walks of the same DOM tree produce the same
+  `:node-key` value per node. React consumes the key for tree-row
+  identity."
+  [node]
+  (hash node))
+
+(defn- nearest-tagged-ancestor
+  "Return the nearest ancestor of `node` that carries a `data-rf-view`
+  attribute, or nil if none. The walk excludes `node` itself."
+  [node]
+  (loop [n (.-parentNode node)]
+    (cond
+      (nil? n)                                  nil
+      (and (some? (.-getAttribute n))
+           (some? (.getAttribute n "data-rf-view"))) n
+      :else                                     (recur (.-parentNode n)))))
+
+(defn- compute-depth
+  "Depth = number of tagged ancestors. 0 for roots (no tagged
+  ancestor). Computed by chasing `nearest-tagged-ancestor`
+  iteratively — O(D) per node where D is the tagged-depth (typically
+  ≤ 10). The memoisation across one walk via the `depths` JS Map cuts
+  repeat work down each shared ancestor chain: if an ancestor is
+  already in the map, we add its cached depth + 1 and stop."
+  [node depths]
+  (loop [n     (nearest-tagged-ancestor node)
+         steps 0]
+    (cond
+      (nil? n)                  steps
+      (.has depths n)           (+ steps 1 (.get depths n))
+      :else                     (recur (nearest-tagged-ancestor n)
+                                       (inc steps)))))
+
+(defn walk!
+  "Walk the document for `[data-rf-view]`-tagged elements and return a
+  depth-first vector of `{:view-id … :depth … :node-key …}` maps in
+  document order. Per Spec 006 §View tagging contract §Walker
+  contract (fallback path).
+
+  Production-elision contract per Spec 009: the body is gated on
+  `interop/debug-enabled?` — under `:advanced` + `goog.DEBUG=false`
+  the entire walk DCEs and the fn returns nil. Bundle-isolation
+  (the `tools/causa/` artefact is forbidden from production bundles)
+  is the first line of defence; this gate is the second.
+
+  Accepts an optional `root` element — defaults to `js/document.body`.
+  Passing a sub-tree root scopes the walk to that subtree's contained
+  tagged elements."
+  ([] (walk! (when (exists? js/document) (.-body js/document))))
+  ([root]
+   (when (and interop/debug-enabled? (some? root))
+     (let [matched (.querySelectorAll root "[data-rf-view]")
+           n       (.-length matched)
+           ;; depths is a JS Map keyed by DOM node → integer depth.
+           ;; Built up as we walk so each node's depth derivation can
+           ;; reuse its ancestors' cached results. A JS Map matches
+           ;; identity-keyed-by-DOM-node lookup more naturally than a
+           ;; CLJS map and stays O(1) per read.
+           depths  (js/Map.)]
+       (loop [i   0
+              acc (transient [])]
+         (if (< i n)
+           (let [node    (aget matched i)
+                 attr    (.getAttribute node "data-rf-view")
+                 view-id (parse-view-id attr)
+                 depth   (compute-depth node depths)]
+             (.set depths node depth)
+             (recur (inc i)
+                    (conj! acc {:view-id  view-id
+                                :depth    depth
+                                :node-key (node-key node)})))
+           (persistent! acc)))))))
+
+;; ---- raw helper for tooling ------------------------------------------------
+
+(defn tagged-elements
+  "Return the JS NodeList of `[data-rf-view]`-tagged elements under
+  `root`. Test-facing — `walk!` already does this internally but
+  consumers (e.g. element-resolvers for click-to-source) need the
+  raw nodes too. Defaults to `js/document.body`.
+
+  Same `interop/debug-enabled?` gate as `walk!`."
+  ([] (tagged-elements (when (exists? js/document) (.-body js/document))))
+  ([root]
+   (when (and interop/debug-enabled? (some? root))
+     (.querySelectorAll root "[data-rf-view]"))))

--- a/tools/causa/test/day8/re_frame2_causa/views/view_walker_dom_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/view_walker_dom_cljs_test.cljs
@@ -1,0 +1,223 @@
+(ns day8.re-frame2-causa.views.view-walker-dom-cljs-test
+  "Per Spec 006 §View tagging contract (rf2-01il5): the fallback view-
+  hierarchy walker reads `[data-rf-view]`-tagged DOM elements and
+  reconstructs parent ⊃ children purely by DOM containment. These tests
+  build synthetic DOM trees (via `document.createElement`) and assert
+  the walker's output matches the documented contract.
+
+  ## Coverage
+
+    - parse-view-id: keyword id, plain string id, nil/non-string inputs.
+    - walk!: document-order enumeration; depth from nearest tagged
+      ancestor; multiple tagged siblings under one parent; tags inside
+      untagged scaffolding; deeply-nested chains.
+    - walk!: empty document returns empty vector.
+    - Documented edge cases (fidelity gaps):
+        * untagged element between tagged ancestor and descendant —
+          the descendant's depth follows the NEAREST TAGGED ancestor,
+          not the untagged scaffolding.
+        * sibling tagged elements at the same depth.
+
+  ## Test target
+
+  This file's filename ends in `_dom_cljs_test.cljs` so it runs under
+  the `:browser-test` build (which provides a real DOM) per
+  `implementation/shadow-cljs.edn` (rf2-2hrj8). The `:node-test`
+  build's `cljs-test$` regex ALSO matches this file's ns suffix
+  (`-dom-cljs-test`), so the parse-view-id pure-fn tests still run on
+  Node — the DOM-dependent tests short-circuit via `(when (exists?
+  js/document) …)` under Node and exercise fully under Chromium."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.views.view-walker :as walker]))
+
+;; ---- DOM scaffolding helpers ----------------------------------------------
+
+(defn- mk
+  "Build a DOM element with optional `data-rf-view` attribute. Returns
+  the new element (not yet attached)."
+  ([tag] (mk tag nil))
+  ([tag view-attr]
+   (let [el (.createElement js/document tag)]
+     (when view-attr
+       (.setAttribute el "data-rf-view" view-attr))
+     el)))
+
+(defn- attach!
+  "Append `child` to `parent` and return `child` for chaining."
+  [parent child]
+  (.appendChild parent child)
+  child)
+
+(defn- mk-host!
+  "Create a hermetic host element under document.body and return it.
+  Each test creates its own host so concurrent test fns don't share
+  walker state."
+  []
+  (let [host (mk "div")]
+    (.setAttribute host "data-rf-test-host" "")
+    (.appendChild (.-body js/document) host)
+    host))
+
+(defn- cleanup-hosts!
+  "Remove every test host. Runs as the after-each fixture."
+  []
+  (when (and (exists? js/document) (.-body js/document))
+    (let [hosts (.querySelectorAll js/document "[data-rf-test-host]")]
+      (dotimes [i (.-length hosts)]
+        (let [h (aget hosts i)]
+          (when (.-parentNode h)
+            (.removeChild (.-parentNode h) h)))))))
+
+(use-fixtures :each
+  {:after cleanup-hosts!})
+
+;; ---- parse-view-id --------------------------------------------------------
+
+(deftest parse-view-id-namespaced-keyword
+  (testing "leading colon + slash → namespaced keyword"
+    (is (= :rf.foo/bar (walker/parse-view-id ":rf.foo/bar"))
+        "splits at the first / for ns + name")))
+
+(deftest parse-view-id-bare-keyword
+  (testing "leading colon, no slash → bare keyword"
+    (is (= :bare (walker/parse-view-id ":bare"))
+        "no slash → unqualified keyword")))
+
+(deftest parse-view-id-raw-string
+  (testing "no leading colon → raw string id (unusual but legal)"
+    (is (= "raw-string" (walker/parse-view-id "raw-string"))
+        "leading-colon absent → keep as raw string")))
+
+(deftest parse-view-id-nil-and-non-string
+  (testing "nil / non-string inputs → nil"
+    (is (nil? (walker/parse-view-id nil)))
+    (is (nil? (walker/parse-view-id 42)))))
+
+;; ---- walk!: empty / no-tagged-elements ------------------------------------
+
+(deftest walk-empty-host-returns-empty
+  (testing "a host with no [data-rf-view] descendants returns an empty
+            vector"
+    (when (exists? js/document)
+      (let [host (mk-host!)]
+        (attach! host (mk "p"))
+        (attach! host (mk "div"))
+        (is (= [] (walker/walk! host))
+            "no tagged elements → empty walk")))))
+
+;; ---- walk!: flat catalogue ------------------------------------------------
+
+(deftest walk-flat-siblings-all-roots
+  (testing "tagged siblings at the same scope are all depth 0"
+    (when (exists? js/document)
+      (let [host (mk-host!)]
+        (attach! host (mk "div" ":app/header"))
+        (attach! host (mk "div" ":app/main"))
+        (attach! host (mk "div" ":app/footer"))
+        (let [out (walker/walk! host)]
+          (is (= 3 (count out)) "three tagged elements")
+          (is (every? #(= 0 (:depth %)) out)
+              "all at depth 0 — siblings share an untagged ancestor")
+          (is (= [:app/header :app/main :app/footer]
+                 (mapv :view-id out))
+              "document order preserved"))))))
+
+;; ---- walk!: nested tagged elements ----------------------------------------
+
+(deftest walk-nested-depth-1
+  (testing "a tagged element inside another tagged element is at depth 1"
+    (when (exists? js/document)
+      (let [host  (mk-host!)
+            outer (attach! host (mk "section" ":app/outer"))
+            _     (attach! outer (mk "div" ":app/inner"))]
+        (let [out (walker/walk! host)]
+          (is (= 2 (count out)))
+          (is (= [{:outer 0} {:inner 1}]
+                 [{:outer (:depth (first out))} {:inner (:depth (second out))}])
+              "outer at depth 0, inner at depth 1")
+          (is (= [:app/outer :app/inner] (mapv :view-id out))
+              "document order preserved"))))))
+
+(deftest walk-nested-depth-2
+  (testing "a deeply-nested tagged element accumulates depth across
+            every tagged ancestor"
+    (when (exists? js/document)
+      (let [host (mk-host!)
+            a    (attach! host (mk "section" ":app/a"))
+            b    (attach! a    (mk "div"     ":app/b"))
+            _    (attach! b    (mk "span"    ":app/c"))]
+        (let [out (walker/walk! host)]
+          (is (= 3 (count out)))
+          (is (= [0 1 2] (mapv :depth out))
+              "depths follow the chain of tagged ancestors"))))))
+
+;; ---- walk!: untagged scaffolding (fidelity gap exemplar) -----------------
+
+(deftest walk-skips-untagged-scaffolding
+  (testing "depth follows the NEAREST TAGGED ancestor — untagged
+            scaffolding (div soup, etc.) between two tagged elements is
+            transparent to the depth calculation"
+    (when (exists? js/document)
+      (let [host    (mk-host!)
+            tagged-a (attach! host (mk "section" ":app/a"))
+            ;; Three layers of untagged divs between A and its child B.
+            untag1  (attach! tagged-a (mk "div"))
+            untag2  (attach! untag1   (mk "div"))
+            untag3  (attach! untag2   (mk "div"))
+            _       (attach! untag3   (mk "span" ":app/b"))]
+        (let [out (walker/walk! host)]
+          (is (= 2 (count out)))
+          (is (= [0 1] (mapv :depth out))
+              "B is depth 1 — its nearest tagged ancestor is A; untagged
+               scaffolding is transparent"))))))
+
+;; ---- walk!: multiple branches under one tagged parent --------------------
+
+(deftest walk-multiple-children-under-one-parent
+  (testing "a tagged parent with two tagged children produces three
+            entries in document order; both children share depth 1"
+    (when (exists? js/document)
+      (let [host   (mk-host!)
+            parent (attach! host (mk "section" ":app/parent"))
+            _      (attach! parent (mk "div" ":app/child-1"))
+            _      (attach! parent (mk "div" ":app/child-2"))]
+        (let [out (walker/walk! host)]
+          (is (= 3 (count out)))
+          (is (= [:app/parent :app/child-1 :app/child-2]
+                 (mapv :view-id out)))
+          (is (= [0 1 1] (mapv :depth out))
+              "parent at 0; two children at depth 1"))))))
+
+;; ---- walk!: node-key uniqueness --------------------------------------------
+
+(deftest walk-node-keys-are-unique-per-walk
+  (testing "every tagged node carries a stable :node-key — distinct
+            across distinct DOM nodes, identical across re-walks of the
+            same tree"
+    (when (exists? js/document)
+      (let [host (mk-host!)
+            _    (attach! host (mk "div" ":app/a"))
+            _    (attach! host (mk "div" ":app/b"))
+            _    (attach! host (mk "div" ":app/c"))]
+        (let [out  (walker/walk! host)
+              keys (mapv :node-key out)]
+          (is (= 3 (count (set keys)))
+              "all three :node-key values are distinct")
+          ;; Re-walk: keys must be identical (identity-stable hash of
+          ;; the underlying JS object).
+          (let [out2 (walker/walk! host)]
+            (is (= keys (mapv :node-key out2))
+                "node-key is stable across consecutive walks of the same DOM")))))))
+
+;; ---- walk!: view-id null-safe on missing attribute -----------------------
+
+(deftest walk-missing-data-rf-view-yields-nil-view-id
+  ;; Defensive: if someone manually constructed a [data-rf-view]
+  ;; node-list and the attribute disappeared between selection and
+  ;; read, parse-view-id should return nil rather than throwing. This
+  ;; isn't reachable in practice from the production wrapper, but
+  ;; pinning the contract.
+  (testing "an element selected via querySelectorAll but whose
+            data-rf-view attribute is absent yields :view-id nil"
+    (is (nil? (walker/parse-view-id nil))
+        "nil attribute → nil view-id (no throw)")))


### PR DESCRIPTION
## Summary

Closes rf2-01il5. **FALLBACK SAFETY NET only** — the primary path is the Fiber-walker (rf2-mxkq7, #1533) which has already shipped. This bead is the React-version-independent escape hatch.

Every reg-view'd component's root DOM element now carries `data-rf-view=\"<id>\"` alongside `data-rf2-source-coord`. A new walker (`tools/causa/.../views/view_walker.cljs`) queries `document.querySelectorAll('[data-rf-view]')` and reconstructs parent ⊃ children purely from DOM containment.

- **Reagent (hiccup walk)**: `inject-source-coord-attr` now merges BOTH `:data-rf2-source-coord` AND `:data-rf-view` into the first concrete element's existing attrs map. Form-2 recursion preserved.
- **UIx + Helix (spine `wrap-view`)**: `React.cloneElement` adds both attributes on the same call. Same Fragment / `:>` / non-DOM-root exemption.
- **Walker (causa)**: depth via nearest-tagged-ancestor (JS Map memoisation); output shape mirrors the Fiber-walker per `View-Hierarchy-Capture.md §Output shape` so consumer code is path-agnostic.
- **CRITICAL constraint honoured**: the wrapper MUTATES the existing first element's attrs. NEVER wraps with a synthetic `[:div]` — wrapping breaks flexbox / Grid / table layouts / `:nth-child` / positioning ancestors / stacking contexts / CSS containment.

## Spec + schema

- **`spec/006-ReactiveSubstrate.md`** — new §View tagging contract (fallback; rf2-01il5) section: attribute format, the mutate-don't-wrap CRITICAL constraint with detailed rationale per layout idiom, documented edge cases (fragments / nil / component-returning-component / portals / `display:none`), production-elision contract, walker contract.
- **`spec/Spec-Schemas.md`** — new `:rf/view-id-attr` schema entry (public layer; v1-required).
- **`spec/View-Hierarchy-Capture.md`** — updated fallback subsection to note \"shipped and dormant\".
- **`implementation/scripts/check-elision.cjs`** — new `data-rf-view` sentinel verified absent under `:advanced` + `goog.DEBUG=false`, present in control.

## Test plan

- [x] `npm run test:cljs` — 3884 tests / 11233 assertions / 0 failures (new per-adapter view-id tests + walker parse tests)
- [x] `npm run test:browser` — 76 tests / 237 assertions / 0 failures (new DOM walker tests run under Chromium with real DOM)
- [x] `npm run test:elision` — 35/35 sentinels absent in production bundle, 35/35 present in control
- [x] `npm run test:bundle-isolation` — pass
- [x] `python -m mkdocs build --strict` — no warnings or errors