### PR TITLE
spec(causa): fix config/enabled? phantom + API.md panel count drift (rf2-md5nv · audit follow-on)

### DIFF
--- a/docs/causa/01-installation.md
+++ b/docs/causa/01-installation.md
@@ -149,7 +149,7 @@ Two ways out:
 ;; 2. Or keep the preload but force the shell off
 {:builds {:app {:compiler-options
                 {:closure-defines
-                 {day8.re-frame2-causa.config/enabled? false}}}}}
+                 {re-frame.interop/debug-enabled? false}}}}}
 ```
 
 Option 2 is for the rare case where you want to disable Causa in a specific dev build (say, when profiling raw render cost). Option 1 is the canonical way to keep Causa out of a release.

--- a/skills/re-frame2-causa/references/launch-modes.md
+++ b/skills/re-frame2-causa/references/launch-modes.md
@@ -148,7 +148,7 @@ App dev pages should keep the default `true` posture and provide
 ```clojure
 ;; Either: remove the preload entry from :devtools/preloads
 ;; Or: closure-define the disable flag in the dev build
-:closure-defines {day8.re-frame2-causa.config/enabled? false}
+:closure-defines {re-frame.interop/debug-enabled? false}
 ```
 
 ## Programmatic init!

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -163,7 +163,7 @@ top-strip control once it lands.
 ### Disable
 
 Remove the `:preloads` entry, or set
-`:closure-defines {day8.re-frame2-causa.config/enabled? false}` to
+`:closure-defines {re-frame.interop/debug-enabled? false}` to
 force-disable in dev.
 
 ### MCP (Causa as an agent surface)

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -278,7 +278,7 @@ provide `[data-rf-causa-host]`.
 Remove the `:preloads` entry, or:
 
 ```clojure
-:closure-defines {day8.re-frame2-causa.config/enabled? false}
+:closure-defines {re-frame.interop/debug-enabled? false}
 ```
 
 …to force-disable in dev.

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -126,7 +126,7 @@ inline host).
 ### Force-disable
 
 ```clojure
