### PR TITLE
fix(causa): cljs-devtools renders current-state collections; home-grown diff stays for Event :db (rf2-dmso5)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -340,27 +340,26 @@
 
 ;; ---- payload renderer ---------------------------------------------------
 ;;
-;; Per spec/021 §5 the per-row "expand payload" surface uses the shared
-;; data-display renderer (`day8.re-frame2-causa.data-display.render/
-;; render-tree`, rf2-jgip1, merged in #1739). The Trace panel passes
-;; the raw trace event as `:value`, with `:default-depth 2` per
-;; spec/021 §5.1 ("depth-2-expanded default").
+;; Per spec/021 §5 the per-row "expand payload" surface shows the trace
+;; event's CURRENT state — so per Mike-direction 2026-05-21 (rf2-dmso5)
+;; it renders through the EDN widget's `browse` variant, which is the
+;; re-frame-10x cljs-devtools look (type-coloured · nested · expanded).
+;; The Trace panel passes the raw trace event as `:value`.
 
 (defn- render-payload
-  "Per-row payload renderer. Wires the shared rf2-jgip1 data-display
-  renderer to the row's raw trace event. Each row gets its own
-  `:render-id` (`trace-row-<id>`) so the renderer's sticky expansion
-  state never collides across rows."
+  "Per-row payload renderer. Wires the EDN widget's current-state
+  `browse` (cljs-devtools) to the row's raw trace event. Each row gets
+  its own `:render-id` (`trace-row-<id>`) so the rendered container's
+  testid is unique per row."
   [{:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-causa-trace-row-" id "-payload")
          :style       {:padding "8px 16px 12px 110px"
                        :background (:bg-1 tokens)
                        :border-bottom (str "1px solid " (:border-subtle tokens))}}
    (edn/browse
-     {:value        raw
-      :panel-id     :trace
-      :render-id    (str "trace-row-" id)
-      :default-depth 2})])
+     {:value     raw
+      :panel-id  :trace
+      :render-id (str "trace-row-" id)})])
 
 (defn- trace-row
   "One row in the trace ribbon.

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render.cljs
@@ -38,11 +38,19 @@
   ## API
 
   - `value->hiccup` — render a CLJS value as hiccup using
-    cljs-devtools' formatters. Top-level entry; never expands
+    cljs-devtools' formatters. Header-only entry; never expands
     `[\"object\" ...]` placeholders (those render as a `▶ {…}`
-    summary). Suitable for non-collection leaves and for the
-    `mini` one-liner.
-  - `jsonml->hiccup` — pure JSONML walker; public for tests.
+    summary). Suitable for the `mini` one-liner and inline chips
+    where a single line is wanted.
+  - `value->tree-hiccup` — render a CLJS value as a FULLY-EXPANDED
+    cljs-devtools tree (the re-frame-10x look · type-coloured ·
+    nested · indented). Recursively expands `[\"object\" ...]`
+    surrogate references up to a depth budget; deeper levels
+    degrade to the collapsed `▶ {…}` summary so a pathological
+    app-db can't blow the call stack. This is the entry the
+    current-state `browse` path uses for collections.
+  - `jsonml->hiccup` — pure JSONML walker; public for tests. The
+    arity that takes an opts map drives recursive expansion.
 
   ## Posture
 
@@ -82,20 +90,48 @@
    :cljs-land-style                ""
    :initial-hierarchy-depth-budget false})
 
