### PR TITLE
docs(story): author docs/story/api/* mini-folder (rf2-elp9l)

### DIFF
--- a/docs/story/api/index.md
+++ b/docs/story/api/index.md
@@ -1,0 +1,60 @@
+# Story API reference
+
+This is the human-facing API reference for Story — the per-frame Storybook for re-frame2 that turns *registered variants* into a navigable, queryable, snapshot-identified surface for design review, visual regression, recording, and pair-programming. The tutorial chapters one folder up walk a developer through the surface from a sitting position; this folder walks it from a standing one, organised by **what part of the contract you're touching** rather than by user journey. Each chapter opens with a paragraph on what the surface is *for* — the problem it solves, the shape of the contract — and only then drops into the function tables.
+
+If you want the dense, single-page contract — every signature, every status keyword, every cross-reference — the [developer-internal spec](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) is still where that lives. This guide is the consumer extract: the surfaces a *story author*, a *host application*, or a *tool integrator* may legitimately reach for, with intuition notes attached. Chrome internals (the panel-host composer, the shell's URL-state engine, the keybinding installer pair, the theme-token namespaces consumed by chrome) are deliberately absent — those are documented for Story's maintainers, not for authors.
+
+## What "canonical" means here
+
+Every row in this reference is **canonical**: a documented, supported v1 surface that downstream authors, hosts, and tools may rely on. There are no "alpha" or "experimental" tiers in the chapters. If a row appears here, you can call it; if a row doesn't appear, it's either chrome internals (the panel-mount aggregators consumed only by Story's shell, the URL-state hydration helpers, the design-token maps) or a `post-v1` extension that hasn't shipped yet. Story-internal surfaces (the late-bind shims, the canonical-vocabulary installer, the panel-host's per-panel mount lifecycle) are explicitly out of scope — hosts that reach for them are reading internal seams that the public-by-default CLJS surface accidentally exposes.
+
+Three audiences read these chapters. **Story authors** writing `reg-story` / `reg-variant` bodies who want to know which registration macros exist, which slots a variant body honours, and what `:play-script` steps mean — they reach for [Registration](registration.md) and [Play scripts](play-script.md). **Host application developers** wiring Story into a dev build who need to know the programmatic runtime (`run-variant`, `snapshot-identity`, `configure!`, `mount-shell!`) — they reach for [Runtime](runtime.md). And **tool integrators** building MCP servers, recording harnesses, or agent-driven test pipelines against Story's read-and-write seam — they reach for [MCP surface](mcp-surface.md) and the [Reference](reference.md) symbol table.
+
+## How to read a row
+
+Every row carries:
+
+- a **signature** — the call shape, in Clojure form
+- a **kind** — `M` (macro) or `Fn` (function); `Fx`, `Cofx`, or `Event` for the fx / cofx / canonical-assertion tables
+- a **status** — `v1` (stable), `v1 (dev-only)` (elided in `:advanced` + `re-frame.story.config/enabled?=false`)
+- an **intuition** — the one-line answer to "what's this for and when do I reach for it?"
+
+Where a surface lives in more than one namespace (e.g. `add-marks` / `set-marks` are re-exported from `re-frame.story` for author-discoverability over the framework's `re-frame.core` definitions) the canonical home is the one named. The registration macros and their `*`-fn partners follow the same convention as `re-frame.core`'s own pair (`dispatch` / `dispatch*`, `reg-event-db` / `reg-event-db*`): the un-starred form is the macro, the `*` form is the underlying runtime fn for higher-order code, fixture loaders, MCP write paths, and hot-reload tooling that synthesises registrations.
+
+## Where surfaces live
+
+Story's user-facing surface splits across the facade plus a small set of sub-namespaces. The facade carries every user-callable surface; the sub-namespaces are public but called from chrome bootstrap, the shell, or the Causa preset — not from authored story bodies. This mirrors `re-frame.core`'s practice: the facade is the ergonomic surface, sub-namespace requires are a discoverability signal that the surface is chrome-internal even when public.
+
+| Namespace | Use when |
+|---|---|
+| `re-frame.story` | The canonical require. Every registration macro + its `*`-fn partner, the run / reset / watch / destroy lifecycle, the registry query family, the assertion + recorder facades, the canonical vocabulary tables, `configure!`, the `*-id` Vars for built-in decorators, the shell-mount surface (CLJS-only), `variant-share-url`, and `add-marks` / `set-marks`. |
+| `re-frame.story.recorder.play-export` | The rich DOM-capture-aware `:play-script` translator (`recording->play-script`, `render-play-script`). Sub-namespace require — the facade exposes only the simpler `gen-play-snippet` projection. |
+| `re-frame.story.ui.causa-embed` | The Causa-RHS embed component (`causa-embed-panel`), `mount-fn-for` dispatch, `popout-full-shell!`. Called by the shell or the embed component, rarely by app code. |
+| `re-frame.story.causa-preset` | The chrome / Causa bridge — `wire-cross-host!`, `causa-available?`, `propagate-project-root!`. |
+| `re-frame.story.theme.*` | The design-token namespaces (`typography`, `colors`, `motion`, `depth`, `glyphs`). Consumed by third-party Story-panel authors; chrome consumes tokens, not raw literals. |
+| `re-frame.story.ui.keybindings` | The chrome's keybinding registry + installer pair. Called by the shell's bootstrap. |
+| `re-frame.story.ui.url-state` | The URL-state engine (`url-from-state`, `params-from-state`, `embed-flag-from-current-url`). Chrome-internal. |
+
+The dependency direction is one-way: hosts depend on `re-frame.story`; tools depend on the registry-query family plus the `*`-suffix runtime helpers; Story's own chrome never depends on anything outside `tools/story/src/`.
+
+## The chapters
+
+The reference is divided into four topical chapters plus a closing symbol-table reference. Each is independent — you can land on any of them from a search result and get something useful without reading the others.
+
+The four topical chapters are **[Registration](registration.md)** (the seven `reg-*` macros, their `*`-fn partners, the EDN-first variant contract, the inclusion-tag vocabulary, the `:rf.story/global-args` / `:rf.story/global-decorators` boot-time entry points), **[Play scripts](play-script.md)** (the `:play-script` grammar — every step, the canonical seven `:rf.assert/*` events, the record-don't-throw discipline, the recorder facade that authors a script from canvas interaction), **[Runtime](runtime.md)** (`run-variant` / `reset-variant` / `watch-variant` / `destroy-variant!`, the four-phase lifecycle, `snapshot-identity`, the registry-query family, `configure!` at boot, the shell-mount surface), and **[MCP surface](mcp-surface.md)** (the wire-elision boundary, the public read primitives consumed by `tools/story-mcp/`, the public write primitives behind the gated agent-write surface, the late-bind `reg-story-panel` contract).
+
+The closing chapter is **[Reference](reference.md)** — the complete symbol table across `re-frame.story` and its sub-namespaces, organised for `Ctrl-F` use. If you want to know whether `gen-play-snippet` lives on the facade or in the recorder sub-namespace, this is the page.
+
+## When to reach for the spec instead
+
+The chapters here are organised for readers; the [normative spec](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) is organised for completeness. If you're looking for *every* row at once — including the chrome-internal surfaces, the resolved-decisions log, the migration notes for surfaces that were renamed mid-alpha — that's where you want to be. If you're writing a story body or wiring Story into a host build and want to know which surfaces *exist* in a given domain, you want a chapter here.
+
+The normative spec docs (`001-Authoring.md`, `002-Runtime.md`, `004-Assertions.md`, `006-MCP-Surface.md`, etc. under [`tools/story/spec/`](https://github.com/day8/re-frame2/tree/main/tools/story/spec)) own the *why* — the design rationale, the alternatives considered, the dispositions. The chapters here cite those when they matter and stay quiet otherwise.
+
+## See also
+
+- [Story tutorial — Your first story](../01-first-story.md) — the chapter-1 walkthrough. Read this first if you've not yet authored a `reg-variant`.
+- [Story tutorial — Recorder + Test Codegen](../03-recorder-codegen.md) — record a canvas interaction, get a `:play-script` body back.
+- [Framework API — Story / variants / workspaces](../../api/15-story.md) — the framework-side reference slice of Story. Pairs with this folder; the two share the same surface, organised for different audiences.
+- [Framework API — Instrumentation](../../api/11-instrumentation.md) — the trace bus the recorder reads, the source-coord stamping that drives Story's "open in editor" affordances.
+- [Causa API reference](../../causa/api/index.md) — the sibling tool's API. Story embeds Causa in its right-hand pane; the two cross-link extensively.

--- a/docs/story/api/mcp-surface.md
+++ b/docs/story/api/mcp-surface.md
@@ -1,0 +1,148 @@
+# MCP surface
+
+This chapter is about the **Story ↔ MCP boundary** — the surfaces Story exposes for the separate `tools/story-mcp/` jar to consume when an agent (Claude / Cursor / Copilot) drives Story over JSON-RPC. The core of it is **two parallel surface bundles** — Story's public *read* primitives (the registry-query family plus `run-variant` / `snapshot-identity` / `variant->edn`) and Story's public *write* primitives (the `*`-suffix registration helpers plus `unregister!` / `clear-kind!` / `clear-all!`). The MCP jar consumes both; Story core stays free of stdio / JSON-RPC concerns.
+
+The architectural split is principled: Story core never depends on `tools/story-mcp/`. The MCP jar attaches to a running app via the Tool-Pair primitives — nREPL-attached process, the agent reads the registry over the wire, runs variants, reads results back. The MCP server itself runs in the agent's process; the Story runtime runs in the app.
+
+```
+┌─────────────────────────────┐         ┌───────────────────────────┐
+│ Agent (Claude / Cursor /    │ stdio + │ tools/story-mcp/          │
+│ Copilot)                    │ JSON-RPC│ day8/re-frame2-story-mcp  │
+└─────────────────────────────┘ <────── │ - tool definitions         │
+                                       │ - schema validation         │
+                                       │ - bridges to ↓              │
+                                       └──────┬─────────────────────┘
+                                              │ in-process or pair-style
+                                              ▼
+                                       ┌───────────────────────────┐
+                                       │ tools/story/ runtime      │
+                                       │ - registry queries        │
+                                       │ - run-variant             │
+                                       │ - snapshot-identity       │
+                                       │ - variant->edn            │
+                                       └───────────────────────────┘
+```
+
+## Public read primitives
+
+Story's core jar exposes these without depending on stdio / JSON-RPC. The MCP jar consumes them via the Tool-Pair bridge. The full per-fn contracts live in [Registration](registration.md) and [Runtime](runtime.md) — this section lists which surfaces are consumed by the MCP read path.
+
+| Fn | Signature | MCP tool |
+|---|---|---|
+| `registrations` | `(registrations kind)` | `list-stories` / `list-variants` / `list-workspaces` / `list-tags` / `list-modes` |
+| `handler-meta` | `(handler-meta kind id)` | `get-story` / `get-variant` / `get-workspace` / `get-decorator` body reads |
+| `ids` | `(ids kind)` | Discovery |
+| `registered?` | `(registered? kind id)` | Discovery |
+| `variants-of` | `(variants-of story-id)` | `list-variants` filtered to one story |
+| `variants-with-tags` | `(variants-with-tags qtags)` | Tag-filtered variant queries |
+| `variant->edn` | `(variant->edn variant-id)` | `get-variant` — the full body as serialisable EDN |
+| `workspace->edn` | `(workspace->edn workspace-id)` | `get-workspace` — the full body as serialisable EDN |
+| `list-tags` | `(list-tags)` | Tag inventory |
+| `list-modes` | `(list-modes)` | Mode inventory |
+| `canonical-tags` | Var (set) | The seven canonical tags surfaced to agents |
+| `run-variant` | `(run-variant variant-id opts)` | `run-variant` — materialise the variant, return result |
+| `reset-variant` | `(reset-variant variant-id opts)` | `reset-variant` |
+| `watch-variant` | `(watch-variant variant-id callback)` | `watch-variant` — live updates |
+| `snapshot-identity` | `(snapshot-identity variant-id opts)` | `snapshot-identity` — content-hash for visual-regression keying |
+| `read-assertions` | `(read-assertions variant-id)` | `get-assertions` — the assertion vector after play |
+| `assertions-passing?` | `(assertions-passing? result)` | `tests-passing?` — single-boolean projection |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` | Discovery |
+| `variant-share-url` | `(variant-share-url variant-id base-url opts)` | `share-variant` — QR-code surface |
+| `registered-substrates` | `(registered-substrates)` | CLJS-only. Substrate inventory. |
+
+The MCP jar wraps each public Story fn in a JSON-RPC tool. The wrapping is mechanical: pull the args off the JSON-RPC request, call the Story fn, project the result through the wire-elision walker (see below), serialise the result back.
+
+## Wire-elision boundary — core is real-values-in, real-values-out
+
+Story core returns **marks-as-data**: the registered bodies and per-frame snapshots travel unchanged across the read primitives above, with `:sensitive` / `:large` declarations carried alongside as declarative metadata. The wire-elision substitution to `:rf/redacted` / `:rf/large` happens at the **MCP jar's egress boundary**, NOT in Story core — every tool-response payload the MCP jar emits is passed through `re-frame.elision/elide-wire-value` before it crosses the JSON-RPC wire.
+
+The split keeps Story's read surface composable:
+
+- **Crosses the wire elided** — every payload returned by a story-mcp tool (`get-variant`, `run-variant`, `snapshot-identity`, registry reads, recorder output). The MCP jar is the wire owner; egress is where elision lands.
+- **Crosses the wire raw** — nothing the MCP jar emits. A future in-process consumer that calls the read primitives directly (without going through the MCP jar) gets real values; this is by design so on-box devtool surfaces can read the same data unredacted.
+
+Story core's contract is **real-values-in, real-values-out**; elision is the MCP jar's responsibility. The same split governs Causa's runtime seam — the framework / Causa / Story emit; tools consume; the contract is the data shape, not the call shape.
+
+## Public write primitives
+
+The MCP jar's gated agent-write surface routes through these. Story always exposes the helpers; the MCP jar decides whether to surface them to agents.
+
+| Fn | Signature | MCP tool |
+|---|---|---|
+| `reg-story*` | `(reg-story* id body)` | `register-story` |
+| `reg-variant*` | `(reg-variant* id body)` | `register-variant` — the headline write tool (agent generates a variant from canvas interaction) |
+| `reg-workspace*` | `(reg-workspace* id body)` | `register-workspace` |
+| `reg-mode*` | `(reg-mode* id body)` | `register-mode` |
+| `reg-story-panel*` | `(reg-story-panel* id body)` | `register-story-panel` |
+| `reg-decorator*` | `(reg-decorator* id body)` | `register-decorator` |
+| `reg-tag*` | `(reg-tag* id body)` | `register-tag` |
+| `unregister!` | `(unregister! kind id)` | `unregister` |
+| `clear-kind!` | `(clear-kind! kind)` | `clear-kind` (rare; mostly used by test fixtures) |
+| `clear-all!` | `(clear-all!)` | `clear-all` (very rare; used by test isolation) |
+
+The MCP jar's `:rf.story-mcp/allow-writes?` config gate determines whether these tools are advertised over the agent surface. Dev builds default the gate to `false`; teams that want agent-driven variant generation flip it explicitly. Story core's helpers are unchanged either way — Story always exposes the surface, the MCP jar decides whether to surface it to agents.
+
+## What ships in the MCP jar vs. Story core
+
+A clean split, no overlap:
+
+| Surface | Where |
+|---|---|
+| `initialize` / `tools/list` / `tools/call` / `ping` / `shutdown` dispatcher | `tools/story-mcp/` |
+| Newline-delimited JSON-RPC over stdio | `tools/story-mcp/` |
+| Cheshire (or equivalent JSON codec) | `tools/story-mcp/` |
+| Protocol-version pin | `tools/story-mcp/` |
+| The 16-tool registry (Dev / Docs / Testing / Write) | `tools/story-mcp/` |
+| The `:rf.story-mcp/allow-writes?` gate | `tools/story-mcp/` |
+| The seven `reg-*` macros (and their `*`-suffix runtime helpers) | `tools/story/` |
+| The four-phase runtime | `tools/story/` |
+| The render shell (when CLJS is the runtime) | `tools/story/` |
+| The trace bus and panel registrations | `tools/story/` |
+| The snapshot-identity computation | `tools/story/` |
+| The canonical seven `:rf.assert/*` events | `tools/story/` |
+
+`tools/story-mcp/` is a thin adapter: takes JSON-RPC requests, calls Story's public CLJS / CLJC functions, serialises responses back over stdio. Zero agent-specific logic lives in `tools/story/`.
+
+## Stage markers — independent cadence
+
+Story's own `re-frame.story/stage` advances as Story's surface extends. The MCP jar carries its own `re-frame.story-mcp.config/stage = :mcp` — the two artefacts have **independent stage progression** and ship at **independent cadence**. A consumer reading the stage marker reads it from the right artefact: Story's surface from `re-frame.story/stage`; the MCP jar's surface from `re-frame.story-mcp.config/stage`.
+
+## Late-bind `reg-story-panel` contract
+
+The `reg-story-panel` surface is the single hook through which tooling embeds itself into the Story chrome. Five rules govern panel hosting (the full statement lives in the [`003-Render-Shell.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/003-Render-Shell.md) spec doc); the summary as it pertains to the MCP surface:
+
+1. **`:render` is a `:view` id.** Late-bind via `(rf/view ...)`. The actual view can register from a different artefact than the panel registration itself.
+2. **Placement is one of five slots** — `:right` / `:left` / `:bottom` / `:top` / `:modal`.
+3. **Visibility flows through `:panel-visibility`** — the shell's on/off switch keyed by panel id.
+4. **Author calls `reg-story-panel` from anywhere.** Built-in panels register from the canonical-vocabulary auto-install; third-party tooling (Causa's epoch view, future statechart-viz panels) registers from its own boot.
+5. **The Causa embed is the canonical late-bind example.** A stub view ships with Story; Causa registers the live view under the same `:rf.story.panel/epoch-view` id when present; the shell picks Causa's view automatically.
+
+The MCP jar consumes neither the panel host nor the view ids directly; it consumes the registry data. But the same contract is what allows the *MCP* to expose new panels to Story-the-tool via agent action: an agent calls `register-variant` *plus* `register-story-panel` (when the write surface is open) to ship a panel.
+
+## Why a separate jar
+
+The MCP server depends on transport machinery (stdio adapter, JSON-RPC framing, asynchronous-handler runtime) that the vast majority of Story consumers never load. Splitting at the jar boundary keeps the Story core lean and lets the MCP surface evolve on its own cadence. The pattern mirrors `tools/causa/` vs. `tools/re-frame2-pair-mcp/` (the runtime seam vs. the MCP server that consumes it).
+
+A typical agent's interaction with Story over the MCP surface:
+
+```
+1. list-stories                  — registrations :story
+2. list-variants                 — registrations :variant
+3. get-variant :s.c/at-five      — variant->edn :s.c/at-five
+4. run-variant :s.c/at-five      — run-variant :s.c/at-five {}
+5. get-assertions :s.c/at-five   — read-assertions :s.c/at-five
+6. snapshot-identity :s.c/at-five — snapshot-identity :s.c/at-five {}
+7. register-variant :s.c/at-six  — reg-variant* :s.c/at-six body (if write surface gated open)
+```
+
+Every read crosses the wire elided; every write goes through the gate. Story core stays composable, the MCP jar stays focused, the contract is the data shape on both sides.
+
+## See also
+
+- [Registration](registration.md) — the `*`-suffix runtime helpers the write surface consumes.
+- [Runtime](runtime.md) — `run-variant` / `snapshot-identity` / `read-assertions` and the four-phase lifecycle the MCP `run-variant` tool calls.
+- [Play scripts](play-script.md) — the `:play-script` body shape an agent emits via the `register-variant` write tool.
+- [Reference](reference.md) — the full symbol table for `Ctrl-F` use.
+- [Framework API — Schemas and data classification](../../api/08-schemas.md) — `elide-wire-value`, the framework primitive the MCP jar's egress boundary calls.
+- [Causa runtime seam](../../causa/api/runtime-seam.md) — the parallel Tool-Pair contract for Causa-the-panel; same emit-and-consume discipline.
+- Normative spec — [`tools/story-mcp/spec/`](https://github.com/day8/re-frame2/tree/main/tools/story-mcp/spec) (the MCP jar's own spec folder: wire protocol, tool registry, write-surface gating).

--- a/docs/story/api/play-script.md
+++ b/docs/story/api/play-script.md
@@ -1,0 +1,166 @@
+# Play scripts
+
+This chapter is about the surface that turns a variant body's `:play-script` slot into a deterministic, replayable sequence of dispatches, DOM gestures, sleeps, and assertions. The core of it is **a ten-step grammar** of bare-vector forms — `[:dispatch ...]`, `[:dispatch-sync ...]`, `[:wait ms]`, `[:click selector]`, `[:type selector text]`, four `[:assert-* ...]` shapes — that the runtime's phase-4 driver walks in order against the variant's frame. Around the grammar sit the **seven canonical `:rf.assert/*` events** (the assertion vocabulary the `[:dispatch-sync ...]` rail rides), the **record-don't-throw** discipline (failures append to the variant's `:assertions` accumulator rather than aborting the play), and the **recorder facade** (six fns that capture canvas gestures and emit a paste-ready `:play-script` body).
+
+`:play-script` is the **canonical AND ONLY** phase-4 play surface as of 2026-05-20 — the legacy `:play` event-vector slot has been removed under pre-alpha posture, with no transitional dual-acceptance.
+
+## The grammar — ten step forms
+
+Every step is a bare vector. Phase 4 of the variant lifecycle iterates the script in order, dispatch-syncs each step into the variant's frame, drains to completion between steps, and records the result.
+
+| Step | Semantics |
+|---|---|
+| `[:dispatch event-vec]` | `rf/dispatch` (async) into the variant's frame. Returns immediately; the runtime drains the cascade before stepping. |
+| `[:dispatch-sync event-vec]` | `rf/dispatch-sync` (synchronous) into the variant's frame. The runtime waits for the drain to settle. The canonical seven `:rf.assert/*` events ride this rail. |
+| `[:wait ms]` | Sleep N milliseconds. Use sparingly — async settlement is the canonical reason to wait, and the runtime already drains between steps. |
+| `[:assert-db path value]` | Assert `(= (get-in @app-db path) value)`. A bare-vector shorthand for `[:dispatch-sync [:rf.assert/path-equals path value]]`. |
+| `[:assert-db path :pred fn-or-sym]` | Assert custom predicate. The predicate is a unary fn over the value at `path`. |
+| `[:assert-dom selector :visible]` | Assert selector resolves to a visible DOM node. |
+| `[:assert-dom selector :hidden]` | Assert selector resolves to nothing. |
+| `[:assert-dom selector :text txt]` | Assert selector's text-content matches `txt`. |
+| `[:click selector]` | Synthetic click event at selector. |
+| `[:type selector text]` | Synthetic input event at selector with `text`. |
+
+The script body can be either:
+
+- **Bare vector** — `:play-script [[:dispatch-sync [:foo]] [:assert-db [:n] 1]]`
+- **Map** — `:play-script {:script [...] :auto-run? bool :name str}`
+
+The map shape carries optional metadata: `:auto-run?` (default `true` — phase 4 fires on variant mount) and `:name` (surfaced in the *Tests* mode pane summary).
+
+## The canonical seven `:rf.assert/*` events
+
+The assertion vocabulary auto-registers at Story load (the auto-install gate fires from the first `reg-*`). All seven record results into the variant frame's `:rf.story/assertions` slot rather than throwing.
+
+| Event id | Payload | Semantics |
+|---|---|---|
+| `:rf.assert/path-equals` | `[path expected]` | `(= (get-in @app-db path) expected)`. The most-cited assertion — most `:play-script` rows that aren't dispatches end here. |
+| `:rf.assert/path-matches` | `[path malli-schema]` | `(m/validate schema (get-in @app-db path))`. Use when the expected shape is a structural match, not a value match. |
+| `:rf.assert/sub-equals` | `[sub-vec expected]` | `(= @(subscribe sub-vec) expected)`. Asserts against a subscription's computed value rather than raw `app-db`. |
+| `:rf.assert/dispatched?` | `[event-vec]` | Was this event dispatched against this frame during phase-4? The accumulator is phase-4-scoped — events dispatched during phase-2 `:events` setup don't count. |
+| `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is `state`. Pairs with the per-variant trace-buffer's `:rf.machine/guard-evaluated` + `:rf.machine/action-ran` ops so failures can be diagnosed against the captured guard / action trace. |
+| `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. The "did anything misbehave?" assertion. |
+| `:rf.assert/effect-emitted` | `[fx-id]` or `[fx-id pred]` | Did the variant's drain emit `fx-id`? The optional `pred` is a unary fn over the matched fx-id keyword (exceptions count as `false`). |
+
+Each handler returns a map:
+
+```clojure
+{:assertion :rf.assert/path-equals
+ :payload   [[:auth :status] :authenticated]
+ :passed?   true
+ :actual    :authenticated
+ :expected  :authenticated
+ :source    {:file "..." :line ...}}             ; source-coord stamped at macro-expansion
+```
+
+The play-runner concatenates these into the variant frame's `:rf.story/assertions` vector. `assertions-passing?` over the final vector projects to a single boolean for `run-variant` callers; the test-runner adapter walks each entry to drive `cljs.test/is` reporting.
+
+## `:rf.assert/effect-emitted` payload shape
+
+The only assertion whose payload carries an **optional second slot**. Both shapes are legal:
+
+- **`[fx-id]`** — passes iff `fx-id` was emitted at least once during phase-4 (the variant's frame accumulates emitted fx-ids into its per-frame `:emitted-fx` slot).
+- **`[fx-id pred]`** — passes iff `fx-id` was emitted **and** `(pred fx-id)` returns truthy. `pred` is a unary fn over the matched fx-id keyword; exceptions thrown by `pred` count as a `false` return.
+
+The pred slot is deliberately a unary fn over the fx-id keyword, not over the fx-args map. The play-runner's emitted-fx accumulator tracks **which fx-ids fired**, not the per-call fx-args payload. Authors who need an argument-level assertion compose two checks: an `:rf.assert/effect-emitted` for the fx-id (set membership) plus an `:rf.assert/path-equals` against the slot in `app-db` the fx writes through.
+
+## Record-don't-throw semantics
+
+Every `:rf.assert/*` event records into `:rf.story/assertions` and continues the play. A failing `:rf.assert/path-equals` does NOT abort the script — phase-4 walks every remaining step, accumulates every assertion record, and the test-runner adapter asks "did every entry pass?" at the end. A play sequence with eight assertions where three fail still runs all eight; you get the full picture from a broken variant, not a stack trace and a single failure.
+
+The discipline diverges from Storybook (which throws on the first assertion failure). Storybook's choice is constrained by JavaScript's async-throw mess; re-frame2's run-to-completion drain gives Story room to do better.
+
+Worked example — a counter variant whose play asserts both the dispatch trace and the resulting `app-db`:
+
+```clojure
+(story/reg-variant :story.counter/clicked-three-times
+  {:doc         "Counter after three increments from zero."
+   :events      [[:counter/initialise 0]]
+   :play-script [[:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:counter/inc]]
+                 [:dispatch-sync [:rf.assert/path-equals [:count] 3]]
+                 [:dispatch-sync [:rf.assert/dispatched? [:counter/inc]]]]
+   :tags        #{:dev :docs :test}
+   :substrates  #{:reagent}})
+```
+
+A subtle but load-bearing detail: the three `:counter/inc` events live in `:play-script`, not `:events`. The `:rf.assert/dispatched?` accumulator is only wired during phase-4 — if the increments were in `:events` (phase-2 setup), the dispatch-trace listener wouldn't have observed them and the assertion would fail. The general rule for hand-authored variants: **assertions about dispatches only see what happens during play, not what happens during setup.**
+
+## Privacy posture
+
+`:rf.assert/*` records build `:actual` / `:expected` / `:payload` slots through `re-frame.elision/elide-wire-value` before landing in `:assertions`. If a variant declared per-frame marks via `(re-frame.core/add-marks <variant-id> {path mark, ...})` or `set-marks`, then a `:rf.assert/path-equals [:auth :token] :rf/redacted` lookup against a path-marked-sensitive slot records `:actual :rf/redacted`, NOT the raw value.
+
+The sentinel literal is a legal `:expected` value. Authors write the `:rf/redacted` sentinel directly into the assertion to pin the redaction contract:
+
+```clojure
+(re-frame.core/add-marks :story.auth/login {:auth.token :sensitive})
+
+(story/reg-variant :story.auth/login
+  {:events      [[:auth/login {:user "alice" :password "..."}]]
+   :play-script [[:dispatch-sync [:rf.assert/path-equals [:auth :token] :rf/redacted]]]})
+```
+
+A passing assertion proves the observation surface saw a sentinel, not the secret. The display contract (the `:test` mode pane and the `[data-test="story-test-row-detail"]` disclosure) matches Causa's posture: a disclosure that revealed the underlying value would be non-conformant.
+
+## The recorder facade
+
+Story's canvas recorder captures dispatched events and DOM-level interactions into a paste-ready `:play-script` body. The facade exposes six entries on `re-frame.story`.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `start-recording!` | `(start-recording! variant-id)` → nil | v1 (dev-only) | Begin recording dispatched events against `variant-id`'s frame. The recorder filters on dispatch-provenance `:rf.story/source :user` — setup-phase events (`:variant-events`) are excluded. |
+| `stop-recording!` | `(stop-recording!)` → events-vec | v1 (dev-only) | Stop the in-flight recording; return the captured events vector. |
+| `clear-recording!` | `(clear-recording!)` → nil | v1 (dev-only) | Drop the buffer + return the recorder to idle. |
+| `recording?` | `(recording?)` → bool | v1 (dev-only) | Predicate — is a recording in flight? |
+| `recorder-state` | `(recorder-state)` → map | v1 (dev-only) | Read-only view of the current recorder state map. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` → string | v1 (dev-only) | Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play-script {:script [...]}})` EDN snippet. Each captured event vector is wrapped as `[:dispatch-sync <event-vec>]`. |
+
+The facade's `gen-play-snippet` is the simpler event-vector → `:dispatch-sync` step projection. A typical recorder modal calls `start-recording!` on the *record* chip click, hooks the user's canvas interaction, then on *stop* calls `stop-recording!` + `gen-play-snippet` to render the modal's EDN body.
+
+### Rich DSL recorder — out of facade
+
+The richer DOM-capture-aware translator (tagged `:click` / `:type` / `:wait` steps derived from the recorder's `:entries` capture stream) is exported by `re-frame.story.recorder.play-export` — a sub-namespace, not re-exported through `re-frame.story`. The facade exposes only `gen-play-snippet`; consumers wanting the rich DOM-derived DSL `:require` the sub-namespace directly.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `recording->play-script` | `(recording->play-script entries opts)` → map | v1 (dev-only) | Translate captured `:entries` into a normalised `:play-script` body map. Derives `[:click selector]`, `[:type selector text]`, `[:wait ms]` steps from the entries stream. |
+| `render-play-script` | `(render-play-script body)` → string | v1 (dev-only) | Render the `:play-script` map to EDN. |
+| `render-variant-form` | `(render-variant-form variant-id metadata)` → string | v1 (dev-only) | Render a full `(reg-variant <id> {...})` form to EDN. |
+
+Lives in `re-frame.story.recorder.play-export`. Two `:require`s — `[re-frame.story :as story]` for the facade plus `[re-frame.story.recorder.play-export :as play-export]` for the rich translator.
+
+## A complete worked example
+
+```clojure
+;; 1. Register the variant with a hand-authored play script.
+(story/reg-variant :story.login/error-then-recovery
+  {:doc         "User enters wrong password, then corrects it."
+   :events      [[:auth/initialise]]
+   :play-script [[:type "[data-test='username']" "alice"]
+                 [:type "[data-test='password']" "wrong"]
+                 [:click "[data-test='submit']"]
+                 [:wait 50]
+                 [:assert-dom "[data-test='error']" :visible]
+                 [:assert-dom "[data-test='error']" :text "Incorrect password."]
+                 [:type "[data-test='password']" "correct"]
+                 [:click "[data-test='submit']"]
+                 [:dispatch-sync [:rf.assert/path-equals [:auth :status] :authenticated]]
+                 [:dispatch-sync [:rf.assert/effect-emitted :http]]
+                 [:dispatch-sync [:rf.assert/no-warnings]]]
+   :tags        #{:dev :test}})
+
+;; 2. The Tests mode tab auto-runs the script on variant mount;
+;;    the sidebar dot flips green when all 11 step records pass.
+```
+
+The script mixes DOM gestures (`:type` / `:click`), explicit dispatches (`:dispatch-sync`), DOM-shape assertions (`:assert-dom`), framework assertions (`:rf.assert/path-equals`, `:rf.assert/effect-emitted`, `:rf.assert/no-warnings`), and a single `:wait`. Each row records into `:rf.story/assertions`; the *Tests* tab's auto-run reports the count.
+
+## See also
+
+- [Registration](registration.md) — the `reg-variant` macro the `:play-script` slot lives on. The `force-fx-stub-id` decorator that mocks fx-handlers for assertion-friendly scripts.
+- [Runtime](runtime.md) — the four-phase lifecycle (`:loaders` → `:events` → render → `:play-script`); `read-assertions` / `assertions-passing?` for post-run inspection.
+- [MCP surface](mcp-surface.md) — the gated agent-write path that calls `reg-variant*` with a generated `:play-script` body.
+- [Story tutorial — Recorder + Test Codegen](../03-recorder-codegen.md) — record a canvas interaction end-to-end; the hero chapter.
+- [Story tutorial — Time-travel in Story](../06-time-travel.md) — Causa embedded in the RHS, scoped per variant frame; pairs with the `:rf.assert/state-is` machine-state assertion.
+- [Framework API — Schemas and data classification](../../api/08-schemas.md) — `add-marks` / `set-marks`, the path-mark primitives `:rf.assert/*` records elide through.

--- a/docs/story/api/reference.md
+++ b/docs/story/api/reference.md
@@ -1,0 +1,258 @@
+# Reference
+
+The complete symbol table for Story's public surface, organised by namespace and section for `Ctrl-F` use. Every row carries a signature, a status, and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
+
+Surfaces fall into the facade plus seven sub-namespaces. The facade carries every user-callable surface — registrations, runtime, recorder, configure!, shell-mount, privacy primitives. The sub-namespaces are public but called from chrome bootstrap, the shell, or the Causa preset, not from authored story bodies.
+
+For the topical walk-through with intuition notes and use-when prose, see [Registration](registration.md), [Play scripts](play-script.md), [Runtime](runtime.md), and [MCP surface](mcp-surface.md). For the index of *what* this reference covers (and what it deliberately omits — Story-internal chrome composers, the URL-state hydration helpers, the theme-token maps consumed only by chrome), see [the index](index.md#what-canonical-means-here).
+
+## `re-frame.story`
+
+The canonical facade. Every user-callable surface lives here.
+
+### Registration — macros
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `reg-story` | `(reg-story id metadata)` | v1 (dev-only) | Register a story (a cluster of variants). |
+| `reg-variant` | `(reg-variant id metadata)` | v1 (dev-only) | Register one variant — view, args, setup events, decorators, `:play-script`. |
+| `reg-workspace` | `(reg-workspace id metadata)` | v1 (dev-only) | Register a workspace — a curated grid of variants. |
+| `reg-decorator` | `(reg-decorator id metadata)` | v1 (dev-only) | Register a decorator. Three kinds: `:hiccup` / `:frame-setup` / `:fx-override`. |
+| `reg-story-panel` | `(reg-story-panel id metadata)` | v1 (dev-only) | Register a custom panel in the Story chrome. Five placement slots. |
+| `reg-tag` | `(reg-tag id metadata)` | v1 (dev-only) | Register a tag. The seven canonical tags auto-install. |
+| `reg-mode` | `(reg-mode id metadata)` | v1 (dev-only) | Register a mode — a saved tuple of args the chrome toggles into. |
+
+### Registration — `*`-suffix runtime helpers
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `reg-story*` | `(reg-story* id body)` | v1 (dev-only) | Programmatic story registration. |
+| `reg-variant*` | `(reg-variant* id body)` | v1 (dev-only) | Programmatic variant registration. The MCP write surface's `register-variant` tool routes here. |
+| `reg-workspace*` | `(reg-workspace* id body)` | v1 (dev-only) | Programmatic workspace registration. |
+| `reg-mode*` | `(reg-mode* id body)` | v1 (dev-only) | Programmatic mode registration. |
+| `reg-story-panel*` | `(reg-story-panel* id body)` | v1 (dev-only) | Programmatic panel registration. |
+| `reg-decorator*` | `(reg-decorator* id body)` | v1 (dev-only) | Programmatic decorator registration. |
+| `reg-tag*` | `(reg-tag* id body)` | v1 (dev-only) | Programmatic tag registration. |
+| `unregister!` | `(unregister! kind id)` | v1 (dev-only) | Remove a single id under `kind`. |
+| `clear-kind!` | `(clear-kind! kind)` | v1 (dev-only) | Remove every registration of `kind`. |
+| `clear-all!` | `(clear-all!)` | v1 (dev-only) | Reset every Story registration. Resets the auto-install gate. |
+| `install-canonical-vocabulary!` | `(install-canonical-vocabulary!)` | v1 (dev-only) | Idempotent explicit boot. Auto-install path is canonical; this is retained for hosts that want a literal boot step. |
+
+### Global args + decorators
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config. Map keyed by `:rf.story/*` and `:rf.privacy/*`. |
+| `reg-global-decorator` | `(reg-global-decorator id body)` / `(reg-global-decorator id body ref-args)` | v1 (dev-only) | Register a decorator AND opt it into the global stack in one call. |
+| `unreg-global-decorator!` | `(unreg-global-decorator! id)` | v1 (dev-only) | Remove `id` from the global-decorators vector. |
+| `global-decorators` | `(global-decorators)` → vec | v1 (dev-only) | Current ordered vector of global-decorator references. |
+
+### Built-in decorator `*-id` Vars
+
+| Symbol | Status | Intuition |
+|---|---|---|
+| `force-fx-stub-id` | v1 (dev-only) | Universal fx-mocking primitive — HTTP, websockets, analytics, storage, navigation. |
+| `layout-debug-measure-id` | v1 (dev-only) | Storybook-style layout measure overlay. |
+| `layout-debug-outline-id` | v1 (dev-only) | Pesticide-style coloured outlines. |
+| `layout-debug-pseudo-id` | v1 (dev-only) | Pseudo-state forcing (`:hover` / `:focus` / `:active` / `:visited`). |
+
+### Programmatic runtime
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `run-variant` | `(run-variant variant-id)` / `(run-variant variant-id opts)` → map | v1 (dev-only) | Materialise the variant — run four-phase lifecycle, return result map. |
+| `reset-variant` | `(reset-variant variant-id)` | v1 (dev-only) | Reset the variant to its post-events baseline. |
+| `watch-variant` | `(watch-variant variant-id)` / `(watch-variant variant-id callback)` | v1 (dev-only) | Live-updating result map. |
+| `unwatch-variant` | `(unwatch-variant variant-id)` | v1 (dev-only) | Stop the live update channel. Idempotent. |
+| `destroy-variant!` | `(destroy-variant! variant-id)` | v1 (dev-only) | Tear down the variant's frame. Symmetric with allocation. |
+| `execute-play!` | `(execute-play! variant-id)` → vec | v1 (dev-only) | Re-run only phase 4 against current `app-db`. |
+| `lifecycle-state` | `(lifecycle-state variant-id)` → keyword | v1 (dev-only) | Current lifecycle-machine state. |
+| `variant-frames` | `(variant-frames)` → set | v1 (dev-only) | Set of variant-ids currently allocated as frames. |
+| `variant-frame?` | `(variant-frame? variant-id)` → bool | v1 (dev-only) | Predicate. |
+| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` → map | v1 (dev-only) | The effective args map (five-layer precedence). |
+| `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` → map | v1 (dev-only) | The resolved decorator stack classified by kind. |
+| `variants-of` | `(variants-of story-id)` → seq | v1 (dev-only) | Variant ids whose namespaced id-prefix matches `story-id`. |
+| `variants-by-story` | `(variants-by-story)` → map | v1 (dev-only) | Map from parent-story-id to variant ids. |
+| `variants-with-tags` | `(variants-with-tags tag-set)` → seq | v1 (dev-only) | Filter the catalogue by tag intersection. |
+| `variant-substrates` | `(variant-substrates variant-id)` → set | v1 (dev-only) | The substrate set for a specific variant. |
+| `variant->edn` | `(variant->edn variant-id)` → map | v1 (dev-only) | Variant body as serialisable EDN. |
+| `workspace->edn` | `(workspace->edn workspace-id)` → map | v1 (dev-only) | Workspace body as serialisable EDN. |
+| `snapshot-identity` | `(snapshot-identity variant-id)` / `(snapshot-identity variant-id opts)` → map | v1 (dev-only) | `{:variant-id ... :content-hash "..."}`. QR-share + visual-regression keying. |
+| `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id base-url opts)` → string | v1 (dev-only) | Sharable URL — encodes active modes + cell-overrides + substrate. |
+| `static-mode?` | `(static-mode?)` → bool | v1 (dev-only) | True iff Story is running in static-export mode. |
+
+### Registry queries
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `registrations` | `(registrations kind)` → seq | v1 (dev-only) | All registrations for `kind`. |
+| `handler-meta` | `(handler-meta kind id)` → any | v1 (dev-only) | Registered body for `id`. |
+| `ids` | `(ids kind)` → seq | v1 (dev-only) | All registered ids of `kind`. |
+| `registered?` | `(registered? kind id)` → bool | v1 (dev-only) | Predicate. |
+| `all-kinds-with-counts` | `(all-kinds-with-counts)` → map | v1 (dev-only) | Map from each kind → registration count. |
+| `list-tags` | `(list-tags)` → seq | v1 (dev-only) | All registered tags. |
+| `list-modes` | `(list-modes)` → seq | v1 (dev-only) | All registered modes. |
+| `canonical-tags` | Var (set) | v1 (dev-only) | The seven canonical tags. |
+| `canonical-axes` | Var | v1 (dev-only) | The four canonical axes (audience / lifecycle / quality / status). |
+| `canonical-status-values` | Var | v1 (dev-only) | Status-axis tag values. |
+| `canonical-role-values` | Var | v1 (dev-only) | Role-axis tag values. |
+| `tags-by-axis` | `(tags-by-axis)` → map | v1 (dev-only) | Tags keyed by axis. |
+| `tags-without-axis` | `(tags-without-axis)` → seq | v1 (dev-only) | Tags not registered against any axis. |
+| `tags-default-excluded` | `(tags-default-excluded)` → set | v1 (dev-only) | Sidebar tag-filter default exclusions. |
+| `tag->axis-index` | `(tag->axis-index)` → map | v1 (dev-only) | Map from tag-id → axis. |
+| `registered-substrates` | `(registered-substrates)` → set | v1 (dev-only) | Registered substrate ids (CLJS-only). |
+
+### Assertions
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `read-assertions` | `(read-assertions variant-id)` → vec | v1 (dev-only) | Current `:rf.story/assertions` vector. |
+| `assertions-passing?` | `(assertions-passing? result)` → bool | v1 (dev-only) | Project assertions vector → single boolean. |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` → set | v1 (dev-only) | The seven canonical `:rf.assert/*` event-ids. |
+
+### Recorder
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `start-recording!` | `(start-recording! variant-id)` | v1 (dev-only) | Begin capturing canvas-dispatched events. |
+| `stop-recording!` | `(stop-recording!)` → vec | v1 (dev-only) | Stop + return captured events. |
+| `clear-recording!` | `(clear-recording!)` | v1 (dev-only) | Drop the buffer + return to idle. |
+| `recording?` | `(recording?)` → bool | v1 (dev-only) | Predicate. |
+| `recorder-state` | `(recorder-state)` → map | v1 (dev-only) | Read-only view of recorder state. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` → string | v1 (dev-only) | Render captured events as a `(reg-variant ...)` EDN snippet. |
+
+### Privacy primitives
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `add-marks` | `(add-marks variant-id marks-map)` | v1 (dev-only) | Merge marks additively. Re-export of `re-frame.core/add-marks`. |
+| `set-marks` | `(set-marks variant-id marks-map)` | v1 (dev-only) | Replace marks wholesale. Re-export of `re-frame.core/set-marks`. |
+
+### Substrate registration
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `register-substrate!` | `(register-substrate! substrate-id render-fn)` | v1 (dev-only) | Register a substrate render fn (CLJS-only). |
+
+### Shell lifecycle (CLJS-only)
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `mount-shell!` | `(mount-shell! mount-point opts)` | v1 (dev-only) | Mount the Story shell. Production short-circuits before any DOM call. |
+| `unmount-shell!` | `(unmount-shell!)` | v1 (dev-only) | Unmount the shell. Idempotent. |
+| `active-shell` | `(active-shell)` → map / nil | v1 (dev-only) | Inspectable handle on the active shell. |
+
+### Stage
+
+| Symbol | Use |
+|---|---|
+| `stage` | Var. The current Story development stage marker. |
+
+## `re-frame.story.recorder.play-export`
+
+The rich DOM-capture-aware `:play-script` translator. Sub-namespace require — the facade exposes only the simpler `gen-play-snippet` projection.
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `recording->play-script` | `(recording->play-script entries opts)` → map | v1 (dev-only) | Translate captured `:entries` into a normalised `:play-script` body map. |
+| `render-play-script` | `(render-play-script body)` → string | v1 (dev-only) | Render the `:play-script` map to EDN. |
+| `render-variant-form` | `(render-variant-form variant-id metadata)` → string | v1 (dev-only) | Render a full `(reg-variant ...)` form to EDN. |
+
+## `re-frame.story.ui.causa-embed`
+
+The Causa-RHS embed component. Reach here from the embed component or the Causa preset, rarely from app code.
+
+| Symbol | Kind | Audience | Intuition |
+|---|---|---|---|
+| `causa-embed-panel` | Reagent component | `user-app` (rare) / `chrome-shell` | The RHS Causa-host Reagent component. Renders the chip-row picker plus the Causa panel-host `<div>`. Feature-detect-safe — graceful no-op when Causa's preload is not on the classpath. |
+| `mount-fn-for` | Pure dispatch fn | `chrome-shell` | `(mount-fn-for panel-id)` returns the Causa `mount-<panel>!` fn for `panel-id` (one of `:event-detail` / `:app-db` / `:views` / `:trace` / `:machines` / `:routing` / `:issues`), or nil for an unknown id. Compile-time symbol resolution. |
+| `popout-full-shell!` | User-callable lifecycle | `user-app` | Pop out the full Causa 4-layer shell into a second window. Gated on `causa-preset/causa-available?` so the chip is a graceful no-op when Causa's preload is absent. |
+
+## `re-frame.story.causa-preset`
+
+The chrome / Causa bridge.
+
+| Symbol | Kind | Audience | Intuition |
+|---|---|---|---|
+| `wire-cross-host!` | Internal bridge | `chrome-shell` | Bridges-only host-wiring helper called by the shell on every variant selection. Threads through Causa's host-installation hooks (project-root, keybinding) but does NOT mount Causa. |
+| `causa-available?` | Pure predicate | `user-app` / `chrome-shell` | True when Causa's preload is on the build. The chip-row, popout, and `wire-cross-host!` all check this. |
+| `propagate-project-root!` | Internal bridge | `chrome-shell` | Bridges Story's `:rf.story/project-root` from `configure!` into Causa's `:rf.causa/project-root` slot so Causa-as-RHS source-coord chips share the same on-disk root. |
+
+## `re-frame.story.theme.*`
+
+The design-token namespaces. Public for third-party Story-panel authors; chrome consumes tokens, not raw literals. The full per-namespace contracts live in [`016-Design-Tokens.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/016-Design-Tokens.md).
+
+| Namespace | Surface | Purpose |
+|---|---|---|
+| `re-frame.story.theme.typography` | `sans-stack`, `mono-stack`, `display-stack`, `type-scale`, `weights`, `inject-font-faces!` | IBM Plex Sans + Mono stacks. Inject `local()`-only `@font-face` rules at shell mount. |
+| `re-frame.story.theme.colors` | `tokens` | Semantic colour map (`:bg-1` / `:text-primary` / `:accent-amber` / `:danger` / `:tag-*-bg` / ...). |
+| `re-frame.story.theme.motion` | `durations`, `easings`, `transitions` | Duration / easing maps + pre-composed transitions. Honours `prefers-reduced-motion`. |
+| `re-frame.story.theme.depth` | `shadows` | Elevation shadow scale (`:elev-1` / `:elev-2` / ...). |
+| `re-frame.story.theme.glyphs` | `story-glyph`, `variant-glyph`, `workspace-glyph`, `chevron-right`, `external-link` | Inline-SVG glyph fns. Draws via `currentColor`. |
+
+### Token contract
+
+- **No raw `font-family` at call sites.** Chrome consumes `sans-stack` / `mono-stack` / `display-stack`; raw `font-family` literals are banned.
+- **No raw hex literals at call sites.** Chrome consumes `(:token-name colors/tokens)`; raw `#xxxxxx` literals are banned.
+- **No raw `transition` literals at call sites.** Chrome consumes `(:row motion/transitions)`; raw `transition` strings are banned.
+- **`prefers-reduced-motion: reduce` is honoured.** Chrome motion falls back to static states behind the user-agent media query.
+
+## `re-frame.story.ui.keybindings`
+
+The chrome's keybinding registry + installer pair.
+
+| Symbol | Kind | Audience | Intuition |
+|---|---|---|---|
+| `bindings` | Pure data table | `pure-data-for-help` | Canonical `{key → handler}` table for the chrome-visibility hotkeys (`f` / `s` / `a` / `t`). |
+| `shortcut-keys` | Pure data → data | `pure-data-for-help` | The sorted list of bound keys. Consumed by the first-visit help overlay. |
+| `install!` | Installer | `chrome-shell` | Install the single `window#keydown` capture-phase listener. Idempotent. |
+| `uninstall!` | Installer | `chrome-shell` | Symmetric teardown. |
+
+## Effects + coeffects registered by Story
+
+| Fx id | Payload | Notes |
+|---|---|---|
+| `:story/set-arg` | `{:variant <id> :key <k> :value <v>}` | Dispatched by control widgets. |
+| `:story/run-play` | `{:variant <id>}` | Run the play sequence. |
+| `:story/reset` | `{:variant <id>}` | Reset to post-events baseline. |
+| `:story/save-layout-as` | `{:workspace <id> :body <transit>}` | Persist active layout as a workspace. |
+
+| Cofx id | Shape | Notes |
+|---|---|---|
+| `:story/active-modes` | `[<mode-id> ...]` | Chrome-toolbar's active mode-set. |
+| `:story/active-args` | `{<arg-key> <value>}` | Deep-merge of all active modes' `:args`. |
+| `:story/substrate` | `:reagent` / `:uix` / `:helix` | Active substrate. |
+
+## Canonical assertion events
+
+The seven `:rf.assert/*` events the auto-install registers at first `reg-*`.
+
+| Event id | Payload | Semantics |
+|---|---|---|
+| `:rf.assert/path-equals` | `[path expected]` | `(= (get-in @app-db path) expected)` |
+| `:rf.assert/path-matches` | `[path malli-schema]` | `(m/validate schema (get-in @app-db path))` |
+| `:rf.assert/sub-equals` | `[sub-vec expected]` | `(= @(subscribe sub-vec) expected)` |
+| `:rf.assert/dispatched?` | `[event-vec]` | Was this event dispatched during phase-4? |
+| `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. |
+| `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. |
+| `:rf.assert/effect-emitted` | `[fx-id]` / `[fx-id pred]` | Did the variant's drain emit fx-id? Optional unary `pred` over the fx-id keyword. |
+
+## What this reference deliberately omits
+
+Several surfaces are **publicly visible** in the CLJS source but explicitly *not part of the contract*. They're documented in the [developer-internal spec](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) for Story's maintainers; this reference omits them on purpose.
+
+- **`re-frame.story.ui.url-state` engine.** `url-from-state`, `params-from-state`, `embed-flag-from-current-url`, `hydrate-embed-flag!` — chrome-internal URL surfaces. The facade exposes `variant-share-url`; the other two URL surfaces (address-bar URL, embed flag) live in this sub-ns and are consumed by the shell's bootstrap.
+- **Story's late-bind shims.** `re-frame.story.late-bind` — the indirection that breaks circular requires between the registrar (consumer) and the canonical installer (producer).
+- **Panel-mount aggregators.** Story's shell calls `mount-<panel>!` aggregators internally; they're not part of the host-facing embed contract.
+- **`re-frame.story.config` atom handles.** Every state setter writes to a `defonce` atom; the atoms are reachable from CLJS-default-public visibility. The setters in `configure!` are the canonical write path.
+
+If you find yourself reading source for a Story-internal symbol because the chapters don't list it, the answer is almost always: the spec considers that surface internal, and a future minor release may rename or `^:private`-mark it. Reach for the documented surfaces in the chapters above instead.
+
+## See also
+
+- [Index](index.md) — the navigation map for the four chapters in this folder.
+- [Registration](registration.md) — the seven `reg-*` macros + `*`-fn partners.
+- [Play scripts](play-script.md) — the `:play-script` grammar + the canonical seven `:rf.assert/*` events.
+- [Runtime](runtime.md) — `configure!`, `run-variant`, `mount-shell!`, the registry-query family.
+- [MCP surface](mcp-surface.md) — the Story-MCP boundary, wire-elision discipline, write-surface gating.
+- [Normative spec — `tools/story/spec/API.md`](https://github.com/day8/re-frame2/blob/main/tools/story/spec/API.md) — the developer-internal source of truth.

--- a/docs/story/api/registration.md
+++ b/docs/story/api/registration.md
@@ -1,0 +1,148 @@
+# Registration
+
+This chapter is about the surfaces that tell Story *what variants exist* — the seven `reg-*` macros, their `*`-suffix runtime helpers, the inclusion-tag and mode vocabulary, the two boot-time entry points for global args and global decorators, and the canonical-vocabulary auto-install that fires on the first registration. The core of it is **two parallel surfaces** — `reg-story` / `reg-variant` / etc. for authoring, and `reg-story*` / `reg-variant*` / etc. for programmatic registration. The macro form is what you write; the `*`-fn form is what hot-reload tooling, fixture loaders, and the MCP write surface call.
+
+Every registration is **idempotent**: re-registering the same id replaces the entry in place. The seven `reg-*` macros all DCE under `:advanced` compilation when `re-frame.story.config/enabled?` is `false` — production builds carry zero Story registration bytes, and `mount-shell!` short-circuits before any DOM call.
+
+## The seven registration macros
+
+All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programmatic use.
+
+| Macro | Kind | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-story` | M | `(reg-story id metadata)` | v1 (dev-only) | Register a story (a cluster of variants under one heading). `metadata` is an EDN map with `:doc`, `:component`, `:args`, `:tags`, `:decorators`, and optional `:variants` (Form B desugaring). |
+| `reg-variant` | M | `(reg-variant id metadata)` | v1 (dev-only) | Register one variant — view, args, setup events, decorators, `:play-script`. The single most-called macro in a typical stories namespace. |
+| `reg-workspace` | M | `(reg-workspace id metadata)` | v1 (dev-only) | Register a workspace — a curated grid of variants for side-by-side review. `metadata` carries `:doc`, `:cells` (an ordered vector of variant ids), and optional `:layout`. |
+| `reg-decorator` | M | `(reg-decorator id metadata)` | v1 (dev-only) | Register a decorator — a fn that wraps a variant's render (locale provider, theme provider, mock-API context). Three kinds: `:hiccup` (wraps the rendered tree), `:frame-setup` (runs at frame creation), `:fx-override` (registers fx stubs). |
+| `reg-story-panel` | M | `(reg-story-panel id metadata)` | v1 (dev-only) | Register a custom panel in the Story chrome — the inspection / control panes that sit beside the rendered variant. Late-bind via `:render` as a `:view` id. Five placement slots: `:right` / `:left` / `:bottom` / `:top` / `:modal`. |
+| `reg-tag` | M | `(reg-tag id metadata)` | v1 (dev-only) | Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`, `:agent`) auto-install on first registration. |
+| `reg-mode` | M | `(reg-mode id metadata)` | v1 (dev-only) | Register a mode — a saved tuple of args the chrome toggles into (light/dark theme, en/fr locale, desktop/mobile viewport). Layer 3 of the five-layer args precedence chain. |
+
+The macros expand to their `*`-suffix runtime fns — `reg-story` expands to `(reg-story* id body)` — so the canonical-vocabulary auto-install (see below) fires from the macro form, programmatic-form, or fixture-load form alike.
+
+### Combined `reg-story` Form B
+
+The combined form `(reg-story id {:variants {...} ...})` desugars at macro-expansion time to N independent `reg-variant` calls plus the bare `reg-story`. This is the ergonomic shortcut for a story whose every variant is a thin override of the same parent body — the parent's `:component` / `:args` / `:decorators` flow into each variant by deep-merge.
+
+```clojure
+(story/reg-story :story.counter
+  {:component :app.ui/counter
+   :args      {:label "Count" :max 100}
+   :variants  {:empty      {:events [[:counter/initialise 0]]}
+               :at-five    {:events [[:counter/initialise 5]]}
+               :at-max     {:events [[:counter/initialise 100]]}}})
+```
+
+The expansion produces three `reg-variant` calls — `:story.counter/empty`, `:story.counter/at-five`, `:story.counter/at-max` — plus the parent `:story.counter` itself. The variant ids are namespaced under the story's id; the parent's args and component flow into each variant's resolved args via the standard precedence chain.
+
+## The seven `*`-suffix runtime helpers
+
+All under `re-frame.story`. The `*`-suffix helpers are the programmatic write path; the macros above expand into them.
+
+| Fn | Kind | Signature | Status | Intuition |
+|---|---|---|---|---|
+| `reg-story*` | Fn | `(reg-story* id body)` | v1 (dev-only) | Programmatic story registration. |
+| `reg-variant*` | Fn | `(reg-variant* id body)` | v1 (dev-only) | Programmatic variant registration. |
+| `reg-workspace*` | Fn | `(reg-workspace* id body)` | v1 (dev-only) | Programmatic workspace registration. |
+| `reg-mode*` | Fn | `(reg-mode* id body)` | v1 (dev-only) | Programmatic mode registration. |
+| `reg-story-panel*` | Fn | `(reg-story-panel* id body)` | v1 (dev-only) | Programmatic panel registration. |
+| `reg-decorator*` | Fn | `(reg-decorator* id body)` | v1 (dev-only) | Programmatic decorator registration. |
+| `reg-tag*` | Fn | `(reg-tag* id body)` | v1 (dev-only) | Programmatic tag registration. |
+
+Reach for the `*` forms when authoring inside a higher-order fn, a fixture loader, an MCP write tool, or a hot-reload pipeline that synthesises registrations from another data source. Authoring-site registrations use the macros above; both paths land on the same registrar side-table and fire the same auto-install gate.
+
+## Unregister + reset
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `unregister!` | `(unregister! kind id)` → nil | v1 (dev-only) | Remove a single id under `kind`. Kinds: `:story` / `:variant` / `:workspace` / `:story-panel` / `:tag` / `:mode` / `:decorator`. |
+| `clear-kind!` | `(clear-kind! kind)` → nil | v1 (dev-only) | Remove every registration of `kind`. Used by test fixtures and hot-reload. |
+| `clear-all!` | `(clear-all!)` → nil | v1 (dev-only) | Reset every Story registration. Wipes the registrar's side-table AND clears the global-decorators vector AND resets the auto-install gate so the next `reg-*` re-installs the canonical vocabulary. |
+
+`clear-all!` is the test-isolation primitive. Tests that want a known starting state call `clear-all!` in a fixture; the next `reg-*` in the test body auto-installs the canonical vocabulary (the seven canonical tags, the `:rf.assert/*` handlers, `force-fx-stub`, the layout-debug decorator trio, the lifecycle machine, the v1.0 panel set) before the test's own registrations land.
+
+## Canonical-vocabulary auto-install
+
+The canonical Story vocabulary auto-installs on the first `reg-*` call. Authors don't call `(story/install-canonical-vocabulary!)` explicitly; the boot is implicit, matching Storybook's ergonomic.
+
+The seven `reg-*` macros expand to their `*`-fn helpers, and the first call to ANY of those helpers flips a single boolean gate in `re-frame.story.canonical` and runs the installer chain: register the seven canonical tags, register the `:rf.assert/*` event handlers, register the `force-fx-stub` decorator, register the layout-debug decorator trio, register the toolbar cofx + subs, register the lifecycle machine, register the v1.0 SOTA panel set, and (CLJS only) register the multi-substrate Reagent default.
+
+| Symbol | Signature | Status | Intuition |
+|---|---|---|---|
+| `install-canonical-vocabulary!` | `(install-canonical-vocabulary!)` → nil | v1 (dev-only) | Idempotent explicit boot. New code should rely on the auto-install path — the explicit call is retained only as a literal-boot affordance for hosts that want one and as a JVM-test diagnostic that asserts a known starting state without a body-of-test `reg-*` call. |
+
+The auto-install gate flips true *before* the installer chain runs, so the registrar writes triggered by the chain itself hit the early-return branch and don't recurse. Subsequent `reg-*` calls (after the gate has flipped) are a single `deref` + `nil` check — negligible on the hot path.
+
+`(clear-all!)` resets the gate to `false`; the next `reg-*` re-runs the full auto-install path. Test fixtures that called `clear-all!` followed by `install-canonical-vocabulary!` under v1 still work — the explicit call is a no-op overlap with the auto-install path that would fire on the first body-of-test `reg-*` anyway — but new tests can drop the explicit boot step entirely.
+
+## Global args and global decorators
+
+Layer 1 of the five-layer args precedence chain (global → story → mode → variant → cell-override) and the global-decorator stack are both project-wide defaults the host application sets once at boot. Both flow through `configure!`; the global-decorator stack additionally has per-registration helpers for the common "register-and-opt-in" path.
+
+| Surface | Signature | Status | Intuition |
+|---|---|---|---|
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level Story configuration. See [Runtime §configure!](runtime.md#configure) for the full key surface. The two relevant keys here are `:rf.story/global-args` (replace the global args map) and `:rf.story/global-decorators` (replace the global-decorator ref vector). |
+| `reg-global-decorator` | `(reg-global-decorator id body)` / `(reg-global-decorator id body ref-args)` → id | v1 (dev-only) | Register a decorator AND opt it into the global stack in one call. Symmetric to the host calling `reg-decorator` + `configure! {:rf.story/global-decorators [...]}` in sequence; preferred when the decorator is exclusively a global-stack member. Earliest-registered-first; re-registering the same id REPLACES the entry in place (same position in the global vector) so hot-reload doesn't reshuffle the stack order. |
+| `unreg-global-decorator!` | `(unreg-global-decorator! id)` → nil | v1 (dev-only) | Remove `id` from the global-decorators vector. The decorator's registration body is NOT unregistered — call `unregister!` for that. Idempotent. |
+| `global-decorators` | `(global-decorators)` → vec | v1 (dev-only) | Return the current ordered vector of global-decorator references (`[[decorator-id & args] ...]`). Earliest-registered first; this is the prefix applied to every variant's resolved decorator stack. |
+
+The five-layer precedence diagram (later wins):
+
+```
+1. global args      ← (story/configure! {:rf.story/global-args {...}})       — boot
+2. story args       ← :args on the parent (reg-story)                         — story default
+3. mode args        ← active :mode's :args (reg-mode)                          — saved tuple
+4. variant args     ← :args on the variant (reg-variant)                      — per-scenario
+5. cell-overrides   ← controls-panel edits at runtime (:story/set-arg)         — live edit
+                     ↓
+              effective args (deep-merge, vectors replaced)
+```
+
+Each layer scopes a different authoring intent: global args ride boot configuration (themes, locales, feature flags); story args set the parent default; mode args pivot the entire variant-grid against a chrome-level toggle; variant args carry the per-scenario override; cell-overrides give the reader a knob without mutating source. Reach for the lowest-numbered layer that scopes the change you want.
+
+## Built-in decorator `*-id` Vars
+
+Three built-in decorators ship with Story's canonical vocabulary. Each has a public `*-id` Var on `re-frame.story` for use in variant `:decorators` slots — the Var pattern lets the registered-id keyword stay opaque (Story can rename the underlying registration without breaking author code).
+
+| Var | Status | Intuition |
+|---|---|---|
+| `force-fx-stub-id` | v1 (dev-only) | The registered decorator id for the built-in `force-fx-stub` decorator — Story's universal effect-mocking primitive. One decorator covers HTTP, websockets, analytics, storage, navigation, geolocation, and anything else registered with `reg-fx`. |
+| `layout-debug-measure-id` | v1 (dev-only) | The Storybook-style layout measure overlay decorator id. Surfaces margin / padding / size annotations on every descendant element. |
+| `layout-debug-outline-id` | v1 (dev-only) | The Pesticide-style coloured outlines decorator id. Surfaces every descendant element's box with a per-element-type colour. |
+| `layout-debug-pseudo-id` | v1 (dev-only) | The pseudo-state forcing decorator id. Ref-args is a set from `#{:hover :focus :active :visited}`; default is `#{:hover}`. |
+
+Worked example:
+
+```clojure
+;; Stub :http for a login-pending variant.
+(story/reg-variant :story.auth/login-pending
+  {:decorators  [[story/force-fx-stub-id :http {:status :pending}]]
+   :play-script [[:dispatch [:auth/login]]
+                 [:dispatch-sync [:rf.assert/effect-emitted :http]]]})
+
+;; Layout debug a button variant.
+(story/reg-variant :story.button/pressed
+  {:decorators [[story/layout-debug-outline-id]
+                [story/layout-debug-pseudo-id #{:hover}]]})
+```
+
+## Privacy primitives
+
+Story authors declare per-frame path-marks against `app-db` using the framework's `add-marks` / `set-marks` primitives. Both are re-exported from `re-frame.core` for author-discoverability — same primitives, same data model, same per-frame semantics — so authors scanning `re-frame.story`'s public surface for privacy primitives find them without chasing cross-references.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `add-marks` | `(add-marks variant-id marks-map)` → nil | v1 (dev-only) | Merge marks additively into the variant frame's mark-set. Re-export of `re-frame.core/add-marks`. |
+| `set-marks` | `(set-marks variant-id marks-map)` → nil | v1 (dev-only) | Replace the variant frame's mark-set wholesale. Re-export of `re-frame.core/set-marks`. |
+
+A `marks-map` is `{path mark, ...}` where `path` is a `get-in`-shaped vector and `mark` is one of `:sensitive` / `:large`. Variant-body usage scopes marks to that variant's frame; the framework's `elide-wire-value` walker substitutes `:rf/redacted` / `:rf/large` at every wire-egress observation point.
+
+## See also
+
+- [Play scripts](play-script.md) — the `:play-script` grammar a `reg-variant`'s `:play-script` slot accepts. The canonical seven `:rf.assert/*` events that drive the variant's assertion accumulator.
+- [Runtime](runtime.md) — `configure!`'s full key surface, the four-phase variant lifecycle, `run-variant` / `reset-variant` / `watch-variant` / `destroy-variant!`, the registry-query family, the shell-mount surface.
+- [MCP surface](mcp-surface.md) — the public read primitives Story exposes for the MCP jar to consume; the public write primitives behind the gated agent-write surface; the late-bind `reg-story-panel` contract.
+- [Reference](reference.md) — the full symbol table for `Ctrl-F` use.
+- [Story tutorial — Your first story](../01-first-story.md) — the chapter-1 worked walkthrough.
+- [Story tutorial — Workspaces + args editor](../04-workspaces.md) — workspaces, modes, the args editor.
+- [Framework API — Schemas and data classification](../../api/08-schemas.md) — `add-marks` / `set-marks` framework definitions.

--- a/docs/story/api/runtime.md
+++ b/docs/story/api/runtime.md
@@ -1,0 +1,213 @@
+# Runtime
+
+This chapter is about the surfaces that bring a registered variant to life — the four-phase lifecycle that allocates a per-variant frame, runs the variant's setup events, renders against the post-setup `app-db`, and walks the play script; the programmatic entry points (`run-variant`, `reset-variant`, `watch-variant`, `destroy-variant!`) that callers reach for from custom shells, test fixtures, and one-shot screenshot pipelines; the registry-query family that tools build against; the boot-time `configure!` surface that sets project-wide defaults; and the CLJS-only shell-mount surface that wires Story's three-pane chrome into the host's DOM.
+
+The core of it is **one runtime, two consumer audiences**. *Story authors* run variants implicitly — the Story shell calls `run-variant` / `reset-variant` / `watch-variant` on the author's behalf as the user clicks through the sidebar. *Host applications and test fixtures* call the same fns directly when they want a one-shot render outside the chrome, a `cljs.test`-shaped assertion, or a snapshot-identity hash for visual-regression keying.
+
+## Per-variant frame allocation
+
+Every variant runs in its own frame. At variant mount the runtime calls `(rf/reg-frame variant-id {:doc ... :app-db {} :substrate :reagent ...})`, records side-table metadata (view id, decorators, play script, tags, modes, substrates), and runs the four-phase lifecycle. At unmount the runtime calls `(rf/destroy-frame! variant-id)` — any state-machines the variant spawned receive their `:rf.machine/destroy` event as part of frame teardown.
+
+Hot-reload preserves the side-table; a re-registration of the same variant calls `reset-frame!` and re-runs the lifecycle.
+
+### Coexistence with host application state
+
+Story installs runtime slots into every variant frame's `app-db` under the reserved `:rf.story/*` namespace:
+
+- `:rf.story/lifecycle` — discrete state of the four-phase lifecycle machine.
+- `:rf.story/loaders-complete?` — boolean signal read by the `:loaders-complete-when` predicate path.
+- `:rf.story/assertions` — vector of assertion records appended by `:rf.assert/*` handlers during phase 4.
+
+A host application's `reg-event-db` handlers — and any other code path that writes `app-db` — MUST preserve the `:rf.story/*` namespace when seeding or resetting `db`. The hazard is the "replace-the-whole-db" idiom: `(fn [_db _event] {...})` wipes the reserved slots and corrupts every Story variant that runs the event. Use `(fn [db _event] (assoc db ...))` or `(merge db {...})` instead — thread `db` through; don't throw it away.
+
+## The four-phase lifecycle
+
+For every variant mount, strict order, drain to completion between phases:
+
+| Phase | Trigger | Semantics |
+|---|---|---|
+| **1. Loaders** | Variant body's `:loaders` | For each event: `dispatch-sync` into the variant's frame, wait for drain to settle, evaluate `:loaders-complete-when` if provided. Long-lived fx (`:websocket`, `:interval`) are "complete" when the first message arrives; HTTP-flavoured fx is complete when the response event has been dispatch-synced. |
+| **2. Events** | `(concat story-events variant-events)` | `dispatch-sync` in order. Drain to completion between events. |
+| **3. Render** | View registered against post-events `app-db` | The view renders with the effective args (five-layer precedence chain) and decorator stack (`(concat globals story variant)`) applied. |
+| **4. Play** | Variant body's `:play-script` | For each step: dispatch-sync, drain. `:rf.assert/*` records into `:assertions`; failures don't throw — they accumulate. See [Play scripts](play-script.md). |
+
+Phase 1 and 4 are async-safe; phases 2 and 3 are sync. Loader failure modes are deterministic — handler-throw, typed `:loader-rejection`, and never-complete-predicate all surface as recorded assertions on `:rf.story/assertions` and park the lifecycle machine at `:error` / `:loading`. The play sequence never runs in a failed-loader case; `(run-variant)` resolves with `assertions-passing?` false.
+
+## Programmatic runtime
+
+All under `re-frame.story`. Reach for these from a custom shell, a test fixture, a `cljs.test` adapter, an MCP-tool body, or any host that wants to materialise a variant outside the standard Story chrome.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `run-variant` | `(run-variant variant-id)` / `(run-variant variant-id opts)` → result-map | v1 (dev-only) | Materialise the variant — allocate the frame, run the four-phase lifecycle, return the result map. One-shot; no live updates. The result carries `:frame` / `:app-db` / `:assertions` / `:rendered-hiccup` / `:elapsed-ms` / `:snapshot` / `:decorators`. |
+| `reset-variant` | `(reset-variant variant-id)` → nil | v1 (dev-only) | Reset the variant's frame to its post-events baseline. The Story shell calls this when the user clicks "reset" on a variant. |
+| `watch-variant` | `(watch-variant variant-id)` → live-result-map / `(watch-variant variant-id callback)` | v1 (dev-only) | Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots. |
+| `unwatch-variant` | `(unwatch-variant variant-id)` → nil | v1 (dev-only) | Stop the live update channel for `variant-id`. Idempotent. |
+| `destroy-variant!` | `(destroy-variant! variant-id)` → nil | v1 (dev-only) | Tear down the variant's frame. Any spawned state-machines receive their `:rf.machine/destroy` event. Idempotent. |
+| `execute-play!` | `(execute-play! variant-id)` → assertions-vec | v1 (dev-only) | Re-run only phase 4 (the `:play-script`) against the variant's current `app-db`. Use for the play-stepper UI's "re-run from here" affordance. |
+| `lifecycle-state` | `(lifecycle-state variant-id)` → keyword | v1 (dev-only) | The current state of the variant's lifecycle machine — one of `:idle` / `:loading` / `:events` / `:rendering` / `:playing` / `:done` / `:error`. |
+
+The `opts` map for `run-variant` accepts:
+
+```clojure
+{:active-modes    [:Mode.app/dark-large]   ;; coll of mode ids, deep-merged into args
+ :cell-overrides  {:label "Override"}      ;; controls-panel-shaped runtime overrides
+ :substrate       :reagent                 ;; / :uix / :helix
+ :render?         true                     ;; when truthy, :rendered-hiccup is populated
+ :assertions      <hook>}                  ;; assertions hook (re-frame.story.assertions)
+```
+
+The result map shape:
+
+```clojure
+{:frame           :story.counter/at-five
+ :app-db          {...}
+ :assertions      [{:assertion :rf.assert/path-equals :passed? true ...} ...]
+ :rendered-hiccup [...]    ;; or nil when :render? was falsy
+ :elapsed-ms      12
+ :snapshot        {:variant-id :story.counter/at-five :content-hash "..."}
+ :decorators      {:hiccup [...] :frame-setup [...] :fx-override [...]}}
+```
+
+## Args + decorator resolution
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` → map | v1 (dev-only) | Materialise the effective args map for a variant given the active modes + cell overrides. The five-layer precedence chain (global → story → mode → variant → cell-override), deep-merged for maps, vector-replaced for vectors. |
+| `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` → map | v1 (dev-only) | Return the variant's resolved decorator stack classified by kind: `{:hiccup [...] :frame-setup [...] :fx-override [...] :errors [...]}`. Composition order: `(concat globals story variant)`. |
+| `variant-frames` | `(variant-frames)` → set | v1 (dev-only) | The set of variant-ids currently allocated as frames. |
+| `variant-frame?` | `(variant-frame? variant-id)` → bool | v1 (dev-only) | Predicate. |
+
+## Snapshot identity + share
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `snapshot-identity` | `(snapshot-identity variant-id)` / `(snapshot-identity variant-id opts)` → map | v1 (dev-only) | The variant's snapshot identity — the variant id plus a content-hash over its setup (args, events, modes, substrate). Returns `{:variant-id ... :content-hash "..."}`. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. The hash computes over real values (pre-substitution); downstream emission goes through `elide-wire-value`. |
+| `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id base-url opts)` → string | v1 (dev-only) | Build a sharable URL for `variant-id` against `base-url`. Encodes active modes + cell-overrides + substrate so a scan-and-share session reproduces the cell. Pure data → data; JVM + CLJS portable. |
+
+## Assertion-side accessors
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `read-assertions` | `(read-assertions variant-id)` → assertions-vec | v1 (dev-only) | The current `:rf.story/assertions` vector for `variant-id`. Each entry is a `:rf.assert/*` record. |
+| `assertions-passing?` | `(assertions-passing? result)` → bool | v1 (dev-only) | Project over a `run-variant` result map (or a raw assertions vector) — true iff every record is `:passed? true`. The single primitive a `cljs.test`-style adapter calls. |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` → set | v1 (dev-only) | The seven canonical `:rf.assert/*` event-ids as a set, for tooling that enumerates the assertion vocabulary. |
+
+## Registry queries
+
+The query family Story exposes for its own chrome, the MCP jar, and any tooling that walks the registrar's side-table.
+
+| Fn | Signature | Returns |
+|---|---|---|
+| `registrations` | `(registrations kind)` | All registrations for `kind` (Story kinds: `:story`, `:variant`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`). |
+| `handler-meta` | `(handler-meta kind id)` | The registered body for `id`. |
+| `ids` | `(ids kind)` | All registered ids of `kind`. |
+| `registered?` | `(registered? kind id)` → bool | Predicate. |
+| `all-kinds-with-counts` | `(all-kinds-with-counts)` | Map from each registered kind to its count. |
+| `variants-of` | `(variants-of story-id)` | Variant ids whose namespaced id-prefix matches `story-id`. |
+| `variants-by-story` | `(variants-by-story)` | Map from parent-story-id to its variant ids. |
+| `variants-with-tags` | `(variants-with-tags tag-set)` | Variant ids whose `:tags` intersect the filter set. |
+| `list-tags` | `(list-tags)` | All registered tags (canonical + project). |
+| `list-modes` | `(list-modes)` | All registered modes. |
+| `canonical-tags` | Var (set) | The seven canonical tags. |
+| `canonical-axes` | Var | The four canonical axes (audience / lifecycle / quality / status). |
+| `canonical-status-values` | Var | The status-axis tag values. |
+| `canonical-role-values` | Var | The role-axis tag values. |
+| `tags-by-axis` | `(tags-by-axis)` | Map from axis → tag-ids registered against it. |
+| `tags-without-axis` | `(tags-without-axis)` | Tags not registered against any axis (project tags). |
+| `tags-default-excluded` | `(tags-default-excluded)` | Tags the sidebar tag-filter excludes by default. |
+| `tag->axis-index` | `(tag->axis-index)` | Map from tag-id → axis. |
+| `registered-substrates` | `(registered-substrates)` | CLJS-only. The substrate set as registered via `register-substrate!`. |
+| `variant-substrates` | `(variant-substrates variant-id)` | The substrate set for a specific variant. |
+
+## `configure!`
+
+The boot-time entry point for project-wide defaults. The host calls it once before mounting the shell.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Set Story's global config. Every key lives under `:rf.story/*` (Story-specific) or `:rf.privacy/*` (cross-tool). Unknown keys are silently ignored for forward-compat. |
+
+The full v1 key surface:
+
+```clojure
+(story/configure!
+  {;; Args — Layer 1 of the five-layer precedence chain
+   :rf.story/global-args
+   {:theme :light :locale :en}
+
+   ;; Decorators — the project-wide prefix of every variant's stack
+   :rf.story/global-decorators
+   [[:app/theme-provider :dark]
+    [:app/locale-provider :en]]
+
+   ;; Editor — drives the source-coord 'Open in editor' chip
+   :rf.story/editor :cursor    ;; / :vscode (default) / :idea / {:custom <tpl>}
+
+   ;; On-disk root — prepended to classpath-relative source-coord :file slots
+   :rf.story/project-root "C:/Users/me/code/my-app"
+
+   ;; Cross-tool privacy gate — read by Story AND Causa
+   :rf.privacy/show-sensitive? false})
+```
+
+Two key behaviours are worth pinning:
+
+- **`:rf.story/project-root` bridges into Causa**. When set, Story propagates the value into Causa's own `:rf.causa/project-root` slot via `re-frame.story.causa-preset/propagate-project-root!` so the Causa-as-RHS source-coord chips share the same on-disk root. The bridge is one-way; hosts that want Causa pointed at a different root call `causa-config/configure!` directly AFTER `story/configure!`.
+- **`:rf.privacy/show-sensitive?` is cross-tool**. The slot is shared with Causa under the `:rf.privacy/*` reservation. Setting it from either Story's or Causa's `configure!` flips both tools' diagnostic surfaces.
+
+## Substrate registration (CLJS-only)
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `register-substrate!` | `(register-substrate! substrate-id render-fn)` → nil | v1 (dev-only) | Register a substrate render fn under `substrate-id`. The host calls this once at boot for each substrate it wants Story to render against (`:uix`, `:helix`, etc.). The `:reagent` substrate is registered automatically by the canonical-vocabulary auto-install. |
+| `registered-substrates` | `(registered-substrates)` → set | v1 (dev-only) | The set of registered substrate ids. Used by tooling that enumerates available substrates for a variant's `:substrates` opt-in. |
+
+## Shell lifecycle (CLJS-only)
+
+The three-pane Reagent component that constitutes Story's UI. The host calls `mount-shell!` from its entry namespace when a hash-routed `#/stories` triggers Story mode.
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `mount-shell!` | `(mount-shell! mount-point opts)` → nil | v1 (dev-only) | Mount the Story shell at `mount-point` (a DOM node). The opts map carries `:initial-variant`, `:initial-mode`, `:theme`, etc. Production builds (`re-frame.story.config/enabled?` false) short-circuit before any DOM call. |
+| `unmount-shell!` | `(unmount-shell!)` → nil | v1 (dev-only) | Unmount the shell. Idempotent. |
+| `active-shell` | `(active-shell)` → map / nil | v1 (dev-only) | Inspectable handle on the active shell — returns nil when no shell is mounted. |
+
+## Static-mode probe
+
+| Fn | Signature | Status | Intuition |
+|---|---|---|---|
+| `static-mode?` | `(static-mode?)` → bool | v1 (dev-only) | True iff Story is running in static-export mode (the bundle was built with `:closure-defines {re-frame.story.config/static-mode? true}`). The shell itself flips its dev-time affordances (hot-reload poll, first-visit help overlay auto-open) off when the flag is true. Surfaced here for tooling / examples that want to render a "this is a published static site" badge. |
+
+## Stage marker
+
+| Var | Use |
+|---|---|
+| `stage` | The current Story development stage marker. Surfaced for tools that gate behaviour on Story's advertised maturity tier. |
+
+## Effects and coeffects registered by Story
+
+Phase 4's `:dispatch` rail emits these fx; the chrome's control widgets and toolbar consume them.
+
+| Fx id | Payload | Notes |
+|---|---|---|
+| `:story/set-arg` | `{:variant <id> :key <k> :value <v>}` | Dispatched by control widgets when args change. Drives Layer 5 (cell-override) of the precedence chain. |
+| `:story/run-play` | `{:variant <id>}` | Run the play sequence (the play-stepper "Run" affordance). |
+| `:story/reset` | `{:variant <id>}` | Reset variant to post-events baseline. |
+| `:story/save-layout-as` | `{:workspace <id> :body <transit>}` | Persist the active layout as a registered workspace. |
+
+| Cofx id | Shape | Notes |
+|---|---|---|
+| `:story/active-modes` | `[<mode-id> ...]` | The chrome-toolbar's active mode-set. Cofx-injected into Layer 3 of the precedence chain. |
+| `:story/active-args` | `{<arg-key> <value>}` | Deep-merge of all active modes' `:args`. |
+| `:story/substrate` | `:reagent` / `:uix` / `:helix` | The active substrate. |
+
+## See also
+
+- [Registration](registration.md) — the registration macros that populate the registrar `run-variant` walks.
+- [Play scripts](play-script.md) — phase 4's full grammar; `read-assertions` / `assertions-passing?` consumers.
+- [MCP surface](mcp-surface.md) — the same fns above, consumed by the `tools/story-mcp/` jar over JSON-RPC.
+- [Story tutorial — Your first story](../01-first-story.md) — `mount-shell!` in context.
+- [Story tutorial — Snapshot identity + QR sharing](../05-snapshot-identity.md) — `snapshot-identity` + `variant-share-url` in worked usage.
+- [Framework API — Lifecycle](../../api/13-lifecycle.md) — `rf/init!` runs before `mount-shell!`. The adapter must be installed before Story attaches.
+- [Causa API — Configuration keys](../../causa/api/config-keys.md) — `:rf.causa/project-root`, the slot Story's `:rf.story/project-root` bridges into.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,13 @@ nav:
     - "5. Snapshot identity + QR sharing": story/05-snapshot-identity.md
     - "6. Time-travel in Story": story/06-time-travel.md
     - "7. Multi-substrate side-by-side": story/07-multi-substrate.md
+    - "API reference":
+      - "Overview": story/api/index.md
+      - "Registration": story/api/registration.md
+      - "Play scripts": story/api/play-script.md
+      - "Runtime": story/api/runtime.md
+      - "MCP surface": story/api/mcp-surface.md
+      - "Reference": story/api/reference.md
 
   - Causa:
     - "Welcome": causa/index.md


### PR DESCRIPTION
Closes rf2-elp9l.

Phase 2 of the tool-API-chapter audit (Story side). Authors six chapters under `docs/story/api/` carrying the consumer-facing extract of `tools/story/spec/API.md`.

## Chapters

- `index.md` — navigation map + audience split (story authors / host devs / tool integrators).
- `registration.md` — the seven `reg-*` macros + `*`-fn partners, canonical-vocabulary auto-install, global args + decorators, built-in decorator `*-id` Vars, privacy primitives.
- `play-script.md` — the `:play-script` grammar (ten step forms), the canonical seven `:rf.assert/*` events, record-don't-throw, the recorder facade.
- `runtime.md` — the four-phase variant lifecycle, `run-variant` / `reset-variant` / `watch-variant` / `destroy-variant!`, the registry-query family, `configure!`, the shell-mount surface.
- `mcp-surface.md` — the Story-MCP boundary, wire-elision discipline (core is real-values-in, real-values-out; MCP jar is the egress owner), public read + write primitives, late-bind `reg-story-panel` contract.
- `reference.md` — full symbol table across `re-frame.story` and its public sub-namespaces, organised for `Ctrl-F` use.

## Voice

Matches the framework `docs/api/*` restructure and the Causa `docs/causa/api/*` mini-folder: one-paragraph "what this surface is for" opener per chapter, intuition notes alongside type signatures, tight tables, "See also" sidebars cross-linking to `docs/api/*`, `docs/causa/api/*`, and `docs/story/*` tutorial chapters. No bead refs in body text per mayor directive.

`mkdocs.yml` adds an "API reference" sub-section under Story, below the tutorial chapters. The six LHS labels are: Overview / Registration / Play scripts / Runtime / MCP surface / Reference — all ≤ 22 chars.

## Gates

- `python -m mkdocs build --strict` — clean.
- `python scripts/check_doc_slugs.py` — clean.
- LHS nav slugs ≤ 22 chars — verified.

## Posture

Pre-alpha v1-polish. Symmetric to the Causa API folder for site-wide structure. The follow-on table-per-fn → H3-per-member conversion sweep will cover both folders at once.