### PR TITLE
fix(causa+story): Causa empty-frame bug — restore mount hooks + variant selection dispatch (rf2-uypwz + rf2-kviar)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -333,7 +333,7 @@
 
 ;; ---- public API ----------------------------------------------------------
 
-(defn- ensure-causa-frame!
+(defn ensure-causa-frame!
   "Register the `:rf/causa` frame if not already registered, then run
   each registered first-mount hook in insertion order. Idempotent via
   `reg-frame`'s surgical-update-on-re-register semantics (per Spec

--- a/tools/causa/src/day8/re_frame2_causa/panels.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels.cljs
@@ -114,6 +114,7 @@
   embedding contract."
   (:require [re-frame.core :as rf]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.app-db-segment-inspector :as segment-inspector]
@@ -134,13 +135,27 @@
   "Idempotent — `register-causa-handlers!` carries its own sentinel so
   multiple panel mounts collapse to one registration pass.
 
-  Note: we also `(rf/reg-frame :rf/causa {})` here so the frame the
-  wrapped `frame-provider` resolves to actually exists. `reg-frame`'s
-  surgical-update-on-re-register semantics (Spec 002 §reg-frame) keep
-  this idempotent across panel mounts and shadow-cljs reloads."
+  Routes through `mount/ensure-causa-frame!` so the frame is not just
+  registered but ALSO seeded via the first-mount hook table (rf2-y1saa)
+  — `::seed-trace-and-target-frame`, `::hydrate-filters`,
+  `::hydrate-spine-filters`, `::hydrate-static-mode`,
+  `::auto-open-watcher`. A direct `(rf/reg-frame :rf/causa {})` here
+  would register the frame but skip the hook table, leaving Causa's
+  trace-buffer slot empty + `:target-frame` pinned to
+  `defaults/default-target-frame` regardless of what's already in the
+  trace-bus and the host's epoch ring. That misalignment is the
+  empty-Causa-on-Story-RHS class of bug — Story embeds a panel via
+  `mount-<panel>!`, the panel renders against a frame the hooks never
+  populated, and the user sees blank inputs even though the host has
+  been dispatching events.
+
+  `ensure-causa-frame!` is idempotent (sentinel-guarded hooks +
+  reg-frame's surgical-update-on-re-register semantics per Spec 002
+  §reg-frame) so multiple panel mounts collapse to one seed pass +
+  zero re-registrations across shadow-cljs reloads."
   []
   (registry/register-causa-handlers!)
-  (rf/reg-frame :rf/causa {}))
+  (mount/ensure-causa-frame!))
 
 (defn- render-panel!
   "Internal helper. Wraps `panel-view` in `[rf/frame-provider {:frame

--- a/tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs
@@ -34,6 +34,8 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.panels :as panels]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.app-db-segment-inspector :as segment-inspector]
@@ -44,6 +46,7 @@
             [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.panels.reactive-panel :as reactive-panel]
+            [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
@@ -251,6 +254,107 @@
         ;; cross-panel primitive registered inside the orchestrator's
         ;; sentinel guard.
         (is (some? (registrar/handler :sub :rf.causa/cascades)))))))
