### PR TITLE
docs(story): refresh tutorial with Steve Yegge voice + annotated-screenshot placeholders (rf2-0pvm3)

### DIFF
--- a/docs/story/01-first-story.md
+++ b/docs/story/01-first-story.md
@@ -1,157 +1,192 @@
 # 1. Your first story
 
-Three lines of code; one registered variant; one canvas paint.
+> **What you'll build.** A working `:story.counter` with one variant — `:story.counter/empty` — that initialises a counter to zero, renders it in the Story canvas, and asserts that `app-db` ends up where you expected. Two macro calls and a route. Roughly twelve lines of source.
+>
+> **You should have working before you start.** A re-frame2 app that boots (the `re-frame2-template` is fine; any working counter is fine). The Story dep on your `:dev` classpath. `shadow-cljs watch` running. A browser pointed at your app's dev URL. If you got the welcome page's *Where to install* section to work, you're set.
+
+There's a particular pleasure in seeing a new tool render your code for the first time. Storybook nailed the experience back in 2017 — you `init`, you run a command, a sidebar appears with one story already in it, and somewhere a developer who has been fighting webpack for six hours feels a small hit of dopamine. That feeling is the entire reason developer tools have onboarding stories at all. Lose it and you lose adoption.
+
+Story aims for the same gesture: three lines of code, one registered variant, one canvas paint.
+
+Here is the smallest interesting `stories.cljs` you can write. (We're going to use a counter as the worked example throughout the tutorial, because counters are the smallest domain that lets the abstractions show their shape without burying them in business logic. If your reaction is *"another counter example, really?"* — yes. We are not above this.)
 
 ```clojure
 (ns counter-with-stories.stories
   (:require [re-frame.story :as story]
+            [counter-with-stories.events]    ; loads the event handlers
+            [counter-with-stories.subs]      ; loads the subscriptions
             [counter-with-stories.views]))   ; loads the view registry
 
 (story/reg-story :story.counter
-  {:doc       "The counter — every state, all in one place."
-   :component :counter-with-stories.views/counter-card
-   :args      {:label "Count"}
-   :tags      #{:dev :docs}
+  {:doc        "The counter — every state, all in one place."
+   :component  :counter-with-stories.views/counter-card
+   :args       {:label "Count"}
+   :tags       #{:dev :docs}
    :substrates #{:reagent}})
 
 (story/reg-variant :story.counter/empty
-  {:doc    "Fresh counter at zero."
-   :events [[:counter/initialise 0]]
-   :play   [[:rf.assert/path-equals [:count] 0]]
-   :tags   #{:dev :docs :test}})
+  {:doc         "Fresh counter at zero."
+   :events      [[:counter/initialise 0]]
+   :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]
+   :tags        #{:dev :docs :test}
+   :substrates  #{:reagent}})
 ```
 
-Save. Reload. Open `#/stories`. You're in.
+Save. Reload the dev build. Open `#/stories`. You're in.
 
-![A registered variant rendered in the Story canvas](../images/story/01-variant-loaded.png)
+> 📸 **Screenshot needed**: the Story shell immediately after the variant loads. Annotate (1) `:story.counter` in the sidebar tree, (2) the `/empty` child variant selected (highlighted), (3) the counter rendered in the canvas, (4) the *Canvas / Docs / Tests* mode-tab strip across the top of the main pane.
+>
+> Save as: `/docs/images/story/01-variant-loaded.png`
 
-## What just happened
+**You should now see:** a sidebar entry called `story.counter` with an `empty` variant under it; clicking that variant renders a counter (whatever your `counter-card` view paints) inside the main pane; the controls panel on the right has one row labelled "label" showing the string "Count".
 
-- `reg-story` registers the **parent story** — a logical group of variants that share a component, default args, decorators, tags. It carries no state on its own; it's a registry entry.
-- `reg-variant` registers **one variant** — one scenario, one frame, one canvas paint.
+If you do, congratulations — that's your first story. The rest of this chapter is about what those twelve lines actually said.
 
-The id grammar is locked. Stories live under `:story.<dotted-path>`. Variants live under `:story.<path>/<variant-name>`. The sidebar tree is built from the dotted path — no separate `:title` field.
+## What `reg-story` does, and doesn't
 
-Three slots in `reg-variant` carry the meat:
+`reg-story` registers the **parent story** — a logical grouping of variants that share a component, default args, decorators, and tags. It carries no state on its own; it's a registry entry. Think of it as the README for a folder of related scenarios. The folder is the story (`:story.counter`); the files are the variants (`:story.counter/empty`, `:story.counter/loaded`, and so on).
 
-- `:events` — a sequence of regular event vectors. They dispatch in source order through the same router that the live app uses. By the time the canvas renders, the variant frame's `app-db` is exactly what those events left behind.
-- `:args` — the variant's prop overrides. Resolved through a three-layer chain (see below).
-- `:play` — the assertion sequence. Runs after `:events` settle. Records its results; doesn't throw.
+The id grammar is locked. Stories live under `:story.<dotted-path>`. Variants live under `:story.<path>/<variant-name>`. The sidebar tree is built from the dotted path — there is no separate `:title` field, no separate `:folder` slot. We've internalised a lot of weird shapes from JS framework configurations over the years (`title: 'Components/Buttons/Primary/Default'` and that whole genre); we are deliberately not going to do that. The keyword *is* the structure.
 
-A variant body is **plain EDN**. No fn slots; no closures; no JSX-shaped DSL. The `:component` is a view-id keyword, not a function ref. That's the contract that lets variants round-trip through MCP, through visual-regression services, through agent input pipelines.
+`:component` is a view-id keyword, not a function reference. This will look unusual if you're coming from Storybook, where stories typically wrap a JSX element or a render fn. In Story, components are registered through `reg-view` and referenced by keyword. The substrate adapter (Reagent / UIx / Helix) knows how to invoke a registered view-id; the variant body never holds a function.
 
-## Three-level args + schema-derived controls
+This single design call — *keyword references, not function references* — is most of why variant bodies stay EDN. If we put a function in there, the body's no longer round-trippable. Round-trippable bodies are the contract that MCP and the visual-regression services and the agent input pipelines all hang off. So the keyword indirection is load-bearing. It looks like a small ergonomic difference; it's actually the architecture.
 
-Args resolve through a three-layer chain:
+## What `reg-variant` does
+
+`reg-variant` registers **one variant** — one scenario, one frame, one canvas paint. Three slots carry the meat:
+
+- **`:events`** — a sequence of regular event vectors. They dispatch in source order through the same router the live app uses. By the time the canvas paints, the variant frame's `app-db` is exactly what those events left behind. This is your *setup phase*: how do you get the world into the state this variant exercises?
+
+- **`:args`** — the variant's prop overrides. Deep-merged into the parent story's args (and into any active mode's args, and any global args, and any live cell-overrides from the controls panel). The resolved map is what the view renders against.
+
+- **`:play-script`** — the assertion sequence. Runs after `:events` settle and the canvas mounts. Each step in the script is a vector with a step-id (`:dispatch-sync`, `:wait`, `:click`, `:type`, `:assert-db`, `:assert-dom`) and its payload. The canonical assertion events from re-frame2 (`:rf.assert/path-equals`, `:rf.assert/sub-equals`, and the rest of the seven) ride the `:dispatch-sync` step.
+
+> 💡 **Note for Storybook refugees.** Storybook's `play` function is JavaScript — you write async functions that call `userEvent.click(...)` and `expect(...).toBeVisible()`. Story's `:play-script` is *data* — a vector of step tuples that a runner interprets. Same role; different substance. The runner lives at `re-frame.story.play.runner`; the step grammar lives in [`API.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) §`:play-script`. The advantage of the data shape is that the recorder (chapter 3) can *generate* a `:play-script` body from your interactions and you can paste it directly into source. Try generating a TypeScript function from a recording and you'll appreciate the difference.
+
+A variant body is **plain EDN**. No fn slots; no closures; no JSX-shaped DSL. We mentioned this in the welcome; we will mention it again throughout this tutorial because every time you reach for "I'll just put a function here" the right answer is "register the thing the function does, reference it by id." It is the discipline that makes the rest of Story work.
+
+## The four-layer args chain
+
+A variant's effective args are the deep-merge of four sources:
 
 ```
 global-args   ← set once via (story/configure! {:rf.story/global-args {...}})
      ↓
-story-args    ← the :args slot on reg-story (parent default)
+mode-args     ← active :Mode/* tuple (chapter 4)
      ↓
-variant-args  ← the :args slot on reg-variant (per-scenario override)
+story-args    ← :args slot on reg-story (parent default)
+     ↓
+variant-args  ← :args slot on reg-variant (per-scenario override)
      ↓
 cell-overrides ← live edits from the controls panel
+     ↓
+effective args (what the view receives)
 ```
 
-Deep-merge, left-to-right. Variants that don't say anything inherit; variants that override win. Modes (next chapter) sit between global and story for a fourth point of leverage.
+(The spec calls this five layers because it counts cell-overrides separately. Same idea.)
 
-The **controls panel** in the right-side pane auto-derives editors. If the parent story carries `:argtypes {:label {:control :text}}`, the panel renders a text input wired to dispatch a cell-override. If you've gone further and tagged the schema in `re-frame.schemas` (see [Guide 04a — Schemas](../guide/04a-schemas.md)), the panel reads the schema directly — a `:keyword` schema becomes a select, an `:int` schema with `:max`/`:min` becomes a number-input or slider, an `:enum` becomes a radio group. **No `argTypes` plumbing**; the schema is the source of truth.
+Deep-merge for nested maps, override-by-replacement for vectors, later layers win. Variants that don't say anything inherit; variants that override win. This is the same model Storybook uses for `parameters` and `args`, and we adopted it on purpose — the precedence story is well-understood.
 
-A variant can also **declare its own schema inline** via the `:rf/schema` slot — useful when one variant exercises a narrower or stricter shape than the component-wide registered schema:
+The **controls panel** in the right-side pane auto-derives editors from the resolved args plus the view's schema. If the parent story carries `:argtypes {:label {:control :text}}`, the panel renders a text input wired to dispatch a cell-override. If you've gone further and registered the view's Malli schema through `reg-view`, the panel reads the schema directly — a `:keyword` schema becomes a select, an `:int` schema with `:min`/`:max` becomes a number-input or slider, an `:enum` becomes a radio group. **No `argTypes` plumbing.** The schema you wrote for runtime validation is the same schema that drives the controls UI.
 
-```clojure
-(story/reg-variant :story.counter/labelled
-  {:rf/schema [:map
-               [:label  :string]
-               [:colour [:enum :red :green :blue]]
-               [:count  [:int {:min 0 :max 99}]]]
-   :args      {:label "Count" :colour :green :count 0}
-   :events    [[:counter/initialise 0]]})
-```
+This is the Story-side of a broader re-frame2 bet that *schemas pay for themselves several times over*. You write them for runtime validation and you get controls. You write them for controls and you get docs. You write them for docs and you get visual-regression diffing. We are not going to stop reaching into your schema for tooling; you might as well let us.
 
-The args editor renders one row per `:map` entry (`:colour` as a select, `:count` as a number-input clamped 0–99). Schema-violation rows flag args that don't conform. One declaration; two pieces of UI.
+## The seven canonical assertions
 
-## Decorators — three kinds
-
-Decorators wrap the canvas with reusable concerns: layout, theming, mock data, fx mocking. Three kinds:
-
-- **`:hiccup` decorators** — wrap the rendered tree. The closure lives at the decorator's registration site, not the variant body.
-  ```clojure
-  (story/reg-decorator :app/centered-layout
-    {:kind :hiccup
-     :wrap (fn [body _ref-args]
-             [:div {:style {:display "flex" :justify-content "center"}} body])})
-
-  (story/reg-variant :story.counter/loaded
-    {:decorators [[:app/centered-layout]]
-     :events     [[:counter/initialise 7]]})
-  ```
-- **`:frame-setup` decorators** — patch the variant's frame at allocation time. Used when several variants share an "assume the user is logged in" setup. The events dispatch before the variant's own `:events`; the patch merges into the variant frame's `app-db`. Pure data, no closures.
-- **`:fx-override` decorators** — stub a network call. The marquee shape is **`force-fx-stub`**, MSW-flavoured, which Story ships built-in:
-  ```clojure
-  (story/reg-variant :story.counter/save-stubbed
-    {:events     [[:counter/initialise 5]
-                  [:counter/save]]
-     :decorators [[story/force-fx-stub-id
-                   :counter/sync-to-server
-                   {:ok? true}]]
-     :play       [[:rf.assert/effect-emitted :counter/sync-to-server]]})
-  ```
-
-Variant bodies reference decorators by id; closures live on the decorator registrations. This is what keeps variant bodies serialisable.
-
-## Play sequences + assertions
-
-The `:play` slot is a sequence of regular event-vectors. They dispatch through the same router as `:events` — but the seven canonical assertion events don't throw on failure; they append a record to `[:rf.story/assertions]` in the variant frame's `app-db`.
-
-The seven:
+The `:rf.assert/*` events register at Story load — you don't write them, they're already there. They're regular re-frame2 events; the difference is that they don't throw on failure. They record into `[:rf.story/assertions]` on the variant frame's `app-db`. The test runner reads the accumulator at play-script completion and reports the aggregate.
 
 | Event id | Payload | Semantics |
 |---|---|---|
 | `:rf.assert/path-equals`     | `[path expected]` | `(= (get-in @app-db path) expected)` |
-| `:rf.assert/path-matches`    | `[path malli-schema]` | Malli validates the value at `path` |
+| `:rf.assert/path-matches`    | `[path schema]` | Malli validates the value at `path` against `schema` |
 | `:rf.assert/sub-equals`      | `[sub-vec expected]` | `(= @(subscribe sub-vec) expected)` |
-| `:rf.assert/dispatched?`     | `[event-or-pred]` | Did this event dispatch during play? |
+| `:rf.assert/dispatched?`     | `[event-vec]` | Did this event dispatch during play? |
 | `:rf.assert/state-is`        | `[machine-id state]` | Is the machine in `state`? |
-| `:rf.assert/no-warnings`     | `[]` | No `:warning` trace events since play start? |
+| `:rf.assert/no-warnings`     | `[]` | Zero `:rf.warn/*` events since play start? |
 | `:rf.assert/effect-emitted`  | `[fx-id]` (or `[fx-id pred]`) | Was this fx-id emitted? |
 
-The **record-don't-throw** shape is the design call. A play sequence with eight assertions where three fail still runs all eight; you get the full picture, not the first failure. Tests then read the accumulator:
+The **record-don't-throw** shape is the design call worth dwelling on. An assertion library that throws on the first failure is fine for unit tests where you want a short feedback loop. It's *terrible* for a visual playground where you want to see the full state of a broken variant. A play sequence with eight assertions where three fail should still run all eight; you should get the full picture; the test runner should ask "did every entry pass?" at the end. Story does this. Storybook 8's interaction tests also do this. The pattern is sound.
 
 ```clojure
-(deftest counter-loaded
+;; cljs test against the variant — same accumulator, same shape:
+(deftest counter-empty
   (cljs.test/async done
-    (-> (story/run-variant :story.counter/loaded)
-        (story.async/then
-          (fn [result]
-            (is (story/assertions-passing? result))
-            (story/destroy-variant! :story.counter/loaded)
-            (done))))))
+    (-> (story/run-variant :story.counter/empty)
+        (.then (fn [result]
+                 (is (story/assertions-passing? result))
+                 (story/destroy-variant! :story.counter/empty)
+                 (done))))))
 ```
 
-`run-variant` returns a promise (CLJS) or future (JVM) of `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :lifecycle}`. The same result map the MCP surface returns when an agent asks for a preview. Same shape; same vocabulary.
+`run-variant` returns a promise of `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms :snapshot :lifecycle}` — the same result map the MCP surface returns when an agent asks for a preview. Same shape; same vocabulary across surfaces.
 
-## Beyond counter: a five-state login form
+## Decorators — three kinds
 
-Counter is the simplest possible variant body — one event in `:events`, one `:rf.assert/path-equals` in `:play`. The login-form testbed at [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form) is the richer shape — five variants over the five FSM states the [welcome page](index.md#a-scenario-before-the-tour) opened with:
+Decorators are the only `reg-*` registration where Story authoring legally holds a closure, and even then the closure is at the registration site, not in any variant body. They come in three flavours:
 
-```clojure
-;; The :submitting variant — a request is in flight.
-(story/reg-variant :story.login/submitting
-  {:doc        "Inputs disabled, button reads 'Signing in…'. The
-                fx-stub records the request and resolves nothing
-                so the canvas locks at :submitting."
-   :events     [[:login/flow [:login/submit {:email    "ada@example.com"
-                                              :password "correct-horse"}]]]
-   :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-   :play       [[:rf.assert/state-is      :login/flow :submitting]
-                [:rf.assert/effect-emitted :rf.http/managed]]
-   :tags       #{:dev :docs :test}})
-```
+- **`:hiccup` decorators** — wrap the rendered tree. The closure lives at the decorator's registration site.
+  ```clojure
+  (story/reg-decorator :app/centered-layout
+    {:kind :hiccup
+     :wrap (fn [body _args]
+             [:div {:style {:display         "flex"
+                            :justify-content "center"
+                            :padding         "1em"}}
+              body])})
 
-The `:events` slot dispatches a real submit event into the FSM. The `force-fx-stub` decorator intercepts the `:rf.http/managed` call the machine's `:issue-request` action emits, so the request never resolves and the canvas locks at `:submitting`. The play sequence asserts the FSM state and that the fx was emitted. Same EDN shape; richer domain.
+  (story/reg-variant :story.counter/loaded
+    {:decorators [[:app/centered-layout]]
+     :events     [[:counter/initialise 7]]
+     :substrates #{:reagent}})
+  ```
 
-Open `http://127.0.0.1:8030/login-form/#/stories` after `npm run test:examples` builds it, and the five variants — `/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated` — show up in the sidebar. The `:Workspace.login/all-states` workspace mounts all five side-by-side. The five FSM states from the tutorial's index page, in one panel paint.
+- **`:frame-setup` decorators** — patch the variant's frame at allocation time. Used when several variants share a setup like "assume the user is logged in." The events dispatch before the variant's own `:events`; the patch merges into the variant frame's `app-db`. Pure data, no closures.
 
-Next: [mode tabs](02-mode-tabs.md) — Canvas, Docs, Tests, viewport, a11y, locale.
+- **`:fx-override` decorators** — stub a network call (or *any* fx — analytics, websockets, geolocation, storage, navigation). The marquee shape is `force-fx-stub`, which Story ships built-in:
+
+  ```clojure
+  (story/reg-variant :story.counter/save-stubbed
+    {:events      [[:counter/initialise 5]]
+     :decorators  [[story/force-fx-stub-id :counter/sync-to-server {:ok? true}]]
+     :play-script [[:dispatch-sync [:counter/save]]
+                   [:dispatch-sync [:rf.assert/path-equals [:saving?] true]]
+                   [:dispatch-sync [:rf.assert/effect-emitted :counter/sync-to-server]]]
+     :substrates  #{:reagent}})
+  ```
+
+The `force-fx-stub-id` Var holds the well-known id for the built-in decorator; we expose it as a Var so you're not memorising keyword paths. Three lines stubs *any* effect handler — `reg-fx`'d HTTP, analytics, websocket, geolocation, storage, navigation. The Storybook ecosystem has a separate addon for each of these (`msw-storybook-addon` for HTTP, separate stuff for analytics, etc.); Story has the one primitive because re-frame2 already names the seam — every side effect runs through a registered `reg-fx` handler the runtime calls. Stubbing it is a one-liner because the seam already exists.
+
+Variant bodies reference decorators by id; the closure lives on the decorator registration. This is the discipline that keeps variant bodies serialisable.
+
+## What you should see now
+
+After the registrations above (the parent `:story.counter` plus the `:story.counter/empty` variant), the playground at `#/stories` should show:
+
+- The `story.counter` parent in the sidebar tree (collapsible), with `empty` underneath.
+- Click `empty`; the canvas paints a counter at zero.
+- The mode-tab strip across the top of the canvas: *Canvas* (selected by default), *Docs*, *Tests*.
+- The right-side controls panel with one row, "label", showing "Count".
+- A green status dot in the sidebar next to `empty` if the variant has `:test` tagged and its play-script passed. (The chrome runs `:test`-tagged variants in the background on registration so sidebar dots reflect current status; you don't need to switch to *Tests* mode to populate them.)
+
+If the variant didn't show up, the most likely causes are below.
+
+## When it doesn't work
+
+A few diagnostic notes from the trenches. Tutorials that pretend everything works the first time are lying to you, so we're going to be honest about the failure modes.
+
+- **The sidebar's empty.** You forgot to `:require` the stories namespace from your app's entry. Story's registrations live on a side-table built by `reg-*` calls; if the namespace never loads, nothing registers. The fix: add `[my-app.stories]` to your entry namespace's `:require` block. Triple-check there's no underscore-vs-hyphen typo; CLJS namespace mismatches give *very* unhelpful errors.
+
+- **The variant shows up but the canvas is blank.** Your view-id keyword doesn't resolve to a registered view. Story has no way to render a view that wasn't `reg-view`'d. Check the spelling of the keyword on `:component`; check that the view's namespace is loaded (transitively); check that the `reg-view` macro actually ran (a typo in `defn` vs `reg-view` is silent until render).
+
+- **You see *Canvas* / *Docs* / *Tests* tabs but the *Tests* tab says "no assertions recorded".** You probably wrote `:play` instead of `:play-script`, or you wrote the play-script body as `[:rf.assert/path-equals [:count] 0]` (a bare event vector) instead of `[:dispatch-sync [:rf.assert/path-equals [:count] 0]]` (a `:dispatch-sync` step containing the event vector). The play-script grammar is *step-tuples*; the canonical assertions ride the `:dispatch-sync` step. (This is a recent rename; some external blog posts still show the old shape.)
+
+- **Variant renders but the right-side controls panel doesn't show your arg.** You probably haven't registered a schema on the view, and your parent story doesn't carry `:argtypes`. The controls panel needs *some* hint about how to render an editor; the schema is the preferred source, `:argtypes` is the override channel. We'll get into this more in chapter 4.
+
+- **The whole shell short-circuits to a blank page on prod build.** That's the elision behaving correctly. Story's production-build short-circuit is by design; `mount-shell!` no-ops when `re-frame.story.config/enabled?` is false. If you actually *want* the playground on a deployed build (against a staging environment for design review, for instance), flip the `:closure-defines` for that build only.
+
+## Where we go next
+
+Chapter 2 walks the chrome — the *Canvas / Docs / Tests* tabs above the canvas and the four orthogonal toolbars below them (viewport, background, a11y, locale). The pattern is: every chrome surface is a thin layer over the variant frame's data, so once you understand the variant, the chrome is just projections.
+
+Next: [the mode tabs](02-mode-tabs.md).

--- a/docs/story/02-mode-tabs.md
+++ b/docs/story/02-mode-tabs.md
@@ -1,55 +1,120 @@
 # 2. Mode tabs
 
-Every selected variant carries a strip of **mode tabs** at the top of the canvas. Three core modes — Canvas, Docs, Tests — and four orthogonal toolbars — viewport, background, a11y, locale.
+> **What you'll build.** A working mental model of the chrome surrounding a single variant: the *Canvas / Docs / Tests* tab strip at the top of the canvas, plus the four orthogonal toolbars (viewport, background, a11y, locale) that sit alongside it. You'll know what each tab and toolbar does, when to reach for it, and which are free and which cost network egress.
+>
+> **You should have working before you start.** Chapter 1 finished — you have at least one variant rendering in the playground. If you have several variants and a few of them are `:test`-tagged, the chapter's much more interesting because the *Tests* tab actually has something to show.
 
-![The mode-tab strip on a variant canvas](../images/story/02-mode-tabs.png)
+If chapter 1 was about getting a single variant to paint, this chapter is about everything *around* the canvas. The lens, not the picture. We're going to spend the chapter clicking around chrome, because the value of a component playground is largely in the secondary affordances: can you flip to docs for this state? Can you run its tests inline? Can you resize the viewport without resizing the browser? Can you pick a locale? An a11y check?
+
+Storybook spent five years iterating on this layout. We borrowed the shape, because the shape is good. We diverged on a couple of details where re-frame2's substrate let us, and we'll call those out.
+
+> 📸 **Screenshot needed**: the mode-tab strip on a variant canvas. Annotate (1) the *Canvas / Docs / Tests* chip row at the top, (2) the viewport selector below it, (3) the background-colour picker, (4) the a11y chip, (5) the locale switcher.
+>
+> Save as: `/docs/images/story/02-mode-tabs.png`
 
 ## Canvas / Docs / Tests
 
-The three core modes are mutually exclusive. The chip you click swaps the canvas content.
+The three core modes sit at the top of the canvas, mutually exclusive. The chip you click swaps the canvas content. This is the *cardinal axis* of the chrome — pretty much every other surface composes with these three.
 
-- **Canvas** — the default. The variant's component renders inside its frame; controls, decorators, the live trace strip all apply.
-- **Docs** — an auto-generated documentation pane: the parent story's `:doc`, the variant's `:doc`, the resolved args table, the resolved decorators table, the resolved parameters, the variant's tags. The args table reads from the three-layer args walk; the decorators table reads from the resolved decorator chain. No `MDX` plumbing; the doc surface is read off the registrations.
-  ![Docs mode for a variant](../images/story/02-docs-mode.png)
-- **Tests** — the variant auto-runs on entry. The pane shows each `:play` assertion in order, with a green/red chip and the full record (path, expected, actual). The pane is a microcosm of the chrome-level test widget: a Run-all button, a counts headline, per-assertion drill-down.
-  ![Test mode for a variant — every assertion in order](../images/story/02-test-mode.png)
+### Canvas
 
-Selection is **per-variant** and persists across reload in `localStorage` under `re-frame.story/active-mode-tab/<variant-id>`. Open a variant where you were on *Tests* last time; you're on *Tests* again.
+The default. The variant's component renders inside its frame; controls, decorators, the live trace strip, all apply. This is what chapter 1 showed you, and it's where you'll spend 80% of your playground time. The Storybook 7+ equivalent is the *Canvas* tab; the gesture is identical.
+
+### Docs
+
+The Docs tab renders an auto-generated documentation pane: the parent story's `:doc`, the variant's `:doc`, the resolved args table, the resolved decorators table, the resolved parameters, the variant's tags. The args table reads from the four-layer args walk; the decorators table reads from the resolved decorator chain. There's no MDX file you have to author and keep in sync. The doc surface is read off the registrations.
+
+We're going to spend a moment on why there's no MDX. Storybook's Docs mode lets you author standalone Markdown-with-JSX (`.mdx`) files for prose around your stories, which is a great feature with a bad failure mode: the prose drifts out of sync with the implementation. If you rename an arg, the prose-mode docs still talk about the old name. If you delete a variant, the MDX still embeds it. The drift is silent until someone reads the docs and gets confused.
+
+Story's Docs mode is *generative* — every section comes from data that the registrations already carry. The `:doc` string on `reg-story` and `reg-variant` is the only prose surface we ask you to write, and it's right next to the code it describes. The cost of writing rich Docs prose is therefore lower; the cost of letting prose go stale is impossible-by-construction.
+
+If you actually need richer per-story documentation (worked-example walkthroughs, embedded screenshots, links out), use a `:prose` workspace (chapter 4) that mixes prose blocks and variant cells. The `:prose` layout is Storybook's MDX-equivalent, except it round-trips as data.
+
+> 📸 **Screenshot needed**: a variant's Docs mode showing the auto-generated sections (`:doc`, args table, decorators table, parameters, tags). Annotate (1) the variant's `:doc` string at the top, (2) the resolved-args table with the four-layer breakdown visible if possible, (3) the decorator stack, (4) the tag chips at the bottom.
+>
+> Save as: `/docs/images/story/02-docs-mode.png`
+
+### Tests
+
+The Tests tab auto-runs the variant's `:play-script` on entry. The pane shows each step in order, with a green/red/grey chip and the full record (path, expected, actual, reason on failure). At the top, an aggregate badge — *3 passed, 0 failed, 0 skipped* — plus a re-run button. The pane is a microcosm of the chrome-level test widget that aggregates across all `:test`-tagged variants; same data, different scope.
+
+This is the surface that matters for *integrating Story into your testing story* (sorry, unavoidable pun). The pattern: tag every variant that exercises a meaningful state with `:test`. The chrome runs them in the background on every load and shows you the aggregate in the sidebar. The CI runner — `serve-and-run-story-play-scripts.cjs` — discovers every variant whose body carries a non-empty `:play-script`, navigates to each, waits for the terminal status, and asserts in CI. Same variants you wrote for visual inspection are running as tests in CI.
+
+> 📸 **Screenshot needed**: the Test-mode tab showing a variant with a mix of passing and failing assertion rows. Annotate (1) the aggregate status pill at top (e.g. "2 passed · 1 failed"), (2) one passing assertion row (green chip, with payload visible), (3) one failing assertion row (red chip), (4) the failure detail expanded with expected / actual diff, (5) the *Re-run* button.
+>
+> Save as: `/docs/images/story/02-test-mode.png`
+
+Selection across the three tabs is **per-variant** and persists across reload in `localStorage` under `re-frame.story/active-mode-tab/<variant-id>`. Open a variant where you were on *Tests* last time, you're on *Tests* again. This is a quality-of-life detail that pays for itself the first time you spend a morning debugging an assertion failure and don't want to keep re-clicking the *Tests* tab every time hot-reload bounces.
 
 ## Viewport — responsive at the panel level
 
-A second strip below the mode tabs picks the **viewport**: mobile / tablet / desktop / wide, plus a *custom* slot. The canvas frame's size adjusts; the rendered component sees the resized viewport. Useful for responsive design — flip three sizes side-by-side without resizing the browser window.
+A strip below the mode tabs picks the **viewport**: mobile / tablet / desktop / wide, plus a *custom* slot where you can pin a pixel size. The canvas frame's size adjusts; the rendered component sees the resized viewport. Useful for responsive design — flip three sizes side-by-side without resizing the browser window or breaking out the Chrome device emulator.
 
-Viewport is independent of mode tabs — *Canvas* with mobile viewport, *Docs* with desktop viewport, etc.
+Viewport is independent of mode tabs. *Canvas* with mobile viewport, *Docs* with desktop viewport, *Tests* with mobile viewport — all coherent picked states. The play-script runner respects the viewport setting too, which means *running your tests at mobile sizes* is the gesture *click the mobile chip, click Re-run*. If you've ever spent an afternoon debugging a "works on desktop, broken on mobile" CSS regression, the value of this is obvious.
 
 ## Background — design context
 
-The third strip is the background-colour picker — *light*, *dark*, *checker*, *brand*, plus custom hex. The canvas's surrounding chrome paints in the picked colour; the component renders on top. This is the chrome equivalent of opening a design tool's artboard and changing the canvas colour to compare contrast.
+The third strip is the background-colour picker — *light*, *dark*, *checker*, *brand*, plus a custom hex slot. The canvas's surrounding chrome paints in the picked colour; the component renders on top. This is the chrome equivalent of opening a design tool's artboard and changing the canvas colour to compare contrast — Storybook has roughly the same affordance via the `backgrounds` parameter.
 
-Background and `:Mode.app/dark` (the args-Mode primitive, see [chapter 4](04-workspaces.md)) are distinct. Background paints the *chrome*; a dark-mode Mode passes `{:theme :dark}` into the component's args. You can run a `:Mode.app/dark` variant on a *checker* background to see which is the component's own dark and which is the chrome.
+A subtle point that's worth getting right: **background is separate from a Mode that says `:theme :dark`**. Background paints the *chrome* (the colour behind the component); a `:Mode.app/dark` Mode passes `{:theme :dark}` into the component's args, so the *component* renders its dark variant. You can — and you sometimes will — run a `:Mode.app/dark` variant on a *checker* background to see which colour is the component's own dark and which is the chrome bleeding through. The two axes compose; that's the point.
 
 ## A11y — axe-core, opt-in
 
-A11y is **opt-in** because axe-core is heavy and most variants don't need it on every render. Toggle it on per-variant via the a11y chip; the panel runs an axe pass on the rendered canvas and renders the results inline — violations in red, passes in green, manual checks in yellow.
+A11y is **opt-in** because axe-core is a 600-kB JS payload and most variants don't need it on every render. Toggle it on per-variant via the a11y chip; the panel runs an axe pass on the rendered canvas and renders the results inline — violations in red, passes in green, manual checks in yellow.
 
-Story 1.0 ships axe-core *vendored locally* — there's no CDN hit, no network roundtrip. The companion bead [rf2-20w5i](https://github.com/day8/re-frame2) tracked the vendor-and-opt-in switch; the upshot is a11y is now a tab away with zero install. (Production builds DCE the entire axe-core path; the prod bundle carries no a11y bytes.)
+A specific note on the engine: at v1.0, axe-core loads from a public CDN with an explicit consent prompt the first time you click the chip. The script tag carries SRI `integrity` + `crossorigin="anonymous"` so a compromised mirror fails closed, and the consent persists in `localStorage` (`:rf.story.a11y/cdn-opt-in`) so you only see the prompt once. The reason for CDN-with-opt-in instead of vendoring 600 kB into Story's bundle: most users don't run a11y checks on most variants, and the dev-build size matters. Production builds DCE the entire axe-core path; the prod bundle carries zero a11y bytes either way.
+
+There are actually two a11y panels sharing the engine:
+
+- `:rf.story.panel/a11y` — scoped to the *variant's* DOM root. The default. Catches violations in your component.
+- `:rf.story.panel/chrome-a11y` — scoped to *Story's chrome itself*. We dogfood axe-core against the Story shell because that's the right way to ship an a11y panel.
+
+The two panels share the engine and the consent decision (one click enables both); their state is independent so chrome violations don't pollute the per-variant panel.
 
 ## Locale
 
 The locale strip cycles through any locales the parent story declares — `:en-AU`, `:fr-FR`, `:ja-JP`, etc. The canvas re-renders with the locale set as a cofx; views that read `(rf/locale)` swap their strings.
 
-Story doesn't ship a translation engine — the parent story just declares which locales are interesting, and the runtime takes it from there. If your app uses `formatjs` or `tongue` or any other i18n surface, point it at the locale strip's selection.
+Story doesn't ship a translation engine. The parent story declares which locales are interesting via its `:locales` slot (or registered as Modes with `:axis :locale`), and the runtime takes it from there. If your app uses `formatjs` or `tongue` or `taoensso.tempura` or whatever other i18n surface, point it at the locale strip's selection. We're agnostic on which i18n library you use; we just give you a chrome-level switch that sets the cofx.
 
-## What "orthogonal" means
+## What "orthogonal" buys you
 
-The four toolbars compose: viewport × background × a11y × locale. *Mobile, dark chrome, a11y-on, ja-JP* is a coherent picked state. The Story shell encodes that picked state into the URL fragment so reload preserves it; the *share* button (see [chapter 5](05-snapshot-identity.md)) serialises it for paste-into-issue.
+The four toolbars compose. *Mobile, dark chrome, a11y-on, ja-JP* is a coherent picked state, and it's the kind of state you actually want to inspect — "does the Japanese translation overflow on mobile in dark mode with the a11y panel flagging contrast issues?" That's a real question with a real answer once you can pick the combination.
 
-The mode tabs sit on top: each picked toolbars-state has its own *Canvas* / *Docs* / *Tests* views. So *Tests* mode with mobile viewport is "run the play assertions against a 375-wide canvas." The shell does this for you; you just click the chips.
+The Story shell encodes the picked state into the URL fragment so reload preserves it; the *share* button (chapter 5) serialises it for paste-into-issue. You can DM a colleague a URL that says *here, look at this combination*, and they'll see exactly what you see.
+
+The mode tabs sit on top of all four toolbars. Each picked-toolbars state has its own *Canvas / Docs / Tests* views. So *Tests* mode with mobile viewport is "run the play assertions against a 375-wide canvas." The shell does this for you; you just click the chips.
+
+> ☝️ **Note on the Storybook lineage.** Storybook ships viewport / background / locale as separate `addons`, each with its own configuration shape and registration ceremony. We took the same affordances and built them into the chrome directly because the substrate gave us no good reason to spin out plugin contracts. Less ceremony; same gestures. We don't think of this as a feature war — Storybook's plugin model has its own virtues — but for the re-frame2 reader the absence of plugin scaffolding is the right default.
 
 ## When you wouldn't use mode tabs
 
-Some variants are deliberately *Canvas-only* — design references, sample compositions, pinned screenshots. Tag the variant `:canvas-only` and the Docs/Tests chips are disabled (with an explanatory tooltip). The :test-runner skips them; the :docs export skips them.
+Some variants are deliberately *Canvas-only* — design references, sample compositions, pinned screenshots. Tag the variant `:canvas-only` and the Docs/Tests chips are disabled (with an explanatory tooltip). The CI test runner skips them; the docs export skips them. This is the escape hatch for "I want this variant to exist but I don't want it noisily failing tests because there are no tests to run."
 
-Tag inverts: `:test`-tagged variants always run in Tests mode at least once per session, even if you stay on Canvas in the UI. The chrome's test widget aggregates the run; the widget headline is "Tests · 3/5" with chips for `✓ ✗ ○ ` (passed / failed / un-run).
+Tag inverts the other way too: `:test`-tagged variants always run in Tests mode at least once per session, even if you stay on Canvas in the UI. The chrome's sidebar test-widget aggregates the run; the widget headline is "Tests · 3/5" with chips for `✓ ✗ ⊘` (passed / failed / skipped).
 
-Next: [the recorder + Test Codegen](03-recorder-codegen.md) — the hero feature.
+## You should now see
+
+After working through this chapter:
+
+- Clicking *Docs* on any variant should show an auto-generated docs pane with at least the `:doc` strings and an args table.
+- Clicking *Tests* on a `:test`-tagged variant should auto-run its `:play-script` and show pass/fail chips per step.
+- Picking a different viewport size should resize the canvas — you'll see the component re-flow at the new width.
+- Clicking the a11y chip should prompt for axe-core consent the first time; subsequent clicks should run the scan and surface results inline.
+- The picked combination of (mode-tab, viewport, background, a11y, locale) should persist across reload.
+
+## When it doesn't work
+
+- **The *Tests* tab is greyed out / shows "no tests registered".** The variant's `:play-script` slot is empty or missing. If you wrote `:play [[:rf.assert/path-equals [:count] 0]]` instead of `:play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]`, that's the symptom. The `:play` slot was retired in favour of `:play-script` per rf2-0wrud; the new shape is *step-tuples* with `:dispatch-sync` wrapping any event vector you want fired. Fix the slot name and the step shape and the tests light up.
+
+- **A11y chip click does nothing visible.** First-time click triggers a consent prompt that's easy to dismiss without noticing. Re-click; read the prompt; accept. If you're in a CSP-locked environment where the axe-core CDN is blocked, you'll see a console error and the panel will stay empty — for those cases either whitelist the CDN or skip a11y in Story (run it elsewhere).
+
+- **Locale switcher is empty.** The parent story didn't declare any locales. Add a `:locales #{:en-AU :ja-JP}` slot on `reg-story`, or register `reg-mode`s with `:axis :locale`.
+
+- **You picked mobile viewport but the component still renders desktop-wide.** Your component likely doesn't use a responsive style that reacts to its containing element's width — a common gotcha if you've wired media queries against the *window* rather than against a container query. Viewport in Story resizes the *canvas frame*, not the browser window. Either use container queries or test responsive components in a separate browser-resize step.
+
+## Where we go next
+
+Chapter 3 is the hero chapter. You're going to click *record* on a canvas, tap through a variant's interaction once, click *stop*, and watch a complete `:play-script` body materialise in a modal. Paste it into your variant. You now have a test for the interaction you just performed. This is the gesture Storybook 9 made their flagship feature; Story's incarnation is cleaner because the output is EDN.
+
+Next: [the recorder + Test Codegen](03-recorder-codegen.md).

--- a/docs/story/03-recorder-codegen.md
+++ b/docs/story/03-recorder-codegen.md
@@ -1,86 +1,178 @@
 # 3. Recorder + Test Codegen
 
-This is the hero chapter. Storybook 9's headline feature is the *interaction-test recorder* — record clicks and form fills on a canvas; out comes a play body. Story's incarnation is cleaner: the captured body is **EDN**, not TypeScript; the same map shape Story already uses for hand-authored `:play` slots.
+> **What you'll build.** A `:play-script` body for a counter-increment scenario by clicking *record*, tapping the increment button three times in the canvas, clicking *stop*, and pasting the generated EDN into a `reg-variant`. You'll come out with a working `:story.counter/clicked-three-times` variant that asserts both *the events dispatched* and *the resulting app-db*, all without typing the assertion by hand.
+>
+> **You should have working before you start.** Chapter 1 finished — at least one variant rendering. Ideally the counter variant from chapter 1, since the recording gestures only make sense if there's something you can interact with.
+
+This is the hero chapter. Storybook 9's headline feature is the *interaction-test recorder* — record clicks and form fills on a canvas, get a `play` function back. The feature reception was, if you read the launch comments, frankly enormous; it was the single thing they could have shipped that they did ship, and it got the most attention of anything in the 9.x line.
+
+We're going to do the same gesture. Story's incarnation is — and we'll defend this claim — *cleaner*. The captured body is EDN, not TypeScript. The output pastes directly into a `reg-variant` form. Round-trips through MCP, through visual-regression services, through agent input pipelines. Same data shape Story already uses for hand-authored `:play-script` slots. Diffs cleanly. Doesn't require a TypeScript runtime to consume. We didn't get here by being cleverer than the Storybook team — we got here because re-frame2 already names everything that the recorder needs to name (dispatches are data, events are data, fx are data) and TypeScript has to invent the names.
+
+Enough preamble. Let's record something.
 
 ## What it does, in one minute
 
-1. Open a variant in Canvas mode.
+1. Open a variant in *Canvas* mode. (We'll use the counter variant from chapter 1 — `:story.counter/empty`.)
 2. Click *record* on the canvas toolbar. The shell starts capturing.
-3. Interact with the component — click buttons, type into inputs, submit, hover. Causa's trace bus is the substrate; every dispatch lands in the recorder's buffer.
+3. Interact with the component — click the *+* button three times.
 4. Click *stop*.
-5. A modal opens. Inside, the **generated `:play` body**:
+5. A modal opens. Inside, the **generated `:play-script` body**:
+
    ```clojure
-   {:play [[:counter/initialise 0]
-           [:counter/increment]
-           [:counter/increment]
-           [:rf.assert/path-equals [:count] 2]]}
+   {:play-script
+    [[:dispatch-sync [:counter/initialise 0]]
+     [:dispatch-sync [:counter/inc]]
+     [:dispatch-sync [:counter/inc]]
+     [:dispatch-sync [:counter/inc]]
+     [:dispatch-sync [:rf.assert/path-equals [:count] 3]]]}
    ```
-6. *Copy*, paste into your stories namespace, save. The recorded interaction is now a canonical test.
 
-That's the whole gesture. The recorder doesn't capture mouse coordinates or DOM-level events; it captures **the re-frame2 events your interactions produced** plus the resulting assertions. The output is portable, readable, and parses by every other tool that consumes Story variants.
+6. *Copy*. Paste into your stories namespace. Save. The recorded interaction is now a canonical variant body.
 
-![Recorder modal — generated `:play` body, paste-ready EDN](../images/story/03-recorder-modal.png)
+That's the whole gesture. The recorder doesn't capture mouse coordinates or DOM-level pixel events; it captures the *re-frame2 events your interactions produced*, plus an inferred `:rf.assert/path-equals` row reflecting the final `app-db` shape. The output is portable, readable, and parses by every other tool that consumes Story variants.
+
+> 📸 **Screenshot needed**: the recorder modal showing a generated `:play-script` body in EDN. Annotate (1) the modal title, (2) the EDN body in the left pane, (3) the live preview run on the right pane, (4) the *Copy* button, (5) the *Edit before pasting* toggle.
+>
+> Save as: `/docs/images/story/03-recorder-modal.png`
 
 ## How the capture works
 
-Story's recorder registers a `:rf.story.recorder/*` listener on the trace bus while recording. Every dispatched event that *originated from canvas interaction* (as distinct from setup events the variant's own `:events` slot fires) is captured into the buffer.
+Story's recorder registers a `:rf.story.recorder/*` listener on the trace bus while recording. Every dispatched event that *originated from canvas interaction* — as distinct from setup events the variant's own `:events` slot fires — is captured into the buffer.
 
-The recorder distinguishes capture-source events from setup events through the trace event's `:dispatch-source` tag — a runtime stamp on every dispatch identifying its provenance. Setup-phase events carry `:rf.story/source :variant-events`; canvas-interaction events carry `:rf.story/source :user`. The recorder filters on `:user` only.
+The recorder distinguishes capture-source events from setup events through a runtime stamp on every dispatch identifying its provenance. Setup-phase events carry `:rf.story/source :variant-events`; canvas-interaction events carry `:rf.story/source :user`. The recorder filters on `:user` only. This is the bit that lets you record over a non-trivial variant — say, one that loads test fixture data via `:events` and *then* lets you interact — without the recorder picking up the fixture loads.
 
-When recording stops, the buffer is shape-mapped into the canonical `:play` form:
+When recording stops, the buffer is shape-mapped into the canonical `:play-script` form:
 
-- Pure dispatches become bare event vectors.
-- Dispatches that produced asserter-relevant `app-db` changes are followed by inferred `:rf.assert/path-equals` rows. (You can disable inference per-recording.)
-- Long click sequences against the same target are coalesced when adjacent.
+- Pure dispatches become `[:dispatch-sync <event-vec>]` step rows.
+- DOM-level events captured through the recorder's `:entries` stream (clicks on selectors, typed text in inputs) become `[:click selector]` / `[:type selector text]` / `[:wait ms]` step rows in the richer DSL.
+- An inferred `:rf.assert/path-equals` row lands at the end reflecting the variant's terminal `app-db` shape. (You can disable inference per-recording.)
 
-The output is human-readable. Storybook 9's TypeScript recorder produces `await canvas.getByRole('button').click(); await expect(...).toHaveTextContent('2');` — Story's recorder produces three EDN tuples. The EDN survives serialisation; the TypeScript surface doesn't.
+The output is human-readable EDN. Storybook 9's TypeScript recorder produces `await canvas.getByRole('button').click(); await expect(...).toHaveTextContent('2');` — Story's recorder produces step-tuples in EDN. The EDN survives serialisation, diffs cleanly, and round-trips through every other tool in the Story / story-mcp stack.
+
+## A worked example
+
+Open the canvas for `:story.counter/empty` (the variant from chapter 1). Click *record* on the canvas toolbar (the chip with the dot).
+
+Click the counter's *+* button three times. Watch the count tick: 1, 2, 3.
+
+Click *stop*. The modal opens; the left pane has the EDN; the right pane runs the captured script against a throwaway frame and shows the result. Click *Copy*.
+
+Open your `stories.cljs`. Add a new variant:
+
+```clojure
+(story/reg-variant :story.counter/clicked-three-times
+  {:doc         "Counter after three increments from zero."
+   :events      [[:counter/initialise 0]]
+   :play-script [[:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:rf.assert/path-equals [:count] 3]]
+                 [:dispatch-sync [:rf.assert/dispatched? [:counter/inc]]]]
+   :tags        #{:dev :docs :test}
+   :substrates  #{:reagent}})
+```
+
+Save. The Story shell hot-reloads; the new variant appears in the sidebar; click it; it auto-runs; you should see a green status pill at the top of the *Tests* tab.
+
+**You should now see:** a new `clicked-three-times` variant under `story.counter`; clicking it shows a counter starting at zero (after the `:events` phase) and the *Tests* tab — auto-run on entry — reports five passing assertions.
+
+There is a subtle but important detail here that's worth dwelling on. Notice that the three `:counter/inc` events live in `:play-script`, not in `:events`. We chose this on purpose: the `:rf.assert/dispatched?` assertion's accumulator is only wired during phase-4 (`:play-script`), not during phase-2 (`:events`). If we'd put the increments in `:events`, the dispatch-trace listener wouldn't have observed them, and `:rf.assert/dispatched?` would fail. The recorder gets this right because it captures from the `:user`-source phase — but the *general rule* matters for hand-authored variants: **assertions about dispatches only see what happens during play, not what happens during setup**. We didn't try to be clever and make this transparent because the cleverness would have hidden a real semantic distinction.
 
 ## Inference and friction
 
 The recorder is *opinionated* about what's worth keeping:
 
-- **Idle settle** — sequences that the runtime quiesces between are recorded as one settle boundary, not a flood of fine-grained events.
-- **Sensitive-flagged events** — events whose handler is metadata-tagged `:sensitive? true` are recorded with elided payload (a `:rf/redacted` marker in their place). The privacy contract from [Guide 23a](../guide/23a-privacy-secrets.md) applies to the recorder too.
-- **Multi-click coalescing** — clicking *+1* five times produces five `[:counter/increment]` rows. Stable. Predictable. (No "5 × [:counter/increment]" coalescing — it'd break diff readability when the recording later needs editing.)
+- **Idle settle.** Sequences that the runtime quiesces between are recorded as one settle boundary, not a flood of fine-grained events. A click that dispatches three events asynchronously through the same router gets coalesced.
 
-You can edit the recording before pasting. The modal's left pane is the EDN; the right pane is a preview run against a throwaway frame, so you see what the play would do *before* committing it.
+- **Sensitive-flagged events.** Events whose handler is metadata-tagged `:sensitive? true` are recorded with elided payload (a `:rf/redacted` marker in their place). The privacy contract from [Guide 23a — Privacy + Secrets](../guide/23a-privacy-secrets.md) applies to the recorder too; you can't accidentally bake a password into a `:play-script` by recording a login flow.
+
+- **Multi-click coalescing.** Clicking *+1* five times produces five `[:dispatch-sync [:counter/inc]]` rows. Stable. Predictable. No `5× [:counter/inc]` coalescing — we deliberated on this and decided against it, because the coalesced form makes diffs less readable when the recording later needs editing.
+
+You can edit the recording before pasting. The modal's left pane is the EDN; the right pane is a preview run against a throwaway frame, so you see what the play would do *before* committing it. If the recorder picked up an extra interaction you didn't mean (a stray hover that fired a dispatch), delete that row from the EDN and watch the preview re-run.
 
 ## Why EDN-first matters
 
-Three things you get for free:
+Three things you get for free from the fact that the recorder's output is data:
 
-- **Round-trips through MCP.** An agent host can call `recorder/start`, `recorder/stop`, get the EDN body back, hand it to `register-variant`. The end-to-end is *generate a test from interaction* without leaving the agent's tool catalogue. Storybook 9's TypeScript output requires the agent to either run TS, or hand-translate.
-- **Visual-regression diffs are stable.** The play body is data — sorted, formatted, comparable. Diff-ing two recordings of the same scenario after a refactor surfaces *what changed in the interaction*, not what changed in the formatting.
-- **The "save current canvas state" affordance falls out for free.** Tweak the controls on an existing variant, click *save as new variant…* at the bottom of the controls panel, and Story emits a `(reg-variant ...)` form pinned to the current selection — args, mode overrides, cell-local edits collapsed into one snapshot. Same modal, same EDN-paste flow.
+- **Round-trips through MCP.** An agent host can call `start-recording!`, `stop-recording!`, get the EDN body back via `gen-play-snippet`, hand it to `reg-variant*`. The end-to-end is *generate a test from interaction* without leaving the agent's tool catalogue. Storybook 9's TypeScript output requires the agent to either run TS or hand-translate; both are friction.
+
+- **Visual-regression diffs are stable.** The play body is data — sorted, formatted, comparable. Diff-ing two recordings of the same scenario after a refactor surfaces *what changed in the interaction*, not what changed in the formatting. (TypeScript whitespace and import order changes pollute every TS recording's diff.)
+
+- **"Save current canvas state" falls out for free.** Tweak the controls on an existing variant, click *save as new variant…* at the bottom of the controls panel, and Story emits a `(reg-variant ...)` form pinned to the current selection — args, mode overrides, cell-local edits collapsed into one snapshot. Same modal, same EDN-paste flow:
+
   ```clojure
-  ;; Click 'save as new variant…' after dragging :n up to 7 in a :dark mode →
+  ;; Click 'save as new variant…' after dragging :n up to 7 in :dark mode →
   (story/reg-variant :story.counter/saved-739221
-    {:extends :story.counter/happy-path
+    {:extends :story.counter/loaded
      :args    {:label "Counter" :n 7 :theme :dark}})
   ```
 
+The `:extends` slot is the inheritance shape; the saved variant inherits everything from the named parent variant except where it overrides. You can save a chain of these without copy-pasting the world.
+
 ## When the recorder isn't the right tool
 
-Three escape routes:
+Three escape routes you'll reach for now and then:
 
-- **A multi-step setup the user wouldn't do interactively.** Reach for the variant's `:events` slot directly — pure setup belongs there, with the play sequence describing only the interactive segment.
-- **An assertion the inferred ones don't cover.** The recorder infers `:rf.assert/path-equals`; for `:rf.assert/sub-equals`, `:rf.assert/state-is`, or any of the other five canonical assertions, edit the captured EDN. The pre-paste preview confirms the edit works.
-- **A test that crosses frame boundaries.** Recorder captures one variant's frame. Cross-frame assertions belong in `cljs.test` against the result map from `run-variant`.
+- **A multi-step setup the user wouldn't do interactively.** Reach for the variant's `:events` slot directly — pure setup belongs there, with the play-script describing only the interactive segment. Don't try to "record yourself doing setup"; setup is data, not interaction.
+
+- **An assertion the inferred ones don't cover.** The recorder infers `:rf.assert/path-equals` against terminal `app-db` shape. For `:rf.assert/sub-equals`, `:rf.assert/state-is`, or any of the other five canonical assertions, edit the captured EDN by hand. The pre-paste preview confirms the edit still runs.
+
+- **A test that crosses frame boundaries.** Recorder captures one variant's frame. Cross-frame assertions belong in `cljs.test` against the result map from `run-variant`. (Most tests don't need this; mention it for completeness.)
 
 The recorder is for the common case: *I just clicked through this; please remember what I did*. The escape hatches are there for the harder cases without polluting the common path.
 
-## MCP write surface
+## The MCP write surface — agent self-healing
 
-The agent-facing surface is the same gesture in reverse. An agent host calls `register-variant` with an EDN body; Story validates against the schema; the variant lands in the registry; the canvas can render it. Combined with the recorder's stop emission, an agent can run the loop:
+Now we come to a use case that didn't exist five years ago and is going to matter more every year. The agent-facing surface is the same gesture in reverse. An agent host calls `reg-variant*` with an EDN body; Story validates against the schema; the variant lands in the registry; the canvas can render it. Combined with the recorder's stop emission, an agent can run the loop:
 
 1. Generate a candidate variant body (from a prose description, from a screenshot, from a code-read).
 2. Register it.
-3. Watch the variant render in the canvas.
-4. Read failures (`read-failures`).
+3. Watch the variant render in the canvas (or read the rendered hiccup off the result map, programmatically).
+4. Read failures (`read-assertions`).
 5. Refine and re-register.
 
 That's the **agent self-healing loop**. It's the reason variant bodies are EDN to begin with.
 
-The agent surface lives at [`tools/story-mcp/`](https://github.com/day8/re-frame2/tree/main/tools/story-mcp) — a stdio JSON-RPC server exposing nineteen tools across Dev / Docs / Testing / Write categories. The Write surface is gated behind `--allow-writes` at startup. The contract is in [`tools/story-mcp/README.md`](https://github.com/day8/re-frame2/blob/main/tools/story-mcp/README.md).
+The agent surface lives at [`tools/story-mcp/`](https://github.com/day8/re-frame2/tree/main/tools/story-mcp) — a stdio JSON-RPC server exposing the dev / docs / testing / write tool categories. The Write surface is gated behind `--allow-writes` at startup so an agent running with read-only intent can't accidentally register variants in production-class environments. The contract is documented at [`tools/story-mcp/spec/API.md`](https://github.com/day8/re-frame2/blob/main/tools/story-mcp/spec/API.md).
+
+We don't expect every reader to be wiring agent loops to their playground today; we *do* expect every reader to be doing this within a couple of years, and we want the substrate to already support it when the time comes. The EDN-first choice is what makes it possible.
+
+## Recorder API surface
+
+For completeness, six facade entries on `re-frame.story`:
+
+| Fn | Signature | Purpose |
+|---|---|---|
+| `start-recording!` | `(start-recording! variant-id)` | Begin recording dispatched events against `variant-id`'s frame. |
+| `stop-recording!` | `(stop-recording!)` | Stop the in-flight recording; return captured events. |
+| `clear-recording!` | `(clear-recording!)` | Drop the buffer + return the recorder to idle. |
+| `recording?` | `(recording?)` | Is a recording in flight? |
+| `recorder-state` | `(recorder-state)` | Read-only view of the current recorder state map. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` | Pure codegen: render a captured event vector as a `(reg-variant ...)` EDN snippet. |
+
+The richer DOM-capture-aware translator (translates the recorder's `:entries` stream into `:click` / `:type` / `:wait` steps) is exported by `re-frame.story.recorder.play-export`; the facade carries only the simpler event → `:dispatch-sync` projection. Most readers will only ever interact with the chrome's *record* / *stop* buttons; the API entries are there for when you want to script recordings from your own tooling.
+
+## You should now see
+
+After working through this chapter:
+
+- The canvas toolbar has a *record* chip; clicking it changes its appearance (a recording-in-progress indicator).
+- Interacting with the canvas while recording captures the dispatches.
+- Clicking *stop* opens a modal with a complete EDN `:play-script` body.
+- Pasting that body into a new `reg-variant` form gives you a working variant whose *Tests* tab auto-runs and reports green.
+
+## When it doesn't work
+
+- **You click *record*, interact, click *stop*, and the modal is empty.** Most common cause: your interactions didn't produce any `:rf.story/source :user` events. The recorder filters out setup-phase dispatches, and it filters out dispatches that don't carry the source stamp. If your view dispatches through some bespoke channel that bypasses the trace bus, the recorder won't see it. Switch the view to the canonical `(dispatch ...)` from `reg-view` and re-record.
+
+- **The modal opens but the inferred assertion expects the wrong value.** The recorder reads `app-db`'s shape *at the moment you click stop*. If your interactions left async work in flight (a debounced save, a network call), the inferred assertion captures the in-flight value. Either wait for the operation to settle before clicking stop, or edit the assertion by hand.
+
+- **You paste the recorded body and the variant says "no assertions recorded" in *Tests* mode.** Easy mistake: you pasted the recorder's `{:play-script [...]}` map inside an existing variant's `{:events [...]}` slot. The `:play-script` is a top-level slot on `reg-variant`, not nested inside `:events`. The two slots have completely different runtime semantics (setup vs play); they're not interchangeable.
+
+- **The recorded body references events that aren't registered.** The view's button is dispatching a different event than you think, or the event handler isn't loaded into the build (typo in `:require` chains is the usual culprit). Open Causa's *Event* tab and check what's actually firing.
+
+## Where we go next
+
+Chapter 4 climbs up a level: instead of one variant in one cell, we mount *several* variants on one page as a *workspace*. We'll cover the args editor on the right (live cell-overrides that let you scrub a variant's args without authoring a new variant), and Modes — the Chromatic-style saved-tuple primitive that pivots a whole grid against a chrome-level theme/viewport/locale switch.
 
 Next: [workspaces + args editor](04-workspaces.md).

--- a/docs/story/04-workspaces.md
+++ b/docs/story/04-workspaces.md
@@ -1,84 +1,154 @@
 # 4. Workspaces + args editor
 
-A workspace is a layout that arranges variants on one page. Five layouts ship; two of them carry most of the workload.
+> **What you'll build.** Two workspaces over your counter variants — a hand-listed `:grid` with four explicit cells, and an auto-enumerating `:variants-grid` that picks up every variant under `:story.counter` without further authoring. You'll also wire one `:Mode.app/dark` saved-tuple Mode and watch the workspace re-render through the chrome's theme toggle.
+>
+> **You should have working before you start.** Chapters 1 and 3 finished. You want at least three variants under one parent story so the workspace has something to lay out. Counter at zero, counter at seven, counter clicked three times — that's plenty.
 
-![A 2×2 workspace mounting four variant states](../images/story/04-workspace-grid.png)
+So you've got a fistful of variants now. The sidebar's getting long. You realise that what you actually want is not to flip between them — you want to *see them at the same time*. Side-by-side, on one page, four cells in a 2×2 grid, so the design lead can squint at the whole set and tell you which one looks wrong.
 
-## Two common shapes
+This is the gesture component playgrounds have been working towards since Bret Victor's *Ladder of Abstraction*, and Storybook's `variants-grid` add-on figured out the rough UX years ago. A workspace is a layout that arranges variants on one page. We ship five layouts; two of them carry most of the workload.
 
-- **`:grid`** — explicit list of variant ids, in order, in a grid. The variant grid you reach for when a story has, say, four named states and you want a screenshot showing all of them.
-  ```clojure
-  (story/reg-workspace :Workspace.counter/all-states
-    {:layout   :grid
-     :variants [:story.counter/empty
-                :story.counter/loaded
-                :story.counter/clicked-three-times
-                :story.counter/save-stubbed]
-     :columns  2})
-  ```
-- **`:variants-grid`** — auto-enumerated from a parent story id. New variants land here without touching the workspace.
-  ```clojure
-  (story/reg-workspace :Workspace.counter/auto-grid
-    {:layout  :variants-grid
-     :for     :story.counter
-     :columns 2})
-  ```
+> 📸 **Screenshot needed**: a 2×2 workspace mounting four variant states (e.g. `:empty`, `:loaded`, `:clicked-three-times`, `:save-stubbed`). Annotate (1) the workspace title bar with the layout selector, (2) each cell labelled with its variant id, (3) the per-cell args-override hint (small chip near the cell), (4) the *share this layout* button.
+>
+> Save as: `/docs/images/story/04-workspace-grid.png`
 
-Three less-common layouts also ship: `:stack` (vertical), `:overlay` (compare two variants in alternate-rows mode), and `:custom` (you pass a hiccup tree with `(story/variant-cell <id>)` placeholders).
+## The two shapes you'll use 90% of the time
+
+### `:grid` — explicit list of variants
+
+You name the variants, in the order you want them, in a grid:
+
+```clojure
+(story/reg-workspace :Workspace.counter/all-states
+  {:doc      "Every named counter state, side-by-side."
+   :layout   :grid
+   :variants [:story.counter/empty
+              :story.counter/loaded
+              :story.counter/clicked-three-times
+              :story.counter/save-stubbed]
+   :columns  2
+   :tags     #{:docs}})
+```
+
+The runtime allocates one frame per cell. Four cells = four frames, all independent. The `:empty` frame can't see the `:loaded` frame's `app-db`; the `:save-stubbed` frame's `force-fx-stub` decorator doesn't bleed into the `:clicked-three-times` frame. (We've laboured this point a few times already; we'll keep labouring it because the frame isolation is what makes the rest of this work.)
+
+The `:grid` layout is the right reach when you have a curated set you want laid out in a particular order. Marketing screenshots; design-review canvases; the "four states the product manager cares about" view.
+
+### `:variants-grid` — auto-enumerated
+
+Sometimes you don't want to list variants by hand because the list changes. You add a new variant, you want it in the grid:
+
+```clojure
+(story/reg-workspace :Workspace.counter/auto-grid
+  {:doc     "Every variant under :story.counter, auto-enumerated."
+   :layout  :variants-grid
+   :for     :story.counter
+   :columns 2
+   :tags    #{:docs}})
+```
+
+Now the workspace renders *every* variant under `:story.counter`. New variants land here without touching the workspace. Variants you delete vanish from the grid. The workspace is *layout-only*; it carries no state of its own.
+
+This is the layout you'll use for the "show me everything" view. It's also the right shape for a `:test`-tagged workspace that lets the CI runner enumerate every variant in one place.
+
+Three less-common layouts also ship:
+
+- `:stack` — vertical stack of cells; useful when each variant is wide.
+- `:tabs` — one cell per tab; useful when the variants are themselves long-scrolling and you don't want a 4×scroll page.
+- `:custom` — pass a hiccup tree with `(story/variant-cell <id>)` placeholders. The escape hatch for "I have a specific layout in mind."
+- `:prose` — alternating prose blocks and variant cells; this is the Story-side of Storybook's MDX surface (we mentioned it in chapter 2's Docs section).
 
 ## Per-cell args + modes
 
-Each variant cell in a workspace can carry **per-cell overrides**: args that apply only to this cell. So the same `:story.counter/loaded` variant can render as `{:n 7}` in one cell and `{:n 99}` in another:
+A subtle but useful trick: each variant cell in a workspace can carry **per-cell overrides** — args that apply only to *this* cell. So the same `:story.counter/loaded` variant can render with `{:n 7}` in one cell and `{:n 99}` in another:
 
 ```clojure
 (story/reg-workspace :Workspace.counter/big-numbers
-  {:layout   :grid
-   :columns  3
-   :cells    [{:variant :story.counter/loaded :args {:n 1}}
-              {:variant :story.counter/loaded :args {:n 50}}
-              {:variant :story.counter/loaded :args {:n 999}}]})
+  {:layout  :grid
+   :columns 3
+   :cells   [{:variant :story.counter/loaded :args {:n 1}}
+             {:variant :story.counter/loaded :args {:n 50}}
+             {:variant :story.counter/loaded :args {:n 999}}]})
 ```
 
-The runtime allocates **a separate frame per cell**. Three loaded-cells = three frames, all independent. Per-cell time-travel (next chapter) is per-frame, so you can rewind one cell without affecting the other two.
+Three cells; same variant; three different `:n` values. The runtime allocates a separate frame per cell — three loaded-cells = three frames, fully independent. Per-cell time-travel (chapter 6) is per-frame, so you can rewind one cell without affecting the other two.
 
-## Modes — saved tuples
+When would you reach for this instead of three separate variants? Mostly when the variants only differ in their args — when you're really showing the *same scenario at three magnitudes*. If they differ in their events, decorators, or play-scripts, those are properly separate variants. If they only differ in their inputs, one variant in three cells is the cleaner shape.
 
-A **Mode** is a Chromatic-style saved tuple of args that any variant can render against:
+## Modes — Chromatic-style saved tuples
+
+A **Mode** is a saved bundle of args that any variant can render against:
 
 ```clojure
 (story/reg-mode :Mode.app/dark
-  {:args {:theme :dark :background "#1e1e1e" :foreground "#e0e0e0"}})
+  {:doc  "Dark theme."
+   :axis :theme
+   :args {:theme :dark :background "#1e1e1e" :foreground "#e0e0e0"}})
 
 (story/reg-mode :Mode.app/light
-  {:args {:theme :light :background "#ffffff" :foreground "#1a1a1a"}})
+  {:doc  "Light theme — the default."
+   :axis :theme
+   :args {:theme :light :background "#ffffff" :foreground "#1a1a1a"}})
 ```
 
-When a variant renders against `:Mode.app/dark`, the mode's `:args` deep-merge into the variant's effective args between the global layer and the story layer (i.e., the mode sits *between* `global-args` and `story-args` in the four-layer chain).
+When a variant renders against `:Mode.app/dark`, the mode's `:args` deep-merge into the variant's effective args between the global layer and the story layer (consult the four-layer chain we sketched in chapter 1; modes slot in *between* global and story).
 
-Each `(variant × mode)` cell has its own **snapshot-identity** — visual-regression services key off it. Dark mode and light mode become two screenshots from one variant body. (See [chapter 5](05-snapshot-identity.md) for the snapshot-identity contract.)
+The `:axis` slot is a faceting hint. Modes with `:axis :theme` are mutually exclusive — toggling `:Mode.app/sepia` deactivates `:Mode.app/dark` automatically. Modes without an axis (or with different axes) compose freely. So `{:Mode.app/dark, :Mode.viewport/mobile, :Mode.locale/ja-JP}` is a coherent active mode-set — three different axes, one mode active per axis.
+
+The chrome's toolbar exposes the registered modes; clicking the chip toggles. Snapshot identity (chapter 5) tracks the mode-set, so visual-regression diffs key off `(variant × mode-set)`.
+
+Why is this called *Modes* rather than something domain-specific like *themes*? Because modes pivot any axis. *Dark* and *Light* are themes, but `:Mode.viewport/mobile` is a viewport mode, `:Mode.locale/ja-JP` is a locale mode, `:Mode.user/impersonating-admin` is a user-context mode. The primitive doesn't care what you're pivoting; you give it args, you give it an axis, the chrome gives you a chip. Generality earns its keep here.
 
 ## The args editor
 
-In the right-side controls panel, every resolved arg gets an editor row. The editor row is auto-derived from the registered schema (or the `:argtypes` fallback). Editing a value dispatches a `:rf.story/cell-override` event that adds a cell-local override; the canvas re-renders against the new effective args.
+In the right-side controls panel, every resolved arg gets an editor row. The editor row is auto-derived from the registered schema (or the `:argtypes` fallback for cases where the schema doesn't carry enough hints). Editing a value dispatches a `:rf.story/cell-override` event that adds a cell-local override; the canvas re-renders against the new effective args.
 
-The editor row honours the schema's constraints. An `:int {:min 0 :max 99}` is a number-input clamped 0–99. An `:enum [:a :b :c]` is a radio group. A `:map` is a nested editor. A `:string` is a text input.
+The editor row honours the schema's constraints. An `:int {:min 0 :max 99}` is a number-input clamped 0–99. An `:enum [:a :b :c]` is a radio group. A `:map` is a nested editor (with the path visible in the header so you don't lose track of where you are). A `:string` is a text input. A `:keyword` becomes a select if there's an enum hint, a text input otherwise. We didn't have to negotiate any of these mappings — the schema's already there.
 
-The cell-overrides are *cell-local* — clicking on a different variant or workspace cell discards them. To make an override stick, click *save as new variant…* (see [chapter 3](03-recorder-codegen.md)).
+The cell-overrides are *cell-local* — clicking on a different variant or workspace cell discards them. The point of cell-overrides is *experimentation*, not authoring. If you want the override to stick, click *save as new variant…* (we covered this in chapter 3) and the controls panel emits a `reg-variant` form with the current effective args baked in. Paste; commit; the experiment is now source.
 
 ## Sharing a workspace state
 
-The workspace + active mode + cell-overrides are **transit-shareable**. The *share this layout* button serialises the picked state into a URL fragment; whoever opens the URL sees the same grid in the same state.
+The (workspace + active modes + cell-overrides) tuple is **transit-shareable**. The *share this layout* button serialises the picked state into a URL fragment; whoever opens the URL sees the same grid in the same state. The URL is small; the embedding is forgiving.
 
-This is the v1 sharing primitive — it's what lets you paste "look at this grid" into a chat message and have the reader see exactly what you see. The URL is small; the embedding is forgiving. For the larger / off-network case, the QR-code share affordance (next chapter) does the same thing with a render-to-image step.
+This is the v1 sharing primitive — it's what lets you paste "look at this grid" into a chat message or an issue, and the reader sees exactly what you see. For the larger / off-network case, the QR-code share affordance (next chapter) does the same thing via a render-to-image step, scannable from a phone.
+
+We didn't have to build a backend for this; the variant body's an EDN map, the active mode-set is a small set, the cell-overrides are a small map. Encode the lot in the URL fragment, you're done. The principle is: *if it's all data, you can share it as data.* re-frame2's bet pays off again — Storybook's per-cell state involves React render-tree introspection and somewhat ad-hoc serialisation; ours involves `pr-str`.
 
 ## Workspaces are layouts, not state
 
-A workspace doesn't hold any runtime state of its own — it's just an ordered list of `(variant + per-cell args)` tuples. So:
+A workspace doesn't hold runtime state. It's just an ordered list of `(variant + per-cell args)` tuples. Consequences:
 
-- New variant added under `:story.counter` → an `:variants-grid` workspace picks it up immediately.
-- Workspace renamed → all the sidebar links auto-update.
-- A variant deletion that leaves a workspace with a dangling reference → the cell renders a "this variant no longer exists" placeholder; the rest of the workspace renders normally.
+- New variant added under `:story.counter` → a `:variants-grid` workspace picks it up immediately.
+- Workspace renamed → all the sidebar links auto-update; URL fragments break (this is correct: rename invalidates short-link URLs you shared, because the new name *is* a different thing).
+- A variant deletion that leaves a workspace with a dangling reference → the cell renders a "this variant no longer exists" placeholder; the rest of the workspace renders normally. Story doesn't blow up the page because one cell's broken.
 
 The contract is "workspaces are layouts over variants"; everything follows from that.
+
+## You should now see
+
+After working through this chapter:
+
+- A `:Workspace.counter/all-states` entry in the sidebar; clicking it shows your four named counter states in a 2×2 grid.
+- A `:Workspace.counter/auto-grid` entry that auto-enumerates every variant under `:story.counter`; adding a new variant lands it in the grid without touching the workspace registration.
+- A `:Mode.app/dark` chip in the toolbar; toggling it re-renders the active variant or workspace with the dark args merged in.
+- The controls panel shows editor rows for the variant's resolved args; editing a value re-renders the canvas live.
+- The *share this layout* button copies a URL that round-trips the picked state.
+
+## When it doesn't work
+
+- **The workspace shows up empty.** A `:variants-grid` workspace pointed at a parent story with zero registered variants is empty by construction. Check the parent story id is correct and that the variants registered (look in the sidebar; they should appear under the parent).
+
+- **Per-cell args don't seem to apply.** The runtime allocates a fresh frame per cell, so per-cell overrides should isolate cleanly. If you see contamination across cells, you've probably got a global side-effect somewhere — a sub that reaches into a different frame, a fx-handler that mutates module state, a Reagent ratom outside the frame's `app-db`. Story's frame isolation can't protect you from genuinely shared mutable state outside the frame; that's an architecture issue in the under-test code.
+
+- **A mode toggle doesn't repaint the canvas.** The mode's `:args` aren't reaching your view. Check that your view reads from args (not from `app-db` directly for the mode-relevant values). Modes pivot the *args* axis; if the view's reading `:theme` from `app-db`, the mode toggle doesn't touch it.
+
+- **Cell-overrides disappear when you click around.** They're meant to. Cell-overrides are intentionally ephemeral — for persisting changes, use *save as new variant…* or edit the `:args` slot in source.
+
+- **The args editor shows no rows for a variant's args.** No schema and no `:argtypes`; the editor can't infer widgets. Add a `reg-view` schema or fall back to `:argtypes {:foo {:control :text}}` for the args you want editable.
+
+## Where we go next
+
+Chapter 5 covers **snapshot identity** — the content-hash that visual-regression services key off so you can rename variants freely without losing baselines. It's a story we couldn't have told in Storybook because Storybook's identity is slug-based; ours is content-based, and the difference matters when you're three months into a project and your design team wants to clean up everyone's names.
 
 Next: [snapshot identity + QR sharing](05-snapshot-identity.md).

--- a/docs/story/05-snapshot-identity.md
+++ b/docs/story/05-snapshot-identity.md
@@ -1,40 +1,50 @@
 # 5. Snapshot identity + QR sharing
 
-You're three weeks into building the login form. Five variants are pinned to Chromatic: `:story.login/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated`. Two weeks of baselines. The design team has signed off on each one. The visual-regression service is happy.
+> **What you'll build.** A conceptual model of how Story keeps your visual-regression baselines stable across variant renames, plus practical understanding of the *share via QR* affordance. No new code in this chapter; the snapshot-identity machinery is already running against every variant you've registered. We're going to look at it.
+>
+> **You should have working before you start.** Chapters 1–4. The chapter's payoff lands harder if you've felt the *pain* it's solving — try renaming a Storybook story sometime and watch Chromatic forget the baseline.
 
-Then a teammate looks at the names and pushes back. *Submitting-retry* is awkward; what's wrong with calling it `:story.login/retrying`? You agree; it's a five-second edit; you push. CI runs Chromatic against the new build. Forty-eight new buckets land in the dashboard, forty-eight old buckets get archived. The diff service shows every "new" screenshot as a 100%-novel image because the bucket key is the variant slug and the slug just changed. Two weeks of baselines, gone — not because the pixels changed, but because the *name* did.
+So here's a scenario. It is going to feel mundane until the bill comes due.
 
-This is the trade-off Storybook 9 ships and most playground tools after it: identity-by-slug. Rename anything and the diff service forgets. It's also the trade-off Story is built to avoid. Story's snapshot identity is **content-based** — a hash of what's rendered, not what it's called. Renames are free. The bucket key tracks the *picked state*, not the *name path*. Same screenshot, same hash, same bucket.
+You're three weeks into building the login form. Five variants are pinned to Chromatic (or Argos, or Percy, or your in-house diff tool): `:story.login/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated`. Two weeks of baselines. The design team has signed off on each one. The visual-regression service is happy. Your team is happy. Everyone is happy.
+
+Then a teammate looks at the names and pushes back. *Submitting-retry* is awkward; what's wrong with calling it `:story.login/retrying`? You agree; it's a five-second edit; you push. CI runs Chromatic against the new build.
+
+Forty-eight new buckets land in the dashboard. Forty-eight old buckets get archived. The diff service shows every "new" screenshot as a 100%-novel image — *because the bucket key is the variant slug and the slug just changed*. Two weeks of baselines, gone. Not because the pixels changed, but because the *name* did.
+
+This is the trade-off Storybook 9 ships and most playground tools after it: **identity-by-slug**. Rename anything and the diff service forgets. The conventional wisdom in the JS community is that you just don't rename things, which is, frankly, a bizarre concession for an industry that otherwise believes deeply in refactoring. Names are bad on day three of a project because nobody knew on day three what the thing would turn into; if you can't fix them on day eighty without losing two months of baselines, the cost of the playground tool has quietly leaked out into the surrounding development culture. Don't rename. Don't restructure. Don't move that variant to a better-named parent story. Your baselines are *fragile*.
+
+Story's snapshot identity is **content-based** — a hash of what's rendered, not what it's called. Renames are free. The bucket key tracks the *picked state*, not the *name path*. Same screenshot, same hash, same bucket. We are not going to be cleverer than the visual-regression services about merging slug histories or whatever else they could plausibly do upstream; we're just going to give them a different key.
 
 ## What identity tracks
 
-Every variant cell — the `(variant × mode × per-cell args)` tuple — has a **snapshot identity**: a content hash of everything that determines what the canvas will render. The hash is the join key visual-regression services use to bucket screenshots; it's how Story tells Chromatic, Argos, Percy, Lost Pixel, or your in-house diff tool "this screenshot is the same scenario as last week's — diff them."
+Every variant cell — the `(variant × mode × per-cell args)` tuple — has a **snapshot identity**: a content hash of everything that determines what the canvas will render. The hash is the join key visual-regression services use to bucket screenshots; it's how Story tells Chromatic, Argos, Percy, Lost Pixel, or your in-house diff tool *this screenshot is the same scenario as last week's — diff them*.
 
-So, concretely, on the five-state login form:
+Concretely, on the five-state login form:
 
 - Renaming `:story.login/submitting-retry` → `:story.login/retrying` doesn't change the identity. **Same bucket; baselines preserved.**
 - Renaming a top-level `:Mode.login/dark` → `:Mode.login/midnight` doesn't change the identity either. **Same bucket; baselines preserved.**
 - Changing the `:heading` arg from `"Sign in"` to `"Welcome back"` *does* change the identity. **New bucket; new baseline required.**
 
-The contract: **identity tracks content; name tracks lineage**. Both are stable, separately.
+The contract: **identity tracks content; name tracks lineage.** Both are stable, separately.
 
-The hash is a SHA-256 of a transit-printed tuple — `:resolved-args`, `:mode-args`, an `:events-fingerprint`, and a `:decorators-fingerprint`. Crucially, the *variant slug itself is not part of the input*. The fingerprint hashes what the variant produces, not what it's called. The hash is deterministic across machines, build tags, and load orders — the contract on `resolved-args` is sorted-keys, canonical types.
+The hash itself is a SHA-256 of a transit-printed tuple — `:resolved-args`, `:mode-args`, an `:events-fingerprint`, and a `:decorators-fingerprint`. Crucially, the *variant slug itself is not part of the input.* The fingerprint hashes what the variant *produces*, not what it's called. The hash is deterministic across machines, build tags, and load orders — the contract on `:resolved-args` enforces sorted-keys and canonical types so two readers computing the same identity will agree byte-for-byte.
 
 ## A worked rename — `:submitting-retry` → `:retrying`
 
 Walk through the rename on the login-form testbed.
 
-**Before** (the variant body in `tools/story/testbeds/login_form/stories.cljs:175`):
+**Before** (the variant body in `tools/story/testbeds/login_form/stories.cljs`):
 
 ```clojure
 (story/reg-variant :story.login/submitting-retry
-  {:doc    "The user corrected the typo and re-submitted."
-   :events [[:login/flow [:login/submit {:email "ada@example.com" :password "wrong"}]]
-            [:login/flow [:login/failure {:failure {:status 401}}]]
-            [:login/flow [:login/retry  {:email "ada@example.com" :password "correct-horse"}]]]
+  {:doc        "The user corrected the typo and re-submitted."
+   :events     [[:login/flow [:login/submit {:email "ada@example.com" :password "wrong"}]]
+                [:login/flow [:login/failure {:failure {:status 401}}]]
+                [:login/flow [:login/retry  {:email "ada@example.com" :password "correct-horse"}]]]
    :decorators [[story/force-fx-stub-id :rf.http/managed {}]]
-   :play   [[:rf.assert/state-is :login/flow :submitting-retry]]
-   :tags   #{:dev :docs :test}
+   :play-script [[:dispatch-sync [:rf.assert/state-is :login/flow :submitting-retry]]]
+   :tags       #{:dev :docs :test}
    :substrates #{:reagent}})
 ```
 
@@ -53,11 +63,11 @@ Notice the slug `:story.login/submitting-retry` is nowhere in that tuple. The SH
 
 ```clojure
 (story/reg-variant :story.login/retrying
-  {:doc    "The user corrected the typo and re-submitted."
-   :events [...]   ; unchanged
+  {:doc        "The user corrected the typo and re-submitted."
+   :events     [...]   ; unchanged
    :decorators [...]   ; unchanged
-   :play   [[:rf.assert/state-is :login/flow :submitting-retry]]   ; <-- arguably should rename too
-   :tags   #{:dev :docs :test}
+   :play-script [[:dispatch-sync [:rf.assert/state-is :login/flow :submitting-retry]]]
+   :tags       #{:dev :docs :test}
    :substrates #{:reagent}})
 ```
 
@@ -65,41 +75,72 @@ Re-run the fingerprint computation on the new variant. The `:resolved-args` are 
 
 Chromatic, Argos, Percy, Lost Pixel — every one of them keys on the hash. The bucket continuity holds. Your two weeks of baselines are intact.
 
-(One nit: if your assertions still pin the *machine* state name `:submitting-retry`, you'd want to rename the machine state separately. The variant identity is decoupled from internal naming — but your tests aren't.)
+(One nit: if your assertions still pin the *machine* state name `:submitting-retry`, you'd want to rename the machine state separately. The variant identity is decoupled from internal naming, but your tests aren't.)
 
 ## QR sharing — local-vendored encoder
 
-Story's *share via QR* button renders the snapshot identity (plus the picked workspace + mode + cell-overrides) into a QR code, displayed inline. Scan with a phone; the phone opens a URL into your locally-served Story instance at that exact picked state.
+Story's *share via QR* button renders the snapshot identity (plus the picked workspace, active modes, and cell-overrides) into a QR code, displayed inline. Scan with a phone; the phone opens a URL into your locally-served Story instance at that exact picked state.
 
-![QR sharing — scan to open the picked variant state on another device](../images/story/05-qr-share.png)
+> 📸 **Screenshot needed**: the QR share popover floating over a variant, with the QR code clearly visible. Annotate (1) the QR image, (2) the URL string below it (truncated), (3) the *Copy as image* button, (4) the *Copy as URL* button.
+>
+> Save as: `/docs/images/story/05-qr-share.png`
 
-The use case: design review against a real device. You've built the login form's `:error` variant; the design lead wants to see it on the actual phone they were thinking about, not the Chrome device emulator. Click the QR, scan with the phone, the phone opens the variant on your dev server — same picked state, same args, same mode, same workspace overrides. Two seconds vs the usual "let me get my laptop on the same WiFi as your phone."
+The motivating use case: design review against a real device. You've built the login form's `:error` variant; the design lead wants to see it on the actual phone they were thinking about, not the Chrome device emulator. Click the QR. Scan with the phone. The phone opens the variant on your dev server at the same picked state — same args, same mode, same workspace overrides. Two seconds, instead of the usual "let me get my laptop on the same WiFi as your phone."
 
-The QR encoder is **vendored locally** (per [rf2-20w5i](https://github.com/day8/re-frame2)). No CDN hit, no external dependency at render time. The vendored encoder is ~3kB after `:advanced` (DCE handles dead modes); production builds short-circuit before the encoder code is reachable.
+The QR encoder is **vendored locally** via the `qrcode-generator` npm package (MIT, ~52 KB unpacked, zero deps) per rf2-20w5i. There's no network roundtrip when you open the popover, no third-party tracking, no leaking the share URL (which encodes your variant state and cell-overrides) to anyone. The encoder lives at `re-frame.story.qr/qr-svg-string` and the popover splices the SVG inline. Production builds short-circuit before the encoder code is reachable; the prod bundle carries no QR bytes.
 
-Two affordances on the QR:
+Two affordances on the QR popover:
 
 - *Copy as image* — for embedding in design docs.
-- *Copy as URL* — same content, text-shaped.
+- *Copy as URL* — same content, text-shaped, for chat / issue trackers.
+
+This is one of those features where the implementation is small (a few dozen lines of glue around a vendored encoder) and the user value is disproportionate. We make this trade often in Story; we'll keep making it. Cheap-but-good is the right default for a developer-session tool.
 
 ## Snapshot artefacts in the static build
 
 Story's `story-static` artefact (built via `npm run story:build` from `implementation/`) materialises one HTML page per `(variant × mode)` cell, named by snapshot identity. Visual-regression services consume the static build directly — each PNG comes with a stable identity, and diffs are by identity.
 
-A few snapshot-identity hygiene rules:
+A few snapshot-identity hygiene rules worth internalising:
 
-- **Don't read non-deterministic values during render.** `(js/Date.)`, `(rand)`, `(.now js/performance)` — any of these inside a view body inflates the identity for the same picked args. Push them out (cofx, decorator-driven mocks). Story will emit a warning trace for non-determinism if it can detect it.
+- **Don't read non-deterministic values during render.** `(js/Date.)`, `(rand)`, `(.now js/performance)` — any of these inside a view body inflates the identity for the same picked args, because the fingerprint walks rendered output. Push them out (cofx, decorator-driven mocks). Story emits a warning trace for non-determinism if it can detect it; it can detect the common shapes but not all of them.
+
 - **`:large?`-tagged slots are elided from the fingerprint.** A 2 MB image payload in `:cart/preview-image` doesn't change the identity if only its byte content changes. Useful for variants that exercise large-payload behaviours without dirtying every diff.
-- **`:sensitive?`-tagged values participate in the fingerprint as a hash of the value, not the value itself.** Story honours the privacy contract — secrets don't leak into snapshot identities the diff service receives.
 
-## Why this is unusual
+- **`:sensitive?`-tagged values participate in the fingerprint as a hash of the value, not the value itself.** Story honours the path-level privacy contract — secrets don't leak into snapshot identities the diff service receives.
 
-Storybook's identity is path-based — slugs, story titles, mode names. Visual-regression buckets follow the slug. Rename anything and you've broken bucket continuity.
+These three rules turn out to cover almost everything you'll hit in practice. The "non-deterministic value during render" gotcha is the most common; the path-marks integration is the most quietly important if you handle credentials anywhere.
 
-Story's identity is *content-based*. Stable identity follows the content. Renames are free. The trade is that an args-tweak is a new identity — which is the point: you want the diff service to flag that the picked state changed.
+## Why content-based identity is unusual
 
-A second trade: the agent self-healing loop relies on this. When an agent generates a new variant via the MCP write surface — say, prompted with "give me an `:error` variant where the server returns 503 instead of 401" — the bucket continuity for the *existing* `:story.login/error` snapshot is determined by the content hash, not the agent's chosen name. The agent can generate-then-name without worrying about colliding bucket keys, and a human can rename what the agent produced without breaking the diff service's history.
+Storybook's identity is path-based — slugs, story titles, mode names. Visual-regression buckets follow the slug. Rename anything and you've broken bucket continuity. The JS community has worked around this with naming-convention discipline ("don't rename") and ad-hoc bucket-migration scripts, but the underlying primitive doesn't help.
 
-The pattern composes: humans rename freely, agents generate freely, the diff service stays anchored to what's actually rendered. That's the whole point.
+Story's identity is *content-based*. Stable identity follows the content. Renames are free. The trade is that an args-tweak is a new identity — which is the point: you *want* the diff service to flag that the picked state changed, because that's a real visual difference.
+
+A second trade worth naming: **the agent self-healing loop relies on this.** When an agent generates a new variant via the MCP write surface — say, prompted with "give me an `:error` variant where the server returns 503 instead of 401" — the bucket continuity for the *existing* `:story.login/error` snapshot is determined by the content hash, not the agent's chosen name. The agent can generate-then-name without worrying about colliding bucket keys, and a human can rename what the agent produced without breaking the diff service's history.
+
+The pattern composes: humans rename freely, agents generate freely, the diff service stays anchored to what's actually rendered. The cost we pay is one extra layer of indirection (`name → content-hash → bucket` instead of `name → bucket`); the cost we save is "everyone has to internalise that names are immutable, forever." For a pre-alpha tool that's going to live with us for years, this is the trade we want to make.
+
+## You should now see
+
+There is no explicit "you should now see" for this chapter — the snapshot identity machinery is already running against every variant you've registered. To verify it's working:
+
+- Call `(story/snapshot-identity :story.counter/empty)` at the REPL (or in cljs-test); you should get a SHA-256 string back.
+- Rename a variant slug; recompute the identity; the hash should be unchanged.
+- Edit a variant's `:args` slot; recompute; the hash *should* change.
+- Click the *share via QR* button on any variant; a QR code should appear inline (no network calls).
+
+## When it doesn't work
+
+- **Two readers / two machines / two CI runs compute different identities for the same variant.** Most common cause: a `js/Date.` or `(rand)` snuck into a view body. The fingerprint walks rendered output; non-determinism in the render inflates the hash. Search the variant's render path for time / random / performance reads.
+
+- **Identity changed but you didn't think you changed anything.** Check `:resolved-args` carefully. A change to `:argtypes` doesn't change identity. A change to `:doc` doesn't change identity. A change to `:tags` doesn't change identity. A change to *any value that survives into args*, or to the `:events` sequence, or to the `:decorators` chain, *does* change identity. Print `(story/snapshot-identity variant-id {:debug? true})` to see the input tuple verbatim.
+
+- **The QR popover loads but the QR code is blank.** The encoder failed; almost always a CSP issue with inline SVG. Check the console; whitelist `data:` URIs if your CSP is strict.
+
+- **Chromatic / Argos / Percy is still rebucketing on rename.** They're keying off the slug, not the snapshot identity. The integration shape is: your visual-regression service should consume the `story-static` artefact's filenames (which are snapshot identities), not the variant slug. If you're feeding it slugs, switch to identities and watch the rebucket noise drop to zero.
+
+## Where we go next
+
+Chapter 6 is short. We've talked about time-travel as a Causa feature throughout the tutorial; chapter 6 spells out *what changes when you time-travel inside Story*, because the per-variant frame isolation makes the gesture qualitatively different from time-travel against a single host app.
 
 Next: [time-travel in Story](06-time-travel.md).

--- a/docs/story/06-time-travel.md
+++ b/docs/story/06-time-travel.md
@@ -1,41 +1,83 @@
 # 6. Time-travel in Story
 
-Time-travel in Story rides [Causa](../causa/03-time-travel.md). Causa is mounted into the Story shell's right-hand pane by default (rf2-sgdd3) — its L1 ribbon (`◀ ▶ ⏭`) + L2 event list are the scrubber; the Trace tab is the cascade view; the Event-tab cascade view is the actions log. There is no Story-side scrubber UI any more; Story's contribution is the *frame isolation* that makes per-variant time-travel meaningful.
+> **What you'll build.** Comfort with the gesture of scrubbing through a variant's epoch history using Causa, which is embedded in the Story shell's right-hand pane by default. You'll learn how frame-per-variant isolation makes per-cell time-travel meaningful, and when *not* to reach for time-travel.
+>
+> **You should have working before you start.** Chapters 1–4. The chapter assumes you've got at least one variant whose `:play-script` does interesting things — a sequence of dispatches, not just a single assertion. The `:story.counter/clicked-three-times` variant from chapter 3 is fine.
 
-## Why per-variant matters
+Time-travel debuggers are one of those features the industry has been recurrently rediscovering since the 1960s. Smalltalk had them. Lisp Machines had them. Bret Victor demoed a particularly affecting incarnation in *Inventing on Principle*. Elm's debugger from 2015 made the gesture mainstream in modern web dev; Redux DevTools and re-frame-10x carried the torch into production teams.
 
-Storybook's interaction recorder runs sequentially against one canvas. To compare two scenarios you re-mount the page.
+The trouble with time-travel debuggers, historically, isn't whether they're *useful* — they're enormously useful, the first ten times you use one. The trouble is that they tend to be *expensive at runtime* (every state must be snapshotted), *fragile under hot-reload* (the stored states get stale), and *difficult to scope* (which thread's history is this, again?).
 
-Story's frame-per-variant isolation makes parallel time-travel natural. A workspace of four variants is four independent frames — each has its own `app-db`, its own dispatch queue, its own epoch buffer. Rewinding *empty* doesn't affect *loaded* or *clicked-three-times* or *save-stubbed*. You can rewind one cell while watching the play sequence in another.
+re-frame2's per-frame epoch buffer addresses each of these. Snapshots are cheap because the substrate is structural-sharing data. Hot-reload preserves the buffer because the buffer's keyed by frame identity, not by code identity. Scoping is per-frame, so there's never ambiguity about "which app-db's history am I looking at."
 
-When you select a variant in the sidebar, Story re-opens Causa scoped to that variant's frame — Causa's ribbon, event list, and detail tabs all bind to the selected frame's spine.
+Story's contribution is to make this *useful in a playground context*: per-variant frame isolation means parallel time-travel is natural. A workspace of four variants is four independent frames — each with its own `app-db`, its own dispatch queue, its own epoch buffer. Rewinding `:empty` doesn't affect `:loaded` or `:clicked-three-times` or `:save-stubbed`. You can rewind one cell while watching the play sequence in another.
+
+## Where the scrubber lives
+
+Time-travel in Story rides [Causa](../causa/03-time-travel.md). Causa is mounted into the Story shell's right-hand pane by default — its L1 ribbon (`◀ ▶ ⏭`) plus L2 event list is the scrubber; the Trace tab is the cascade view; the Event-tab is the actions log. There is no Story-side scrubber UI any more; Story's contribution is the *frame isolation* that makes per-variant time-travel meaningful.
+
+When you select a variant in the sidebar, Story re-opens Causa scoped to that variant's frame — Causa's ribbon, event list, and detail tabs all bind to the selected frame's spine. Click a different variant; Causa rebinds. The RHS chip-row picker lets you swap between Causa's panels (event-detail / app-db / views / trace / machines / routing / issues) without losing the selected variant.
+
+> 📸 **Screenshot needed**: a variant in Canvas mode with Causa embedded in the RHS, showing the L1 epoch-scrubber ribbon and the L2 event list. Annotate (1) the Story shell's main canvas on the left, (2) the Causa RHS panel, (3) the `◀ ▶ ⏭` ribbon at the top of Causa, (4) a selected epoch in the event list, (5) the chip-row picker that swaps between Causa's panel views.
+>
+> Save as: `/docs/images/story/06-time-travel.png`
+
+(Yes, we know — for re-frame v1 users, this is the part where you brace for the "but where did 10x go?" question. The answer is: Causa is the post-v2 successor. Same gestures; better scoping; embedded in Story instead of hovering as a floating widget. You'll like it once your fingers retrain.)
 
 ## What you'd reach for it for
 
-- **"My play sequence asserts something that's wrong at step 4. Why?"** — open the variant in Canvas mode, run the play step-by-step, scrub backwards in Causa from the failing assertion. The epoch one back from the failure is the state the assertion ran against.
-- **"I want to capture the canvas at three points in the variant's lifecycle."** — `:play` it; the runtime records an epoch per step; navigate Causa's L2 event list to each, screenshot.
-- **"I'm tuning a play sequence."** — write the events, walk them in Causa, see what each one did to `app-db`. Edit. Re-run. The buffer is fresh each session.
+- **"My play sequence asserts something that's wrong at step 4. Why?"** Open the variant in Canvas mode, let the play-script run, scrub backwards in Causa from the failing assertion. The epoch one back from the failure is the state the assertion ran against. Look at `app-db` there; ask whether it matches your mental model. Usually it doesn't, and that's the bug.
 
-## The six failure modes, again
+- **"I want to capture the canvas at three points in the variant's lifecycle."** Run the play-script; the runtime records one epoch per dispatched event; navigate Causa's L2 event list to each point of interest; screenshot. This is the gesture you'd use for documenting a flow's intermediate states.
 
-`restore-epoch` against a variant frame has the same six failure modes as against the host app's frame (see [Causa chapter 3](../causa/03-time-travel.md)):
+- **"I'm tuning a play sequence."** Write the events, walk them in Causa, see what each one did to `app-db`. Edit. Re-run. The buffer is fresh each session — `restore-epoch` resets cleanly between play-script runs.
 
-- Unknown frame
-- Unknown epoch
-- Schema mismatch
-- Missing handler
-- Version mismatch
-- Concurrent-drain rejection
+- **"A variant test failed in CI and I want to reproduce the broken state locally."** Cause's epoch buffer plus the snapshot-identity machinery from chapter 5 lets the CI runner emit "open Story to this variant at epoch N" deep-links. Click; scrub; debug. (This integration is alpha but we mention it for direction.)
 
-Causa renders the failure mode inline — same red toast, same `:reason` / `:explain` / `:missing-id` / `:expected`-`:got` payload. The runtime's contract is stable; Causa renders against it the same whether the frame is the host app's or a Story variant's.
+## The six failure modes
+
+`restore-epoch` against a variant frame has the same six failure modes as against any other frame (see [Causa chapter 3 — Time-travel](../causa/03-time-travel.md) for the full grammar):
+
+- **Unknown frame** — the variant's frame was destroyed (e.g. by `destroy-variant!`) before `restore-epoch` fired.
+- **Unknown epoch** — the epoch id isn't in the buffer (truncated, never recorded).
+- **Schema mismatch** — the stored `app-db` no longer conforms to the registered schema (hot-reload changed the shape).
+- **Missing handler** — an event in the epoch's chain references a handler that's been unregistered.
+- **Version mismatch** — the runtime's domino-version is newer than the stored epoch (rare).
+- **Concurrent-drain rejection** — a drain is in flight; restore queued until it settles.
+
+Causa renders the failure mode inline — same red toast, same `:reason` / `:explain` / `:missing-id` / `:expected`-`:got` payload. The runtime's contract is stable; Causa renders against it the same way whether the frame is the host app's or a Story variant's. This is the value of stable cross-host contracts — write one inspector, point it at any frame, the affordances work.
 
 ## When time-travel isn't the right tool
 
-Two cases:
+Two cases where you should reach for something else:
 
-- **"I want to replay the variant from the start with a tweaked arg."** That's not time-travel; that's *re-run with override*. Edit the arg in the controls panel; the variant re-runs from the start with the new arg. Time-travel is for *examining what already happened*, not for re-running with changes.
-- **"I want to time-travel the trace bus, not the app-db."** The trace bus is a log, not a state. To re-render the trace from a different angle, use Causa's Trace tab filters (the same `:op-type` / tag / free-text filters Causa offers across all hosts).
+- **"I want to replay the variant from the start with a tweaked arg."** That's not time-travel; that's *re-run with override*. Edit the arg in the controls panel; the variant re-runs from the start with the new arg. Time-travel is for *examining what already happened*; not for *re-running with changes*. The distinction matters because the user-intent is different: time-travel preserves the past, re-run replaces it.
 
-The point of time-travel here, as in Causa, is that *the runtime already recorded the state*. Story is just the lens that lets you compare two variants' epoch buffers side-by-side, each in its own frame.
+- **"I want to time-travel the trace bus, not the app-db."** The trace bus is a log, not a state. To re-render the trace from a different angle, use Causa's Trace tab filters (`:op-type`, tag, free-text). The trace is data you query; the app-db is a state you scrub.
+
+The point of time-travel here, as in Causa, is that *the runtime already recorded the state.* Story is just the lens that lets you compare two variants' epoch buffers side-by-side, each in its own frame.
+
+## You should now see
+
+After working through this chapter:
+
+- Selecting a variant in the sidebar should populate the RHS Causa panel with that variant's epoch history.
+- Clicking the `◀` button in Causa's ribbon should step backwards through epochs; the canvas re-renders as `app-db` rewinds.
+- Switching to a different variant should rebind Causa to the new frame's spine — fresh history, no contamination from the previous variant.
+- A workspace with multiple cells should let each cell time-travel independently.
+
+## When it doesn't work
+
+- **Causa's panel is empty / says "no frame selected".** Either your build doesn't have Causa's preload on the classpath (check `re-frame.story.causa-preset/causa-available?` returns true), or you've not selected a variant (the shell needs an active variant to bind Causa against). The graceful degradation here is by design — Story is feature-detect-safe and renders a no-op when Causa's absent.
+
+- **Time-travel buttons are greyed out.** The variant's frame hasn't recorded any epochs yet — usually means the `:events` slot is empty and the `:play-script` hasn't started. Run the play-script and try again.
+
+- **Restoring an old epoch shows the failure-mode toast.** That's working as intended — the contract surfaces *why* the restore failed (schema mismatch, missing handler, etc.). Read the toast's payload; that's your bug. The most common cause in playgrounds is hot-reload changing the schema shape; reset the variant via the *Re-run* button to get a fresh buffer.
+
+- **You can scrub past the boundary into another variant's history.** You can't; each variant frame has its own buffer; Causa is scoped to one at a time. If you think you're seeing cross-variant history, you're probably looking at the host app's default frame, not the variant's frame — check the chip in Causa's header.
+
+## Where we go next
+
+Chapter 7 is the final stretch — multi-substrate rendering. Same variant, three substrates (Reagent, UIx, Helix), three cells side-by-side. The audience for this chapter is narrow (adapter authors, component-library maintainers, projects migrating substrates), but the use case is genuinely interesting: visual diff *across rendering implementations*.
 
 Next: [multi-substrate side-by-side](07-multi-substrate.md).

--- a/docs/story/07-multi-substrate.md
+++ b/docs/story/07-multi-substrate.md
@@ -1,8 +1,24 @@
 # 7. Multi-substrate side-by-side
 
-re-frame2 ships with four view-substrate adapters: **Reagent**, **Reagent-slim**, **UIx**, and **Helix**. Most apps pick one and stay there. But for component-library maintainers and adapter authors, *the same variant rendered under multiple substrates* is the daily diff.
+> **What you'll build.** A `:substrates` slot on `reg-story` that pivots the variant grid to render under multiple view substrates side-by-side. You'll know which audiences this chapter is for, and (more importantly) the shape of view code that has to hold up under all of them.
+>
+> **You should have working before you start.** Chapters 1–6. Concretely, you need view code that's *substrate-agnostic* — registered via `reg-view`, no substrate-specific imports inside the view body. If your views are still importing `reagent.core` directly inside their bodies, this chapter won't help yet; come back after you've moved to `reg-view`.
 
-Story's `:substrates` slot on `reg-story` declares which substrates the parent story exercises:
+We need to be upfront about the audience here. Most apps pick one view substrate at `init!` time and stay there for the life of the project. If you've picked Reagent (or UIx, or Helix, or Reagent-slim), and you're going to stay on it, the multi-substrate machinery in this chapter is genuinely not something you'll need. You can read this chapter as a curiosity, or skip it and treat the tutorial as complete after chapter 6.
+
+The audience this chapter *is* for:
+
+- **Adapter authors.** When you're writing a new adapter (or fixing a regression in an existing one), you compare the same variant under your new adapter and the canonical Reagent. Visual divergence is a bug in the new adapter, with very high probability. The diff is per-variant, per-arg-tuple, per-mode — a tiny budget for differences.
+
+- **Component-library maintainers.** A re-frame2 component library that ships across substrates lives or dies on whether `:re-com/dropdown` renders the same way under all four. Side-by-side is the regression test that doesn't exist anywhere else in the ecosystem, because no other framework has multi-substrate adapters in the first place.
+
+- **Apps migrating substrates.** When a project moves from Reagent v1 to Reagent v2, or from Reagent to Reagent-slim for bundle-size reasons, or from any substrate to any other substrate, side-by-side variants are the safety net during the rolling migration.
+
+If none of those three describe you, treat this chapter as background. If one of them does, the chapter's the daily diff.
+
+## How to declare it
+
+re-frame2 ships with four view-substrate adapters: **Reagent**, **Reagent-slim**, **UIx**, and **Helix**. Story's `:substrates` slot on `reg-story` (or per-variant on `reg-variant`) declares which substrates the parent story exercises:
 
 ```clojure
 (story/reg-story :story.counter
@@ -11,54 +27,86 @@ Story's `:substrates` slot on `reg-story` declares which substrates the parent s
    :args       {:label "Count"}})
 ```
 
-Now every variant under `:story.counter` mounts under all three substrates, side-by-side, in a tri-cell layout.
+Now every variant under `:story.counter` mounts under all three substrates, side-by-side, in a tri-cell layout. Pick whatever subset you need; the runtime picks the layout dimensions based on the cardinality.
+
+> 📸 **Screenshot needed**: the same variant rendered side-by-side under Reagent, UIx, and Helix. Annotate (1) each substrate's column header (the substrate name as a chip), (2) the visually-identical rendered component in each cell, (3) the per-cell selection indicator if visible. Bonus: pick a counter variant where the three substrates render byte-identically — that's the gestural payoff.
+>
+> Save as: `/docs/images/story/07-multi-substrate.png`
 
 ## What you see
 
-Three columns. Same variant. Three substrates rendering it. The component must be substrate-agnostic — keyword view-id, registered through `reg-view`, no substrate-specific imports in the view body. The runtime knows how to invoke the keyword under each substrate.
+Three columns. Same variant. Three substrates rendering it. If a substrate-specific behaviour diverges — Reagent's r-atom mount semantics vs UIx's signal mount, say — the three columns diverge visibly. That's the entire point of the side-by-side: visual confirmation of behaviour parity.
 
-![Same variant rendered side-by-side under Reagent, UIx, and Helix](../images/story/07-multi-substrate.png)
-
-If a substrate-specific behaviour diverges (e.g., Reagent's r-atom mount semantics vs UIx's signal mount), the three columns diverge visibly. That's the point of the side-by-side: visual confirmation of behaviour parity.
+The three columns aren't independent renders of three different variants; they're the *same variant body* mounted under three different substrate adapters, each in its own frame, each computing its own snapshot identity. Visual-regression services key off the `(variant × substrate)` pair as separate buckets — so a regression in only the UIx adapter doesn't pollute the Reagent baselines.
 
 ## The contract on substrate-agnostic views
 
 For `:substrates` to work, your view registration must be substrate-agnostic. Concretely:
 
-- No `:require` of substrate-specific libraries from inside the view body. (`reagent.core`, `uix.core`, `helix.dom` — none of them.)
-- Use `reg-view` (not Reagent's `defn` shape or UIx's `defui` shape directly). `reg-view` is the substrate-agnostic registration macro; the adapters interpret the registered body.
-- For host-specific affordances (Reagent's `:>` shape, UIx's `$` shape), guard them behind a `(case (rf/substrate) :reagent ... :uix ...)` switch. Most apps don't need this.
+- **No `:require` of substrate-specific libraries from inside the view body.** No `reagent.core`, no `uix.core`, no `helix.dom`. The substrate-specific libs may be needed at the *adapter* level, but not in your view code.
 
-Views that *do* need substrate-specific code aren't covered by `:substrates`; they live under a single-substrate parent story. The adapter chapters at [Guide 19 — Adapters](../guide/19-adapters.md) walk the gotchas.
+- **Use `reg-view`, not `defn` returning hiccup.** `reg-view` is the substrate-agnostic registration macro; the adapters interpret the registered body. A bare `defn` returning Reagent-flavoured hiccup will work under Reagent and break under UIx because the hiccup conventions differ subtly between substrates.
+
+- **For host-specific affordances, guard them.** Reagent's `[:>]` shape, UIx's `$` shape — if you genuinely need substrate-specific code (rare, but happens), guard it behind `(case (rf/substrate) :reagent ... :uix ...)`. Most apps never need this.
+
+Views that *do* need substrate-specific code aren't covered by `:substrates`; they live under a single-substrate parent story. The adapter chapters at [Guide 19 — Adapters](../guide/19-adapters.md) walk the gotchas in detail.
+
+The discipline of writing substrate-agnostic views is, frankly, also a discipline you should be aiming at *in general* — it pays for itself even if you never multi-substrate. Substrate-agnostic views are easier to test, easier to read, less coupled to the host React conventions, and (the kicker) immune to the periodic React-internal breaking changes that ripple through every framework downstream. We are not subtle about wanting you to write them this way regardless of multi-substrate.
 
 ## What the side-by-side diff is for
 
-Three audiences reach for this:
+Three audiences, the same primitive, slightly different uses:
 
-- **Adapter authors.** When you're writing a new adapter (or fixing a regression in an existing one), you compare the same variant under your new adapter and the canonical Reagent. Visual divergence = bug in the new adapter. The diff is per-variant, per-arg-tuple, per-mode — a tiny budget for differences.
-- **Component-library maintainers.** A re-frame2 component library that ships across substrates lives or dies on whether `:re-com/dropdown` renders the same way under all four. Side-by-side is the regression test.
-- **Apps migrating substrates.** When a project moves from Reagent v1 to Reagent v2, or from Reagent to Reagent-slim for bundle-size reasons, side-by-side variants are the safety net.
+- **Adapter author writing a new substrate.** The diff is your validation suite. You implement the adapter; you run an existing variant grid; you visually inspect the new column against the canonical Reagent column. Where they diverge, you have a bug. The diff replaces the manual test plan you'd otherwise have to write.
 
-For most app code, you don't need this. You pick a substrate at `init!` time and your stories run under that substrate. Multi-substrate is for the cases where multi-substrate is the point.
+- **Component-library maintainer.** The diff is your regression test. Every release, you run the variant grid across substrates; visually-identical = no regression. The CI pipeline can run the static-build artefact through visual-regression services per `(variant × substrate)` pair and gate the release on byte-stable diffs.
+
+- **Project mid-migration.** You're moving from Reagent to UIx. You want to know which components are safe to flip and which aren't. The diff tells you: anywhere the columns diverge is somewhere you haven't yet ported correctly. Work your way through, one component at a time, until the diff goes clean. Then you can flip the adapter at `init!` and delete the old substrate.
 
 ## What's deferred
 
 Two surfaces aren't in v1.0:
 
-- **Per-substrate args.** You can't currently say "use these args under Reagent and those args under UIx" — args are substrate-agnostic. If the substrates need different args to produce the same output, the registered view is doing something host-specific that probably should be factored out.
-- **Cross-substrate snapshot identity.** Today every substrate produces its own snapshot identity (because the rendered DOM is hashed). A future `:semantic-fingerprint` slot would let visual-regression diff *intended output* rather than *rendered output*. The spec rev is open; today the right tool is human visual review.
+- **Per-substrate args.** You can't currently say "use these args under Reagent and those args under UIx." Args are substrate-agnostic. If the substrates need different args to produce the same output, the registered view is doing something host-specific that probably should be factored out. (If we built per-substrate args, we'd be giving you the rope to hang yourself with.)
+
+- **Cross-substrate snapshot identity.** Today every substrate produces its own snapshot identity, because the rendered DOM is hashed. A future `:semantic-fingerprint` slot would let visual-regression diff *intended output* rather than *rendered output*; the spec rev is open. Today the right tool is human visual review against the side-by-side.
+
+We'd rather ship the smaller, sharper primitive and grow into it than ship a feature-rich version that locks us into the wrong abstractions. Pre-alpha posture.
+
+## You should now see
+
+After working through this chapter:
+
+- A story with `:substrates #{:reagent :uix}` should render two columns when selected, one per substrate.
+- Visual divergence between columns should be obvious at a glance — that's the design.
+- Adding a substrate to the `:substrates` slot should immediately add a column on next render.
+- Removing a substrate should remove the column.
+
+## When it doesn't work
+
+- **Only one column shows up.** Most common cause: only one substrate is *registered* in the host app's boot. The `:substrates` slot on a story is the intersection of `(registered substrates × declared substrates)`; if you've only `init!`'d Reagent, that's all you'll see regardless of what's declared. Check `(story/registered-substrates)` at the REPL.
+
+- **One column renders, the others say "substrate not supported".** Same root cause as the above, but more transparent — the adapter for that substrate isn't on the classpath. Add the adapter dep to `:dev` and re-cycle the build.
+
+- **The columns look subtly different in ways you can't explain.** Welcome to substrate semantics. Reagent uses r-atoms with batched updates; UIx uses signals; Helix uses hooks; the mount lifecycles differ. The cases where you see visible divergence are *real* — that's information about your view code's portability. Read the differences; either fix the substrate-specific behaviour or accept that this variant is single-substrate.
+
+- **The variant's `:play-script` runs against only one substrate.** Correct — play-scripts run per frame, and the multi-substrate render allocates multiple frames. The CI runner's gate is per `(variant × substrate)` to match. If you want a play-script to assert across substrates, that's a `cljs-test` against multiple `run-variant` calls, not a play-script feature.
 
 ---
 
-That's Story.
+## That's Story
 
-You've seen:
+We've covered:
 
-- The three load-bearing rules: frame-per-variant, EDN bodies, record-don't-throw.
-- The four daily affordances: variants, mode tabs, recorder, workspaces.
-- The three surfaces unusual for the Storybook lineage: snapshot identity, time-travel, multi-substrate.
-- The agent surface (story-mcp) that consumes all of the above through MCP tools.
+- **The three load-bearing rules** — frame-per-variant, EDN bodies, record-don't-throw. Internalise these and the rest of Story makes sense as a consequence.
+- **The daily affordances** — variants, mode tabs, the recorder, workspaces. The 80% of the playground you'll reach for in a normal week.
+- **The differentiators** — snapshot identity (content-based, rename-safe), time-travel (per-variant Causa embed), multi-substrate (same variant, several adapters). These are the bets re-frame2's substrate let us make that weren't available to upstream Storybook.
+- **The agent surface** — story-mcp, the EDN-first variant body, the recorder's data output. The self-healing loop that wasn't a use case five years ago and is going to matter more every year.
 
-If you want to look at the worked example end-to-end, [`tools/story/testbeds/counter_with_stories/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/counter_with_stories) wires the seven `reg-*` macros against the canonical counter app — four variants, two workspaces, every assertion shape, every decorator kind, plus a passing integration test.
+If you want to look at a worked example end-to-end, [`tools/story/testbeds/counter_with_stories/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/counter_with_stories) wires every macro and every authoring shape against the canonical counter app — five variants, several workspaces, every assertion shape, every decorator kind, plus passing integration tests. It's the closest thing to a reference implementation of the patterns this tutorial walks.
 
-Or open `#/stories` against your own app, register one variant, and see how it feels.
+For the richer five-state login form we kept gesturing at, [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form) is the runnable testbed — the variant set that pulls together FSM-driven scenarios, `force-fx-stub`-mocked HTTP, and the full chrome surface in one place.
+
+Or, more usefully than any worked example: open `#/stories` against your own app, register one variant, and see how it feels. The point of a playground tool is its ergonomics, and ergonomics need to be felt rather than read about. The twelve-line `stories.cljs` from chapter 1 is enough to get there. We'd rather you experience the surface than read another chapter about it.
+
+Welcome to Story. Tell us what's awkward; we're listening.

--- a/docs/story/index.md
+++ b/docs/story/index.md
@@ -2,58 +2,77 @@
 
 **Storybook, for frames.**
 
-Story is the component playground for re-frame2 apps. You catalogue every state a component can be in — empty, loading, error, loaded, the dropdown-open, the disabled, the impersonating — and render them all side-by-side. Forms. Dropdowns. Cards. Whatever component you'd reach for Storybook to drive, you'd reach for Story.
+Here's the thing about UI bugs: most of them aren't bugs of *logic*. They're bugs of *state combinations the developer never thought to look at*. The empty list — fine. The list with one item — fine. The list with one item where the user is impersonating an admin, the network is mid-flight, and the locale just switched to Japanese — *that's* where the bug lives, and you've never once seen the page in that exact configuration because reproducing it by hand takes eleven clicks across three modal dialogs.
 
-Where Storybook is a separate runtime running outside your app, Story is *the same runtime, allocated differently*. Each variant runs in its own re-frame2 frame ([Guide 06a — Frames](../guide/06a-frames.md) is the dedicated chapter). Each variant body is plain data, not a function (no `Counter.story.tsx` with inline JSX). Args resolve through a three-layer chain. Assertions ride the same `dispatch` pipeline as production events. Time-travel scrubs through `restore-epoch`. When you scaffold a new component, you're not reaching for a separate `.stories.tsx` file — you're declaring `reg-story` and `reg-variant` against the same component you're shipping.
+The whole industry has known this for the better part of two decades. Storybook is the canonical answer: pull each visual state out into its own file, render them all on one page, and stop trying to navigate to the bug. The pattern is so well-validated at this point that arguing with it is roughly the same energy as arguing that we should go back to writing CSS in `<font>` tags. We're not going to do that. Storybook won.
 
-![The Story shell — sidebar, canvas, inspectors](../images/story/01-shell-overview.png)
+So Story isn't a category invention. We're not pitching you on a new way to think about UI development; that work was done. Story is *the same idea*, plumbed into re-frame2 hard enough that the experience changes shape. You catalogue every state a component can be in — empty, loading, error, loaded, dropdown-open, disabled, impersonating, first-login-welcome — and the playground renders them all side-by-side. Forms. Dropdowns. Cards. Whatever you'd reach for Storybook to drive.
 
-## A scenario, before the tour
+The reason for an entirely separate tool — instead of, say, an MDX bridge to upstream Storybook — comes down to one structural fact: **Storybook was designed before frames existed**. The whole Storybook architecture assumes that each story is a render fn, that state lives in component closures or context providers, and that `useState` is the cleanest available primitive for "this scenario has some local state." Storybook 9 added an interaction recorder and an Args API and a thousand other refinements on top of that foundation, but the foundation is still "render fn plus closure state."
 
-You're building a login form. There's an empty state, a loading state, an error state, an impersonating-as-admin state, and a "first-login welcome" state.
+re-frame2's foundation is different. Frames *exist*. They're a first-class allocation primitive. So in Story, each variant *runs in its own frame* — fresh `app-db`, fresh queue, fresh sub-cache, fresh interceptor chain, fresh trace bus, the works. There's no "shared mutable state between stories" footgun because there's no shared state to begin with. The variant body is plain EDN data — no JSX-shaped DSL, no inline render fns, no closures except inside decorator registrations where they belong. Assertions ride the same `dispatch` pipeline as production events. Time-travel hands you Causa scoped to the variant's epoch buffer. When you scaffold a new component, you're not reaching for a separate `.stories.tsx` file — you're declaring `reg-story` and `reg-variant` in plain Clojure against the same component you're shipping.
 
-The old loop: render the form, click around, screenshot, repeat. To compare empty against error you'd refresh the whole page. To compare error against loaded you'd refresh again. Five states, five refresh cycles per change.
+If you've used Storybook, the gestures will feel deeply familiar. We mean for them to. Most of what's in here is "Storybook patterns, but the substrate happens to be honest about state isolation."
+
+> 📸 **Screenshot needed**: the Story shell with sidebar, canvas, and right-hand inspector visible. Annotate (1) the sidebar tree showing parent stories and their variants, (2) the canvas with a variant rendering, (3) the right-pane Causa embed, (4) the mode-tab strip above the canvas, (5) the controls panel with arg editors.
+>
+> Save as: `/docs/images/story/01-shell-overview.png`
+
+## A scenario, to fix the picture
+
+You're building a login form. There's an empty state. A loading state. An error state when the password's wrong. An impersonating-as-admin state. A "welcome back, first time in this account" state.
+
+The old loop: render the form, click around until you're in the state you want, screenshot, repeat. To compare empty against error you refresh the whole page. To compare error against loaded you refresh again. Five states, five refresh cycles per change. You sit there with your finger on Cmd-R like a lab rat in a behavioural-economics paper, except instead of getting a pellet at the end you get to see whether the disabled-button colour token still works.
 
 The Story loop:
 
 1. Open `#/stories` in your dev build.
 2. Click each state in the left sidebar. The canvas swaps in 30ms.
 3. Open a workspace that mounts all five side-by-side; design review against the grid.
-4. Switch to *Test* mode; every variant's `:play` assertions run automatically; the sidebar dots flip green.
-5. Click *Test Codegen* on the canvas; tap through the form once; out comes an EDN `:play` body that exactly captures your interaction. Paste it into the variant.
+4. Switch to *Tests* mode; every variant's `:play-script` assertions run automatically; the sidebar dots flip green.
+5. Click *record* on the canvas toolbar, tap through the form once, click *stop*; out comes an EDN `:play-script` body that captures exactly what you just did. Paste it into the variant.
 6. Ship.
 
-Storybook 9 has roughly the same loop; Story's differentiators are *EDN-first* (variants round-trip through MCP, visual-regression services, the agent input pipeline), *schema-derived controls* (no `argTypes` plumbing), *frame-per-variant isolation* (no state leaks), and *test-mode parity with Vitest* — every variant with a `:test` tag has a runnable assertion bundle.
+If you've used Storybook 9 the rough shape is going to look familiar — record-and-replay is their flagship feature too. Where it diverges:
+
+- **Variant bodies are EDN, not TypeScript.** The recorder emits EDN that pastes straight into a `reg-variant` form. MCP, visual-regression tools, and agent input pipelines all consume the same shape.
+- **Controls auto-derive from the view's Malli schema.** No `argTypes` plumbing. The schema is the source of truth; the editor is the consequence.
+- **Each variant gets its own frame.** State doesn't leak between scenarios. The `:empty` variant and the `:loaded` variant cannot, by construction, see each other's `app-db`.
+- **Tests run inline; failures record rather than throw.** A play sequence with eight assertions where three fail still runs all eight — you get the full picture, not the first failure.
 
 !!! tip "Run the scenario yourself"
 
-    The five-state login flow above is a runnable testbed at [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form). Clone the repo, run `npm run test:examples` from `implementation/`, then open `http://127.0.0.1:8030/login-form/#/stories`. The sidebar lists five variants — `/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated` — and a workspace that mounts all five side-by-side. Click each variant; the canvas swaps in 30ms. Switch to *Test* mode; the assertion dots flip green. Every contract this tutorial mentions (frame-per-variant isolation, `force-fx-stub`, three-layer args, EDN-first variant bodies, `:rf.assert/*` shapes) is exercised on the same testbed.
+    The five-state login flow above is a runnable testbed at [`tools/story/testbeds/login_form/`](https://github.com/day8/re-frame2/tree/main/tools/story/testbeds/login_form). The sidebar lists five variants — `/idle`, `/submitting`, `/error`, `/submitting-retry`, `/authenticated` — and a workspace that mounts all five at once. Every contract this tutorial mentions (frame-per-variant isolation, `force-fx-stub`, the four-layer args resolution chain, EDN-first variant bodies, `:rf.assert/*` shapes) is exercised on that testbed.
 
-The chapters:
+## The chapters
 
-- [1. Your first story](01-first-story.md) — `reg-story`, `reg-variant`, schema-derived controls.
-- [2. Mode tabs](02-mode-tabs.md) — Canvas / Docs / Tests / viewport / a11y / locale.
-- [3. Recorder + Test Codegen](03-recorder-codegen.md) — the hero feature; record interactions, get `:play` bodies.
-- [4. Workspaces + args editor](04-workspaces.md) — multiple variants on one page; live arg overrides.
-- [5. Snapshot identity + QR sharing](05-snapshot-identity.md) — content-hashed snapshots; share a layout state via QR.
-- [6. Time-travel in Story](06-time-travel.md) — Causa embedded in the RHS, scoped per variant.
-- [7. Multi-substrate side-by-side](07-multi-substrate.md) — render the same variant under Reagent, UIx, Helix.
+We'll walk through the surface roughly in the order you'd reach for it. First story, then chrome, then the recorder, then the things you grow into.
+
+- [1. Your first story](01-first-story.md) — `reg-story`, `reg-variant`, schema-derived controls. The hello-world.
+- [2. Mode tabs](02-mode-tabs.md) — the *Canvas / Docs / Tests* switcher, plus the viewport / background / a11y / locale toolbars.
+- [3. Recorder + Test Codegen](03-recorder-codegen.md) — the hero chapter. Record an interaction, get an EDN `:play-script` body, paste it in.
+- [4. Workspaces + args editor](04-workspaces.md) — multiple variants on one page; modes; live arg overrides.
+- [5. Snapshot identity + QR sharing](05-snapshot-identity.md) — content-hashed snapshots that survive renames. The visual-regression integration story.
+- [6. Time-travel in Story](06-time-travel.md) — Causa embedded in the RHS, scoped per variant frame.
+- [7. Multi-substrate side-by-side](07-multi-substrate.md) — the same variant under Reagent, UIx, Helix. For adapter authors and component-library maintainers.
 
 ## Three load-bearing rules
 
-Before the chapters, three contracts:
+Before we dive in, three contracts that nothing else in Story makes sense without:
 
-1. **Each variant runs in its own frame.** Fresh `app-db`, fresh queue, fresh sub-cache. State doesn't leak between scenarios. What you see is what production would render against the same fixture.
-2. **Variant bodies are data — never functions.** A variant body is a map with `:events`, `:args`, `:decorators`, `:play`, etc. Every slot is plain EDN, round-trippable across the network. This is the lock that lets MCP, visual-regression services, and agent input pipelines all consume the same shape.
-3. **Assertions record, don't throw.** A failing `:rf.assert/path-equals` doesn't blow up the variant — it appends an entry to the variant frame's assertion accumulator. The play sequence runs to completion either way; the test runner asks "did every entry pass?" at the end.
+1. **Each variant runs in its own frame.** Fresh `app-db`, fresh queue, fresh sub-cache. State doesn't leak between scenarios. What you see is what production would render against the same fixture. This sounds like a small thing; it isn't. It's the reason every other rule on this list is sustainable.
 
-Most of Story's distinctive properties — the test-mode reporter, the snapshot identity, the MCP write surface — are downstream of those three rules.
+2. **Variant bodies are data — never functions.** A variant body is a map with `:events`, `:args`, `:decorators`, `:play-script`, etc. Every slot is plain EDN, round-trippable across the network. Closures live in exactly one place: inside decorator registrations, where they're a registration-site concern, not a variant-body concern. This is the lock that lets MCP, visual-regression services, and agent input pipelines all consume the same shape.
+
+3. **Assertions record, don't throw.** A failing `:rf.assert/path-equals` doesn't blow up the variant — it appends an entry to the variant frame's assertion accumulator. The play sequence runs to completion either way; the test runner asks "did every entry pass?" at the end. You get the full picture from a broken variant, not a stack trace and a single failure.
+
+Most of Story's distinctive properties — the test-mode reporter, the snapshot identity, the MCP write surface, the agent self-healing loop — are downstream consequences of those three rules. Internalise them now; the rest of the tutorial spends its time showing what they buy you.
 
 ## Where to install
 
-### One-liner — scaffold a fresh Story-enabled app
+### The one-liner — scaffold a fresh Story-enabled app
 
-The canonical [`re-frame2-template`](https://github.com/day8/re-frame2/tree/main/tools/template) scaffolds a working Reagent app with the Story playground wired in. One invocation, one command:
+The canonical [`re-frame2-template`](https://github.com/day8/re-frame2/tree/main/tools/template) scaffolds a working Reagent app with the Story playground wired in. One invocation:
 
 ```bash
 clojure -Tnew create \
@@ -62,16 +81,16 @@ clojure -Tnew create \
         :include-story? true
 ```
 
-The generated tree carries a `src/acme/my_app/stories.cljs` namespace with the canonical `reg-story` / `reg-variant` / `reg-workspace` shapes wired against the counter, a `core.cljs` entry that hash-routes `#/stories` to the Story shell, and a `deps.edn` / `package.json` with Story on the dev classpath. `cd my-app && npm install && npx shadow-cljs watch app`, open `http://localhost:8280/#/stories`, and you're in.
+The generated tree carries a `src/acme/my_app/stories.cljs` namespace with the canonical `reg-story` / `reg-variant` / `reg-workspace` shapes wired against a counter, a `core.cljs` entry that hash-routes `#/stories` to the Story shell, and the Story dep already in `:dev`. Run `cd my-app && npm install && npx shadow-cljs watch app`, open `http://localhost:8280/#/stories`, and you're in.
 
-This is the Story-flavoured equivalent of `npx storybook init` (rf2-jg11l — audit D-1). The `:include-story?` flag is Reagent-only at v1; UIx + Helix variants follow once Story's adapter coverage matches Reagent's. See [`tools/template/README.md`](https://github.com/day8/re-frame2/tree/main/tools/template/README.md) for the full flag matrix and the local-development variant of the invocation.
+This is the Story-flavoured equivalent of `npx storybook init`. The `:include-story?` flag is Reagent-only at v1; UIx + Helix variants follow once Story's adapter coverage catches up.
 
 ### Adding Story to an existing app
 
 Story lives at [`tools/story/`](https://github.com/day8/re-frame2/tree/main/tools/story) under coord `day8/re-frame2-story`. While re-frame2 is in alpha, vendor through a checkout:
 
 ```clojure
-;; deps.edn — Story should be a dev-shape dep; production builds DCE it.
+;; deps.edn — Story is a dev-shape dep; production builds DCE it.
 {:aliases
  {:dev
   {:extra-deps {day8/re-frame2-story {:local/root "tools/story"}}}}}
@@ -80,18 +99,23 @@ Story lives at [`tools/story/`](https://github.com/day8/re-frame2/tree/main/tool
 In your app's entry namespace:
 
 ```clojure
-(:require [re-frame.story :as story]
-          [my-app.stories])    ; loads the registrations
+(ns my-app.core
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [my-app.adapters.reagent :as reagent-adapter]
+            [my-app.stories]))    ; loads the registrations
 
 (defn run []
   (rf/init! reagent-adapter/adapter)
   ;; ... normal app boot ...
   (when (= "#/stories" js/window.location.hash)
-    (story/mount-shell! (js/document.getElementById "app"))))
+    (story/mount-shell! (js/document.getElementById "app") {})))
 ```
 
-No explicit `(story/install-canonical-vocabulary!)` call — the first `reg-*` in `my-app.stories` (loaded via the `:require` above) auto-installs the seven canonical tags, the lifecycle machine, the `:rf.assert/*` handlers, the built-in `force-fx-stub` decorator, and the v1.0 panel set per rf2-p1ydc. The boot ceremony is implicit; Storybook has no equivalent step, neither does Story. Production builds — where `re-frame.story.config/enabled?` is `false` via `:closure-defines` — short-circuit at registration time, and `mount-shell!` short-circuits before any DOM call.
+Notice what's *not* in that boot snippet: there's no explicit `(story/install-canonical-vocabulary!)` call. The first `reg-*` in `my-app.stories` (loaded via the `:require` above) auto-installs the seven canonical tags, the lifecycle machine, the `:rf.assert/*` handlers, the built-in `force-fx-stub` decorator, and the v1.0 panel set. The boot ceremony is implicit. Storybook has no equivalent step; neither does Story.
 
-The shell is a three-pane Reagent component: a **left sidebar** (stories tree + tag filter + workspaces), the **main pane** (selected variant's canvas or selected workspace), and a **right panel** — Causa embedded as the primary inspector, plus controls, the dispatch console, play status, and any project-custom `reg-story-panel` placements (rf2-sgdd3).
+Production builds — where `re-frame.story.config/enabled?` is `false` via `:closure-defines` — short-circuit at registration time, and `mount-shell!` short-circuits before any DOM call. The Story playground is a development-only artefact; it does not ship to your users.
+
+The shell is a three-pane Reagent component: a **left sidebar** (stories tree + tag filter + workspaces), the **main pane** (selected variant's canvas or selected workspace), and a **right panel** — Causa embedded as the primary inspector, plus controls, dispatch console, and any project-custom `reg-story-panel` placements.
 
 Ready? Start at [your first story](01-first-story.md).


### PR DESCRIPTION
Closes rf2-0pvm3.

## Summary

Refreshes all eight Story tutorial files at `/docs/story/` to modern user-tutorial standards. Every chapter now opens with explicit "What you'll build" + "You should have working before you start" prereq blocks, closes with "You should now see" confirmation + "When it doesn't work" diagnostic sections, and links cleanly to the next chapter.

The voice is Steve Yegge — long-form paragraphs that wander productively, dry wit, opinions backed by reasoning, anecdotes that build intuition before syntax. First-person plural conversational throughout. Storybook is referenced where it's load-bearing for orientation (recorder, Modes, snapshot identity) and otherwise left out — no running comparison commentary.

## Technical corrections against the live `tools/story/spec/` contract

- Every `:play` slot replaced with `:play-script` carrying `[:dispatch-sync ...]` step-tuples (rf2-0wrud retired the legacy `:play` slot). Worked examples in chapters 1, 3, 5 updated.
- Chapter 2's a11y description: corrected to CDN-with-opt-in + SRI integrity (per spec/005 SOTA-Features) rather than "vendored locally."
- Chapter 5's QR encoder: confirmed correctly described as locally-vendored via the `qrcode-generator` npm package (per rf2-20w5i).
- `force-fx-stub-id` Var referenced as the canonical surface for the built-in fx-stub decorator.
- Four-layer args resolution chain (global / mode / story / variant + live cell-overrides) spelled out consistently in chapters 1 and 4.
- Cross-links to Causa (chapter 6) and Guide chapters (19 adapters, 23a privacy) verified to resolve.

## Screenshot placeholders

Ten `> 📸 Screenshot needed` admonitions across the chapters mark exactly which annotated captures Mike should take later, each with numbered callouts and a save-path under `/docs/images/story/<chapter>-<topic>.png`. The agent has no browser-control and cannot capture live UI; these placeholders are the prose substitute.

## Gates

- `python scripts/check_doc_slugs.py` — passes (exit 0)
- `python -m mkdocs build --strict` — passes (built docs in 8.15s, no warnings on Story chapters)

## Test plan

- [ ] Read each chapter end-to-end as a new user; does the narrative arc carry from "first story" to "advanced work"?
- [ ] Verify the corrected `:play-script` shape against any pre-existing user code samples elsewhere in docs (none expected; spec was the source of truth).
- [ ] Capture the ten screenshots and drop them at the indicated paths.
- [ ] (Optional) Spot-check Yegge voice — is it Yegge-ish without being parodic?