### PR TITLE
feat(story): canvas assertion-strip C2 polish bundle (rf2-txdnw + rf2-wibgi + rf2-c1rlg)

### DIFF
--- a/tools/story/src/re_frame/story/ui/assertion_strip.cljs
+++ b/tools/story/src/re_frame/story/ui/assertion_strip.cljs
@@ -21,7 +21,10 @@
      drills only when something demands attention). A click toggles.
   3. **Token-coloured left border** — green / red / grey by status.
   4. **Truncate long values** — the inline summary clamps to one line
-     with ellipsis; the expanded panel renders the full content.
+     with ellipsis; the expanded panel renders the full content, but a
+     long `:expected` / `:actual` value (e.g. a large map) clamps inside
+     the panel too with a click-to-reveal-full chord, so it never blows
+     the panel into the canvas height.
   5. **Group by dispatching event** — assertions cluster under the
      `:event` slot they were dispatched from. Multiple `:rf.assert/*`
      dispatches against the same play-step land together visually.
@@ -64,6 +67,17 @@
   shape at a glance."
   72)
 
+(def ^:private detail-value-len
+  "Maximum character length for a single `:expected` / `:actual` value
+  rendered inside the *expanded* detail panel. The row head's one-line
+  summary already clamps to `truncate-len`; this second cap stops a
+  large map (e.g. an `:rf.assert/sub-equals` comparing a whole app-db
+  slice) from blowing the expanded panel into the canvas height. Beyond
+  this length the value renders clamped with an ellipsis and a
+  click-to-reveal chord that swaps in the full `pr-str` inline — same
+  no-modal disclosure pattern as the row head (Storybook pattern #4)."
+  120)
+
 (defn truncate
   "Clamp `s` to at most `n` chars, suffixing `\"…\"` when truncated.
   Pure data → string. Returns `\"\"` for nil input."
@@ -74,6 +88,27 @@
      (not (string? s))          (truncate (str s) n)
      (<= (count s) n)           s
      :else                      (str (subs s 0 (max 0 (dec n))) "…"))))
+
+(defn value-display
+  "Pure projection of one detail value (`:expected` / `:actual`) into the
+  shape the detail panel renders: a `pr-str` rendering plus a clamped,
+  click-to-reveal-aware view.
+
+  Returns:
+
+      {:full     <full pr-str string>
+       :clamped  <truncate(full, n) — full when short>
+       :long?    <bool: was the full rendering longer than n?>}
+
+  `:long?` is the renderer's signal to attach the click-to-reveal chord;
+  short values render `:clamped` (= `:full`) directly with no chord. Pure
+  data → data; JVM-testable shape."
+  ([v] (value-display v detail-value-len))
+  ([v n]
+   (let [full (pr-str v)]
+     {:full    full
+      :clamped (truncate full n)
+      :long?   (> (count full) n)})))
 
 (defn summary-line
   "Render the one-line inline summary for one assertion-row projection.
@@ -208,7 +243,18 @@
                  :border-radius "0 3px 3px 0"}
    :detail-key  {:color         (:info colors/tokens)
                  :margin-right  "4px"}
