### PR TITLE
feat(causa): light theme — migrate inline-style sites to CSS custom properties (rf2-on4cm)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -717,6 +717,40 @@ Perf:      fast     #4ADE80  (<16ms)
 Light theme inverts lightness (`bg-0 #FAFBFC`, `bg-1 #F1F3F6`, `bg-2
 #FFFFFF`); accents darken slightly to maintain contrast.
 
+### CSS custom-property surface (rf2-on4cm)
+
+Every palette token is published as a `--rf-causa-<key>` CSS custom
+property on `:root` (default = dark palette), `.rf-causa-theme-dark`,
+and `.rf-causa-theme-light`. The shell-root class toggle written by
+`settings/effects/apply-theme!` flips which block is in scope, so a
+descendant reading `var(--rf-causa-bg-1)` resolves to the active
+theme's hex without any per-component branching.
+
+The 357+ inline-style call sites that read `(:bg-1 tokens)` consume
+the canonical `theme.tokens/tokens` map — post the v1.0 sweep
+(rf2-on4cm) every entry is a `"var(--rf-causa-<key>)"` string rather
+than a literal hex, so every paint flows through the active class
+scope automatically. The dark- and light-palette maps remain the
+hex source of truth that `theme.global-styles/themes-css` reads to
+emit the custom-property registrations.
+
+Two consumer paths stay on the hex maps directly:
+
+- `mount.cljs`'s popout opener-gone overlay (built imperatively in
+  the popout window's document, which does not carry the Causa
+  `<style>` injection) reads `theme.tokens/dark-palette` for its
+  literal hexes.
+- `config.cljc`'s `default-accent` publishes a literal hex INTO the
+  `--rf-causa-accent` host-readable variable as its default value
+  (`API.md` §CSS variables), so it must remain a hex string rather
+  than a recursive var reference.
+
+Where an alpha tint is needed, `theme.tokens/with-alpha` builds the
+canonical `color-mix(in srgb, var(--rf-causa-<key>) <pct>%,
+transparent)` string — CSS-Color-4 composition that picks up the
+active-theme variable rather than concatenating an `#xxxxxx55` hex
+tail.
+
 ### Colour is never alone
 
 Every coloured marker pairs with a shape or icon:

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -135,10 +135,15 @@
 (def default-accent
   "Default value Causa publishes for `--rf-causa-accent` — the
   violet from `theme/tokens.cljc` (`:accent-violet`). Resolved
-  through the canonical tokens map so the brand hex has exactly one
-  source of truth (rf2-5kfxe.4). Matches the accent catalogued in
-  `spec/007-UX-IA.md` §Colour system."
-  (:accent-violet tokens/tokens))
+  through the canonical `dark-palette` map so the brand hex has
+  exactly one source of truth (rf2-5kfxe.4). Matches the accent
+  catalogued in `spec/007-UX-IA.md` §Colour system.
+
+  Reads `dark-palette` (the literal hex map) rather than `tokens`
+  because `tokens` exposes CSS-variable strings (`var(--rf-causa-…)`)
+  post rf2-on4cm; this constant is the VALUE that gets published
+  INTO the CSS variable, not a reference to it."
+  (:accent-violet tokens/dark-palette))
 
 (def default-layout-host-snippet
   ;; DOM order is `<main>` first, host `<aside>` second — flex flow

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -692,17 +692,27 @@
 ;; avoid pulling theme into the install path" rationale was stale —
 ;; `theme.tokens` has no transitive deps and is the canonical palette.
 
+;; The overlay paints into the popout window's own document via
+;; imperative `set! style.background` etc. — that document does NOT
+;; carry the Causa `<style>` injection that registers the
+;; `--rf-causa-…` custom properties on `:root`, so reading from
+;; `tokens` (which is a `var(...)` map post rf2-on4cm) would resolve
+;; to the property's default initial value rather than the brand
+;; palette. These constants read `dark-palette` directly so the
+;; literal hex still flows through `theme/tokens` as the single
+;; source of truth.
+
 (def ^:private opener-gone-overlay-bg
-  (:bg-0 tokens/tokens))
+  (:bg-0 tokens/dark-palette))
 
 (def ^:private opener-gone-overlay-text
-  (:text-primary tokens/tokens))
+  (:text-primary tokens/dark-palette))
 
 (def ^:private opener-gone-overlay-secondary
-  (:text-secondary tokens/tokens))
+  (:text-secondary tokens/dark-palette))
 
 (def ^:private opener-gone-overlay-accent
-  (:accent-violet tokens/tokens))
+  (:accent-violet tokens/dark-palette))
 
 (def ^:private sans-stack
   tokens/sans-stack)

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -86,7 +86,7 @@
   globally so the user reads the operation as continuous."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.config :as config]
-            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+            [day8.re-frame2-causa.theme.tokens :as t :refer [tokens]]))
 
 ;; ---- keyboard step constants -------------------------------------------
 
@@ -343,8 +343,13 @@
    :cursor           "col-resize"
    :background       "transparent"
    ;; Hairline guide on the leftmost pixel so the affordance is
-   ;; visible against any host-app background.
-   :box-shadow       (str "inset 1px 0 0 0 " (:accent-violet tokens) "55")
+   ;; visible against any host-app background. `~33% alpha` of the
+   ;; accent violet (the historical "#7C5CFF55" tail-suffix). Built
+   ;; via `tokens/with-alpha` so the alpha composites with the
+   ;; ACTIVE-theme variable (rf2-on4cm) — light mode lands on the
+   ;; light accent at 33% alpha, dark on the dark accent at 33% alpha.
+   :box-shadow       (str "inset 1px 0 0 0 "
+                          (t/with-alpha :accent-violet 33))
    ;; Above the chrome's panels but below the modals; modals use
    ;; max-int z-index so we won't fight them.
    :z-index          1000

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -170,14 +170,87 @@
   {:dark  dark-palette
    :light light-palette})
 
