### PR TITLE
feat(story): structured assertion-row treatment in canvas strip (rf2-29lw1)

### DIFF
--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -1,0 +1,400 @@
+(ns re-frame.story.ui.assertion-strip
+  "Structured assertion-row treatment for inline canvas / workspace
+  strips.
+
+  The canvas + workspace cells previously `pr-str`-d raw assertion maps
+  into one verbose row per assertion — hard-to-parse EDN. The `:test`
+  mode pane (`re-frame.story.ui.test-mode.view`) already lifts the
+  Storybook-inspired shape — status glyph + label + collapsible
+  detail — but the inline strip never adopted it. This namespace lifts
+  that shape into a small, dependency-free leaf the inline strip + the
+  workspace cell share.
+
+  ## What 'Storybook-inspired' means here
+
+  Five patterns from the Storybook addon-tests interactions panel:
+
+  1. **Structured row** — status glyph (✓/✗/⊘) + assertion label +
+     one-line summary, not raw EDN.
+  2. **Auto-collapse pass · auto-expand fail** — failed assertions
+     surface their full detail; passed ones stay collapsed (the user
+     drills only when something demands attention). A click toggles.
+  3. **Token-coloured left border** — green / red / grey by status.
+  4. **Truncate long values** — the inline summary clamps to one line
+     with ellipsis; the expanded panel renders the full content.
+  5. **Group by dispatching event** — assertions cluster under the
+     `:event` slot they were dispatched from. Multiple `:rf.assert/*`
+     dispatches against the same play-step land together visually.
+
+  ## Why a shared namespace
+
+  The canvas inline strip (`re-frame.story.ui.canvas/render-assertions`)
+  and the workspace cell's trailing strip (`re-frame.story.ui.workspace`)
+  both `pr-str`-ed raw records into a divs-of-one-line shape. Two call
+  sites · one component = lift, don't duplicate. The `:test` mode pane
+  keeps its richer per-row table (it has space for `:expected` /
+  `:actual` / `:reason` columns); the inline strip is the compact
+  version of the same shape.
+
+  ## Pure where possible
+
+  `truncate`, `summary-line`, and `group-by-event` are pure-data
+  helpers — they project the record vector into the rendered shape.
+  Reagent state lives in a per-mount `r/atom` for the expand/collapse
+  set; the rendered hiccup is read off the projected data + the atom.
+
+  CLJS-only. The inline strip never lands in production (Story is a
+  dev-only artefact); the test-mode pane already lives at
+  `tools/story/src/re_frame/story/ui/test_mode/view.cljs` and is
+  CLJS-only for the same reason."
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [re-frame.story.ui.test-mode.pure :as tm-pure]
+            [re-frame.story.theme.typography :as typography :refer [mono-stack]]
+            [re-frame.story.theme.colors :as colors]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(def ^:private truncate-len
+  "Maximum character length for an inline summary line. Beyond this the
+  summary truncates with an ellipsis; the user clicks to expand for the
+  full value. Tuned against the densest realistic case (a
+  `:rf.assert/sub-equals` carrying a moderate map shape) — readable in
+  one line of a narrow canvas while still surfacing the assertion's
+  shape at a glance."
+  72)
+
+(defn truncate
+  "Clamp `s` to at most `n` chars, suffixing `\"…\"` when truncated.
+  Pure data → string. Returns `\"\"` for nil input."
+  ([s] (truncate s truncate-len))
+  ([s n]
+   (cond
+     (nil? s)                   ""
+     (not (string? s))          (truncate (str s) n)
+     (<= (count s) n)           s
+     :else                      (str (subs s 0 (max 0 (dec n))) "…"))))
+
+(defn summary-line
+  "Render the one-line inline summary for one assertion-row projection.
+  Pure data → string. Empty string when no useful summary is present.
+
+  For failures: surfaces `:reason`, else a compact `expected vs actual`.
+  For passes: leaves blank — the label already names the assertion.
+  For skips: surfaces `:reason` when present.
+
+  Always truncated to `truncate-len` characters."
+  [row]
+  (let [{:keys [status detail]} row
+        {:keys [reason expected actual]} detail]
+    (truncate
+      (case status
+        :fail (cond
+                (and (some? reason) (string? reason)) reason
+                (some? reason)                        (pr-str reason)
+                (or (some? expected) (some? actual))  (str "expected " (pr-str expected)
+                                                           " · actual " (pr-str actual))
+                :else                                 "")
+        :skip (cond
+                (string? reason) reason
+                (some? reason)   (pr-str reason)
+                :else            "skipped")
+        :pass ""
+        ""))))
+
+(defn group-by-event
+  "Pure: cluster assertion records by their dispatching `:event` slot.
+  Returns an ordered vector of group maps:
+
+      [{:event <event-vec-or-nil>
+        :records [<record> ...]}
+       ...]
+
+  Records that carry no `:event` (e.g. `:rf.assert/*` dispatched outside
+  a play step — phase-0 setup assertions, decorator-throws) cluster
+  under a leading `nil`-event group. Order within each group preserves
+  the original record order.
+
+  Pure data → data; JVM-testable shape (though this namespace itself is
+  CLJS — the pure helpers move to `pure.cljc` once a second consumer
+  appears)."
+  [records]
+  (let [recs (vec (or records []))]
+    (->> recs
+         (reduce
+           (fn [{:keys [order groups]} rec]
+             (let [k (or (:event rec) ::no-event)
+                   seen? (contains? groups k)]
+               {:order  (if seen? order (conj order k))
+                :groups (update groups k (fnil conj []) rec)}))
+           {:order [] :groups {}})
+         ((fn [{:keys [order groups]}]
+            (mapv (fn [k]
+                    {:event   (when (not= k ::no-event) k)
+                     :records (get groups k)})
+                  order))))))
+
+;; ---- styling --------------------------------------------------------------
+;;
+;; The strip's style map. Sized small enough to read as a compact band
+;; below the variant render; the per-row left-border carries the status
+;; colour so the eye sweeps the colour band before reading any text.
+
+(def ^:private styles
+  {:wrap        {:margin-top    "8px"
+                 :display       "flex"
+                 :flex-direction "column"
+                 :gap           "4px"}
+   :group       {:display       "flex"
+                 :flex-direction "column"
+                 :gap           "2px"}
+   :group-head  {:font-family   mono-stack
+                 :font-size     (:micro typography/type-scale)
+                 :color         (:text-tertiary colors/tokens)
+                 :text-transform "uppercase"
+                 :letter-spacing "0.04em"
+                 :padding       "2px 4px"
+                 :margin-top    "4px"}
+   :row         {:display       "flex"
+                 :align-items   "baseline"
+                 :gap           "8px"
+                 :padding       "4px 8px"
+                 :border-left   "3px solid transparent"
+                 :background    (:bg-2 colors/tokens)
+                 :border-radius "0 3px 3px 0"
+                 :font-family   mono-stack
+                 :font-size     (:caption typography/type-scale)
+                 :cursor        "pointer"
+                 :user-select   "none"}
+   :row-pass    {:border-left-color (:success colors/tokens)}
+   :row-fail    {:border-left-color (:danger colors/tokens)
+                 :background        (:danger-bg colors/tokens)}
+   :row-skip    {:border-left-color (:text-tertiary colors/tokens)}
+   :glyph       {:flex          "0 0 auto"
+                 :width         "1em"
+                 :text-align    "center"
+                 :font-weight   "bold"}
+   :glyph-pass  {:color         (:success colors/tokens)}
+   :glyph-fail  {:color         (:danger colors/tokens)}
+   :glyph-skip  {:color         (:text-tertiary colors/tokens)}
+   :label       {:flex          "0 0 auto"
+                 :color         (:text-primary colors/tokens)
+                 :white-space   "nowrap"
+                 :overflow      "hidden"
+                 :text-overflow "ellipsis"
+                 :max-width     "50%"}
+   :summary     {:flex          "1 1 auto"
+                 :color         (:text-secondary colors/tokens)
+                 :white-space   "nowrap"
+                 :overflow      "hidden"
+                 :text-overflow "ellipsis"
+                 :min-width     "0"}
+   :summary-fail {:color        (:danger colors/tokens)}
+   :tog         {:flex          "0 0 auto"
+                 :color         (:text-tertiary colors/tokens)
+                 :font-size     (:micro typography/type-scale)
+                 :background    "transparent"
+                 :border        "none"
+                 :padding       "0"
+                 :cursor        "pointer"}
+   :detail      {:background    (:bg-2 colors/tokens)
+                 :border-left   (str "3px solid " (:danger colors/tokens))
+                 :padding       "6px 12px"
+                 :margin        "0 0 0 0"
+                 :font-family   mono-stack
+                 :font-size     (:caption typography/type-scale)
+                 :color         (:text-primary colors/tokens)
+                 :white-space   "pre-wrap"
+                 :border-radius "0 3px 3px 0"}
+   :detail-key  {:color         (:info colors/tokens)
+                 :margin-right  "4px"}
+   :detail-line {:margin        "2px 0"}})
+
+(def ^:private status->row-style
+  {:pass (:row-pass styles)
+   :fail (:row-fail styles)
+   :skip (:row-skip styles)})
+
+(def ^:private status->glyph-style
+  {:pass (:glyph-pass styles)
+   :fail (:glyph-fail styles)
+   :skip (:glyph-skip styles)})
+
+(def status-glyph
+  "Status-glyph map. Public so tests can pin the shape."
+  {:pass "✓"
+   :fail "✗"
+   :skip "⊘"})
+
+;; ---- rendering ------------------------------------------------------------
+
+(defn- row-detail
+  "Render the expanded detail for one row. Surfaces `:reason` /
+  `:expected` / `:actual` / `:event` / `:phase` / `:predicate` and the
+  source-coord stamp. Mirrors the test-mode pane's `row-detail` but
+  inline-sized (no headings; one line per key)."
+  [detail]
+  (let [{:keys [reason expected actual event phase predicate source]} detail]
+    [:div {:style     (:detail styles)
+           :data-test "story-canvas-assertion-detail"}
+     (when (some? reason)
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "reason:"]
+        (if (string? reason) reason (pr-str reason))])
+     (when (or (some? expected) (false? expected))
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "expected:"]
+        (pr-str expected)])
+     (when (or (some? actual) (false? actual))
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "actual:"]
+        (pr-str actual)])
+     (when (some? event)
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "event:"]
+        (pr-str event)])
+     (when (some? phase)
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "phase:"]
+        (pr-str phase)])
+     (when (some? predicate)
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "predicate:"]
+        (pr-str predicate)])
+     (when (and (map? source) (or (:file source) (:line source)))
+       [:div {:style (:detail-line styles)}
+        [:span {:style (:detail-key styles)} "at:"]
+        (str (:file source)
+             (when (:line source) (str ":" (:line source))))])]))
+
+(defn render-row
+  "Render one assertion row. `row` is the `assertion-row` projection;
+  `open?` controls whether the detail panel is expanded; `on-toggle` is
+  fired on click. Pure shape: takes the projection + boolean, returns
+  hiccup. CLJS-only (Reagent is `:require`d at the ns top), but the
+  return value is a plain hiccup vector — JVM tests CAN walk it via
+  `cljs.test`'s shape assertions running under CLJS.
+
+  Per pattern #2 the click toggles the detail visibility for ANY row
+  (pass / fail / skip); per pattern #2's default-arm, `open?` starts as
+  `(= :fail status)` so failures land already-open and passes stay
+  collapsed."
+  [row open? on-toggle]
+  (let [{:keys [status label]} row
+        glyph       (get status-glyph status "·")
+        row-style   (merge (:row styles)
+                           (get status->row-style status))
+        glyph-style (merge (:glyph styles)
+                           (get status->glyph-style status))
+        summary     (summary-line row)
+        fail?       (= :fail status)]
+    [:div {:data-test     "story-canvas-assertion-row"
+           :data-status   (name status)
+           :data-row-key  (:row-key row)}
+     [:div {:style       row-style
+            :on-click    (fn [_] (on-toggle (:row-key row)))
+            :role        "button"
+            :tabIndex    "0"
+            :aria-expanded (if open? "true" "false")
+            :aria-label  (str (name status) ": " label)}
+      [:span {:style       glyph-style
+              :data-test   "story-canvas-assertion-glyph"
+              :aria-hidden "true"}
+       glyph]
+      [:span {:style     (:label styles)
+              :data-test "story-canvas-assertion-label"}
+       label]
+      (when (seq summary)
+        [:span {:style     (merge (:summary styles)
+                                  (when fail? (:summary-fail styles)))
+                :data-test "story-canvas-assertion-summary"
+                :title     summary}
+         summary])
+      [:span {:style     (:tog styles)
+              :data-test "story-canvas-assertion-tog"
+              :aria-hidden "true"}
+       (if open? "−" "+")]]
+     (when open?
+       (row-detail (:detail row)))]))
+
+(defn- group-head
+  "Render the group head label. `event` is the dispatching event vector
+  (e.g. `[:counter/inc]`) or nil for assertions outside a play step."
+  [event]
+  (let [text (if (nil? event)
+               "setup"
+               (let [evt-id (first event)
+                     args   (rest event)]
+                 (str (pr-str evt-id)
+                      (when (seq args)
+                        (let [args-str (str/join " " (map pr-str args))]
+                          (str " " (truncate args-str 40)))))))]
+    [:div {:style     (:group-head styles)
+           :data-test "story-canvas-assertion-group-head"
+           :data-event (pr-str event)}
+     text]))
+
+(defn assertion-strip
+  "Reagent component rendering a compact structured assertion strip for
+  inline canvas / workspace use.
+
+  `assertions` is the variant frame's accumulated `:rf.story/assertions`
+  vector (the runtime's record shape — `{:assertion :passed?
+  :payload :expected :actual :reason :event :phase :source ...}`).
+  Each record is projected through `tm-pure/assertion-row` to derive
+  status / label / row-key / detail.
+
+  Renders nothing when `assertions` is empty. Otherwise renders one
+  group per dispatching `:event`, with one row per assertion under the
+  group. Failed rows auto-expand; passed/skipped rows stay collapsed.
+  Clicking any row toggles its detail panel.
+
+  Local-state: a per-mount `r/atom` carries the expanded-row-keys set.
+  Failed rows are seeded into the set on first render so the user lands
+  on already-disclosed failures."
+  [_assertions]
+  (let [expanded (r/atom nil)]            ;; nil until first render seeds
+    (fn [assertions]
+      (when (seq assertions)
+        (let [rows    (mapv tm-pure/assertion-row assertions)
+              ;; Seed the expanded set on first render: every failed
+              ;; row's :row-key lands open so the user doesn't have to
+              ;; click to disclose. After first render the atom is the
+              ;; canonical state.
+              _seed   (when (nil? @expanded)
+                        (reset! expanded
+                                (into #{}
+                                      (comp (filter #(= :fail (:status %)))
+                                            (map :row-key))
+                                      rows)))
+              ;; Re-projection: group the original records (carrying
+              ;; :event), then for each record look up the matching row
+              ;; by stable identity. This avoids re-doing the projection
+              ;; twice while keeping group-by data-shape pure.
+              groups  (group-by-event assertions)
+              row-for (fn [rec]
+                        (tm-pure/assertion-row rec))
+              toggle  (fn [row-key]
+                        (swap! expanded
+                               (fn [s]
+                                 (if (contains? s row-key)
+                                   (disj s row-key)
+                                   (conj s row-key)))))
+              ;; Only render group heads when we have >1 group; a
+              ;; single group reads cleanly without a header (the
+              ;; canvas surface is space-constrained).
+              multi-group? (> (count groups) 1)]
+          [:div {:style     (:wrap styles)
+                 :data-test "story-canvas-assertion-strip"}
+           (for [[gi {:keys [event records]}] (map-indexed vector groups)]
+             ^{:key (str "group-" gi)}
+             [:div {:style     (:group styles)
+                    :data-test "story-canvas-assertion-group"}
+              (when multi-group?
+                (group-head event))
+              (for [[ri rec] (map-indexed vector records)]
+                (let [row   (row-for rec)
+                      rkey  (:row-key row)
+                      open? (contains? @expanded rkey)]
+                  ^{:key (str gi "/" ri "/" rkey)}
+                  (render-row row open? toggle)))])])))))

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -26,6 +26,7 @@
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.runtime :as runtime]
+            [re-frame.story.ui.assertion-strip :as assertion-strip]
             [re-frame.story.ui.multi-substrate :as multi-substrate]
             [re-frame.story.ui.open-in-editor :as open-in-editor]
             [re-frame.story.ui.share :as share]
@@ -128,12 +129,6 @@
               :font-family mono-stack
               :font-size (:caption typography/type-scale)
               :border-radius "3px"}
-   :assertion {:padding "4px 8px"
-               :border-left "3px solid #be4040"
-               :margin "2px 0"
-               :font-family mono-stack
-               :font-size (:caption typography/type-scale)
-               :background (:danger-bg colors/tokens)}
    ;; rf2-0s4p1 — identity-bearing loading skeleton during the
    ;; four-phase loader lifecycle. Reads as "workshop loading" — amber-
    ;; shimmer pulse on a slate ground — not the generic Storybook
@@ -345,13 +340,15 @@
        ^{:key i}
        [:div (pr-str e)])]))
 
-(defn- render-assertions [assertions]
+(defn- render-assertions
+  "Render the variant frame's accumulated assertions in a structured
+  row treatment — status glyph + label + one-line summary with click-
+  to-expand detail. Sourced from the shared
+  `re-frame.story.ui.assertion-strip` component the workspace cell
+  also consumes (single source of truth for the inline strip shape)."
+  [assertions]
   (when (seq assertions)
-    [:div
-     (for [[i a] (map-indexed vector assertions)]
-       ^{:key i}
-       [:div {:style (:assertion styles)}
-        (pr-str a)])]))
+    [assertion-strip/assertion-strip assertions]))
 
 ;; ---- the canvas component ------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -87,6 +87,7 @@
                        ;; namespaced ids of the form `:story.x/y`, and a
                        ;; namespace-dropping provider would scope the
                        ;; subtree to `:y` — a frame that does not exist.
+                       [re-frame.story.ui.assertion-strip :as assertion-strip]
                        [re-frame.story.ui.canvas :as canvas]
                        [re-frame.story.ui.state :as state]])
             #?(:cljs [re-frame.story.ui.markdown :as md])
@@ -309,16 +310,13 @@
            (for [[i e] (map-indexed vector errors)]
              ^{:key i}
              [:div (pr-str e)])])
+        ;; Cell's inline assertion strip — the structured-row treatment
+        ;; (status glyph + label + summary + click-to-expand detail) is
+        ;; shared with the canvas strip via the assertion-strip
+        ;; component; both render off the same per-record projection
+        ;; rather than `pr-str`-ing raw maps.
         (when (seq assertions)
-          [:div {:style {:margin-top "6px"}}
-           (for [[i a] (map-indexed vector assertions)]
-             ^{:key i}
-             [:div {:style {:padding "2px 6px"
-                            :border-left "3px solid #be4040"
-                            :margin "2px 0"
-                            :background (:danger-bg colors/tokens)
-                            :font-size (:micro typography/type-scale)}}
-              (pr-str a)])])])))
+          [assertion-strip/assertion-strip assertions])])))
 
 #?(:cljs
    (defn- variant-cell

--- a/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
@@ -1,0 +1,310 @@
+(ns re-frame.story.ui.assertion-strip-cljs-test
+  "CLJS-side regression net for the shared inline assertion strip.
+
+  The strip is consumed by both the canvas inline strip and the
+  workspace cell — see `re-frame.story.ui.canvas/render-assertions` +
+  `re-frame.story.ui.workspace/variant-cell-inner`. The legacy inline
+  rendering `pr-str`-ed raw assertion records; this strip lifts the
+  Storybook-inspired shape that already lives in
+  `re-frame.story.ui.test-mode.view`.
+
+  Surface covered (pure + rendered):
+
+  - `truncate`        — clamp with ellipsis
+  - `summary-line`    — fail → reason/expected vs actual; pass → blank;
+                        skip → reason
+  - `group-by-event`  — cluster records by dispatching :event, preserve
+                        insertion order, nil-event records cluster under
+                        a leading group
+  - `assertion-strip` rendered hiccup shape — wrap div with the canonical
+                        data-test, one row per record, group head only
+                        appears when there are >1 groups, failed rows
+                        seed the expanded set so the detail panel
+                        renders on first paint
+  - `render-row`      — status / label / glyph wiring; click toggles
+                        through the `on-toggle` callback"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.story.ui.assertion-strip :as strip]))
+
+;; ---- pure: truncate ------------------------------------------------------
+
+(deftest truncate-short-passthrough
+  (testing "strings shorter than the limit pass through unchanged"
+    (is (= "abc"   (strip/truncate "abc" 10)))
+    (is (= ""      (strip/truncate nil 10)))
+    (is (= "1"     (strip/truncate "1" 10)))))
+
+(deftest truncate-long-ellipsis
+  (testing "strings longer than the limit truncate with a single ellipsis char"
+    (let [out (strip/truncate "aaaaaaaaaaaaaaaaaa" 5)]
+      (is (= 5 (count out))
+          "output length matches the limit (ellipsis included)")
+      (is (= "aaaa…" out)
+          "last char is the ellipsis"))))
+
+(deftest truncate-coerces-non-string
+  (testing "non-string input is coerced through pr-str-ish (str)"
+    (is (= "42"    (strip/truncate 42 10)))))
+
+;; ---- pure: summary-line --------------------------------------------------
+
+(deftest summary-line-pass-blank
+  (testing "passing rows return the empty string — the label already names
+            the assertion and the strip stays compact"
+    (let [row {:status :pass
+               :detail {:expected 1 :actual 1}}]
+      (is (= "" (strip/summary-line row))))))
+
+(deftest summary-line-fail-reason
+  (testing "failing rows surface the :reason when present"
+    (let [row {:status :fail
+               :detail {:reason "values differ"}}]
+      (is (= "values differ" (strip/summary-line row))))))
+
+(deftest summary-line-fail-expected-actual
+  (testing "failing rows with no :reason fall back to expected vs actual"
+    (let [row {:status :fail
+               :detail {:expected 99 :actual 0}}]
+      (is (= "expected 99 · actual 0" (strip/summary-line row))))))
+
+(deftest summary-line-skip-reason
+  (testing "skipped rows surface the :reason (or a default placeholder)"
+    (is (= "feature gated"
+           (strip/summary-line {:status :skip
+                                :detail {:reason "feature gated"}})))
+    (is (= "skipped"
+           (strip/summary-line {:status :skip :detail {}}))
+        "no :reason → 'skipped' placeholder")))
+
+(deftest summary-line-fail-truncates
+  (testing "long :reason values clamp to the strip's character limit"
+    (let [long-reason (apply str (repeat 200 "x"))
+          row         {:status :fail :detail {:reason long-reason}}
+          out         (strip/summary-line row)]
+      (is (<= (count out) 72)
+          "output respects the truncate-len cap")
+      (is (re-find #"…$" out)
+          "truncated output ends in an ellipsis"))))
+
+;; ---- pure: group-by-event ------------------------------------------------
+
+(deftest group-by-event-clusters
+  (testing "records with the same :event cluster under one group in
+            insertion order"
+    (let [records [{:assertion :rf.assert/path-equals :event [:counter/inc]}
+                   {:assertion :rf.assert/path-equals :event [:counter/inc]}
+                   {:assertion :rf.assert/path-equals :event [:counter/dec]}]
+          groups  (strip/group-by-event records)]
+      (is (= 2 (count groups)))
+      (is (= [:counter/inc] (-> groups (nth 0) :event)))
+      (is (= 2 (-> groups (nth 0) :records count)))
+      (is (= [:counter/dec] (-> groups (nth 1) :event)))
+      (is (= 1 (-> groups (nth 1) :records count))))))
+
+(deftest group-by-event-preserves-insertion-order
+  (testing "the first occurrence of each :event sets that group's position
+            in the output, even if the records interleave later"
+    (let [records [{:event [:a]} {:event [:b]} {:event [:a]} {:event [:c]}]
+          groups  (strip/group-by-event records)]
+      (is (= [[:a] [:b] [:c]] (mapv :event groups))
+          "groups appear in first-seen order")
+      (is (= 2 (-> groups (nth 0) :records count))
+          ":a cluster carries both records"))))
+
+(deftest group-by-event-nil-event-cluster
+  (testing "records with no :event (phase-0 setup assertions, decorator
+            throws) cluster under a leading nil-event group"
+    (let [records [{:assertion :rf.assert/x}
+                   {:assertion :rf.assert/y :event [:click]}
+                   {:assertion :rf.assert/z}]
+          groups  (strip/group-by-event records)]
+      (is (= 2 (count groups)))
+      (is (nil? (-> groups (nth 0) :event))
+          ":event nil cluster is its own group")
+      (is (= 2 (-> groups (nth 0) :records count))
+          "both nil-event records cluster together"))))
+
+(deftest group-by-event-empty
+  (testing "empty input → empty groups vector"
+    (is (= [] (strip/group-by-event [])))
+    (is (= [] (strip/group-by-event nil)))))
+
+;; ---- pure: status-glyph map ----------------------------------------------
+
+(deftest status-glyph-shape
+  (testing "the three status glyphs (Storybook-inspired pattern #1)
+            are exposed publicly so tests + downstream consumers can
+            pin them"
+    (is (= "✓" (:pass strip/status-glyph)))
+    (is (= "✗" (:fail strip/status-glyph)))
+    (is (= "⊘" (:skip strip/status-glyph)))))
+
+;; ---- rendered: render-row ------------------------------------------------
+
+(defn- find-prop
+  "Walk `hiccup` and return the first prop-map carrying `(= (get m k) v)`.
+  Returns nil when nothing matches. Used by these tests to assert the
+  structured row treatment lands the canonical data-test attributes."
+  [hiccup k v]
+  (let [match? (fn [x]
+                 (and (map? x) (= v (get x k))))]
+    (letfn [(walk [node]
+              (cond
+                (match? node) node
+                (vector? node)
+                (some walk node)
+                (seq? node)
+                (some walk node)
+                :else nil))]
+      (walk hiccup))))
+
+(deftest render-row-pass-shape
+  (testing "a passing row carries the data-test stamps the chrome-level
+            test widget reads + the spec-pinned status glyph"
+    (let [row    {:status   :pass
+                  :label    ":rf.assert/path-equals [[:counter] 1]"
+                  :row-key  ":rf.assert/path-equals [[:counter] 1]"
+                  :detail   {:expected 1 :actual 1}}
+          hiccup (strip/render-row row false (fn [_]))]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-row"))
+          "row wrapper carries the canonical data-test")
+      (let [row-wrapper (find-prop hiccup :data-test "story-canvas-assertion-row")]
+        (is (= "pass" (:data-status row-wrapper))
+            ":data-status reflects the row's status keyword (lowercased)"))
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-glyph")))
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-label"))))))
+
+(deftest render-row-fail-shape-summary-on-reason
+  (testing "a failing row surfaces the :reason as the inline summary AND
+            carries the fail-status stamp"
+    (let [row    {:status  :fail
+                  :label   ":rf.assert/path-equals [[:counter] 99]"
+                  :row-key ":rf.assert/path-equals [[:counter] 99]"
+                  :detail  {:expected 99 :actual 0 :reason "values differ"}}
+          hiccup (strip/render-row row true (fn [_]))
+          wrap   (find-prop hiccup :data-test "story-canvas-assertion-row")]
+      (is (= "fail" (:data-status wrap)))
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-summary"))
+          "inline summary span renders when status is :fail with a :reason")
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-detail"))
+          "open? true → the detail panel renders inline"))))
+
+(deftest render-row-skip-shape-no-detail-when-collapsed
+  (testing "a skipped row stays collapsed by default — detail panel
+            absent unless the caller passes open? true"
+    (let [row    {:status  :skip
+                  :label   ":rf.assert/skipped"
+                  :row-key ":rf.assert/skipped"
+                  :detail  {:reason "feature gated"}}
+          hiccup (strip/render-row row false (fn [_]))]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-summary"))
+          ":skip rows surface the reason summary even when collapsed")
+      (is (nil? (find-prop hiccup :data-test "story-canvas-assertion-detail"))
+          "detail panel suppressed when open? false"))))
+
+;; ---- rendered: assertion-strip component ---------------------------------
+;;
+;; The component returns a reagent inner-fn (closure-with-state pattern).
+;; Calling `(strip/assertion-strip assertions)` returns the outer fn; we
+;; invoke it once with the assertions vector to get the inner fn, then
+;; invoke that with the same vector to get the hiccup. This is the
+;; standard reagent-with-init shape; tests pin the rendered tree without
+;; standing up a React mount.
+
+(defn- render-strip
+  "Invoke the assertion-strip component and return its rendered hiccup."
+  [assertions]
+  (let [inner (strip/assertion-strip assertions)]
+    (inner assertions)))
+
+(deftest assertion-strip-empty-renders-nil
+  (testing "empty / nil assertions → no inline strip"
+    (is (nil? (render-strip [])))
+    (is (nil? (render-strip nil)))))
+
+(deftest assertion-strip-wrap-carries-canonical-data-test
+  (testing "the wrap div stamps `story-canvas-assertion-strip` so the
+            chrome-level test widget can scope queries to the strip"
+    (let [assertions [{:assertion :rf.assert/path-equals
+                       :passed?   true
+                       :payload   [[:c] 1]
+                       :expected  1 :actual 1}]
+          hiccup     (render-strip assertions)]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-strip"))))))
+
+(deftest assertion-strip-one-row-per-record
+  (testing "the strip renders exactly one row per assertion record"
+    (let [assertions [{:assertion :rf.assert/path-equals
+                       :passed? true :payload [[:c] 1] :expected 1 :actual 1}
+                      {:assertion :rf.assert/path-equals
+                       :passed? false :payload [[:c] 2] :expected 2 :actual 0
+                       :reason "values differ"}
+                      {:assertion :rf.assert/skipped
+                       :passed? false :reason "feature gated"}]
+          hiccup     (render-strip assertions)
+          rows       (atom [])]
+      (letfn [(walk [node]
+                (cond
+                  (and (map? node) (= "story-canvas-assertion-row" (:data-test node)))
+                  (swap! rows conj node)
+                  (vector? node) (run! walk node)
+                  (seq? node)    (run! walk node)))]
+        (walk hiccup))
+      (is (= 3 (count @rows)))
+      (is (= #{"pass" "fail" "skip"}
+             (into #{} (map :data-status @rows)))))))
+
+(deftest assertion-strip-fail-auto-expands
+  (testing "pattern #2 — failed assertions land already-open; the
+            detail panel renders on first paint without a user click"
+    (let [assertions [{:assertion :rf.assert/path-equals
+                       :passed? true :payload [[:c] 1] :expected 1 :actual 1}
+                      {:assertion :rf.assert/path-equals
+                       :passed? false :payload [[:c] 2]
+                       :expected 2 :actual 0 :reason "values differ"}]
+          hiccup     (render-strip assertions)]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-detail"))
+          "the failing row's detail panel is open on first render"))))
+
+(deftest assertion-strip-pass-stays-collapsed
+  (testing "pattern #2 — passing assertions stay collapsed by default;
+            no detail panel renders without a click"
+    (let [assertions [{:assertion :rf.assert/path-equals
+                       :passed? true :payload [[:c] 1] :expected 1 :actual 1}
+                      {:assertion :rf.assert/path-equals
+                       :passed? true :payload [[:c] 2] :expected 2 :actual 2}]
+          hiccup     (render-strip assertions)]
+      (is (nil? (find-prop hiccup :data-test "story-canvas-assertion-detail"))
+          "all-passing strip renders zero detail panels — the user sees
+           just the row band"))))
+
+(deftest assertion-strip-single-group-suppresses-head
+  (testing "pattern #5 — when all records share a single :event (or
+            all carry no event) the group head is suppressed to keep
+            the strip compact"
+    (let [assertions [{:assertion :rf.assert/path-equals :passed? true
+                       :event [:click] :payload [[:c] 1]}
+                      {:assertion :rf.assert/path-equals :passed? true
+                       :event [:click] :payload [[:c] 2]}]
+          hiccup     (render-strip assertions)]
+      (is (nil? (find-prop hiccup :data-test "story-canvas-assertion-group-head"))
+          "single-group renders no group-head — only the rows"))))
+
+(deftest assertion-strip-multi-group-renders-heads
+  (testing "pattern #5 — when records cluster across >1 :event slots,
+            each cluster is labelled with a group head"
+    (let [assertions [{:assertion :rf.assert/path-equals :passed? true
+                       :event [:click]}
+                      {:assertion :rf.assert/path-equals :passed? true
+                       :event [:submit]}]
+          hiccup     (render-strip assertions)
+          heads      (atom [])]
+      (letfn [(walk [node]
+                (cond
+                  (and (map? node) (= "story-canvas-assertion-group-head" (:data-test node)))
+                  (swap! heads conj node)
+                  (vector? node) (run! walk node)
+                  (seq? node)    (run! walk node)))]
+        (walk hiccup))
+      (is (= 2 (count @heads))
+          "one head per dispatching event"))))


### PR DESCRIPTION
Closes rf2-29lw1.

## Summary

- The canvas inline strip + workspace cell previously pr-str-ed raw assertion maps into one verbose row per record. The `:test` mode pane already implemented the Storybook-inspired structured shape — the inline strip just never adopted it (the rf2-fj332 audit finding).
- Lift that shape into a new shared `re-frame.story.ui.assertion-strip` component the canvas + workspace cell both consume. Single source of truth for inline strip rendering; `:test` mode pane keeps its richer per-row table (it has space for expected/actual columns).
- Five Storybook-inspired patterns applied: status glyph + label + summary; auto-expand fail / auto-collapse pass; token-coloured left border; truncate long values; group by dispatching `:event`.

## Files

- `tools/story/src/re_frame/story/ui/assertion_strip.cljs` (new, ~280 LoC) — shared component with pure-data helpers (`truncate`, `summary-line`, `group-by-event`) and the Reagent renderer.
- `tools/story/src/re_frame/story/ui/canvas.cljs` — `render-assertions` now delegates to the shared component; legacy inline `:assertion` style removed.
- `tools/story/src/re_frame/story/ui/workspace.cljc` — cell `(seq assertions)` branch delegates to the shared component.
- `tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs` (new) — pure-data + rendered-hiccup contract tests.

## Test plan

- [x] `npm run test:cljs` — 3871 tests passing, including 22 new tests in `assertion-strip-cljs-test`
- [x] `clojure -M:test` from `tools/story` — 841 tests passing
- [x] `python -m mkdocs build --strict` — clean
- [x] No new Playwright; CLJS unit tests pin rendered hiccup shape per pre-alpha posture