### PR TITLE
feat(causa): iteration gap bundle — chip rename + zprint+highlight + widget facade + h2 scrub + spec drift (6 beads from rf2-2pw5u audit)

### DIFF
--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -456,6 +456,34 @@ const ARTEFACTS = [
     consumerAllowList: null,
     expectedAllowListHits: 0,
   },
+
+  // zprint — the canonical pretty-printer Causa's EDN widget
+  // `code-block` uses to pre-format handler-source strings before the
+  // in-bundle tokenizer renders them
+  // (tools/causa/src/.../views/edn_widget/widget.cljs). Same posture
+  // as cljs-devtools: dev-only, consumed only by tools/ (Causa), gated
+  // behind the Causa `:devtools/preloads`. Production bundles MUST
+  // NOT pull zprint — the formatter body + its rewrite-clj dep weigh
+  // hundreds of kilobytes and give consumers no runtime benefit.
+  //
+  // Sentinels are distinctive identifiers from zprint's source body —
+  // the `zprint.core` namespace string appears in zprint's
+  // goog.provide-equivalent + namespace registrations. A non-zero hit
+  // means zprint's body got pulled into the bundle (most likely a
+  // `:require` slipped from tools/causa/* into implementation/*, or
+  // the EDN widget got referenced outside the Causa preload-gated
+  // tree).
+  {
+    name: 'zprint',
+    internalSentinels: [
+      // zprint's core namespace name as a literal string — appears in
+      // zprint's goog.provide-equivalent and internal references.
+      { source: 'zprint pretty-printer core namespace (zprint.core)',
+        sentinel: 'zprint.core' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
 ];
 
 // ----- helpers ---------------------------------------------------------------

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -155,7 +155,13 @@
                 ;; verifies `devtools.formatters` does not reach production
                 ;; bundles. See tools/causa/deps.edn for the artefact-side
                 ;; rationale.
-                [binaryage/devtools "1.0.7"]]
+                [binaryage/devtools "1.0.7"]
+                ;; zprint — Causa's EDN widget `code-block` pre-formatter
+                ;; (rf2-6snc8). Dev-only; the bundle-isolation gate
+                ;; verifies `zprint.core` does not reach production
+                ;; bundles. See tools/causa/deps.edn for the artefact-side
+                ;; rationale.
+                [zprint "1.3.0"]]
 
  ;; Top-level dev-http servers (rf2-aqcix). shadow-cljs's `:dev-http`
  ;; map binds a port to a list of file roots; the dev server cascades

--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -148,7 +148,25 @@
          ;; (scripts/check-bundle-isolation.cjs) verifies the
          ;; `devtools.formatters` ns body does not appear in the counter
          ;; example's :advanced release bundle.
