### PR TITLE
spec(009): canonise :rf.error/id discriminator slot + 3 exemplars (rf2-befku.1 . cluster A)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -414,10 +414,11 @@
       ;; inheritable envelope keys per Spec 002 §Cascade propagation.
       ;;
       ;; Generic typed-throw routing (rf2-eb4lp + rf2-on7sj-class
-      ;; pattern): if a reserved-fx body throws with an `:error`-keyed
-      ;; ex-data slot carrying a keyword category, route it through
-      ;; the always-on `error-emit` substrate so prod monitors get
-      ;; the typed signal; ex-data is preserved verbatim including
+      ;; pattern): if a reserved-fx body throws with the canonical
+      ;; `:rf.error/id` discriminator slot (per Spec 009 §The
+      ;; thrown-error shape) carrying a keyword category, route it
+      ;; through the always-on `error-emit` substrate so prod monitors
+      ;; get the typed signal; ex-data is preserved verbatim including
       ;; any reserved-fx-specific slots (e.g. `:cycle`). Reached via
       ;; the late-bind hook `:error-emit/dispatch-on-error` (fx.cljc
       ;; cannot statically require error-emit — would form a load
@@ -430,7 +431,7 @@
         (emit-handled! fx-id args frame-id)
         (catch #?(:clj Throwable :cljs :default) e
           (let [d        (ex-data e)
-                category (:error d)]
+                category (:rf.error/id d)]
             (if (keyword? category)
               (let [msg  #?(:clj (.getMessage ^Throwable e)
                             :cljs (.-message e))
@@ -459,7 +460,7 @@
                                         :exception         e
                                         :exception-message msg
                                         :recovery          :no-recovery}
-                                       (dissoc d :error))
+                                       (dissoc d :rf.error/id))
                      :recovery  :no-recovery}))
                 ;; Trace path for dev consumers; DCE'd in CLJS prod.
                 (trace/emit-error! category
@@ -470,7 +471,7 @@
                                            :exception         e
                                            :exception-message msg
                                            :recovery          :no-recovery}
-                                          (dissoc d :error))))
+                                          (dissoc d :rf.error/id))))
               ;; Untyped reserved-fx throw — preserve crash-loud
               ;; contract by re-throwing.
               (throw e)))))

--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -143,14 +143,21 @@
   `:rf.error/<artefact>-artefact-missing` ex-info when the hook is
   unregistered.
 
+  Carries the canonical thrown-error shape (per Spec 009 §The
+  thrown-error shape):
+
     Message:  `<error-keyword>` printed as a string (e.g.
               \":rf.error/flows-artefact-missing\").
-    ex-data:  {:where    <where-sym>
-               :recovery :no-recovery
-               :reason   \"<where-sym> requires <maven> on the classpath;
-                          add it to deps and require <require-ns> at app boot.\"
+    ex-data:  {:rf.error/id <error-keyword>  ;; canonical discriminator
+               :where       <where-sym>
+               :recovery    :no-recovery
+               :reason      \"<where-sym> requires <maven> on the classpath;
+                             add it to deps and require <require-ns> at app boot.\"
                & extra-data}
 
+  The `:rf.error/id` slot is the canonical discriminator consumers read
+  uniformly (Causa, pair-tool, `:on-error`); the message string is the
+  stringified kw so `.getMessage` pivots to the same category.
   `where-sym` is the user-facing fn symbol stamped on the error.
   `artefact-info` carries `{:error-keyword :maven :require-ns}`.
   `extra-data` is the per-call ex-data merged in (e.g. `:flow-id`,
@@ -162,9 +169,10 @@
   ([hook-key where-sym {:keys [error-keyword maven require-ns]} extra-data]
    (or (get @hooks hook-key)
        (throw (ex-info (str error-keyword)
-                       (merge {:where    where-sym
-                               :recovery :no-recovery
-                               :reason   (str where-sym " requires " maven
-                                              " on the classpath; add it to deps and require "
-                                              require-ns " at app boot.")}
+                       (merge {:rf.error/id error-keyword
+                               :where       where-sym
+                               :recovery    :no-recovery
+                               :reason      (str where-sym " requires " maven
+                                                 " on the classpath; add it to deps and require "
+                                                 require-ns " at app boot.")}
                               extra-data))))))

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -66,7 +66,12 @@
   [adapter]
   (when @installed-adapter
     (throw (ex-info ":rf.error/adapter-already-installed"
-                    {:installed @installed-adapter :attempted adapter})))
+                    {:rf.error/id :rf.error/adapter-already-installed
+                     :where       'rf/init!
+                     :recovery    :no-recovery
+                     :reason      "A second install-adapter! was called without an intervening (rf/destroy-adapter!); the existing adapter remains installed (per Spec 006 §Single adapter per process)."
+                     :installed   @installed-adapter
+                     :attempted   adapter})))
   (reset! installed-adapter adapter)
   (reset! disposed? false)
   adapter)
