### PR TITLE
fix(errors): apply canonical :rf.error/id shape across 8 surface clusters (rf2-befku.2-.9)

### DIFF
--- a/implementation/adapters/reagent-slim/FORM-3.md
+++ b/implementation/adapters/reagent-slim/FORM-3.md
@@ -25,9 +25,10 @@ the keys it excludes, and walks through the canonical Form-3 use case
 | `:display-name` | A string used by React DevTools and error messages. Compile-time only — zero runtime cost. |
 
 **Any other key throws.** The throw fires at `create-class` call time (registration
-time, not render time — fail fast) with `:type :rf.error/create-class-key-unsupported`,
+time, not render time — fail fast) with the canonical discriminator
+`:rf.error/id :rf.error/create-class-key-unsupported` (per Spec 009),
 the offending key(s) in `:keys`, and the supported set in `:supported-keys`. The
-error message names the supported keys and points the user at the migration paths
+`:reason` slot names the supported keys and points the user at the migration paths
 in §3 below.
 
 The cap is checked once per `create-class` call site. Components passing the

--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -595,15 +595,16 @@ Any other key throws `:rf.error/create-class-key-unsupported` at `create-class` 
     (when (seq unsupported)
       (throw
         (ex-info ":rf.error/create-class-key-unsupported"
-          {:type            :rf.error/create-class-key-unsupported
-           :keys            (vec unsupported)
-           :supported-keys  supported
+          {:rf.error/id     :rf.error/create-class-key-unsupported
+           :where           'reagent2.core/create-class
+           :recovery        :no-recovery
            :reason          (str "create-class accepts a 7-key cap. "
                                  "Unsupported: " (pr-str unsupported) ". "
                                  "Migrate to the supported keys, restructure "
                                  "via :on-create / :on-destroy events, or "
                                  "switch to day8/reagent-classic.")
-           :recovery        :no-recovery})))
+           :keys            (vec unsupported)
+           :supported-keys  supported})))
     spec))
 ```
 
@@ -963,13 +964,16 @@ Each shim is a `defn` whose body throws an `ex-info` with the migration message.
   "REMOVED under React 19. See migration message."
   [& _]
   (throw
-    (ex-info "reagent.dom/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead. See https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path."
-      {:type :rf.error/react-19-removed-surface
-       :symbol 'reagent2.dom/render
-       :recovery :no-recovery})))
+    (ex-info ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.dom/render
+       :recovery    :no-recovery
+       :reason      "reagent.dom/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead."
+       :surface     'reagent2.dom/render
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path"})))
 ```
 
-The `:type` keyword `:rf.error/react-19-removed-surface` is shared across all five shims so a try/catch-as-migration-helper can match all of them with one `(= :rf.error/react-19-removed-surface (:type (ex-data e)))` check.
+The canonical `:rf.error/id` discriminator (per Spec 009) `:rf.error/react-19-removed-surface` is shared across all five shims so a try/catch-as-migration-helper can match all of them with one `(= :rf.error/react-19-removed-surface (:rf.error/id (ex-data e)))` check. The message string is the stringified discriminator kw; the human-readable explanation rides on `:reason` and the migration-guide URL on `:migration`.
 
 ### §10.3 Static-analysis friendliness
 
@@ -1033,7 +1037,7 @@ Per the bead description and Stage 2 §5 risk register R-001..R-007.
 | `reagent2.ratom` | `ratom_test.cljs` | RAtom + Reaction lifecycle; protocol satisfaction; equality memoisation; `IDisposable` reify; cross-substrate cache-wiring contract. |
 | `reagent2.dom.client` | `dom_client_test.cljs` | create-root / render / unmount / hydrate-root happy-paths; flush-views! determinism contract per §4.6; React-19 `act` cooperation. |
 | `reagent2.dom.server` | `dom_server_test.cljs` + `parity_test.cljs` | render-to-static-markup output for representative corpus; parity against `react-dom/server` per §8.7. |
-| `reagent2.dom` (throw shims) | `dom_throw_test.cljs` | each of the 5 throw-on-call symbols throws an `ex-info` of `:type :rf.error/react-19-removed-surface` with the right migration message. |
+| `reagent2.dom` (throw shims) | `dom_throw_test.cljs` | each of the 5 throw-on-call symbols throws an `ex-info` of `:rf.error/id :rf.error/react-19-removed-surface` with the migration explanation on `:reason` and the guide URL on `:migration`. |
 | `reagent2.impl.template` | `impl/template_test.cljs` | hiccup → React-element shapes; narrowed convert-prop-value (R-001); kebab-camel cache; tag parsing; sequence-children handling; `:>` / `:<>` / `:r>` / `:f>` interop. |
 | `reagent2.impl.component` | `impl/component_test.cljs` | create-class 7-key cap (R-002); throw-on-unsupported-key per banned key; lifecycle method mapping per §6.4; `:component-did-catch` error-boundary integration per §6.5; `:get-snapshot-before-update` pairing per §6.6. |
 | `reagent2.impl.batching` | `impl/batching_test.cljs` | microtask scheduling; dirty-set dedup; flush! synchronous drain; after-render queue; React 19 transition cooperation (R-005). |

--- a/implementation/adapters/reagent-slim/src/reagent2/core.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/core.cljs
@@ -26,7 +26,8 @@
 
   Symbols **shipped as Class B throw-on-call shims** (per Stage 4-F /
   IMPL-SPEC §10.1 — surfaces React 19 removed; calls throw an `ex-info`
-  whose `:type` is `:rf.error/react-19-removed-surface`):
+  whose canonical `:rf.error/id` discriminator (per Spec 009) is
+  `:rf.error/react-19-removed-surface`):
 
     render            — Use reagent2.dom.client/{create-root, render}.
     dom-node          — findDOMNode is removed; use :ref / useRef.
@@ -166,8 +167,9 @@
 ;; Two of the five React-19-removed surfaces live on `reagent.core` in
 ;; stock Reagent: `reagent.core/render` and `reagent.core/dom-node`.
 ;; The three `reagent.dom/*` shims live in `reagent2.dom`. All five
-;; share `:type :rf.error/react-19-removed-surface` so a single
-;; try/catch in a migration helper matches the lot.
+;; share `:rf.error/id :rf.error/react-19-removed-surface` (the
+;; canonical discriminator per Spec 009) so a single try/catch in a
+;; migration helper matches the lot.
 ;;
 ;; Static-analysis friendliness: each shim's body is a single throw,
 ;; so :advanced Closure compilation can DCE the symbol when no call
@@ -186,10 +188,13 @@
   [& _]
   (throw
     (ex-info
-      "reagent.core/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead. See https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path."
-      {:type     :rf.error/react-19-removed-surface
-       :surface  'reagent2.core/render
-       :recovery :no-recovery})))
+      ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.core/render
+       :recovery    :no-recovery
+       :reason      "reagent.core/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead."
+       :surface     'reagent2.core/render
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path"})))
 
 (defn dom-node
   "REMOVED under React 19. See migration message; throws on first call.
@@ -201,7 +206,10 @@
   [& _]
   (throw
     (ex-info
-      "reagent.core/dom-node depended on findDOMNode which is removed in React 19. Use a :ref callback or React.useRef instead. See https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#dom-node-removal."
-      {:type     :rf.error/react-19-removed-surface
-       :surface  'reagent2.core/dom-node
-       :recovery :no-recovery})))
+      ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.core/dom-node
+       :recovery    :no-recovery
+       :reason      "reagent.core/dom-node depended on findDOMNode which is removed in React 19. Use a :ref callback or React.useRef instead."
+       :surface     'reagent2.core/dom-node
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#dom-node-removal"})))

--- a/implementation/adapters/reagent-slim/src/reagent2/dom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom.cljs
@@ -11,10 +11,11 @@
 
   The three shims here mirror stock Reagent's `reagent.dom` namespace
   so a `s/reagent\\./reagent2./g` import-site rewrite continues to
-  resolve. The body throws an `ex-info` whose `:type` is
-  `:rf.error/react-19-removed-surface` — a single try/catch in a
-  migration helper can match all five Class B shims (the two
-  `reagent2.core` shims share the same `:type` per IMPL-SPEC §10.1).
+  resolve. The body throws an `ex-info` whose canonical `:rf.error/id`
+  discriminator (per Spec 009) is `:rf.error/react-19-removed-surface`
+  — a single try/catch in a migration helper can match all five Class B
+  shims (the two `reagent2.core` shims share the same `:rf.error/id`
+  per IMPL-SPEC §10.1).
 
   Static-analysis friendliness: each shim's body is a single throw, so
   `:advanced` Closure compilation can DCE the symbol when no call site
@@ -41,10 +42,13 @@
   [& _]
   (throw
     (ex-info
-      "reagent.dom/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead. See https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path."
-      {:type     :rf.error/react-19-removed-surface
-       :surface  'reagent2.dom/render
-       :recovery :no-recovery})))
+      ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.dom/render
+       :recovery    :no-recovery
+       :reason      "reagent.dom/render is removed under React 19. Use reagent2.dom.client/{create-root, render} instead."
+       :surface     'reagent2.dom/render
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path"})))
 
 (defn unmount-component-at-node
   "REMOVED under React 19. See migration message; throws on first call.
@@ -53,10 +57,13 @@
   [& _]
   (throw
     (ex-info
-      "reagent.dom/unmount-component-at-node is removed under React 19. Use reagent2.dom.client/unmount instead. See https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path."
-      {:type     :rf.error/react-19-removed-surface
-       :surface  'reagent2.dom/unmount-component-at-node
-       :recovery :no-recovery})))
+      ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.dom/unmount-component-at-node
+       :recovery    :no-recovery
+       :reason      "reagent.dom/unmount-component-at-node is removed under React 19. Use reagent2.dom.client/unmount instead."
+       :surface     'reagent2.dom/unmount-component-at-node
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path"})))
 
 (defn force-update-all
   "REMOVED under React 19. See migration message; throws on first call.
@@ -67,7 +74,10 @@
   []
   (throw
     (ex-info
-      "reagent.dom/force-update-all is removed (it iterated React 17 internals). If you have a legitimate use case, file an issue at https://github.com/day8/re-frame2/issues."
-      {:type     :rf.error/react-19-removed-surface
-       :surface  'reagent2.dom/force-update-all
-       :recovery :no-recovery})))
+      ":rf.error/react-19-removed-surface"
+      {:rf.error/id :rf.error/react-19-removed-surface
+       :where       'reagent2.dom/force-update-all
+       :recovery    :no-recovery
+       :reason      "reagent.dom/force-update-all is removed (it iterated React 17 internals). If you have a legitimate use case, file an issue at https://github.com/day8/re-frame2/issues."
+       :surface     'reagent2.dom/force-update-all
+       :migration   "https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md#legacy-mount-path"})))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -80,13 +80,14 @@
   (if-let [f @as-element-fn]
     (f hiccup)
     (throw (ex-info ":rf.error/as-element-fn-unregistered"
-             {:type     :rf.error/as-element-fn-unregistered
-              :hiccup   hiccup
-              :reason   (str "reagent2.impl.template/as-element was not"
-                             " registered before render. Require"
-                             " reagent2.impl.template (or reagent2.core)"
-                             " so its ns-load wires the as-element seam.")
-              :recovery :no-recovery}))))
+             {:rf.error/id :rf.error/as-element-fn-unregistered
+              :where       'reagent2.impl.component/->react-element
+              :recovery    :no-recovery
+              :reason      (str "reagent2.impl.template/as-element was not"
+                                " registered before render. Require"
+                                " reagent2.impl.template (or reagent2.core)"
+                                " so its ns-load wires the as-element seam.")
+              :hiccup      hiccup}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Dynamic var: in-flight component instance
@@ -134,15 +135,16 @@
     (when (seq unsupported)
       (throw
         (ex-info ":rf.error/create-class-key-unsupported"
-          {:type           :rf.error/create-class-key-unsupported
-           :keys           unsupported
-           :supported-keys cap-keys
+          {:rf.error/id    :rf.error/create-class-key-unsupported
+           :where          'reagent2.core/create-class
+           :recovery       :no-recovery
            :reason         (str "create-class accepts a 7-key cap. "
                                 "Unsupported: " (pr-str unsupported) ". "
                                 "Migrate to the supported keys, restructure "
                                 "via :on-create / :on-destroy events, or "
                                 "switch to day8/reagent-classic.")
-           :recovery       :no-recovery}))))
+           :keys           unsupported
+           :supported-keys cap-keys}))))
   spec)
 
 ;; ---------------------------------------------------------------------------