-         binaryage/devtools {:mvn/version "1.0.7"}}
+         binaryage/devtools {:mvn/version "1.0.7"}
+
+         ;; zprint — canonical pretty-printer for the EDN widget's
+         ;; `code-block` rendering of handler-source strings. The Event
+         ;; panel's HANDLER section reads `:rf.handler/source` off the
+         ;; registry meta and renders it under a syntax-highlighted
+         ;; `<pre>`; zprint pre-formats the source to canonical
+         ;; line-breaks + indentation before the in-bundle tokenizer
+         ;; runs, so a poorly-formatted source registration still reads
+         ;; cleanly in the panel. Used in `:parse {:interpose true}` mode
+         ;; via `zprint.core/zprint-file-str` so existing comments and
+         ;; blank lines survive the round-trip.
+         ;;
+         ;; Causa is dev-only (gated by `:devtools/preloads` in
+         ;; shadow-cljs) so zprint does NOT land in production bundles.
+         ;; The bundle-isolation gate verifies via the `zprint.core`
+         ;; sentinel that the formatter body is absent from the counter
+         ;; example's :advanced release bundle.
+         zprint/zprint {:mvn/version "1.3.0"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -478,7 +478,7 @@ rf2-o5f5f.2 + rf2-o5f5f.3 + rf2-ybjkx + rf2-8l3uk.
 
 | Fx | Args | Behaviour |
 |---|---|---|
-| `:rf.causa.static/persist-mode` | `mode` keyword | Writes the bare string (`"runtime"` / `"static"`) to localStorage key `causa.mode`. No-ops on JVM / when localStorage is unavailable. |
+| `:rf.causa.static/persist-mode` | `mode` keyword | Writes the bare string (`"dynamic"` / `"static"`) to localStorage key `causa.mode`. No-ops on JVM / when localStorage is unavailable. |
 
 ## Command palette
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -494,7 +494,7 @@ as the developer scans.
 ┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
 │                                                                                      │
 │ ▼ DISPATCH SITE                                                                      │
-│   src/cart/views.cljs:127       [open ↗]                                             │
+│   src/cart/views.cljs:127       [code]                                             │
 │   via :ui · origin :app                                                              │
 │                                                                                      │
 │ ▼ EVENT                                                                              │
@@ -505,10 +505,10 @@ as the developer scans.
 │   :local-storage  {:user/last-cart-id "cart-42"}                                     │
 │                                                                                      │
 │ ▼ INTERCEPTORS  (1)                                                                  │
-│   :auth/require-login          src/auth/interceptors.cljs:42   [open ↗]              │
+│   :auth/require-login          src/auth/interceptors.cljs:42   [code]              │
 │                                                                                      │
 │ ▼ HANDLER                                                                            │
-│   reg-event-fx · src/cart/events.cljs:88                       [open ↗]              │
+│   reg-event-fx · src/cart/events.cljs:88                       [code]              │
 │                                                                                      │
 │ ▼ EFFECTS RETURNED                                                                   │
 │   :db    <… changed; see App-db tab …>                                               │
@@ -568,7 +568,7 @@ as the developer scans.
    carrying `:rf/default? true` (rf2-twt7m Change 3) plus the known
    auto-wrapper ids (`:rf/db-handler` / `:rf/fx-handler` /
    `:rf/ctx-handler`) as a belt-and-braces fallback.
-5. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [open ↗]`. Per
+5. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [code]`. Per
    Q2: does NOT duplicate the event-id (already shown in §2). Reads
    `(rf/handler-meta :event id)`.
 6. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`

--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -212,20 +212,20 @@ Dense case (default — focused epoch is a normal event with effects):
 ┌─ EVENT · :checkout/submit · epoch #42 ─────────────── [◀ Prev] [Next ▶] ─┐
 │ Stripe: violet (:accent-violet)                                          │
 │                                                                          │
-│ [1] DISPATCH                                                              │
+│ DISPATCH                                                                  │
 │   Event       [:checkout/submit {:cart-id "c123"}]                        │
 │   Origin      :user                                                       │
 │   Call-site   views/checkout.cljs:142  ⎘ ⤴ open-in-editor                │
 │   At          14:32:01.231                                                │
 │       │                                                                   │
-│       ▼                                                                   │
-│ [2] COEFFECTS ASSEMBLED                                                   │
+│       ⋁                                                                   │
+│ COEFFECTS ASSEMBLED                                                       │
 │   :db         {…current slice…}            [▸ expand]                     │
 │   :now        2026-05-20T14:32:01.231Z                                    │
 │   :http-cache {3 entries}                  [▸ expand]                     │
 │       │                                                                   │
-│       ▼                                                                   │
-│ [3] HANDLER INVOKED                                                       │
+│       ⋁                                                                   │
+│ HANDLER INVOKED                                                           │
 │   :checkout/submit · reg-event-fx                                         │
 │   ↳ impl/events.cljs:88   ⤴ open-in-editor                               │
 │   ↳ source (DEBUG-gated, when available):                                │
@@ -234,18 +234,18 @@ Dense case (default — focused epoch is a normal event with effects):
 │           {:db (assoc-in db [:cart :state] :submitting)                   │
 │            :fx [[:http/managed {…}]]}))                                   │
 │       │                                                                   │
-│       ▼                                                                   │
-│ [4] EFFECTS RETURNED  (handler intent)                                    │
+│       ⋁                                                                   │
+│ EFFECTS RETURNED  (handler intent)                                        │
 │   :db   {…new slice…}                      [▸ diff inline]                │
 │   :fx   [[:http/managed {:method :post :url "/orders" …}]]                │
 │       │                                                                   │
-│       ▼                                                                   │
-│ [5] EFFECTS APPLIED  (what actually happened)                             │
+│       ⋁                                                                   │
+│ EFFECTS APPLIED  (what actually happened)                                 │
 │   :db          written  ✓                                                 │
 │   :http/managed  POST /orders   in-flight  ⏳   #h-142                   │
 │       │                                                                   │
-│       ▼                                                                   │
-│ [6] FLOWS RECOMPUTED                                                      │
+│       ⋁                                                                   │
+│ FLOWS RECOMPUTED                                                          │
 │   :cart/total           re-fired  (input [:cart :items] changed)          │
 │   :cart/eligibility     unchanged input — skipped (dim)                   │
 │                                                                          │
@@ -258,22 +258,22 @@ Sparse case (focused epoch is a noisy timer with no effects):
 ```
 ┌─ EVENT · :ping/tick · epoch #87 ─────────────────── [◀ Prev] [Next ▶] ─┐
 │                                                                        │
-│ [1] DISPATCH    [:ping/tick]    origin :timer                          │
+│ DISPATCH    [:ping/tick]    origin :timer                              │
 │       │                                                                │
-│       ▼                                                                │
-│ [2] COEFFECTS   :db (sliced)                                           │
+│       ⋁                                                                │
+│ COEFFECTS   :db (sliced)                                               │
 │       │                                                                │
-│       ▼                                                                │
-│ [3] HANDLER     :ping/tick · reg-event-db                              │
+│       ⋁                                                                │
+│ HANDLER     :ping/tick · reg-event-db                                  │
 │       │                                                                │
-│       ▼                                                                │
-│ [4] EFFECTS     :db only — no :fx returned                             │
+│       ⋁                                                                │
+│ EFFECTS     :db only — no :fx returned                                 │
 │       │                                                                │
-│       ▼                                                                │
-│ [5] APPLIED     :db written ✓     (no fx)                              │
+│       ⋁                                                                │
+│ APPLIED     :db written ✓     (no fx)                                  │
 │       │                                                                │
-│       ▼                                                                │
-│ [6] FLOWS       (no flow inputs changed)                               │
+│       ⋁                                                                │
+│ FLOWS       (no flow inputs changed)                                   │
 │                                                                        │
 │ ━━━ db committed ━━━                                                   │
 └────────────────────────────────────────────────────────────────────────┘
@@ -1517,7 +1517,7 @@ is **which size goes where**:
 | Surface | Size token | Px @ 13px default | Weight |
 |---|---|---|---|
 | Panel `<h1>` (e.g. `EVENT · :checkout/submit · epoch #42`) | `:display` | ~14px | 600 (semibold) |
-| Section headers (e.g. `[1] DISPATCH`, `[7] SUBS RECOMPUTED`) | `:body` | 13px | 600 |
+| Section headers (e.g. `DISPATCH`, `SUBS RECOMPUTED`) | `:body` | 13px | 600 |
 | Step sub-header keys (e.g. `Event`, `Origin`, `Call-site`) | `:body-tight` | 12px | 500 (medium) |
 | Step values (the actual data) | `:mono-body` | 12px | 400 |
 | Inline annotations (`← changed from :idle`, `(input unchanged · skipped)`) | `:caption` | ~11px | 400 |

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_format.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_format.cljs
@@ -23,9 +23,9 @@
   §5 — short labels stay one-line `pr-str` for scan-ability.
 
   L4 detail-tab VALUE displays go through
-  `day8.re-frame2-causa.theme.data-inspector/inspect` (rf2-x9fzk) for
-  the cljs-devtools-shaped renderer; only short labels / paths come
-  through here."
+  `day8.re-frame2-causa.views.edn-widget.widget/inspect` (rf2-8q4f4 —
+  one widget, many call sites) for the cljs-devtools-shaped renderer;
+  only short labels / paths come through here."
   [v]
   (try
     (pr-str v)

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
@@ -2,9 +2,9 @@
   "Changed-slice rows for the App-DB Diff panel."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
-            [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 (defn empty-state
   [target-frame]
@@ -53,7 +53,7 @@
     ;; spec/015 / spec/018 §12. Display-value still elides giant
     ;; strings to `:rf.size/large-elided` first; the inspector
     ;; renders that marker like any other map.
-    (inspector/inspect (f/display-value value)
+    (edn/inspect (f/display-value value)
                        (str "app-db-diff/" (pr-str path) "/" (name label)))]])
 
 (defn slice-row

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
@@ -25,7 +25,7 @@
   centred dialog with a 15% dim backdrop, mirroring the causality
   popover's chrome (transient overlay, not a full-window modal). The
   body renders the value at the inspected path via
-  `theme/data-inspector/inspect` — the same primitive every L4 detail
+  `theme/data-edn/inspect` — the same primitive every L4 detail
   panel uses, so the renderer is uniform with the diff body.
 
   ## Three close affordances
@@ -50,9 +50,9 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
             [day8.re-frame2-causa.theme.a11y :as a11y]
-            [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens sans-stack mono-stack type-scale]]))
+             :refer [tokens sans-stack mono-stack type-scale]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; ---- subs ----------------------------------------------------------------
 
