### PR TITLE
cleanup: examples docs + notebook lazy-mount (rf2-hm5k9)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -34,9 +34,11 @@ examples/
     nine_states/
     routing/
     ssr/
+    ssr_streaming/                      <-- streaming SSR worked example (Spec 011 §Streaming)
     managed_http_counter/
     long_running_work/                  <-- Pattern-LongRunningWork worked example
     websocket/                          <-- Pattern-WebSocket worked example
+    notebook/                           <-- design-led example (Editorial Warm identity)
     login/
   uix/                                  <-- UIx adapter examples (counter + login + dashboard)
     counter_uix/                        <-- folder name carries the namespace suffix so it
@@ -54,7 +56,7 @@ The orchestrator and the runner consume `playwright` and `http-server` out of `i
 
 ## Reagent
 
-The full set of worked examples — nineteen in total (counting each 7GUIs task individually), each paired with a shadow-cljs build id. Per rf2-8cevm there is no per-example Playwright spec — adapter-level smoke coverage lives at [`implementation/adapters/reagent/testbed/spec.cjs`](../implementation/adapters/reagent/testbed/spec.cjs) and the broader contract coverage lives in `npm run test:cljs` / `test:causa-feature-gate` / `test:bundle-isolation` / `test:perf-bundle`.
+The full set of worked examples — twenty-one in total (counting each 7GUIs task individually), each paired with a shadow-cljs build id. There is no per-example Playwright spec — adapter-level smoke coverage lives at [`implementation/adapters/reagent/testbed/spec.cjs`](../implementation/adapters/reagent/testbed/spec.cjs) and the broader contract coverage lives in `npm run test:cljs` / `test:causa-feature-gate` / `test:bundle-isolation` / `test:perf-bundle`.
 
 Build any example directly via shadow-cljs:
 
@@ -84,6 +86,8 @@ shadow-cljs watch examples/counter
 | 17 | [`reagent/7Guis/circle_drawer/`](reagent/7Guis/circle_drawer/circle_drawer.cljs) | Benchmark | `examples/circle-drawer` | [004 Views](../spec/004-Views.md), [002 Frames](../spec/002-Frames.md) | 7GUIs #6 — Circle drawer. Undo/redo via an interceptor that snapshots `:circles`; modal dialog as state. |
 | 18 | [`reagent/7Guis/cells/`](reagent/7Guis/cells/cells.cljs) | Benchmark | `examples/cells` | [006 ReactiveSubstrate](../spec/006-ReactiveSubstrate.md), [004 Views](../spec/004-Views.md) | 7GUIs #7 — Cells. Formula evaluation; subscription-graph propagation; cycle detection; pure parser+evaluator. |
 | 19 | [`reagent/realworld/`](reagent/realworld/README.md) | Worked scaffold | `examples/realworld` | [014 HTTPRequests](../spec/014-HTTPRequests.md), [012 Routing](../spec/012-Routing.md), [005 StateMachines](../spec/005-StateMachines.md), [011 SSR](../spec/011-SSR.md), [Pattern-RemoteData](../spec/Pattern-RemoteData.md), [Pattern-Forms](../spec/Pattern-Forms.md) | [RealWorld (Conduit)](https://github.com/gothinkster/realworld) — the de-facto cross-framework benchmark. Auth, feeds, routing, comments, editor, profile, favorites, settings, and SSR-hydration glue are all sketched on the current API surface. |
+| 20 | [`reagent/ssr_streaming/`](reagent/ssr_streaming/) | Pedagogical sketch | `examples/ssr-streaming` | [011 SSR §Streaming](../spec/011-SSR.md#streaming-ssr), [004 Views](../spec/004-Views.md) | Streaming SSR walkthrough. A dashboard with three slow cards: the page's shell + header render immediately on the server, then each card streams its content as its data fetch resolves. Demonstrates the `:rf/suspense-boundary` hiccup marker, per-card fallback hiccup, inline-fallback failure semantics, and interleaved per-subtree hydration. |
+| 21 | [`reagent/notebook/`](reagent/notebook/) | Design-led | `examples/notebook` | [002 Frames](../spec/002-Frames.md), [004 Views](../spec/004-Views.md) | Three-pane editorial layout (documents tree · markdown editor · live preview). The design-led Reagent counterpart to `uix/dashboard_uix/` and `helix/process_monitor_helix/` — all three substrates share the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css). Tiny pure-CLJS markdown parser keeps the bundle small. |
 
 > Story Stage 8 (`tools/story` end-to-end on the canonical counter — seven `reg-*` macros, four variants, two workspaces, plus the privacy + size elision demo) lives as a **tool-owned testbed** at [`tools/story/testbeds/counter_with_stories/`](../tools/story/testbeds/counter_with_stories/). It builds under `:examples/counter-with-stories` and is exercised by `npm run test:story-feature-load` — but it's catalogued with the tool that owns it rather than with the tutorial examples. Same for [`tools/causa/testbeds/`](../tools/causa/) (the canonical multi-frame `parallel_frames` demo, the deterministic `feature_matrix` sweep, the Panel-view `panel_gallery`, and the perf-instrumented `perf_counter`).
 
@@ -97,6 +101,7 @@ The UIx adapter ships a curated subset rather than a 1:1 mirror of the Reagent s
 |---|---|---|---|---|
 | 1 | [`uix/counter_uix/`](uix/counter_uix/) | Pedagogical sketch | `examples/counter-uix` | The Reagent [`counter/`](reagent/counter/) dataflow rendered through the UIx adapter — same events, subs, and `app-db` shape; the view layer is `defui` components consuming subs via the `use-subscribe` hook. |
 | 2 | [`uix/login_uix/`](uix/login_uix/) | Pedagogical sketch | `examples/login-uix` | The Reagent [`login/`](reagent/login/) example through UIx — schemas, machine, and managed-HTTP stub are unchanged (substrate-agnostic); only the view layer differs. |
+| 3 | [`uix/dashboard_uix/`](uix/dashboard_uix/) | Design-led | `examples/dashboard-uix` | Design-led example proving UIx can drive a substantive multi-pane layout. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and Helix `process_monitor_helix/` siblings. |
 
 ## Helix
 
@@ -106,6 +111,7 @@ The Helix adapter ships the same subset shape as UIx — counter + login (plus t
 |---|---|---|---|---|
 | 1 | [`helix/counter_helix/`](helix/counter_helix/) | Pedagogical sketch | `examples/counter-helix` | The Reagent [`counter/`](reagent/counter/) dataflow rendered through the Helix adapter — same events, subs, and `app-db` shape; the view layer is `defnc` components consuming subs via the `use-subscribe` hook. |
 | 2 | [`helix/login_helix/`](helix/login_helix/) | Pedagogical sketch | `examples/login-helix` | The Reagent [`login/`](reagent/login/) example through Helix — schemas, machine, and managed-HTTP stub are unchanged (substrate-agnostic); only the view layer differs. |
+| 3 | [`helix/process_monitor_helix/`](helix/process_monitor_helix/) | Design-led | `examples/process-monitor-helix` | Design-led example proving Helix can drive a substantive multi-pane layout. Shares the "Editorial Warm" identity from [`examples/_shared/css/style.css`](_shared/css/style.css) with the Reagent `notebook/` and UIx `dashboard_uix/` siblings. |
 
 The bundle-isolation grep at `implementation/scripts/check-bundle-isolation.cjs` runs against the Reagent `examples/counter` bundle — separate per-example shadow-cljs builds per substrate let CI verify a Reagent-substrate example carries no UIx or Helix code, a UIx-substrate example carries no Reagent or Helix code, and a Helix-substrate example carries no Reagent or UIx code.
 

--- a/examples/helix/README.md
+++ b/examples/helix/README.md
@@ -2,14 +2,15 @@
 
 The Helix adapter (see [Spec 006 §CLJS reference: Helix as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-helix-as-alternative-substrate-rf2-2qit)). Helix is the third canonical browser substrate alongside Reagent and UIx; the eight UIx decisions transferred unchanged because Helix and UIx share the React + hooks substrate model. The adapter consumes the same `re-frame.adapter.context` React Context object the Reagent and UIx adapters expose (Decision 2), so a single app can in principle mix-and-match — though the canonical pattern is to choose one substrate per app.
 
-This directory holds the **smoke-test subset** for the Helix adapter, not a 1:1 mirror of the Reagent set. Per [Conventions §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy): non-canonical adapters ship a representative subset; the standard trio is **counter + login + realworld**, and for Helix that is reduced to **counter + login** — realworld is heavy with Reagent-flavoured idioms and is deferred until a Helix user wants it.
+This directory holds the **smoke-test subset** for the Helix adapter, not a 1:1 mirror of the Reagent set. Per [Conventions §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy): non-canonical adapters ship a representative subset. For Helix the subset is **counter + login + process-monitor** — the counter and login pair share their dataflow with the Reagent siblings (substrate-agnostic events, subs, schemas, machine, managed-HTTP stub); the process-monitor is a design-led example proving Helix can drive a polished multi-pane layout. The Reagent realworld scaffold is heavy with Reagent-flavoured idioms and is deferred until a Helix user wants it.
 
 ## Layout
 
 ```
 helix/
