### PR TITLE
ci(lint): triage kondo baseline + tighten gate to fail-loud (rf2-60nez)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,38 +1,149 @@
 ;; clj-kondo config for re-frame2 — repo-root.
 ;;
 ;; Activates project-aware analysis so editor integrations (Calva,
-;; CIDER, Cursive) and CI lints share one source of truth. Minimal
-;; but useful — enable the high-signal linters and let the per-artefact
-;; classpaths (under implementation/, tools/, examples/) inherit.
+;; CIDER, Cursive) and CI lints share one source of truth.
 ;;
-;; The re-frame2 defining forms (`reg-event-db`, `reg-sub`, `reg-fx`,
-;; `reg-view`, …) are recognised by clj-kondo's built-in support for
-;; clojure.core-style defining forms — no hook lib required for the
-;; canonical shapes. Add :hooks here as the framework's macros grow
-;; surfaces clj-kondo's defaults can't infer.
+;; The re-frame2 reg-* macros emit a defmacro under `re-frame.core` (see
+;; `core_reg_macros.cljc` → `defreg-macro` / `defreg-event-macro`). Each
+;; user-facing reg-* macro takes the shape `(reg-foo :id ... body)` —
+;; structurally a `def`-like top-level form. `reg-view` is the outlier
+;; (`(reg-view sym [args] body)`) and lints-as `defn`.
+;;
+;; Story's authoring macros (`reg-story` / `reg-variant` / `reg-workspace`
+;; / `reg-mode` / `reg-story-panel` / `reg-decorator` / `reg-tag`) and
+;; the Helix substrate's `defnc` (and the matching `defnc-` from
+;; `re-frame.adapter.helix`) follow the same shape and get lint-as'd
+;; here too.
 {:linters
  {:unresolved-symbol {:level :warning}
   :unused-binding    {:level :warning}
   :unused-referred-var {:level :warning}
   :unused-namespace  {:level :warning}
   :redefined-var     {:level :warning}
-  :inline-def        {:level :warning}}
+  ;; Disabled — re-frame2's reg-view hook (see
+  ;; `.clj-kondo/hooks/re_frame/core.clj`) rewrites `(reg-view sym [args]
+  ;; body)` to `(defn sym [args] ...)`. When that call sits inside a
+  ;; `(testing ...)` block (idiomatic for the per-test view-registration
+  ;; pattern in `reg_view_test.clj`, the adapter view-tests, and the SSR
+  ;; streaming tests) the rewritten `defn` reads as `inline-def`. The
+  ;; signal/noise on `inline-def` is dominated by the rewrite; turning
+  ;; the linter off avoids hand-decorating every test call site.
+  :inline-def        {:level :off}
+  ;; Disabled — the reg-* registration macros are `:lint-as
+  ;; clojure.core/do` so calls inside `(defn install! ...)` don't trip
+  ;; `inline-def` (see the rationale on the `:lint-as` block below).
+  ;; That choice yields `redundant do` false positives at every reg-*
+  ;; call site (a single-form `do`), so we silence it project-wide.
+  ;; There is no production-pattern in re-frame2 codebase where
+  ;; `redundant-do` is high signal — the warning's intended target is
+  ;; "(do (single-expr))" which is harmless either way.
+  :redundant-do      {:level :off}
+
+  ;; `:unresolved-var` exclusions — the framework's reg-* macros are
+  ;; defined under `#?(:clj (defmacro …))` using the `defreg-macro`
+  ;; meta-macro (see `core_reg_macros.cljc`). kondo can't statically
+  ;; trace the macro-defining-macro, so the resulting Vars look
+  ;; unresolved even though our `:lint-as` rewrites the call sites.
+  ;; Exclude them by qualified-symbol so editor integrations and CI
+  ;; agree.
+  :unresolved-var
+  {:level :warning
+   :exclude [re-frame.core/reg-event-db
+             re-frame.core/reg-event-fx
+             re-frame.core/reg-event-ctx
+             re-frame.core/reg-sub
+             re-frame.core/reg-sub-raw
+             re-frame.core/reg-fx
+             re-frame.core/reg-cofx
+             re-frame.core/reg-frame
+             re-frame.core/reg-flow
+             re-frame.core/reg-route
+             re-frame.core/reg-app-schema
+             re-frame.core/reg-app-schemas
+             re-frame.core/reg-error-projector
+             re-frame.core/reg-head
+             re-frame.core/reg-http-interceptor
+             re-frame.core/reg-machine
+             re-frame.core/reg-view
+             re-frame.story/reg-story
+             re-frame.story/reg-variant
+             re-frame.story/reg-workspace
+             re-frame.story/reg-mode
+             re-frame.story/reg-story-panel
+             re-frame.story/reg-decorator
+             re-frame.story/reg-tag]}}
 
  :lint-as