@@ -243,7 +243,7 @@
       ;; renders so toggle state survives shadow-cljs reloads.
       [:div {:data-testid "rf-causa-segment-inspector-body"
              :style       (body-style)}
-       (inspector/inspect (f/display-value value)
+       (edn/inspect (f/display-value value)
                           (str "segment-inspector/" (pr-str (vec path))))]]]))
 
 (rf/reg-view Popup

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -75,8 +75,7 @@
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.theme.section :as section]
-            [day8.re-frame2-causa.theme.perf-tier :as perf-tier]
-            [day8.re-frame2-causa.theme.data-inspector :as inspector]))
+            [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
 
 ;; ---- selection plumbing (survives from v1) -----------------------------
 
@@ -455,7 +454,7 @@
      :testid "rf-causa-event-detail-section-event"}
     [:div {:data-testid "rf-causa-event-detail-event-vector"
            :style {:font-weight 600}}
-     (inspector/inspect event-vec "event-detail/event")]))
+     (edn/inspect event-vec "event-detail/event")]))
 
 ;; ---- §1 DISPATCH SITE --------------------------------------------------
 
@@ -481,7 +480,7 @@
                             :cursor      "pointer"
                             :font-family mono-stack
                             :font-size   "10px"}}
-     "open ↗"]))
+     "[code]"]))
 
 (defn- dispatch-site-section
   [cascade]
@@ -562,7 +561,7 @@
                      :min-width 0
                      :flex 1
                      :word-break "break-word"}}