-  counter_helix/   <-- the Reagent counter dataflow rendered through Helix
-  login_helix/     <-- the Reagent login example through Helix
+  counter_helix/          <-- the Reagent counter dataflow rendered through Helix
+  login_helix/            <-- the Reagent login example through Helix
+  process_monitor_helix/  <-- design-led example proving multi-pane layout on Helix
 ```
 
 Each example sits in its own folder with the CLJS source (`core.cljs`), a hand-written `index.html`, and a Playwright smoke spec (`<name>.spec.cjs`). The on-disk folder names carry the `_helix` suffix because the CLJS namespaces (`counter-helix.core`, `login-helix.core`) are deliberately distinct from their Reagent siblings (`counter.core`, `login.core`) and UIx siblings (`counter-uix.core`, `login-uix.core`) — every substrate tree ends up on the same shadow-cljs classpath, so the namespaces have to be unique. The folder name follows the namespace convention (`-` becomes `_` on disk).
@@ -26,6 +27,9 @@ Per Decision 4 the `reg-view` macro stays Reagent-only; Helix users write `defnc
 - **`helix/login_helix/`** ([build id `examples/login-helix`](../../implementation/shadow-cljs.edn))
   Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`/`:locked-out`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent and UIx login examples. The view layer is a Helix `defnc` form using `helix.hooks/use-state` for local input state. Smoke-spec drives credentials → submit → asserts the welcome banner appears on success.
 
+- **`helix/process_monitor_helix/`** ([build id `examples/process-monitor-helix`](../../implementation/shadow-cljs.edn))
+  Design-led example proving Helix can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" identity with the Reagent notebook and UIx dashboard counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.
+
 ## Running
 
 The Helix examples are wired into the same orchestrator as the Reagent and UIx sets. From `implementation/`:
@@ -34,7 +38,7 @@ The Helix examples are wired into the same orchestrator as the Reagent and UIx s
 npm run test:examples
 ```
 