-(defn- with-prefs
-  "Run `f` with the Causa-overridden cljs-devtools prefs swapped in,
-  restoring the previous prefs after. Mirrors re-frame-10x's
-  `with-cljs-devtools-prefs` macro at runtime (no macro needed — we
-  swap once at the boundary, render, swap back). Defensive try/finally
-  so an exception inside the markup builder never leaves global prefs
-  in the Causa-overridden state."
-  [f]
+(def ^:private causa-expanded-prefs
+  "Extra prefs for the FULLY-EXPANDED current-state tree
+  (`value->tree-hiccup`, rf2-dmso5). cljs-devtools defaults inline only
+  `:max-print-level 2` / `:body-line-max-print-level 3` levels and
+  `:max-header-elements 5` entries before degrading a value to a
+  collapsed `▸ {…}` reference — that's the one-line summary look. For
+  Causa's current-state surfaces we want the re-frame-10x
+  fully-expanded look, so the tree renderer lifts the inline budgets
+  generously (the per-leaf header preview then inlines the whole
+  structure for ordinary app-db depths) and `value->tree-hiccup`'s
+  body-recursion picks up anything past them. `value->hiccup` / `mini`
+  do NOT use these — they stay one-line."
+  (merge causa-prefs
+         {:max-print-level           10
+          :body-line-max-print-level 10
+          :max-header-elements       100
+          :max-number-body-items     1000}))
+
+(defn- with-prefs*
+  "Run `f` with `prefs` merged over the live cljs-devtools prefs,
+  restoring the previous prefs after. Defensive try/finally so an
+  exception inside the markup builder never leaves global prefs in the
+  Causa-overridden state."
+  [prefs f]
   (let [previous (devtools-prefs/get-prefs)]
     (try
-      (devtools-prefs/set-prefs! (merge previous causa-prefs))
+      (devtools-prefs/set-prefs! (merge previous prefs))
       (f)
       (finally
         (devtools-prefs/set-prefs! previous)))))
+
+(defn- with-prefs
+  "One-line-summary prefs (the shallow `causa-prefs`). Used by
+  `value->hiccup` + `mini`."
+  [f]
+  (with-prefs* causa-prefs f))
+
+(defn- with-expanded-prefs
+  "Fully-expanded prefs (`causa-expanded-prefs`). Used by
+  `value->tree-hiccup` for the re-frame-10x current-state look."
+  [f]
+  (with-prefs* causa-expanded-prefs f))
 
 ;; ---- JSONML → hiccup walker ---------------------------------------------
 ;;
@@ -128,20 +164,24 @@
   matching hiccup keyword so the resulting tree renders verbatim."
   #{"div" "span" "ol" "li" "table" "tr" "td"})
 
+(def ^:private default-max-depth
+  "How deep `value->tree-hiccup` recursively expands `object`
+  surrogate references before degrading to the collapsed `▶ {…}`
+  summary. App-db is rarely deeper than this; the cap is a stack-guard
+  against pathological / cyclic structures more than a UI choice. The
+  re-frame-10x look reads as fully-expanded for ordinary data."
+  12)
+
 (declare jsonml->hiccup)
 
-(defn- render-object-placeholder
-  "Render an `[\"object\" {object: v, config: c}]` JSONML node as an
-  inline `▶ <header>` summary. We don't expand inline (Causa's diff
-  engine + `data-display/render` own the expansion contract for
-  collections in `browse`/`diff`; `value->hiccup` is used for LEAVES
-  and the `mini` one-liner). The summary keeps the visual signal —
-  user sees \"there's nested structure here\" — without committing
-  to an expansion state."
-  [obj]
-  ;; cljs-devtools' object placeholder carries `.object` (the value)
-  ;; and `.config`. We render a single ▶ + the header markup of the
-  ;; object so the row remains informative.
+(defn- render-object-summary
+  "Render an `[\"object\" {object: v, config: c}]` surrogate as an
+  inline `▸ <header>` ONE-LINE summary (no body expansion). Used as
+  the leaf-fallback in `value->hiccup` and as the depth-budget cap in
+  `value->tree-hiccup`: the user still sees \"there is nested structure
+  here\" via the collection's one-line `{…}` header without the tree
+  committing to expand it."
+  [obj opts]
   (let [^js o obj
         v    (some-> o .-object)
         cfg  (some-> o .-config)]
@@ -150,16 +190,74 @@
      [:span {:style {:color (:text-tertiary tokens)
                      :margin-right "2px"}}
       "▸"]
-     ;; Render the *header* of the nested object recursively. The
-     ;; recursion terminates because cljs-devtools only emits "object"
-     ;; nodes for collection-shaped values, and the header of a
-     ;; collection is the one-line `{...}` summary (no further
-     ;; "object" children).
+     ;; Render the *header* of the nested surrogate. The header of a
+     ;; collection is its one-line `{...}` summary, so this terminates.
      (let [inner (try
                    (formatters/header-api-call v cfg)
                    (catch :default _ nil))]
        (when (some? inner)
-         [:span (jsonml->hiccup inner)]))]))
+         [:span (jsonml->hiccup inner opts)]))]))
+
+(defn- render-object-expanded
+  "Recursively EXPAND an `[\"object\" {object: surrogate}]` reference:
+  render the surrogate's header inline, then — when it has a body and
+  we're within the depth budget — render that body indented underneath.
+  This is what produces the re-frame-10x nested-tree look for
+  collections. Beyond the depth budget the reference degrades to the
+  one-line `render-object-summary`.
+
+  `binaryage/cljs-devtools` models a value's expandable rows as a
+  surrogate whose `body-api-call` returns an `[\"ol\" …]` of `[\"li\" …]`
+  lines; each line embeds the child values as further `object`
+  references — so recursing on `body-api-call` walks the whole
+  structure."
+  [obj {:keys [depth max-depth] :as opts}]
+  (let [^js o     obj
+        surrogate (some-> o .-object)
+        cfg       (some-> o .-config)
+        header    (try (formatters/header-api-call surrogate cfg)
+                       (catch :default _ nil))
+        has-body? (try (boolean (formatters/has-body-api-call surrogate cfg))
+                       (catch :default _ false))]
+    (cond
+      ;; Couldn't even get a header — fall back to the inline summary.
+      (nil? header)
+      (render-object-summary obj opts)
+
+      ;; Leaf-shaped surrogate (no expandable body) — header only.
+      (not has-body?)
+      [:span {:style {:font-family mono-stack}}
+       (jsonml->hiccup header opts)]
+
+      ;; Depth budget hit — keep the one-line summary so we never
+      ;; recurse without bound on a deep / cyclic structure.
+      (>= depth max-depth)
+      (render-object-summary obj opts)
+
+      ;; Within budget + has a body — expand: header line, then the
+      ;; body's rows indented one level deeper.
+      :else
+      (let [body      (try (formatters/body-api-call surrogate cfg)
+                           (catch :default _ nil))
+            next-opts (assoc opts :depth (inc depth))]
+        [:span {:style {:font-family mono-stack}}
+         [:span {:style {:display "block"}}
+          (jsonml->hiccup header opts)]
+         (when (some? body)
+           [:div {:style {:padding-left "14px"
+                          :border-left  (str "1px solid " (:border-subtle tokens))
+                          :margin-left  "2px"}}
+            (jsonml->hiccup body next-opts)])]))))
+
+(defn- render-object
+  "Route an `object` reference to the expanding or summary renderer
+  based on `opts`. `:expand? true` (set by `value->tree-hiccup`) walks
+  the surrogate's body; otherwise (header-only `value->hiccup`,
+  `mini`) it renders the one-line summary."
+  [obj opts]
+  (if (:expand? opts)
+    (render-object-expanded obj opts)
+    (render-object-summary obj opts)))
 
 (defn jsonml->hiccup
   "Pure walker — convert JSONML to hiccup. Public for tests.
@@ -167,78 +265,95 @@
   Numbers / strings pass through verbatim (CLJS keeps them as plain
   values; hiccup renders them as text children). JS arrays whose first
   element is a known container tag become the equivalent hiccup vector.
-  `object` placeholders render via `render-object-placeholder`.
-  `annotation` (cljs-devtools' path-marker) wraps its children in a
-  bare `[:span]`."
-  [jsonml]
-  (cond
-    (nil? jsonml)     nil
-    (number? jsonml)  jsonml
-    (string? jsonml)  jsonml
-    (boolean? jsonml) (str jsonml)
-    ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
-    ;; `array?` predicate identifies the JS array shape.
-    (array? jsonml)
-    (let [tag-name   (aget jsonml 0)
-          attrs      (aget jsonml 1)
-          child-cnt  (.-length jsonml)]
-      (cond
-        (contains? known-tags tag-name)
-        (let [style (attrs-style->map attrs)
-              base  [(keyword tag-name)
-                     {:style (assoc style :font-family mono-stack)}]]
-          (loop [i 2 acc base]
-            (if (>= i child-cnt)
-              acc
-              (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i)))))))
+  `object` references route through `render-object` — expanded into a
+  nested tree when `opts` carries `:expand? true`, collapsed to a
+  one-line `▸ {…}` summary otherwise. `annotation` (cljs-devtools'
+  path-marker) wraps its children in a bare `[:span]`.
 
-        (= tag-name "object")
-        (render-object-placeholder attrs)
+  Single-arg arity renders header-only (no expansion). The opts arity
+  threads `{:expand? :depth :max-depth}` so a caller can drive the
+  recursive tree walk."
+  ([jsonml] (jsonml->hiccup jsonml {:expand? false :depth 0 :max-depth 0}))
+  ([jsonml opts]
+   (cond
+     (nil? jsonml)     nil
+     (number? jsonml)  jsonml
+     (string? jsonml)  jsonml
+     (boolean? jsonml) (str jsonml)
+     ;; JSONML is a JS array of [tag attrs ...children]. ClojureScript's
+     ;; `array?` predicate identifies the JS array shape.
+     (array? jsonml)
+     (let [tag-name   (aget jsonml 0)
+           attrs      (aget jsonml 1)
+           child-cnt  (.-length jsonml)]
+       (cond
+         (contains? known-tags tag-name)
+         (let [style (attrs-style->map attrs)
+               base  [(keyword tag-name)
+                      {:style (assoc style :font-family mono-stack)}]]
+           (loop [i 2 acc base]
+             (if (>= i child-cnt)
+               acc
+               (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts))))))
 
-        (= tag-name "annotation")
-        (loop [i 2 acc [:span {}]]
-          (if (>= i child-cnt)
-            acc
-            (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i))))))
+         (= tag-name "object")
+         (render-object attrs opts)
 
-        :else
-        ;; Unknown tag — fall back to a plain span so the markup
-        ;; doesn't disappear silently.
-        (loop [i 2 acc [:span {}]]
-          (if (>= i child-cnt)
-            acc
-            (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i))))))))
+         (= tag-name "annotation")
+         (loop [i 2 acc [:span {}]]
+           (if (>= i child-cnt)
+             acc
+             (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))
 
-    ;; Some JSONML producers wrap their content in a CLJS vector
-    ;; instead of a JS array (e.g. when re-routed through edn->js).
-    ;; Walk those too.
-    (vector? jsonml)
-    (let [[tag-name attrs & children] jsonml]
-      (cond
-        (contains? known-tags tag-name)
-        (let [style (attrs-style->map attrs)]
-          (into [(keyword tag-name)
-                 {:style (assoc style :font-family mono-stack)}]
-                (map jsonml->hiccup)
-                children))
+         :else
+         ;; Unknown tag — fall back to a plain span so the markup
+         ;; doesn't disappear silently.
+         (loop [i 2 acc [:span {}]]
+           (if (>= i child-cnt)
+             acc
+             (recur (inc i) (conj acc (jsonml->hiccup (aget jsonml i) opts)))))))
 
-        (= tag-name "object") (render-object-placeholder attrs)
+     ;; Some JSONML producers wrap their content in a CLJS vector
+     ;; instead of a JS array (e.g. when re-routed through edn->js).
+     ;; Walk those too.
+     (vector? jsonml)
+     (let [[tag-name attrs & children] jsonml]
+       (cond
+         (contains? known-tags tag-name)
+         (let [style (attrs-style->map attrs)]
+           (into [(keyword tag-name)
+                  {:style (assoc style :font-family mono-stack)}]
+                 (map #(jsonml->hiccup % opts))
+                 children))
 
-        :else (into [:span {}] (map jsonml->hiccup) children)))
+         (= tag-name "object") (render-object attrs opts)
 
-    :else
-    (try (pr-str jsonml) (catch :default _ (str jsonml)))))
+         :else (into [:span {}] (map #(jsonml->hiccup % opts)) children)))
+
+     :else
+     (try (pr-str jsonml) (catch :default _ (str jsonml))))))
 
 ;; ---- public entry --------------------------------------------------------
 