@@ -481,9 +483,12 @@
   [spec]
   (validate-spec! spec)
   (let [render-fn (or (:reagent-render spec)
-                      (throw (ex-info "create-class spec missing :reagent-render"
-                               {:type :rf.error/create-class-missing-render
-                                :spec spec})))
+                      (throw (ex-info ":rf.error/create-class-missing-render"
+                               {:rf.error/id :rf.error/create-class-missing-render
+                                :where       'reagent2.core/create-class
+                                :recovery    :no-recovery
+                                :reason      "create-class spec is missing the required :reagent-render fn."
+                                :spec        spec})))
         ;; The constructor: extends React.Component via prototype chain.
         ^js klass (fn [props]
                     (this-as this

--- a/implementation/adapters/reagent-slim/test/reagent2/dom_throw_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom_throw_cljs_test.cljs
@@ -2,10 +2,14 @@
   "Tests for the Class B throw-on-call shims (Stage 4-F, rf2-6hyy).
 
   Per IMPL-SPEC §10.1 + §12.1: five React-19-removed surfaces ship as
-  throw-on-call shims; each throws an `ex-info` of `:type
-  :rf.error/react-19-removed-surface` carrying the offending symbol on
-  `:surface`. The shared `:type` lets a single try/catch in a
-  migration helper match all five.
+  throw-on-call shims; each throws an `ex-info` whose canonical
+  `:rf.error/id` discriminator (per Spec 009) is
+  `:rf.error/react-19-removed-surface`, carrying the offending symbol on
+  `:surface`, the human-readable explanation on `:reason`, and the
+  migration-guide URL on `:migration`. The shared `:rf.error/id` lets a
+  single try/catch in a migration helper match all five; the message
+  string is the stringified discriminator kw so `.getMessage` pivots to
+  the same category without ex-data.
 
     reagent2.dom/render
     reagent2.dom/unmount-component-at-node
@@ -19,10 +23,10 @@
             [reagent2.core :as r]))
 
 ;; ---------------------------------------------------------------------------
-;; Shared `:type` invariant — one try/catch matches all five
+;; Shared `:rf.error/id` invariant — one try/catch matches all five
 ;; ---------------------------------------------------------------------------
 
-(def ^:private expected-type :rf.error/react-19-removed-surface)
+(def ^:private expected-id :rf.error/react-19-removed-surface)
 
 (defn- caught-ex-data
   "Invoke `f`, expect it to throw, return the `ex-data` of the
@@ -51,40 +55,39 @@
     (let [data (caught-ex-data #(rdom/render [:div "hi"] (js-obj)))]
       (is (some? data)
           "call threw")
-      (is (= expected-type (:type data))
-          ":type identifies the React-19-removed-surface class")
+      (is (= expected-id (:rf.error/id data))
+          ":rf.error/id identifies the React-19-removed-surface class")
       (is (= 'reagent2.dom/render (:surface data))
           ":surface names the offending symbol")
       (is (= :no-recovery (:recovery data))
-          ":recovery is :no-recovery — there is no fallback path"))
+          ":recovery is :no-recovery — there is no fallback path")
+      (is (re-find #"reagent\.dom/render" (:reason data))
+          ":reason names the legacy stock-Reagent symbol")
+      (is (re-find #"reagent2\.dom\.client/" (:reason data))
+          ":reason points at the reagent2 migration target")
+      (is (re-find #"migration/from-re-frame-v1/README\.md#legacy-mount-path" (:migration data))
+          ":migration links to the migration guide anchor"))
     (let [msg (caught-message #(rdom/render [:div "hi"] (js-obj)))]
-      (is (string? msg))
-      (is (re-find #"reagent\.dom/render" msg)
-          "message names the legacy stock-Reagent symbol")
-      (is (re-find #"reagent2\.dom\.client/" msg)
-          "message points at the reagent2 migration target")
-      (is (re-find #"migration/from-re-frame-v1/README\.md#legacy-mount-path" msg)
-          "message links to the migration guide anchor"))))
+      (is (= ":rf.error/react-19-removed-surface" msg)
+          "message is the stringified discriminator kw"))))
 
 (deftest reagent2-dom-unmount-throws
   (testing "reagent2.dom/unmount-component-at-node throws"
     (let [data (caught-ex-data #(rdom/unmount-component-at-node (js-obj)))]
-      (is (= expected-type (:type data)))
-      (is (= 'reagent2.dom/unmount-component-at-node (:surface data))))
-    (let [msg (caught-message #(rdom/unmount-component-at-node (js-obj)))]
-      (is (re-find #"unmount-component-at-node" msg))
-      (is (re-find #"reagent2\.dom\.client/unmount" msg)
-          "message points at the unmount migration target"))))
+      (is (= expected-id (:rf.error/id data)))
+      (is (= 'reagent2.dom/unmount-component-at-node (:surface data)))
+      (is (re-find #"unmount-component-at-node" (:reason data)))
+      (is (re-find #"reagent2\.dom\.client/unmount" (:reason data))
+          ":reason points at the unmount migration target"))))
 
 (deftest reagent2-dom-force-update-all-throws
   (testing "reagent2.dom/force-update-all throws"
     (let [data (caught-ex-data #(rdom/force-update-all))]
-      (is (= expected-type (:type data)))
-      (is (= 'reagent2.dom/force-update-all (:surface data))))
-    (let [msg (caught-message #(rdom/force-update-all))]
-      (is (re-find #"force-update-all" msg))
-      (is (re-find #"file an issue" msg)
-          "message points at the issue tracker — there is no replacement"))))
+      (is (= expected-id (:rf.error/id data)))
+      (is (= 'reagent2.dom/force-update-all (:surface data)))
+      (is (re-find #"force-update-all" (:reason data)))
+      (is (re-find #"file an issue" (:reason data))
+          ":reason points at the issue tracker — there is no replacement"))))
 
 ;; ---------------------------------------------------------------------------
 ;; reagent2.core shims
@@ -93,37 +96,35 @@
 (deftest reagent2-core-render-throws
   (testing "reagent2.core/render throws"
     (let [data (caught-ex-data #(r/render [:div "hi"] (js-obj)))]
-      (is (= expected-type (:type data)))
-      (is (= 'reagent2.core/render (:surface data))))
-    (let [msg (caught-message #(r/render [:div "hi"] (js-obj)))]
-      (is (re-find #"reagent\.core/render" msg))
-      (is (re-find #"reagent2\.dom\.client/" msg)))))
+      (is (= expected-id (:rf.error/id data)))
+      (is (= 'reagent2.core/render (:surface data)))
+      (is (re-find #"reagent\.core/render" (:reason data)))
+      (is (re-find #"reagent2\.dom\.client/" (:reason data))))))
 
 (deftest reagent2-core-dom-node-throws
   (testing "reagent2.core/dom-node throws"
     (let [data (caught-ex-data #(r/dom-node (js-obj)))]
-      (is (= expected-type (:type data)))
-      (is (= 'reagent2.core/dom-node (:surface data))))
-    (let [msg (caught-message #(r/dom-node (js-obj)))]
-      (is (re-find #"findDOMNode" msg)
-          "message names the underlying React 17 API that was removed")
-      (is (re-find #"ref" msg)
-          "message points at the :ref migration target")
-      (is (re-find #"migration/from-re-frame-v1/README\.md#dom-node-removal" msg)
-          "message links to the migration guide anchor"))))
+      (is (= expected-id (:rf.error/id data)))
+      (is (= 'reagent2.core/dom-node (:surface data)))
+      (is (re-find #"findDOMNode" (:reason data))
+          ":reason names the underlying React 17 API that was removed")
+      (is (re-find #"ref" (:reason data))
+          ":reason points at the :ref migration target")
+      (is (re-find #"migration/from-re-frame-v1/README\.md#dom-node-removal" (:migration data))
+          ":migration links to the migration guide anchor"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-shim contract — one try/catch matches all five
 ;; ---------------------------------------------------------------------------
 
-(deftest all-five-shims-share-the-error-type
-  (testing "a single try/catch keyed on :type matches every Class B shim"
+(deftest all-five-shims-share-the-error-id
+  (testing "a single try/catch keyed on :rf.error/id matches every Class B shim"
     (let [shims [#(rdom/render [:div] (js-obj))
                  #(rdom/unmount-component-at-node (js-obj))
                  #(rdom/force-update-all)
                  #(r/render [:div] (js-obj))
                  #(r/dom-node (js-obj))]
-          types (mapv (fn [f] (:type (caught-ex-data f))) shims)]
-      (is (every? #(= expected-type %) types)
-          (str "all five shims must use :type " expected-type
-               "; observed: " (pr-str types))))))
+          ids (mapv (fn [f] (:rf.error/id (caught-ex-data f))) shims)]
+      (is (every? #(= expected-id %) ids)
+          (str "all five shims must use :rf.error/id " expected-id
+               "; observed: " (pr-str ids))))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/component_cljs_test.cljs
@@ -78,7 +78,7 @@
                       :component-will-receive-props (fn [_this _new-props])})
                    nil
                    (catch :default e (ex-data e)))]
-      (is (= :rf.error/create-class-key-unsupported (:type thrown)))
+      (is (= :rf.error/create-class-key-unsupported (:rf.error/id thrown)))
       (is (contains? (set (:keys thrown)) :component-will-receive-props)
           "the offending key is named in the ex-data")
       (is (= component/cap-keys (:supported-keys thrown))
@@ -94,7 +94,7 @@
                       :component-will-mount         (fn [_])})
                    nil
                    (catch :default e (ex-data e)))]
-      (is (= :rf.error/create-class-key-unsupported (:type thrown)))
+      (is (= :rf.error/create-class-key-unsupported (:rf.error/id thrown)))
       (is (= #{:component-will-receive-props
                :should-component-update
                :component-will-mount}
@@ -107,7 +107,7 @@
                    (component/create-class* {:display-name "Foo"})
                    nil
                    (catch :default e (ex-data e)))]
-      (is (= :rf.error/create-class-missing-render (:type thrown))))))
+      (is (= :rf.error/create-class-missing-render (:rf.error/id thrown))))))
 
 (deftest create-class-accepts-every-cap-key
   (testing "spec with all 7 cap keys is accepted (no throw)"
@@ -666,8 +666,8 @@
                           (.call render instance)
                           nil
                           (catch :default e (ex-data e)))]
-          (is (= :rf.error/as-element-fn-unregistered (:type thrown))
-              ":type identifies the unregistered seam class")
+          (is (= :rf.error/as-element-fn-unregistered (:rf.error/id thrown))
+              ":rf.error/id identifies the unregistered seam class")
           (is (= :no-recovery (:recovery thrown))
               ":recovery is :no-recovery — there is no fallback path")
           (is (string? (:reason thrown))

--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -70,13 +70,34 @@
                  ;; "cannot count a string" — we honour that intent by
                  ;; refusing strings AND Characters (a string element
                  ;; landed as a char during seq iteration).
+                 ;; The :count builtin's MESSAGE is deliberately surfaced
+                 ;; downstream as the sub-exception trace's
+                 ;; :exception-message (the conformance corpus pins it),
+                 ;; so — like the :throw DSL op — the message string stays
+                 ;; the human prose rather than the discriminator kw. The
+                 ;; canonical :rf.error/id rides on ex-data for structured
+                 ;; branching.
                  (cond
-                   (string? x)    (throw (ex-info "cannot count a string" {}))
-                   (char? x)      (throw (ex-info "cannot count a string" {}))
-                   (nil? x)       (throw (ex-info "cannot count nil" {}))
+                   (string? x)    (throw (ex-info "cannot count a string"
+                                                   {:rf.error/id :rf.error/conformance-cannot-count-string
+                                                    :where    'rf/conformance-eval
+                                                    :recovery :no-recovery}))
+                   (char? x)      (throw (ex-info "cannot count a string"
+                                                   {:rf.error/id :rf.error/conformance-cannot-count-string
+                                                    :where    'rf/conformance-eval
+                                                    :recovery :no-recovery}))
+                   (nil? x)       (throw (ex-info "cannot count nil"
+                                                   {:rf.error/id :rf.error/conformance-cannot-count-nil
+                                                    :where    'rf/conformance-eval
+                                                    :recovery :no-recovery}))
                    :else          (count x)))
     :item-amount (fn [item] (* (:qty item) (:price item)))
-    (throw (ex-info "unknown :fn builtin" {:builtin k}))))
+    (throw (ex-info ":rf.error/conformance-unknown-fn-builtin"
+                    {:rf.error/id :rf.error/conformance-unknown-fn-builtin
+                     :where    'rf/conformance-eval
+                     :recovery :no-recovery
+                     :reason   (str "unknown :fn builtin " k)
+                     :builtin  k}))))
 
 ;; ---- value resolver -------------------------------------------------------
 
@@ -264,9 +285,14 @@
 
               :noop acc
 
-              (throw (ex-info "unknown :before DSL op"
-                              {:op step :allowed #{:assoc-in-request
-                                                   :dispatch :noop}})))))
+              (throw (ex-info ":rf.error/conformance-unknown-before-op"
+                              {:rf.error/id :rf.error/conformance-unknown-before-op
+                               :where    'rf/conformance-eval
+                               :recovery :no-recovery
+                               :reason   "unknown :before DSL op"
+                               :op       step
+                               :allowed  #{:assoc-in-request
+                                           :dispatch :noop}})))))
         chain-ctx
         steps))))
 
@@ -352,8 +378,16 @@
     :dispatch-sync (let [ev (resolve-value (second step) ctx)]
                      (assoc ctx :fx (conj (or fx []) [:dispatch-sync ev])))
 
+    ;; The :throw DSL op exists to surface a FIXTURE-SUPPLIED message
+    ;; downstream (the runtime re-emits it as :exception-message), so —
+    ;; uniquely among conformance throws — the message string stays the
+    ;; fixture's text rather than the discriminator kw. The canonical
+    ;; :rf.error/id slot still rides on ex-data for structured branching.
     :throw     (throw (ex-info (str (second step))
-                               {:from-fixture? true}))
+                               {:rf.error/id   :rf.error/conformance-throw-step
+                                :where         'rf/conformance-eval
+                                :recovery      :no-recovery
+                                :from-fixture? true}))
 
     ;; :get and :reduce-input are sub-body ops; the realise-sub-handler
     ;; reads them separately. Treated as no-op here.
@@ -361,7 +395,12 @@
     :reduce-input ctx
     :db-get    ctx
 
-    (throw (ex-info "unknown DSL op" {:op step}))))
+    (throw (ex-info ":rf.error/conformance-unknown-dsl-op"
+                    {:rf.error/id :rf.error/conformance-unknown-dsl-op
+                     :where    'rf/conformance-eval
+                     :recovery :no-recovery
+                     :reason   "unknown DSL op"
+                     :op       step}))))
 
 (defn realise-event-db-handler
   "DSL → an event-db handler fn (db, event) → new-db.

--- a/implementation/core/src/re_frame/core_artefact.cljc
+++ b/implementation/core/src/re_frame/core_artefact.cljc
@@ -162,8 +162,12 @@
      (let [attrs (cond
                    (map? docstring-or-attrs)    docstring-or-attrs
                    (string? docstring-or-attrs) {:doc docstring-or-attrs}
-                   :else (throw (ex-info "defwrapper: expected docstring or attr-map"
-                                         {:got docstring-or-attrs})))
+                   :else (throw (ex-info ":rf.error/defwrapper-bad-args"
+                                         {:rf.error/id :rf.error/defwrapper-bad-args
+                                          :where       'defwrapper
+                                          :recovery    :fix-registration
+                                          :reason      "defwrapper's second argument must be a docstring or an attr-map"
+                                          :got         docstring-or-attrs})))
            attrs (cond-> attrs
                    (:arglists spec) (assoc :arglists (:arglists spec)))
            spec    (update spec :where #(or % (list 'quote (symbol "rf" (str name-sym)))))

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -91,9 +91,12 @@
      [sym]
      (let [v (ns-resolve (find-ns 're-frame.core) sym)]
        (when (nil? v)
-         (throw (ex-info (str "defreg-macro: cannot resolve delegate symbol " sym
-                              " in re-frame.core")
-                         {:sym sym})))
+         (throw (ex-info ":rf.error/defreg-macro-bad-delegate"
+                         {:rf.error/id :rf.error/defreg-macro-bad-delegate
+                          :where       'defreg-macro
+                          :recovery    :fix-registration
+                          :reason      (str "defreg-macro cannot resolve delegate symbol " sym " in re-frame.core")
+                          :sym         sym})))
        (symbol (str (.ns ^clojure.lang.Var v))
                (str (.sym ^clojure.lang.Var v))))))
 

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -93,12 +93,18 @@
            slot-meta (dissoc sym-meta :rf/id)]
        (when (nil? parsed)
          (throw (ex-info
-                  (str "reg-view second argument must be an args vector "
-                       "(defn-shape: (reg-view sym [args] body)). Got "
-                       (describe-reg-view-bad-second-arg (first more))
-                       ". For runtime registration, use "
-                       "(re-frame.core/reg-view* :id render-fn).")
-                  {:sym sym :got (first more) :args-after-sym (vec more)})))
+                  ":rf.error/reg-view-bad-args"
+                  {:rf.error/id    :rf.error/reg-view-bad-args
+                   :where          'rf/reg-view
+                   :recovery       :fix-registration
+                   :reason         (str "reg-view's second argument must be an args vector "
+                                        "(defn-shape: (reg-view sym [args] body)). Got "
+                                        (describe-reg-view-bad-second-arg (first more))
+                                        ". For runtime registration, use "
+                                        "(re-frame.core/reg-view* :id render-fn).")
+                   :sym            sym
+                   :got            (first more)
+                   :args-after-sym (vec more)})))
        (let [{:keys [docstring args body]} parsed
              form-tag (reagent-slim-form-tag body)
              def-form (if docstring
@@ -164,10 +170,15 @@
        ;; runtime error far from the call site.
        (vector? bindings)
        (throw (ex-info
-                (str "with-frame: vector binding must be [sym expr] (Shape 2). "
-                     "Got " (count bindings) " element"
-                     (when-not (= 1 (count bindings)) "s") ".")
-                {:got bindings :count (count bindings)}))
+                ":rf.error/with-frame-bad-binding"
+                {:rf.error/id :rf.error/with-frame-bad-binding
+                 :where       'rf/with-frame
+                 :recovery    :fix-registration
+                 :reason      (str "with-frame's vector binding must be [sym expr] (Shape 2). "
+                                   "Got " (count bindings) " element"
+                                   (when-not (= 1 (count bindings)) "s") ".")
+                 :got         bindings
+                 :count       (count bindings)}))
 
        :else
        `(binding [re-frame.frame/*current-frame* ~bindings]

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -105,7 +105,8 @@
   (when (and (attaches-validate-at-boundary-interceptor? interceptors)
              (not (and (map? meta) (contains? meta :schema))))
     (throw (ex-info ":rf.error/at-boundary-missing-schema"
-                    {:error    :rf.error/at-boundary-missing-schema
+                    {:rf.error/id :rf.error/at-boundary-missing-schema
+                     :where    'rf/reg-event-db
                      :reg-fn   reg-fn-name
                      :id       id
                      :reason
@@ -282,15 +283,24 @@
           (map? middle)    [middle [] handler]
           (vector? middle) [{} middle handler]
           :else            (throw (ex-info
-                                    "reg-event-*: middle slot must be a metadata-map or an interceptor-vector"
-                                    {:args     args
-                                     :got      middle
-                                     :expected "metadata-map (e.g. {:doc \"...\"}) OR interceptor-vector (e.g. [(path :a)])"}))))
+                                    ":rf.error/reg-event-bad-middle-slot"
+                                    {:rf.error/id :rf.error/reg-event-bad-middle-slot
+                                     :where       'rf/reg-event-db
+                                     :recovery    :fix-registration
+                                     :reason      "the middle slot of a reg-event-* call must be a metadata-map (e.g. {:doc \"...\"}) or an interceptor-vector (e.g. [(path :a)])"
+                                     :args        args
+                                     :got         middle
+                                     :expected    "metadata-map (e.g. {:doc \"...\"}) OR interceptor-vector (e.g. [(path :a)])"}))))
     3 (let [[meta interceptors handler] args]
         [meta (or interceptors []) handler])
     (throw (ex-info
-             "reg-event-* arity error — expected (id handler), (id metadata handler), or (id metadata interceptors handler)"
-             {:args args :count (count args)}))))
+             ":rf.error/reg-event-bad-arity"
+             {:rf.error/id :rf.error/reg-event-bad-arity
+              :where       'rf/reg-event-db
+              :recovery    :fix-registration
+              :reason      "reg-event-* expects (id handler), (id metadata handler), or (id metadata interceptors handler)"
+              :args        args
+              :count       (count args)}))))
 
 (defn- merge-form-source
   "Merge `*pending-form-source*` into `m` under `:rf.handler/source`

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -244,8 +244,13 @@
   surface — `(rf2-6w7zn)`."
   [kind id metadata]
   (when-not (valid-kind? kind)
-    (throw (ex-info (str "re-frame2: unknown registry kind: " kind)
-                    {:kind kind :id id})))
+    (throw (ex-info ":rf.error/unknown-registry-kind"
+                    {:rf.error/id :rf.error/unknown-registry-kind
+                     :where       'rf/register-handler
+                     :recovery    :fix-registration
+                     :reason      (str "unknown registry kind " kind " — not one of the registered registry kinds")
+                     :kind        kind
+                     :id          id})))
   ;; Always-on error-coord parallel registry (rf2-3un2g §Production
   ;; elision). When a public reg-* macro is on the stack `*pending-coords*`
   ;; carries the captured coord-map (slim in CLJS prod — no `:column`).

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -87,8 +87,13 @@
 
         :else
         (throw (ex-info
-                 "reg-sub: bad args — expected layer-1 (handler-fn), layer-2 single (:<- [:upstream] handler-fn), or layer-2 multi (:<- [:a] :<- [:b] handler-fn)"
-                 {:id id :remaining remaining}))))))
+                 ":rf.error/reg-sub-bad-args"
+                 {:rf.error/id :rf.error/reg-sub-bad-args
+                  :where       'rf/reg-sub
+                  :recovery    :fix-registration
+                  :reason      "reg-sub expects layer-1 (handler-fn), layer-2 single (:<- [:upstream] handler-fn), or layer-2 multi (:<- [:a] :<- [:b] handler-fn)"
+                  :id          id
+                  :remaining   remaining}))))))
 
 (defn reg-sub
   "Register a subscription under `id`. The only sub-registration form

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -425,12 +425,23 @@
         (is (= 1 (get-frame-db [:n]))))"
   [node event-key & args]
   (when-not (vector? node)
-    (throw (ex-info "invoke-handler: node must be a hiccup vector"
-                    {:node node :event-key event-key})))
+    (throw (ex-info ":rf.error/invoke-handler-bad-node"
+                    {:rf.error/id :rf.error/invoke-handler-bad-node
+                     :where     'rf/invoke-handler
+                     :recovery  :no-recovery
+                     :reason    "invoke-handler's node must be a hiccup vector"
+                     :node      node
+                     :event-key event-key})))
   (let [h (extract-handler node event-key)]
     (when-not (fn? h)
-      (throw (ex-info (str "invoke-handler: no handler under " event-key)
-                      {:node node :event-key event-key :handler h})))
+      (throw (ex-info ":rf.error/invoke-handler-missing"
+                      {:rf.error/id :rf.error/invoke-handler-missing
+                       :where     'rf/invoke-handler
+                       :recovery  :no-recovery
+                       :reason    (str "invoke-handler found no handler fn under " event-key)
+                       :node      node
+                       :event-key event-key
+                       :handler   h})))
     (apply h args)))
 
 ;; ---------------------------------------------------------------------------
@@ -582,11 +593,14 @@
   (if-let [view *current-root-view*]
     (apply view *current-root-view-args*)
     (throw (ex-info
-             (str "expect-text / wait-until called outside a "
-                  "`with-app-fixture` body, OR the fixture did not "
-                  "supply :root-view. Pass an explicit tree as the "
-                  "first arg, or set :root-view in the fixture opts.")
-             {:rf.test-helpers/error :no-root-view}))))
+             ":rf.error/no-root-view"
+             {:rf.error/id :rf.error/no-root-view
+              :where    'rf/expect-text
+              :recovery :no-recovery
+              :reason   (str "expect-text / wait-until called outside a "
+                             "`with-app-fixture` body, OR the fixture did not "
+                             "supply :root-view. Pass an explicit tree as the "
+                             "first arg, or set :root-view in the fixture opts.")}))))
 
 (defn- coerce-testid-string
   "Allow testids supplied as keywords (`:counter-display`) at the call
@@ -598,10 +612,13 @@
     (keyword? testid) (name testid)
     (string?  testid) testid
     :else
-    (throw (ex-info (str "testid must be a keyword or string, got "
-                         (pr-str testid))
-                    {:rf.test-helpers/error :bad-testid
-                     :testid                testid}))))
+    (throw (ex-info ":rf.error/testid-bad-arg"
+                    {:rf.error/id :rf.error/testid-bad-arg
+                     :where    'rf/find-by-testid
+                     :recovery :no-recovery
+                     :reason   (str "testid must be a keyword or string, got "
+                                    (pr-str testid))
+                     :testid   testid}))))
 
 (defn expect-text
   "Assert that the hiccup node carrying `:data-testid testid` has
@@ -665,13 +682,17 @@
 
 (defn- wait-timeout-error
   "Shared timeout-error constructor so test code can pattern-match on
-  `:rf.test-helpers/wait-timeout` regardless of runtime."
+  the canonical `:rf.error/id :rf.error/wait-until-timeout` discriminator
+  (per Spec 009) regardless of runtime."
   [label elapsed-ms]
-  (ex-info (str "wait-until timed out"
-                (when label (str " — " label)))
-           {:rf.test-helpers/wait-timeout true
-            :elapsed-ms                   elapsed-ms
-            :label                        label}))
+  (ex-info ":rf.error/wait-until-timeout"
+           {:rf.error/id :rf.error/wait-until-timeout
+            :where       'rf/wait-until
+            :recovery    :no-recovery
+            :reason      (str "wait-until timed out"
+                              (when label (str " — " label)))
+            :elapsed-ms  elapsed-ms
+            :label       label}))
 
 #?(:clj
    (defn- jvm-wait-until-pred

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -521,13 +521,18 @@
 
 (defn- poll-timeout-error
   "Shared timeout-error constructor — same shape JVM / CLJS so test code
-  that pattern-matches on `:rf.test/poll-timeout` works on either runtime."
+  that pattern-matches on the canonical `:rf.error/id
+  :rf.error/poll-until-timeout` discriminator (per Spec 009) works on
+  either runtime."
   [label elapsed-ms]
-  (ex-info (str "poll-until timed out"
-                (when label (str " — " label)))
-           {:rf.test/poll-timeout true
-            :elapsed-ms elapsed-ms
-            :label label}))
+  (ex-info ":rf.error/poll-until-timeout"
+           {:rf.error/id :rf.error/poll-until-timeout
+            :where       'rf/poll-until
+            :recovery    :no-recovery
+            :reason      (str "poll-until timed out"
+                              (when label (str " — " label)))
+            :elapsed-ms  elapsed-ms
+            :label       label}))
 
 #?(:clj
    (defn poll-until

--- a/implementation/core/test/re_frame/core_api_additions_test.clj
+++ b/implementation/core/test/re_frame/core_api_additions_test.clj
@@ -133,16 +133,20 @@
       (let [e (try (expand [] '((do nil))) nil
                    (catch clojure.lang.ExceptionInfo e e))]
         (is (some? e) "[] must throw")
-        (is (re-find #"with-frame: vector binding must be \[sym expr\]"
-                     (.getMessage ^Throwable e))
-            "the message carries the structured reason"))
+        (is (= :rf.error/with-frame-bad-binding (:rf.error/id (ex-data e)))
+            ":rf.error/id is the canonical discriminator")
+        (is (re-find #"with-frame's vector binding must be \[sym expr\]"
+                     (:reason (ex-data e)))
+            ":reason carries the structured explanation"))
       ;; 3-element vector — typo of `[sym expr]` with extra tail.
       (let [e (try (expand '[f g h] '((do nil))) nil
                    (catch clojure.lang.ExceptionInfo e e))]
         (is (some? e) "[f g h] must throw")
-        (is (re-find #"with-frame: vector binding must be \[sym expr\]"
-                     (.getMessage ^Throwable e))
-            "the message carries the structured reason")))))
+        (is (= :rf.error/with-frame-bad-binding (:rf.error/id (ex-data e)))
+            ":rf.error/id is the canonical discriminator")
+        (is (re-find #"with-frame's vector binding must be \[sym expr\]"
+                     (:reason (ex-data e)))
+            ":reason carries the structured explanation")))))
 
 ;; ===========================================================================
 ;; rf2-ewku — (rf/registrations kind pred-fn) filter arity

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -391,21 +391,31 @@
 
 (deftest normalise-args-rejects-overlong-and-malformed
   (testing "tail count > 3 throws the arity error"
-    (is (thrown-with-msg?
-          clojure.lang.ExceptionInfo
-          #"reg-event-\* arity error"
-          (rf/reg-event-db :test.fuudi/too-many
-            {:doc "..."}
-            [{:id :a :before identity :after identity}]
-            (fn [db _] db)
-            :surplus))))
+    (let [ex (try
+               (rf/reg-event-db :test.fuudi/too-many
+                 {:doc "..."}
+                 [{:id :a :before identity :after identity}]
+                 (fn [db _] db)
+                 :surplus)
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (= ":rf.error/reg-event-bad-arity" (ex-message ex))
+          "message is the stringified discriminator kw")
+      (is (= :rf.error/reg-event-bad-arity (:rf.error/id (ex-data ex))))
+      (is (re-find #"reg-event-\*" (:reason (ex-data ex)))
+          ":reason names the arity error")))
   (testing "two-arg middle slot that is neither a map nor a vector throws"
-    (is (thrown-with-msg?
-          clojure.lang.ExceptionInfo
-          #"middle slot must be a metadata-map or an interceptor-vector"
-          (rf/reg-event-db :test.fuudi/bad-middle
-            "not-a-map-or-vector"
-            (fn [db _] db))))))
+    (let [ex (try
+               (rf/reg-event-db :test.fuudi/bad-middle
+                 "not-a-map-or-vector"
+                 (fn [db _] db))
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex))
+      (is (= ":rf.error/reg-event-bad-middle-slot" (ex-message ex)))
+      (is (= :rf.error/reg-event-bad-middle-slot (:rf.error/id (ex-data ex))))
+      (is (re-find #"interceptor-vector" (:reason (ex-data ex)))))))
 
 ;; ---- rf2-twt7m Change 3 — :rf/default? tag on auto-wrappers ---------------
 ;;
@@ -536,8 +546,8 @@
                         [at-boundary-stub]
                         (fn [_ _] {}))
                       (catch clojure.lang.ExceptionInfo e (ex-data e)))]
-        (is (= :rf.error/at-boundary-missing-schema (:error data))
-            ":error keyword matches the catalogued :rf.error/* category")
+        (is (= :rf.error/at-boundary-missing-schema (:rf.error/id data))
+            ":rf.error/id matches the catalogued :rf.error/* category")
         (is (= "reg-event-fx" (:reg-fn data)))
         (is (= :test.iftj4/data-probe (:id data)))
         (is (string? (:reason data)))

--- a/implementation/core/test/re_frame/reg_view_test.clj
+++ b/implementation/core/test/re_frame/reg_view_test.clj
@@ -73,47 +73,63 @@
 
 ;; ---- compile-error contract ----------------------------------------------
 
+;; The macro throw conforms to the canonical thrown-error shape
+;; (Spec 009): the message is the stringified discriminator kw and the
+;; human-readable prose rides on the `:reason` ex-data slot. A
+;; macroexpansion error wraps the original ex-info as its cause, so the
+;; ex-data is read off the cause when present.
+
+(defn- ex-data-in-chain
+  "Walk the cause chain of `e` and return the first ex-data carrying the
+  canonical `:rf.error/id` slot — the compiler wraps macro-side
+  ex-infos in a CompilerException whose own ex-data is a
+  `:clojure.error/*` map, so we skip past it to the real throw."
+  [e]
+  (loop [t e]
+    (when t
+      (let [d (ex-data t)]
+        (if (contains? d :rf.error/id)
+          d
+          (recur (.getCause ^Throwable t)))))))
+
+(defn- reg-view-error-reason
+  "Run `thunk` (which must throw a reg-view macro error) and return the
+  `:reason` from the canonical ex-data (walking the compiler's cause
+  chain)."
+  [thunk]
+  (try (thunk) nil
+       (catch Throwable e
+         (:reason (ex-data-in-chain e)))))
+
 (deftest reg-view-rejects-var-ref-body
   (testing "(reg-view sym some-fn) — a symbol where the args vector should be
             — throws at macroexpand"
-    (let [exp-fn (fn []
-                   (eval `(rf/reg-view bad-var ~'some-fn-ref)))
-          err    (try (exp-fn) nil
-                      (catch Exception e
-                        (or (some-> e .getCause .getMessage)
-                            (.getMessage e))))]
-      (is (some? err)
+    (let [reason (reg-view-error-reason
+                   (fn [] (eval `(rf/reg-view bad-var ~'some-fn-ref))))]
+      (is (some? reason)
           "macroexpand throws when the second arg is a symbol")
-      (is (re-find #"args vector" err)
-          "the message points at the missing args vector")
-      (is (re-find #"reg-view\*" err)
-          "the message points the user at the reg-view* escape hatch"))))
+      (is (re-find #"args vector" reason)
+          ":reason points at the missing args vector")
+      (is (re-find #"reg-view\*" reason)
+          ":reason points the user at the reg-view* escape hatch"))))
 
 (deftest reg-view-rejects-create-class-body
   (testing "(reg-view sym (reagent.core/create-class …)) — a list where the
             args vector should be — throws at macroexpand"
-    (let [exp-fn (fn []
-                   (eval `(rf/reg-view bad-cc (reagent.core/create-class {}))))
-          err    (try (exp-fn) nil
-                      (catch Exception e
-                        (or (some-> e .getCause .getMessage)
-                            (.getMessage e))))]
-      (is (some? err)
+    (let [reason (reg-view-error-reason
+                   (fn [] (eval `(rf/reg-view bad-cc (reagent.core/create-class {})))))]
+      (is (some? reason)
           "macroexpand throws when the second arg is a create-class call")
-      (is (re-find #"args vector" err)
-          "the message points at the missing args vector")
-      (is (re-find #"reg-view\*" err)
-          "the message points the user at the reg-view* escape hatch"))))
+      (is (re-find #"args vector" reason)
+          ":reason points at the missing args vector")
+      (is (re-find #"reg-view\*" reason)
+          ":reason points the user at the reg-view* escape hatch"))))
 
 (deftest reg-view-rejects-computed-body
   (testing "(reg-view sym (some-fn-returning-a-fn)) — a non-fn call where
             the args vector should be — throws at macroexpand"
-    (let [exp-fn (fn []
-                   (eval `(rf/reg-view bad-comp (~'compute-render-fn))))
-          err    (try (exp-fn) nil
-                      (catch Exception e
-                        (or (some-> e .getCause .getMessage)
-                            (.getMessage e))))]
+    (let [err (reg-view-error-reason
+                (fn [] (eval `(rf/reg-view bad-comp (~'compute-render-fn)))))]
       (is (some? err)
           "macroexpand throws when the second arg is a non-fn call")
       (is (re-find #"args vector" err)
@@ -122,20 +138,24 @@
 ;; ---- error message template ----------------------------------------------
 
 (deftest reg-view-error-message-matches-template
-  (testing "the compile-error message follows the documented template"
-    (let [err (try (eval `(rf/reg-view broken ~'naked-symbol))
-                   nil
-                   (catch Exception e
-                     (or (some-> e .getCause .getMessage)
-                         (.getMessage e))))]
-      (is (some? err))
-      (is (re-find #"reg-view second argument must be an args vector" err)
+  (testing "the canonical :reason follows the documented template; the
+            message string is the stringified discriminator kw"
+    (let [{:keys [reason id]}
+          (try (eval `(rf/reg-view broken ~'naked-symbol))
+               nil
+               (catch Throwable e
+                 (let [d (ex-data-in-chain e)]
+                   {:reason (:reason d)
+                    :id     (:rf.error/id d)})))]
+      (is (= :rf.error/reg-view-bad-args id)
+          ":rf.error/id is the canonical discriminator")
+      (is (re-find #"reg-view's second argument must be an args vector" reason)
           "leading clause matches the template")
-      (is (re-find #"defn-shape" err)
+      (is (re-find #"defn-shape" reason)
           "mentions defn-shape")
-      (is (re-find #"For runtime registration, use" err)
+      (is (re-find #"For runtime registration, use" reason)
           "directs the user to the escape hatch")
-      (is (re-find #"reg-view\*" err)
+      (is (re-find #"reg-view\*" reason)
           "names reg-view* explicitly"))))
 
 ;; ---- docstring slot ------------------------------------------------------

--- a/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_app_fixture_cljs_test.cljc
@@ -222,14 +222,14 @@
 #?(:clj
    (deftest wait-until-pred-throws-on-timeout
      (testing "JVM: pred that never goes truthy throws ex-info with
-               :rf.test-helpers/wait-timeout true"
+               :rf.error/id :rf.error/wait-until-timeout"
        (let [e (try (th/wait-until (constantly false)
                                    {:timeout-ms 30 :interval-ms 5
                                     :label "never"})
                     nil
                     (catch clojure.lang.ExceptionInfo e e))]
          (is (some? e) "timeout threw")
-         (is (true? (:rf.test-helpers/wait-timeout (ex-data e))))
+         (is (= :rf.error/wait-until-timeout (:rf.error/id (ex-data e))))
          (is (= "never" (:label (ex-data e))))))))
 
 #?(:clj
@@ -259,8 +259,8 @@
 
 #?(:cljs
    (deftest wait-until-pred-rejects-on-timeout
-     (testing "CLJS: wait-until rejects with :rf.test-helpers/wait-timeout
-               on deadline elapse"
+     (testing "CLJS: wait-until rejects with :rf.error/id
+               :rf.error/wait-until-timeout on deadline elapse"
        (async done
          (-> (th/wait-until (constantly false)
                             {:timeout-ms 20 :interval-ms 5
@@ -270,6 +270,6 @@
                       (done)))
              (.catch (fn [e]
                        (let [data (ex-data e)]
-                         (is (true? (:rf.test-helpers/wait-timeout data)))
+                         (is (= :rf.error/wait-until-timeout (:rf.error/id data)))
                          (is (= "never" (:label data))))
                        (done))))))))

--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -28,8 +28,10 @@
   apps still load the namespace; the decode call falls through to a
   no-op (returns the parsed value) when Malli isn't on the classpath.
 
-  The schema-validation failure throws an ex-info with `:malli-error?
-  true`; the caller (`http-transport/handle-response!`) classifies as
+  The schema-validation failure throws an ex-info with
+  `:rf.error/id :rf.error/http-schema-validation-failed` (the canonical
+  discriminator per Spec 009); the caller
+  (`http-transport/handle-response!`) classifies as
   `:rf.http/decode-failure :schema-validation-failure? true`."
   (:require [clojure.string  :as str]
             [re-frame.http-privacy :as privacy]
@@ -117,8 +119,13 @@
                       :else                    value)]
     (when validate
       (when-not (validate schema decoded)
-        (throw (ex-info "schema validation failed"
-                        {:schema schema :value decoded :malli-error? true}))))
+        (throw (ex-info ":rf.error/http-schema-validation-failed"
+                        {:rf.error/id :rf.error/http-schema-validation-failed
+                         :where       'rf.http/decode-response-body
+                         :recovery    :no-recovery
+                         :reason      "the decoded response body failed Malli schema validation; the caller classifies this as :rf.http/decode-failure"
+                         :schema      schema
+                         :value       decoded}))))
     decoded))
 
 (defn decode-response-body
@@ -129,9 +136,10 @@
   `:max-decoded-keys` slot (from the request args' `:rf.http/max-decoded-keys`,
   defaulted at the handler) is threaded into `util-json/json-parse`.
   The Malli-schema branch propagates the cap-throw rather than
-  swallowing it — a `:rf.error/malformed-json :reason :too-many-keys`
-  is a security-relevant signal and must surface as
-  `:rf.http/decode-failure`, not be masked behind a malli rejection."
+  swallowing it — a `:rf.error/id :rf.error/malformed-json`
+  (`:cause :too-many-keys`) is a security-relevant signal and must
+  surface as `:rf.http/decode-failure`, not be masked behind a malli
+  rejection."
   [{:keys [body-text headers decode decode-supplied? request-id url sensitive?
            max-decoded-keys]}]
   (let [content-type (content-type-of headers)
@@ -187,7 +195,7 @@
       (let [parsed (try (util-json/json-parse body-text parse-opts)
                         (catch #?(:clj Throwable :cljs :default) e
                           (let [d (ex-data e)]
-                            (if (= :rf.error/malformed-json (:kind d))
+                            (if (= :rf.error/malformed-json (:rf.error/id d))
                               (throw e)
                               body-text))))]
         (malli-decode resolved parsed))

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -169,13 +169,19 @@
             (let [out (before acc)]
               (if (map? out)
                 out
-                ;; rf2-m32t9 — include the interceptor id in the cause
-                ;; string so a chain failure printed via the outer
-                ;; ex-info's :cause is locatable without reaching for
-                ;; ex-data. The :id key in ex-data is kept for
-                ;; programmatic consumers.
-                (throw (ex-info (str "interceptor " id " :before did not return a ctx map")
-                                {:id id :returned out}))))
+                ;; Canonical thrown-error shape (Spec 009): message is
+                ;; the stringified discriminator kw; the descriptive
+                ;; sentence (naming the offending interceptor id) rides
+                ;; on :reason. The outer wrapper carries :interceptor-id
+                ;; so a chain failure is locatable via ex-data; the :id
+                ;; key here is kept for programmatic consumers.
+                (throw (ex-info ":rf.error/http-interceptor-bad-return"
+                                {:rf.error/id :rf.error/http-interceptor-bad-return
+                                 :where       'rf/reg-http-interceptor
+                                 :recovery    :no-recovery
+                                 :reason      (str "interceptor " id " :before did not return a ctx map")
+                                 :id          id
+                                 :returned    out}))))
             (catch #?(:clj Throwable :cljs :default) t
               (let [data (ex-info ":rf.error/http-interceptor-failed"
                                   {:where    'run-http-interceptor-chain!
@@ -183,8 +189,15 @@
                                    :frame    frame-id
                                    :interceptor-id id
                                    :url      (get-in acc [:request :url])
-                                   :cause    #?(:clj  (.getMessage ^Throwable t)
-                                                :cljs (.-message t))})]
+                                   ;; Prefer the inner throw's :reason
+                                   ;; (a human sentence naming the
+                                   ;; offending interceptor) over the
+                                   ;; raw message — canonical throws
+                                   ;; stringify the discriminator kw as
+                                   ;; their message.
+                                   :cause    (or (:reason (ex-data t))
+                                                 #?(:clj  (.getMessage ^Throwable t)
+                                                    :cljs (.-message t)))})]
                 (when interop/debug-enabled?
                   ;; rf2-1jcpm — route through the privacy composer so a
                   ;; denylisted query param (`?api_key=…`) is scrubbed

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -109,10 +109,16 @@
                                                  (fn []
                                                    (try (.abort internal-controller "timeout")
                                                         (catch :default _ nil))
-                                                   (reject (ex-info "timeout"
-                                                                    {:rf.http/timeout? true
-                                                                     :elapsed-ms timeout-ms
-                                                                     :limit-ms timeout-ms})))
+                                                   (reject (ex-info ":rf.error/http-timeout"
+                                                                    {:rf.error/id      :rf.error/http-timeout
+                                                                     :where            ':rf.http/managed
+                                                                     :recovery         :no-recovery
+                                                                     :reason           (str "the request exceeded its " timeout-ms "ms timeout and was aborted")
+                                                                     ;; co-stamp the registry-hook signal the
+                                                                     ;; downstream classifier branches on
+                                                                     :rf.http/timeout? true
+                                                                     :elapsed-ms       timeout-ms
+                                                                     :limit-ms         timeout-ms})))
                                                  timeout-ms)))))])
                (.then (fn [resp]
                         (when-let [h @timeout-handle] (js/clearTimeout h))
@@ -680,7 +686,8 @@
                :body-text                  body-text
                :cause                      #?(:clj (.getMessage ^Throwable e)
                                               :cljs (.-message e))
-               :schema-validation-failure? (boolean (:malli-error? d))}))))
+               :schema-validation-failure? (= :rf.error/http-schema-validation-failed
+                                              (:rf.error/id d))}))))
 
       :else
       ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx that the

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -33,9 +33,9 @@
   worst case. Both readers enforce a per-call cap on the number of
   unique keys decoded (default `default-max-decoded-keys` = 10000;
   overridable per request via `(json-parse s {:max-decoded-keys N})`).
-  Overflow throws `:rf.error/malformed-json :reason :too-many-keys` —
-  the `:rf.http/managed` cascade classifies this as
-  `:rf.http/decode-failure`."
+  Overflow throws `:rf.error/id :rf.error/malformed-json` with
+  `:cause :too-many-keys` — the `:rf.http/managed` cascade classifies
+  this as `:rf.http/decode-failure`."
   #?(:clj  (:require [cheshire.core :as cheshire])))
 
 (def ^:const default-max-decoded-keys
@@ -61,7 +61,7 @@
   `opts` (optional) — currently a single key:
    - `:max-decoded-keys` — cap on unique object keys (rf2-wu1n5).
      Default: `default-max-decoded-keys`. Overflow throws
-     `:rf.error/malformed-json :reason :too-many-keys`.
+     `:rf.error/id :rf.error/malformed-json` with `:cause :too-many-keys`.
 
   Per rf2-wu1n5, both branches enforce the keyword-cap. The JVM
   Cheshire branch installs a `:key-fn` callback that counts distinct
@@ -77,10 +77,13 @@
                                (when-not (.contains seen k)
                                  (.add seen k)
                                  (when (> (.size seen) max-keys)
-                                   (throw (ex-info "json: too many unique keys"
-                                                   {:kind   :rf.error/malformed-json
-                                                    :reason :too-many-keys
-                                                    :limit  max-keys}))))
+                                   (throw (ex-info ":rf.error/malformed-json"
+                                                   {:rf.error/id :rf.error/malformed-json
+                                                    :where       'rf.http/json-parse
+                                                    :recovery    :no-recovery
+                                                    :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
+                                                    :cause       :too-many-keys
+                                                    :limit       max-keys}))))
                                (keyword k))]
                   (cheshire/parse-string s key-fn)))
         :cljs (let [parsed (js/JSON.parse s)
@@ -104,10 +107,13 @@
                                            (when-not (contains? @seen k)
                                              (vswap! seen conj k)
                                              (when (> (count @seen) max-keys)
-                                               (throw (ex-info "json: too many unique keys"
-                                                               {:kind   :rf.error/malformed-json
-                                                                :reason :too-many-keys
-                                                                :limit  max-keys})))))
+                                               (throw (ex-info ":rf.error/malformed-json"
+                                                               {:rf.error/id :rf.error/malformed-json
+                                                                :where       'rf.http/json-parse
+                                                                :recovery    :no-recovery
+                                                                :reason      (str "JSON payload exceeded the per-call unique-key cap (" max-keys ") — a keyword-interning DoS guard")
+                                                                :cause       :too-many-keys
+                                                                :limit       max-keys})))))
                                          (doseq [k ks] (walk (aget v k))))))]
                              (walk parsed))]
                 (js->clj parsed :keywordize-keys true))))))

--- a/implementation/http/test/re_frame/util_json_test.clj
+++ b/implementation/http/test/re_frame/util_json_test.clj
@@ -4,8 +4,9 @@
   Beads:
    - rf2-wu1n5 — JSON keyword-interning DoS: cap on unique keys decoded
                  (configurable via `:max-decoded-keys` option per call).
-                 Overflow throws `:rf.error/malformed-json :reason :too-many-keys`,
-                 which the `:rf.http/managed` cascade classifies as
+                 Overflow throws `:rf.error/id :rf.error/malformed-json`
+                 with `:cause :too-many-keys`, which the
+                 `:rf.http/managed` cascade classifies as
                  `:rf.http/decode-failure`.
    - rf2-dgsu1 — Cheshire is a hard JVM dep (no fallback reader). Native
                  Cheshire `JsonParseException`s propagate to the transport
@@ -45,8 +46,10 @@
                      (ex-data thrown))]
         (is (instance? clojure.lang.ExceptionInfo thrown)
             "expected ex-info when key-count exceeds cap")
-        (is (= :rf.error/malformed-json (:kind data)))
-        (is (= :too-many-keys (:reason data)))
+        (is (= :rf.error/malformed-json (:rf.error/id data)))
+        (is (= :too-many-keys (:cause data)))
+        (is (string? (:reason data))
+            ":reason is a human-readable sentence (canonical shape)")
         (is (= 10 (:limit data)))))))
 
 (deftest default-cap-enforced-at-default-max
@@ -63,8 +66,8 @@
                    (ex-data thrown))]
       (is (instance? clojure.lang.ExceptionInfo thrown)
           "10001-key payload with no opts must trip the default cap")
-      (is (= :rf.error/malformed-json (:kind data)))
-      (is (= :too-many-keys (:reason data)))
+      (is (= :rf.error/malformed-json (:rf.error/id data)))
+      (is (= :too-many-keys (:cause data)))
       (is (= util-json/default-max-decoded-keys (:limit data))))))
 
 (deftest cap-counts-unique-not-total

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -24,6 +24,37 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
+;; Every validation throw shares the canonical thrown-error skeleton
+;; (per Spec 009 §The thrown-error shape — the :rf.error/id ex-data
+;; contract):
+;;
+;;   {:rf.error/id <category-kw>     ;; CANONICAL DISCRIMINATOR
+;;    :where       'rf/reg-machine    ;; user-facing fn for greping the call site
+;;    :recovery    :fix-registration  ;; "the caller fixes their machine map and retries"
+;;    :reason      "<diagnostic>"     ;; one human-readable sentence
+;;    + per-site slots (:state / :slot / :guard / :action / :region / …)}
+;;
+;; `:rf.error/id` is read uniformly by every consumer (Causa's error
+;; widget, the pair-tool overlay, `:on-error` policies); the message
+;; string is the stringified kw so `.getMessage` / `ex-message` pivots
+;; to the same category without ex-data. Modelled on
+;; `re-frame.flows.registry/flow-error`.
+
+(defn- validation-error
+  "Build a machine-validation ex-info with the canonical thrown-error
+  shape (per Spec 009). `error-kw` becomes the message AND the
+  `:rf.error/id` discriminator slot; `reason` is the human-readable
+  diagnostic; `extras` merges per-site slots (e.g. `:state`, `:slot`,
+  `:guard`)."
+  ([error-kw reason] (validation-error error-kw reason nil))
+  ([error-kw reason extras]
+   (ex-info (str error-kw)
+            (merge {:rf.error/id error-kw
+                    :where       'rf/reg-machine
+                    :recovery    :fix-registration
+                    :reason      reason}
+                   extras))))
+
 (defn- validate-no-invoke-timeout-ms!
   "Per rf2-3y3y / Spec 005 §Wall-clock timeouts on :spawn — use parent
   state's `:after`, the pre-release `:timeout-ms` / `:on-timeout` slots
@@ -36,18 +67,18 @@
       (let [t  (:timeout-ms spec)
             ot (:on-timeout spec)]
         (when (or (some? t) (some? ot))
-          (throw (ex-info ":rf.error/spawn-timeout-ms-removed"
-                          {:state      state-key
-                           :slot       slot-key
-                           :timeout-ms t
-                           :on-timeout ot
-                           :reason
-                           (str ":timeout-ms / :on-timeout on " slot-key
-                                " were dropped per rf2-3y3y. Use the parent "
-                                "state's :after slot for wall-clock guards. "
-                                "See migration/from-re-frame-v1/README.md §M-44 "
-                                "for the rewrite recipe.")
-                           :migration "migration/from-re-frame-v1/README.md §M-44"})))))))
+          (throw (validation-error
+                   :rf.error/spawn-timeout-ms-removed
+                   (str ":timeout-ms / :on-timeout on " slot-key
+                        " were dropped. Use the parent state's :after slot "
+                        "for wall-clock guards. See "
+                        "migration/from-re-frame-v1/README.md §M-44 for the "
+                        "rewrite recipe.")
+                   {:state      state-key
+                    :slot       slot-key
+                    :timeout-ms t
+                    :on-timeout ot
+                    :migration  "migration/from-re-frame-v1/README.md §M-44"})))))))
 
 (defn- validate-invoke-all!
   "Per Spec 005 §Spawn-and-join via `:spawn-all` (rf2-6vmw): walk the
@@ -67,60 +98,73 @@
   (let [inv-all (:spawn-all state-node)]
     (when inv-all
       (when (:spawn state-node)
-        (throw (ex-info ":rf.error/machine-spawn-all-with-spawn"
-                        {:state state-key})))
+        (throw (validation-error
+                 :rf.error/machine-spawn-all-with-spawn
+                 "a state node cannot declare both :spawn and :spawn-all (they are mutually exclusive)"
+                 {:state state-key})))
       (when-not (map? inv-all)
-        (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                        {:state state-key
-                         :reason "invoke-all slot must be a map"})))
+        (throw (validation-error
+                 :rf.error/machine-spawn-all-bad-shape
+                 "invoke-all slot must be a map"
+                 {:state state-key})))
       (let [children (:children inv-all)]
         (when-not (and (vector? children) (seq children))
-          (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                          {:state state-key
-                           :reason ":children must be a non-empty vector of child specs"})))
+          (throw (validation-error
+                   :rf.error/machine-spawn-all-bad-shape
+                   ":children must be a non-empty vector of child specs"
+                   {:state state-key})))
         (doseq [c children]
           (when-not (and (map? c) (keyword? (:id c)))
-            (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                            {:state state-key
-                             :reason "each child invoke-spec must declare an :id keyword"
-                             :child c})))
+            (throw (validation-error
+                     :rf.error/machine-spawn-all-bad-shape
+                     "each child invoke-spec must declare an :id keyword"
+                     {:state state-key
+                      :child c})))
           (when-not (or (:machine-id c) (:definition c))
-            (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                            {:state state-key
-                             :reason "each child invoke-spec must declare :machine-id or :definition"
-                             :child c}))))
+            (throw (validation-error
+                     :rf.error/machine-spawn-all-bad-shape
+                     "each child invoke-spec must declare :machine-id or :definition"
+                     {:state state-key
+                      :child c}))))
         (let [ids (map :id children)]
           (when (not= (count ids) (count (set ids)))
             (let [dup (->> (frequencies ids) (filter (fn [[_ n]] (> n 1))) (map first))]
-              (throw (ex-info ":rf.error/machine-spawn-all-duplicate-id"
-                              {:state state-key :duplicate-ids dup}))))))
+              (throw (validation-error
+                       :rf.error/machine-spawn-all-duplicate-id
+                       "two children share an :id keyword inside the same :spawn-all block"
+                       {:state state-key :duplicate-ids dup}))))))
       (when-not (keyword? (:on-child-done inv-all))
-        (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                        {:state state-key
-                         :reason ":on-child-done is required (event keyword)"})))
+        (throw (validation-error
+                 :rf.error/machine-spawn-all-bad-shape
+                 ":on-child-done is required (event keyword)"
+                 {:state state-key})))
       (when-not (keyword? (:on-child-error inv-all))
-        (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                        {:state state-key
-                         :reason ":on-child-error is required (event keyword)"})))
+        (throw (validation-error
+                 :rf.error/machine-spawn-all-bad-shape
+                 ":on-child-error is required (event keyword)"
+                 {:state state-key})))
       (let [join (:join inv-all :all)]
         (cond
           (= :all join)
           (when-not (vector? (:on-all-complete inv-all))
-            (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                            {:state state-key
-                             :reason ":on-all-complete event-vector is required when :join is :all (default)"})))
+            (throw (validation-error
+                     :rf.error/machine-spawn-all-bad-shape
+                     ":on-all-complete event-vector is required when :join is :all (default)"
+                     {:state state-key})))
           (or (= :any join)
               (and (map? join) (or (pos-int? (:n join))
                                    (fn? (:fn join)))))
           (when-not (vector? (:on-some-complete inv-all))
-            (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                            {:state state-key
-                             :reason ":on-some-complete event-vector is required when :join is :any / {:n N} / {:fn ...}"})))
+            (throw (validation-error
+                     :rf.error/machine-spawn-all-bad-shape
+                     ":on-some-complete event-vector is required when :join is :any / {:n N} / {:fn ...}"
+                     {:state state-key})))
           :else
-          (throw (ex-info ":rf.error/machine-spawn-all-bad-shape"
-                          {:state state-key
-                           :reason ":join must be :all, :any, {:n pos-int}, or {:fn fn?}"
-                           :join join})))))))
+          (throw (validation-error
+                   :rf.error/machine-spawn-all-bad-shape
+                   ":join must be :all, :any, {:n pos-int}, or {:fn fn?}"
+                   {:state state-key
+                    :join join})))))))
 
 (defn- validate-parallel!
   "Per Spec 005 §Parallel regions (rf2-l67o / Stage 2) and Spec-Schemas
@@ -139,35 +183,42 @@
   [machine]
   (when (parallel/parallel? machine)
     (when-not (and (map? (:regions machine)) (seq (:regions machine)))
-      (throw (ex-info ":rf.error/machine-parallel-bad-shape"
-                      {:reason ":type :parallel requires a non-empty :regions map"})))
+      (throw (validation-error
+               :rf.error/machine-parallel-bad-shape
+               ":type :parallel requires a non-empty :regions map")))
     (when (or (contains? machine :initial) (contains? machine :states))
-      (throw (ex-info ":rf.error/machine-parallel-bad-shape"
-                      {:reason ":type :parallel is mutually exclusive with :initial / :states at the root"})))
+      (throw (validation-error
+               :rf.error/machine-parallel-bad-shape
+               ":type :parallel is mutually exclusive with :initial / :states at the root")))
     (doseq [[region-name region-body] (:regions machine)]
       (when-not (keyword? region-name)
-        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
-                        {:reason "region names must be keywords"
-                         :region region-name})))
+        (throw (validation-error
+                 :rf.error/machine-parallel-bad-shape
+                 "region names must be keywords"
+                 {:region region-name})))
       (when-not (and (map? region-body) (seq region-body))
-        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
-                        {:reason "each region body must be a non-empty state-node map"
-                         :region region-name})))
+        (throw (validation-error
+                 :rf.error/machine-parallel-bad-shape
+                 "each region body must be a non-empty state-node map"
+                 {:region region-name})))
       (when (= :parallel (:type region-body))
-        (throw (ex-info ":rf.error/machine-parallel-nested-not-supported"
-                        {:reason "nested parallel regions are not supported in v1"
-                         :region region-name})))
+        (throw (validation-error
+                 :rf.error/machine-parallel-nested-not-supported
+                 "nested parallel regions are not supported in v1"
+                 {:region region-name})))
       (when-not (keyword? (:initial region-body))
-        (throw (ex-info ":rf.error/machine-parallel-bad-shape"
-                        {:reason "each region body must declare :initial (the cascade entry-point)"
-                         :region region-name})))
+        (throw (validation-error
+                 :rf.error/machine-parallel-bad-shape
+                 "each region body must declare :initial (the cascade entry-point)"
+                 {:region region-name})))
       (letfn [(walk [path nodes]
                 (doseq [[k n] nodes]
                   (when (= :parallel (:type n))
-                    (throw (ex-info ":rf.error/machine-parallel-nested-not-supported"
-                                    {:reason "nested parallel regions are not supported in v1"
-                                     :region region-name
-                                     :state-path (conj path k)})))
+                    (throw (validation-error
+                             :rf.error/machine-parallel-nested-not-supported
+                             "nested parallel regions are not supported in v1"
+                             {:region region-name
+                              :state-path (conj path k)})))
                   (when (:states n)
                     (walk (conj path k) (:states n)))))]
         (walk [] (:states region-body))))))
@@ -214,23 +265,26 @@
     (do
       (when (or (contains? state-node :states)
                 (contains? state-node :initial))
-        (throw (ex-info ":rf.error/machine-final-state-compound"
-                        {:state state-key
-                         :reason "a :final? state cannot be compound (no :states / :initial)."})))
+        (throw (validation-error
+                 :rf.error/machine-final-state-compound
+                 "a :final? state cannot be compound (no :states / :initial)."
+                 {:state state-key})))
       (doseq [bad-key [:on :always :after :spawn :spawn-all]]
         (when (contains? state-node bad-key)
-          (throw (ex-info ":rf.error/machine-final-state-has-transitions"
-                          {:state    state-key
-                           :slot     bad-key
-                           :reason   (str "a :final? state cannot declare " bad-key
-                                          " — final means final; no further transitions.")})))))
+          (throw (validation-error
+                   :rf.error/machine-final-state-has-transitions
+                   (str "a :final? state cannot declare " bad-key
+                        " — final means final; no further transitions.")
+                   {:state state-key
+                    :slot  bad-key})))))
 
     ;; Non-final state declaring :output-key — error per D3.
     (contains? state-node :output-key)
-    (throw (ex-info ":rf.error/machine-output-key-without-final"
-                    {:state      state-key
-                     :output-key (:output-key state-node)
-                     :reason     ":output-key is only meaningful on a :final? state."}))))
+    (throw (validation-error
+             :rf.error/machine-output-key-without-final
+             ":output-key is only meaningful on a :final? state."
+             {:state      state-key
+              :output-key (:output-key state-node)}))))
 
 (defn validate-machine!
   "Run every registration-time check the machine grammar requires (rf2-f9tu).
@@ -266,13 +320,17 @@
         check-guard! (fn [g s]
                        (when (and (keyword? g)
                                   (not (contains? guards-map g)))
-                         (throw (ex-info ":rf.error/machine-unresolved-guard"
-                                         {:guard g :state s}))))
+                         (throw (validation-error
+                                  :rf.error/machine-unresolved-guard
+                                  (str "guard ref " g " does not resolve against the machine's :guards map")
+                                  {:guard g :state s}))))
         check-action! (fn [a s]
                         (when (and (keyword? a)
                                    (not (contains? actions-map a)))
-                          (throw (ex-info ":rf.error/machine-unresolved-action"
-                                          {:action a :state s}))))]
+                          (throw (validation-error
+                                   :rf.error/machine-unresolved-action
+                                   (str "action ref " a " does not resolve against the machine's :actions map")
+                                   {:action a :state s}))))]
     (doseq [[s state-node] (walk-state-nodes machine)]
       (doseq [[_ t] (:on state-node)
               t     (if (vector? t) t [t])]

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -41,6 +41,33 @@
   [url]
   (url/malformed-url? url))
 
+;; ---- canonical thrown-error shape ----------------------------------------
+;; Per Spec 009 §The thrown-error shape — the :rf.error/id ex-data
+;; contract. Every routing throw carries :rf.error/id (the canonical
+;; discriminator), :where (the public surface fn symbol the caller
+;; wrote — 'rf/route-url, 'rf/match-url, 'rf/reg-route — so a grep
+;; lands on the call site), :recovery, and a human-readable :reason.
+;; Per-site slots (:route-id / :slot / :value / :error / :param / :url
+;; / :limit / :count / :pattern) merge on top.
+;;
+;; NOTE the :error per-site slot (on :rf.error/route-url-validation)
+;; holds a Malli explainer payload — that is a SEPARATE contract from
+;; the :rf.error/id discriminator and is preserved verbatim.
+
+(defn- route-error
+  "Build a routing ex-info with the canonical thrown-error shape (per
+  Spec 009). `error-kw` becomes the message AND the `:rf.error/id`
+  discriminator slot; `where-sym` names the public surface; `reason` is
+  the human-readable diagnostic; `extras` merges per-site slots."
+  ([error-kw where-sym reason] (route-error error-kw where-sym reason nil))
+  ([error-kw where-sym reason extras]
+   (ex-info (str error-kw)
+            (merge {:rf.error/id error-kw
+                    :where       where-sym
+                    :recovery    :no-recovery
+                    :reason      reason}
+                   extras))))
+
 ;; ---- registration ---------------------------------------------------------
 ;; Pattern validation, the single-pass pattern parser, and the
 ;; `segment-end` / `canonical-route-pattern` helpers moved to
@@ -460,11 +487,13 @@
                           (reduced ::malformed-query)
                           (let [m' (assoc m kstr vstr)]
                             (when (> (count m') default-max-decoded-keys)
-                              (throw (ex-info ":rf.error/route-too-many-keys"
-                                              {:kind   :rf.error/route-too-many-keys
-                                               :url    url
-                                               :limit  default-max-decoded-keys
-                                               :count  (count m')})))
+                              (throw (route-error
+                                       :rf.error/route-too-many-keys
+                                       'rf/match-url
+                                       (str "the query string exceeded the per-call unique-key cap (" default-max-decoded-keys ") — a keyword-interning DoS guard; the URL is treated as a route-miss")
+                                       {:url   url
+                                        :limit default-max-decoded-keys
+                                        :count (count m')})))
                             m'))))
                     (array-map)
                     pairs))))]
@@ -572,7 +601,11 @@
          meta    (registrar/lookup :route route-id)
          pattern (:path meta)]
      (when (nil? pattern)
-       (throw (ex-info ":rf.error/no-such-route" {:route-id route-id})))
+       (throw (route-error
+                :rf.error/no-such-route
+                'rf/route-url
+                (str "no route is registered under id " route-id)
+                {:route-id route-id})))
      ;; Per Spec 012 §Bidirectional URL ↔ params: validate the caller's
      ;; inputs against the route's :params / :query schemas BEFORE
      ;; emitting the URL. A schema mismatch is a caller bug; raise with
@@ -581,18 +614,24 @@
      ;; registered, this is a no-op.
      (let [[p-failed? p-error] (validate-route-shape meta :params path-params)]
        (when p-failed?
-         (throw (ex-info ":rf.error/route-url-validation"
-                         {:route-id route-id
-                          :slot     :params
-                          :value    path-params
-                          :error    p-error}))))
+         (throw (route-error
+                  :rf.error/route-url-validation
+                  'rf/route-url
+                  (str "the supplied :params did not validate against route " route-id "'s :params schema")
+                  {:route-id route-id
+                   :slot     :params
+                   :value    path-params
+                   :error    p-error}))))
      (let [[q-failed? q-error] (validate-route-shape meta :query query-params)]
        (when q-failed?
-         (throw (ex-info ":rf.error/route-url-validation"
-                         {:route-id route-id
-                          :slot     :query
-                          :value    query-params
-                          :error    q-error}))))
+         (throw (route-error
+                  :rf.error/route-url-validation
+                  'rf/route-url
+                  (str "the supplied :query did not validate against route " route-id "'s :query schema")
+                  {:route-id route-id
+                   :slot     :query
+                   :value    query-params
+                   :error    q-error}))))
      (let [n      (count pattern)
            ;; Per Spec 012 §Bidirectional URL ↔ params: optional groups
            ;; are emitted only when every inner param is supplied. The
@@ -658,8 +697,11 @@
                          ;; `if-some` discriminates correctly.
                          v     (if-some [v (get path-params k)]
                                  v
-                                 (throw (ex-info ":rf.error/missing-route-param"
-                                                 {:param k :route-id route-id})))]
+                                 (throw (route-error
+                                          :rf.error/missing-route-param
+                                          'rf/route-url
+                                          (str "route " route-id " requires path param " k " but it was absent (or nil)")
+                                          {:param k :route-id route-id})))]
                      (recur end (conj parts (url/url-encode v))))
 
                    (= ch \*)
@@ -668,8 +710,11 @@
                          k     (keyword (subs pattern start end))
                          v     (if-some [v (get path-params k)]
                                  v
-                                 (throw (ex-info ":rf.error/missing-route-param"
-                                                 {:param k :route-id route-id})))]
+                                 (throw (route-error
+                                          :rf.error/missing-route-param
+                                          'rf/route-url
+                                          (str "route " route-id " requires splat param " k " but it was absent (or nil)")
+                                          {:param k :route-id route-id})))]
                      (recur end (conj parts (url/url-encode-splat v))))
 
                    :else

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -53,11 +53,18 @@
   #"^[A-Za-z][A-Za-z0-9_-]*$")
 
 (defn- route-pattern-error!
+  ;; Canonical thrown-error shape per Spec 009: :rf.error/id is the
+  ;; discriminator, :where names the public surface (reg-route compiles
+  ;; the pattern at registration), :recovery + :reason complete the
+  ;; required slots. Per-site :route-id / :pattern / :index merge on top.
   [route-id pattern reason index]
   (throw (ex-info ":rf.error/invalid-route-pattern"
-                  (cond-> {:route-id route-id
-                           :pattern  pattern
-                           :reason   reason}
+                  (cond-> {:rf.error/id :rf.error/invalid-route-pattern
+                           :where       'rf/reg-route
+                           :recovery    :no-recovery
+                           :reason      reason
+                           :route-id    route-id
+                           :pattern     pattern}
                     (some? index) (assoc :index index)))))
 
 (defn- valid-route-name? [s]

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -1813,7 +1813,8 @@
       (is (instance? clojure.lang.ExceptionInfo thrown)
           "over-cap URL throws ex-info")
       (let [data (ex-data thrown)]
-        (is (= :rf.error/route-too-many-keys (:kind data)))
+        (is (= :rf.error/route-too-many-keys (:rf.error/id data)))
+        (is (= 'rf/match-url (:where data)))
         (is (= routing/default-max-decoded-keys (:limit data)))
         (is (>= (:count data) routing/default-max-decoded-keys))))))
 

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -1302,7 +1302,7 @@
                           (fn [_ _] {}))
                         (catch clojure.lang.ExceptionInfo e
                           (ex-data e)))]
-          (is (= :rf.error/at-boundary-missing-schema (:error data)))
+          (is (= :rf.error/at-boundary-missing-schema (:rf.error/id data)))
           (is (= "reg-event-fx" (:reg-fn data)))
           (is (= :api/no-schema-2-data (:id data)))
           (is (string? (:reason data)))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -201,10 +201,16 @@
   [{:keys [on-create root-view] :as opts}]
   (when-not on-create
     (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
-                    {:reason "ssr-handler requires :on-create (an event vector)"})))
+                    {:rf.error/id :rf.error/ssr-ring-missing-on-create
+                     :where    'rf.ssr/ssr-handler
+                     :reason   "ssr-handler requires :on-create (an event vector)"
+                     :recovery :no-recovery})))
   (when-not root-view
     (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
-                    {:reason "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"})))
+                    {:rf.error/id :rf.error/ssr-ring-missing-root-view
+                     :where    'rf.ssr/ssr-handler
+                     :reason   "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"
+                     :recovery :no-recovery})))
   (payload-policy/validate-policy-opts! opts)
   (trust/validate-trusted-shell-opts! opts))
 

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/cookie.clj
@@ -66,7 +66,9 @@
   (let [s (str v)]
     (when (re-find header-injection-chars-re s)
       (throw (ex-info ":rf.error/cookie-invalid-attribute"
-                      {:reason    (str "cookie attribute " attr-key
+                      {:rf.error/id :rf.error/cookie-invalid-attribute
+                       :where     'rf.ssr/cookie->set-cookie-header
+                       :reason    (str "cookie attribute " attr-key
                                        " contains CR/LF/NUL — forbidden by"
                                        " RFC 7230 §3.2.4 (header-splitting"
                                        " injection)")
@@ -90,7 +92,9 @@
     (if (re-matches cookie-name-token-grammar s)
       s
       (throw (ex-info ":rf.error/cookie-invalid-name"
-                      {:reason   (str "cookie :name violates RFC 6265 §4.1.1"
+                      {:rf.error/id :rf.error/cookie-invalid-name
+                       :where    'rf.ssr/cookie->set-cookie-header
+                       :reason   (str "cookie :name violates RFC 6265 §4.1.1"
                                       " token grammar (no CTLs, whitespace,"
                                       " or separators ()<>@,;:\\\"/[]?={}); got "
                                       (pr-str s))
@@ -131,8 +135,11 @@
     :as cookie}]
   (when (nil? name)
     (throw (ex-info ":rf.error/cookie-missing-name"
-                    {:reason "cookie map must carry :name"
-                     :cookie cookie})))
+                    {:rf.error/id :rf.error/cookie-missing-name
+                     :where    'rf.ssr/cookie->set-cookie-header
+                     :reason   "cookie map must carry :name"
+                     :cookie   cookie
+                     :recovery :no-recovery})))
   ;; rf2-rpedl §P2.4 — RFC 6265 §4.1.1 cookie-name token grammar.
   (validate-cookie-name! name)
   ;; Per audit rf2-asmj1 R7 / cluster rf2-sljs1: `Instant/ofEpochMilli`
@@ -143,7 +150,9 @@
   ;; surfaces with the cookie's actual shape attached.
   (when (and (some? expires) (not (integer? expires)))
     (throw (ex-info ":rf.error/cookie-invalid-expires"
-                    {:reason   (str ":expires must be an epoch-millis long; got " (.getName (class expires)))
+                    {:rf.error/id :rf.error/cookie-invalid-expires
+                     :where    'rf.ssr/cookie->set-cookie-header
+                     :reason   (str ":expires must be an epoch-millis long; got " (.getName (class expires)))
                      :expires  expires
                      :cookie   cookie
                      :recovery :no-recovery})))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -62,8 +62,11 @@
     (fn?     root-view) (root-view)
     :else
     (throw (ex-info ":rf.error/invalid-root-view"
-                    {:reason   "root-view must be a hiccup vector or a 0-arity fn"
-                     :received root-view}))))
+                    {:rf.error/id :rf.error/invalid-root-view
+                     :where    'rf.ssr/ssr-handler
+                     :reason   "root-view must be a hiccup vector or a 0-arity fn"
+                     :received root-view
+                     :recovery :no-recovery}))))
 
 (defn resolve-head
   "Resolve the active route's `:head` against `frame-id` (or the default
@@ -112,5 +115,8 @@
   (if (vector? on-create)
     on-create
     (throw (ex-info ":rf.error/invalid-on-create"
-                    {:reason   ":on-create must be a vector (event)"
-                     :received on-create}))))
+                    {:rf.error/id :rf.error/invalid-on-create
+                     :where    'rf.ssr/ssr-handler
+                     :reason   ":on-create must be a vector (event)"
+                     :received on-create
+                     :recovery :no-recovery}))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/trust.clj
@@ -72,7 +72,9 @@
       (let [v (get opts k)]
         (when (and (some? v) (not (string? v)))
           (throw (ex-info ":rf.error/ssr-trusted-shell-opt-invalid"
-                          {:reason   (str "ssr-handler / stream-handler " (pr-str k)
+                          {:rf.error/id :rf.error/ssr-trusted-shell-opt-invalid
+                           :where    'rf.ssr/trusted-shell
+                           :reason   (str "ssr-handler / stream-handler " (pr-str k)
                                           " must be a string (or nil) — the four "
                                           "trusted shell-hook opts ("
                                           (str/join ", " (map pr-str trusted-shell-string-opts))

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -90,7 +90,9 @@
   (when-not (and (string? tag-name)
                  (re-matches tag-name-re tag-name))
     (throw (ex-info ":rf.error/invalid-tag-name"
-                    {:reason   (str "tag-name " (pr-str tag-name)
+                    {:rf.error/id :rf.error/invalid-tag-name
+                     :where    'rf.ssr/emit
+                     :reason   (str "tag-name " (pr-str tag-name)
                                     " (from hiccup head " (pr-str source-kw) ")"
                                     " does not match the HTML5/SVG/MathML"
                                     " element-name grammar"

--- a/implementation/ssr/src/re_frame/ssr/head/registry.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/registry.cljc
@@ -134,7 +134,9 @@
         meta  (registrar/lookup :head head-id)]
     (when-not meta
       (throw (ex-info ":rf.error/no-such-head"
-                      {:head-id  head-id
+                      {:rf.error/id :rf.error/no-such-head
+                       :where    'rf/active-head
+                       :head-id  head-id
                        :reason   (str "No head registered under " head-id ".")
                        :recovery :no-recovery})))
     (let [head-fn (:handler-fn meta)

--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -94,7 +94,9 @@
     (if (re-matches attr-name-grammar s)
       s
       (throw (ex-info ":rf.error/ssr-invalid-attribute-name"
-                      {:reason    (str "attribute name violates HTML5 grammar "
+                      {:rf.error/id :rf.error/ssr-invalid-attribute-name
+                       :where     'rf.ssr/html-helpers
+                       :reason    (str "attribute name violates HTML5 grammar "
                                        "[A-Za-z][A-Za-z0-9_:-]*; got "
                                        (pr-str s))
                        :attribute k

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -121,15 +121,20 @@
     ;; missing-policy bucket.
     (some? payload-policy)
     (throw (ex-info ":rf.error/ssr-unknown-payload-policy"
-                    {:reason         (str "ssr-handler :payload-policy must be "
+                    {:rf.error/id    :rf.error/ssr-unknown-payload-policy
+                     :where          'rf.ssr/payload-policy
+                     :reason         (str "ssr-handler :payload-policy must be "
                                           (pr-str whole-app-db-policy)
                                           " (or omit it and pass :payload-keys instead)")
                      :got            payload-policy
-                     :recognised     #{whole-app-db-policy}}))
+                     :recognised     #{whole-app-db-policy}
+                     :recovery       :declare-payload-policy}))
 
     :else
     (throw (ex-info ":rf.error/ssr-missing-payload-policy"
-                    {:reason   (str "ssr-handler requires an explicit hydration-"
+                    {:rf.error/id :rf.error/ssr-missing-payload-policy
+                     :where    'rf.ssr/payload-policy
+                     :reason   (str "ssr-handler requires an explicit hydration-"
                                     "payload policy: pass :payload-keys "
                                     "[<top-level-app-db-keys>] (allowlist, "
                                     "preferred) OR :payload-policy "

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -100,7 +100,9 @@
   (let [s (str v)]
     (when (re-find header-injection-chars-re s)
       (throw (ex-info ":rf.error/header-invalid-value"
-                      {:reason   (str "header " (pr-str header-name)
+                      {:rf.error/id :rf.error/header-invalid-value
+                       :where    'rf.ssr/response
+                       :reason   (str "header " (pr-str header-name)
                                       " value contains CR/LF/NUL — forbidden"
                                       " by RFC 7230 §3.2.4 (header-splitting"
                                       " injection)")
@@ -119,7 +121,9 @@
   (let [s (str loc)]
     (when (re-find header-injection-chars-re s)
       (throw (ex-info ":rf.error/redirect-invalid-location"
-                      {:reason   (str "redirect :location contains CR/LF/NUL"
+                      {:rf.error/id :rf.error/redirect-invalid-location
+                       :where    'rf.ssr/response
+                       :reason   (str "redirect :location contains CR/LF/NUL"
                                       " — forbidden by RFC 7230 §3.2.4"
                                       " (header-splitting injection)")
                        :location loc
@@ -155,7 +159,9 @@
   (let [s (str n)]
     (when-not (re-matches token-grammar-re s)
       (throw (ex-info ":rf.error/header-invalid-name"
-                      {:reason   (str "header :name " (pr-str s)
+                      {:rf.error/id :rf.error/header-invalid-name
+                       :where    'rf.ssr/response
+                       :reason   (str "header :name " (pr-str s)
                                       " violates RFC 7230 §3.2.6 token grammar"
                                       " (no CTLs, whitespace, or separators"
                                       " ()<>@,;:\\\"/[]?={})")
@@ -171,13 +177,17 @@
   [n]
   (when (nil? n)
     (throw (ex-info ":rf.error/cookie-invalid-name"
-                    {:reason   "cookie :name is required"
+                    {:rf.error/id :rf.error/cookie-invalid-name
+                     :where    'rf.ssr/response
+                     :reason   "cookie :name is required"
                      :name     n
                      :recovery :no-recovery})))
   (let [s (#?(:clj clojure.core/name :cljs cljs.core/name) n)]
     (when-not (re-matches token-grammar-re s)
       (throw (ex-info ":rf.error/cookie-invalid-name"
-                      {:reason   (str "cookie :name " (pr-str s)
+                      {:rf.error/id :rf.error/cookie-invalid-name
+                       :where    'rf.ssr/response
+                       :reason   (str "cookie :name " (pr-str s)
                                       " violates RFC 6265 §4.1.1 token grammar"
                                       " (no CTLs, whitespace, or separators"
                                       " ()<>@,;:\\\"/[]?={})")
@@ -193,14 +203,17 @@
   [field-key v]
   (let [s (str v)]
     (when (re-find header-injection-chars-re s)
-      (throw (ex-info (str ":rf.error/cookie-invalid-" (name field-key))
-                      {:reason   (str "cookie " field-key " " (pr-str s)
-                                      " contains CR/LF/NUL — forbidden by"
-                                      " RFC 7230 §3.2.4 (header-splitting"
-                                      " injection)")
-                       :field    field-key
-                       :value    v
-                       :recovery :no-recovery})))
+      (let [error-kw (keyword "rf.error" (str "cookie-invalid-" (name field-key)))]
+        (throw (ex-info (str error-kw)
+                        {:rf.error/id error-kw
+                         :where    'rf.ssr/response
+                         :reason   (str "cookie " field-key " " (pr-str s)
+                                        " contains CR/LF/NUL — forbidden by"
+                                        " RFC 7230 §3.2.4 (header-splitting"
+                                        " injection)")
+                         :field    field-key
+                         :value    v
+                         :recovery :no-recovery}))))
     s))
 
 (defn- validate-cookie!

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -237,7 +237,9 @@
         n        (count children)]
     (when-not (suspense-attrs? attrs)
       (throw (ex-info ":rf.error/suspense-boundary-invalid-attrs"
-                      {:reason   ":rf/suspense-boundary requires {:id … :fallback …} attrs map"
+                      {:rf.error/id :rf.error/suspense-boundary-invalid-attrs
+                       :where    'rf.ssr/streaming
+                       :reason   ":rf/suspense-boundary requires {:id … :fallback …} attrs map"
                        :got      attrs
                        :element  el
                        :recovery :no-recovery})))

--- a/implementation/ssr/src/re_frame/ssr/substrate.cljc
+++ b/implementation/ssr/src/re_frame/ssr/substrate.cljc
@@ -53,7 +53,10 @@
   ;; adapter is a programmer error worth surfacing loudly. Per Spec 006
   ;; §Plain-atom adapter and rf2-z1ke.
   (throw (ex-info ":rf.error/render-on-headless-adapter"
-                  {:reason "render is not supported on the SSR adapter; use render-to-string"})))
+                  {:rf.error/id :rf.error/render-on-headless-adapter
+                   :where    'rf/render
+                   :reason   "render is not supported on the SSR adapter; use render-to-string"
+                   :recovery :no-recovery})))
 
 (defn- ssr-register-context-provider [_frame-keyword]
   ;; No React context on the JVM; users thread frames as arguments per

--- a/tools/causa/src/day8/re_frame2_causa/drop_in.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/drop_in.cljc
@@ -337,14 +337,23 @@
      (detach!)
      (let [state (case mode
                    :push  (attach-push!)
-                   :atom  #?(:clj  (throw (ex-info ":atom mode requires a CLJS runtime"
-                                                   {:mode :atom}))
+                   :atom  #?(:clj  (throw (ex-info ":rf.error/causa-atom-mode-requires-cljs"
+                                                   {:rf.error/id :rf.error/causa-atom-mode-requires-cljs
+                                                    :where    'causa/attach!
+                                                    :recovery :no-recovery
+                                                    :reason   ":atom drop-in mode requires a CLJS runtime"
+                                                    :mode     :atom}))
                              :cljs (attach-atom! trace-source))
                    :sub   (attach-subscribe! trace-source)
                    ;; Unknown mode — pre-alpha posture says no
                    ;; silent fallback; raise so a misconfigured
                    ;; attach fails loudly at the call site.
-                   (throw (ex-info "Unknown drop-in mode" {:mode mode})))]
+                   (throw (ex-info ":rf.error/causa-unknown-drop-in-mode"
+                                   {:rf.error/id :rf.error/causa-unknown-drop-in-mode
+                                    :where    'causa/attach!
+                                    :recovery :no-recovery
+                                    :reason   (str "unknown drop-in mode " (pr-str mode) " — expected :push, :atom, or :sub")
+                                    :mode     mode})))]
        (reset! attached-state state)))
    nil))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/ai_generate.cljc
@@ -190,10 +190,13 @@
 
 (defn- default-resolver [_prompt]
   (throw (ex-info
-           (str "ai-generate/generate-machine called without a :resolver opt. "
-                "Inject a resolver fn (string -> string) that bridges to "
-                "your LLM of choice; see the ns docstring for the contract.")
-           {:reason :ai-generate/no-resolver})))
+           ":ai-generate/no-resolver"
+           {:rf.error/id :ai-generate/no-resolver
+            :where    'machines-viz/generate-machine
+            :recovery :no-recovery
+            :reason   (str "ai-generate/generate-machine called without a :resolver opt. "
+                           "Inject a resolver fn (string -> string) that bridges to "
+                           "your LLM of choice; see the ns docstring for the contract.")})))
 
 ;; ---------------------------------------------------------------------------
 ;; Public API
@@ -249,15 +252,21 @@
          response      (resolver-fn full-prompt)
          _             (when-not (string? response)
                          (throw (ex-info
-                                  "resolver must return a string"
-                                  {:reason   :ai-generate/parse-failed
+                                  ":ai-generate/parse-failed"
+                                  {:rf.error/id :ai-generate/parse-failed
+                                   :where    'machines-viz/generate-machine
+                                   :recovery :no-recovery
+                                   :reason   "resolver must return a string"
                                    :response response})))
          stripped      (strip-fences response)
          [stage spec-or-reason] (parse-edn stripped)]
      (cond
        (= :err stage)
-       (throw (ex-info (str "could not parse resolver output as EDN: " spec-or-reason)
-                       {:reason   :ai-generate/parse-failed
+       (throw (ex-info ":ai-generate/parse-failed"
+                       {:rf.error/id :ai-generate/parse-failed
+                        :where    'machines-viz/generate-machine
+                        :recovery :no-recovery
+                        :reason   (str "could not parse resolver output as EDN: " spec-or-reason)
                         :response response
                         :stripped stripped}))
 
@@ -265,8 +274,11 @@
        (let [[stage2 ok-or-reason] (validate-spec spec-or-reason)]
          (if (= :ok stage2)
            ok-or-reason
-           (throw (ex-info (str "resolver output was not a valid machine spec: "
-                                ok-or-reason)
-                           {:reason   :ai-generate/invalid-spec
+           (throw (ex-info ":ai-generate/invalid-spec"
+                           {:rf.error/id :ai-generate/invalid-spec
+                            :where    'machines-viz/generate-machine
+                            :recovery :no-recovery
+                            :reason   (str "resolver output was not a valid machine spec: "
+                                           ok-or-reason)
                             :response response
                             :spec     spec-or-reason}))))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -259,8 +259,12 @@
     (= :parallel (:type machine-spec))
     (let [{:keys [regions]} machine-spec]
       (when-not (and (map? regions) (seq regions))
-        (throw (ex-info "parallel spec requires non-empty :regions"
-                        {:reason :scxml/invalid-spec :spec machine-spec})))
+        (throw (ex-info ":scxml/invalid-spec"
+                        {:rf.error/id :scxml/invalid-spec
+                         :where    'machines-viz/spec->scxml
+                         :recovery :no-recovery
+                         :reason   "parallel spec requires non-empty :regions"
+                         :spec     machine-spec})))
       (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
            (str/join "\n" (emit-parallel machine-spec 0))))
 
@@ -269,8 +273,12 @@
          (str/join "\n" (emit-flat-or-compound machine-spec 0)))
 
     :else
-    (throw (ex-info "spec must carry :initial + non-empty :states, or :type :parallel + :regions"
-                    {:reason :scxml/invalid-spec :spec machine-spec}))))
+    (throw (ex-info ":scxml/invalid-spec"
+                    {:rf.error/id :scxml/invalid-spec
+                     :where    'machines-viz/spec->scxml
+                     :recovery :no-recovery
+                     :reason   "spec must carry :initial + non-empty :states, or :type :parallel + :regions"
+                     :spec     machine-spec}))))
 
 ;; ---------------------------------------------------------------------------
 ;; XML parse — minimal regex-based reader for the SCXML subset we
@@ -504,9 +512,12 @@
                                           rs (rest remaining)]
                                      (cond
                                        (empty? rs)
-                                       (throw (ex-info (str "unclosed <" tag ">")
-                                                       {:reason :scxml/parse-error
-                                                        :tag    tag}))
+                                       (throw (ex-info ":scxml/parse-error"
+                                                       {:rf.error/id :scxml/parse-error
+                                                        :where    'machines-viz/scxml->spec
+                                                        :recovery :no-recovery
+                                                        :reason   (str "unclosed <" tag ">")
+                                                        :tag      tag}))
 
                                        (and (= :end (:kind (first rs)))
                                             (= tag (:tag (first rs)))
@@ -588,13 +599,20 @@
   `:states`)."
   [scxml-string]
   (when-not (string? scxml-string)
-    (throw (ex-info "scxml->spec expects a string"
-                    {:reason :scxml/parse-error :input scxml-string})))
+    (throw (ex-info ":scxml/parse-error"
+                    {:rf.error/id :scxml/parse-error
+                     :where    'machines-viz/scxml->spec
+                     :recovery :no-recovery
+                     :reason   "scxml->spec expects a string"
+                     :input    scxml-string})))
   (let [tokens (-> scxml-string strip-prolog strip-comments tokenize vec)
         root-start (first (filter #(= "scxml" (:tag %)) tokens))]
     (when-not root-start
-      (throw (ex-info "no <scxml> root element found"
-                      {:reason :scxml/parse-error})))
+      (throw (ex-info ":scxml/parse-error"
+                      {:rf.error/id :scxml/parse-error
+                       :where    'machines-viz/scxml->spec
+                       :recovery :no-recovery
+                       :reason   "no <scxml> root element found"})))
     (let [token-vec (vec tokens)
           start-idx (some (fn [i] (when (identical? (nth token-vec i) root-start) i))
                           (range (count token-vec)))
@@ -604,8 +622,11 @@
                 end-idx (loop [i 0 depth 1]
                           (cond
                             (>= i (count tail))
-                            (throw (ex-info "unclosed <scxml>"
-                                            {:reason :scxml/parse-error}))
+                            (throw (ex-info ":scxml/parse-error"
+                                            {:rf.error/id :scxml/parse-error
+                                             :where    'machines-viz/scxml->spec
+                                             :recovery :no-recovery
+                                             :reason   "unclosed <scxml>"}))
 
                             (and (= :start (:kind (nth tail i)))
                                  (= "scxml" (:tag (nth tail i))))
@@ -633,8 +654,11 @@
               end-idx (loop [i 0 depth 1]
                         (cond
                           (>= i (count tail))
-                          (throw (ex-info "unclosed <parallel>"
-                                          {:reason :scxml/parse-error}))
+                          (throw (ex-info ":scxml/parse-error"
+                                          {:rf.error/id :scxml/parse-error
+                                           :where    'machines-viz/scxml->spec
+                                           :recovery :no-recovery
+                                           :reason   "unclosed <parallel>"}))
 
                           (and (= :start (:kind (nth tail i)))
                                (= "parallel" (:tag (nth tail i))))
@@ -664,7 +688,10 @@
               states (into {}
                            (map parse-state-block top-state-blocks))]
           (when (empty? states)
-            (throw (ex-info "scxml document has no <state> or <final> elements"
-                            {:reason :scxml/invalid-spec})))
+            (throw (ex-info ":scxml/invalid-spec"
+                            {:rf.error/id :scxml/invalid-spec
+                             :where    'machines-viz/scxml->spec
+                             :recovery :no-recovery
+                             :reason   "scxml document has no <state> or <final> elements"})))
           (cond-> {:states states}
             initial-str (assoc :initial (unescape-id-string initial-str))))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -261,7 +261,11 @@
     (nil? density) chart-regular
     (contains? density->chart-map density) (get density->chart-map density)
     :else
-    (throw (ex-info (str "Unknown chart density: " (pr-str density)
-                         ". Expected one of " (pr-str densities) ".")
-                    {:density   density
+    (throw (ex-info ":rf.error/machines-viz-unknown-chart-density"
+                    {:rf.error/id :rf.error/machines-viz-unknown-chart-density
+                     :where     'machines-viz/resolve-chart-density
+                     :recovery  :no-recovery
+                     :reason    (str "unknown chart density: " (pr-str density)
+                                     ". Expected one of " (pr-str densities) ".")
+                     :density   density
                      :expected  densities}))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/ai_generate_cljs_test.cljc
@@ -128,7 +128,7 @@
                nil
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
-      (is (= :ai-generate/no-resolver (:reason (ex-data ex)))))))
+      (is (= :ai-generate/no-resolver (:rf.error/id (ex-data ex)))))))
 
 (deftest generate-with-non-string-resolver-response-throws-parse-failed
   (testing "resolver returning a non-string throws :parse-failed"
@@ -138,7 +138,7 @@
                nil
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
-      (is (= :ai-generate/parse-failed (:reason (ex-data ex)))))))
+      (is (= :ai-generate/parse-failed (:rf.error/id (ex-data ex)))))))
 
 (deftest generate-with-unparseable-edn-throws-parse-failed
   (testing "resolver returning malformed EDN throws :parse-failed"
@@ -148,7 +148,7 @@
                nil
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
-      (is (= :ai-generate/parse-failed (:reason (ex-data ex)))))))
+      (is (= :ai-generate/parse-failed (:rf.error/id (ex-data ex)))))))
 
 (deftest generate-with-non-machine-spec-throws-invalid-spec
   (testing "resolver returning valid EDN that isn't a machine shape
@@ -159,7 +159,7 @@
                nil
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
-      (is (= :ai-generate/invalid-spec (:reason (ex-data ex)))))))
+      (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex)))))))
 
 (deftest generate-with-non-map-spec-throws-invalid-spec
   (testing "resolver returning a vector / number / string throws :invalid-spec"
@@ -170,7 +170,7 @@
                  nil
                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
         (is ex (str "expected ex for " bad))
-        (is (= :ai-generate/invalid-spec (:reason (ex-data ex))))))))
+        (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex))))))))
 
 (deftest generate-rejects-parallel-without-regions
   (testing ":type :parallel without :regions throws :invalid-spec"
@@ -180,7 +180,7 @@
                nil
                (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
       (is ex)
-      (is (= :ai-generate/invalid-spec (:reason (ex-data ex)))))))
+      (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; End-to-end — generated specs work with the rest of the substrate

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -197,8 +197,11 @@
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate patches-schema patches)
-        (throw (ex-info "diff-encode patch grammar violated"
-                        {:rf.error/code  :rf.error/bad-diff-patches
+        (throw (ex-info ":rf.error/bad-diff-patches"
+                        {:rf.error/id    :rf.error/bad-diff-patches
+                         :where          'mcp-base/diff-encode-db-after
+                         :recovery       :no-recovery
+                         :reason         "diff-encode patch grammar violated"
                          :schema         patches-schema
                          :patches        patches})))))
   nil)
@@ -212,8 +215,11 @@
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate sections-schema sections)
-        (throw (ex-info "diff-encode section grammar violated"
-                        {:rf.error/code :rf.error/bad-diff-sections
+        (throw (ex-info ":rf.error/bad-diff-sections"
+                        {:rf.error/id   :rf.error/bad-diff-sections
+                         :where         'mcp-base/diff-encode-db-after
+                         :recovery      :no-recovery
+                         :reason        "diff-encode section grammar violated"
                          :schema        sections-schema
                          :sections      sections})))))
   nil)

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -277,14 +277,14 @@
     (let [bad [[[:a] :replace 1]]]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"diff-encode patch grammar violated"
+            #":rf\.error/bad-diff-patches"
             (#'de/validate-patches! bad)))
       (try
         (#'de/validate-patches! bad)
         (is false "expected throw")
         (catch clojure.lang.ExceptionInfo e
           (is (= :rf.error/bad-diff-patches
-                 (:rf.error/code (ex-data e)))
+                 (:rf.error/id (ex-data e)))
               "ex-info carries the reserved :rf.error/* code"))))))
 
 ;; ---------------------------------------------------------------------------
@@ -306,17 +306,17 @@
     ;; reduce starts.
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
-          #"diff-encode patch grammar violated"
+          #":rf\.error/bad-diff-patches"
           (de/apply-patches {} [[[:a]]]))))
   (testing "unknown op throws"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
-          #"diff-encode patch grammar violated"
+          #":rf\.error/bad-diff-patches"
           (de/apply-patches {} [[[:a] :replace 1]]))))
   (testing "non-vector path throws"
     (is (thrown-with-msg?
           clojure.lang.ExceptionInfo
-          #"diff-encode patch grammar violated"
+          #":rf\.error/bad-diff-patches"
           (de/apply-patches {} [[:a :assoc 1]]))))
   (testing "ex-info carries reserved :rf.error/bad-diff-patches code"
     (try
@@ -324,7 +324,7 @@
       (is false "expected throw")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/bad-diff-patches
-               (:rf.error/code (ex-data e))))))))
+               (:rf.error/id (ex-data e))))))))
 
 (deftest apply-patches-well-formed-input-passes-validation
   ;; Soft contract: well-formed patches pass the gate silently and

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -54,10 +54,13 @@
   "Look up the nREPL port. Returns an integer or throws with a hint."
   []
   (or (nrepl/read-port-from-fs)
-      (throw (ex-info "nREPL port not found"
-                      {:hint (str "Start your shadow-cljs dev build "
-                                  "(`shadow-cljs watch <build>`), or set "
-                                  "SHADOW_CLJS_NREPL_PORT explicitly.")}))))
+      (throw (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
+                      {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found
+                       :where    'pair-mcp/resolve-port
+                       :recovery :no-recovery
+                       :reason   (str "nREPL port not found. Start your shadow-cljs dev build "
+                                      "(`shadow-cljs watch <build>`), or set "
+                                      "SHADOW_CLJS_NREPL_PORT explicitly.")}))))
 
 (defn- new-conn []
   (let [port (resolve-port)]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -126,8 +126,13 @@
   ;; Binding names must be symbols — they appear verbatim in the source
   ;; (no quoting) so body forms can refer to them by name.
   (when-not (symbol? n)
-    (throw (ex-info "rt-let binding name must be a symbol"
-                    {:name n :type (type n)})))
+    (throw (ex-info ":rf.error/pair-mcp-rt-let-binding-bad-shape"
+                    {:rf.error/id :rf.error/pair-mcp-rt-let-binding-bad-shape
+                     :where    'pair-mcp/rt-let
+                     :recovery :no-recovery
+                     :reason   "rt-let binding name must be a symbol"
+                     :name     n
+                     :type     (type n)})))
   (name n))
 
 (defn- emit-body [forms]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -244,7 +244,11 @@
           :snapshot-map (run-snapshot-map payload opts)
           :epoch-vector (run-epoch-vector payload opts)
           :scalar-value (run-scalar-value payload opts)
-          (throw (ex-info "run-wire-pipeline: unknown :kind"
-                          {:kind  kind
-                           :valid #{:snapshot-map :epoch-vector :scalar-value}})))]
+          (throw (ex-info ":rf.error/pair-mcp-unknown-wire-pipeline-kind"
+                          {:rf.error/id :rf.error/pair-mcp-unknown-wire-pipeline-kind
+                           :where    'pair-mcp/run-wire-pipeline
+                           :recovery :no-recovery
+                           :reason   (str "run-wire-pipeline got an unknown :kind " (pr-str kind))
+                           :kind     kind
+                           :valid    #{:snapshot-map :epoch-vector :scalar-value}})))]
     (assoc out :value (source-uri/decorate value (config/get-editor)))))

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -132,8 +132,11 @@
   (try
     (json/parse-string s true)
     (catch Throwable e
-      (throw (ex-info "re-frame2-story-mcp: JSON parse failure"
-                      {:rf.error :rf.error/parse-error
+      (throw (ex-info ":rf.error/story-mcp-json-parse-failure"
+                      {:rf.error/id :rf.error/story-mcp-json-parse-failure
+                       :where    'story-mcp/parse-json
+                       :recovery :no-recovery
+                       :reason   "re-frame2-story-mcp: JSON parse failure"
                        :raw      (when s (subs s 0 (min 200 (count s))))}
                       e)))))
 
@@ -207,8 +210,11 @@
       (cond
         (nil? line)                   eof-sentinel
         (= ::frame-too-large line)    (throw (ex-info
-                                               "re-frame2-story-mcp: frame exceeds cap"
-                                               {:rf.error :rf.error/frame-too-large
+                                               ":rf.error/story-mcp-frame-too-large"
+                                               {:rf.error/id :rf.error/story-mcp-frame-too-large
+                                                :where     'story-mcp/read-frame
+                                                :recovery  :no-recovery
+                                                :reason    "re-frame2-story-mcp: frame exceeds cap"
                                                 :max-bytes max-frame-bytes}))
         (str/blank? line)             (recur)
         :else                         (parse-json line)))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -149,7 +149,16 @@
     :else
     (try
       (let [edn (b64-decode s)
-            v   (edn/read-string {:default (fn [_t _v] (throw (ex-info "bad tag" {})))} edn)]
+            v   (edn/read-string {:default (fn [_t _v]
+                                             ;; Caught by the surrounding try
+                                             ;; → ::malformed; the canonical
+                                             ;; :rf.error/id rides on ex-data
+                                             ;; for any consumer that inspects.
+                                             (throw (ex-info ":rf.error/story-mcp-bad-edn-tag"
+                                                             {:rf.error/id :rf.error/story-mcp-bad-edn-tag
+                                                              :where    'story-mcp/decode-cursor
+                                                              :recovery :no-recovery
+                                                              :reason   "EDN cursor carried a tagged literal — none are permitted"})))} edn)]
         (if (and (map? v)
                  (= 1 (:v v))
                  (integer? (:offset v))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -123,8 +123,11 @@
         (let [parsed (edn/read-string
                        {:readers {}
                         :default (fn [tag _]
-                                   (throw (ex-info "tagged literals not permitted"
-                                                   {:rf.error :rf.story-mcp/edn-tagged-literal
+                                   (throw (ex-info ":rf.error/story-mcp-tagged-literal-rejected"
+                                                   {:rf.error/id :rf.error/story-mcp-tagged-literal-rejected
+                                                    :where    'story-mcp/parse-edn-body
+                                                    :recovery :no-recovery
+                                                    :reason   "tagged literals are not permitted in EDN write bodies"
                                                     :tag      tag})))}
                        body)]
           (if (> (value-depth parsed) max-edn-depth)

--- a/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
@@ -71,12 +71,12 @@
       (is (= 1 (:id m))))))
 
 (deftest json-parse-throws-on-malformed
-  (testing "malformed JSON throws ex-info with rf.error/parse-error"
+  (testing "malformed JSON throws ex-info with :rf.error/story-mcp-json-parse-failure"
     (try
       (proto/parse-json "{not json")
       (is false "should have thrown")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/parse-error (:rf.error (ex-data e))))))))
+        (is (= :rf.error/story-mcp-json-parse-failure (:rf.error/id (ex-data e))))))))
 
 (deftest json-encode-roundtrip
   (testing "encode then decode yields the same map (keywordised)"
@@ -117,7 +117,7 @@
         (proto/read-frame r)
         (is false "should have thrown")
         (catch clojure.lang.ExceptionInfo e
-          (is (= :rf.error/parse-error (:rf.error (ex-data e)))))))))
+          (is (= :rf.error/story-mcp-json-parse-failure (:rf.error/id (ex-data e)))))))))
 
 (deftest write-frame-roundtrips
   (testing "write-frame appends a newline; round-trip via reader"

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1975,8 +1975,8 @@
         (proto/read-frame reader)
         (is false "should have thrown")
         (catch clojure.lang.ExceptionInfo e
-          (is (= :rf.error/frame-too-large (:rf.error (ex-data e)))
-              "ex-data carries the rf.error tag the run-loop dispatches on"))))))
+          (is (= :rf.error/story-mcp-frame-too-large (:rf.error/id (ex-data e)))
+              "ex-data carries the canonical :rf.error/id the run-loop dispatches on"))))))
 
 (deftest read-frame-survives-after-oversize-frame
   (testing "the next frame after an oversize one is still readable"

--- a/tools/story/src/re_frame/story/extends.cljc
+++ b/tools/story/src/re_frame/story/extends.cljc
@@ -60,16 +60,21 @@
         (vec (reverse acc))
 
         (contains? visited parent-id)
-        (throw (ex-info (str "re-frame2-story: :extends cycle through "
-                             parent-id)
-                        {:rf.error :rf.error/extends-cycle
+        (throw (ex-info ":rf.error/story-extends-cycle"
+                        {:rf.error/id :rf.error/story-extends-cycle
+                         :where    'rf.story/reg-variant
+                         :recovery :fix-registration
+                         :reason   (str "re-frame2-story: :extends cycle through " parent-id)
                          :chain    (conj (vec visited) parent-id)
                          :id       parent-id}))
 
         (>= depth *max-extends-depth*)
-        (throw (ex-info (str "re-frame2-story: :extends chain exceeds "
-                             *max-extends-depth* " levels at " parent-id)
-                        {:rf.error :rf.error/extends-cycle
+        (throw (ex-info ":rf.error/story-extends-chain-too-long"
+                        {:rf.error/id :rf.error/story-extends-chain-too-long
+                         :where    'rf.story/reg-variant
+                         :recovery :fix-registration
+                         :reason   (str "re-frame2-story: :extends chain exceeds "
+                                        *max-extends-depth* " levels at " parent-id)
                          :chain    (conj (vec visited) parent-id)
                          :id       parent-id}))
 
@@ -79,9 +84,12 @@
                  parent
                  (conj visited parent-id)
                  (inc depth))
-          (throw (ex-info (str "re-frame2-story: :extends references "
-                               "unregistered variant " parent-id)
-                          {:rf.error :rf.error/extends-unknown
+          (throw (ex-info ":rf.error/story-extends-unknown"
+                          {:rf.error/id :rf.error/story-extends-unknown
+                           :where    'rf.story/reg-variant
+                           :recovery :fix-registration
+                           :reason   (str "re-frame2-story: :extends references "
+                                          "unregistered variant " parent-id)
                            :parent   parent-id})))))))
 
 (defn resolve-extends

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -91,12 +91,20 @@
   Per spec/007 §Canonical id grammar."
   [story-id variant-name]
   (when-not (keyword? story-id)
-    (throw (ex-info "re-frame2-story: story id must be a keyword"
-                    {:story-id story-id})))
+    (throw (ex-info ":rf.error/story-bad-id"
+                    {:rf.error/id :rf.error/story-bad-id
+                     :where    'rf.story/reg-story
+                     :recovery :fix-registration
+                     :reason   "re-frame2-story: story id must be a keyword"
+                     :story-id story-id})))
   (when-not (keyword? variant-name)
-    (throw (ex-info (str "re-frame2-story: variant-name in :variants map "
-                         "must be a keyword (got " (pr-str variant-name) ")")
-                    {:variant-name variant-name})))
+    (throw (ex-info ":rf.error/story-bad-variant-name"
+                    {:rf.error/id :rf.error/story-bad-variant-name
+                     :where    'rf.story/reg-story
+                     :recovery :fix-registration
+                     :reason   (str "re-frame2-story: variant-name in :variants map "
+                                    "must be a keyword (got " (pr-str variant-name) ")")
+                     :variant-name variant-name})))
   (let [story-str (subs (str story-id) 1)]    ; strip leading colon
     (keyword story-str (name variant-name))))
 

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -203,12 +203,16 @@
   on a miss. Returns the body unchanged on success."
   [kind id body]
   (when-let [explain (schemas/validate kind body)]
-    (throw (ex-info (str "re-frame2-story: " (name kind) " body for "
-                         id " does not match " (name kind) " schema")
-                    {:rf.error (keyword "rf.error" (str (name kind) "-shape"))
-                     :kind     kind
-                     :id       id
-                     :explain  explain})))
+    (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))]
+      (throw (ex-info (str error-kw)
+                      {:rf.error/id error-kw
+                       :where    'rf.story/reg-story
+                       :recovery :fix-registration
+                       :reason   (str "re-frame2-story: " (name kind) " body for "
+                                      id " does not match " (name kind) " schema")
+                       :kind     kind
+                       :id       id
+                       :explain  explain}))))
   body)
 
 (defn- validate-tag-membership!
@@ -233,9 +237,12 @@
                                   (not (contains? registered-tag-ids base))))
                               tags)]
       (when (seq unknown)
-        (throw (ex-info (str "re-frame2-story: unregistered tag(s) on " id
-                             ": " (pr-str unknown))
-                        {:rf.error :rf.error/unknown-tag
+        (throw (ex-info ":rf.error/unknown-tag"
+                        {:rf.error/id :rf.error/unknown-tag
+                         :where    'rf.story/reg-story
+                         :recovery :fix-registration
+                         :reason   (str "re-frame2-story: unregistered tag(s) on " id
+                                        ": " (pr-str unknown))
                          :id       id
                          :unknown  unknown}))))))
 
@@ -256,11 +263,15 @@
               :tag         keyword?
               keyword?)]
     (when-not (ok? id)
-      (throw (ex-info (str "re-frame2-story: " (name kind) " id " (pr-str id)
-                           " does not match the canonical id grammar")
-                      {:rf.error (keyword "rf.error" (str (name kind) "-id-shape"))
-                       :kind     kind
-                       :id       id})))))
+      (let [error-kw (keyword "rf.error" (str (name kind) "-id-shape"))]
+        (throw (ex-info (str error-kw)
+                        {:rf.error/id error-kw
+                         :where    'rf.story/reg-story
+                         :recovery :fix-registration
+                         :reason   (str "re-frame2-story: " (name kind) " id " (pr-str id)
+                                        " does not match the canonical id grammar")
+                         :kind     kind
+                         :id       id}))))))
 
 ;; ---- auto-install hook (rf2-p1ydc) ---------------------------------------
 ;;

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -58,10 +58,10 @@
         {:tags "not-a-set"})                         ; :tags must be a set
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-shape (:rf.error (ex-data e)))
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e)))
             "ex-data carries the :rf.error/variant-shape sentinel")
-        (is (re-find #"variant schema" (.getMessage e))
-            "message names the failing kind")))))
+        (is (re-find #"variant schema" (:reason (ex-data e)))
+            ":reason names the failing kind")))))
 
 (deftest reg-workspace-bad-shape-carries-error-key
   (testing "an invalid workspace body raises with :rf.error in ex-data"
@@ -70,8 +70,8 @@
         {:layout :unknown-layout})                   ; :layout must be one of five
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/workspace-shape (:rf.error (ex-data e))))
-        (is (re-find #"workspace schema" (.getMessage e)))))))
+        (is (= :rf.error/workspace-shape (:rf.error/id (ex-data e))))
+        (is (re-find #"workspace schema" (:reason (ex-data e))))))))
 
 (deftest reg-workspace-isolation-slot-accepts-both-values
   ;; rf2-gqid4 — the optional `:isolation` slot accepts `:isolated`
@@ -89,7 +89,7 @@
         {:layout :variants-grid :isolation :sandboxed})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/workspace-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/workspace-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-decorator-bad-shape-carries-error-key
   (testing "an invalid decorator body raises with :rf.error in ex-data"
@@ -98,7 +98,7 @@
         {:kind :not-a-decorator-kind})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/decorator-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/decorator-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-tag-bad-shape-carries-error-key
   (testing "an invalid tag body raises with :rf.error in ex-data"
@@ -107,7 +107,7 @@
         {:default-filter :sometimes})                ; only :include / :exclude
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/tag-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/tag-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-mode-bad-shape-carries-error-key
   (testing "an invalid mode body raises with :rf.error in ex-data"
@@ -116,7 +116,7 @@
         {:args "not-a-map"})                         ; :args must be a map
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/mode-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/mode-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-story-panel-bad-shape-carries-error-key
   (testing "an invalid story-panel body raises with :rf.error in ex-data"
@@ -126,7 +126,7 @@
          :render    :some/view})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/story-panel-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/story-panel-shape (:rf.error/id (ex-data e))))))))
 
 ;; ===========================================================================
 ;; rf2-tl7zk — :plays multi-play schema contract
@@ -151,7 +151,7 @@
          :plays  []})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-variant-plays-without-name-rejected
   (testing "each :plays entry must carry a :name"
@@ -161,7 +161,7 @@
          :plays  [{:script [[:dispatch [:foo]]]}]})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-variant-plays-duplicate-names-rejected
   (testing ":plays entries must have unique :name values"
@@ -172,7 +172,7 @@
                   {:name "p" :script [[:dispatch [:b]]]}]})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 (deftest reg-variant-play-script-and-plays-mutually-exclusive
   (testing "a variant may not declare BOTH :play-script and :plays"
@@ -183,7 +183,7 @@
          :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+        (is (= :rf.error/variant-shape (:rf.error/id (ex-data e))))))))
 
 ;; ===========================================================================
 ;; UNKNOWN-TAG CONTRACT — tag-vocab cross-check error carries the offending set
@@ -197,7 +197,7 @@
          :tags   #{:dev :totally-made-up :also-fake}})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/unknown-tag (:rf.error (ex-data e))))
+        (is (= :rf.error/unknown-tag (:rf.error/id (ex-data e))))
         (let [unknown (set (:unknown (ex-data e)))]
           (is (contains? unknown :totally-made-up))
           (is (contains? unknown :also-fake))
@@ -216,7 +216,7 @@
          :events  []})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/extends-unknown (:rf.error (ex-data e))))
+        (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))
         (is (= :story.x/no-such-parent (:parent (ex-data e))))))))
 
 ;; ===========================================================================
@@ -230,14 +230,16 @@
       (story/reg-variant* "not-a-keyword" {:events []})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/variant-id-shape (:rf.error (ex-data e))))
-        (is (re-find #"canonical id grammar" (.getMessage e)))))))
+        (is (= :rf.error/variant-id-shape (:rf.error/id (ex-data e))))
+        (is (re-find #"canonical id grammar" (:reason (ex-data e))))))))
 
 (deftest reg-workspace-bad-id-grammar-rejected
   (testing "a workspace id outside :Workspace.<path>/<name> is rejected"
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"canonical id grammar"
-                          (story/reg-workspace* :NotAWorkspaceId {:layout :variants-grid})))))
+    (let [e (try (story/reg-workspace* :NotAWorkspaceId {:layout :variants-grid})
+                 nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :rf.error/workspace-id-shape (:rf.error/id (ex-data e))))
+      (is (re-find #"canonical id grammar" (:reason (ex-data e)))))))
 
 ;; ===========================================================================
 ;; SOURCE-COORD STAMPING — END-TO-END VIA THE FORM-B EXPANSION
@@ -292,14 +294,18 @@
 ;; a malformed registry id.
 
 (deftest variant-id-for-rejects-non-keyword-story-id
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                        #"story id must be a keyword"
-                        (macros/variant-id-for "story.foo" :a))))
+  (let [e (try (macros/variant-id-for "story.foo" :a)
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+    (is (= :rf.error/story-bad-id (:rf.error/id (ex-data e))))
+    (is (re-find #"story id must be a keyword" (:reason (ex-data e))))))
 
 (deftest variant-id-for-rejects-non-keyword-variant-name
-  (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                        #"variant-name in :variants map"
-                        (macros/variant-id-for :story.foo "a"))))
+  (let [e (try (macros/variant-id-for :story.foo "a")
+               nil
+               (catch clojure.lang.ExceptionInfo e e))]
+    (is (= :rf.error/story-bad-variant-name (:rf.error/id (ex-data e))))
+    (is (re-find #"variant-name in :variants map" (:reason (ex-data e))))))
 
 (deftest variant-id-for-builds-canonical-id
   (testing "the canonical :story.<path>/<variant> id shape"

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -239,7 +239,7 @@
                (:placement (story/handler-meta :story-panel pid))))))
     (testing "an off-vocab placement is rejected"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"story-panel schema"
+                            #":rf\.error/story-panel-shape"
                             (story/reg-story-panel :rf.story.test/bad-placement
                               {:title     "bad"
                                :placement :nowhere

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -169,16 +169,16 @@
 (deftest reg-story-id-shape
   (testing "reg-story rejects ids outside the :story.<path> grammar"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match the canonical id grammar"
+                          #":rf\.error/story-id-shape"
                           (story/reg-story* :NotAStoryId {})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match the canonical id grammar"
+                          #":rf\.error/story-id-shape"
                           (story/reg-story* :foo.bar {})))))
 
 (deftest reg-story-bad-shape
   (testing "reg-story rejects a body that violates the schema"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match story schema"
+                          #":rf\.error/story-shape"
                           (story/reg-story :story.ui.bad
                             {:tags "not-a-set"})))))
 
@@ -188,7 +188,7 @@
       (story/reg-story :story.ui.bad {:tags #{:dev :totally-made-up}})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/unknown-tag (:rf.error (ex-data e))))
+        (is (= :rf.error/unknown-tag (:rf.error/id (ex-data e))))
         (is (= [:totally-made-up] (:unknown (ex-data e))))))))
 
 ;; ---- reg-variant basic -------------------------------------------------
@@ -250,7 +250,7 @@
          :events  []})
       (is false "expected an exception")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :rf.error/extends-unknown (:rf.error (ex-data e))))))))
+        (is (= :rf.error/story-extends-unknown (:rf.error/id (ex-data e))))))))
 
 (deftest extends-cycle-detection
   (testing ":extends cycle raises :rf.error/extends-cycle"
@@ -263,7 +263,7 @@
                                  #(get lookup %))
         (is false "expected an exception")
         (catch clojure.lang.ExceptionInfo e
-          (is (= :rf.error/extends-cycle (:rf.error (ex-data e)))))))))
+          (is (= :rf.error/story-extends-cycle (:rf.error/id (ex-data e)))))))))
 
 (deftest extends-depth-cap
   (testing ":extends depth cap fires at *max-extends-depth*"
@@ -284,7 +284,7 @@
                                    #(get chain %))
           (is false "expected an exception")
           (catch clojure.lang.ExceptionInfo e
-            (is (= :rf.error/extends-cycle (:rf.error (ex-data e))))))))))
+            (is (= :rf.error/story-extends-chain-too-long (:rf.error/id (ex-data e))))))))))
 
 ;; ---- Form-B desugaring -------------------------------------------------
 
@@ -375,7 +375,7 @@
 (deftest reg-workspace-bad-layout
   (testing "a :grid workspace without :variants fails validation"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match workspace schema"
+                          #":rf\.error/workspace-shape"
                           (story/reg-workspace :Workspace.bad/empty
                             {:layout :grid})))))
 
@@ -424,7 +424,7 @@
        :init [[:auth/restore-session {:user "alice"}]]})
     (is (= :frame-setup (:kind (story/handler-meta :decorator :mock-auth))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match decorator schema"
+                          #":rf\.error/decorator-shape"
                           (story/reg-decorator :mock-empty
                             {:kind :frame-setup})))))
 
@@ -442,7 +442,7 @@
 (deftest reg-decorator-unknown-kind
   (testing "decorator with an unknown :kind fails the schema"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match decorator schema"
+                          #":rf\.error/decorator-shape"
                           (story/reg-decorator :bad-kind
                             {:kind :no-such-kind})))))
 
@@ -515,14 +515,14 @@
 (deftest reg-tag-rejects-bad-default-filter
   (testing ":default-filter must be :include or :exclude"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match tag schema"
+                          #":rf\.error/tag-shape"
                           (story/reg-tag :bad/df
                             {:default-filter :sometimes})))))
 
 (deftest reg-tag-rejects-non-keyword-axis
   (testing ":axis must be a keyword"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"does not match tag schema"
+                          #":rf\.error/tag-shape"
                           (story/reg-tag :bad/axis
                             {:axis "status"})))))
 
@@ -541,7 +541,7 @@
 (deftest tags-with-bang-prefix-rejects-unknown
   (testing "the !-prefix variant rejects unknown base tags"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"unregistered tag"
+                          #":rf\.error/unknown-tag"
                           (story/reg-variant :story.bang/bad
                             {:events []
                              :tags   #{:!totally-unknown}})))))

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -53,13 +53,22 @@
             (symbol? raw)  (keyword (name raw))
             (string? raw)  (keyword (string/replace raw #"^:" ""))
             :else
-            (throw (ex-info (str "Unrecognised :substrate value: " (pr-str raw))
-                            {:substrate raw})))]
+            (throw (ex-info ":rf.error/template-unrecognised-substrate"
+                            {:rf.error/id :rf.error/template-unrecognised-substrate
+                             :where     'template/coerce-substrate
+                             :recovery  :fix-registration
+                             :reason    (str "unrecognised :substrate value: " (pr-str raw))
+                             :substrate raw})))]
     (when-not (valid-substrates s)
-      (throw (ex-info (str ":substrate must be one of "
-                           (pr-str valid-substrates)
-                           " (got " (pr-str s) ")")
-                      {:substrate s :valid valid-substrates})))
+      (throw (ex-info ":rf.error/template-substrate-must-be-one-of"
+                      {:rf.error/id :rf.error/template-substrate-must-be-one-of
+                       :where     'template/coerce-substrate
+                       :recovery  :fix-registration
+                       :reason    (str ":substrate must be one of "
+                                       (pr-str valid-substrates)
+                                       " (got " (pr-str s) ")")
+                       :substrate s
+                       :valid     valid-substrates})))
     s))
 
 ;; -- :include-story? coercion ----------------------------------------------
@@ -74,9 +83,13 @@
     (true? raw)         true
     (false? raw)        false
     :else
-    (throw (ex-info (str ":include-story? must be true or false (got "
-                         (pr-str raw) ")")
-                    {:include-story? raw}))))
+    (throw (ex-info ":rf.error/template-bad-include-story-flag"
+                    {:rf.error/id :rf.error/template-bad-include-story-flag
+                     :where     'template/coerce-include-story?
+                     :recovery  :fix-registration
+                     :reason    (str ":include-story? must be true or false (got "
+                                     (pr-str raw) ")")
+                     :include-story? raw}))))
 
 ;; -- name derivations ------------------------------------------------------
 ;;
@@ -145,12 +158,16 @@
         include-story?  (coerce-include-story? (:include-story? data))
         _               (when (and include-story? (not= substrate :reagent))
                           (throw (ex-info
-                                   (str ":include-story? is Reagent-only in v1 "
-                                        "(got :substrate " substrate
-                                        "). UIx + Helix variants follow once "
-                                        "Story's adapter coverage matches "
-                                        "Reagent's.")
-                                   {:substrate substrate
+                                   ":rf.error/template-include-story-reagent-only"
+                                   {:rf.error/id :rf.error/template-include-story-reagent-only
+                                    :where     'template/data-fn
+                                    :recovery  :fix-registration
+                                    :reason    (str ":include-story? is Reagent-only in v1 "
+                                                    "(got :substrate " substrate
+                                                    "). UIx + Helix variants follow once "
+                                                    "Story's adapter coverage matches "
+                                                    "Reagent's.")
+                                    :substrate substrate
                                     :include-story? include-story?})))
         substrate-nm    (name substrate)
         top             (:top data)

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -349,7 +349,7 @@
     (let [tmp (tmp-dir "rf2-template-bad-")]
       (try
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":substrate must be one of"
+                              #":rf\.error/template-substrate-must-be-one-of"
                               (run-template! tmp "acme/my-app" :svelte))
             "unknown substrate is rejected")
         (finally
@@ -449,11 +449,11 @@
     (let [tmp (tmp-dir "rf2-template-story-uix-")]
       (try
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":include-story\? is Reagent-only"
+                              #":rf\.error/template-include-story-reagent-only"
                               (run-template! tmp "acme/my-app" :uix true))
             ":include-story? + :uix is rejected at the entry-fn")
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":include-story\? is Reagent-only"
+                              #":rf\.error/template-include-story-reagent-only"
                               (run-template! tmp "acme/my-app" :helix true))
             ":include-story? + :helix is rejected at the entry-fn")
         (finally
@@ -464,7 +464,7 @@
     (let [tmp (tmp-dir "rf2-template-story-bad-")]
       (try
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #":include-story\? must be true or false"
+                              #":rf\.error/template-bad-include-story-flag"
                               (run-template! tmp "acme/my-app" :reagent "yes"))
             "non-boolean :include-story? is rejected")
         (finally


### PR DESCRIPTION
Closes rf2-befku.2 + .3 + .4 + .5 + .6 + .7 + .8 + .9. Phase 2 B-I of the error-message quality audit · conforms to the cluster-A contract (spec/009 §The thrown-error shape — the :rf.error/id ex-data contract).

## Summary
Routes every `(throw (ex-info …))` site across 8 disjoint surface clusters through the canonical thrown-error shape: `:rf.error/id` discriminator slot, `:where` (the user-facing surface fn symbol), `:recovery`, and a human-readable `:reason`; message string is the stringified discriminator kw. Surface-specific payload slots are preserved.

- **B · machines** — 24 validation throws via a new `validation-error` helper (`:rf.error/machine-*`).
- **C · reagent-slim** — React-19-removed + create-class family lifted from the non-canonical `:type` slot; migration prose moves to `:reason`/`:migration`.
- **D · http** — schema-validation / malformed-json (lifts `:kind`) / interceptor-bad-return / timeout; downstream classifiers branch on `:rf.error/id`.
- **E · routing** — new `route-error` helper; drops `:kind`; preserves the Malli-explainer `:error` slot (separate contract).
- **F · core** — reg-event/sub/registrar/macros + canonicalises `at-boundary-missing-schema` off the `:error` slot.
- **G · SSR** — stamps `:where` + `:rf.error/id` on every ssr/ + ssr-ring/ validation throw (payloads were already strong).
- **H · conformance + test seams** — DSL evaluator + invoke-handler / wait-until / poll-until; two DSL surfaces whose message is surfaced downstream keep prose messages with `:rf.error/id` on ex-data.
- **I · tools** — causa / pair-mcp / story / story-mcp / template / mcp-base / machines-viz; story moves off `:rf.error`, story-mcp + mcp-base off `:rf.error/code`, machines-viz keeps `:scxml/*`/`:ai-generate/*` tool-domain ids but lifts them to `:rf.error/id`.

Tests that asserted on old slots (`:type`/`:kind`/`:error`/`:reason`-as-kw) or prose messages updated to read `:rf.error/id` and assert prose on `:reason`.

## Test plan
- [x] `clojure -M:test` — machines, reagent-slim, http, routing, core, schemas, ssr, ssr-ring, story, story-mcp, mcp-base, machines-viz, template, causa (all green)
- [x] `npm run test:cljs` (3883 tests, 0 failures)
- [x] `npm run test:bundle-isolation`
- [x] `npm run test:reagent-slim:bundle-isolation`
- [ ] pair-mcp node test (CLJS-only; runs in CI — local node build needs `npm install` in the tool dir)