### PR TITLE
feat(causa): adopt binaryage/cljs-devtools formatters in EDN widget (rf2-gycfj)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -426,6 +426,36 @@ const ARTEFACTS = [
     consumerAllowList: null,
     expectedAllowListHits: 0,
   },
+
+  // binaryage/cljs-devtools — the Chrome custom-formatters library
+  // Causa's EDN widget adopts for value-rendering
+  // (tools/causa/src/.../views/edn_widget/cljs_devtools_render.cljs).
+  // Same posture as xyflow + elkjs: dev-only, consumed only by tools/
+  // (Causa), gated behind the Causa `:devtools/preloads`. Production
+  // bundles MUST NOT pull cljs-devtools — the formatters body weighs
+  // tens of kilobytes and gives consumers no runtime benefit (Chrome's
+  // console isn't relevant to end users).
+  //
+  // Sentinels are distinctive identifiers from cljs-devtools' internal
+  // namespaces. `devtools.formatters.markup` is the ns that emits
+  // JSONML; `devtools_formatters$markup` is its munged form under
+  // :advanced. The literal namespace-name string appears in
+  // cljs-devtools' source body (in ex-info contexts, in goog.provide
+  // calls, in the prefs map). A non-zero hit means cljs-devtools' body
+  // got pulled into the bundle — most likely a `:require` slipped from
+  // tools/causa/* into implementation/*, or the EDN widget got
+  // referenced outside the Causa preload-gated tree.
+  {
+    name: 'cljs-devtools',
+    internalSentinels: [
+      // The namespace name as a literal string — appears in
+      // cljs-devtools' goog.provide-equivalent and prefs metadata.
+      { source: 'binaryage/cljs-devtools formatters namespace (devtools.formatters)',
+        sentinel: 'devtools.formatters' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -149,7 +149,13 @@
                 [metosin/malli     "0.20.1"]
                 [com.pitch/uix.core "1.4.4"]
                 [com.pitch/uix.dom  "1.4.4"]
-                [lilactown/helix   "0.2.2"]]
+                [lilactown/helix   "0.2.2"]
+                ;; binaryage/devtools — Causa's EDN widget value-rendering
+                ;; layer (rf2-gycfj). Dev-only; the bundle-isolation gate
+                ;; verifies `devtools.formatters` does not reach production
+                ;; bundles. See tools/causa/deps.edn for the artefact-side
+                ;; rationale.
+                [binaryage/devtools "1.0.7"]]
 
  ;; Top-level dev-http servers (rf2-aqcix). shadow-cljs's `:dev-http`
  ;; map binds a port to a list of file roots; the dev server cascades

--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -128,7 +128,27 @@
          ;; adapter governs the render path; the slim dep here is purely
          ;; transitive-classpath assembly so Causa's published artefact
          ;; carries an adapter on the consumer side.
-         day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}}
+         day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
+
+         ;; binaryage/devtools — Chrome custom-formatters library that
+         ;; the EDN widget's value-rendering layer adopts (see
+         ;; views/edn_widget/cljs_devtools_render.cljs). Causa wraps
+         ;; `devtools.formatters.core/header-api-call` on a CLJS value
+         ;; to obtain the same coloured, structure-aware JSONML the
+         ;; Chrome DevTools console renders, then walks it into hiccup
+         ;; via a small adapter (modelled on re-frame-10x's same-named
+         ;; component). Faithful CLJS-aware rendering: records keep
+         ;; their type tag, persistent collections render with their
+         ;; native delimiters, metadata is annotated, and datafy/nav
+         ;; flows through `devtools.formatters` when applicable.
+         ;;
+         ;; Causa is dev-only (gated by `:devtools/preloads` in
+         ;; shadow-cljs) so this dep does NOT land in production
+         ;; bundles. The bundle-isolation gate
+         ;; (scripts/check-bundle-isolation.cjs) verifies the
+         ;; `devtools.formatters` ns body does not appear in the counter
+         ;; example's :advanced release bundle.
+         binaryage/devtools {:mvn/version "1.0.7"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render.cljs
@@ -1,0 +1,262 @@
+(ns day8.re-frame2-causa.views.edn-widget.cljs-devtools-render
+  "Adapter from `binaryage/cljs-devtools`'s formatters API onto Causa's
+  pure-hiccup rendering surface (rf2-gycfj).
+
+  ## What this gives us
+
+  `devtools.formatters.core/header-api-call` is the same entry point
+  Chrome DevTools invokes when it renders a CLJS value in the console.
+  Output is JSONML — a hiccup-shaped JS-array tree carrying
+  syntax-coloured spans for keywords / strings / numbers / records,
+  with `[\"object\" {...}]` placeholders where the user would expand
+  a nested structure.
+
+  Adopting this engine (rather than continuing to hand-roll the leaf
+  renderer Causa shipped through Phase 1) gives us the curated CLJS
+  knowledge `binaryage/cljs-devtools` accrued over a decade: records
+  keep their type tag, persistent collections render with their
+  native delimiters, metadata is annotated, `datafy`/`nav` flows
+  through when the value implements it, IRecord vs IMap is faithfully
+  preserved. Same engine re-frame-10x adopted for the same reason.
+
+  ## What this is NOT
+
+  - **Not** a registration of Chrome's custom formatters. We never
+    call `(devtools.core/install!)`; this ns only INVOKES the markup
+    builders. The console's formatter story is orthogonal.
+  - **Not** a replacement for Causa's diff engine. The diff machinery
+    in `data-display/render` walks CLJS values pairwise, paints the
+    §10.3 gutter glyphs, and threads the sticky expansion state
+    through `:rf.causa/data-display-expansion`. cljs-devtools knows
+    nothing about any of that — it operates on a single value.
+    Callers that want diff stay on `render-tree`; cljs-devtools
+    handles the LEAF rendering inside that engine and the
+    `mini` one-liner.
+  - **Not** a substrate adapter call. Hiccup out, no React/Reagent
+    requires.
+
+  ## API
+
+  - `value->hiccup` — render a CLJS value as hiccup using
+    cljs-devtools' formatters. Top-level entry; never expands
+    `[\"object\" ...]` placeholders (those render as a `▶ {…}`
+    summary). Suitable for non-collection leaves and for the
+    `mini` one-liner.
+  - `jsonml->hiccup` — pure JSONML walker; public for tests.
+
+  ## Posture
+
+  Pure hiccup; substrate-agnostic. Dev-only — Causa's preload gate
+  keeps `devtools.formatters` out of production bundles per the
+  bundle-isolation contract (`tools/README.md`)."
+  (:require [clojure.string :as str]
+            [devtools.formatters.core :as formatters]
+            [devtools.prefs :as devtools-prefs]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack]]))
+
+;; ---- prefs ---------------------------------------------------------------
+;;
+;; cljs-devtools ships sensible default prefs but they bake assumptions
+;; about Chrome's console (border-left rules, item-style padding) that
+;; clash with Causa's in-page chrome. We override the chrome bits below
+;; to defer to Causa's theme tokens; the rest (token classification,
+;; collection delimiters, IRecord handling, metadata rendering) we
+;; inherit unchanged.
+;;
+;; `body-style` / `cljs-land-style` are CSS strings cljs-devtools
+;; embeds into its JSONML attribute maps. Setting them to empty strings
+;; removes the inline rules and lets our parent container's tokens win.
+
+(def ^:private causa-prefs
+  "Causa overrides on cljs-devtools' default prefs. Hide the index tags
+  (we render flat collection content); zero out the body/cljs-land
+  background+padding so the rendered JSONML inherits our parent
+  container's `:bg-2` + monospace stack rather than cljs-devtools'
+  console defaults; lift the depth budget so deeply-nested app-db
+  values render in full."
+  {:index-tag                      [:span :none-style]
+   :none-style                     "display:none;"
+   :item-style                     "display:inline-block;white-space:nowrap;padding:0;margin:0;"
+   :body-style                     "display:inline-block;padding:0;margin:0;border:0;"
+   :cljs-land-style                ""
+   :initial-hierarchy-depth-budget false})
+
+(defn- with-prefs
+  "Run `f` with the Causa-overridden cljs-devtools prefs swapped in,
+  restoring the previous prefs after. Mirrors re-frame-10x's
+  `with-cljs-devtools-prefs` macro at runtime (no macro needed — we
+  swap once at the boundary, render, swap back). Defensive try/finally
+  so an exception inside the markup builder never leaves global prefs
+  in the Causa-overridden state."
+  [f]
+  (let [previous (devtools-prefs/get-prefs)]
+    (try
+      (devtools-prefs/set-prefs! (merge previous causa-prefs))
+      (f)
+      (finally
+        (devtools-prefs/set-prefs! previous)))))
+
+;; ---- JSONML → hiccup walker ---------------------------------------------
+;;
+;; JSONML shape (per Chrome's Custom Object Formatters spec):
+;;
+;;     ["tag-name" attrs-js-obj child ... child]
+;;
+;; where `tag-name` is a string ("div", "span", "object", "annotation"
+;; for cljs-devtools' path annotations), `attrs-js-obj` is a plain JS
+;; object (usually `{"style": "color:red;..."}` or for "object" carries
+;; `.object` + `.config` properties), and children are either numbers /
+;; strings / nested JSONML arrays.
+
+(defn- attrs-style->map
+  "Convert a JSONML inline-style string (`\"color:red;padding:2px;\"`)
+  into a hiccup `:style` map. Returns `{}` when no style is present."
+  [^js attrs]
+  (if-let [css (some-> attrs (.-style))]
+    (->> (str/split css #";")
+         (keep (fn [decl]
+                 (when-let [[prop value] (when-not (str/blank? decl)
+                                           (str/split decl #":" 2))]
+                   (when (and prop value)
+                     [(keyword (str/trim prop)) (str/trim value)]))))
+         (into {}))
+    {}))
+
+(def ^:private known-tags
+  "JSONML container tags cljs-devtools emits. We map each onto the
+  matching hiccup keyword so the resulting tree renders verbatim."
+  #{"div" "span" "ol" "li" "table" "tr" "td"})
+
+(declare jsonml->hiccup)
+
+(defn- render-object-placeholder
+  "Render an `[\"object\" {object: v, config: c}]` JSONML node as an
+  inline `▶ <header>` summary. We don't expand inline (Causa's diff
+  engine + `data-display/render` own the expansion contract for
+  collections in `browse`/`diff`; `value->hiccup` is used for LEAVES
+  and the `mini` one-liner). The summary keeps the visual signal —
+  user sees \"there's nested structure here\" — without committing
+  to an expansion state."
+  [obj]
+  ;; cljs-devtools' object placeholder carries `.object` (the value)
+  ;; and `.config`. We render a single ▶ + the header markup of the
+  ;; object so the row remains informative.
+  (let [^js o obj
+        v    (some-> o .-object)
+        cfg  (some-> o .-config)]
+    [:span {:style {:font-family mono-stack
+                    :color       (:text-secondary tokens)}}
+     [:span {:style {:color (:text-tertiary tokens)
+                     :margin-right "2px"}}
+      "▸"]
+     ;; Render the *header* of the nested object recursively. The
+     ;; recursion terminates because cljs-devtools only emits "object"
+     ;; nodes for collection-shaped values, and the header of a
+     ;; collection is the one-line `{...}` summary (no further
+     ;; "object" children).
+     (let [inner (try
+                   (formatters/header-api-call v cfg)
+                   (catch :default _ nil))]
+       (when (some? inner)
+         [:span (jsonml->hiccup inner)]))]))
+
+(defn jsonml->hiccup
+  "Pure walker — convert JSONML to hiccup. Public for tests.
+
+  Numbers / strings pass through verbatim (CLJS keeps them as plain
+  values; hiccup renders them as text children). JS arrays whose first
+  element is a known container tag become the equivalent hiccup vector.
+  `object` placeholders render via `render-object-placeholder`.
+  `annotation` (cljs-devtools' path-marker) wraps its children in a
+  bare `[:span]`."
+  [jsonml]
+  (cond
+    (nil? jsonml)     nil
+    (number? jsonml)  jsonml
+    (string? jsonml)  jsonml
+    (boolean? jsonml) (str jsonml)
+    ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
+    ;; `array?` predicate identifies the JS array shape.
+    (array? jsonml)
+    (let [tag-name   (aget jsonml 0)
+          attrs      (aget jsonml 1)
+          child-cnt  (.-length jsonml)]
+      (cond
+        (contains? known-tags tag-name)
+        (let [style (attrs-style->map attrs)
+              base  [(keyword tag-name)
+                     {:style (assoc style :font-family mono-stack)}]]
+          (loop [i 2 acc base]
+            (if (>= i child-cnt)
+              acc
+              (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i)))))))
+
+        (= tag-name "object")
+        (render-object-placeholder attrs)
+
+        (= tag-name "annotation")
+        (loop [i 2 acc [:span {}]]
+          (if (>= i child-cnt)
+            acc
+            (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i))))))
+
+        :else
+        ;; Unknown tag — fall back to a plain span so the markup
+        ;; doesn't disappear silently.
+        (loop [i 2 acc [:span {}]]
+          (if (>= i child-cnt)
+            acc
+            (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i))))))))
+
+    ;; Some JSONML producers wrap their content in a CLJS vector
+    ;; instead of a JS array (e.g. when re-routed through edn->js).
+    ;; Walk those too.
+    (vector? jsonml)
+    (let [[tag-name attrs & children] jsonml]
+      (cond
+        (contains? known-tags tag-name)
+        (let [style (attrs-style->map attrs)]
+          (into [(keyword tag-name)
+                 {:style (assoc style :font-family mono-stack)}]
+                (map jsonml->hiccup)
+                children))
+
+        (= tag-name "object") (render-object-placeholder attrs)
+
+        :else (into [:span {}] (map jsonml->hiccup) children)))
+
+    :else
+    (try (pr-str jsonml) (catch :default _ (str jsonml)))))
+
+;; ---- public entry --------------------------------------------------------
+
+(defn value->hiccup
+  "Render a CLJS `value` as hiccup via cljs-devtools' formatters.
+  Returns hiccup — substrate-agnostic, no Reagent/React/UIx in scope.
+
+  The output renders inline (a `[:span ...]`) — cljs-devtools' header
+  markup is a one-line summary. Use for leaves, chips, and the `mini`
+  one-liner; for full expandable trees, the diff/browse engine in
+  `data-display/render` owns the contract."
+  [value]
+  (try
+    (with-prefs
+      (fn []
+        (let [jsonml (formatters/header-api-call value nil)]
+          (if (nil? jsonml)
+            ;; cljs-devtools returns nil for values it considers
+            ;; uninteresting (the rare scalar surfaces that aren't
+            ;; cljs-typed — plain JS objects passed through, e.g.).
+            ;; Fall back to pr-str so the leaf still renders.
+            [:span {:style {:font-family mono-stack
+                            :color       (:text-primary tokens)}}
+             (try (pr-str value) (catch :default _ (str value)))]
+            (jsonml->hiccup jsonml)))))
+    (catch :default _
+      ;; Defensive — any throw in cljs-devtools' markup builder
+      ;; degrades gracefully to a pr-str leaf rather than crashing
+      ;; the panel.
+      [:span {:style {:font-family mono-stack
+                      :color       (:text-primary tokens)}}
+       (try (pr-str value) (catch :default _ (str value)))])))

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.views.edn-widget.widget
-  "Canonical Causa EDN widget (rf2-9wsdy, Mike-direction 2026-05-21).
+  "Canonical Causa EDN widget — Mike-direction 2026-05-21
+  (`cljs-devtools EDN widget`).
 
   ## Purpose
 