+(defn- pr-str-fallback
+  "Defensive degrade — a plain pr-str span for when cljs-devtools
+  refuses a value or throws inside its markup builder."
+  [value]
+  [:span {:style {:font-family mono-stack
+                  :color       (:text-primary tokens)}}
+   (try (pr-str value) (catch :default _ (str value)))])
+
 (defn value->hiccup
-  "Render a CLJS `value` as hiccup via cljs-devtools' formatters.
-  Returns hiccup — substrate-agnostic, no Reagent/React/UIx in scope.
+  "Render a CLJS `value` as hiccup via cljs-devtools' formatters,
+  HEADER-ONLY. Returns hiccup — substrate-agnostic, no Reagent/React/
+  UIx in scope.
 
   The output renders inline (a `[:span ...]`) — cljs-devtools' header
-  markup is a one-line summary. Use for leaves, chips, and the `mini`
-  one-liner; for full expandable trees, the diff/browse engine in
-  `data-display/render` owns the contract."
+  markup is a one-line summary; nested collections show as a `▸ {…}`
+  summary, not expanded. Use for the `mini` one-liner and inline chips
+  where a single line is wanted. For the full expandable current-state
+  tree (App-DB / Trace payloads / Event :fx / coeffects) use
+  `value->tree-hiccup`."
   [value]
   (try
     (with-prefs
@@ -249,14 +364,57 @@
             ;; uninteresting (the rare scalar surfaces that aren't
             ;; cljs-typed — plain JS objects passed through, e.g.).
             ;; Fall back to pr-str so the leaf still renders.
-            [:span {:style {:font-family mono-stack
-                            :color       (:text-primary tokens)}}
-             (try (pr-str value) (catch :default _ (str value)))]
+            (pr-str-fallback value)
             (jsonml->hiccup jsonml)))))
     (catch :default _
       ;; Defensive — any throw in cljs-devtools' markup builder
       ;; degrades gracefully to a pr-str leaf rather than crashing
       ;; the panel.
-      [:span {:style {:font-family mono-stack
-                      :color       (:text-primary tokens)}}
-       (try (pr-str value) (catch :default _ (str value)))])))
+      (pr-str-fallback value))))
+
+(defn value->tree-hiccup
+  "Render a CLJS `value` as a FULLY-EXPANDED cljs-devtools tree — the
+  re-frame-10x current-state look: type-coloured leaves, native
+  collection delimiters, records keeping their type tag, nested
+  structure expanded and indented. Returns hiccup; substrate-agnostic.
+
+  Implementation: take the value's header (the one-line `{…}` / `[…]`
+  summary) and, when the value has an expandable body, render that body
+  underneath — recursively expanding each nested `object` surrogate
+  reference up to `max-depth` (defaults to `default-max-depth`). A
+  scalar value (no body) renders exactly like `value->hiccup`.
+
+  This is the entry the current-state `browse` path uses for
+  collections; the diff path (Event panel `:db`) stays on the
+  home-grown smallest-diff engine in `data-display/render`."
+  ([value] (value->tree-hiccup value default-max-depth))
+  ([value max-depth]
+   (try
+     (with-expanded-prefs
+       (fn []
+         (let [header    (formatters/header-api-call value nil)
+               has-body? (boolean (formatters/has-body-api-call value nil))]
+           (cond
+             (nil? header)
+             (pr-str-fallback value)
+
+             ;; Scalar / leaf — no body to expand. Render the header.
+             (not has-body?)
+             [:span {:style {:font-family mono-stack}}
+              (jsonml->hiccup header {:expand? false :depth 0 :max-depth max-depth})]
+
+             ;; Collection — render the header line, then the expanded
+             ;; body indented underneath.
+             :else
+             (let [body (formatters/body-api-call value nil)
+                   opts {:expand? true :depth 1 :max-depth max-depth}]
+               [:span {:style {:font-family mono-stack}}
+                [:span {:style {:display "block"}}
+                 (jsonml->hiccup header opts)]
+                (when (some? body)
+                  [:div {:style {:padding-left "14px"
+                                 :border-left  (str "1px solid " (:border-subtle tokens))
+                                 :margin-left  "2px"}}
+                   (jsonml->hiccup body opts)])])))))
+     (catch :default _
+       (pr-str-fallback value)))))

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -67,72 +67,116 @@
              :as cdt]
             [zprint.core :as zprint]))
 