-   :detail-line {:margin        "2px 0"}})
+   :detail-line {:margin        "2px 0"}
+   ;; click-to-reveal chord on a long :expected / :actual value inside
+   ;; the expanded panel. The clamped value renders inline; the chord
+   ;; swaps in the full pr-str — no modal, same row.
+   :value-reveal {:color        (:info colors/tokens)
+                  :margin-left  "6px"
+                  :font-size    (:micro typography/type-scale)
+                  :background   "transparent"
+                  :border       "none"
+                  :padding      "0"
+                  :cursor       "pointer"
+                  :text-decoration "underline"}})
 
 (def ^:private status->row-style
   {:pass (:row-pass styles)
@@ -228,11 +274,47 @@
 
 ;; ---- rendering ------------------------------------------------------------
 
+(defn detail-value
+  "Reagent component rendering one `:expected` / `:actual` value inside
+  the expanded detail panel with click-to-reveal-full.
+
+  Short values (`(value-display v)` `:long?` false) render their full
+  `pr-str` directly with no chord. Long values render the clamped form
+  plus a `(reveal)` chord; clicking the chord swaps in the full value
+  inline (no modal) and toggles back. Per-mount `r/atom` carries the
+  revealed? flag.
+
+  `data-test` is `story-canvas-assertion-detail-value`; the reveal chord
+  is `story-canvas-assertion-detail-reveal`. `data-revealed` reflects the
+  current disclosure state so tests + the agent reader can pin it."
+  [_label _v]
+  (let [revealed? (r/atom false)]
+    (fn [label v]
+      (let [{:keys [full clamped long?]} (value-display v)]
+        [:div {:style        (:detail-line styles)
+               :data-test    "story-canvas-assertion-detail-value"
+               :data-key     label
+               :data-revealed (str (boolean (and long? @revealed?)))}
+         [:span {:style (:detail-key styles)} (str label ":")]
+         (if (and long? (not @revealed?)) clamped full)
+         (when long?
+           [:button {:style     (:value-reveal styles)
+                     :data-test "story-canvas-assertion-detail-reveal"
+                     :type      "button"
+                     :on-click  (fn [e]
+                                  (.stopPropagation e)
+                                  (swap! revealed? not))}
+            (if @revealed? "less" "reveal")])]))))
+
 (defn- row-detail
   "Render the expanded detail for one row. Surfaces `:reason` /
   `:expected` / `:actual` / `:event` / `:phase` / `:predicate` and the
   source-coord stamp. Mirrors the test-mode pane's `row-detail` but
-  inline-sized (no headings; one line per key)."
+  inline-sized (no headings; one line per key).
+
+  `:expected` / `:actual` route through `detail-value` so a large map
+  (the densest realistic case) renders clamped with a click-to-reveal
+  chord rather than blowing the panel into the canvas height."
   [detail]
   (let [{:keys [reason expected actual event phase predicate source]} detail]
     [:div {:style     (:detail styles)
@@ -242,13 +324,9 @@
         [:span {:style (:detail-key styles)} "reason:"]
         (if (string? reason) reason (pr-str reason))])
      (when (or (some? expected) (false? expected))
-       [:div {:style (:detail-line styles)}
-        [:span {:style (:detail-key styles)} "expected:"]
-        (pr-str expected)])
+       [detail-value "expected" expected])
      (when (or (some? actual) (false? actual))
-       [:div {:style (:detail-line styles)}
-        [:span {:style (:detail-key styles)} "actual:"]
-        (pr-str actual)])
+       [detail-value "actual" actual])
      (when (some? event)
        [:div {:style (:detail-line styles)}
         [:span {:style (:detail-key styles)} "event:"]

--- a/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
@@ -11,6 +11,8 @@
   Surface covered (pure + rendered):
 
   - `truncate`        — clamp with ellipsis
+  - `value-display`   — clamp a detail :expected / :actual value with a
+                        :long? flag for the click-to-reveal chord
   - `summary-line`    — fail → reason/expected vs actual; pass → blank;
                         skip → reason
   - `group-by-event`  — cluster records by dispatching :event, preserve
@@ -308,3 +310,69 @@
         (walk hiccup))
       (is (= 2 (count @heads))
           "one head per dispatching event"))))