-That compiles `examples/counter-helix` and `examples/login-helix` alongside every Reagent and UIx example, stages each `index.html`, serves the lot, and drives the per-example smoke specs. The bundle-isolation grep at [`implementation/scripts/check-bundle-isolation.cjs`](../../implementation/scripts/check-bundle-isolation.cjs) runs against the Reagent counter; the per-substrate-per-example shadow-cljs builds let CI verify a Reagent example's `main.js` carries no Helix code and vice versa (and likewise for UIx ↔ Helix).
+That compiles `examples/counter-helix`, `examples/login-helix`, and `examples/process-monitor-helix` alongside every Reagent and UIx example, stages each `index.html`, serves the lot, and drives the adapter-level smoke specs. The bundle-isolation grep at [`implementation/scripts/check-bundle-isolation.cjs`](../../implementation/scripts/check-bundle-isolation.cjs) runs against the Reagent counter; the per-substrate-per-example shadow-cljs builds let CI verify a Reagent example's `main.js` carries no Helix code and vice versa (and likewise for UIx ↔ Helix).
 
 To iterate on one Helix example interactively, from `implementation/`:
 
@@ -50,3 +54,4 @@ shadow-cljs watch examples/counter-helix
 - [`spec/Conventions.md` §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy) — adapter test matrix policy: Reagent canonical, UIx and Helix smoke-tested.
 - [`examples/reagent/counter/`](../reagent/counter/) and [`examples/reagent/login/`](../reagent/login/) — the canonical Reagent counterparts (same dataflow; different view layer; namespace prefix without the `_helix` suffix).
 - [`examples/uix/counter_uix/`](../uix/counter_uix/) and [`examples/uix/login_uix/`](../uix/login_uix/) — the UIx siblings; the dataflow is identical, the view layer uses `defui` + `use-subscribe` rather than `defnc` + `use-subscribe`.