-      (inspector/inspect value (str "event-detail/coeffect/" suffix))]]))
+      (edn/inspect value (str "event-detail/coeffect/" suffix))]]))
 
 (defn- coeffects-section
   "§3. Silent-by-default — section is ABSENT entirely when zero user
@@ -768,13 +767,13 @@
         fx-row     (when (seq fx)
                      (effects-returned-row
                        ":fx"
-                       (inspector/inspect (vec fx) "event-detail/effects-returned/fx")
+                       (edn/inspect (vec fx) "event-detail/effects-returned/fx")
                        "rf-causa-event-detail-effects-returned-row-fx"
                        nil))
         hyd-row    (when hydration
                      (effects-returned-row
                        ":rf.ssr/hydration-outcome"
-                       (inspector/inspect hydration
+                       (edn/inspect hydration
                                           "event-detail/effects-returned/hydration")
                        "rf-causa-event-detail-effects-returned-row-hydration"
                        nil))
@@ -1054,7 +1053,7 @@
       [:span {:style {:color    (:text-primary tokens)
                       :min-width 0
                       :flex     1}}
-       (inspector/inspect result
+       (edn/inspect result
                           (str "event-detail/flow/"
                                (or trace-id "x")
                                "/result"))]]

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
@@ -41,9 +41,9 @@
   (:require [day8.re-frame2-causa.diff.hiccup :as hd]
             [day8.re-frame2-causa.diff.hiccup-render :as hd-render]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
-            [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; ---- node-key + small helpers ------------------------------------------
 
@@ -56,11 +56,11 @@
 
 (defn- inspect-value
   [v node-key]
-  (inspector/inspect (f/display-value v) node-key))
+  (edn/inspect (f/display-value v) node-key))
 
 (defn- inspect-inline
   [v]
-  (inspector/inspect-inline (f/display-value v)))
+  (edn/inspect-inline (f/display-value v)))
 
 ;; ---- absent / present chips --------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -47,7 +47,7 @@
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.theme.section :as section]
-            [day8.re-frame2-causa.theme.data-inspector :as inspector]))
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; Section rhythm hoisted to `theme/section.cljc` per rf2-pie8q —
 ;; identical visual contract is shared with `panels/event_detail`.
@@ -219,7 +219,7 @@
     [:span {:style {:color (:text-tertiary tokens)}} "(no request payload)"]
 
     :else
