### PR TITLE
docs(guide): fix stale where-next link labels 20 to 22 (rf2-l0q71)

### DIFF
--- a/docs/guide/18-routing.md
+++ b/docs/guide/18-routing.md
@@ -272,5 +272,5 @@ URL-validation failures (a route's path matches but its `:params` schema rejects
 You now have the URL ↔ state loop: routes are registry entries, navigation is an event, the route is a sub, `:on-match` loads data, and unmatched URLs fall through to `:rf.route/not-found`. The per-topic reference half picks up the rest:
 
 - [17a — Routing: reference and advanced topics](19-routing-ref.md) — `:on-error`, the full nav-token walkthrough, the `:can-leave` protocol for unsaved-changes prompts, query-string defaults and retain keys, multi-frame routing, the pure `match-url` / `route-url` helpers, and a RealWorld worked example.
-- [20 — Where to go next](22-where-next.md) — the chapter wrap-up, with pointers to the worked examples, pattern docs, the API ref, and the spec.
+- [22 — Where to go next](22-where-next.md) — the chapter wrap-up, with pointers to the worked examples, pattern docs, the API ref, and the spec.
 - [chapter 13 — The server side](13-server-side.md) — how routing folds into SSR.

--- a/docs/guide/19-routing-ref.md
+++ b/docs/guide/19-routing-ref.md
@@ -318,5 +318,5 @@ That's the bet the previous chapter was defending: the URL is a sub.
 ## Next
 
 - [18 — From re-frame v1](20-migration.md) — appendix-shaped migration notes if you're carrying a re-frame v1 app forward.
-- [20 — Where to go next](22-where-next.md) — the chapter wrap-up, with pointers to the worked examples and pattern docs.
+- [22 — Where to go next](22-where-next.md) — the chapter wrap-up, with pointers to the worked examples and pattern docs.
 - [chapter 13](13-server-side.md) — how routing folds into SSR.

--- a/docs/guide/20-migration.md
+++ b/docs/guide/20-migration.md
@@ -93,4 +93,4 @@ Flows are frame-scoped, evaluated in topological order after each event drain, s
 
 - [`skills/re-frame-migration/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/SKILL.md) — the skill that drives the migration end-to-end.
 - [19 — Adapters](21-adapters.md) — substrate-agnostic story, the `init!` call shape, the three adapter packages, the slim-Reagent option.
-- [20 — Where to go next](22-where-next.md) — once the migration settles, where to head next.
+- [22 — Where to go next](22-where-next.md) — once the migration settles, where to head next.

--- a/docs/guide/21-adapters.md
+++ b/docs/guide/21-adapters.md
@@ -73,4 +73,4 @@ For apps where bundle size matters, the `day8/reagent-slim` artefact wires re-fr
 
 ## Where next
 
-If you've finished the chapters, [20 — Where to go next](22-where-next.md) is the one-screen exit pointer — examples, pattern docs, and the API reference.
+If you've finished the chapters, [22 — Where to go next](22-where-next.md) is the one-screen exit pointer — examples, pattern docs, and the API reference.

--- a/examples/reagent/README.md
+++ b/examples/reagent/README.md
@@ -39,7 +39,7 @@ From `implementation/`:
 npm run test:examples
 ```
 
-That compiles every Reagent build under `out/examples/<name>/`, stages the hand-written `index.html` next to `main.js`, serves the output on port 8030, and drives the Playwright specs. See [examples/README.md §End-to-end verification](../README.md#end-to-end-verification) for orchestrator details.
+That compiles every Reagent build under `out/examples/<name>/`, stages the hand-written `index.html` next to `main.js`, and serves the output on port 8030 so you can open each example in a browser. Examples are test-free — real-regression coverage lives in the substrate contract tests and framework gates, not under `examples/`. See [examples/README.md §End-to-end verification](../README.md#end-to-end-verification) for orchestrator details.
 
 To iterate on one example interactively, watch its build directly from `implementation/`:
 


### PR DESCRIPTION
Closes rf2-l0q71. Label-text fix; link targets were already correct.

The where-next chapter moved from ch.20 to ch.22 in the guide renumber. The four guide cross-links already pointed at `22-where-next.md` (slug gate passes) but the visible numeric label still read "20 — Where to go next". Updated the label number in:

- docs/guide/18-routing.md
- docs/guide/19-routing-ref.md
- docs/guide/20-migration.md
- docs/guide/21-adapters.md

Also dropped the stale "drives the Playwright specs" prose in examples/reagent/README.md, since the examples tree is now test-free (rf2-8cevm) — the orchestrator only compiles and serves the builds.

Gates: `mkdocs build --strict` (exit 0) + `python scripts/check_doc_slugs.py` (exit 0).