### PR TITLE
docs: sweep repo READMEs for stale cross-links post Guide+API restructure (rf2-ael8n)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -124,7 +124,7 @@ If you've finished the guide and want to see code:
 3. **Then [`reagent/todomvc/`](reagent/todomvc/README.md)** — classic benchmark shape: persistence, editing, filters, and browser routing pressure.
 4. **Then [`reagent/routing/`](reagent/routing/)** or [`reagent/ssr/`](reagent/ssr/) — pick whichever is closer to your interest.
 5. **Then [`reagent/managed_http_counter/`](reagent/managed_http_counter/)** — the smallest possible Spec 014 demo, before the broader RealWorld surface.
-6. **Then [`reagent/state_machine_walkthrough/`](reagent/state_machine_walkthrough/)** — the ch.09 prose as runnable code, with smoke tests for every section.
+6. **Then [`reagent/state_machine_walkthrough/`](reagent/state_machine_walkthrough/)** — the ch.11 prose as runnable code, with smoke tests for every section.
 7. **Then [`reagent/7Guis/`](reagent/7Guis/)** — survey of the pattern across many UI shapes.
 8. **Then [`reagent/nine_states/`](reagent/nine_states/README.md)** — the page-level cardinality / lifecycle conventions wired together.
 9. **Then [`reagent/realworld/`](reagent/realworld/)** — substantial-app shape across the widest surface in the repo.

--- a/examples/reagent/README.md
+++ b/examples/reagent/README.md
@@ -18,7 +18,7 @@ reagent/
   ssr/                         <-- CP-9 worked example (Spec 011)
   ssr_streaming/               <-- streaming SSR worked example (Spec 011 §Streaming)
   managed_http_counter/        <-- compact Spec 014 demo
-  state_machine_walkthrough/   <-- runnable companion to docs/guide/09
+  state_machine_walkthrough/   <-- runnable companion to docs/guide/11-machines
   nine_states/                 <-- the nine canonical UI states
   boot/                        <-- Pattern-Boot worked example
   long_running_work/           <-- Pattern-LongRunningWork worked example


### PR DESCRIPTION
## Summary
Swept all 80 in-repo READMEs for stale cross-links after this session''s heavy churn to link targets (guide chapter renumber, API restructure to docs/api/*, Causa/Story API mini-folders, migration README heading renames).

- Verified every relative-path target, every `#anchor`, and every published-site (`day8.github.io`) chapter slug resolves across all 80 READMEs.
- Confirmed no links to deleted surfaces (`chrome_a11y`, Static views/events tabs, 10x epoch stub).
- Fixed two stale prose chapter references: the state-machine walkthrough companion pointer cited the old chapter 09 (now Interceptors) — state machines moved to chapter 11. Corrected in `examples/README.md` and `examples/reagent/README.md`.

## What was already correct
The guide renumber and API restructure were thorough — repo-root README''s `day8.github.io` URLs (18-routing, 13-server-side, 11-machines, 20-migration, 05-schemas, 24-privacy), the guide README''s prose chapter numbers, and the docs/api README''s "sixteen chapters" prose all matched current state. Only the two walkthrough pointers had drifted.

## Test plan
- [x] `python scripts/check_doc_slugs.py` — exit 0 (zero broken)
- [x] `mkdocs build --strict` — exit 0, no WARNING/ERROR
- [x] Custom 80-README scan (targets + anchors + self-anchors) — 0 broken

Closes rf2-ael8n.