+
+;; ---- pure: value-display -------------------------------------------------
+
+(deftest value-display-short-no-clamp
+  (testing "a short value's :clamped equals :full and :long? is false —
+            no click-to-reveal chord needed"
+    (let [out (strip/value-display 42)]
+      (is (= "42" (:full out)))
+      (is (= "42" (:clamped out)))
+      (is (false? (:long? out)))))
+  (testing "a moderate map under the cap also passes through unclamped"
+    (let [out (strip/value-display {:a 1 :b 2})]
+      (is (false? (:long? out)))
+      (is (= (:full out) (:clamped out))))))
+
+(deftest value-display-long-clamps
+  (testing "a value whose pr-str exceeds the detail cap clamps with an
+            ellipsis and flags :long? so the renderer attaches the
+            click-to-reveal chord"
+    (let [big {:k (apply str (repeat 300 "x"))}
+          out (strip/value-display big)]
+      (is (true? (:long? out)))
+      (is (re-find #"…$" (:clamped out))
+          ":clamped ends in an ellipsis")
+      (is (< (count (:clamped out)) (count (:full out)))
+          ":clamped is shorter than the full pr-str")
+      (is (= (pr-str big) (:full out))
+          ":full carries the complete pr-str for the revealed view"))))
+
+(deftest value-display-respects-explicit-cap
+  (testing "the 2-arity form clamps at the caller-supplied length"
+    (let [out (strip/value-display "abcdefghij" 5)]
+      (is (true? (:long? out)))
+      (is (= 5 (count (:clamped out)))))))
+
+;; ---- rendered: detail-value ----------------------------------------------
+;;
+;; detail-value is a reagent component (closure-with-state). Invoke the
+;; outer fn to get the inner render fn, then invoke that to get hiccup —
+;; same shape as render-strip above.
+
+(defn- render-detail-value
+  [label v]
+  (let [inner (strip/detail-value label v)]
+    (inner label v)))
+
+(deftest detail-value-short-no-reveal-chord
+  (testing "a short value renders inline with NO reveal chord —
+            click-to-reveal only attaches when the value is long"
+    (let [hiccup (render-detail-value "expected" 7)]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-detail-value"))
+          "the value line carries the canonical data-test")
+      (is (nil? (find-prop hiccup :data-test "story-canvas-assertion-detail-reveal"))
+          "no reveal chord for a short value"))))
+
+(deftest detail-value-long-renders-reveal-chord-collapsed
+  (testing "a long value renders the reveal chord and starts collapsed —
+            data-revealed is false on first paint so the panel stays
+            compact — avoid blowing the panel height"
+    (let [big    {:k (apply str (repeat 300 "x"))}
+          hiccup (render-detail-value "actual" big)
+          line   (find-prop hiccup :data-test "story-canvas-assertion-detail-value")]
+      (is (some? (find-prop hiccup :data-test "story-canvas-assertion-detail-reveal"))
+          "reveal chord present for a long value")
+      (is (= "false" (:data-revealed line))
+          "starts collapsed — full value hidden until the chord is clicked"))))


### PR DESCRIPTION
Closes rf2-txdnw + rf2-wibgi + rf2-c1rlg. C2 follow-ons from rf2-fj332.

## Verified per-bead against #1821 (rf2-29lw1)

Per the dispatch note, the rf2-29lw1 worker already shipped several of these patterns. Verified each against current source before building:

- **rf2-txdnw (C2.2)** — auto-collapse pass / auto-expand fail + token-coloured left borders: **already shipped in #1821**. The strip seeds the expanded set with failed rows (`assertion-strip-fail-auto-expands`); pass/skip rows stay collapsed (`assertion-strip-pass-stays-collapsed`). The left border routes through `colors/tokens` (`:success` / `:danger` / `:text-tertiary`) with `:danger-bg` on fail — no hard-coded `#be4040` remains. No new work needed.
- **rf2-c1rlg (C2.4)** — group assertions by play step: **already shipped in #1821** as `group-by-event`. The strip only receives the `assertions` vector, whose records carry `:event` (the dispatched event vector), not a play-step index or the `[:dispatch-sync ...]` step form. Grouping by the dispatching `:event` is the achievable grouping at this call site, with a labelled head per group (suppressed for a single group). No new work needed.
- **rf2-wibgi (C2.3)** — truncate long `:expected` / `:actual` with click-to-reveal: the **row-head** one-line summary clamp + click-to-expand shipped in #1821, but the **expanded detail panel** still rendered `:expected` / `:actual` via raw untruncated `pr-str`, so a large map (e.g. a `sub-equals` comparing a whole app-db slice) blew the panel into the canvas height. This PR lands that remaining piece.

## What's new (the genuine C2.3 remainder)

- `value-display` — pure helper projecting a detail value into `{:full :clamped :long?}` (JVM-testable shape; clamps at 120 chars).
- `detail-value` — reagent component with per-mount reveal state. Short values render inline with no chord; long values render clamped with an inline `reveal` chord that swaps in the full `pr-str` (no modal, same row) and toggles back. `:expected` / `:actual` route through it.
- CLJS unit tests pin both (pure projection + rendered collapsed/reveal shape).

## Gates
- `npm run test:cljs` — 3880 tests, 0 failures
- `clojure -M:test` (tools/story) — 841 tests, 0 failures
- `mkdocs build --strict` — built clean