### PR TITLE
docs(api): table-per-fn → H3-per-member structured format (rf2-s8lhz)

### DIFF
--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -10,42 +10,280 @@ This is the surface every re-frame2 app touches. You're answering "what events c
 
 **Return value.** Every `reg-*` returns its **primary id** — the keyword (or path, for `reg-app-schema`) you registered with. This lets you write `(let [sub-id (rf/reg-sub ::foo ...)] ...)` to thread the id through your code without retyping it. The convention is uniform across the surface.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-event-db` | M | `(reg-event-db id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | "When this event arrives, transform `app-db` and return the new one." The simplest handler shape — pure `(fn [db event-vec] new-db)`. Use it for the 80% of handlers that just update state. |
-| `reg-event-fx` | M | `(reg-event-fx id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | "When this event arrives, return an effect map." The richer shape — `(fn [cofx event-vec] {:db ... :fx [...]})`. Use it when you need to dispatch follow-up events, fire HTTP, navigate, or read cofx. |
-| `reg-event-ctx` | M | `(reg-event-ctx id ?metadata-or-interceptors handler)` | v1 (preserved + extended) | The escape hatch — you get the raw interceptor context and return a modified context. Almost no app needs this; reach for it when you're writing infrastructure. |
-| `reg-sub` | M | `(reg-sub id ?metadata signal-fn? computation-fn)` | v1 (preserved + extended) | "Computed view over `app-db` and other subs." The `:<-` sugar form for declaring upstream subs is preserved from v1. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see [16 — Removed](16-removed.md) for the replacement guidance). |
-| `reg-fx` | M | `(reg-fx id ?metadata handler)` | v1 (preserved + extended) | "Define a named side effect." The handler runs against the args the effect map carries; unary `(fn [args] ...)` is the canonical shape, binary `(fn [args ctx] ...)` is available when you need the originating context. |
-| `reg-cofx` | M | `(reg-cofx id ?metadata handler)` | v1 (preserved) | "Inject something into the handler's coeffect map." A `:now` cofx hands the current time; an `:rf.server/request` cofx hands the active HTTP request. Reading a sub from a handler is also done by cofx-wrapping — see [Guide ch.06 §Reading a sub from a handler](../guide/06-coeffects.md#reading-a-sub-from-a-handler). |
-| `reg-frame` | M | `(reg-frame id metadata)` | v1 | Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one cascade — and `reg-frame` minted it with metadata you can later read via `frame-meta`. |
-| `make-frame` | Fn | `(make-frame opts) → :rf.frame/<id>` | v1 | Anonymous-frame shortcut. The id is gensym'd; useful for tests, transient sandboxes, and the SSR per-request frame pattern. |
-| `reg-view` | M | `(reg-view sym [args] body+)` and shape-variants | v1 | `defn`-shape view registration. Auto-defs the symbol; auto-derives an id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. See [02 — Views](02-views.md). |
-| `reg-view*` | Fn | `(reg-view* id render-fn)` / `(reg-view* id metadata render-fn)` | v1 | Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. |
-| `reg-machine` | M | `(reg-machine machine-id machine-spec)` | v1 | Registers a state machine as an event handler (the machine *is* the handler — the body comes from `make-machine-handler`). Walks the literal spec form at expansion time and stamps per-element source coords for click-to-source navigation. See [04 — Machines](04-machines.md). |
-| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines or REPL workflows. |
-| `reg-app-schema` | M | `(reg-app-schema path schema)` / `(reg-app-schema path schema opts)` | v1 | "Declare the Malli schema for this `app-db` path." **Path is the registration id** — the only `reg-*` keyed by path rather than keyword, because schemas-at-paths matches the dataflow grain. See [08 — Schemas](08-schemas.md). |
-| `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, ...})` | v1 | Bulk plural form for feature-modular apps that register 5–20 paths together. Each entry routes through the singular form and is stamped with this call's source-coords. |
-| `add-marks` | Fn | `(add-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks for data classification — `:sensitive` paths render as `:rf/redacted` at egress; `:large` paths surface as `:rf/large` summaries. **Additively merges** with existing marks. See [08 — Schemas](08-schemas.md#data-classification). |
-| `set-marks` | Fn | `(set-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set (paths not mentioned are cleared). Schema-attached marks are preserved either way. |
-| `reg-flow` | Fn | `(reg-flow flow)` / `(reg-flow flow opts)` | v1 | Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. See [05 — Flows](05-flows.md). |
-| `reg-route` | M | `(reg-route id metadata)` | v1 | Register a route as data: `:path`, `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`. See [06 — Routing](06-routing.md). |
-| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | SSR: register a `(fn [db route] head-model)` keyed by id; routes opt-in via `:head` metadata. See [09 — SSR](09-ssr.md). |
-| `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | SSR: register a `(fn [trace-event] :rf/public-error)`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. |
+### `reg-event-db`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-event-db id ?metadata-or-interceptors handler)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: "When this event arrives, transform `app-db` and return the new one." The simplest handler shape — pure `(fn [db event-vec] new-db)`. Use it for the 80% of handlers that just update state.
+
+### `reg-event-fx`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-event-fx id ?metadata-or-interceptors handler)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: "When this event arrives, return an effect map." The richer shape — `(fn [cofx event-vec] {:db ... :fx [...]})`. Use it when you need to dispatch follow-up events, fire HTTP, navigate, or read cofx.
+
+### `reg-event-ctx`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-event-ctx id ?metadata-or-interceptors handler)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: The escape hatch — you get the raw interceptor context and return a modified context. Almost no app needs this; reach for it when you're writing infrastructure.
+
+### `reg-sub`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-sub id ?metadata signal-fn? computation-fn)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: "Computed view over `app-db` and other subs." The `:<-` sugar form for declaring upstream subs is preserved from v1. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see [16 — Removed](16-removed.md) for the replacement guidance).
+
+### `reg-fx`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-fx id ?metadata handler)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: "Define a named side effect." The handler runs against the args the effect map carries; unary `(fn [args] ...)` is the canonical shape, binary `(fn [args ctx] ...)` is available when you need the originating context.
+
+### `reg-cofx`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-cofx id ?metadata handler)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Inject something into the handler's coeffect map." A `:now` cofx hands the current time; an `:rf.server/request` cofx hands the active HTTP request. Reading a sub from a handler is also done by cofx-wrapping — see [Guide ch.06 §Reading a sub from a handler](../guide/06-coeffects.md#reading-a-sub-from-a-handler).
+
+### `reg-frame`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-frame id metadata)
+  ```
+- **Status**: v1
+- **Description**: Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one cascade — and `reg-frame` minted it with metadata you can later read via `frame-meta`.
+
+### `make-frame`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (make-frame opts) → :rf.frame/<id>
+  ```
+- **Status**: v1
+- **Description**: Anonymous-frame shortcut. The id is gensym'd; useful for tests, transient sandboxes, and the SSR per-request frame pattern.
+
+### `reg-view`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-view sym [args] body+)
+  ```
+  (plus shape-variants — see [02 — Views](02-views.md))
+- **Status**: v1
+- **Description**: `defn`-shape view registration. Auto-defs the symbol; auto-derives an id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. See [02 — Views](02-views.md).
+
+### `reg-view*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-view* id render-fn)
+  (reg-view* id metadata render-fn)
+  ```
+- **Status**: v1
+- **Description**: Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var.
+
+### `reg-machine`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-machine machine-id machine-spec)
+  ```
+- **Status**: v1
+- **Description**: Registers a state machine as an event handler (the machine *is* the handler — the body comes from `make-machine-handler`). Walks the literal spec form at expansion time and stamps per-element source coords for click-to-source navigation. See [04 — Machines](04-machines.md).
+
+### `reg-machine*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-machine* machine-id machine-spec)
+  ```
+- **Status**: v1
+- **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines or REPL workflows.
+
+### `reg-app-schema`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-app-schema path schema)
+  (reg-app-schema path schema opts)
+  ```
+- **Status**: v1
+- **Description**: "Declare the Malli schema for this `app-db` path." **Path is the registration id** — the only `reg-*` keyed by path rather than keyword, because schemas-at-paths matches the dataflow grain. See [08 — Schemas](08-schemas.md).
+
+### `reg-app-schemas`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-app-schemas {path-1 schema-1, ...})
+  ```
+- **Status**: v1
+- **Description**: Bulk plural form for feature-modular apps that register 5–20 paths together. Each entry routes through the singular form and is stamped with this call's source-coords.
+
+### `add-marks`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (add-marks frame-id {path mark, ...})
+  ```
+- **Status**: v1
+- **Description**: Frame-scoped path-marks for data classification — `:sensitive` paths render as `:rf/redacted` at egress; `:large` paths surface as `:rf/large` summaries. **Additively merges** with existing marks. See [08 — Schemas](08-schemas.md#data-classification).
+
+### `set-marks`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-marks frame-id {path mark, ...})
+  ```
+- **Status**: v1
+- **Description**: Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set (paths not mentioned are cleared). Schema-attached marks are preserved either way.
+
+### `reg-flow`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-flow flow)
+  (reg-flow flow opts)
+  ```
+- **Status**: v1
+- **Description**: Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. See [05 — Flows](05-flows.md).
+
+### `reg-route`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-route id metadata)
+  ```
+- **Status**: v1
+- **Description**: Register a route as data: `:path`, `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`. See [06 — Routing](06-routing.md).
+
+### `reg-head`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-head id ?metadata head-fn)
+  ```
+- **Status**: v1
+- **Description**: SSR: register a `(fn [db route] head-model)` keyed by id; routes opt-in via `:head` metadata. See [09 — SSR](09-ssr.md).
+
+### `reg-error-projector`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-error-projector id ?metadata projector-fn)
+  ```
+- **Status**: v1
+- **Description**: SSR: register a `(fn [trace-event] :rf/public-error)`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata.
 
 ### Clearing registrations
 
 The inverse surface. Each `clear-*` removes an entry from the registrar; the no-arg form clears the whole kind. Use clearing in tests (the `with-fresh-registrar` fixture relies on these), in REPL workflows, and during teardown.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `clear-event` | `(clear-event)` / `(clear-event id)` | v1 (preserved) | "Forget this event-handler." No-arg clears the whole `:event` registry. |
-| `clear-sub` | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) | "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe` (see below). |
-| `clear-fx` | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) | "Forget this fx." |
-| `clear-flow` | `(clear-flow id)` / `(clear-flow id opts)` | v1 | Deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only. See [05 — Flows](05-flows.md). |
-| `destroy-frame!` | `(destroy-frame! frame-id)` | v1 | The normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this single call. |
-| `reset-frame!` | `(reset-frame! frame-id)` | v1 | Reset the frame's `app-db` to its initial value without destroying the frame itself. |
-| `clear-sub-cache!` | `(clear-sub-cache! frame-id?)` | v1 (preserved) | Force-clear the sub-cache for a frame (or all frames). Tests; rarely needed in app code. |
+#### `clear-event`
+
+- **Signature**:
+  ```clojure
+  (clear-event)
+  (clear-event id)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Forget this event-handler." No-arg clears the whole `:event` registry.
+
+#### `clear-sub`
+
+- **Signature**:
+  ```clojure
+  (clear-sub)
+  (clear-sub id)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe` (see below).
+
+#### `clear-fx`
+
+- **Signature**:
+  ```clojure
+  (clear-fx)
+  (clear-fx id)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Forget this fx."
+
+#### `clear-flow`
+
+- **Signature**:
+  ```clojure
+  (clear-flow id)
+  (clear-flow id opts)
+  ```
+- **Status**: v1
+- **Description**: Deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only. See [05 — Flows](05-flows.md).
+
+#### `destroy-frame!`
+
+- **Signature**:
+  ```clojure
+  (destroy-frame! frame-id)
+  ```
+- **Status**: v1
+- **Description**: The normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this single call.
+
+#### `reset-frame!`
+
+- **Signature**:
+  ```clojure
+  (reset-frame! frame-id)
+  ```
+- **Status**: v1
+- **Description**: Reset the frame's `app-db` to its initial value without destroying the frame itself.
+
+#### `clear-sub-cache!`
+
+- **Signature**:
+  ```clojure
+  (clear-sub-cache! frame-id?)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: Force-clear the sub-cache for a frame (or all frames). Tests; rarely needed in app code.
 
 ### See also
 
@@ -59,17 +297,103 @@ These are the two verbs that drive the cascade. `dispatch` says "an event happen
 
 Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, `subscribe`) captures the call-site source coords so tools like re-frame-10x and Causa can navigate from a trace event back to the originating expression. The **`*` fn** form (`dispatch*`, `dispatch-sync*`, `subscribe*`) skips the stamping — needed when you compose dispatch through a higher-order function (`(map dispatch* events)`) where a macro can't sit. Both route through the same dispatcher; only the trace stamping differs.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `dispatch` | M | `(dispatch event)` / `(dispatch event opts)` | v1 (preserved + extended); macro | Async dispatch — drops the event onto the frame's queue, returns immediately. The default; use it for everything that isn't a synchronous test setup. |
-| `dispatch*` | Fn | `(dispatch* event)` / `(dispatch* event opts)` | v1 (extended) | Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping. |
-| `dispatch-sync` | M | `(dispatch-sync event)` / `(dispatch-sync event opts)` | v1 (preserved + extended); macro | Synchronous dispatch — runs the cascade to completion before returning. Tests, REPL workflows, and one-shot app-boot events live here. Do not use in handlers (it'll deadlock the queue). |
-| `dispatch-sync*` | Fn | `(dispatch-sync* event)` / `(dispatch-sync* event opts)` | v1 (extended) | Fn variant of `dispatch-sync`. |
-| `subscribe` | M | `(subscribe query-v)` / `(subscribe frame-id query-v)` | v1 (preserved + extended); macro | The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Use inside views, inside other subs, and (carefully) inside event handlers via the cofx wrapper. |
-| `subscribe*` | Fn | `(subscribe* query-v)` / `(subscribe* frame-id query-v)` | v1 (extended) | Fn variant of `subscribe`. |
-| `subscribe-once` | Fn | `(subscribe-once query-v)` / `(subscribe-once frame-id query-v)` → value | v1 | One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views. |
-| `unsubscribe` | Fn | `(unsubscribe query-v)` / `(unsubscribe frame-id query-v)` → nil | v1 | Decrement the cache ref-count for a query. When the count hits zero, disposal is scheduled after the configured `:sub-cache` grace-period. Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount. |
-| `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot | v1 | Sugar over `(subscribe [:rf/machine machine-id])`. See [04 — Machines](04-machines.md). |
+### `dispatch`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (dispatch event)
+  (dispatch event opts)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: Async dispatch — drops the event onto the frame's queue, returns immediately. The default; use it for everything that isn't a synchronous test setup.
+
+### `dispatch*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (dispatch* event)
+  (dispatch* event opts)
+  ```
+- **Status**: v1 (extended)
+- **Description**: Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping.
+
+### `dispatch-sync`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (dispatch-sync event)
+  (dispatch-sync event opts)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: Synchronous dispatch — runs the cascade to completion before returning. Tests, REPL workflows, and one-shot app-boot events live here. Do not use in handlers (it'll deadlock the queue).
+
+### `dispatch-sync*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (dispatch-sync* event)
+  (dispatch-sync* event opts)
+  ```
+- **Status**: v1 (extended)
+- **Description**: Fn variant of `dispatch-sync`.
+
+### `subscribe`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (subscribe query-v)
+  (subscribe frame-id query-v)
+  ```
+- **Status**: v1 (preserved + extended)
+- **Description**: The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Use inside views, inside other subs, and (carefully) inside event handlers via the cofx wrapper.
+
+### `subscribe*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (subscribe* query-v)
+  (subscribe* frame-id query-v)
+  ```
+- **Status**: v1 (extended)
+- **Description**: Fn variant of `subscribe`.
+
+### `subscribe-once`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (subscribe-once query-v) → value
+  (subscribe-once frame-id query-v) → value
+  ```
+- **Status**: v1
+- **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views.
+
+### `unsubscribe`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (unsubscribe query-v) → nil
+  (unsubscribe frame-id query-v) → nil
+  ```
+- **Status**: v1
+- **Description**: Decrement the cache ref-count for a query. When the count hits zero, disposal is scheduled after the configured `:sub-cache` grace-period. Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount.
+
+### `sub-machine`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sub-machine machine-id) → reaction over snapshot
+  ```
+- **Status**: v1
+- **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. See [04 — Machines](04-machines.md).
 
 **The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in [002 §Routing: the dispatch envelope](../../spec/002-Frames.md#routing-the-dispatch-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
 
@@ -104,10 +428,24 @@ A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most
 
 `reg-frame` and `make-frame` are rowed in **Registration** above. The two read-side surfaces:
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `frame-ids` | `(frame-ids)` / `(frame-ids ns-prefix)` | v1 | "What frames currently exist?" Returns the set of registered ids. The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames. |
-| `frame-meta` | `(frame-meta frame-id)` | v1 | "What did the frame declare at registration?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings. |
+### `frame-ids`
+
+- **Signature**:
+  ```clojure
+  (frame-ids)
+  (frame-ids ns-prefix)
+  ```
+- **Status**: v1
+- **Description**: "What frames currently exist?" Returns the set of registered ids. The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames.
+
+### `frame-meta`
+
+- **Signature**:
+  ```clojure
+  (frame-meta frame-id)
+  ```
+- **Status**: v1
+- **Description**: "What did the frame declare at registration?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
 
 See [12 — Registrar](12-registrar.md) for the rest of the registrar-query surface.
 

--- a/docs/api/02-views.md
+++ b/docs/api/02-views.md
@@ -8,11 +8,38 @@ This chapter covers the registration surface (`reg-view`, `reg-view*`, `view`), 
 
 The view registry is what `[my-view "arg"]` resolves against. Every view you register lives in it; every view that emits hiccup ends up rendered through it. The registry is keyed by id (a keyword, conventionally `(keyword *ns* sym)` so the view's id matches its symbol).
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-view` | M | `(reg-view sym [args] body+)` <br> `(reg-view sym docstring [args] body+)` <br> `(reg-view ^{:rf/id :explicit/id} sym [args] body+)` | v1 | The defn-shape view registration. Auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. The 80% of registrations want this form. |
-| `reg-view*` | Fn | `(reg-view* id render-fn)` <br> `(reg-view* id metadata render-fn)` | v1 | The plain-fn surface beneath `reg-view`. No auto-def (the caller manages the Var or computed id), no auto-inject, no compile check. Reach for it when you need: computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var. |
-| `view` | Fn | `(view view-id)` → render-fn | v1 | Runtime lookup handle. Returns the **registered render-fn**, not hiccup. Use in hiccup as `[(rf/view :id) args...]` when you need to late-bind a view by id (computed id, plugin-style dispatch, dynamic chrome). |
+### `reg-view`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-view sym [args] body+)
+  (reg-view sym docstring [args] body+)
+  (reg-view ^{:rf/id :explicit/id} sym [args] body+)
+  ```
+- **Status**: v1
+- **Description**: The defn-shape view registration. Auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. The 80% of registrations want this form.
+
+### `reg-view*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-view* id render-fn)
+  (reg-view* id metadata render-fn)
+  ```
+- **Status**: v1
+- **Description**: The plain-fn surface beneath `reg-view`. No auto-def (the caller manages the Var or computed id), no auto-inject, no compile check. Reach for it when you need: computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var.
+
+### `view`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (view view-id) → render-fn
+  ```
+- **Status**: v1
+- **Description**: Runtime lookup handle. Returns the **registered render-fn**, not hiccup. Use in hiccup as `[(rf/view :id) args...]` when you need to late-bind a view by id (computed id, plugin-style dispatch, dynamic chrome).
 
 ### How `reg-view` reads
 
@@ -67,13 +94,56 @@ Bare keyword-tagged hiccup (`[:my-view "args"]`) is **removed in v2** — it was
 
 These five surfaces work the same across Reagent, UIx, and Helix. They're how views interact with the running app without being tied to any single substrate's idiom.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `frame-provider` | Component (Reagent) | `[rf/frame-provider {:frame :todo} & children]` | v1 | "Children inside this provider see `:todo` as their current frame." Lexical scope for the implicit frame; nestable; pairs with `with-frame` for non-component code. |
-| `with-frame` | M | `(with-frame :keyword body)` *or* `(with-frame [sym expr] body)` | v1 | "Run this code as if the current frame were `:keyword`." Two shapes — bare keyword vs let-binding — documented in [002 §with-frame](../../spec/002-Frames.md#with-frame). |
-| `bound-fn` | M | `(bound-fn [args] body)` | v1 | "Capture the current dynamic-var bindings (frame, registrar, etc.) into a closure that will be invoked later, possibly after the calling stack has unwound." CLJS-only macro. Use for event-callback wiring where Promise / setTimeout / IntersectionObserver / WebSocket message handlers run outside the original render call. |
-| `dispatcher` | Fn | `(dispatcher)` → `(fn [event] ...)` | v1 | "Hand me a frame-bound dispatch function I can call later." Captures the current frame at call time and returns a closure that dispatches against that frame. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound. |
-| `subscriber` | Fn | `(subscriber)` → `(fn [query-v] ...)` | v1 | "Hand me a frame-bound subscribe function I can call later." Companion to `dispatcher` for the subscribe side. |
+### `frame-provider`
+
+- **Kind**: Reagent component
+- **Signature**:
+  ```clojure
+  [rf/frame-provider {:frame :todo} & children]
+  ```
+- **Status**: v1
+- **Description**: "Children inside this provider see `:todo` as their current frame." Lexical scope for the implicit frame; nestable; pairs with `with-frame` for non-component code.
+
+### `with-frame`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (with-frame :keyword body)
+  (with-frame [sym expr] body)
+  ```
+- **Status**: v1
+- **Description**: "Run this code as if the current frame were `:keyword`." Two shapes — bare keyword vs let-binding — documented in [002 §with-frame](../../spec/002-Frames.md#with-frame).
+
+### `bound-fn`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (bound-fn [args] body)
+  ```
+- **Status**: v1
+- **Description**: "Capture the current dynamic-var bindings (frame, registrar, etc.) into a closure that will be invoked later, possibly after the calling stack has unwound." CLJS-only macro. Use for event-callback wiring where Promise / setTimeout / IntersectionObserver / WebSocket message handlers run outside the original render call.
+
+### `dispatcher`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (dispatcher) → (fn [event] ...)
+  ```
+- **Status**: v1
+- **Description**: "Hand me a frame-bound dispatch function I can call later." Captures the current frame at call time and returns a closure that dispatches against that frame. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound.
+
+### `subscriber`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (subscriber) → (fn [query-v] ...)
+  ```
+- **Status**: v1
+- **Description**: "Hand me a frame-bound subscribe function I can call later." Companion to `dispatcher` for the subscribe side.
 
 ### When to use `dispatcher` / `subscriber` instead of `dispatch` / `subscribe`
 
@@ -134,15 +204,81 @@ The adapter spec map — the value `(rf/init!)` consumes — lives at `re-frame.
 
 UIx and Helix expose React's hooks model directly. The re-frame2 adapter for each ships in its own artefact (`day8/re-frame2-uix`, `day8/re-frame2-helix`) and exposes a small, parallel surface — the same shape across both, because the Helix decisions transfer the UIx decisions one-for-one.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `<adapter>/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
-| `<adapter>/use-subscribe` | Fn (hook) | `(use-subscribe query-v)` / `(use-subscribe frame-kw query-v)` → value | v1 | The hook-shaped read. Matches the React/UIx/Helix idiom; there's no auto-injection — components call the hook and `(rf/dispatcher)` directly. |
-| `<adapter>/use-current-frame` | Fn (hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks. |
-| `<adapter>/frame-provider` | Fn (component) | `($ frame-provider {:frame :session :children […]})` | v1 | The component-shaped equivalent of Reagent's `frame-provider`. The underlying React Context (`re-frame.adapter.context`) is **shared** across all three substrates, so a mixed-substrate app's frame-provider chain composes across substrate boundaries. |
-| `<adapter>/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord annotation. Most UIx / Helix users register through `reg-view*` and let the adapter wrap; `wrap-view` is exposed for code-gen and library scaffolding. |
-| `<adapter>/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. Drain queued state updates before assertions. |
-| `<adapter>/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR. |
+In the entries below, `<adapter>` stands for the adapter namespace alias the consumer chose at require — typically `uix-adapter` or `helix-adapter`.
+
+### `<adapter>/adapter`
+
+- **Kind**: Var (map)
+- **Signature**:
+  ```clojure
+  {:make-state-container …
+   :render …
+   :dispose-adapter! …}
+  ```
+- **Status**: v1
+- **Description**: The adapter spec passed to `(rf/init! ...)`.
+
+### `<adapter>/use-subscribe`
+
+- **Kind**: hook (function)
+- **Signature**:
+  ```clojure
+  (use-subscribe query-v) → value
+  (use-subscribe frame-kw query-v) → value
+  ```
+- **Status**: v1
+- **Description**: The hook-shaped read. Matches the React/UIx/Helix idiom; there's no auto-injection — components call the hook and `(rf/dispatcher)` directly.
+
+### `<adapter>/use-current-frame`
+
+- **Kind**: hook (function)
+- **Signature**:
+  ```clojure
+  (use-current-frame) → frame-kw
+  ```
+- **Status**: v1
+- **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
+
+### `<adapter>/frame-provider`
+
+- **Kind**: component (function)
+- **Signature**:
+  ```clojure
+  ($ frame-provider {:frame :session :children […]})
+  ```
+- **Status**: v1
+- **Description**: The component-shaped equivalent of Reagent's `frame-provider`. The underlying React Context (`re-frame.adapter.context`) is **shared** across all three substrates, so a mixed-substrate app's frame-provider chain composes across substrate boundaries.
+
+### `<adapter>/wrap-view`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (wrap-view id metadata user-fn) → wrapped fn
+  ```
+- **Status**: v1
+- **Description**: Adapter-side source-coord annotation. Most UIx / Helix users register through `reg-view*` and let the adapter wrap; `wrap-view` is exposed for code-gen and library scaffolding.
+
+### `<adapter>/flush-views!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (flush-views!)
+  (flush-views! f)
+  ```
+- **Status**: v1
+- **Description**: Wraps React's `act()` for tests. Drain queued state updates before assertions.
+
+### `<adapter>/set-hiccup-emitter!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-hiccup-emitter! f)
+  ```
+- **Status**: v1
+- **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
 
 The UIx / Helix adapters do **not** support `reg-view` (the macro is Reagent-specific in its `defn`-shape rewriting). UIx and Helix users register with `rf/reg-view*` when they need registry-keyed view addressing — most don't, because UIx and Helix components compose by Var reference like ordinary React components.
 

--- a/docs/api/03-effects.md
+++ b/docs/api/03-effects.md
@@ -42,14 +42,61 @@ The interceptor chain wraps the handler. Every interceptor has a `:before` (runs
 
 The v2 standard-interceptor surface is **three specific helpers** plus the `->interceptor` primitive. The principle is: keep helpers that do specific, non-trivial work; drop helpers that are just `(->interceptor :before f)` with no other logic. Five v1 interceptors are removed (`debug`, `trim-v`, `on-changes`, `enrich`, `after`); see [16 — Removed](16-removed.md).
 
-| API | M/Fn | Signature | Purpose |
-|---|---|---|---|
-| `inject-cofx` | M | `(inject-cofx id)` / `(inject-cofx id value)` | Inject a registered cofx into the handler's coeffect map. Macro: captures the call-site for `:rf.trace/call-site` on errors emitted from the cofx body. Does specific work — `:cofx` registry lookup — not subsumable by `->interceptor`. |
-| `inject-cofx*` | Fn | `(inject-cofx* id)` / `(inject-cofx* id value)` | Fn form for HoF / programmatic interceptor construction — no call-site stamping. |
-| `path` | Fn | `(path & path)` | Focus the handler on an `app-db` sub-slice. `:before` rewrites the `:db` cofx to `(get-in db path)`; `:after` splices the result back into the parent. The handler sees and returns a sub-tree, not the full db. |
-| `unwrap` | (val) | `unwrap` | Assert `[id payload-map]` event shape; replace the `:event` coeffect with just the payload map; restore on `:after`. Sugar over the canonical map-payload form (per [MIGRATION §M-19](../../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)). |
-| `->interceptor` | Fn | `(->interceptor & {:keys [id before after]})` | The primitive. Build a custom interceptor with `:before` and / or `:after`. **Use this for any work not covered by the three specific helpers above** — analytics, logging, validation, ad-hoc context manipulation. The resulting interceptor is named, addressable, and queryable like any other artefact. |
-| `validate-at-boundary-interceptor` | Var (value) | `validate-at-boundary-interceptor` | A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary schema validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`. |
+### `inject-cofx`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (inject-cofx id)
+  (inject-cofx id value)
+  ```
+- **Description**: Inject a registered cofx into the handler's coeffect map. Macro: captures the call-site for `:rf.trace/call-site` on errors emitted from the cofx body. Does specific work — `:cofx` registry lookup — not subsumable by `->interceptor`.
+
+### `inject-cofx*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (inject-cofx* id)
+  (inject-cofx* id value)
+  ```
+- **Description**: Fn form for HoF / programmatic interceptor construction — no call-site stamping.
+
+### `path`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (path & path)
+  ```
+- **Description**: Focus the handler on an `app-db` sub-slice. `:before` rewrites the `:db` cofx to `(get-in db path)`; `:after` splices the result back into the parent. The handler sees and returns a sub-tree, not the full db.
+
+### `unwrap`
+
+- **Kind**: Var (interceptor value)
+- **Signature**:
+  ```clojure
+  unwrap
+  ```
+- **Description**: Assert `[id payload-map]` event shape; replace the `:event` coeffect with just the payload map; restore on `:after`. Sugar over the canonical map-payload form (per [MIGRATION §M-19](../../migration/from-re-frame-v1/README.md#m-19-multi-positional-dispatch--subscribe-vectors--map-payload-form-opt-in)).
+
+### `->interceptor`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (->interceptor & {:keys [id before after]})
+  ```
+- **Description**: The primitive. Build a custom interceptor with `:before` and / or `:after`. **Use this for any work not covered by the three specific helpers above** — analytics, logging, validation, ad-hoc context manipulation. The resulting interceptor is named, addressable, and queryable like any other artefact.
+
+### `validate-at-boundary-interceptor`
+
+- **Kind**: Var (interceptor value)
+- **Signature**:
+  ```clojure
+  validate-at-boundary-interceptor
+  ```
+- **Description**: A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary schema validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`.
 
 ### The `path` interceptor: focus on a slice
 
@@ -94,12 +141,49 @@ The map-of-keyword-args API is deliberate — `{:id :before :after}` is the enti
 
 The interceptor context — the ctx — is the value threaded through the chain. It carries `:coeffects` (everything available to the handler before it runs), `:effects` (everything the handler produced), and the queue / stack of remaining interceptors. Most app code never reaches into ctx directly; the four accessors below are for the rare interceptor body that does.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `get-coeffect` | Fn | `(get-coeffect ctx)` <br> `(get-coeffect ctx key)` <br> `(get-coeffect ctx key not-found)` | v1 (preserved) | "Read the coeffect map (or one slot of it)." |
-| `assoc-coeffect` | Fn | `(assoc-coeffect ctx key value)` | v1 (preserved) | "Write a coeffect slot in the ctx." |
-| `get-effect` | Fn | `(get-effect ctx)` <br> `(get-effect ctx key)` <br> `(get-effect ctx key not-found)` | v1 (preserved) | "Read the effect map (or one slot)." |
-| `assoc-effect` | Fn | `(assoc-effect ctx key value)` | v1 (preserved) | "Write an effect slot in the ctx." |
+### `get-coeffect`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (get-coeffect ctx)
+  (get-coeffect ctx key)
+  (get-coeffect ctx key not-found)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Read the coeffect map (or one slot of it)."
+
+### `assoc-coeffect`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (assoc-coeffect ctx key value)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Write a coeffect slot in the ctx."
+
+### `get-effect`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (get-effect ctx)
+  (get-effect ctx key)
+  (get-effect ctx key not-found)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Read the effect map (or one slot)."
+
+### `assoc-effect`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (assoc-effect ctx key value)
+  ```
+- **Status**: v1 (preserved)
+- **Description**: "Write an effect slot in the ctx."
 
 These are stable surfaces preserved from v1. If you're writing an interceptor that needs to read or modify what the handler will see / what the handler emitted, this is the surface.
 
@@ -107,9 +191,15 @@ These are stable surfaces preserved from v1. If you're writing an interceptor th
 
 The runtime supports three ways to swap fx behaviour without touching the handler. They differ in scope: per-frame (lexical to the frame), lexical (around a body of code), and per-call (on a single dispatch).
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `with-fx-overrides` | M | `(with-fx-overrides {fx-id -> override, …} body+)` | v1 | "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`. Renamed from v1's `with-overrides` per [MIGRATION §M-50](../../migration/from-re-frame-v1/README.md#m-50-with-overrides-macro-renamed-to-with-fx-overrides). |
+### `with-fx-overrides`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (with-fx-overrides {fx-id -> override, …} body+)
+  ```
+- **Status**: v1
+- **Description**: "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`. Renamed from v1's `with-overrides` per [MIGRATION §M-50](../../migration/from-re-frame-v1/README.md#m-50-with-overrides-macro-renamed-to-with-fx-overrides).
 
 The three scopes compose with a clear precedence:
 

--- a/docs/api/04-machines.md
+++ b/docs/api/04-machines.md
@@ -10,12 +10,45 @@ For the *why* — the design rationale, the v1 vs post-v1 split, the capability 
 
 ## Registration
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-machine` | M | `(reg-machine machine-id machine-spec)` | v1 | The canonical macro. Walks the literal spec form at expansion time and stamps per-element source coords under `:rf.machine/source-coords` — Causa uses these to navigate from a snapshot back to the state-node definition. Top-level call-site coords land on `handler-meta`. |
-| `reg-machine*` | Fn | `(reg-machine* machine-id machine-spec)` | v1 | Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data. |
-| `make-machine-handler` | Fn | `(make-machine-handler spec)` → event-handler fn | v1 | Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually. |
-| `machine-transition` | Fn | `(machine-transition definition snapshot event)` → `[next-snapshot effects]` | v1 | The pure transition fn. Given a machine definition, a current snapshot, and an event, returns the next snapshot and the effect map. JVM-runnable; the conformance harness uses this as its primary test surface for machine behaviour. |
+### `reg-machine`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-machine machine-id machine-spec)
+  ```
+- **Status**: v1
+- **Description**: The canonical macro. Walks the literal spec form at expansion time and stamps per-element source coords under `:rf.machine/source-coords` — Causa uses these to navigate from a snapshot back to the state-node definition. Top-level call-site coords land on `handler-meta`.
+
+### `reg-machine*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-machine* machine-id machine-spec)
+  ```
+- **Status**: v1
+- **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data.
+
+### `make-machine-handler`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (make-machine-handler spec) → event-handler fn
+  ```
+- **Status**: v1
+- **Description**: Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually.
+
+### `machine-transition`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine-transition definition snapshot event) → [next-snapshot effects]
+  ```
+- **Status**: v1
+- **Description**: The pure transition fn. Given a machine definition, a current snapshot, and an event, returns the next snapshot and the effect map. JVM-runnable; the conformance harness uses this as its primary test surface for machine behaviour.
 
 ### A minimal machine
 
@@ -40,13 +73,56 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
 
 ## Inspection and subscription
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `sub-machine` | Fn | `(sub-machine machine-id)` → reaction over snapshot | v1 | Sugar over `(subscribe [:rf/machine machine-id])`. Use inside views — gives you a reaction over `{:state :data}`. |
-| `machines` | Fn | `(machines)` → seq of machine-ids | v1 | "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`. |
-| `machine-meta` | Fn | `(machine-meta machine-id)` → registration-metadata map | v1 | "What did `reg-machine` stamp at this machine's id?" Returns the transition table, doc, schemas, and the per-element source-coords. Equivalent to `(handler-meta :event machine-id)`. |
-| `machine-by-system-id` | Fn | `(machine-by-system-id system-id)` <br> `(machine-by-system-id system-id frame-id)` | v1 | Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`. |
-| `machine-has-tag?` | Fn | `(machine-has-tag? machine-id tag)` → reaction | v1 | Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership. |
+### `sub-machine`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sub-machine machine-id) → reaction over snapshot
+  ```
+- **Status**: v1
+- **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. Use inside views — gives you a reaction over `{:state :data}`.
+
+### `machines`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machines) → seq of machine-ids
+  ```
+- **Status**: v1
+- **Description**: "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`.
+
+### `machine-meta`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine-meta machine-id) → registration-metadata map
+  ```
+- **Status**: v1
+- **Description**: "What did `reg-machine` stamp at this machine's id?" Returns the transition table, doc, schemas, and the per-element source-coords. Equivalent to `(handler-meta :event machine-id)`.
+
+### `machine-by-system-id`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine-by-system-id system-id)
+  (machine-by-system-id system-id frame-id)
+  ```
+- **Status**: v1
+- **Description**: Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`.
+
+### `machine-has-tag?`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine-has-tag? machine-id tag) → reaction
+  ```
+- **Status**: v1
+- **Description**: Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership.
 
 ### Standard registered subs (machines)
 
@@ -58,9 +134,16 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
 
 ## Cross-machine messaging
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `dispatch-to-system` | Fn | `(dispatch-to-system system-id event)` <br> `(dispatch-to-system system-id event frame-id)` | v1 | Sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`. No-op when the `system-id` is unbound. The third-arity targets a non-default frame. |
+### `dispatch-to-system`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (dispatch-to-system system-id event)
+  (dispatch-to-system system-id event frame-id)
+  ```
+- **Status**: v1
+- **Description**: Sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`. No-op when the `system-id` is unbound. The third-arity targets a non-default frame.
 
 When a child actor spawns under a parent, the parent's `:data` often gets the child's id stamped via `:on-spawn`. `dispatch-to-system` lets the parent name the child by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by gensym'd id. The per-frame `[:rf/system-ids]` reverse index resolves the name. See [005 §Named addressing via `:system-id`](../../spec/005-StateMachines.md).
 
@@ -107,11 +190,31 @@ See [005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-
 
 ## Post-v1 tooling exports
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `machine->xstate-json` | Fn | `(machine->xstate-json definition)` → JSON string | post-v1 lib | Export a machine definition to XState JSON. The XState visualiser consumes it; useful for design review and documentation. |
-| `machine->mermaid` | Fn | `(machine->mermaid definition)` → string | post-v1 lib | Export to Mermaid state-diagram syntax. Drops cleanly into Markdown docs that render Mermaid (this site does). |
-| `:child-machine` (transition-table key) | — | Declarative state-scoped child-machine binding. | post-v1 lib | A state node can declare a child machine that lives only while the parent is in that state. Symmetric with the imperative `:spawn` / `:destroy` cycle. |
+### `machine->xstate-json`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine->xstate-json definition) → JSON string
+  ```
+- **Status**: post-v1 lib
+- **Description**: Export a machine definition to XState JSON. The XState visualiser consumes it; useful for design review and documentation.
+
+### `machine->mermaid`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine->mermaid definition) → string
+  ```
+- **Status**: post-v1 lib
+- **Description**: Export to Mermaid state-diagram syntax. Drops cleanly into Markdown docs that render Mermaid (this site does).
+
+### `:child-machine`
+
+- **Kind**: transition-table key (declarative)
+- **Status**: post-v1 lib
+- **Description**: Declarative state-scoped child-machine binding. A state node can declare a child machine that lives only while the parent is in that state. Symmetric with the imperative `:spawn` / `:destroy` cycle.
 
 The post-v1 surfaces live in `day8/re-frame2-machines` (the scaffolding library). The v1 foundation in `re-frame.core` covers the machine-as-event-handler primitive; the scaffolding library layers the higher-level features on top.
 

--- a/docs/api/05-flows.md
+++ b/docs/api/05-flows.md
@@ -8,10 +8,27 @@ The normative source is [013-Flows.md](../../spec/013-Flows.md).
 
 ## The flow surface
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-flow` | Fn | `(reg-flow flow)` <br> `(reg-flow flow opts)` | v1 | Register a flow. The flow map carries `:id`, `:inputs`, `:output`, `:path`. `opts` is a map (currently `{:frame frame-id}`) selecting the owning frame. Returns the flow's `:id` (per the `reg-*` return-value convention). |
-| `clear-flow` | Fn | `(clear-flow id)` <br> `(clear-flow id opts)` | v1 | Deregister the flow from the named frame and `dissoc-in` its `:path` from that frame's `app-db` only. Sibling frames' state is preserved. |
+### `reg-flow`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-flow flow)
+  (reg-flow flow opts)
+  ```
+- **Status**: v1
+- **Description**: Register a flow. The flow map carries `:id`, `:inputs`, `:output`, `:path`. `opts` is a map (currently `{:frame frame-id}`) selecting the owning frame. Returns the flow's `:id` (per the `reg-*` return-value convention).
+
+### `clear-flow`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (clear-flow id)
+  (clear-flow id opts)
+  ```
+- **Status**: v1
+- **Description**: Deregister the flow from the named frame and `dissoc-in` its `:path` from that frame's `app-db` only. Sibling frames' state is preserved.
 
 ### A minimal flow
 

--- a/docs/api/06-routing.md
+++ b/docs/api/06-routing.md
@@ -8,9 +8,15 @@ This chapter covers the registration shape, the dispatch / sub / fx surface, and
 
 ## Registration
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-route` | M | `(reg-route id metadata)` | v1 | Register a route as data. The id is a keyword you'll later dispatch against (`[:rf.route/navigate :route/cart]`); the metadata carries the URL shape, the match events, and the guards. |
+### `reg-route`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-route id metadata)
+  ```
+- **Status**: v1
+- **Description**: Register a route as data. The id is a keyword you'll later dispatch against (`[:rf.route/navigate :route/cart]`); the metadata carries the URL shape, the match events, and the guards.
 
 ### A minimal route
 
@@ -43,11 +49,36 @@ Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata sc
 
 ## URL helpers
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `match-url` | Fn | `(match-url url)` → `{:route-id :params :query :validation-failed?}` or `nil` | v1 | "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests. |
-| `route-url` | Fn | `(route-url route-id path-params)` <br> `(route-url route-id path-params query-params)` → URL string | v1 | "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable. |
-| `route-link` | Fn (registered view) | `[rf/route-link {:to :route-id :params {...} :query {...} :fragment "..."} & children]` | v1 | A registered view at `:route/link`. Renders an `<a>` with the right `href` and intercepts plain primary-button clicks to dispatch `:rf/url-requested` instead of navigating natively. |
+### `match-url`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (match-url url) → {:route-id :params :query :validation-failed?} or nil
+  ```
+- **Status**: v1
+- **Description**: "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests.
+
+### `route-url`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (route-url route-id path-params) → URL string
+  (route-url route-id path-params query-params) → URL string
+  ```
+- **Status**: v1
+- **Description**: "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable.
+
+### `route-link`
+
+- **Kind**: registered view (function)
+- **Signature**:
+  ```clojure
+  [rf/route-link {:to :route-id :params {...} :query {...} :fragment "..."} & children]
+  ```
+- **Status**: v1
+- **Description**: A registered view at `:route/link`. Renders an `<a>` with the right `href` and intercepts plain primary-button clicks to dispatch `:rf/url-requested` instead of navigating natively.
 
 ### `route-link` click semantics
 

--- a/docs/api/07-http.md
+++ b/docs/api/07-http.md
@@ -8,10 +8,19 @@ This chapter covers the canonical fx, the verb helpers, the test stubs, the requ
 
 ## The canonical fx
 
-| API | Kind | Signature / shape | Status | Intuition |
-|---|---|---|---|---|
-| `[:rf.http/managed args-map]` | fx | args per [014 §The args map](../../spec/014-HTTPRequests.md#the-args-map) and `:rf.fx/managed-args` | v1 (optional capability) | The one fx-id. Args carry the request envelope, decode policy, accept fn, retry policy, timeout, success / failure target events, request-id (for abort), and optional abort-signal. |
-| `[:rf.http/managed-abort request-id]` | fx | request-id | v1 (optional capability) | Abort the in-flight request with the given `:request-id`. The aborted request's reply fires with `{:rf/reply {:kind :failure :failure {:kind :rf.http/aborted ...}}}`. |
+### `[:rf.http/managed args-map]`
+
+- **Kind**: fx
+- **Args**: per [014 §The args map](../../spec/014-HTTPRequests.md#the-args-map) and `:rf.fx/managed-args`
+- **Status**: v1 (optional capability)
+- **Description**: The one fx-id. Args carry the request envelope, decode policy, accept fn, retry policy, timeout, success / failure target events, request-id (for abort), and optional abort-signal.
+
+### `[:rf.http/managed-abort request-id]`
+
+- **Kind**: fx
+- **Args**: request-id
+- **Status**: v1 (optional capability)
+- **Description**: Abort the in-flight request with the given `:request-id`. The aborted request's reply fires with `{:rf/reply {:kind :failure :failure {:kind :rf.http/aborted ...}}}`.
 
 ### A minimal request
 
@@ -34,15 +43,75 @@ That's enough to issue a request, decode the JSON reply, and dispatch the result
 
 Call-site helpers for the common shapes. They're pure synthesis fns that produce the canonical `[:rf.http/managed args-map]` fx vector — no magic, no hidden state. The point is ergonomics: writing `(rf.http/get "/api/cart")` reads better at the call site than spelling out the full args map for a no-frills GET.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `re-frame.http/get` | `(rf.http/get url)` / `(rf.http/get url args)` | v1 (optional) | "Synthesise a GET fx vector." Pure; no side effect — drop the result into `:fx`. |
-| `re-frame.http/post` | `(rf.http/post url)` / `(rf.http/post url args)` | v1 (optional) | POST. Pass `:body` in `args`. |
-| `re-frame.http/put` | `(rf.http/put url)` / `(rf.http/put url args)` | v1 (optional) | PUT. |
-| `re-frame.http/delete` | `(rf.http/delete url)` / `(rf.http/delete url args)` | v1 (optional) | DELETE. |
-| `re-frame.http/patch` | `(rf.http/patch url)` / `(rf.http/patch url args)` | v1 (optional) | PATCH. |
-| `re-frame.http/head` | `(rf.http/head url)` / `(rf.http/head url args)` | v1 (optional) | HEAD. |
-| `re-frame.http/options` | `(rf.http/options url)` / `(rf.http/options url args)` | v1 (optional) | OPTIONS. |
+### `re-frame.http/get`
+
+- **Signature**:
+  ```clojure
+  (rf.http/get url)
+  (rf.http/get url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: "Synthesise a GET fx vector." Pure; no side effect — drop the result into `:fx`.
+
+### `re-frame.http/post`
+
+- **Signature**:
+  ```clojure
+  (rf.http/post url)
+  (rf.http/post url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: POST. Pass `:body` in `args`.
+
+### `re-frame.http/put`
+
+- **Signature**:
+  ```clojure
+  (rf.http/put url)
+  (rf.http/put url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: PUT.
+
+### `re-frame.http/delete`
+
+- **Signature**:
+  ```clojure
+  (rf.http/delete url)
+  (rf.http/delete url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: DELETE.
+
+### `re-frame.http/patch`
+
+- **Signature**:
+  ```clojure
+  (rf.http/patch url)
+  (rf.http/patch url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: PATCH.
+
+### `re-frame.http/head`
+
+- **Signature**:
+  ```clojure
+  (rf.http/head url)
+  (rf.http/head url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: HEAD.
+
+### `re-frame.http/options`
+
+- **Signature**:
+  ```clojure
+  (rf.http/options url)
+  (rf.http/options url args)
+  ```
+- **Status**: v1 (optional)
+- **Description**: OPTIONS.
 
 The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
 
@@ -92,10 +161,27 @@ See [014 §Failure categories](../../spec/014-HTTPRequests.md#failure-categories
 
 Sometimes you want to inject behaviour into every request — adding an auth header, stamping a request ID, logging. Re-frame2's answer is a small middleware surface that mirrors the rest of the `reg-*` family.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-http-interceptor` | Fn | `(reg-http-interceptor id before)` <br> `(reg-http-interceptor id opts before)` | v1 (optional) | Register a request-side interceptor on a frame's `:rf.http/managed` middleware chain. `before` is `(fn [ctx] ctx')` where ctx is `{:request :args :frame :event}`. `opts` carries `:frame` (default `:rf/default`) plus the standard `:rf/registration-metadata`. |
-| `clear-http-interceptor` | Fn | `(clear-http-interceptor id)` <br> `(clear-http-interceptor frame id)` | v1 (optional) | Unregister an interceptor by id. Single-arity targets `:rf/default`. |
+### `reg-http-interceptor`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-http-interceptor id before)
+  (reg-http-interceptor id opts before)
+  ```
+- **Status**: v1 (optional)
+- **Description**: Register a request-side interceptor on a frame's `:rf.http/managed` middleware chain. `before` is `(fn [ctx] ctx')` where ctx is `{:request :args :frame :event}`. `opts` carries `:frame` (default `:rf/default`) plus the standard `:rf/registration-metadata`.
+
+### `clear-http-interceptor`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (clear-http-interceptor id)
+  (clear-http-interceptor frame id)
+  ```
+- **Status**: v1 (optional)
+- **Description**: Unregister an interceptor by id. Single-arity targets `:rf/default`.
 
 ```clojure
 (rf/reg-http-interceptor :auth/inject
@@ -110,14 +196,57 @@ The interceptor runs *before* the request is dispatched to the platform's HTTP c
 
 Tests want to drive the cascade without hitting the network. The test-support surface provides canned-reply fx and a stubbing macro that reroutes requests at the routes you name.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `[:rf.http/managed-canned-success {:value v}]` | fx | — | v1 (optional, dev/test) | Synthesise the canonical success reply directly into `:fx`. Useful for "stub THIS request inline" patterns. Registered at load of `re-frame.http-test-support`. |
-| `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]` | fx | — | v1 (optional, dev/test) | Synthesise the canonical failure reply directly into `:fx`. |
-| `with-managed-request-stubs` | M | `(with-managed-request-stubs route-map body+)` | v1 (optional, dev/test) | Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply <value-or-failure>}}`. Inside the body, requests matching a stubbed route bypass the real client. |
-| `with-managed-request-stubs*` | Fn | `(with-managed-request-stubs* route-map body-fn)` | v1 (optional, dev/test) | Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies. |
-| `install-managed-request-stubs!` | Fn | `(install-managed-request-stubs! route-map)` | v1 (optional, dev/test) | Lower-level than `with-managed-request-stubs`: install stubs that persist until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s. |
-| `uninstall-managed-request-stubs!` | Fn | `(uninstall-managed-request-stubs!)` | v1 (optional, dev/test) | Drop installed stubs; restore real-request routing. Idempotent. |
+### `[:rf.http/managed-canned-success {:value v}]`
+
+- **Kind**: fx
+- **Status**: v1 (optional, dev/test)
+- **Description**: Synthesise the canonical success reply directly into `:fx`. Useful for "stub THIS request inline" patterns. Registered at load of `re-frame.http-test-support`.
+
+### `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]`
+
+- **Kind**: fx
+- **Status**: v1 (optional, dev/test)
+- **Description**: Synthesise the canonical failure reply directly into `:fx`.
+
+### `with-managed-request-stubs`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (with-managed-request-stubs route-map body+)
+  ```
+- **Status**: v1 (optional, dev/test)
+- **Description**: Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply <value-or-failure>}}`. Inside the body, requests matching a stubbed route bypass the real client.
+
+### `with-managed-request-stubs*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (with-managed-request-stubs* route-map body-fn)
+  ```
+- **Status**: v1 (optional, dev/test)
+- **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies.
+
+### `install-managed-request-stubs!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (install-managed-request-stubs! route-map)
+  ```
+- **Status**: v1 (optional, dev/test)
+- **Description**: Lower-level than `with-managed-request-stubs`: install stubs that persist until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s.
+
+### `uninstall-managed-request-stubs!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (uninstall-managed-request-stubs!)
+  ```
+- **Status**: v1 (optional, dev/test)
+- **Description**: Drop installed stubs; restore real-request routing. Idempotent.
 
 All the test-support surfaces live in `re-frame.http-test-support` (the single home per audit of audits #15). One namespace; same artefact (`day8/re-frame2-http`) as the production code.
 

--- a/docs/api/08-schemas.md
+++ b/docs/api/08-schemas.md
@@ -8,10 +8,26 @@ This chapter covers the registration macros (rowed in [01 — Core](01-core.md),
 
 ## Registration
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-app-schema` | M | `(reg-app-schema path schema)` <br> `(reg-app-schema path schema opts)` | v1 | "Attach this Malli schema to this `app-db` path." **Path is the registration id** — the `:app-schema` registry kind is path-keyed because schemas-at-paths matches the dataflow grain. `(app-schema-at [:user])` looks up by the same path vector. |
-| `reg-app-schemas` | M | `(reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})` | v1 | Bulk plural form. Feature-modular apps registering 5–20 paths against the same prefix reach for this. Each entry routes through the singular form and is stamped with this call's source coords. Returns the vector of paths registered. |
+### `reg-app-schema`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-app-schema path schema)
+  (reg-app-schema path schema opts)
+  ```
+- **Status**: v1
+- **Description**: "Attach this Malli schema to this `app-db` path." **Path is the registration id** — the `:app-schema` registry kind is path-keyed because schemas-at-paths matches the dataflow grain. `(app-schema-at [:user])` looks up by the same path vector.
+
+### `reg-app-schemas`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})
+  ```
+- **Status**: v1
+- **Description**: Bulk plural form. Feature-modular apps registering 5–20 paths against the same prefix reach for this. Each entry routes through the singular form and is stamped with this call's source coords. Returns the vector of paths registered.
 
 The path-keyed-not-id-keyed asymmetry is principled. Paths are first-class in `get-in` / `assoc-in` / `update-in`; schemas-at-paths matches the dataflow grain; the lookup site (`app-schema-at [:user]`) reads the same way the write site (`(assoc-in db [:user] ...)`) reads. Spelling it as `(reg-app-schema :user/schema schema)` would have shifted the registration's id away from the dataflow grain.
 
@@ -21,30 +37,98 @@ See [Conventions §`reg-*` return-value rule](../../spec/Conventions.md#reg--ret
 
 The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-schemas`); consumers `(:require [re-frame.schemas :as schemas])`. They are *not* re-exported from `re-frame.core` — the registration macros live in `re-frame.core` and route through the schemas artefact at registration time, but the read-side surface stays in its own namespace.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `app-schemas` | Fn | `(app-schemas)` <br> `(app-schemas {:frame frame-id})` | v1 | "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface. |
-| `app-schema-at` | Fn | `(app-schema-at path)` <br> `(app-schema-at path {:frame frame-id})` | v1 | "Schema for this exact path." Returns the schema value or `nil`. |
-| `app-schema-meta-at` | Fn | `(app-schema-meta-at path)` <br> `(app-schema-meta-at path opts-or-frame-id)` | v1 | "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed. |
-| `app-schemas-digest` | Fn | `(app-schemas-digest)` <br> `(app-schemas-digest {:frame frame-id})` → string | v1 | "Single hash over the frame's whole schema surface." Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema. |
+### `app-schemas`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (app-schemas)
+  (app-schemas {:frame frame-id})
+  ```
+- **Status**: v1
+- **Description**: "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface.
+
+### `app-schema-at`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (app-schema-at path)
+  (app-schema-at path {:frame frame-id})
+  ```
+- **Status**: v1
+- **Description**: "Schema for this exact path." Returns the schema value or `nil`.
+
+### `app-schema-meta-at`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (app-schema-meta-at path)
+  (app-schema-meta-at path opts-or-frame-id)
+  ```
+- **Status**: v1
+- **Description**: "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed.
+
+### `app-schemas-digest`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (app-schemas-digest) → string
+  (app-schemas-digest {:frame frame-id}) → string
+  ```
+- **Status**: v1
+- **Description**: "Single hash over the frame's whole schema surface." Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema.
 
 ### Validator-extension seams
 
 The default validator ships Malli's `validate` / `explain` pair. These seams let apps swap in their own validator — typically to drop the Malli dep entirely, or to add a custom explainer that formats failures for the app's domain.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `set-schema-validator!` | Fn | `(set-schema-validator! validate-fn)` <br> `(set-schema-validator! {:validate validate-fn :explain explain-fn})` | v1 | "Install the validator the framework uses at every dev-time schema-validation site." `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework. |
-| `set-schema-explainer!` | Fn | `(set-schema-explainer! explain-fn)` | v1 | "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." Companion to `set-schema-validator!`. |
-| `set-schema-printer!` | Fn | `(set-schema-printer! print-fn)` | v1 | "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract. |
+#### `set-schema-validator!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-schema-validator! validate-fn)
+  (set-schema-validator! {:validate validate-fn :explain explain-fn})
+  ```
+- **Status**: v1
+- **Description**: "Install the validator the framework uses at every dev-time schema-validation site." `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework.
+
+#### `set-schema-explainer!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-schema-explainer! explain-fn)
+  ```
+- **Status**: v1
+- **Description**: "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." Companion to `set-schema-validator!`.
+
+#### `set-schema-printer!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-schema-printer! print-fn)
+  ```
+- **Status**: v1
+- **Description**: "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract.
 
 The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for digest (`printer`). Most apps use the defaults; ports and apps swap them selectively.
 
 ### The boundary interceptor
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `validate-at-boundary-interceptor` | Var (interceptor value) | `validate-at-boundary-interceptor` | v1 | A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`. |
+#### `validate-at-boundary-interceptor`
+
+- **Kind**: Var (interceptor value)
+- **Signature**:
+  ```clojure
+  validate-at-boundary-interceptor
+  ```
+- **Status**: v1
+- **Description**: A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`.
 
 ```clojure
 (rf/reg-event-db ::receive-from-server
@@ -60,10 +144,25 @@ The same schemas that drive validation also drive **redaction** and **size-elisi
 
 ### The mark-set
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `add-marks` | Fn | `(add-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Additively merges** into the frame's existing mark-set — paths not mentioned keep their prior state. Schema-attached marks per `reg-app-schema` `:sensitive?` / `:large?` are preserved and union at lookup time. Pure declaration — does not mutate `app-db`. Returns `frame-id`. |
-| `set-marks` | Fn | `(set-marks frame-id {path mark, ...})` | v1 | Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set — paths not mentioned are CLEARED. Schema-attached marks are preserved. Pure declaration. Returns `frame-id`. |
+#### `add-marks`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (add-marks frame-id {path mark, ...})
+  ```
+- **Status**: v1
+- **Description**: Frame-scoped path-marks. **Additively merges** into the frame's existing mark-set — paths not mentioned keep their prior state. Schema-attached marks per `reg-app-schema` `:sensitive?` / `:large?` are preserved and union at lookup time. Pure declaration — does not mutate `app-db`. Returns `frame-id`.
+
+#### `set-marks`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-marks frame-id {path mark, ...})
+  ```
+- **Status**: v1
+- **Description**: Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set — paths not mentioned are CLEARED. Schema-attached marks are preserved. Pure declaration. Returns `frame-id`.
 
 The two-verb shape (`add` vs `set`) follows the [Conventions §Tear-down verb axis](../../spec/Conventions.md) — `add-` merges; `set-` replaces. Most apps reach for `add-marks` because path classifications accumulate (an audit reveals a new sensitive path; you `add-marks` the path without affecting the rest of the corpus). Reach for `set-marks` when you're declaring the entire authoritative classification at once (a server-pushed policy update; a feature-flag toggle that swaps the whole privacy posture).
 
@@ -71,11 +170,37 @@ The two-verb shape (`add` vs `set`) follows the [Conventions §Tear-down verb ax
 
 This is the framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots. Every tool that emits wire data — off-box error-monitor forwarders, the Causa-MCP and re-frame2-pair-mcp and story-mcp servers, the on-box dev panels — routes through this walker. **The walker is the single normative emission site for the `:rf/redacted` sentinel and the `:rf.size/large-elided` marker.** Per-tool reimplementation is prohibited.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `elide-wire-value` | Fn | `(elide-wire-value v opts)` → `v` or an elision-marker substitution | v1 | Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. `opts` map: `{:rf.size/include-large? :rf.size/include-sensitive? :rf.size/include-digests? :rf.size/threshold-bytes :path :frame}`. Defaults: both `include-*` flags `false` (maximum elision); `:rf.size/threshold-bytes` falls back to `(rf/configure :elision ...)` then `16384`. |
-| `elision-declarations` | Fn | `(elision-declarations)` <br> `(elision-declarations frame-id)` | v1 | "What paths has the frame nominated for elision?" Returns the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool and introspection reader. |
-| `populate-elision-from-schemas!` | Fn | `(populate-elision-from-schemas!)` <br> `(populate-elision-from-schemas! frame-id)` → vector of paths populated | v1 | Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. No-op when the schemas artefact isn't on the classpath. |
+#### `elide-wire-value`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (elide-wire-value v opts) → v or an elision-marker substitution
+  ```
+- **Status**: v1
+- **Description**: Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. `opts` map: `{:rf.size/include-large? :rf.size/include-sensitive? :rf.size/include-digests? :rf.size/threshold-bytes :path :frame}`. Defaults: both `include-*` flags `false` (maximum elision); `:rf.size/threshold-bytes` falls back to `(rf/configure :elision ...)` then `16384`.
+
+#### `elision-declarations`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (elision-declarations)
+  (elision-declarations frame-id)
+  ```
+- **Status**: v1
+- **Description**: "What paths has the frame nominated for elision?" Returns the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool and introspection reader.
+
+#### `populate-elision-from-schemas!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (populate-elision-from-schemas!) → vector of paths populated
+  (populate-elision-from-schemas! frame-id) → vector of paths populated
+  ```
+- **Status**: v1
+- **Description**: Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. No-op when the schemas artefact isn't on the classpath.
 
 ### Composition rule
 
@@ -91,10 +216,25 @@ The single normative reference for "schemas are the only path" lives in [Guide c
 
 The trace runtime stamps `:sensitive? true` at the top level of every trace event emitted inside the scope of a handler whose schema-derived path overlap declares sensitivity. (The legacy handler-meta `:sensitive?` annotation has been removed — sensitive data marking is path-based per the data-classification mechanism above.) Framework-published trace consumers — Sentry / Honeybadger forwarders, the re-frame2-pair server, Causa, Story, story-mcp, re-frame2-pair-mcp — MUST default-drop the stamped events at their egress boundary.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `sensitive?` | Fn | `(sensitive? trace-event)` → `boolean` | v1 | The framework-published predicate every consumer composes against. Replaces per-consumer reimplementations of the same five-token check. |
-| `redact-interceptor` | Fn | `(redact-interceptor paths)` → interceptor | post-v1 (planned) | Build a positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel **before the handler chain runs**. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. `paths` is a vector of `get-in`-style key paths into the payload map. |
+### `sensitive?`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sensitive? trace-event) → boolean
+  ```
+- **Status**: v1
+- **Description**: The framework-published predicate every consumer composes against. Replaces per-consumer reimplementations of the same five-token check.
+
+### `redact-interceptor`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (redact-interceptor paths) → interceptor
+  ```
+- **Status**: post-v1 (planned)
+- **Description**: Build a positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel **before the handler chain runs**. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. `paths` is a vector of `get-in`-style key paths into the payload map.
 
 The composition pattern: schema-derived `:sensitive?` marks drive `elide-wire-value` at egress, and `redact-interceptor` scrubs in-place where the trace surface needs to see only a partial view. The two surfaces stack — the interceptor scrubs the trace; the walker enforces redaction at the wire boundary.
 

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -10,21 +10,72 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
 
 ## Rendering primitives
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `render-to-string` | Fn | `(render-to-string view-or-hiccup opts)` → HTML string | v1 | The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure. |
-| `render-tree-hash` | Fn | `(render-tree-hash render-tree)` → 32-bit FNV-1a structural hash (lowercase hex) | v1 | A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe. |
-| `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error` | v1 | Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection." |
+### `render-to-string`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (render-to-string view-or-hiccup opts) → HTML string
+  ```
+- **Status**: v1
+- **Description**: The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure.
+
+### `render-tree-hash`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (render-tree-hash render-tree) → 32-bit FNV-1a structural hash (lowercase hex)
+  ```
+- **Status**: v1
+- **Description**: A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe.
+
+### `project-error`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (project-error frame-id trace-event) → :rf/public-error
+  ```
+- **Status**: v1
+- **Description**: Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection."
 
 ### Streaming render
 
 Larger pages benefit from streaming — emit the shell-html and continue rendering boundary subtrees as their data becomes available. Re-frame2's streaming model uses `:rf/suspense-boundary` markers in the render tree; each boundary becomes a continuation.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `streaming-render-shell` | Fn | `(streaming-render-shell root-hiccup)` → `{:shell-html "..." :continuations [{:id :subtree} ...]}` | v1 | Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain. |
-| `streaming-render-continuation` | Fn | `(streaming-render-continuation frame-id entry)` → `{:id :html :delta :failed?}` | v1 | Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline (per [011 §Failure semantics — inline fallback](../../spec/011-SSR.md#failure-semantics--inline-fallback)). |
-| `streaming-build-final-payload` | Fn | `(streaming-build-final-payload frame-id render-hash opts)` → canonical `:rf/hydration-payload` | v1 | Called after all continuations drain to populate the `__rf_payload` final chunk. |
+### `streaming-render-shell`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (streaming-render-shell root-hiccup)
+    → {:shell-html "..." :continuations [{:id :subtree} ...]}
+  ```
+- **Status**: v1
+- **Description**: Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain.
+
+### `streaming-render-continuation`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (streaming-render-continuation frame-id entry)
+    → {:id :html :delta :failed?}
+  ```
+- **Status**: v1
+- **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline (per [011 §Failure semantics — inline fallback](../../spec/011-SSR.md#failure-semantics--inline-fallback)).
+
+### `streaming-build-final-payload`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (streaming-build-final-payload frame-id render-hash opts)
+    → canonical :rf/hydration-payload
+  ```
+- **Status**: v1
+- **Description**: Called after all continuations drain to populate the `__rf_payload` final chunk.
 
 The streaming surface is host-adapter territory — the SSR-aware host (`re-frame.ssr.ring` or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly.
 
@@ -32,13 +83,57 @@ The streaming surface is host-adapter territory — the SSR-aware host (`re-fram
 
 The `<head>` of an SSR document is structurally separate from the body. Re-frame2 models it as a head-model — a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, `:body-attrs` — registered per-route and rendered separately from the body.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-head` | M | `(reg-head id ?metadata head-fn)` | v1 | Register a head-fn keyed by id. Signature: `(fn [db route] head-model)`. Routes opt-in via `:head` route metadata. |
-| `render-head` | Fn | `(render-head head-id opts)` → `:rf/head-model` | v1 | Evaluate the registered head-fn for `head-id`. Returns a head-model. |
-| `active-head` | Fn | `(active-head)` / `(active-head frame-id)` → `:rf/head-model` | v1 | Resolve the head-model for the currently active route in the named frame. Sub-shape: `[:rf/head]` subscribes to this. |
-| `head-model->html` | Fn | `(head-model->html head-model)` <br> `(head-model->html head-model {:wrap? bool})` → inner-head HTML string | v1 | Render a head-model to its HTML representation. `:wrap?` controls whether `<head>` tags are emitted (default: false, so the result can be composed into a larger shell). |
-| `head-snapshot` | Fn | `(head-snapshot frame-id)` → `{head-id → :rf/head-model}` | v1 | Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call. Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`. |
+### `reg-head`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-head id ?metadata head-fn)
+  ```
+- **Status**: v1
+- **Description**: Register a head-fn keyed by id. Signature: `(fn [db route] head-model)`. Routes opt-in via `:head` route metadata.
+
+### `render-head`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (render-head head-id opts) → :rf/head-model
+  ```
+- **Status**: v1
+- **Description**: Evaluate the registered head-fn for `head-id`. Returns a head-model.
+
+### `active-head`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (active-head) → :rf/head-model
+  (active-head frame-id) → :rf/head-model
+  ```
+- **Status**: v1
+- **Description**: Resolve the head-model for the currently active route in the named frame. Sub-shape: `[:rf/head]` subscribes to this.
+
+### `head-model->html`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (head-model->html head-model) → inner-head HTML string
+  (head-model->html head-model {:wrap? bool}) → inner-head HTML string
+  ```
+- **Status**: v1
+- **Description**: Render a head-model to its HTML representation. `:wrap?` controls whether `<head>` tags are emitted (default: false, so the result can be composed into a larger shell).
+
+### `head-snapshot`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (head-snapshot frame-id) → {head-id → :rf/head-model}
+  ```
+- **Status**: v1
+- **Description**: Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call. Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`.
 
 ## Standard SSR events
 
@@ -92,10 +187,17 @@ Detail in [011 §`:platforms` metadata on `reg-fx`](../../spec/011-SSR.md#platfo
 
 A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-error-detail? ...}` map on its `reg-frame` / `make-frame` metadata. This is **per-frame metadata**, not a `configure` key — different frames in the same process can carry different projector / dev-detail settings, so the natural lifetime is per-frame.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-error-projector` | M | `(reg-error-projector id ?metadata projector-fn)` | v1 | Register a projector keyed by id. Signature: `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. |
-| `project-error` | Fn | `(project-error frame-id trace-event)` → `:rf/public-error` | v1 | (Rowed above in **Rendering primitives**.) Apply the active projector for the named frame. |
+### `reg-error-projector`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-error-projector id ?metadata projector-fn)
+  ```
+- **Status**: v1
+- **Description**: Register a projector keyed by id. Signature: `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata.
+
+The companion `project-error` accessor is rowed above in [§Rendering primitives](#project-error) — same signature; same job. Apply the active projector for the named frame.
 
 Full rationale: [Conventions §Configuration surfaces](../../spec/Conventions.md#configuration-surfaces-configure-vs-set--vs-per-frame-metadata) bucket 3 and [011 §Server error projection](../../spec/011-SSR.md#server-error-projection).
 

--- a/docs/api/10-testing.md
+++ b/docs/api/10-testing.md
@@ -14,25 +14,97 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
 
 ## Runtime-state assertions (`re-frame.test-support`)
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `dispatch-sequence` | Fn | `(dispatch-sequence events)` <br> `(dispatch-sequence events opts)` | v1 | "Run this list of events end-to-end against the current frame." `opts`: `:after-each (fn [db ev] ...)` for between-event assertions, `:frame` for non-default targets. Returns the final `app-db`. |
-| `assert-path-equals` | Fn | `(assert-path-equals path expected-val)` <br> `(assert-path-equals path expected-val opts)` | v1 | "Assert `(get-in db path) == expected-val`." Mismatch fires a `clojure.test/is`-style failure via `do-report`. The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel. |
-| `assert-db-equals` | Fn | `(assert-db-equals expected-db)` <br> `(assert-db-equals expected-db opts)` | v1 | Full-db sync assertion. Mismatch fires a `clojure.test/is`-style failure. Companion to `assert-path-equals`; reach for it when the whole-db identity matters. |
-| `poll-until` | Fn | `(poll-until pred)` <br> `(poll-until pred opts)` | v1 | Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` with `:rf.test/poll-timeout true` on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`. |
-| `with-fx-overrides` | M | `(with-fx-overrides {fx-id -> override, …} body+)` | v1 | (Rowed in [03 — Effects and interceptors](03-effects.md).) Lexical-scope fx override; the most common test surface for "stub THIS fx within THIS block." Lives in `re-frame.core` but is rowed here for discoverability. |
-| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | Pure sub computation against an `app-db` *value*. No cache, no reactivity — just walk the sub graph and return the value. JVM-runnable. Use in tests where you want "what would this sub return given this db?" without setting up frames. |
+### `dispatch-sequence`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (dispatch-sequence events)
+  (dispatch-sequence events opts)
+  ```
+- **Status**: v1
+- **Description**: "Run this list of events end-to-end against the current frame." `opts`: `:after-each (fn [db ev] ...)` for between-event assertions, `:frame` for non-default targets. Returns the final `app-db`.
+
+### `assert-path-equals`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (assert-path-equals path expected-val)
+  (assert-path-equals path expected-val opts)
+  ```
+- **Status**: v1
+- **Description**: "Assert `(get-in db path) == expected-val`." Mismatch fires a `clojure.test/is`-style failure via `do-report`. The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel.
+
+### `assert-db-equals`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (assert-db-equals expected-db)
+  (assert-db-equals expected-db opts)
+  ```
+- **Status**: v1
+- **Description**: Full-db sync assertion. Mismatch fires a `clojure.test/is`-style failure. Companion to `assert-path-equals`; reach for it when the whole-db identity matters.
+
+### `poll-until`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (poll-until pred)
+  (poll-until pred opts)
+  ```
+- **Status**: v1
+- **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` with `:rf.test/poll-timeout true` on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
+
+### `with-fx-overrides`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (with-fx-overrides {fx-id -> override, …} body+)
+  ```
+- **Status**: v1
+- **Description**: Rowed in [03 — Effects and interceptors](03-effects.md). Lexical-scope fx override; the most common test surface for "stub THIS fx within THIS block." Lives in `re-frame.core` but is rowed here for discoverability.
+
+### `compute-sub`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (compute-sub query-v db)
+  ```
+- **Status**: v1
+- **Description**: Pure sub computation against an `app-db` *value*. No cache, no reactivity — just walk the sub graph and return the value. JVM-runnable. Use in tests where you want "what would this sub return given this db?" without setting up frames.
 
 ### Snapshot the registrar; restore after
 
 These are the fixture primitives. The pattern is "snapshot the registrar before the test mutates registrations; restore after, regardless of pass / fail."
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `snapshot-registrar` | per docstring | v1 | Capture the current registrar state. |
-| `restore-registrar!` | per docstring | v1 | Restore a previously captured registrar state. |
-| `with-fresh-registrar` | per docstring | v1 | The composed macro — snapshot + body + restore. Most tests reach for this rather than the lower-level primitives. |
-| `make-reset-runtime-fixture` | per docstring | v1 | Build a `clojure.test` fixture that resets the runtime between tests. Pair with `use-fixtures :each`. |
+#### `snapshot-registrar`
+
+- **Signature**: per docstring
+- **Status**: v1
+- **Description**: Capture the current registrar state.
+
+#### `restore-registrar!`
+
+- **Signature**: per docstring
+- **Status**: v1
+- **Description**: Restore a previously captured registrar state.
+
+#### `with-fresh-registrar`
+
+- **Signature**: per docstring
+- **Status**: v1
+- **Description**: The composed macro — snapshot + body + restore. Most tests reach for this rather than the lower-level primitives.
+
+#### `make-reset-runtime-fixture`
+
+- **Signature**: per docstring
+- **Status**: v1
+- **Description**: Build a `clojure.test` fixture that resets the runtime between tests. Pair with `use-fixtures :each`.
 
 ### A typical test
 
@@ -50,21 +122,136 @@ The pattern: fresh registrar, register the handler, dispatch synchronously, asse
 
 The view-assertion surface treats a view as what it is — a function that returns hiccup — and walks the returned hiccup data structure. **JVM-runnable. No JSDOM. No React. No `act()`.** Pairs with `render-to-string` (the HTML-string view-test path per [Spec 011](../../spec/011-SSR.md)): hiccup-walk for structure / handler assertions, `render-to-string` for HTML-markup assertions.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `expand-tree` | Fn | `(expand-tree tree)` → tree | v1 | Recursively expand fn-components and Form-3 class components inside a hiccup tree. After expansion every vector's first element is a keyword tag or a non-component value. Run this first when your view tree contains other registered views you want to assert through. |
-| `attrs` | Fn | `(attrs node)` → map | v1 | Return the attrs map of a hiccup node, or `nil`. |
-| `children` | Fn | `(children node)` → vector | v1 | Return everything after the tag (and optional attrs map). |
-| `text-content` | Fn | `(text-content node)` → string | v1 | Recursively collect string leaves under `node` and join. Numbers coerce to strings; nils are skipped. "What's the visible text?" |
-| `extract-handler` | Fn | `(extract-handler node event-key)` → fn | v1 | "Get the handler attached at this attribute on this node." Returns the value or `nil`. |
-| `find-by-attr` | Fn | `(find-by-attr tree attr val)` → node | v1 | First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom. |
-| `find-all-by-attr` | Fn | `(find-all-by-attr tree attr val)` → vector | v1 | Every matching node, in depth-first order. |
-| `find-by-attr-prefix` | Fn | `(find-by-attr-prefix tree attr prefix)` → vector | v1 | Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match. |
-| `find-by-testid` | Fn | `(find-by-testid tree test-id)` → node | v1 | Convenience over `find-by-attr` keyed on `:data-testid`. The common case. |
-| `find-all-by-testid` | Fn | `(find-all-by-testid tree test-id)` → vector | v1 | Convenience over `find-all-by-attr` keyed on `:data-testid`. |
-| `find-by-testid-prefix` | Fn | `(find-by-testid-prefix tree prefix)` → vector | v1 | Convenience over `find-by-attr-prefix` keyed on `:data-testid`. |
-| `invoke-handler` | Fn | `(invoke-handler node event-key & args)` → any | v1 | Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** when the node has no attrs map or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug). |
-| `testid` | Fn | `(testid id)` / `(testid id extra)` → map | v1 | Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Authoring helper at the view call site — pair it with `find-by-testid` at the assertion site. |
+### `expand-tree`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (expand-tree tree) → tree
+  ```
+- **Status**: v1
+- **Description**: Recursively expand fn-components and Form-3 class components inside a hiccup tree. After expansion every vector's first element is a keyword tag or a non-component value. Run this first when your view tree contains other registered views you want to assert through.
+
+### `attrs`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (attrs node) → map
+  ```
+- **Status**: v1
+- **Description**: Return the attrs map of a hiccup node, or `nil`.
+
+### `children`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (children node) → vector
+  ```
+- **Status**: v1
+- **Description**: Return everything after the tag (and optional attrs map).
+
+### `text-content`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (text-content node) → string
+  ```
+- **Status**: v1
+- **Description**: Recursively collect string leaves under `node` and join. Numbers coerce to strings; nils are skipped. "What's the visible text?"
+
+### `extract-handler`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (extract-handler node event-key) → fn
+  ```
+- **Status**: v1
+- **Description**: "Get the handler attached at this attribute on this node." Returns the value or `nil`.
+
+### `find-by-attr`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-by-attr tree attr val) → node
+  ```
+- **Status**: v1
+- **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom.
+
+### `find-all-by-attr`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-all-by-attr tree attr val) → vector
+  ```
+- **Status**: v1
+- **Description**: Every matching node, in depth-first order.
+
+### `find-by-attr-prefix`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-by-attr-prefix tree attr prefix) → vector
+  ```
+- **Status**: v1
+- **Description**: Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match.
+
+### `find-by-testid`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-by-testid tree test-id) → node
+  ```
+- **Status**: v1
+- **Description**: Convenience over `find-by-attr` keyed on `:data-testid`. The common case.
+
+### `find-all-by-testid`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-all-by-testid tree test-id) → vector
+  ```
+- **Status**: v1
+- **Description**: Convenience over `find-all-by-attr` keyed on `:data-testid`.
+
+### `find-by-testid-prefix`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (find-by-testid-prefix tree prefix) → vector
+  ```
+- **Status**: v1
+- **Description**: Convenience over `find-by-attr-prefix` keyed on `:data-testid`.
+
+### `invoke-handler`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (invoke-handler node event-key & args) → any
+  ```
+- **Status**: v1
+- **Description**: Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** when the node has no attrs map or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug).
+
+### `testid`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (testid id) → map
+  (testid id extra) → map
+  ```
+- **Status**: v1
+- **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Authoring helper at the view call site — pair it with `find-by-testid` at the assertion site.
 
 ### A view-assertion test
 

--- a/docs/api/11-instrumentation.md
+++ b/docs/api/11-instrumentation.md
@@ -12,10 +12,25 @@ A minimal always-on listener surface that survives `:advanced` + `goog.DEBUG=fal
 
 Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:event` slot is passed through `elide-wire-value` (see below) once before fan-out, so schema-marked `:sensitive?` paths land as `:rf/redacted` and `:large?` paths land as `:rf.size/large-elided`.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `register-event-listener!` | Fn | `(register-event-listener! id listener-fn)` | v1 | Receive one event-record per processed event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. |
-| `unregister-event-listener!` | Fn | `(unregister-event-listener! id)` → nil | v1 | The inverse. |
+### `register-event-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (register-event-listener! id listener-fn)
+  ```
+- **Status**: v1
+- **Description**: Receive one event-record per processed event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
+
+### `unregister-event-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (unregister-event-listener! id) → nil
+  ```
+- **Status**: v1
+- **Description**: The inverse.
 
 ## Error-emit (always-on, production-survivable)
 
@@ -23,27 +38,122 @@ Sibling of the event-emit surface above. Runs through the SAME always-on error-e
 
 Record shape: `{:error :event :event-id :frame :time :exception :elapsed-ms}`. The `:event` slot is passed through `elide-wire-value` once before fan-out (same redaction posture as event-emit). The two paths from the substrate (corpus-wide listeners AND the per-frame `:on-error` policy fn) are mutually isolated; either may throw without affecting the other.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `register-error-listener!` | Fn | `(register-error-listener! id listener-fn)` | v1 | Receive one error-record per `:rf.error/*` event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`. |
-| `unregister-error-listener!` | Fn | `(unregister-error-listener! id)` → nil | v1 | The inverse. |
+### `register-error-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (register-error-listener! id listener-fn)
+  ```
+- **Status**: v1
+- **Description**: Receive one error-record per `:rf.error/*` event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
+
+### `unregister-error-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (unregister-error-listener! id) → nil
+  ```
+- **Status**: v1
+- **Description**: The inverse.
 
 ## Tracing (dev-only)
 
 The rich-detail trace surface. **Dev-only — elided in production via Closure DCE under `:advanced` + `goog.DEBUG=false`.** See [009 §Tracing](../../spec/009-Instrumentation.md) for emit semantics and synchronous listener delivery.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `register-listener!` | Fn | `(register-listener! key callback-fn)` | v1 (dev-only) | "Receive every trace event the runtime emits." Synchronous delivery; the callback returns before the next trace event is processed. |
-| `unregister-listener!` | Fn | `(unregister-listener! key)` → nil | v1 (dev-only) | The inverse. |
-| `emit-trace-event!` | Fn | `(emit-trace-event! op-type operation tags)` → nil | v1 (dev-only) | "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about. |
-| `re-frame.interop/debug-enabled?` | Var | `^boolean` | v1 | **CLJS:** alias of `goog.DEBUG` — constant-folded by Closure under `:advanced`, so `:advanced` + `goog.DEBUG=false` builds DCE every `(when interop/debug-enabled? ...)` branch. **JVM:** a `def` read ONCE at ns-load from the Java system property `-Dre-frame.debug` (winning on conflict) or the environment variable `RE_FRAME_DEBUG`; defaults `true` (dev parity). Accepts the conventional false-y vocabulary case-insensitively (`false`, `0`, `no`, `off`, empty string) with whitespace trimmed; anything else leaves the flag at `true`. SSR / webhook receivers / long-running JVMs facing untrusted input MUST set the gate `false` explicitly. |
-| `re-frame.performance/enabled?` | Var | `^boolean` | v1 | `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op. |
-| `trace-buffer` | Fn | `(trace-buffer)` / `(trace-buffer opts)` → vector of trace events, oldest-first | v1 (dev-only) | "What's in the ring right now?" Reads the buffer non-destructively. Pair tools and Causa use this for post-mortem inspection. |
-| `clear-trace-buffer!` | Fn | `(clear-trace-buffer!)` → nil | v1 (dev-only) | Empty the ring. |
-| `(rf/configure :trace-buffer {:depth N})` | — | | v1 (dev-only) | Buffer depth knob. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
-| `group-cascades` | Fn | `(group-cascades events)` → vector of cascade records | v1 (dev-only) | Pure data projection of a list of trace events into per-cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. JVM-runnable. Re-exported from `re-frame.trace.projection`. |
-| `domino-bucket` | Fn | `(domino-bucket trace-event)` → `#{:event :handler :fx :effect :sub :render :other}` | v1 (dev-only) | Classify a raw trace event into the six-domino slot used by `group-cascades`. Pure. |
+### `register-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (register-listener! key callback-fn)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: "Receive every trace event the runtime emits." Synchronous delivery; the callback returns before the next trace event is processed.
+
+### `unregister-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (unregister-listener! key) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The inverse.
+
+### `emit-trace-event!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (emit-trace-event! op-type operation tags) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about.
+
+### `re-frame.interop/debug-enabled?`
+
+- **Kind**: Var (`^boolean`)
+- **Status**: v1
+- **Description**: **CLJS:** alias of `goog.DEBUG` — constant-folded by Closure under `:advanced`, so `:advanced` + `goog.DEBUG=false` builds DCE every `(when interop/debug-enabled? ...)` branch. **JVM:** a `def` read ONCE at ns-load from the Java system property `-Dre-frame.debug` (winning on conflict) or the environment variable `RE_FRAME_DEBUG`; defaults `true` (dev parity). Accepts the conventional false-y vocabulary case-insensitively (`false`, `0`, `no`, `off`, empty string) with whitespace trimmed; anything else leaves the flag at `true`. SSR / webhook receivers / long-running JVMs facing untrusted input MUST set the gate `false` explicitly.
+
+### `re-frame.performance/enabled?`
+
+- **Kind**: Var (`^boolean`)
+- **Status**: v1
+- **Description**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op.
+
+### `trace-buffer`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (trace-buffer) → vector of trace events, oldest-first
+  (trace-buffer opts) → vector of trace events, oldest-first
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: "What's in the ring right now?" Reads the buffer non-destructively. Pair tools and Causa use this for post-mortem inspection.
+
+### `clear-trace-buffer!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (clear-trace-buffer!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Empty the ring.
+
+### `(rf/configure :trace-buffer …)`
+
+- **Kind**: config key
+- **Signature**:
+  ```clojure
+  (rf/configure :trace-buffer {:depth N})
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Buffer depth knob. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
+
+### `group-cascades`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (group-cascades events) → vector of cascade records
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Pure data projection of a list of trace events into per-cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. JVM-runnable. Re-exported from `re-frame.trace.projection`.
+
+### `domino-bucket`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (domino-bucket trace-event) → #{:event :handler :fx :effect :sub :render :other}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Classify a raw trace event into the six-domino slot used by `group-cascades`. Pure.
 
 ### Trace-emission opt-out
 
@@ -59,14 +169,65 @@ Used by framework-internal bookkeeping handlers (Causa, Story, re-frame2-pair-mc
 
 Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used by pair-shaped tools for time-travel and post-mortem analysis. **Production builds elide entirely.**
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `epoch-history` | Fn | `(epoch-history frame-id)` → vector of epoch records | v1 (dev-only) | Returns `[]` for an unknown / destroyed frame. |
-| `restore-epoch` | Fn | `(restore-epoch frame-id epoch-id)` → boolean | v1 (dev-only) | Restore the frame's `app-db` to the named epoch. Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`). |
-| `reset-frame-db!` | Fn | `(reset-frame-db! frame-id new-db)` → boolean | v1 (dev-only) | Pair-tool write surface (state injection). Direct write to `app-db` — bypasses the cascade. Returns `true` on success. |
-| `register-epoch-listener!` | Fn | `(register-epoch-listener! key callback-fn)` | v1 (dev-only) | Process-global assembled-epoch listener. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace. |
-| `unregister-epoch-listener!` | Fn | `(unregister-epoch-listener! key)` | v1 (dev-only) | The inverse. |
-| `(rf/configure :epoch-history {:depth N :trace-events-keep N :redact-fn fn})` | — | | v1 (dev-only) | Buffer-depth and redactor knobs. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
+### `epoch-history`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (epoch-history frame-id) → vector of epoch records
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Returns `[]` for an unknown / destroyed frame.
+
+### `restore-epoch`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (restore-epoch frame-id epoch-id) → boolean
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Restore the frame's `app-db` to the named epoch. Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`).
+
+### `reset-frame-db!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reset-frame-db! frame-id new-db) → boolean
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Pair-tool write surface (state injection). Direct write to `app-db` — bypasses the cascade. Returns `true` on success.
+
+### `register-epoch-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (register-epoch-listener! key callback-fn)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Process-global assembled-epoch listener. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace.
+
+### `unregister-epoch-listener!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (unregister-epoch-listener! key)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The inverse.
+
+### `(rf/configure :epoch-history …)`
+
+- **Kind**: config key
+- **Signature**:
+  ```clojure
+  (rf/configure :epoch-history {:depth N :trace-events-keep N :redact-fn fn})
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Buffer-depth and redactor knobs. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
 
 ### Trace events emitted by epoch-history machinery
 
@@ -89,11 +250,37 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
 
 `elide-wire-value` is the framework primitive that walks tree-shaped values at the wire boundary and substitutes elision markers for sensitive or large slots. **This walker is the single normative emission site for the `:rf/redacted` sensitive sentinel and the `:rf.size/large-elided` size marker.** Per-tool reimplementation is prohibited.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `elide-wire-value` | Fn | `(elide-wire-value v opts)` → `v` or an elision-marker substitution | v1 | Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. |
-| `elision-declarations` | Fn | `(elision-declarations)` / `(elision-declarations frame-id)` | v1 | Read the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool / introspection reader. |
-| `populate-elision-from-schemas!` | Fn | `(populate-elision-from-schemas!)` / `(populate-elision-from-schemas! frame-id)` → vector of paths populated | v1 | Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. |
+### `elide-wire-value`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (elide-wire-value v opts) → v or an elision-marker substitution
+  ```
+- **Status**: v1
+- **Description**: Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots.
+
+### `elision-declarations`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (elision-declarations)
+  (elision-declarations frame-id)
+  ```
+- **Status**: v1
+- **Description**: Read the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool / introspection reader.
+
+### `populate-elision-from-schemas!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (populate-elision-from-schemas!) → vector of paths populated
+  (populate-elision-from-schemas! frame-id) → vector of paths populated
+  ```
+- **Status**: v1
+- **Description**: Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent.
 
 Composition rule: when both predicates match (sensitive AND large for the same path), **sensitive drop wins** — the size marker is suppressed because it would leak `:path` / `:bytes` / `:digest` from a sensitive slot.
 
@@ -101,10 +288,25 @@ See [08 — Schemas](08-schemas.md) for the registration side (`add-marks`, `set
 
 ## Privacy predicate
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `sensitive?` | Fn | `(sensitive? trace-event)` → `boolean` | v1 | True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check. |
-| `redact-interceptor` | Fn | `(redact-interceptor paths)` → interceptor | post-v1 (planned) | Positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel before the handler chain runs. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. |
+### `sensitive?`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sensitive? trace-event) → boolean
+  ```
+- **Status**: v1
+- **Description**: True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check.
+
+### `redact-interceptor`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (redact-interceptor paths) → interceptor
+  ```
+- **Status**: post-v1 (planned)
+- **Description**: Positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel before the handler chain runs. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only.
 
 ## DOM source-coord annotations
 

--- a/docs/api/12-registrar.md
+++ b/docs/api/12-registrar.md
@@ -8,11 +8,36 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
 
 ## Handlers
 
-| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
-|---|---|---|---|---|---|
-| `registrations` | Fn | `(registrations kind)` <br> `(registrations kind pred-fn)` → `{id metadata-map}` | v1 | ✓ | **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map. |
-| `handler-ids` | Fn | `(handler-ids kind)` → id set | v1 | ✓ | **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections). |
-| `handler-meta` | Fn | `(handler-meta kind id)` → registration-metadata map | v1 | ✓ | "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup. |
+### `registrations`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (registrations kind) → {id metadata-map}
+  (registrations kind pred-fn) → {id metadata-map}
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map.
+
+### `handler-ids`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (handler-ids kind) → id set
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections).
+
+### `handler-meta`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (handler-meta kind id) → registration-metadata map
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
 
 `kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`, `:app-schema`. The full list lives in [001-Vision §Registry model](../../spec/000-Vision.md).
 
@@ -20,28 +45,93 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
 
 These are derived views over the event registrar — a machine is registered as an event handler with `:rf/machine? true`, so `(machines)` is just `(registrations :event)` filtered by that flag. They're rowed here separately because tools reach for them often enough that the convenience is worth it.
 
-| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
-|---|---|---|---|---|---|
-| `machines` | Fn | `(machines)` → seq of machine-ids | v1 | ✓ | Enumerate registered machines. |
-| `machine-meta` | Fn | `(machine-meta machine-id)` → registration-metadata map | v1 | ✓ | Transition table, doc, schemas. Equivalent to `(handler-meta :event machine-id)`. |
+### `machines`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machines) → seq of machine-ids
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: Enumerate registered machines.
+
+### `machine-meta`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (machine-meta machine-id) → registration-metadata map
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: Transition table, doc, schemas. Equivalent to `(handler-meta :event machine-id)`.
 
 See [04 — Machines](04-machines.md) for the rest of the machine surface (subscription helpers, system-id reverse lookup, etc).
 
 ## Frames
 
-| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
-|---|---|---|---|---|---|
-| `frame-ids` | Fn | `(frame-ids)` <br> `(frame-ids ns-prefix)` | v1 | ✓ | "What frames exist?" The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames. |
-| `frame-meta` | Fn | `(frame-meta frame-id)` | v1 | ✓ | "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings. |
-| `get-frame-db` | Fn | `(get-frame-db frame-id)` → app-db value (plain map) | v1 | ✓ | "What's the current `app-db` for this frame?" Returns `nil` for an unknown / destroyed frame. |
-| `snapshot-of` | Fn | `(snapshot-of path)` <br> `(snapshot-of path opts)` | v1 | ✓ | "What's at this path in `app-db` right now?" Convenience over `get-frame-db` + `get-in`. |
+### `frame-ids`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (frame-ids)
+  (frame-ids ns-prefix)
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: "What frames exist?" The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames.
+
+### `frame-meta`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (frame-meta frame-id)
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
+
+### `get-frame-db`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (get-frame-db frame-id) → app-db value (plain map)
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: "What's the current `app-db` for this frame?" Returns `nil` for an unknown / destroyed frame.
+
+### `snapshot-of`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (snapshot-of path)
+  (snapshot-of path opts)
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: "What's at this path in `app-db` right now?" Convenience over `get-frame-db` + `get-in`.
 
 ## Sub graph
 
-| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
-|---|---|---|---|---|---|
-| `sub-topology` | Fn | `(sub-topology)` → `{sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}` | v1 | ✓ | Static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1 subs); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them. |
-| `sub-cache` | Fn | `(sub-cache frame-id)` → live cache state | v1 | ✗ (CLJS-only) | The runtime cache. CLJS-only because it holds live `Reaction` objects; on JVM there are no reactions to hold. Tools that walk the cache for tab labels / counts in Causa go through this. |
+### `sub-topology`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sub-topology) → {sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: Static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1 subs); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them.
+
+### `sub-cache`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (sub-cache frame-id) → live cache state
+  ```
+- **Status**: v1 · CLJS-only
+- **Description**: The runtime cache. CLJS-only because it holds live `Reaction` objects; on JVM there are no reactions to hold. Tools that walk the cache for tab labels / counts in Causa go through this.
 
 The split — `sub-topology` JVM-runnable, `sub-cache` CLJS-only — is principled. Topology is a static property of the registration; the cache is a runtime property of the sub graph. Tools that want the design-time picture (linter, doc generator, conformance harness) reach for `sub-topology`; tools that want the runtime picture (Causa's sub-cache tab) reach for `sub-cache`.
 
@@ -58,9 +148,15 @@ The schema-introspection surfaces are rowed in [08 — Schemas](08-schemas.md). 
 
 `compute-sub` is the test-friendly companion to `subscribe`. It runs the sub graph against a value of `app-db` — no cache, no reactivity, no frame — and returns the value.
 
-| API | M/Fn | Signature | Status | JVM-runnable? | Intuition |
-|---|---|---|---|---|---|
-| `compute-sub` | Fn | `(compute-sub query-v db)` | v1 | ✓ | Pure sub computation against an `app-db` value. Use in tests; use in agent tooling that wants to evaluate subs against an artificial state. |
+### `compute-sub`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (compute-sub query-v db)
+  ```
+- **Status**: v1 · JVM-runnable
+- **Description**: Pure sub computation against an `app-db` value. Use in tests; use in agent tooling that wants to evaluate subs against an artificial state.
 
 (Cross-rowed in [10 — Testing](10-testing.md).)
 

--- a/docs/api/13-lifecycle.md
+++ b/docs/api/13-lifecycle.md
@@ -6,11 +6,35 @@ There's also a small inspection surface for "what's currently installed?" — `c
 
 ## Adapter selection
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `init!` | Fn | `(init! adapter-map)` | v1 | The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time — the no-arg arity was cut so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. Ensures `:rf/default` frame is present. |
-| `install-adapter!` | Fn | `(install-adapter! adapter-map)` | v1 | Must be called before any frame is created. **Lower-level than `init!`**; most consumers call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation. |
-| `destroy-adapter!` | Fn | `(destroy-adapter!)` | v2 | Tear down the installed adapter. Calls the adapter spec's `:dispose-adapter!` fn (if present), clears the install slot so a new adapter can install, and flips the `adapter-disposed?` breadcrumb. Symmetric with `install-adapter!` and with `destroy-frame!` — same `destroy-` verb-cluster (lifecycle boundary). |
+### `init!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (init! adapter-map)
+  ```
+- **Status**: v1
+- **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time — the no-arg arity was cut so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. Ensures `:rf/default` frame is present.
+
+### `install-adapter!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (install-adapter! adapter-map)
+  ```
+- **Status**: v1
+- **Description**: Must be called before any frame is created. **Lower-level than `init!`**; most consumers call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
+
+### `destroy-adapter!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (destroy-adapter!)
+  ```
+- **Status**: v2
+- **Description**: Tear down the installed adapter. Calls the adapter spec's `:dispose-adapter!` fn (if present), clears the install slot so a new adapter can install, and flips the `adapter-disposed?` breadcrumb. Symmetric with `install-adapter!` and with `destroy-frame!` — same `destroy-` verb-cluster (lifecycle boundary).
 
 The adapter-spec **map key** `:dispose-adapter!` is an internal contract slot adapters implement; ignore it unless you're authoring an adapter.
 
@@ -28,11 +52,35 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
 
 ## Inspection
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `current-adapter` | Fn | `(current-adapter)` → discriminator keyword | v1 | "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code. |
-| `current-adapter-spec` | Fn | `(current-adapter-spec)` → installed adapter spec map | v1 | "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`. |
-| `adapter-disposed?` | Fn | `(adapter-disposed?)` → boolean | v1 | "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only — the breadcrumb is owned by the install / destroy pair. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down). |
+### `current-adapter`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (current-adapter) → discriminator keyword
+  ```
+- **Status**: v1
+- **Description**: "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
+
+### `current-adapter-spec`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (current-adapter-spec) → installed adapter spec map
+  ```
+- **Status**: v1
+- **Description**: "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
+
+### `adapter-disposed?`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (adapter-disposed?) → boolean
+  ```
+- **Status**: v1
+- **Description**: "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only — the breadcrumb is owned by the install / destroy pair. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down).
 
 The split between `current-adapter` (keyword) and `current-adapter-spec` (map) is principled. The keyword is for switch-like code that branches on substrate identity. The spec map is for code that needs to call adapter fns or compare adapter identity across reinstalls.
 
@@ -51,9 +99,15 @@ The two states share the "no current adapter" surface but answer different quest
 
 The `configure` fn is the lifecycle's adjacent surface — process-level data knobs that you typically set once at boot, possibly tweak in tests, and rarely touch in app code.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `configure` | Fn | `(configure key opts)` | v1 | Runtime config. One of three orthogonal configuration surfaces — `configure` for process-level data knobs; `set-!` / `install-!` for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys lives in [01 — Core §Configure keys](01-core.md#runtime-configuration-configure). |
+### `configure`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (configure key opts)
+  ```
+- **Status**: v1
+- **Description**: Runtime config. One of three orthogonal configuration surfaces — `configure` for process-level data knobs; `set-!` / `install-!` for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys lives in [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
 
 The three configuration surfaces — `configure`, the `set-!` / `install-!` setters (`set-schema-validator!`, etc.), and per-frame metadata — are deliberately separate. Each answers a different question: `configure` for data knobs (depth, threshold, grace period); the setters for hook-shaped pluggability (which validator to use, which printer); per-frame metadata for frame-scoped overrides (which projector, which `:fx-overrides`).
 

--- a/docs/api/14-adapters.md
+++ b/docs/api/14-adapters.md
@@ -32,15 +32,79 @@ The slim variant is bundle-isolated — the `npm run test:reagent-slim:bundle-is
 
 UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-uix`). The hook is named `use-subscribe` (matching the React/UIx idiom); there is no auto-injection — UIx components call the hook and `(rf/dispatcher)` directly. The full decision set lives at [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `uix-adapter/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
-| `uix-adapter/use-subscribe` | Fn (UIx hook) | `(use-subscribe query-v)` <br> `(use-subscribe frame-kw query-v)` → current sub value | v1 | "Subscribe inside a UIx component." The hook-shaped equivalent of `subscribe` for UIx components. Re-renders when the sub value changes. |
-| `uix-adapter/use-current-frame` | Fn (UIx hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks. |
-| `uix-adapter/frame-provider` | Fn (UIx component) | `($ uix-adapter/frame-provider {:frame :session :children […]})` | v1 | The UIx-shaped frame provider. |
-| `uix-adapter/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding. |
-| `uix-adapter/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. |
-| `uix-adapter/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR. |
+### `uix-adapter/adapter`
+
+- **Kind**: Var (map)
+- **Signature**:
+  ```clojure
+  {:make-state-container …
+   :render …
+   :dispose-adapter! …}
+  ```
+- **Status**: v1
+- **Description**: The adapter spec passed to `(rf/init! ...)`.
+
+### `uix-adapter/use-subscribe`
+
+- **Kind**: UIx hook (function)
+- **Signature**:
+  ```clojure
+  (use-subscribe query-v) → current sub value
+  (use-subscribe frame-kw query-v) → current sub value
+  ```
+- **Status**: v1
+- **Description**: "Subscribe inside a UIx component." The hook-shaped equivalent of `subscribe` for UIx components. Re-renders when the sub value changes.
+
+### `uix-adapter/use-current-frame`
+
+- **Kind**: UIx hook (function)
+- **Signature**:
+  ```clojure
+  (use-current-frame) → frame-kw
+  ```
+- **Status**: v1
+- **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
+
+### `uix-adapter/frame-provider`
+
+- **Kind**: UIx component (function)
+- **Signature**:
+  ```clojure
+  ($ uix-adapter/frame-provider {:frame :session :children […]})
+  ```
+- **Status**: v1
+- **Description**: The UIx-shaped frame provider.
+
+### `uix-adapter/wrap-view`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (wrap-view id metadata user-fn) → wrapped fn
+  ```
+- **Status**: v1
+- **Description**: Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding.
+
+### `uix-adapter/flush-views!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (flush-views!)
+  (flush-views! f)
+  ```
+- **Status**: v1
+- **Description**: Wraps React's `act()` for tests.
+
+### `uix-adapter/set-hiccup-emitter!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-hiccup-emitter! f)
+  ```
+- **Status**: v1
+- **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
 
 UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx. Full rationale: [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
 
@@ -60,17 +124,81 @@ UIx users register their views by Var (the React-component idiom) or with `rf/re
 
 ## The Helix adapter
 
-Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-frame2-helix`). The Helix adapter mirrors the UIx adapter exactly — the eight UIx decisions transfer one-for-one. The surface table below is identical in shape to the UIx table above.
+Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-frame2-helix`). The Helix adapter mirrors the UIx adapter exactly — the eight UIx decisions transfer one-for-one. The surface below is identical in shape to the UIx surface above.
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `helix-adapter/adapter` | Var (map) | `{:make-state-container … :render … :dispose-adapter! …}` | v1 | The adapter spec passed to `(rf/init! ...)`. |
-| `helix-adapter/use-subscribe` | Fn (Helix hook) | `(use-subscribe query-v)` <br> `(use-subscribe frame-kw query-v)` → current sub value | v1 | "Subscribe inside a Helix component." |
-| `helix-adapter/use-current-frame` | Fn (Helix hook) | `(use-current-frame)` → frame-kw | v1 | "What frame am I in?" |
-| `helix-adapter/frame-provider` | Fn (Helix component) | `($ helix-adapter/frame-provider {:frame :session :children […]})` | v1 | The Helix-shaped frame provider. |
-| `helix-adapter/wrap-view` | Fn | `(wrap-view id metadata user-fn)` → wrapped fn | v1 | Adapter-side source-coord injection. |
-| `helix-adapter/flush-views!` | Fn | `(flush-views!)` / `(flush-views! f)` | v1 | Wraps React's `act()` for tests. |
-| `helix-adapter/set-hiccup-emitter!` | Fn | `(set-hiccup-emitter! f)` | v1 | Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam. |
+### `helix-adapter/adapter`
+
+- **Kind**: Var (map)
+- **Signature**:
+  ```clojure
+  {:make-state-container …
+   :render …
+   :dispose-adapter! …}
+  ```
+- **Status**: v1
+- **Description**: The adapter spec passed to `(rf/init! ...)`.
+
+### `helix-adapter/use-subscribe`
+
+- **Kind**: Helix hook (function)
+- **Signature**:
+  ```clojure
+  (use-subscribe query-v) → current sub value
+  (use-subscribe frame-kw query-v) → current sub value
+  ```
+- **Status**: v1
+- **Description**: "Subscribe inside a Helix component."
+
+### `helix-adapter/use-current-frame`
+
+- **Kind**: Helix hook (function)
+- **Signature**:
+  ```clojure
+  (use-current-frame) → frame-kw
+  ```
+- **Status**: v1
+- **Description**: "What frame am I in?"
+
+### `helix-adapter/frame-provider`
+
+- **Kind**: Helix component (function)
+- **Signature**:
+  ```clojure
+  ($ helix-adapter/frame-provider {:frame :session :children […]})
+  ```
+- **Status**: v1
+- **Description**: The Helix-shaped frame provider.
+
+### `helix-adapter/wrap-view`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (wrap-view id metadata user-fn) → wrapped fn
+  ```
+- **Status**: v1
+- **Description**: Adapter-side source-coord injection.
+
+### `helix-adapter/flush-views!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (flush-views!)
+  (flush-views! f)
+  ```
+- **Status**: v1
+- **Description**: Wraps React's `act()` for tests.
+
+### `helix-adapter/set-hiccup-emitter!`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (set-hiccup-emitter! f)
+  ```
+- **Status**: v1
+- **Description**: Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
 
 The duplication between UIx and Helix is intentional — both expose the same hooks-first idiom; both decisions sets transfer; both surfaces are structurally identical. The two adapters are separate artefacts because the *underlying React-substrate libraries* are separate, not because the re-frame2 contract differs between them.
 

--- a/docs/api/15-story.md
+++ b/docs/api/15-story.md
@@ -8,30 +8,129 @@ This chapter is a reference. If you want narrative — "what's the workflow, wha
 
 ## Registration
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-story` | M | `(reg-story id metadata)` | post-v1 lib | Register a story (a cluster of variants under one heading). |
-| `reg-variant` | M | `(reg-variant id metadata)` | post-v1 lib | Register one variant — view, args, setup events, decorators. |
-| `reg-workspace` | M | `(reg-workspace id metadata)` | post-v1 lib | Register a workspace — a curated grid of variants for side-by-side review. |
-| `reg-tag` | M | `(reg-tag id metadata)` | post-v1 lib | Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. |
-| `reg-decorator` | M | `(reg-decorator id metadata)` | post-v1 lib | Register a decorator — a function that wraps a variant's render (locale, theme, mock-API context). |
-| `reg-story-panel` | M | `(reg-story-panel id metadata)` | post-v1 lib | Register a custom panel in the Story shell — the inspection / control panes that sit beside the rendered variant. |
+### `reg-story`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-story id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register a story (a cluster of variants under one heading).
+
+### `reg-variant`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-variant id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register one variant — view, args, setup events, decorators.
+
+### `reg-workspace`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-workspace id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register a workspace — a curated grid of variants for side-by-side review.
+
+### `reg-tag`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-tag id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue.
+
+### `reg-decorator`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-decorator id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register a decorator — a function that wraps a variant's render (locale, theme, mock-API context).
+
+### `reg-story-panel`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-story-panel id metadata)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Register a custom panel in the Story shell — the inspection / control panes that sit beside the rendered variant.
 
 ## Running variants
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `run-variant` | Fn | `(run-variant variant-id)` → result map | post-v1 lib | Materialise the variant — run its setup events, render its view, return the result map. One-shot; no live updates. |
-| `watch-variant` | Fn | `(watch-variant variant-id)` → live-updating result map | post-v1 lib | Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots. |
-| `reset-variant` | Fn | `(reset-variant variant-id)` | post-v1 lib | Reset the variant's frame to its initial setup. The Story shell calls this when the user clicks "reset" on a variant. |
+### `run-variant`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (run-variant variant-id) → result map
+  ```
+- **Status**: post-v1 lib
+- **Description**: Materialise the variant — run its setup events, render its view, return the result map. One-shot; no live updates.
+
+### `watch-variant`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (watch-variant variant-id) → live-updating result map
+  ```
+- **Status**: post-v1 lib
+- **Description**: Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots.
+
+### `reset-variant`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reset-variant variant-id)
+  ```
+- **Status**: post-v1 lib
+- **Description**: Reset the variant's frame to its initial setup. The Story shell calls this when the user clicks "reset" on a variant.
 
 ## Discovery
 
-| API | M/Fn | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `variants-with-tags` | Fn | `(variants-with-tags tag-set)` → seq of variant ids | post-v1 lib | Filter the catalogue. `(variants-with-tags #{:cart :empty-state})` returns every cart-related empty-state variant. |
-| `snapshot-identity` | Fn | `(snapshot-identity variant-id)` → `{:variant-id ... :content-hash "..."}` | post-v1 lib | The variant's snapshot identity — the variant id plus a content-hash over its setup. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. |
-| `story-view` | Fn | `(story-view variant-id)` → hiccup | post-v1 lib | Render the variant directly to hiccup. Use in custom shells that need to embed variants without the full Story chrome. |
+### `variants-with-tags`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (variants-with-tags tag-set) → seq of variant ids
+  ```
+- **Status**: post-v1 lib
+- **Description**: Filter the catalogue. `(variants-with-tags #{:cart :empty-state})` returns every cart-related empty-state variant.
+
+### `snapshot-identity`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (snapshot-identity variant-id) → {:variant-id ... :content-hash "..."}
+  ```
+- **Status**: post-v1 lib
+- **Description**: The variant's snapshot identity — the variant id plus a content-hash over its setup. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args.
+
+### `story-view`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (story-view variant-id) → hiccup
+  ```
+- **Status**: post-v1 lib
+- **Description**: Render the variant directly to hiccup. Use in custom shells that need to embed variants without the full Story chrome.
 
 ## See also
 

--- a/docs/causa/api/config-keys.md
+++ b/docs/causa/api/config-keys.md
@@ -6,9 +6,14 @@ Boot-time configuration is **process-global**: the setters write to `defonce` at
 
 ## The bulk-set entry point
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level Causa configuration. Accepts a map keyed by `:rf.causa/*` (Causa-specific) and `:rf.privacy/*` (cross-tool) keys. Unknown keys are silently ignored (forward-compat — newer hosts passing older-Causa-unaware keys MUST NOT break). Hosts typically call once at boot, before Causa auto-opens. |
+### `configure!`
+
+- **Signature**:
+  ```clojure
+  (configure! opts) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Top-level Causa configuration. Accepts a map keyed by `:rf.causa/*` (Causa-specific) and `:rf.privacy/*` (cross-tool) keys. Unknown keys are silently ignored (forward-compat — newer hosts passing older-Causa-unaware keys MUST NOT break). Hosts typically call once at boot, before Causa auto-opens.
 
 `configure!` is re-exported from `core` for boot-time ergonomics. The two require paths are interchangeable:
 
@@ -54,10 +59,23 @@ Every key lives under a reserved namespace — `:rf.causa/*` for Causa-specific 
 
 Every panel that surfaces a source-coord wraps the coord in a clickable `open` chip. Clicking sets `window.location.href` to a URI-scheme handler the OS dispatches to the configured editor.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Set the editor preference. Accepts `:vscode` (default), `:cursor`, `:windsurf`, `:zed`, `:idea`, `{:custom <uri-template>}`. `nil` resets to `:vscode`. Re-exported from `core`. |
-| `set-project-root!` | `(set-project-root! path)` → nil | v1 (dev-only) | On-disk root prepended to the source-coord's classpath-relative `:file` slot before the editor URI ships. Default `nil` — hosts whose source paths are already absolute leave this unset. Nil / blank clears the slot; an absent key in `configure!` leaves the current value untouched. |
+### `set-editor!`
+
+- **Signature**:
+  ```clojure
+  (set-editor! editor) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Set the editor preference. Accepts `:vscode` (default), `:cursor`, `:windsurf`, `:zed`, `:idea`, `{:custom <uri-template>}`. `nil` resets to `:vscode`. Re-exported from `core`.
+
+### `set-project-root!`
+
+- **Signature**:
+  ```clojure
+  (set-project-root! path) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: On-disk root prepended to the source-coord's classpath-relative `:file` slot before the editor URI ships. Default `nil` — hosts whose source paths are already absolute leave this unset. Nil / blank clears the slot; an absent key in `configure!` leaves the current value untouched.
 
 The URI schemes:
 
@@ -78,10 +96,23 @@ Causa's editor preference is **independent** of Story's `:rf.story/editor` (host
 
 The launch cluster controls the auto-open posture and the layout-host wiring. Set these *before* the preload runs (before `rf/init!` returns) so the first auto-open path reads the right values.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Whether the preload auto-opens the shell into the inline host on adapter readiness. Default `true`. Set `false` from tool-owned pages that deliberately don't reserve app real estate for Causa (Story-only canvases, internal dev tools whose layout can't host a right column). Explicit `(causa/open!)` calls still mount after suppression. Re-exported from `core`. |
-| `set-layout-host-selector!` | `(set-layout-host-selector! css-selector)` → nil | v1 (dev-only) | The CSS selector the auto-open path queries on adapter readiness. Default `[data-rf-causa-host]`. Override when your host's preferred selector differs (e.g. `#devtools-causa`). |
+### `set-auto-open!`
+
+- **Signature**:
+  ```clojure
+  (set-auto-open! bool) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Whether the preload auto-opens the shell into the inline host on adapter readiness. Default `true`. Set `false` from tool-owned pages that deliberately don't reserve app real estate for Causa (Story-only canvases, internal dev tools whose layout can't host a right column). Explicit `(causa/open!)` calls still mount after suppression. Re-exported from `core`.
+
+### `set-layout-host-selector!`
+
+- **Signature**:
+  ```clojure
+  (set-layout-host-selector! css-selector) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The CSS selector the auto-open path queries on adapter readiness. Default `[data-rf-causa-host]`. Override when your host's preferred selector differs (e.g. `#devtools-causa`).
 
 The default selector `[data-rf-causa-host]` is published as a CLJS constant — `day8.re-frame2-causa.config/default-layout-host-selector` — so docs generators and tool chrome can re-emit the canonical spelling without forking the string.
 
@@ -99,9 +130,14 @@ Three more published constants name the inline-host CSS contract. These are cons
 
 Causa installs a global `Ctrl+Shift+C` keydown listener as one of the preload's six side-effects. Standalone Causa always needs the listener; embed hosts (Story mounts Causa as a right-hand-side panel) sometimes need to take the chord back.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `set-keybinding-enabled!` | `(set-keybinding-enabled! bool)` → nil | v1 (dev-only) | Whether `keybinding/attach!` installs the global window-level keydown listener. Default `true` — standalone Causa needs the listener. Embed hosts set `false` so their own global keybindings (typically `Cmd/Ctrl+K` for the host's command palette) are not swallowed by Causa's capture-phase listener. MUST be set BEFORE the Causa preload runs. |
+### `set-keybinding-enabled!`
+
+- **Signature**:
+  ```clojure
+  (set-keybinding-enabled! bool) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Whether `keybinding/attach!` installs the global window-level keydown listener. Default `true` — standalone Causa needs the listener. Embed hosts set `false` so their own global keybindings (typically `Cmd/Ctrl+K` for the host's command palette) are not swallowed by Causa's capture-phase listener. MUST be set BEFORE the Causa preload runs.
 
 The setter suppresses the install at attach time; embed hosts whose mount lifecycle runs AFTER Causa's preload has already attached use the imperative escape hatch instead:
 
@@ -118,9 +154,14 @@ The setter suppresses the install at attach time; embed hosts whose mount lifecy
 
 The privacy cluster carries one cross-tool gate that Causa, Story, and any other re-frame2 tool consuming the trace bus all read. The key lives under `:rf.privacy/*` (not `:rf.causa/*`) because the slot is shared.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | The cross-tool `:rf.privacy/show-sensitive?` flag. When `false` (default), Causa's trace collector drops `:sensitive? true` events and the bottom rail surfaces a `[● REDACTED N]` hint. Set to `true` while debugging redaction policy to see the raw cascade. `nil` resets to the default. Re-exported from `core`. |
+### `set-show-sensitive!`
+
+- **Signature**:
+  ```clojure
+  (set-show-sensitive! bool) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The cross-tool `:rf.privacy/show-sensitive?` flag. When `false` (default), Causa's trace collector drops `:sensitive? true` events and the bottom rail surfaces a `[● REDACTED N]` hint. Set to `true` while debugging redaction policy to see the raw cascade. `nil` resets to the default. Re-exported from `core`.
 
 The single normative emission site for `:sensitive?` redaction is the framework's `elide-wire-value` (see [framework API instrumentation §The wire-boundary walker](../../api/11-instrumentation.md#the-wire-boundary-walker)). Causa's gate just decides whether the redacted-out events reach the buffer at all.
 
@@ -128,11 +169,32 @@ The single normative emission site for `:sensitive?` redaction is the framework'
 
 The Settings popup carries the user-mutable knobs — theme, density, buffer depths, AI provider config, filter persistence settings. The bulk-set escape hatch lets a host ship its own default Settings shape; the per-knob writes flow through the popup's normal `:rf.causa/settings-update` event.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `update-setting!` | `(update-setting! path value)` → nil | v1 (dev-only) | Set one Settings slot. `path` is a vector into the settings map (e.g. `[:general :density]`); `value` is the new value. Persists through localStorage. The popup's event surface is the canonical write path; reach for this only from REPL / test contexts. |
-| `reset-settings!` | `(reset-settings!)` → nil | v1 (dev-only) | Reset every Settings slot to its default shape. Wipes the localStorage slot. Mostly a test-isolation helper; hosts that want to ship a non-default shape use `configure! {:rf.causa/settings ...}` instead. |
-| `reset-suppressed-count!` | `(reset-suppressed-count!)` → nil | v1 (dev-only) | Clear the `[● REDACTED N]` bottom-rail counter that surfaces when filters elide events. Reach for this when wiring a Settings-popup "Clear suppression counter" button or a test-harness fixture-reset. |
+### `update-setting!`
+
+- **Signature**:
+  ```clojure
+  (update-setting! path value) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Set one Settings slot. `path` is a vector into the settings map (e.g. `[:general :density]`); `value` is the new value. Persists through localStorage. The popup's event surface is the canonical write path; reach for this only from REPL / test contexts.
+
+### `reset-settings!`
+
+- **Signature**:
+  ```clojure
+  (reset-settings!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Reset every Settings slot to its default shape. Wipes the localStorage slot. Mostly a test-isolation helper; hosts that want to ship a non-default shape use `configure! {:rf.causa/settings ...}` instead.
+
+### `reset-suppressed-count!`
+
+- **Signature**:
+  ```clojure
+  (reset-suppressed-count!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Clear the `[● REDACTED N]` bottom-rail counter that surfaces when filters elide events. Reach for this when wiring a Settings-popup "Clear suppression counter" button or a test-harness fixture-reset.
 
 The Settings shape (validated by Malli):
 
@@ -160,10 +222,23 @@ The settings persist under the localStorage key `day8.re-frame2-causa/settings/v
 
 The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ frame`) that drive in / out filtering of the displayed events. Filter state persists in localStorage across reloads; hosts that want to seed a starting filter set on first install reach for the filters cluster.
 
-| Setter | Signature | Status | Intuition |
-|---|---|---|---|
-| `set-filter-seed!` | `(set-filter-seed! seed-map)` → nil | v1 (dev-only) | Host-supplied seed pill set the registry hydrates `:active-filters` with on FIRST install (when localStorage is empty). Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — first session boots with no filters (first-session honesty beats first-session quietness). Story testbeds use this to inject a known starting point for reproducibility. |
-| `set-filters-storage-key!` | `(set-filters-storage-key! key)` → nil | v1 (dev-only) | The localStorage key the filter persistence layer reads / writes. Default `"re-frame2.causa.filters.v1"`. Hosts that run multiple Causa instances (Story testbeds, multi-mode tool pages) override for isolation between instances. |
+### `set-filter-seed!`
+
+- **Signature**:
+  ```clojure
+  (set-filter-seed! seed-map) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Host-supplied seed pill set the registry hydrates `:active-filters` with on FIRST install (when localStorage is empty). Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — first session boots with no filters (first-session honesty beats first-session quietness). Story testbeds use this to inject a known starting point for reproducibility.
+
+### `set-filters-storage-key!`
+
+- **Signature**:
+  ```clojure
+  (set-filters-storage-key! key) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The localStorage key the filter persistence layer reads / writes. Default `"re-frame2.causa.filters.v1"`. Hosts that run multiple Causa instances (Story testbeds, multi-mode tool pages) override for isolation between instances.
 
 Set both *before* the preload runs so the first registry-handlers registration reads the right values.
 

--- a/docs/causa/api/mount-control.md
+++ b/docs/causa/api/mount-control.md
@@ -6,21 +6,63 @@ There's also a small JS-side mirror — the same six verbs exposed on `window.da
 
 ## The three open verbs
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `open!` | `(causa/open!)` → mount-state map or missing-host diagnostic map | v1 (dev-only) | Mount + show the shell true-inline into the host's normal-flow layout host (`[data-rf-causa-host]` by default). The canonical default. On first call, creates `#rf-causa-root` inside the host and renders the shell. On subsequent calls (already mounted), flips the container to `display: block`. No-op (returns `nil`) when no substrate adapter is installed. |
-| `open-overlay!` | `(causa/open-overlay!)` | v1 (dev-only) | Debug / fallback path: mount Causa as a fixed overlay under `<body>`. Floats above the host layout without participating in it. Reach for this when the host's normal-flow layout cannot accommodate a right column — a full-screen canvas tool, a story-only tool page, a prototype with no layout host. |
-| `popout!` | `(causa/popout!)` | v1 (dev-only) | Open Causa in a same-origin second window. The shell mounts into its own document context — own React root, own theme cascade, own keybinding listener. The popped window uses `window.opener` to reach the host's runtime, so all observation surfaces (trace bus, epoch history, registrar) work unchanged. Useful when the panel is competing with the app for screen space. |
+### `open!`
+
+- **Signature**:
+  ```clojure
+  (causa/open!) → mount-state map or missing-host diagnostic map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Mount + show the shell true-inline into the host's normal-flow layout host (`[data-rf-causa-host]` by default). The canonical default. On first call, creates `#rf-causa-root` inside the host and renders the shell. On subsequent calls (already mounted), flips the container to `display: block`. No-op (returns `nil`) when no substrate adapter is installed.
+
+### `open-overlay!`
+
+- **Signature**:
+  ```clojure
+  (causa/open-overlay!)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Debug / fallback path: mount Causa as a fixed overlay under `<body>`. Floats above the host layout without participating in it. Reach for this when the host's normal-flow layout cannot accommodate a right column — a full-screen canvas tool, a story-only tool page, a prototype with no layout host.
+
+### `popout!`
+
+- **Signature**:
+  ```clojure
+  (causa/popout!)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Open Causa in a same-origin second window. The shell mounts into its own document context — own React root, own theme cascade, own keybinding listener. The popped window uses `window.opener` to reach the host's runtime, so all observation surfaces (trace bus, epoch history, registrar) work unchanged. Useful when the panel is competing with the app for screen space.
 
 The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inline!` alias). Inline-vs-overlay-vs-window is a kind-of-mount axis, not a mode axis. A reader who treats `open!` / `open-overlay!` as "default vs overlay" and `popout!` as "its own verb" is reading the contract correctly — bare `open!` *is* the canonical default, and the asymmetry telegraphs the rank.
 
 ## Visibility control
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `close!` | `(causa/close!)` | v1 (dev-only) | Hide the shell — flip the container to `display: none`. The DOM tree and substrate render tree stay in place so re-opening is a CSS-only toggle (sub-80ms first paint). Use when the host wants to programmatically dismiss the panel without unmounting it. |
-| `toggle!` | `(causa/toggle!)` | v1 (dev-only) | Flip visibility. First call mounts + shows; subsequent calls toggle between `display: block` and `display: none`. The `Ctrl+Shift+C` global keybinding is wired to this. |
-| `status` | `(causa/status)` → map | v1 (dev-only) | Inspectable shell state. Returns `{:mounted? :visible? :last-host-diagnostic ...}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_causa.status()`. |
+### `close!`
+
+- **Signature**:
+  ```clojure
+  (causa/close!)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Hide the shell — flip the container to `display: none`. The DOM tree and substrate render tree stay in place so re-opening is a CSS-only toggle (sub-80ms first paint). Use when the host wants to programmatically dismiss the panel without unmounting it.
+
+### `toggle!`
+
+- **Signature**:
+  ```clojure
+  (causa/toggle!)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Flip visibility. First call mounts + shows; subsequent calls toggle between `display: block` and `display: none`. The `Ctrl+Shift+C` global keybinding is wired to this.
+
+### `status`
+
+- **Signature**:
+  ```clojure
+  (causa/status) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Inspectable shell state. Returns `{:mounted? :visible? :last-host-diagnostic ...}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_causa.status()`.
 
 ## Manual install — the alternative to `:preloads`
 
@@ -28,9 +70,15 @@ The canonical install path is wiring `day8.re-frame2-causa.preload` into shadow-
 
 For hosts that want to control the install timing — a custom boot pipeline with steps between adapter install and Causa attach, a test harness needing fine-grained sequencing, a host that ships its own preload bundle — `init!` is the alternative.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `init!` | `(init!)` / `(init! opts)` → nil | v1 (dev-only) | Mount Causa manually. Idempotent: a second call is a no-op (each underlying side-effect is `defonce`-guarded). Bypasses the preload path. Use when the `:preloads` wiring isn't available — test harnesses, host-controlled boot pipelines, dev builds with a custom preload bundle. |
+### `init!`
+
+- **Signature**:
+  ```clojure
+  (init!) → nil
+  (init! opts) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Mount Causa manually. Idempotent: a second call is a no-op (each underlying side-effect is `defonce`-guarded). Bypasses the preload path. Use when the `:preloads` wiring isn't available — test harnesses, host-controlled boot pipelines, dev builds with a custom preload bundle.
 
 The `opts` map accepts these keys today (pre-alpha — additional keys land under follow-on work):
 
@@ -48,10 +96,23 @@ Pre-alpha posture wires the four foundation side-effects (registry, trace collec
 
 Most apps run one host frame (`:rf/default`) and Causa observes it implicitly. Multi-frame hosts — Story, parallel-frames testbeds, story-mode chrome wrapping a tool surface — need to tell Causa which frame the scrubber and panels are observing.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `target-frame` | `(causa/target-frame)` → keyword | v1 (dev-only) | Read the currently-targeted host frame. Defaults to `:rf/default` until `set-target-frame!` flips it. One-shot read (does NOT register for reactive re-render). Reactive consumers subscribe to `:rf.causa/target-frame` directly via the framework's sub surface. |
-| `set-target-frame!` | `(causa/set-target-frame! frame-id)` → nil | v1 (dev-only) | Set the host frame Causa targets. Dispatches `:rf.causa/set-target-frame` into the `:rf/causa` frame so the sub and every dependent panel re-fire on the standard reactive path. `nil` resets to the default. |
+### `target-frame`
+
+- **Signature**:
+  ```clojure
+  (causa/target-frame) → keyword
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Read the currently-targeted host frame. Defaults to `:rf/default` until `set-target-frame!` flips it. One-shot read (does NOT register for reactive re-render). Reactive consumers subscribe to `:rf.causa/target-frame` directly via the framework's sub surface.
+
+### `set-target-frame!`
+
+- **Signature**:
+  ```clojure
+  (causa/set-target-frame! frame-id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Set the host frame Causa targets. Dispatches `:rf.causa/set-target-frame` into the `:rf/causa` frame so the sub and every dependent panel re-fire on the standard reactive path. `nil` resets to the default.
 
 The L1 frame picker chip in the shell's top strip is wired to this — clicking flips `set-target-frame!`, and every panel in view (Trace, Views, Machines, App-DB Diff) rescopes to the new frame. Hosts can drive the same flip programmatically from a per-route effect, a Settings-popup wire-up, or a test harness assertion.
 
@@ -59,9 +120,14 @@ The L1 frame picker chip in the shell's top strip is wired to this — clicking 
 
 One surface declared by the spec ships as a stub that emits a `:rf.warning/*` trace and otherwise no-ops.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `load-theme` | `(causa/load-theme css-string)` → nil | TBD-impl | Programmatically swap the Causa shell's CSS theme. The theme module exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-swap surface is not yet wired. Calling emits `:rf.warning/causa-load-theme-not-yet-implemented` so the gap is visible in the trace stream. Forward-compatible — host code may call with a CSS string today and expect the impl to land later. |
+### `load-theme`
+
+- **Signature**:
+  ```clojure
+  (causa/load-theme css-string) → nil
+  ```
+- **Status**: TBD-impl
+- **Description**: Programmatically swap the Causa shell's CSS theme. The theme module exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-swap surface is not yet wired. Calling emits `:rf.warning/causa-load-theme-not-yet-implemented` so the gap is visible in the trace stream. Forward-compatible — host code may call with a CSS string today and expect the impl to land later.
 
 ## The browser-global JS mirror
 

--- a/docs/causa/api/runtime-seam.md
+++ b/docs/causa/api/runtime-seam.md
@@ -40,10 +40,20 @@ Every mutation the runtime performs on behalf of a tool client carries `:tags :o
   :causa-mcp)
 ```
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `*current-origin*` | `^:dynamic` Var | v1 (dev-only) | Default `:causa-mcp`. The tool client wraps each eval'd form in `(binding [runtime/*current-origin* :my-tool] ...)` for the synchronous extent. |
-| `current-origin` | `(current-origin)` → keyword | v1 (dev-only) | Read accessor — answers "what's the current `:origin` tag?". Public so tests can pin the rebind contract without `#'`-piercing the dynamic var. |
+### `*current-origin*`
+
+- **Kind**: `^:dynamic` Var
+- **Status**: v1 (dev-only)
+- **Description**: Default `:causa-mcp`. The tool client wraps each eval'd form in `(binding [runtime/*current-origin* :my-tool] ...)` for the synchronous extent.
+
+### `current-origin`
+
+- **Signature**:
+  ```clojure
+  (current-origin) → keyword
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Read accessor — answers "what's the current `:origin` tag?". Public so tests can pin the rebind contract without `#'`-piercing the dynamic var.
 
 The async-tagging gap: a dispatched event's downstream cascade carries the origin only through the synchronous handler frame. Later cascades pick up the framework's natural origin tagging.
 
@@ -67,27 +77,118 @@ Callers pass plain `:include-sensitive?` / `:include-large?` opts; the runtime t
 
 Nine read-only accessors. Every one returns a map; success is `:ok? true`; failure is `:ok? false :reason <kw> :hint <str>`.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `get-trace-buffer` | `(get-trace-buffer opts)` → `{:ok? true :events <vec> :count <n>}` | v1 (dev-only) | Filtered slice of the framework's trace stream. Filter keys are the canonical Spec 009 vocabulary — `:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`. |
-| `get-epoch-history` | `(get-epoch-history opts)` → `{:ok? true :frame <id> :epochs <vec> :count <n>}` | v1 (dev-only) | The per-frame epoch ring buffer. Each epoch is a `:rf/epoch-record` (drain-completion snapshot with `:db-before` / `:db-after`). Default depth 50. |
-| `get-app-db` | `(get-app-db opts)` → `{:ok? true :frame <id> :path <vec> :value <edn>}` | v1 (dev-only) | The live `app-db` for a frame, optionally scoped by `:path` for sub-tree reads. Reads through `elide-wire-value` so `:sensitive?` / `:large?`-marked paths egress as elision markers. |
-| `get-app-db-diff` | `(get-app-db-diff opts)` → `{:ok? true :frame <id> :epoch-id <uuid> :diff {:before … :after …}}` | v1 (dev-only) | Reads `:db-before` + `:db-after` off a named epoch record. Heavy nested-diff projection lives on the MCP server side; this accessor returns the raw before / after pair. |
-| `get-machine-state` | `(get-machine-state opts)` → `{:ok? true :frame <id> :machine-id <kw> :state <edn>}` | v1 (dev-only) | Per-machine state read. The Stately-grade state-chart inspector reads this; tools that want machine-state pinning for a record-replay assertion compose against it directly. |
-| `get-machine-list` | `(get-machine-list opts)` → `{:ok? true :machines <map> :count <n>}` | v1 (dev-only) | Map of every machine registered in the active frame, keyed by machine-id. Used by the machine-inspector dropdown and by tools enumerating the machine surface. |
-| `get-issues` | `(get-issues opts)` → `{:ok? true :issues <vec> :count <n>}` | v1 (dev-only) | Projection over the trace buffer filtered to issue-tier op-types — `:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`. The Issues ribbon paints this; tools that want "what's broken right now?" reach for it. |
-| `get-handlers` | `(get-handlers opts)` → `{:ok? true :handlers <vec> :count <n>}` | v1 (dev-only) | Registrar listing, optionally narrowed by `:kind ∈ #{:event :sub :fx :cofx :machine :flow :reg-machine :frame :view}`. Source-coord metadata travels with each row. |
-| `get-source-coord` | `(get-source-coord opts)` → `{:ok? true :kind <kw> :id <any> :source-coord <map>}` | v1 (dev-only) | Per-registration source-coord projection. Resolves an event-id / sub-id / handler-id back to the `{:ns :file :line :column}` of where it was registered. The "click anywhere, walk to the line" backbone. |
+### `get-trace-buffer`
+
+- **Signature**:
+  ```clojure
+  (get-trace-buffer opts) → {:ok? true :events <vec> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Filtered slice of the framework's trace stream. Filter keys are the canonical Spec 009 vocabulary — `:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`.
+
+### `get-epoch-history`
+
+- **Signature**:
+  ```clojure
+  (get-epoch-history opts) → {:ok? true :frame <id> :epochs <vec> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The per-frame epoch ring buffer. Each epoch is a `:rf/epoch-record` (drain-completion snapshot with `:db-before` / `:db-after`). Default depth 50.
+
+### `get-app-db`
+
+- **Signature**:
+  ```clojure
+  (get-app-db opts) → {:ok? true :frame <id> :path <vec> :value <edn>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The live `app-db` for a frame, optionally scoped by `:path` for sub-tree reads. Reads through `elide-wire-value` so `:sensitive?` / `:large?`-marked paths egress as elision markers.
+
+### `get-app-db-diff`
+
+- **Signature**:
+  ```clojure
+  (get-app-db-diff opts) → {:ok? true :frame <id> :epoch-id <uuid> :diff {:before … :after …}}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Reads `:db-before` + `:db-after` off a named epoch record. Heavy nested-diff projection lives on the MCP server side; this accessor returns the raw before / after pair.
+
+### `get-machine-state`
+
+- **Signature**:
+  ```clojure
+  (get-machine-state opts) → {:ok? true :frame <id> :machine-id <kw> :state <edn>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Per-machine state read. The Stately-grade state-chart inspector reads this; tools that want machine-state pinning for a record-replay assertion compose against it directly.
+
+### `get-machine-list`
+
+- **Signature**:
+  ```clojure
+  (get-machine-list opts) → {:ok? true :machines <map> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Map of every machine registered in the active frame, keyed by machine-id. Used by the machine-inspector dropdown and by tools enumerating the machine surface.
+
+### `get-issues`
+
+- **Signature**:
+  ```clojure
+  (get-issues opts) → {:ok? true :issues <vec> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Projection over the trace buffer filtered to issue-tier op-types — `:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`. The Issues ribbon paints this; tools that want "what's broken right now?" reach for it.
+
+### `get-handlers`
+
+- **Signature**:
+  ```clojure
+  (get-handlers opts) → {:ok? true :handlers <vec> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Registrar listing, optionally narrowed by `:kind ∈ #{:event :sub :fx :cofx :machine :flow :reg-machine :frame :view}`. Source-coord metadata travels with each row.
+
+### `get-source-coord`
+
+- **Signature**:
+  ```clojure
+  (get-source-coord opts) → {:ok? true :kind <kw> :id <any> :source-coord <map>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Per-registration source-coord projection. Resolves an event-id / sub-id / handler-id back to the `{:ns :file :line :column}` of where it was registered. The "click anywhere, walk to the line" backbone.
 
 ## Mutation band
 
 Three write accessors. Every mutation tags the runtime cascade with `:tags :origin *current-origin*` so the action surfaces in the trace stream and downstream tool consumers can distinguish tool-driven cascades from app-driven ones.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `dispatch!` | `(dispatch! event-vec opts)` → `{:ok? true :event-id <kw> :frame <id> :origin <kw> :mode :queued/:sync}` | v1 (dev-only) | Fire an event tagged with the current origin. Modes: `:queued` (default — non-blocking `rf/dispatch`) or `:sync` (`rf/dispatch-sync`). Frame resolution mirrors the read-side accessors. |
-| `restore-epoch!` | `(restore-epoch! opts)` → `{:ok? true/false :frame <id> :epoch-id <uuid> :origin <kw>}` | v1 (dev-only) | Rewind a frame's `app-db` to the named epoch's `:db-after` via `rf/restore-epoch`. Failures (six documented modes — see [Tool-Pair §Time-travel — Restore](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md)) emit a structured `:rf.epoch/*` trace and leave `app-db` unchanged; the accessor surfaces `:reason :rf.epoch/restore-failed` + a hint pointing to the trace bus. |
-| `reset-frame-db!` | `(reset-frame-db! opts)` → `{:ok? true/false :frame <id> :origin <kw>}` | v1 (dev-only) | Inject `:value` into a frame's `app-db`. Schema-validates via `rf/reset-frame-db!`; the three failure rows (`:rf.error/no-such-handler` / `:rf.epoch/reset-frame-db-during-drain` / `:rf.epoch/reset-frame-db-schema-mismatch`) surface on the trace bus; the accessor projects `:reason :rf.epoch/reset-failed` + a hint. |
+### `dispatch!`
+
+- **Signature**:
+  ```clojure
+  (dispatch! event-vec opts)
+    → {:ok? true :event-id <kw> :frame <id> :origin <kw> :mode :queued/:sync}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Fire an event tagged with the current origin. Modes: `:queued` (default — non-blocking `rf/dispatch`) or `:sync` (`rf/dispatch-sync`). Frame resolution mirrors the read-side accessors.
+
+### `restore-epoch!`
+
+- **Signature**:
+  ```clojure
+  (restore-epoch! opts) → {:ok? true/false :frame <id> :epoch-id <uuid> :origin <kw>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Rewind a frame's `app-db` to the named epoch's `:db-after` via `rf/restore-epoch`. Failures (six documented modes — see [Tool-Pair §Time-travel — Restore](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md)) emit a structured `:rf.epoch/*` trace and leave `app-db` unchanged; the accessor surfaces `:reason :rf.epoch/restore-failed` + a hint pointing to the trace bus.
+
+### `reset-frame-db!`
+
+- **Signature**:
+  ```clojure
+  (reset-frame-db! opts) → {:ok? true/false :frame <id> :origin <kw>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Inject `:value` into a frame's `app-db`. Schema-validates via `rf/reset-frame-db!`; the three failure rows (`:rf.error/no-such-handler` / `:rf.epoch/reset-frame-db-during-drain` / `:rf.epoch/reset-frame-db-schema-mismatch`) surface on the trace bus; the accessor projects `:reason :rf.epoch/reset-failed` + a hint.
 
 The three together compose the Tool-Pair time-travel surface: read an epoch, restore to that epoch, or directly inject a known-good state for "try anyway" recovery.
 
@@ -95,45 +196,104 @@ The three together compose the Tool-Pair time-travel surface: read an epoch, res
 
 Three subscription-bookkeeping accessors. The runtime records metadata for in-flight subscriptions; per-tick drain pumps and queue-overflow bookkeeping live on the MCP server side.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `subscribe!` | `(subscribe! opts)` → `{:ok? true :sub-id <uuid> :topic <kw> :filter <map>}` | v1 (dev-only) | Open a streaming subscription for `:topic ∈ #{:trace :epoch :fx :error}` with `:filter`. The runtime records metadata; the MCP server's tick loop drains and forwards. |
-| `unsubscribe!` | `(unsubscribe! opts)` → `{:ok? true :sub-id <id> :existed? <bool>}` | v1 (dev-only) | Idempotent close. `:existed? false` for an unknown id. |
-| `list-subscriptions` | `(list-subscriptions)` → `{:ok? true :subs <vec> :count <n>}` | v1 (dev-only) | Diagnostic enumerating active runtime-side subscription metadata. Per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events` fields live on the MCP server side. |
+### `subscribe!`
+
+- **Signature**:
+  ```clojure
+  (subscribe! opts) → {:ok? true :sub-id <uuid> :topic <kw> :filter <map>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Open a streaming subscription for `:topic ∈ #{:trace :epoch :fx :error}` with `:filter`. The runtime records metadata; the MCP server's tick loop drains and forwards.
+
+### `unsubscribe!`
+
+- **Signature**:
+  ```clojure
+  (unsubscribe! opts) → {:ok? true :sub-id <id> :existed? <bool>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Idempotent close. `:existed? false` for an unknown id.
+
+### `list-subscriptions`
+
+- **Signature**:
+  ```clojure
+  (list-subscriptions) → {:ok? true :subs <vec> :count <n>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Diagnostic enumerating active runtime-side subscription metadata. Per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events` fields live on the MCP server side.
 
 ## Escape hatch
 
 One accessor handles arbitrary CLJS forms — the MCP server's `eval-cljs` channel renders the user-supplied form inside the runtime's `binding` wrapper.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `eval-form-result` | `(eval-form-result value opts)` → `{:ok? true :value <elided>}` | v1 (dev-only) | The runtime-side result shaper. The MCP server renders the user's form inside a `(binding [*current-origin* …] …)` wrapper, `cljs-eval`s the wrapped form directly, and the result passes through `eval-form-result` for privacy + size scrubbing. Caller's `:include-sensitive?` / `:include-large?` opts gate the egress. |
+### `eval-form-result`
+
+- **Signature**:
+  ```clojure
+  (eval-form-result value opts) → {:ok? true :value <elided>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The runtime-side result shaper. The MCP server renders the user's form inside a `(binding [*current-origin* …] …)` wrapper, `cljs-eval`s the wrapped form directly, and the result passes through `eval-form-result` for privacy + size scrubbing. Caller's `:include-sensitive?` / `:include-large?` opts gate the egress.
 
 ## Meta band
 
 Two introspection accessors used by the tool client's discovery + change-detect protocols.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `health` | `(health)` → `{:ok? true :session-id <uuid> :debug-enabled? <bool> :frames <vec> :ambiguous-frame? <bool> :coord-annotation-enabled? <bool> :origin <kw>}` | v1 (dev-only) | One-call summary of the runtime's view of the world. Side-effect-free — Causa-the-panel's preload owns the trace + epoch listeners; this accessor installs no listeners of its own. Used by `discover-app` tools. |
-| `tail-build-probe` | `(tail-build-probe)` → `{:ok? true :probe <int> :session-id <uuid> :build-tick <int>}` | v1 (dev-only) | Returns a fresh monotonic counter every call. MCP servers poll until the value changes — proving a hot-reload landed and the runtime re-evaluated. The counter survives `:after-load` (`defonce`) and resets only on full page refresh (same lifetime as `session-id`). Change-detect lives MCP-side. |
+### `health`
+
+- **Signature**:
+  ```clojure
+  (health)
+    → {:ok? true :session-id <uuid> :debug-enabled? <bool> :frames <vec>
+       :ambiguous-frame? <bool> :coord-annotation-enabled? <bool> :origin <kw>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: One-call summary of the runtime's view of the world. Side-effect-free — Causa-the-panel's preload owns the trace + epoch listeners; this accessor installs no listeners of its own. Used by `discover-app` tools.
+
+### `tail-build-probe`
+
+- **Signature**:
+  ```clojure
+  (tail-build-probe) → {:ok? true :probe <int> :session-id <uuid> :build-tick <int>}
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Returns a fresh monotonic counter every call. MCP servers poll until the value changes — proving a hot-reload landed and the runtime re-evaluated. The counter survives `:after-load` (`defonce`) and resets only on full page refresh (same lifetime as `session-id`). Change-detect lives MCP-side.
 
 ## Test support
 
 One test-fixture isolation helper. Production code never calls this.
 
-| Accessor | Signature | Status | Intuition |
-|---|---|---|---|
-| `reset-for-test!` | `(reset-for-test!)` → nil | v1 (test-only) | Clears `subscriptions` + `probe-counter` for fixture isolation. Does NOT touch `session-id` (per-preload constant by design) or the JS-global sentinel. Test-only — never call from production code. |
+### `reset-for-test!`
+
+- **Signature**:
+  ```clojure
+  (reset-for-test!) → nil
+  ```
+- **Status**: v1 (test-only)
+- **Description**: Clears `subscriptions` + `probe-counter` for fixture isolation. Does NOT touch `session-id` (per-preload constant by design) or the JS-global sentinel. Test-only — never call from production code.
 
 ## Keybinding lifecycle
 
 The keybinding lifecycle pair lives in a sibling namespace — `day8.re-frame2-causa.keybinding` — but its shape and intended audience put it closer to the runtime seam than to the mount facade. The pair is the embed-host escape hatch: hosts that mount Causa as a right-hand-side panel (Story, third-party tool surfaces) and want to take the `Ctrl+Shift+C` chord back reach for `detach!`.
 
-| API | Signature | Status | Intuition |
-|---|---|---|---|
-| `attach!` | `(attach!)` → nil | v1 (dev-only) | Install the global `Ctrl+Shift+C` keydown listener once. No-op on second + subsequent calls (the `attached-state` sentinel survives reloads). Honours the `:rf.causa/keybinding-enabled?` config slot — when `false` the listener is NOT installed. |
-| `detach!` | `(detach!)` → nil | v1 (dev-only) | Remove the global keydown listener if one is currently attached. Idempotent — safe to call when nothing is attached (no-op), and safe to call twice in a row (the second call is a no-op). Symmetric with `attach!`. |
+### `attach!`
+
+- **Signature**:
+  ```clojure
+  (attach!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Install the global `Ctrl+Shift+C` keydown listener once. No-op on second + subsequent calls (the `attached-state` sentinel survives reloads). Honours the `:rf.causa/keybinding-enabled?` config slot — when `false` the listener is NOT installed.
+
+### `detach!`
+
+- **Signature**:
+  ```clojure
+  (detach!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Remove the global keydown listener if one is currently attached. Idempotent — safe to call when nothing is attached (no-op), and safe to call twice in a row (the second call is a no-op). Symmetric with `attach!`.
 
 The two surfaces compose: standalone Causa calls `attach!` from the preload's six side-effects; an embed host that loaded Causa first and wants to take the chord back from inside its own mount lifecycle calls `detach!` after Causa has already attached.
 

--- a/docs/story/api/play-script.md
+++ b/docs/story/api/play-script.md
@@ -107,14 +107,59 @@ A passing assertion proves the observation surface saw a sentinel, not the secre
 
 Story's canvas recorder captures dispatched events and DOM-level interactions into a paste-ready `:play-script` body. The facade exposes six entries on `re-frame.story`.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `start-recording!` | `(start-recording! variant-id)` → nil | v1 (dev-only) | Begin recording dispatched events against `variant-id`'s frame. The recorder filters on dispatch-provenance `:rf.story/source :user` — setup-phase events (`:variant-events`) are excluded. |
-| `stop-recording!` | `(stop-recording!)` → events-vec | v1 (dev-only) | Stop the in-flight recording; return the captured events vector. |
-| `clear-recording!` | `(clear-recording!)` → nil | v1 (dev-only) | Drop the buffer + return the recorder to idle. |
-| `recording?` | `(recording?)` → bool | v1 (dev-only) | Predicate — is a recording in flight? |
-| `recorder-state` | `(recorder-state)` → map | v1 (dev-only) | Read-only view of the current recorder state map. |
-| `gen-play-snippet` | `(gen-play-snippet events opts)` → string | v1 (dev-only) | Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play-script {:script [...]}})` EDN snippet. Each captured event vector is wrapped as `[:dispatch-sync <event-vec>]`. |
+### `start-recording!`
+
+- **Signature**:
+  ```clojure
+  (start-recording! variant-id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Begin recording dispatched events against `variant-id`'s frame. The recorder filters on dispatch-provenance `:rf.story/source :user` — setup-phase events (`:variant-events`) are excluded.
+
+### `stop-recording!`
+
+- **Signature**:
+  ```clojure
+  (stop-recording!) → events-vec
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Stop the in-flight recording; return the captured events vector.
+
+### `clear-recording!`
+
+- **Signature**:
+  ```clojure
+  (clear-recording!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Drop the buffer + return the recorder to idle.
+
+### `recording?`
+
+- **Signature**:
+  ```clojure
+  (recording?) → bool
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Predicate — is a recording in flight?
+
+### `recorder-state`
+
+- **Signature**:
+  ```clojure
+  (recorder-state) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Read-only view of the current recorder state map.
+
+### `gen-play-snippet`
+
+- **Signature**:
+  ```clojure
+  (gen-play-snippet events opts) → string
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play-script {:script [...]}})` EDN snippet. Each captured event vector is wrapped as `[:dispatch-sync <event-vec>]`.
 
 The facade's `gen-play-snippet` is the simpler event-vector → `:dispatch-sync` step projection. A typical recorder modal calls `start-recording!` on the *record* chip click, hooks the user's canvas interaction, then on *stop* calls `stop-recording!` + `gen-play-snippet` to render the modal's EDN body.
 
@@ -122,11 +167,32 @@ The facade's `gen-play-snippet` is the simpler event-vector → `:dispatch-sync`
 
 The richer DOM-capture-aware translator (tagged `:click` / `:type` / `:wait` steps derived from the recorder's `:entries` capture stream) is exported by `re-frame.story.recorder.play-export` — a sub-namespace, not re-exported through `re-frame.story`. The facade exposes only `gen-play-snippet`; consumers wanting the rich DOM-derived DSL `:require` the sub-namespace directly.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `recording->play-script` | `(recording->play-script entries opts)` → map | v1 (dev-only) | Translate captured `:entries` into a normalised `:play-script` body map. Derives `[:click selector]`, `[:type selector text]`, `[:wait ms]` steps from the entries stream. |
-| `render-play-script` | `(render-play-script body)` → string | v1 (dev-only) | Render the `:play-script` map to EDN. |
-| `render-variant-form` | `(render-variant-form variant-id metadata)` → string | v1 (dev-only) | Render a full `(reg-variant <id> {...})` form to EDN. |
+### `recording->play-script`
+
+- **Signature**:
+  ```clojure
+  (recording->play-script entries opts) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Translate captured `:entries` into a normalised `:play-script` body map. Derives `[:click selector]`, `[:type selector text]`, `[:wait ms]` steps from the entries stream.
+
+### `render-play-script`
+
+- **Signature**:
+  ```clojure
+  (render-play-script body) → string
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Render the `:play-script` map to EDN.
+
+### `render-variant-form`
+
+- **Signature**:
+  ```clojure
+  (render-variant-form variant-id metadata) → string
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Render a full `(reg-variant <id> {...})` form to EDN.
 
 Lives in `re-frame.story.recorder.play-export`. Two `:require`s — `[re-frame.story :as story]` for the facade plus `[re-frame.story.recorder.play-export :as play-export]` for the rich translator.
 

--- a/docs/story/api/registration.md
+++ b/docs/story/api/registration.md
@@ -8,15 +8,75 @@ Every registration is **idempotent**: re-registering the same id replaces the en
 
 All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programmatic use.
 
-| Macro | Kind | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-story` | M | `(reg-story id metadata)` | v1 (dev-only) | Register a story (a cluster of variants under one heading). `metadata` is an EDN map with `:doc`, `:component`, `:args`, `:tags`, `:decorators`, and optional `:variants` (Form B desugaring). |
-| `reg-variant` | M | `(reg-variant id metadata)` | v1 (dev-only) | Register one variant — view, args, setup events, decorators, `:play-script`. The single most-called macro in a typical stories namespace. |
-| `reg-workspace` | M | `(reg-workspace id metadata)` | v1 (dev-only) | Register a workspace — a curated grid of variants for side-by-side review. `metadata` carries `:doc`, `:cells` (an ordered vector of variant ids), and optional `:layout`. |
-| `reg-decorator` | M | `(reg-decorator id metadata)` | v1 (dev-only) | Register a decorator — a fn that wraps a variant's render (locale provider, theme provider, mock-API context). Three kinds: `:hiccup` (wraps the rendered tree), `:frame-setup` (runs at frame creation), `:fx-override` (registers fx stubs). |
-| `reg-story-panel` | M | `(reg-story-panel id metadata)` | v1 (dev-only) | Register a custom panel in the Story chrome — the inspection / control panes that sit beside the rendered variant. Late-bind via `:render` as a `:view` id. Five placement slots: `:right` / `:left` / `:bottom` / `:top` / `:modal`. |
-| `reg-tag` | M | `(reg-tag id metadata)` | v1 (dev-only) | Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`, `:agent`) auto-install on first registration. |
-| `reg-mode` | M | `(reg-mode id metadata)` | v1 (dev-only) | Register a mode — a saved tuple of args the chrome toggles into (light/dark theme, en/fr locale, desktop/mobile viewport). Layer 3 of the five-layer args precedence chain. |
+### `reg-story`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-story id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a story (a cluster of variants under one heading). `metadata` is an EDN map with `:doc`, `:component`, `:args`, `:tags`, `:decorators`, and optional `:variants` (Form B desugaring).
+
+### `reg-variant`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-variant id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register one variant — view, args, setup events, decorators, `:play-script`. The single most-called macro in a typical stories namespace.
+
+### `reg-workspace`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-workspace id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a workspace — a curated grid of variants for side-by-side review. `metadata` carries `:doc`, `:cells` (an ordered vector of variant ids), and optional `:layout`.
+
+### `reg-decorator`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-decorator id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a decorator — a fn that wraps a variant's render (locale provider, theme provider, mock-API context). Three kinds: `:hiccup` (wraps the rendered tree), `:frame-setup` (runs at frame creation), `:fx-override` (registers fx stubs).
+
+### `reg-story-panel`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-story-panel id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a custom panel in the Story chrome — the inspection / control panes that sit beside the rendered variant. Late-bind via `:render` as a `:view` id. Five placement slots: `:right` / `:left` / `:bottom` / `:top` / `:modal`.
+
+### `reg-tag`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-tag id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`, `:agent`) auto-install on first registration.
+
+### `reg-mode`
+
+- **Kind**: macro
+- **Signature**:
+  ```clojure
+  (reg-mode id metadata)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a mode — a saved tuple of args the chrome toggles into (light/dark theme, en/fr locale, desktop/mobile viewport). Layer 3 of the five-layer args precedence chain.
 
 The macros expand to their `*`-suffix runtime fns — `reg-story` expands to `(reg-story* id body)` — so the canonical-vocabulary auto-install (see below) fires from the macro form, programmatic-form, or fixture-load form alike.
 
@@ -39,25 +99,106 @@ The expansion produces three `reg-variant` calls — `:story.counter/empty`, `:s
 
 All under `re-frame.story`. The `*`-suffix helpers are the programmatic write path; the macros above expand into them.
 
-| Fn | Kind | Signature | Status | Intuition |
-|---|---|---|---|---|
-| `reg-story*` | Fn | `(reg-story* id body)` | v1 (dev-only) | Programmatic story registration. |
-| `reg-variant*` | Fn | `(reg-variant* id body)` | v1 (dev-only) | Programmatic variant registration. |
-| `reg-workspace*` | Fn | `(reg-workspace* id body)` | v1 (dev-only) | Programmatic workspace registration. |
-| `reg-mode*` | Fn | `(reg-mode* id body)` | v1 (dev-only) | Programmatic mode registration. |
-| `reg-story-panel*` | Fn | `(reg-story-panel* id body)` | v1 (dev-only) | Programmatic panel registration. |
-| `reg-decorator*` | Fn | `(reg-decorator* id body)` | v1 (dev-only) | Programmatic decorator registration. |
-| `reg-tag*` | Fn | `(reg-tag* id body)` | v1 (dev-only) | Programmatic tag registration. |
+### `reg-story*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-story* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic story registration.
+
+### `reg-variant*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-variant* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic variant registration.
+
+### `reg-workspace*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-workspace* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic workspace registration.
+
+### `reg-mode*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-mode* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic mode registration.
+
+### `reg-story-panel*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-story-panel* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic panel registration.
+
+### `reg-decorator*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-decorator* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic decorator registration.
+
+### `reg-tag*`
+
+- **Kind**: function
+- **Signature**:
+  ```clojure
+  (reg-tag* id body)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Programmatic tag registration.
 
 Reach for the `*` forms when authoring inside a higher-order fn, a fixture loader, an MCP write tool, or a hot-reload pipeline that synthesises registrations from another data source. Authoring-site registrations use the macros above; both paths land on the same registrar side-table and fire the same auto-install gate.
 
 ## Unregister + reset
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `unregister!` | `(unregister! kind id)` → nil | v1 (dev-only) | Remove a single id under `kind`. Kinds: `:story` / `:variant` / `:workspace` / `:story-panel` / `:tag` / `:mode` / `:decorator`. |
-| `clear-kind!` | `(clear-kind! kind)` → nil | v1 (dev-only) | Remove every registration of `kind`. Used by test fixtures and hot-reload. |
-| `clear-all!` | `(clear-all!)` → nil | v1 (dev-only) | Reset every Story registration. Wipes the registrar's side-table AND clears the global-decorators vector AND resets the auto-install gate so the next `reg-*` re-installs the canonical vocabulary. |
+### `unregister!`
+
+- **Signature**:
+  ```clojure
+  (unregister! kind id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Remove a single id under `kind`. Kinds: `:story` / `:variant` / `:workspace` / `:story-panel` / `:tag` / `:mode` / `:decorator`.
+
+### `clear-kind!`
+
+- **Signature**:
+  ```clojure
+  (clear-kind! kind) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Remove every registration of `kind`. Used by test fixtures and hot-reload.
+
+### `clear-all!`
+
+- **Signature**:
+  ```clojure
+  (clear-all!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Reset every Story registration. Wipes the registrar's side-table AND clears the global-decorators vector AND resets the auto-install gate so the next `reg-*` re-installs the canonical vocabulary.
 
 `clear-all!` is the test-isolation primitive. Tests that want a known starting state call `clear-all!` in a fixture; the next `reg-*` in the test body auto-installs the canonical vocabulary (the seven canonical tags, the `:rf.assert/*` handlers, `force-fx-stub`, the layout-debug decorator trio, the lifecycle machine, the v1.0 panel set) before the test's own registrations land.
 
@@ -67,9 +208,14 @@ The canonical Story vocabulary auto-installs on the first `reg-*` call. Authors 
 
 The seven `reg-*` macros expand to their `*`-fn helpers, and the first call to ANY of those helpers flips a single boolean gate in `re-frame.story.canonical` and runs the installer chain: register the seven canonical tags, register the `:rf.assert/*` event handlers, register the `force-fx-stub` decorator, register the layout-debug decorator trio, register the toolbar cofx + subs, register the lifecycle machine, register the v1.0 SOTA panel set, and (CLJS only) register the multi-substrate Reagent default.
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `install-canonical-vocabulary!` | `(install-canonical-vocabulary!)` → nil | v1 (dev-only) | Idempotent explicit boot. New code should rely on the auto-install path — the explicit call is retained only as a literal-boot affordance for hosts that want one and as a JVM-test diagnostic that asserts a known starting state without a body-of-test `reg-*` call. |
+### `install-canonical-vocabulary!`
+
+- **Signature**:
+  ```clojure
+  (install-canonical-vocabulary!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Idempotent explicit boot. New code should rely on the auto-install path — the explicit call is retained only as a literal-boot affordance for hosts that want one and as a JVM-test diagnostic that asserts a known starting state without a body-of-test `reg-*` call.
 
 The auto-install gate flips true *before* the installer chain runs, so the registrar writes triggered by the chain itself hit the early-return branch and don't recurse. Subsequent `reg-*` calls (after the gate has flipped) are a single `deref` + `nil` check — negligible on the hot path.
 
@@ -79,12 +225,42 @@ The auto-install gate flips true *before* the installer chain runs, so the regis
 
 Layer 1 of the five-layer args precedence chain (global → story → mode → variant → cell-override) and the global-decorator stack are both project-wide defaults the host application sets once at boot. Both flow through `configure!`; the global-decorator stack additionally has per-registration helpers for the common "register-and-opt-in" path.
 
-| Surface | Signature | Status | Intuition |
-|---|---|---|---|
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level Story configuration. See [Runtime §configure!](runtime.md#configure) for the full key surface. The two relevant keys here are `:rf.story/global-args` (replace the global args map) and `:rf.story/global-decorators` (replace the global-decorator ref vector). |
-| `reg-global-decorator` | `(reg-global-decorator id body)` / `(reg-global-decorator id body ref-args)` → id | v1 (dev-only) | Register a decorator AND opt it into the global stack in one call. Symmetric to the host calling `reg-decorator` + `configure! {:rf.story/global-decorators [...]}` in sequence; preferred when the decorator is exclusively a global-stack member. Earliest-registered-first; re-registering the same id REPLACES the entry in place (same position in the global vector) so hot-reload doesn't reshuffle the stack order. |
-| `unreg-global-decorator!` | `(unreg-global-decorator! id)` → nil | v1 (dev-only) | Remove `id` from the global-decorators vector. The decorator's registration body is NOT unregistered — call `unregister!` for that. Idempotent. |
-| `global-decorators` | `(global-decorators)` → vec | v1 (dev-only) | Return the current ordered vector of global-decorator references (`[[decorator-id & args] ...]`). Earliest-registered first; this is the prefix applied to every variant's resolved decorator stack. |
+### `configure!` (global args + decorators)
+
+- **Signature**:
+  ```clojure
+  (configure! opts) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Top-level Story configuration. See [Runtime §configure!](runtime.md#configure) for the full key surface. The two relevant keys here are `:rf.story/global-args` (replace the global args map) and `:rf.story/global-decorators` (replace the global-decorator ref vector).
+
+### `reg-global-decorator`
+
+- **Signature**:
+  ```clojure
+  (reg-global-decorator id body) → id
+  (reg-global-decorator id body ref-args) → id
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a decorator AND opt it into the global stack in one call. Symmetric to the host calling `reg-decorator` + `configure! {:rf.story/global-decorators [...]}` in sequence; preferred when the decorator is exclusively a global-stack member. Earliest-registered-first; re-registering the same id REPLACES the entry in place (same position in the global vector) so hot-reload doesn't reshuffle the stack order.
+
+### `unreg-global-decorator!`
+
+- **Signature**:
+  ```clojure
+  (unreg-global-decorator! id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Remove `id` from the global-decorators vector. The decorator's registration body is NOT unregistered — call `unregister!` for that. Idempotent.
+
+### `global-decorators`
+
+- **Signature**:
+  ```clojure
+  (global-decorators) → vec
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Return the current ordered vector of global-decorator references (`[[decorator-id & args] ...]`). Earliest-registered first; this is the prefix applied to every variant's resolved decorator stack.
 
 The five-layer precedence diagram (later wins):
 
@@ -104,12 +280,29 @@ Each layer scopes a different authoring intent: global args ride boot configurat
 
 Three built-in decorators ship with Story's canonical vocabulary. Each has a public `*-id` Var on `re-frame.story` for use in variant `:decorators` slots — the Var pattern lets the registered-id keyword stay opaque (Story can rename the underlying registration without breaking author code).
 
-| Var | Status | Intuition |
-|---|---|---|
-| `force-fx-stub-id` | v1 (dev-only) | The registered decorator id for the built-in `force-fx-stub` decorator — Story's universal effect-mocking primitive. One decorator covers HTTP, websockets, analytics, storage, navigation, geolocation, and anything else registered with `reg-fx`. |
-| `layout-debug-measure-id` | v1 (dev-only) | The Storybook-style layout measure overlay decorator id. Surfaces margin / padding / size annotations on every descendant element. |
-| `layout-debug-outline-id` | v1 (dev-only) | The Pesticide-style coloured outlines decorator id. Surfaces every descendant element's box with a per-element-type colour. |
-| `layout-debug-pseudo-id` | v1 (dev-only) | The pseudo-state forcing decorator id. Ref-args is a set from `#{:hover :focus :active :visited}`; default is `#{:hover}`. |
+### `force-fx-stub-id`
+
+- **Kind**: Var
+- **Status**: v1 (dev-only)
+- **Description**: The registered decorator id for the built-in `force-fx-stub` decorator — Story's universal effect-mocking primitive. One decorator covers HTTP, websockets, analytics, storage, navigation, geolocation, and anything else registered with `reg-fx`.
+
+### `layout-debug-measure-id`
+
+- **Kind**: Var
+- **Status**: v1 (dev-only)
+- **Description**: The Storybook-style layout measure overlay decorator id. Surfaces margin / padding / size annotations on every descendant element.
+
+### `layout-debug-outline-id`
+
+- **Kind**: Var
+- **Status**: v1 (dev-only)
+- **Description**: The Pesticide-style coloured outlines decorator id. Surfaces every descendant element's box with a per-element-type colour.
+
+### `layout-debug-pseudo-id`
+
+- **Kind**: Var
+- **Status**: v1 (dev-only)
+- **Description**: The pseudo-state forcing decorator id. Ref-args is a set from `#{:hover :focus :active :visited}`; default is `#{:hover}`.
 
 Worked example:
 
@@ -130,10 +323,23 @@ Worked example:
 
 Story authors declare per-frame path-marks against `app-db` using the framework's `add-marks` / `set-marks` primitives. Both are re-exported from `re-frame.core` for author-discoverability — same primitives, same data model, same per-frame semantics — so authors scanning `re-frame.story`'s public surface for privacy primitives find them without chasing cross-references.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `add-marks` | `(add-marks variant-id marks-map)` → nil | v1 (dev-only) | Merge marks additively into the variant frame's mark-set. Re-export of `re-frame.core/add-marks`. |
-| `set-marks` | `(set-marks variant-id marks-map)` → nil | v1 (dev-only) | Replace the variant frame's mark-set wholesale. Re-export of `re-frame.core/set-marks`. |
+### `add-marks`
+
+- **Signature**:
+  ```clojure
+  (add-marks variant-id marks-map) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Merge marks additively into the variant frame's mark-set. Re-export of `re-frame.core/add-marks`.
+
+### `set-marks`
+
+- **Signature**:
+  ```clojure
+  (set-marks variant-id marks-map) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Replace the variant frame's mark-set wholesale. Re-export of `re-frame.core/set-marks`.
 
 A `marks-map` is `{path mark, ...}` where `path` is a `get-in`-shaped vector and `mark` is one of `:sensitive` / `:large`. Variant-body usage scopes marks to that variant's frame; the framework's `elide-wire-value` walker substitutes `:rf/redacted` / `:rf/large` at every wire-egress observation point.
 

--- a/docs/story/api/runtime.md
+++ b/docs/story/api/runtime.md
@@ -37,15 +37,70 @@ Phase 1 and 4 are async-safe; phases 2 and 3 are sync. Loader failure modes are 
 
 All under `re-frame.story`. Reach for these from a custom shell, a test fixture, a `cljs.test` adapter, an MCP-tool body, or any host that wants to materialise a variant outside the standard Story chrome.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `run-variant` | `(run-variant variant-id)` / `(run-variant variant-id opts)` → result-map | v1 (dev-only) | Materialise the variant — allocate the frame, run the four-phase lifecycle, return the result map. One-shot; no live updates. The result carries `:frame` / `:app-db` / `:assertions` / `:rendered-hiccup` / `:elapsed-ms` / `:snapshot` / `:decorators`. |
-| `reset-variant` | `(reset-variant variant-id)` → nil | v1 (dev-only) | Reset the variant's frame to its post-events baseline. The Story shell calls this when the user clicks "reset" on a variant. |
-| `watch-variant` | `(watch-variant variant-id)` → live-result-map / `(watch-variant variant-id callback)` | v1 (dev-only) | Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots. |
-| `unwatch-variant` | `(unwatch-variant variant-id)` → nil | v1 (dev-only) | Stop the live update channel for `variant-id`. Idempotent. |
-| `destroy-variant!` | `(destroy-variant! variant-id)` → nil | v1 (dev-only) | Tear down the variant's frame. Any spawned state-machines receive their `:rf.machine/destroy` event. Idempotent. |
-| `execute-play!` | `(execute-play! variant-id)` → assertions-vec | v1 (dev-only) | Re-run only phase 4 (the `:play-script`) against the variant's current `app-db`. Use for the play-stepper UI's "re-run from here" affordance. |
-| `lifecycle-state` | `(lifecycle-state variant-id)` → keyword | v1 (dev-only) | The current state of the variant's lifecycle machine — one of `:idle` / `:loading` / `:events` / `:rendering` / `:playing` / `:done` / `:error`. |
+### `run-variant`
+
+- **Signature**:
+  ```clojure
+  (run-variant variant-id) → result-map
+  (run-variant variant-id opts) → result-map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Materialise the variant — allocate the frame, run the four-phase lifecycle, return the result map. One-shot; no live updates. The result carries `:frame` / `:app-db` / `:assertions` / `:rendered-hiccup` / `:elapsed-ms` / `:snapshot` / `:decorators`.
+
+### `reset-variant`
+
+- **Signature**:
+  ```clojure
+  (reset-variant variant-id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Reset the variant's frame to its post-events baseline. The Story shell calls this when the user clicks "reset" on a variant.
+
+### `watch-variant`
+
+- **Signature**:
+  ```clojure
+  (watch-variant variant-id) → live-result-map
+  (watch-variant variant-id callback)
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots.
+
+### `unwatch-variant`
+
+- **Signature**:
+  ```clojure
+  (unwatch-variant variant-id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Stop the live update channel for `variant-id`. Idempotent.
+
+### `destroy-variant!`
+
+- **Signature**:
+  ```clojure
+  (destroy-variant! variant-id) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Tear down the variant's frame. Any spawned state-machines receive their `:rf.machine/destroy` event. Idempotent.
+
+### `execute-play!`
+
+- **Signature**:
+  ```clojure
+  (execute-play! variant-id) → assertions-vec
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Re-run only phase 4 (the `:play-script`) against the variant's current `app-db`. Use for the play-stepper UI's "re-run from here" affordance.
+
+### `lifecycle-state`
+
+- **Signature**:
+  ```clojure
+  (lifecycle-state variant-id) → keyword
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The current state of the variant's lifecycle machine — one of `:idle` / `:loading` / `:events` / `:rendering` / `:playing` / `:done` / `:error`.
 
 The `opts` map for `run-variant` accepts:
 
@@ -71,62 +126,259 @@ The result map shape:
 
 ## Args + decorator resolution
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` → map | v1 (dev-only) | Materialise the effective args map for a variant given the active modes + cell overrides. The five-layer precedence chain (global → story → mode → variant → cell-override), deep-merged for maps, vector-replaced for vectors. |
-| `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` → map | v1 (dev-only) | Return the variant's resolved decorator stack classified by kind: `{:hiccup [...] :frame-setup [...] :fx-override [...] :errors [...]}`. Composition order: `(concat globals story variant)`. |
-| `variant-frames` | `(variant-frames)` → set | v1 (dev-only) | The set of variant-ids currently allocated as frames. |
-| `variant-frame?` | `(variant-frame? variant-id)` → bool | v1 (dev-only) | Predicate. |
+### `resolve-args`
+
+- **Signature**:
+  ```clojure
+  (resolve-args variant-id) → map
+  (resolve-args variant-id opts) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Materialise the effective args map for a variant given the active modes + cell overrides. The five-layer precedence chain (global → story → mode → variant → cell-override), deep-merged for maps, vector-replaced for vectors.
+
+### `resolve-decorators`
+
+- **Signature**:
+  ```clojure
+  (resolve-decorators variant-id) → map
+  (resolve-decorators variant-id opts) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Return the variant's resolved decorator stack classified by kind: `{:hiccup [...] :frame-setup [...] :fx-override [...] :errors [...]}`. Composition order: `(concat globals story variant)`.
+
+### `variant-frames`
+
+- **Signature**:
+  ```clojure
+  (variant-frames) → set
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The set of variant-ids currently allocated as frames.
+
+### `variant-frame?`
+
+- **Signature**:
+  ```clojure
+  (variant-frame? variant-id) → bool
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Predicate.
 
 ## Snapshot identity + share
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `snapshot-identity` | `(snapshot-identity variant-id)` / `(snapshot-identity variant-id opts)` → map | v1 (dev-only) | The variant's snapshot identity — the variant id plus a content-hash over its setup (args, events, modes, substrate). Returns `{:variant-id ... :content-hash "..."}`. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. The hash computes over real values (pre-substitution); downstream emission goes through `elide-wire-value`. |
-| `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id base-url opts)` → string | v1 (dev-only) | Build a sharable URL for `variant-id` against `base-url`. Encodes active modes + cell-overrides + substrate so a scan-and-share session reproduces the cell. Pure data → data; JVM + CLJS portable. |
+### `snapshot-identity`
+
+- **Signature**:
+  ```clojure
+  (snapshot-identity variant-id) → map
+  (snapshot-identity variant-id opts) → map
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The variant's snapshot identity — the variant id plus a content-hash over its setup (args, events, modes, substrate). Returns `{:variant-id ... :content-hash "..."}`. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. The hash computes over real values (pre-substitution); downstream emission goes through `elide-wire-value`.
+
+### `variant-share-url`
+
+- **Signature**:
+  ```clojure
+  (variant-share-url variant-id) → string
+  (variant-share-url variant-id base-url opts) → string
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Build a sharable URL for `variant-id` against `base-url`. Encodes active modes + cell-overrides + substrate so a scan-and-share session reproduces the cell. Pure data → data; JVM + CLJS portable.
 
 ## Assertion-side accessors
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `read-assertions` | `(read-assertions variant-id)` → assertions-vec | v1 (dev-only) | The current `:rf.story/assertions` vector for `variant-id`. Each entry is a `:rf.assert/*` record. |
-| `assertions-passing?` | `(assertions-passing? result)` → bool | v1 (dev-only) | Project over a `run-variant` result map (or a raw assertions vector) — true iff every record is `:passed? true`. The single primitive a `cljs.test`-style adapter calls. |
-| `canonical-assertion-ids` | `(canonical-assertion-ids)` → set | v1 (dev-only) | The seven canonical `:rf.assert/*` event-ids as a set, for tooling that enumerates the assertion vocabulary. |
+### `read-assertions`
+
+- **Signature**:
+  ```clojure
+  (read-assertions variant-id) → assertions-vec
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The current `:rf.story/assertions` vector for `variant-id`. Each entry is a `:rf.assert/*` record.
+
+### `assertions-passing?`
+
+- **Signature**:
+  ```clojure
+  (assertions-passing? result) → bool
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Project over a `run-variant` result map (or a raw assertions vector) — true iff every record is `:passed? true`. The single primitive a `cljs.test`-style adapter calls.
+
+### `canonical-assertion-ids`
+
+- **Signature**:
+  ```clojure
+  (canonical-assertion-ids) → set
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The seven canonical `:rf.assert/*` event-ids as a set, for tooling that enumerates the assertion vocabulary.
 
 ## Registry queries
 
 The query family Story exposes for its own chrome, the MCP jar, and any tooling that walks the registrar's side-table.
 
-| Fn | Signature | Returns |
-|---|---|---|
-| `registrations` | `(registrations kind)` | All registrations for `kind` (Story kinds: `:story`, `:variant`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`). |
-| `handler-meta` | `(handler-meta kind id)` | The registered body for `id`. |
-| `ids` | `(ids kind)` | All registered ids of `kind`. |
-| `registered?` | `(registered? kind id)` → bool | Predicate. |
-| `all-kinds-with-counts` | `(all-kinds-with-counts)` | Map from each registered kind to its count. |
-| `variants-of` | `(variants-of story-id)` | Variant ids whose namespaced id-prefix matches `story-id`. |
-| `variants-by-story` | `(variants-by-story)` | Map from parent-story-id to its variant ids. |
-| `variants-with-tags` | `(variants-with-tags tag-set)` | Variant ids whose `:tags` intersect the filter set. |
-| `list-tags` | `(list-tags)` | All registered tags (canonical + project). |
-| `list-modes` | `(list-modes)` | All registered modes. |
-| `canonical-tags` | Var (set) | The seven canonical tags. |
-| `canonical-axes` | Var | The four canonical axes (audience / lifecycle / quality / status). |
-| `canonical-status-values` | Var | The status-axis tag values. |
-| `canonical-role-values` | Var | The role-axis tag values. |
-| `tags-by-axis` | `(tags-by-axis)` | Map from axis → tag-ids registered against it. |
-| `tags-without-axis` | `(tags-without-axis)` | Tags not registered against any axis (project tags). |
-| `tags-default-excluded` | `(tags-default-excluded)` | Tags the sidebar tag-filter excludes by default. |
-| `tag->axis-index` | `(tag->axis-index)` | Map from tag-id → axis. |
-| `registered-substrates` | `(registered-substrates)` | CLJS-only. The substrate set as registered via `register-substrate!`. |
-| `variant-substrates` | `(variant-substrates variant-id)` | The substrate set for a specific variant. |
+### `registrations`
+
+- **Signature**:
+  ```clojure
+  (registrations kind)
+  ```
+- **Description**: All registrations for `kind` (Story kinds: `:story`, `:variant`, `:workspace`, `:story-panel`, `:tag`, `:mode`, `:decorator`).
+
+### `handler-meta`
+
+- **Signature**:
+  ```clojure
+  (handler-meta kind id)
+  ```
+- **Description**: The registered body for `id`.
+
+### `ids`
+
+- **Signature**:
+  ```clojure
+  (ids kind)
+  ```
+- **Description**: All registered ids of `kind`.
+
+### `registered?`
+
+- **Signature**:
+  ```clojure
+  (registered? kind id) → bool
+  ```
+- **Description**: Predicate.
+
+### `all-kinds-with-counts`
+
+- **Signature**:
+  ```clojure
+  (all-kinds-with-counts)
+  ```
+- **Description**: Map from each registered kind to its count.
+
+### `variants-of`
+
+- **Signature**:
+  ```clojure
+  (variants-of story-id)
+  ```
+- **Description**: Variant ids whose namespaced id-prefix matches `story-id`.
+
+### `variants-by-story`
+
+- **Signature**:
+  ```clojure
+  (variants-by-story)
+  ```
+- **Description**: Map from parent-story-id to its variant ids.
+
+### `variants-with-tags`
+
+- **Signature**:
+  ```clojure
+  (variants-with-tags tag-set)
+  ```
+- **Description**: Variant ids whose `:tags` intersect the filter set.
+
+### `list-tags`
+
+- **Signature**:
+  ```clojure
+  (list-tags)
+  ```
+- **Description**: All registered tags (canonical + project).
+
+### `list-modes`
+
+- **Signature**:
+  ```clojure
+  (list-modes)
+  ```
+- **Description**: All registered modes.
+
+### `canonical-tags`
+
+- **Kind**: Var (set)
+- **Description**: The seven canonical tags.
+
+### `canonical-axes`
+
+- **Kind**: Var
+- **Description**: The four canonical axes (audience / lifecycle / quality / status).
+
+### `canonical-status-values`
+
+- **Kind**: Var
+- **Description**: The status-axis tag values.
+
+### `canonical-role-values`
+
+- **Kind**: Var
+- **Description**: The role-axis tag values.
+
+### `tags-by-axis`
+
+- **Signature**:
+  ```clojure
+  (tags-by-axis)
+  ```
+- **Description**: Map from axis → tag-ids registered against it.
+
+### `tags-without-axis`
+
+- **Signature**:
+  ```clojure
+  (tags-without-axis)
+  ```
+- **Description**: Tags not registered against any axis (project tags).
+
+### `tags-default-excluded`
+
+- **Signature**:
+  ```clojure
+  (tags-default-excluded)
+  ```
+- **Description**: Tags the sidebar tag-filter excludes by default.
+
+### `tag->axis-index`
+
+- **Signature**:
+  ```clojure
+  (tag->axis-index)
+  ```
+- **Description**: Map from tag-id → axis.
+
+### `registered-substrates`
+
+- **Signature**:
+  ```clojure
+  (registered-substrates)
+  ```
+- **Description**: CLJS-only. The substrate set as registered via `register-substrate!`.
+
+### `variant-substrates`
+
+- **Signature**:
+  ```clojure
+  (variant-substrates variant-id)
+  ```
+- **Description**: The substrate set for a specific variant.
 
 ## `configure!`
 
 The boot-time entry point for project-wide defaults. The host calls it once before mounting the shell.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Set Story's global config. Every key lives under `:rf.story/*` (Story-specific) or `:rf.privacy/*` (cross-tool). Unknown keys are silently ignored for forward-compat. |
+### `configure!`
+
+- **Signature**:
+  ```clojure
+  (configure! opts) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Set Story's global config. Every key lives under `:rf.story/*` (Story-specific) or `:rf.privacy/*` (cross-tool). Unknown keys are silently ignored for forward-compat.
 
 The full v1 key surface:
 
@@ -158,32 +410,72 @@ Two key behaviours are worth pinning:
 
 ## Substrate registration (CLJS-only)
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `register-substrate!` | `(register-substrate! substrate-id render-fn)` → nil | v1 (dev-only) | Register a substrate render fn under `substrate-id`. The host calls this once at boot for each substrate it wants Story to render against (`:uix`, `:helix`, etc.). The `:reagent` substrate is registered automatically by the canonical-vocabulary auto-install. |
-| `registered-substrates` | `(registered-substrates)` → set | v1 (dev-only) | The set of registered substrate ids. Used by tooling that enumerates available substrates for a variant's `:substrates` opt-in. |
+### `register-substrate!`
+
+- **Signature**:
+  ```clojure
+  (register-substrate! substrate-id render-fn) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Register a substrate render fn under `substrate-id`. The host calls this once at boot for each substrate it wants Story to render against (`:uix`, `:helix`, etc.). The `:reagent` substrate is registered automatically by the canonical-vocabulary auto-install.
+
+### `registered-substrates` (substrate registration)
+
+- **Signature**:
+  ```clojure
+  (registered-substrates) → set
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: The set of registered substrate ids. Used by tooling that enumerates available substrates for a variant's `:substrates` opt-in.
 
 ## Shell lifecycle (CLJS-only)
 
 The three-pane Reagent component that constitutes Story's UI. The host calls `mount-shell!` from its entry namespace when a hash-routed `#/stories` triggers Story mode.
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `mount-shell!` | `(mount-shell! mount-point opts)` → nil | v1 (dev-only) | Mount the Story shell at `mount-point` (a DOM node). The opts map carries `:initial-variant`, `:initial-mode`, `:theme`, etc. Production builds (`re-frame.story.config/enabled?` false) short-circuit before any DOM call. |
-| `unmount-shell!` | `(unmount-shell!)` → nil | v1 (dev-only) | Unmount the shell. Idempotent. |
-| `active-shell` | `(active-shell)` → map / nil | v1 (dev-only) | Inspectable handle on the active shell — returns nil when no shell is mounted. |
+### `mount-shell!`
+
+- **Signature**:
+  ```clojure
+  (mount-shell! mount-point opts) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Mount the Story shell at `mount-point` (a DOM node). The opts map carries `:initial-variant`, `:initial-mode`, `:theme`, etc. Production builds (`re-frame.story.config/enabled?` false) short-circuit before any DOM call.
+
+### `unmount-shell!`
+
+- **Signature**:
+  ```clojure
+  (unmount-shell!) → nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Unmount the shell. Idempotent.
+
+### `active-shell`
+
+- **Signature**:
+  ```clojure
+  (active-shell) → map / nil
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: Inspectable handle on the active shell — returns nil when no shell is mounted.
 
 ## Static-mode probe
 
-| Fn | Signature | Status | Intuition |
-|---|---|---|---|
-| `static-mode?` | `(static-mode?)` → bool | v1 (dev-only) | True iff Story is running in static-export mode (the bundle was built with `:closure-defines {re-frame.story.config/static-mode? true}`). The shell itself flips its dev-time affordances (hot-reload poll, first-visit help overlay auto-open) off when the flag is true. Surfaced here for tooling / examples that want to render a "this is a published static site" badge. |
+### `static-mode?`
+
+- **Signature**:
+  ```clojure
+  (static-mode?) → bool
+  ```
+- **Status**: v1 (dev-only)
+- **Description**: True iff Story is running in static-export mode (the bundle was built with `:closure-defines {re-frame.story.config/static-mode? true}`). The shell itself flips its dev-time affordances (hot-reload poll, first-visit help overlay auto-open) off when the flag is true. Surfaced here for tooling / examples that want to render a "this is a published static site" badge.
 
 ## Stage marker
 
-| Var | Use |
-|---|---|
-| `stage` | The current Story development stage marker. Surfaced for tools that gate behaviour on Story's advertised maturity tier. |
+### `stage`
+
+- **Kind**: Var
+- **Description**: The current Story development stage marker. Surfaced for tools that gate behaviour on Story's advertised maturity tier.
 
 ## Effects and coeffects registered by Story
 


### PR DESCRIPTION
Closes rf2-s8lhz. Sweeps docs/api/* + docs/causa/api/* + docs/story/api/* per Mike-direction (2026-05-21).

## Summary
- Convert per-fn API tables to per-member H3 subheadings with structured fields (**Kind** / **Signature** / **Status** / **Description**). Signatures move into fenced `clojure` blocks for syntax highlighting; every member gets a deep-linkable anchor; no more awkward column wrap.
- 21 detail chapters converted: `docs/api/01-core`…`15-story`, `docs/causa/api/{mount-control,config-keys,runtime-seam}`, `docs/story/api/{registration,play-script,runtime}`.
- Tables that genuinely tabulate are left as tables: fx-id / sub / cofx / event vocabularies, reserved-metadata-key lists, failure-category sets, URI-scheme maps, published-constant value tables, theme tokens, lifecycle-phase grammars, the removed/tombstone register (`16-removed.md`), the MCP fn→tool mapping tables, and the two flat `reference.md` symbol indexes (multi-section Ctrl-F tables whose rows intentionally repeat across sections).

## Notes
- `attr_list` is not enabled in mkdocs.yml, so explicit `{#id}` heading ids are not used. The pymdownx slugifier strips trailing `*`/`!`, so starred-fn members (e.g. `reg-view*`) auto-disambiguate to `reg-view_1` while the macro keeps the clean `reg-view` anchor — both deep-linkable; no existing cross-link breaks.

## Test plan
- [x] `python scripts/check_doc_slugs.py` → exit 0 (no broken targets/anchors)
- [x] `mkdocs build --strict` → builds clean (no warnings escalated)
- [x] Reading sample: `docs/api/01-core.md` reads better than the prior table — per-member H3 + highlighted signatures, no column wrap