-:closure-defines {day8.re-frame2-causa.config/enabled? false}
+:closure-defines {re-frame.interop/debug-enabled? false}
 ```
 
 When set false (or in a production build via `goog.DEBUG=false`), the
@@ -194,7 +194,7 @@ authoritative list.
 | Namespace | Source | Public surfaces |
 |---|---|---|
 | `day8.re-frame2-causa.core` | `core.cljs` | The 12 canonical re-exports above (`init!`, `open!`, `open-overlay!`, `close!`, `toggle!`, `popout!`, `status`, `target-frame`, `set-target-frame!`, `load-theme`, plus the four highest-traffic config setters re-exported for boot-time convenience: `configure!`, `set-auto-open!`, `set-editor!`, `set-show-sensitive!`). |
-| `day8.re-frame2-causa.panels.*` | `panels/*.cljs` | The 6 `Panel` reg-views — `event-detail/Panel`, `app-db-diff/Panel`, `views/Panel`, `trace/Panel`, `machine-inspector/Panel`, `issues-ribbon/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). |
+| `day8.re-frame2-causa.panels.*` | `panels/*.cljs` | The 7 `Panel` reg-views — `event-detail/Panel`, `app-db-diff/Panel`, `views/Panel`, `trace/Panel`, `machine-inspector/Panel`, `issues-ribbon/Panel`, `machines-canvas/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). |
 | `day8.re-frame2-causa.config` | `config.cljc` | The `configure!` map dispatcher, the per-key setters (`set-editor!`, `set-project-root!`, `set-layout-host-selector!`, `set-auto-open!`, `set-keybinding-enabled!`, `set-static-mode-enabled!`, `set-show-sensitive!`, `set-filter-seed!`, `set-filters-storage-key!`, `update-setting!`, `reset-settings!`, `reset-suppressed-count!`) and the published constants enumerated in §Published layout-host constants above. The full normative key inventory lives in [`015-Configuration.md`](./015-Configuration.md); the **key-naming axis** (how authors navigate the 10-now-30-planned key surface by topical cluster prefix — editor / launch / keybinding / static-mode / settings / filters / render / trace / logging) is documented at [`015-Configuration.md` §Key-naming axis](./015-Configuration.md#key-naming-axis--navigation-map-rf2-dz35f--audit-of-audits-16) per `rf2-dz35f`. |
 | `day8.re-frame2-causa.keybinding` | `keybinding.cljs` | `attach!` / `detach!` — the symmetric, idempotent lifecycle pair for the `Ctrl+Shift+C` global listener. `detach!` is the embed-host escape hatch documented at [`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!` and [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Full-shell embed contract — needed when an embed host's mount lifecycle runs after Causa's preload and wants to take the chord back. |
 | `day8.re-frame2-causa.runtime` | `runtime.cljs` | The Causa ↔ MCP read-and-mutate seam. The accessor surface this namespace exposes is enumerated normatively in §Runtime accessor surface below. Tool clients (`tools/re-frame2-pair-mcp/` today) evaluate forms addressed at this namespace via `eval-cljs`. |
@@ -243,13 +243,14 @@ day8.re-frame2-causa.panels.views/Panel
 day8.re-frame2-causa.panels.trace/Panel
 day8.re-frame2-causa.panels.machine-inspector/Panel
 day8.re-frame2-causa.panels.issues-ribbon/Panel
+day8.re-frame2-causa.panels.machines-canvas/Panel
 ```
 
 (rf2-qy0nu — the 8-panel dead-code sweep removed `causality-graph`,
 `time-travel`, `effects`, `flows`, `routes`, `performance`, `schema-
 violation-timeline`, `hydration-debugger`, and `mcp-server`. The
-4-layer shell switches over the 6 L3 tab ids in `spec/018-Event-
-Spine.md` §5 — these six are the surviving `Panel` exports.)
+4-layer shell switches over the L3 tab ids in `spec/018-Event-
+Spine.md` §5 — these seven are the surviving `Panel` exports.)
 
 These `Panel` components are the leaves the shell composes — they
 are NOT a host-facing single-panel embed surface. Hosts that want to

--- a/tools/causa/spec/findings/re-frame-10x-v2-design.md
+++ b/tools/causa/spec/findings/re-frame-10x-v2-design.md
@@ -432,7 +432,7 @@ The hard rule: **opening Causa must not change observable INP** on a typical app
 
 That's it. The preload registers under `register-trace-listener!` and `register-epoch-listener!`, mounts a hidden DOM root, listens for `Ctrl+Shift+X`. No code change in the app itself.
 
-Disabling: remove the `:preloads` entry, or set `:closure-defines {day8.re-frame2-causa.config/enabled? false}` to force-disable even in dev.
+Disabling: remove the `:preloads` entry, or set `:closure-defines {re-frame.interop/debug-enabled? false}` to force-disable even in dev.
 
 We follow v1's preload convention exactly — muscle memory transfer is free.
 


### PR DESCRIPTION
Closes rf2-md5nv. Two doc-side drifts identified by `ai/findings/2026-05-21-causa-public-api-classification.md` §Spec drift.

## Drift #1 — `config/enabled?` phantom symbol

`day8.re-frame2-causa.config/enabled?` is referenced in 6 docs but does not exist in `config.cljc`. The codebase uses `re-frame.interop/debug-enabled?` (preload.cljs:229).

**Pick (mayor''s call, alpha-honest):** fix the docs, not the symbol. The framework-level interop gate is the right discriminator; minting a Causa-local mirror would add a new public surface without value.

Replaced `{day8.re-frame2-causa.config/enabled? false}` with `{re-frame.interop/debug-enabled? false}` in:
- `tools/causa/README.md`
- `docs/causa/01-installation.md`
- `skills/re-frame2-causa/references/launch-modes.md`
- `tools/causa/spec/findings/re-frame-10x-v2-design.md`
- `tools/causa/spec/011-Launch-Modes.md`
- `tools/causa/spec/API.md`

## Drift #2 — API.md panel count

`tools/causa/spec/API.md §Panel reg-views` said "6 panels survived the dead-code sweep" but `machines-canvas/Panel` at `tools/causa/src/day8/re_frame2_causa/panels/machines_canvas/panel.cljs:348` is a 7th internal survivor.

Updated:
- Row description (line 197): count 6 → 7, added `machines-canvas/Panel`.
- Canonical symbol list: appended `day8.re-frame2-causa.panels.machines-canvas/Panel`.
- Trailing parenthetical: "six are the surviving Panel exports" → "seven", and dropped the "6 L3 tab ids" claim (the panel/tab counts are not 1:1 — keep the prose generic).

## Posture

Pre-alpha. No back-compat shims. Doc + spec only — no code changes.

## Gates

- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py` — clean