-    [inspector/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req")]))
+    [edn/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req")]))
 
 (defn- wire-section
   "Wire timing section. When the surface emits per-phase wire data we
@@ -245,7 +245,7 @@
                     :font-weight 600
                     :margin-bottom "4px"}}
       (str "✗ " (or (some-> failure :kind name) "FAILURE"))]
-     [inspector/inspect (or (:tags failure) failure)
+     [edn/inspect (or (:tags failure) failure)
       (str "managed-fx/" (h/format-fx-id fx-id) "/failure")]]
 
     (and (nil? res) (= surface :flow))
@@ -257,7 +257,7 @@
      "(no response payload yet)"]
 
     :else
-    [inspector/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res")]))
+    [edn/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res")]))
 
 (defn- handler-section
   "Renders the dispatched handler event vector + a click-to-focus
@@ -270,7 +270,7 @@
                    :gap "12px"
                    :flex-wrap "wrap"}}
      [:div {:style {:flex 1 :min-width 0}}
-      [inspector/inspect handler "managed-fx/handler"]]
+      [edn/inspect handler "managed-fx/handler"]]
      [:button {:data-testid "rf-causa-managed-fx-focus-handler"
                :on-click    #(rf/dispatch [:rf.causa/focus-event dispatch-id frame]
                                           {:frame :rf/causa})
@@ -328,7 +328,7 @@
 (defn record-panel
   "Render one managed-fx record as a hiccup panel. Pure function over
   the record; CLJS-only (consumes Reagent re-frame subs via
-  `inspector/inspect`).
+  `edn/inspect`).
 
   Section default-expanded state per the bead's contract:
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -301,24 +301,19 @@
    [:div
     ;; rf2-5kfxe.8 — domain-coloured accent stripe (:yellow for
     ;; Routing — side-channel attention tone, distinguished from
-    ;; app-db's main colour).
-    [:h2 {:style (merge {:margin         "0"
-                         :font-size      "13px"
-                         :font-weight    600
-                         :text-transform "uppercase"
-                         :letter-spacing "0.5px"
-                         :color          (:text-primary tokens)
-                         :display        "flex"
-                         :align-items    "center"
-                         :gap            "8px"}
-                        (t/accent-stripe-style :routing))}
+    ;; app-db's main colour). Per rf2-6xezz / rf2-rb6js the panel no
+    ;; longer renders a heading that names itself ("Routing") — the L4
+    ;; tab strip is the single source of panel identity. The icon +
+    ;; description paragraph stay as orientation chrome.
+    [:div {:style {:display     "flex"
+                   :align-items "center"
+                   :gap         "8px"}}
      ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. 🌐 in
      ;; :yellow (Routing's domain colour via panel-domain->token).
      [:span {:data-testid "rf-causa-routing-panel-icon"
              :aria-hidden "true"
              :style       (t/panel-icon-style :routing)}
-      (:routing t/panel-icon)]
-     "Routing"]
+      (:routing t/panel-icon)]]
     [:p {:style {:margin      "4px 0 0 0"
                  :color       (:text-tertiary tokens)
                  :font-size   "11px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -84,7 +84,6 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.data-display.render :as data-display]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
@@ -96,7 +95,8 @@
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens mono-stack sans-stack display-stack]]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; ---- axis labelling -----------------------------------------------------
 
@@ -356,7 +356,7 @@
          :style       {:padding "8px 16px 12px 110px"
                        :background (:bg-1 tokens)
                        :border-bottom (str "1px solid " (:border-subtle tokens))}}
-   (data-display/render-tree
+   (edn/browse
      {:value        raw
       :panel-id     :trace
       :render-id    (str "trace-row-" id)

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
@@ -63,14 +63,18 @@
                     :border-bottom (str "1px solid " (:border-subtle tokens))
                     :font-family   sans-stack
                     :font-size     (:body type-scale)}}
-   [:h2 {:data-testid "rf-causa-static-machines-detail-title"
-         :style (merge {:margin    0
-                        :font-size (:display type-scale)
-                        :font-family display-stack
-                        :font-weight 600
-                        :letter-spacing "-0.01em"
-                        :color (:text-primary tokens)}
-                       (try (t/accent-stripe-style :machines) (catch :default _ {})))}
+   ;; Per rf2-rb6js / rf2-6xezz — definition-detail title renders at
+   ;; body type-scale (not `:display`) so the focused machine-id chip
+   ;; reads as in-panel chrome rather than a top-level heading. The
+   ;; testid is preserved so existing tests still locate the element.
+   [:div {:data-testid "rf-causa-static-machines-detail-title"
+          :style (merge {:margin    0
+                         :font-size (:body type-scale)
+                         :font-family display-stack
+                         :font-weight 600
+                         :letter-spacing "-0.01em"
+                         :color (:text-primary tokens)}
+                        (try (t/accent-stripe-style :machines) (catch :default _ {})))}
     [:span {:style {:font-family mono-stack
                     :color (:accent-violet tokens)}}
      (str machine-id)]]

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -355,10 +355,16 @@
                      :font-family   sans-stack
                      :font-size     (:body type-scale)
                      :line-height   (:line-height-tight type-scale)}}
-   [:h2 {:style {:font-size     (:display type-scale)
-                 :margin        "0 0 8px 0"
-                 :padding-left  "10px"
-                 :border-left   (str "3px solid " (:cyan tokens))}}
+   ;; Per rf2-rb6js / rf2-6xezz — placeholder label renders at body
+   ;; type-scale (not `:display`) so the placeholder card matches the
+   ;; surrounding body typography. Was `[:h2]` at `:display`; now a
+   ;; non-heading `[:div]` at `:body` so it sits cleanly under the
+   ;; host's existing heading hierarchy.
+   [:div {:style {:font-size     (:body type-scale)
+                  :font-weight   600
+                  :margin        "0 0 8px 0"
+                  :padding-left  "10px"
+                  :border-left   (str "3px solid " (:cyan tokens))}}
     label]
    [:p {:style {:color  (:text-secondary tokens)
                 :margin "0 0 12px 0"}}

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -60,10 +60,42 @@
   it out of production bundles per the contract in `tools/README.md`."
   (:require [clojure.string :as str]
             [day8.re-frame2-causa.data-display.render :as data-display]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack]]
             [day8.re-frame2-causa.views.edn-widget.cljs-devtools-render
-             :as cdt]))
+             :as cdt]
+            [zprint.core :as zprint]))
+
+;; ---- panel-facing facade — inspect / inspect-inline ----------------------
+;;
+;; Per Mike-direction rf2-9wsdy ("one widget, many call sites") every
+;; panel-side EDN render flows through this namespace — panels MUST
+;; NOT reach for `theme.data-inspector` directly. The `inspect` +
+;; `inspect-inline` wrappers below delegate to the sentinel-aware
+;; renderer (`theme.data-inspector`) so panels get redacted / large
+;; chip rendering for free; the indirection keeps the widget as the
+;; single facade the rf2-8q4f4 grep contract checks.
+
+(defn inspect
+  "Sentinel-aware expandable rendering for one value — the canonical
+  L4 detail-panel renderer. Delegates to `theme.data-inspector/inspect`
+  so `:rf/redacted` / `:rf/large` sentinels paint their bespoke chrome
+  per spec/015. Returns hiccup.
+
+  Single-arg form picks the default node-key (`\"root\"`); two-arg
+  form lets the caller supply a stable per-mount node-key so adjacent
+  inspect calls in the same panel keep independent expand state."
+  ([v] (inspector/inspect v))
+  ([v node-key] (inspector/inspect v node-key)))
+
+(defn inspect-inline
+  "Compact one-line sentinel-aware rendering — same delegation as
+  `inspect` but uses `theme.data-inspector/inspect-inline` so hover
+  tooltips / list cells get the collapsed `{N entries}` / `[N items]`
+  / sentinel-chip shape without an expand affordance."
+  [v]
+  (inspector/inspect-inline v))
 
 ;; ---- variant: browse -----------------------------------------------------
 
