### PR TITLE
ci(lint): add clj-kondo + Splint CI gates as dual-linter posture (rf2-4v147)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -25,4 +25,14 @@
   re-frame.core/reg-event-fx    clojure.core/def
   re-frame.core/reg-sub         clojure.core/def
   re-frame.core/reg-fx          clojure.core/def
-  re-frame.core/reg-cofx        clojure.core/def}}
+  re-frame.core/reg-cofx        clojure.core/def}
+
+ ;; rf2-4v147 — outputs filtered post-analysis. `tools/template/resources/`
+ ;; ships deps-new template resources whose `.cljs` files contain
+ ;; `{{placeholder}}` substitutions and are not valid Clojure (see
+ ;; tools/deps.edn → "Why template is NOT in the base :deps map" for
+ ;; the matching shadow-cljs exclusion). The CI workflow also avoids
+ ;; passing that path to `--lint`; this filter is the belt-and-braces
+ ;; for editor integrations and ad-hoc local runs that pass the broader
+ ;; `tools/` path.
+ :output {:exclude-files ["tools/template/resources/"]}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,185 @@
+name: lint
+
+# Dual-linter CI gate (rf2-4v147 · Mike-confirmed 2026-05-21).
+#
+# Two complementary linters run as parallel jobs:
+#
+#   - clj-kondo: bug-class linter (unresolved symbols, arity mismatches,
+#     redefined vars, unused bindings). The `.clj-kondo/config.edn` at
+#     repo root is the shared source of truth — editor integrations
+#     (Calva, CIDER, Cursive) read the same file.
+#
+#   - Splint (noahtheduke/splint): style-shape linter inspired by the
+#     Clojure Style Guide. Catches idiomatic-Clojure smells that
+#     kondo's lexical analysis is not designed to surface. Per-project
+#     config lives in `.splint.edn` at repo root.
+#
+# FIRST-ITERATION POSTURE: both jobs are REPORT-ONLY
+# (`continue-on-error: true`). The baseline at landing is ~4100 kondo
+# warnings + 25 errors and ~1660 Splint warnings + 4 errors — a mix of
+# pre-existing test-fixture quirks (slashed keywords like `:no/such/event`
+# in trace tests), kondo's "Unresolved var" noise on the framework's
+# dynamically-defined registration macros, and Splint's style suggestions
+# that need triaging before they earn their teeth. Follow-on bead tightens
+# both gates once the baseline is triaged.
+#
+# Lint surface: implementation/, tools/ (minus template/resources/),
+# examples/, testbeds/. Generated trees (.shadow-cljs/, target/,
+# node_modules/, .beads/, ai/) are excluded by virtue of the explicit
+# `--lint` paths below. The `tools/template/resources/` deps-new
+# template tree is excluded explicitly — those `.cljs` files carry
+# `{{placeholder}}` substitutions and are not valid Clojure (see
+# tools/deps.edn for the matching shadow-cljs exclusion rationale).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'implementation/**'
+      - 'tools/**'
+      - 'examples/**'
+      - 'testbeds/**'
+      - '.clj-kondo/**'
+      - '.github/workflows/lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'implementation/**'
+      - 'tools/**'
+      - 'examples/**'
+      - 'testbeds/**'
+      - '.clj-kondo/**'
+      - '.github/workflows/lint.yml'
+  # Nightly run keeps the gate honest even when no lint-surface file
+  # changes (e.g. a dep bump in another tree might silently break kondo
+  # via :lint-as). 03:30 UTC sits below the 04:00 UTC `expensive-tests`
+  # window so the lint gate's signal lands before the deeper sweep.
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clj-kondo:
+    name: clj-kondo (report-only, first iteration)
+    runs-on: ubuntu-latest
+    # First-iteration posture: kondo is informational while we baseline
+    # the 25-ish pre-existing errors (a mix of test-fixture keywords
+    # like `:no/such/event`, internal-private references, and a couple
+    # of arity drifts in test code). Follow-on bead tightens this to
+    # fail-loud once those are triaged. See rf2-4v147 PR description for
+    # the baseline report.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      # Install the official binary directly — the published GitHub
+      # Actions for clj-kondo are either unmaintained (DeLaGuardo's runs
+      # on node12, deprecated by GitHub) or community-forked. The
+      # upstream `install-clj-kondo` script is the documented path and
+      # leaves the binary on $PATH.
+      - name: Install clj-kondo
+        run: |
+          curl -fsSL -o install-clj-kondo \
+            https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
+          chmod +x install-clj-kondo
+          sudo ./install-clj-kondo --version 2026.04.15
+          clj-kondo --version
+
+      # Cache the kondo classpath / project-analysis under
+      # ~/.clj-kondo so subsequent runs reuse the type info. The cache
+      # key is keyed on every `deps.edn` in the lint surface so a dep
+      # bump invalidates the cache.
+      - name: Cache clj-kondo analysis
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.clj-kondo
+            .clj-kondo/.cache
+          key: ${{ runner.os }}-kondo-${{ hashFiles('.clj-kondo/config.edn', 'implementation/**/deps.edn', 'tools/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-kondo-
+
+      # `tools/template/resources/` is excluded — those `.cljs` files
+      # ship deps-new placeholders (`{{top/ns}}`) and are not valid
+      # Clojure (see tools/deps.edn → "Why template is NOT in the base
+      # :deps map" for the matching shadow-cljs exclusion). `tools/`
+      # subdirs are listed explicitly to skip resources/ while keeping
+      # tools/template/{src,test}.
+      #
+      # `--parallel` fans out file analysis across cores. `|| true`
+      # caps the first-iteration report-only posture (belt-and-braces
+      # with continue-on-error so a non-zero exit from kondo doesn't
+      # bubble up either way).
+      - name: Run clj-kondo
+        run: |
+          clj-kondo \
+            --parallel \
+            --lint implementation \
+            --lint examples \
+            --lint testbeds \
+            --lint tools/causa \
+            --lint tools/machines-viz \
+            --lint tools/mcp-base \
+            --lint tools/mcp-conformance \
+            --lint tools/re-frame2-pair-mcp \
+            --lint tools/story \
+            --lint tools/story-mcp \
+            --lint tools/template/src \
+            --lint tools/template/test \
+            || true
+
+  splint:
+    name: Splint (report-only, first iteration)
+    runs-on: ubuntu-latest
+    # Splint never fails the gate at first-iteration. The `continue-on-error`
+    # at the job level is intentional: we want PR authors to see the report
+    # without blocking on style noise until the baseline stabilises.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-splint-${{ hashFiles('implementation/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-splint-
+            ${{ runner.os }}-clj-
+
+      # Splint is JVM-only and lives on the `:splint` alias of the
+      # top-level coordinator. Running from `implementation/` keeps the
+      # alias next to the artefacts it lints; the explicit path args
+      # widen the surface to tools/ + examples/ + testbeds/.
+      #
+      # `|| true` is the report-only gate: Splint exits non-zero when it
+      # finds style warnings, but we don't fail the workflow on that.
+      # Combined with the job-level continue-on-error this gives us two
+      # belt-and-braces against blocking PRs on style noise.
+      - name: Run Splint
+        working-directory: implementation
+        run: |
+          clojure -M:splint \
+            ../implementation \
+            ../tools \
+            ../examples \
+            ../testbeds \
+            || true