@@ -9,22 +10,30 @@
   operator learns one expand/collapse + path-click + diff interaction
   and applies it everywhere.
 
-  ## Adoption
+  ## Two engines, one facade
 
-  The widget is a thin Reagent-agnostic facade on top of the existing
-  `data-display/render` engine (rf2-jgip1) which already implements the
-  lazy collapsible tree, sticky per-node expansion, diff gutters,
-  keyword-violet type coloring, click-to-navigate path segments, and
-  the §10.7 evicted-epoch placeholder. The facade exists so call sites
-  address ONE widget by name (Mike's 2026-05-21 design direction —
-  `cljs-devtools EDN widget`) regardless of how the engine evolves
-  underneath.
+  The widget is a thin Reagent-agnostic facade over two cooperating
+  engines:
 
-  Per the bead's variant taxonomy:
+  1. **`data-display/render`** — Causa's tree walker (collapsible,
+     diff-aware, path-clickable). Owns the contract for `browse` +
+     `diff` because diff semantics are pairwise over the CLJS values,
+     and sticky expansion lives in `:rf.causa/data-display-expansion`.
+     Neither concern is in scope for cljs-devtools.
 
-    `browse` — single-value tree (default; `:variant :browse`)
-    `diff`   — before/after tree (`:variant :diff` · `:before` slot)
-    `mini`   — one-liner inline (`:variant :mini` · for chips + rows)
+  2. **`cljs-devtools-render`** — `binaryage/cljs-devtools`'s
+     formatters, the same engine re-frame-10x uses, walked into hiccup
+     by a small JSONML→hiccup adapter (Phase 1 hand-rolled a per-leaf
+     classifier and stopped at primitive shapes; that stand-in is
+     gone). Owns the CLJS-aware rendering for non-collection leaves +
+     the `mini` one-liner: records keep their type tag, persistent
+     collections render with native delimiters, metadata gets the
+     `^{...}` annotation, IRecord vs IMap is distinguished. Faithful
+     CLJS-aware rendering — records · persistent-collections · meta ·
+     datafy/nav.
+
+  Callers don't see the split — they call `browse` / `diff` / `mini` /
+  `code-block` and the facade routes.
 
   ## Public API
 