+;; `inspect` / `inspect-inline` (the panel-facing current-state facade)
+;; delegate to `browse` / `mini`, which are defined further down — forward
+;; declare so the facade can sit at the top of the file where callers look.
+(declare browse mini)
+
 ;; ---- panel-facing facade — inspect / inspect-inline ----------------------
 ;;
 ;; Per Mike-direction rf2-9wsdy ("one widget, many call sites") every
 ;; panel-side EDN render flows through this namespace — panels MUST
 ;; NOT reach for `theme.data-inspector` directly. The `inspect` +
-;; `inspect-inline` wrappers below delegate to the sentinel-aware
-;; renderer (`theme.data-inspector`) so panels get redacted / large
-;; chip rendering for free; the indirection keeps the widget as the
-;; single facade the rf2-8q4f4 grep contract checks.
+;; `inspect-inline` wrappers are the canonical CURRENT-STATE renderers
+;; (App-DB · Trace payloads · Event :fx / coeffects · machine snapshots
+;; · Issues ex-data). Per Mike-direction 2026-05-21 (rf2-dmso5)
+;; current-state rendering is the re-frame-10x cljs-devtools look:
+;; collections AND scalars route through cljs-devtools (`browse`).
+;;
+;; The data-classification sentinels (`:rf/redacted` / `:rf/large` per
+;; spec/015) have no cljs-devtools vocabulary, so `inspect` keeps the
+;; bespoke chip chrome from `theme.data-inspector` for those —
+;; cljs-devtools renders everything else.
 
 (defn inspect
-  "Sentinel-aware expandable rendering for one value — the canonical
-  L4 detail-panel renderer. Delegates to `theme.data-inspector/inspect`
-  so `:rf/redacted` / `:rf/large` sentinels paint their bespoke chrome
-  per spec/015. Returns hiccup.
+  "Sentinel-aware current-state rendering for one value — the canonical
+  L4 detail-panel renderer. Routes the value through cljs-devtools
+  (the re-frame-10x look · type-coloured · expandable nested) via the
+  `browse` path, EXCEPT for the spec/015 data-classification sentinels
+  (`:rf/redacted` / `:rf/large`), which keep their bespoke chip chrome
+  from `theme.data-inspector` (cljs-devtools has no sentinel
+  vocabulary). Returns hiccup.
 
   Single-arg form picks the default node-key (`\"root\"`); two-arg
-  form lets the caller supply a stable per-mount node-key so adjacent
-  inspect calls in the same panel keep independent expand state."
-  ([v] (inspector/inspect v))
-  ([v node-key] (inspector/inspect v node-key)))
+  form lets the caller supply a stable per-mount `node-key` — used as
+  the cljs-devtools `render-id` so adjacent inspects in a panel keep
+  independent testids.
+
+  Diff rendering (Event panel `:db` before→after smallest-diff) is a
+  DIFFERENT contract — call `diff`, which stays on the home-grown
+  `data-display/render-tree` engine."
+  ([v] (inspect v "root"))
+  ([v node-key]
+   (cond
+     ;; spec/015 sentinels keep their bespoke chip chrome — cljs-devtools
+     ;; has no diff/redaction vocabulary.
+     (inspector/redacted-sentinel? v)
+     (inspector/inspect v node-key)
+
+     (some? (inspector/redacted+size-meta v))
+     (inspector/inspect v node-key)
+
+     (some? (inspector/large-meta v))
+     (inspector/inspect v node-key)
+
+     ;; Everything else — collections + scalars — render through
+     ;; cljs-devtools (current-state browse).
+     :else
+     (browse {:value     v
+              :panel-id  :inspect
+              :render-id (str node-key)}))))
 
 (defn inspect-inline
-  "Compact one-line sentinel-aware rendering — same delegation as
-  `inspect` but uses `theme.data-inspector/inspect-inline` so hover
-  tooltips / list cells get the collapsed `{N entries}` / `[N items]`
-  / sentinel-chip shape without an expand affordance."
+  "Compact one-line current-state rendering for hover tooltips / list
+  cells. Sentinels keep their chip shape (via `theme.data-inspector`);
+  everything else renders as a one-line cljs-devtools header summary
+  (`mini`)."
   [v]
-  (inspector/inspect-inline v))
+  (cond
+    (inspector/redacted-sentinel? v)
+    (inspector/inspect-inline v)
+
+    (some? (inspector/redacted+size-meta v))
+    (inspector/inspect-inline v)
+
+    (some? (inspector/large-meta v))
+    (inspector/inspect-inline v)
+
+    :else
+    (mini v)))
 
 ;; ---- variant: browse -----------------------------------------------------
 
