### PR TITLE
docs(api): strip Status + add examples + in-the-wild /examples links (rf2-law2f)

### DIFF
--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -17,8 +17,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-event-db id ?metadata-or-interceptors handler)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: "When this event arrives, transform `app-db` and return the new one." The simplest handler shape — pure `(fn [db event-vec] new-db)`. Use it for the 80% of handlers that just update state.
+- **Example**:
+  ```clojure
+  (rf/reg-event-db :counter/inc
+    (fn [db _event] (update db :counter/value inc)))
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `reg-event-fx`
 
@@ -27,8 +32,17 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-event-fx id ?metadata-or-interceptors handler)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: "When this event arrives, return an effect map." The richer shape — `(fn [cofx event-vec] {:db ... :fx [...]})`. Use it when you need to dispatch follow-up events, fire HTTP, navigate, or read cofx.
+- **Example**:
+  ```clojure
+  (rf/reg-event-fx :counter/load
+    (fn [{:keys [db]} _event]
+      {:db (assoc db :status :loading)
+       :fx [[:rf.http/managed {:request    {:method :get :url "/api/count"}
+                               :on-success [:counter/loaded]
+                               :on-failure [:counter/load-failed]}]]}))
+  ```
+- **In the wild**: [managed_http_counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter)
 
 ### `reg-event-ctx`
 
@@ -37,7 +51,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-event-ctx id ?metadata-or-interceptors handler)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: The escape hatch — you get the raw interceptor context and return a modified context. Almost no app needs this; reach for it when you're writing infrastructure.
 
 ### `reg-sub`
@@ -47,8 +60,19 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-sub id ?metadata signal-fn? computation-fn)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: "Computed view over `app-db` and other subs." The `:<-` sugar form for declaring upstream subs is preserved from v1. This is the only sub-registration form in v2 — `reg-sub-raw` is gone (see [15 — Removed](15-removed.md) for the replacement guidance).
+- **Example**:
+  ```clojure
+  ;; Layer-2 — read straight off app-db
+  (rf/reg-sub :counter/value
+    (fn [db _query] (:counter/value db)))
+
+  ;; Layer-3 — compose upstream subs via the :<- sugar
+  (rf/reg-sub :counter/doubled
+    :<- [:counter/value]
+    (fn [value _query] (* 2 value)))
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `reg-fx`
 
@@ -57,8 +81,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-fx id ?metadata handler)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: "Define a named side effect." The handler runs against the args the effect map carries; unary `(fn [args] ...)` is the canonical shape, binary `(fn [args ctx] ...)` is available when you need the originating context.
+- **Example**:
+  ```clojure
+  (rf/reg-fx :app/scroll-to-top
+    (fn [_args] (js/window.scrollTo 0 0)))
+  ```
+- **In the wild**: [managed_http_counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter)
 
 ### `reg-cofx`
 
@@ -67,8 +96,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-cofx id ?metadata handler)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Inject something into the handler's coeffect map." A `:now` cofx hands the current time; an `:rf.server/request` cofx hands the active HTTP request. Reading a sub from a handler is also done by cofx-wrapping — see [Guide ch.06 §Reading a sub from a handler](../guide/06-coeffects.md#reading-a-sub-from-a-handler).
+- **Example**:
+  ```clojure
+  (rf/reg-cofx :app/now
+    (fn [ctx] (assoc-in ctx [:coeffects :app/now] (js/Date.now))))
+  ```
+- **In the wild**: [todomvc](https://github.com/day8/re-frame2/tree/main/examples/reagent/todomvc)
 
 ### `reg-frame`
 
@@ -77,8 +111,14 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-frame id metadata)
   ```
-- **Status**: v1
 - **Description**: Atomic create-and-register. A frame is the scoping unit — one `app-db`, one event queue, one cascade — and `reg-frame` minted it with metadata you can later read via `frame-meta`.
+- **Example**:
+  ```clojure
+  (rf/reg-frame :rf/default
+    {:doc          "App demo frame."
+     :fx-overrides {:rf.http/managed :rf.http/managed.demo}})
+  ```
+- **In the wild**: [boot](https://github.com/day8/re-frame2/tree/main/examples/reagent/boot)
 
 ### `make-frame`
 
@@ -87,8 +127,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (make-frame opts) → :rf.frame/<id>
   ```
-- **Status**: v1
 - **Description**: Anonymous-frame shortcut. The id is gensym'd; useful for tests, transient sandboxes, and the SSR per-request frame pattern.