@@ -46,40 +55,52 @@
 
   ## Posture
 
-  Pre-alpha · NO back-compat shims · dev-only · the underlying engine
-  must not leak into production bundles (bundle-isolation gate holds —
-  Causa as a whole is `:devtools/preloads`-gated).
-
-  ## Why not cljs-devtools formatters yet
-
-  Mike's direction names cljs-devtools as the formatter library; the
-  binaryage/cljs-devtools artefact would register Chrome
-  custom-formatters so opening DevTools' console sees pretty CLJS
-  values. That is complementary — it improves the console story, not
-  the in-Causa rendering surface. The in-DOM widget here delivers the
-  pixel contract Mike sketched; a follow-on bead can layer the
-  cljs-devtools console formatters on the same dep when needed."
+  Pre-alpha · NO back-compat shims · dev-only · bundle-isolated. The
+  cljs-devtools dep is Causa-only; the `:devtools/preloads` gate keeps
+  it out of production bundles per the contract in `tools/README.md`."
   (:require [clojure.string :as str]
             [day8.re-frame2-causa.data-display.render :as data-display]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack]]))
+             :refer [tokens mono-stack]]
+            [day8.re-frame2-causa.views.edn-widget.cljs-devtools-render
+             :as cdt]))
 
 ;; ---- variant: browse -----------------------------------------------------
 
