### PR TITLE
docs(api): restructure into engaging human-readable chapters (rf2-kti8s)

### DIFF
--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -1,0 +1,139 @@
+# 01 — Core
+
+The Core chapter is what you `:require` from `re-frame.core` to make an app exist at all. Five clusters live in here, and they're the surfaces you'll see in every app you ever write: **registration** (`reg-event-*`, `reg-sub`, `reg-fx`, `reg-cofx`), **dispatch and subscribe** (the two verbs that drive the cascade), **frames** (the scoping primitive — `reg-frame` / `make-frame`), **runtime configuration** (`configure`), and **clearing** (the inverse of registration).
+
+If you read only one chapter of this reference, this is the one to read. Everything in the other chapters builds on these five clusters.
+
+## Registration
+
+This is the surface every re-frame2 app touches. You're answering "what events can my app handle, what data can it subscribe to, what side effects can it action, what state can it inject as coeffects?" Every entry is a registration of a named handler into the frame's registrar.
+
+**Return value.** Every `reg-*` returns its **primary id** — the keyword (or path, for `reg-app-schema`) you registered with. This lets you write `(let [sub-id (rf/reg-sub ::foo ...)] ...)` to thread the id through your code without retyping it. The convention is uniform across the surface.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-event-db` | M | `(reg-event-db id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | "When this event arrives, transform `app-db` and return the new one." The simplest handler shape — pure `(fn [db event-vec] new-db)`. Use it for the 80% of handlers that just update state. |
+| `reg-event-fx` | M | `(reg-event-fx id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | "When this event arrives, return an effect map." The richer shape — `(fn [cofx event-vec] {:db ... :fx [...]})`. Use it when you need to dispatch follow-up events, fire HTTP, navigate, or read cofx. |
+| `reg-event-ctx` | M | `(reg-event-ctx id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | The escape hatch — you get the raw interceptor context and return a modified context. Almost no app needs this; reach for it when you're writing infrastructure. |
+| `reg-sub` | M | `(reg-sub id ?metadata signal-fn? computation-fn)` | v1 (preserved + extended) | "Computed view over `app-db` and other subs." The `:<-` sugar form for declaring upstream subs is preserved from v1. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see [16 — Removed](16-removed.md) for the replacement guidance). |
+| `reg-fx` | M | `(reg-fx id ?metadata handler)` | v1 (preserved + extended) | "Define a named side effect." The handler runs against the args the effect map carries; unary `(fn [args] ...)` is the canonical shape, binary `(fn [args ctx] ...)` is available when you need the originating context. |
+| `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | "Inject something into the handler's coeffect map." A `:now` cofx hands the current time; an `:rf.server/request` cofx hands the active HTTP request. Reading a sub from a handler is also done by cofx-wrapping — see [Guide ch.06 §Reading a sub from a handler](../guide/06-coeffects.md#reading-a-sub-from-a-handler). |
+| `reg-frame` | M | `(reg-frame id metadata)` | v1 | Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one cascade — and `reg-frame` minted it with metadata you can later read via `frame-meta`. |
+| `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | Anonymous-frame shortcut. The id is gensym'd; useful for tests, transient sandboxes, and the SSR per-request frame pattern. |
+| `reg-view` | M | `(reg-view sym [args] body+)` and shape-variants | v1 | `defn`-shape view registration. Auto-defs the symbol; auto-derives an id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. See [02 — Views](02-views.md). |
+| `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. |
+| `reg-machine` | M | `(reg-machine machine-id machine-spec)` | v1 | Registers a state machine as an event handler (the machine *is* the handler — the body comes from `make-machine-handler`). Walks the literal spec form at expansion time and stamps per-element source coords for click-to-source navigation. See [04 — Machines](04-machines.md). |
+| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines or REPL workflows. |
+| `reg-app-schema` | M | `(reg-app-schema path schema)` / `(reg-app-schema path schema opts)` | v1 | "Declare the Malli schema for this `app-db` path." **Path is the registration id** — the only `reg-*` keyed by path rather than keyword, because schemas-at-paths matches the dataflow grain. See [08 — Schemas](08-schemas.md). |
+| `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, ...})` | v1 | Bulk plural form for feature-modular apps that register 5–20 paths together. Each entry routes through the singular form and is stamped with this call's source-coords. |
+| `add-marks` | Fn | `(add-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks for data classification — `:sensitive` paths render as `:rf/redacted` at egress; `:large` paths surface as `:rf/large` summaries. **Additively merges** with existing marks. See [08 — Schemas](08-schemas.md#data-classification). |
+| `set-marks` | Fn | `(set-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set (paths not mentioned are cleared). Schema-attached marks are preserved either way. |
+| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow flow opts)` | v1 | Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. See [05 — Flows](05-flows.md). |
+| `reg-route` | M | `(reg-route id metadata)` | v1 | Register a route as data: `:path`, `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`. See [06 — Routing](06-routing.md). |
+| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | SSR: register a `(fn [db route] head-model)` keyed by id; routes opt-in via `:head` metadata. See [09 — SSR](09-ssr.md). |
+| `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | SSR: register a `(fn [trace-event] :rf/public-error)`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. |
+
+### Clearing registrations
+
+The inverse surface. Each `clear-*` removes an entry from the registrar; the no-arg form clears the whole kind. Use clearing in tests (the `with-fresh-registrar` fixture relies on these), in REPL workflows, and during teardown.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `clear-event` | `(clear-event)` / `(clear-event id)` | v1 (preserved) | "Forget this event-handler." No-arg clears the whole `:event` registry. |
+| `clear-sub` | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) | "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe` (see below). |
+| `clear-fx` | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) | "Forget this fx." |
+| `clear-flow` | `(clear-flow id)` / `(clear-flow id opts)` | v1 | Deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only. See [05 — Flows](05-flows.md). |
+| `destroy-frame!` | `(destroy-frame! frame-id)` | v1 | The normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this single call. |
+| `reset-frame!` | `(reset-frame! frame-id)` | v1 | Reset the frame's `app-db` to its initial value without destroying the frame itself. |
+| `clear-sub-cache!` | `(clear-sub-cache! frame-id?)` | v1 (preserved) | Force-clear the sub-cache for a frame (or all frames). Tests; rarely needed in app code. |
+
+### See also
+
+- [02 — Views](02-views.md) for `reg-view*` in detail, the `view` lookup form, and the substrate-agnostic ergonomic surface (`dispatcher`, `subscriber`, `with-frame`).
+- [03 — Effects and interceptors](03-effects.md) for what the `reg-event-fx` handler's return value can carry.
+- [12 — Registrar](12-registrar.md) for the read-side of the registrar — `registrations`, `handler-ids`, `handler-meta`.
+
+## Dispatch and subscribe
+
+These are the two verbs that drive the cascade. `dispatch` says "an event happened, run it through the cascade"; `subscribe` says "give me a reactive handle on this query's value." Every other surface in re-frame2 either composes them or sits beside them.
+
+Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, `subscribe`) captures the call-site source coords so tools like re-frame-10x and Causa can navigate from a trace event back to the originating expression. The **`*` fn** form (`dispatch*`, `dispatch-sync*`, `subscribe*`) skips the stamping — needed when you compose dispatch through a higher-order function (`(map dispatch* events)`) where a macro can't sit. Both route through the same dispatcher; only the trace stamping differs.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `dispatch` | M | `(dispatch event)` / `(dispatch event opts)` | v1 (preserved + extended); macro | Async dispatch — drops the event onto the frame's queue, returns immediately. The default; use it for everything that isn't a synchronous test setup. |
+| `dispatch*` | Fn | `(dispatch* event)` / `(dispatch* event opts)` | v1 (extended) | Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping. |
+| `dispatch-sync` | M | `(dispatch-sync event)` / `(dispatch-sync event opts)` | v1 (preserved + extended); macro | Synchronous dispatch — runs the cascade to completion before returning. Tests, REPL workflows, and one-shot app-boot events live here. Do not use in handlers (it'll deadlock the queue). |
+| `dispatch-sync*` | Fn | `(dispatch-sync* event)` / `(dispatch-sync* event opts)` | v1 (extended) | Fn variant of `dispatch-sync`. |
+| `subscribe` | M | `(subscribe query-v)` / `(subscribe frame-id query-v)` | v1 (preserved + extended); macro | The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Use inside views, inside other subs, and (carefully) inside event handlers via the cofx wrapper. |
+| `subscribe*` | Fn | `(subscribe* query-v)` / `(subscribe* frame-id query-v)` | v1 (extended) | Fn variant of `subscribe`. |
+| `subscribe-once` | Fn | `(subscribe-once query-v)` / `(subscribe-once frame-id query-v)` → value | v1 | One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views. |
+| `unsubscribe` | Fn | `(unsubscribe query-v)` / `(unsubscribe frame-id query-v)` → nil | v1 | Decrement the cache ref-count for a query. When the count hits zero, disposal is scheduled after the configured `:sub-cache` grace-period. Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. |
+| `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot | v1 | Sugar over `(subscribe [:rf/machine machine-id])`. See [04 — Machines](04-machines.md). |
+
+**The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in [002 §Routing: the dispatch envelope](../../spec/002-Frames.md#routing-the-dispatch-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
+
+### Canonical event-vector shape
+
+The runtime tolerates several shapes; the linter nudges new code toward one:
+
+- `[<id>]` — trivial events
+- `[<id> <single-scalar>]` — single-arg events
+- `[<id> {<k> <v>}]` — multi-arg events as a single map payload (the canonical form for two-or-more args)
+
+Variadic `[<id> a b c]` is tolerated for v1-migration and caller convenience, but the map form is the one to reach for in new code — it survives field-additions without breaking callers and reads at the call site. Full rationale: [Conventions §Canonical event-vector shape](../../spec/Conventions.md#canonical-event-vector-shape-best-practice).
+
+### The `dispatch-*` family: two sub-shapes
+
+The family has two sub-shapes that look alike on first read but answer different questions.
+
+**Stamping pair** (`dispatch` / `dispatch*` and `dispatch-sync` / `dispatch-sync*`). The pair-shape question is "do you want call-site stamping or not?" The macro captures source coords for `:rf.trace/call-site`; the `*` fn-form skips the stamping for HoF composition. Both route through the same dispatcher.
+
+**Named-target sugar** (`dispatch-to-system`, per [04 — Machines](04-machines.md)). The question is "do you have a `:system-id` instead of a target machine-id?" `dispatch-to-system` resolves through the per-frame `[:rf/system-ids]` reverse index and then calls `dispatch`. It's *not* a different kind of dispatch — it's named-addressing sugar on top of the same dispatcher.
+
+The two sub-families compose: `dispatch-to-system` ultimately calls `dispatch`, so the same trace stamping fires (at the `dispatch-to-system` invocation, since that's the macro you wrote).
+
+### See also
+
+- [02 — Views](02-views.md) — `dispatcher` and `subscriber` capture the current frame at call time and return frame-bound fns that survive callbacks where the dynamic-var binding has unwound.
+- [03 — Effects and interceptors](03-effects.md) — the effect map's `:fx` vector is how event handlers schedule more dispatches.
+
+## Frames: the scoping primitive
+
+A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most apps have exactly one frame (the default, `:rf/default`, autocreated on `init!`). Apps that need isolation between subsystems — embedded widgets, multi-tab pair tools, the SSR per-request runtime — declare additional frames and dispatch / subscribe against them via `{:frame :other}`.
+
+`reg-frame` and `make-frame` are rowed in **Registration** above. The two read-side surfaces:
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `frame-ids` | `(frame-ids)` / `(frame-ids ns-prefix)` | v1 | "What frames currently exist?" Returns the set of registered ids. The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames. |
+| `frame-meta` | `(frame-meta frame-id)` | v1 | "What did the frame declare at registration?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings. |
+
+See [12 — Registrar](12-registrar.md) for the rest of the registrar-query surface.
+
+## Runtime configuration: `configure`
+
+Process-level data knobs live behind `(rf/configure <key> <opts>)`. The vocabulary of keys is closed-and-additive — existing keys cannot be renamed; new keys are added by extending the table. Currently four keys ship:
+
+| Key | Opts | Default | Status | What it tunes |
+|---|---|---|---|---|
+| `:epoch-history` | `{:depth N :trace-events-keep N :redact-fn fn}` | `{:depth 50, :redact-fn nil}` | v1 (dev-only) | Per-frame epoch ring depth (the time-travel buffer), trace-event retention cap per record, and an optional redactor invoked once per assembled record so ring and listeners see the same shape. |
+| `:trace-buffer` | `{:depth N}` | `{:depth 200}` | v1 (dev-only) | The dev-only trace event ring depth. 0 disables. |
+| `:sub-cache` | `{:grace-period-ms N}` | `{:grace-period-ms 50}` | v1 | How long the sub-cache holds a ref-count-zero query before disposing. 0 selects synchronous disposal — usually surprising; the default exists so transient unmount/remount sequences don't thrash. |
+| `:elision` | `{:rf.size/threshold-bytes N}` | `{:rf.size/threshold-bytes 16384}` | v1 | The size threshold above which `elide-wire-value` substitutes a `:rf.size/large-elided` marker. 0 disables runtime auto-detect (only declared / schema entries elide). See [11 — Instrumentation](11-instrumentation.md). |
+
+SSR error-projection policy (`:public-error-id`, `:dev-error-detail?`) is **not** a `configure` key — it's per-frame metadata on the frame's `:ssr` map, because different frames in the same process can carry different projector settings.
+
+### Opts-key naming rule
+
+The opts map deliberately mixes two key shapes:
+
+- **Framework-owned semantic sub-keys use a namespaced keyword** — `:rf.size/threshold-bytes`. The namespace identifies the cross-spec policy area; the same key shape appears verbatim wherever that policy is consumed (here under `:elision`, but also as a per-call opt to `elide-wire-value`).
+- **Ergonomic per-knob sub-keys are unqualified bare keywords** — `:depth`, `:grace-period-ms`, `:trace-events-keep`. Local to a single `configure` key; no cross-surface identity to encode.
+
+The discriminator is whether the sub-key names a cross-surface contract or a one-off knob. The rule is closed — there's no third shape.
+
+### See also
+
+- [03 — Effects and interceptors](03-effects.md) — `with-fx-overrides` and the per-call `:fx-overrides` envelope are the *other* configuration surfaces (per-frame metadata is the third).
+- [13 — Lifecycle](13-lifecycle.md) — `init!` / `install-adapter!` / `destroy-adapter!` set up and tear down the running process.

--- a/docs/api/02-views.md
+++ b/docs/api/02-views.md
@@ -1,0 +1,165 @@
+# 02 — Views
+
+Views are where the cascade ends and pixels begin. The view layer in re-frame2 is **substrate-agnostic** — the same `reg-view` registration works against Reagent, UIx, and Helix; the same `dispatcher` and `subscriber` helpers compose across all three. The substrates differ in how they emit React calls; the re-frame2 contract sits above that and stays uniform.
+
+This chapter covers the registration surface (`reg-view`, `reg-view*`, `view`), the substrate-agnostic ergonomic surface (`dispatcher`, `subscriber`, `with-frame`, `bound-fn`, `frame-provider`), and points at the per-adapter chapters for the substrate-specific hooks. If you want the Reagent vs UIx vs Helix conventions, see [13 — Lifecycle](13-lifecycle.md) and [14 — Adapters](14-adapters.md).
+
+## The view registry
+
+The view registry is what `[my-view "arg"]` resolves against. Every view you register lives in it; every view that emits hiccup ends up rendered through it. The registry is keyed by id (a keyword, conventionally `(keyword *ns* sym)` so the view's id matches its symbol).
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-view` | M | `(reg-view sym [args] body+)` <br> `(reg-view sym docstring [args] body+)` <br> `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | The defn-shape view registration. Auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. The 80% of registrations want this form. |
+| `reg-view*` | Fn | `(reg-view* id render-fn)` <br> `(reg-view* id metadata render-fn)` | v1 | The plain-fn surface beneath `reg-view`. No auto-def (the caller manages the Var or computed id), no auto-inject, no compile check. Reach for it when you need: computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. |
+| `view` | Fn | `(view view-id)` → render-fn | v1 | Runtime lookup handle. Returns the **registered render-fn**, not hiccup. Use in hiccup as `[(rf/view :id) args...]` when you need to late-bind a view by id (computed id, plugin-style dispatch, dynamic chrome). |
+
+### How `reg-view` reads
+
+The macro accepts three shapes for the same registration. They produce the same registered view; the choice is about what you want at the source level.
+
+```clojure
+;; Bare form — id derived as :my.app.cart/cart-line
+(rf/reg-view cart-line [item]
+  [:tr
+    [:td (:name item)]
+    [:td (:qty item)]])
+
+;; With docstring — useful for the registry's :doc field
+(rf/reg-view cart-line
+  "One row in the cart table; receives a normalised item map."
+  [item]
+  [:tr ...])
+
+;; With explicit id via metadata — useful when the symbol shouldn't drive the id
+;; (e.g. you want a stable id across rename, or you're matching an external contract).
+(rf/reg-view ^{:rf/id :cart/line} cart-line [item]
+  [:tr ...])
+```
+
+In all three cases the symbol `cart-line` is `def`-ed so you can write `[cart-line item]` from sibling code. The macro also injects `dispatch` and `subscribe` as lexical bindings so you can call them without the `rf/` prefix inside the body — this matters less than it used to (the `rf/` prefix is conventional) but the seam is preserved for muscle-memory and macro composition.
+
+### When to reach for `reg-view*`
+
+The starred form is the right call when:
+
+- **The id is computed.** Code-gen pipelines, plugin systems, story / variant scaffolding — anywhere the id isn't a literal symbol at the call site.
+- **You don't want a Var.** Inside a `let` or a closure, or when the view is a one-off built from configuration data.
+- **You're writing a Form-3 component.** Reagent's `create-class` wraps a map of lifecycle methods around a render-fn; the call shape is `(rf/reg-view* :id (r/create-class {...}))`.
+- **You're consumer-side library code.** Libraries that ship registered views (a charting library, a table widget) often want to register without imposing a `def` on the consumer's namespace.
+
+The `*` follows Clojure's own `let` / `let*`, `fn` / `fn*` idiom — the un-starred form is the macro shorthand; the starred form is the underlying primitive.
+
+### The `view` lookup form
+
+```clojure
+[(rf/view :app/header) {:title "Cart"}]   ;; resolves the registered render-fn at render time
+```
+
+Two shapes coexist in hiccup:
+
+- **Var form** `[my-view arg1 arg2]` — the canonical, source-readable form. Reagent / UIx / Helix all resolve a function-in-tag-position by calling it with the trailing args.
+- **Lookup form** `[(rf/view :my/id) arg1 arg2]` — for late-binding by id. Same render outcome; different addressing scheme.
+
+Bare keyword-tagged hiccup (`[:my-view "args"]`) is **removed in v2** — it was a v1 footgun that collided with HTML tag keywords. Use the Var form or the lookup form.
+
+## The substrate-agnostic ergonomic surface
+
+These five surfaces work the same across Reagent, UIx, and Helix. They're how views interact with the running app without being tied to any single substrate's idiom.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `frame-provider` | Component (Reagent) | `[rf/frame-provider {:frame :todo} & children]` | v1 | "Children inside this provider see `:todo` as their current frame." Lexical scope for the implicit frame; nestable; pairs with `with-frame` for non-component code. |
+| `with-frame` | M | `(with-frame :keyword body)` *or* `(with-frame [sym expr] body)` | v1 | "Run this code as if the current frame were `:keyword`." Two shapes — bare keyword vs let-binding — documented in [002 §with-frame](../../spec/002-Frames.md#with-frame). |
+| `bound-fn` | M | `(bound-fn [args] body)` | v1 | "Capture the current dynamic-var bindings (frame, registrar, etc.) into a closure that will be invoked later, possibly after the calling stack has unwound." CLJS-only macro. Use for event-callback wiring where Promise / setTimeout / IntersectionObserver / WebSocket message handlers run outside the original render call. |
+| `dispatcher` | Fn | `(dispatcher)` → `(fn [event] ...)` | v1 | "Hand me a frame-bound dispatch function I can call later." Captures the current frame at call time and returns a closure that dispatches against that frame. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound. |
+| `subscriber` | Fn | `(subscriber)` → `(fn [query-v] ...)` | v1 | "Hand me a frame-bound subscribe function I can call later." Companion to `dispatcher` for the subscribe side. |
+
+### When to use `dispatcher` / `subscriber` instead of `dispatch` / `subscribe`
+
+The verbs `dispatch` and `subscribe` read the current frame from the dynamic-var stack at call time. That's fine when the call sits *inside* the cascade — inside a render, an event handler, a sub computation. It breaks when the call sits *outside* the cascade — a Promise callback, a `setTimeout`, a WebSocket `onmessage`, an IntersectionObserver. By the time the callback fires, the dynamic-var binding has unwound, and `(rf/dispatch [::foo])` will hit the default frame (or throw, depending on the substrate).
+
+The fix is to capture the frame *at the point you have it* and use the captured closure later:
+
+```clojure
+(rf/reg-view alert-widget []
+  (let [dispatch (rf/dispatcher)]                          ;; captures NOW
+    [:button {:on-click
+              (fn [_]
+                (.then (fetch "/notify")
+                       (fn [_] (dispatch [::notified]))))} ;; runs LATER, but bound
+     "Notify"]))
+```
+
+The pattern composes inside `with-frame`:
+
+```clojure
+(rf/with-frame :tool
+  (let [dispatch (rf/dispatcher)]              ;; captures :tool frame
+    (js/setTimeout #(dispatch [::tick]) 1000))) ;; fires :tool even after with-frame unwinds
+```
+
+`bound-fn` is the broader hammer — it captures *every* dynamic-var binding into the closure, not just the frame. Use `dispatcher` / `subscriber` for the common frame-capture case; reach for `bound-fn` when the closure needs to honour other bindings (interceptor overrides, the dev-time trace context, etc.).
+
+### `with-frame`'s two shapes
+
+```clojure
+;; Bare keyword — most common
+(rf/with-frame :todo
+  (rf/dispatch [::add-item ...]))
+
+;; Let-binding — when you want the keyword in a local
+(let [f (compute-frame-id ...)]
+  (rf/with-frame [chosen f]
+    (rf/dispatch [::action chosen])))
+```
+
+Full semantics in [002 §with-frame](../../spec/002-Frames.md#with-frame).
+
+## Reagent: the default substrate
+
+The CLJS reference implementation ships against Reagent as the default substrate. There's no separate `re-frame.adapter.reagent` namespace to require — `re-frame.core` includes the Reagent adapter inline, because that's the historical default and the path of least surprise for re-frame v1 migrators.
+
+Reagent views are plain Clojure functions returning hiccup; re-frame2's `reg-view` macro is the typed sugar over `defn` + `reg-view*`. Form-2 (a fn that returns a fn) and Form-3 (`create-class`) are both supported; the wrapping the macro emits is transparent to either pattern.
+
+The adapter spec map — the value `(rf/init!)` consumes — lives at `re-frame.adapter.reagent/adapter` (Reagent-full) or `re-frame.adapter.reagent-slim/adapter` (Reagent without the React server-rendering tax, for SSR pipelines).
+
+```clojure
+(:require [re-frame.adapter.reagent :as reagent])
+
+(rf/init! reagent/adapter)
+```
+
+## UIx and Helix: hooks-shaped substrates
+
+UIx and Helix expose React's hooks model directly. The re-frame2 adapter for each ships in its own artefact (`day8/re-frame2-uix`, `day8/re-frame2-helix`) and exposes a small, parallel surface — the same shape across both, because the Helix decisions transfer the UIx decisions one-for-one.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `<adapter>/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
+| `<adapter>/use-subscribe` | Fn (hook) | `(use-subscribe query-v)` / `(use-subscribe frame-kw query-v)` → value | v1 | The hook-shaped read. Matches the React/UIx/Helix idiom; there's no auto-injection — components call the hook and `(rf/dispatcher)` directly. |
+| `<adapter>/use-current-frame` | Fn (hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks. |
+| `<adapter>/frame-provider` | Fn (component) | `($ frame-provider {:frame :session :children […]})` | v1 | The component-shaped equivalent of Reagent's `frame-provider`. The underlying React Context (`re-frame.adapter.context`) is **shared** across all three substrates, so a mixed-substrate app's frame-provider chain composes across substrate boundaries. |
+| `<adapter>/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord annotation. Most UIx / Helix users register through `reg-view*` and let the adapter wrap; `wrap-view` is exposed for code-gen and library scaffolding. |
+| `<adapter>/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. Drain queued state updates before assertions. |
+| `<adapter>/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR. |
+
+The UIx / Helix adapters do **not** support `reg-view` (the macro is Reagent-specific in its `defn`-shape rewriting). UIx and Helix users register with `rf/reg-view*` when they need registry-keyed view addressing — most don't, because UIx and Helix components compose by Var reference like ordinary React components.
+
+See [14 — Adapters](14-adapters.md) for the per-substrate detail.
+
+## DOM source-coord annotations
+
+Every adapter whose host has a DOM-attribute concept (Reagent / UIx / Helix on the browser; not Plain Atom) injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. The annotation is **mandatory** at the adapter contract level; it's what powers click-to-source navigation in Causa and re-frame2-pair.
+
+Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`). Production `:advanced` builds elide the attribute via dead-code elimination — there's no DOM-bytes cost in shipped bundles.
+
+The JVM SSR emitter mirrors the same contract so server-rendered HTML can be clicked back to the source position before any hydration happens.
+
+Full contract: [Spec 006 §Source-coord annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1) and [Spec 011 §Source-coord annotation under SSR](../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+
+## See also
+
+- [01 — Core](01-core.md) — `dispatch`, `subscribe`, `reg-view` rowed in registration.
+- [03 — Effects and interceptors](03-effects.md) — `with-fx-overrides` for scoping fx behaviour inside a view's event handlers.
+- [14 — Adapters](14-adapters.md) — full per-substrate surface tables.

--- a/docs/api/03-effects.md
+++ b/docs/api/03-effects.md
@@ -1,0 +1,130 @@
+# 03 — Effects and interceptors
+
+The effect map is what an event handler returns. The interceptor chain is what runs before and after the handler. Together they're the load-bearing trick that makes re-frame2 a *pattern* — handlers stay pure (they return descriptions of effects, not the effects themselves), and the runtime actions those descriptions against the real world at exactly one point. That separation is why the trace bus, time-travel, and effect-overrides all work; if handlers fired effects directly, none of those would compose.
+
+This chapter covers what an `:fx` map can carry (`:db`, `:fx`, the standard fx-ids), what an interceptor is and the surface for building one (`->interceptor`), the four ergonomic interceptors v2 ships (`inject-cofx`, `path`, `unwrap`, the pre-built `validate-at-boundary-interceptor`), and the override surfaces that let tests and tools swap fx behaviour at runtime (`with-fx-overrides`, the per-call `:fx-overrides` opt).
+
+## The effect map: closed shape
+
+Closed: **`:db` + `:fx` only**. That's the entire effect-map vocabulary in v2.
+
+| Key | Notes |
+|---|---|
+| `:db` | The new `app-db` value. Replaces the current value in the cascade's commit phase. |
+| `:fx` | A vector of `[fx-id args]` pairs. Each is run by the runtime's fx walker against the registered `reg-fx` handler. |
+
+If you remember v1's `:dispatch` / `:dispatch-later` / `:dispatch-n` at the top level of the effect map, those don't exist any more — they're inside `:fx`. The migration is mechanical; see [MIGRATION §M-8](../../migration/from-re-frame-v1/README.md). The closed shape is what lets the conformance harness validate handler outputs across implementations.
+
+Full schema: [Spec-Schemas §`:rf/effect-map`](../../spec/Spec-Schemas.md#rfeffect-map).
+
+## Standard `:fx` entries
+
+Anything in `:fx` is a `[fx-id args]` pair. The runtime looks up `fx-id` in the `:fx` registrar and runs the registered handler against `args`. User code registers its own fx-ids via `reg-fx`; a small set of fx-ids is framework-reserved.
+
+| `[fx-id args]` | Args | Status | Spec | Intuition |
+|---|---|---|---|---|
+| `[:dispatch event-vec]` | event vector | v1 | 002 | "Schedule this event on the same queue." Async — runs after the current cascade completes. |
+| `[:dispatch-later {:ms ms :dispatch event-vec}]` | options map | v1 | 002 | "Schedule this event after N ms." |
+| `[:rf.http/managed args-map]` | per `:rf.fx/managed-args` | v1 (optional) | 014 | The canonical managed-HTTP fx. See [07 — HTTP](07-http.md). |
+| `[:rf.nav/push-url url-string]` | URL string | v1 | 012 | Navigate. See [06 — Routing](06-routing.md). |
+| `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
+| `[:rf.machine/spawn spawn-spec]` | per `:rf.fx/spawn-args` | v1 | 005 | Spawn a dynamic actor instance whose snapshot lives at `[:rf/machines <gensym'd-id>]`. See [04 — Machines](04-machines.md). |
+| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | Symmetric counterpart to `:rf.machine/spawn`. Runs the actor's `:exit` action, dissociates `[:rf/machines <id>]`, clears its event-handler registration. |
+| `[:rf.fx/reg-flow flow-map]` | flow map | v1 | 013 | Register a flow at runtime via `:fx`. See [05 — Flows](05-flows.md). |
+| `[:rf.fx/clear-flow id]` | id | v1 | 013 | Clear a registered flow at runtime via `:fx`. |
+| `[:http args]` | impl-specific | — | — | User-registered via `reg-fx`. The legacy un-managed shape; new code uses `:rf.http/managed`. |
+
+SSR-side server-only fx (`:rf.server/set-status`, `:rf.server/set-header`, `:rf.server/redirect`, etc.) are rowed in [09 — SSR](09-ssr.md). Their `:platforms` metadata gates them off the client.
+
+## Standard interceptors
+
+The interceptor chain wraps the handler. Every interceptor has a `:before` (runs before the handler) and / or `:after` (runs after the handler). The runtime threads a context map — the **ctx** — through the chain, and the chain composes deterministically. Interceptors are how you add cross-cutting behaviour (validation, cofx injection, focus-on-path) without writing it into every handler.
+
+The v2 standard-interceptor surface is **three specific helpers** plus the `->interceptor` primitive. The principle is: keep helpers that do specific, non-trivial work; drop helpers that are just `(->interceptor :before f)` with no other logic. Five v1 interceptors are removed (`debug`, `trim-v`, `on-changes`, `enrich`, `after`); see [16 — Removed](16-removed.md).
+
+| API | M/Fn | Signature | Purpose |
+|---|---|---|---|
+| `inject-cofx` | M | `(inject-cofx id)` / `(inject-cofx id value)` | Inject a registered cofx into the handler's coeffect map. Macro: captures the call-site for `:rf.trace/call-site` on errors emitted from the cofx body. Does specific work — `:cofx` registry lookup — not subsumable by `->interceptor`. |
+| `inject-cofx*` | Fn | `(inject-cofx* id)` / `(inject-cofx* id value)` | Fn form for HoF / programmatic interceptor construction — no call-site stamping. |
+| `path` | Fn | `(path & path)` | Focus the handler on an `app-db` sub-slice. `:before` rewrites the `:db` cofx to `(get-in db path)`; `:after` splices the result back into the parent. The handler sees and returns a sub-tree, not the full db. |
+| `unwrap` | (val) | `unwrap` | Assert `[id payload-map]` event shape; replace the `:event` coeffect with just the payload map; restore on `:after`. Sugar over the canonical map-payload form (per [MIGRATION §M-19](../../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)). |
+| `->interceptor` | Fn | `(->interceptor & {:keys [id before after]})` | The primitive. Build a custom interceptor with `:before` and / or `:after`. **Use this for any work not covered by the three specific helpers above** — analytics, logging, validation, ad-hoc context manipulation. The resulting interceptor is named, addressable, and queryable like any other artefact. |
+| `validate-at-boundary-interceptor` | Var (value) | `validate-at-boundary-interceptor` | A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary schema validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`. |
+
+### The `path` interceptor: focus on a slice
+
+```clojure
+(rf/reg-event-db :cart/add-item
+  [(rf/path [:cart :items])]
+  (fn [items {:keys [item]}]
+    (conj items item)))                       ;; the handler sees and returns the slice
+```
+
+The `:before` rewrites `(:db cofx)` to `(get-in db [:cart :items])`. The handler returns the new slice. The `:after` splices it back with `(assoc-in db [:cart :items] result)`. Compose `path` with `inject-cofx` to focus a handler on a slice and inject auxiliary state in one go.
+
+### The `unwrap` interceptor
+
+```clojure
+(rf/reg-event-fx :foo/update
+  [rf/unwrap]
+  (fn [cofx {:keys [id new-value]}]           ;; :event coeffect is the payload map
+    ...))
+```
+
+You wrote `(rf/dispatch [:foo/update {:id 1 :new-value "x"}])`; the handler receives the payload map directly under `:event` instead of the full vector. Sugar — it's not load-bearing — but it composes cleanly with the canonical map-payload form.
+
+### Building custom interceptors with `->interceptor`
+
+```clojure
+(def log-on-error
+  (rf/->interceptor
+    :id     :log-on-error
+    :after  (fn [ctx]
+              (when-let [err (:rf.error/last-event ctx)]
+                (js/console.error err))
+              ctx)))
+
+(rf/reg-event-fx ::save-cart [log-on-error]
+  (fn [cofx _] ...))
+```
+
+The map-of-keyword-args API is deliberate — `{:id :before :after}` is the entire vocabulary; the resulting interceptor value carries those keys and the runtime threads it. Every standard interceptor is just a `->interceptor` call with specific behaviour baked in.
+
+## Context plumbing
+
+The interceptor context — the ctx — is the value threaded through the chain. It carries `:coeffects` (everything available to the handler before it runs), `:effects` (everything the handler produced), and the queue / stack of remaining interceptors. Most app code never reaches into ctx directly; the four accessors below are for the rare interceptor body that does.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `get-coeffect` | Fn | `(get-coeffect ctx)` <br> `(get-coeffect ctx key)` <br> `(get-coeffect ctx key not-found)` | v1 (preserved) | "Read the coeffect map (or one slot of it)." |
+| `assoc-coeffect` | Fn | `(assoc-coeffect ctx key value)` | v1 (preserved) | "Write a coeffect slot in the ctx." |
+| `get-effect` | Fn | `(get-effect ctx)` <br> `(get-effect ctx key)` <br> `(get-effect ctx key not-found)` | v1 (preserved) | "Read the effect map (or one slot)." |
+| `assoc-effect` | Fn | `(assoc-effect ctx key value)` | v1 (preserved) | "Write an effect slot in the ctx." |
+
+These are stable surfaces preserved from v1. If you're writing an interceptor that needs to read or modify what the handler will see / what the handler emitted, this is the surface.
+
+## Override surfaces
+
+The runtime supports three ways to swap fx behaviour without touching the handler. They differ in scope: per-frame (lexical to the frame), lexical (around a body of code), and per-call (on a single dispatch).
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `with-fx-overrides` | M | `(with-fx-overrides {fx-id -> override, …} body+)` | v1 | "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`. Renamed from v1's `with-overrides` per [MIGRATION §M-50](../../migration/from-re-frame-v1/README.md#m-50-with-overrides-macro-renamed-to-with-fx-overrides). |
+
+The three scopes compose with a clear precedence:
+
+1. **Per-call** — `(rf/dispatch event {:fx-overrides {...}})` wins.
+2. **Lexical** — `with-fx-overrides` wraps the body.
+3. **Per-frame** — `(rf/reg-frame :todo {:fx-overrides {...}})` is the baseline.
+
+Most tests reach for `with-fx-overrides` because it scopes the swap to the test body without polluting the frame. Pair tools and Story variants reach for per-call overrides because the swap is specific to a single recorded dispatch.
+
+### `:fx-overrides` asymmetry
+
+At the pattern level (`(rf/dispatch event {:fx-overrides {:my/fx :other-fx-id}})`) the override value is an **id** — the registry name of another fx handler. The CLJS reference implementation **also** accepts a **fn** value (`{:my/fx (fn [args] ...)}`) for ergonomic test wiring. The asymmetry is documented: ports that don't ship fn-valued overrides remain pattern-conformant. See [002 §`:fx-overrides`](../../spec/002-Frames.md#fx-overrides--replace-fx-handlers).
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-event-fx`, `reg-fx`, `reg-cofx`, `dispatch` rowed in the registration and dispatch sections.
+- [10 — Testing](10-testing.md) — `with-fx-overrides` and the testing fixtures that use it.
+- [09 — SSR](09-ssr.md) — `:platforms` metadata on `reg-fx` for client vs server gating.

--- a/docs/api/04-machines.md
+++ b/docs/api/04-machines.md
@@ -1,0 +1,127 @@
+# 04 — State machines
+
+A state machine in re-frame2 is registered with one call (`reg-machine`) and *is* an event handler. The transition table is data — a map of `:states`, `:on`, `:entry`, `:exit`, `:after` — that gets compiled into a `reg-event-fx` handler at registration time. Dispatch an event at the machine's id and the table decides the transition; the resulting `:db` and `:fx` flow through the normal cascade.
+
+The point of the machine surface isn't novelty — Statecharts have been around since 1987 — it's that the same trace bus, time-travel, and override surfaces that work for plain event handlers also work for machines, *because the machine is an event handler*. There's no parallel runtime to debug, no second store to inspect, no separate event log. Causa shows the machine state alongside `app-db`; the epoch buffer captures the snapshot the same way it captures everything else.
+
+This chapter covers the registration surface (`reg-machine`, `reg-machine*`, `make-machine-handler`), the inspection / subscription surface (`sub-machine`, `machines`, `machine-meta`, `machine-by-system-id`), the dispatch sugar (`dispatch-to-system`, `:raise`), the actor-lifecycle fx (`:rf.machine/spawn`, `:rf.machine/destroy`), and the post-v1 tooling exports (`machine->xstate-json`, `machine->mermaid`).
+
+For the *why* — the design rationale, the v1 vs post-v1 split, the capability matrix — see [005-StateMachines.md](../../spec/005-StateMachines.md).
+
+## Registration
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-machine` | M | `(reg-machine machine-id machine-spec)` | v1 | The canonical macro. Walks the literal spec form at expansion time and stamps per-element source coords under `:rf.machine/source-coords` — Causa uses these to navigate from a snapshot back to the state-node definition. Top-level call-site coords land on `handler-meta`. |
+| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data. |
+| `make-machine-handler` | Fn | `(make-machine-handler spec)` → event-handler fn | v1 | Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually. |
+| `machine-transition` | Fn | `(machine-transition definition snapshot event)` → `[next-snapshot effects]` | v1 | The pure transition fn. Given a machine definition, a current snapshot, and an event, returns the next snapshot and the effect map. JVM-runnable; the conformance harness uses this as its primary test surface for machine behaviour. |
+
+### A minimal machine
+
+```clojure
+(rf/reg-machine :session
+  {:initial :anonymous
+   :states  {:anonymous     {:on {:login {:target :authenticating
+                                          :data   (fn [data event]
+                                                    (assoc data :credentials (second event)))}}}
+             :authenticating {:after  {500 {:target :timeout}}
+                              :entry  [{:fx [[:rf.http/managed {...}]]}]
+                              :on     {:auth-ok   {:target :authenticated}
+                                       :auth-fail {:target :anonymous}}}
+             :authenticated {:on {:logout {:target :anonymous}}}
+             :timeout       {:on {:retry {:target :anonymous}}}}})
+
+;; The machine IS an event handler — dispatch at its id.
+(rf/dispatch [:session [:login {:user "alice" :pass "..."}]])
+```
+
+The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:state :anonymous :data {...}}` (plus framework-managed slots for `:after` timer epochs and tags). Read it via `sub-machine` or directly with `subscribe-once`.
+
+## Inspection and subscription
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot | v1 | Sugar over `(subscribe [:rf/machine machine-id])`. Use inside views — gives you a reaction over `{:state :data}`. |
+| `machines` | Fn | `(machines)` → seq of machine-ids | v1 | "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`. |
+| `machine-meta` | Fn | `(machine-meta machine-id)` → registration-metadata map | v1 | "What did `reg-machine` stamp at this machine's id?" Returns the transition table, doc, schemas, and the per-element source-coords. Equivalent to `(handler-meta :event machine-id)`. |
+| `machine-by-system-id` | Fn | `(machine-by-system-id system-id)` <br> `(machine-by-system-id system-id frame-id)` | v1 | Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`. |
+| `machine-has-tag?` | Fn | `(machine-has-tag? machine-id tag)` → reaction | v1 | Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership. |
+
+### Standard registered subs (machines)
+
+| Sub | Returns | Spec |
+|---|---|---|
+| `[:rf/machine <machine-id>]` | The machine's snapshot `{:state :data}` (or `nil` if not yet initialised) | 005 |
+
+`sub-machine` is sugar over this — see [005 §Subscribing to machines](../../spec/005-StateMachines.md#subscribing-to-machines-via-sub-machine).
+
+## Cross-machine messaging
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `dispatch-to-system` | Fn | `(dispatch-to-system system-id event)` <br> `(dispatch-to-system system-id event frame-id)` | v1 | Sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`. No-op when the `system-id` is unbound. The third-arity targets a non-default frame. |
+
+When a child actor spawns under a parent, the parent's `:data` often gets the child's id stamped via `:on-spawn`. `dispatch-to-system` lets the parent name the child by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by gensym'd id. The per-frame `[:rf/system-ids]` reverse index resolves the name. See [005 §Named addressing via `:system-id`](../../spec/005-StateMachines.md).
+
+## The actor-lifecycle fx
+
+| `[fx-id args]` | Args | Status | Spec | Intuition |
+|---|---|---|---|---|
+| `[:rf.machine/spawn spawn-spec]` | spawn-spec map (per `:rf.fx/spawn-args`) | v1 | 005 | "Spawn a dynamic actor instance." Args carry `:machine-id` (the definition to instantiate), `:id-prefix`, `:data` (initial), `:on-spawn` (event dispatched with the gensym'd id), and `:start` (events to deliver immediately). Emitted from any event handler's `:fx` (including machine actions and the `:spawn` desugar). |
+| `[:rf.machine/destroy actor-id]` | actor id (keyword) | v1 | 005 | "Tear down this actor." Runs the actor's `:exit` action, dissociates `[:rf/machines <actor-id>]`, and clears the actor's event-handler registration. Symmetric counterpart to `:rf.machine/spawn`. |
+| `[:raise event-vec]` | event vector | v1 | 005 | **Machine-only.** Inside a machine action's `:fx`, routes the event back into the same machine atomically and pre-commit. Unbound outside machine actions. |
+
+### Spawn pattern
+
+```clojure
+(rf/reg-event-fx :session/start-logger
+  (fn [_ _]
+    {:fx [[:rf.machine/spawn
+           {:machine-id :machines/log-shipper
+            :id-prefix  :logger
+            :data       {:buffer []}
+            :on-spawn   [:session/logger-spawned]
+            :start      [[:logger/connect]]}]]}))
+
+;; The handler at :session/logger-spawned receives the gensym'd id:
+;; [:session/logger-spawned :logger.4f7c2a]
+(rf/reg-event-db :session/logger-spawned
+  (fn [db [_ logger-id]]
+    (assoc-in db [:session :logger] logger-id)))
+```
+
+## Final states and `:on-done`
+
+Machines support **final states** — leaf states marked `:final?` that auto-destroy the machine on entry. The parent (if any) receives `:on-done` with the child's `:data` slot.
+
+| State-node key | What it does |
+|---|---|
+| `:final?` | Marks a leaf state as terminal. Entering it auto-destroys the machine. Capability axis `:fsm/final-states`. |
+| `:output-key` | Requires `:final?`. Designates the child's `:data` slot reported back via the parent's `:on-done`. |
+| `:on-done` (spawn-spec key) | `(fn [{:keys [data result]}] new-data)` on the parent's `:spawn` map. Fires synchronously when the spawned child enters a `:final?` state. `result` is the child's `:data` slot named by the final state's `:output-key` (or `nil`). |
+
+The pattern: a spawn-shaped sub-process completes, the parent receives the result through `:on-done`, the framework destroys the child. No manual `:rf.machine/destroy` needed.
+
+See [005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-done--output-key).
+
+## Post-v1 tooling exports
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `machine->xstate-json` | Fn | `(machine->xstate-json definition)` → JSON string | post-v1 lib | Export a machine definition to XState JSON. The XState visualiser consumes it; useful for design review and documentation. |
+| `machine->mermaid` | Fn | `(machine->mermaid definition)` → string | post-v1 lib | Export to Mermaid state-diagram syntax. Drops cleanly into Markdown docs that render Mermaid (this site does). |
+| `:child-machine` (transition-table key) | — | Declarative state-scoped child-machine binding. | post-v1 lib | A state node can declare a child machine that lives only while the parent is in that state. Symmetric with the imperative `:spawn` / `:destroy` cycle. |
+
+The post-v1 surfaces live in `day8/re-frame2-machines` (the scaffolding library). The v1 foundation in `re-frame.core` covers the machine-as-event-handler primitive; the scaffolding library layers the higher-level features on top.
+
+## Capability matrix
+
+The v1 transition-table grammar covers a specific subset of Statechart capabilities — sequencing, `:after` timers, internal-vs-external transitions, guards, action lists, hierarchical states, parallel regions where the framework's epoch model can tolerate them, and final-state semantics. The exact subset and its rationale lives at [005 §Capability matrix](../../spec/005-StateMachines.md#capability-matrix); the schema shape is [Spec-Schemas §`:rf/transition-table`](../../spec/Spec-Schemas.md#rftransition-table).
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-machine` rowed in registration.
+- [08 — Schemas](08-schemas.md) — machines declare schemas for their `:data` slot the same way ordinary handlers do.
+- [11 — Instrumentation](11-instrumentation.md) — machine snapshots are part of the epoch buffer; transitions emit trace events.
+- [Spec 005 — State Machines](../../spec/005-StateMachines.md) — the normative source.

--- a/docs/api/05-flows.md
+++ b/docs/api/05-flows.md
@@ -1,0 +1,84 @@
+# 05 — Flows
+
+A flow is a piece of derived state. You declare its inputs (other paths or subs), its computation (a pure fn over those inputs), and the path in `app-db` it should write its output to. The runtime watches the inputs, recomputes the output when any of them change, and writes the result. It's a sub-with-a-side-effect-on-`app-db` — useful exactly when you want derived state that other code reads via plain `get-in` (or a plain sub), without having to remember to recompute it manually.
+
+Flows replace v1's `on-changes` interceptor and a chunk of what `reg-sub-raw` was used for. They also replace much of what `enrich` did. The point: derived state is now a *registered, named, observable, restorable* thing, not a closure hidden behind an interceptor.
+
+The normative source is [013-Flows.md](../../spec/013-Flows.md).
+
+## The flow surface
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-flow` | Fn | `(reg-flow flow)` <br> `(reg-flow flow opts)` | v1 | Register a flow. The flow map carries `:id`, `:inputs`, `:output`, `:path`. `opts` is a map (currently `{:frame frame-id}`) selecting the owning frame. Returns the flow's `:id` (per the `reg-*` return-value convention). |
+| `clear-flow` | Fn | `(clear-flow id)` <br> `(clear-flow id opts)` | v1 | Deregister the flow from the named frame and `dissoc-in` its `:path` from that frame's `app-db` only. Sibling frames' state is preserved. |
+
+### A minimal flow
+
+```clojure
+(rf/reg-flow
+  {:id     :cart/total
+   :inputs {:items [:cart :items]
+            :rate  [:tax :rate]}
+   :output (fn [{:keys [items rate]}]
+             (let [subtotal (reduce + (map :price items))]
+               {:subtotal subtotal
+                :tax      (* subtotal rate)
+                :total    (* subtotal (+ 1 rate))}))
+   :path   [:cart :total]})
+
+;; Now [:cart :total] in app-db is always derived. Read it via a plain sub
+;; or with subscribe-once. Adding an item triggers recompute; updating the
+;; rate triggers recompute; nothing else writes [:cart :total].
+```
+
+The shape is data — no fn registration with a separate id, no interceptor wiring, no closure capture. The conformance harness validates flows by walking the registered data and applying it to a synthesised `app-db`.
+
+### The flow map
+
+| Key | Required | Notes |
+|---|---|---|
+| `:id` | yes | The registry key. Use a namespaced keyword. |
+| `:inputs` | yes | A map of `{slot-name path-or-sub-vector}`. Path vectors read from `app-db`; sub-vectors subscribe through the sub graph. |
+| `:output` | yes | `(fn [inputs-map] new-output)`. Pure; called every time inputs change; must be deterministic. |
+| `:path` | yes | Where to write the output in `app-db`. |
+| `:live?` | no | Predicate fn — when present, the flow only fires while it returns true. Used to short-circuit expensive flows when their consumer isn't on-screen. |
+
+### Frame-scoping
+
+The `:flow` registrar slot is **last-registration-wins across frames** — registering the same id against multiple frames shares one registrar slot keyed by `flow-id` only. For full per-frame discovery use `@re-frame.flows/flows` directly; the per-frame runtime registry is the source of truth for evaluation. See [013 §Frame-scoping](../../spec/013-Flows.md#frame-scoping).
+
+### Frame-destroy teardown
+
+`destroy-frame!` releases every per-frame piece of flow state — registry slot, `last-inputs` rows, registrar entries for ids the destroyed frame was last owner of. Sibling frames' state is preserved. See [013 §Frame-destroy teardown](../../spec/013-Flows.md#frame-destroy-teardown).
+
+## Runtime registration via `:fx`
+
+Sometimes you want to register or clear a flow from inside an event handler — feature-flag gates, demand-driven registration, the SSR per-request frame setting up flows for the request and tearing them down on response. Two reserved fx-ids cover that:
+
+| `[fx-id args]` | Args | Status | Intuition |
+|---|---|---|---|
+| `[:rf.fx/reg-flow flow-map]` | a flow map (same shape as `reg-flow`) | v1 | Register a flow at runtime via `:fx`. |
+| `[:rf.fx/clear-flow id]` | flow id | v1 | Clear a registered flow at runtime via `:fx`. |
+
+The signature mirrors `reg-flow` / `clear-flow` exactly — same opts, same return semantics. Use whichever surface matches your call site.
+
+## Failure semantics
+
+**Production-survivable.** A throw inside a flow's `:output` fn surfaces as `:rf.error/flow-eval-exception` on the **always-on error-emit substrate** — registered `:on-error` policy fns and `register-error-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is *not* trace-only; production deployments catch it.
+
+See [Spec 013 §Failure semantics](../../spec/013-Flows.md#failure-semantics) rule 4 and [Spec 009 §Production builds](../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code).
+
+## Flow vs sub: when to reach for which
+
+- **Sub** when the value is computed *on read* and never written back to `app-db`. Cached; ref-counted; lazy.
+- **Flow** when the value should *live in `app-db`* — because other code reads it via path, other flows depend on it via path, or you want it captured by the epoch snapshot for time-travel.
+
+A useful rule: if you find yourself writing `(reg-sub ::derived-total (fn [...]))` and immediately needing to read its value from a plain handler via `subscribe-once`, that's a flow. If you find yourself writing a flow that no path-shaped consumer ever reads (only sub-shaped ones do), it should probably be a sub.
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-flow` and `clear-flow` rowed in registration / clearing.
+- [03 — Effects and interceptors](03-effects.md) — `[:rf.fx/reg-flow ...]` rowed in `:fx` entries.
+- [Spec 013 — Flows](../../spec/013-Flows.md) — the normative source.
+- [16 — Removed](16-removed.md) — `on-changes` (replaced by flows) and `enrich` (replaced by flows / schemas).

--- a/docs/api/06-routing.md
+++ b/docs/api/06-routing.md
@@ -1,0 +1,114 @@
+# 06 — Routing
+
+Routes in re-frame2 are *data*. You register a route with metadata — `:path`, `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave` — and the runtime turns URL changes into events the same way every other input source does. There's no parallel router state; current route lives in `app-db` under `:rf/route`; navigation is just dispatching an event; in-flight navigation is just an event sequence the cascade is mid-way through.
+
+The point isn't novelty — every SPA framework has a router. The point is that **routing-as-state** means the router is debuggable with the same tools that debug everything else. Time-travel works. The trace bus sees navigation. Tests dispatch `:rf.route/navigate` like any other event. There's no special "router debug mode" because the router doesn't have its own mode.
+
+This chapter covers the registration shape, the dispatch / sub / fx surface, and the helpers that map URLs to/from route ids. For nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing, see [Guide ch.19 — Routing reference](../guide/19-routing-ref.md). The normative source is [012-Routing.md](../../spec/012-Routing.md).
+
+## Registration
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-route` | M | `(reg-route id metadata)` | v1 | Register a route as data. The id is a keyword you'll later dispatch against (`[:rf.route/navigate :route/cart]`); the metadata carries the URL shape, the match events, and the guards. |
+
+### A minimal route
+
+```clojure
+(rf/reg-route :route/cart
+  {:path     "/cart"
+   :on-match [[:cart/load-items]]})
+```
+
+`:path` is the URL shape — colon-prefixed segments capture into `:params`. `:on-match` is the event vector (or vector of event vectors) the runtime dispatches when the route activates. That's the whole minimal contract; everything else is optional.
+
+### Reserved metadata keys
+
+| Key | Notes |
+|---|---|
+| `:doc` | Free-form description; pair tools read this. |
+| `:path` | The URL shape — `/users/:id/posts/:slug`, etc. |
+| `:params` | Schemas for path segments (per [Spec-Schemas](../../spec/Spec-Schemas.md)). |
+| `:query` | Schemas for query-string keys. |
+| `:query-defaults` | Default values for query keys absent from the URL. |
+| `:query-retain` | Keys to preserve across navigations to other routes. |
+| `:tags` | Free-form classification — `#{:auth-required :admin-only :public}`. |
+| `:parent` | Another route id; builds a chain readable via `:rf.route/chain`. |
+| `:on-match` | Event vector(s) to dispatch when the route activates. |
+| `:on-error` | Event vector dispatched if any `:on-match` event errors. |
+| `:can-leave` | Predicate or guard event; blocks navigation when truthy. See [Guide ch.19 — Navigation blocking](../guide/19-routing-ref.md#navigation-blocking--the-can-leave-protocol). |
+| `:scroll` | Scroll-restoration behaviour for this route. |
+
+Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata schema is [Spec-Schemas §`:rf/route-metadata`](../../spec/Spec-Schemas.md#rfroute-metadata).
+
+## URL helpers
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `match-url` | Fn | `(match-url url)` → `{:route-id :params :query :validation-failed?}` or `nil` | v1 | "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests. |
+| `route-url` | Fn | `(route-url route-id path-params)` <br> `(route-url route-id path-params query-params)` → URL string | v1 | "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable. |
+| `route-link` | Fn (registered view) | `[rf/route-link {:to :route-id :params {...} :query {...} :fragment "..."} & children]` | v1 | A registered view at `:route/link`. Renders an `<a>` with the right `href` and intercepts plain primary-button clicks to dispatch `:rf/url-requested` instead of navigating natively. |
+
+### `route-link` click semantics
+
+A plain primary-button click (no modifier keys, no `defaultPrevented`) calls `.preventDefault` and dispatches:
+
+```clojure
+[:rf/url-requested {:url      <synthesised>
+                    :to       <route-id>
+                    :params   {...}
+                    :query    {...}
+                    :fragment "..."}]
+```
+
+Modifier-key clicks (cmd / ctrl / shift / alt) and middle-button clicks defer to the browser so the native `href` opens in a new tab. A caller-supplied `:on-click` runs first; if it calls `.preventDefault` (or otherwise leaves `defaultPrevented` true) the framework's interception is skipped. Keys other than `:to` / `:params` / `:query` / `:fragment` / `:on-click` pass through to the underlying `<a>` element.
+
+Detailed semantics in [012-Routing.md §Linking from views](../../spec/012-Routing.md#linking-from-views--plain-anchor-semantics).
+
+## Events
+
+These are the standard events the runtime dispatches (or you dispatch) around routing.
+
+| Event | Notes | Spec |
+|---|---|---|
+| `:rf.route/navigate` | Navigate to a registered route. Args: `{:to :route-id :params {...} :query {...}}`. | 012 |
+| `:rf.route/handle-url-change` | Default handler for `:rf.route/transitioned`. You'd override this if you want custom transition handling. | 012 |
+| `:rf.route/transitioned` | The browser URL changed (popstate, pushState, etc.). The runtime dispatches this; you read it. | 012 |
+| `:rf/url-requested` | The user clicked a framework-owned link. `route-link` synthesises this event; you usually let the default handler take it. | 012 |
+| `:rf.route/navigation-blocked` | A `:can-leave` guard rejected a navigation. The pending nav slot in `app-db` carries the rejected navigation. | 012 |
+| `:rf.route/continue` | User-dispatched event proceeding a blocked navigation — "yes, leave the page." | 012 |
+| `:rf.route/cancel` | User-dispatched event abandoning a blocked navigation — "stay here, drop the pending nav." | 012 |
+
+## Subscriptions
+
+The full `:rf/route` slice is `{:id :params :query :transition :error}`. The standard subs are projections of that slice plus a couple of conveniences.
+
+| Sub | Returns | Spec |
+|---|---|---|
+| `:rf/route` | The full `:rf/route` slice `{:id :params :query :transition :error}` | 012 |
+| `:rf.route/id` | Current route id | 012 |
+| `:rf.route/params` | Current path params | 012 |
+| `:rf.route/query` | Current query params | 012 |
+| `:rf.route/transition` | `:idle` / `:loading` / `:error` | 012 |
+| `:rf.route/error` | Current error map (when `:transition = :error`) | 012 |
+| `:rf.route/fragment` | Current URL fragment (string or `nil`) | 012 |
+| `:rf.route/chain` | Vector of route ids from parent-most to current (per `:parent` links) | 012 |
+| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise | 012 |
+
+## Fx
+
+| Fx | Args | Platforms | Notes |
+|---|---|---|---|
+| `[:rf.nav/push-url url-string]` | URL string | `:client` | Push a new URL onto the browser history. |
+| `[:rf.nav/replace-url url-string]` | URL string | `:client` | Replace the current URL without adding a history entry. |
+| `[:rf.nav/scroll scroll-spec]` | scroll-spec map | `:client` | Restore or set scroll position. |
+| `[:rf.route/with-nav-token {:do <fx-entry> :nav-token <token>}]` | universal | universal | Wrap an fx with a navigation token. If the token has been superseded by a later navigation, the wrapped fx is suppressed and `:rf.route.nav-token/stale-suppressed` fires. |
+
+The nav-token wrapper is what makes "user navigates away mid-load" safe: the older load's reply carries the stale token, the runtime suppresses it, and you don't see the older page's data overwrite the newer page's state. Full semantics in [Guide ch.19 — Navigation tokens](../guide/19-routing-ref.md#navigation-tokens--stale-result-suppression).
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-route` rowed in registration.
+- [09 — SSR](09-ssr.md) — routes participate in SSR; the active route's `:head` registration is what `render-head` looks up.
+- [Guide ch.18 — Routing](../guide/18-routing.md) and [Guide ch.19 — Routing reference](../guide/19-routing-ref.md) — narrative coverage including nav-token semantics, `:can-leave` flows, query strings, and multi-frame routing.
+- [Spec 012 — Routing](../../spec/012-Routing.md) — the normative source.

--- a/docs/api/07-http.md
+++ b/docs/api/07-http.md
@@ -1,0 +1,151 @@
+# 07 — HTTP
+
+Managed HTTP is the answer to "I want my app to talk to a server, but I don't want to write a custom fx-handler every time, and I want retries / cancellation / timeouts / decode / failure-classification to be the framework's problem, not mine." `:rf.http/managed` is one fx-id that takes one args map and gives you back one reply event with one closed taxonomy of failure kinds.
+
+You don't get this for free — Spec 014 is an **optional capability**. Implementations ship it (the CLJS reference does, on Fetch in the browser and `java.net.http.HttpClient` on the JVM); ports that omit it must not reuse the `:rf.http/*` namespace for anything else. If you're using the CLJS reference, you have it; if you're vendoring a port that doesn't, you're back to writing your own.
+
+This chapter covers the canonical fx, the verb helpers, the test stubs, the request-interceptor surface, and the closed failure taxonomy. The normative source — args map, decode pipeline, retry semantics, reply addressing — lives at [014-HTTPRequests.md](../../spec/014-HTTPRequests.md).
+
+## The canonical fx
+
+| API | Kind | Signature / shape | Status | Intuition |
+|---|---|---|---|---|
+| `[:rf.http/managed args-map]` | fx | args per [014 §The args map](../../spec/014-HTTPRequests.md#the-args-map) and `:rf.fx/managed-args` | v1 (optional capability) | The one fx-id. Args carry the request envelope, decode policy, accept fn, retry policy, timeout, success / failure target events, request-id (for abort), and optional abort-signal. |
+| `[:rf.http/managed-abort request-id]` | fx | request-id | v1 (optional capability) | Abort the in-flight request with the given `:request-id`. The aborted request's reply fires with `{:rf/reply {:kind :failure :failure {:kind :rf.http/aborted ...}}}`. |
+
+### A minimal request
+
+```clojure
+(rf/reg-event-fx :cart/load
+  (fn [_ _]
+    {:fx [[:rf.http/managed
+           {:request    {:method :get :url "/api/cart"}
+            :on-success [:cart/loaded]
+            :on-failure [:cart/load-failed]}]]}))
+
+(rf/reg-event-db :cart/loaded
+  (fn [db [_ {:keys [rf/reply]}]]
+    (assoc-in db [:cart :items] (:value reply))))
+```
+
+That's enough to issue a request, decode the JSON reply, and dispatch the result back. Retries, timeouts, schema validation, abort, decode customisation, accept-fn refinement — all of those are optional keys in the args map; you reach for them when the problem asks for them.
+
+## Verb helpers
+
+Call-site helpers for the common shapes. They're pure synthesis fns that produce the canonical `[:rf.http/managed args-map]` fx vector — no magic, no hidden state. The point is ergonomics: writing `(rf.http/get "/api/cart")` reads better at the call site than spelling out the full args map for a no-frills GET.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `re-frame.http/get` | `(rf.http/get url)` / `(rf.http/get url args)` | v1 (optional) | "Synthesise a GET fx vector." Pure; no side effect — drop the result into `:fx`. |
+| `re-frame.http/post` | `(rf.http/post url)` / `(rf.http/post url args)` | v1 (optional) | POST. Pass `:body` in `args`. |
+| `re-frame.http/put` | `(rf.http/put url)` / `(rf.http/put url args)` | v1 (optional) | PUT. |
+| `re-frame.http/delete` | `(rf.http/delete url)` / `(rf.http/delete url args)` | v1 (optional) | DELETE. |
+| `re-frame.http/patch` | `(rf.http/patch url)` / `(rf.http/patch url args)` | v1 (optional) | PATCH. |
+| `re-frame.http/head` | `(rf.http/head url)` / `(rf.http/head url args)` | v1 (optional) | HEAD. |
+| `re-frame.http/options` | `(rf.http/options url)` / `(rf.http/options url args)` | v1 (optional) | OPTIONS. |
+
+The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
+
+```clojure
+{:fx [(rf.http/get "/api/cart"
+        {:on-success [:cart/loaded]
+         :on-failure [:cart/load-failed]
+         :retry      {:on #{:rf.http/transport :rf.http/timeout}
+                      :max-attempts 3
+                      :backoff-ms 100}})]}
+```
+
+## Reply addressing
+
+Every reply lands under `:rf/reply` in the dispatched event's payload map. Two shapes:
+
+```clojure
+;; Success
+{:rf/reply {:kind :success :value decoded-body}}
+
+;; Failure
+{:rf/reply {:kind    :failure
+            :failure {:kind  :rf.http/<category>
+                      :tags  {...}}}}
+```
+
+**Default reply addressing** dispatches `[<originating-event-id> (assoc original-msg :rf/reply ...)]` back to the same handler — your `:cart/load` handler sees the reply at `:rf/reply`. **Explicit `:on-success` / `:on-failure`** targets append the reply payload as the last event-vector arg — your `:cart/loaded` handler sees `[:cart/loaded {:rf/reply ...}]`. Both shapes detailed in [014 §Reply addressing](../../spec/014-HTTPRequests.md#reply-addressing).
+
+## Failure categories (closed set)
+
+Eight failure `:kind` values, all reserved under `:rf.http/*`. The set is closed — ports that ship Spec 014 deliver exactly these eight categories, and your handler's failure switch can be exhaustive.
+
+| `:kind` | Meaning |
+|---|---|
+| `:rf.http/transport` | Network / DNS / connection error pre-HTTP. |
+| `:rf.http/cors` | CORS preflight rejected (CLJS-only). |
+| `:rf.http/timeout` | Per-attempt timeout fired. |
+| `:rf.http/http-4xx` | Non-2xx 4xx response. |
+| `:rf.http/http-5xx` | Non-2xx 5xx response. |
+| `:rf.http/decode-failure` | 2xx response but decode rejected the body. |
+| `:rf.http/accept-failure` | `:accept` returned `{:failure user-map}`. |
+| `:rf.http/aborted` | Request aborted via `:request-id` or `:abort-signal`. |
+
+See [014 §Failure categories](../../spec/014-HTTPRequests.md#failure-categories-closed-set) for tags-by-kind.
+
+## Request-interceptor middleware
+
+Sometimes you want to inject behaviour into every request — adding an auth header, stamping a request ID, logging. Re-frame2's answer is a small middleware surface that mirrors the rest of the `reg-*` family.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-http-interceptor` | Fn | `(reg-http-interceptor id before)` <br> `(reg-http-interceptor id opts before)` | v1 (optional) | Register a request-side interceptor on a frame's `:rf.http/managed` middleware chain. `before` is `(fn [ctx] ctx')` where ctx is `{:request :args :frame :event}`. `opts` carries `:frame` (default `:rf/default`) plus the standard `:rf/registration-metadata`. |
+| `clear-http-interceptor` | Fn | `(clear-http-interceptor id)` <br> `(clear-http-interceptor frame id)` | v1 (optional) | Unregister an interceptor by id. Single-arity targets `:rf/default`. |
+
+```clojure
+(rf/reg-http-interceptor :auth/inject
+  (fn [{:keys [request] :as ctx}]
+    (assoc-in ctx [:request :headers "Authorization"]
+              (str "Bearer " (token-from-app-db)))))
+```
+
+The interceptor runs *before* the request is dispatched to the platform's HTTP client. If a `:before` throws, the request is **not** dispatched; `:rf.error/http-interceptor-failed` fires with `:frame`, `:interceptor-id`, `:url`, and `:cause`. See [014 §Middleware](../../spec/014-HTTPRequests.md#middleware).
+
+## Testing: stubbed responses
+
+Tests want to drive the cascade without hitting the network. The test-support surface provides canned-reply fx and a stubbing macro that reroutes requests at the routes you name.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `[:rf.http/managed-canned-success {:value v}]` | fx | — | v1 (optional, dev/test) | Synthesise the canonical success reply directly into `:fx`. Useful for "stub THIS request inline" patterns. Registered at load of `re-frame.http-test-support`. |
+| `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]` | fx | — | v1 (optional, dev/test) | Synthesise the canonical failure reply directly into `:fx`. |
+| `with-managed-request-stubs` | M | `(with-managed-request-stubs route-map body+)` | v1 (optional, dev/test) | Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply <value-or-failure>}}`. Inside the body, requests matching a stubbed route bypass the real client. |
+| `with-managed-request-stubs*` | Fn | `(with-managed-request-stubs* route-map body-fn)` | v1 (optional, dev/test) | Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies. |
+| `install-managed-request-stubs!` | Fn | `(install-managed-request-stubs! route-map)` | v1 (optional, dev/test) | Lower-level than `with-managed-request-stubs`: install stubs that persist until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s. |
+| `uninstall-managed-request-stubs!` | Fn | `(uninstall-managed-request-stubs!)` | v1 (optional, dev/test) | Drop installed stubs; restore real-request routing. Idempotent. |
+
+All the test-support surfaces live in `re-frame.http-test-support` (the single home per audit of audits #15). One namespace; same artefact (`day8/re-frame2-http`) as the production code.
+
+```clojure
+(deftest cart-loads
+  (with-managed-request-stubs
+    {[:get "/api/cart"] {:reply [{:id 1 :name "widget"}]}}
+    (rf/dispatch-sync [:cart/load])
+    (is (= 1 (count (subscribe-once [:cart/items]))))))
+```
+
+## Schema-reflection metadata
+
+Handlers may declare `:rf.http/decode-schemas [<schema> ...]` in their `reg-event-fx` metadata-map; pair tools and generators read it via `(rf/handler-meta :event id)`. Optional, never enforced — pure metadata for tooling. See [014 §Schema reflection](../../spec/014-HTTPRequests.md#schema-reflection-optional-ergonomic).
+
+## Trace events emitted by `:rf.http/managed`
+
+| `:operation` | `:op-type` | When |
+|---|---|---|
+| `:rf.http/retry-attempt` | `:info` | Per intermediate attempt that matched `:retry :on`. Carries `:attempt`, `:max-attempts`, `:failure`, `:next-backoff-ms`. |
+| `:rf.warning/decode-defaulted` | `:warning` | The request relied on `:decode :auto` (the default). Informational; not an error. |
+| `:rf.http.interceptor/registered` | `:info` | A `reg-http-interceptor` succeeded. Carries `:frame`, `:id`. |
+| `:rf.http.interceptor/cleared` | `:info` | A `clear-http-interceptor` removed an existing slot. |
+| `:rf.error/http-interceptor-failed` | `:error` | A request-interceptor `:before` threw. Carries `:frame`, `:interceptor-id`, `:url`, `:cause`. The request is NOT dispatched. |
+
+## See also
+
+- [03 — Effects and interceptors](03-effects.md) — `:rf.http/managed` rowed in the standard fx table.
+- [08 — Schemas](08-schemas.md) — `:rf.http/decode-schemas` and the `:schema` metadata key.
+- [10 — Testing](10-testing.md) — patterns for combining HTTP stubs with `dispatch-sequence`.
+- [Spec 014 — HTTP Requests](../../spec/014-HTTPRequests.md) — the normative source.

--- a/docs/api/08-schemas.md
+++ b/docs/api/08-schemas.md
@@ -1,0 +1,108 @@
+# 08 — Schemas and data classification
+
+Schemas in re-frame2 are *Malli schemas attached to `app-db` paths*. You register them with `reg-app-schema` (path-keyed, not id-keyed — the only `reg-*` that breaks that pattern, deliberately); the runtime validates `app-db` writes against the matching schemas in dev; production builds elide the validation at the call sites; and a small set of marks (`:sensitive?`, `:large?`) on the schemas drive automatic redaction and size-elision at every wire boundary.
+
+The payoff is that the same schema declaration drives three separate surfaces: dev-time validation, observability redaction (Causa, story-mcp, off-box error forwarders), and bundle-time size protection. You don't write the privacy rules three times in three different places; you declare them once on the schema, and the framework's wire-boundary walker enforces them everywhere.
+
+This chapter covers the registration macros (rowed in [01 — Core](01-core.md), summarised here), the introspection surface in `re-frame.schemas`, the validator-extension seams (`set-schema-validator!` etc.), the boundary-validation interceptor, and the data-classification mechanism (`add-marks`, `set-marks`, plus the egress-side `sensitive?` / `redact-interceptor` / `elide-wire-value` surface). For the canonical contract, see [010-Schemas.md](../../spec/010-Schemas.md) and [Privacy.md](../../spec/Privacy.md).
+
+## Registration
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-app-schema` | M | `(reg-app-schema path schema)` <br> `(reg-app-schema path schema opts)` | v1 | "Attach this Malli schema to this `app-db` path." **Path is the registration id** — the `:app-schema` registry kind is path-keyed because schemas-at-paths matches the dataflow grain. `(app-schema-at [:user])` looks up by the same path vector. |
+| `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})` | v1 | Bulk plural form. Feature-modular apps registering 5–20 paths against the same prefix reach for this. Each entry routes through the singular form and is stamped with this call's source coords. Returns the vector of paths registered. |
+
+The path-keyed-not-id-keyed asymmetry is principled. Paths are first-class in `get-in` / `assoc-in` / `update-in`; schemas-at-paths matches the dataflow grain; the lookup site (`app-schema-at [:user]`) reads the same way the write site (`(assoc-in db [:user] ...)`) reads. Spelling it as `(reg-app-schema :user/schema schema)` would have shifted the registration's id away from the dataflow grain.
+
+See [Conventions §`reg-*` return-value rule](../../spec/Conventions.md#reg--return-value-convention) for the wider convention this row participates in.
+
+## Introspection
+
+The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-schemas`); consumers `(:require [re-frame.schemas :as schemas])`. They are *not* re-exported from `re-frame.core` — the registration macros live in `re-frame.core` and route through the schemas artefact at registration time, but the read-side surface stays in its own namespace.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `app-schemas` | Fn | `(app-schemas)` <br> `(app-schemas {:frame frame-id})` | v1 | "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface. |
+| `app-schema-at` | Fn | `(app-schema-at path)` <br> `(app-schema-at path {:frame frame-id})` | v1 | "Schema for this exact path." Returns the schema value or `nil`. |
+| `app-schema-meta-at` | Fn | `(app-schema-meta-at path)` <br> `(app-schema-meta-at path opts-or-frame-id)` | v1 | "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed. |
+| `app-schemas-digest` | Fn | `(app-schemas-digest)` <br> `(app-schemas-digest {:frame frame-id})` → string | v1 | "Single hash over the frame's whole schema surface." Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema. |
+
+### Validator-extension seams
+
+The default validator ships Malli's `validate` / `explain` pair. These seams let apps swap in their own validator — typically to drop the Malli dep entirely, or to add a custom explainer that formats failures for the app's domain.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `set-schema-validator!` | Fn | `(set-schema-validator! validate-fn)` <br> `(set-schema-validator! {:validate validate-fn :explain explain-fn})` | v1 | "Install the validator the framework uses at every dev-time schema-validation site." `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework. |
+| `set-schema-explainer!` | Fn | `(set-schema-explainer! explain-fn)` | v1 | "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." Companion to `set-schema-validator!`. |
+| `set-schema-printer!` | Fn | `(set-schema-printer! print-fn)` | v1 | "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract. |
+
+The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for digest (`printer`). Most apps use the defaults; ports and apps swap them selectively.
+
+### The boundary interceptor
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `validate-at-boundary-interceptor` | Var (interceptor value) | `validate-at-boundary-interceptor` | v1 | A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`. |
+
+```clojure
+(rf/reg-event-db ::receive-from-server
+  [rf/validate-at-boundary-interceptor]
+  (fn [db [_ payload]] (assoc db :data payload)))
+```
+
+The pattern: dev-time validation runs at every commit by default; production-time validation runs only at handlers wearing `validate-at-boundary-interceptor`. Use it on handlers that ingest data from outside the app's trust boundary (HTTP replies, websocket frames, postMessage handlers).
+
+## Data classification
+
+The same schemas that drive validation also drive **redaction** and **size-elision** at every wire boundary. The mechanism: schemas carry `:sensitive?` and `:large?` flags on the paths that need them; the framework's egress-side walker `elide-wire-value` consults the registered marks; sensitive paths render as `:rf/redacted` and large paths render as `:rf.size/large-elided` summaries.
+
+### The mark-set
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `add-marks` | Fn | `(add-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Additively merges** into the frame's existing mark-set — paths not mentioned keep their prior state. Schema-attached marks per `reg-app-schema` `:sensitive?` / `:large?` are preserved and union at lookup time. Pure declaration — does not mutate `app-db`. Returns `frame-id`. |
+| `set-marks` | Fn | `(set-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set — paths not mentioned are CLEARED. Schema-attached marks are preserved. Pure declaration. Returns `frame-id`. |
+
+The two-verb shape (`add` vs `set`) follows the [Conventions §Tear-down verb axis](../../spec/Conventions.md) — `add-` merges; `set-` replaces. Most apps reach for `add-marks` because path classifications accumulate (an audit reveals a new sensitive path; you `add-marks` the path without affecting the rest of the corpus). Reach for `set-marks` when you're declaring the entire authoritative classification at once (a server-pushed policy update; a feature-flag toggle that swaps the whole privacy posture).
+
+### The egress-side surface: `elide-wire-value`
+
+This is the framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots. Every tool that emits wire data — off-box error-monitor forwarders, the Causa-MCP and re-frame2-pair-mcp and story-mcp servers, the on-box dev panels — routes through this walker. **The walker is the single normative emission site for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker.** Per-tool reimplementation is prohibited.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `elide-wire-value` | Fn | `(elide-wire-value v opts)` → `v` or an elision-marker substitution | v1 | Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. `opts` map: `{:rf.size/include-large? :rf.size/include-sensitive? :rf.size/include-digests? :rf.size/threshold-bytes :path :frame}`. Defaults: both `include-*` flags `false` (maximum elision); `:rf.size/threshold-bytes` falls back to `(rf/configure :elision ...)` then `16384`. |
+| `elision-declarations` | Fn | `(elision-declarations)` <br> `(elision-declarations frame-id)` | v1 | "What paths has the frame nominated for elision?" Returns the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool and introspection reader. |
+| `populate-elision-from-schemas!` | Fn | `(populate-elision-from-schemas!)` <br> `(populate-elision-from-schemas! frame-id)` → vector of paths populated | v1 | Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. No-op when the schemas artefact isn't on the classpath. |
+
+### Composition rule
+
+When both predicates match (`:sensitive?` AND `:large?` apply to the same path), **sensitive drop wins** — the size marker is suppressed because it would leak `:path` / `:bytes` / `:digest` information from a sensitive slot. The walker's composition rule is normative; per [009 §Size elision in traces](../../spec/009-Instrumentation.md#size-elision-in-traces).
+
+### Schema-only declaration path
+
+The `[:rf/elision]` registry has exactly two slots: `:declarations` (schema-derived `:large?` paths, populated by `populate-elision-from-schemas!`) and `:sensitive-declarations` (schema-derived `:sensitive?` paths). **There is no runtime declaration API** — apps declare `:large?` / `:sensitive?` on the Malli schema and `rf/reg-app-schema` it; the boot-time hydrator does the rest.
+
+The single normative reference for "schemas are the only path" lives in [Guide ch.25 — Large blobs](../guide/25-large-blobs.md).
+
+## Privacy: the always-on predicate and the interceptor
+
+The trace runtime stamps `:sensitive? true` at the top level of every trace event emitted inside the scope of a handler whose schema-derived path overlap declares sensitivity. (The legacy handler-meta `:sensitive?` annotation has been removed — sensitive data marking is path-based per the data-classification mechanism above.) Framework-published trace consumers — Sentry / Honeybadger forwarders, the re-frame2-pair server, Causa, Story, story-mcp, re-frame2-pair-mcp — MUST default-drop the stamped events at their egress boundary.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `sensitive?` | Fn | `(sensitive? trace-event)` → `boolean` | v1 | The framework-published predicate every consumer composes against. Replaces per-consumer reimplementations of the same five-token check. |
+| `redact-interceptor` | Fn | `(redact-interceptor paths)` → interceptor | post-v1 (planned) | Build a positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel **before the handler chain runs**. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. `paths` is a vector of `get-in`-style key paths into the payload map. |
+
+The composition pattern: schema-derived `:sensitive?` marks drive `elide-wire-value` at egress, and `redact-interceptor` scrubs in-place where the trace surface needs to see only a partial view. The two surfaces stack — the interceptor scrubs the trace; the walker enforces redaction at the wire boundary.
+
+See [Security §Privacy / secret handling](../../spec/Security.md#privacy--secret-handling) for the framework-wide pattern-level posture, and [Privacy.md](../../spec/Privacy.md) for the cross-artefact inventory and composition order.
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-app-schema` / `reg-app-schemas` / `add-marks` / `set-marks` rowed in registration.
+- [03 — Effects and interceptors](03-effects.md) — `validate-at-boundary-interceptor` rowed in the interceptor table.
+- [11 — Instrumentation](11-instrumentation.md) — `elide-wire-value` and the trace-surface privacy posture.
+- [Spec 010 — Schemas](../../spec/010-Schemas.md), [Privacy.md](../../spec/Privacy.md), [Security.md](../../spec/Security.md).

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -1,0 +1,113 @@
+# 09 — SSR
+
+Server-side rendering in re-frame2 is the same framework as the client side — same registrations, same cascade, same `app-db`, same subs. The differences are: the request creates a frame (the per-request frame pattern), the cascade runs to completion before the response is built, the resulting hiccup is emitted as an HTML string, and a hydration payload is shipped with it so the client can pick up where the server left off without re-rendering.
+
+This works because the framework was designed around immutable data and an explicit cascade boundary. The handler that runs server-side is the same handler the client would run; the only differences are which fx are gated to which platform (`:platforms` metadata) and which cofx are server-only (`:rf.server/request`).
+
+This chapter covers the rendering primitives (`render-to-string`, the streaming triple, the structural-hash), the head model (`reg-head`, `active-head`, `render-head`), the per-request response accumulator and its server-only fx, the error-projection seam (`reg-error-projector`, `project-error`), and the `:platforms` metadata that gates fx execution by active platform.
+
+The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces live in `re-frame.ssr` (artefact `day8/re-frame2-ssr`); the Ring host-adapter lives in `re-frame.ssr.ring`. Neither is re-exported from `re-frame.core` — apps targeting SSR add the artefacts to their deps and require the namespace directly.
+
+## Rendering primitives
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `render-to-string` | Fn | `(render-to-string view-or-hiccup opts)` → HTML string | v1 | The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure. |
+| `render-tree-hash` | Fn | `(render-tree-hash render-tree)` → 32-bit FNV-1a structural hash (lowercase hex) | v1 | A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe. |
+| `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error` | v1 | Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection." |
+
+### Streaming render
+
+Larger pages benefit from streaming — emit the shell-html and continue rendering boundary subtrees as their data becomes available. Re-frame2's streaming model uses `:rf/suspense-boundary` markers in the render tree; each boundary becomes a continuation.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `streaming-render-shell` | Fn | `(streaming-render-shell root-hiccup)` → `{:shell-html "..." :continuations [{:id :subtree} ...]}` | v1 | Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain. |
+| `streaming-render-continuation` | Fn | `(streaming-render-continuation frame-id entry)` → `{:id :html :delta :failed?}` | v1 | Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline (per [011 §Failure semantics — inline fallback](../../spec/011-SSR.md#failure-semantics--inline-fallback)). |
+| `streaming-build-final-payload` | Fn | `(streaming-build-final-payload frame-id render-hash opts)` → canonical `:rf/hydration-payload` | v1 | Called after all continuations drain to populate the `__rf_payload` final chunk. |
+
+The streaming surface is host-adapter territory — the SSR-aware host (`re-frame.ssr.ring` or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly.
+
+## The head model
+
+The `<head>` of an SSR document is structurally separate from the body. Re-frame2 models it as a head-model — a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, `:body-attrs` — registered per-route and rendered separately from the body.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | Register a head-fn keyed by id. Signature: `(fn [db route] head-model)`. Routes opt-in via `:head` route metadata. |
+| `render-head` | Fn | `(render-head head-id opts)` → `:rf/head-model` | v1 | Evaluate the registered head-fn for `head-id`. Returns a head-model. |
+| `active-head` | Fn | `(active-head)` / `(active-head frame-id)` → `:rf/head-model` | v1 | Resolve the head-model for the currently active route in the named frame. Sub-shape: `[:rf/head]` subscribes to this. |
+| `head-model->html` | Fn | `(head-model->html head-model)` <br> `(head-model->html head-model {:wrap? bool})` → inner-head HTML string | v1 | Render a head-model to its HTML representation. `:wrap?` controls whether `<head>` tags are emitted (default: false, so the result can be composed into a larger shell). |
+| `head-snapshot` | Fn | `(head-snapshot frame-id)` → `{head-id → :rf/head-model}` | v1 | Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call. Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`. |
+
+## Standard SSR events
+
+| Event | What it does | Spec |
+|---|---|---|
+| `:rf/server-init` | Per-request server-side initialisation. Reads request cofx; dispatches setup events. `:platforms #{:server}`. | 011 |
+| `:rf/hydrate` | Seed the client-side `app-db` from the server-supplied payload. Runs once on client bootstrap. | 011 |
+
+## Standard SSR fx (server-only)
+
+All server-only — `:platforms #{:server}`. These build the response accumulator that the host adapter turns into the HTTP response.
+
+| Fx | Args | Spec |
+|---|---|---|
+| `[:rf.server/set-status int]` | per `:rf.fx.server/set-status-args` | 011 |
+| `[:rf.server/set-header {:name :value}]` | per `:rf.fx.server/set-header-args` | 011 |
+| `[:rf.server/append-header {:name :value}]` | per `:rf.fx.server/append-header-args` | 011 |
+| `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map | 011 |
+| `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — | 011 |
+| `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML | 011 |
+
+## Standard SSR subs
+
+| Sub | Returns | Spec |
+|---|---|---|
+| `:rf/response` | The current request's response accumulator (status / headers / cookies / redirect) | 011 |
+| `:rf/head` | The head model for the active route (resolved via `(active-head)`) | 011 |
+| `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise | 011 |
+
+## Standard SSR cofx
+
+| Cofx | Returns | Spec |
+|---|---|---|
+| `:rf.server/request` | The active HTTP request map. | 011 |
+
+## `:platforms` metadata on `reg-fx`
+
+`reg-fx` accepts a `:platforms` metadata key — a set containing `:server` and / or `:client` — that gates fx execution by active platform. Default `#{:server :client}` (universal) when the key is absent.
+
+```clojure
+(rf/reg-fx :my/fx
+  ^{:platforms #{:server}}
+  (fn [args] ...))
+```
+
+Skipped fx emit a `:rf.fx/skipped-on-platform` trace event so debug tools see the gate firing. The cofx side has a mirror trace event, `:rf.cofx/skipped-on-platform`.
+
+Detail in [011 §`:platforms` metadata on `reg-fx`](../../spec/011-SSR.md#platforms-metadata-on-reg-fx).
+
+## Per-frame error-projection policy
+
+A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key — different frames in the same process can carry different projector / dev-detail settings, so the natural lifetime is per-frame.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | Register a projector keyed by id. Signature: `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. |
+| `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error` | v1 | (Rowed above in **Rendering primitives**.) Apply the active projector for the named frame. |
+
+Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) bucket 3 and [011 §Server error projection](../../spec/011-SSR.md#server-error-projection).
+
+## Hydration
+
+The server-rendered HTML carries a `__rf_payload` chunk that the client deserialises into `app-db` on bootstrap. The structural-hash from `render-tree-hash` is captured at render time and checked at hydration; mismatch surfaces `:rf.ssr/version-mismatch` or `:rf.ssr/schema-digest-mismatch` rather than silently mounting a broken DOM.
+
+The hydration payload shape lives at [Spec-Schemas §`:rf/hydration-payload`](../../spec/Spec-Schemas.md#rfhydration-payload).
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-head` / `reg-error-projector` rowed in registration.
+- [06 — Routing](06-routing.md) — routes opt into head models via `:head` metadata.
+- [11 — Instrumentation](11-instrumentation.md) — the SSR-specific trace events live in the error catalogue.
+- [Spec 011 — SSR](../../spec/011-SSR.md) — the normative source.

--- a/docs/api/10-testing.md
+++ b/docs/api/10-testing.md
@@ -1,0 +1,107 @@
+# 10 — Testing
+
+The testing surface is structured around one premise: **the framework's discipline at the call site pays for the tests at the boundary.** Pure handlers, an immutable `app-db`, effects-as-data, the registrar as a queryable data structure — every one of those choices makes the test path simpler. You can drive the cascade synchronously with `dispatch-sync`. You can swap fx behaviour with `with-fx-overrides`. You can assert on `app-db` via paths instead of mocking subs. You can walk a view's hiccup output without a DOM.
+
+The surface lives across **three namespaces** because the three concerns separate cleanly:
+
+- `re-frame.core` — the production primitives that double as testing entry points (`make-frame`, `with-frame`, `dispatch-sync`, `with-fx-overrides`, `get-frame-db`, `snapshot-of`, `compute-sub`, `machine-transition`, `sub-topology`).
+- `re-frame.test-support` — the test-only fixture machinery and test-flavoured helpers. **Runtime-state axis**: registrar, frames, `app-db`, drain.
+- `re-frame.test-helpers` — the view-assertion helpers (hiccup-walk + the `testid` authoring helper). **View-tree axis**: hiccup data, testids, attached handlers.
+
+`re-frame.test-support` does **not** re-export from `re-frame.core` — a test file requires both `[re-frame.core :as rf]` and `[re-frame.test-support :as ts]`, and additionally `[re-frame.test-helpers :as th]` for view-assertion tests. The seam between the three namespaces is deliberate: production code never picks up test-flavoured assertion machinery by accident.
+
+For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` compatibility), see [008-Testing.md](../../spec/008-Testing.md).
+
+## Runtime-state assertions (`re-frame.test-support`)
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `dispatch-sequence` | Fn | `(dispatch-sequence events)` <br> `(dispatch-sequence events opts)` | v1 | "Run this list of events end-to-end against the current frame." `opts`: `:after-each (fn [db ev] ...)` for between-event assertions, `:frame` for non-default targets. Returns the final `app-db`. |
+| `assert-path-equals` | Fn | `(assert-path-equals path expected-val)` <br> `(assert-path-equals path expected-val opts)` | v1 | "Assert `(get-in db path) == expected-val`." Mismatch fires a `clojure.test/is`-style failure via `do-report`. The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel. |
+| `assert-db-equals` | Fn | `(assert-db-equals expected-db)` <br> `(assert-db-equals expected-db opts)` | v1 | Full-db sync assertion. Mismatch fires a `clojure.test/is`-style failure. Companion to `assert-path-equals`; reach for it when the whole-db identity matters. |
+| `poll-until` | Fn | `(poll-until pred)` <br> `(poll-until pred opts)` | v1 | Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` with `:rf.test/poll-timeout true` on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`. |
+| `with-fx-overrides` | M | `(with-fx-overrides {fx-id -> override, …} body+)` | v1 | (Rowed in [03 — Effects and interceptors](03-effects.md).) Lexical-scope fx override; the most common test surface for "stub THIS fx within THIS block." Lives in `re-frame.core` but is rowed here for discoverability. |
+| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | Pure sub computation against an `app-db` *value*. No cache, no reactivity — just walk the sub graph and return the value. JVM-runnable. Use in tests where you want "what would this sub return given this db?" without setting up frames. |
+
+### Snapshot the registrar; restore after
+
+These are the fixture primitives. The pattern is "snapshot the registrar before the test mutates registrations; restore after, regardless of pass / fail."
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `snapshot-registrar` | per docstring | v1 | Capture the current registrar state. |
+| `restore-registrar!` | per docstring | v1 | Restore a previously captured registrar state. |
+| `with-fresh-registrar` | per docstring | v1 | The composed macro — snapshot + body + restore. Most tests reach for this rather than the lower-level primitives. |
+| `make-reset-runtime-fixture` | per docstring | v1 | Build a `clojure.test` fixture that resets the runtime between tests. Pair with `use-fixtures :each`. |
+
+### A typical test
+
+```clojure
+(deftest cart-add
+  (with-fresh-registrar
+    (rf/reg-event-db ::add (fn [db [_ item]] (update db :cart conj item)))
+    (rf/dispatch-sync [::add {:id 1 :name "widget"}])
+    (assert-path-equals [:cart] [{:id 1 :name "widget"}])))
+```
+
+The pattern: fresh registrar, register the handler, dispatch synchronously, assert against the path. No mocks; no JSDOM; no React; just data.
+
+## View assertions (`re-frame.test-helpers`)
+
+The view-assertion surface treats a view as what it is — a function that returns hiccup — and walks the returned hiccup data structure. **JVM-runnable. No JSDOM. No React. No `act()`.** Pairs with `render-to-string` (the HTML-string view-test path per [Spec 011](../../spec/011-SSR.md)): hiccup-walk for structure / handler assertions, `render-to-string` for HTML-markup assertions.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `expand-tree` | Fn | `(expand-tree tree)` → tree | v1 | Recursively expand fn-components and Form-3 class components inside a hiccup tree. After expansion every vector's first element is a keyword tag or a non-component value. Run this first when your view tree contains other registered views you want to assert through. |
+| `attrs` | Fn | `(attrs node)` → map | v1 | Return the attrs map of a hiccup node, or `nil`. |
+| `children` | Fn | `(children node)` → vector | v1 | Return everything after the tag (and optional attrs map). |
+| `text-content` | Fn | `(text-content node)` → string | v1 | Recursively collect string leaves under `node` and join. Numbers coerce to strings; nils are skipped. "What's the visible text?" |
+| `extract-handler` | Fn | `(extract-handler node event-key)` → fn | v1 | "Get the handler attached at this attribute on this node." Returns the value or `nil`. |
+| `find-by-attr` | Fn | `(find-by-attr tree attr val)` → node | v1 | First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom. |
+| `find-all-by-attr` | Fn | `(find-all-by-attr tree attr val)` → vector | v1 | Every matching node, in depth-first order. |
+| `find-by-attr-prefix` | Fn | `(find-by-attr-prefix tree attr prefix)` → vector | v1 | Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match. |
+| `find-by-testid` | Fn | `(find-by-testid tree test-id)` → node | v1 | Convenience over `find-by-attr` keyed on `:data-testid`. The common case. |
+| `find-all-by-testid` | Fn | `(find-all-by-testid tree test-id)` → vector | v1 | Convenience over `find-all-by-attr` keyed on `:data-testid`. |
+| `find-by-testid-prefix` | Fn | `(find-by-testid-prefix tree prefix)` → vector | v1 | Convenience over `find-by-attr-prefix` keyed on `:data-testid`. |
+| `invoke-handler` | Fn | `(invoke-handler node event-key & args)` → any | v1 | Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** when the node has no attrs map or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug). |
+| `testid` | Fn | `(testid id)` / `(testid id extra)` → map | v1 | Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Authoring helper at the view call site — pair it with `find-by-testid` at the assertion site. |
+
+### A view-assertion test
+
+```clojure
+(rf/reg-view cart-row
+  [item]
+  [:tr (th/testid (str "cart-row-" (:id item)))
+    [:td (:name item)]
+    [:td.qty (:qty item)]
+    [:button {:on-click #(rf/dispatch [::remove (:id item)])} "remove"]])
+
+(deftest cart-row-renders-and-dispatches
+  (let [tree (cart-row {:id 1 :name "widget" :qty 3})
+        node (th/find-by-testid (th/expand-tree tree) "cart-row-1")]
+    (is (= "widget" (th/text-content (th/find-by-attr node :td.name nil))))
+    (is (fn? (th/extract-handler (th/find-by-attr node :button nil) :on-click)))))
+```
+
+No JSDOM; no `act()`; no JSON serialisation; no DOM walk. The hiccup is data; the assertions walk data.
+
+## Multi-frame and machine testing
+
+Tests targeting multiple frames or machines reach for the same surfaces with explicit frame opts. `dispatch-sync` accepts a frame in its envelope; `subscribe-once` accepts a frame in its second arity; `compute-sub` works against any `app-db` value (so you can drive a machine through `machine-transition` and assert on the resulting snapshot directly).
+
+```clojure
+(let [definition (rf/machine-meta :session)
+      snapshot   {:state :anonymous :data {}}
+      [next-snap effects] (rf/machine-transition definition snapshot [:login {:user "alice"}])]
+  (is (= :authenticating (:state next-snap)))
+  (is (= "alice" (get-in next-snap [:data :credentials :user])))
+  (is (= [[:rf.http/managed ...]] (:fx effects))))
+```
+
+## See also
+
+- [01 — Core](01-core.md) — `dispatch-sync`, `subscribe-once`, `make-frame`, `with-frame` rowed in dispatch / registration.
+- [03 — Effects and interceptors](03-effects.md) — `with-fx-overrides` and the precedence rules.
+- [07 — HTTP](07-http.md) — HTTP test stubs (`with-managed-request-stubs`, canned-reply fx).
+- [12 — Registrar](12-registrar.md) — `registrations`, `handler-meta`, `sub-topology` for tests that introspect what's registered.
+- [Spec 008 — Testing](../../spec/008-Testing.md) — the normative source.

--- a/docs/api/11-instrumentation.md
+++ b/docs/api/11-instrumentation.md
@@ -1,0 +1,126 @@
+# 11 — Instrumentation
+
+The instrumentation surface is two surfaces stacked. The first is **dev-only**: a trace bus that emits one richly-tagged record per noteworthy event (dispatch, sub recompute, fx walk, render, machine transition, schema validation, error), buffered into a ring, fanned out to registered listeners synchronously, and elided entirely under `:advanced` + `goog.DEBUG=false`. The second is **always-on**: a pair of tight, production-survivable substrates (event-emit, error-emit) that deliver one record per processed event and one record per `:rf.error/*` event. Together they let the same app feed Causa in dev and Sentry / Datadog / Honeybadger in production from the same registration.
+
+This is the load-bearing surface for the pair-shape architecture — every tool that watches a running re-frame2 app composes against one of these surfaces. Causa subscribes to the dev trace bus. The MCP servers do the same. The event-emit substrate is what hosted observability shippers consume. The error-emit substrate is what hosted error monitors consume. Same registrations, three audiences.
+
+This chapter covers the event-emit listener surface, the error-emit listener surface, the dev-only tracing surface, the epoch buffer (time-travel), the performance instrumentation gate, the source-coord annotation contract, the wire-boundary elision walker, and the error contract.
+
+## Event-emit (always-on, production-survivable)
+
+A minimal always-on listener surface that survives `:advanced` + `goog.DEBUG=false` and delivers one tight record per processed event. The intended consumers are hosted observability back-ends (Datadog, Honeycomb, Sentry, …). **Parallel to (not a fallback for) the dev-only trace surface; per-event only — no per-sub, per-fx, or per-`:event/db-changed` records.**
+
+Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:event` slot is passed through `elide-wire-value` (see below) once before fan-out, so schema-marked `:sensitive?` paths land as `:rf/redacted` and `:large?` paths land as `:rf.size/large-elided`.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `register-event-listener!` | Fn | `(register-event-listener! id listener-fn)` | v1 | Receive one event-record per processed event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. |
+| `unregister-event-listener!` | Fn | `(unregister-event-listener! id)` → nil | v1 | The inverse. |
+
+## Error-emit (always-on, production-survivable)
+
+Sibling of the event-emit surface above. Runs through the SAME always-on error-emit substrate as the per-frame `:on-error` slot ([002-Frames.md](../../spec/002-Frames.md)) but along an INDEPENDENT corpus-wide fan-out path. Survives `:advanced` + `goog.DEBUG=false`. Intended consumers are hosted error monitors (Sentry, Honeybadger, Rollbar).
+
+Record shape: `{:error :event :event-id :frame :time :exception :elapsed-ms}`. The `:event` slot is passed through `elide-wire-value` once before fan-out (same redaction posture as event-emit). The two paths from the substrate (corpus-wide listeners AND the per-frame `:on-error` policy fn) are mutually isolated; either may throw without affecting the other.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `register-error-listener!` | Fn | `(register-error-listener! id listener-fn)` | v1 | Receive one error-record per `:rf.error/*` event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. |
+| `unregister-error-listener!` | Fn | `(unregister-error-listener! id)` → nil | v1 | The inverse. |
+
+## Tracing (dev-only)
+
+The rich-detail trace surface. **Dev-only — elided in production via Closure DCE under `:advanced` + `goog.DEBUG=false`.** See [009 §Tracing](../../spec/009-Instrumentation.md) for emit semantics and synchronous listener delivery.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `register-listener!` | Fn | `(register-listener! key callback-fn)` | v1 (dev-only) | "Receive every trace event the runtime emits." Synchronous delivery; the callback returns before the next trace event is processed. |
+| `unregister-listener!` | Fn | `(unregister-listener! key)` → nil | v1 (dev-only) | The inverse. |
+| `emit-trace-event!` | Fn | `(emit-trace-event! op-type operation tags)` → nil | v1 (dev-only) | "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about. |
+| `re-frame.interop/debug-enabled?` | Var | `^boolean` | v1 | **CLJS:** alias of `goog.DEBUG` — constant-folded by Closure under `:advanced`, so `:advanced` + `goog.DEBUG=false` builds DCE every `(when interop/debug-enabled? ...)` branch. **JVM:** a `def` read ONCE at ns-load from the Java system property `-Dre-frame.debug` (winning on conflict) or the environment variable `RE_FRAME_DEBUG`; defaults `true` (dev parity). Accepts the conventional false-y vocabulary case-insensitively (`false`, `0`, `no`, `off`, empty string) with whitespace trimmed; anything else leaves the flag at `true`. SSR / webhook receivers / long-running JVMs facing untrusted input MUST set the gate `false` explicitly. |
+| `re-frame.performance/enabled?` | Var | `^boolean` | v1 | `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op. |
+| `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | "What's in the ring right now?" Reads the buffer non-destructively. Pair tools and Causa use this for post-mortem inspection. |
+| `clear-trace-buffer!` | Fn | `(clear-trace-buffer!)` → nil | v1 (dev-only) | Empty the ring. |
+| `(rf/configure :trace-buffer {:depth N})` | — | | v1 (dev-only) | Buffer depth knob. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
+| `group-cascades` | Fn | `(group-cascades events)` → vector of cascade records | v1 (dev-only) | Pure data projection of a list of trace events into per-cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. JVM-runnable. Re-exported from `re-frame.trace.projection`. |
+| `domino-bucket` | Fn | `(domino-bucket trace-event)` → `#{:event :handler :fx :effect :sub :render :other}` | v1 (dev-only) | Classify a raw trace event into the six-domino slot used by `group-cascades`. Pure. |
+
+### Trace-emission opt-out
+
+Event-handler registration accepts a `:rf.trace/no-emit? true` metadata flag. When set, the runtime suppresses **every** trace emission and event-emit record within the handler's scope — the handler runs invisibly to the trace surface, the event-emit substrate, and (transitively) the epoch buffer.
+
+| Metadata key | Where | Value | Default | Effect |
+|---|---|---|---|---|
+| `:rf.trace/no-emit?` | `reg-event-db` / `reg-event-fx` / `reg-event-ctx` metadata map | boolean | `false` | When `true`, suppresses all trace + event-emit emissions inside the handler's scope. |
+
+Used by framework-internal bookkeeping handlers (Causa, Story, re-frame2-pair-mcp, story-mcp) that would otherwise saturate the trace stream. The `:rf.trace/*` namespace is framework-owned (per [Conventions §Reserved namespaces](../../spec/Conventions.md#reserved-namespaces-framework-owned)).
+
+## Epoch history (Tool-Pair)
+
+Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used by pair-shaped tools for time-travel and post-mortem analysis. **Production builds elide entirely.**
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `epoch-history` | Fn | `(epoch-history frame-id)` → vector of epoch records | v1 (dev-only) | Returns `[]` for an unknown / destroyed frame. |
+| `restore-epoch` | Fn | `(restore-epoch frame-id epoch-id)` → boolean | v1 (dev-only) | Restore the frame's `app-db` to the named epoch. Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`). |
+| `reset-frame-db!` | Fn | `(reset-frame-db! frame-id new-db)` → boolean | v1 (dev-only) | Pair-tool write surface (state injection). Direct write to `app-db` — bypasses the cascade. Returns `true` on success. |
+| `register-epoch-listener!` | Fn | `(register-epoch-listener! key callback-fn)` | v1 (dev-only) | Process-global assembled-epoch listener. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. |
+| `unregister-epoch-listener!` | Fn | `(unregister-epoch-listener! key)` | v1 (dev-only) | The inverse. |
+| `(rf/configure :epoch-history {:depth N :trace-events-keep N :redact-fn fn})` | — | | v1 (dev-only) | Buffer-depth and redactor knobs. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
+
+### Trace events emitted by epoch-history machinery
+
+| `:operation` | Tags |
+|---|---|
+| `:rf.epoch/snapshotted` | `:frame`, `:epoch-id`, `:event-id` |
+| `:rf.epoch/restored` | `:frame`, `:epoch-id` |
+| `:rf.epoch/db-replaced` | `:frame`, `:epoch-id` |
+| `:rf.epoch/restore-unknown-epoch` | `:frame`, `:epoch-id`, `:history-size` |
+| `:rf.epoch/restore-schema-mismatch` | `:frame`, `:epoch-id`, `:schema-digest-recorded`, `:schema-digest-current`, `:failing-paths` |
+| `:rf.epoch/restore-missing-handler` | `:frame`, `:epoch-id`, `:missing` |
+| `:rf.epoch/restore-version-mismatch` | `:frame`, `:epoch-id`, `:machine-id`, `:version-recorded`, `:version-current` |
+| `:rf.epoch/restore-during-drain` | `:frame`, `:epoch-id` |
+| `:rf.epoch/restore-non-ok-record` | `:frame`, `:epoch-id`, `:outcome`, `:halt-reason` |
+| `:rf.epoch/reset-frame-db-during-drain` | `:frame` |
+| `:rf.epoch/reset-frame-db-schema-mismatch` | `:frame`, `:failing-paths` |
+| `:rf.epoch.cb/silenced-on-frame-destroy` | `:frame`, `:cb-id` |
+
+## The wire-boundary walker
+
+`elide-wire-value` is the framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots. **This walker is the single normative emission site for the `:rf/redacted` sensitive sentinel and the `:rf.size/large-elided` size marker.** Per-tool reimplementation is prohibited.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `elide-wire-value` | Fn | `(elide-wire-value v opts)` → `v` or an elision-marker substitution | v1 | Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. |
+| `elision-declarations` | Fn | `(elision-declarations)` / `(elision-declarations frame-id)` | v1 | Read the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool / introspection reader. |
+| `populate-elision-from-schemas!` | Fn | `(populate-elision-from-schemas!)` / `(populate-elision-from-schemas! frame-id)` → vector of paths populated | v1 | Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. |
+
+Composition rule: when both predicates match (sensitive AND large for the same path), **sensitive drop wins** — the size marker is suppressed because it would leak `:path` / `:bytes` / `:digest` from a sensitive slot.
+
+See [08 — Schemas](08-schemas.md) for the registration side (`add-marks`, `set-marks`, `reg-app-schema` with `:sensitive?` / `:large?` flags).
+
+## Privacy predicate
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `sensitive?` | Fn | `(sensitive? trace-event)` → `boolean` | v1 | True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check. |
+| `redact-interceptor` | Fn | `(redact-interceptor paths)` → interceptor | post-v1 (planned) | Positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel before the handler chain runs. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. |
+
+## DOM source-coord annotations
+
+Every adapter whose host has a DOM-attribute concept (Reagent / UIx / Helix on the browser) injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions live in [Spec 006 §Source-coord annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1).
+
+The annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the contract per [Spec 011 §Source-coord annotation under SSR](../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+
+## The error contract
+
+Errors are emitted as structured trace events with `:op-type :error` (or `:warning` / `:info` / `:fx` / `:flow` / `:frame`) and a per-category `:operation` keyword. The complete normative catalogue — every `:rf.error/*`, `:rf.warning/*`, `:rf.fx/*`, `:rf.cofx/*`, `:rf.ssr/*`, `:rf.epoch/*`, `:rf.flow/*`, `:rf.http/*`, `:rf.http.interceptor/*`, `:rf.frame/*`, and `:rf.route.nav-token/*` event the runtime emits — lives at [009 §Error event catalogue](../../spec/009-Instrumentation.md#error-event-catalogue) (single source of truth for category names, `:op-type` discriminator, trigger conditions, default `:recovery`, and `:tags` payload keys).
+
+Per-category Malli `:tags` schemas are canonicalised at [Spec-Schemas §Per-category `:tags` schemas](../../spec/Spec-Schemas.md#per-category-tags-schemas) — one schema per catalogue row.
+
+## See also
+
+- [01 — Core](01-core.md) — the `:trace-buffer`, `:epoch-history`, `:elision` configure keys.
+- [08 — Schemas](08-schemas.md) — the registration side of the elision posture.
+- [Spec 009 — Instrumentation](../../spec/009-Instrumentation.md) — the normative source.
+- [Tool-Pair](../../spec/Tool-Pair.md) — how the epoch buffer, trace bus, and source-coord annotations compose into the pair-shaped tools.

--- a/docs/api/12-registrar.md
+++ b/docs/api/12-registrar.md
@@ -1,0 +1,83 @@
+# 12 — Registrar query API
+
+The registrar is the data structure that holds every registered handler — events, subs, fx, cofx, flows, machines, views, schemas, the lot. Treating it as a queryable data structure is what makes the framework's tools possible: Causa enumerates handlers to build its UI; the linter walks the registrar to find unreachable handlers; the migration agent reads `handler-meta` to discover source coords; the MCP servers expose handler metadata to LLM clients.
+
+This chapter is the read-side surface. The write-side surface is `reg-*` / `clear-*` (rowed in [01 — Core](01-core.md)).
+
+Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reaction` objects in CLJS).
+
+## Handlers
+
+| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
+|---|---|---|---|---|---|
+| `registrations` | Fn | `(registrations kind)` <br> `(registrations kind pred-fn)` → `{id metadata-map}` | v1 | ✓ | **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map. |
+| `handler-ids` | Fn | `(handler-ids kind)` → id set | v1 | ✓ | **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections). |
+| `handler-meta` | Fn | `(handler-meta kind id)` → registration-metadata map | v1 | ✓ | "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup. |
+
+`kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`, `:app-schema`. The full list lives in [001-Vision §Registry model](../../spec/000-Vision.md).
+
+## Machines
+
+These are derived views over the event registrar — a machine is registered as an event handler with `:rf/machine? true`, so `(machines)` is just `(registrations :event)` filtered by that flag. They're rowed here separately because tools reach for them often enough that the convenience is worth it.
+
+| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
+|---|---|---|---|---|---|
+| `machines` | Fn | `(machines)` → seq of machine-ids | v1 | ✓ | Enumerate registered machines. |
+| `machine-meta` | Fn | `(machine-meta machine-id)` → registration-metadata map | v1 | ✓ | Transition table, doc, schemas. Equivalent to `(handler-meta :event machine-id)`. |
+
+See [04 — Machines](04-machines.md) for the rest of the machine surface (subscription helpers, system-id reverse lookup, etc).
+
+## Frames
+
+| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
+|---|---|---|---|---|---|
+| `frame-ids` | Fn | `(frame-ids)` <br> `(frame-ids ns-prefix)` | v1 | ✓ | "What frames exist?" The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames. |
+| `frame-meta` | Fn | `(frame-meta frame-id)` | v1 | ✓ | "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings. |
+| `get-frame-db` | Fn | `(get-frame-db frame-id)` → app-db value (plain map) | v1 | ✓ | "What's the current `app-db` for this frame?" Returns `nil` for an unknown / destroyed frame. |
+| `snapshot-of` | Fn | `(snapshot-of path)` <br> `(snapshot-of path opts)` | v1 | ✓ | "What's at this path in `app-db` right now?" Convenience over `get-frame-db` + `get-in`. |
+
+## Sub graph
+
+| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
+|---|---|---|---|---|---|
+| `sub-topology` | Fn | `(sub-topology)` → `{sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}` | v1 | ✓ | Static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1 subs); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them. |
+| `sub-cache` | Fn | `(sub-cache frame-id)` → live cache state | v1 | ✗ (CLJS-only) | The runtime cache. CLJS-only because it holds live `Reaction` objects; on JVM there are no reactions to hold. Tools that walk the cache for tab labels / counts in Causa go through this. |
+
+The split — `sub-topology` JVM-runnable, `sub-cache` CLJS-only — is principled. Topology is a static property of the registration; the cache is a runtime property of the sub graph. Tools that want the design-time picture (linter, doc generator, conformance harness) reach for `sub-topology`; tools that want the runtime picture (Causa's sub-cache tab) reach for `sub-cache`.
+
+## Schemas
+
+The schema-introspection surfaces are rowed in [08 — Schemas](08-schemas.md). They're JVM-runnable and ship in `re-frame.schemas`:
+
+- `app-schemas` — every schema-at-path for the frame
+- `app-schema-at` — schema for one path
+- `app-schema-meta-at` — full registration metadata for one path
+- `app-schemas-digest` — single hash over the whole schema surface
+
+## Pure sub computation
+
+`compute-sub` is the test-friendly companion to `subscribe`. It runs the sub graph against a value of `app-db` — no cache, no reactivity, no frame — and returns the value.
+
+| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
+|---|---|---|---|---|---|
+| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | ✓ | Pure sub computation against an `app-db` value. Use in tests; use in agent tooling that wants to evaluate subs against an artificial state. |
+
+(Cross-rowed in [10 — Testing](10-testing.md).)
+
+## Behaviour against destroyed frames
+
+The pair-tool surfaces all share a common behaviour against destroyed frames, documented at [Tool-Pair §Surface behaviour against destroyed frames](../../spec/Tool-Pair.md#surface-behaviour-against-destroyed-frames):
+
+- `get-frame-db` → `nil`
+- `epoch-history` → `[]`
+- `restore-epoch` → `false` (and emits `:rf.error/no-such-handler` of kind `:frame`)
+- `reset-frame-db!` → `false` (same error)
+- `register-epoch-listener!` whose observed frame is destroyed → receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace
+
+The pattern: dynamic-ID queries don't throw on absent frames — they return `nil` / `[]` / `false` so callers can compose without try/catch. Errors fire on the trace surface where tools can pick them up.
+
+## See also
+
+- [01 — Core](01-core.md) — the write-side surface (`reg-*` / `clear-*`).
+- [04 — Machines](04-machines.md), [05 — Flows](05-flows.md), [06 — Routing](06-routing.md), [08 — Schemas](08-schemas.md), [09 — SSR](09-ssr.md) — the feature-specific surfaces each register their own kind into the registrar.
+- [11 — Instrumentation](11-instrumentation.md) — the trace bus is what Causa and the pair tools layer on top of the registrar to give "what's running" alongside "what's registered."

--- a/docs/api/13-lifecycle.md
+++ b/docs/api/13-lifecycle.md
@@ -1,0 +1,87 @@
+# 13 — Lifecycle
+
+This chapter is about the surfaces that bring a re-frame2 process up and take it down. The core of it is **adapter selection at boot** — `init!` takes an adapter spec (Reagent / UIx / Helix / Plain Atom / SSR) and installs it; everything else hangs off that. The right call shape (`(rf/init! reagent/adapter)`, not `(rf/init!)`) is enforced at the language level so the missing-adapter mistake surfaces at compile / load time rather than as a runtime confusion.
+
+There's also a small inspection surface for "what's currently installed?" — `current-adapter`, `current-adapter-spec`, `adapter-disposed?` — and the symmetric `destroy-adapter!` for tear-down. Together these are the lifecycle vocabulary.
+
+## Adapter selection
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `init!` | Fn | `(init! adapter-map)` | v1 | The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time — the no-arg arity was cut so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. Ensures `:rf/default` frame is present. |
+| `install-adapter!` | Fn | `(install-adapter! adapter-map)` | v1 | Must be called before any frame is created. **Lower-level than `init!`**; most consumers call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation. |
+| `destroy-adapter!` | Fn | `(destroy-adapter!)` | v2 | Tear down the installed adapter. Calls the adapter spec's `:dispose-adapter!` fn (if present), clears the install slot so a new adapter can install, and flips the `adapter-disposed?` breadcrumb. Symmetric with `install-adapter!` and with `destroy-frame!` — same `destroy-` verb-cluster (lifecycle boundary). |
+
+The adapter-spec **map key** `:dispose-adapter!` is an internal contract slot adapters implement; ignore it unless you're authoring an adapter.
+
+### What an adapter ships
+
+The adapter spec is a map with three keys:
+
+| Slot | What it does |
+|---|---|
+| `:make-state-container` | The substrate's reactive primitive. Reagent ships `r/atom`; UIx and Helix ship hook-shaped containers. |
+| `:render` | The substrate's mount fn. Reagent ships `r/render`; UIx ships `uix/render-root`; Helix ships its render. |
+| `:dispose-adapter!` | The teardown hook. Adapter-specific cleanup; called by `destroy-adapter!`. |
+
+Most app code never sees the spec map — you just pass the adapter's `adapter` Var into `init!` and forget about it.
+
+## Inspection
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `current-adapter` | Fn | `(current-adapter)` → discriminator keyword | v1 | "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code. |
+| `current-adapter-spec` | Fn | `(current-adapter-spec)` → installed adapter spec map | v1 | "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`. |
+| `adapter-disposed?` | Fn | `(adapter-disposed?)` → boolean | v1 | "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only — the breadcrumb is owned by the install / destroy pair. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down). |
+
+The split between `current-adapter` (keyword) and `current-adapter-spec` (map) is principled. The keyword is for switch-like code that branches on substrate identity. The spec map is for code that needs to call adapter fns or compare adapter identity across reinstalls.
+
+## The disposed-vs-never-installed distinction
+
+These two states surface as different errors because they have different recovery paths:
+
+| State | Detection | Typical fix |
+|---|---|---|
+| Never installed | `(current-adapter)` returns `nil`; `(adapter-disposed?)` returns `false` | Call `(rf/init! adapter)`. |
+| Disposed | `(current-adapter)` returns `nil`; `(adapter-disposed?)` returns `true` | A new `(rf/init! adapter)` is required. Tooling that observed the previous install needs to re-attach. |
+
+The two states share the "no current adapter" surface but answer different questions about the process's history. Per [006 §Disposed-vs-never-installed](../../spec/006-ReactiveSubstrate.md#disposed-vs-never-installed-rf2-6wxys).
+
+## Configuration
+
+The `configure` fn is the lifecycle's adjacent surface — process-level data knobs that you typically set once at boot, possibly tweak in tests, and rarely touch in app code.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `configure` | Fn | `(configure key opts)` | v1 | Runtime config. One of three orthogonal configuration surfaces — `configure` for process-level data knobs; `set-!` / `install-!` for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys lives in [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
+
+The three configuration surfaces — `configure`, the `set-!` / `install-!` setters (`set-schema-validator!`, etc.), and per-frame metadata — are deliberately separate. Each answers a different question: `configure` for data knobs (depth, threshold, grace period); the setters for hook-shaped pluggability (which validator to use, which printer); per-frame metadata for frame-scoped overrides (which projector, which `:fx-overrides`).
+
+Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata).
+
+## Bootstrap pattern
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent]
+            [reagent.dom :as rdom]
+            [my.app.views :as views]
+            [my.app.events]      ;; side-effecting requires for handler registration
+            [my.app.subs]
+            [my.app.routes]))
+
+(defn ^:export main []
+  (rf/init! reagent/adapter)
+  (rf/configure :sub-cache {:grace-period-ms 100})
+  (rdom/render [views/root] (js/document.getElementById "app")))
+```
+
+That's the whole boot. `init!` installs the adapter and primes `:rf/default`; the side-effecting requires register the handlers / subs / routes into the registrar; `configure` tunes the runtime; the substrate's render fn mounts the root view.
+
+## See also
+
+- [01 — Core](01-core.md) — `reg-frame` / `make-frame` / `configure` rowed in registration and configuration.
+- [02 — Views](02-views.md) — adapter-side surfaces (UIx / Helix hooks, the shared React Context).
+- [14 — Adapters](14-adapters.md) — per-substrate surface tables.
+- [Spec 006 — Reactive Substrate](../../spec/006-ReactiveSubstrate.md) — the adapter contract.

--- a/docs/api/14-adapters.md
+++ b/docs/api/14-adapters.md
@@ -1,0 +1,108 @@
+# 14 — Adapters
+
+An adapter is the seam between re-frame2's substrate-agnostic core and a specific React-flavoured reactive system. Reagent ships as the default. UIx and Helix are hooks-first React substrates with their own idioms; their adapters live in separate artefacts and expose a small, parallel surface that matches the React/hooks convention without forcing it onto the Reagent path.
+
+This chapter is the per-substrate surface reference. The substrate-agnostic ergonomic surface (`dispatcher`, `subscriber`, `with-frame`, `bound-fn`, `frame-provider`) is rowed in [02 — Views](02-views.md) because those compose across all three substrates. This chapter is for the per-substrate hooks and the adapter-spec map.
+
+Architecturally, the dependency direction is one-way: the adapter artefacts depend on `re-frame.core`; `re-frame.core` does not depend on any adapter. That's why UIx and Helix surfaces live in `re-frame.adapter.uix` / `re-frame.adapter.helix` rather than being re-exported from core — apps require the adapter they want and pass its `adapter` Var into `init!`.
+
+## The Reagent adapter
+
+The CLJS reference's default substrate. Reagent ships in `re-frame.adapter.reagent` (full) and `re-frame.adapter.reagent-slim` (without the React server-rendering tax, for SSR pipelines that don't want to ship `react-dom/server`).
+
+There's no per-substrate hook surface — Reagent's idiom is "views are plain functions returning hiccup," and `reg-view` is the typed sugar over that pattern. The substrate-agnostic surface (`dispatcher`, `subscriber`, `with-frame`, `frame-provider`) is the full Reagent-side API; everything else flows through `reg-view*` and `dispatch` / `subscribe`.
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.reagent :as reagent])
+
+(rf/init! reagent/adapter)
+```
+
+The two Reagent adapters differ in what they include:
+
+| Adapter | Includes | Use case |
+|---|---|---|
+| `re-frame.adapter.reagent/adapter` | Full Reagent (`reagent.core`, `reagent.dom`, `reagent.dom.server`) | Client-side apps that may also render to string on the JVM. |
+| `re-frame.adapter.reagent-slim/adapter` | Reagent without `reagent.dom.server` | Client-side apps that ship their bundle to browsers. Drops ~30KB by excluding `react-dom/server`. |
+
+The slim variant is bundle-isolated — the `npm run test:reagent-slim:bundle-isolation` gate verifies stock Reagent / `react-dom/server` don't leak into builds that select the slim adapter.
+
+## The UIx adapter
+
+UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-uix`). The hook is named `use-subscribe` (matching the React/UIx idiom); there is no auto-injection — UIx components call the hook and `(rf/dispatcher)` directly. The full decision set lives at [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `uix-adapter/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
+| `uix-adapter/use-subscribe` | Fn (UIx hook) | `(use-subscribe query-v)` <br> `(use-subscribe frame-kw query-v)` → current sub value | v1 | "Subscribe inside a UIx component." The hook-shaped equivalent of `subscribe` for UIx components. Re-renders when the sub value changes. |
+| `uix-adapter/use-current-frame` | Fn (UIx hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks. |
+| `uix-adapter/frame-provider` | Fn (UIx component) | `($ uix-adapter/frame-provider {:frame :session :children […]})` | v1 | The UIx-shaped frame provider. |
+| `uix-adapter/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding. |
+| `uix-adapter/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. |
+| `uix-adapter/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR. |
+
+UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx. Full rationale: [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.uix :as uix-adapter]
+          [uix.core :refer [$ defui]])
+
+(rf/init! uix-adapter/adapter)
+
+(defui cart-row [{:keys [item]}]
+  (let [count (uix-adapter/use-subscribe [:cart/count])]
+    ($ :tr
+       ($ :td (:name item))
+       ($ :td count))))
+```
+
+## The Helix adapter
+
+Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-frame2-helix`). The Helix adapter mirrors the UIx adapter exactly — the eight UIx decisions transfer one-for-one. The surface table below is identical in shape to the UIx table above.
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `helix-adapter/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
+| `helix-adapter/use-subscribe` | Fn (Helix hook) | `(use-subscribe query-v)` <br> `(use-subscribe frame-kw query-v)` → current sub value | v1 | "Subscribe inside a Helix component." |
+| `helix-adapter/use-current-frame` | Fn (Helix hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" |
+| `helix-adapter/frame-provider` | Fn (Helix component) | `($ helix-adapter/frame-provider {:frame :session :children […]})` | v1 | The Helix-shaped frame provider. |
+| `helix-adapter/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord injection. |
+| `helix-adapter/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. |
+| `helix-adapter/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam. |
+
+The duplication between UIx and Helix is intentional — both expose the same hooks-first idiom; both decisions sets transfer; both surfaces are structurally identical. The two adapters are separate artefacts because the *underlying React-substrate libraries* are separate, not because the re-frame2 contract differs between them.
+
+## The shared React Context
+
+The `frame-provider` in all three adapters (Reagent, UIx, Helix) consumes the **same** `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). The shared context is what makes a future mixed-substrate app compose: a Reagent `frame-provider` can wrap a UIx subtree; a Helix subtree can be wrapped by a UIx provider; the chain composes across substrate boundaries because there's exactly one Context, not three. Full rationale: [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
+
+## DOM source-coord annotations
+
+Every adapter whose host has a DOM-attribute concept (all three — Reagent / UIx / Helix on the browser) injects `data-rf2-source-coord="<ns>:<sym>:<line>:<col>"` on the rendered root DOM element of each registered view. Format and exemptions (Fragments, non-DOM roots) are documented in [Spec 006 §Source-coord annotation](../../spec/006-ReactiveSubstrate.md#source-coord-annotation-mandatory-rf2-z7f7--rf2-z9n1).
+
+Annotation is gated on `interop/debug-enabled?` (the CLJS mirror of `goog.DEBUG`); production `:advanced` builds elide the attribute via dead-code elimination — there is no DOM-bytes cost in shipped bundles. The JVM SSR emitter mirrors the contract per [Spec 011 §Source-coord annotation under SSR](../../spec/011-SSR.md#source-coord-annotation-under-ssr).
+
+## The Plain Atom adapter
+
+There's a fourth adapter — Plain Atom — that ships in core and exists for two purposes:
+
+1. **Tests that don't need a substrate.** JVM-runnable unit tests of pure handlers / subs / machines use Plain Atom as the no-render baseline.
+2. **Non-rendering hosts.** JVM CLI tools, scheduler runners, conformance harnesses — anything that wants the re-frame2 cascade without the React layer.
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.plain-atom :as plain])
+
+(rf/init! plain/adapter)
+```
+
+`current-adapter` returns `:rf.adapter/plain-atom` when Plain Atom is installed. There's no view registry surface from this adapter — calling `reg-view` against a Plain Atom runtime works (the registry accepts the registration) but rendering is the host's problem.
+
+## See also
+
+- [02 — Views](02-views.md) — the substrate-agnostic ergonomic surface (`dispatcher`, `subscriber`, `with-frame`, `bound-fn`, `frame-provider`).
+- [13 — Lifecycle](13-lifecycle.md) — `init!`, `install-adapter!`, `destroy-adapter!`, `current-adapter`, `adapter-disposed?`.
+- [Spec 006 — Reactive Substrate](../../spec/006-ReactiveSubstrate.md) — the adapter contract.
+- [Guide ch.21 — Adapters](../guide/21-adapters.md) — narrative coverage with worked examples.

--- a/docs/api/15-story.md
+++ b/docs/api/15-story.md
@@ -1,0 +1,40 @@
+# 15 — Story / variants / workspaces (post-v1)
+
+Story is the post-v1 library that turns *registered variants* into a navigable, queryable, snapshot-identified surface for design review, visual regression, and pair-programming workflows. A **variant** is a view + arguments + setup — a single rendered state worth pinning to a URL. A **story** is a cluster of variants. A **workspace** is a grid view of variants you've assembled for side-by-side review.
+
+Story is **post-v1 lib** — the design lives in [Spec 007](../../spec/007-Stories.md) and ships in `day8/re-frame2-story`. The surface below is what the library exposes; the rest of Story (UI shell, MCP server, recorder, QR-share, time-travel mini-player) is documented in the [Story guide](../story/index.md).
+
+This chapter is a reference. If you want narrative — "what's the workflow, what does the shell look like, how do I record a variant" — start at the [Story guide](../story/index.md).
+
+## Registration
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-story` | M | `(reg-story id metadata)` | post-v1 lib | Register a story (a cluster of variants under one heading). |
+| `reg-variant` | M | `(reg-variant id metadata)` | post-v1 lib | Register one variant — view, args, setup events, decorators. |
+| `reg-workspace` | M | `(reg-workspace id metadata)` | post-v1 lib | Register a workspace — a curated grid of variants for side-by-side review. |
+| `reg-tag` | M | `(reg-tag id metadata)` | post-v1 lib | Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. |
+| `reg-decorator` | M | `(reg-decorator id metadata)` | post-v1 lib | Register a decorator — a function that wraps a variant's render (locale, theme, mock-API context). |
+| `reg-story-panel` | M | `(reg-story-panel id metadata)` | post-v1 lib | Register a custom panel in the Story shell — the inspection / control panes that sit beside the rendered variant. |
+
+## Running variants
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `run-variant` | Fn | `(run-variant variant-id)` → result map | post-v1 lib | Materialise the variant — run its setup events, render its view, return the result map. One-shot; no live updates. |
+| `watch-variant` | Fn | `(watch-variant variant-id)` → live-updating result map | post-v1 lib | Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots. |
+| `reset-variant` | Fn | `(reset-variant variant-id)` | post-v1 lib | Reset the variant's frame to its initial setup. The Story shell calls this when the user clicks "reset" on a variant. |
+
+## Discovery
+
+| API | M/Fn | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `variants-with-tags` | Fn | `(variants-with-tags tag-set)` → seq of variant ids | post-v1 lib | Filter the catalogue. `(variants-with-tags #{:cart :empty-state})` returns every cart-related empty-state variant. |
+| `snapshot-identity` | Fn | `(snapshot-identity variant-id)` → `{:variant-id ... :content-hash "..."}` | post-v1 lib | The variant's snapshot identity — the variant id plus a content-hash over its setup. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. |
+| `story-view` | Fn | `(story-view variant-id)` → hiccup | post-v1 lib | Render the variant directly to hiccup. Use in custom shells that need to embed variants without the full Story chrome. |
+
+## See also
+
+- [Spec 007 — Stories](../../spec/007-Stories.md) — the normative source.
+- [Story guide](../story/index.md) — narrative coverage of the workflow, the shell, the recorder, and the MCP integration.
+- [Guide ch.15 — Testing](../guide/15-testing.md) — the assertion-shaped `:rf.assert/*` event family that pairs with `reg-variant`'s `:play` block.

--- a/docs/api/16-removed.md
+++ b/docs/api/16-removed.md
@@ -1,0 +1,45 @@
+# 16 — Removed / not shipped
+
+This chapter is the tombstone register. It exists so v1 migrators and readers cross-checking against blog posts can find out, in one place, **what's gone**, **what was proposed but not shipped**, and **what to use instead**.
+
+If a row says "(proposed earlier)," that means the surface was named in an early draft of the v2 spec and dropped before ship. The replacement is canonical; the proposed name never existed at run-time.
+
+| Removed / not shipped | What to do instead | Reference |
+|---|---|---|
+| `dispatch-with` (master) | `(dispatch event {:fx-overrides {...}})` | MIGRATION M-4 |
+| `dispatch-sync-with` (master) | `(dispatch-sync event {:fx-overrides {...}})` | MIGRATION M-4 |
+| `dispatch-to` (proposed earlier) | `(dispatch event {:frame :todo})` | 002 |
+| `subscribe-to` (proposed earlier) | `(subscribe query-v {:frame :todo})` | 002 |
+| `frame-dispatcher` (proposed earlier) | `dispatcher` — captures the current frame at call time; safe to call during render and from async callbacks | 002 |
+| `bound-dispatcher` / `bound-subscriber` (proposed earlier) | Cut as pure aliases for `dispatcher` / `subscriber`. The verb-form names already imply capture-at-call-time semantics. | 002 |
+| `enable-performance-api-tracing!` (proposed earlier) | Performance-API instrumentation is gated on the compile-time `re-frame.performance/enabled?` `goog-define`, not a runtime toggle. See [11 — Instrumentation](11-instrumentation.md). | 009 |
+| `add-trace-listener` / `remove-trace-listener` (proposed earlier) | `register-listener!` / `unregister-listener!` | 009 |
+| `register-trace-listener` / `unregister-trace-listener` (no-bang, proposed earlier) | Renamed to `register-listener!` / `unregister-listener!` — the bang form matches the side-effecting nature of listener registration. | 009 |
+| Bare `[:my-view "args"]` keyword-tagged hiccup | Var form `[my-view "args"]` (canonical) or `[(rf/view :my-view) "args"]` for late-binding by id. | 004 |
+| `h` macro (proposed earlier) | Removed. Use the Var form `[my-view "args"]` or `[(rf/view :my-view) "args"]`. | 004 |
+| `reg-global-interceptor` | `reg-frame :interceptors` — frame-level is the canonical "global within this frame." For cross-frame observation, use `register-listener!`. | MIGRATION M-17 |
+| `clear-global-interceptor` | No replacement needed — re-register `reg-frame` with an updated `:interceptors` vector (absent-key semantics clear it). | MIGRATION M-17 |
+| `reg-sub-raw` | `reg-sub` for app-db reads; Pattern-AsyncEffect for non-app-db sources; state machines for lifecycle; the [006](../../spec/006-ReactiveSubstrate.md) adapter contract for bridging external reactivity. | MIGRATION M-18 |
+| `re-frame.alpha/reg` | Per-kind macros: `reg-event-db` / `reg-event-fx` / `reg-event-ctx` / `reg-sub` / `reg-fx` / `reg-cofx` / `reg-flow`. The `re-frame.alpha` namespace is dissolved. | MIGRATION M-23 |
+| `re-frame.alpha/sub` | Vector-form `(rf/subscribe [::id arg])`. | MIGRATION M-23 |
+| `re-frame.alpha/reg-sub-lifecycle` and built-in lifecycle policies (`:safe`, `:no-cache`, `:reactive`, `:forever`) | Sub-cache uses a single algorithm — deferred ref-counting with grace-period. For specific edge cases, file a follow-up bead. | MIGRATION M-23 |
+| `debug` interceptor | Trace surface ([Spec 009](../../spec/009-Instrumentation.md)) + 10x / re-frame-pair | MIGRATION M-21 |
+| `trim-v` interceptor | Canonical map-payload call shape | MIGRATION M-21 |
+| `on-changes` interceptor | Flows ([Spec 013](../../spec/013-Flows.md)) | MIGRATION M-21 |
+| `enrich` interceptor | Flows (derived state) / `:schema` (validation) / custom `->interceptor` (escape hatch) | MIGRATION M-21 |
+| `after` interceptor | Registered fx (`:fx [[:my-fx ...]]`) for side-effects; custom `->interceptor` for context-shaped work; vendor from v1 if the helper is wanted as a local utility | MIGRATION M-21 |
+| `with-overrides` (v1 macro name) | Renamed to `with-fx-overrides`. | MIGRATION M-50 |
+
+## Why these went
+
+A few one-line rationales for the larger cuts:
+
+- **`reg-global-interceptor`** — the v1 surface conflated "global" (process-wide) and "global within this frame" (frame-wide). The frame-wide answer is `reg-frame :interceptors`; the process-wide answer is `register-listener!` (observation, not mutation). Splitting the two ended the confusion.
+- **`reg-sub-raw`** — the v1 escape hatch covered four distinct use cases (app-db reads, async sources, lifecycle, external reactivity). Each now has its own surface — `reg-sub`, Pattern-AsyncEffect, state machines, the adapter contract — and the escape hatch isn't necessary.
+- **`re-frame.alpha`** — the alpha namespace was an experiment to unify registration / dispatch under generic `reg` / `sub` / `dis` verbs. The unification didn't pay for itself — the per-kind macros read better at the call site and survive better in the linter — and the alpha namespace is dissolved. No APIs in this reference live outside `re-frame.core` (with the documented per-namespace exceptions).
+- **The five v1 interceptors** (`debug`, `trim-v`, `on-changes`, `enrich`, `after`) — each was either trivially `->interceptor`-able (so didn't earn its own surface), or replaced by a richer mechanism (flows, schemas, the trace surface).
+
+## See also
+
+- [MIGRATION.md](../../migration/from-re-frame-v1/README.md) — the AI-driven migration spec, with one rule per row above.
+- [01 — Core](01-core.md) — the surfaces that replaced the removed ones.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,56 @@
+# The re-frame2 API
+
+This is the human-facing API reference for the ClojureScript implementation of re-frame2. It's organised by **what you're trying to do** rather than by alphabetical surface listing. Each chapter opens with a paragraph on what the surface is *for* — the problem it solves, the shape of the contract — and only then drops into the function tables.
+
+If you want the dense, single-page contract — every signature, every status, every cross-reference — the [normative reference](../../spec/API.md) is still where that lives. This guide is the same surface, walked through by topic, with intuition notes attached.
+
+## What's a "canonical" API?
+
+Every row in this reference is **canonical**: a documented, supported v1 (or post-v1 library) API that downstream apps and tools may rely on. There are no "alpha", "experimental", or "advanced" tiers in this surface. If a row appears here, you can call it; if a row doesn't appear here, it's either internal plumbing or a `post-v1` library scaffold that hasn't shipped yet. The rare internal carve-outs (two macro-helpers re-exposed for pre-split tests) are explicitly out of scope.
+
+## How to read a row
+
+Every row carries:
+
+- a **signature** — the call shape, in Clojure form
+- a **status** — `v1`, `v1 (preserved)` (carried unchanged from re-frame v1), `v1 (preserved + extended)` (carried with new arity or behaviour), `post-v1 lib` (designed in v1 but ships in a follow-on library), and a `dev-only` qualifier where the surface is elided in `:advanced` production builds
+- an **intuition** — the one-line answer to "what's this for and when do I reach for it?"
+
+Macros and functions are marked `M` or `Fn`. Where a `*` variant exists (`dispatch` / `dispatch*`, `reg-view` / `reg-view*`, etc.) the un-starred form is the macro; the `*` form is the underlying function, useful inside higher-order code where a macro can't sit. The `*` follows Clojure's own `let` / `let*`, `fn` / `fn*` idiom.
+
+## Where surfaces live
+
+The core surfaces live in `re-frame.core`. Per-feature artefacts ship their own public namespace, and consumers require it directly:
+
+| Namespace | Artefact | Use when |
+|---|---|---|
+| `re-frame.core` | core | Always. The registration / dispatch / subscribe / interceptor / lifecycle / configure surfaces all live here. |
+| `re-frame.test-support` | core | Test code. Fixture machinery, `dispatch-sequence`, `assert-path-equals` / `assert-db-equals`, `poll-until`. |
+| `re-frame.test-helpers` | core | View-assertion tests. Hiccup-walk, `find-by-testid`, `text-content`, `invoke-handler`, the `testid` authoring helper. |
+| `re-frame.schemas` | `day8/re-frame2-schemas` | Schema introspection (the registration macros live in `re-frame.core`). |
+| `re-frame.http` | `day8/re-frame2-http` | HTTP verb helpers `get` / `post` / `put` / `delete` / `patch` / `head` / `options`. |
+| `re-frame.machines` | `day8/re-frame2-machines` | Direct machine surface (the `reg-machine` macro is re-exported through `re-frame.core`). |
+| `re-frame.ssr` | `day8/re-frame2-ssr` | Server-side rendering — `render-to-string`, streaming, head model, error projection. |
+| `re-frame.ssr.ring` | `day8/re-frame2-ssr-ring` | Ring host-adapter for SSR. |
+| `re-frame.epoch` | `day8/re-frame2-epoch` | Time-travel surfaces — `epoch-history`, `restore-epoch`, `reset-frame-db!`. Re-exported through `re-frame.core` via late-bind. |
+| `re-frame.adapter.uix` / `re-frame.adapter.helix` | `day8/re-frame2-uix` / `-helix` | The per-substrate adapter surfaces and hooks. |
+
+The dependency direction is one-way: adapters and feature artefacts depend on core; core never depends on them. Apps load whatever subset they need.
+
+## The chapters
+
+The reference is divided into sixteen chapters. Each is independent — you can land on any of them from a search result and get something useful without reading the others.
+
+The first three are foundational — **Core** (registration, dispatch, subscribe), **Views** (the view registry and the substrate-agnostic ergonomic surface), **Effects and interceptors** (the effect map, the standard interceptors, the context plumbing).
+
+The next six cover feature domains: **State machines**, **Flows**, **Routing**, **HTTP**, **Schemas and data classification**, **SSR**.
+
+The next four cover the operational surfaces: **Testing**, **Instrumentation** (listeners, tracing, epoch, performance), **Registrar** (the query API tools build against), **Lifecycle** (adapter install / dispose, `configure`).
+
+Then **Adapters** (the per-substrate surfaces — Reagent, UIx, Helix), **Story** (post-v1 — variants, workspaces, snapshot identity), and a closing **Removed / not shipped** chapter that says what's gone and what to use instead.
+
+## When to reach for the spec instead
+
+The chapters here are organised for readers; the [normative API reference](../../spec/API.md) is organised for completeness. If you're looking for *every* row at once — a `Ctrl-F` target across the full surface — that's where you want to be. If you're writing a new app and want to know which surfaces *exist* in a given domain, you want a chapter here.
+
+The normative spec docs (`002-Frames.md`, `005-StateMachines.md`, etc.) own the *why* — the design rationale, the alternatives considered, the dispositions. The chapters here cite those when they matter, and stay quiet otherwise.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,24 @@ nav:
     - re-frame2-pair-retro: skills/re-frame2-pair-retro.md
 
   - API:
-    - Reference: spec/API.md
+    - Overview: api/README.md
+    - "01 — Core": api/01-core.md
+    - "02 — Views": api/02-views.md
+    - "03 — Effects": api/03-effects.md
+    - "04 — Machines": api/04-machines.md
+    - "05 — Flows": api/05-flows.md
+    - "06 — Routing": api/06-routing.md
+    - "07 — HTTP": api/07-http.md
+    - "08 — Schemas": api/08-schemas.md
+    - "09 — SSR": api/09-ssr.md
+    - "10 — Testing": api/10-testing.md
+    - "11 — Instrumentation": api/11-instrumentation.md
+    - "12 — Registrar": api/12-registrar.md
+    - "13 — Lifecycle": api/13-lifecycle.md
+    - "14 — Adapters": api/14-adapters.md
+    - "15 — Story": api/15-story.md
+    - "16 — Removed": api/16-removed.md
+    - "Normative reference": spec/API.md
 
   - Migration:
     - "From re-frame v1": migration/from-re-frame-v1/README.md

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -96,13 +96,19 @@ def on_pre_build(config):
             shutil.rmtree(dest)
         shutil.copytree(src, dest)
 
-# Case 1a: guide/* and skills/* pages link to spec via ../../spec/ — collapse
-# one level. Both trees live at docs/<tree>/X.md (depth 2 below repo root),
-# so from the source tree the correct ref to spec/ is ../../spec/, while in
-# the staged docs_dir (where spec/ is copied to docs/spec/) the correct ref
-# is ../spec/. The rewrite is identical for both trees because they share
-# the same depth.
+# Case 1a: guide/*, skills/*, and api/* pages link to spec via ../../spec/ —
+# collapse one level. All three trees live at docs/<tree>/X.md (depth 2 below
+# repo root), so from the source tree the correct ref to spec/ is ../../spec/,
+# while in the staged docs_dir (where spec/ is copied to docs/spec/) the
+# correct ref is ../spec/. The rewrite is identical for all three trees
+# because they share the same depth.
 _GUIDE_TO_SPEC = re.compile(r'\]\(\.\./\.\./spec/')
+
+# Case 1a-mig: depth-2 pages (guide/*, skills/*, api/*) link to migration via
+# ../../migration/. The staged tree puts migration/ at docs/migration/, so
+# from a depth-2 page the correct path is ../migration/. Same depth-collapse
+# rule as Case 1a, against the migration tree instead of the spec tree.
+_GUIDE_TO_MIGRATION = re.compile(r'\]\(\.\./\.\./migration/')
 
 # Case 1a-deep: chapter sub-pages live at docs/guide/<chapter-dir>/X.md (depth
 # 3 below repo root). From the source tree the correct ref to spec/ is
@@ -231,7 +237,7 @@ def on_page_markdown(markdown, page, config, files):
     """
     src = page.file.src_path.replace('\\', '/')
 
-    if src.startswith('guide/') or src.startswith('skills/'):
+    if src.startswith('guide/') or src.startswith('skills/') or src.startswith('api/'):
         # Choose by source depth. A guide sub-chapter at
         # docs/guide/<chapter-dir>/X.md is depth 3; its source spec ref is
         # ../../../spec/ and the staged path is ../../spec/. Plain
@@ -248,6 +254,7 @@ def on_page_markdown(markdown, page, config, files):
             markdown = _GUIDE_CAUSA_DIR.sub('](../../causa/index.md)', markdown)
         else:
             markdown = _GUIDE_TO_SPEC.sub('](../spec/', markdown)
+            markdown = _GUIDE_TO_MIGRATION.sub('](../migration/', markdown)
             # Bare ../../skills/X/ -> ../skills/X.md (in-tree summary page).
             # Only depth-2 guide pages emit this shape today; skills/ sub-
             # paths (e.g. ../../skills/X/SKILL.md) fall through to the


### PR DESCRIPTION
Closes rf2-kti8s.

Splits the single `spec/API.md` projection (~800 lines) into 17 docs/api/ chapters with a tight intuition column and engaging Yegge-leaning prose:

- 01 Core / 02 Views / 03 Effects / 04 Machines / 05 Flows / 06 Routing
- 07 HTTP / 08 Schemas / 09 SSR / 10 Testing / 11 Instrumentation
- 12 Registrar / 13 Lifecycle / 14 Adapters / 15 Story / 16 Removed
- README overview

Each chapter opens with a paragraph on what the surface is *for*, runs tight tables with one-line intuition notes per row, and closes with 'see also' sidebars. `spec/API.md` stays in place as the normative single-page reference (still cited by every spec doc); the new chapters are the docs-side engaging projection.

**Conventions held:**
- No bead refs in body text (spec anchors and M-NN migration numbers retained)
- LHS nav slugs all ≤ 20 chars
- `mkdocs build --strict` passes
- `check_doc_slugs.py` passes (350 files, 0 broken targets/anchors)
- mkdocs_hooks.py extended to rewrite `../../spec/` and `../../migration/` for depth-2 `docs/api/` pages (parallel to existing guide/skills handling)

**Scope held:**
- Includes: `docs/api/*`, `mkdocs.yml`, `mkdocs_hooks.py` rewrite extension
- Excludes: `docs/guide/`, `docs/causa/`, `docs/story/`, `docs/migration/`, `docs/cljs/`, `spec/API.md`