### PR TITLE
fix(story): port Causa open-in-editor impl + document custom-editor config (rf2-r2un8)

### DIFF
--- a/docs/causa/05-click-to-source.md
+++ b/docs/causa/05-click-to-source.md
@@ -26,7 +26,26 @@ Inside Causa, the gesture is one click. Three places it shows up:
 2. **In any panel that names a registered id** — Subscriptions, Effects, Machines, Flows, Routes. Click the id, jump to its registration.
 3. **From the host page directly** — switch Causa into *pick mode* (`Ctrl+Shift+S`), hover any DOM element, and the panel highlights the coord. Click to commit the gesture.
 
-The jump uses your editor's URL handler — VS Code (`vscode://`), IntelliJ (`idea://`), Emacs (`emacs://`), or a generic `file://` fallback. Configure the handler in Causa's settings panel; the default tries VS Code first.
+The jump uses your editor's URL handler — VS Code (`vscode://`), IntelliJ (`idea://`), Emacs (`emacs://`), or a generic `file://` fallback. The default is VS Code; if you use something else, configure it once at boot:
+
+```clojure
+(causa-config/configure!
+  {:rf.causa/editor :cursor       ; or :idea, :windsurf, :zed, :vscode (default)
+   :rf.causa/project-root "C:/Users/me/code/my-app"})
+```
+
+Supported keywords: `:vscode`, `:cursor`, `:windsurf`, `:zed`, `:idea` (the JetBrains family — IDEA, WebStorm, PyCharm all answer to `idea://`).
+
+For editors whose URI scheme we don't ship out of the box, pass a `{:custom "<uri-template>"}` form with `{file}` (alias `{path}`), `{line}`, `{column}` placeholders:
+
+```clojure
+(causa-config/configure!
+  {:rf.causa/editor {:custom "myeditor://open?path={file}&row={line}&col={column}"}})
+```
+
+The chip refuses `http:` / `https:` / `javascript:` / `data:` / `vbscript:` regardless of what a custom template resolves to — launching the OS-side editor is the only thing this affordance does, anything else would be a surprise.
+
+`:project-root` is the on-disk root the chip prepends to the (typically classpath-relative) source-coord file before handing the URI to the OS — VS Code in particular silently fails on relative paths.
 
 ## The contract — `data-rf2-source-coord`
 

--- a/docs/story/02-mode-tabs.md
+++ b/docs/story/02-mode-tabs.md
@@ -77,6 +77,35 @@ The locale strip cycles through any locales the parent story declares — `:en-A
 
 Story doesn't ship a translation engine. The parent story declares which locales are interesting via its `:locales` slot (or registered as Modes with `:axis :locale`), and the runtime takes it from there. If your app uses `formatjs` or `tongue` or `taoensso.tempura` or whatever other i18n surface, point it at the locale strip's selection. We're agnostic on which i18n library you use; we just give you a chrome-level switch that sets the cofx.
 
+## Open in editor
+
+Look at the top-right of any variant canvas — there's a small **`open`** chip. Click it. Your editor — VS Code by default — opens at the variant's source file, on the exact line `reg-variant` was called. This is a navigation affordance, not a development environment; the point is *jump from "this variant looks wrong in the playground" to "the code I need to edit" without scrolling through search results*.
+
+The chip works by building a URI in the editor's custom scheme — `vscode://file/...`, `cursor://file/...`, `idea://open?file=...` — and handing it to the OS. The browser doesn't navigate the tab; the OS handler chain matches the scheme and launches the registered editor. If the editor isn't installed (or its URI handler isn't registered), the click silently no-ops.
+
+**Pick your editor.** The default is VS Code. If you use something else, configure it once at boot:
+
+```clojure
+(story/configure!
+  {:rf.story/editor :cursor       ; or :idea, :windsurf, :zed, :vscode (default)
+   :rf.story/project-root "C:/Users/me/code/my-app"})
+```
+
+The supported keywords are `:vscode`, `:cursor`, `:windsurf`, `:zed`, and `:idea` (the JetBrains family — IDEA, WebStorm, PyCharm all answer to the `idea://` scheme).
+
+**Custom editor.** If you use an editor whose URI scheme we don't ship, pass a `{:custom "<uri-template>"}` form with placeholders the chip substitutes per click:
+
+```clojure
+(story/configure!
+  {:rf.story/editor {:custom "myeditor://open?path={file}&row={line}&col={column}"}})
+```
+
+The placeholders are `{file}` (alias `{path}`), `{line}`, and `{column}`. Missing placeholders in the template are left alone, so `"subl://open?path={path}&line={line}"` is a valid Sublime-Text template that omits the column.
+
+The chip refuses to navigate to `http:` / `https:` / `javascript:` / `data:` / `vbscript:` schemes regardless of what a custom template resolves to — those are launch-time no-ops because *launching the OS-side editor is the only thing this affordance does*; anything else would be a surprise.
+
+**About `:project-root`.** Editors' URI handlers resolve `<path>` against the filesystem, and a relative path lands nowhere good — VS Code in particular silently fails on relative paths. Source-coords stamped at registration time are classpath-relative (e.g. `"src/app/views.cljs"`); `:project-root` is the on-disk root the chip prepends so the URI ships an absolute path. Set it once to the directory above your build's source-paths and forget about it. If you skip the slot, the chip ships the file string verbatim — useful for tests, generally not what you want in the playground.
+
 ## What "orthogonal" buys you
 
 The four toolbars compose. *Mobile, dark chrome, a11y-on, ja-JP* is a coherent picked state, and it's the kind of state you actually want to inspect — "does the Japanese translation overflow on mobile in dark mode with the a11y panel flagging contrast issues?" That's a real question with a real answer once you can pick the combination.

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -3,6 +3,17 @@
   the editor at a source-coord's file:line. Per rf2-evgf5 + Spec 005-
   SOTA-Features.md §'Open in editor' per variant.
 