+(defn- collection-value?
+  "True when `v` is a collection — anything `data-display/render-tree`'s
+  tree walker treats as a node with children (map / vector / list / set).
+  Non-collections route through cljs-devtools' single-value formatter."
+  [v]
+  (or (map? v) (vector? v) (set? v) (sequential? v)))
+
 (defn browse
-  "Render `:value` as a path-aware expand/collapse tree. Browse mode —
-  no diff semantics. Returns hiccup.
+  "Render `:value` as a path-aware expand/collapse tree (collections)
+  or as a single cljs-devtools-formatted hiccup span (non-collection
+  leaves). Browse mode — no diff semantics. Returns hiccup.
 
   Required: `:value :panel-id :render-id`.
   Optional: `:default-depth` (defaults to 2 per §10.4)."
   [{:keys [value panel-id render-id default-depth]
     :or   {default-depth 2}}]
-  (data-display/render-tree
-    {:value         value
-     :diff?         false
-     :panel-id      panel-id
-     :render-id     render-id
-     :default-depth default-depth}))
+  (if (collection-value? value)
+    (data-display/render-tree
+      {:value         value
+       :diff?         false
+       :panel-id      panel-id
+       :render-id     render-id
+       :default-depth default-depth})
+    ;; Non-collection — record / scalar / function / etc. cljs-devtools
+    ;; owns the leaf shape (type tag, metadata, IRecord chrome).
+    [:div {:data-testid (str "rf-causa-edn-widget-browse-"
+                             (name (or panel-id :unknown))
+                             "-"
+                             (str (or render-id "")))
+           :style {:font-family mono-stack
+                   :font-size   "12px"
+                   :color       (:text-primary tokens)
+                   :line-height 1.4}}
+     (cdt/value->hiccup value)]))
 
 ;; ---- variant: diff -------------------------------------------------------
 
@@ -88,6 +109,11 @@
   the §10.3 gutter glyphs (+ added / - removed / ~ modified / ◴ has
   changed descendant) and a `← changed from <prior>` chip on modified
   leaves. Returns hiccup.