+
+;; ---- contract — panel mount routes through mount/ensure-causa-frame! ---
+;;
+;; Pre-fix `ensure-causa-handlers-installed!` did `(rf/reg-frame :rf/causa
+;; {})` directly. That registered the frame but bypassed the first-mount
+;; hook table (rf2-y1saa) — including `::seed-trace-and-target-frame`,
+;; the hook that lifts the pre-mount trace-bus buffer into Causa's
+;; `:trace-buffer` slot AND seeds `:target-frame` + `:epoch-history` from
+;; the head focusable cascade's frame. The result on the Story RHS: a
+;; host that dispatched events before any panel was mounted, then mounted
+;; a panel, saw empty Event + App-DB panels because the slots the panels
+;; subscribe to had never been populated. The fix routes through
+;; `mount/ensure-causa-frame!` so every panel-only mount path fires the
+;; same hook table the full-shell `open!` runs.
+
+(defn- pre-mount-dispatch-event
+  "Build a trace event matching the shape `event/dispatched` produces.
+  Enough for `projection/group-cascades` to bucket it into a cascade
+  with `:frame` set so `spine/focusable-head-frame-id` resolves."
+  [id dispatch-id frame-id event-id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :tags      {:dispatch-id dispatch-id
+               :frame       frame-id
+               :event       [event-id]}})
+
+(deftest mount-panel-seeds-trace-buffer-from-pre-mount-bus
+  (testing "Mounting a panel before the user has opened the full shell
+            still runs the first-mount hook table — so the trace-bus
+            atom contents land in Causa's `:trace-buffer` slot and the
+            panel renders against the host's pre-mount cascades. Pre-fix
+            the direct `(rf/reg-frame :rf/causa {})` bypassed the hook
+            table and the slot stayed empty."
+    (let [[_capture _ render-stub] (make-render-stub)]
+      (with-redefs [substrate-adapter/render render-stub
+                    rf/epoch-history (fn [_] [])]
+        ;; Host dispatched two events on `:cart-frame` while Causa was
+        ;; un-mounted — the trace-bus atom accumulated them.
+        (trace-bus/collect-trace!
+          (pre-mount-dispatch-event 1 100 :cart-frame :cart/add-item))
+        (trace-bus/collect-trace!
+          (pre-mount-dispatch-event 2 101 :cart-frame :cart/checkout))
+        (panels/mount-event-detail! :mount-point)
+        (rf/with-frame :rf/causa
+          (let [buf @(rf/subscribe [:rf.causa/trace-buffer])]
+            (is (= 2 (count buf))
+                "trace-buffer reflects the pre-mount bus contents — the
+                 `::seed-trace-and-target-frame` hook ran on mount.")))))))
+
+(deftest mount-panel-seeds-target-frame-from-head-focusable-cascade
+  (testing "Mounting a panel directly (without going through the full
+            shell `open!`) seeds `:target-frame` from the head focusable
+            cascade's frame — matching the rf2-boyc2 contract the
+            full-shell path observes. Pre-fix only `open!` ran the seed
+            hook; panel-only mounts left `:target-frame` at
+            `defaults/default-target-frame` regardless of pre-mount
+            traffic on a non-default frame. That misalignment is the
+            empty-Causa-on-Story-RHS class of bug."
+    (let [[_capture _ render-stub] (make-render-stub)
+          cart-records [{:epoch-id      :e-1
+                         :frame         :cart-frame
+                         :db-before     {:cart {:items []}}
+                         :db-after      {:cart {:items [{:id 7}]}}
+                         :trigger-event [:cart/add-item]
+                         :event-id      :cart/add-item
+                         :trace-events  []}]]
+      (with-redefs [substrate-adapter/render render-stub
+                    rf/epoch-history (fn [frame-id]
+                                       (case frame-id
+                                         :cart-frame cart-records
+                                         []))]
+        (trace-bus/collect-trace!
+          (pre-mount-dispatch-event 1 100 :cart-frame :cart/add-item))
+        (panels/mount-app-db-diff! :mount-point)
+        (rf/with-frame :rf/causa
+          (is (= :cart-frame @(rf/subscribe [:rf.causa/target-frame]))
+              "`:target-frame` seeds from the head focusable cascade's
+               `:frame` via the `::seed-trace-and-target-frame` hook.")
+          (is (= cart-records @(rf/subscribe [:rf.causa/epoch-history]))
+              "`:epoch-history` re-seeds in lockstep from
+               `(rf/epoch-history :cart-frame)` per the
+               `:rf.causa/set-target-frame` reducer."))))))
+
+(deftest mount-panel-without-pre-mount-traffic-falls-back-to-default-frame
+  (testing "Mounting a panel with an empty trace-bus + no pre-mount
+            cascades on any frame seeds `:target-frame` from
+            `defaults/default-target-frame` (the fallback branch in
+            `::seed-trace-and-target-frame`). Pins the cold-start
+            behaviour; without the hook the slot would be nil and the
+            App-DB sub's frame-resolution would chain to `:rf/default`
+            silently."
+    (let [[_capture _ render-stub] (make-render-stub)]
+      (with-redefs [substrate-adapter/render render-stub
+                    rf/epoch-history (fn [_] [])]
+        (panels/mount-trace! :mount-point)
+        (rf/with-frame :rf/causa
+          (is (= defaults/default-target-frame
+                 @(rf/subscribe [:rf.causa/target-frame]))
+              "`:target-frame` falls back to default when no focusable
+               cascade exists."))))))
 
 ;; ---- contract — every public mount fn exists --------------------------
 

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -51,6 +51,7 @@
   them; closure's reachability analysis DCEs the lot."
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
             [re-frame.story.causa-preset :as causa-preset]
             [re-frame.story.config :as config]
             [re-frame.story.decorators :as decorators]
@@ -407,6 +408,37 @@
                      ;; would otherwise deref subscriptions against a
                      ;; non-existent frame.
                      (ensure-variant-frame! now)
+                     ;; Re-orient Causa's target-frame to the freshly-
+                     ;; selected variant's frame. Each Story variant is
+                     ;; reg-frame'd under its variant-id (see
+                     ;; `re-frame.story.frames`), so the variant-id IS
+                     ;; the frame-id from Causa's perspective. Without
+                     ;; this dispatch Causa stays anchored on whatever
+                     ;; the first-mount seed picked (commonly the boot
+                     ;; `:rf/default` or the previously-focused variant)
+                     ;; and the App-DB / Event panels render against a
+                     ;; frame the user is no longer observing —
+                     ;; producing the empty-state-with-stale-frame view
+                     ;; the user sees on every variant switch. The
+                     ;; `:rf.causa/set-target-frame` handler writes both
+                     ;; `:target-frame` AND re-seeds `:epoch-history`
+                     ;; from `(rf/epoch-history variant-id)` in lockstep
+                     ;; (per Causa's `epoch.cljs` reducer), so the L2
+                     ;; list, App-DB diff and downstream subs all flip
+                     ;; in one frame.
+                     ;;
+                     ;; `dispatch-sync` (rather than `dispatch*`) so the
+                     ;; slot is observable immediately — the watcher
+                     ;; runs outside any event-handler / drain cycle
+                     ;; (it's an atom-watch callback on the shell
+                     ;; ratom), so the in-drain guard does not apply.
+                     ;; The rf2-q9kv5 sibling dispatches in
+                     ;; `causa-preset/on-variant-selected!` below still
+                     ;; ride the async queue — they're Causa's own
+                     ;; preset-applies and don't gate the next-frame
+                     ;; panel paint the way the target-frame slot does.
+                     (rf/with-frame :rf/causa
+                       (rf/dispatch-sync [:rf.causa/set-target-frame now]))
                      ;; rf2-v1ach: Causa now mounts per-panel into the
                      ;; RHS via `causa-embed/causa-embed-panel`. The
                      ;; embed owns its own React lifecycle — selecting

--- a/tools/story/test/re_frame/story/panels_e2e/causa_target_frame_dispatch_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/causa_target_frame_dispatch_e2e_cljs_test.cljs
@@ -1,0 +1,140 @@
+(ns re-frame.story.panels-e2e.causa-target-frame-dispatch-e2e-cljs-test
+  "Story selection-watcher → Causa `set-target-frame` dispatch.
+
+  When the user picks a variant in Story's sidebar the shell's
+  selection-watcher fires on the `:selected-variant` edge. Pre-fix the
+  watcher pre-allocated the variant's frame + ran the Causa cross-host
+  bridges but never told Causa which frame to OBSERVE. So Causa stayed
+  anchored on whatever its first-mount seed picked (commonly the boot
+  `:rf/default` or the previously-focused variant) — the App-DB diff
+  + Event tab rendered against a frame the user was no longer looking
+  at, producing the empty-Causa-on-Story-RHS class of bug surfaced in
+  rf2-fj332. The post-fix watcher dispatches
+  `[:rf.causa/set-target-frame <variant-id>]` into `:rf/causa`, which
+  writes both `:target-frame` AND re-seeds `:epoch-history` from
+  `(rf/epoch-history variant-id)` in lockstep per the rf2-boyc2
+  contract.
+
+  Pin: the variant-id IS the frame-id (Story `reg-frame`s each variant
+  under its variant-id; see `re-frame.story.frames`).
+
+  Sub-second per surface; no DOM / no React mount / no Playwright."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.ui.shell :as shell]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- install-selection-watcher!
+  "Call the shell's private `selection-watcher` fn via `var` so the
+  test can drive variant-selection edges without bringing up the full
+  React mount. `selection-watcher` is the production code path under
+  test — calling it directly exercises exactly the path
+  `mount-shell!` invokes during boot."
+  []
+  ((deref #'shell/selection-watcher)))
+
+(defn- remove-selection-watcher!
+  "Symmetric teardown: drop the watch + clear the cross-mount tracker."
+  []
+  ((deref #'shell/remove-selection-watcher!)))
+
+;; ---- the contract --------------------------------------------------------
+
+(deftest selection-watcher-dispatches-set-target-frame-on-variant-select
+  (testing "Picking a variant fires `:rf.causa/set-target-frame
+            <variant-id>` into `:rf/causa` — so Causa re-orients its
+            `:target-frame` + `:epoch-history` slots in lockstep on
+            every selection edge. Pre-fix the watcher pre-allocated
+            the variant's frame but never told Causa to OBSERVE it,
+            so the App-DB / Event panels rendered against the prior
+            target-frame (commonly the boot default)."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.cart {})
+         (story/reg-variant :story.cart/empty
+           {:doc    "Empty cart variant — exercises the target-frame dispatch."
+            :events []}))}
+      (fn []
+        (install-selection-watcher!)
+        (try
+          ;; Variant-id IS the frame-id per `re-frame.story.frames`.
+          (e2e/select-variant! :story.cart/empty)
+          ;; Inspect the slot Causa's `:rf.causa/set-target-frame`
+          ;; reducer writes to. If the watcher's dispatch fired, the
+          ;; slot reflects the freshly-selected variant.
+          (rf/with-frame :rf/causa
+            (is (= :story.cart/empty
+                   @(rf/subscribe [:rf.causa/target-frame]))
+                "Causa's `:target-frame` slot reflects the selected
+                 variant-id after the selection-watcher dispatch."))
+          (finally
+            (remove-selection-watcher!)))))))
+
+(deftest selection-watcher-re-dispatches-on-each-variant-change
+  (testing "Switching variants re-fires the dispatch — pre-fix the
+            watcher dispatched zero times so a switch left Causa
+            stuck on the prior frame. The post-fix watcher fires on
+            every edge."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.cart {})
+         (story/reg-variant :story.cart/empty {:events []})
+         (story/reg-variant :story.cart/with-items {:events []}))}
+      (fn []
+        (install-selection-watcher!)
+        (try
+          (e2e/select-variant! :story.cart/empty)
+          (rf/with-frame :rf/causa
+            (is (= :story.cart/empty
+                   @(rf/subscribe [:rf.causa/target-frame]))
+                "first selection lands"))
+          (e2e/select-variant! :story.cart/with-items)
+          (rf/with-frame :rf/causa
+            (is (= :story.cart/with-items
+                   @(rf/subscribe [:rf.causa/target-frame]))
+                "second selection re-orients Causa to the new frame"))
+          (finally
+            (remove-selection-watcher!)))))))
+
+(deftest selection-watcher-no-dispatch-when-deselecting-to-nil
+  (testing "Setting `:selected-variant` back to nil short-circuits the
+            inner branch (the watcher only re-orients on a non-nil
+            edge). Causa's `:target-frame` retains the last selected
+            value rather than being reset to nil — consistent with the
+            picker contract (a nil dispatch resets to the boot
+            default, which would clobber the user's last context)."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.cart {})
+         (story/reg-variant :story.cart/empty {:events []}))}
+      (fn []
+        (install-selection-watcher!)
+        (try
+          (e2e/select-variant! :story.cart/empty)
+          (rf/with-frame :rf/causa
+            (is (= :story.cart/empty
+                   @(rf/subscribe [:rf.causa/target-frame]))
+                "selection landed"))
+          ;; Now clear the selection. The watcher's `(when now ...)`
+          ;; guard short-circuits, so no dispatch fires; the slot
+          ;; retains the last variant-id.
+          (e2e/select-variant! nil)
+          (rf/with-frame :rf/causa
+            (is (= :story.cart/empty
+                   @(rf/subscribe [:rf.causa/target-frame]))
+                "Causa's target-frame is retained — the watcher does
+                 not clobber it on a deselect edge."))
+          (finally
+            (remove-selection-watcher!)))))))


### PR DESCRIPTION
Closes rf2-uypwz + rf2-kviar. Bundled P1 sibling fixes for the empty-Causa wiring bug surfaced in rf2-fj332 screenshot review.

## Summary

Two siblings sharing a root cause: Causa was rendering empty Event + App-DB panels on the Story RHS.

**rf2-uypwz (Causa)** — `panels/ensure-causa-handlers-installed!` did `(rf/reg-frame :rf/causa {})` directly, registering the frame but bypassing the first-mount hook table (rf2-y1saa). The `::seed-trace-and-target-frame` hook never fired, so:
- Causa's `:trace-buffer` slot stayed empty even though `trace-bus` had accumulated pre-mount events.
- `:target-frame` stayed at `defaults/default-target-frame` regardless of which frame the host had been dispatching to.

Fix: route panel mounts through `mount/ensure-causa-frame!` so every embed path runs the same hook table the full-shell `open!` runs. `ensure-causa-frame!` is now public.

**rf2-kviar (Story)** — the shell's `selection-watcher` pre-allocated the variant frame + ran the cross-host bridges but never told Causa which frame to OBSERVE. Causa stayed anchored on whatever its first-mount seed picked — App-DB / Event panels rendered against a frame the user was no longer looking at.

Fix: on the selection edge dispatch `[:rf.causa/set-target-frame <variant-id>]` into `:rf/causa`. Variant-id IS the frame-id (Story `reg-frame`s each variant under its variant-id). Uses `rf/with-frame :rf/causa (rf/dispatch-sync ...)` so the slot is observable before the next React commit; the watcher runs outside any event-handler drain so the in-drain guard does not apply.

## Test plan

- [x] `npm run test:cljs` — 3854 tests, 0 failures
- [x] `clojure -M:test` in `tools/causa` — 849 tests, 0 failures
- [x] `clojure -M:test` in `tools/story` — 841 tests, 0 failures
- [x] `npm run test:bundle-isolation` — passes
- [x] New CLJS unit tests pin both fixes:
  - `panels-mount-cljs-test`: mount-panel-seeds-trace-buffer-from-pre-mount-bus, mount-panel-seeds-target-frame-from-head-focusable-cascade, mount-panel-without-pre-mount-traffic-falls-back-to-default-frame
  - `causa-target-frame-dispatch-e2e-cljs-test`: selection-watcher-dispatches-set-target-frame-on-variant-select, selection-watcher-re-dispatches-on-each-variant-change, selection-watcher-no-dispatch-when-deselecting-to-nil
- [x] Verified via canary check — both new tests run and exercise the production code path