-(defn- collection-value?
-  "True when `v` is a collection — anything `data-display/render-tree`'s
-  tree walker treats as a node with children (map / vector / list / set).
-  Non-collections route through cljs-devtools' single-value formatter."
-  [v]
-  (or (map? v) (vector? v) (set? v) (sequential? v)))
-
 (defn browse
-  "Render `:value` as a path-aware expand/collapse tree (collections)
-  or as a single cljs-devtools-formatted hiccup span (non-collection
-  leaves). Browse mode — no diff semantics. Returns hiccup.
+  "Render `:value` as a current-state tree via cljs-devtools — the
+  re-frame-10x look: type-coloured leaves, native collection
+  delimiters, records keeping their type tag, nested structure
+  expanded + indented. Browse mode is current-state · no diff
+  semantics; cljs-devtools owns the WHOLE value (collections AND
+  scalars), per Mike-direction 2026-05-21 (rf2-dmso5).
+
+  Diff semantics (Event panel `:db` before→after smallest-diff) stay
+  on the home-grown `data-display/render-tree` engine via `diff`.
 
   Required: `:value :panel-id :render-id`.
-  Optional: `:default-depth` (defaults to 2 per §10.4)."
-  [{:keys [value panel-id render-id default-depth]
-    :or   {default-depth 2}}]
-  (if (collection-value? value)
-    (data-display/render-tree
-      {:value         value
-       :diff?         false
-       :panel-id      panel-id
-       :render-id     render-id
-       :default-depth default-depth})
-    ;; Non-collection — record / scalar / function / etc. cljs-devtools
-    ;; owns the leaf shape (type tag, metadata, IRecord chrome).
-    [:div {:data-testid (str "rf-causa-edn-widget-browse-"
-                             (name (or panel-id :unknown))
-                             "-"
-                             (str (or render-id "")))
-           :style {:font-family mono-stack
-                   :font-size   "12px"
-                   :color       (:text-primary tokens)
-                   :line-height 1.4}}
-     (cdt/value->hiccup value)]))
+  Optional: `:max-depth` (recursion cap for cljs-devtools' surrogate
+            expansion · defaults to `cdt/default-max-depth`)."
+  [{:keys [value panel-id render-id max-depth]}]
+  ;; Every browse value — map / vector / set / record / scalar —
+  ;; routes through cljs-devtools. Collections expand into the nested
+  ;; tree; scalars render as a single coloured span. The home-grown
+  ;; render-tree is now diff-only.
+  [:div {:data-testid (str "rf-causa-edn-widget-browse-"
+                           (name (or panel-id :unknown))
+                           "-"
+                           (str (or render-id "")))
+         :style {:font-family mono-stack
+                 :font-size   "12px"
+                 :color       (:text-primary tokens)
+                 :line-height 1.4}}
+   (if (some? max-depth)
+     (cdt/value->tree-hiccup value max-depth)
+     (cdt/value->tree-hiccup value))])
 
 ;; ---- variant: diff -------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -415,9 +415,10 @@
       (is (= #{} @(rf/subscribe [:rf.causa/trace-expanded-row-ids]))
           ":rf.causa/clear-trace-expand drops every expanded id"))))
 
