### PR TITLE
fix(story): chrome_fullscreen_render_e2e_cljs_test SHADOW import error (rf2-f4h6a · #1786 regression)

### DIFF
--- a/tools/story/test/re_frame/story/panels_e2e/chrome_fullscreen_render_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/chrome_fullscreen_render_e2e_cljs_test.cljs
@@ -61,7 +61,7 @@
             [re-frame.story.ui.toolbar :as toolbar]))
 
 (use-fixtures :each
-  (test-support/reset-runtime-fixture-factory {:adapter plain-atom/adapter}))
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; The `dispatch!` fn is private — bind through the var so the test
 ;; reaches the same dispatcher the `keydown` capture listener routes to.

--- a/tools/story/test/re_frame/story/panels_e2e/viewport_indicator_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/viewport_indicator_e2e_cljs_test.cljs
@@ -59,7 +59,7 @@
             [re-frame.story.ui.viewport-switcher :as vs]))
 
 (use-fixtures :each
-  (test-support/reset-runtime-fixture-factory {:adapter plain-atom/adapter}))
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers: render the indicator from effective-viewport --------------
 ;;


### PR DESCRIPTION
Closes rf2-f4h6a. Fixes the node-test gate.

## Summary
- Two panel-e2e tests added by #1786 referenced `test-support/reset-runtime-fixture-factory`, which is not a real fn. The canonical name is `make-reset-runtime-fixture`.
- The undeclared-var warning at compile time produced a SHADOW import `TypeError` at runtime (calling `.cljs$core$IFn$_invoke$arity$1` on undefined), which crashed `node-test` before any test ran and blocked all CI.
- Affected files:
  - `tools/story/test/re_frame/story/panels_e2e/chrome_fullscreen_render_e2e_cljs_test.cljs`
  - `tools/story/test/re_frame/story/panels_e2e/viewport_indicator_e2e_cljs_test.cljs` (same typo, would have failed similarly)

## Test plan
- [x] `npm run test:cljs` from `implementation/` — 3949 tests / 11425 assertions, 0 failures
- [x] `clojure -M:test` from `tools/story/` — 841 tests / 2483 assertions, 0 failures