### PR TITLE
fix(ssr): re-route error-projection to re-frame.emit/register-error-listener! (rf2-it01g · audit#3)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -37,7 +37,7 @@
   ssr/error-known-mapping, ssr/error-sanitisation, ssr/cookie,
   ssr/redirect, ssr/set-status, fx/platforms)."
   (:require [re-frame.cofx :as cofx]
-            [re-frame.error-emit :as error-emit]
+            [re-frame.emit :as rf-emit]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
@@ -274,8 +274,8 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
 ;; flows through `re-frame.error-emit/dispatch-on-error!` —
 ;; `:rf.error/handler-exception` (router), `:rf.error/fx-handler-
 ;; exception` family (fx), `:rf.error/flow-eval-exception` (flows).
-(error-emit/register-error-listener! ::error-projection
-                                          error-listener/error-emit-projection-listener)
+(rf-emit/register-error-listener! ::error-projection
+                                  error-listener/error-emit-projection-listener)
 
 ;; rf2-fb598 — secondary install site: the dev-only trace surface,
 ;; preserved for `:rf.error/*` categories that emit ONLY via


### PR DESCRIPTION
Closes rf2-it01g. Final audit-rename item. Post-rf2-ic1sv (PR #1796) ns-update.

## Summary

- One-file ns-update at `implementation/ssr/src/re_frame/ssr.cljc`.
- SSR always-on error-projection listener install moves from substrate-internal `re-frame.error-emit/register-error-listener!` to the public facade `re-frame.emit/register-error-listener!` introduced by rf2-ic1sv.
- Alias chosen: `[re-frame.emit :as rf-emit]` because the existing `[re-frame.ssr.emit :as emit]` require already owns the `emit` alias in this file.
- No behavioural change. Substrate-internal references (e.g. tests that `requiring-resolve` `re-frame.error-emit/dispatch-on-error!` + the listeners atom) keep their substrate-direct path intentionally.

Pre-alpha posture: NO back-compat shims.

## Gates

- `npm run test:cljs` -> 3940 tests / 0 failures / 0 errors
- `clojure -M:test` from `implementation/ssr` -> 193 tests / 0 failures / 0 errors
- `clojure -M:test` from `implementation/ssr-ring` -> 63 tests / 0 failures / 0 errors
- `mkdocs build --strict` -> PASS