+- **Example**:
+  ```clojure
+  (rf/with-frame [f (rf/make-frame {:on-create [:temp/initialise]})]
+    (rf/dispatch [:temp/set-celsius 21]))
+  ```
+- **In the wild**: [7Guis](https://github.com/day8/re-frame2/tree/main/examples/reagent/7Guis)
 
 ### `reg-view`
 
@@ -98,8 +143,16 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-view sym [args] body+)
   ```
   (plus shape-variants — see [02 — Views](02-views.md))
-- **Status**: v1
 - **Description**: `defn`-shape view registration. Auto-defs the symbol; auto-derives an id from `(keyword *ns* sym)`; auto-injects `dispatch` / `subscribe` as lexical bindings; rejects non-defn-shape bodies at macroexpand. See [02 — Views](02-views.md).
+- **Example**:
+  ```clojure
+  (rf/reg-view counter-buttons []
+    [:div
+     [:button {:on-click #(dispatch [:counter/dec])} "-"]
+     [:span @(subscribe [:counter/value])]
+     [:button {:on-click #(dispatch [:counter/inc])} "+"]])
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `reg-view*`
 
@@ -109,7 +162,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-view* id render-fn)
   (reg-view* id metadata render-fn)
   ```
-- **Status**: v1
 - **Description**: Plain-fn surface beneath `reg-view`. No auto-def, no auto-inject, no compile check. Use for computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var.
 
 ### `reg-machine`
@@ -119,8 +171,16 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-machine machine-id machine-spec)
   ```
-- **Status**: v1
 - **Description**: Registers a state machine as an event handler (the machine *is* the handler — the body comes from `make-machine-handler`). Walks the literal spec form at expansion time and stamps per-element source coords for click-to-source navigation. See [04 — Machines](04-machines.md).
+- **Example**:
+  ```clojure
+  (rf/reg-machine :auth.login/flow
+    {:initial :idle
+     :states  {:idle      {:on {:submit :submitting}}
+               :submitting {:on {:ok :done :err :idle}}
+               :done      {}}})
+  ```
+- **In the wild**: [state_machine_walkthrough](https://github.com/day8/re-frame2/tree/main/examples/reagent/state_machine_walkthrough)
 
 ### `reg-machine*`
 
@@ -129,7 +189,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-machine* machine-id machine-spec)
   ```
-- **Status**: v1
 - **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines or REPL workflows.
 
 ### `reg-app-schema`
@@ -140,8 +199,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-app-schema path schema)
   (reg-app-schema path schema opts)
   ```
-- **Status**: v1
 - **Description**: "Declare the Malli schema for this `app-db` path." **Path is the registration id** — the only `reg-*` keyed by path rather than keyword, because schemas-at-paths matches the dataflow grain. See [08 — Schemas](08-schemas.md).
+- **Example**:
+  ```clojure
+  (rf/reg-app-schema [:cells]
+    [:map [:cells/grid [:map-of :keyword :string]]])
+  ```
+- **In the wild**: [7Guis](https://github.com/day8/re-frame2/tree/main/examples/reagent/7Guis)
 
 ### `reg-app-schemas`
 
@@ -150,8 +214,15 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-app-schemas {path-1 schema-1, ...})
   ```
-- **Status**: v1
 - **Description**: Bulk plural form for feature-modular apps that register 5–20 paths together. Each entry routes through the singular form and is stamped with this call's source-coords.
+- **Example**:
+  ```clojure
+  (rf/reg-app-schemas
+    {[:auth]     AuthState
+     [:articles] ArticlesState
+     [:profile]  ProfileState})
+  ```
+- **In the wild**: [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 ### `add-marks`
 
@@ -160,7 +231,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (add-marks frame-id {path mark, ...})
   ```
-- **Status**: v1
 - **Description**: Frame-scoped path-marks for data classification — `:sensitive` paths render as `:rf/redacted` at egress; `:large` paths surface as `:rf/large` summaries. **Additively merges** with existing marks. See [08 — Schemas](08-schemas.md#data-classification).
 
 ### `set-marks`
@@ -170,7 +240,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (set-marks frame-id {path mark, ...})
   ```
-- **Status**: v1
 - **Description**: Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set (paths not mentioned are cleared). Schema-attached marks are preserved either way.
 
 ### `reg-flow`
@@ -181,8 +250,15 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-flow flow)
   (reg-flow flow opts)
   ```
-- **Status**: v1
 - **Description**: Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. See [05 — Flows](05-flows.md).
+- **Example**:
+  ```clojure
+  (rf/reg-flow
+    {:id     :cart/total
+     :inputs {:items [:cart :items]}
+     :output (fn [{:keys [items]}] (reduce + (map :price items)))
+     :path   [:cart :total]})
+  ```
 
 ### `reg-route`
 
@@ -191,8 +267,14 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-route id metadata)
   ```
-- **Status**: v1
 - **Description**: Register a route as data: `:path`, `:params`, `:query`, `:on-match`, `:on-error`, `:can-leave`. See [06 — Routing](06-routing.md).
+- **Example**:
+  ```clojure
+  (rf/reg-route :route/home
+    {:path     "/"
+     :on-match [[:home/load]]})
+  ```
+- **In the wild**: [routing](https://github.com/day8/re-frame2/tree/main/examples/reagent/routing)
 
 ### `reg-head`
 
@@ -201,8 +283,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-head id ?metadata head-fn)
   ```
-- **Status**: v1
 - **Description**: SSR: register a `(fn [db route] head-model)` keyed by id; routes opt-in via `:head` metadata. See [09 — SSR](09-ssr.md).
+- **Example**:
+  ```clojure
+  (rf/reg-head :app/head
+    (fn [db _route]
+      {:title (str "MyApp — " (:page-title db))}))
+  ```
 
 ### `reg-error-projector`
 
@@ -211,7 +298,6 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   ```clojure
   (reg-error-projector id ?metadata projector-fn)
   ```
-- **Status**: v1
 - **Description**: SSR: register a `(fn [trace-event] :rf/public-error)`; named per-frame via the frame's `:ssr {:public-error-id ...}` metadata.
 
 ### Clearing registrations
@@ -225,7 +311,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-event)
   (clear-event id)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Forget this event-handler." No-arg clears the whole `:event` registry.
 
 #### `clear-sub`
@@ -235,7 +320,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-sub)
   (clear-sub id)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Forget this sub." Note: this is the registrar-side clear (the inverse of `reg-sub`). The runtime cache decrement is `unsubscribe` (see below).
 
 #### `clear-fx`
@@ -245,7 +329,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-fx)
   (clear-fx id)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Forget this fx."
 
 #### `clear-flow`
@@ -255,7 +338,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   (clear-flow id)
   (clear-flow id opts)
   ```
-- **Status**: v1
 - **Description**: Deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only. See [05 — Flows](05-flows.md).
 
 #### `destroy-frame!`
@@ -264,7 +346,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   ```clojure
   (destroy-frame! frame-id)
   ```
-- **Status**: v1
 - **Description**: The normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this single call.
 
 #### `reset-frame!`
@@ -273,7 +354,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   ```clojure
   (reset-frame! frame-id)
   ```
-- **Status**: v1
 - **Description**: Reset the frame's `app-db` to its initial value without destroying the frame itself.
 
 #### `clear-sub-cache!`
@@ -282,7 +362,6 @@ The inverse surface. Each `clear-*` removes an entry from the registrar; the no-
   ```clojure
   (clear-sub-cache! frame-id?)
   ```
-- **Status**: v1 (preserved)
 - **Description**: Force-clear the sub-cache for a frame (or all frames). Tests; rarely needed in app code.
 
 ### See also
@@ -305,8 +384,12 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (dispatch event)
   (dispatch event opts)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: Async dispatch — drops the event onto the frame's queue, returns immediately. The default; use it for everything that isn't a synchronous test setup.
+- **Example**:
+  ```clojure
+  [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `dispatch*`
 
@@ -316,7 +399,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (dispatch* event)
   (dispatch* event opts)
   ```
-- **Status**: v1 (extended)
 - **Description**: Fn variant of `dispatch`. Compose through `map` / `comp` / `partial`; skips call-site stamping.
 
 ### `dispatch-sync`
@@ -327,8 +409,12 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (dispatch-sync event)
   (dispatch-sync event opts)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: Synchronous dispatch — runs the cascade to completion before returning. Tests, REPL workflows, and one-shot app-boot events live here. Do not use in handlers (it'll deadlock the queue).
+- **Example**:
+  ```clojure
+  (rf/dispatch-sync [:counter/initialise])   ;; one-shot app-boot event
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `dispatch-sync*`
 
@@ -338,7 +424,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (dispatch-sync* event)
   (dispatch-sync* event opts)
   ```
-- **Status**: v1 (extended)
 - **Description**: Fn variant of `dispatch-sync`.
 
 ### `subscribe`
@@ -349,8 +434,12 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (subscribe query-v)
   (subscribe frame-id query-v)
   ```
-- **Status**: v1 (preserved + extended)
 - **Description**: The reactive handle. Returns a reaction whose value is the registered sub's current output; recomputes when upstreams change. Use inside views, inside other subs, and (carefully) inside event handlers via the cofx wrapper.
+- **Example**:
+  ```clojure
+  [:span @(rf/subscribe [:counter/value])]
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `subscribe*`
 
@@ -360,7 +449,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (subscribe* query-v)
   (subscribe* frame-id query-v)
   ```
-- **Status**: v1 (extended)
 - **Description**: Fn variant of `subscribe`.
 
 ### `subscribe-once`
@@ -371,7 +459,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (subscribe-once query-v) → value
   (subscribe-once frame-id query-v) → value
   ```
-- **Status**: v1
 - **Description**: One-shot read: subscribe, deref, immediately unsubscribe. Use in handler bodies, machine actions, REPL — anywhere you want the *current* value without the reactive plumbing. Not for views.
 
 ### `unsubscribe`
@@ -382,7 +469,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   (unsubscribe query-v) → nil
   (unsubscribe frame-id query-v) → nil
   ```
-- **Status**: v1
 - **Description**: Decrement the cache ref-count for a query. When the count hits zero, disposal is scheduled after the configured `:sub-cache` grace-period. Most callers don't reach for this directly — Reagent / UIx / Helix adapters wire it on unmount.
 
 ### `sub-machine`
@@ -392,7 +478,6 @@ Both come in macro + fn pairs. The **macro** form (`dispatch`, `dispatch-sync`, 
   ```clojure
   (sub-machine machine-id) → reaction over snapshot
   ```
-- **Status**: v1
 - **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. See [04 — Machines](04-machines.md).
 
 **The `opts` map.** `dispatch` and `subscribe` accept a uniform opts map: `:frame`, `:fx-overrides`, `:interceptor-overrides`, `:trace-id`, `:source`. Envelope shape and semantics live in [002 §Routing: the dispatch envelope](../../spec/002-Frames.md#routing-the-dispatch-envelope). The most common pattern is `(rf/dispatch [::save x] {:frame :todo})` to target a non-default frame.
@@ -435,7 +520,6 @@ A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most
   (frame-ids)
   (frame-ids ns-prefix)
   ```
-- **Status**: v1
 - **Description**: "What frames currently exist?" Returns the set of registered ids. The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames.
 
 ### `frame-meta`
@@ -444,7 +528,6 @@ A frame is the scoping unit for `app-db`, the event queue, and the cascade. Most
   ```clojure
   (frame-meta frame-id)
   ```
-- **Status**: v1
 - **Description**: "What did the frame declare at registration?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
 
 See [12 — Registrar](12-registrar.md) for the rest of the registrar-query surface.

--- a/docs/api/02-views.md
+++ b/docs/api/02-views.md
@@ -17,8 +17,16 @@ The view registry is what `[my-view "arg"]` resolves against. Every view you reg
   (reg-view sym docstring [args] body+)
   (reg-view ^{:rf/id :explicit/id} sym [args] body+)
   ```
-- **Status**: v1
 - **Description**: The defn-shape view registration. Auto-defs the symbol, auto-derives the id from `(keyword *ns* sym)`, auto-injects `dispatch` / `subscribe` as lexical bindings, and rejects non-defn-shape bodies at macroexpand. The 80% of registrations want this form.
+- **Example**:
+  ```clojure
+  (rf/reg-view counter-buttons []
+    [:div
+     [:button {:on-click #(dispatch [:counter/dec])} "-"]
+     [:span @(subscribe [:counter/value])]
+     [:button {:on-click #(dispatch [:counter/inc])} "+"]])
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `reg-view*`
 
@@ -28,7 +36,6 @@ The view registry is what `[my-view "arg"]` resolves against. Every view you reg
   (reg-view* id render-fn)
   (reg-view* id metadata render-fn)
   ```
-- **Status**: v1
 - **Description**: The plain-fn surface beneath `reg-view`. No auto-def (the caller manages the Var or computed id), no auto-inject, no compile check. Reach for it when you need: computed ids, library-generated views, Reagent Form-3 (`create-class`), or registration without a Var.
 
 ### `view`
@@ -38,7 +45,6 @@ The view registry is what `[my-view "arg"]` resolves against. Every view you reg
   ```clojure
   (view view-id) → render-fn
   ```
-- **Status**: v1
 - **Description**: Runtime lookup handle. Returns the **registered render-fn**, not hiccup. Use in hiccup as `[(rf/view :id) args...]` when you need to late-bind a view by id (computed id, plugin-style dispatch, dynamic chrome).
 
 ### How `reg-view` reads
@@ -101,7 +107,6 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   ```clojure
   [rf/frame-provider {:frame :todo} & children]
   ```
-- **Status**: v1
 - **Description**: "Children inside this provider see `:todo` as their current frame." Lexical scope for the implicit frame; nestable; pairs with `with-frame` for non-component code.
 
 ### `with-frame`
@@ -112,7 +117,6 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   (with-frame :keyword body)
   (with-frame [sym expr] body)
   ```
-- **Status**: v1
 - **Description**: "Run this code as if the current frame were `:keyword`." Two shapes — bare keyword vs let-binding — documented in [002 §with-frame](../../spec/002-Frames.md#with-frame).
 
 ### `bound-fn`
@@ -122,7 +126,6 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   ```clojure
   (bound-fn [args] body)
   ```
-- **Status**: v1
 - **Description**: "Capture the current dynamic-var bindings (frame, registrar, etc.) into a closure that will be invoked later, possibly after the calling stack has unwound." CLJS-only macro. Use for event-callback wiring where Promise / setTimeout / IntersectionObserver / WebSocket message handlers run outside the original render call.
 
 ### `dispatcher`
@@ -132,7 +135,6 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   ```clojure
   (dispatcher) → (fn [event] ...)
   ```
-- **Status**: v1
 - **Description**: "Hand me a frame-bound dispatch function I can call later." Captures the current frame at call time and returns a closure that dispatches against that frame. Safe to call during render AND from async callbacks where the dynamic-var binding has unwound.
 
 ### `subscriber`
@@ -142,7 +144,6 @@ These five surfaces work the same across Reagent, UIx, and Helix. They're how vi
   ```clojure
   (subscriber) → (fn [query-v] ...)
   ```
-- **Status**: v1
 - **Description**: "Hand me a frame-bound subscribe function I can call later." Companion to `dispatcher` for the subscribe side.
 
 ### When to use `dispatcher` / `subscriber` instead of `dispatch` / `subscribe`
@@ -215,8 +216,14 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
    :render …
    :dispose-adapter! …}
   ```
-- **Status**: v1
 - **Description**: The adapter spec passed to `(rf/init! ...)`.
+- **Example**:
+  ```clojure
+  (:require [re-frame.adapter.uix :as uix-adapter])
+
+  (rf/init! uix-adapter/adapter)
+  ```
+- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/uix/counter_uix) · [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/helix/counter_helix)
 
 ### `<adapter>/use-subscribe`
 
@@ -226,8 +233,14 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   (use-subscribe query-v) → value
   (use-subscribe frame-kw query-v) → value
   ```
-- **Status**: v1
 - **Description**: The hook-shaped read. Matches the React/UIx/Helix idiom; there's no auto-injection — components call the hook and `(rf/dispatcher)` directly.
+- **Example**:
+  ```clojure
+  (let [count    (uix-adapter/use-subscribe [:count])
+        dispatch (rf/dispatcher)]
+    ($ :button {:on-click #(dispatch [:inc])} count))
+  ```
+- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/uix/counter_uix) · [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/helix/counter_helix)
 
 ### `<adapter>/use-current-frame`
 
@@ -236,7 +249,6 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   ```clojure
   (use-current-frame) → frame-kw
   ```
-- **Status**: v1
 - **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
 
 ### `<adapter>/frame-provider`
@@ -246,7 +258,6 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   ```clojure
   ($ frame-provider {:frame :session :children […]})
   ```
-- **Status**: v1
 - **Description**: The component-shaped equivalent of Reagent's `frame-provider`. The underlying React Context (`re-frame.adapter.context`) is **shared** across all three substrates, so a mixed-substrate app's frame-provider chain composes across substrate boundaries.
 
 ### `<adapter>/wrap-view`
@@ -256,7 +267,6 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   ```clojure
   (wrap-view id metadata user-fn) → wrapped fn
   ```
-- **Status**: v1
 - **Description**: Adapter-side source-coord annotation. Most UIx / Helix users register through `reg-view*` and let the adapter wrap; `wrap-view` is exposed for code-gen and library scaffolding.
 
 ### `<adapter>/flush-views!`
@@ -267,7 +277,6 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   (flush-views!)
   (flush-views! f)
   ```
-- **Status**: v1
 - **Description**: Wraps React's `act()` for tests. Drain queued state updates before assertions.
 
 ### `<adapter>/set-hiccup-emitter!`
@@ -277,7 +286,6 @@ In the entries below, `<adapter>` stands for the adapter namespace alias the con
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Status**: v1
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
 
 The UIx / Helix adapters do **not** support `reg-view` (the macro is Reagent-specific in its `defn`-shape rewriting). UIx and Helix users register with `rf/reg-view*` when they need registry-keyed view addressing — most don't, because UIx and Helix components compose by Var reference like ordinary React components.

--- a/docs/api/03-effects.md
+++ b/docs/api/03-effects.md
@@ -51,6 +51,14 @@ The v2 standard-interceptor surface is **three specific helpers** plus the `->in
   (inject-cofx id value)
   ```
 - **Description**: Inject a registered cofx into the handler's coeffect map. Macro: captures the call-site for `:rf.trace/call-site` on errors emitted from the cofx body. Does specific work — `:cofx` registry lookup — not subsumable by `->interceptor`.
+- **Example**:
+  ```clojure
+  (rf/reg-event-fx :todo/load
+    [(rf/inject-cofx :todo.storage/todos)]
+    (fn [{:keys [todo.storage/todos]} _event]
+      {:db {:todos todos}}))
+  ```
+- **In the wild**: [todomvc](https://github.com/day8/re-frame2/tree/main/examples/reagent/todomvc)
 
 ### `inject-cofx*`
 
@@ -150,7 +158,6 @@ The interceptor context — the ctx — is the value threaded through the chain.
   (get-coeffect ctx key)
   (get-coeffect ctx key not-found)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Read the coeffect map (or one slot of it)."
 
 ### `assoc-coeffect`
@@ -160,7 +167,6 @@ The interceptor context — the ctx — is the value threaded through the chain.
   ```clojure
   (assoc-coeffect ctx key value)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Write a coeffect slot in the ctx."
 
 ### `get-effect`
@@ -172,7 +178,6 @@ The interceptor context — the ctx — is the value threaded through the chain.
   (get-effect ctx key)
   (get-effect ctx key not-found)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Read the effect map (or one slot)."
 
 ### `assoc-effect`
@@ -182,7 +187,6 @@ The interceptor context — the ctx — is the value threaded through the chain.
   ```clojure
   (assoc-effect ctx key value)
   ```
-- **Status**: v1 (preserved)
 - **Description**: "Write an effect slot in the ctx."
 
 These are stable surfaces preserved from v1. If you're writing an interceptor that needs to read or modify what the handler will see / what the handler emitted, this is the surface.
@@ -198,7 +202,6 @@ The runtime supports three ways to swap fx behaviour without touching the handle
   ```clojure
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
-- **Status**: v1
 - **Description**: "For the duration of this body, every `dispatch` / `dispatch-sync` merges this fx-overrides map into its envelope." Lexical scope; composes with `with-frame`. Renamed from v1's `with-overrides` per [MIGRATION §M-50](../../migration/from-re-frame-v1/README.md#m-50-with-overrides-macro-renamed-to-with-fx-overrides).
 
 The three scopes compose with a clear precedence:

--- a/docs/api/04-machines.md
+++ b/docs/api/04-machines.md
@@ -17,8 +17,8 @@ For the *why* — the design rationale, the v1 vs post-v1 split, the capability 
   ```clojure
   (reg-machine machine-id machine-spec)
   ```
-- **Status**: v1
 - **Description**: The canonical macro. Walks the literal spec form at expansion time and stamps per-element source coords under `:rf.machine/source-coords` — Causa uses these to navigate from a snapshot back to the state-node definition. Top-level call-site coords land on `handler-meta`.
+- **In the wild**: [state_machine_walkthrough](https://github.com/day8/re-frame2/tree/main/examples/reagent/state_machine_walkthrough) · [websocket](https://github.com/day8/re-frame2/tree/main/examples/reagent/websocket)
 
 ### `reg-machine*`
 
@@ -27,7 +27,6 @@ For the *why* — the design rationale, the v1 vs post-v1 split, the capability 
   ```clojure
   (reg-machine* machine-id machine-spec)
   ```
-- **Status**: v1
 - **Description**: Plain-fn surface beneath the macro. No source-coord walking. Use for code-gen pipelines, REPL workflows, or conformance harnesses that synthesise specs from data.
 
 ### `make-machine-handler`
@@ -37,7 +36,6 @@ For the *why* — the design rationale, the v1 vs post-v1 split, the capability 
   ```clojure
   (make-machine-handler spec) → event-handler fn
   ```
-- **Status**: v1
 - **Description**: Compiles a transition table into the event-handler fn that `reg-machine` would register. Useful when you want to inspect the compiled fn or compose it manually.
 
 ### `machine-transition`
@@ -47,7 +45,6 @@ For the *why* — the design rationale, the v1 vs post-v1 split, the capability 
   ```clojure
   (machine-transition definition snapshot event) → [next-snapshot effects]
   ```
-- **Status**: v1
 - **Description**: The pure transition fn. Given a machine definition, a current snapshot, and an event, returns the next snapshot and the effect map. JVM-runnable; the conformance harness uses this as its primary test surface for machine behaviour.
 
 ### A minimal machine
@@ -80,8 +77,13 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   ```clojure
   (sub-machine machine-id) → reaction over snapshot
   ```
-- **Status**: v1
 - **Description**: Sugar over `(subscribe [:rf/machine machine-id])`. Use inside views — gives you a reaction over `{:state :data}`.
+- **Example**:
+  ```clojure
+  (let [{:keys [state data]} @(rf/sub-machine :auth.login/flow)]
+    [:div "State: " (name state)])
+  ```
+- **In the wild**: [state_machine_walkthrough](https://github.com/day8/re-frame2/tree/main/examples/reagent/state_machine_walkthrough)
 
 ### `machines`
 
@@ -90,7 +92,6 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   ```clojure
   (machines) → seq of machine-ids
   ```
-- **Status**: v1
 - **Description**: "What machines have been registered?" Derived view over `(registrations :event)` filtered by `:rf/machine? true`.
 
 ### `machine-meta`
@@ -100,7 +101,6 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   ```clojure
   (machine-meta machine-id) → registration-metadata map
   ```
-- **Status**: v1
 - **Description**: "What did `reg-machine` stamp at this machine's id?" Returns the transition table, doc, schemas, and the per-element source-coords. Equivalent to `(handler-meta :event machine-id)`.
 
 ### `machine-by-system-id`
@@ -111,7 +111,6 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   (machine-by-system-id system-id)
   (machine-by-system-id system-id frame-id)
   ```
-- **Status**: v1
 - **Description**: Reverse-lookup: given a `system-id`, what's the spawned machine bound to it? Returns the spawned-machine id or `nil`.
 
 ### `machine-has-tag?`
@@ -121,7 +120,6 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   ```clojure
   (machine-has-tag? machine-id tag) → reaction
   ```
-- **Status**: v1
 - **Description**: Sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])`. Reactive predicate over the machine's snapshot's `:tags` set. Use in views to render conditionally on state-tag membership.
 
 ### Standard registered subs (machines)
@@ -142,7 +140,6 @@ The snapshot lives at `[:rf/machines :session]` in `app-db`. The shape is `{:sta
   (dispatch-to-system system-id event)
   (dispatch-to-system system-id event frame-id)
   ```
-- **Status**: v1
 - **Description**: Sugar over `(when-let [m (machine-by-system-id system-id)] (dispatch [m event]))`. No-op when the `system-id` is unbound. The third-arity targets a non-default frame.
 
 When a child actor spawns under a parent, the parent's `:data` often gets the child's id stamped via `:on-spawn`. `dispatch-to-system` lets the parent name the child by *role* (`:logger`, `:websocket`, `:retry-coordinator`) instead of by gensym'd id. The per-frame `[:rf/system-ids]` reverse index resolves the name. See [005 §Named addressing via `:system-id`](../../spec/005-StateMachines.md).
@@ -197,7 +194,6 @@ See [005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-
   ```clojure
   (machine->xstate-json definition) → JSON string
   ```
-- **Status**: post-v1 lib
 - **Description**: Export a machine definition to XState JSON. The XState visualiser consumes it; useful for design review and documentation.
 
 ### `machine->mermaid`
@@ -207,13 +203,11 @@ See [005 §Final states](../../spec/005-StateMachines.md#final-states-final--on-
   ```clojure
   (machine->mermaid definition) → string
   ```
-- **Status**: post-v1 lib
 - **Description**: Export to Mermaid state-diagram syntax. Drops cleanly into Markdown docs that render Mermaid (this site does).
 
 ### `:child-machine`
 
 - **Kind**: transition-table key (declarative)
-- **Status**: post-v1 lib
 - **Description**: Declarative state-scoped child-machine binding. A state node can declare a child machine that lives only while the parent is in that state. Symmetric with the imperative `:spawn` / `:destroy` cycle.
 
 The post-v1 surfaces live in `day8/re-frame2-machines` (the scaffolding library). The v1 foundation in `re-frame.core` covers the machine-as-event-handler primitive; the scaffolding library layers the higher-level features on top.

--- a/docs/api/05-flows.md
+++ b/docs/api/05-flows.md
@@ -16,7 +16,6 @@ The normative source is [013-Flows.md](../../spec/013-Flows.md).
   (reg-flow flow)
   (reg-flow flow opts)
   ```
-- **Status**: v1
 - **Description**: Register a flow. The flow map carries `:id`, `:inputs`, `:output`, `:path`. `opts` is a map (currently `{:frame frame-id}`) selecting the owning frame. Returns the flow's `:id` (per the `reg-*` return-value convention).
 
 ### `clear-flow`
@@ -27,7 +26,6 @@ The normative source is [013-Flows.md](../../spec/013-Flows.md).
   (clear-flow id)
   (clear-flow id opts)
   ```
-- **Status**: v1
 - **Description**: Deregister the flow from the named frame and `dissoc-in` its `:path` from that frame's `app-db` only. Sibling frames' state is preserved.
 
 ### A minimal flow

--- a/docs/api/06-routing.md
+++ b/docs/api/06-routing.md
@@ -15,8 +15,8 @@ This chapter covers the registration shape, the dispatch / sub / fx surface, and
   ```clojure
   (reg-route id metadata)
   ```
-- **Status**: v1
 - **Description**: Register a route as data. The id is a keyword you'll later dispatch against (`[:rf.route/navigate :route/cart]`); the metadata carries the URL shape, the match events, and the guards.
+- **In the wild**: [routing](https://github.com/day8/re-frame2/tree/main/examples/reagent/routing) · [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 ### A minimal route
 
@@ -56,7 +56,6 @@ Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata sc
   ```clojure
   (match-url url) → {:route-id :params :query :validation-failed?} or nil
   ```
-- **Status**: v1
 - **Description**: "What route does this URL match?" Pure — JVM-runnable; useful for server-side rendering and tests.
 
 ### `route-url`
@@ -67,7 +66,6 @@ Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata sc
   (route-url route-id path-params) → URL string
   (route-url route-id path-params query-params) → URL string
   ```
-- **Status**: v1
 - **Description**: "Render this route to a URL." The inverse of `match-url`. Pure; JVM-runnable.
 
 ### `route-link`
@@ -77,8 +75,12 @@ Canonical detail in [012-Routing.md](../../spec/012-Routing.md); the metadata sc
   ```clojure
   [rf/route-link {:to :route-id :params {...} :query {...} :fragment "..."} & children]
   ```
-- **Status**: v1
 - **Description**: A registered view at `:route/link`. Renders an `<a>` with the right `href` and intercepts plain primary-button clicks to dispatch `:rf/url-requested` instead of navigating natively.
+- **Example**:
+  ```clojure
+  [rf/route-link {:to :route/article :params {:slug slug}} (:title article)]
+  ```
+- **In the wild**: [routing](https://github.com/day8/re-frame2/tree/main/examples/reagent/routing) · [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 ### `route-link` click semantics
 

--- a/docs/api/07-http.md
+++ b/docs/api/07-http.md
@@ -12,14 +12,13 @@ This chapter covers the canonical fx, the verb helpers, the test stubs, the requ
 
 - **Kind**: fx
 - **Args**: per [014 §The args map](../../spec/014-HTTPRequests.md#the-args-map) and `:rf.fx/managed-args`
-- **Status**: v1 (optional capability)
 - **Description**: The one fx-id. Args carry the request envelope, decode policy, accept fn, retry policy, timeout, success / failure target events, request-id (for abort), and optional abort-signal.
+- **In the wild**: [managed_http_counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/managed_http_counter) · [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 ### `[:rf.http/managed-abort request-id]`
 
 - **Kind**: fx
 - **Args**: request-id
-- **Status**: v1 (optional capability)
 - **Description**: Abort the in-flight request with the given `:request-id`. The aborted request's reply fires with `{:rf/reply {:kind :failure :failure {:kind :rf.http/aborted ...}}}`.
 
 ### A minimal request
@@ -50,7 +49,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/get url)
   (rf.http/get url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: "Synthesise a GET fx vector." Pure; no side effect — drop the result into `:fx`.
 
 ### `re-frame.http/post`
@@ -60,7 +58,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/post url)
   (rf.http/post url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: POST. Pass `:body` in `args`.
 
 ### `re-frame.http/put`
@@ -70,7 +67,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/put url)
   (rf.http/put url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: PUT.
 
 ### `re-frame.http/delete`
@@ -80,7 +76,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/delete url)
   (rf.http/delete url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: DELETE.
 
 ### `re-frame.http/patch`
@@ -90,7 +85,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/patch url)
   (rf.http/patch url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: PATCH.
 
 ### `re-frame.http/head`
@@ -100,7 +94,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/head url)
   (rf.http/head url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: HEAD.
 
 ### `re-frame.http/options`
@@ -110,7 +103,6 @@ Call-site helpers for the common shapes. They're pure synthesis fns that produce
   (rf.http/options url)
   (rf.http/options url args)
   ```
-- **Status**: v1 (optional)
 - **Description**: OPTIONS.
 
 The verb helpers live in `re-frame.http` — users `(:require [re-frame.http :as rf.http])` alongside `re-frame.core`. The namespace ships in `day8/re-frame2-http`, the same artefact as the fx itself, so loading the helpers and the fx is a single dep decision.
@@ -169,8 +161,8 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
   (reg-http-interceptor id before)
   (reg-http-interceptor id opts before)
   ```
-- **Status**: v1 (optional)
 - **Description**: Register a request-side interceptor on a frame's `:rf.http/managed` middleware chain. `before` is `(fn [ctx] ctx')` where ctx is `{:request :args :frame :event}`. `opts` carries `:frame` (default `:rf/default`) plus the standard `:rf/registration-metadata`.
+- **In the wild**: [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 ### `clear-http-interceptor`
 
@@ -180,7 +172,6 @@ Sometimes you want to inject behaviour into every request — adding an auth hea
   (clear-http-interceptor id)
   (clear-http-interceptor frame id)
   ```
-- **Status**: v1 (optional)
 - **Description**: Unregister an interceptor by id. Single-arity targets `:rf/default`.
 
 ```clojure
@@ -199,13 +190,11 @@ Tests want to drive the cascade without hitting the network. The test-support su
 ### `[:rf.http/managed-canned-success {:value v}]`
 
 - **Kind**: fx
-- **Status**: v1 (optional, dev/test)
 - **Description**: Synthesise the canonical success reply directly into `:fx`. Useful for "stub THIS request inline" patterns. Registered at load of `re-frame.http-test-support`.
 
 ### `[:rf.http/managed-canned-failure {:kind <:rf.http/*> :tags {...}}]`
 
 - **Kind**: fx
-- **Status**: v1 (optional, dev/test)
 - **Description**: Synthesise the canonical failure reply directly into `:fx`.
 
 ### `with-managed-request-stubs`
@@ -215,7 +204,6 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (with-managed-request-stubs route-map body+)
   ```
-- **Status**: v1 (optional, dev/test)
 - **Description**: Lexical-scope stubbing. `route-map` is `{[<method> <url>] {:reply <value-or-failure>}}`. Inside the body, requests matching a stubbed route bypass the real client.
 
 ### `with-managed-request-stubs*`
@@ -225,7 +213,6 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (with-managed-request-stubs* route-map body-fn)
   ```
-- **Status**: v1 (optional, dev/test)
 - **Description**: Plain-fn surface beneath the macro. Use for computed route-maps or non-literal bodies.
 
 ### `install-managed-request-stubs!`
@@ -235,7 +222,6 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (install-managed-request-stubs! route-map)
   ```
-- **Status**: v1 (optional, dev/test)
 - **Description**: Lower-level than `with-managed-request-stubs`: install stubs that persist until `uninstall-managed-request-stubs!`. Use when stubs span multiple `deftest`s.
 
 ### `uninstall-managed-request-stubs!`
@@ -245,7 +231,6 @@ Tests want to drive the cascade without hitting the network. The test-support su
   ```clojure
   (uninstall-managed-request-stubs!)
   ```
-- **Status**: v1 (optional, dev/test)
 - **Description**: Drop installed stubs; restore real-request routing. Idempotent.
 
 All the test-support surfaces live in `re-frame.http-test-support` (the single home per audit of audits #15). One namespace; same artefact (`day8/re-frame2-http`) as the production code.

--- a/docs/api/08-schemas.md
+++ b/docs/api/08-schemas.md
@@ -16,8 +16,13 @@ This chapter covers the registration macros (rowed in [01 — Core](01-core.md),
   (reg-app-schema path schema)
   (reg-app-schema path schema opts)
   ```
-- **Status**: v1
 - **Description**: "Attach this Malli schema to this `app-db` path." **Path is the registration id** — the `:app-schema` registry kind is path-keyed because schemas-at-paths matches the dataflow grain. `(app-schema-at [:user])` looks up by the same path vector.
+- **Example**:
+  ```clojure
+  (rf/reg-app-schema [:cells]
+    [:map [:cells/grid [:map-of :keyword :string]]])
+  ```
+- **In the wild**: [7Guis](https://github.com/day8/re-frame2/tree/main/examples/reagent/7Guis)
 
 ### `reg-app-schemas`
 
@@ -26,8 +31,14 @@ This chapter covers the registration macros (rowed in [01 — Core](01-core.md),
   ```clojure
   (reg-app-schemas {path-1 schema-1, path-2 schema-2, ...})
   ```
-- **Status**: v1
 - **Description**: Bulk plural form. Feature-modular apps registering 5–20 paths against the same prefix reach for this. Each entry routes through the singular form and is stamped with this call's source coords. Returns the vector of paths registered.
+- **Example**:
+  ```clojure
+  (rf/reg-app-schemas
+    {[:auth]     AuthState
+     [:articles] ArticlesState})
+  ```
+- **In the wild**: [realworld](https://github.com/day8/re-frame2/tree/main/examples/reagent/realworld)
 
 The path-keyed-not-id-keyed asymmetry is principled. Paths are first-class in `get-in` / `assoc-in` / `update-in`; schemas-at-paths matches the dataflow grain; the lookup site (`app-schema-at [:user]`) reads the same way the write site (`(assoc-in db [:user] ...)`) reads. Spelling it as `(reg-app-schema :user/schema schema)` would have shifted the registration's id away from the dataflow grain.
 
@@ -45,7 +56,6 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas)
   (app-schemas {:frame frame-id})
   ```
-- **Status**: v1
 - **Description**: "Hand me every registered schema-at-path for this frame." Returns `{path schema}`. Tools and agents walk this to enumerate the app's schema surface.
 
 ### `app-schema-at`
@@ -56,7 +66,6 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-at path)
   (app-schema-at path {:frame frame-id})
   ```
-- **Status**: v1
 - **Description**: "Schema for this exact path." Returns the schema value or `nil`.
 
 ### `app-schema-meta-at`
@@ -67,7 +76,6 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schema-meta-at path)
   (app-schema-meta-at path opts-or-frame-id)
   ```
-- **Status**: v1
 - **Description**: "Full registration-metadata map for this path." Returns `:path`, `:schema`, `:frame`, plus source-coords (`:ns` / `:line` / `:file`) and the rest of `:rf/registration-metadata`. Pair tools and 10x reach for this when they need the registration anchor for click-back-to-code. The lighter `app-schema-at` is the right call when only the schema value is needed.
 
 ### `app-schemas-digest`
@@ -78,7 +86,6 @@ The introspection surfaces live in `re-frame.schemas` (artefact `day8/re-frame2-
   (app-schemas-digest) → string
   (app-schemas-digest {:frame frame-id}) → string
   ```
-- **Status**: v1
 - **Description**: "Single hash over the frame's whole schema surface." Used by SSR hydration compatibility checks and by tools that want to know "has the schema corpus changed?" without diffing schema-by-schema.
 
 ### Validator-extension seams
@@ -93,7 +100,6 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   (set-schema-validator! validate-fn)
   (set-schema-validator! {:validate validate-fn :explain explain-fn})
   ```
-- **Status**: v1
 - **Description**: "Install the validator the framework uses at every dev-time schema-validation site." `nil` disables validation entirely. The default ships Malli's pair; this seam is for apps that want to swap to a different validator without forking the framework.
 
 #### `set-schema-explainer!`
@@ -103,7 +109,6 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   ```clojure
   (set-schema-explainer! explain-fn)
   ```
-- **Status**: v1
 - **Description**: "Install the explainer the framework uses to enrich `:rf.error/schema-validation-failure` traces' `:explain` key." Companion to `set-schema-validator!`.
 
 #### `set-schema-printer!`
@@ -113,7 +118,6 @@ The default validator ships Malli's `validate` / `explain` pair. These seams let
   ```clojure
   (set-schema-printer! print-fn)
   ```
-- **Status**: v1
 - **Description**: "Install the schema-print companion the digest pipeline hashes." `(fn [schema-value] canonical-string)`. Must be pure and deterministic across runtimes. `nil` falls back to the default EDN canonicaliser, so the digest is never undefined. Parallel to the validator / explainer setters: non-Malli ports register their own serialiser so cross-runtime digest comparison reflects their port's contract.
 
 The three setters answer three different questions: validation correctness (`validator`), human-readable failure messages (`explainer`), and stable canonical printing for digest (`printer`). Most apps use the defaults; ports and apps swap them selectively.
@@ -127,7 +131,6 @@ The three setters answer three different questions: validation correctness (`val
   ```clojure
   validate-at-boundary-interceptor
   ```
-- **Status**: v1
 - **Description**: A **pre-built interceptor value**, not a fn (interceptor `:id` is `:rf.schema/at-boundary`). Add it to a `reg-event-*`'s positional interceptor vector for production-boundary validation. **Do not call it as a fn** — it has no fn arity; invoking `(rf/validate-at-boundary-interceptor ...)` raises `ArityException`.
 
 ```clojure
@@ -151,7 +154,6 @@ The same schemas that drive validation also drive **redaction** and **size-elisi
   ```clojure
   (add-marks frame-id {path mark, ...})
   ```
-- **Status**: v1
 - **Description**: Frame-scoped path-marks. **Additively merges** into the frame's existing mark-set — paths not mentioned keep their prior state. Schema-attached marks per `reg-app-schema` `:sensitive?` / `:large?` are preserved and union at lookup time. Pure declaration — does not mutate `app-db`. Returns `frame-id`.
 
 #### `set-marks`
@@ -161,7 +163,6 @@ The same schemas that drive validation also drive **redaction** and **size-elisi
   ```clojure
   (set-marks frame-id {path mark, ...})
   ```
-- **Status**: v1
 - **Description**: Frame-scoped path-marks. **Wholesale replaces** the frame's prior mark-set — paths not mentioned are CLEARED. Schema-attached marks are preserved. Pure declaration. Returns `frame-id`.
 
 The two-verb shape (`add` vs `set`) follows the [Conventions §Tear-down verb axis](../../spec/Conventions.md) — `add-` merges; `set-` replaces. Most apps reach for `add-marks` because path classifications accumulate (an audit reveals a new sensitive path; you `add-marks` the path without affecting the rest of the corpus). Reach for `set-marks` when you're declaring the entire authoritative classification at once (a server-pushed policy update; a feature-flag toggle that swaps the whole privacy posture).
@@ -177,7 +178,6 @@ This is the framework primitive that walks tree-shaped values at the wire bounda
   ```clojure
   (elide-wire-value v opts) → v or an elision-marker substitution
   ```
-- **Status**: v1
 - **Description**: Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots. `opts` map: `{:rf.size/include-large? :rf.size/include-sensitive? :rf.size/include-digests? :rf.size/threshold-bytes :path :frame}`. Defaults: both `include-*` flags `false` (maximum elision); `:rf.size/threshold-bytes` falls back to `(rf/configure :elision ...)` then `16384`.
 
 #### `elision-declarations`
@@ -188,7 +188,6 @@ This is the framework primitive that walks tree-shaped values at the wire bounda
   (elision-declarations)
   (elision-declarations frame-id)
   ```
-- **Status**: v1
 - **Description**: "What paths has the frame nominated for elision?" Returns the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool and introspection reader.
 
 #### `populate-elision-from-schemas!`
@@ -199,7 +198,6 @@ This is the framework primitive that walks tree-shaped values at the wire bounda
   (populate-elision-from-schemas!) → vector of paths populated
   (populate-elision-from-schemas! frame-id) → vector of paths populated
   ```
-- **Status**: v1
 - **Description**: Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent. No-op when the schemas artefact isn't on the classpath.
 
 ### Composition rule
@@ -223,7 +221,6 @@ The trace runtime stamps `:sensitive? true` at the top level of every trace even
   ```clojure
   (sensitive? trace-event) → boolean
   ```
-- **Status**: v1
 - **Description**: The framework-published predicate every consumer composes against. Replaces per-consumer reimplementations of the same five-token check.
 
 ### `redact-interceptor`
@@ -233,7 +230,6 @@ The trace runtime stamps `:sensitive? true` at the top level of every trace even
   ```clojure
   (redact-interceptor paths) → interceptor
   ```
-- **Status**: post-v1 (planned)
 - **Description**: Build a positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel **before the handler chain runs**. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only. `paths` is a vector of `get-in`-style key paths into the payload map.
 
 The composition pattern: schema-derived `:sensitive?` marks drive `elide-wire-value` at egress, and `redact-interceptor` scrubs in-place where the trace surface needs to see only a partial view. The two surfaces stack — the interceptor scrubs the trace; the walker enforces redaction at the wire boundary.

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -17,8 +17,13 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
   ```clojure
   (render-to-string view-or-hiccup opts) → HTML string
   ```
-- **Status**: v1
 - **Description**: The canonical server-side render. Walks the hiccup tree once, emits a string. JVM-runnable. Test-friendly because it's pure.
+- **Example**:
+  ```clojure
+  (rf/with-frame [f (rf/make-frame {:on-create [:app/server-init]})]
+    (ssr/render-to-string [app-root] {:frame f}))
+  ```
+- **In the wild**: [ssr](https://github.com/day8/re-frame2/tree/main/examples/reagent/ssr)
 
 ### `render-tree-hash`
 
@@ -27,7 +32,6 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
   ```clojure
   (render-tree-hash render-tree) → 32-bit FNV-1a structural hash (lowercase hex)
   ```
-- **Status**: v1
 - **Description**: A deterministic structural fingerprint of a render tree. Same canonical-EDN representation produces the same hash on JVM and CLJS. Used by the hydration compatibility check — if the server's hash doesn't match the client's hash, hydration is unsafe.
 
 ### `project-error`
@@ -37,7 +41,6 @@ The normative source is [011-SSR.md](../../spec/011-SSR.md). The SSR surfaces li
   ```clojure
   (project-error frame-id trace-event) → :rf/public-error
   ```
-- **Status**: v1
 - **Description**: Apply the active error-projector (selected by the frame's `:ssr {:public-error-id ...}` metadata) for the named frame. This is the seam between "internal error trace event with full diagnostic detail" and "client-safe public-error projection."
 
 ### Streaming render
@@ -52,8 +55,8 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-render-shell root-hiccup)
     → {:shell-html "..." :continuations [{:id :subtree} ...]}
   ```
-- **Status**: v1
 - **Description**: Walk the tree once; at each `:rf/suspense-boundary` emit a `<template …suspense-fallback>` placeholder and record a continuation. Returns the shell-html (ready to flush) and the continuations to drain.
+- **In the wild**: [ssr_streaming](https://github.com/day8/re-frame2/tree/main/examples/reagent/ssr_streaming)
 
 ### `streaming-render-continuation`
 
@@ -63,7 +66,6 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-render-continuation frame-id entry)
     → {:id :html :delta :failed?}
   ```
-- **Status**: v1
 - **Description**: Drain one continuation against `frame-id`'s app-db. Snapshots before-db / after-db and computes the per-subtree delta. Catches throws and surfaces the original fallback HTML inline (per [011 §Failure semantics — inline fallback](../../spec/011-SSR.md#failure-semantics--inline-fallback)).
 
 ### `streaming-build-final-payload`
@@ -74,7 +76,6 @@ Larger pages benefit from streaming — emit the shell-html and continue renderi
   (streaming-build-final-payload frame-id render-hash opts)
     → canonical :rf/hydration-payload
   ```
-- **Status**: v1
 - **Description**: Called after all continuations drain to populate the `__rf_payload` final chunk.
 
 The streaming surface is host-adapter territory — the SSR-aware host (`re-frame.ssr.ring` or equivalent) wires it. Most app code interacts via the host adapter and never touches `streaming-render-*` directly.
@@ -90,8 +91,14 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   ```clojure
   (reg-head id ?metadata head-fn)
   ```
-- **Status**: v1
 - **Description**: Register a head-fn keyed by id. Signature: `(fn [db route] head-model)`. Routes opt-in via `:head` route metadata.
+- **Example**:
+  ```clojure
+  (rf/reg-head :app/head
+    (fn [db _route]
+      {:title (str "MyApp — " (:page-title db))
+       :meta  [{:name "description" :content (:summary db)}]}))
+  ```
 
 ### `render-head`
 
@@ -100,7 +107,6 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   ```clojure
   (render-head head-id opts) → :rf/head-model
   ```
-- **Status**: v1
 - **Description**: Evaluate the registered head-fn for `head-id`. Returns a head-model.
 
 ### `active-head`
@@ -111,7 +117,6 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (active-head) → :rf/head-model
   (active-head frame-id) → :rf/head-model
   ```
-- **Status**: v1
 - **Description**: Resolve the head-model for the currently active route in the named frame. Sub-shape: `[:rf/head]` subscribes to this.
 
 ### `head-model->html`
@@ -122,7 +127,6 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   (head-model->html head-model) → inner-head HTML string
   (head-model->html head-model {:wrap? bool}) → inner-head HTML string
   ```
-- **Status**: v1
 - **Description**: Render a head-model to its HTML representation. `:wrap?` controls whether `<head>` tags are emitted (default: false, so the result can be composed into a larger shell).
 
 ### `head-snapshot`
@@ -132,7 +136,6 @@ The `<head>` of an SSR document is structurally separate from the body. Re-frame
   ```clojure
   (head-snapshot frame-id) → {head-id → :rf/head-model}
   ```
-- **Status**: v1
 - **Description**: Read the per-frame snapshot of last-produced head-models. Returns `{}` for a frame that has never seen a `render-head` call. Useful for tests, introspection, and tools. Re-exported as `rf/head-snapshot`.
 
 ## Standard SSR events
@@ -194,8 +197,14 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```clojure
   (reg-error-projector id ?metadata projector-fn)
   ```
-- **Status**: v1
 - **Description**: Register a projector keyed by id. Signature: `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata.
+- **Example**:
+  ```clojure
+  (rf/reg-error-projector :app/public-error
+    (fn [trace-event]
+      {:status  500
+       :message "Something went wrong."}))
+  ```
 
 The companion `project-error` accessor is rowed above in [§Rendering primitives](#project-error) — same signature; same job. Apply the active projector for the named frame.
 

--- a/docs/api/10-testing.md
+++ b/docs/api/10-testing.md
@@ -22,7 +22,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (dispatch-sequence events)
   (dispatch-sequence events opts)
   ```
-- **Status**: v1
 - **Description**: "Run this list of events end-to-end against the current frame." `opts`: `:after-each (fn [db ev] ...)` for between-event assertions, `:frame` for non-default targets. Returns the final `app-db`.
 
 ### `assert-path-equals`
@@ -33,7 +32,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (assert-path-equals path expected-val)
   (assert-path-equals path expected-val opts)
   ```
-- **Status**: v1
 - **Description**: "Assert `(get-in db path) == expected-val`." Mismatch fires a `clojure.test/is`-style failure via `do-report`. The fn-side counterpart to the `:rf.assert/path-equals` story event-family — same name root, different runner channel.
 
 ### `assert-db-equals`
@@ -44,7 +42,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (assert-db-equals expected-db)
   (assert-db-equals expected-db opts)
   ```
-- **Status**: v1
 - **Description**: Full-db sync assertion. Mismatch fires a `clojure.test/is`-style failure. Companion to `assert-path-equals`; reach for it when the whole-db identity matters.
 
 ### `poll-until`
@@ -55,7 +52,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   (poll-until pred)
   (poll-until pred opts)
   ```
-- **Status**: v1
 - **Description**: Bounded-deadline poll. JVM: synchronous — returns the truthy value, throws `ex-info` with `:rf.test/poll-timeout true` on timeout. CLJS: returns a `js/Promise` resolving with the truthy value or rejecting on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label`.
 
 ### `with-fx-overrides`
@@ -65,7 +61,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   ```clojure
   (with-fx-overrides {fx-id -> override, …} body+)
   ```
-- **Status**: v1
 - **Description**: Rowed in [03 — Effects and interceptors](03-effects.md). Lexical-scope fx override; the most common test surface for "stub THIS fx within THIS block." Lives in `re-frame.core` but is rowed here for discoverability.
 
 ### `compute-sub`
@@ -75,7 +70,6 @@ For the wider testing philosophy (fixtures, framework adapters, `re-frame-test` 
   ```clojure
   (compute-sub query-v db)
   ```
-- **Status**: v1
 - **Description**: Pure sub computation against an `app-db` *value*. No cache, no reactivity — just walk the sub graph and return the value. JVM-runnable. Use in tests where you want "what would this sub return given this db?" without setting up frames.
 
 ### Snapshot the registrar; restore after
@@ -85,25 +79,21 @@ These are the fixture primitives. The pattern is "snapshot the registrar before 
 #### `snapshot-registrar`
 
 - **Signature**: per docstring
-- **Status**: v1
 - **Description**: Capture the current registrar state.
 
 #### `restore-registrar!`
 
 - **Signature**: per docstring
-- **Status**: v1
 - **Description**: Restore a previously captured registrar state.
 
 #### `with-fresh-registrar`
 
 - **Signature**: per docstring
-- **Status**: v1
 - **Description**: The composed macro — snapshot + body + restore. Most tests reach for this rather than the lower-level primitives.
 
 #### `make-reset-runtime-fixture`
 
 - **Signature**: per docstring
-- **Status**: v1
 - **Description**: Build a `clojure.test` fixture that resets the runtime between tests. Pair with `use-fixtures :each`.
 
 ### A typical test
@@ -129,7 +119,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (expand-tree tree) → tree
   ```
-- **Status**: v1
 - **Description**: Recursively expand fn-components and Form-3 class components inside a hiccup tree. After expansion every vector's first element is a keyword tag or a non-component value. Run this first when your view tree contains other registered views you want to assert through.
 
 ### `attrs`
@@ -139,7 +128,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (attrs node) → map
   ```
-- **Status**: v1
 - **Description**: Return the attrs map of a hiccup node, or `nil`.
 
 ### `children`
@@ -149,7 +137,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (children node) → vector
   ```
-- **Status**: v1
 - **Description**: Return everything after the tag (and optional attrs map).
 
 ### `text-content`
@@ -159,7 +146,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (text-content node) → string
   ```
-- **Status**: v1
 - **Description**: Recursively collect string leaves under `node` and join. Numbers coerce to strings; nils are skipped. "What's the visible text?"
 
 ### `extract-handler`
@@ -169,7 +155,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (extract-handler node event-key) → fn
   ```
-- **Status**: v1
 - **Description**: "Get the handler attached at this attribute on this node." Returns the value or `nil`.
 
 ### `find-by-attr`
@@ -179,7 +164,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-by-attr tree attr val) → node
   ```
-- **Status**: v1
 - **Description**: First hiccup node whose attrs map carries `attr == val`, or `nil`. Generic over the attribute keyword — `:data-testid`, `:id`, `:data-test`, custom.
 
 ### `find-all-by-attr`
@@ -189,7 +173,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-all-by-attr tree attr val) → vector
   ```
-- **Status**: v1
 - **Description**: Every matching node, in depth-first order.
 
 ### `find-by-attr-prefix`
@@ -199,7 +182,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-by-attr-prefix tree attr prefix) → vector
   ```
-- **Status**: v1
 - **Description**: Every node whose `attr` value (a string) STARTS with `prefix`. Non-string attr values do not match.
 
 ### `find-by-testid`
@@ -209,7 +191,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-by-testid tree test-id) → node
   ```
-- **Status**: v1
 - **Description**: Convenience over `find-by-attr` keyed on `:data-testid`. The common case.
 
 ### `find-all-by-testid`
@@ -219,7 +200,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-all-by-testid tree test-id) → vector
   ```
-- **Status**: v1
 - **Description**: Convenience over `find-all-by-attr` keyed on `:data-testid`.
 
 ### `find-by-testid-prefix`
@@ -229,7 +209,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (find-by-testid-prefix tree prefix) → vector
   ```
-- **Status**: v1
 - **Description**: Convenience over `find-by-attr-prefix` keyed on `:data-testid`.
 
 ### `invoke-handler`
@@ -239,7 +218,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   ```clojure
   (invoke-handler node event-key & args) → any
   ```
-- **Status**: v1
 - **Description**: Find the handler under `event-key` on `node` and call it with `args`. Returns the handler's return value. **Throws** when the node has no attrs map or no handler is registered — the throwing failure mode is deliberate (a missing handler is almost always a test bug).
 
 ### `testid`
@@ -250,7 +228,6 @@ The view-assertion surface treats a view as what it is — a function that retur
   (testid id) → map
   (testid id extra) → map
   ```
-- **Status**: v1
 - **Description**: Build an attrs map carrying `:data-testid id`. The 2-arity merges `extra` into the map; `:data-testid` always wins on collision. Authoring helper at the view call site — pair it with `find-by-testid` at the assertion site.
 
 ### A view-assertion test

--- a/docs/api/11-instrumentation.md
+++ b/docs/api/11-instrumentation.md
@@ -19,7 +19,6 @@ Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:even
   ```clojure
   (register-event-listener! id listener-fn)
   ```
-- **Status**: v1
 - **Description**: Receive one event-record per processed event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
 
 ### `unregister-event-listener!`
@@ -29,7 +28,6 @@ Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:even
   ```clojure
   (unregister-event-listener! id) → nil
   ```
-- **Status**: v1
 - **Description**: The inverse.
 
 ## Error-emit (always-on, production-survivable)
@@ -45,7 +43,6 @@ Record shape: `{:error :event :event-id :frame :time :exception :elapsed-ms}`. T
   ```clojure
   (register-error-listener! id listener-fn)
   ```
-- **Status**: v1
 - **Description**: Receive one error-record per `:rf.error/*` event. Re-registering the same `id` replaces. Returns `id`. **Always-on**: survives CLJS `:advanced` + `goog.DEBUG=false`.
 
 ### `unregister-error-listener!`
@@ -55,7 +52,6 @@ Record shape: `{:error :event :event-id :frame :time :exception :elapsed-ms}`. T
   ```clojure
   (unregister-error-listener! id) → nil
   ```
-- **Status**: v1
 - **Description**: The inverse.
 
 ## Tracing (dev-only)
@@ -69,7 +65,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (register-listener! key callback-fn)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: "Receive every trace event the runtime emits." Synchronous delivery; the callback returns before the next trace event is processed.
 
 ### `unregister-listener!`
@@ -79,7 +74,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (unregister-listener! key) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The inverse.
 
 ### `emit-trace-event!`
@@ -89,19 +83,16 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (emit-trace-event! op-type operation tags) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: "Emit a custom trace event." Use sparingly — the framework emits the load-bearing events; custom emission is for app-specific cross-cutting concerns the framework can't know about.
 
 ### `re-frame.interop/debug-enabled?`
 
 - **Kind**: Var (`^boolean`)
-- **Status**: v1
 - **Description**: **CLJS:** alias of `goog.DEBUG` — constant-folded by Closure under `:advanced`, so `:advanced` + `goog.DEBUG=false` builds DCE every `(when interop/debug-enabled? ...)` branch. **JVM:** a `def` read ONCE at ns-load from the Java system property `-Dre-frame.debug` (winning on conflict) or the environment variable `RE_FRAME_DEBUG`; defaults `true` (dev parity). Accepts the conventional false-y vocabulary case-insensitively (`false`, `0`, `no`, `off`, empty string) with whitespace trimmed; anything else leaves the flag at `true`. SSR / webhook receivers / long-running JVMs facing untrusted input MUST set the gate `false` explicitly.
 
 ### `re-frame.performance/enabled?`
 
 - **Kind**: Var (`^boolean`)
-- **Status**: v1
 - **Description**: `goog-define`d (CLJS) / `^:const false` (JVM). Set via `:closure-defines {re-frame.performance/enabled? true}` to bracket event dispatch / sub recompute / fx walk / view render in `performance.mark` + `performance.measure` calls (User-Timing entries `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*`). **Compile-time only** — not a `(rf/configure ...)` knob; runtime mutation has no effect. Default `false`; under `:advanced` + default the bracket DCEs and shipped binaries carry zero User-Timing instrumentation. CLJS-only — JVM is a no-op.
 
 ### `trace-buffer`
@@ -112,7 +103,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   (trace-buffer) → vector of trace events, oldest-first
   (trace-buffer opts) → vector of trace events, oldest-first
   ```
-- **Status**: v1 (dev-only)
 - **Description**: "What's in the ring right now?" Reads the buffer non-destructively. Pair tools and Causa use this for post-mortem inspection.
 
 ### `clear-trace-buffer!`
@@ -122,7 +112,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (clear-trace-buffer!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Empty the ring.
 
 ### `(rf/configure :trace-buffer …)`
@@ -132,7 +121,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (rf/configure :trace-buffer {:depth N})
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Buffer depth knob. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
 
 ### `group-cascades`
@@ -142,7 +130,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (group-cascades events) → vector of cascade records
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Pure data projection of a list of trace events into per-cascade records `{:dispatch-id :event :handler :fx :effects :subs :renders :other}`, sorted by emission order. JVM-runnable. Re-exported from `re-frame.trace.projection`.
 
 ### `domino-bucket`
@@ -152,7 +139,6 @@ The rich-detail trace surface. **Dev-only — elided in production via Closure D
   ```clojure
   (domino-bucket trace-event) → #{:event :handler :fx :effect :sub :render :other}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Classify a raw trace event into the six-domino slot used by `group-cascades`. Pure.
 
 ### Trace-emission opt-out
@@ -176,7 +162,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (epoch-history frame-id) → vector of epoch records
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Returns `[]` for an unknown / destroyed frame.
 
 ### `restore-epoch`
@@ -186,7 +171,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (restore-epoch frame-id epoch-id) → boolean
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Restore the frame's `app-db` to the named epoch. Returns `true` on success; `false` for an unknown / destroyed frame (and emits `:rf.error/no-such-handler` of kind `:frame`).
 
 ### `reset-frame-db!`
@@ -196,7 +180,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (reset-frame-db! frame-id new-db) → boolean
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Pair-tool write surface (state injection). Direct write to `app-db` — bypasses the cascade. Returns `true` on success.
 
 ### `register-epoch-listener!`
@@ -206,7 +189,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (register-epoch-listener! key callback-fn)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Process-global assembled-epoch listener. A callback whose previously-observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace.
 
 ### `unregister-epoch-listener!`
@@ -216,7 +198,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (unregister-epoch-listener! key)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The inverse.
 
 ### `(rf/configure :epoch-history …)`
@@ -226,7 +207,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (rf/configure :epoch-history {:depth N :trace-events-keep N :redact-fn fn})
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Buffer-depth and redactor knobs. See [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
 
 ### Trace events emitted by epoch-history machinery
@@ -257,7 +237,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   ```clojure
   (elide-wire-value v opts) → v or an elision-marker substitution
   ```
-- **Status**: v1
 - **Description**: Walk `v` consulting `[:rf/elision :declarations]` and `[:rf/elision :sensitive-declarations]` of the named frame's `app-db`. Substitute `:rf/redacted` for sensitive slots and `:rf.size/large-elided` markers for large slots.
 
 ### `elision-declarations`
@@ -268,7 +247,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   (elision-declarations)
   (elision-declarations frame-id)
   ```
-- **Status**: v1
 - **Description**: Read the current `[:rf/elision :declarations]` map for the frame (or `{}`). Pair-tool / introspection reader.
 
 ### `populate-elision-from-schemas!`
@@ -279,7 +257,6 @@ Per-frame epoch snapshots, recorded on each drain-completion in dev builds. Used
   (populate-elision-from-schemas!) → vector of paths populated
   (populate-elision-from-schemas! frame-id) → vector of paths populated
   ```
-- **Status**: v1
 - **Description**: Boot-time hydrator that walks the frame's registered app-schemas and writes `{:large? true :source :schema}` declarations for every path whose Malli schema carries `:large? true`. Idempotent.
 
 Composition rule: when both predicates match (sensitive AND large for the same path), **sensitive drop wins** — the size marker is suppressed because it would leak `:path` / `:bytes` / `:digest` from a sensitive slot.
@@ -295,7 +272,6 @@ See [08 — Schemas](08-schemas.md) for the registration side (`add-marks`, `set
   ```clojure
   (sensitive? trace-event) → boolean
   ```
-- **Status**: v1
 - **Description**: True iff `trace-event` is a map carrying `:sensitive? true` at the top level (not under `:tags`). The framework-published predicate every consumer composes against — replaces per-consumer reimplementations of the same five-token check.
 
 ### `redact-interceptor`
@@ -305,7 +281,6 @@ See [08 — Schemas](08-schemas.md) for the registration side (`add-marks`, `set
   ```clojure
   (redact-interceptor paths) → interceptor
   ```
-- **Status**: post-v1 (planned)
 - **Description**: Positional interceptor that overwrites the named keys in the event vector's payload map with the `:rf/redacted` sentinel before the handler chain runs. The handler body itself sees the UNREDACTED payload via the regular `:event` coeffect slot; the redaction is for the trace surface only.
 
 ## DOM source-coord annotations

--- a/docs/api/12-registrar.md
+++ b/docs/api/12-registrar.md
@@ -16,7 +16,6 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
   (registrations kind) → {id metadata-map}
   (registrations kind pred-fn) → {id metadata-map}
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: **Use when you want metadata.** Walk the registrar with the full metadata map per id — source-coords, `:rf/sensitive`, `:rf/machine?`, `:platforms`, the doc string. Optional `pred-fn` filters by the metadata map.
 
 ### `handler-ids`
@@ -26,7 +25,6 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
   ```clojure
   (handler-ids kind) → id set
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: **Use when you only need to enumerate.** Canonical alias for `(-> (registrations kind) keys set)`. Saves both the metadata-map allocations and the `keys` walk — meaningful at scale (completion lists, existence checks, set-shaped intersections).
 
 ### `handler-meta`
@@ -36,7 +34,6 @@ Everything here is **JVM-runnable** except `sub-cache` (which holds live `Reacti
   ```clojure
   (handler-meta kind id) → registration-metadata map
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: "What did `reg-*` stamp at this id?" View registrations include source-coord keys (`:ns` / `:line` / `:column` / `:file`) per `:rf/source-coord-meta`; pair tools resolve `data-rf2-source-coord` DOM annotations to `:file` via this lookup.
 
 `kind` is one of `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:flow`, `:route`, `:head`, `:error-projector`, `:app-schema`. The full list lives in [001-Vision §Registry model](../../spec/000-Vision.md).
@@ -52,7 +49,6 @@ These are derived views over the event registrar — a machine is registered as 
   ```clojure
   (machines) → seq of machine-ids
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: Enumerate registered machines.
 
 ### `machine-meta`
@@ -62,7 +58,6 @@ These are derived views over the event registrar — a machine is registered as 
   ```clojure
   (machine-meta machine-id) → registration-metadata map
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: Transition table, doc, schemas. Equivalent to `(handler-meta :event machine-id)`.
 
 See [04 — Machines](04-machines.md) for the rest of the machine surface (subscription helpers, system-id reverse lookup, etc).
@@ -77,7 +72,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   (frame-ids)
   (frame-ids ns-prefix)
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: "What frames exist?" The optional prefix filters by namespace — `(rf/frame-ids :rf.story/)` for tool-owned frames.
 
 ### `frame-meta`
@@ -87,7 +81,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   ```clojure
   (frame-meta frame-id)
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: "What did `reg-frame` / `make-frame` stamp at this frame?" Returns the metadata map: `:fx-overrides`, `:interceptors`, `:ssr`, `:on-error`, schema bindings.
 
 ### `get-frame-db`
@@ -97,7 +90,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   ```clojure
   (get-frame-db frame-id) → app-db value (plain map)
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: "What's the current `app-db` for this frame?" Returns `nil` for an unknown / destroyed frame.
 
 ### `snapshot-of`
@@ -108,7 +100,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   (snapshot-of path)
   (snapshot-of path opts)
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: "What's at this path in `app-db` right now?" Convenience over `get-frame-db` + `get-in`.
 
 ## Sub graph
@@ -120,7 +111,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   ```clojure
   (sub-topology) → {sub-id {:inputs [<input-sub-ids>] :doc :ns :line :file}}
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: Static dependency graph from `:<-` declarations. Pure data over the registrar; `:inputs` always present (empty for layer-1 subs); the per-entry `:doc` / `:ns` / `:line` / `:file` keys are present when registration carries them.
 
 ### `sub-cache`
@@ -130,7 +120,6 @@ See [04 — Machines](04-machines.md) for the rest of the machine surface (subsc
   ```clojure
   (sub-cache frame-id) → live cache state
   ```
-- **Status**: v1 · CLJS-only
 - **Description**: The runtime cache. CLJS-only because it holds live `Reaction` objects; on JVM there are no reactions to hold. Tools that walk the cache for tab labels / counts in Causa go through this.
 
 The split — `sub-topology` JVM-runnable, `sub-cache` CLJS-only — is principled. Topology is a static property of the registration; the cache is a runtime property of the sub graph. Tools that want the design-time picture (linter, doc generator, conformance harness) reach for `sub-topology`; tools that want the runtime picture (Causa's sub-cache tab) reach for `sub-cache`.
@@ -155,7 +144,6 @@ The schema-introspection surfaces are rowed in [08 — Schemas](08-schemas.md). 
   ```clojure
   (compute-sub query-v db)
   ```
-- **Status**: v1 · JVM-runnable
 - **Description**: Pure sub computation against an `app-db` value. Use in tests; use in agent tooling that wants to evaluate subs against an artificial state.
 
 (Cross-rowed in [10 — Testing](10-testing.md).)

--- a/docs/api/13-lifecycle.md
+++ b/docs/api/13-lifecycle.md
@@ -13,8 +13,14 @@ There's also a small inspection surface for "what's currently installed?" — `c
   ```clojure
   (init! adapter-map)
   ```
-- **Status**: v1
 - **Description**: The idempotent boot. Required arg: the adapter spec map. Each adapter ns exports an `adapter` Var; consumers require the ns and pass the Var, e.g. `(rf/init! reagent/adapter)`. Calling `(init!)` with no args raises a language-level `ArityException` at compile / load time — the no-arg arity was cut so the missing-adapter mistake surfaces before runtime. Calling `(init! nil)` or `(init! :reagent)` raises `:rf.error/no-adapter-specified` at runtime. Ensures `:rf/default` frame is present.
+- **Example**:
+  ```clojure
+  (:require [re-frame.adapter.reagent :as reagent-adapter])
+
+  (rf/init! reagent-adapter/adapter)
+  ```
+- **In the wild**: [counter](https://github.com/day8/re-frame2/tree/main/examples/reagent/counter)
 
 ### `install-adapter!`
 
@@ -23,7 +29,6 @@ There's also a small inspection surface for "what's currently installed?" — `c
   ```clojure
   (install-adapter! adapter-map)
   ```
-- **Status**: v1
 - **Description**: Must be called before any frame is created. **Lower-level than `init!`**; most consumers call `init!` instead. Use it when you're writing a custom boot pipeline that has additional steps between adapter-install and first-frame creation.
 
 ### `destroy-adapter!`
@@ -33,7 +38,6 @@ There's also a small inspection surface for "what's currently installed?" — `c
   ```clojure
   (destroy-adapter!)
   ```
-- **Status**: v2
 - **Description**: Tear down the installed adapter. Calls the adapter spec's `:dispose-adapter!` fn (if present), clears the install slot so a new adapter can install, and flips the `adapter-disposed?` breadcrumb. Symmetric with `install-adapter!` and with `destroy-frame!` — same `destroy-` verb-cluster (lifecycle boundary).
 
 The adapter-spec **map key** `:dispose-adapter!` is an internal contract slot adapters implement; ignore it unless you're authoring an adapter.
@@ -59,7 +63,6 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
   ```clojure
   (current-adapter) → discriminator keyword
   ```
-- **Status**: v1
 - **Description**: "What substrate am I on?" Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/helix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
 
 ### `current-adapter-spec`
@@ -69,7 +72,6 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
   ```clojure
   (current-adapter-spec) → installed adapter spec map
   ```
-- **Status**: v1
 - **Description**: "Give me the adapter fns to call." The value passed to `(rf/init! ...)`, or `nil` when no adapter is installed. Use for tools / routing / identity checks across the install / dispose lifecycle. For the discriminator keyword, use `current-adapter`.
 
 ### `adapter-disposed?`
@@ -79,7 +81,6 @@ Most app code never sees the spec map — you just pass the adapter's `adapter` 
   ```clojure
   (adapter-disposed?) → boolean
   ```
-- **Status**: v1
 - **Description**: "Was the adapter torn down?" Returns `true` iff the most recent lifecycle event was a successful `destroy-adapter!` and no subsequent `install-adapter!` has fired. `false` for never-installed (fresh process) AND after a fresh install. Read-only — the breadcrumb is owned by the install / destroy pair. Use to distinguish `:rf.error/no-adapter-installed` (fresh process) from `:rf.error/adapter-disposed` (torn down).
 
 The split between `current-adapter` (keyword) and `current-adapter-spec` (map) is principled. The keyword is for switch-like code that branches on substrate identity. The spec map is for code that needs to call adapter fns or compare adapter identity across reinstalls.
@@ -106,7 +107,6 @@ The `configure` fn is the lifecycle's adjacent surface — process-level data kn
   ```clojure
   (configure key opts)
   ```
-- **Status**: v1
 - **Description**: Runtime config. One of three orthogonal configuration surfaces — `configure` for process-level data knobs; `set-!` / `install-!` for adapter-pluggable hooks; per-frame metadata for frame-scoped overrides. The vocabulary of keys lives in [01 — Core §Configure keys](01-core.md#runtime-configuration-configure).
 
 The three configuration surfaces — `configure`, the `set-!` / `install-!` setters (`set-schema-validator!`, etc.), and per-frame metadata — are deliberately separate. Each answers a different question: `configure` for data knobs (depth, threshold, grace period); the setters for hook-shaped pluggability (which validator to use, which printer); per-frame metadata for frame-scoped overrides (which projector, which `:fx-overrides`).

--- a/docs/api/14-adapters.md
+++ b/docs/api/14-adapters.md
@@ -41,8 +41,8 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
    :render …
    :dispose-adapter! …}
   ```
-- **Status**: v1
 - **Description**: The adapter spec passed to `(rf/init! ...)`.
+- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/uix/counter_uix)
 
 ### `uix-adapter/use-subscribe`
 
@@ -52,8 +52,8 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Status**: v1
 - **Description**: "Subscribe inside a UIx component." The hook-shaped equivalent of `subscribe` for UIx components. Re-renders when the sub value changes.
+- **In the wild**: [counter_uix](https://github.com/day8/re-frame2/tree/main/examples/uix/counter_uix)
 
 ### `uix-adapter/use-current-frame`
 
@@ -62,7 +62,6 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```clojure
   (use-current-frame) → frame-kw
   ```
-- **Status**: v1
 - **Description**: "What frame am I in?" — for components that need to thread the frame through hand-written child callbacks.
 
 ### `uix-adapter/frame-provider`
@@ -72,7 +71,6 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```clojure
   ($ uix-adapter/frame-provider {:frame :session :children […]})
   ```
-- **Status**: v1
 - **Description**: The UIx-shaped frame provider.
 
 ### `uix-adapter/wrap-view`
@@ -82,7 +80,6 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```clojure
   (wrap-view id metadata user-fn) → wrapped fn
   ```
-- **Status**: v1
 - **Description**: Adapter-side source-coord injection. Most users register through `reg-view*`; `wrap-view` is for code-gen and library scaffolding.
 
 ### `uix-adapter/flush-views!`
@@ -93,7 +90,6 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   (flush-views!)
   (flush-views! f)
   ```
-- **Status**: v1
 - **Description**: Wraps React's `act()` for tests.
 
 ### `uix-adapter/set-hiccup-emitter!`
@@ -103,7 +99,6 @@ UIx-specific surfaces live in `re-frame.adapter.uix` (artefact `day8/re-frame2-u
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Status**: v1
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent adapter's late-bind seam for SSR.
 
 UIx users register their views by Var (the React-component idiom) or with `rf/reg-view*` if they want registry-keyed view addressing — `reg-view` (the Reagent macro) does **not** cover UIx. Full rationale: [Spec 006 §CLJS reference: UIx as alternative substrate](../../spec/006-ReactiveSubstrate.md#cljs-reference-uix-as-alternative-substrate-rf2-3yij).
@@ -135,8 +130,8 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
    :render …
    :dispose-adapter! …}
   ```
-- **Status**: v1
 - **Description**: The adapter spec passed to `(rf/init! ...)`.
+- **In the wild**: [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/helix/counter_helix)
 
 ### `helix-adapter/use-subscribe`
 
@@ -146,8 +141,8 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   (use-subscribe query-v) → current sub value
   (use-subscribe frame-kw query-v) → current sub value
   ```
-- **Status**: v1
 - **Description**: "Subscribe inside a Helix component."
+- **In the wild**: [counter_helix](https://github.com/day8/re-frame2/tree/main/examples/helix/counter_helix)
 
 ### `helix-adapter/use-current-frame`
 
@@ -156,7 +151,6 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```clojure
   (use-current-frame) → frame-kw
   ```
-- **Status**: v1
 - **Description**: "What frame am I in?"
 
 ### `helix-adapter/frame-provider`
@@ -166,7 +160,6 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```clojure
   ($ helix-adapter/frame-provider {:frame :session :children […]})
   ```
-- **Status**: v1
 - **Description**: The Helix-shaped frame provider.
 
 ### `helix-adapter/wrap-view`
@@ -176,7 +169,6 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```clojure
   (wrap-view id metadata user-fn) → wrapped fn
   ```
-- **Status**: v1
 - **Description**: Adapter-side source-coord injection.
 
 ### `helix-adapter/flush-views!`
@@ -187,7 +179,6 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   (flush-views!)
   (flush-views! f)
   ```
-- **Status**: v1
 - **Description**: Wraps React's `act()` for tests.
 
 ### `helix-adapter/set-hiccup-emitter!`
@@ -197,7 +188,6 @@ Helix-specific surfaces live in `re-frame.adapter.helix` (artefact `day8/re-fram
   ```clojure
   (set-hiccup-emitter! f)
   ```
-- **Status**: v1
 - **Description**: Install a render-tree → HTML fn. Parity with the Reagent and UIx adapters' late-bind seam.
 
 The duplication between UIx and Helix is intentional — both expose the same hooks-first idiom; both decisions sets transfer; both surfaces are structurally identical. The two adapters are separate artefacts because the *underlying React-substrate libraries* are separate, not because the re-frame2 contract differs between them.

--- a/docs/causa/api/config-keys.md
+++ b/docs/causa/api/config-keys.md
@@ -12,7 +12,6 @@ Boot-time configuration is **process-global**: the setters write to `defonce` at
   ```clojure
   (configure! opts) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Top-level Causa configuration. Accepts a map keyed by `:rf.causa/*` (Causa-specific) and `:rf.privacy/*` (cross-tool) keys. Unknown keys are silently ignored (forward-compat — newer hosts passing older-Causa-unaware keys MUST NOT break). Hosts typically call once at boot, before Causa auto-opens.
 
 `configure!` is re-exported from `core` for boot-time ergonomics. The two require paths are interchangeable:
@@ -65,7 +64,6 @@ Every panel that surfaces a source-coord wraps the coord in a clickable `open` c
   ```clojure
   (set-editor! editor) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Set the editor preference. Accepts `:vscode` (default), `:cursor`, `:windsurf`, `:zed`, `:idea`, `{:custom <uri-template>}`. `nil` resets to `:vscode`. Re-exported from `core`.
 
 ### `set-project-root!`
@@ -74,7 +72,6 @@ Every panel that surfaces a source-coord wraps the coord in a clickable `open` c
   ```clojure
   (set-project-root! path) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: On-disk root prepended to the source-coord's classpath-relative `:file` slot before the editor URI ships. Default `nil` — hosts whose source paths are already absolute leave this unset. Nil / blank clears the slot; an absent key in `configure!` leaves the current value untouched.
 
 The URI schemes:
@@ -102,7 +99,6 @@ The launch cluster controls the auto-open posture and the layout-host wiring. Se
   ```clojure
   (set-auto-open! bool) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Whether the preload auto-opens the shell into the inline host on adapter readiness. Default `true`. Set `false` from tool-owned pages that deliberately don't reserve app real estate for Causa (Story-only canvases, internal dev tools whose layout can't host a right column). Explicit `(causa/open!)` calls still mount after suppression. Re-exported from `core`.
 
 ### `set-layout-host-selector!`
@@ -111,7 +107,6 @@ The launch cluster controls the auto-open posture and the layout-host wiring. Se
   ```clojure
   (set-layout-host-selector! css-selector) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The CSS selector the auto-open path queries on adapter readiness. Default `[data-rf-causa-host]`. Override when your host's preferred selector differs (e.g. `#devtools-causa`).
 
 The default selector `[data-rf-causa-host]` is published as a CLJS constant — `day8.re-frame2-causa.config/default-layout-host-selector` — so docs generators and tool chrome can re-emit the canonical spelling without forking the string.
@@ -136,7 +131,6 @@ Causa installs a global `Ctrl+Shift+C` keydown listener as one of the preload's 
   ```clojure
   (set-keybinding-enabled! bool) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Whether `keybinding/attach!` installs the global window-level keydown listener. Default `true` — standalone Causa needs the listener. Embed hosts set `false` so their own global keybindings (typically `Cmd/Ctrl+K` for the host's command palette) are not swallowed by Causa's capture-phase listener. MUST be set BEFORE the Causa preload runs.
 
 The setter suppresses the install at attach time; embed hosts whose mount lifecycle runs AFTER Causa's preload has already attached use the imperative escape hatch instead:
@@ -160,7 +154,6 @@ The privacy cluster carries one cross-tool gate that Causa, Story, and any other
   ```clojure
   (set-show-sensitive! bool) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The cross-tool `:rf.privacy/show-sensitive?` flag. When `false` (default), Causa's trace collector drops `:sensitive? true` events and the bottom rail surfaces a `[● REDACTED N]` hint. Set to `true` while debugging redaction policy to see the raw cascade. `nil` resets to the default. Re-exported from `core`.
 
 The single normative emission site for `:sensitive?` redaction is the framework's `elide-wire-value` (see [framework API instrumentation §The wire-boundary walker](../../api/11-instrumentation.md#the-wire-boundary-walker)). Causa's gate just decides whether the redacted-out events reach the buffer at all.
@@ -175,7 +168,6 @@ The Settings popup carries the user-mutable knobs — theme, density, buffer dep
   ```clojure
   (update-setting! path value) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Set one Settings slot. `path` is a vector into the settings map (e.g. `[:general :density]`); `value` is the new value. Persists through localStorage. The popup's event surface is the canonical write path; reach for this only from REPL / test contexts.
 
 ### `reset-settings!`
@@ -184,7 +176,6 @@ The Settings popup carries the user-mutable knobs — theme, density, buffer dep
   ```clojure
   (reset-settings!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Reset every Settings slot to its default shape. Wipes the localStorage slot. Mostly a test-isolation helper; hosts that want to ship a non-default shape use `configure! {:rf.causa/settings ...}` instead.
 
 ### `reset-suppressed-count!`
@@ -193,7 +184,6 @@ The Settings popup carries the user-mutable knobs — theme, density, buffer dep
   ```clojure
   (reset-suppressed-count!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Clear the `[● REDACTED N]` bottom-rail counter that surfaces when filters elide events. Reach for this when wiring a Settings-popup "Clear suppression counter" button or a test-harness fixture-reset.
 
 The Settings shape (validated by Malli):
@@ -228,7 +218,6 @@ The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ fr
   ```clojure
   (set-filter-seed! seed-map) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Host-supplied seed pill set the registry hydrates `:active-filters` with on FIRST install (when localStorage is empty). Shape: `{:in [{...}] :out [{...}]}`. Default `nil` — first session boots with no filters (first-session honesty beats first-session quietness). Story testbeds use this to inject a known starting point for reproducibility.
 
 ### `set-filters-storage-key!`
@@ -237,7 +226,6 @@ The Trace panel ships filter pills (`+ pattern`, `- pattern`, `+ :origin`, `+ fr
   ```clojure
   (set-filters-storage-key! key) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The localStorage key the filter persistence layer reads / writes. Default `"re-frame2.causa.filters.v1"`. Hosts that run multiple Causa instances (Story testbeds, multi-mode tool pages) override for isolation between instances.
 
 Set both *before* the preload runs so the first registry-handlers registration reads the right values.

--- a/docs/causa/api/mount-control.md
+++ b/docs/causa/api/mount-control.md
@@ -12,7 +12,6 @@ There's also a small JS-side mirror — the same six verbs exposed on `window.da
   ```clojure
   (causa/open!) → mount-state map or missing-host diagnostic map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Mount + show the shell true-inline into the host's normal-flow layout host (`[data-rf-causa-host]` by default). The canonical default. On first call, creates `#rf-causa-root` inside the host and renders the shell. On subsequent calls (already mounted), flips the container to `display: block`. No-op (returns `nil`) when no substrate adapter is installed.
 
 ### `open-overlay!`
@@ -21,7 +20,6 @@ There's also a small JS-side mirror — the same six verbs exposed on `window.da
   ```clojure
   (causa/open-overlay!)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Debug / fallback path: mount Causa as a fixed overlay under `<body>`. Floats above the host layout without participating in it. Reach for this when the host's normal-flow layout cannot accommodate a right column — a full-screen canvas tool, a story-only tool page, a prototype with no layout host.
 
 ### `popout!`
@@ -30,7 +28,6 @@ There's also a small JS-side mirror — the same six verbs exposed on `window.da
   ```clojure
   (causa/popout!)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Open Causa in a same-origin second window. The shell mounts into its own document context — own React root, own theme cascade, own keybinding listener. The popped window uses `window.opener` to reach the host's runtime, so all observation surfaces (trace bus, epoch history, registrar) work unchanged. Useful when the panel is competing with the app for screen space.
 
 The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inline!` alias). Inline-vs-overlay-vs-window is a kind-of-mount axis, not a mode axis. A reader who treats `open!` / `open-overlay!` as "default vs overlay" and `popout!` as "its own verb" is reading the contract correctly — bare `open!` *is* the canonical default, and the asymmetry telegraphs the rank.
@@ -43,7 +40,6 @@ The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inli
   ```clojure
   (causa/close!)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Hide the shell — flip the container to `display: none`. The DOM tree and substrate render tree stay in place so re-opening is a CSS-only toggle (sub-80ms first paint). Use when the host wants to programmatically dismiss the panel without unmounting it.
 
 ### `toggle!`
@@ -52,7 +48,6 @@ The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inli
   ```clojure
   (causa/toggle!)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Flip visibility. First call mounts + shows; subsequent calls toggle between `display: block` and `display: none`. The `Ctrl+Shift+C` global keybinding is wired to this.
 
 ### `status`
@@ -61,7 +56,6 @@ The three verbs are **deliberately not** a mode-symmetric triplet (no `open-inli
   ```clojure
   (causa/status) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Inspectable shell state. Returns `{:mounted? :visible? :last-host-diagnostic ...}`. Reach for this from tests, from a debug-console one-liner, or when wiring a host's "is the panel up?" indicator. The browser-global mirror exposes the same value as `window.day8.re_frame2_causa.status()`.
 
 ## Manual install — the alternative to `:preloads`
@@ -77,7 +71,6 @@ For hosts that want to control the install timing — a custom boot pipeline wit
   (init!) → nil
   (init! opts) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Mount Causa manually. Idempotent: a second call is a no-op (each underlying side-effect is `defonce`-guarded). Bypasses the preload path. Use when the `:preloads` wiring isn't available — test harnesses, host-controlled boot pipelines, dev builds with a custom preload bundle.
 
 The `opts` map accepts these keys today (pre-alpha — additional keys land under follow-on work):
@@ -102,7 +95,6 @@ Most apps run one host frame (`:rf/default`) and Causa observes it implicitly. M
   ```clojure
   (causa/target-frame) → keyword
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Read the currently-targeted host frame. Defaults to `:rf/default` until `set-target-frame!` flips it. One-shot read (does NOT register for reactive re-render). Reactive consumers subscribe to `:rf.causa/target-frame` directly via the framework's sub surface.
 
 ### `set-target-frame!`
@@ -111,7 +103,6 @@ Most apps run one host frame (`:rf/default`) and Causa observes it implicitly. M
   ```clojure
   (causa/set-target-frame! frame-id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Set the host frame Causa targets. Dispatches `:rf.causa/set-target-frame` into the `:rf/causa` frame so the sub and every dependent panel re-fire on the standard reactive path. `nil` resets to the default.
 
 The L1 frame picker chip in the shell's top strip is wired to this — clicking flips `set-target-frame!`, and every panel in view (Trace, Views, Machines, App-DB Diff) rescopes to the new frame. Hosts can drive the same flip programmatically from a per-route effect, a Settings-popup wire-up, or a test harness assertion.
@@ -126,7 +117,6 @@ One surface declared by the spec ships as a stub that emits a `:rf.warning/*` tr
   ```clojure
   (causa/load-theme css-string) → nil
   ```
-- **Status**: TBD-impl
 - **Description**: Programmatically swap the Causa shell's CSS theme. The theme module exists (`day8.re-frame2-causa.theme/*`) but the runtime CSS-swap surface is not yet wired. Calling emits `:rf.warning/causa-load-theme-not-yet-implemented` so the gap is visible in the trace stream. Forward-compatible — host code may call with a CSS string today and expect the impl to land later.
 
 ## The browser-global JS mirror

--- a/docs/causa/api/reference.md
+++ b/docs/causa/api/reference.md
@@ -1,6 +1,6 @@
 # Reference
 
-The complete symbol table for Causa's public surface, organised by namespace for `Ctrl-F` use. Every row carries a signature, a status, and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
+The complete symbol table for Causa's public surface, organised by namespace for `Ctrl-F` use. Every row carries a signature and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
 
 Surfaces fall into six namespaces and one browser global. The split is principled — each namespace answers a distinct question — but the row count varies wildly. `core` carries 12 surfaces; `runtime` carries 20; `keybinding` carries 2. If you're scanning for a single function and don't remember which namespace owns it, the right move is `Ctrl-F` on this page.
 
@@ -10,22 +10,22 @@ For the topical walk-through with intuition notes and use-when prose, see [Mount
 
 The canonical facade. The day-to-day require for host integrations. Twelve surfaces total — the mount facade, the frame picker, the TBD theme stub, and four high-traffic config re-exports.
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `init!` | `(init!)` / `(init! opts)` → nil | v1 (dev-only) | Manual install — the alternative to wiring `:preloads`. Idempotent. |
-| `open!` | `(open!)` → mount-state map or missing-host diagnostic | v1 (dev-only) | Mount + show the shell true-inline into the host's layout host. The canonical default. |
-| `open-overlay!` | `(open-overlay!)` | v1 (dev-only) | Mount as a fixed overlay under `<body>`. Floats above host layout. |
-| `close!` | `(close!)` | v1 (dev-only) | Hide the shell — flip the container to `display: none`. DOM stays in place. |
-| `toggle!` | `(toggle!)` | v1 (dev-only) | Flip visibility. Wired to `Ctrl+Shift+C`. |
-| `popout!` | `(popout!)` | v1 (dev-only) | Open Causa in a same-origin second window. Own React root, own keybinding. |
-| `status` | `(status)` → map | v1 (dev-only) | Inspectable shell state. `{:mounted? :visible? :last-host-diagnostic ...}`. |
-| `target-frame` | `(target-frame)` → keyword | v1 (dev-only) | Read the currently-targeted host frame. One-shot read; not reactive. |
-| `set-target-frame!` | `(set-target-frame! frame-id)` → nil | v1 (dev-only) | Set the host frame Causa targets. `nil` resets to default. |
-| `load-theme` | `(load-theme css-string)` → nil | TBD-impl | Programmatic theme swap. Stub — emits `:rf.warning/causa-load-theme-not-yet-implemented`. |
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config — re-exported from `config`. See [Configuration keys](config-keys.md). |
-| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Re-exported from `config`. Whether the preload auto-opens. |
-| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Re-exported from `config`. Sets the "Open in editor" preference. |
-| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | Re-exported from `config`. Cross-tool `:rf.privacy/show-sensitive?` flag. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `init!` | `(init!)` / `(init! opts)` → nil | Manual install — the alternative to wiring `:preloads`. Idempotent. |
+| `open!` | `(open!)` → mount-state map or missing-host diagnostic | Mount + show the shell true-inline into the host's layout host. The canonical default. |
+| `open-overlay!` | `(open-overlay!)` | Mount as a fixed overlay under `<body>`. Floats above host layout. |
+| `close!` | `(close!)` | Hide the shell — flip the container to `display: none`. DOM stays in place. |
+| `toggle!` | `(toggle!)` | Flip visibility. Wired to `Ctrl+Shift+C`. |
+| `popout!` | `(popout!)` | Open Causa in a same-origin second window. Own React root, own keybinding. |
+| `status` | `(status)` → map | Inspectable shell state. `{:mounted? :visible? :last-host-diagnostic ...}`. |
+| `target-frame` | `(target-frame)` → keyword | Read the currently-targeted host frame. One-shot read; not reactive. |
+| `set-target-frame!` | `(set-target-frame! frame-id)` → nil | Set the host frame Causa targets. `nil` resets to default. |
+| `load-theme` | `(load-theme css-string)` → nil | Programmatic theme swap. Stub — emits `:rf.warning/causa-load-theme-not-yet-implemented`. |
+| `configure!` | `(configure! opts)` → nil | Top-level config — re-exported from `config`. See [Configuration keys](config-keys.md). |
+| `set-auto-open!` | `(set-auto-open! bool)` → nil | Re-exported from `config`. Whether the preload auto-opens. |
+| `set-editor!` | `(set-editor! editor)` → nil | Re-exported from `config`. Sets the "Open in editor" preference. |
+| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | Re-exported from `config`. Cross-tool `:rf.privacy/show-sensitive?` flag. |
 
 ## `day8.re-frame2-causa.config`
 
@@ -33,20 +33,20 @@ The full configuration surface. Reach here when you're flipping a knob the facad
 
 ### Setters
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config. Map keyed by `:rf.causa/*` and `:rf.privacy/*`. |
-| `set-editor!` | `(set-editor! editor)` → nil | v1 (dev-only) | Editor preference. `:vscode` (default) / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <tpl>}`. |
-| `set-project-root!` | `(set-project-root! path)` → nil | v1 (dev-only) | On-disk root prepended to classpath-relative `:file` slots before editor URIs ship. |
-| `set-layout-host-selector!` | `(set-layout-host-selector! css-selector)` → nil | v1 (dev-only) | CSS selector for the auto-open path. Default `[data-rf-causa-host]`. |
-| `set-auto-open!` | `(set-auto-open! bool)` → nil | v1 (dev-only) | Whether the preload auto-opens on adapter readiness. Default `true`. |
-| `set-keybinding-enabled!` | `(set-keybinding-enabled! bool)` → nil | v1 (dev-only) | Whether `keybinding/attach!` installs the global listener. Default `true`. |
-| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | v1 (dev-only) | Cross-tool `:rf.privacy/show-sensitive?` flag. Default `false`. |
-| `set-filter-seed!` | `(set-filter-seed! seed-map)` → nil | v1 (dev-only) | Host-supplied seed pill set for first install. Shape: `{:in [{...}] :out [{...}]}`. |
-| `set-filters-storage-key!` | `(set-filters-storage-key! key)` → nil | v1 (dev-only) | localStorage key the filter persistence layer uses. Default `"re-frame2.causa.filters.v1"`. |
-| `update-setting!` | `(update-setting! path value)` → nil | v1 (dev-only) | Set one Settings slot. `path` is a vector into the settings map. |
-| `reset-settings!` | `(reset-settings!)` → nil | v1 (dev-only) | Reset every Settings slot to its default. Wipes the localStorage slot. |
-| `reset-suppressed-count!` | `(reset-suppressed-count!)` → nil | v1 (dev-only) | Clear the `[● REDACTED N]` bottom-rail counter. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `configure!` | `(configure! opts)` → nil | Top-level config. Map keyed by `:rf.causa/*` and `:rf.privacy/*`. |
+| `set-editor!` | `(set-editor! editor)` → nil | Editor preference. `:vscode` (default) / `:cursor` / `:windsurf` / `:zed` / `:idea` / `{:custom <tpl>}`. |
+| `set-project-root!` | `(set-project-root! path)` → nil | On-disk root prepended to classpath-relative `:file` slots before editor URIs ship. |
+| `set-layout-host-selector!` | `(set-layout-host-selector! css-selector)` → nil | CSS selector for the auto-open path. Default `[data-rf-causa-host]`. |
+| `set-auto-open!` | `(set-auto-open! bool)` → nil | Whether the preload auto-opens on adapter readiness. Default `true`. |
+| `set-keybinding-enabled!` | `(set-keybinding-enabled! bool)` → nil | Whether `keybinding/attach!` installs the global listener. Default `true`. |
+| `set-show-sensitive!` | `(set-show-sensitive! bool)` → nil | Cross-tool `:rf.privacy/show-sensitive?` flag. Default `false`. |
+| `set-filter-seed!` | `(set-filter-seed! seed-map)` → nil | Host-supplied seed pill set for first install. Shape: `{:in [{...}] :out [{...}]}`. |
+| `set-filters-storage-key!` | `(set-filters-storage-key! key)` → nil | localStorage key the filter persistence layer uses. Default `"re-frame2.causa.filters.v1"`. |
+| `update-setting!` | `(update-setting! path value)` → nil | Set one Settings slot. `path` is a vector into the settings map. |
+| `reset-settings!` | `(reset-settings!)` → nil | Reset every Settings slot to its default. Wipes the localStorage slot. |
+| `reset-suppressed-count!` | `(reset-suppressed-count!)` → nil | Clear the `[● REDACTED N]` bottom-rail counter. |
 
 ### Published constants
 
@@ -64,10 +64,10 @@ The full configuration surface. Reach here when you're flipping a knob the facad
 
 The lifecycle pair for the global `Ctrl+Shift+C` keydown listener. Reach here from embed hosts that need to take the chord back after Causa has already attached.
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `attach!` | `(attach!)` → nil | v1 (dev-only) | Install the global listener once. Honours `:rf.causa/keybinding-enabled?`. No-op on second + subsequent calls. |
-| `detach!` | `(detach!)` → nil | v1 (dev-only) | Remove the global listener. Idempotent. Symmetric with `attach!`. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `attach!` | `(attach!)` → nil | Install the global listener once. Honours `:rf.causa/keybinding-enabled?`. No-op on second + subsequent calls. |
+| `detach!` | `(detach!)` → nil | Remove the global listener. Idempotent. Symmetric with `attach!`. |
 
 ## `day8.re-frame2-causa.runtime`
 
@@ -75,50 +75,50 @@ The Causa ↔ tool read-and-mutate seam. Twenty surfaces — discovery, origin t
 
 ### Discovery + origin
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `session-id` | Var (string UUID) | v1 (dev-only) | Per-preload random UUID. Survives `:after-load`; wiped on full page refresh. Proves the runtime landed. |
-| `*current-origin*` | `^:dynamic` Var | v1 (dev-only) | The `:tags :origin` value the runtime stamps onto every mutation. Default `:causa-mcp`. Tool clients rebind for synchronous extent. |
-| `current-origin` | `(current-origin)` → keyword | v1 (dev-only) | Read accessor — answers "what's the current `:origin` tag?". |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `session-id` | Var (string UUID) | Per-preload random UUID. Survives `:after-load`; wiped on full page refresh. Proves the runtime landed. |
+| `*current-origin*` | `^:dynamic` Var | The `:tags :origin` value the runtime stamps onto every mutation. Default `:causa-mcp`. Tool clients rebind for synchronous extent. |
+| `current-origin` | `(current-origin)` → keyword | Read accessor — answers "what's the current `:origin` tag?". |
 
 ### Inspection band (9 read-only)
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `get-trace-buffer` | `(get-trace-buffer opts)` → map | v1 (dev-only) | Filtered slice of the framework's trace stream. Filter keys per Spec 009. |
-| `get-epoch-history` | `(get-epoch-history opts)` → map | v1 (dev-only) | Per-frame epoch ring buffer. Default depth 50. |
-| `get-app-db` | `(get-app-db opts)` → map | v1 (dev-only) | Live `app-db` for a frame, optionally scoped by `:path`. Routes through `elide-wire-value`. |
-| `get-app-db-diff` | `(get-app-db-diff opts)` → map | v1 (dev-only) | `:db-before` + `:db-after` off a named epoch record. |
-| `get-machine-state` | `(get-machine-state opts)` → map | v1 (dev-only) | Per-machine state read for the registered machine spec. |
-| `get-machine-list` | `(get-machine-list opts)` → map | v1 (dev-only) | Map of every machine in the active frame, keyed by machine-id. |
-| `get-issues` | `(get-issues opts)` → map | v1 (dev-only) | Trace events filtered to issue-tier op-types — error / warning / schema violation / hydration mismatch. |
-| `get-handlers` | `(get-handlers opts)` → map | v1 (dev-only) | Registrar listing, optionally narrowed by `:kind`. |
-| `get-source-coord` | `(get-source-coord opts)` → map | v1 (dev-only) | Per-registration source-coord projection. `{:ns :file :line :column}`. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `get-trace-buffer` | `(get-trace-buffer opts)` → map | Filtered slice of the framework's trace stream. Filter keys per Spec 009. |
+| `get-epoch-history` | `(get-epoch-history opts)` → map | Per-frame epoch ring buffer. Default depth 50. |
+| `get-app-db` | `(get-app-db opts)` → map | Live `app-db` for a frame, optionally scoped by `:path`. Routes through `elide-wire-value`. |
+| `get-app-db-diff` | `(get-app-db-diff opts)` → map | `:db-before` + `:db-after` off a named epoch record. |
+| `get-machine-state` | `(get-machine-state opts)` → map | Per-machine state read for the registered machine spec. |
+| `get-machine-list` | `(get-machine-list opts)` → map | Map of every machine in the active frame, keyed by machine-id. |
+| `get-issues` | `(get-issues opts)` → map | Trace events filtered to issue-tier op-types — error / warning / schema violation / hydration mismatch. |
+| `get-handlers` | `(get-handlers opts)` → map | Registrar listing, optionally narrowed by `:kind`. |
+| `get-source-coord` | `(get-source-coord opts)` → map | Per-registration source-coord projection. `{:ns :file :line :column}`. |
 
 ### Mutation band (3 write)
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `dispatch!` | `(dispatch! event-vec opts)` → map | v1 (dev-only) | Fire an event tagged with the current origin. Modes `:queued` / `:sync`. |
-| `restore-epoch!` | `(restore-epoch! opts)` → map | v1 (dev-only) | Rewind a frame's `app-db` to a named epoch's `:db-after`. |
-| `reset-frame-db!` | `(reset-frame-db! opts)` → map | v1 (dev-only) | Inject a value into a frame's `app-db`. Schema-validates. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `dispatch!` | `(dispatch! event-vec opts)` → map | Fire an event tagged with the current origin. Modes `:queued` / `:sync`. |
+| `restore-epoch!` | `(restore-epoch! opts)` → map | Rewind a frame's `app-db` to a named epoch's `:db-after`. |
+| `reset-frame-db!` | `(reset-frame-db! opts)` → map | Inject a value into a frame's `app-db`. Schema-validates. |
 
 ### Streaming band (3 subscription)
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `subscribe!` | `(subscribe! opts)` → map | v1 (dev-only) | Open a streaming subscription. `:topic ∈ #{:trace :epoch :fx :error}`. |
-| `unsubscribe!` | `(unsubscribe! opts)` → map | v1 (dev-only) | Idempotent close. |
-| `list-subscriptions` | `(list-subscriptions)` → map | v1 (dev-only) | Diagnostic enumerating active runtime-side subscription metadata. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `subscribe!` | `(subscribe! opts)` → map | Open a streaming subscription. `:topic ∈ #{:trace :epoch :fx :error}`. |
+| `unsubscribe!` | `(unsubscribe! opts)` → map | Idempotent close. |
+| `list-subscriptions` | `(list-subscriptions)` → map | Diagnostic enumerating active runtime-side subscription metadata. |
 
 ### Escape hatch + meta + test
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `eval-form-result` | `(eval-form-result value opts)` → map | v1 (dev-only) | Runtime-side result shaper for the MCP server's `eval-cljs` channel. Privacy + size scrubbing. |
-| `health` | `(health)` → map | v1 (dev-only) | One-call summary. `{:session-id :debug-enabled? :frames :ambiguous-frame? :coord-annotation-enabled? :origin}`. |
-| `tail-build-probe` | `(tail-build-probe)` → map | v1 (dev-only) | Monotonic counter for hot-reload change-detect. Survives `:after-load`. |
-| `reset-for-test!` | `(reset-for-test!)` → nil | v1 (test-only) | Clears subscriptions + probe-counter. Test-only. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `eval-form-result` | `(eval-form-result value opts)` → map | Runtime-side result shaper for the MCP server's `eval-cljs` channel. Privacy + size scrubbing. |
+| `health` | `(health)` → map | One-call summary. `{:session-id :debug-enabled? :frames :ambiguous-frame? :coord-annotation-enabled? :origin}`. |
+| `tail-build-probe` | `(tail-build-probe)` → map | Monotonic counter for hot-reload change-detect. Survives `:after-load`. |
+| `reset-for-test!` | `(reset-for-test!)` → nil | Clears subscriptions + probe-counter. Test-only. |
 
 ## `day8.re-frame2-causa.preload`
 

--- a/docs/causa/api/runtime-seam.md
+++ b/docs/causa/api/runtime-seam.md
@@ -43,7 +43,6 @@ Every mutation the runtime performs on behalf of a tool client carries `:tags :o
 ### `*current-origin*`
 
 - **Kind**: `^:dynamic` Var
-- **Status**: v1 (dev-only)
 - **Description**: Default `:causa-mcp`. The tool client wraps each eval'd form in `(binding [runtime/*current-origin* :my-tool] ...)` for the synchronous extent.
 
 ### `current-origin`
@@ -52,7 +51,6 @@ Every mutation the runtime performs on behalf of a tool client carries `:tags :o
   ```clojure
   (current-origin) → keyword
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Read accessor — answers "what's the current `:origin` tag?". Public so tests can pin the rebind contract without `#'`-piercing the dynamic var.
 
 The async-tagging gap: a dispatched event's downstream cascade carries the origin only through the synchronous handler frame. Later cascades pick up the framework's natural origin tagging.
@@ -83,7 +81,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-trace-buffer opts) → {:ok? true :events <vec> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Filtered slice of the framework's trace stream. Filter keys are the canonical Spec 009 vocabulary — `:operation` / `:op-type` / `:since` / `:frame` / `:severity` / `:event-id` / `:handler-id` / `:source` / `:origin` / `:dispatch-id` / `:since-ms` / `:between` / `:pred`.
 
 ### `get-epoch-history`
@@ -92,7 +89,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-epoch-history opts) → {:ok? true :frame <id> :epochs <vec> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The per-frame epoch ring buffer. Each epoch is a `:rf/epoch-record` (drain-completion snapshot with `:db-before` / `:db-after`). Default depth 50.
 
 ### `get-app-db`
@@ -101,7 +97,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-app-db opts) → {:ok? true :frame <id> :path <vec> :value <edn>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The live `app-db` for a frame, optionally scoped by `:path` for sub-tree reads. Reads through `elide-wire-value` so `:sensitive?` / `:large?`-marked paths egress as elision markers.
 
 ### `get-app-db-diff`
@@ -110,7 +105,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-app-db-diff opts) → {:ok? true :frame <id> :epoch-id <uuid> :diff {:before … :after …}}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Reads `:db-before` + `:db-after` off a named epoch record. Heavy nested-diff projection lives on the MCP server side; this accessor returns the raw before / after pair.
 
 ### `get-machine-state`
@@ -119,7 +113,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-machine-state opts) → {:ok? true :frame <id> :machine-id <kw> :state <edn>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Per-machine state read. The Stately-grade state-chart inspector reads this; tools that want machine-state pinning for a record-replay assertion compose against it directly.
 
 ### `get-machine-list`
@@ -128,7 +121,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-machine-list opts) → {:ok? true :machines <map> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Map of every machine registered in the active frame, keyed by machine-id. Used by the machine-inspector dropdown and by tools enumerating the machine surface.
 
 ### `get-issues`
@@ -137,7 +129,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-issues opts) → {:ok? true :issues <vec> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Projection over the trace buffer filtered to issue-tier op-types — `:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`. The Issues ribbon paints this; tools that want "what's broken right now?" reach for it.
 
 ### `get-handlers`
@@ -146,7 +137,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-handlers opts) → {:ok? true :handlers <vec> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Registrar listing, optionally narrowed by `:kind ∈ #{:event :sub :fx :cofx :machine :flow :reg-machine :frame :view}`. Source-coord metadata travels with each row.
 
 ### `get-source-coord`
@@ -155,7 +145,6 @@ Nine read-only accessors. Every one returns a map; success is `:ok? true`; failu
   ```clojure
   (get-source-coord opts) → {:ok? true :kind <kw> :id <any> :source-coord <map>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Per-registration source-coord projection. Resolves an event-id / sub-id / handler-id back to the `{:ns :file :line :column}` of where it was registered. The "click anywhere, walk to the line" backbone.
 
 ## Mutation band
@@ -169,7 +158,6 @@ Three write accessors. Every mutation tags the runtime cascade with `:tags :orig
   (dispatch! event-vec opts)
     → {:ok? true :event-id <kw> :frame <id> :origin <kw> :mode :queued/:sync}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Fire an event tagged with the current origin. Modes: `:queued` (default — non-blocking `rf/dispatch`) or `:sync` (`rf/dispatch-sync`). Frame resolution mirrors the read-side accessors.
 
 ### `restore-epoch!`
@@ -178,7 +166,6 @@ Three write accessors. Every mutation tags the runtime cascade with `:tags :orig
   ```clojure
   (restore-epoch! opts) → {:ok? true/false :frame <id> :epoch-id <uuid> :origin <kw>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Rewind a frame's `app-db` to the named epoch's `:db-after` via `rf/restore-epoch`. Failures (six documented modes — see [Tool-Pair §Time-travel — Restore](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md)) emit a structured `:rf.epoch/*` trace and leave `app-db` unchanged; the accessor surfaces `:reason :rf.epoch/restore-failed` + a hint pointing to the trace bus.
 
 ### `reset-frame-db!`
@@ -187,7 +174,6 @@ Three write accessors. Every mutation tags the runtime cascade with `:tags :orig
   ```clojure
   (reset-frame-db! opts) → {:ok? true/false :frame <id> :origin <kw>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Inject `:value` into a frame's `app-db`. Schema-validates via `rf/reset-frame-db!`; the three failure rows (`:rf.error/no-such-handler` / `:rf.epoch/reset-frame-db-during-drain` / `:rf.epoch/reset-frame-db-schema-mismatch`) surface on the trace bus; the accessor projects `:reason :rf.epoch/reset-failed` + a hint.
 
 The three together compose the Tool-Pair time-travel surface: read an epoch, restore to that epoch, or directly inject a known-good state for "try anyway" recovery.
@@ -202,7 +188,6 @@ Three subscription-bookkeeping accessors. The runtime records metadata for in-fl
   ```clojure
   (subscribe! opts) → {:ok? true :sub-id <uuid> :topic <kw> :filter <map>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Open a streaming subscription for `:topic ∈ #{:trace :epoch :fx :error}` with `:filter`. The runtime records metadata; the MCP server's tick loop drains and forwards.
 
 ### `unsubscribe!`
@@ -211,7 +196,6 @@ Three subscription-bookkeeping accessors. The runtime records metadata for in-fl
   ```clojure
   (unsubscribe! opts) → {:ok? true :sub-id <id> :existed? <bool>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Idempotent close. `:existed? false` for an unknown id.
 
 ### `list-subscriptions`
@@ -220,7 +204,6 @@ Three subscription-bookkeeping accessors. The runtime records metadata for in-fl
   ```clojure
   (list-subscriptions) → {:ok? true :subs <vec> :count <n>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Diagnostic enumerating active runtime-side subscription metadata. Per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events` fields live on the MCP server side.
 
 ## Escape hatch
@@ -233,7 +216,6 @@ One accessor handles arbitrary CLJS forms — the MCP server's `eval-cljs` chann
   ```clojure
   (eval-form-result value opts) → {:ok? true :value <elided>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The runtime-side result shaper. The MCP server renders the user's form inside a `(binding [*current-origin* …] …)` wrapper, `cljs-eval`s the wrapped form directly, and the result passes through `eval-form-result` for privacy + size scrubbing. Caller's `:include-sensitive?` / `:include-large?` opts gate the egress.
 
 ## Meta band
@@ -248,7 +230,6 @@ Two introspection accessors used by the tool client's discovery + change-detect 
     → {:ok? true :session-id <uuid> :debug-enabled? <bool> :frames <vec>
        :ambiguous-frame? <bool> :coord-annotation-enabled? <bool> :origin <kw>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: One-call summary of the runtime's view of the world. Side-effect-free — Causa-the-panel's preload owns the trace + epoch listeners; this accessor installs no listeners of its own. Used by `discover-app` tools.
 
 ### `tail-build-probe`
@@ -257,7 +238,6 @@ Two introspection accessors used by the tool client's discovery + change-detect 
   ```clojure
   (tail-build-probe) → {:ok? true :probe <int> :session-id <uuid> :build-tick <int>}
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Returns a fresh monotonic counter every call. MCP servers poll until the value changes — proving a hot-reload landed and the runtime re-evaluated. The counter survives `:after-load` (`defonce`) and resets only on full page refresh (same lifetime as `session-id`). Change-detect lives MCP-side.
 
 ## Test support
@@ -270,7 +250,6 @@ One test-fixture isolation helper. Production code never calls this.
   ```clojure
   (reset-for-test!) → nil
   ```
-- **Status**: v1 (test-only)
 - **Description**: Clears `subscriptions` + `probe-counter` for fixture isolation. Does NOT touch `session-id` (per-preload constant by design) or the JS-global sentinel. Test-only — never call from production code.
 
 ## Keybinding lifecycle
@@ -283,7 +262,6 @@ The keybinding lifecycle pair lives in a sibling namespace — `day8.re-frame2-c
   ```clojure
   (attach!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Install the global `Ctrl+Shift+C` keydown listener once. No-op on second + subsequent calls (the `attached-state` sentinel survives reloads). Honours the `:rf.causa/keybinding-enabled?` config slot — when `false` the listener is NOT installed.
 
 ### `detach!`
@@ -292,7 +270,6 @@ The keybinding lifecycle pair lives in a sibling namespace — `day8.re-frame2-c
   ```clojure
   (detach!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Remove the global keydown listener if one is currently attached. Idempotent — safe to call when nothing is attached (no-op), and safe to call twice in a row (the second call is a no-op). Symmetric with `attach!`.
 
 The two surfaces compose: standalone Causa calls `attach!` from the preload's six side-effects; an embed host that loaded Causa first and wants to take the chord back from inside its own mount lifecycle calls `detach!` after Causa has already attached.

--- a/docs/story/api/play-script.md
+++ b/docs/story/api/play-script.md
@@ -113,7 +113,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (start-recording! variant-id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Begin recording dispatched events against `variant-id`'s frame. The recorder filters on dispatch-provenance `:rf.story/source :user` — setup-phase events (`:variant-events`) are excluded.
 
 ### `stop-recording!`
@@ -122,7 +121,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (stop-recording!) → events-vec
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Stop the in-flight recording; return the captured events vector.
 
 ### `clear-recording!`
@@ -131,7 +129,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (clear-recording!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Drop the buffer + return the recorder to idle.
 
 ### `recording?`
@@ -140,7 +137,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (recording?) → bool
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Predicate — is a recording in flight?
 
 ### `recorder-state`
@@ -149,7 +145,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (recorder-state) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Read-only view of the current recorder state map.
 
 ### `gen-play-snippet`
@@ -158,7 +153,6 @@ Story's canvas recorder captures dispatched events and DOM-level interactions in
   ```clojure
   (gen-play-snippet events opts) → string
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play-script {:script [...]}})` EDN snippet. Each captured event vector is wrapped as `[:dispatch-sync <event-vec>]`.
 
 The facade's `gen-play-snippet` is the simpler event-vector → `:dispatch-sync` step projection. A typical recorder modal calls `start-recording!` on the *record* chip click, hooks the user's canvas interaction, then on *stop* calls `stop-recording!` + `gen-play-snippet` to render the modal's EDN body.
@@ -173,7 +167,6 @@ The richer DOM-capture-aware translator (tagged `:click` / `:type` / `:wait` ste
   ```clojure
   (recording->play-script entries opts) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Translate captured `:entries` into a normalised `:play-script` body map. Derives `[:click selector]`, `[:type selector text]`, `[:wait ms]` steps from the entries stream.
 
 ### `render-play-script`
@@ -182,7 +175,6 @@ The richer DOM-capture-aware translator (tagged `:click` / `:type` / `:wait` ste
   ```clojure
   (render-play-script body) → string
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Render the `:play-script` map to EDN.
 
 ### `render-variant-form`
@@ -191,7 +183,6 @@ The richer DOM-capture-aware translator (tagged `:click` / `:type` / `:wait` ste
   ```clojure
   (render-variant-form variant-id metadata) → string
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Render a full `(reg-variant <id> {...})` form to EDN.
 
 Lives in `re-frame.story.recorder.play-export`. Two `:require`s — `[re-frame.story :as story]` for the facade plus `[re-frame.story.recorder.play-export :as play-export]` for the rich translator.

--- a/docs/story/api/reference.md
+++ b/docs/story/api/reference.md
@@ -1,6 +1,6 @@
 # Reference
 
-The complete symbol table for Story's public surface, organised by namespace and section for `Ctrl-F` use. Every row carries a signature, a status, and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
+The complete symbol table for Story's public surface, organised by namespace and section for `Ctrl-F` use. Every row carries a signature and a one-line intuition — the same shape as the topical chapters, but flat and exhaustive. Reach for the topical chapters when you want context and prose around the contract; reach for this page when you know what you're looking for and just want the row.
 
 Surfaces fall into the facade plus seven sub-namespaces. The facade carries every user-callable surface — registrations, runtime, recorder, configure!, shell-mount, privacy primitives. The sub-namespaces are public but called from chrome bootstrap, the shell, or the Causa preset, not from authored story bodies.
 
@@ -12,135 +12,135 @@ The canonical facade. Every user-callable surface lives here.
 
 ### Registration — macros
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `reg-story` | `(reg-story id metadata)` | v1 (dev-only) | Register a story (a cluster of variants). |
-| `reg-variant` | `(reg-variant id metadata)` | v1 (dev-only) | Register one variant — view, args, setup events, decorators, `:play-script`. |
-| `reg-workspace` | `(reg-workspace id metadata)` | v1 (dev-only) | Register a workspace — a curated grid of variants. |
-| `reg-decorator` | `(reg-decorator id metadata)` | v1 (dev-only) | Register a decorator. Three kinds: `:hiccup` / `:frame-setup` / `:fx-override`. |
-| `reg-story-panel` | `(reg-story-panel id metadata)` | v1 (dev-only) | Register a custom panel in the Story chrome. Five placement slots. |
-| `reg-tag` | `(reg-tag id metadata)` | v1 (dev-only) | Register a tag. The seven canonical tags auto-install. |
-| `reg-mode` | `(reg-mode id metadata)` | v1 (dev-only) | Register a mode — a saved tuple of args the chrome toggles into. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `reg-story` | `(reg-story id metadata)` | Register a story (a cluster of variants). |
+| `reg-variant` | `(reg-variant id metadata)` | Register one variant — view, args, setup events, decorators, `:play-script`. |
+| `reg-workspace` | `(reg-workspace id metadata)` | Register a workspace — a curated grid of variants. |
+| `reg-decorator` | `(reg-decorator id metadata)` | Register a decorator. Three kinds: `:hiccup` / `:frame-setup` / `:fx-override`. |
+| `reg-story-panel` | `(reg-story-panel id metadata)` | Register a custom panel in the Story chrome. Five placement slots. |
+| `reg-tag` | `(reg-tag id metadata)` | Register a tag. The seven canonical tags auto-install. |
+| `reg-mode` | `(reg-mode id metadata)` | Register a mode — a saved tuple of args the chrome toggles into. |
 
 ### Registration — `*`-suffix runtime helpers
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `reg-story*` | `(reg-story* id body)` | v1 (dev-only) | Programmatic story registration. |
-| `reg-variant*` | `(reg-variant* id body)` | v1 (dev-only) | Programmatic variant registration. The MCP write surface's `register-variant` tool routes here. |
-| `reg-workspace*` | `(reg-workspace* id body)` | v1 (dev-only) | Programmatic workspace registration. |
-| `reg-mode*` | `(reg-mode* id body)` | v1 (dev-only) | Programmatic mode registration. |
-| `reg-story-panel*` | `(reg-story-panel* id body)` | v1 (dev-only) | Programmatic panel registration. |
-| `reg-decorator*` | `(reg-decorator* id body)` | v1 (dev-only) | Programmatic decorator registration. |
-| `reg-tag*` | `(reg-tag* id body)` | v1 (dev-only) | Programmatic tag registration. |
-| `unregister!` | `(unregister! kind id)` | v1 (dev-only) | Remove a single id under `kind`. |
-| `clear-kind!` | `(clear-kind! kind)` | v1 (dev-only) | Remove every registration of `kind`. |
-| `clear-all!` | `(clear-all!)` | v1 (dev-only) | Reset every Story registration. Resets the auto-install gate. |
-| `install-canonical-vocabulary!` | `(install-canonical-vocabulary!)` | v1 (dev-only) | Idempotent explicit boot. Auto-install path is canonical; this is retained for hosts that want a literal boot step. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `reg-story*` | `(reg-story* id body)` | Programmatic story registration. |
+| `reg-variant*` | `(reg-variant* id body)` | Programmatic variant registration. The MCP write surface's `register-variant` tool routes here. |
+| `reg-workspace*` | `(reg-workspace* id body)` | Programmatic workspace registration. |
+| `reg-mode*` | `(reg-mode* id body)` | Programmatic mode registration. |
+| `reg-story-panel*` | `(reg-story-panel* id body)` | Programmatic panel registration. |
+| `reg-decorator*` | `(reg-decorator* id body)` | Programmatic decorator registration. |
+| `reg-tag*` | `(reg-tag* id body)` | Programmatic tag registration. |
+| `unregister!` | `(unregister! kind id)` | Remove a single id under `kind`. |
+| `clear-kind!` | `(clear-kind! kind)` | Remove every registration of `kind`. |
+| `clear-all!` | `(clear-all!)` | Reset every Story registration. Resets the auto-install gate. |
+| `install-canonical-vocabulary!` | `(install-canonical-vocabulary!)` | Idempotent explicit boot. Auto-install path is canonical; this is retained for hosts that want a literal boot step. |
 
 ### Global args + decorators
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `configure!` | `(configure! opts)` → nil | v1 (dev-only) | Top-level config. Map keyed by `:rf.story/*` and `:rf.privacy/*`. |
-| `reg-global-decorator` | `(reg-global-decorator id body)` / `(reg-global-decorator id body ref-args)` | v1 (dev-only) | Register a decorator AND opt it into the global stack in one call. |
-| `unreg-global-decorator!` | `(unreg-global-decorator! id)` | v1 (dev-only) | Remove `id` from the global-decorators vector. |
-| `global-decorators` | `(global-decorators)` → vec | v1 (dev-only) | Current ordered vector of global-decorator references. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `configure!` | `(configure! opts)` → nil | Top-level config. Map keyed by `:rf.story/*` and `:rf.privacy/*`. |
+| `reg-global-decorator` | `(reg-global-decorator id body)` / `(reg-global-decorator id body ref-args)` | Register a decorator AND opt it into the global stack in one call. |
+| `unreg-global-decorator!` | `(unreg-global-decorator! id)` | Remove `id` from the global-decorators vector. |
+| `global-decorators` | `(global-decorators)` → vec | Current ordered vector of global-decorator references. |
 
 ### Built-in decorator `*-id` Vars
 
-| Symbol | Status | Intuition |
-|---|---|---|
-| `force-fx-stub-id` | v1 (dev-only) | Universal fx-mocking primitive — HTTP, websockets, analytics, storage, navigation. |
-| `layout-debug-measure-id` | v1 (dev-only) | Storybook-style layout measure overlay. |
-| `layout-debug-outline-id` | v1 (dev-only) | Pesticide-style coloured outlines. |
-| `layout-debug-pseudo-id` | v1 (dev-only) | Pseudo-state forcing (`:hover` / `:focus` / `:active` / `:visited`). |
+| Symbol | Intuition |
+| --- | --- |
+| `force-fx-stub-id` | Universal fx-mocking primitive — HTTP, websockets, analytics, storage, navigation. |
+| `layout-debug-measure-id` | Storybook-style layout measure overlay. |
+| `layout-debug-outline-id` | Pesticide-style coloured outlines. |
+| `layout-debug-pseudo-id` | Pseudo-state forcing (`:hover` / `:focus` / `:active` / `:visited`). |
 
 ### Programmatic runtime
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `run-variant` | `(run-variant variant-id)` / `(run-variant variant-id opts)` → map | v1 (dev-only) | Materialise the variant — run four-phase lifecycle, return result map. |
-| `reset-variant` | `(reset-variant variant-id)` | v1 (dev-only) | Reset the variant to its post-events baseline. |
-| `watch-variant` | `(watch-variant variant-id)` / `(watch-variant variant-id callback)` | v1 (dev-only) | Live-updating result map. |
-| `unwatch-variant` | `(unwatch-variant variant-id)` | v1 (dev-only) | Stop the live update channel. Idempotent. |
-| `destroy-variant!` | `(destroy-variant! variant-id)` | v1 (dev-only) | Tear down the variant's frame. Symmetric with allocation. |
-| `execute-play!` | `(execute-play! variant-id)` → vec | v1 (dev-only) | Re-run only phase 4 against current `app-db`. |
-| `lifecycle-state` | `(lifecycle-state variant-id)` → keyword | v1 (dev-only) | Current lifecycle-machine state. |
-| `variant-frames` | `(variant-frames)` → set | v1 (dev-only) | Set of variant-ids currently allocated as frames. |
-| `variant-frame?` | `(variant-frame? variant-id)` → bool | v1 (dev-only) | Predicate. |
-| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` → map | v1 (dev-only) | The effective args map (five-layer precedence). |
-| `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` → map | v1 (dev-only) | The resolved decorator stack classified by kind. |
-| `variants-of` | `(variants-of story-id)` → seq | v1 (dev-only) | Variant ids whose namespaced id-prefix matches `story-id`. |
-| `variants-by-story` | `(variants-by-story)` → map | v1 (dev-only) | Map from parent-story-id to variant ids. |
-| `variants-with-tags` | `(variants-with-tags tag-set)` → seq | v1 (dev-only) | Filter the catalogue by tag intersection. |
-| `variant-substrates` | `(variant-substrates variant-id)` → set | v1 (dev-only) | The substrate set for a specific variant. |
-| `variant->edn` | `(variant->edn variant-id)` → map | v1 (dev-only) | Variant body as serialisable EDN. |
-| `workspace->edn` | `(workspace->edn workspace-id)` → map | v1 (dev-only) | Workspace body as serialisable EDN. |
-| `snapshot-identity` | `(snapshot-identity variant-id)` / `(snapshot-identity variant-id opts)` → map | v1 (dev-only) | `{:variant-id ... :content-hash "..."}`. QR-share + visual-regression keying. |
-| `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id base-url opts)` → string | v1 (dev-only) | Sharable URL — encodes active modes + cell-overrides + substrate. |
-| `static-mode?` | `(static-mode?)` → bool | v1 (dev-only) | True iff Story is running in static-export mode. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `run-variant` | `(run-variant variant-id)` / `(run-variant variant-id opts)` → map | Materialise the variant — run four-phase lifecycle, return result map. |
+| `reset-variant` | `(reset-variant variant-id)` | Reset the variant to its post-events baseline. |
+| `watch-variant` | `(watch-variant variant-id)` / `(watch-variant variant-id callback)` | Live-updating result map. |
+| `unwatch-variant` | `(unwatch-variant variant-id)` | Stop the live update channel. Idempotent. |
+| `destroy-variant!` | `(destroy-variant! variant-id)` | Tear down the variant's frame. Symmetric with allocation. |
+| `execute-play!` | `(execute-play! variant-id)` → vec | Re-run only phase 4 against current `app-db`. |
+| `lifecycle-state` | `(lifecycle-state variant-id)` → keyword | Current lifecycle-machine state. |
+| `variant-frames` | `(variant-frames)` → set | Set of variant-ids currently allocated as frames. |
+| `variant-frame?` | `(variant-frame? variant-id)` → bool | Predicate. |
+| `resolve-args` | `(resolve-args variant-id)` / `(resolve-args variant-id opts)` → map | The effective args map (five-layer precedence). |
+| `resolve-decorators` | `(resolve-decorators variant-id)` / `(resolve-decorators variant-id opts)` → map | The resolved decorator stack classified by kind. |
+| `variants-of` | `(variants-of story-id)` → seq | Variant ids whose namespaced id-prefix matches `story-id`. |
+| `variants-by-story` | `(variants-by-story)` → map | Map from parent-story-id to variant ids. |
+| `variants-with-tags` | `(variants-with-tags tag-set)` → seq | Filter the catalogue by tag intersection. |
+| `variant-substrates` | `(variant-substrates variant-id)` → set | The substrate set for a specific variant. |
+| `variant->edn` | `(variant->edn variant-id)` → map | Variant body as serialisable EDN. |
+| `workspace->edn` | `(workspace->edn workspace-id)` → map | Workspace body as serialisable EDN. |
+| `snapshot-identity` | `(snapshot-identity variant-id)` / `(snapshot-identity variant-id opts)` → map | `{:variant-id ... :content-hash "..."}`. QR-share + visual-regression keying. |
+| `variant-share-url` | `(variant-share-url variant-id)` / `(variant-share-url variant-id base-url opts)` → string | Sharable URL — encodes active modes + cell-overrides + substrate. |
+| `static-mode?` | `(static-mode?)` → bool | True iff Story is running in static-export mode. |
 
 ### Registry queries
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `registrations` | `(registrations kind)` → seq | v1 (dev-only) | All registrations for `kind`. |
-| `handler-meta` | `(handler-meta kind id)` → any | v1 (dev-only) | Registered body for `id`. |
-| `ids` | `(ids kind)` → seq | v1 (dev-only) | All registered ids of `kind`. |
-| `registered?` | `(registered? kind id)` → bool | v1 (dev-only) | Predicate. |
-| `all-kinds-with-counts` | `(all-kinds-with-counts)` → map | v1 (dev-only) | Map from each kind → registration count. |
-| `list-tags` | `(list-tags)` → seq | v1 (dev-only) | All registered tags. |
-| `list-modes` | `(list-modes)` → seq | v1 (dev-only) | All registered modes. |
-| `canonical-tags` | Var (set) | v1 (dev-only) | The seven canonical tags. |
-| `canonical-axes` | Var | v1 (dev-only) | The four canonical axes (audience / lifecycle / quality / status). |
-| `canonical-status-values` | Var | v1 (dev-only) | Status-axis tag values. |
-| `canonical-role-values` | Var | v1 (dev-only) | Role-axis tag values. |
-| `tags-by-axis` | `(tags-by-axis)` → map | v1 (dev-only) | Tags keyed by axis. |
-| `tags-without-axis` | `(tags-without-axis)` → seq | v1 (dev-only) | Tags not registered against any axis. |
-| `tags-default-excluded` | `(tags-default-excluded)` → set | v1 (dev-only) | Sidebar tag-filter default exclusions. |
-| `tag->axis-index` | `(tag->axis-index)` → map | v1 (dev-only) | Map from tag-id → axis. |
-| `registered-substrates` | `(registered-substrates)` → set | v1 (dev-only) | Registered substrate ids (CLJS-only). |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `registrations` | `(registrations kind)` → seq | All registrations for `kind`. |
+| `handler-meta` | `(handler-meta kind id)` → any | Registered body for `id`. |
+| `ids` | `(ids kind)` → seq | All registered ids of `kind`. |
+| `registered?` | `(registered? kind id)` → bool | Predicate. |
+| `all-kinds-with-counts` | `(all-kinds-with-counts)` → map | Map from each kind → registration count. |
+| `list-tags` | `(list-tags)` → seq | All registered tags. |
+| `list-modes` | `(list-modes)` → seq | All registered modes. |
+| `canonical-tags` | Var (set) | The seven canonical tags. |
+| `canonical-axes` | Var | The four canonical axes (audience / lifecycle / quality / status). |
+| `canonical-status-values` | Var | Status-axis tag values. |
+| `canonical-role-values` | Var | Role-axis tag values. |
+| `tags-by-axis` | `(tags-by-axis)` → map | Tags keyed by axis. |
+| `tags-without-axis` | `(tags-without-axis)` → seq | Tags not registered against any axis. |
+| `tags-default-excluded` | `(tags-default-excluded)` → set | Sidebar tag-filter default exclusions. |
+| `tag->axis-index` | `(tag->axis-index)` → map | Map from tag-id → axis. |
+| `registered-substrates` | `(registered-substrates)` → set | Registered substrate ids (CLJS-only). |
 
 ### Assertions
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `read-assertions` | `(read-assertions variant-id)` → vec | v1 (dev-only) | Current `:rf.story/assertions` vector. |
-| `assertions-passing?` | `(assertions-passing? result)` → bool | v1 (dev-only) | Project assertions vector → single boolean. |
-| `canonical-assertion-ids` | `(canonical-assertion-ids)` → set | v1 (dev-only) | The seven canonical `:rf.assert/*` event-ids. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `read-assertions` | `(read-assertions variant-id)` → vec | Current `:rf.story/assertions` vector. |
+| `assertions-passing?` | `(assertions-passing? result)` → bool | Project assertions vector → single boolean. |
+| `canonical-assertion-ids` | `(canonical-assertion-ids)` → set | The seven canonical `:rf.assert/*` event-ids. |
 
 ### Recorder
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `start-recording!` | `(start-recording! variant-id)` | v1 (dev-only) | Begin capturing canvas-dispatched events. |
-| `stop-recording!` | `(stop-recording!)` → vec | v1 (dev-only) | Stop + return captured events. |
-| `clear-recording!` | `(clear-recording!)` | v1 (dev-only) | Drop the buffer + return to idle. |
-| `recording?` | `(recording?)` → bool | v1 (dev-only) | Predicate. |
-| `recorder-state` | `(recorder-state)` → map | v1 (dev-only) | Read-only view of recorder state. |
-| `gen-play-snippet` | `(gen-play-snippet events opts)` → string | v1 (dev-only) | Render captured events as a `(reg-variant ...)` EDN snippet. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `start-recording!` | `(start-recording! variant-id)` | Begin capturing canvas-dispatched events. |
+| `stop-recording!` | `(stop-recording!)` → vec | Stop + return captured events. |
+| `clear-recording!` | `(clear-recording!)` | Drop the buffer + return to idle. |
+| `recording?` | `(recording?)` → bool | Predicate. |
+| `recorder-state` | `(recorder-state)` → map | Read-only view of recorder state. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` → string | Render captured events as a `(reg-variant ...)` EDN snippet. |
 
 ### Privacy primitives
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `add-marks` | `(add-marks variant-id marks-map)` | v1 (dev-only) | Merge marks additively. Re-export of `re-frame.core/add-marks`. |
-| `set-marks` | `(set-marks variant-id marks-map)` | v1 (dev-only) | Replace marks wholesale. Re-export of `re-frame.core/set-marks`. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `add-marks` | `(add-marks variant-id marks-map)` | Merge marks additively. Re-export of `re-frame.core/add-marks`. |
+| `set-marks` | `(set-marks variant-id marks-map)` | Replace marks wholesale. Re-export of `re-frame.core/set-marks`. |
 
 ### Substrate registration
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `register-substrate!` | `(register-substrate! substrate-id render-fn)` | v1 (dev-only) | Register a substrate render fn (CLJS-only). |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `register-substrate!` | `(register-substrate! substrate-id render-fn)` | Register a substrate render fn (CLJS-only). |
 
 ### Shell lifecycle (CLJS-only)
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `mount-shell!` | `(mount-shell! mount-point opts)` | v1 (dev-only) | Mount the Story shell. Production short-circuits before any DOM call. |
-| `unmount-shell!` | `(unmount-shell!)` | v1 (dev-only) | Unmount the shell. Idempotent. |
-| `active-shell` | `(active-shell)` → map / nil | v1 (dev-only) | Inspectable handle on the active shell. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `mount-shell!` | `(mount-shell! mount-point opts)` | Mount the Story shell. Production short-circuits before any DOM call. |
+| `unmount-shell!` | `(unmount-shell!)` | Unmount the shell. Idempotent. |
+| `active-shell` | `(active-shell)` → map / nil | Inspectable handle on the active shell. |
 
 ### Stage
 
@@ -152,11 +152,11 @@ The canonical facade. Every user-callable surface lives here.
 
 The rich DOM-capture-aware `:play-script` translator. Sub-namespace require — the facade exposes only the simpler `gen-play-snippet` projection.
 
-| Symbol | Signature | Status | Intuition |
-|---|---|---|---|
-| `recording->play-script` | `(recording->play-script entries opts)` → map | v1 (dev-only) | Translate captured `:entries` into a normalised `:play-script` body map. |
-| `render-play-script` | `(render-play-script body)` → string | v1 (dev-only) | Render the `:play-script` map to EDN. |
-| `render-variant-form` | `(render-variant-form variant-id metadata)` → string | v1 (dev-only) | Render a full `(reg-variant ...)` form to EDN. |
+| Symbol | Signature | Intuition |
+| --- | --- | --- |
+| `recording->play-script` | `(recording->play-script entries opts)` → map | Translate captured `:entries` into a normalised `:play-script` body map. |
+| `render-play-script` | `(render-play-script body)` → string | Render the `:play-script` map to EDN. |
+| `render-variant-form` | `(render-variant-form variant-id metadata)` → string | Render a full `(reg-variant ...)` form to EDN. |
 
 ## `re-frame.story.ui.causa-embed`
 

--- a/docs/story/api/registration.md
+++ b/docs/story/api/registration.md
@@ -15,8 +15,14 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-story id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a story (a cluster of variants under one heading). `metadata` is an EDN map with `:doc`, `:component`, `:args`, `:tags`, `:decorators`, and optional `:variants` (Form B desugaring).
+- **Example**:
+  ```clojure
+  (story/reg-story :story.counter
+    {:doc       "The app counter."
+     :component :app.ui/counter
+     :args      {:label "Count"}})
+  ```
 
 ### `reg-variant`
 
@@ -25,8 +31,13 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-variant id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register one variant — view, args, setup events, decorators, `:play-script`. The single most-called macro in a typical stories namespace.
+- **Example**:
+  ```clojure
+  (story/reg-variant :story.counter/at-five
+    {:component :app.ui/counter
+     :events    [[:counter/initialise 5]]})
+  ```
 
 ### `reg-workspace`
 
@@ -35,7 +46,6 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-workspace id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a workspace — a curated grid of variants for side-by-side review. `metadata` carries `:doc`, `:cells` (an ordered vector of variant ids), and optional `:layout`.
 
 ### `reg-decorator`
@@ -45,7 +55,6 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-decorator id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a decorator — a fn that wraps a variant's render (locale provider, theme provider, mock-API context). Three kinds: `:hiccup` (wraps the rendered tree), `:frame-setup` (runs at frame creation), `:fx-override` (registers fx stubs).
 
 ### `reg-story-panel`
@@ -55,7 +64,6 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-story-panel id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a custom panel in the Story chrome — the inspection / control panes that sit beside the rendered variant. Late-bind via `:render` as a `:view` id. Five placement slots: `:right` / `:left` / `:bottom` / `:top` / `:modal`.
 
 ### `reg-tag`
@@ -65,7 +73,6 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-tag id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a tag (free-form classification — `#{:auth-required :empty-state :error}`). Tags filter the variant catalogue. The seven canonical tags (`:dev`, `:docs`, `:test`, `:screenshot`, `:experimental`, `:internal`, `:agent`) auto-install on first registration.
 
 ### `reg-mode`
@@ -75,7 +82,6 @@ All under `re-frame.story`. All paired with a `*`-suffix runtime fn for programm
   ```clojure
   (reg-mode id metadata)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a mode — a saved tuple of args the chrome toggles into (light/dark theme, en/fr locale, desktop/mobile viewport). Layer 3 of the five-layer args precedence chain.
 
 The macros expand to their `*`-suffix runtime fns — `reg-story` expands to `(reg-story* id body)` — so the canonical-vocabulary auto-install (see below) fires from the macro form, programmatic-form, or fixture-load form alike.
@@ -106,7 +112,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-story* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic story registration.
 
 ### `reg-variant*`
@@ -116,7 +121,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-variant* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic variant registration.
 
 ### `reg-workspace*`
@@ -126,7 +130,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-workspace* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic workspace registration.
 
 ### `reg-mode*`
@@ -136,7 +139,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-mode* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic mode registration.
 
 ### `reg-story-panel*`
@@ -146,7 +148,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-story-panel* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic panel registration.
 
 ### `reg-decorator*`
@@ -156,7 +157,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-decorator* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic decorator registration.
 
 ### `reg-tag*`
@@ -166,7 +166,6 @@ All under `re-frame.story`. The `*`-suffix helpers are the programmatic write pa
   ```clojure
   (reg-tag* id body)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Programmatic tag registration.
 
 Reach for the `*` forms when authoring inside a higher-order fn, a fixture loader, an MCP write tool, or a hot-reload pipeline that synthesises registrations from another data source. Authoring-site registrations use the macros above; both paths land on the same registrar side-table and fire the same auto-install gate.
@@ -179,7 +178,6 @@ Reach for the `*` forms when authoring inside a higher-order fn, a fixture loade
   ```clojure
   (unregister! kind id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Remove a single id under `kind`. Kinds: `:story` / `:variant` / `:workspace` / `:story-panel` / `:tag` / `:mode` / `:decorator`.
 
 ### `clear-kind!`
@@ -188,7 +186,6 @@ Reach for the `*` forms when authoring inside a higher-order fn, a fixture loade
   ```clojure
   (clear-kind! kind) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Remove every registration of `kind`. Used by test fixtures and hot-reload.
 
 ### `clear-all!`
@@ -197,7 +194,6 @@ Reach for the `*` forms when authoring inside a higher-order fn, a fixture loade
   ```clojure
   (clear-all!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Reset every Story registration. Wipes the registrar's side-table AND clears the global-decorators vector AND resets the auto-install gate so the next `reg-*` re-installs the canonical vocabulary.
 
 `clear-all!` is the test-isolation primitive. Tests that want a known starting state call `clear-all!` in a fixture; the next `reg-*` in the test body auto-installs the canonical vocabulary (the seven canonical tags, the `:rf.assert/*` handlers, `force-fx-stub`, the layout-debug decorator trio, the lifecycle machine, the v1.0 panel set) before the test's own registrations land.
@@ -214,7 +210,6 @@ The seven `reg-*` macros expand to their `*`-fn helpers, and the first call to A
   ```clojure
   (install-canonical-vocabulary!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Idempotent explicit boot. New code should rely on the auto-install path — the explicit call is retained only as a literal-boot affordance for hosts that want one and as a JVM-test diagnostic that asserts a known starting state without a body-of-test `reg-*` call.
 
 The auto-install gate flips true *before* the installer chain runs, so the registrar writes triggered by the chain itself hit the early-return branch and don't recurse. Subsequent `reg-*` calls (after the gate has flipped) are a single `deref` + `nil` check — negligible on the hot path.
@@ -231,7 +226,6 @@ Layer 1 of the five-layer args precedence chain (global → story → mode → v
   ```clojure
   (configure! opts) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Top-level Story configuration. See [Runtime §configure!](runtime.md#configure) for the full key surface. The two relevant keys here are `:rf.story/global-args` (replace the global args map) and `:rf.story/global-decorators` (replace the global-decorator ref vector).
 
 ### `reg-global-decorator`
@@ -241,7 +235,6 @@ Layer 1 of the five-layer args precedence chain (global → story → mode → v
   (reg-global-decorator id body) → id
   (reg-global-decorator id body ref-args) → id
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a decorator AND opt it into the global stack in one call. Symmetric to the host calling `reg-decorator` + `configure! {:rf.story/global-decorators [...]}` in sequence; preferred when the decorator is exclusively a global-stack member. Earliest-registered-first; re-registering the same id REPLACES the entry in place (same position in the global vector) so hot-reload doesn't reshuffle the stack order.
 
 ### `unreg-global-decorator!`
@@ -250,7 +243,6 @@ Layer 1 of the five-layer args precedence chain (global → story → mode → v
   ```clojure
   (unreg-global-decorator! id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Remove `id` from the global-decorators vector. The decorator's registration body is NOT unregistered — call `unregister!` for that. Idempotent.
 
 ### `global-decorators`
@@ -259,7 +251,6 @@ Layer 1 of the five-layer args precedence chain (global → story → mode → v
   ```clojure
   (global-decorators) → vec
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Return the current ordered vector of global-decorator references (`[[decorator-id & args] ...]`). Earliest-registered first; this is the prefix applied to every variant's resolved decorator stack.
 
 The five-layer precedence diagram (later wins):
@@ -283,25 +274,21 @@ Three built-in decorators ship with Story's canonical vocabulary. Each has a pub
 ### `force-fx-stub-id`
 
 - **Kind**: Var
-- **Status**: v1 (dev-only)
 - **Description**: The registered decorator id for the built-in `force-fx-stub` decorator — Story's universal effect-mocking primitive. One decorator covers HTTP, websockets, analytics, storage, navigation, geolocation, and anything else registered with `reg-fx`.
 
 ### `layout-debug-measure-id`
 
 - **Kind**: Var
-- **Status**: v1 (dev-only)
 - **Description**: The Storybook-style layout measure overlay decorator id. Surfaces margin / padding / size annotations on every descendant element.
 
 ### `layout-debug-outline-id`
 
 - **Kind**: Var
-- **Status**: v1 (dev-only)
 - **Description**: The Pesticide-style coloured outlines decorator id. Surfaces every descendant element's box with a per-element-type colour.
 
 ### `layout-debug-pseudo-id`
 
 - **Kind**: Var
-- **Status**: v1 (dev-only)
 - **Description**: The pseudo-state forcing decorator id. Ref-args is a set from `#{:hover :focus :active :visited}`; default is `#{:hover}`.
 
 Worked example:
@@ -329,7 +316,6 @@ Story authors declare per-frame path-marks against `app-db` using the framework'
   ```clojure
   (add-marks variant-id marks-map) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Merge marks additively into the variant frame's mark-set. Re-export of `re-frame.core/add-marks`.
 
 ### `set-marks`
@@ -338,7 +324,6 @@ Story authors declare per-frame path-marks against `app-db` using the framework'
   ```clojure
   (set-marks variant-id marks-map) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Replace the variant frame's mark-set wholesale. Re-export of `re-frame.core/set-marks`.
 
 A `marks-map` is `{path mark, ...}` where `path` is a `get-in`-shaped vector and `mark` is one of `:sensitive` / `:large`. Variant-body usage scopes marks to that variant's frame; the framework's `elide-wire-value` walker substitutes `:rf/redacted` / `:rf/large` at every wire-egress observation point.

--- a/docs/story/api/runtime.md
+++ b/docs/story/api/runtime.md
@@ -44,7 +44,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   (run-variant variant-id) → result-map
   (run-variant variant-id opts) → result-map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Materialise the variant — allocate the frame, run the four-phase lifecycle, return the result map. One-shot; no live updates. The result carries `:frame` / `:app-db` / `:assertions` / `:rendered-hiccup` / `:elapsed-ms` / `:snapshot` / `:decorators`.
 
 ### `reset-variant`
@@ -53,7 +52,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   ```clojure
   (reset-variant variant-id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Reset the variant's frame to its post-events baseline. The Story shell calls this when the user clicks "reset" on a variant.
 
 ### `watch-variant`
@@ -63,7 +61,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   (watch-variant variant-id) → live-result-map
   (watch-variant variant-id callback)
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Like `run-variant` but the result map updates live as `app-db` changes. Use for live shells; use `run-variant` for one-shot screenshots.
 
 ### `unwatch-variant`
@@ -72,7 +69,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   ```clojure
   (unwatch-variant variant-id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Stop the live update channel for `variant-id`. Idempotent.
 
 ### `destroy-variant!`
@@ -81,7 +77,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   ```clojure
   (destroy-variant! variant-id) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Tear down the variant's frame. Any spawned state-machines receive their `:rf.machine/destroy` event. Idempotent.
 
 ### `execute-play!`
@@ -90,7 +85,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   ```clojure
   (execute-play! variant-id) → assertions-vec
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Re-run only phase 4 (the `:play-script`) against the variant's current `app-db`. Use for the play-stepper UI's "re-run from here" affordance.
 
 ### `lifecycle-state`
@@ -99,7 +93,6 @@ All under `re-frame.story`. Reach for these from a custom shell, a test fixture,
   ```clojure
   (lifecycle-state variant-id) → keyword
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The current state of the variant's lifecycle machine — one of `:idle` / `:loading` / `:events` / `:rendering` / `:playing` / `:done` / `:error`.
 
 The `opts` map for `run-variant` accepts:
@@ -133,7 +126,6 @@ The result map shape:
   (resolve-args variant-id) → map
   (resolve-args variant-id opts) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Materialise the effective args map for a variant given the active modes + cell overrides. The five-layer precedence chain (global → story → mode → variant → cell-override), deep-merged for maps, vector-replaced for vectors.
 
 ### `resolve-decorators`
@@ -143,7 +135,6 @@ The result map shape:
   (resolve-decorators variant-id) → map
   (resolve-decorators variant-id opts) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Return the variant's resolved decorator stack classified by kind: `{:hiccup [...] :frame-setup [...] :fx-override [...] :errors [...]}`. Composition order: `(concat globals story variant)`.
 
 ### `variant-frames`
@@ -152,7 +143,6 @@ The result map shape:
   ```clojure
   (variant-frames) → set
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The set of variant-ids currently allocated as frames.
 
 ### `variant-frame?`
@@ -161,7 +151,6 @@ The result map shape:
   ```clojure
   (variant-frame? variant-id) → bool
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Predicate.
 
 ## Snapshot identity + share
@@ -173,7 +162,6 @@ The result map shape:
   (snapshot-identity variant-id) → map
   (snapshot-identity variant-id opts) → map
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The variant's snapshot identity — the variant id plus a content-hash over its setup (args, events, modes, substrate). Returns `{:variant-id ... :content-hash "..."}`. Used by QR-share and the Story recorder to identify what the user is looking at without leaking the variant's args. The hash computes over real values (pre-substitution); downstream emission goes through `elide-wire-value`.
 
 ### `variant-share-url`
@@ -183,7 +171,6 @@ The result map shape:
   (variant-share-url variant-id) → string
   (variant-share-url variant-id base-url opts) → string
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Build a sharable URL for `variant-id` against `base-url`. Encodes active modes + cell-overrides + substrate so a scan-and-share session reproduces the cell. Pure data → data; JVM + CLJS portable.
 
 ## Assertion-side accessors
@@ -194,7 +181,6 @@ The result map shape:
   ```clojure
   (read-assertions variant-id) → assertions-vec
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The current `:rf.story/assertions` vector for `variant-id`. Each entry is a `:rf.assert/*` record.
 
 ### `assertions-passing?`
@@ -203,7 +189,6 @@ The result map shape:
   ```clojure
   (assertions-passing? result) → bool
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Project over a `run-variant` result map (or a raw assertions vector) — true iff every record is `:passed? true`. The single primitive a `cljs.test`-style adapter calls.
 
 ### `canonical-assertion-ids`
@@ -212,7 +197,6 @@ The result map shape:
   ```clojure
   (canonical-assertion-ids) → set
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The seven canonical `:rf.assert/*` event-ids as a set, for tooling that enumerates the assertion vocabulary.
 
 ## Registry queries
@@ -377,7 +361,6 @@ The boot-time entry point for project-wide defaults. The host calls it once befo
   ```clojure
   (configure! opts) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Set Story's global config. Every key lives under `:rf.story/*` (Story-specific) or `:rf.privacy/*` (cross-tool). Unknown keys are silently ignored for forward-compat.
 
 The full v1 key surface:
@@ -416,7 +399,6 @@ Two key behaviours are worth pinning:
   ```clojure
   (register-substrate! substrate-id render-fn) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Register a substrate render fn under `substrate-id`. The host calls this once at boot for each substrate it wants Story to render against (`:uix`, `:helix`, etc.). The `:reagent` substrate is registered automatically by the canonical-vocabulary auto-install.
 
 ### `registered-substrates` (substrate registration)
@@ -425,7 +407,6 @@ Two key behaviours are worth pinning:
   ```clojure
   (registered-substrates) → set
   ```
-- **Status**: v1 (dev-only)
 - **Description**: The set of registered substrate ids. Used by tooling that enumerates available substrates for a variant's `:substrates` opt-in.
 
 ## Shell lifecycle (CLJS-only)
@@ -438,7 +419,6 @@ The three-pane Reagent component that constitutes Story's UI. The host calls `mo
   ```clojure
   (mount-shell! mount-point opts) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Mount the Story shell at `mount-point` (a DOM node). The opts map carries `:initial-variant`, `:initial-mode`, `:theme`, etc. Production builds (`re-frame.story.config/enabled?` false) short-circuit before any DOM call.
 
 ### `unmount-shell!`
@@ -447,7 +427,6 @@ The three-pane Reagent component that constitutes Story's UI. The host calls `mo
   ```clojure
   (unmount-shell!) → nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Unmount the shell. Idempotent.
 
 ### `active-shell`
@@ -456,7 +435,6 @@ The three-pane Reagent component that constitutes Story's UI. The host calls `mo
   ```clojure
   (active-shell) → map / nil
   ```
-- **Status**: v1 (dev-only)
 - **Description**: Inspectable handle on the active shell — returns nil when no shell is mounted.
 
 ## Static-mode probe
@@ -467,7 +445,6 @@ The three-pane Reagent component that constitutes Story's UI. The host calls `mo
   ```clojure
   (static-mode?) → bool
   ```
-- **Status**: v1 (dev-only)
 - **Description**: True iff Story is running in static-export mode (the bundle was built with `:closure-defines {re-frame.story.config/static-mode? true}`). The shell itself flips its dev-time affordances (hot-reload poll, first-visit help overlay auto-open) off when the flag is true. Surfaced here for tooling / examples that want to render a "this is a published static site" badge.
 
 ## Stage marker


### PR DESCRIPTION
## Summary

Three changes across all three API-doc trees (`docs/api/*`, `docs/causa/api/*`, `docs/story/api/*`) per Mike-direction 2026-05-21:

1. **Removed the Status annotation from every API member.** Stripped 309 `- **Status**: ...` H3 bullets, plus the `Status` column from the Causa and Story `reference.md` member tables (intro prose updated to match). The framework reference tables (configure-keys, `:fx`-entry tables in 01/03/04/05) keep their Status columns — those carry differentiating per-entry data (`v1 (optional)`, `v1 (dev-only)`, `—` for legacy), not the redundant per-member noise the directive targets.

2. **Added `- **Example**:` snippets where they clarify.** Canonical call shapes on the registration macros/fns (`reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-frame`, `make-frame`, `reg-view`, `reg-machine`, `reg-app-schema(s)`, `reg-flow`, `reg-route`, `reg-head`, `reg-error-projector`, `dispatch`, `dispatch-sync`, `subscribe`, `sub-machine`, `inject-cofx`, `route-link`, `render-to-string`, `init!`, the UIx/Helix `use-subscribe`/`adapter`, Story's `reg-story`/`reg-variant`). Skipped trivial accessors/predicates and members already carrying canonical prose examples.

3. **Added `- **In the wild**:` links to real `/examples` usage.** GitHub repo URLs (not relative mkdocs paths — `/examples` lives outside `docs_dir`), grounded by grepping each member's actual usage: counter, managed_http_counter, todomvc, 7Guis, realworld, routing, state_machine_walkthrough, websocket, ssr, ssr_streaming, counter_uix, counter_helix. Members with no real example exercising them (`reg-flow`, `reg-head`, `reg-error-projector`) get an Example but no link.

## Test plan

- [x] `mkdocs build --strict` passes (exit 0; every internal link resolves; GitHub `/examples` URLs are external by design)
- [x] `python scripts/check_doc_slugs.py` passes (exit 0)
- [x] Spot-checked 01-core, 02-views, 04-machines, 13/14-adapters, causa/story reference + mount-control: Status gone, member shape is Kind → Signature → Description → Example → In the wild, tables render correctly

Closes rf2-law2f.