+- [`examples/reagent/notebook/`](../reagent/notebook/) and [`examples/uix/dashboard_uix/`](../uix/dashboard_uix/) — the Reagent and UIx design-led siblings of `process_monitor_helix`; same "Editorial Warm" identity, different substrate.

--- a/examples/reagent/README.md
+++ b/examples/reagent/README.md
@@ -2,9 +2,9 @@
 
 The canonical substrate for re-frame2: every Spec (002 Frames, 004 Views, 005 StateMachines, 006 ReactiveSubstrate, 010 Schemas, 011 SSR, 012 Routing, 014 HTTPRequests, every Pattern-* doc) was authored against the Reagent adapter, and every JVM `clojure -M:test` run, every shadow-cljs `node-test` build, every `:browser-test` run, and every `npm run test:examples` invocation exercises the Reagent path end-to-end. See [Conventions §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy) for the policy and rationale.
 
-This directory holds the **full set of nineteen worked Reagent examples** (counting each 7GUIs task individually) that ship in the catalogue at [examples/README.md](../README.md). Each example sits in its own self-contained sub-folder with the CLJS source, a hand-written `index.html`, and a Playwright smoke spec (`<name>.spec.cjs`). The 7GUIs cluster has its own internal grouping under [`7Guis/`](7Guis/README.md).
+This directory holds the **full set of worked Reagent examples** (counting each 7GUIs task individually) that ship in the catalogue at [examples/README.md](../README.md). Each example sits in its own self-contained sub-folder with the CLJS source and a hand-written `index.html`. The 7GUIs cluster has its own internal grouping under [`7Guis/`](7Guis/README.md).
 
-Story Stage 8 (`tools/story` end-to-end on the counter) moved out to a tool-owned testbed at [`tools/story/testbeds/counter_with_stories/`](../../tools/story/testbeds/counter_with_stories/) per rf2-p8f2s.
+Story Stage 8 (`tools/story` end-to-end on the counter) lives as a tool-owned testbed at [`tools/story/testbeds/counter_with_stories/`](../../tools/story/testbeds/counter_with_stories/) — catalogued with the tool that owns it rather than alongside the tutorial examples.
 
 ## Layout
 
@@ -16,12 +16,14 @@ reagent/
   todomvc/                     <-- canonical benchmark (TodoMVC spec)
   routing/                     <-- CP-7 worked example (Spec 012)
   ssr/                         <-- CP-9 worked example (Spec 011)
+  ssr_streaming/               <-- streaming SSR worked example (Spec 011 §Streaming)
   managed_http_counter/        <-- compact Spec 014 demo
   state_machine_walkthrough/   <-- runnable companion to docs/guide/09
   nine_states/                 <-- the nine canonical UI states
-  boot/                        <-- Pattern-Boot worked example (rf2-dsm2)
-  long_running_work/           <-- Pattern-LongRunningWork worked example (rf2-o9fg)
-  websocket/                   <-- Pattern-WebSocket worked example (rf2-yf97)
+  boot/                        <-- Pattern-Boot worked example
+  long_running_work/           <-- Pattern-LongRunningWork worked example
+  websocket/                   <-- Pattern-WebSocket worked example
+  notebook/                    <-- design-led example (Editorial Warm identity)
   7Guis/                       <-- 7GUIs benchmark cluster
     cells/  circle_drawer/  crud/  flight_booker/  temperature/  timer/
   realworld/                   <-- the canonical multi-artefact integration test

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -256,11 +256,19 @@
 ;; ============================================================================
 ;; MOUNT
 ;; ============================================================================