-(deftest expanded-row-renders-data-display-payload
-  (testing "rf2-7dyi8 — when a row's :id is in the expanded set, the
-            shared rf2-jgip1 data-display renderer mounts below the row."
+(deftest expanded-row-renders-cljs-devtools-payload
+  (testing "rf2-7dyi8 + rf2-dmso5 — when a row's :id is in the expanded
+            set, the current-state cljs-devtools browse renderer mounts
+            below the row (Trace payloads are current-state)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 13 :op-type :event :operation :event/dispatched
@@ -431,14 +432,13 @@
       (let [tree    (trace/Panel)
             payload (find-by-testid tree "rf-causa-trace-row-13-payload")]
         (is (some? payload) "payload block renders when row is expanded")
-        ;; rf2-jgip1's render-tree always renders a wrapper div with
-        ;; data-testid `rf-causa-data-display-trace-<render-id>`; pin
-        ;; that the panel's render-id wiring lands in the canonical
-        ;; per-row slot so two adjacent expansions don't collide on
-        ;; sticky expansion state.
+        ;; Per rf2-dmso5 browse is current-state cljs-devtools — the
+        ;; widget stamps `rf-causa-edn-widget-browse-trace-<render-id>`;
+        ;; pin that the panel's per-row render-id wiring lands in the
+        ;; canonical per-row slot.
         (is (some? (find-by-testid tree
-                                   "rf-causa-data-display-trace-trace-row-13"))
-            "shared rf2-jgip1 renderer mounted with per-row render-id")))))
+                                   "rf-causa-edn-widget-browse-trace-trace-row-13"))
+            "cljs-devtools browse mounted with per-row render-id")))))
 
 (deftest source-coord-click-fires-open-in-editor
   (testing "clicking the source-coord chip fires :rf.causa/open-in-editor;

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/cljs_devtools_render_cljs_test.cljs
@@ -168,3 +168,100 @@
   (testing "function passes through without throwing"
     (let [out (cdt/value->hiccup (fn [_]))]
       (is (vector? out)))))
+
+;; ---- value->tree-hiccup (full current-state expansion, rf2-dmso5) --------
+;;
+;; `value->tree-hiccup` is the re-frame-10x current-state look: a
+;; collection expands into a nested, indented tree rather than the
+;; one-line `▸ {…}` summary `value->hiccup` produces. These assert the
+;; whole value renders — every key + value surfaces in the tree.
+
+(deftest tree-hiccup-scalar-matches-header
+  (testing "a scalar (no body) renders as hiccup carrying the value"
+    (let [out (cdt/value->tree-hiccup :foo/bar)]
+      (is (vector? out))
+      (is (contains-text? out ":foo/bar")))))
+
+(deftest tree-hiccup-map-expands-keys-and-values
+  (testing "a top-level map expands: every key + value renders"
+    (let [out (cdt/value->tree-hiccup {:alpha 1 :beta 2 :gamma 3})]
+      (is (vector? out))
+      (is (contains-text? out ":alpha"))
+      (is (contains-text? out ":beta"))
+      (is (contains-text? out ":gamma"))
+      (is (contains-text? out "1"))
+      (is (contains-text? out "2"))
+      (is (contains-text? out "3")))))
+
+(deftest tree-hiccup-large-map-expands-all-entries
+  (testing "a map with more than the cljs-devtools preview cap still
+            expands every entry (no collapsed-by-default)"
+    (let [m   (zipmap (map #(keyword (str "k" %)) (range 12)) (range 12))
+          out (cdt/value->tree-hiccup m)]
+      (is (contains-text? out ":k0"))
+      (is (contains-text? out ":k11")))))
+
+(deftest tree-hiccup-nested-map-expands-recursively
+  (testing "nested collections expand recursively — inner keys/values render"
+    (let [out (cdt/value->tree-hiccup {:outer {:inner {:deep 99}}})]
+      (is (contains-text? out ":outer"))
+      (is (contains-text? out ":inner"))
+      (is (contains-text? out ":deep"))
+      (is (contains-text? out "99")))))
+
+(deftest tree-hiccup-vector-of-maps-expands
+  (testing "a vector of maps expands each element"
+    (let [out (cdt/value->tree-hiccup [{:a 1} {:b 2}])]
+      (is (contains-text? out ":a"))
+      (is (contains-text? out ":b"))
+      (is (contains-text? out "1"))
+      (is (contains-text? out "2")))))
+
+(deftest tree-hiccup-deeply-nested-renders-without-blowing-up
+  (testing "a structure deeper than the inline print-level budget still
+            renders (the body-recursion depth cap is a stack guard, not
+            a crash) — the outermost keys surface and the deep tail
+            degrades to a ▸ summary somewhere"
+    ;; Build a 20-deep nest — past the inline print-level (10) so the
+    ;; deep tail must fall through to the body-recursion summary path.
+    (let [deep (reduce (fn [acc i] {(keyword (str "lvl" i)) acc})
+                       {:bottom 1}
+                       (range 20))
+          out  (cdt/value->tree-hiccup deep)]
+      (is (vector? out))
+      ;; The outermost key still renders.
+      (is (contains-text? out ":lvl19"))
+      ;; Somewhere down the tail, a collapsed ▸ summary appears (the
+      ;; structure exceeds the inline budget).
+      (is (contains-text? out "▸")))))
+
+(deftest tree-hiccup-body-recursion-cap-summarises
+  (testing "an explicit small max-depth caps the BODY recursion: a wide
+            map (forces a body, since >5 entries) whose values are
+            themselves wide maps collapses the nested level to ▸"
+    ;; A map of 8 entries forces a body (header caps at the preview
+    ;; size for the body path); each value is another 8-entry map. With
+    ;; max-depth 1 the body's nested maps hit the cap → ▸ summary.
+    (let [wide  (zipmap (map #(keyword (str "k" %)) (range 8))
+                        (range 8))
+          outer (zipmap (map #(keyword (str "g" %)) (range 8))
+                        (repeat wide))
+          out   (cdt/value->tree-hiccup outer 1)]
+      (is (vector? out))
+      (is (contains-text? out ":g0"))
+      (is (contains-text? out "▸")))))
+
+(deftest tree-hiccup-record-keeps-type-tag
+  (testing "a record value keeps its type tag / fields under expansion"
+    (let [pt  (->TestPoint 7 8)
+          out (cdt/value->tree-hiccup pt)
+          all (apply str (filter string? (mapcat rest (walk-hiccup out))))]
+      (is (vector? out))
+      (is (or (re-find #"TestPoint" all)
+              (re-find #":x" all)
+              (re-find #":y" all))))))
+
+(deftest tree-hiccup-never-throws-for-unusual-input
+  (testing "JS object / function degrade gracefully (no throw, hiccup out)"
+    (is (vector? (cdt/value->tree-hiccup #js {:foo 1})))
+    (is (vector? (cdt/value->tree-hiccup (fn [_]))))))

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -47,61 +47,143 @@
        first))
 
 ;; ---- variant: browse -----------------------------------------------------
+;;
+;; Per Mike-direction 2026-05-21 (rf2-dmso5) browse mode is the
+;; re-frame-10x current-state look: collections AND scalars route
+;; through cljs-devtools. The home-grown `data-display` engine is now
+;; diff-only. So `browse` of either a map or a scalar produces the
+;; `rf-causa-edn-widget-browse-<panel>-<render-id>` container with
+;; cljs-devtools markup inside (never a `rf-causa-data-display-*` node).
 
-(deftest browse-of-collection-routes-through-data-display
+(defn- contains-text?
+  "True when some string/number descendant of `tree` contains `s`.
+  cljs-devtools renders numeric leaves as JS numbers, so scan both."
+  [tree s]
+  (let [hit (atom false)
+        re  (re-pattern s)]
+    (letfn [(scan [n]
+              (cond
+                (string? n)  (when (re-find re n) (reset! hit true))
+                (number? n)  (when (re-find re (str n)) (reset! hit true))
+                (boolean? n) (when (re-find re (str n)) (reset! hit true))
+                (vector? n)  (doseq [c (rest n)] (scan c))
+                (seq? n)     (doseq [c n] (scan c))))]
+      (scan tree))
+    @hit))
+
+(deftest browse-of-collection-routes-through-cljs-devtools
   (let [out (w/browse {:value     {:a 1 :b 2}
                        :panel-id  :test
                        :render-id "browse-1"})]
-    (testing "browse of a map returns a [:div ...] root with the panel-keyed data-testid"
+    (testing "browse of a map returns the cljs-devtools browse container"
       (is (vector? out))
       (is (= :div (first out)))
-      ;; The underlying render-tree stamps the panel-keyed root testid.
-      (is (some? (find-by-testid out "rf-causa-data-display-test-browse-1"))))))
+      ;; The widget's cljs-devtools browse path stamps this testid;
+      ;; the home-grown data-display root testid must NOT appear.
+      (is (some? (find-by-testid out "rf-causa-edn-widget-browse-test-browse-1")))
+      (let [ids (->> (walk-hiccup out)
+                     (keep #(some-> (second %) :data-testid))
+                     (filter string?))]
+        (is (not-any? #(.startsWith % "rf-causa-data-display-") ids)
+            "browse no longer routes collections through the home-grown engine")))))
 
-(defn- find-testid-prefix
-  "Return the first hiccup node whose :data-testid attr starts with
-  `prefix`. The engine's leaf-testid is dynamic
-  (`rf-causa-data-display-leaf-<path>`) so callers asserting that a
-  leaf rendered cannot match exactly."
-  [tree prefix]
-  (->> (walk-hiccup tree)
-       (filter (fn [n]
-                 (and (vector? n)
-                      (map? (second n))
-                      (let [id (get (second n) :data-testid)]
-                        (and (string? id)
-                             (.startsWith id prefix))))))
-       first))
+(deftest browse-of-collection-renders-keys-and-values
+  (let [out (w/browse {:value     {:k :foo/bar}
+                       :panel-id  :test
+                       :render-id "kw-1"})]
+    (testing "the expanded cljs-devtools tree surfaces the key and value"
+      (is (contains-text? out ":k"))
+      (is (contains-text? out ":foo/bar")))))
 
-(deftest browse-of-collection-still-routes-keyword-leaf-to-engine
-  (let [out  (w/browse {:value     {:k :foo/bar}
-                        :panel-id  :test
-                        :render-id "kw-1"})
-        leaf (find-testid-prefix out "rf-causa-data-display-leaf-")]
-    (testing "map containing a keyword routes through the engine's leaf renderer"
-      (is (some? leaf)))))
+(deftest browse-of-nested-collection-expands-recursively
+  (let [out (w/browse {:value     {:outer {:inner 99}}
+                       :panel-id  :test
+                       :render-id "nested-1"})]
+    (testing "a nested map's inner key + value render (full expansion)"
+      (is (contains-text? out ":outer"))
+      (is (contains-text? out ":inner"))
+      (is (contains-text? out "99")))))
 
 (deftest browse-of-non-collection-routes-through-cljs-devtools
   (let [out (w/browse {:value     :foo/bar
                        :panel-id  :test
                        :render-id "scalar-1"})]
-    (testing "non-collection browse returns a [:div ...] container"
+    (testing "non-collection browse returns the cljs-devtools container"
       (is (vector? out))
       (is (= :div (first out)))
       (is (some? (find-by-testid out
-                                 "rf-causa-edn-widget-browse-test-scalar-1"))))))
+                                 "rf-causa-edn-widget-browse-test-scalar-1")))
+      (is (contains-text? out ":foo/bar")))))
 
 ;; ---- variant: diff -------------------------------------------------------
+;;
+;; Diff mode (Event panel `:db` before→after smallest-diff) STAYS on
+;; the home-grown `data-display/render-tree` engine — cljs-devtools has
+;; no diff vocabulary. rf2-dmso5 must not disturb this.
 
 (deftest diff-emits-diff-tree
   (let [out (w/diff {:before    {:a 1}
                      :after     {:a 2}
                      :panel-id  :test
                      :render-id "diff-1"})]
-    (testing "diff returns the diff-mode tree"
+    (testing "diff returns the home-grown data-display diff-mode tree"
       (is (vector? out))
       (is (= :div (first out)))
       (is (some? (find-by-testid out "rf-causa-data-display-test-diff-1"))))))
+
+;; ---- facade: inspect / inspect-inline (current-state, rf2-dmso5) ---------
+;;
+;; The panel-facing `inspect` facade is the current-state renderer. Per
+;; rf2-dmso5 it routes the value through cljs-devtools (browse) EXCEPT
+;; for the spec/015 data-classification sentinels, which keep their
+;; bespoke chip chrome from `theme.data-inspector`.
+
+(deftest inspect-collection-routes-through-cljs-devtools
+  (let [out (w/inspect {:a 1 :b 2} "node-1")]
+    (testing "a plain map inspects through the cljs-devtools browse path"
+      (is (= :div (first out)))
+      (is (some? (find-by-testid out "rf-causa-edn-widget-browse-inspect-node-1")))
+      (is (contains-text? out ":a"))
+      (is (contains-text? out ":b"))
+      ;; NOT the home-grown data-inspector chrome.
+      (let [ids (->> (walk-hiccup out)
+                     (keep #(some-> (second %) :data-testid))
+                     (filter string?))]
+        (is (not-any? #(.startsWith % "rf-causa-data-inspector") ids))))))
+
+(deftest inspect-scalar-routes-through-cljs-devtools
+  (let [out (w/inspect :hello/world "node-2")]
+    (testing "a scalar inspects through cljs-devtools too"
+      (is (= :div (first out)))
+      (is (contains-text? out ":hello/world")))))
+
+(deftest inspect-redacted-sentinel-keeps-chip
+  (let [out (w/inspect :rf/redacted "node-3")]
+    (testing "a :rf/redacted sentinel keeps the bespoke redacted chip"
+      (is (some? (find-by-testid out "rf-causa-data-inspector-redacted"))))))
+
+(deftest inspect-large-sentinel-keeps-chip
+  (let [out (w/inspect {:rf/large {:bytes 1024 :head "preview"}} "node-4")]
+    (testing "a :rf/large sentinel keeps the bespoke large chip"
+      (is (some? (find-by-testid out "rf-causa-data-inspector-large"))))))
+
+(deftest inspect-default-node-key-renders
+  (testing "single-arg inspect renders (default node-key)"
+    (let [out (w/inspect {:x 1})]
+      (is (= :div (first out)))
+      (is (some? (find-by-testid out "rf-causa-edn-widget-browse-inspect-root"))))))
+
+(deftest inspect-inline-collection-routes-through-mini
+  (let [out (w/inspect-inline {:a 1})]
+    (testing "inline current-state renders the one-line cljs-devtools mini"
+      (is (= :span (first out)))
+      (is (= "rf-causa-edn-widget-mini" (-> out second :data-testid))))))
+
+(deftest inspect-inline-redacted-sentinel-keeps-chip
+  (let [out (w/inspect-inline :rf/redacted)]
+    (testing "inline redacted sentinel keeps the chip"
+      (is (= "rf-causa-data-inspector-redacted"
+             (-> out second :data-testid))))))
 
 ;; ---- variant: mini -------------------------------------------------------
 


### PR DESCRIPTION
Closes rf2-dmso5.

## What changed

Current-state views now render the WHOLE value (collections + scalars) through cljs-devtools — the re-frame-10x look (type-coloured, native delimiters, expanded nested structure). Previously only non-collection scalar leaves routed through cljs-devtools, so app-db (always a map) never hit it.

- **App-DB + Trace payloads + Event :fx / coeffects** -> cljs-devtools (10x look)
- **Event panel :db diff** -> home-grown smallest-diff (`data-display/render-tree`), UNCHANGED — cljs-devtools has no diff vocabulary

## How

- `cljs_devtools_render`: new `value->tree-hiccup` — a fully-expanded renderer. Lifts cljs-devtools print-level prefs (so the header inlines deeply for ordinary app-db) and recursively expands surrogate `object` references up to a depth budget (stack guard for deep/cyclic data). The one-line `value->hiccup` / `mini` path keeps the shallow prefs.
- `widget/browse`: routes the whole value through cljs-devtools; the home-grown `data-display` engine is now diff-only.
- `widget/inspect` + `inspect-inline`: the panel current-state facade delegates to `browse` / `mini`, while keeping the spec/015 sentinel chip chrome (`:rf/redacted` / `:rf/large`).
- `widget/diff`: unchanged (home-grown smallest-diff focusing).

## Gates (all green)

- `npm run test:cljs` (3905 tests, 0 failures)
- `clojure -M:test` from `tools/causa` (849 tests, 0 failures)
- `npm run test:bundle-isolation` (cljs-devtools stays dev-only)
- `npm run test:perf-bundle`
- `npm run test:causa-feature-gate` (13 scenarios, 0 failures)