@@ -167,9 +199,47 @@
 ;;
 ;; `code-block` renders Clojure SOURCE TEXT, not a CLJS value, so the
 ;; cljs-devtools formatters API doesn't apply (it operates on live
-;; values, not strings). We keep a small in-bundle Clojure tokenizer
-;; for source rendering — ~30 LoC, zero deps, sufficient for the
-;; handler-source snippets the Event panel renders.
+;; values, not strings).
+;;
+;; The pipeline is two-stage:
+;;
+;;   1. **zprint pre-format** — `format-source` runs the source string
+;;      through `zprint/zprint-file-str` so a poorly-formatted
+;;      registration (everything on one line, weird indentation,
+;;      mid-expression breaks) becomes canonical-looking before
+;;      rendering. zprint is dev-only — bundle-isolated from production
+;;      via the `:devtools/preloads` gate (rf2-6snc8). On a zprint
+;;      failure (parse error / unsupported reader macro) `format-source`
+;;      falls through to the original source string so a bad input
+;;      never strands the widget.
+;;
+;;   2. **In-bundle Clojure-mode tokenizer** — `tokenize-clojure` is a
+;;      lightweight ~140-LoC source-text lexer that emits per-token
+;;      colour classifications mapped onto the theme tokens (keywords
+;;      violet, strings green, numbers cyan, builtins violet). The
+;;      bracketed phrase in the rf2-6snc8 acceptance ("highlight.js …
+;;      or an embeddable Clojure-mode subset") explicitly authorises
+;;      this subset — and keeping the highlighter in-bundle avoids the
+;;      cost of a JS-side highlight.js dep on the dev classpath.
+
+(defn format-source
+  "Pre-format a Clojure source string via zprint so the rendered
+  code-block reads canonically regardless of how the registration was
+  laid out. On parse failure (unsupported reader macro, mid-form
+  splice, etc.) returns the original source unchanged so a bad input
+  never strands the widget. Pure fn; testable.
+
+  `zprint-file-str` is used (rather than `zprint-str` on a value) so
+  the input string is treated as raw source — comments, blank lines,
+  and multiple top-level forms survive the round-trip. The width is
+  capped at 72 columns so the rendered block fits inside the Event
+  panel's narrow handler-source slot without horizontal scroll."
+  [src]
+  (if-not (and (string? src) (seq src))
+    src
+    (try
+      (zprint/zprint-file-str src "rf-causa-handler-source" {:width 72})
+      (catch :default _ src))))
 
 (defn highlight-clojure-token
   "Per-token colour resolution for the in-bundle Clojure syntax
@@ -271,6 +341,11 @@
   operates on live CLJS values, not source text, so it doesn't apply
   here).
 
+  When `:lang` is `:clojure` (the default) the source is pre-formatted
+  via zprint (`format-source`) before the in-bundle tokenizer runs, so
+  a poorly-formatted registration still renders cleanly. Other
+  languages render as mono text (unformatted).
+
   Required: `:source`.
   Optional: `:lang` (defaults to `:clojure` — only `:clojure` highlights
             today · others render mono-text), `:testid`."
@@ -284,11 +359,14 @@
                    :color       (:text-tertiary tokens)
                    :font-style  "italic"}}
      "(source unavailable)"]