+  Mirrors `day8.re-frame2-causa.open-in-editor` — same shape, same
+  click-time gate, same launcher seam. Per rf2-r2un8: the two surfaces
+  were drifting; Causa's structure (resolve-uri helper + dispatch-based
+  path + install! registration) is the canonical shape both tools
+  consume now. Story keeps its existing public chip API
+  (`open-chip` / `open-chip-for-variant` / `open-source-coord!`) but
+  delegates URI resolution to `resolve-uri` and adds a parallel
+  dispatch path (`:rf.story/open-in-editor` reg-event-fx) so a panel
+  that doesn't render the chip directly can still hand off a
+  source-coord through re-frame.
+
   The component reads the user's editor preference from
   `re-frame.story.config/editor` (set at boot via `story/configure!`)
   and consults `re-frame.source-coords.editor-uri/editor-uri` to build
@@ -68,7 +79,9 @@
 
   Lives in the Story CLJS bundle; production builds elide the entire
   UI shell so this ns never enters a release bundle."
-  (:require [re-frame.story.config :as config]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.story.config :as config]
             [re-frame.source-coords.editor-uri :as editor-uri]
             [re-frame.story.theme.typography :as typography :refer [mono-stack]]
             [re-frame.story.theme.colors :as colors]))
@@ -98,6 +111,86 @@
                :margin-left     "8px"
                :text-decoration "none"
                :display         "inline-block"}})
