### PR TITLE
docs(causa): author docs/causa/api/* mini-folder (rf2-bmaoz)

### DIFF
--- a/docs/causa/api/config-keys.md
+++ b/docs/causa/api/config-keys.md
@@ -1,0 +1,189 @@
+# Configuration keys
+
+This chapter is about the surfaces that tell Causa *how* to behave — which editor to open source-coords in, where the inline-host element lives in the DOM, whether to auto-open on boot, whether to surface sensitive trace events. The core of it is **one bulk-set entry point** — `configure!` — that takes a single map keyed by namespaced keywords, plus a parallel set of per-key setters for hosts that prefer to flip one knob at a time. The two surfaces are equivalent — `(configure! {:rf.causa/editor :cursor})` is identical to `(set-editor! :cursor)` — and you choose between them by ergonomics.
+
+Boot-time configuration is **process-global**: the setters write to `defonce` atoms inside `config.cljc`, and Causa's own subs / events read those atoms via getters. This means hosts call `configure!` once at boot, before Causa's preload auto-opens, and the resulting posture is fixed for the session. Settings persisted through the in-shell Settings popup live in a parallel slot in `localStorage`; the relationship between the two is documented at the end of this chapter under [§Boot-time config vs persisted Settings](#boot-time-config-vs-persisted-settings).
+
+## The bulk-set entry point
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level Causa configuration. Accepts a map keyed by `:rf.causa/*` (Causa-specific) and `:rf.privacy/*` (cross-tool) keys. Unknown keys are silently ignored (forward-compat — newer hosts passing older-Causa-unaware keys MUST NOT break). Hosts typically call once at boot, before Causa auto-opens. |
+
+`configure!` is re-exported from `core` for boot-time ergonomics. The two require paths are interchangeable:
+
+```clojure
+;; via the core facade — already on your require list for open!
+(require '[day8.re-frame2-causa.core :as causa])
+(causa/configure! {:rf.causa/editor :cursor})
+
+;; via the config namespace — when boot code is routing all knobs through configure!
+(require '[day8.re-frame2-causa.config :as causa-config])
+(causa-config/configure! {:rf.causa/editor :cursor})
+```
+
+The full v1 key surface, grouped by topical cluster:
+
+```clojure
+(causa-config/configure!
+  {;; Editor cluster — Open in editor preference
+   :rf.causa/editor                :cursor   ; / :vscode (default) / :windsurf / :zed / :idea / {:custom <uri-template>}
+   :rf.causa/project-root          "C:/Users/me/code/my-app"
+
+   ;; Launch cluster — boot-time mount posture
+   :rf.causa/auto-open?            true      ; default — preload auto-opens into the inline host
+   :rf.causa/layout-host-selector  "#causa"  ; default "[data-rf-causa-host]"
+
+   ;; Keybinding cluster — global listener install
+   :rf.causa/keybinding-enabled?   true      ; default — set false from embed hosts that own the chord
+
+   ;; Privacy cluster — cross-tool sensitive-event gate
+   :rf.privacy/show-sensitive?     false     ; default — drop :sensitive? true events from the trace buffer
+
+   ;; Settings cluster — bulk-replace the Settings popup state
+   :rf.causa/settings              {:theme :dark :general {:density :cosy}}
+
+   ;; Filters cluster — host-supplied seed pill set on first install
+   :rf.causa/filters               {:out [{:pattern ":mouse-move"}]}
+   :rf.causa/filters-storage-key   "re-frame2.causa.filters.v1"})
+```
+
+Every key lives under a reserved namespace — `:rf.causa/*` for Causa-specific knobs, `:rf.privacy/*` for cross-tool slots Story and any other re-frame2 tool also reads. Unknown keys are silently ignored so newer hosts (passing keys an older Causa hasn't shipped yet) don't break, and newer Causa releases shipping additional keys don't break older hosts.
+
+## Editor cluster
+
+Every panel that surfaces a source-coord wraps the coord in a clickable `open` chip. Clicking sets `window.location.href` to a URI-scheme handler the OS dispatches to the configured editor.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Set the editor preference. Accepts `:vscode` (default), `:cursor`, `:windsurf`, `:zed`, `:idea`, `{:custom <uri-template>}`. `nil` resets to `:vscode`. Re-exported from `core`. |
+| `set-project-root!` | `(set-project-root! path)` → nil | v1 (dev-only) | On-disk root prepended to the source-coord's classpath-relative `:file` slot before the editor URI ships. Default `nil` — hosts whose source paths are already absolute leave this unset. Nil / blank clears the slot; an absent key in `configure!` leaves the current value untouched. |
+
+The URI schemes:
+
+| Editor key | URI scheme |
+|---|---|
+| `:vscode` (default) | `vscode://file/<path>:<line>:<column>` |
+| `:cursor` | `cursor://file/<path>:<line>:<column>` |
+| `:windsurf` | `windsurf://file/<path>:<line>:<column>` |
+| `:zed` | `zed://file/<path>:<line>:<column>` |
+| `:idea` | `idea://open?file=<path>&line=<line>&column=<column>` |
+| `{:custom <tpl>}` | User template with `{path}` / `{file}` / `{line}` / `{column}` placeholders |
+
+Unknown keywords fall back to `:vscode` so a typo still yields a clickable URI rather than a no-op. Source-coords without `:file` hide the chip entirely.
+
+Causa's editor preference is **independent** of Story's `:rf.story/editor` (hosts that run both tools can route each to a different editor). The shared URI builder lives at `re-frame.source-coords.editor-uri` in the framework core; Causa's chip is a thin wrapper that consumes it.
+
+## Launch cluster
+
+The launch cluster controls the auto-open posture and the layout-host wiring. Set these *before* the preload runs (before `rf/init!` returns) so the first auto-open path reads the right values.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Whether the preload auto-opens the shell into the inline host on adapter readiness. Default `true`. Set `false` from tool-owned pages that deliberately don't reserve app real estate for Causa (Story-only canvases, internal dev tools whose layout can't host a right column). Explicit `(causa/open!)` calls still mount after suppression. Re-exported from `core`. |
+| `set-layout-host-selector!` | `(set-layout-host-selector! css-selector)` → nil | v1 (dev-only) | The CSS selector the auto-open path queries on adapter readiness. Default `[data-rf-causa-host]`. Override when your host's preferred selector differs (e.g. `#devtools-causa`). |
+
+The default selector `[data-rf-causa-host]` is published as a CLJS constant — `day8.re-frame2-causa.config/default-layout-host-selector` — so docs generators and tool chrome can re-emit the canonical spelling without forking the string.
+
+Three more published constants name the inline-host CSS contract. These are constants (values, not setters) — overriding the CSS custom property happens in the host's stylesheet, not through CLJS.
+
+| Constant | Value | Use |
+|---|---|---|
+| `default-layout-host-css-var` | `"--rf-causa-inline-width"` | The CSS custom property the recommended host snippet reads for its `flex-basis`. Causa never reads this property; the host's stylesheet is the single source of truth for inline width. |
+| `default-layout-host-width` | `"560px"` | Causa's recommended default value for `--rf-causa-inline-width`. |
+| `default-accent-css-var` | `"--rf-causa-accent"` | The CSS custom property the recommended host snippet publishes on `:root` for Causa's brand-accent colour. Host stylesheets read `var(--rf-causa-accent)` to colour their own dev chrome (resize handles, dock separators, story chips). |
+| `default-accent` | `"#7C5CFF"` | Causa's default brand-accent hex (matches `theme/tokens.cljc :accent-violet`). |
+| `default-layout-host-snippet` | HTML+CSS block | A copy-pasteable host snippet carrying the recommended markup, `flex-basis` rule, `:root` accent publish, and `min-width: 320px` floor. Reported back to the user in the missing-host diagnostic so the actionable `console.error` already carries the fix. |
+
+## Keybinding cluster
+
+Causa installs a global `Ctrl+Shift+C` keydown listener as one of the preload's six side-effects. Standalone Causa always needs the listener; embed hosts (Story mounts Causa as a right-hand-side panel) sometimes need to take the chord back.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `set-keybinding-enabled!` | `(set-keybinding-enabled! bool)` → nil | v1 (dev-only) | Whether `keybinding/attach!` installs the global window-level keydown listener. Default `true` — standalone Causa needs the listener. Embed hosts set `false` so their own global keybindings (typically `Cmd/Ctrl+K` for the host's command palette) are not swallowed by Causa's capture-phase listener. MUST be set BEFORE the Causa preload runs. |
+
+The setter suppresses the install at attach time; embed hosts whose mount lifecycle runs AFTER Causa's preload has already attached use the imperative escape hatch instead:
+
+```clojure
+(require '[day8.re-frame2-causa.keybinding :as causa-keybinding])
+
+;; Take the chord back.
+(causa-keybinding/detach!)
+```
+
+`detach!` is symmetric and idempotent. See [the runtime-seam chapter §Keybinding lifecycle](runtime-seam.md#keybinding-lifecycle) for the full attach / detach contract.
+
+## Privacy cluster
+
+The privacy cluster carries one cross-tool gate that Causa, Story, and any other re-frame2 tool consuming the trace bus all read. The key lives under `:rf.privacy/*` (not `:rf.causa/*`) because the slot is shared.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | The cross-tool `:rf.privacy/show-sensitive?` flag. When `false` (default), Causa's trace collector drops `:sensitive? true` events and the bottom rail surfaces a `[● REDACTED N]` hint. Set to `true` while debugging redaction policy to see the raw cascade. `nil` resets to the default. Re-exported from `core`. |
+
+The single normative emission site for `:sensitive?` redaction is the framework's `elide-wire-value` (see [framework API instrumentation §The wire-boundary walker](../../api/11-instrumentation.md#the-wire-boundary-walker)). Causa's gate just decides whether the redacted-out events reach the buffer at all.
+
+## Settings cluster
+
+The Settings popup carries the user-mutable knobs — theme, density, buffer depths, AI provider config, filter persistence settings. The bulk-set escape hatch lets a host ship its own default Settings shape; the per-knob writes flow through the popup's normal `:rf.causa/settings-update` event.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `update-setting!` | `(update-setting! path value)` → nil | v1 (dev-only) | Set one Settings slot. `path` is a vector into the settings map (e.g. `[:general :density]`); `value` is the new value. Persists through localStorage. The popup's event surface is the canonical write path; reach for this only from REPL / test contexts. |
+| `reset-settings!` | `(reset-settings!)` → nil | v1 (dev-only) | Reset every Settings slot to its default shape. Wipes the localStorage slot. Mostly a test-isolation helper; hosts that want to ship a non-default shape use `configure! {:rf.causa/settings ...}` instead. |
+| `reset-suppressed-count!` | `(reset-suppressed-count!)` → nil | v1 (dev-only) | Clear the `[● REDACTED N]` bottom-rail counter that surfaces when filters elide events. Reach for this when wiring a Settings-popup "Clear suppression counter" button or a test-harness fixture-reset. |
+
+The Settings shape (validated by Malli):
+
+```clojure
+{:theme         :dark / :light / :high-contrast
+ :density       :compact / :cosy / :comfy
+ :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
+                 :api-key      "sk-..."
+                 :model        "claude-3-5-sonnet"
+                 :system-prompt "..."
+                 :custom-url   "https://..."   ;; only when :provider = :custom
+                 :custom-headers {"X-..." "..."}}
+ :buffer-depths {:trace 200 :epoch 50}
+ :default-frame :app/main
+ :sidebar-mode  :grouped / :show-all
+ :launcher-pill {:hidden? false}
+ :keybindings   {:toggle ["Ctrl+Shift+C"] ...}}
+```
+
+Corruption (schema fails) → Causa wipes the slot and writes the default shape, surfacing a one-time toast: "Settings were corrupted and have been reset to defaults."
+
+The settings persist under the localStorage key `day8.re-frame2-causa/settings/v1` (also published as the CLJS constant `day8.re-frame2-causa.config/settings-storage-key`).
+
+## Filters cluster
+
+The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ frame`) that drive in / out filtering of the displayed events. Filter state persists in localStorage across reloads; hosts that want to seed a starting filter set on first install reach for the filters cluster.
+
+| Setter | Signature | Status | Intuition |
+|---|---|---|---|
+| `set-filter-seed!` | `(set-filter-seed! seed-map)` → nil | v1 (dev-only) | Host-supplied seed pill set the registry hydrates `:active-filters` with on FIRST install (when localStorage is empty). Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — first session boots with no filters (first-session honesty beats first-session quietness). Story testbeds use this to inject a known starting point for reproducibility. |
+| `set-filters-storage-key!` | `(set-filters-storage-key! key)` → nil | v1 (dev-only) | The localStorage key the filter persistence layer reads / writes. Default `"re-frame2.causa.filters.v1"`. Hosts that run multiple Causa instances (Story testbeds, multi-mode tool pages) override for isolation between instances. |
+
+Set both *before* the preload runs so the first registry-handlers registration reads the right values.
+
+## Boot-time config vs persisted Settings
+
+Causa carries three orthogonal configuration surfaces. The split is principled — each answers a different question — and the merge order is fixed.
+
+| Surface | Where | Lifetime | Examples |
+|---|---|---|---|
+| **Defaults** | Hardcoded in `config.cljc` | Compile-time constants | Editor `:vscode`, auto-open `true`, layout host `[data-rf-causa-host]` |
+| **Boot-time `configure!`** | Host's app boot | Process-global, fixed for session | `(configure! {:rf.causa/editor :cursor})` — flips the editor for this dev session |
+| **Persisted Settings** | The Settings popup | User-mutable, localStorage | User picks `:density :comfy` from the popup — sticks across reloads |
+
+**Merge order: defaults < `configure!` < persisted Settings.** A host config knob is the *default* from the user's perspective; the user's Settings overrides win at the per-knob level. `(causa/init! opts)` receives the merged config.
+
+The three answer different questions: `configure!` is the boot-time data knob (set once, don't change at runtime); the in-shell Settings popup is the user-mutable preference layer (user changes density from `:cosy` to `:comfy`, sticks across reloads); per-frame metadata (not in scope here) is the frame-scoped override.
+
+## See also
+
+- [Mount control](mount-control.md) — `open!` / `close!` / `toggle!` / `popout!` and the lifecycle the auto-open setting drives.
+- [Runtime seam](runtime-seam.md) — the keybinding `attach!` / `detach!` lifecycle pair the keybinding cluster setters control.
+- [Causa tutorial — Installation](../01-installation.md) — the five-minute wiring walkthrough with the recommended host snippet.
+- [Framework API — Instrumentation](../../api/11-instrumentation.md#the-wire-boundary-walker) — `elide-wire-value`, the single normative emission site for `:sensitive?` redaction that the privacy cluster gates.

--- a/docs/causa/api/index.md
+++ b/docs/causa/api/index.md
@@ -1,0 +1,57 @@
+# Causa API reference
+
+This is the human-facing API reference for Causa — the dev-only panel that renders re-frame2's runtime as fourteen panels over a single observation surface. The tutorial chapters one folder up walk a developer through the surface from a sitting position; this folder walks it from a standing one, organised by **what part of the contract you're touching** rather than by user journey. Each chapter opens with a paragraph on what the surface is *for* — the problem it solves, the shape of the contract — and only then drops into the function tables.
+
+If you want the dense, single-page contract — every signature, every status keyword, every cross-reference — the [developer-internal spec](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/API.md) is still where that lives. This guide is the consumer extract: the surfaces a *host application* or a *tool integrator* may legitimately reach for, with intuition notes attached. Internal seams (the panel reg-views composed by Causa's own shell, the shell composer, the registry's per-key handlers) are deliberately absent — those are documented for Causa's maintainers, not for hosts.
+
+## What "canonical" means here
+
+Every row in this reference is **canonical**: a documented, supported v1 surface that downstream hosts and tools may rely on. There are no "alpha" or "experimental" tiers in the chapters. If a row appears here, you can call it; if a row doesn't appear, it's either internal plumbing or a `post-v1` extension that hasn't shipped yet. The Causa-internal surfaces (panel mount aggregators consumed only by Causa's shell, atom handles publishing the same state setters write to, the static-mode catalogues) are explicitly out of scope — hosts that reach for them are reading internal seams that the public-by-default CLJS surface accidentally exposes.
+
+Three audiences read these chapters. **Host application developers** who want to wire Causa into their dev build and tune its boot-time posture — they reach for [Mount control](mount-control.md) and [Configuration keys](config-keys.md). **Tool integrators** building MCP servers, IDE plugins, or record-replay harnesses against Causa's read-and-mutate seam — they reach for [Runtime seam](runtime-seam.md). And **library authors and reference seekers** who want to scan the full surface in one pass — they reach for the [symbol table](reference.md).
+
+## How to read a row
+
+Every row carries:
+
+- a **signature** — the call shape, in Clojure form
+- a **status** — `v1` (stable), `v1 (dev-only)` (elided in `:advanced` + `goog.DEBUG=false`), `TBD-impl` (declared by the spec but the runtime path is a stub)
+- an **intuition** — the one-line answer to "what's this for and when do I reach for it?"
+
+Where a surface lives in more than one namespace (e.g. `configure!` is re-exported from `core` for boot-time ergonomics over the underlying `config` definition) the canonical home is the one named. Reach for the re-export when it's already on the require list you've imported for `open!`; reach for the original when you're scoping a require to a single concern.
+
+## Where surfaces live
+
+Causa's user-facing surface splits across six namespaces. Five are CLJS / CLJC source; one is a JavaScript-mirror global the preload installs. The split is principled — each namespace answers a distinct question, and `core` re-exports the high-traffic surfaces from the others so a single require covers the common boot path.
+
+| Namespace | Use when |
+|---|---|
+| `day8.re-frame2-causa.core` | The canonical require. The mount facade (`open!` / `close!` / `toggle!` / `popout!` / `status`), the frame picker (`target-frame` / `set-target-frame!`), and the four highest-traffic config setters re-exported for boot-time convenience. |
+| `day8.re-frame2-causa.config` | The full configuration surface — `configure!` plus every per-key setter. Reach here when you're flipping a knob the facade doesn't re-export, or when your boot code is already routing all config through `configure!`. |
+| `day8.re-frame2-causa.keybinding` | The `attach!` / `detach!` lifecycle pair. Embed hosts (Story mounting Causa as a right-hand-side panel) reach here to take the `Ctrl+Shift+C` chord back. |
+| `day8.re-frame2-causa.runtime` | The Causa ↔ tool read-and-mutate seam. The MCP server, an IDE plugin, a record-replay harness — anything driving a running re-frame2 app from out-of-process reads the trace bus and epoch history through these accessors. |
+| `day8.re-frame2-causa.preload` | The dev-only side-effect bundle wired into shadow-cljs's `:devtools/preloads`. You don't *call* anything here directly; you list the namespace in your `:preloads` and the rest happens. |
+| `window.day8.re_frame2_causa.*` | The browser-global JS mirror the preload installs. Reach from a devtools console, a JS host that doesn't `:require` CLJS namespaces, or a `puppeteer` automation script. |
+
+The dependency direction is one-way: hosts depend on `core` (or on the wider surfaces directly); tools depend on `runtime`; Causa's own internals never depend on anything outside `tools/causa/src/`.
+
+## The chapters
+
+The reference is divided into four chapters. Each is independent — you can land on any of them from a search result and get something useful without reading the others.
+
+The first three are topical — **[Mount control](mount-control.md)** (`init!`, `open!`, `close!`, `toggle!`, `popout!`, `status`, the frame picker, the JS browser-global mirror), **[Configuration keys](config-keys.md)** (`configure!`, every per-key setter, the editor preference, the inline-host CSS contract, the privacy gate), **[Runtime seam](runtime-seam.md)** (the seventeen accessors that compose the Causa ↔ tool read-and-mutate contract — trace buffer, epoch history, app-db diff, machine state, dispatch, restore-epoch).
+
+The closing chapter is **[Reference](reference.md)** — the complete symbol table across all six namespaces, organised by namespace for `Ctrl-F` use. If you want to know whether `set-project-root!` is in `config` or `core`, this is the page.
+
+## When to reach for the spec instead
+
+The chapters here are organised for readers; the [normative spec](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/API.md) is organised for completeness. If you're looking for *every* row at once — including the internal-but-visible surfaces, the resolved-decisions log, the migration notes for surfaces that were renamed mid-alpha — that's where you want to be. If you're writing a host integration and want to know which surfaces *exist* in a given domain, you want a chapter here.
+
+The normative spec docs (`007-UX-IA.md`, `011-Launch-Modes.md`, `015-Configuration.md`, etc. under [`tools/causa/spec/`](https://github.com/day8/re-frame2/tree/main/tools/causa/spec)) own the *why* — the design rationale, the alternatives considered, the dispositions. The chapters here cite those when they matter and stay quiet otherwise.
+
+## See also
+
+- [Causa tutorial — Installation](../01-installation.md) — the five-minute, three-edits walk-through. Read this first if you've not yet wired Causa into a dev build.
+- [Causa tutorial — Panel tour](../02-panel-tour.md) — what each panel is for, when you'd open it.
+- [Framework API — Instrumentation](../../api/11-instrumentation.md) — the trace bus, the epoch buffer, the source-coord contract Causa reads. Causa adds no analogues; the framework owns the observation surface, Causa renders it.
+- [Framework API — Lifecycle](../../api/13-lifecycle.md) — `rf/init!` runs before Causa attaches. The adapter must be installed before the auto-open path resolves the host.

--- a/docs/causa/api/mount-control.md
+++ b/docs/causa/api/mount-control.md
@@ -1,0 +1,157 @@
+# Mount control
+
+This chapter is about the surfaces that bring Causa's shell into view and take it away again. The core of it is **three distinct mount verbs** — `open!`, `open-overlay!`, `popout!` — that name three distinct surfaces, not modal variants of one shape. `open!` is the default; you reach for the other two when the host's layout can't accommodate the inline column, or when the user wants the panel in its own window. Around the open verbs sit `close!`, `toggle!`, and `status` for state inspection, plus a frame picker (`target-frame` / `set-target-frame!`) for telling Causa which host frame to observe, plus `init!` for the manual-install path that bypasses shadow-cljs preloads.
+
+There's also a small JS-side mirror — the same six verbs exposed on `window.day8.re_frame2_causa.*` so a devtools console, a JS host that doesn't `:require` CLJS, or a `puppeteer` script can reach the same shell. Production builds elide the install entirely via the `:advanced` + `goog.DEBUG=false` gate; you never have to scrub the global manually.
+
+## The three open verbs
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `open!` | `(causa/open!)` → mount-state map or missing-host diagnostic map | v1 (dev-only) | Mount + show the shell true-inline into the host's normal-flow layout host (`[data-rf-causa-host]` by default). The canonical default. On first call, creates `#rf-causa-root` inside the host and renders the shell. On subsequent calls (already mounted), flips the container to `display: block`. No-op (returns `nil`) when no substrate adapter is installed. |
+| `open-overlay!` | `(causa/open-overlay!)` | v1 (dev-only) | Debug / fallback path: mount Causa as a fixed overlay under `<body>`. Floats above the host layout without participating in it. Reach for this when the host's normal-flow layout cannot accommodate a right column — a full-screen canvas tool, a story-only tool page, a prototype with no layout host. |
+| `popout!` | `(causa/popout!)` | v1 (dev-only) | Open Causa in a same-origin second window. The shell mounts into its own document context — own React root, own theme cascade, own keybinding listener. The popped window uses `window.opener` to reach the host's runtime, so all observation surfaces (trace bus, epoch history, registrar) work unchanged. Useful when the panel is competing with the app for screen space. |
+
+The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inline!` alias). Inline-vs-overlay-vs-window is a kind-of-mount axis, not a mode axis. A reader who treats `open!` / `open-overlay!` as "default vs overlay" and `popout!` as "its own verb" is reading the contract correctly — bare `open!` *is* the canonical default, and the asymmetry telegraphs the rank.
+
+## Visibility control
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `close!` | `(causa/close!)` | v1 (dev-only) | Hide the shell — flip the container to `display: none`. The DOM tree and substrate render tree stay in place so re-opening is a CSS-only toggle (sub-80ms first paint). Use when the host wants to programmatically dismiss the panel without unmounting it. |
+| `toggle!` | `(causa/toggle!)` | v1 (dev-only) | Flip visibility. First call mounts + shows; subsequent calls toggle between `display: block` and `display: none`. The `Ctrl+Shift+C` global keybinding is wired to this. |
+| `status` | `(causa/status)` → map | v1 (dev-only) | Inspectable shell state. Returns `{:mounted? :visible? :last-host-diagnostic ...}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_causa.status()`. |
+
+## Manual install — the alternative to `:preloads`
+
+The canonical install path is wiring `day8.re-frame2-causa.preload` into shadow-cljs's `:devtools/preloads`. The preload runs six side-effects (registry, trace collector, epoch collector, browser-global install, keybinding listener, auto-open into the inline host) on app boot, all gated on `re-frame.interop/debug-enabled?` and all idempotent so shadow-cljs's `:after-load` cycle re-runs them safely.
+
+For hosts that want to control the install timing — a custom boot pipeline with steps between adapter install and Causa attach, a test harness needing fine-grained sequencing, a host that ships its own preload bundle — `init!` is the alternative.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `init!` | `(init!)` / `(init! opts)` → nil | v1 (dev-only) | Mount Causa manually. Idempotent: a second call is a no-op (each underlying side-effect is `defonce`-guarded). Bypasses the preload path. Use when the `:preloads` wiring isn't available — test harnesses, host-controlled boot pipelines, dev builds with a custom preload bundle. |
+
+The `opts` map accepts these keys today (pre-alpha — additional keys land under follow-on work):
+
+```clojure
+{:default-frame :app/main          ;; target-frame for the scrubber
+ :theme         :dark              ;; / :light / :high-contrast (TBD-impl)
+ :density       :compact           ;; / :cosy (TBD-impl)
+ :ai-provider   {:provider :claude ;; ...} (TBD-impl)
+ :buffer-depths {:trace 200 :epoch 50}}
+```
+
+Pre-alpha posture wires the four foundation side-effects (registry, trace collector, epoch collector, keybinding listener) and threads `:default-frame` through to `:rf.causa/set-target-frame`. The other keys (`:theme`, `:density`, `:ai-provider`, `:buffer-depths`) are accepted today but ignored at runtime — passing them now keeps host code forward-compatible.
+
+## Frame picker
+
+Most apps run one host frame (`:rf/default`) and Causa observes it implicitly. Multi-frame hosts — Story, parallel-frames testbeds, story-mode chrome wrapping a tool surface — need to tell Causa which frame the scrubber and panels are observing.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `target-frame` | `(causa/target-frame)` → keyword | v1 (dev-only) | Read the currently-targeted host frame. Defaults to `:rf/default` until `set-target-frame!` flips it. One-shot read (does NOT register for reactive re-render). Reactive consumers subscribe to `:rf.causa/target-frame` directly via the framework's sub surface. |
+| `set-target-frame!` | `(causa/set-target-frame! frame-id)` → nil | v1 (dev-only) | Set the host frame Causa targets. Dispatches `:rf.causa/set-target-frame` into the `:rf/causa` frame so the sub and every dependent panel re-fire on the standard reactive path. `nil` resets to the default. |
+
+The L1 frame picker chip in the shell's top strip is wired to this — clicking flips `set-target-frame!`, and every panel in view (Trace, Views, Machines, App-DB Diff) rescopes to the new frame. Hosts can drive the same flip programmatically from a per-route effect, a Settings-popup wire-up, or a test harness assertion.
+
+## The TBD-impl stub
+
+One surface declared by the spec ships as a stub that emits a `:rf.warning/*` trace and otherwise no-ops.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `load-theme` | `(causa/load-theme css-string)` → nil | TBD-impl | Programmatically swap the Causa shell's CSS theme. The theme module exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-swap surface is not yet wired. Calling emits `:rf.warning/causa-load-theme-not-yet-implemented` so the gap is visible in the trace stream. Forward-compatible — host code may call with a CSS string today and expect the impl to land later. |
+
+## The browser-global JS mirror
+
+The preload installs a JS-side mirror under `window.day8.re_frame2_causa.*` so JS hosts, devtools-console one-liners, and `puppeteer` automation scripts can reach the same surfaces without a CLJS compile. The exact spellings carry Closure's `_BANG_` suffix for ClojureScript-style mutating fns.
+
+```javascript
+window.day8.re_frame2_causa.open_BANG_()         // (causa/open!)
+window.day8.re_frame2_causa.open_overlay_BANG_() // (causa/open-overlay!)
+window.day8.re_frame2_causa.close_BANG_()        // (causa/close!)
+window.day8.re_frame2_causa.toggle_BANG_()       // (causa/toggle!)
+window.day8.re_frame2_causa.popout_BANG_()       // (causa/popout!)
+window.day8.re_frame2_causa.status()             // (causa/status) → map
+```
+
+The mirror is gated on `re-frame.interop/debug-enabled?` — production builds (`:advanced` + `goog.DEBUG=false`) elide the install entirely; there is no `window.day8` pollution in shipped binaries.
+
+Once `core.cljs` has loaded, the same six fns are also reachable under `window.day8.re_frame2_causa.core.*` so JS-console users see the canonical facade names. Both spellings are stable contracts.
+
+## The mount lifecycle, end-to-end
+
+A complete boot, from preload-wiring through to the first scrubber tick:
+
+```clojure
+;; shadow-cljs.edn — dev build only
+{:builds
+ {:app
+  {:devtools {:preloads [day8.re-frame2-causa.preload]}}}}
+```
+
+```html
+<!-- index.html -->
+<div class="app-shell">
+  <main id="app"></main>
+  <aside data-rf-causa-host></aside>
+</div>
+```
+
+```css
+.app-shell { display: flex; min-height: 100vh; }
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 560px);
+  min-width: 320px;
+}
+```
+
+```clojure
+(ns my.app
+  (:require [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent]
+            [reagent.dom :as rdom]
+            [my.app.views :as views]))
+
+(defn ^:export main []
+  (rf/init! reagent/adapter)             ;; install the substrate adapter
+  (rdom/render [views/root]
+               (js/document.getElementById "app")))
+```
+
+That's the full boot. The preload registers Causa's listeners and auto-opens into `[data-rf-causa-host]` once `rf/init!` has installed the substrate. No `(require '[day8.re-frame2-causa.core])`, no `init!` call. The preload plus the host element are the integration surface.
+
+Hosts that want explicit control — a Story tool page that suppresses auto-open, an embed host that needs to bypass the preload — reach for the imperative facade above:
+
+```clojure
+(ns my.app.tool-page
+  (:require [day8.re-frame2-causa.core :as causa]
+            [day8.re-frame2-causa.config :as causa-config]))
+
+;; Suppress the preload's auto-open path.
+(causa-config/configure! {:rf.causa/auto-open? false})
+
+;; Later — from a button, a route handler, a test harness:
+(causa/open!)
+(causa/set-target-frame! :app/tool-canvas)
+```
+
+## Production: nothing ships
+
+Causa is **dev-only** by construction. Under `:advanced` compilation with `goog.DEBUG=false`:
+
+- The preload entry is reachable only through dev-build paths; production builds don't `:require` it.
+- The framework's trace bus is gated on `re-frame.interop/debug-enabled?`. Every `register-listener!` registration elides at the source.
+- The browser-global JS mirror's install is gated the same way; production bundles carry no `window.day8` pollution.
+- Source-coord stamping (`data-rf2-source-coord` on every rendered DOM element) elides under the same gate; rendered HTML in production carries no source-coord bytes.
+
+A CI gate ([`implementation/scripts/check-bundle-isolation.cjs`](https://github.com/day8/re-frame2/blob/main/implementation/scripts/check-bundle-isolation.cjs)) greps the plain production bundle for Causa-internal sentinel strings; any hit is a PR-failing regression. The elision holds whether you remember to remove the preload or not.
+
+## See also
+
+- [Configuration keys](config-keys.md) — `configure!` and the per-key setters that flip the auto-open posture, the inline-host selector, the editor preference, the privacy gate.
+- [Runtime seam](runtime-seam.md) — the read-and-mutate accessors that tools compose against Causa's mount.
+- [Causa tutorial — Installation](../01-installation.md) — the five-minute, three-edits walk-through.
+- [Framework API — Lifecycle](../../api/13-lifecycle.md) — `rf/init!` and the adapter install pair. The adapter must land before Causa's auto-open path resolves the host.
+- [Framework API — Instrumentation](../../api/11-instrumentation.md) — the trace bus and epoch buffer Causa renders.

--- a/docs/causa/api/reference.md
+++ b/docs/causa/api/reference.md
@@ -1,0 +1,192 @@
+# Reference
+
+The complete symbol table for Causa's public surface, organised by namespace for `Ctrl-F` use. Every row carries a signature, a status, and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
+
+Surfaces fall into six namespaces and one browser global. The split is principled — each namespace answers a distinct question — but the row count varies wildly. `core` carries 12 surfaces; `runtime` carries 20; `keybinding` carries 2. If you're scanning for a single function and don't remember which namespace owns it, the right move is `Ctrl-F` on this page.
+
+For the topical walk-through with intuition notes and use-when prose, see [Mount control](mount-control.md), [Configuration keys](config-keys.md), and [Runtime seam](runtime-seam.md). For the index of *what* this reference covers (and what it deliberately omits — the Causa-internal panel composers, the static-mode catalogues, the atom handles that mirror state the setters write to), see [the index](index.md#what-canonical-means-here).
+
+## `day8.re-frame2-causa.core`
+
+The canonical facade. The day-to-day require for host integrations. Twelve surfaces total — the mount facade, the frame picker, the TBD theme stub, and four high-traffic config re-exports.
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `init!` | `(init!)` / `(init! opts)` → nil | v1 (dev-only) | Manual install — the alternative to wiring `:preloads`. Idempotent. |
+| `open!` | `(open!)` → mount-state map or missing-host diagnostic | v1 (dev-only) | Mount + show the shell true-inline into the host's layout host. The canonical default. |
+| `open-overlay!` | `(open-overlay!)` | v1 (dev-only) | Mount as a fixed overlay under `<body>`. Floats above host layout. |
+| `close!` | `(close!)` | v1 (dev-only) | Hide the shell — flip the container to `display: none`. DOM stays in place. |
+| `toggle!` | `(toggle!)` | v1 (dev-only) | Flip visibility. Wired to `Ctrl+Shift+C`. |
+| `popout!` | `(popout!)` | v1 (dev-only) | Open Causa in a same-origin second window. Own React root, own keybinding. |
+| `status` | `(status)` → map | v1 (dev-only) | Inspectable shell state. `{:mounted? :visible? :last-host-diagnostic ...}`. |
+| `target-frame` | `(target-frame)` → keyword | v1 (dev-only) | Read the currently-targeted host frame. One-shot read; not reactive. |
+| `set-target-frame!` | `(set-target-frame! frame-id)` → nil | v1 (dev-only) | Set the host frame Causa targets. `nil` resets to default. |
+| `load-theme` | `(load-theme css-string)` → nil | TBD-impl | Programmatic theme swap. Stub — emits `:rf.warning/causa-load-theme-not-yet-implemented`. |
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config — re-exported from `config`. See [Configuration keys](config-keys.md). |
+| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Re-exported from `config`. Whether the preload auto-opens. |
+| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Re-exported from `config`. Sets the "Open in editor" preference. |
+| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | Re-exported from `config`. Cross-tool `:rf.privacy/show-sensitive?` flag. |
+
+## `day8.re-frame2-causa.config`
+
+The full configuration surface. Reach here when you're flipping a knob the facade doesn't re-export, or when boot code is routing all config through `configure!`. Twelve setter surfaces plus seven published constants — the constants are values (not call-shapes) for docs generators, snippet helpers, and host stylesheet authoring.
+
+### Setters
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config. Map keyed by `:rf.causa/*` and `:rf.privacy/*`. |
+| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Editor preference. `:vscode` (default) / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <tpl>}`. |
+| `set-project-root!` | `(set-project-root! path)` → nil | v1 (dev-only) | On-disk root prepended to classpath-relative `:file` slots before editor URIs ship. |
+| `set-layout-host-selector!` | `(set-layout-host-selector! css-selector)` → nil | v1 (dev-only) | CSS selector for the auto-open path. Default `[data-rf-causa-host]`. |
+| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Whether the preload auto-opens on adapter readiness. Default `true`. |
+| `set-keybinding-enabled!` | `(set-keybinding-enabled! bool)` → nil | v1 (dev-only) | Whether `keybinding/attach!` installs the global listener. Default `true`. |
+| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | Cross-tool `:rf.privacy/show-sensitive?` flag. Default `false`. |
+| `set-filter-seed!` | `(set-filter-seed! seed-map)` → nil | v1 (dev-only) | Host-supplied seed pill set for first install. Shape: `{:in [{...}] :out [{...}]}`. |
+| `set-filters-storage-key!` | `(set-filters-storage-key! key)` → nil | v1 (dev-only) | localStorage key the filter persistence layer uses. Default `"re-frame2.causa.filters.v1"`. |
+| `update-setting!` | `(update-setting! path value)` → nil | v1 (dev-only) | Set one Settings slot. `path` is a vector into the settings map. |
+| `reset-settings!` | `(reset-settings!)` → nil | v1 (dev-only) | Reset every Settings slot to its default. Wipes the localStorage slot. |
+| `reset-suppressed-count!` | `(reset-suppressed-count!)` → nil | v1 (dev-only) | Clear the `[● REDACTED N]` bottom-rail counter. |
+
+### Published constants
+
+| Symbol | Value | Use |
+|---|---|---|
+| `default-layout-host-selector` | `"[data-rf-causa-host]"` | The default CSS selector. Re-emit in docs generators / diagnostics. |
+| `default-layout-host-css-var` | `"--rf-causa-inline-width"` | The CSS custom property the host snippet reads for `flex-basis`. |
+| `default-layout-host-width` | `"560px"` | The default value Causa recommends for `--rf-causa-inline-width`. |
+| `default-accent-css-var` | `"--rf-causa-accent"` | The CSS custom property the host snippet publishes on `:root`. |
+| `default-accent` | `"#7C5CFF"` | The default brand-accent hex (matches `theme/tokens.cljc :accent-violet`). |
+| `default-layout-host-snippet` | HTML + CSS block | Copy-pasteable host snippet. Carried in the missing-host diagnostic. |
+| `settings-storage-key` | `"day8.re-frame2-causa/settings/v1"` | localStorage key for the Settings popup state. |
+
+## `day8.re-frame2-causa.keybinding`
+
+The lifecycle pair for the global `Ctrl+Shift+C` keydown listener. Reach here from embed hosts that need to take the chord back after Causa has already attached.
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `attach!` | `(attach!)` → nil | v1 (dev-only) | Install the global listener once. Honours `:rf.causa/keybinding-enabled?`. No-op on second + subsequent calls. |
+| `detach!` | `(detach!)` → nil | v1 (dev-only) | Remove the global listener. Idempotent. Symmetric with `attach!`. |
+
+## `day8.re-frame2-causa.runtime`
+
+The Causa ↔ tool read-and-mutate seam. Twenty surfaces — discovery, origin tag, eighteen accessors split across inspection / mutation / streaming / escape-hatch / meta / test bands. Reach here when you're writing tool-shaped code: an MCP server, an IDE plugin, a record-replay harness, a custom in-app debug panel.
+
+### Discovery + origin
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `session-id` | Var (string UUID) | v1 (dev-only) | Per-preload random UUID. Survives `:after-load`; wiped on full page refresh. Proves the runtime landed. |
+| `*current-origin*` | `^:dynamic` Var | v1 (dev-only) | The `:tags :origin` value the runtime stamps onto every mutation. Default `:causa-mcp`. Tool clients rebind for synchronous extent. |
+| `current-origin` | `(current-origin)` → keyword | v1 (dev-only) | Read accessor — answers "what's the current `:origin` tag?". |
+
+### Inspection band (9 read-only)
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `get-trace-buffer` | `(get-trace-buffer opts)` → map | v1 (dev-only) | Filtered slice of the framework's trace stream. Filter keys per Spec 009. |
+| `get-epoch-history` | `(get-epoch-history opts)` → map | v1 (dev-only) | Per-frame epoch ring buffer. Default depth 50. |
+| `get-app-db` | `(get-app-db opts)` → map | v1 (dev-only) | Live `app-db` for a frame, optionally scoped by `:path`. Routes through `elide-wire-value`. |
+| `get-app-db-diff` | `(get-app-db-diff opts)` → map | v1 (dev-only) | `:db-before` + `:db-after` off a named epoch record. |
+| `get-machine-state` | `(get-machine-state opts)` → map | v1 (dev-only) | Per-machine state read for the registered machine spec. |
+| `get-machine-list` | `(get-machine-list opts)` → map | v1 (dev-only) | Map of every machine in the active frame, keyed by machine-id. |
+| `get-issues` | `(get-issues opts)` → map | v1 (dev-only) | Trace events filtered to issue-tier op-types — error / warning / schema violation / hydration mismatch. |
+| `get-handlers` | `(get-handlers opts)` → map | v1 (dev-only) | Registrar listing, optionally narrowed by `:kind`. |
+| `get-source-coord` | `(get-source-coord opts)` → map | v1 (dev-only) | Per-registration source-coord projection. `{:ns :file :line :column}`. |
+
+### Mutation band (3 write)
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `dispatch!` | `(dispatch! event-vec opts)` → map | v1 (dev-only) | Fire an event tagged with the current origin. Modes `:queued` / `:sync`. |
+| `restore-epoch!` | `(restore-epoch! opts)` → map | v1 (dev-only) | Rewind a frame's `app-db` to a named epoch's `:db-after`. |
+| `reset-frame-db!` | `(reset-frame-db! opts)` → map | v1 (dev-only) | Inject a value into a frame's `app-db`. Schema-validates. |
+
+### Streaming band (3 subscription)
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `subscribe!` | `(subscribe! opts)` → map | v1 (dev-only) | Open a streaming subscription. `:topic ∈ #{:trace :epoch :fx :error}`. |
+| `unsubscribe!` | `(unsubscribe! opts)` → map | v1 (dev-only) | Idempotent close. |
+| `list-subscriptions` | `(list-subscriptions)` → map | v1 (dev-only) | Diagnostic enumerating active runtime-side subscription metadata. |
+
+### Escape hatch + meta + test
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `eval-form-result` | `(eval-form-result value opts)` → map | v1 (dev-only) | Runtime-side result shaper for the MCP server's `eval-cljs` channel. Privacy + size scrubbing. |
+| `health` | `(health)` → map | v1 (dev-only) | One-call summary. `{:session-id :debug-enabled? :frames :ambiguous-frame? :coord-annotation-enabled? :origin}`. |
+| `tail-build-probe` | `(tail-build-probe)` → map | v1 (dev-only) | Monotonic counter for hot-reload change-detect. Survives `:after-load`. |
+| `reset-for-test!` | `(reset-for-test!)` → nil | v1 (test-only) | Clears subscriptions + probe-counter. Test-only. |
+
+## `day8.re-frame2-causa.preload`
+
+The dev-only side-effect bundle. You don't call anything here directly — you list the namespace in shadow-cljs's `:devtools/preloads` and the rest happens. The bundle runs six side-effects on load:
+
+1. Register Causa's `:rf.causa/*` subs / events / fxs.
+2. Register the trace collector as a `:rf.causa/trace-collector` listener.
+3. Register the epoch-settle pump as a `:rf.causa/epoch-collector` listener.
+4. Install the browser API on `window.day8.re_frame2_causa.*`.
+5. Attach the global `Ctrl+Shift+C` keydown listener.
+6. Auto-open the shell true-inline into the host's layout host once the substrate adapter is ready.
+
+All gated on `re-frame.interop/debug-enabled?` so production bundles strip them via Closure DCE, and all idempotent so shadow-cljs's `:after-load` cycle re-runs without double-registration.
+
+## `window.day8.re_frame2_causa.*` (browser-global JS mirror)
+
+The preload installs a JS-side mirror so JS hosts, devtools-console one-liners, and `puppeteer` automation scripts can reach Causa's surfaces without a CLJS compile. Closure-mangled names with `_BANG_` suffixes for mutating fns.
+
+| JS spelling | CLJS equivalent | Intuition |
+|---|---|---|
+| `window.day8.re_frame2_causa.open_BANG_()` | `(causa/open!)` | Mount + show the shell. |
+| `window.day8.re_frame2_causa.open_overlay_BANG_()` | `(causa/open-overlay!)` | Mount as overlay. |
+| `window.day8.re_frame2_causa.close_BANG_()` | `(causa/close!)` | Hide. |
+| `window.day8.re_frame2_causa.toggle_BANG_()` | `(causa/toggle!)` | Flip visibility. |
+| `window.day8.re_frame2_causa.popout_BANG_()` | `(causa/popout!)` | Pop out into a new window. |
+| `window.day8.re_frame2_causa.status()` | `(causa/status)` | Inspectable status map. |
+
+Once `core.cljs` has loaded, the same six fns are reachable under `window.day8.re_frame2_causa.core.*` so JS-console users see the canonical facade names. Both spellings are stable contracts.
+
+## Panel reg-views (composed by the shell)
+
+Eight `Panel` reg-views ship in `day8.re-frame2-causa.panels.*`. They are **not** a host-facing single-panel embed surface — hosts that want to mount Causa embed the full shell via the [embedding contract](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/008-Embedding-Contract.md). The panel exports are documented here for tool integrators (Story's chip-catalogue, the panel-gallery testbed) that compose against them.
+
+| Panel | Namespace | Surface |
+|---|---|---|
+| Event Detail | `day8.re-frame2-causa.panels.event-detail` | `Panel` reg-view |
+| App-DB Diff | `day8.re-frame2-causa.panels.app-db-diff` | `Panel` reg-view |
+| Reactive (Views) | `day8.re-frame2-causa.panels.reactive-panel` | `Panel` reg-view |
+| Trace | `day8.re-frame2-causa.panels.trace` | `Panel` reg-view |
+| Machine Inspector | `day8.re-frame2-causa.panels.machine-inspector` | `Panel` reg-view |
+| Machines Canvas | `day8.re-frame2-causa.panels.machines-canvas.panel` | `Panel` reg-view |
+| Routing | `day8.re-frame2-causa.panels.routing` | `Panel` reg-view |
+| Issues Ribbon | `day8.re-frame2-causa.panels.issues-ribbon` | `Panel` reg-view |
+
+Four parallel Static-mode panels browse the registrar rather than the event spine:
+
+| Panel | Namespace | Surface |
+|---|---|---|
+| Static Flows | `day8.re-frame2-causa.static.flows.panel` | `Panel` reg-view |
+| Static Interceptors | `day8.re-frame2-causa.static.interceptors.panel` | `Panel` reg-view |
+| Static Routes | `day8.re-frame2-causa.static.routes.panel` | `Panel` reg-view |
+| Static Schemas | `day8.re-frame2-causa.static.schemas.panel` | `Panel` reg-view |
+
+## What this reference deliberately omits
+
+Several surfaces are **publicly visible** in the CLJS source but explicitly *not part of the contract*. They're documented in the [developer-internal spec](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/API.md) for Causa's maintainers; this reference omits them on purpose.
+
+- **`config.cljc` atom handles.** Every state setter writes to a `defonce` atom (`auto-open?`, `editor`, `keybinding-enabled?`, …); the atoms are reachable as `@day8.re-frame2-causa.config/<atom>` due to CLJS-default-public visibility. The setters are the canonical write path, the getters are the canonical read path. Reaching for the atom directly is reading an internal seam.
+- **Internal `mount-<panel>!` aggregators.** The shell composer calls these to mount individual panels; they're not part of the host-facing embed contract. Full-shell embedding lives at [`008-Embedding-Contract.md`](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/008-Embedding-Contract.md).
+- **Predicate / mutation helpers.** `sensitive-event?`, `suppress-sensitive?`, `note-suppressed!`, `clamp-panel-width-px`, `editor-uri` — thin wrappers Causa's own modules consume.
+- **`register-toggle-off-callback!` / `unregister-toggle-off-callback!`.** Internal — Causa modules wire their buffer-clear hooks here. Host applications should NOT register.
+
+If you find yourself reading source for a Causa-internal symbol because the chapters don't list it, the answer is almost always: the spec considers that surface internal, and a future minor release may rename or `^:private`-mark it. Reach for the documented surfaces in the chapters above instead.
+
+## See also
+
+- [Index](index.md) — the navigation map for the four chapters in this folder.
+- [Mount control](mount-control.md) — `init!`, `open!`, `close!`, `toggle!`, `popout!`, `status`, the frame picker.
+- [Configuration keys](config-keys.md) — `configure!` and the per-key setters.
+- [Runtime seam](runtime-seam.md) — the read-and-mutate accessor surface for tools.
+- [Normative spec — `tools/causa/spec/API.md`](https://github.com/day8/re-frame2/blob/main/tools/causa/spec/API.md) — the developer-internal source of truth.

--- a/docs/causa/api/runtime-seam.md
+++ b/docs/causa/api/runtime-seam.md
@@ -1,0 +1,169 @@
+# Runtime seam
+
+This chapter is about the **Causa ↔ tool read-and-mutate seam** — the contract a tool client (an MCP server, an IDE plugin, a record-replay harness, a future AI co-pilot drop) composes against when it wants to drive a running re-frame2 app from out-of-process. The core of it is **a namespace of pure-data accessors** — `day8.re-frame2-causa.runtime/<accessor>` — that a tool client renders as EDN forms over an nREPL channel to shadow-cljs, which evaluates them in the browser tab against the runtime that Causa's preload installed. The return values come back over the bencode-framed channel.
+
+The seam is **public-for-tools, not public-for-host-apps**. A host application reaches for the runtime accessors only when it's writing tool-shaped code (a custom debug panel, a test-harness assertion, a record-replay export). The same Tool-Pair-style discipline that governs the framework's trace bus applies — Causa emits, the tool consumes — but the runtime is also a *mutation* surface (`dispatch!`, `restore-epoch!`, `reset-frame-db!`) for tool clients that need to drive the app rather than just observe it.
+
+A keybinding lifecycle pair (`attach!` / `detach!`) lives in a sibling namespace and is also documented here because the embed-host escape hatch shape is closer to the runtime seam than to the mount facade.
+
+## What the contract is
+
+`day8.re-frame2-causa.runtime` lives on the browser side of an nREPL-shaped channel. It rides Causa's `:devtools/preloads` (no separate preload entry) so a consumer app that already loads Causa automatically carries the runtime. Today's reference consumer is `tools/re-frame2-pair-mcp/`; tomorrow's might be any MCP server, IDE plugin, or record-replay harness — the contract is the same.
+
+Three load-bearing supports underpin every accessor:
+
+- **`session-id`** — a random UUID set once per preload load. The MCP-server-side preload probe reads this to confirm the runtime landed.
+- **`*current-origin*`** — a `^:dynamic` var holding the `:tags :origin` value the runtime stamps onto every mutation it performs. Tool clients rebind it for the synchronous extent of an eval'd form to identify themselves.
+- **`health`** — a one-call summary of the runtime's view of the world. Used by `discover-app` tools.
+
+All install side-effects are gated on `re-frame.interop/debug-enabled?`. A stray production load is a no-op — no `js/globalThis` pollution, no listener install.
+
+## Discovery sentinel
+
+Two markers prove the runtime landed in the host browser process.
+
+| Marker | Spelling | Lifetime |
+|---|---|---|
+| CLJS var | `day8.re-frame2-causa.runtime/session-id` | Random UUID set once per preload load. Survives shadow-cljs `:after-load`; wiped by full page refresh. |
+| JS global mirror | `js/globalThis.__day8_re_frame2_causa_runtime` | JS object carrying `session-id` + `installed` ms-timestamp. The MCP-server-side probe reads this without a CLJS compile round-trip. |
+
+A page-refresh-cleared sentinel surfaces as `{:reason :runtime-not-preloaded}` on the next `discover-app` tool call, carrying a setup hint that points at the missing `:preloads` entry.
+
+## Origin tag
+
+Every mutation the runtime performs on behalf of a tool client carries `:tags :origin <tool-name>`. The runtime exposes a `^:dynamic` var the tool rebinds:
+
+```clojure
+(def ^:dynamic *current-origin*
+  "Default :causa-mcp. Tool clients re-bind for the synchronous extent
+   of an eval'd form to their own origin tag."
+  :causa-mcp)
+```
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `*current-origin*` | `^:dynamic` Var | v1 (dev-only) | Default `:causa-mcp`. The tool client wraps each eval'd form in `(binding [runtime/*current-origin* :my-tool] ...)` for the synchronous extent. |
+| `current-origin` | `(current-origin)` → keyword | v1 (dev-only) | Read accessor — answers "what's the current `:origin` tag?". Public so tests can pin the rebind contract without `#'`-piercing the dynamic var. |
+
+The async-tagging gap: a dispatched event's downstream cascade carries the origin only through the synchronous handler frame. Later cascades pick up the framework's natural origin tagging.
+
+## Frame resolution
+
+Every accessor that operates on a frame resolves it via the same three-step fallback ladder:
+
+1. Caller-supplied `:frame <id>` arg.
+2. The sole registered frame (when exactly one is registered).
+3. `nil` → accessor returns `{:ok? false :reason :no-frame-resolved :hint "Pass :frame :foo or register at least one frame."}`.
+
+Multi-frame apps without an explicit `:frame` pick are surfaced via `discover-app`'s `:ambiguous-frame? true` flag rather than silently picking one. The tool-arg layer in the MCP server is the right place to refuse mutations against an ambiguous resolution; reads degrade through the documented `:no-frame-resolved` fallback.
+
+## Privacy egress
+
+Every direct-read accessor routes returned values through `re-frame.core/elide-wire-value` before egress. The single normative emission site for the `:rf/redacted` sensitive sentinel and the `:rf.size/large-elided` size marker lives in the framework; the runtime's job is to call it with `:include-sensitive?` and `:include-large?` defaulting `false` and to honour the caller's opt-in.
+
+Callers pass plain `:include-sensitive?` / `:include-large?` opts; the runtime translates to the framework's `:rf.size/*` namespaced opt keys.
+
+## Inspection band
+
+Nine read-only accessors. Every one returns a map; success is `:ok? true`; failure is `:ok? false :reason <kw> :hint <str>`.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `get-trace-buffer` | `(get-trace-buffer opts)` → `{:ok? true :events <vec> :count <n>}` | v1 (dev-only) | Filtered slice of the framework's trace stream. Filter keys are the canonical Spec 009 vocabulary — `:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`. |
+| `get-epoch-history` | `(get-epoch-history opts)` → `{:ok? true :frame <id> :epochs <vec> :count <n>}` | v1 (dev-only) | The per-frame epoch ring buffer. Each epoch is a `:rf/epoch-record` (drain-completion snapshot with `:db-before` / `:db-after`). Default depth 50. |
+| `get-app-db` | `(get-app-db opts)` → `{:ok? true :frame <id> :path <vec> :value <edn>}` | v1 (dev-only) | The live `app-db` for a frame, optionally scoped by `:path` for sub-tree reads. Reads through `elide-wire-value` so `:sensitive?` / `:large?`-marked paths egress as elision markers. |
+| `get-app-db-diff` | `(get-app-db-diff opts)` → `{:ok? true :frame <id> :epoch-id <uuid> :diff {:before … :after …}}` | v1 (dev-only) | Reads `:db-before` + `:db-after` off a named epoch record. Heavy nested-diff projection lives on the MCP server side; this accessor returns the raw before / after pair. |
+| `get-machine-state` | `(get-machine-state opts)` → `{:ok? true :frame <id> :machine-id <kw> :state <edn>}` | v1 (dev-only) | Per-machine state read. The Stately-grade state-chart inspector reads this; tools that want machine-state pinning for a record-replay assertion compose against it directly. |
+| `get-machine-list` | `(get-machine-list opts)` → `{:ok? true :machines <map> :count <n>}` | v1 (dev-only) | Map of every machine registered in the active frame, keyed by machine-id. Used by the machine-inspector dropdown and by tools enumerating the machine surface. |
+| `get-issues` | `(get-issues opts)` → `{:ok? true :issues <vec> :count <n>}` | v1 (dev-only) | Projection over the trace buffer filtered to issue-tier op-types — `:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`. The Issues ribbon paints this; tools that want "what's broken right now?" reach for it. |
+| `get-handlers` | `(get-handlers opts)` → `{:ok? true :handlers <vec> :count <n>}` | v1 (dev-only) | Registrar listing, optionally narrowed by `:kind ∈ #{:event :sub :fx :cofx :machine :flow :reg-machine :frame :view}`. Source-coord metadata travels with each row. |
+| `get-source-coord` | `(get-source-coord opts)` → `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | v1 (dev-only) | Per-registration source-coord projection. Resolves an event-id / sub-id / handler-id back to the `{:ns :file :line :column}` of where it was registered. The "click anywhere, walk to the line" backbone. |
+
+## Mutation band
+
+Three write accessors. Every mutation tags the runtime cascade with `:tags :origin *current-origin*` so the action surfaces in the trace stream and downstream tool consumers can distinguish tool-driven cascades from app-driven ones.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `dispatch!` | `(dispatch! event-vec opts)` → `{:ok? true :event-id <kw> :frame <id> :origin <kw> :mode :queued/:sync}` | v1 (dev-only) | Fire an event tagged with the current origin. Modes: `:queued` (default — non-blocking `rf/dispatch`) or `:sync` (`rf/dispatch-sync`). Frame resolution mirrors the read-side accessors. |
+| `restore-epoch!` | `(restore-epoch! opts)` → `{:ok? true/false :frame <id> :epoch-id <uuid> :origin <kw>}` | v1 (dev-only) | Rewind a frame's `app-db` to the named epoch's `:db-after` via `rf/restore-epoch`. Failures (six documented modes — see [Tool-Pair §Time-travel — Restore](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md)) emit a structured `:rf.epoch/*` trace and leave `app-db` unchanged; the accessor surfaces `:reason :rf.epoch/restore-failed` + a hint pointing to the trace bus. |
+| `reset-frame-db!` | `(reset-frame-db! opts)` → `{:ok? true/false :frame <id> :origin <kw>}` | v1 (dev-only) | Inject `:value` into a frame's `app-db`. Schema-validates via `rf/reset-frame-db!`; the three failure rows (`:rf.error/no-such-handler` / `:rf.epoch/reset-frame-db-during-drain` / `:rf.epoch/reset-frame-db-schema-mismatch`) surface on the trace bus; the accessor projects `:reason :rf.epoch/reset-failed` + a hint. |
+
+The three together compose the Tool-Pair time-travel surface: read an epoch, restore to that epoch, or directly inject a known-good state for "try anyway" recovery.
+
+## Streaming band
+
+Three subscription-bookkeeping accessors. The runtime records metadata for in-flight subscriptions; per-tick drain pumps and queue-overflow bookkeeping live on the MCP server side.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `subscribe!` | `(subscribe! opts)` → `{:ok? true :sub-id <uuid> :topic <kw> :filter <map>}` | v1 (dev-only) | Open a streaming subscription for `:topic ∈ #{:trace :epoch :fx :error}` with `:filter`. The runtime records metadata; the MCP server's tick loop drains and forwards. |
+| `unsubscribe!` | `(unsubscribe! opts)` → `{:ok? true :sub-id <id> :existed? <bool>}` | v1 (dev-only) | Idempotent close. `:existed? false` for an unknown id. |
+| `list-subscriptions` | `(list-subscriptions)` → `{:ok? true :subs <vec> :count <n>}` | v1 (dev-only) | Diagnostic enumerating active runtime-side subscription metadata. Per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events` fields live on the MCP server side. |
+
+## Escape hatch
+
+One accessor handles arbitrary CLJS forms — the MCP server's `eval-cljs` channel renders the user-supplied form inside the runtime's `binding` wrapper.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `eval-form-result` | `(eval-form-result value opts)` → `{:ok? true :value <elided>}` | v1 (dev-only) | The runtime-side result shaper. The MCP server renders the user's form inside a `(binding [*current-origin* …] …)` wrapper, `cljs-eval`s the wrapped form directly, and the result passes through `eval-form-result` for privacy + size scrubbing. Caller's `:include-sensitive?` / `:include-large?` opts gate the egress. |
+
+## Meta band
+
+Two introspection accessors used by the tool client's discovery + change-detect protocols.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `health` | `(health)` → `{:ok? true :session-id <uuid> :debug-enabled? <bool> :frames <vec> :ambiguous-frame? <bool> :coord-annotation-enabled? <bool> :origin <kw>}` | v1 (dev-only) | One-call summary of the runtime's view of the world. Side-effect-free — Causa-the-panel's preload owns the trace + epoch listeners; this accessor installs no listeners of its own. Used by `discover-app` tools. |
+| `tail-build-probe` | `(tail-build-probe)` → `{:ok? true :probe <int> :session-id <uuid> :build-tick <int>}` | v1 (dev-only) | Returns a fresh monotonic counter every call. MCP servers poll until the value changes — proving a hot-reload landed and the runtime re-evaluated. The counter survives `:after-load` (`defonce`) and resets only on full page refresh (same lifetime as `session-id`). Change-detect lives MCP-side. |
+
+## Test support
+
+One test-fixture isolation helper. Production code never calls this.
+
+| Accessor | Signature | Status | Intuition |
+|---|---|---|---|
+| `reset-for-test!` | `(reset-for-test!)` → nil | v1 (test-only) | Clears `subscriptions` + `probe-counter` for fixture isolation. Does NOT touch `session-id` (per-preload constant by design) or the JS-global sentinel. Test-only — never call from production code. |
+
+## Keybinding lifecycle
+
+The keybinding lifecycle pair lives in a sibling namespace — `day8.re-frame2-causa.keybinding` — but its shape and intended audience put it closer to the runtime seam than to the mount facade. The pair is the embed-host escape hatch: hosts that mount Causa as a right-hand-side panel (Story, third-party tool surfaces) and want to take the `Ctrl+Shift+C` chord back reach for `detach!`.
+
+| API | Signature | Status | Intuition |
+|---|---|---|---|
+| `attach!` | `(attach!)` → nil | v1 (dev-only) | Install the global `Ctrl+Shift+C` keydown listener once. No-op on second + subsequent calls (the `attached-state` sentinel survives reloads). Honours the `:rf.causa/keybinding-enabled?` config slot — when `false` the listener is NOT installed. |
+| `detach!` | `(detach!)` → nil | v1 (dev-only) | Remove the global keydown listener if one is currently attached. Idempotent — safe to call when nothing is attached (no-op), and safe to call twice in a row (the second call is a no-op). Symmetric with `attach!`. |
+
+The two surfaces compose: standalone Causa calls `attach!` from the preload's six side-effects; an embed host that loaded Causa first and wants to take the chord back from inside its own mount lifecycle calls `detach!` after Causa has already attached.
+
+Calling them in sequence — `attach! → detach! → attach!` — flips between attached / not-attached cleanly without leaking listeners or stale sentinel state.
+
+## Cross-side coupling — one-way
+
+The MCP server depends on the accessor signatures above (the contract). The runtime is independent of any server — Causa-the-panel loads `runtime.cljs` without an MCP server running, and any future MCP consumer can attach later without the runtime needing to know.
+
+Adding an accessor is an additive change at the Causa layer; removing or renaming one is a breaking change to the Tool-Pair contract and requires a major-version bump. This is the same Tool-Pair discipline that governs the framework's trace bus and epoch history: the framework / Causa emits; tools consume; the contract is the data shape, not the call shape.
+
+## A complete tool client interaction
+
+A tool client's typical flow:
+
+```
+1. discover-app                  — runtime/health, reports :session-id, :frames, :ambiguous-frame?
+2. get-trace-buffer               — runtime/get-trace-buffer {:since-ms 5000}
+3. dispatch                       — runtime/dispatch! [:my.app/click 42] {:frame :app/main}
+4. get-app-db                     — runtime/get-app-db {:frame :app/main :path [:counter]}
+5. restore-epoch                  — runtime/restore-epoch! {:frame :app/main :epoch-id <uuid>}
+6. unsubscribe / cleanup          — runtime/unsubscribe! for any open streaming subs
+```
+
+Every call carries an `:origin` tag (the tool client's identifier rebound for the synchronous extent of the eval'd form); every mutation surfaces in the trace stream where Causa's panel — running in the same browser — paints it. The tool client and the panel observe the same surface; neither coordinates with the other.
+
+## See also
+
+- [Mount control](mount-control.md) — the host-facing facade `open!` / `close!` / `toggle!` / `popout!` the runtime seam is parallel to.
+- [Configuration keys](config-keys.md) — `:rf.causa/keybinding-enabled?` and the boot-time gate the `attach!` lifecycle pair reads.
+- [Framework API — Instrumentation](../../api/11-instrumentation.md) — the trace bus, the epoch buffer, and `elide-wire-value` the runtime accessors consume.
+- [Framework API — Registrar](../../api/12-registrar.md) — `rf/registrations` and `rf/handler-meta`, the framework primitives `get-handlers` and `get-source-coord` project over.
+- [Tool-Pair spec](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md) — the normative contract for the framework / Causa emit, tool consume discipline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,12 @@ nav:
     - "7. Hydration debugger": causa/07-hydration.md
     - "8. Machine inspector": causa/08-machine-inspector.md
     - "9. App-DB diff": causa/09-app-db-diff.md
+    - "API reference":
+      - "Overview": causa/api/index.md
+      - "Mount control": causa/api/mount-control.md
+      - "Configuration keys": causa/api/config-keys.md
+      - "Runtime seam": causa/api/runtime-seam.md
+      - "Reference": causa/api/reference.md
 
   - Skills:
     - Overview: skills/index.md


### PR DESCRIPTION
Closes rf2-bmaoz.

Phase 2 of rf2-b0nt7 tool-API-chapter audit (Causa side). Authors five chapters under `docs/causa/api/` carrying the consumer-facing extract of `tools/causa/spec/API.md`.

## Chapters

- `index.md` — navigation map + audience split (host devs / tool integrators / reference seekers).
- `mount-control.md` — `open!` / `close!` / `toggle!` / `popout!`, `init!`, frame picker, JS browser-global mirror. The three distinct open verbs and the production-elision contract.
- `config-keys.md` — `configure!` plus every per-key setter, grouped by topical cluster (editor / launch / keybinding / privacy / settings / filters). Published constants for the inline-host CSS contract.
- `runtime-seam.md` — the 18-accessor Causa <-> tool read-and-mutate contract (inspection / mutation / streaming / escape-hatch / meta bands) plus the `attach!` / `detach!` keybinding lifecycle pair.
- `reference.md` — full symbol table across all six namespaces, organised by namespace for Ctrl-F use.

## Voice

Matches the framework `docs/api/*` restructure (#1812): one-paragraph "what this surface is for" opener per chapter, intuition notes alongside type signatures, tight tables, "See also" sidebars cross-linking to `docs/api/*` and `docs/causa/*` tutorial chapters. No bead refs in body text per Mike directive 2026-05-21.

## mkdocs.yml

Adds an "API reference" sub-section under Causa, below the nine tutorial chapters. LHS labels: "Overview", "Mount control", "Configuration keys", "Runtime seam", "Reference" (all <=22 chars).

## Test plan

- [x] `mkdocs build --strict` passes (no new warnings tied to the five new pages).
- [x] `python scripts/check_doc_slugs.py` passes (exit 0).
- [x] LHS nav slugs all <=22 chars.
- [x] No `rf2-xxxxx` bead refs in body text (the single `data-rf2-source-coord` hit is the literal DOM-attribute name, not a bead citation).
- [x] Cross-links to `docs/api/*` chapters (lifecycle, instrumentation, registrar) resolve.
- [x] Cross-links to `docs/causa/01-installation.md` and `docs/causa/02-panel-tour.md` resolve.