--- a/.splint.edn
+++ b/.splint.edn
@@ -1,0 +1,14 @@
+;; Splint configuration (rf2-4v147 · dual-linter CI gate).
+;;
+;; First-iteration posture: report-only (no rules disabled here; the
+;; `lint.yml` workflow runs Splint with `continue-on-error: true`).
+;; Triage + rule-tuning lands in a follow-on bead.
+;;
+;; The only configuration we MUST carry is the exclusion of
+;; `tools/template/resources/` — those `.cljs` files ship deps-new
+;; placeholder substitutions (`{{top/ns}}`) and are not valid Clojure
+;; (see tools/deps.edn → "Why template is NOT in the base :deps map"
+;; for the matching shadow-cljs exclusion). Splint's parser errors on
+;; them.
+
+{global {:excludes ["tools/template/resources/"]}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,43 @@ no tilde — so every artefact's lockfile and `deps.edn` resolves identically.
 If you bump a shared dep, bump it everywhere in the same PR; CI gates this
 across the matrix.
 
+## Linting
+
+Two complementary linters run on every PR (rf2-4v147):
+
+- **clj-kondo** — bug-class linter (unresolved symbols, arity mismatches,
+  redefined vars, unused bindings). Config lives at
+  [`.clj-kondo/config.edn`](.clj-kondo/config.edn); editor integrations (Calva,
+  CIDER, Cursive) read the same file.
+- **Splint** — style-shape linter inspired by the
+  [Clojure Style Guide](https://guide.clojure.style). Catches idiomatic-Clojure
+  smells outside kondo's lexical analysis. Per-project config in
+  [`.splint.edn`](.splint.edn).
+
+**First-iteration posture (rf2-4v147 follow-on bead pending):** both jobs are
+**report-only** — they surface findings in the PR's check log but do not block
+the merge. The baseline at landing is ~4 000 kondo warnings + 25 errors and
+~1 600 Splint warnings + 4 errors, a mix of pre-existing test-fixture quirks
+(slashed keywords in trace tests), kondo's "Unresolved var" noise on the
+framework's dynamically-defined registration macros, and Splint's style
+suggestions that need triaging before they earn their teeth. The follow-on
+bead tightens the gates once the baseline is triaged.
+
+Run locally before opening a PR:
+
+```bash
+# clj-kondo (install via https://github.com/clj-kondo/clj-kondo#installation)
+clj-kondo --lint implementation tools examples testbeds
+
+# Splint (no install — the alias pins the dep)
+cd implementation
+clojure -M:splint ../implementation ../tools ../examples ../testbeds
+```
+
+Editor integration is kondo-only for now — Calva/CIDER/Cursive consume the
+shared `.clj-kondo/config.edn` automatically. Splint is CI-only at first
+iteration.
+
 ## Security issues
 
 Please do not file security-relevant problems as public issues or pull

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -79,4 +79,18 @@
                  day8/re-frame2-test-quiet {:local/root "test-quiet"}
                  io.github.cognitect-labs/test-runner
                  {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-   :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}
+   :main-opts   ["-m" "re-frame.test-quiet.runner"]}
+
+  ;; Splint (rf2-4v147) — Mike-confirmed dual-linter posture
+  ;; (2026-05-21): clj-kondo catches bugs (unresolved symbols, arity
+  ;; mismatch); Splint catches style smells inspired by the Clojure
+  ;; Style Guide. CI invokes the alias from `.github/workflows/lint.yml`;
+  ;; locally run `clojure -M:splint <paths>` from this directory.
+  ;;
+  ;; Splint is JVM-only and operates on text, so it does not need any
+  ;; of the per-artefact classpaths — pinning the dep on the top-level
+  ;; coordinator keeps the version in one place. Pre-1.0 we exact-pin
+  ;; per the lockstep convention.
+  :splint
+  {:replace-deps {io.github.noahtheduke/splint {:mvn/version "1.24.0"}}
+   :main-opts    ["-m" "noahtheduke.splint"]}}}