+
+;; ---- pure: resolve a source-coord to a launchable URI --------------------
+;;
+;; Per rf2-r2un8 (porting Causa's structure): URI building is extracted
+;; into one helper so the chip path and the dispatch path share the same
+;; logic — chip's `:href`, chip's `:on-click`, the inspector launcher, and
+;; the `:rf.story/open-in-editor` event-fx all call `resolve-uri`.
+
+(defn- parse-file-line
+  "Parse a `\"file:line\"` (or bare `\"file\"`) display string into the
+  structured source-coord map shape `editor-uri/editor-uri` expects.
+
+  Some Story-host integrations (e.g. agents replaying open-in-editor
+  via the MCP surface, panels that flatten a coord to a display
+  string at projection time) ship the coord as a string rather than a
+  map. The parser walks the string back to the structured form.
+
+  The split is on the LAST `:` so a Windows-style
+  `\"C:/users/.../x.cljs:42\"` parses correctly (drive-letter colon
+  stays with the path). Returns `{:file ... :line <int-or-nil>}` —
+  `:column` falls through to `editor-uri`'s default of 1."
+  [s]
+  (when (and (string? s) (not (str/blank? s)))
+    (let [trimmed  (str/triml s)
+          colon-ix (str/last-index-of trimmed ":")
+          tail     (when (and colon-ix (pos? colon-ix))
+                     (subs trimmed (inc colon-ix)))]
+      (if (and tail (seq tail) (re-matches #"\d+" tail))
+        {:file (subs trimmed 0 colon-ix)
+         :line (js/parseInt tail 10)}
+        {:file trimmed}))))
+
+(defn- coerce-coord
+  "Normalise a dispatch payload to a structured source-coord map.
+
+  Accepts (in order of preference):
+
+    - A bare structured map `{:file ... :line ...}` (the canonical
+      shape every Story panel writes).
+    - A wrapper map `{:source-coord <coord>}` where `<coord>` is
+      either a structured map OR a `\"file:line\"` display string
+      (the dispatch shape an external integration may emit).
+    - A bare display string `\"file:line\"` (defensive).
+
+  Returns the map form; callers feed it to `editor-uri/editor-uri`
+  unchanged. Mirrors Causa's `coerce-coord` (rf2-r2un8 port)."
+  [payload]
+  (let [unwrapped (if (and (map? payload) (contains? payload :source-coord))
+                    (:source-coord payload)
+                    payload)]
+    (cond
+      (map? unwrapped)    unwrapped
+      (string? unwrapped) (parse-file-line unwrapped)
+      :else               nil)))
+
+(defn resolve-uri
+  "Pure-data: source-coord → launchable URI string, or nil. Returns nil
+  when the coord lacks `:file`, when `editor-uri/editor-uri` returns nil
+  (a forbidden scheme per rf2-vwcsq), or when the resolved URI's scheme
+  is outside `editor-uri/allowed-editor-uri-schemes` (the shared
+  positive allowlist per rf2-cm93v / rf2-p887o).
+
+  Per rf2-zfy1e: threads the configured project-root through
+  `editor-uri/editor-uri`'s 3-arg form so a classpath-relative source-
+  coord (the common case — macros capture the form-meta `:file` slot,
+  typically classpath-relative) resolves to an absolute on-disk path
+  the OS-side editor handler can find. The `:project-root` opt is
+  nil-tolerant — when unset, behaviour matches v1 (file ships
+  verbatim) so legacy hosts and tests aren't broken.
+
+  The chip render path, `open-source-coord!` (element-inspector), and
+  the `:rf.editor/open` reg-fx all call this — one source of truth for
+  the URI shape across the data path and the side-effect path. Mirrors
+  Causa's `resolve-uri` (rf2-r2un8 port)."
+  [source-coord]
+  (when (editor-uri/has-source? source-coord)
+    (let [opts {:project-root (config/get-project-root)}
+          uri  (editor-uri/editor-uri (config/get-editor) source-coord opts)]
+      (when (and uri (editor-uri/allowed-uri? uri))
+        uri))))
 
 ;; ---- side-effect: open the editor ----------------------------------------
 ;;
@@ -140,8 +233,10 @@
   seam (default `Location.assign`). Custom URI schemes hand off to
   the OS handler chain. Returns nothing.
 
-  Public so the element-inspector (rf2-h0jc0) can share the exact same
-  click-time gate the chip uses — one launcher, one allowlist seam.
+  Public so the element-inspector (rf2-h0jc0), the `:rf.editor/open`
+  reg-fx (registered in `install!`), and any host panel that wants the
+  click-time gate can share the exact same launcher. One launcher, one
+  allowlist seam.
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
   already rejects `javascript:` / `data:` / `vbscript:` schemes by
@@ -176,7 +271,7 @@
 (defn open-chip
   "Render an 'Open' chip for a source-coord. Reads the current editor
   preference from `config/editor`; constructs the URI via
-  `editor-uri/editor-uri`; click fires `window.location.href := uri`.
+  `resolve-uri`; click fires `(open! uri)`.
 
   Returns nil when the source-coord has no usable `:file` slot, when
   `editor-uri/editor-uri` returns nil (a scheme rejected by the
@@ -197,36 +292,27 @@
   ([source-coord]
    (open-chip source-coord :title))
   ([source-coord variant-of-style]
-   (when (editor-uri/has-source? source-coord)
+   (when-let [uri (resolve-uri source-coord)]
      (let [editor (config/get-editor)
-           ;; Per rf2-zfy1e: prepend the configured project-root to the
-           ;; source-coord's `:file` slot (typically classpath-relative)
-           ;; so the URI carries an absolute on-disk path the OS-side
-           ;; editor handler can resolve. The `:project-root` opt is
-           ;; nil-tolerant — when unset, behaviour matches v1 (file
-           ;; ships verbatim) so legacy hosts and tests aren't broken.
-           opts   {:project-root (config/get-project-root)}
-           uri    (editor-uri/editor-uri editor source-coord opts)
            style  (case variant-of-style
                     :test-detail (:chip-test chip-styles)
                     (:chip chip-styles))]
-       (when (and uri (editor-uri/allowed-uri? uri))
-         [:a {:style       style
-              :href        uri
-              :title       (editor-uri/open-button-title source-coord)
-              :data-test   "story-open-in-editor"
-              :data-editor (cond
-                             (map? editor) "custom"
-                             :else         (name editor))
-              :on-click    (fn [e]
-                             ;; Prevent React/Reagent's default link
-                             ;; navigation (otherwise the browser
-                             ;; tries to render the custom URI inside
-                             ;; the tab); explicitly call `open!` so
-                             ;; the OS handler fires.
-                             (.preventDefault e)
-                             (open! uri))}
-          "open"])))))
+       [:a {:style       style
+            :href        uri
+            :title       (editor-uri/open-button-title source-coord)
+            :data-test   "story-open-in-editor"
+            :data-editor (cond
+                           (map? editor) "custom"
+                           :else         (name editor))
+            :on-click    (fn [e]
+                           ;; Prevent React/Reagent's default link
+                           ;; navigation (otherwise the browser
+                           ;; tries to render the custom URI inside
+                           ;; the tab); explicitly call `open!` so
+                           ;; the OS handler fires.
+                           (.preventDefault e)
+                           (open! uri))}
+        "open"]))))
 
 (defn open-source-coord!
   "Resolve `source-coord` to an editor URI via the current Story config
@@ -238,18 +324,14 @@
   This is the imperative path the element-inspector (rf2-h0jc0) uses
   when the user clicks a DOM element while inspector mode is on. The
   chip's `:on-click` (above) takes the same shape: build URI via
-  `editor-uri`, gate via `allowed-uri?`, hand to `open!`.
+  `resolve-uri`, hand to `open!`.
 
   `source-coord` shape: `{:file :line :column}` per
   `re-frame.source-coords`."
   [source-coord]
-  (when (editor-uri/has-source? source-coord)
-    (let [editor (config/get-editor)
-          opts   {:project-root (config/get-project-root)}
-          uri    (editor-uri/editor-uri editor source-coord opts)]
-      (when (and uri (editor-uri/allowed-uri? uri))
-        (open! uri)
-        true))))
+  (when-let [uri (resolve-uri source-coord)]
+    (open! uri)
+    true))
 
 (defn open-chip-for-variant
   "Render an open-chip for a variant — reads the source-coord off the
@@ -260,3 +342,79 @@
   `re-frame.story.registrar/handler-meta :variant variant-id`."
   [variant-body]
   (open-chip (:source variant-body) :title))