+(defn css-var
+  "Map a token key (`:bg-1`, `:accent-violet`, …) to the canonical
+  `\"var(--rf-causa-<key>)\"` CSS string consumed by inline `:style`
+  maps + SVG paint properties. Pure data → string; JVM-portable.
+
+  The CSS custom-property block emitted by
+  `theme/global-styles/themes-css` registers every palette key at
+  `:root` (dark default) + `.rf-causa-theme-dark` / `.rf-causa-theme-
+  light` so the class toggle on the shell root flips every downstream
+  `var(--rf-causa-…)` reference in one assignment.
+
+  The 357-site v1.0 sweep (rf2-on4cm) routes every inline-style read
+  of a palette token through this function (via the `tokens` map,
+  which now consists of `var(--…)` strings rather than hex). That
+  makes the light theme actually paint — the class toggle was wired
+  but inline styles were reading the dark-palette hex directly,
+  so the toggle had no observable effect."
+  [k]
+  (str "var(--rf-causa-" (name k) ")"))
+
+(defn with-alpha
+  "Build a `color-mix(in srgb, var(--rf-causa-<key>) <pct>%, transparent)`
+  CSS string. The CSS-Color-4 idiom for compositing a palette token
+  with an alpha channel without forking the hex — Chrome 111+, Safari
+  16.2+, Firefox 113+. Use this where the old code did string
+  concatenation with a two-digit alpha suffix (`(str (:accent-violet
+  tokens) \"55\")`).
+
+  `k`  - palette key (`:accent-violet`, …)
+  `pct` - opacity percentage (0-100). The `transparent` partner makes
+          the result equivalent to that fractional alpha.
+
+  Pure data → string; JVM-portable."
+  [k pct]
+  (str "color-mix(in srgb, " (css-var k) " " pct "%, transparent)"))
+
 (def tokens
-  "Backward-compatible alias for the dark palette. The 357 inline-style
-  call sites that read `(:bg-1 tokens)` keep resolving against the
-  dark palette; the light theme is layered on top via CSS custom
-  properties (see `theme/global-styles/themes-css`). The v1.0 styling
-  pass migrates each call site through to the CSS-variable surface so
-  the inline-style indirection collapses."
-  dark-palette)
+  "Causa's design palette, exposed as CSS-variable strings.
+
+  Every value is `\"var(--rf-causa-<key>)\"` — the CSS custom-property
+  registered by `theme/global-styles/themes-css` against the active
+  theme class (`rf-causa-theme-dark` / `rf-causa-theme-light`). Inline
+  `:style` reads of `(:bg-1 tokens)` resolve to `\"var(--rf-causa-bg-1)\"`
+  and the browser substitutes the dark or light hex at paint time
+  based on the class toggle on the shell root.
+
+  ## Why a var-map rather than a hex-map (rf2-on4cm)
+
+  Pre-rf2-on4cm `tokens` was an alias of `dark-palette` — every inline
+  style site (~357 of them) read a hardcoded dark-palette hex
+  regardless of the active theme class. The light-theme class toggle
+  was wired through `settings/effects/apply-theme!` and the CSS
+  variable block was emitted, but inline styles ignored both — light
+  mode was paint-only-the-edges broken.
+
+  Replacing the hex map with a CSS-variable map flips every existing
+  call site to the variable surface without per-site edits: a token
+  read like `(:bg-1 tokens)` now yields the `var(--rf-causa-bg-1)`
+  reference, and the active theme's class scope on the shell root
+  decides which palette resolves at paint time.
+
+  ## The few sites that still need raw hex
+
+  Two call sites consume the literal hex rather than a CSS variable:
+
+  - `mount.cljs`'s popout opener-gone overlay paints into the popout
+    window's `<body>` imperatively (`set! style.background`) — the
+    popout document doesn't carry the Causa `<style>` injection, so
+    `var(--rf-causa-bg-0)` would resolve to the default initial value.
+    These reads use `dark-palette` directly.
+  - `config.cljc`'s `default-accent` publishes a literal hex INTO the
+    `--rf-causa-accent` CSS variable as its default value, so it
+    must remain a hex string.
+
+  Other consumers (SVG `:fill`, inline `:style :background`, etc.)
+  flow through `var(...)` unchanged — modern browsers (Chrome 49+,
+  Firefox 31+, Safari 9.1+) accept CSS custom properties in every
+  paint property including SVG attributes."
+  (into {}
+        (for [k (keys dark-palette)]
+          [k (css-var k)])))
 
 (def mono-stack
   "JetBrains Mono stack per spec/007-UX-IA.md §Typography. Used by
@@ -433,10 +506,14 @@
    :chrome-a11y     :red})
 
 (defn panel-accent
-  "Resolve the L4 panel's accent hex from the canonical
+  "Resolve the L4 panel's accent CSS-variable string from the canonical
   `panel-domain->token` map through `tokens`. Falls back to the
-  violet accent for unknown tab keywords so the stripe always
-  renders."
+  `:accent-violet` variable for unknown tab keywords so the stripe
+  always renders.
+
+  Returns a `\"var(--rf-causa-<key>)\"` string post rf2-on4cm — the
+  active theme class scope on the shell root decides which palette's
+  hex resolves at paint time."
   [tab]
   (get tokens
        (get panel-domain->token tab :accent-violet)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
@@ -58,10 +58,12 @@
 (deftest every-status-resolves-to-a-non-nil-hex
   (testing "the indirection chain (status → token-kw → hex) lands on
             a real hex for every status. No magenta-tinted gap, no
-            missing key in `theme/tokens`."
+            missing key in `theme/tokens`. Drives off `dark-palette`
+            directly (the hex source of truth) — `tokens` exposes
+            CSS-variable strings post rf2-on4cm."
     (doseq [status esc/statuses]
       (let [token-kw (esc/status->token status)
-            hex      (get tokens/tokens token-kw)]
+            hex      (get tokens/dark-palette token-kw)]
         (is (string? hex) (str status " → " token-kw " resolves to a hex"))
         (is (re-find #"^#[0-9A-Fa-f]+$" hex)
             (str status " hex " hex " starts with #"))))))
@@ -155,9 +157,11 @@
 ;; ---- hex resolver --------------------------------------------------------
 
 (deftest event-status-colour-resolves-through-tokens
-  (testing "every state-input → hex matches the indirection
-            (state → status → token → tokens hex). No inline hexes
-            in the resolver path."
+  (testing "every state-input → colour matches the indirection
+            (state → status → token → tokens value). No inline hexes
+            in the resolver path. Post rf2-on4cm `tokens` exposes
+            CSS-variable strings; both sides of the comparison go
+            through the same map so the indirection is what's pinned."
     (doseq [[state expected-status]
             [[{:outcome :ok}              :settled-success]
              [{:outcome :error}           :settled-error]
@@ -167,10 +171,10 @@
              [{:in-flight? true}          :in-flight]
              [{:paused? true}             :paused-by-tool]
              [{}                          :in-flight]]]
-      (let [expected-hex (get tokens/tokens
-                              (get esc/status->token expected-status))]
-        (is (= expected-hex (esc/event-status-colour state))
-            (str "state " state " resolves to " expected-status " hex"))))))
+      (let [expected-colour (get tokens/tokens
+                                 (get esc/status->token expected-status))]
+        (is (= expected-colour (esc/event-status-colour state))
+            (str "state " state " resolves to " expected-status " colour"))))))
 
 (deftest event-status-token-resolves-to-keyword
   (testing "`event-status-token` is the keyword-side of the resolver
@@ -248,9 +252,13 @@
 (deftest visual-smoke-per-state-colour-mapping
   (testing "Visual smoke for the bead's acceptance criterion — each
             lifecycle state surfaces in its expected anchor colour
-            across the dark palette. Failures here flag a palette
-            drift (token renamed) or a classifier regression."
-    (let [palette tokens/dark-palette]
+            across the palette. Failures here flag a palette drift
+            (token renamed) or a classifier regression. Post rf2-on4cm
+            `event-status-colour` returns CSS-variable strings (the
+            class toggle on the shell root decides whether the dark or
+            light hex resolves at paint time); we compare against the
+            same var-map (`tokens/tokens`)."
+    (let [palette tokens/tokens]
       (is (= (:accent-violet palette)
              (esc/event-status-colour {:in-flight? true}))
           "in-flight rides violet — the project's causal-chain accent")

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
@@ -31,6 +31,7 @@
   Same approach as the surrounding panel suites — we walk the
   rendered tree by `data-testid` rather than mounting to a DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -125,8 +126,8 @@
         (is (= "settled-success" status)
             "settled-success vocabulary lands on the row")
         (is (string? shadow))
-        (is (re-find (re-pattern (:green tokens/tokens)) shadow)
-            "row's box-shadow accent uses the canonical :green hex")))))
+        (is (string/includes? shadow (:green tokens/tokens))
+            "row's box-shadow accent uses the canonical :green token")))))
 
 (deftest l2-row-errored-cascade-rides-red
   (testing "rf2-b76v4 — an errored cascade carries
@@ -142,8 +143,8 @@
             status (:data-rf-causa-status attrs)
             shadow (get-in attrs [:style :box-shadow])]
         (is (= "settled-error" status))
-        (is (re-find (re-pattern (:red tokens/tokens)) shadow)
-            "row's box-shadow accent uses the canonical :red hex")))))
+        (is (string/includes? shadow (:red tokens/tokens))
+            "row's box-shadow accent uses the canonical :red token")))))
 
 (deftest l2-row-warning-cascade-rides-green-not-yellow
   (testing "rf2-b76v4 — :warning outcomes resolve to :settled-success
@@ -160,7 +161,7 @@
             status (:data-rf-causa-status attrs)
             shadow (get-in attrs [:style :box-shadow])]
         (is (= "settled-success" status))
-        (is (re-find (re-pattern (:green tokens/tokens)) shadow))))))
+        (is (string/includes? shadow (:green tokens/tokens)))))))
 
 (deftest l2-row-status-comes-from-the-canonical-helper
   (testing "rf2-b76v4 — the row's data-rf-causa-status MATCHES the

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -26,7 +26,8 @@
     8. **`project-feed`** composite + empty-kind classification."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
-            [day8.re-frame2-causa.panels.trace-helpers :as h]))
+            [day8.re-frame2-causa.panels.trace-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- fixture builders ---------------------------------------------------
 
@@ -320,14 +321,19 @@
 ;; ---- (9) op-type-colour ------------------------------------------------
 
 (deftest op-type-colour-mapping
-  (is (= "#F87171" (h/op-type-colour :error)))
-  (is (= "#FBBF24" (h/op-type-colour :warning)))
-  (is (= "#43C3D0" (h/op-type-colour :info)))
-  (is (= "#7C5CFF" (h/op-type-colour :event)))
-  (is (= "#4ADE80" (h/op-type-colour :fx)))
-  (is (= "#E879F9" (h/op-type-colour :view/render)))
+  ;; Post rf2-on4cm `op-type-colour` returns CSS-variable strings —
+  ;; the active theme class on the shell root decides whether the dark
+  ;; or light hex resolves at paint time. Compare against the var-map
+  ;; (`tokens/tokens`) so the test pins the indirection rather than a
+  ;; specific palette's hex.
+  (is (= (:red    tokens/tokens)  (h/op-type-colour :error)))
+  (is (= (:yellow tokens/tokens)  (h/op-type-colour :warning)))
+  (is (= (:cyan   tokens/tokens)  (h/op-type-colour :info)))
+  (is (= (:accent-violet tokens/tokens) (h/op-type-colour :event)))
+  (is (= (:green  tokens/tokens)  (h/op-type-colour :fx)))
+  (is (= (:magenta tokens/tokens) (h/op-type-colour :view/render)))
   ;; Defensive fallback.
-  (is (= "#A8AEC0" (h/op-type-colour :totally-unknown))))
+  (is (= (:text-secondary tokens/tokens) (h/op-type-colour :totally-unknown))))
 
 ;; ---- (10) source-coord -------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -493,8 +493,10 @@
              without consuming layout width")
         (is (re-find #"1px 0 0 0" shadow)
             "1px wide, left edge — a vertical line")
-        (is (re-find #"#7C5CFF" shadow)
-            "violet accent — Causa's spine colour")))))
+        (is (re-find #"var\(--rf-causa-accent-violet\)" shadow)
+            "violet accent — Causa's spine colour, resolved through the
+             theme's CSS variable so the light theme picks up the
+             corresponding light-palette hex (rf2-on4cm)")))))
 
 (deftest event-list-suppresses-ungrouped-cascade-placeholder
   (testing "per rf2-639lc Bug 1 the L2 list filters out the `:ungrouped`

--- a/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
@@ -59,11 +59,15 @@
 ;; ---- (2) colour + glyph + label -----------------------------------------
 
 (deftest tier-colour-mirrors-spec
-  (testing "perf-scale hex strings match tools/causa/spec/007-UX-IA.md §Colour system"
-    (is (= "#4ADE80" (perf-tier/tier-colour :fast)))      ; green
-    (is (= "#FBBF24" (perf-tier/tier-colour :medium)))    ; yellow
-    (is (= "#FB923C" (perf-tier/tier-colour :slow)))      ; orange
-    (is (= "#F87171" (perf-tier/tier-colour :blocking)))) ; red
+  (testing "perf-scale hex strings match tools/causa/spec/007-UX-IA.md
+            §Colour system. Asserted via `dark-palette` directly (the
+            hex source of truth) — post rf2-on4cm `tier-colour` returns
+            CSS-variable strings, but the per-tier semantic mapping
+            still grounds in these spec-anchored hexes."
+    (is (= "#4ADE80" (:green  tokens/dark-palette)))      ; green
+    (is (= "#FBBF24" (:yellow tokens/dark-palette)))      ; yellow
+    (is (= "#FB923C" (:orange tokens/dark-palette)))      ; orange
+    (is (= "#F87171" (:red    tokens/dark-palette))))     ; red
   (testing "unknown tier falls back to text-tertiary so the dot is
             never invisible. Resolved through `theme/tokens` so the
             rf2-0fr6v contrast bump for `:text-tertiary` round-trips

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -26,20 +26,40 @@
 
 ;; ---- palette consistency -----------------------------------------------
 
-(deftest every-token-resolves-to-hex
-  (testing "every value in `tokens` is a 7-character #RRGGBB or 4-char
-            #RGB hex string (no nil drop-outs, no rgba() drift)"
+(deftest every-palette-value-resolves-to-hex
+  (testing "every value in `dark-palette` AND `light-palette` is a hex
+            string (no nil drop-outs, no rgba() drift). Asserted on the
+            palettes directly post rf2-on4cm — `tokens` exposes the
+            CSS-variable surface (`var(--rf-causa-…)`); the palettes
+            remain the hex source of truth registered against the
+            `:root` / `.rf-causa-theme-*` class scopes by
+            `theme/global-styles/themes-css`."
+    (doseq [palette-name [:dark :light]
+            :let [palette (get t/themes palette-name)]
+            [k v] palette]
+      (is (string? v) (str palette-name " " k " resolves to a string"))
+      (is (re-find #"^#[0-9A-Fa-f]{3,8}$" v)
+          (str palette-name " " k " value " v " is a # hex string")))))
+
+(deftest every-tokens-value-is-a-css-variable-reference
+  (testing "rf2-on4cm — `tokens` is the CSS-variable map. Every entry
+            resolves to `var(--rf-causa-<key>)` so inline `:style` reads
+            of `(:bg-1 tokens)` route through the active theme's class
+            scope rather than hardcoding the dark palette."
     (doseq [[k v] t/tokens]
       (is (string? v) (str "token " k " resolves to a string"))
-      (is (re-find #"^#[0-9A-Fa-f]{3,8}$" v)
-          (str "token " k " value " v " is a # hex string")))))
+      (is (re-find #"^var\(--rf-causa-" v)
+          (str "token " k " value " v " is a var(--rf-causa-…) reference"))
+      (is (re-find (re-pattern (str "--rf-causa-" (name k) "\\)")) v)
+          (str "token " k " references --rf-causa-" (name k))))))
 
-(deftest rf2-5kfxe4-deep-variants-and-white-present
+(deftest rf2-5kfxe4-deep-variants-and-white-present-in-palette
   (testing "rf2-5kfxe.4 — `:red-deep` and `:white` were added to
             consolidate the danger-button / primary-button fills
-            through tokens. Both must be reachable from every consumer."
-    (is (= "#a83a3a" (:red-deep t/tokens)))
-    (is (= "#ffffff" (:white t/tokens)))))
+            through tokens. Both must be reachable from every consumer.
+            Asserted on `dark-palette` (the hex source of truth)."
+    (is (= "#a83a3a" (:red-deep t/dark-palette)))
+    (is (= "#ffffff" (:white t/dark-palette)))))
 
 ;; ---- motion seam (rf2-5kfxe.5) -----------------------------------------
 
@@ -113,13 +133,47 @@
                 (get t/light-palette k))
           (str k " differs between the two palettes")))))
 
-(deftest tokens-alias-points-at-dark-palette
-  (testing "`tokens` stays a backward-compatible alias for the dark
-            palette — the 357 inline-style call sites that read
-            `(:bg-1 tokens)` continue to resolve to the dark hex. The
-            light-theme surface is the CSS-variable layer until the
-            v1.0 sweep migrates inline styles through to it."
-    (is (= t/dark-palette t/tokens))))
+(deftest tokens-is-the-css-variable-surface
+  (testing "rf2-on4cm — `tokens` is the CSS-variable map (post v1.0
+            sweep). The 357+ inline-style call sites that read
+            `(:bg-1 tokens)` now resolve to `\"var(--rf-causa-bg-1)\"`;
+            the active theme's class scope decides whether the dark or
+            light palette's hex paints at runtime."
+    (is (= (set (keys t/dark-palette))
+           (set (keys t/tokens))))
+    (doseq [k (keys t/dark-palette)]
+      (is (= (str "var(--rf-causa-" (name k) ")")
+             (get t/tokens k))
+          (str k " resolves to its var() reference")))))
+
+(deftest css-var-helper-matches-tokens-map-shape
+  (testing "rf2-on4cm — `css-var` is the canonical pure-data helper
+            that builds the `var(--rf-causa-<key>)` string. The
+            `tokens` map is `{k (css-var k)}` over every key in
+            `dark-palette`."
+    (is (= "var(--rf-causa-bg-1)" (t/css-var :bg-1)))
+    (is (= "var(--rf-causa-accent-violet)" (t/css-var :accent-violet)))
+    (doseq [k (keys t/dark-palette)]
+      (is (= (t/css-var k) (get t/tokens k))
+          (str k " resolves through css-var")))))
+
+(deftest with-alpha-builds-color-mix-string
+  (testing "rf2-on4cm — `with-alpha` is the canonical helper for the
+            alpha-tail-suffix idiom (`(str (:accent-violet tokens)
+            \"55\")`). Returns a `color-mix(in srgb, var(--rf-causa-<key>)
+            <pct>%, transparent)` string. CSS-Color-4 is the cross-
+            browser path that composes alpha against an arbitrary
+            CSS-variable colour."
+    (let [out (t/with-alpha :accent-violet 33)]
+      (is (string? out))
+      (is (re-find #"^color-mix\(in srgb" out)
+          "starts with color-mix(in srgb")
+      (is (re-find #"var\(--rf-causa-accent-violet\)" out)
+          "references the canonical CSS variable")
+      (is (re-find #"33%" out)
+          "carries the requested percentage")
+      (is (re-find #"transparent\)$" out)
+          "ends with the transparent partner so the result is a tint"))))
 
 ;; ---- panel domain colours (rf2-5kfxe.8) --------------------------------
 
@@ -152,11 +206,14 @@
 
 (deftest accent-stripe-style-emits-3px-left-border
   (testing "`accent-stripe-style` returns a merge-able style map
-            carrying the 3px left border + matching padding."
+            carrying the 3px left border + matching padding. Post
+            rf2-on4cm the border resolves through the active theme's
+            CSS variable (`var(--rf-causa-…)`) rather than a hardcoded
+            hex."
     (let [s (t/accent-stripe-style :issues)]
       (is (re-find #"3px solid" (:border-left s)))
-      (is (re-find #"#" (:border-left s))
-          "the border ends with a hex colour")
+      (is (re-find #"var\(--rf-causa-" (:border-left s))
+          "the border ends with a CSS-variable reference, not a hardcoded hex")
       (is (string? (:padding-left s))
           "padding-left compensates for the border so text doesn't shift"))))
 
@@ -331,12 +388,14 @@
   (testing "rf2-0fr6v + audit finding #7 — `:text-tertiary` on `:bg-1`
             must clear WCAG 2.1 AA's 4.5:1 floor for small body text.
             The pre-rf2-0fr6v hex `#6B7080` landed at ~3.5:1 — below
-            the floor. The bumped hex `#8990A0` lands ~4.7:1."
-    (let [ratio (contrast-ratio (:text-tertiary t/tokens)
-                                (:bg-1 t/tokens))]
+            the floor. The bumped hex `#8990A0` lands ~4.7:1. Reads
+            `dark-palette` directly (the hex source of truth) — `tokens`
+            exposes CSS-variable strings post rf2-on4cm."
+    (let [ratio (contrast-ratio (:text-tertiary t/dark-palette)
+                                (:bg-1 t/dark-palette))]
       (is (>= ratio 4.5)
-          (str ":text-tertiary " (:text-tertiary t/tokens)
-               " on :bg-1 " (:bg-1 t/tokens)
+          (str ":text-tertiary " (:text-tertiary t/dark-palette)
+               " on :bg-1 " (:bg-1 t/dark-palette)
                " contrast ratio " ratio
                " must clear WCAG 2.1 AA 4.5:1")))))
 
@@ -347,33 +406,33 @@
             to bg-2 in luminance). Pre-fix hex landed ~3.2:1 — even
             further below the floor — so the bumped hex must clear AA
             on this surface too."
-    (let [ratio (contrast-ratio (:text-tertiary t/tokens)
-                                (:bg-2 t/tokens))]
+    (let [ratio (contrast-ratio (:text-tertiary t/dark-palette)
+                                (:bg-2 t/dark-palette))]
       (is (>= ratio 4.5)
-          (str ":text-tertiary " (:text-tertiary t/tokens)
-               " on :bg-2 " (:bg-2 t/tokens)
+          (str ":text-tertiary " (:text-tertiary t/dark-palette)
+               " on :bg-2 " (:bg-2 t/dark-palette)
                " contrast ratio " ratio
                " must clear WCAG 2.1 AA 4.5:1")))))
 
 (deftest text-tertiary-is-bumped-from-pre-fix-hex
   (testing "rf2-0fr6v — guard against silent revert. The pre-fix
             value `#6B7080` was below AA; the new value differs."
-    (is (not= "#6B7080" (:text-tertiary t/tokens))
+    (is (not= "#6B7080" (:text-tertiary t/dark-palette))
         "the audit-flagged pre-fix hex must not regress")))
 
 (deftest text-secondary-still-passes-wcag-aaa
   (testing "Sanity guard — bumping `:text-tertiary` must not have
             collateral effect on `:text-secondary`. Per the audit
             inventory `:text-secondary` lands at ~9:1 on bg-1 (AAA)."
-    (let [ratio (contrast-ratio (:text-secondary t/tokens)
-                                (:bg-1 t/tokens))]
+    (let [ratio (contrast-ratio (:text-secondary t/dark-palette)
+                                (:bg-1 t/dark-palette))]
       (is (>= ratio 7.0)
           (str ":text-secondary must remain >= 7:1 (AAA), got " ratio)))))
 
 (deftest text-primary-still-passes-wcag-aaa
   (testing "Sanity guard — `:text-primary` at AAA."
-    (let [ratio (contrast-ratio (:text-primary t/tokens)
-                                (:bg-1 t/tokens))]
+    (let [ratio (contrast-ratio (:text-primary t/dark-palette)
+                                (:bg-1 t/dark-palette))]
       (is (>= ratio 7.0)
           (str ":text-primary must remain >= 7:1 (AAA), got " ratio)))))
 

--- a/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
@@ -1,0 +1,297 @@
+(ns day8.re-frame2-causa.theme.var-resolution-cljs-test
+  "Pins the rf2-on4cm contract: every Causa inline `:style` site reads
+  from `theme/tokens` resolves to a `var(--rf-causa-<key>)` CSS-variable
+  reference, NOT a literal hex string.
+
+  ## Why this matters
+
+  Pre-rf2-on4cm the `tokens` map was an alias for `dark-palette` — every
+  inline `:style` declaration that referenced `(:bg-1 tokens)` painted
+  the dark-palette hex regardless of the active theme class. The
+  light-theme class toggle was wired (`rf-causa-theme-light` on the
+  shell root) and the CSS-variable block was emitted, but inline styles
+  ignored both, so light mode rendered as paint-only-the-edges broken.
+
+  Post rf2-on4cm `tokens` is a CSS-variable map (`{:bg-1
+  \"var(--rf-causa-bg-1)\"}`), so every inline-style call site flows
+  through the theme's class scope. The active theme class on the shell
+  root decides which palette's hex actually paints.
+
+  ## What this test pins
+
+  Three layers:
+
+    1. **`tokens` is a var-map** — every entry resolves to
+       `var(--rf-causa-<key>)`. Pinned in `tokens_cljs_test.cljc`
+       too; reinforced here to keep the contract co-located.
+
+    2. **Helpers route through the var-map** — `panel-accent`,
+       `accent-stripe-style`, `panel-icon-style`, `tier-colour`,
+       `severity-colour`, `op-type-colour`, `event-status-colour` —
+       every public colour helper returns a CSS-variable string.
+
+    3. **Rendered hiccup carries var() references** — render small
+       view fragments and walk every `:style` map: no value is a
+       palette hex literal (`#7C5CFF`, `#15171B`, …); every colour
+       value is either a `var(--rf-causa-…)` reference, a
+       `color-mix(...)` composition, a non-colour string (`\"transparent\"`,
+       `\"none\"`, etc.), or a non-string (numeric padding, line-height
+       multipliers).
+
+  ## Posture (test-direction memory)
+
+  Per the user's `feedback_causa_story_cljs_unit_tests_not_playwright`
+  memory: validate the visual contract via CLJS unit tests reading
+  rendered hiccup, NOT new Playwright probes. The existing browser-
+  test infra is unchanged."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as string]
+            [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as issues-h]
+            [day8.re-frame2-causa.panels.trace-helpers :as trace-h]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            [day8.re-frame2-causa.theme.perf-tier :as perf-tier]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- (1) tokens IS the var-map ------------------------------------------
+
+(deftest tokens-map-resolves-every-key-through-css-variables
+  (testing "rf2-on4cm — `tokens` is the CSS-variable surface. Every
+            entry is `\"var(--rf-causa-<key>)\"`."
+    (is (seq tokens/tokens)
+        "the map is non-empty (sanity guard against an empty palette)")
+    (doseq [[k v] tokens/tokens]
+      (is (string? v)
+          (str k " value is a string"))
+      (is (re-find #"^var\(--rf-causa-" v)
+          (str k " (" v ") starts with the rf-causa CSS-variable prefix"))
+      (is (re-find (re-pattern (str "--rf-causa-" (name k) "\\)")) v)
+          (str k " value references --rf-causa-" (name k))))))
+
+(deftest tokens-map-has-no-hex-literals
+  (testing "rf2-on4cm — no entry in `tokens` is a hex literal. Guards
+            against an accidental regression to the pre-sweep
+            dark-palette alias shape."
+    (doseq [[k v] tokens/tokens]
+      (is (not (re-find #"^#[0-9A-Fa-f]" v))
+          (str k " (" v ") is NOT a hex literal — it's a var() reference")))))
+
+(deftest tokens-keys-match-dark-palette-keys
+  (testing "rf2-on4cm — every key in the dark palette has a matching
+            entry in `tokens` (the var-map covers the same surface)."
+    (is (= (set (keys tokens/dark-palette))
+           (set (keys tokens/tokens))))))
+
+;; ---- (2) helpers route through the var-map ------------------------------
+
+(deftest css-var-helper-builds-rf-causa-prefixed-reference
+  (testing "rf2-on4cm — `tokens/css-var` is the canonical helper that
+            shapes the var() reference. Pure data, JVM-portable."
+    (is (= "var(--rf-causa-bg-1)" (tokens/css-var :bg-1)))
+    (is (= "var(--rf-causa-text-tertiary)"
+           (tokens/css-var :text-tertiary)))
+    (is (= "var(--rf-causa-accent-violet)"
+           (tokens/css-var :accent-violet)))))
+
+(deftest panel-accent-returns-css-variable-string
+  (testing "rf2-on4cm — `panel-accent` materialises the panel-domain
+            accent through the var-map. Used by the 3px left-border
+            on every L4 panel <h1>."
+    (doseq [tab (keys tokens/panel-domain->token)]
+      (let [v (tokens/panel-accent tab)]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-causa-" v)
+            (str "panel-accent " tab " resolves to a CSS variable"))))))
+
+(deftest accent-stripe-style-border-references-css-variable
+  (testing "rf2-on4cm — the canonical 3px-left-border builder produces
+            a border-left value that references a CSS variable, not
+            a hardcoded hex."
+    (doseq [tab (keys tokens/panel-domain->token)]
+      (let [border (:border-left (tokens/accent-stripe-style tab))]
+        (is (string? border))
+        (is (re-find #"3px solid var\(--rf-causa-" border)
+            (str tab " stripe references the canonical var() prefix"))
+        (is (not (re-find #"#[0-9A-Fa-f]" border))
+            (str tab " stripe has no hex literal in the border declaration"))))))
+
+(deftest panel-icon-style-colour-references-css-variable
+  (testing "rf2-on4cm — the panel-icon header glyph rides the same
+            domain colour as the accent stripe, resolved through the
+            var-map."
+    (doseq [tab (keys tokens/panel-icon)]
+      (let [colour (:color (tokens/panel-icon-style tab))]
+        (is (string? colour))
+        (is (re-find #"^var\(--rf-causa-" colour)
+            (str tab " icon colour resolves to a CSS variable"))))))
+
+(deftest tier-colour-returns-css-variable-string
+  (testing "rf2-on4cm — `perf-tier/tier-colour` is read through tokens
+            so the four tier accents land on var(--rf-causa-<key>)."
+    (doseq [tier perf-tier/tier-order]
+      (let [v (perf-tier/tier-colour tier)]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-causa-" v)
+            (str "tier-colour " tier " resolves to a CSS variable"))))))
+
+(deftest severity-colour-returns-css-variable-string
+  (testing "rf2-on4cm — `issues-ribbon-helpers/severity-colour` is
+            read through tokens so the per-row severity dot resolves
+            to a CSS variable."
+    (doseq [severity [:error :warning :advisory]]
+      (let [v (issues-h/severity-colour severity)]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-causa-" v)
+            (str "severity-colour " severity " resolves to a CSS variable"))))))
+
+(deftest op-type-colour-returns-css-variable-string
+  (testing "rf2-on4cm — `trace-helpers/op-type-colour` returns the
+            per-row Trace dot colour as a CSS variable."
+    (doseq [op-type [:error :warning :info :event :fx :view/render]]
+      (let [v (trace-h/op-type-colour op-type)]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-causa-" v)
+            (str "op-type-colour " op-type " resolves to a CSS variable"))))))
+
+(deftest event-status-colour-returns-css-variable-string
+  (testing "rf2-on4cm — the lifecycle-status helper consumed by the
+            L2 row + Event header + Trace timeline returns a CSS
+            variable."
+    (doseq [state [{:outcome :ok} {:outcome :error} {:in-flight? true}
+                   {:paused? true} {:stale? true}]]
+      (let [v (event-status/event-status-colour state)]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-causa-" v)
+            (str "event-status-colour " state " resolves to a CSS variable"))))))
+
+;; ---- (3) with-alpha builds color-mix ------------------------------------
+
+(deftest with-alpha-composites-against-css-variable
+  (testing "rf2-on4cm — the alpha-tail-suffix idiom (`(str token \"55\")`)
+            is replaced by `tokens/with-alpha` which builds a CSS-Color-4
+            color-mix(...) string that composites the active theme's
+            CSS variable with `transparent`."
+    (doseq [k [:accent-violet :red :green :cyan :yellow]
+            pct [10 33 50 75]]
+      (let [v (tokens/with-alpha k pct)]
+        (is (string? v))
+        (is (re-find #"^color-mix\(in srgb" v)
+            (str "with-alpha " k " " pct " starts with color-mix"))
+        (is (re-find (re-pattern (str "var\\(--rf-causa-" (name k) "\\)")) v)
+            (str "with-alpha " k " " pct " references --rf-causa-" (name k)))
+        (is (re-find (re-pattern (str pct "%")) v)
+            (str "with-alpha " k " " pct " carries the requested percentage"))
+        (is (re-find #"transparent\)$" v)
+            (str "with-alpha " k " " pct " ends with `transparent)`"))))))
+
+;; ---- (4) palette source-of-truth integrity ------------------------------
+
+(deftest dark-palette-and-light-palette-are-hex-maps
+  (testing "rf2-on4cm — `dark-palette` + `light-palette` remain the
+            hex source of truth (consumed by themes-css to register
+            the `--rf-causa-<key>` custom properties). They MUST stay
+            hex maps so the CSS-variable block emits actual paint values
+            and so the few raw-hex consumers (mount.cljs popout overlay,
+            config/default-accent) keep landing on real colours."
+    (doseq [palette-name [:dark :light]
+            :let [palette (get tokens/themes palette-name)]
+            [k v] palette]
+      (is (string? v)
+          (str palette-name " " k " is a string"))
+      (is (re-find #"^#[0-9A-Fa-f]+$" v)
+          (str palette-name " " k " (" v ") is a hex literal")))))
+
+(deftest light-and-dark-palettes-share-the-canonical-key-set
+  (testing "rf2-on4cm — every dark token has a light counterpart so
+            the class-toggle flip is total (no `var(--rf-causa-foo)`
+            resolves to the property's default initial value because
+            `:foo` was missing from the active theme's block)."
+    (is (= (set (keys tokens/dark-palette))
+           (set (keys tokens/light-palette))))))
+
+;; ---- (5) rendered hiccup carries no palette hex literals ----------------
+;;
+;; The strongest pin: walk a rendered hiccup tree and assert NO `:style`
+;; value is a palette hex literal. Catches a regression where a new
+;; inline-style site sneaks in a hardcoded `\"#1B1E24\"` instead of
+;; reading through the token map.
+
+(defn- collect-style-strings
+  "Depth-first walk: collect every string value found in any `:style`
+  map across the hiccup tree. Skips non-string values (numerics,
+  line-height multipliers, etc.) since the contract is about colour
+  values."
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk-node [node]
+              (when (vector? node)
+                (let [attrs (when (map? (second node)) (second node))]
+                  (when-let [style (:style attrs)]
+                    (when (map? style)
+                      (doseq [[_ v] style]
+                        (when (string? v)
+                          (swap! out conj v)))))
+                  (doseq [child (rest node)]
+                    (cond
+                      (vector? child) (walk-node child)
+                      (seq? child)    (doseq [c child] (walk-node c)))))))]
+      (walk-node tree))
+    @out))
+
+(def ^:private palette-hex-pattern
+  ;; A palette hex literal: `#` + 3-to-8 hex digits at a word boundary.
+  ;; Matches `#7C5CFF`, `#a83a3a`, `#fff` — but does NOT match the inside
+  ;; of a `var(--rf-causa-…)` reference (no hex digits in the var name).
+  #"#[0-9A-Fa-f]{3,8}\b")
+
+(deftest data-inspector-rendered-hiccup-has-no-palette-hex-literals
+  (testing "rf2-on4cm — the canonical L4-panel value renderer
+            (`theme/data-inspector/inspect`) emits hiccup whose every
+            `:style` colour value flows through a CSS variable. Walk
+            the rendered tree across a representative mix of values
+            (collection, keyword, string, number, nil, sentinel) and
+            assert NO `:style` string is a `#xxxxxx` palette hex
+            literal. Guards against a regression where a new inline-
+            style site is added with a hardcoded hex."
+    (doseq [v [{:a 1 :b 2 :c [1 2 3]}      ; map + nested vec
+               [:foo :bar {:baz nil}]      ; vector with primitives + map
+               #{1 2 3}                    ; set
+               "a string"                  ; string leaf
+               :keyword                    ; keyword leaf
+               42                          ; number leaf
+               true                        ; boolean leaf
+               nil                         ; nil leaf
+               :rf/redacted                ; redacted sentinel
+               {:rf/large {:bytes 1234     ; large sentinel
+                           :head "abc"}}]]
+      (let [tree (inspector/inspect v "test")
+            styles (collect-style-strings tree)]
+        (is (seq styles)
+            (str "render of " (pr-str v) " produced style strings to inspect"))
+        (doseq [s styles]
+          (is (not (re-find palette-hex-pattern s))
+              (str "style string " (pr-str s)
+                   " in render of " (pr-str v)
+                   " contains a palette hex literal "
+                   "(should be a var(--rf-causa-…) reference)")))))))
+
+(deftest accent-stripe-style-output-has-no-palette-hex-literal
+  (testing "rf2-on4cm — every panel's accent-stripe style map (the
+            3px left border on L4 panel <h1>) is hex-free."
+    (doseq [tab (keys tokens/panel-domain->token)]
+      (let [s (tokens/accent-stripe-style tab)]
+        (doseq [[k v] s]
+          (when (string? v)
+            (is (not (re-find palette-hex-pattern v))
+                (str tab " stripe style key " k " value "
+                     (pr-str v) " contains a palette hex literal"))))))))
+
+(deftest panel-icon-style-output-has-no-palette-hex-literal
+  (testing "rf2-on4cm — every panel's header-icon style map is hex-free."
+    (doseq [tab (keys tokens/panel-icon)]
+      (let [s (tokens/panel-icon-style tab)]
+        (doseq [[k v] s]
+          (when (string? v)
+            (is (not (re-find palette-hex-pattern v))
+                (str tab " icon style key " k " value "
+                     (pr-str v) " contains a palette hex literal"))))))))


### PR DESCRIPTION
Closes rf2-on4cm.

## Summary

Pre-fix the light theme rendered as paint-only-the-edges broken: the class toggle was wired and the CSS-variable block was emitted, but the ~1,300 inline `:style` reads of `(:bg-1 tokens)` ignored both because `tokens` was a hex-string alias of `dark-palette`. The fix flips the canonical `tokens` map to a CSS-variable map (`{:bg-1 "var(--rf-causa-bg-1)" ...}`) — every existing call site automatically resolves through the active theme's class scope.

- `dark-palette` + `light-palette` remain the hex source of truth that `themes-css` registers as `--rf-causa-<key>` custom properties.
- Two raw-hex consumer paths (popout opener-gone overlay; `default-accent` published into `--rf-causa-accent`) read `dark-palette` directly.
- New helpers: `tokens/css-var` (kw → `"var(--rf-causa-<key>)"`) and `tokens/with-alpha` (replaces `(str (:accent-violet tokens) "55")` with `color-mix(in srgb, var(--rf-causa-accent-violet) 33%, transparent)` — picks up the active-theme variable rather than hardcoding the dark accent).

## Contract pin (new CLJS unit test)

`theme/var-resolution-cljs-test.cljs` pins:

1. `tokens` map: every entry resolves to `var(--rf-causa-<key>)`, no hex literals.
2. Every public colour helper returns a CSS-variable string.
3. Rendered hiccup carries no palette hex literal — walks the data-inspector render across 10 representative value shapes asserting no inline `:style` colour string contains a `#xxxxxx` literal.

Per `feedback_causa_story_cljs_unit_tests_not_playwright`: validation via CLJS unit tests reading rendered hiccup, NOT new Playwright probes.

## Test plan

- [x] `clojure -M:test` from `tools/causa` — 865/2,813; 0 fail
- [x] `npm run test:cljs` — 3,959/12,134; 0 fail (14 new tests + 359 new assertions)
- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `scripts/test-jvm-tools.sh` — PASS
- [x] `npm run test:bundle-isolation` — PASS (no production-bundle drift)
- [x] `python -m mkdocs build --strict` — exit 0
- [ ] Manual visual smoke: open Causa, toggle Settings → Theme → Light, verify every panel flips palette (no dark-coloured island fragments)