### PR DESCRIPTION
Closes rf2-4v147. Per Mike's 2026-05-21 decision: keep clj-kondo + add Splint alongside, complementary rule sets.

## Summary

- New `.github/workflows/lint.yml` runs two parallel jobs on PR + push + nightly:
  - **clj-kondo** (`v2026.04.15`) — bug-class linter (unresolved symbols, arity mismatches, redefined vars, unused bindings).
  - **Splint** (`io.github.noahtheduke/splint v1.24.0`) — style-shape linter inspired by the Clojure Style Guide.
- Both jobs are **report-only** at first iteration (`continue-on-error: true` + trailing `|| true`). Triage of the existing baseline lives in follow-on **rf2-60nez**, which then tightens both gates to fail-loud.
- `tools/template/resources/` is excluded from both linters — those `.cljs` files ship deps-new template placeholders (`{{top/ns}}`) and are not valid Clojure (same rationale as the shadow-cljs exclusion documented in `tools/deps.edn`).

## Why report-only first

The spec-reference impl is large and pre-alpha; the very first cross-repo lint sweep surfaces a lot of noise that is mostly pre-existing, not a regression. Per Mike's posture guidance the gate goes in informational so it does not immediately become "the gate that's always red"; the follow-on bead then triages + tightens.

## Sample run (local, ubuntu via WSL2)