+
+  Diff semantics live in `data-display/render-tree` — the engine walks
+  before/after pairwise and threads diff-op classification through the
+  tree. cljs-devtools doesn't know about diff (it operates on a single
+  value), so diff stays here.
 
   Required: `:before :after :panel-id :render-id`.
   Optional: `:default-depth` (defaults to 2 per §10.4)."
@@ -104,35 +130,52 @@
 ;; ---- variant: mini -------------------------------------------------------
 
 (defn mini
-  "One-liner inline rendering of `value`. No expansion, no diff — used
-  in chip rows / table cells where the full tree would crowd the
-  layout. Returns hiccup `[:span ...]` shape so callers can embed
-  inline.
+  "One-liner inline rendering of `value` via cljs-devtools' formatters.
+  No expansion, no diff — used in chip rows / table cells where the
+  full tree would crowd the layout. Returns hiccup `[:span ...]` shape
+  so callers can embed inline.
 
-  Truncates at `max-len` (default 80) — long values get an ellipsis
-  plus the full value in the title attribute so hover reveals the full
-  pr-str."
+  When the formatter's coloured-span output renders longer than the
+  caller's pixel budget the parent's `text-overflow: ellipsis` kicks
+  in via the surrounding container; we still cap raw `pr-str` length
+  in the `:title` attribute so hover reveals up to `max-len` characters
+  of the underlying value."
   ([value] (mini value 80))
   ([value max-len]
-   (let [s   (try (pr-str value) (catch :default _ (str value)))
-         len (count s)
-         out (if (<= len max-len) s (str (subs s 0 max-len) "…"))]
+   (let [pr        (try (pr-str value) (catch :default _ (str value)))
+         truncated (if (<= (count pr) max-len)
+                     pr
+                     (str (subs pr 0 max-len) "…"))]
      [:span {:data-testid "rf-causa-edn-widget-mini"
-             :title       s
+             :title       pr
              :style       {:font-family mono-stack
                            :font-size   "11px"
                            :color       (:text-primary tokens)
                            :white-space "nowrap"
                            :overflow    "hidden"
-                           :text-overflow "ellipsis"}}
-      out])))
+                           :text-overflow "ellipsis"
+                           :max-width   "100%"
+                           :display     "inline-block"
+                           :vertical-align "bottom"}
+             ;; A `data-pr` attribute carries the raw pr-str so test
+             ;; assertions + a11y readers can still reach the value
+             ;; even when the visible content is cljs-devtools markup.
+             :data-pr     truncated}
+      (cdt/value->hiccup value)])))
 
 ;; ---- code-block (handler / interceptor source rendering) ----------------
