### PR TITLE
fix(causa): L1 frame picker persists in Static mode (rf2-jtqsv)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1499,7 +1499,7 @@ panel). Static drops L2 — there is no spine in Static mode because the
 surface is event-independent — and renders 3 layers:
 
     ┌───────────────────────────────────────────────────────┐
-    │ L1  Top ribbon (56px) — mode pill + right icons       │
+    │ L1  Top ribbon — mode pill · frame picker · icons     │
     ├───────────────────────────────────────────────────────┤
     │ L3  Tab bar (40px) — 5 tabs                           │
     ├───────────────────────────────────────────────────────┤
@@ -1508,6 +1508,16 @@ surface is event-independent — and renders 3 layers:
 
 L2's absence is also a functional signal — see §Mode-signal mechanism
 below.
+
+The L1 frame picker is **mode-independent**. Static is also
+frame-scoped — registered events, subs, machines, routes, schemas,
+flows, and interceptors all live in a particular frame, so the user
+must be able to pick which frame they are browsing whether the lens is
+event-coupled (Dynamic) or event-independent (Static). Both shells
+mount the same `frame_switcher/frame-switcher-view` (the canonical L1
+contract); the selection persists across mode toggles. Dynamic's
+spine-coupled clusters (nav `[◀ ▶ ⏭]`, filter pills) remain hidden in
+Static — those have no meaning without a spine.
 
 ### Sub-tab inventory (Static L3)
 

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -16,12 +16,18 @@
   because Static is event-INDEPENDENT — and renders 3 layers:
 
       ┌───────────────────────────────────────────────────────┐
-      │ L1  Top ribbon (56px) — mode pill + right icons       │
+      │ L1  Top ribbon — mode pill · frame picker · icons     │
       ├───────────────────────────────────────────────────────┤
       │ L3  Tab bar (40px) — 5 tabs                           │
       ├───────────────────────────────────────────────────────┤
       │ L4  Detail panel (fills remaining canvas)             │
       └───────────────────────────────────────────────────────┘
+
+  The L1 frame picker is mode-INDEPENDENT — Static registrations are
+  still frame-scoped, so the user must be able to pick which frame
+  they are browsing. The picker uses the canonical
+  `frame_switcher/frame-switcher-view` (same contract as Dynamic's
+  ribbon); mode toggles preserve the selection.
 
   L2 is also a functional signal: its absence is one of the four
   stacked mode-signal mechanisms (chrome silhouette) the parent epic
@@ -86,6 +92,7 @@
     - rf2-uhsqb   — Flows registry browse
     - rf2-o5f5f.6 — Interceptors lens"
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
             ;; Static panel views (Machines / Routes / Schemas / Views /
@@ -208,9 +215,19 @@
   "L1 ribbon — 56px chrome, Static-flavoured. Per parent-epic rf2-
   o5f5f mode-signal mechanism the ribbon paints a 2-px left-edge
   stripe in CYAN (Static) vs VIOLET (Dynamic). Mode pill sits at
-  ribbon-left; right-icons (Settings · Close) sit at ribbon-right.
-  Dynamic's nav / frame / filter clusters are HIDDEN — Static is
-  event-independent, those clusters have no meaning here.
+  ribbon-left; the L1 frame-switcher sits between mode-pill and the
+  right-icons cluster; right-icons (Settings · Close) sit at ribbon-
+  right.
+
+  The frame picker is MODE-INDEPENDENT — Static is also frame-scoped
+  (registrations — events · subs · machines · routes · schemas · flows
+  · interceptors — live in a particular frame, so the user must be
+  able to pick which frame they are browsing). Reaching through
+  `frame_switcher.cljs` (the canonical contract surface) keeps Static
+  on the same picker as Dynamic; mode toggles preserve the selection.
+  Dynamic's nav cluster (`[◀ ▶ ⏭]`) and filter pills remain HIDDEN in
+  Static — those clusters are spine-coupled and have no meaning in an
+  event-independent surface.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -228,6 +245,14 @@
                  :font-family      sans-stack
                  :font-size        (:body type-scale)}}
    [mode-pill/mode-pill]
+   ;; L1 frame-switcher slot (rf2-iwwou) — same contract as Dynamic's
+   ;; ribbon (`shell.cljs/ribbon`). The view reads `:rf.causa/current-
+   ;; frame` + `:rf.causa/available-frames` and writes via
+   ;; `:rf.causa/select-frame`. Mode-independent: the picker persists
+   ;; across mode toggles so the user can keep browsing the same
+   ;; frame's registrations as they flip between event-coupled
+   ;; (Dynamic) and event-independent (Static) lenses.
+   [frame-switcher/frame-switcher-view]
    [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
     [ribbon-right-icons]]])
 

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -226,26 +226,33 @@
         (is (nil? (find-by-testid tree "rf-causa-event-list"))
             "no L2 event list (Static is event-INDEPENDENT)")))))
 
