### PR TITLE
ci(lint): triage Splint baseline + flip Splint job to fail-loud (rf2-ps9u9)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,11 @@ name: lint
 #   - Splint (noahtheduke/splint): style-shape linter inspired by the
 #     Clojure Style Guide. Catches idiomatic-Clojure smells that
 #     kondo's lexical analysis is not designed to surface. Per-project
-#     config lives in `.splint.edn` at repo root. The Splint job stays
-#     report-only at first iteration — fail-loud follows in a separate
-#     iteration once the warning baseline is triaged.
+#     config lives in `.splint.edn` at repo root. The job runs with
+#     `--fail-on-errors`, so an introduced ERROR (a file Splint cannot
+#     parse — `splint/parsing-error` and friends) blocks the PR while
+#     style warnings stay informational — the same shape as the
+#     clj-kondo job's `--fail-level error`.
 #
 # Lint surface: implementation/, tools/ (minus template/resources/),
 # examples/, testbeds/. Generated trees (.shadow-cljs/, target/,
@@ -126,12 +128,12 @@ jobs:
             --lint tools/template/test
 
   splint:
-    name: Splint (report-only, first iteration)
+    name: Splint (fail on errors, warnings informational)
     runs-on: ubuntu-latest
-    # Splint never fails the gate at first-iteration. The `continue-on-error`
-    # at the job level is intentional: we want PR authors to see the report
-    # without blocking on style noise until the baseline stabilises.
-    continue-on-error: true
+    # The job runs with `--fail-on-errors` so an introduced ERROR (a
+    # file Splint cannot parse) blocks the PR. Style warnings still
+    # print to the log for triage but never fail the gate — the same
+    # shape as the clj-kondo job above.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -163,16 +165,20 @@ jobs:
       # alias next to the artefacts it lints; the explicit path args
       # widen the surface to tools/ + examples/ + testbeds/.
       #
-      # `|| true` is the report-only gate: Splint exits non-zero when it
-      # finds style warnings, but we don't fail the workflow on that.
-      # Combined with the job-level continue-on-error this gives us two
-      # belt-and-braces against blocking PRs on style noise.
+      # The alias entry-point is `re-frame.splint-main` (a thin
+      # cross-platform shim around Splint's own runner — see
+      # implementation/deps.edn). Its `--fail-on-errors` flag makes the
+      # process exit non-zero ONLY when an error-class diagnostic is
+      # present (a file Splint could not parse). Style warnings still
+      # print to the log but never fail the run — matching the kondo
+      # job's `--fail-level error`. No `|| true` / continue-on-error:
+      # an introduced parse-error genuinely blocks the PR.
       - name: Run Splint
         working-directory: implementation
         run: |
           clojure -M:splint \
+            --fail-on-errors \
             ../implementation \
             ../tools \
             ../examples \
-            ../testbeds \
-            || true
+            ../testbeds

--- a/.splint.edn
+++ b/.splint.edn
@@ -1,14 +1,34 @@
-;; Splint configuration (rf2-4v147 · dual-linter CI gate).
+;; Splint configuration (rf2-4v147 · dual-linter CI gate; tightened in
+;; rf2-ps9u9).
 ;;
-;; First-iteration posture: report-only (no rules disabled here; the
-;; `lint.yml` workflow runs Splint with `continue-on-error: true`).
-;; Triage + rule-tuning lands in a follow-on bead.
+;; ## Gate posture — fail on errors, warnings informational
 ;;