### clj-kondo
```
linting took 10154ms, errors: 25, warnings: 4123
```

Top error themes (full list in `rf2-60nez`):
- 11x `Invalid keyword: :no/such/event` etc. — deliberate sentinel keywords in trace + epoch + SSR conformance tests (Clojure reader accepts; kondo's strict EBNF rejects).
- 2x arity drift in test code (`init!` 0-arg, `get-frame-db` 0-arg) — likely real bugs.
- 2x `Invalid require: no libs specified to load` — `(:cljs (:require))` empty forms.
- 2x private-var access (`#'cljs.core/pr-writer`, `#'day8.re-frame2-causa.panels.machine-canvas/view-mode-toggle`).
- 1x duplicate `case` constant.

Top warning themes (4123 total):
- 2494x `inline def` — `(def ...)` inside `(testing ...)` blocks.
- 1158x `Unresolved symbol` / `Unresolved var` for the framework's registration macros (`reg-frame`, `reg-flow`, `reg-route`, `reg-app-schema*`, `reg-machine`, `reg-error-projector`, `reg-head`, `reg-http-interceptor`, `reg-event-ctx`, `reg-view`) — `.clj-kondo/config.edn` only `:lint-as` covers `reg-event-db/fx`, `reg-sub`, `reg-fx`, `reg-cofx`. Extending the `:lint-as` map clears most of this; landed as a sub-task of rf2-60nez.

### Splint
```
Linting took 11381ms, checked 1191 files, 1663 style warnings, 4 errors
```

Top rule-genre frequencies:
- 831 `[lint/*]` — likely-bugs (identical branches, let-when, let-if, catch-throwable, into-literal).
- 722 `[style/*]` — style smells (`eq-zero` → `zero?`, `prefer-clj-string`, `eq-true`, `tostring`, `plus-one`, `redundant-let`).
- 110 `[naming/*]` — lisp-case + conversion-fn naming.
- 4 `[splint/parsing-error]` — the same slashed-keyword test fixtures kondo trips on.

## File-by-file

- **`.github/workflows/lint.yml`** — new workflow. Direct download of the official clj-kondo binary (the published GitHub Action runs on deprecated node12). Splint uses the standard `setup-java` + `setup-clojure` pair, matching `test.yml`'s SHA-pinned conventions.
- **`.clj-kondo/config.edn`** — adds `:output {:exclude-files ["tools/template/resources/"]}` for editor-integration consistency. Editor integrations (Calva, CIDER, Cursive) read the same file.
- **`.splint.edn`** — new file, mirrors the template/resources exclusion via Splint's `global :excludes` key.
- **`implementation/deps.edn`** — adds `:splint` alias pinning `io.github.noahtheduke/splint {:mvn/version "1.24.0"}` via `:replace-deps` (exact-pin per the lockstep convention).
- **`CONTRIBUTING.md`** — new "Linting" section documents the dual-linter posture, local-run commands (kondo + Splint), and editor-integration scope.

## Test plan

- [ ] `lint` workflow appears in PR checks as `clj-kondo` + `Splint` jobs.
- [ ] Both jobs succeed (report-only / `continue-on-error: true`).
- [ ] kondo + Splint output visible in the run log with the expected baseline counts (above).
- [ ] No effect on the `tests` / `docs` workflows (path-filtered).