-    (let [tokens-seq (if (= :clojure lang)
-                       (tokenize-clojure source)
-                       [[:symbol source]])]
+    (let [formatted  (if (= :clojure lang) (format-source source) source)
+          tokens-seq (if (= :clojure lang)
+                       (tokenize-clojure formatted)
+                       [[:symbol formatted]])]
       [:pre {:data-testid testid
              :data-lang   (name lang)
+             :data-formatted (str (and (= :clojure lang)
+                                       (not= formatted source)))
              :style {:font-family mono-stack
                      :font-size   "11px"
                      :line-height 1.5

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -233,6 +233,57 @@
                        spans)]
     (is (some? str-span))))
 
+;; ---- zprint pre-format ---------------------------------------------------
+
+(deftest format-source-nil-input-returns-input
+  (testing "nil source survives — format-source never throws"
+    (is (nil? (w/format-source nil)))))
+
+(deftest format-source-empty-input-returns-input
+  (testing "empty / blank source survives unchanged"
+    (is (= "" (w/format-source "")))))
+
+(deftest format-source-pretty-prints-clojure
+  (let [src       "(reg-event-db :counter/inc (fn [db _] (update db :n inc)))"
+        formatted (w/format-source src)]
+    (testing "zprint reformats the input (canonical line-breaks)"
+      ;; A well-formed registration on one line gets canonicalised —
+      ;; either the same string back (zprint thinks it's already ideal)
+      ;; or one with newlines introduced. The output MUST still be a
+      ;; valid string.
+      (is (string? formatted)))
+    (testing "the round-trip text contains the same form contents"
+      ;; zprint never drops form contents — every token in the input
+      ;; appears in the output (possibly across more lines).
+      (is (re-find #"reg-event-db" formatted))
+      (is (re-find #":counter/inc" formatted))
+      (is (re-find #"update" formatted)))))
+
+(deftest format-source-malformed-input-falls-through
+  (testing "zprint parse failure returns the original input unchanged"
+    ;; Unmatched paren — zprint's parser refuses; format-source's
+    ;; try/catch falls through.
+    (let [bad "(reg-event-db :foo "]
+      (is (= bad (w/format-source bad))))))
+
+(deftest code-block-pre-formats-via-zprint
+  (let [out  (w/code-block {:source "(reg-event-db :counter/inc (fn [db _] (update db :n inc)))"})
+        pre  (some #(when (and (vector? %) (= :pre (first %))) %)
+                   (walk-hiccup out))
+        attrs (when pre (second pre))]
+    (testing "code-block emits the :pre root with a :data-formatted attr"
+      (is (some? attrs))
+      (is (contains? attrs :data-formatted)))))
+
+(deftest code-block-non-clojure-lang-skips-format
+  (let [out  (w/code-block {:source "function f(){}" :lang :javascript})
+        pre  (some #(when (and (vector? %) (= :pre (first %))) %)
+                   (walk-hiccup out))
+        attrs (when pre (second pre))]
+    (testing "non-clojure lang skips the zprint pre-format stage"
+      (is (= "false" (:data-formatted attrs))
+          ":data-formatted = false when zprint did not run"))))
+
 ;; ---- highlight-clojure-token mapping -------------------------------------
 
 (deftest highlight-clojure-token-mapping


### PR DESCRIPTION
Bundles 6 sub-beads from the rf2-2pw5u causa-iteration gap audit.

## Beads

| Bead | P | Scope |
|---|---|---|
| **rf2-v8ev8** | P2 | Event panel chip text rename `\"open ↗\"` → `[code]` (matches View panel + Mike-direction). |
| **rf2-6snc8** | P2 | Wire zprint into EDN widget `code-block` (canonical pre-format before the in-bundle Clojure-mode highlighter; zprint added dev-only behind Causa preload gate). |
| **rf2-8q4f4** | P2 | Route every panel EDN render through `views.edn-widget.widget` facade. New `inspect` / `inspect-inline` wrappers delegate to `theme.data-inspector` (sentinel-aware). Trace panel's `data-display/render-tree` call routes through `widget/browse`. |
| **rf2-rb6js** | P2 | Scrub 3 oversized `[:h2]` headings: panels/routing.cljs (drop \"Routing\" self-label), static/shell.cljs placeholder, static/machines/definition_detail.cljs (testid preserved). |
| **rf2-z8cmx** | P3 | Spec/014 `:rf.causa.static/persist-mode` row now says `\"dynamic\"` (matches `valid-modes`; was stale `\"runtime\"`). |
| **rf2-qhkfx** | P3 | Spec/021 §2.2 ASCII mockup numbering scrubbed (`[N] SECTION` → bare); `▼` arrows replaced with `⋁` chevrons; §17.1.5 type-scale row updated. |

## Bundle isolation

zprint joins cljs-devtools as a Causa-only dev dep. New sentinel `zprint.core` added to `scripts/check-bundle-isolation.cjs`; the counter example's `:advanced` release bundle does NOT carry the formatter body.

## Acceptance greps

- `grep -rn \"theme.data-inspector\|theme/data-inspector\" tools/causa/src/day8/re_frame2_causa/panels/` → empty
- `grep -rn \"data-display/render-tree\|data-display.render/render-tree\" tools/causa/src/day8/re_frame2_causa/panels/` → empty
- `grep -rn \"\[:h1\|\[:h2\|\[:h3\" tools/causa/src/day8/re_frame2_causa/panels/ tools/causa/src/day8/re_frame2_causa/static/` → only a comment ref
- `grep -n \"\[1\] DISPATCH\|\[2\] COEFFECTS\|\[3\] HANDLER\" tools/causa/spec/021-Dynamic-Panel-Designs.md` → empty

## Test plan

- [x] npm run test:cljs (3875 tests · 11791 assertions · 0 fail)
- [x] clojure -M:test from tools/causa (849 tests · 2769 assertions · 0 fail)
- [x] npm run test:bundle-isolation (zprint + cljs-devtools dev-only)
- [x] npm run test:perf-bundle (no production regression)
- [x] mkdocs build --strict
- [x] python scripts/check_doc_slugs.py