- {;; Common re-frame2 registration macros that share clojure.core/def
-  ;; arglist shape — clj-kondo lints the body as a fn definition.
-  re-frame.core/reg-event-db    clojure.core/def
-  re-frame.core/reg-event-fx    clojure.core/def
-  re-frame.core/reg-sub         clojure.core/def
-  re-frame.core/reg-fx          clojure.core/def
-  re-frame.core/reg-cofx        clojure.core/def}
+ {;; Core registration macros — `(reg-foo :id ... body)` is a
+  ;; *registration* call (handler installed in the registrar by side
+  ;; effect), NOT a `def` introducing a Var. `:lint-as clojure.core/do`
+  ;; tells clj-kondo to lint each argument as an expression — the
+  ;; nested fn-form body still gets full lexical-binding analysis, but
+  ;; the form is not treated as a top-level def, so calls inside
+  ;; `(defn install! ...)` (Causa's deferred-registration pattern)
+  ;; don't trip `inline-def`. The trade-off: the `:id` argument is not
+  ;; registered as a Var, but that's fine — re-frame2 callers reference
+  ;; registered handlers by keyword, not by symbol.
+  re-frame.core/reg-event-db        clojure.core/do
+  re-frame.core/reg-event-fx        clojure.core/do
+  re-frame.core/reg-event-ctx       clojure.core/do
+  re-frame.core/reg-sub             clojure.core/do
+  re-frame.core/reg-sub-raw         clojure.core/do
+  re-frame.core/reg-fx              clojure.core/do
+  re-frame.core/reg-cofx            clojure.core/do
+  re-frame.core/reg-frame           clojure.core/do
+  re-frame.core/reg-flow            clojure.core/do
+  re-frame.core/reg-route           clojure.core/do
+  re-frame.core/reg-app-schema      clojure.core/do
+  re-frame.core/reg-app-schemas     clojure.core/do
+  re-frame.core/reg-error-projector clojure.core/do
+  re-frame.core/reg-head            clojure.core/do
+  re-frame.core/reg-http-interceptor clojure.core/do
+  re-frame.core/reg-machine         clojure.core/do
 
- ;; rf2-4v147 — outputs filtered post-analysis. `tools/template/resources/`
- ;; ships deps-new template resources whose `.cljs` files contain
- ;; `{{placeholder}}` substitutions and are not valid Clojure (see
- ;; tools/deps.edn → "Why template is NOT in the base :deps map" for
- ;; the matching shadow-cljs exclusion). The CI workflow also avoids
- ;; passing that path to `--lint`; this filter is the belt-and-braces
- ;; for editor integrations and ad-hoc local runs that pass the broader
+  ;; `reg-view` is `(reg-view sym [args] body)` — defn-shape, but the
+  ;; macro auto-injects `dispatch` / `subscribe` into the body. Handled
+  ;; by the dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` —
+  ;; lint-as wouldn't surface the injected bindings.
+
+  ;; `with-frame` has two shapes — `(with-frame :keyword body+)` and
+  ;; `(with-frame [sym expr] body+)`. The latter is `let`-shape; the
+  ;; former is `do`-shape with a leading keyword. Handled by the
+  ;; dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` so both
+  ;; shapes parse cleanly and the binding-vector case surfaces the
+  ;; lexical `sym`.
+
+  ;; Story authoring macros — `(reg-foo :id metadata)` is a registration
+  ;; call, same shape as the core reg-* family. Same `do`-shape lint-as
+  ;; rationale.
+  re-frame.story/reg-story         clojure.core/do
+  re-frame.story/reg-variant       clojure.core/do
+  re-frame.story/reg-workspace     clojure.core/do
+  re-frame.story/reg-mode          clojure.core/do
+  re-frame.story/reg-story-panel   clojure.core/do
+  re-frame.story/reg-decorator     clojure.core/do
+  re-frame.story/reg-tag           clojure.core/do
+
+  ;; Helix authoring — `defnc` / `defnc-` are `defn`-shaped wrappers
+  ;; from `helix.core`. clj-kondo doesn't ship a built-in hook for
+  ;; them; lint-as gives us the basics (arity check, body lint, name
+  ;; resolution) without the prop-spec analysis a real hook would do.
+  helix.core/defnc                  clojure.core/defn
+  helix.core/defnc-                 clojure.core/defn-
+
+  ;; UIx authoring — `defui` from `uix.core` is also `defn`-shaped.
+  uix.core/defui                    clojure.core/defn}
+
+ :hooks
+ {:analyze-call
+  {re-frame.core/reg-view   hooks.re-frame.core/reg-view
+   re-frame.core/with-frame hooks.re-frame.core/with-frame}}
+
+ ;; `tools/template/resources/` ships deps-new template `.cljs` files
+ ;; whose `{{placeholder}}` substitutions are not valid Clojure (see
+ ;; `tools/deps.edn` → "Why template is NOT in the base :deps map" for
+ ;; the matching shadow-cljs exclusion). The CI workflow's `--lint`
+ ;; paths skip that directory; this filter is the belt-and-braces for
+ ;; editor integrations and ad-hoc local runs that pass the broader
  ;; `tools/` path.
  :output {:exclude-files ["tools/template/resources/"]}}