@@ -164,23 +169,28 @@
        case so test diagnostics, post-mortem traces, and pair-tool
        overlays can point at the right remedy.
 
-  Shape matches the broader missing-fn throw contract (the
-  `re-frame.late-bind/require-fn!` helper, rf2-h824v, rf2-uchhp):
+  Carries the canonical thrown-error shape (per Spec 009 §The
+  thrown-error shape), matching the broader missing-fn throw contract
+  (the `re-frame.late-bind/require-fn!` helper):
 
     Message: \":rf.error/<tag>\"
-    ex-data: {:where    <where-sym>
-              :recovery :no-recovery
-              :reason   <human-readable string>}
+    ex-data: {:rf.error/id :rf.error/<tag>  ;; canonical discriminator
+              :where       <where-sym>
+              :recovery    :no-recovery
+              :reason      <human-readable string>}
 
-  `where-sym` is stamped on the throw so grep-for-symbol finds the
-  delegation site in user code. Private — callers in this ns thread
-  the symbol of the public surface they implement (e.g.
-  `'rf/make-state-container`)."
+  The `:rf.error/id` slot is the canonical discriminator consumers read
+  uniformly; the message string is the stringified kw so `.getMessage`
+  pivots to the same category. `where-sym` is stamped on the throw so
+  grep-for-symbol finds the delegation site in user code. Private —
+  callers in this ns thread the symbol of the public surface they
+  implement (e.g. `'rf/make-state-container`)."
   [where-sym]
   (or @installed-adapter
       (if @disposed?
         (throw (ex-info ":rf.error/adapter-disposed"
-                        {:where    where-sym
+                        {:rf.error/id :rf.error/adapter-disposed
+                         :where    where-sym
                          :recovery :no-recovery
                          :reason   (str where-sym " was called after"
                                         " (rf/destroy-adapter!); the previously"
@@ -188,7 +198,8 @@
                                         " Install a fresh adapter via"
                                         " (rf/init! <adapter>) before calling.")}))
         (throw (ex-info ":rf.error/no-adapter-installed"
-                        {:where    where-sym
+                        {:rf.error/id :rf.error/no-adapter-installed
+                         :where    where-sym
                          :recovery :no-recovery
                          :reason   (str where-sym " was called before (rf/init! ...);"
                                         " require an adapter ns and pass its `adapter` Var,"

--- a/implementation/core/test/re_frame/boot_test.clj
+++ b/implementation/core/test/re_frame/boot_test.clj
@@ -108,6 +108,8 @@
              (some-> thrown ex-message))
           "the thrown exception carries the :rf.error/adapter-already-installed tag")
       (let [data (ex-data thrown)]
+        (is (= :rf.error/adapter-already-installed (:rf.error/id data))
+            "ex-data carries the canonical :rf.error/id discriminator (per Spec 009 §The thrown-error shape)")
         (is (some? (:installed data))
             "ex-data carries the currently :installed adapter")
         (is (some? (:attempted data))
@@ -396,6 +398,11 @@
                  (some-> thrown ex-message))
               (str where-sym " ex-message carries the :rf.error/no-adapter-installed tag"))
           (let [data (ex-data thrown)]
+            ;; Per Spec 009 §The thrown-error shape: canonical
+            ;; discriminator slot is `:rf.error/id` (require-adapter!
+            ;; now stamps it).
+            (is (= :rf.error/no-adapter-installed (:rf.error/id data))
+                (str where-sym " ex-data carries the canonical :rf.error/id discriminator"))
             (is (= where-sym (:where data))
                 (str where-sym " ex-data :where echoes the offending public surface symbol"))
             (is (= :no-recovery (:recovery data))
@@ -474,6 +481,8 @@
                  (some-> thrown ex-message))
               (str where-sym " ex-message carries the :rf.error/adapter-disposed tag (not :no-adapter-installed)"))
           (let [data (ex-data thrown)]
+            (is (= :rf.error/adapter-disposed (:rf.error/id data))
+                (str where-sym " ex-data carries the canonical :rf.error/id discriminator"))
             (is (= where-sym (:where data))
                 (str where-sym " ex-data :where echoes the offending public surface symbol"))
             (is (= :no-recovery (:recovery data))

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -80,32 +80,38 @@
   [x]
   (and (vector? x) (seq x) (every? valid-path-element? x)))
 
-;; Every validation throw shares the same ex-data skeleton:
+;; Every validation throw shares the canonical thrown-error skeleton
+;; (per Spec 009 §The thrown-error shape):
 ;;
-;;   {:where     'rf/reg-flow      ;; user-facing fn for greping the call site
-;;    :recovery  :fix-registration  ;; "the caller fixes their flow map and retries"
-;;    :reason    "<diagnostic>"
-;;    :flow      <the supplied flow>}
+;;   {:rf.error/id <category-kw>    ;; CANONICAL DISCRIMINATOR — :rf.error/<category>
+;;    :where       'rf/reg-flow     ;; user-facing fn for greping the call site
+;;    :recovery    :fix-registration ;; "the caller fixes their flow map and retries"
+;;    :reason      "<diagnostic>"
+;;    :flow        <the supplied flow>}
 ;;
-;; The `:where` / `:recovery` slots mirror the late-bind-missing throw
-;; shape standardised by `re-frame.late-bind/require-fn!` and used by
-;; every `re-frame.core-<artefact>` wrapper — tools (Causa, 10x,
-;; debuggers) read the same fields uniformly across error sources.
-;; Per-clause extras (`:bad-entries` / `:bad-elements`) merge on top.
+;; The `:rf.error/id` discriminator slot is read uniformly by every
+;; consumer (Causa's error widget, the pair-tool overlay, `:on-error`
+;; policies); the message string is the stringified kw so `.getMessage`
+;; pivots to the same category without ex-data. The `:where` / `:recovery`
+;; slots mirror the missing-artefact throw shape standardised by
+;; `re-frame.late-bind/require-fn!` and used by every
+;; `re-frame.core-<artefact>` wrapper. Per-clause extras (`:bad-entries`
+;; / `:bad-elements`) merge on top.
 
 (defn- flow-error
-  "Build the validate-flow ex-info with the standard shape. `error-kw`
-  becomes the message AND the `:error` slot; `reason` is the human-
+  "Build the validate-flow ex-info with the canonical thrown-error shape
+  (per Spec 009 §The thrown-error shape). `error-kw` becomes the message
+  AND the `:rf.error/id` discriminator slot; `reason` is the human-
   readable diagnostic; `extras` merges per-clause slots (e.g.
   `:bad-entries`)."
   ([error-kw reason flow] (flow-error error-kw reason flow nil))
   ([error-kw reason flow extras]
    (ex-info (str error-kw)
-            (merge {:error    error-kw
-                    :where    'rf/reg-flow
-                    :recovery :fix-registration
-                    :reason   reason
-                    :flow     flow}
+            (merge {:rf.error/id error-kw
+                    :where       'rf/reg-flow
+                    :recovery    :fix-registration
+                    :reason      reason
+                    :flow        flow}
                    extras))))
 
 (defn- validate-flow [flow]

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -86,12 +86,14 @@
           ;; vector built from a dead end would lie to tools (Causa,
           ;; the flow panel) about the offending chain.
           (throw (ex-info ":rf.error/flow-cycle-extract-invariant"
-                          {:reason   ":rf.error/flow-cycle-extract-invariant"
-                           :node     node
-                           :stack    stack
-                           :seen     seen
-                           :remaining remaining
-                           :recovery :no-recovery}))
+                          {:rf.error/id :rf.error/flow-cycle-extract-invariant
+                           :where     'rf/reg-flow
+                           :recovery  :no-recovery
+                           :reason    "Cycle-path extraction reached a dead end: a stuck node found no stuck dependency to follow. Internal topo invariant violated — report with the :node / :stack / :seen / :remaining payload."
+                           :node      node
+                           :stack     stack
+                           :seen      seen
+                           :remaining remaining}))
 
           (contains? seen next-dep)
           ;; Cycle found. Slice the stack from the revisited node
@@ -168,16 +170,17 @@
                              rem0)]
               (recur ready' remaining' (conj order n)))
             (if (seq remaining)
-              ;; Per rf2-6mxr2: cycle ex-info carries the standard shape
-              ;; every other flow ex-info uses (`:error` / `:where` /
-              ;; `:recovery` / `:reason`) so tools (Causa, re-frame-10x,
-              ;; late-bind-missing wrappers) can read these slots
-              ;; uniformly across error surfaces. `topo.cljc` is the
-              ;; pure-data module — no `:require`s — so the shape is
-              ;; inlined rather than reaching for `registry.cljc`'s
-              ;; `flow-error` helper.
+              ;; Cycle ex-info carries the canonical thrown-error shape
+              ;; (per Spec 009 §The thrown-error shape) every other flow
+              ;; ex-info uses (`:rf.error/id` / `:where` / `:recovery` /
+              ;; `:reason`) so tools (Causa, re-frame-10x,
+              ;; late-bind-missing wrappers) read the `:rf.error/id`
+              ;; discriminator uniformly across error surfaces.
+              ;; `topo.cljc` is the pure-data module — no `:require`s —
+              ;; so the shape is inlined rather than reaching for
+              ;; `registry.cljc`'s `flow-error` helper.
               (throw (ex-info ":rf.error/flow-cycle"
-                              {:error    :rf.error/flow-cycle
+                              {:rf.error/id :rf.error/flow-cycle
                                :where    'rf/reg-flow
                                :recovery :no-recovery
                                :reason   "Cyclic flow dependency — at least one pair of flows' :path / :inputs overlap mutually (per Spec 013 §Dependency rule). The closing-repeat :cycle vector names the offending chain."

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -220,6 +220,39 @@
 (defn- flow-bad-path? [^Throwable t]
   (= ":rf.error/flow-bad-path" (ex-message t)))
 
+(deftest reg-flow-error-carries-canonical-rf-error-id-slot
+  ;; Per Spec 009 §The thrown-error shape: every thrown runtime error
+  ;; carries the discriminator under the canonical `:rf.error/id` slot
+  ;; (NOT the legacy `:error` slot), and the message string is the
+  ;; stringified kw so `.getMessage` pivots to the same category.
+  (testing "flow validation throw stamps :rf.error/id (canonical discriminator)"
+    (let [ex (try
+               (rf/reg-flow {:id :bad :inputs :not-a-vector
+                             :output (fn [_ _] nil) :path [:out]})
+               (catch Throwable t t))
+          data (ex-data ex)]
+      (is (some? ex) "registration threw")
+      (is (= :rf.error/flow-bad-inputs (:rf.error/id data))
+          ":rf.error/id slot carries the discriminator keyword")
+      (is (= ":rf.error/flow-bad-inputs" (ex-message ex))
+          "message string is the stringified discriminator kw")
+      (is (nil? (:error data))
+          "the legacy :error slot is gone (rename, not back-compat shim)")
+      (is (= 'rf/reg-flow (:where data)) ":where names the user-facing surface")
+      (is (= :fix-registration (:recovery data)) ":recovery names the disposition")
+      (is (string? (:reason data)) ":reason is a human-readable sentence")))
+  (testing "flow cycle throw stamps :rf.error/id"
+    (reset! flows/flows {})
+    (reset! (deref (resolve 're-frame.flows/last-inputs)) {})
+    (rf/reg-flow {:id :a :inputs [[:b]] :output identity :path [:a]})
+    (let [ex (try
+               (rf/reg-flow {:id :b :inputs [[:a]] :output identity :path [:b]})
+               (catch Throwable t t))
+          data (ex-data ex)]
+      (is (= :rf.error/flow-cycle (:rf.error/id data))
+          "cycle throw carries :rf.error/id (topo.cljc inlined shape)")
+      (is (nil? (:error data)) "legacy :error slot is gone on the cycle throw"))))
+
 (deftest reg-flow-rejects-bare-keyword-inputs
   (testing ":inputs [:foo :bar] is rejected (vector of bare keywords, not vector-of-paths)"
     ;; Pre-fix this would pass validate-flow and then throw with

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -51,8 +51,10 @@
              (.getMessage ^Throwable thrown))
           "the documented invariant id appears in the message")
       (let [data (ex-data thrown)]
-        (is (= ":rf.error/flow-cycle-extract-invariant" (:reason data))
-            "ex-data carries :reason naming the invariant")
+        (is (= :rf.error/flow-cycle-extract-invariant (:rf.error/id data))
+            "ex-data carries the canonical :rf.error/id discriminator (per Spec 009 §The thrown-error shape)")
+        (is (string? (:reason data))
+            "ex-data carries :reason as a human-readable sentence (no longer the overloaded kw)")
         (is (= :no-recovery (:recovery data))
             "ex-data carries :recovery :no-recovery — the dead-end means topo state is internally inconsistent")
         (is (= :a (:node data))
@@ -78,7 +80,7 @@
            (topo/topo-sort {:a {:id :a :inputs [[:n]] :output identity :path [:a]}})))))
 
 (deftest topo-sort-detects-cycle
-  (testing "two flows forming a cycle raise :rf.error/flow-cycle with the standard error shape (rf2-6mxr2)"
+  (testing "two flows forming a cycle raise :rf.error/flow-cycle with the canonical thrown-error shape (per Spec 009 §The thrown-error shape)"
     (let [flow-map {:a {:id :a :inputs [[:b]] :output identity :path [:a]}
                     :b {:id :b :inputs [[:a]] :output identity :path [:b]}}
           thrown   (try (topo/topo-sort flow-map)
@@ -88,8 +90,10 @@
       (is (= ":rf.error/flow-cycle" (.getMessage ^Throwable thrown))
           "ex-info message is the documented category")
       (let [data (ex-data thrown)]
-        (is (= :rf.error/flow-cycle (:error data))
-            "ex-data carries :error :rf.error/flow-cycle (standard shape — rf2-6mxr2)")
+        (is (= :rf.error/flow-cycle (:rf.error/id data))
+            "ex-data carries the canonical :rf.error/id discriminator")
+        (is (nil? (:error data))
+            "the legacy :error slot is gone (rename, not back-compat shim)")
         (is (= 'rf/reg-flow (:where data))
             "ex-data carries :where 'rf/reg-flow — points at the user-facing call site")
         (is (= :no-recovery (:recovery data))
@@ -100,9 +104,9 @@
             "ex-data carries :cycle as a vector")
         (is (>= (count (:cycle data)) 2)
             "the cycle vector closes (at least two entries including the closing repeat)")
-        (is (= #{:error :where :recovery :reason :cycle}
+        (is (= #{:rf.error/id :where :recovery :reason :cycle}
                (set (keys data)))
-            "ex-data carries exactly the standard slots + :cycle (no extras, no missing)")))))
+            "ex-data carries exactly the canonical slots + :cycle (no extras, no missing)")))))
 
 ;; ---------------------------------------------------------------------------
 ;; rf2-m05md — depends-on? direct function-boundary tests

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -522,8 +522,8 @@
         (is (some? (:exception r))
             ":exception is the thrown ex-info carrying the cycle data")
         (let [d (ex-data (:exception r))]
-          (is (= :rf.error/flow-cycle (:error d))
-              "exception ex-data carries :error :rf.error/flow-cycle")
+          (is (= :rf.error/flow-cycle (:rf.error/id d))
+              "exception ex-data carries the canonical :rf.error/id discriminator (per Spec 009 §The thrown-error shape)")
           (is (vector? (:cycle d))
               "exception ex-data carries :cycle — the closing-repeat chain tools render"))))))
 

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -53,6 +53,11 @@
           (is (= ":rf.error/flows-artefact-missing" (.getMessage thrown))
               "the documented error category appears in the message")
           (let [data (ex-data thrown)]
+            ;; Per Spec 009 §The thrown-error shape: the canonical
+            ;; discriminator slot is `:rf.error/id` (require-fn! now
+            ;; stamps it; previously the kw lived only in the message).
+            (is (= :rf.error/flows-artefact-missing (:rf.error/id data))
+                "ex-data carries the canonical :rf.error/id discriminator")
             (is (= 'rf/clear-flow (:where data))
                 "ex-data carries :where = 'rf/clear-flow")
             (is (= :no-recovery (:recovery data))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1021,6 +1021,50 @@ All error trace events are open maps with these required keys:
 
 `:source` and `:recovery` are top-level fields hoisted out of `:tags` by the runtime; both are present on every error event. `:frame` rides under `:tags` (every emit site that knows the frame supplies it there). The `:tags` payload's category-specific keys are documented per category below, and each category has a registered Malli schema so consumers can validate / branch on the payload safely.
 
+### The thrown-error shape — the `:rf.error/id` ex-data contract
+
+Most runtime failures emit a **trace event** (the shape above) and let the cascade recover. A minority are **thrown** — a registration is rejected, an optional artefact is absent, a delegation surface is reached before `(rf/init! …)`. These surface as `ex-info` rather than as trace events (the catalogue's "Surfaced as a thrown ex-info, not a trace" rows). Thrown errors carry their own canonical ex-data shape so a single consumer path — Causa's error widget, the pair-tool overlay, an `:on-error` policy, a `try`/`catch` in user code — reads one discriminator slot uniformly regardless of which surface threw.
+
+The discriminator slot is **`:rf.error/id`** — a `:rf.error/<category>` keyword from the [§Error event catalogue](#error-event-catalogue). This is the **single normative discriminator for thrown errors**; the four-slot skeleton below is the canonical shape every `(throw (ex-info …))` site in the runtime conforms to:
+
+```clojure
+(throw (ex-info ":rf.error/<id>"               ;; message = the stringified discriminator kw
+                {:rf.error/id <category-kw>     ;; CANONICAL DISCRIMINATOR — :rf.error/<category>
+                 :where       'rf/<surface>     ;; the user-facing fn symbol that threw
+                 :recovery    <disposition>     ;; :no-recovery / :fix-registration / :skipped / …
+                 :reason      "<one sentence>"  ;; what failed + why, human-readable
+                 ;; + surface-specific payload merges on top:
+                 ;; :flow / :route-id / :machine-id / :received / :cycle / …
+                 }))
+```
+
+Required slots on every thrown runtime error: `:rf.error/id`, `:where`, `:recovery`, `:reason`. Surface-specific payload (`:flow`, `:bad-entries`, `:cycle`, `:installed`, `:attempted`, `:received`, …) merges on top.
+
+Two consumer pivots, both stable:
+
+- **Message string** — the `.getMessage` / `(ex-message e)` is the stringified discriminator kw (e.g. `":rf.error/flows-artefact-missing"`). A consumer with no ex-data access (a raw stack trace, a log line) still pivots to a stable category from the message alone.
+- **`:rf.error/id` slot** — `(:rf.error/id (ex-data e))` returns the discriminator as a keyword for structured branching. Tools `case` / `condp` on this slot rather than parsing the message string.
+
+The `:where` slot names the **user-facing surface fn symbol** (`'rf/reg-flow`, `'rf/make-state-container`) so a grep-for-symbol lands on the call site in user code; `:recovery` reuses the [§Recovery contract](#recovery-contract) vocabulary plus `:fix-registration` (the caller fixes their registration map and retries); `:reason` is one human-readable sentence naming what failed and the fix.
+
+This shape is the throw-side companion of the trace-event shape above. A category that can both throw and emit (e.g. a registration rejection that is also catalogued) uses `:operation` on the trace event and `:rf.error/id` on the thrown ex-info — the **same `:rf.error/<category>` keyword** in both slots, so a consumer reads one vocabulary across both surfaces. The pairing with `re-frame.core-artefact/defwrapper` (per [Conventions §single-import contract](Conventions.md#feature-modularity-prefix-convention)) and the missing-artefact wrappers (`:rf.error/<feature>-artefact-missing`) is the canonical reference.
+
+#### Discriminator-slot migration — five variants collapse to one
+
+Pre-canonicalisation, thrown-error ex-data carried the discriminator under **five different slots** depending on the surface:
+
+| Old slot | Old shape | Where it lived |
+|---|---|---|
+| `:error` | `{:error :rf.error/flow-cycle …}` | flows registry / topo (the dominant variant) |
+| `:type` | `{:type :rf.error/… …}` | reagent-slim React-19-removed family |
+| `:kind` | `{:kind :rf.error/… …}` | http `util_json`, routing `route-too-many-keys` |
+| `:reason` (overloaded) | the kw doubling as the human reason | machines-viz scxml, ai-generate |
+| *(none)* | kw only in the message string, no ex-data slot | most other sites (`require-fn!`, `require-adapter!`, …) |
+
+All five collapse to the single canonical `:rf.error/id` slot. The migration is a **rename, not a deprecation** (pre-alpha posture — no back-compat shim): the old slot is removed and `:rf.error/id` added in its place. Where the kw lived only in the message string (the *(none)* row), `:rf.error/id` is added as a new slot carrying the same keyword the message stringifies — the message string is unchanged, the structured slot is new. Where `:reason` was overloaded to carry the discriminator kw, `:reason` reverts to a human-readable sentence and `:rf.error/id` carries the keyword.
+
+The three reference exemplars — `re-frame.flows.registry/flow-error` (was `:error`), `re-frame.late-bind/require-fn!` (was *none*), `re-frame.substrate.adapter/require-adapter!` (was *none*) — demonstrate the canonical shape on first read.
+
 #### `:rf.trace/trigger-handler` — naming the in-scope handler
 
 The optional top-level `:rf.trace/trigger-handler` slot names the handler whose execution produced the trace event and carries its registration-site source-coord. Tools (Causa, pair, IDE jump-to-source) render click-to-jump links from this field — given a trace event, the user lands on the line of code that defined the responsible handler.


### PR DESCRIPTION
Closes rf2-befku.1. Normative error-shape; blocks clusters B-I.

## Summary
- Adds the normative **thrown-error ex-data shape** to `spec/009-Instrumentation.md` (`### The thrown-error shape — the :rf.error/id ex-data contract`), pinning `:rf.error/id` as the single discriminator slot for thrown `ex-info`. This is distinct from the existing trace-event `:operation`/`:op-type`/`:tags` model — the two surfaces now use the **same `:rf.error/<category>` vocabulary** in their respective discriminator slots.
- Documents the five-variant -> one slot migration (`:error` / `:type` / `:kind` / overloaded `:reason` / none) so the B-I clusters have a reference table. Rename, not deprecation (pre-alpha, no back-compat shim).
- Updates the three reference exemplars to the canonical shape:
  - `flows/registry.cljc#flow-error` (was `:error`) + `flows/topo.cljc` cycle / extract-invariant throws (same artefact, kept consistent)
  - `core/late_bind.cljc#require-fn!` (kw was message-only; added `:rf.error/id` slot)
  - `core/substrate/adapter.cljc#require-adapter!` + `install-adapter!` (added `:rf.error/id` slot)
- Migrates the load-bearing core consumer `core/fx.cljc` (reserved-fx typed-throw routing) to read `:rf.error/id`, and updates the exemplar tests to assert the canonical slot + the absence of the legacy `:error` slot.

The error-emit **listener-record** `:error` field (a separate contract in `error_emit.cljc`) is intentionally untouched — it is not the thrown-ex-data discriminator and is out of this bead's scope.

## Test plan
- [x] `clojure -M:test` from `implementation/flows` (92 tests, 0 failures)
- [x] `clojure -M:test` from `implementation/core` (684 tests, 0 failures)
- [x] `clojure -M:test` from `implementation/routing` (shares `require-fn!`; 108 tests, 0 failures)
- [x] `npm run test:cljs` (3875 tests, 0 failures)
- [x] `python -m mkdocs build --strict` (exit 0, no warnings)