+
+;; ---- registration: the data-driven open-in-editor path ------------------
+;;
+;; Per rf2-r2un8 (porting Causa's structure): a dispatch-based path
+;; alongside the imperative chip. Hosts that don't render the chip
+;; directly — agents replaying via MCP, custom Story-host panels — can
+;; dispatch `[:rf.story/open-in-editor coord]` and let the registered
+;; fx fire the URI through the same allowlist gate the chip uses. The
+;; `:rf.editor/open` reg-fx is namespaced under `:rf.editor/*` (not
+;; `:rf.story.fx/*`) because the gate is editor-related, not Story-
+;; specific — Causa registers the same fx-id, idempotently. Either tool
+;; loading first wins; the registered handler is the same shape so the
+;; runtime cost of double-registration is zero.
+
+(defn install!
+  "Idempotent install for the dispatch-side open-in-editor wiring
+  (rf2-r2un8).
+
+  Registers two framework primitives:
+
+    - `:rf.story/open-in-editor` reg-event-fx — the dispatch shape any
+      host panel that wants the trace bus to record the click can fire.
+      Accepts either a bare source-coord map or a wrapper
+      `{:source-coord <coord-or-string>}`. The handler resolves the URI
+      and returns `{:fx [[:rf.editor/open {:uri ...}]]}`.
+
+    - `:rf.editor/open` reg-fx — the side-effectful launcher. Calls
+      `open!` (which applies the rf2-cm93v allowlist + writes
+      `window.location` via the navigator seam). Shares the
+      `:rf.editor/*` namespace with Causa's parallel registration so
+      both tools observe a single registered fx-id at runtime; whichever
+      preload loads first wins, the handler body is identical so it
+      doesn't matter.
+
+  Idempotent — safe to call on every reload. Hosts that drive the
+  Story shell don't need to call this directly; the shell mount path
+  calls it once at boot.
+
+  The handler does NOT write to `db` — the click is a pure navigation,
+  not a state transition. Per Spec 002 §Effect map shape, omitting
+  `:db` from the return leaves the app-db untouched."
+  []
+  ;; ---- :rf.editor/open ----
+  ;;
+  ;; Side-effect handler. Two arg shapes accepted:
+  ;;
+  ;;   {:uri "vscode://..."}                 — pre-resolved URI
+  ;;   {:source-coord {:file ... :line ...}} — resolve via `resolve-uri`
+  ;;                                            first
+  ;;
+  ;; The pre-resolved form is the canonical shape the
+  ;; `:rf.story/open-in-editor` event-fx emits; the `:source-coord`
+  ;; form is a convenience for callers that want one-step dispatch.
+  (rf/reg-fx :rf.editor/open
+    (fn [_ctx args]
+      (let [uri (or (:uri args)
+                    (when-let [coord (:source-coord args)]
+                      (resolve-uri coord)))]
+        (open! uri))))
+
+  ;; ---- :rf.story/open-in-editor ----
+  ;;
+  ;; Event handler. Accepts the same coord-shape `coerce-coord`
+  ;; recognises (bare map, `{:source-coord ...}` wrapper, or a
+  ;; `"file:line"` display string). Resolves the URI through the
+  ;; allowlist seam and routes it to `:rf.editor/open`.
+  (rf/reg-event-fx :rf.story/open-in-editor
+    (fn [_ctx [_event-id payload]]
+      (let [coord (coerce-coord payload)
+            uri   (resolve-uri coord)]
+        ;; Always emit the fx — even when uri is nil. `open!` is a
+        ;; no-op for nil, and routing through the fx (rather than
+        ;; short-circuiting in the handler) keeps the side-effect
+        ;; bookkeeping in one place + makes the fx the single
+        ;; instrumentable seam for replay/dev-tools.
+        {:fx [[:rf.editor/open {:uri uri}]]}))))

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -9,8 +9,12 @@
   - `open-chip` renders an `<a>` hiccup tag with the current editor's
     URI when the coord carries `:file`.
   - The chip carries the `data-test` hook for the e2e suite.
-  - `open-chip-for-variant` reads `:source` off the variant body."
+  - `open-chip-for-variant` reads `:source` off the variant body.
+  - rf2-r2un8 — `:rf.story/open-in-editor` reg-event-fx + `:rf.editor/open`
+    reg-fx produce a resolved URI through the same allowlist seam the
+    chip uses (Causa-parity port)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
             [re-frame.story.config :as config]
             [re-frame.story.ui.open-in-editor :as open-in-editor]))
 