+;;
+;; Lazy mount: defer `create-root` to `run` so ns-load is DOM-side-effect-free.
+;; This is the mount-isolation convention documented at
+;; [examples/TESTING.md §Example mount-isolation convention] — multiple example
+;; namespaces co-exist in the `:browser-test` bundle and share one DOM, so a
+;; ns-load `create-root` would race roots onto the same container.
 
-(defonce react-root
-  (rdc/create-root (js/document.getElementById "app")))
+(defonce react-root (atom nil))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:notebook/initialise])
-  (rdc/render react-root [notebook]))
+  (when (exists? js/document)
+    (when-not @react-root
+      (reset! react-root (rdc/create-root (js/document.getElementById "app"))))
+    (rdc/render @react-root [notebook])))

--- a/examples/uix/README.md
+++ b/examples/uix/README.md
@@ -2,14 +2,15 @@
 
 The UIx adapter (see [Spec 006 §Adapter shipping convention](../../spec/006-ReactiveSubstrate.md)). UIx is the second adapter to ship; it consumes the same `re-frame.adapter.context` React Context that the Reagent adapter exposes (Decision 2), so a single app can in principle mix-and-match — though the canonical pattern is to choose one substrate per app.
 
-This directory holds the **smoke-test subset** for the UIx adapter, not a 1:1 mirror of the Reagent set. Per Decision 7 of [Spec 006 §Adapter shipping convention](../../spec/006-ReactiveSubstrate.md) and [Conventions §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy): non-canonical adapters ship a representative subset; the standard trio is **counter + login + realworld**, and for UIx that is reduced to **counter + login** — realworld is heavy with Reagent-flavoured idioms and is deferred until a UIx user wants it.
+This directory holds the **smoke-test subset** for the UIx adapter, not a 1:1 mirror of the Reagent set. Per Decision 7 of [Spec 006 §Adapter shipping convention](../../spec/006-ReactiveSubstrate.md) and [Conventions §Adapter test matrix policy](../../spec/Conventions.md#adapter-test-matrix-policy): non-canonical adapters ship a representative subset. For UIx the subset is **counter + login + dashboard** — the counter and login pair share their dataflow with the Reagent siblings (substrate-agnostic events, subs, schemas, machine, managed-HTTP stub); the dashboard is a design-led example proving UIx can drive a polished multi-pane layout. The Reagent realworld scaffold is heavy with Reagent-flavoured idioms and is deferred until a UIx user wants it.
 
 ## Layout
 
 ```
 uix/
-  counter_uix/   <-- the Reagent counter dataflow rendered through UIx
-  login_uix/     <-- the Reagent login example through UIx
+  counter_uix/    <-- the Reagent counter dataflow rendered through UIx
+  login_uix/      <-- the Reagent login example through UIx
+  dashboard_uix/  <-- design-led example proving multi-pane layout on UIx
 ```
 
 Each example sits in its own folder with the CLJS source (`core.cljs`), a hand-written `index.html`, and a Playwright smoke spec (`<name>.spec.cjs`). The on-disk folder names carry the `_uix` suffix because the CLJS namespaces (`counter-uix.core`, `login-uix.core`) are deliberately distinct from their Reagent siblings (`counter.core`, `login.core`) — both substrate trees end up on the same shadow-cljs classpath, so the namespaces have to be unique. The folder name follows the namespace convention (`-` becomes `_` on disk).
@@ -24,6 +25,9 @@ The dataflow — events, subs, schemas, machine, managed-HTTP stub — is **iden
 - **`uix/login_uix/`** ([build id `examples/login-uix`](../../implementation/shadow-cljs.edn))
   Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent login example. The view layer is a UIx `defui` form. Smoke-spec drives credentials → submit → asserts the welcome banner appears on success.
 
+- **`uix/dashboard_uix/`** ([build id `examples/dashboard-uix`](../../implementation/shadow-cljs.edn))
+  Design-led example proving UIx can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" visual identity with the Reagent notebook and Helix process-monitor counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.
+
 ## Running
 
 The UIx examples are wired into the same orchestrator as the Reagent set. From `implementation/`:
@@ -32,7 +36,7 @@ The UIx examples are wired into the same orchestrator as the Reagent set. From `
 npm run test:examples
 ```
 
-That compiles `examples/counter-uix` and `examples/login-uix` alongside every Reagent example, stages each `index.html`, serves the lot, and drives the per-example smoke specs. The bundle-isolation grep at [`implementation/scripts/check-bundle-isolation.cjs`](../../implementation/scripts/check-bundle-isolation.cjs) runs against the Reagent counter; the per-substrate-per-example shadow-cljs builds let CI verify a Reagent example's `main.js` carries no UIx code and vice versa.
+That compiles `examples/counter-uix`, `examples/login-uix`, and `examples/dashboard-uix` alongside every Reagent example, stages each `index.html`, serves the lot, and drives the adapter-level smoke specs. The bundle-isolation grep at [`implementation/scripts/check-bundle-isolation.cjs`](../../implementation/scripts/check-bundle-isolation.cjs) runs against the Reagent counter; the per-substrate-per-example shadow-cljs builds let CI verify a Reagent example's `main.js` carries no UIx code and vice versa.
 
 To iterate on one UIx example interactively, from `implementation/`:
 
@@ -47,3 +51,4 @@ shadow-cljs watch examples/counter-uix
 - [`spec/006-ReactiveSubstrate.md`](../../spec/006-ReactiveSubstrate.md) — the substrate contract that adapters implement; the seven decisions (frame Context, hooks-first, `use-subscribe`, no auto-injection, source-coord injection at the substrate boundary, `flush-views!` for tests, and the smoke-test subset).
 - [`spec/Conventions.md`](../../spec/Conventions.md#adapter-test-matrix-policy) — adapter test matrix policy: Reagent canonical, UIx and Helix smoke-tested.
 - [`examples/reagent/counter/`](../reagent/counter/) and [`examples/reagent/login/`](../reagent/login/) — the canonical Reagent counterparts (same dataflow; different view layer; namespace prefix without the `_uix` suffix).
+- [`examples/reagent/notebook/`](../reagent/notebook/) — the Reagent design-led sibling of `dashboard_uix`; same "Editorial Warm" identity, different substrate.


### PR DESCRIPTION
Closes rf2-hm5k9. 5 doc updates + 1 lazy-mount fix on `examples/reagent/notebook/core.cljs`.

## Doc fixes (5)

- `examples/uix/README.md` — UIx subset is **counter + login + dashboard** (3 examples), not 2. The README claimed "counter + login only" but `dashboard_uix/` has shipped.
- `examples/helix/README.md` — Helix subset is **counter + login + process-monitor** (3), not 2. Same gap.
- `examples/README.md` — top-level catalogue gains `ssr_streaming` and `notebook` rows; count bumped from "nineteen" to "twenty-one". UIx and Helix tables gain the design-led example rows.
- `examples/README.md` — layout block adds `reagent/ssr_streaming/` and `reagent/notebook/` lines (previously missing).
- `examples/reagent/README.md` — layout block adds `ssr_streaming/` and `notebook/`; drops the hard-coded "nineteen" count.

## Code fix (1)

- `examples/reagent/notebook/core.cljs` — switch from `(defonce react-root (rdc/create-root ...))` at ns-load to the canonical lazy pattern: `(defonce react-root (atom nil))` + `create-root` inside `^:export run`. This matches the mount-isolation convention documented in `examples/TESTING.md` and avoids racing roots onto `#app` when multiple example namespaces co-load into the `:browser-test` bundle.

## Test plan

- [x] `npm run test:cljs` — 3830 tests, 11707 assertions, 0 failures
- [x] `shadow-cljs compile examples/notebook` — clean (lazy-mount fix)
- [x] `shadow-cljs compile examples/dashboard-uix examples/process-monitor-helix examples/ssr-streaming` — clean (verifies build IDs cited in the docs)
- [x] `mkdocs build --strict` — exit 0