--- a/.clj-kondo/hooks/re_frame/core.clj
+++ b/.clj-kondo/hooks/re_frame/core.clj
@@ -1,0 +1,96 @@
+(ns hooks.re-frame.core
+  "clj-kondo macro hook for `re-frame.core/reg-view`.
+
+  Per spec/004-Views.md, `reg-view` is a defn-shape macro that auto-
+  injects two lexical bindings — `dispatch` (from `(re-frame.core/
+  dispatcher)`) and `subscribe` (from `(re-frame.core/subscriber)`) —
+  into the body. clj-kondo doesn't macroexpand by default, so without
+  this hook the body's `dispatch` / `subscribe` references all read as
+  `Unresolved symbol`.
+
+  The hook rewrites `(reg-view sym [args] body)` into
+
+      (defn sym [args]
+        (let [dispatch  (re-frame.core/dispatcher)
+              subscribe (re-frame.core/subscriber)]
+          body))
+
+  preserving any leading docstring + optional attr-map, so kondo's
+  built-in `defn` analysis covers arglist + arity + lexical bindings."
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-frame
+  "clj-kondo macro hook for `re-frame.core/with-frame`.
+
+  Two shapes — per Spec 002 §with-frame:
+
+      (with-frame :keyword body+)        ;; pin to existing frame
+      (with-frame [sym expr] body+)      ;; lexical bind, run, dispose
+
+  Rewrites:
+    - keyword shape → `(do body)`
+    - binding shape → `(let [sym expr] body)`"
+  [{:keys [node]}]
+  (let [[_with-frame discriminator & body] (:children node)]
+    (cond
+      ;; `(with-frame [sym expr] body+)` — binding-vector shape.
+      (api/vector-node? discriminator)
+      {:node (api/list-node
+               (list* (api/token-node 'let)
+                      discriminator
+                      body))}
+      ;; `(with-frame :keyword body+)` — keyword shape; the keyword is
+      ;; eval'd as an expression (a no-op) and the body runs sequentially.
+      :else
+      {:node (api/list-node
+               (list* (api/token-node 'do)
+                      discriminator
+                      body))})))
+
+(defn reg-view
+  "Hook entry — see ns doc."
+  [{:keys [node]}]
+  (let [[_reg-view & rest-children] (:children node)
+        sym-node (first rest-children)
+        tail     (rest rest-children)
+        ;; Split off optional docstring + attr-map (per `reg-view` parse).
+        [docstring tail] (if (and (seq tail) (api/string-node? (first tail)))
+                           [(first tail) (rest tail)]
+                           [nil tail])
+        [attr-map tail]  (if (and (seq tail) (api/map-node? (first tail)))
+                           [(first tail) (rest tail)]
+                           [nil tail])
+        args-node (first tail)
+        body      (rest tail)
+        defn-children
+        (cond-> [(api/token-node 'clojure.core/defn) sym-node]
+          docstring (conj docstring)
+          attr-map  (conj attr-map)
+          true      (conj args-node)
+          true      (conj
+                      (api/list-node
+                        (list*
+                          (api/token-node 'let)
+                          (api/vector-node
+                            [(api/token-node 'dispatch)
+                             (api/list-node
+                               [(api/token-node 're-frame.core/dispatcher)])
+                             (api/token-node 'subscribe)
+                             (api/list-node
+                               [(api/token-node 're-frame.core/subscriber)])])
+                          ;; Insert a leading no-op reference to
+                          ;; `dispatch` / `subscribe` so kondo's
+                          ;; unused-binding linter sees both bindings
+                          ;; referenced (a view body that only uses one
+                          ;; of the injections would otherwise trip the
+                          ;; linter on the unused side). The leading
+                          ;; position is harmless to kondo's body-shape
+                          ;; analysis — only the LAST form is the
+                          ;; return value, which is the user's body.
+                          (cons
+                            (api/list-node
+                              [(api/token-node 'do)
+                               (api/token-node 'dispatch)
+                               (api/token-node 'subscribe)])
+                            body)))))]
+    {:node (api/list-node defn-children)}))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,27 +1,22 @@
 name: lint
 
-# Dual-linter CI gate (rf2-4v147 · Mike-confirmed 2026-05-21).
+# Dual-linter CI gate.
 #
 # Two complementary linters run as parallel jobs:
 #
 #   - clj-kondo: bug-class linter (unresolved symbols, arity mismatches,
 #     redefined vars, unused bindings). The `.clj-kondo/config.edn` at
 #     repo root is the shared source of truth — editor integrations
-#     (Calva, CIDER, Cursive) read the same file.
+#     (Calva, CIDER, Cursive) read the same file. The job runs with
+#     `--fail-level error`, so an introduced ERROR blocks the PR while
+#     warnings remain informational for triage.
 #
 #   - Splint (noahtheduke/splint): style-shape linter inspired by the
 #     Clojure Style Guide. Catches idiomatic-Clojure smells that
 #     kondo's lexical analysis is not designed to surface. Per-project
-#     config lives in `.splint.edn` at repo root.
-#
-# FIRST-ITERATION POSTURE: both jobs are REPORT-ONLY
-# (`continue-on-error: true`). The baseline at landing is ~4100 kondo
-# warnings + 25 errors and ~1660 Splint warnings + 4 errors — a mix of
-# pre-existing test-fixture quirks (slashed keywords like `:no/such/event`
-# in trace tests), kondo's "Unresolved var" noise on the framework's
-# dynamically-defined registration macros, and Splint's style suggestions
-# that need triaging before they earn their teeth. Follow-on bead tightens
-# both gates once the baseline is triaged.
+#     config lives in `.splint.edn` at repo root. The Splint job stays
+#     report-only at first iteration — fail-loud follows in a separate
+#     iteration once the warning baseline is triaged.
 #
 # Lint surface: implementation/, tools/ (minus template/resources/),
 # examples/, testbeds/. Generated trees (.shadow-cljs/, target/,
@@ -64,15 +59,11 @@ concurrency:
 
 jobs:
   clj-kondo:
-    name: clj-kondo (report-only, first iteration)
+    name: clj-kondo (fail on errors, warnings informational)
     runs-on: ubuntu-latest
-    # First-iteration posture: kondo is informational while we baseline
-    # the 25-ish pre-existing errors (a mix of test-fixture keywords
-    # like `:no/such/event`, internal-private references, and a couple
-    # of arity drifts in test code). Follow-on bead tightens this to
-    # fail-loud once those are triaged. See rf2-4v147 PR description for
-    # the baseline report.
-    continue-on-error: true
+    # The job runs with `--fail-level error` so an introduced ERROR
+    # blocks the PR. Warnings stay informational and surface in the
+    # job log for triage.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -110,14 +101,17 @@ jobs:
       # subdirs are listed explicitly to skip resources/ while keeping
       # tools/template/{src,test}.
       #
-      # `--parallel` fans out file analysis across cores. `|| true`
-      # caps the first-iteration report-only posture (belt-and-braces
-      # with continue-on-error so a non-zero exit from kondo doesn't
-      # bubble up either way).
+      # `--parallel` fans out file analysis across cores. `--fail-level
+      # error` makes kondo exit non-zero only when an ERROR-level
+      # finding is reported (warnings still print to the log for
+      # triage). The `continue-on-error` job-level flag was removed
+      # alongside the trailing `|| true` so a kondo error genuinely
+      # blocks the PR.
       - name: Run clj-kondo
         run: |
           clj-kondo \
             --parallel \
+            --fail-level error \
             --lint implementation \
             --lint examples \
             --lint testbeds \
@@ -129,8 +123,7 @@ jobs:
             --lint tools/story \
             --lint tools/story-mcp \
             --lint tools/template/src \
-            --lint tools/template/test \
-            || true
+            --lint tools/template/test
 
   splint:
     name: Splint (report-only, first iteration)

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -137,6 +137,13 @@
 
 (defn- pr-atom [a writer opts s v]
   (-write writer (str "#object[reagent2.ratom." s " "))
+  ;; `pr-writer` is marked private in cljs.core but is the documented
+  ;; entrypoint for nested `IPrintWithWriter` dispatch (every reagent2
+  ;; ratom's `-pr-writer` delegates to it for the value's recursive
+  ;; print). The "private" tag is a CLJS-packaging artefact, not an
+  ;; API contract — silence kondo's private-call check at the one
+  ;; call site rather than blanket-excluding the linter.
+  #_:clj-kondo/ignore
   (pr-writer (binding [*ratom-context* nil] v) writer opts)
   (-write writer "]"))
 

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -223,6 +223,11 @@
         ;; Form-3 reagent class — call its render-fn directly with
         ;; the hiccup args. Skips React instantiation entirely.
         (some? render-fn)
+        ;; clj-kondo can't refine `render-fn` to non-nil through the
+        ;; surrounding `cond`+`some?` guard, so it reads the `apply`
+        ;; below as "received: nil". The guard is correct — silence
+        ;; the type-inference miss.
+        #_:clj-kondo/ignore
         (expand-tree (apply render-fn (rest tree)))
 
         ;; Plain function component — invoke as Reagent would.

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -193,6 +193,7 @@
     (is (nil? (adapter/current-adapter))
         "precondition: no adapter installed")
     (let [thrown (try
+                   #_:clj-kondo/ignore
                    (rf/init!)
                    nil
                    (catch clojure.lang.ArityException e e))]

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -152,7 +152,7 @@
       (rf/dispatch-sync [:send-broken] {:frame :test/main})
 
       ;; ---- :rf.error/no-such-handler --------------------------------------
-      (rf/dispatch-sync [:no/such/event] {:frame :test/main})
+      (rf/dispatch-sync [:no.such/event] {:frame :test/main})
 
       ;; ---- :rf.error/handler-exception ------------------------------------
       (rf/reg-event-db :throws (fn [_ _] (throw (ex-info "oops" {:bad? true}))))
@@ -195,7 +195,7 @@
 
       ;; ---- :rf.error/frame-destroyed --------------------------------------
       ;; Subscribe against a frame that doesn't exist.
-      (rf/subscribe-once :no/such/frame [:n])
+      (rf/subscribe-once :no.such/frame [:n])
 
       ;; ---- :rf.error/drain-depth-exceeded ---------------------------------
       ;; A handler that re-dispatches itself; the drain bound (default 100)
@@ -451,7 +451,7 @@
           (is (has-op? events :error :rf.error/no-such-handler)
               "expected :error :rf.error/no-such-handler")
           (let [t (:tags (find-op events :error :rf.error/no-such-handler))]
-            (is (= :no/such/event (:event-id t)))
+            (is (= :no.such/event (:event-id t)))
             (is (= :event         (:kind t)))))
 
         (testing ":error :rf.error/no-such-sub"

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -412,13 +412,13 @@
 (deftest restore-failure-unknown-frame
   (testing "restore-epoch on an unknown frame fires :rf.error/no-such-handler (kind :frame)"
     (let [recorded (record-trace!)
-          ok?      (rf/restore-epoch :no/such/frame :ignored)]
+          ok?      (rf/restore-epoch :no.such/frame :ignored)]
       (is (false? ok?))
       (let [events @recorded]
         (is (has-error-op? events :rf.error/no-such-handler))
         (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %) events)]
           (is (= :frame (:kind (:tags ev))))
-          (is (= :no/such/frame (:frame (:tags ev)))))))))
+          (is (= :no.such/frame (:frame (:tags ev)))))))))
 
 (deftest restore-failure-unknown-epoch
   (testing "restore-epoch with an epoch-id not in history fires :rf.epoch/restore-unknown-epoch"
@@ -1353,13 +1353,13 @@
   (testing "reset-frame-db! on an unknown frame returns false and emits
             :rf.error/no-such-handler (kind :frame); no-op on app-db"
     (let [recorded (record-trace!)
-          ok?      (rf/reset-frame-db! :no/such/frame {:any 'value})]
+          ok?      (rf/reset-frame-db! :no.such/frame {:any 'value})]
       (is (false? ok?))
       (is (has-error-op? @recorded :rf.error/no-such-handler))
       (let [ev (some #(when (= :rf.error/no-such-handler (:operation %)) %)
                      @recorded)]
         (is (= :frame (:kind (:tags ev))))
-        (is (= :no/such/frame (:frame (:tags ev))))))))
+        (is (= :no.such/frame (:frame (:tags ev))))))))
 
 (deftest reset-frame-db!-failure-during-drain
   (testing "reset-frame-db! called from inside a drain returns false and
@@ -1653,7 +1653,7 @@
     (rf/destroy-frame! :test/short-lived)
     (is (= [] (rf/epoch-history :test/short-lived))
         "after destroy, epoch-history returns the empty vector")
-    (is (= [] (rf/epoch-history :no/such/frame))
+    (is (= [] (rf/epoch-history :no.such/frame))
         "for a never-registered frame, epoch-history returns the empty vector")))
 
 (deftest destroyed-frame-get-frame-db-returns-nil
@@ -1668,7 +1668,7 @@
     (rf/destroy-frame! :test/short-lived)
     (is (nil? (rf/get-frame-db :test/short-lived))
         "after destroy, get-frame-db returns nil")
-    (is (nil? (rf/get-frame-db :no/such/frame))
+    (is (nil? (rf/get-frame-db :no.such/frame))
         "for a never-registered frame, get-frame-db returns nil")))
 
 (deftest destroyed-frame-restore-epoch-raises-no-such-handler

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -36,8 +36,7 @@
   Overflow throws `:rf.error/malformed-json :reason :too-many-keys` —
   the `:rf.http/managed` cascade classifies this as
   `:rf.http/decode-failure`."
-  #?(:clj  (:require [cheshire.core :as cheshire])
-     :cljs (:require)))
+  #?(:clj  (:require [cheshire.core :as cheshire])))
 
 (def ^:const default-max-decoded-keys
   "Default cap on the number of unique object keys a single `json-parse`

--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -408,7 +408,7 @@
     ;; rf2-ojakd / rf2-olb64 (a) — :rf/suspense-boundary streaming SSR.
     ;; Three call kinds; one per Spec 011 §Streaming SSR step.
 
-    :ssr/streaming/render-shell
+    :ssr.streaming/render-shell
     (let [{:keys [shell-html continuations]}
           (try (ssr/streaming-render-shell (:input call))
                (catch Throwable e {:shell-html (str "<error: " (.getMessage e) ">")
@@ -429,7 +429,7 @@
                          (str "    continuations expected: " (pr-str conts-want) "\n"
                               "    continuations actual:   " (pr-str conts-actual) "\n"))))})
 
-    :ssr/streaming/render-continuation
+    :ssr.streaming/render-continuation
     (let [out  (try (ssr/streaming-render-continuation
                       :rf/default (:input call))
                     (catch Throwable e {:html (str "<error: " (.getMessage e) ">")
@@ -455,7 +455,7 @@
                          (str "    failed? expected: " (:failed? want) "\n"
                               "    failed? actual:   " (:failed? out) "\n"))))})
 
-    :ssr/streaming/build-final-payload
+    :ssr.streaming/build-final-payload
     (let [payload (try (ssr/streaming-build-final-payload
                          :rf/default
                          (:render-hash (:input call))

--- a/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_conformance_test.clj
@@ -7,8 +7,8 @@
   Sibling to `re-frame.ssr-conformance-test` which drives the full
   `ssr-*.edn` corpus through the more elaborate runner (handler
   realisation, frame setup, request-result assertions). The streaming
-  fixture is a smaller direct-call shape — `:ssr/streaming/render-shell`,
-  `:ssr/streaming/render-continuation`, `:ssr/streaming/build-final-payload`
+  fixture is a smaller direct-call shape — `:ssr.streaming/render-shell`,
+  `:ssr.streaming/render-continuation`, `:ssr.streaming/build-final-payload`
   — and runs cleaner as a dedicated focused test that mirrors the
   conformance fixture step-for-step."
   (:require [clojure.edn :as edn]
@@ -57,7 +57,7 @@
   (testing "render-shell emits the shell HTML + 2 continuations the fixture pins"
     (let [fixture (load-streaming-fixture)
           shell-call (->> (:fixture/calls fixture)
-                          (filter #(= :ssr/streaming/render-shell (:call %)))
+                          (filter #(= :ssr.streaming/render-shell (:call %)))
                           first)
           {:keys [shell-html continuations]}
           (ssr/streaming-render-shell (:input shell-call))
@@ -74,7 +74,7 @@
   (testing "Each continuation's HTML matches the fixture's :html-includes pin"
     (let [fixture (load-streaming-fixture)
           cont-calls (->> (:fixture/calls fixture)
-                          (filter #(= :ssr/streaming/render-continuation (:call %))))
+                          (filter #(= :ssr.streaming/render-continuation (:call %))))
           ;; A frame to drain against — :rf/default. The fixture sets
           ;; :platform :server via :fixture/frame-config; reset-runtime
           ;; creates :rf/default and reset+reg-fixture-handlers wired the
@@ -92,7 +92,7 @@
   (testing "build-final-payload emits the four canonical :rf/* keys"
     (let [fixture (load-streaming-fixture)
           fp-call (->> (:fixture/calls fixture)
-                       (filter #(= :ssr/streaming/build-final-payload (:call %)))
+                       (filter #(= :ssr.streaming/build-final-payload (:call %)))
                        first)
           input   (:input fp-call)
           expect  (:expect fp-call)

--- a/spec/conformance/fixtures/ssr-streaming.edn
+++ b/spec/conformance/fixtures/ssr-streaming.edn
@@ -76,7 +76,7 @@
   ;; outer structure plus inline rendering of :streaming.test/article-list,
   ;; with two <template … suspense-fallback> placeholders in document
   ;; order at the suspense-boundary sites.
-  {:call   :ssr/streaming/render-shell
+  {:call   :ssr.streaming/render-shell
    :input  [:streaming.test/root]
    :expect
    {:shell-html-includes
@@ -108,7 +108,7 @@
   ;; the view root per Spec 006). The fixture asserts head + content
   ;; substrings rather than full-string equality so it is robust to
   ;; the source-coord annotation's per-port surface variance.
-  {:call   :ssr/streaming/render-continuation
+  {:call   :ssr.streaming/render-continuation
    :input  {:id :streaming.test/comments
             :subtree [:streaming.test/comments-section]}
    :expect
@@ -119,7 +119,7 @@
     :failed? false}}
 
   ;; Step 3 — drain continuation #2 (FIFO continues).
-  {:call   :ssr/streaming/render-continuation
+  {:call   :ssr.streaming/render-continuation
    :input  {:id :streaming.test/related
             :subtree [:streaming.test/related]}
    :expect
@@ -138,7 +138,7 @@
   ;; conformance fixture opts in to whole-app-db so the payload-keys
   ;; expectation below covers the full canonical shape rather than a
   ;; sliced subset.
-  {:call   :ssr/streaming/build-final-payload
+  {:call   :ssr.streaming/build-final-payload
    :input  {:render-hash    "00000000"          ;; placeholder; the implementation
                                                 ;; supplies the real FNV-1a hex here
             :version        1

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -174,7 +174,10 @@
 
 (defn view-mode-toggle
   "Two-button pill — Canvas | List — at the section header. Wires
-  click → `:set-view-mode`."
+  click → `:set-view-mode`. Public so the sibling `machine_inspector`
+  panel can mount the same toggle — cross-panel reuse was already
+  happening via the private symbol; promote to public rather than
+  re-publish via a wrapper."
   [{:keys [machine-id mode]}]
   (let [tab-style (fn [active?]
                     {:background    (if active?

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -467,7 +467,7 @@
             removed; Static mode is unconditionally available)"
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (let [tree (shell/ribbon)]
+      (let [tree (shell/ribbon nil)]
         (is (some? (find-by-testid tree "rf-causa-mode-pill"))
             "mode pill mounts in the Dynamic ribbon unconditionally")))))
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
@@ -32,8 +32,7 @@
   `byte-estimate-per-entry`). It is intentionally rough — the marker
   is consumed by agents for *planning* (\"is this slice worth
   drilling into?\"), not for precise budgeting. Agents needing a
-  precise size measure their drill-down result directly."
-  (:require))
+  precise size measure their drill-down result directly.")
 
 (def summary-keys-cap
   "Top-N keys included verbatim in a tree-summary marker. Above this,

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/lazy_summary_test.cljs
@@ -249,7 +249,7 @@
                          (map #(hash-map :value % :ref-count %) (range 100)))
       :machines  {:ids   (mapv #(keyword (str "m" %)) (range 30))
                   :state (zipmap (map #(keyword (str "m" %)) (range 30))
-                                 (map #(hash-map :state :idle :context big-map) (range 30)))}
+                                 (map (fn [_] (hash-map :state :idle :context big-map)) (range 30)))}
       :epochs    (vec (for [i (range 10)]
                         {:event-id   (keyword (str "e" i))
                          :db-before  big-map

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -110,7 +110,7 @@
   [frame-id]
   (swap! run-state dissoc frame-id)
   (swap! runs-by-play (fn [m]
-                        (into {} (remove (fn [[[fid _]] _]
+                        (into {} (remove (fn [[[fid _]]]
                                            (= fid frame-id)) m))))
   (swap! active-play dissoc frame-id)
   nil)


### PR DESCRIPTION
Closes rf2-60nez.

## Summary

- Triages the clj-kondo baseline: **25 errors / 4100 warnings → 0 errors / ~650 warnings** via `:lint-as` mappings for the framework's reg-* macros, two macro-hooks (`reg-view` and `with-frame`), and per-site fixes for the residual real findings.
- Flips the clj-kondo CI job to fail-loud — `continue-on-error` and `|| true` are gone, `--fail-level error` blocks PRs when an introduced ERROR shows up. Warnings still surface in the log for triage.
- The Splint job stays report-only this iteration. The local Splint config-loader fails on Windows backslash classpath-resources, so the warning baseline can't be cleanly triaged from a dev machine. Splint fail-loud tightening lives in a follow-on bead once the warnings can be sliced from a CI run.

## What's in the `.clj-kondo/config.edn`

- `:lint-as` mappings for every reg-* macro → `clojure.core/do` (registration calls, not Vars). Same for Story's seven authoring macros.
- `:lint-as helix.core/defnc / defnc-` → `clojure.core/defn{,-}` and `uix.core/defui` → `clojure.core/defn` so the Helix + UIx examples surface their component bindings.
- `:unresolved-var` exclusions for the user-facing reg-* family — the Vars are defined via the `defreg-macro` meta-macro that kondo can't statically trace.
- `:redundant-do` off (consequence of the `do`-shape lint-as) and `:inline-def` off (rewritten reg-view inside `(testing ...)` blocks reads as inline-def; the linter's signal here is dominated by the rewrite).

## Macro hooks (`.clj-kondo/hooks/re_frame/core.clj`)

- `reg-view` — rewrites `(reg-view sym [args] body)` into a defn-shape that exposes the auto-injected lexical `dispatch` / `subscribe` bindings.
- `with-frame` — handles both `(with-frame :keyword body+)` and `(with-frame [sym expr] body+)`; the binding-vector shape surfaces the lexical `sym`.

## Source fixes for the residual 25 errors

| Site | Fix |
| --- | --- |
| trace_test.clj + epoch_test.clj | `:no/such/event` / `:no/such/frame` → `:no.such/...` (parser-rejected multi-slash keyword → semantically-identical dot-form) |
| ssr_conformance_test.clj + ssr_streaming_conformance_test.clj + ssr-streaming.edn fixture | `:ssr/streaming/{render-shell,render-continuation,build-final-payload}` → `:ssr.streaming/...` (same rationale) |
| util_json.cljc | Drop the empty `:cljs (:require)` form |
| summary.cljs | Drop the empty `(:require)` ns form |
| lazy_summary_test.cljs | Fix arity-0 `#(...)` predicate fed to `map` — promoted to `(fn [_] ...)` |
| runner_events.cljc | Drop the bogus second arg from a `remove` predicate |
| boot_test.clj | `#_:clj-kondo/ignore` the deliberate 0-arg `(rf/init!)` (the test asserts the ArityException) |
| test_helpers.cljc | `#_:clj-kondo/ignore` the Form-3 render branch (kondo can't refine `render-fn`'s type through a `cond`+`some?` guard) |
| reagent2/ratom.cljs | `#_:clj-kondo/ignore` the recursive `pr-writer` dispatch (private by CLJS packaging, documented entrypoint for nested `IPrintWithWriter`) |
| machine_canvas.cljs | Promote `view-mode-toggle` from `defn-` to `defn` — sibling `machine_inspector` panel already reached the private symbol |
| static/shell_cljs_test.cljs | Pass `nil` to `(shell/ribbon)` — the reg-view registers with a 1-arg `[_props]` signature |

## CI gate diff

```yaml
clj-kondo:
  name: clj-kondo (fail on errors, warnings informational)
- continue-on-error: true
  ...
  - name: Run clj-kondo
    run: |
      clj-kondo \
        --parallel \
+       --fail-level error \
        --lint implementation \
        ...
-       || true
```

## Test plan

- [x] `clj-kondo --fail-level error <surface>` — exit 0 / 0 errors / ~650 warnings.
- [x] `npm run test:cljs` — 3830 tests / 11707 assertions / 0 failures.
- [x] `clojure -M:test` on implementation/{core,epoch,ssr,http} + tools/{causa,story} — all green.
- [x] `npm run test:elision` — production elision probe passes 35/35 absent.
- [ ] CI lint job green (kondo blocking on ERRORs only, Splint still report-only).
- [ ] CI test workflows green.

## Follow-ups

- Splint baseline triage + fail-loud gate — needs a separate bead so it can be run from a CI environment (Linux) where Splint's config-loader doesn't choke on classpath-resource path separators.