+;;
+;; `code-block` renders Clojure SOURCE TEXT, not a CLJS value, so the
+;; cljs-devtools formatters API doesn't apply (it operates on live
+;; values, not strings). We keep a small in-bundle Clojure tokenizer
+;; for source rendering — ~30 LoC, zero deps, sufficient for the
+;; handler-source snippets the Event panel renders.
 
 (defn highlight-clojure-token
-  "Per-token colour resolution for the bundled lightweight Clojure
-  syntax highlighter. Pure data -> token-keyword for the token-type
-  classification. Public for unit tests."
+  "Per-token colour resolution for the in-bundle Clojure syntax
+  highlighter (source-text rendering only; CLJS-value rendering goes
+  through `cljs-devtools-render`). Pure data → token-keyword for the
+  token-type classification. Public for unit tests."
   [tok-type]
   (case tok-type
     :keyword  :accent-violet
@@ -145,7 +188,7 @@
     :text-primary))
 
 (def clojure-builtins
-  "Recognised Clojure builtins for the in-bundle lightweight
+  "Recognised Clojure builtins for the in-bundle source-text
   highlighter. Public so tests can assert membership."
   #{"def" "defn" "defn-" "defmacro" "let" "if" "when" "when-not"
     "cond" "case" "do" "loop" "recur" "fn" "fn*" "reify"
@@ -156,10 +199,10 @@
     "->" "->>" "some->" "some->>"})
 
 (defn classify-token
-  "Classify a Clojure token literal string. Pure fn; lightweight —
-  handles the cases that matter for handler-source rendering
-  (keywords, strings, numbers, comments, parens, builtins, plain
-  symbols)."
+  "Classify a Clojure source-text token literal string. Pure fn;
+  lightweight — handles the cases that matter for handler-source
+  rendering (keywords, strings, numbers, comments, parens, builtins,
+  plain symbols)."
   [s]
   (cond
     (str/blank? s)                            :whitespace
@@ -176,11 +219,7 @@
   "Split a Clojure source string into a vector of `[token-type
   literal]` pairs. Pure fn; greedy single-pass tokenizer good enough
   for the inline-source rendering. Strings + comments are matched
-  before symbols so they capture greedily.
-
-  This is intentionally lightweight — re-frame handlers are typically
-  short. A heavier highlight.js integration could land via a follow-on
-  bead; for now this keeps the bundle small and CSS-free."
+  before symbols so they capture greedily."
   [src]
   (loop [acc [] s src]
     (cond
@@ -228,8 +267,9 @@
 
 (defn code-block
   "Render `:source` as a syntax-highlighted code block. Pure hiccup —
-  Clojure-only highlighter (lightweight bundled tokenizer; cljs-devtools
-  + a heavier highlight.js can land in a follow-on bead).
+  Clojure-only highlighter for source-text strings (cljs-devtools
+  operates on live CLJS values, not source text, so it doesn't apply
+  here).
 
   Required: `:source`.
   Optional: `:lang` (defaults to `:clojure` — only `:clojure` highlights

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render_cljs_test.cljs
@@ -1,0 +1,170 @@
+(ns day8.re-frame2-causa.views.edn-widget.cljs-devtools-render-cljs-test
+  "Tests for the cljs-devtools formatters → hiccup adapter.
+
+  ## What's under test
+
+  1. **`value->hiccup` for primitives** — keyword / string / number /
+     nil / boolean / symbol each produce some kind of `[:span ...]`
+     hiccup tree (the exact colour/structure is cljs-devtools' to
+     decide; we only assert the shape contract holds).
+  2. **`value->hiccup` for collections** — maps / vectors / sets /
+     lists produce hiccup with at least one nested coloured span
+     (rather than degrading to a `pr-str` string fallback).
+  3. **Records** — `defrecord`-typed values produce hiccup carrying
+     the type tag in some descendant span. This is the core 'faithful
+     CLJS-aware rendering' guarantee the bead calls out.
+  4. **`jsonml->hiccup` pure walker** — known tag names map to the
+     equivalent hiccup keyword; nested children walk recursively.
+  5. **Defensive fallback** — values cljs-devtools refuses to format
+     still produce hiccup (never throw, never return nil).
+
+  Pure-data scope — no DOM mount; hiccup-shape assertions only."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.views.edn-widget.cljs-devtools-render
+             :as cdt]))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- walk-hiccup
+  [tree]
+  (let [out (atom [])]
+    (letfn [(walk [node]
+              (when (vector? node)
+                (swap! out conj node)
+                (doseq [child (rest node)]
+                  (cond
+                    (vector? child) (walk child)
+                    (seq? child)    (doseq [c child] (walk c))))))]
+      (walk tree))
+    @out))
+
+(defn- contains-text?
+  "True when some string descendant of `tree` contains `s`, OR some
+  number/boolean descendant stringifies to `s`. cljs-devtools' JSONML
+  renders numeric leaves as JS numbers (not strings), so the walker
+  must inspect both."
+  [tree s]
+  (let [hit (atom false)
+        re  (re-pattern s)]
+    (letfn [(scan [n]
+              (cond
+                (string? n)  (when (re-find re n) (reset! hit true))
+                (number? n)  (when (re-find re (str n)) (reset! hit true))
+                (boolean? n) (when (re-find re (str n)) (reset! hit true))
+                (vector? n)  (doseq [c (rest n)] (scan c))
+                (seq? n)     (doseq [c n] (scan c))))]
+      (scan tree))
+    @hit))
+
+;; ---- primitives ---------------------------------------------------------
+
+(deftest value-to-hiccup-keyword-shape
+  (let [out (cdt/value->hiccup :foo/bar)]
+    (testing "keyword produces hiccup vector"
+      (is (vector? out)))
+    (testing "the rendered tree contains the keyword text"
+      (is (contains-text? out ":foo/bar")))))
+
+(deftest value-to-hiccup-string-shape
+  (let [out (cdt/value->hiccup "hello")]
+    (is (vector? out))
+    (is (contains-text? out "hello"))))
+
+(deftest value-to-hiccup-number-shape
+  (let [out (cdt/value->hiccup 42)]
+    (is (vector? out))
+    (is (or (contains-text? out "42")
+            ;; cljs-devtools may render the number as a JS number child
+            ;; rather than a string — accept either by walking the tree
+            ;; for a numeric leaf.
+            (some #(and (number? %) (= 42 %))
+                  (mapcat rest (walk-hiccup out)))))))
+
+(deftest value-to-hiccup-nil-shape
+  (let [out (cdt/value->hiccup nil)]
+    (is (vector? out))
+    (is (contains-text? out "nil"))))
+
+(deftest value-to-hiccup-boolean-shape
+  (let [out (cdt/value->hiccup true)]
+    (is (vector? out))
+    (is (contains-text? out "true"))))
+
+;; ---- collections --------------------------------------------------------
+
+(deftest value-to-hiccup-map-shape
+  (let [out (cdt/value->hiccup {:a 1 :b 2})]
+    (testing "map produces hiccup with coloured spans for each key/value"
+      (is (vector? out))
+      ;; At least one nested :span beyond the root.
+      (let [spans (walk-hiccup out)]
+        (is (some #(and (vector? %) (= :span (first %))) (rest spans)))))))
+
+(deftest value-to-hiccup-vector-shape
+  (let [out (cdt/value->hiccup [1 2 3])]
+    (is (vector? out))
+    (is (contains-text? out "1"))))
+
+(deftest value-to-hiccup-set-shape
+  (let [out (cdt/value->hiccup #{:a :b})]
+    (is (vector? out))
+    ;; Either keyword is acceptable — set ordering isn't guaranteed.
+    (is (or (contains-text? out ":a") (contains-text? out ":b")))))
+
+(deftest value-to-hiccup-list-shape
+  (let [out (cdt/value->hiccup '(1 2 3))]
+    (is (vector? out))))
+
+;; ---- records ------------------------------------------------------------
+
+(defrecord TestPoint [x y])
+
+(deftest value-to-hiccup-record-preserves-type-tag
+  (let [pt  (->TestPoint 3 4)
+        out (cdt/value->hiccup pt)
+        all (apply str (filter string? (mapcat rest (walk-hiccup out))))]
+    (testing "record value carries its type tag in the rendered output"
+      (is (vector? out))
+      ;; cljs-devtools includes the record's munged or readable type
+      ;; tag in the rendered hiccup. Accept either the readable name
+      ;; ('TestPoint') or the field text — what we want to confirm is
+      ;; that it's NOT just a plain '{}' map rendering.
+      (is (or (re-find #"TestPoint" all)
+              (re-find #":x" all)
+              (re-find #":y" all))
+          "record rendering surfaces type tag or fields"))))
+
+;; ---- jsonml->hiccup pure walker -----------------------------------------
+
+(deftest jsonml-passes-through-number-and-string
+  (is (= 42 (cdt/jsonml->hiccup 42)))
+  (is (= "hi" (cdt/jsonml->hiccup "hi"))))
+
+(deftest jsonml-nil-is-nil
+  (is (nil? (cdt/jsonml->hiccup nil))))
+
+(deftest jsonml-vector-shape-walked
+  ;; cljs-devtools emits JS arrays at runtime, but the walker also
+  ;; accepts CLJS vectors (defensive). Use the vector path here so
+  ;; the test is JVM-portable and doesn't need a real JS array.
+  (let [out (cdt/jsonml->hiccup ["span" #js {} "x"])]
+    (testing "vector with known tag maps to hiccup keyword"
+      (is (= :span (first out))))
+    (testing "children walk through"
+      (is (some #{"x"} (rest out))))))
+
+(deftest jsonml-unknown-tag-falls-back-to-span
+  (let [out (cdt/jsonml->hiccup ["mystery" #js {} "child"])]
+    (testing "unknown tag becomes a bare [:span ...]"
+      (is (= :span (first out)))
+      (is (some #{"child"} (rest out))))))
+
+;; ---- defensive fallback -------------------------------------------------
+
+(deftest value-to-hiccup-never-throws-for-unusual-input
+  (testing "JS object passes through without throwing"
+    (let [out (cdt/value->hiccup #js {:foo 1})]
+      (is (vector? out))))
+  (testing "function passes through without throwing"
+    (let [out (cdt/value->hiccup (fn [_]))]
+      (is (vector? out)))))

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -1,16 +1,21 @@
 (ns day8.re-frame2-causa.views.edn-widget.widget-cljs-test
-  "Tests for the canonical Causa EDN widget (rf2-9wsdy).
+  "Tests for the canonical Causa EDN widget.
 
   ## What's under test
 
   1. **Variant dispatch** — `browse` / `diff` / `mini` / `render` route
-     to the right underlying engine call shape.
+     to the right underlying engine call shape. `browse` of a
+     collection routes through `data-display/render-tree`; `browse` of
+     a non-collection routes through `cljs-devtools-render`; `mini`
+     always routes through `cljs-devtools-render`.
   2. **Code-block tokenizer** — `tokenize-clojure` classifies keywords,
      strings, numbers, parens, builtins, and plain symbols correctly.
+     This is the source-text highlighter (not CLJS-value rendering;
+     cljs-devtools owns values, this tokenizer owns source strings).
   3. **Code-block rendering** — `code-block` returns the expected
      `[:pre [:code ...]]` shape with per-token colour spans.
-  4. **Mini truncation** — long values get the ellipsis + the full
-     value lands in the title attribute.
+  4. **Mini chrome** — `:title`, `:data-pr`, and `:data-testid`
+     attributes are set; long pr-str gets truncated in `:data-pr`.
 
   Pure-data scope — no DOM mount; hiccup-shape assertions only."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -43,23 +48,48 @@
 
 ;; ---- variant: browse -----------------------------------------------------
 
-(deftest browse-returns-tree-hiccup
+(deftest browse-of-collection-routes-through-data-display
   (let [out (w/browse {:value     {:a 1 :b 2}
                        :panel-id  :test
                        :render-id "browse-1"})]
-    (testing "browse returns a [:div ...] root with the panel-keyed data-testid"
+    (testing "browse of a map returns a [:div ...] root with the panel-keyed data-testid"
       (is (vector? out))
       (is (= :div (first out)))
       ;; The underlying render-tree stamps the panel-keyed root testid.
       (is (some? (find-by-testid out "rf-causa-data-display-test-browse-1"))))))
 
-(deftest browse-renders-keyword-value-in-violet
-  (let [out  (w/browse {:value     :foo/bar
+(defn- find-testid-prefix
+  "Return the first hiccup node whose :data-testid attr starts with
+  `prefix`. The engine's leaf-testid is dynamic
+  (`rf-causa-data-display-leaf-<path>`) so callers asserting that a
+  leaf rendered cannot match exactly."
+  [tree prefix]
+  (->> (walk-hiccup tree)
+       (filter (fn [n]
+                 (and (vector? n)
+                      (map? (second n))
+                      (let [id (get (second n) :data-testid)]
+                        (and (string? id)
+                             (.startsWith id prefix))))))
+       first))
+
+(deftest browse-of-collection-still-routes-keyword-leaf-to-engine
+  (let [out  (w/browse {:value     {:k :foo/bar}
                         :panel-id  :test
                         :render-id "kw-1"})
-        leaf (find-by-testid out "rf-causa-data-display-leaf-")]
-    (testing "browse routes through the canonical leaf renderer"
+        leaf (find-testid-prefix out "rf-causa-data-display-leaf-")]
+    (testing "map containing a keyword routes through the engine's leaf renderer"
       (is (some? leaf)))))
+
+(deftest browse-of-non-collection-routes-through-cljs-devtools
+  (let [out (w/browse {:value     :foo/bar
+                       :panel-id  :test
+                       :render-id "scalar-1"})]
+    (testing "non-collection browse returns a [:div ...] container"
+      (is (vector? out))
+      (is (= :div (first out)))
+      (is (some? (find-by-testid out
+                                 "rf-causa-edn-widget-browse-test-scalar-1"))))))
 
 ;; ---- variant: diff -------------------------------------------------------
 
@@ -75,23 +105,37 @@
 
 ;; ---- variant: mini -------------------------------------------------------
 
-(deftest mini-short-value-is-not-truncated
+(deftest mini-returns-span-shape
   (let [out (w/mini {:a 1})]
-    (testing "short pr-str fits — no ellipsis"
+    (testing "mini returns a [:span ...] with the canonical testid"
       (is (= :span (first out)))
-      (let [body (last out)]
-        (is (string? body))
-        (is (not (re-find #"…$" body)))))))
+      (is (= "rf-causa-edn-widget-mini"
+             (-> out second :data-testid))))))
 
-(deftest mini-long-value-is-truncated-and-title-carries-full
+(deftest mini-short-value-data-pr-not-truncated
+  (let [out   (w/mini {:a 1})
+        attrs (second out)]
+    (testing "short pr-str fits — no ellipsis in :data-pr"
+      (is (= (pr-str {:a 1}) (:title attrs)))
+      (is (not (re-find #"…$" (:data-pr attrs)))))))
+
+(deftest mini-long-value-data-pr-truncated-but-title-full
   (let [v   (zipmap (map #(keyword (str "key-" %)) (range 30))
                     (range 30))
         out (w/mini v 40)
         attrs (second out)]
-    (testing "ellipsis appended when over max-len"
-      (is (re-find #"…$" (last out))))
-    (testing "title attr carries the full pr-str"
+    (testing "ellipsis appended to :data-pr when over max-len"
+      (is (re-find #"…$" (:data-pr attrs))))
+    (testing ":title attr carries the full pr-str"
       (is (= (pr-str v) (:title attrs))))))
+
+(deftest mini-renders-cljs-devtools-markup-inside
+  (let [out   (w/mini :hello)
+        spans (walk-hiccup out)]
+    (testing "mini embeds cljs-devtools-rendered hiccup as children"
+      ;; cljs-devtools renders a keyword as a coloured span; we should
+      ;; see at least one nested :span under the outer :span.
+      (is (some #(and (vector? %) (= :span (first %))) (rest spans))))))
 
 ;; ---- code-block tokenizer ------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-gycfj (rf2-9wsdy follow-on).

## Summary

The Causa EDN widget's value-rendering layer now delegates to
`binaryage/cljs-devtools` for the non-collection cases —
the same engine re-frame-10x uses. Faithful CLJS-aware rendering:
records keep their type tag, persistent collections render with
native delimiters, metadata is annotated, IRecord vs IMap is
distinguished, `datafy`/`nav` flows through when applicable.

## What changed

- **New ns** `views/edn_widget/cljs_devtools_render.cljs` — wraps
  `devtools.formatters.core/header-api-call` and walks the JSONML
  into hiccup. Pure-data; substrate-agnostic.
- **`browse`** of a non-collection now routes through the new
  renderer; collections still flow through `data-display/render-tree`
  (diff semantics + sticky expansion are engine-owned).
- **`mini`** renders the value via cljs-devtools markup; `:title`
  + `:data-pr` attrs still carry the `pr-str` for a11y + tests.
- **`diff`** unchanged — the engine in `data-display/render` owns
  pairwise diff classification; cljs-devtools operates on a single
  value and has no diff vocabulary.
- **`code-block`** unchanged — it renders Clojure source TEXT, not
  CLJS values, so cljs-devtools doesn't apply.
- **Bundle-isolation gate** extended with a `cljs-devtools` sentinel
  (`devtools.formatters` literal) so production bundles can never
  pull the formatters body. Verified absent from the counter
  `:advanced` release bundle.

## Test plan

- [x] `npm run test:cljs` (3848 tests, 11740 assertions, 0 failures)
- [x] `clojure -M:test` from `tools/causa` (849 tests, 2769 assertions, 0 failures)
- [x] `npm run test:bundle-isolation` (15 artefact entries, 32 internal sentinels absent)
- [x] `npm run test:perf-bundle`
- [x] `npm run test:elision`
- [x] `npm run test:reagent-slim:bundle-isolation`
- [x] `mkdocs build --strict`

## Posture

Pre-alpha · no back-compat shims · dev-only. The cljs-devtools dep
is Causa-only; `:devtools/preloads` gate keeps it out of production.

## Consumers

The widget's public API (`browse` / `diff` / `mini` / `code-block`
/ `render`) is preserved — `panels/app_db_diff/`, `panels/trace/`,
`panels/event_detail`, machine inspector snapshot rendering all
continue to call the same surface.