-(deftest static-ribbon-mounts-mode-pill-and-right-icons
-  (testing "Static ribbon carries the mode pill at left + right icons
-            cluster (Settings · Close). Dynamic's nav / frame /
-            filter clusters are hidden (Static has no spine)."
+(deftest static-ribbon-mounts-mode-pill-frame-picker-and-right-icons
+  (testing "Static ribbon carries the mode pill at left + the L1 frame
+            picker + right icons cluster (Settings · Close). The frame
+            picker is mode-INDEPENDENT — Static registrations are
+            frame-scoped, so the picker mounts in both modes. Dynamic's
+            spine-coupled nav / filter clusters remain hidden (Static
+            has no spine)."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (static-shell/surface)]
         (is (some? (find-by-testid tree "rf-causa-mode-pill"))
             "mode pill present at ribbon-left")
+        ;; L1 frame picker mounts in Static (the picker collapses to a
+        ;; flat label when only one frame is available — match either
+        ;; the `<select>` or the label fallback).
+        (is (or (some? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
+                (some? (find-by-testid tree "rf-causa-ribbon-frame")))
+            "L1 frame picker present (picker `<select>` or label fallback)")
         (is (some? (find-by-testid tree "rf-causa-static-ribbon-icons"))
             "right icons cluster present")
         (is (some? (find-by-testid tree "rf-causa-static-icon-settings"))
             "settings icon present")
         (is (some? (find-by-testid tree "rf-causa-static-icon-close"))
             "close icon present")
-        ;; Dynamic ribbon clusters MUST NOT mount in Static surface
+        ;; Spine-coupled clusters MUST NOT mount in Static surface
         (is (nil? (find-by-testid tree "rf-causa-ribbon-nav"))
             "no nav cluster")
-        (is (nil? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
-            "no frame picker")
         (is (nil? (find-by-testid tree "rf-causa-ribbon-filters"))
             "no filter pills")))))
 
@@ -463,6 +470,43 @@
       (let [tree (shell/ribbon)]
         (is (some? (find-by-testid tree "rf-causa-mode-pill"))
             "mode pill mounts in the Dynamic ribbon unconditionally")))))
+
+;; -------------------------------------------------------------------------
+;; (8a) L1 frame picker is mode-independent — mounts in BOTH modes
+;; -------------------------------------------------------------------------
+;;
+;; Static is also frame-scoped: registrations (events · subs · machines
+;; · routes · schemas · flows · interceptors) live in a particular frame,
+;; so the user must be able to pick which frame they are browsing in
+;; both Dynamic (event-coupled spine) AND Static (event-independent
+;; registry browse) lenses. The composer renders the L1 ribbon for each
+;; mode and the ribbon mounts `frame-switcher/frame-switcher-view` in
+;; both.
+
+(deftest l1-frame-picker-mounts-in-dynamic-mode
+  (testing "Dynamic surface mounts the L1 frame picker (picker `<select>`
+            or single-frame label fallback per the frame-switcher
+            contract)"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/set-mode :dynamic])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/surface-composer)]
+        (is (or (some? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
+                (some? (find-by-testid tree "rf-causa-ribbon-frame")))
+            "L1 frame picker (or single-frame label) present in Dynamic")))))
+
+(deftest l1-frame-picker-mounts-in-static-mode
+  (testing "Static surface mounts the L1 frame picker — Static is also
+            frame-scoped (registrations live in a particular frame),
+            so the picker is mode-INDEPENDENT and persists across mode
+            toggles"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/surface-composer)]
+        (is (or (some? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
+                (some? (find-by-testid tree "rf-causa-ribbon-frame")))
+            "L1 frame picker (or single-frame label) present in Static")))))
 
 ;; -------------------------------------------------------------------------
 ;; (9) Static tab inventory — pure-data shape


### PR DESCRIPTION
Closes rf2-jtqsv. Static is frame-scoped; the picker is mode-independent.

## Summary

- Static surface now mounts the same canonical `frame-switcher/frame-switcher-view` in its L1 ribbon (between mode-pill and right-icons). Registrations — events / subs / machines / routes / schemas / flows / interceptors — live in a particular frame, so the user must be able to pick which frame they are browsing in both Dynamic (event-coupled spine) and Static (event-independent registry browse) lenses.
- Mode toggles preserve the selection (the picker reads / writes `:rf.causa/current-frame` + `:rf.causa/select-frame` — same slot for both shells).
- Spec 007 §Static mode chrome silhouette updated + paragraph documenting the mode-independent picker added.
- Tests: flipped the prior `no frame picker` assertion in `static/shell_cljs_test.cljs`; added two parametric `surface-composer` tests asserting the L1 picker mounts in both Dynamic and Static.

## Test plan

- [x] `npm run test:cljs` (3974 tests / 12088 assertions · 0 failures · 0 errors)
- [x] `clojure -M:test` from `tools/causa` (849 tests / 2769 assertions · 0 failures · 0 errors)
- [x] `mkdocs build --strict` (exit 0)