-;; The only configuration we MUST carry is the exclusion of
-;; `tools/template/resources/` — those `.cljs` files ship deps-new
-;; placeholder substitutions (`{{top/ns}}`) and are not valid Clojure
+;; The `lint.yml` Splint job runs the `:splint` alias with
+;; `--fail-on-errors`, matching the clj-kondo job's `--fail-level
+;; error`. An *error-class* diagnostic — a file Splint cannot parse
+;; (`splint/parsing-error` / `splint/error` / `splint/unknown-error`) —
+;; blocks the PR. Style/lint *warnings* print to the log for triage but
+;; never fail the gate. No rules are disabled below: the warning stream
+;; stays high-signal and visible. Per-rule suppressions for genres we
+;; deliberately accept can be added here as conventions solidify, e.g.
+;;
+;;   style/eq-zero {:enabled false}
+;;
+;; — but that is a follow-on judgment call, not a gate prerequisite.
+;;
+;; ## The one MUST-carry exclusion — the deps-new template tree
+;;
+;; `tools/template/resources/` ships deps-new template `.cljs` files
+;; whose `{{top/ns}}` placeholder substitutions are not valid Clojure
 ;; (see tools/deps.edn → "Why template is NOT in the base :deps map"
-;; for the matching shadow-cljs exclusion). Splint's parser errors on
-;; them.
-
-{global {:excludes ["tools/template/resources/"]}}
+;; for the matching shadow-cljs exclusion). Splint's reader errors on
+;; them — exactly the error-class the gate now blocks on — so they MUST
+;; be excluded.
+;;
+;; `:excludes` entries are matched as REGEXES against the file path
+;; (Splint's default `re-find:` matcher — see
+;; noahtheduke.splint.path-matcher). The pattern accepts BOTH path
+;; separators (`/` on Linux/macOS CI, `\` on Windows dev machines) so
+;; the exclusion holds cross-platform. (A bare `tools/template/...`
+;; string silently failed to match on Windows, where paths use `\`.)
+{global {:excludes ["tools[/\\\\]template[/\\\\]resources[/\\\\]"]}}

--- a/implementation/deps.edn
+++ b/implementation/deps.edn
@@ -91,6 +91,17 @@
   ;; of the per-artefact classpaths — pinning the dep on the top-level
   ;; coordinator keeps the version in one place. Pre-1.0 we exact-pin
   ;; per the lockstep convention.
+  ;;
+  ;; The entry-point is `re-frame.splint-main` (under
+  ;; `scripts/splint/`), a thin cross-platform shim around Splint's own
+  ;; `-main`. Splint v1.24.0 builds its default-config + version
+  ;; resource paths with `(str (io/file ...))`, which on Windows joins
+  ;; with `\` — and `io/resource` only accepts `/`-separated keys, so
+  ;; Splint dies with `Cannot open <nil> as a Reader.` on Windows dev
+  ;; machines. The shim re-binds those two vars to forward-slash
+  ;; lookups before delegating; on Linux/macOS it is a no-op
+  ;; normalisation. Remove once Splint ships an upstream fix.
   :splint
   {:replace-deps {io.github.noahtheduke/splint {:mvn/version "1.24.0"}}
-   :main-opts    ["-m" "noahtheduke.splint"]}}}
+   :extra-paths  ["scripts/splint"]
+   :main-opts    ["-m" "re-frame.splint-main"]}}}

--- a/implementation/scripts/splint/re_frame/splint_main.clj
+++ b/implementation/scripts/splint/re_frame/splint_main.clj
@@ -1,0 +1,91 @@
+(ns re-frame.splint-main
+  "Cross-platform entry-point for Splint (noahtheduke/splint v1.24.0)
+  with a kondo-shaped `--fail-on-errors` gate.
+
+  ## Why a shim — the Windows config-loader bug
+
+  Splint's config-loader builds two classpath-resource paths with
+  `(str (io/file \"a\" \"b\" \"c\"))`. On Windows `io/file` joins segments
+  with the platform separator (`\\`), and `io/resource` only accepts
+  `/`-separated keys, so the lookup returns nil and Splint dies with
+  `Cannot open <nil> as a Reader.` on every Windows dev machine.
+
+  The two affected vars in `noahtheduke.splint.config` are:
+
+    - `version`             — a delay that reads `noahtheduke/splint/SPLINT_VERSION`
+    - `default-config-file` — a def that resolves `noahtheduke/splint/config/default.edn`
+      (and `default-config`, the delay that slurps it)
+
+  This shim re-binds those vars to forward-slash resource lookups
+  before Splint forces the delays / reads the config. On Linux/macOS
+  the forward-slash form is identical to what Splint already computes,
+  so CI behaviour is unchanged — the shim is a pure cross-platform
+  normalisation. Remove once Splint ships a fix (upstream patch:
+  replace `(str (io/file ...))` in config.clj with a `/`-joined key).
+
+  ## Why a custom gate — matching the clj-kondo job shape
+
+  Splint's own exit code is `(if (pos? (count diagnostics)) 1 0)` — it
+  exits non-zero on ANY finding, with no severity distinction. The
+  clj-kondo job in `.github/workflows/lint.yml` runs `--fail-level
+  error`: an introduced ERROR blocks the PR while warnings stay
+  informational. To give Splint the same shape we add `--fail-on-errors`:
+  Splint runs and prints everything normally, but the process exits
+  non-zero only when an *error-class* diagnostic is present
+  (`splint/error`, `splint/parsing-error`, `splint/unknown-error` —
+  Splint's own operational failures, e.g. a file it could not parse).
+  Style/lint warnings print to the log for triage but never fail the
+  gate. Without the flag the shim is a pass-through to Splint's normal
+  exit code.
+
+  Invoked via the `:splint` alias in implementation/deps.edn."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   ;; Requiring `noahtheduke.splint` (the main ns) is load-bearing: it
+   ;; pulls in every `noahtheduke.splint.rules.*` namespace, which is
+   ;; how each rule registers itself into the global rule registry.
+   ;; Without it `runner/run` finds no rules and reports zero findings.
+   [noahtheduke.splint]
+   [noahtheduke.splint.config :as config]
+   [noahtheduke.splint.runner :as runner]))
+
+;; Splint classifies these rule-names as operational errors (not style
+;; warnings). Mirrors `noahtheduke.splint.printer/error-diagnostic`.
+(def ^:private error-rule-names
+  #{'splint/error 'splint/parsing-error 'splint/unknown-error})
+
+(defn- patch-config!
+  "Re-bind Splint's two backslash-broken resource lookups to
+  forward-slash keys so the linter loads on Windows."
+  []
+  (alter-var-root
+   #'config/version
+   (constantly
+    (delay
+      (-> (io/resource "noahtheduke/splint/SPLINT_VERSION")
+          (slurp)
+          (str/trim)))))
+  (let [default-config-file (io/resource "noahtheduke/splint/config/default.edn")]
+    (alter-var-root #'config/default-config-file (constantly default-config-file))
+    (alter-var-root
+     #'config/default-config
+     (constantly (delay (config/slurp-edn default-config-file))))))
+
+(defn -main [& args]
+  (patch-config!)
+  (let [fail-on-errors? (some #(= "--fail-on-errors" %) args)
+        ;; `--fail-on-errors` is our flag, not Splint's — strip it
+        ;; before delegating so Splint's CLI parser does not reject it.
+        splint-args (vec (remove #(= "--fail-on-errors" %) args))
+        {:keys [exit diagnostics]} (runner/run splint-args)
+        error-count (if (seq diagnostics)
+                      (count (filter #(contains? error-rule-names (:rule-name %))
+                                     diagnostics))
+                      0)]
+    (System/exit
+     (cond
+       ;; In error-gate mode, fail only on error-class diagnostics;
+       ;; warnings stay informational (kondo `--fail-level error` shape).
+       fail-on-errors? (if (pos? error-count) 1 0)
+       :else (or exit 0)))))


### PR DESCRIPTION
Closes rf2-ps9u9. Follow-on to rf2-60nez (PR #1814, clj-kondo side).

## Problem

Splint stayed report-only because Splint v1.24.0's config-loader builds its default-config + version classpath-resource paths with `(str (io/file ...))`. On Windows that joins segments with `\`, and `io/resource` only accepts `/`-separated keys — so Splint died with `Cannot open <nil> as a Reader.` on every Windows dev machine, and the warning baseline could not be sliced locally.

## Changes

- **Cross-platform shim** (`re-frame.splint-main`, under `implementation/scripts/splint/`): re-binds Splint's two backslash-broken `config` vars (`version`, `default-config-file` / `default-config`) to forward-slash resource lookups before delegating to Splint's runner. On Linux/macOS the form is identical, so CI behaviour is unchanged.
- **`--fail-on-errors` gate**: Splint's own exit code fails on ANY finding (no severity distinction). The shim adds `--fail-on-errors` so the process exits non-zero ONLY on error-class diagnostics (`splint/parsing-error` / `splint/error` / `splint/unknown-error` — files Splint cannot parse). Style warnings still print for triage but never fail the gate — matching the clj-kondo job's `--fail-level error`.
- **Fixed the template-tree exclusion**: Splint matches `:excludes` as a regex against the path, so the bare `tools/template/resources/` forward-slash pattern silently failed on Windows backslash paths, surfacing 13 spurious parsing-errors from the deps-new `{{placeholder}}` template files. The pattern now accepts both separators.
- **Flipped `lint.yml`**: removed `continue-on-error` + the trailing `|| true` from the Splint job; it now runs `--fail-on-errors`.

## Baseline + triage

- **0 errors**, **1697 style warnings** (informational).
- Top genres: `lint/prefer-method-values` (515), `style/eq-zero` (235), `lint/identical-branches` (142), `style/prefer-clj-string` (110).
- The `identical-branches` findings are intentional `cond`-clause structuring (distinct conditions mapping to the same result, e.g. in the hot SSR prop-handling path) — style smells, not bugs. They are left as informational warnings rather than mass-rewritten, matching the kondo posture of keeping warnings visible for follow-on per-rule triage.

## Test plan

- [x] `clojure -M:splint --fail-on-errors <surface>` exits 0 (1697 warnings printed, 0 errors)
- [x] `--fail-on-errors` exits 1 when a parse-error is present (verified against a deliberately-broken file)
- [x] Template-tree exclusion verified cross-platform (0 parsing-errors)
- [x] `lint.yml` validated as well-formed YAML; no residual `continue-on-error` / `|| true`
- [x] `deps.edn` parses; `:splint` alias resolves