@@ -381,3 +385,136 @@
              (:href (second hiccup)))
           "trailing separator stripped; backslashes inside the root
            preserved (VSCode accepts both on Windows)"))))
+
+;; ---- resolve-uri (rf2-r2un8) --------------------------------------------
+;;
+;; `resolve-uri` is the extracted URI-building helper the chip path, the
+;; `open-source-coord!` imperative path, and the dispatch-based event-fx
+;; all share. Pinning its contract here means the chip's `:href`, the
+;; inspector launcher, and the fx-emitted `:uri` always agree on the
+;; URI shape — one source of truth. Mirrors Causa's resolve-uri (port
+;; per rf2-r2un8).
+
+(deftest resolve-uri-returns-vscode-default
+  (testing "resolve-uri builds a vscode://file URI by default"
+    (is (= "vscode://file/src/app.cljs:42:7"
+           (open-in-editor/resolve-uri
+             {:file "src/app.cljs" :line 42 :column 7})))))
+
+(deftest resolve-uri-respects-editor-preference
+  (testing "switching editor flips the URI scheme"
+    (config/set-editor! :cursor)
+    (is (= "cursor://file/src/x.cljs:1:1"
+           (open-in-editor/resolve-uri
+             {:file "src/x.cljs" :line 1 :column 1})))))
+
+(deftest resolve-uri-applies-project-root
+  (testing "configured project-root prepends to the source-coord file"
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (is (= "vscode://file/C:/Users/me/code/my-app/src/app.cljs:17:3"
+           (open-in-editor/resolve-uri
+             {:file "src/app.cljs" :line 17 :column 3})))))
+
+(deftest resolve-uri-nil-when-source-missing
+  (testing "resolve-uri returns nil for coords without :file"
+    (is (nil? (open-in-editor/resolve-uri nil)))
+    (is (nil? (open-in-editor/resolve-uri {:line 1})))
+    (is (nil? (open-in-editor/resolve-uri {:file ""})))))
+
+(deftest resolve-uri-nil-for-disallowed-custom-scheme
+  (testing "resolve-uri returns nil when a {:custom ...} template
+            resolves to a scheme outside `allowed-editor-uri-schemes`
+            — defense-in-depth alongside the chip's render-time gate"
+    (config/set-editor! {:custom "http://evil.example/{path}"})
+    (is (nil? (open-in-editor/resolve-uri {:file "src/x.cljs"})))
+    (config/set-editor! {:custom "javascript:alert(1)"})
+    (is (nil? (open-in-editor/resolve-uri {:file "src/x.cljs"})))))
+
+;; ---- :rf.story/open-in-editor + :rf.editor/open (rf2-r2un8) ------------
+;;
+;; The dispatch-based path Story exposes alongside the imperative chip.
+;; Hosts that don't render the chip directly (agents replaying via MCP,
+;; custom panels) can dispatch `[:rf.story/open-in-editor coord]` and
+;; let the registered fx fire the URI through the same allowlist gate.
+;; Mirrors Causa's `:rf.causa/open-in-editor` + `:rf.editor/open`
+;; pairing (port per rf2-r2un8). Tests stub the `:rf.editor/open` reg-fx
+;; with a capture, mirroring the Causa test pattern — no `window.location`
+;; mutation under the test runner.
+
+(defonce ^:private captured-editor-fx (atom []))
+
+(defn- install-with-capture!
+  "Install Story's open-in-editor handlers then replace the
+  `:rf.editor/open` reg-fx with a capture stub so the test can inspect
+  the fx args without touching `window.location`. Same pattern Causa's
+  test suite uses."
+  []
+  (reset! captured-editor-fx [])
+  (open-in-editor/install!)
+  (rf/reg-fx :rf.editor/open
+    (fn [_ctx args] (swap! captured-editor-fx conj args))))
+
+(deftest open-in-editor-event-emits-fx-with-resolved-uri
+  (testing "rf2-r2un8 — dispatching `:rf.story/open-in-editor` with a
+            bare coord produces a `:rf.editor/open` fx whose :uri is the
+            resolved URI"
+    (install-with-capture!)
+    (rf/dispatch-sync [:rf.story/open-in-editor
+                       {:file "src/app/events.cljs" :line 17 :column 3}])
+    (is (= 1 (count @captured-editor-fx))
+        "exactly one open-fx fires per dispatch")
+    (is (= "vscode://file/src/app/events.cljs:17:3"
+           (:uri (first @captured-editor-fx)))
+        "the resolved vscode:// URI rides on the fx args")))
+
+(deftest open-in-editor-event-accepts-wrapped-shape
+  (testing "rf2-r2un8 — dispatching with `{:source-coord coord}` (the
+            wrapper shape some panels use) produces the same fx as the
+            bare-coord form"
+    (install-with-capture!)
+    (rf/dispatch-sync [:rf.story/open-in-editor
+                       {:source-coord {:file "src/x.cljs" :line 5 :column 1}}])
+    (is (= "vscode://file/src/x.cljs:5:1"
+           (:uri (first @captured-editor-fx))))))
+
+(deftest open-in-editor-event-parses-display-string-coord
+  (testing "rf2-r2un8 — the dispatch handler parses `\"file:line\"`
+            display strings back to the structured form so panels that
+            flatten coords at projection time can dispatch them as
+            strings without losing line info"
+    (install-with-capture!)
+    (rf/dispatch-sync [:rf.story/open-in-editor
+                       {:source-coord "src/app/events.cljs:42"}])
+    (is (= "vscode://file/src/app/events.cljs:42:1"
+           (:uri (first @captured-editor-fx))))))
+
+(deftest open-in-editor-event-parses-bare-display-string
+  (testing "rf2-r2un8 — bare display string (no wrapper) defensively
+            handled by the parser"
+    (install-with-capture!)
+    (rf/dispatch-sync [:rf.story/open-in-editor "src/x.cljs:7"])
+    (is (= "vscode://file/src/x.cljs:7:1"
+           (:uri (first @captured-editor-fx))))))
+
+(deftest open-in-editor-event-honours-editor-preference
+  (testing "rf2-r2un8 — the fx's URI reflects `config/get-editor`
+            (the same source of truth the chip render uses)"
+    (install-with-capture!)
+    (config/set-editor! :cursor)
+    (rf/dispatch-sync [:rf.story/open-in-editor
+                       {:file "src/x.cljs" :line 10}])
+    (is (= "cursor://file/src/x.cljs:10:1"
+           (:uri (first @captured-editor-fx))))))
+
+(deftest open-in-editor-event-rejects-disallowed-scheme
+  (testing "rf2-r2un8 / rf2-cm93v — a custom template that resolves
+            outside the allowlist produces a fx with nil :uri (which
+            `open!` is a no-op for); the handler doesn't short-circuit"
+    (install-with-capture!)
+    (config/set-editor! {:custom "http://evil.example/{path}"})
+    (rf/dispatch-sync [:rf.story/open-in-editor
+                       {:file "src/x.cljs" :line 1}])
+    (is (= 1 (count @captured-editor-fx))
+        "fx still fires — the handler doesn't short-circuit")
+    (is (nil? (:uri (first @captured-editor-fx)))
+        "the resolved URI is nil — `open!` will refuse to navigate")))


### PR DESCRIPTION
Closes rf2-r2un8.

Story's open-in-editor surface now mirrors Causa's structure end-to-end. Editor-config doc added for non-VS Code users (`:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom "<template>"}`).

## Summary

- **Code port.** Extracted `resolve-uri` helper, added `parse-file-line` + `coerce-coord` (Causa's three accepted coord shapes), added `install!` fn that registers `:rf.story/open-in-editor` reg-event-fx + `:rf.editor/open` reg-fx. Public chip API preserved (`open-chip`, `open-chip-for-variant`, `open-source-coord!`, `set-navigator!`, `open!` — every existing test still passes).
- **Tests.** Cover `resolve-uri` (default / project-root / editor preference / disallowed scheme) and the dispatch surface (bare coord / wrapper / display-string / editor preference / disallowed scheme). Pattern mirrors Causa's `:rf.editor/open` capture-stub.
- **Docs.** `docs/story/02-mode-tabs.md` gets a new "Open in editor" section documenting the supported editor keywords and the `{:custom "<template>"}` form. `docs/causa/05-click-to-source.md` gets a symmetric callout expanding its existing one-liner.

## Test plan

- [x] `npm run test:cljs` — 3970 tests, 12126 assertions, 0 failures.
- [x] `clojure -M:test` from `tools/story` — 841 tests, 2483 assertions, 0 failures.
- [x] `mkdocs build --strict` — clean (existing nav warnings unchanged).
- [ ] Manual smoke (Mike): click an `open` chip in counter-with-stories on `#/stories`; verify VS Code opens at the right file:line.