### PR TITLE
feat(machines-viz): xyflow :after countdown-ring overlay (rf2-uv1on)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
@@ -9,17 +9,26 @@
   time; in retrospective mode (scrubber not at `:present`) it freezes
   at the position it occupied when the scrubber was paused.
 
-  ## Architecture
+  ## Architecture (rf2-uv1on — xyflow Phase 2)
+
+  The rf2-gpzb4 xyflow migration moved POSITIONING out of this ns:
+  xyflow owns node positions in the rendered DOM, so the overlay must
+  WALK the DOM rather than read a positioned graph. The split is now:
 
     1. **Helpers (`machine_after_rings_helpers.cljc`)** — pure
        projection from the trace buffer into a vector of timer
-       records + the ring-fraction maths. JVM-runnable.
-    2. **This ns** — installs the sub/event family + mounts the SVG
-       overlay + drives the rAF tick loop that re-renders the rings
-       in live mode.
-    3. **`chart/svg.cljc`** — owns the `countdown-ring` primitive (a
-       pure-data SVG hiccup builder). The view here positions one ring
-       per active timer over the chart's positioned graph.
+       records + the ring-fraction maths + the
+       `timers->ring-specs` projection into machines-viz overlay
+       specs. JVM-runnable.
+    2. **This ns** — installs the sub/event family, drives the single
+       per-chart rAF tick loop (Lock #8), and is the DATA owner: it
+       projects the trace buffer into presentation-ready ring-specs
+       and delegates positioning + paint to (3).
+    3. **`day8.re-frame2-machines-viz.chart.overlays.after-rings`** —
+       the machines-viz xyflow overlay. Walks the rendered node DOM
+       (`[data-testid=rf-mv-chart-node-...]`) to position each ring +
+       paints the `countdown-ring` glyph. Owns no clock — it
+       re-measures whenever this ns re-renders it (tick bump).
 
   ## Subs/events surface
 
@@ -73,22 +82,10 @@
   (:require [re-frame.core :as rf]
             [re-frame.interop :as interop]
             [day8.re-frame2-causa.chart.layout :as chart-layout]
-            [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-machines-viz.chart.overlays.after-rings
+             :as mv-after-rings]
             [day8.re-frame2-causa.panels.machine-after-rings-helpers
              :as rings-h]))
-
-;; ---- positioned-nodes index --------------------------------------------
-;;
-;; Build a `{node-id node}` map for cheap ring-overlay lookups. Inlined
-;; here (rf2-y9xmf) so the rings overlay does not depend on
-;; `machine_inspector_arc_helpers.cljc` (deleted with the arc UI).
-
-(defn- nodes->index
-  "Build a `{node-id node}` map for the positioned graph. Pure fn."
-  [positioned-nodes]
-  (into {}
-        (map (fn [n] [(:node-id n) n]))
-        (or positioned-nodes [])))
 
 ;; ---- wall-clock reader (overridable for tests) -------------------------
 
@@ -266,109 +263,75 @@
   []
   (swap! tick-state assoc :running? false))
 
-;; ---- view: SVG ring overlay --------------------------------------------
+;; ---- view: xyflow ring overlay -----------------------------------------
+;;
+;; rf2-uv1on (xyflow Phase 2) — positioning moved to the machines-viz
+;; `chart.overlays.after-rings/AfterRingsOverlay`, which WALKS the
+;; rendered xyflow node DOM (`[data-testid=rf-mv-chart-node-...]`) to
+;; find each bearing node's bounding box. xyflow owns node positions
+;; post-migration, so the old positioned-graph SVG model (resolving
+;; `{:cx :cy :r}` from elk coordinates + a viewport-transform) is
+;; gone. This ns stays the DATA owner: it projects Causa's trace
+;; buffer into presentation-ready ring-specs and drives the rAF tick
+;; clock; the machines-viz overlay owns DOM measurement + paint.
+
+(defn- timer-hovered!
+  "Wire a ring's hover into the Causa timer-hover slot. The overlay
+  passes the bearing node-id back; we re-resolve the timer identity
+  from the live spec list so the slot carries the full
+  `(machine-id, state, epoch)` tuple a follow-on rich tooltip wants."
+  [specs node-id]
+  (when-let [spec (some (fn [s] (when (= node-id (:node-id s)) s)) specs)]
+    (rf/dispatch [:rf.causa/timer-hover
+                  {:machine-id (:machine-id spec)
+                   :state      (:state spec)
+                   :epoch      (:epoch spec)}]
+                 {:frame :rf/causa})))
 
 (defn AfterRingsOverlay
-  "Renders the focused machine's `:after` countdown rings as an SVG
-  overlay positioned over the chart's `<svg>` viewport. Takes the
-  chart's positioned graph (so it can resolve timer states to node-
-  centres + radii); subscribes to the timers + now-ms internally.
+  "Mounts the focused machine's `:after` countdown rings over the
+  xyflow chart. Subscribes to the active timers + now-ms + scrubber
+  internally; projects each timer into a presentation-ready ring-spec
+  (scrubber-aware fraction baked in — retrospective mode freezes the
+  ring at the scrubber's anchor instant); kicks the single per-chart
+  rAF clock in live mode; then delegates positioning + paint to the
+  machines-viz `AfterRingsOverlay`, which walks the xyflow node DOM.
 
-  Accepts the positioned graph either as the first positional arg
-  (legacy single-arity call site) OR as the `:positioned` key in an
-  options map. The map form additionally accepts:
+  Accepts an optional opts map (currently unused — reserved for a
+  future per-call testid override). The legacy positioned-graph /
+  viewport-transform args are GONE (xyflow owns positions; the
+  overlay reads them off the DOM).
 
-    :viewport-transform — rf2-obp4z. Optional `{:scale s :tx tx :ty ty}`
-                          map carrying the chart's current zoom + pan.
-                          When supplied (non-identity), the rings group
-                          is wrapped in `<g transform=\"translate(tx,ty)
-                          scale(s)\">` so the rings track the chart
-                          nodes as the user zooms / pans. nil / absent
-                          leaves the overlay at 1:1 (back-compat for
-                          callers that don't have a viewport — the
-                          legacy single-arity Inspector path takes
-                          this branch).
-
-  Returns nil when the projection has no active timers (the SVG layer
-  drops out of the chart so unrelated chart hover handlers aren't
-  shadowed)."
-  ([positioned]
-   (AfterRingsOverlay positioned nil))
-  ([{:keys [nodes width height]} {:keys [viewport-transform]}]
-   (let [timers   @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
-         now      @(rf/subscribe [:rf.causa/now-ms])
-         scrub    @(rf/subscribe [:rf.causa/machine-scrubber-position])
-         node-idx (nodes->index nodes)
+  Returns nil when the projection has no active timers (the overlay
+  layer drops out so unrelated chart hover handlers aren't shadowed)."
+  ([] (AfterRingsOverlay nil))
+  ([_opts]
+   (let [timers @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
+         now    @(rf/subscribe [:rf.causa/now-ms])
+         scrub  @(rf/subscribe [:rf.causa/machine-scrubber-position])
          ;; Kick the rAF loop iff ticking is needed (live mode + at
          ;; least one armed timer). Cheap to call per render — the
-         ;; `:running?` sentinel collapses duplicate kicks.
-         _        (when (rings-h/needs-ticking? timers scrub)
-                    (kick-tick!))
-         rings    (rings-h/timers->ring-positions
-                    timers node-idx chart-layout/highlight-id)
-         ;; rf2-obp4z — align the rings with the chart's viewport
-         ;; transform. The chart wraps its body in `translate(tx,ty)
-         ;; scale(s)`; we mirror that transform on the rings group
-         ;; so the rings track their node centres under zoom + pan.
-         ;; When the viewport is identity (or absent) the transform
-         ;; attr is omitted entirely — back-compat: the legacy
-         ;; single-arity call site (Machine Inspector pre-canvas
-         ;; path) gets a byte-identical render.
-         {:keys [scale tx ty]
-          :or   {scale 1 tx 0 ty 0}}
-         (or viewport-transform {})
-         transform-applied? (or (not= 1 scale) (not= 0 tx) (not= 0 ty))
-         rings-transform    (when transform-applied?
-                              (str "translate(" tx "," ty ")"
-                                   " scale(" scale ")"))]
-     (when (seq rings)
-       [:svg {:data-testid "rf-causa-machine-inspector-after-rings-overlay"
-              :data-timer-count (count rings)
-              :data-viewport-scale (str scale)
-              :data-viewport-tx (str tx)
-              :data-viewport-ty (str ty)
-              :viewBox (str "0 0 " (or width 0) " " (or height 0))
-              :width "100%"
-              :preserveAspectRatio "xMidYMin meet"
-              :style {:position "absolute"
-                      :top 0
-                      :left 0
-                      :width "100%"
-                      :height "100%"
-                      :pointer-events "none"   ;; rings opt in below
-                      :overflow "visible"}}
-        (into [:g (cond-> {:data-testid "rf-causa-machine-inspector-after-rings"
-                           :style {:pointer-events "all"}}
-                    rings-transform (assoc :transform rings-transform))]
-              (for [{:keys [timer cx cy r]} rings
-                    :let [fraction (rings-h/ring-fraction timer now)
-                          color    (rings-h/timer-color timer now)
-                          cancelled? (= :cancelled (:status timer))
-                          tooltip  (rings-h/format-timer-tooltip timer now)
-                          state-id (if (keyword? (:state timer))
-                                     (name (:state timer))
-                                     (pr-str (:state timer)))
-                          testid   (str "rf-causa-machine-inspector-after-ring-"
-                                        state-id)]]
-                ^{:key (str (:state timer) "/" (:epoch timer))}
-                [:g {:on-mouse-enter
-                     (fn [_]
-                       (rf/dispatch [:rf.causa/timer-hover
-                                     {:machine-id (:machine-id timer)
-                                      :state      (:state timer)
-                                      :epoch      (:epoch timer)}]
-                                    {:frame :rf/causa}))
-                     :on-mouse-leave
-                     (fn [_]
+         ;; `:running?` sentinel collapses duplicate kicks. Per Lock #8
+         ;; this is the SINGLE per-chart clock (O(charts), not
+         ;; O(rings × charts)); the machines-viz overlay runs no clock
+         ;; of its own — it just re-measures the DOM when `:tick` bumps.
+         _      (when (rings-h/needs-ticking? timers scrub)
+                  (kick-tick!))
+         specs  (rings-h/timers->ring-specs
+                  timers chart-layout/highlight-id now)]
+     (when (seq specs)
+       [mv-after-rings/AfterRingsOverlay
+        {:ring-specs specs
+         ;; `now` is the rAF-bumped (or scrubber-pinned) instant —
+         ;; bumping it on every frame forces the overlay to re-measure
+         ;; the DOM + repaint the swept arcs (Lock #8 60Hz-when-visible
+         ;; cadence, driven by THIS ns's clock, not the overlay's).
+         :tick       now
+         :testid     "rf-causa-machine-inspector-after-rings-overlay"
+         :on-hover   (fn [node-id] (timer-hovered! specs node-id))
+         :on-leave   (fn [_node-id]
                        (rf/dispatch [:rf.causa/timer-hover nil]
-                                    {:frame :rf/causa}))}
-                 (chart-svg/countdown-ring
-                   {:cx cx :cy cy :r r
-                    :fraction fraction
-                    :color    color
-                    :cancelled? cancelled?
-                    :testid   testid
-                    :tooltip  tooltip})]))]))))
+                                    {:frame :rf/causa}))}]))))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings_helpers.cljc
@@ -422,46 +422,55 @@
 
       (str state-s " · " (when status (name status))))))
 
-;; ---- geometry for the chart overlay -------------------------------------
+;; ---- xyflow overlay ring-specs (rf2-uv1on) -----------------------------
 
-(defn state-node-center
-  "Resolve the `[cx cy r]` triple for a chart-node corresponding to
-  `state`. `id-fn` is `chart.layout/highlight-id` (passed in to avoid
-  a compile-time dep from this ns into the chart layout); `node-index`
-  is the `{node-id node}` map produced by `arc-h/nodes->index`.
+(defn timer->ring-spec
+  "Project a single `timer` record into the presentation-ready ring
+  spec the machines-viz xyflow `AfterRingsOverlay` consumes. The
+  overlay walks the DOM to POSITION the ring (xyflow owns node
+  positions post-migration); this helper supplies the colour /
+  fraction / tooltip + the `:node-id` the overlay queries the DOM
+  for. Pure fn — JVM-runnable.
 
-  The radius is half the longer node dimension + a small breathing
-  gap so the ring sits OUTSIDE the node rectangle. Returns nil when
-  the state has no corresponding node in the positioned graph."
-  [state node-index id-fn]
-  (when (and state id-fn node-index)
-    (let [nid (id-fn state)
-          n   (get node-index nid)]
-      (when n
-        (let [cx (+ (:x n) (quot (:width n) 2))
-              cy (+ (:y n) (quot (:height n) 2))
-              ;; Radius = half-diagonal + a 4px breathing gap so the
-              ;; ring sits clearly outside the node's stroke.
-              w  (:width n)
-              h  (:height n)
-              r  (+ 4 (quot (long (Math/ceil (Math/sqrt
-                                               (+ (* w w) (* h h))))) 2))]
-          [cx cy r])))))
+  `id-fn` is `chart.layout/highlight-id` (passed in to keep this ns
+  free of a compile-time dep on the chart layout). It resolves the
+  timer's `:state` keyword / path to the string node-id xyflow stamps
+  on the bearing node's `data-testid`.
 
-(defn timers->ring-positions
-  "For each armed/cancelled `timer`, resolve its centre + radius via
-  `state-node-center`. Returns a vec of `{:timer <r> :cx :cy :r}` —
-  the view maps over this to render each ring. Pure fn.
+  `now-ms` is the wall-clock instant the fraction freezes at — live
+  mode passes the rAF-bumped now; retrospective mode passes the
+  scrubber's anchor time, so the ring's swept arc reflects the
+  scrubbed instant (scrubber-aware retro-replay).
 
-  Drops timers whose state has no corresponding chart node (e.g. a
-  compound parent without leaves in the projected graph)."
-  [timers node-index id-fn]
+  Returns nil when the state has no resolvable node-id."
+  [timer id-fn now-ms]
+  (when-let [nid (and id-fn (some-> (:state timer) id-fn))]
+    (let [state-id (if (keyword? (:state timer))
+                     (name (:state timer))
+                     (pr-str (:state timer)))]
+      {:node-id    nid
+       :fraction   (ring-fraction timer now-ms)
+       :color      (timer-color timer now-ms)
+       :cancelled? (= :cancelled (:status timer))
+       :tooltip    (format-timer-tooltip timer now-ms)
+       :testid     (str "rf-causa-machine-inspector-after-ring-" state-id)
+       ;; Carried through so the host's hover handler can key the
+       ;; timer-hover slot by its identity tuple.
+       :machine-id (:machine-id timer)
+       :state      (:state timer)
+       :epoch      (:epoch timer)})))
+
+(defn timers->ring-specs
+  "Map a vector of `timers` into machines-viz overlay ring-specs.
+  Drops timers whose state has no resolvable node-id. Pure fn —
+  JVM-runnable. Replaces the SVG-era `timers->ring-positions` (which
+  resolved `{:cx :cy :r}` from a positioned graph); positioning now
+  lives in the overlay's DOM walk, so this fn only carries the
+  presentation payload + the `:node-id` the overlay queries."
+  [timers id-fn now-ms]
   (vec
-    (keep
-      (fn [t]
-        (when-let [[cx cy r] (state-node-center (:state t) node-index id-fn)]
-          {:timer t :cx cx :cy cy :r r}))
-      (or timers []))))
+    (keep (fn [t] (timer->ring-spec t id-fn now-ms))
+          (or timers []))))
 
 ;; ---- tick driver gating -------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
@@ -11,9 +11,11 @@
     3. `:rf.causa/now-ms` is driven by the timer-tick event AND by the
        test-only override slot.
     4. `:rf.causa/timer-hover` writes / clears the slot.
-    5. The rings overlay component emits a stable SVG hiccup tree
-       (renders nothing without active timers; renders one ring per
-       active timer).
+    5. The rings overlay component (rf2-uv1on xyflow Phase 2) projects
+       the trace buffer into ring-specs + delegates positioning + paint
+       to the machines-viz `AfterRingsOverlay` (renders nothing without
+       active timers; one ring-spec per active timer; hover keys the
+       timer-hover slot by node-id).
     6. The rAF tick loop's `needs-ticking?` gate stops the loop when
        no armed timers are present."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
@@ -27,7 +29,9 @@
             [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
-            [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]))
+            [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]
+            [day8.re-frame2-machines-viz.chart.overlays.after-rings
+             :as mv-after-rings]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -159,37 +163,23 @@
     (rf/dispatch-sync [:rf.causa/timer-hover nil])
     (is (nil? @(rf/subscribe [:rf.causa/timer-hover])))))
 
-;; ---- (5) overlay view --------------------------------------------------
+;; ---- (5) overlay view (rf2-uv1on xyflow Phase 2) -----------------------
+;;
+;; Post-migration the Causa overlay is the DATA owner: it projects the
+;; trace buffer into ring-specs + delegates positioning + paint to the
+;; machines-viz `AfterRingsOverlay`, which walks the xyflow node DOM.
+;; The Causa overlay returns `[mv-after-rings/AfterRingsOverlay {...}]`
+;; (or nil when no active timers). We assert the delegated PROPS — the
+;; DOM-walk geometry is exercised by the machines-viz overlay's own
+;; suite + the geometry helper's JVM tests. (The old SVG-positioned-
+;; graph + viewport-transform tests are gone with the elk renderer.)
 
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq tree))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(def ^:private fixture-positioned
-  ;; `node-id` is the STRING the chart-layout primitive mints from a
-  ;; state path (per `chart.layout/node-id`). The rings overlay
-  ;; resolves a timer's `:state` keyword to this id via
-  ;; `chart-layout/highlight-id`; mismatching the shape silently
-  ;; drops every ring.
-  {:nodes [{:node-id "idle"    :x 100 :y 100 :width 140 :height 48
-            :path [:idle] :depth 0 :initial? true}
-           {:node-id "authing" :x 300 :y 100 :width 140 :height 48
-            :path [:authing] :depth 1}
-           {:node-id "timeout" :x 500 :y 100 :width 140 :height 48
-            :path [:timeout] :depth 2}
-           {:node-id "done"    :x 700 :y 100 :width 140 :height 48
-            :path [:done] :depth 2}]
-   :edges []
-   :width 900
-   :height 250
-   :initial-id "idle"})
+(defn- delegated-props
+  "Pull the props map the Causa overlay hands to the machines-viz
+  overlay. The overlay's render returns `[Component props]`; props is
+  the second element."
+  [tree]
+  (when (vector? tree) (second tree)))
 
 (deftest overlay-returns-nil-with-no-active-timers
   (setup-causa-frame!)
@@ -197,24 +187,30 @@
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 1000)
-    (is (nil? (after-rings/AfterRingsOverlay fixture-positioned)))))
+    (is (nil? (after-rings/AfterRingsOverlay)))
+    (is (nil? (after-rings/AfterRingsOverlay nil))
+        "opts-arity also returns nil with no timers")))
 
-(deftest overlay-renders-one-ring-per-active-timer
+(deftest overlay-delegates-one-ring-spec-per-active-timer
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
-    (let [tree (after-rings/AfterRingsOverlay fixture-positioned)
-          ;; The svg overlay container.
-          overlay (find-by-testid tree
-                    "rf-causa-machine-inspector-after-rings-overlay")]
-      (is (some? overlay))
-      (is (= "1" (str (-> overlay second :data-timer-count))))
-      ;; One ring with the state-id stamped.
-      (is (some? (find-by-testid tree
-                   "rf-causa-machine-inspector-after-ring-idle"))))))
+    (let [tree  (after-rings/AfterRingsOverlay)
+          props (delegated-props tree)
+          specs (:ring-specs props)]
+      (is (= mv-after-rings/AfterRingsOverlay (first tree))
+          "delegates to the machines-viz xyflow overlay")
+      (is (= 1 (count specs)))
+      (is (= "idle" (-> specs first :node-id))
+          "node-id is the string the overlay queries the DOM for")
+      (is (= "rf-causa-machine-inspector-after-rings-overlay" (:testid props)))
+      (is (= 2000 (:tick props))
+          "now-ms threads through as :tick so the overlay re-measures per frame")
+      (is (fn? (:on-hover props)))
+      (is (fn? (:on-leave props))))))
 
 (deftest overlay-stops-rendering-fired-timers
   (setup-causa-frame!)
@@ -224,11 +220,11 @@
     (pin-now-ms! 7000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
     (push-fired!     6000 :auth/login :idle 0)
-    (is (nil? (after-rings/AfterRingsOverlay fixture-positioned))
+    (is (nil? (after-rings/AfterRingsOverlay))
         "fired timers are filtered out of the active projection — the
          whole overlay drops out")))
 
-(deftest overlay-renders-rings-for-multiple-concurrent-timers
+(deftest overlay-delegates-specs-for-multiple-concurrent-timers
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
     (override-machines!    [:auth/login])
@@ -236,88 +232,41 @@
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle    5000 0)
     (push-scheduled! 1500 :auth/login :authing 3000 0)
-    (let [tree (after-rings/AfterRingsOverlay fixture-positioned)]
-      (is (= "2" (str (-> (find-by-testid tree
-                            "rf-causa-machine-inspector-after-rings-overlay")
-                          second :data-timer-count))))
-      (is (some? (find-by-testid tree
-                   "rf-causa-machine-inspector-after-ring-idle")))
-      (is (some? (find-by-testid tree
-                   "rf-causa-machine-inspector-after-ring-authing"))))))
+    (let [specs (-> (after-rings/AfterRingsOverlay) delegated-props :ring-specs)]
+      (is (= 2 (count specs)))
+      (is (= #{"idle" "authing"} (set (map :node-id specs)))))))
 
-;; ---- (5b) rf2-obp4z viewport-transform alignment -----------------------
-;;
-;; Regression coverage for rf2-obp4z: when the chart's viewport-transform
-;; is non-identity, the rings group MUST carry the same transform so the
-;; rings track their node centres under zoom + pan. The legacy single-
-;; arity call site stays at 1:1 (back-compat).
-
-(defn- find-rings-group
-  "Walk the hiccup tree for the rings `<g>` (testid
-  `rf-causa-machine-inspector-after-rings`)."
-  [tree]
-  (find-by-testid tree "rf-causa-machine-inspector-after-rings"))
-
-(deftest overlay-omits-transform-without-viewport
+(deftest overlay-on-hover-keys-timer-hover-by-node-id
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (pin-now-ms! 2000)
     (push-scheduled! 1000 :auth/login :idle 5000 0)
-    (testing "single-arity call site renders without a transform attr (back-compat)"
-      (let [tree     (after-rings/AfterRingsOverlay fixture-positioned)
-            rings-g  (find-rings-group tree)]
-        (is (some? rings-g))
-        (is (nil? (:transform (second rings-g)))
-            "no viewport-transform passed → rings group carries no transform attr")))
-    (testing "explicit nil viewport-transform also omits the transform attr"
-      (let [tree (after-rings/AfterRingsOverlay
-                   fixture-positioned
-                   {:viewport-transform nil})]
-        (is (nil? (:transform (second (find-rings-group tree)))))))
-    (testing "identity viewport (scale 1, tx 0, ty 0) omits the transform attr"
-      (let [tree (after-rings/AfterRingsOverlay
-                   fixture-positioned
-                   {:viewport-transform {:scale 1 :tx 0 :ty 0}})]
-        (is (nil? (:transform (second (find-rings-group tree)))))))))
-
-(deftest overlay-applies-viewport-transform-when-supplied
-  (setup-causa-frame!)
-  (rf/with-frame :rf/causa
-    (override-machines!    [:auth/login])
-    (override-definitions! {:auth/login fixture-definition})
-    (pin-now-ms! 2000)
-    (push-scheduled! 1000 :auth/login :idle 5000 0)
-    (testing "non-identity viewport-transform stamps a translate+scale transform on the rings group"
-      (let [tree    (after-rings/AfterRingsOverlay
-                      fixture-positioned
-                      {:viewport-transform {:scale 1.5 :tx 40 :ty -20}})
-            rings-g (find-rings-group tree)
-            attrs   (second rings-g)]
-        (is (some? rings-g))
-        (is (= "translate(40,-20) scale(1.5)"
-               (:transform attrs))
-            "transform attr matches the chart's translate(tx,ty) scale(s) order — same vector as the chart body")
-        (testing "the overlay svg root exposes the viewport for data-binding / inspection"
-          (let [overlay (find-by-testid tree
-                          "rf-causa-machine-inspector-after-rings-overlay")
-                a       (second overlay)]
-            (is (= "1.5" (:data-viewport-scale a)))
-            (is (= "40"  (:data-viewport-tx a)))
-            (is (= "-20" (:data-viewport-ty a)))))))
-    (testing "scale-only zoom (no pan) still stamps a transform"
-      (let [tree (after-rings/AfterRingsOverlay
-                   fixture-positioned
-                   {:viewport-transform {:scale 2.0 :tx 0 :ty 0}})]
-        (is (= "translate(0,0) scale(2)"
-               (:transform (second (find-rings-group tree)))))))
-    (testing "pan-only (no zoom) still stamps a transform"
-      (let [tree (after-rings/AfterRingsOverlay
-                   fixture-positioned
-                   {:viewport-transform {:scale 1 :tx 25 :ty 15}})]
-        (is (= "translate(25,15) scale(1)"
-               (:transform (second (find-rings-group tree)))))))))
+    (let [props    (-> (after-rings/AfterRingsOverlay) delegated-props)
+          on-hover (:on-hover props)
+          on-leave (:on-leave props)
+          spec     (-> props :ring-specs first)]
+      ;; The overlay hands the bearing node-id back; the host re-resolves
+      ;; the timer identity tuple for the hover slot. The dispatch is
+      ;; async (production path), so rather than race the router drain we
+      ;; assert (a) the spec carries the identity tuple the resolution
+      ;; keys on, and (b) the callbacks are wired + a known / unknown
+      ;; node-id is handled without throwing.
+      (is (= {:machine-id :auth/login :state :idle :epoch 0}
+             (select-keys spec [:machine-id :state :epoch]))
+          "spec carries the (machine-id, state, epoch) tuple the hover
+           handler re-resolves from the bearing node-id")
+      (is (fn? on-hover))
+      (is (fn? on-leave))
+      ;; Exercise both branches — known + unknown node-id — to pin the
+      ;; callbacks don't throw on either path. (Slot-value assertions
+      ;; live in the dedicated dispatch-sync test above; the production
+      ;; callback dispatches async, so racing the router drain here would
+      ;; be flaky.)
+      (is (nil? (do (on-hover "ghost") nil)) "unknown node-id is a no-op")
+      (is (nil? (do (on-hover "idle") (on-leave "idle") nil))
+          "known node-id hover + leave run cleanly"))))
 
 ;; ---- (6) frame isolation ----------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_helpers_cljs_test.cljc
@@ -21,7 +21,9 @@
     5. `ring-color` / `timer-color`         — colour tier mapping +
                                               status-based overrides.
     6. `format-timer-tooltip`               — per-status messages.
-    7. `state-node-center` / `timers->ring-positions` — node geometry.
+    7. `timer->ring-spec` / `timers->ring-specs` — xyflow overlay
+       ring-spec projection (rf2-uv1on; replaced the SVG-era
+       `state-node-center` / `timers->ring-positions`).
     8. `needs-ticking?`                     — rAF tick driver gate.
     9. `ms-remaining`                       — tooltip-ms calc."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
@@ -319,45 +321,63 @@
                  {:state :idle :status :guard-suppressed :duration-ms 5000
                   :closed-at 2000} 3000))))
 
-;; ---- (7) state-node-center / timers->ring-positions --------------------
-
-(def ^:private fixture-nodes
-  ;; Two flat nodes — a chart of `:idle / :authing`.
-  [{:node-id :idle    :x 100 :y 100 :width 140 :height 48}
-   {:node-id :authing :x 300 :y 100 :width 140 :height 48}])
-
-(def ^:private fixture-node-index
-  ;; { :idle <node> :authing <node> }
-  (into {} (map (fn [n] [(:node-id n) n]) fixture-nodes)))
+;; ---- (7) timer->ring-spec / timers->ring-specs (rf2-uv1on) -------------
+;;
+;; Post-xyflow the helper no longer resolves `{:cx :cy :r}` from a
+;; positioned graph — xyflow owns positions in the DOM and the
+;; machines-viz overlay walks it. The helper now projects each timer
+;; into a presentation-ready ring-spec (`:node-id` + colour / fraction
+;; / tooltip); positioning is the overlay's job.
 
 (defn- id-fn
   "Stub the chart-layout/highlight-id resolver — flat keywords map to
-  themselves."
+  their string node-id (matching `chart.layout/node-id`'s shape for
+  flat states); a `:ghost` state resolves to nil so the spec is
+  dropped."
   [state]
   (cond
-    (keyword? state) state
-    (vector?  state) (first state)
+    (= :ghost state) nil
+    (keyword? state) (name state)
+    (vector?  state) (name (first state))
     :else            nil))
 
-(deftest state-node-center-returns-cx-cy-r
-  (let [[cx cy r] (h/state-node-center :idle fixture-node-index id-fn)]
-    (is (= 170 cx)  "x + width/2")
-    (is (= 124 cy)  "y + height/2")
-    (is (pos? r)    "radius is positive (half-diagonal + 4px gap)")))
+(deftest timer->ring-spec-carries-node-id-and-presentation-payload
+  (let [spec (h/timer->ring-spec
+               {:machine-id :auth/login :state :idle :status :armed
+                :armed-at 1000 :fires-at 6000 :duration-ms 5000 :epoch 0}
+               id-fn 2000)]
+    (is (= "idle" (:node-id spec)) "resolves the bearing node-id via id-fn")
+    (is (= 0.8    (:fraction spec)) "(6000-2000)/5000 = 0.8 remaining")
+    (is (= :green (:color spec))    "0.8 fraction → green tier")
+    (is (false?  (:cancelled? spec)))
+    (is (re-find #"idle" (:tooltip spec)))
+    (is (= "rf-causa-machine-inspector-after-ring-idle" (:testid spec)))
+    (is (= :auth/login (:machine-id spec)))
+    (is (= :idle (:state spec)))
+    (is (= 0 (:epoch spec)) "identity tuple carried for the hover slot")))
 
-(deftest state-node-center-nil-when-state-not-in-graph
-  (is (nil? (h/state-node-center :ghost fixture-node-index id-fn))))
+(deftest timer->ring-spec-cancelled-flag
+  (let [spec (h/timer->ring-spec
+               {:machine-id :m :state :idle :status :cancelled
+                :duration-ms 5000 :closed-at 2000} id-fn 3000)]
+    (is (true? (:cancelled? spec)))
+    (is (= :gray (:color spec)) "cancelled rings render gray")))
 
-(deftest state-node-center-nil-on-nil-state
-  (is (nil? (h/state-node-center nil fixture-node-index id-fn))))
+(deftest timer->ring-spec-nil-when-state-unresolvable
+  (is (nil? (h/timer->ring-spec {:state :ghost :status :armed} id-fn 1000))
+      "no node-id → no spec (overlay would have nothing to position)")
+  (is (nil? (h/timer->ring-spec {:state nil :status :armed} id-fn 1000))))
 
-(deftest timers-ring-positions-maps-each-armed-timer
-  (let [timers [{:state :idle    :status :armed}
-                {:state :authing :status :cancelled}
-                {:state :ghost   :status :armed}]   ;; dropped — no node
-        rings  (h/timers->ring-positions timers fixture-node-index id-fn)]
-    (is (= 2 (count rings)))
-    (is (every? (every-pred :cx :cy :r :timer) rings))))
+(deftest timers->ring-specs-maps-each-resolvable-timer
+  (let [timers [{:machine-id :m :state :idle    :status :armed
+                 :armed-at 1000 :fires-at 6000 :duration-ms 5000 :epoch 0}
+                {:machine-id :m :state :authing :status :cancelled
+                 :duration-ms 3000 :closed-at 2000 :epoch 0}
+                {:machine-id :m :state :ghost   :status :armed}]  ;; dropped
+        specs  (h/timers->ring-specs timers id-fn 2000)]
+    (is (= 2 (count specs)) "ghost (no node-id) is dropped")
+    (is (every? :node-id specs))
+    (is (= #{"idle" "authing"} (set (map :node-id specs))))))
 
 ;; ---- (8) needs-ticking? -------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -48,6 +48,8 @@
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.nodes :as nodes]
             [day8.re-frame2-machines-viz.chart.edges :as edges]
+            [day8.re-frame2-machines-viz.chart.overlays.after-rings
+             :as after-rings]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]))
 
 ;; ---- xyflow React-class adapters ----------------------------------------
@@ -289,6 +291,23 @@
                          built-in zoom/pan/fit Controls.
     :show-background?  — when true (default true) render xyflow's
                          dot-pattern Background.
+    :after-ring-specs  — rf2-uv1on. Optional vector of presentation-
+                         ready `:after`-timer ring-specs (each
+                         `{:node-id :fraction :color :cancelled?
+                         :tooltip :testid}`). When non-empty the chart
+                         mounts the `chart.overlays.after-rings`
+                         overlay as a sibling of the canvas; it walks
+                         the rendered node DOM to position each ring.
+                         The host owns the trace→spec projection +
+                         the scrubber-aware fraction (Causa supplies
+                         these from its trace buffer). nil / empty →
+                         no overlay layer.
+    :after-ring-tick   — opaque value the host bumps to force the
+                         overlay to re-measure the DOM + repaint the
+                         swept arcs (Causa passes `now-ms`; Lock #8 —
+                         one rAF clock per chart, owned host-side).
+    :on-after-ring-hover / :on-after-ring-leave — `(fn [node-id] ...)`
+                         hover callbacks the overlay wires on each ring.
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
@@ -298,6 +317,8 @@
                  sim? on-state-click read-only?
                  direction layout-options
                  height show-minimap? show-controls? show-background?
+                 after-ring-specs after-ring-tick
+                 on-after-ring-hover on-after-ring-leave
                  testid]
           :or   {direction         :tb
                  height            "100%"
@@ -417,7 +438,23 @@
                 [:> MiniMap {:zoomable true
                              :pannable true
                              :nodeColor (fn [_] (:bg-3 tokens/tokens))
-                             :maskColor (tokens/with-alpha :bg-0 0.6)}])]]))))))
+                             :maskColor (tokens/with-alpha :bg-0 0.6)}])]
+             ;; rf2-uv1on — `:after`-timer countdown rings. The overlay
+             ;; is a sibling of the xyflow canvas inside this
+             ;; position:relative wrapper; it walks the rendered node DOM
+             ;; (`rf-mv-chart-node-<id>`) to position each ring. Hosts
+             ;; that want rings pass presentation-ready `:after-ring-specs`
+             ;; (see `chart.overlays.after-rings`); the host owns the
+             ;; trace→spec projection + the rAF clock that bumps
+             ;; `:after-ring-tick` (Lock #8 — one clock per chart). Causa
+             ;; mounts the same overlay via its `machine_canvas` wrapper;
+             ;; this prop path serves standalone hosts (viewer, Story).
+             (when (seq after-ring-specs)
+               [after-rings/AfterRingsOverlay
+                {:ring-specs after-ring-specs
+                 :tick       after-ring-tick
+                 :on-hover   on-after-ring-hover
+                 :on-leave   on-after-ring-leave}])]))))))
 
 ;; ---- empty-graph convenience for callers --------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -1,0 +1,258 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.after-rings
+  "xyflow `:after`-timer countdown-ring overlay (rf2-uv1on · xyflow
+  Phase 2).
+
+  ## Why this exists
+
+  The rf2-gpzb4 xyflow migration ported the MachineChart from
+  ELK+hand-rolled-SVG to `@xyflow/react`. Under the old renderer the
+  chart published a positioned graph (`{:nodes [{:x :y :width
+  :height}]}`) and the after-rings overlay (Causa-side) read positions
+  straight off that data. xyflow owns node positions in the rendered
+  DOM instead — so the overlay can no longer read a positioned graph;
+  it must WALK THE DOM to find each bearing node's bounding box.
+
+  This ns is the machines-viz home for that overlay (per the bead's
+  Surface §). It is pure presentation + DOM measurement:
+
+    - It takes a vector of presentation-ready `ring-specs` (each
+      carrying `:node-id` + the `countdown-ring` payload — `:fraction`
+      `:color` `:cancelled?` `:tooltip` `:testid`). The host (Causa's
+      machine inspector) projects its trace buffer into these specs
+      and supplies the scrubber-aware `:fraction` / `:color`, so the
+      retro-replay behaviour (ring frozen at the scrubbed instant)
+      lives host-side in Causa's helpers — unchanged by this
+      migration.
+    - It walks the chart's node DOM by `data-testid`
+      (`rf-mv-chart-node-<node-id>`, the `chart.nodes/state-node`
+      contract) with `getBoundingClientRect`, computes each ring's
+      `{:cx :cy :r}` in overlay-local coordinates via the pure
+      `after_rings_geometry` helper, and absolute-positions a
+      `countdown-ring` glyph there.
+
+  ## Why presentation-ready specs (not Causa's trace subs)
+
+  machines-viz is bundle-isolated from Causa — it cannot `:require`
+  Causa's trace-buffer subs. Keeping the overlay's input a flat
+  data vector means the overlay is pure-data-testable on the JVM
+  (geometry) + the CLJS DOM walk is the only browser-specific seam.
+  Causa stays the data owner; this ns owns positioning + paint.
+
+  ## Coordinate model — no viewport-transform
+
+  xyflow lays the DOM out in final on-screen coordinates (its pan +
+  zoom are baked into the rendered node rects), so the overlay reads
+  the rects AS RENDERED and positions rings at those exact screen
+  positions. The rf2-obp4z `translate(tx,ty) scale(s)` machinery the
+  SVG renderer needed is gone — there is no separate viewport to
+  mirror.
+
+  ## Re-measure triggers (Lock #8 — 60Hz when visible)
+
+  The overlay re-measures on:
+
+    - mount + every render where the ring-spec set changes,
+    - a host-driven `:tick` value bump (Causa's rAF loop bumps
+      `now-ms`, which flows into fresh `:fraction`s + a changed
+      `:tick`), and
+    - window resize (xyflow nodes may reflow).
+
+  The host owns the rAF clock (single per-chart clock per Lock #8) —
+  this overlay does NOT run its own animation loop; it just re-reads
+  the DOM whenever the host re-renders it. That keeps the O(charts)
+  clock invariant intact.
+
+  ## Theming
+
+  Ring colours resolve through `theme/tokens/css-var`
+  (`var(--rf-causa-<key>, <hex>)`) so light + dark both flow through
+  the host's CSS custom-property surface (per the bead's `var(--*)`
+  requirement). The overlay chrome adds no opaque colours of its own."
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.primitives :as prim]
+            [day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
+             :as geo]))
+
+;; ---- DOM measurement ----------------------------------------------------
+
+(defn- rect->map
+  "JS DOMRect → the `{:left :top :width :height}` map the geometry
+  helper consumes."
+  [^js dom-rect]
+  (when dom-rect
+    {:left   (.-left dom-rect)
+     :top    (.-top dom-rect)
+     :width  (.-width dom-rect)
+     :height (.-height dom-rect)}))
+
+(defn- query-node-rect
+  "Resolve a node-id's bounding rect by walking `root`'s subtree for
+  `[data-testid=\"rf-mv-chart-node-<id>\"]`. Returns the rect map or
+  nil when the node isn't in the DOM (off-screen / not yet mounted /
+  compound parent without a leaf)."
+  [^js root node-id]
+  (when (and root node-id)
+    (when-let [testid (geo/state->node-testid node-id)]
+      (let [sel (str "[data-testid=\"" testid "\"]")
+            el  (.querySelector root sel)]
+        (when el
+          (rect->map (.getBoundingClientRect el)))))))
+
+(defn- measure-rings
+  "Walk the DOM under `root` for every ring-spec's bearing node and
+  return the positioned rings (`ring-specs` merged with `{:cx :cy
+  :r}`). `root` is the chart wrapper element (the overlay's offset
+  parent); we read its own rect as the coordinate origin.
+
+  Uses the pure `geo/overlay-rings` so the math is JVM-testable —
+  this fn only gathers the DOM rects."
+  [^js root ring-specs]
+  (when root
+    (let [container-rect (rect->map (.getBoundingClientRect root))
+          ;; xyflow bakes zoom into the rendered rects, so the
+          ;; overlay reads them as-is (zoom 1.0 → no extra scaling of
+          ;; the gap; the node's measured size already carries zoom).
+          rects (reduce
+                  (fn [acc {:keys [node-id]}]
+                    (if (contains? acc node-id)
+                      acc
+                      (assoc acc node-id (query-node-rect root node-id))))
+                  {}
+                  (or ring-specs []))
+          ;; Drop nils so overlay-rings' `get` only sees measured nodes.
+          rects (into {} (remove (comp nil? val)) rects)]
+      (geo/overlay-rings ring-specs rects container-rect 1.0))))
+
+;; ---- ring SVG paint -----------------------------------------------------
+
+(defn- ring-glyph
+  "Paint one positioned ring. `spec` carries `:cx :cy :r` (from the
+  DOM measurement) + the `countdown-ring` presentation payload. The
+  optional `:on-hover` / `:on-leave` callbacks (host-supplied) wire
+  the ring's pointer-events for a side-rail tooltip; v1 also exposes
+  the native SVG `<title>` so the tooltip works without JS wiring."
+  [{:keys [cx cy r fraction color cancelled? tooltip testid node-id
+           on-hover on-leave] :as _spec}]
+  [:g (cond-> {:data-testid (str "rf-mv-chart-after-ring-group-" node-id)
+               :data-node-id node-id}
+        on-hover (assoc :on-mouse-enter (fn [_] (on-hover node-id)))
+        on-leave (assoc :on-mouse-leave (fn [_] (on-leave node-id))))
+   (prim/countdown-ring
+     {:cx cx :cy cy :r r
+      :fraction   fraction
+      :color      (or color :gray)
+      :cancelled? cancelled?
+      :tooltip    tooltip
+      :testid     (or testid (str "rf-mv-chart-after-ring-" node-id))})])
+
+;; ---- overlay component --------------------------------------------------
+
+(defn AfterRingsOverlay
+  "Absolute-positioned SVG overlay that paints `:after`-timer
+  countdown rings over the xyflow chart by walking the rendered node
+  DOM. Reagent component (form-3 — needs a ref + lifecycle to read
+  the DOM after xyflow has laid out).
+
+  Props (single map):
+
+    :ring-specs  — vector of `{:node-id <string> :fraction <0..1|nil>
+                   :color <:green|:amber|:red|:gray> :cancelled? <bool>
+                   :tooltip <string> :testid <string?>}`. `:node-id`
+                   is the string `chart.layout/node-id` mints from the
+                   bearing state's path (the host resolves a timer's
+                   `:state` to it via `chart.layout/highlight-id`).
+                   The presentation payload is host-computed so the
+                   scrubber-aware retro-replay fraction comes pre-
+                   baked.
+    :tick        — opaque value the host bumps to force a re-measure
+                   (Causa passes `now-ms` so each rAF frame re-reads
+                   the DOM + repaints the swept arcs). Optional.
+    :testid      — overlay root `data-testid`; defaults to
+                   `\"rf-mv-chart-after-rings-overlay\"`.
+    :on-hover    — `(fn [node-id] ...)`; fires on ring mouse-enter.
+                   Optional (Causa wires its timer-hover slot).
+    :on-leave    — `(fn [node-id] ...)`; fires on ring mouse-leave.
+
+  Returns nil when there are no ring-specs (the overlay layer drops
+  out so unrelated chart hover handlers aren't shadowed).
+
+  Mounting: place this as a SIBLING of the xyflow chart inside a
+  `position: relative` wrapper. The overlay finds the chart nodes by
+  querying its own `offsetParent` (the wrapper) for the
+  `rf-mv-chart-node-<id>` testids. Both must share the same
+  positioned ancestor for the coordinate math to line up."
+  [_initial-props]
+  (let [root-ref     (r/atom nil)     ;; the overlay's offset-parent
+        positioned   (r/atom [])      ;; measured rings (with :cx :cy :r)
+        ;; Re-measure both on a tick bump AND on window resize. We stash
+        ;; the latest props in an atom so the resize listener can read
+        ;; them without a stale closure.
+        latest-specs (r/atom [])
+        remeasure!   (fn []
+                       (when-let [root @root-ref]
+                         (reset! positioned
+                                 (vec (measure-rings root @latest-specs)))))
+        resize-fn    (fn [_] (remeasure!))]
+    (r/create-class
+      {:display-name "MachinesViz.AfterRingsOverlay"
+
+       :component-did-mount
+       (fn [_this]
+         (when (exists? js/window)
+           (.addEventListener js/window "resize" resize-fn))
+         (remeasure!))
+
+       :component-did-update
+       (fn [_this _prev]
+         ;; Props (ring-specs / tick) changed → re-read the DOM. xyflow
+         ;; has already committed its layout by the time React calls
+         ;; did-update, so the node rects are current.
+         (remeasure!))
+
+       :component-will-unmount
+       (fn [_this]
+         (when (exists? js/window)
+           (.removeEventListener js/window "resize" resize-fn)))
+
+       :reagent-render
+       (fn [{:keys [ring-specs tick testid on-hover on-leave]
+             :or   {testid "rf-mv-chart-after-rings-overlay"}}]
+         ;; Keep the latest specs visible to the lifecycle + resize
+         ;; closures. `tick` is referenced so a bump re-runs render →
+         ;; did-update → remeasure (the host's rAF clock drives it).
+         (reset! latest-specs (vec (or ring-specs [])))
+         (when (seq ring-specs)
+           (let [rings @positioned]
+             [:div {:data-testid testid
+                    :data-ring-count (str (count ring-specs))
+                    :data-tick (when (some? tick) (str tick))
+                    :ref (fn [el]
+                           ;; The overlay's offsetParent is the
+                           ;; position:relative wrapper that ALSO holds
+                           ;; the xyflow chart — query node testids from
+                           ;; there so both share the coordinate origin.
+                           (reset! root-ref
+                                   (when el (.-offsetParent el))))
+                    :style {:position       "absolute"
+                            :top            0
+                            :left           0
+                            :width          "100%"
+                            :height         "100%"
+                            :pointer-events "none"  ;; rings opt back in
+                            :overflow       "visible"
+                            :z-index        3}}
+              (into [:svg {:data-testid (str testid "-svg")
+                           :data-positioned-count (str (count rings))
+                           :width  "100%"
+                           :height "100%"
+                           :style {:position "absolute"
+                                   :top 0 :left 0
+                                   :width "100%" :height "100%"
+                                   :overflow "visible"
+                                   :pointer-events "none"}}]
+                    (for [{:keys [node-id] :as spec} rings]
+                      ^{:key node-id}
+                      [:g {:style {:pointer-events "all"}}
+                       (ring-glyph (assoc spec
+                                          :on-hover on-hover
+                                          :on-leave on-leave))]))])))})))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
@@ -1,0 +1,130 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
+  "Pure geometry for the xyflow `:after`-timer countdown-ring overlay
+  (rf2-uv1on · xyflow Phase 2).
+
+  ## Why a separate .cljc
+
+  The xyflow chart owns node positions in the rendered DOM — the
+  overlay reads each bearing node's bounding box with
+  `getBoundingClientRect` and absolute-positions a `countdown-ring`
+  glyph over it. The DOM walk + ref plumbing is CLJS-only and lives
+  in `after_rings.cljs`, but the geometry that turns a node rect +
+  the overlay container's rect into a ring's `{:cx :cy :r}` in
+  overlay-local coordinates is pure data → data, so it lives here
+  where the JVM test corpus can pin it.
+
+  ## Coordinate model
+
+  `getBoundingClientRect` returns viewport-relative rects (`{:left
+  :top :width :height}`). The overlay `<svg>` is absolutely
+  positioned at the top-left of the chart wrapper, so a node centre
+  in overlay-local space is the node's viewport centre MINUS the
+  container's viewport origin. xyflow's internal pan/zoom is already
+  baked into the rendered rects, so the overlay needs no separate
+  viewport-transform (the rf2-obp4z `translate(tx,ty) scale(s)`
+  machinery the SVG renderer needed is obsolete — xyflow lays the
+  DOM out in final on-screen coordinates).
+
+  ## Ring radius
+
+  Radius is half the node's longer dimension plus a breathing gap so
+  the ring sits clearly OUTSIDE the node's border, then scaled by the
+  rendered zoom (the node rect is already zoom-scaled by xyflow, so a
+  proportional gap keeps the ring crisp at any zoom level)."
+  (:require [clojure.string :as str]))
+
+(def ring-gap-px
+  "Breathing gap (px, at 1x zoom) between the node's bounding box and
+  the inside edge of the countdown ring. Keeps the ring clear of the
+  node's border + box-shadow affordance."
+  6)
+
+(def min-ring-radius-px
+  "Floor for the ring radius so a tiny / unmeasured node still draws a
+  visible ring rather than collapsing to a dot."
+  18)
+
+(defn rect-center
+  "Centre `[cx cy]` of a viewport rect `{:left :top :width :height}`."
+  [{:keys [left top width height]}]
+  [(+ (or left 0) (/ (double (or width 0)) 2.0))
+   (+ (or top 0) (/ (double (or height 0)) 2.0))])
+
+(defn ring-radius
+  "Radius for a ring around a node rect of `width` × `height`,
+  rendered at `zoom` (defaults to 1.0). Half the longer dimension +
+  a zoom-scaled breathing gap, floored at `min-ring-radius-px`.
+
+  Pure fn — JVM-runnable."
+  ([rect] (ring-radius rect 1.0))
+  ([{:keys [width height]} zoom]
+   (let [z   (if (and zoom (pos? zoom)) (double zoom) 1.0)
+         w   (double (or width 0))
+         h   (double (or height 0))
+         ;; The node rect from getBoundingClientRect is ALREADY scaled
+         ;; by xyflow's zoom, so half the longer measured side is the
+         ;; on-screen half-extent; we add a proportional gap.
+         half (/ (max w h) 2.0)
+         r    (+ half (* z ring-gap-px))]
+     (max (double min-ring-radius-px) r))))
+
+(defn node->ring
+  "Project a single bearing node into the ring's overlay-local
+  geometry. Takes the node's viewport rect, the overlay container's
+  viewport rect, and the rendered `zoom`. Returns `{:cx :cy :r}` in
+  coordinates relative to the overlay container's top-left, or nil
+  when either rect is missing / degenerate.
+
+  Pure fn — JVM-runnable. The CLJS overlay calls this once per ring
+  after reading the rects off the DOM."
+  ([node-rect container-rect] (node->ring node-rect container-rect 1.0))
+  ([node-rect container-rect zoom]
+   (when (and node-rect container-rect
+              (pos? (or (:width node-rect) 0))
+              (pos? (or (:height node-rect) 0)))
+     (let [[ncx ncy] (rect-center node-rect)
+           cx-origin (or (:left container-rect) 0)
+           cy-origin (or (:top container-rect) 0)]
+       {:cx (- ncx cx-origin)
+        :cy (- ncy cy-origin)
+        :r  (ring-radius node-rect zoom)}))))
+
+(defn state->node-testid
+  "The xyflow node `data-testid` the overlay queries for a given
+  resolved node-id. Mirrors `chart.nodes/state-node`'s
+  `(str \"rf-mv-chart-node-\" id)` contract — the overlay walks the
+  DOM with `[data-testid=\"<this>\"]` to find the bearing node.
+
+  `node-id` is the string `chart.layout/node-id` mints from a state
+  path; the overlay's `:id-fn` resolves a timer's `:state` to it.
+
+  Returns nil for a nil / blank node-id so the overlay skips the
+  ring rather than querying for a garbage selector."
+  [node-id]
+  (when (and node-id (not (str/blank? (str node-id))))
+    (str "rf-mv-chart-node-" node-id)))
+
+(defn overlay-rings
+  "Pure projection: for each `{:node-id ...}`-bearing ring spec, merge
+  in the computed `{:cx :cy :r}` resolved from the supplied
+  `rects-by-node-id` map (`{node-id {:left :top :width :height}}`) +
+  the overlay `container-rect` + `zoom`. Drops any ring whose node has
+  no measured rect (node off-screen / not yet mounted / compound
+  parent without a leaf).
+
+  This is the seam the CLJS component drives after walking the DOM:
+  it gathers the rects, then this fn does the math. Pure → JVM-
+  testable end-to-end without a DOM.
+
+  Each input ring spec carries the presentation payload the
+  `countdown-ring` glyph needs (`:fraction :color :cancelled?
+  :tooltip :testid`) plus the `:node-id` to position it. The output
+  preserves those keys and adds `:cx :cy :r`."
+  [ring-specs rects-by-node-id container-rect zoom]
+  (vec
+    (keep
+      (fn [{:keys [node-id] :as spec}]
+        (when-let [rect (get rects-by-node-id node-id)]
+          (when-let [geom (node->ring rect container-rect zoom)]
+            (merge spec geom))))
+      (or ring-specs []))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
@@ -65,7 +65,12 @@
         arc-len   (* f circ)
         gap-len   (- circ arc-len)
         token-key (get ring-color->token color :text-tertiary)
-        stroke    (get tokens/tokens token-key)
+        ;; rf2-uv1on — resolve through `var(--rf-causa-<key>, <hex>)`
+        ;; so light + dark themes both flow through the host's CSS
+        ;; custom-property surface (the xyflow overlay paints from the
+        ;; same palette the chart + host do). Falls back to the dark-
+        ;; palette hex for standalone embeds + the JVM hiccup tests.
+        stroke    (tokens/css-var token-key)
         opacity   (if cancelled? 0.4 0.85)]
     [:g {:data-testid    (or testid "rf-mv-chart-countdown-ring")
          :data-color     (name color)
@@ -74,7 +79,7 @@
          :pointer-events "all"}
      [:circle {:cx cx :cy cy :r r
                :fill "none"
-               :stroke (:border-subtle tokens/tokens)
+               :stroke (tokens/css-var :border-subtle)
                :stroke-width (* 0.6 sw)
                :opacity 0.4
                :pointer-events "none"}]
@@ -92,7 +97,7 @@
        (let [diag (long (* 0.707 r))]
          [:line {:x1 (- cx diag) :y1 (- cy diag)
                  :x2 (+ cx diag) :y2 (+ cy diag)
-                 :stroke (:red tokens/tokens)
+                 :stroke (tokens/css-var :red)
                  :stroke-width (* 0.8 sw)
                  :stroke-linecap "round"
                  :opacity 0.7

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -207,6 +207,31 @@
                (str "rgba(" r ", " g ", " b ", " alpha ")")
                hex)))))
 
+;; ---- CSS-variable theming (rf2-uv1on) ----------------------------------
+
+(defn css-var
+  "Resolve `token-key` to a `var(--rf-causa-<key>, <hex-fallback>)`
+  CSS string so a host that publishes the Causa CSS custom-property
+  surface (light + dark themes both live there) gets live theme-
+  switching, while a standalone embed degrades to the dark-palette
+  hex.
+
+  This mirrors Causa's own `theme/tokens/css-var` naming so the
+  variables resolve against the SAME host-published `:root` block —
+  the chart and the host paint from one palette. The fallback comes
+  from `dark-palette` (the chart's default surface) so a host that
+  does NOT publish the variables still renders correctly.
+
+  Pure data → string; JVM-portable. rf2-uv1on uses it for the
+  `:after`-ring overlay chrome so light + dark both flow through
+  `var(--*)` per the bead's theming requirement."
+  ([token-key] (css-var token-key dark-palette))
+  ([token-key palette]
+   (let [hex (get palette token-key)]
+     (if hex
+       (str "var(--rf-causa-" (name token-key) ", " hex ")")
+       (str "var(--rf-causa-" (name token-key) ")")))))
+
 ;; ---- motion seam (rf2-xfx6l) -------------------------------------------
 
 (def motion

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
@@ -1,0 +1,109 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry-cljs-test
+  "Pure-data tests for the xyflow `:after`-ring overlay geometry
+  (rf2-uv1on · xyflow Phase 2).
+
+  The overlay walks the rendered DOM to find each bearing node's
+  bounding rect; this geometry layer turns those rects + the overlay
+  container's rect into the ring's `{:cx :cy :r}` in overlay-local
+  coordinates. Pure → JVM-runnable, so the math is pinned without a
+  DOM.
+
+  Dual-target via the `_cljs_test.cljc` extension — same pattern every
+  machines-viz helper test uses."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
+             :as geo]))
+
+;; ---- rect-center --------------------------------------------------------
+
+(deftest rect-center-is-midpoint
+  (is (= [150.0 124.0]
+         (geo/rect-center {:left 100 :top 100 :width 100 :height 48}))))
+
+(deftest rect-center-handles-zero-origin
+  (is (= [70.0 24.0]
+         (geo/rect-center {:left 0 :top 0 :width 140 :height 48}))))
+
+;; ---- ring-radius --------------------------------------------------------
+
+(deftest ring-radius-half-longer-side-plus-gap
+  ;; 140 × 48 → half longer side = 70; + gap (6) = 76.
+  (is (= 76.0 (geo/ring-radius {:width 140 :height 48})))
+  ;; portrait node — height is the longer side.
+  (is (= 106.0 (geo/ring-radius {:width 48 :height 200}))))
+
+(deftest ring-radius-scales-gap-by-zoom
+  ;; At 2x zoom the gap doubles (12) but the measured half-side is
+  ;; UNCHANGED — xyflow already scaled the rect, so only the gap scales.
+  (is (= 82.0 (geo/ring-radius {:width 140 :height 48} 2.0))))
+
+(deftest ring-radius-floors-at-minimum
+  ;; A tiny / unmeasured node still draws a visible ring.
+  (is (= (double geo/min-ring-radius-px)
+         (geo/ring-radius {:width 4 :height 4})))
+  (is (= (double geo/min-ring-radius-px)
+         (geo/ring-radius {:width 0 :height 0}))))
+
+;; ---- node->ring ---------------------------------------------------------
+
+(deftest node->ring-translates-into-container-local-coords
+  ;; Node centred at (170, 124) in the viewport; container origin at
+  ;; (20, 10) → overlay-local centre (150, 114).
+  (let [g (geo/node->ring {:left 100 :top 100 :width 140 :height 48}
+                          {:left 20  :top 10  :width 900 :height 400})]
+    (is (= 150.0 (:cx g)))
+    (is (= 114.0 (:cy g)))
+    (is (= 76.0  (:r g)))))
+
+(deftest node->ring-nil-on-missing-or-degenerate-rect
+  (is (nil? (geo/node->ring nil {:left 0 :top 0 :width 10 :height 10})))
+  (is (nil? (geo/node->ring {:left 0 :top 0 :width 10 :height 10} nil)))
+  (is (nil? (geo/node->ring {:left 0 :top 0 :width 0 :height 48}
+                            {:left 0 :top 0 :width 10 :height 10}))
+      "zero-width node (not laid out yet) → no ring"))
+
+;; ---- state->node-testid -------------------------------------------------
+
+(deftest state->node-testid-matches-state-node-contract
+  (is (= "rf-mv-chart-node-idle" (geo/state->node-testid "idle")))
+  (is (= "rf-mv-chart-node-auth_login__idle"
+         (geo/state->node-testid "auth_login__idle"))))
+
+(deftest state->node-testid-nil-on-blank
+  (is (nil? (geo/state->node-testid nil)))
+  (is (nil? (geo/state->node-testid "")))
+  (is (nil? (geo/state->node-testid "   "))))
+
+;; ---- overlay-rings (the seam the CLJS overlay drives) ------------------
+
+(def ^:private container {:left 0 :top 0 :width 900 :height 400})
+
+(deftest overlay-rings-positions-each-measured-spec
+  (let [specs [{:node-id "idle"    :color :green :fraction 0.8}
+               {:node-id "authing" :color :amber :fraction 0.5}]
+        rects {"idle"    {:left 100 :top 100 :width 140 :height 48}
+               "authing" {:left 300 :top 100 :width 140 :height 48}}
+        rings (geo/overlay-rings specs rects container 1.0)]
+    (is (= 2 (count rings)))
+    (is (= 170.0 (-> rings first :cx)) "idle centre x")
+    (is (= 124.0 (-> rings first :cy)))
+    ;; Presentation payload is preserved alongside the geometry.
+    (is (= :green (-> rings first :color)))
+    (is (= 0.8    (-> rings first :fraction)))
+    (is (= 370.0 (-> rings second :cx)) "authing centre x")))
+
+(deftest overlay-rings-drops-unmeasured-nodes
+  ;; A spec whose node has no measured rect (off-screen / not mounted /
+  ;; compound parent without a leaf) is dropped — the overlay has
+  ;; nothing to position.
+  (let [specs [{:node-id "idle"  :color :green}
+               {:node-id "ghost" :color :red}]   ;; no rect → dropped
+        rects {"idle" {:left 100 :top 100 :width 140 :height 48}}
+        rings (geo/overlay-rings specs rects container 1.0)]
+    (is (= 1 (count rings)))
+    (is (= "idle" (-> rings first :node-id)))))
+
+(deftest overlay-rings-empty-on-no-specs
+  (is (= [] (geo/overlay-rings [] {} container 1.0)))
+  (is (= [] (geo/overlay-rings nil nil container 1.0))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/primitives_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/primitives_cljs_test.cljc
@@ -1,0 +1,135 @@
+(ns day8.re-frame2-machines-viz.chart.primitives-cljs-test
+  "Shape + theming pins for the chart `countdown-ring` glyph
+  (rf2-uv1on · xyflow Phase 2).
+
+  The `:after`-timer countdown ring is the load-bearing primitive the
+  xyflow after-rings overlay paints (per
+  `chart.overlays.after-rings`). These tests pin:
+
+    - the hiccup structure (track circle + arc circle, optional
+      cancelled cross-line + tooltip),
+    - the `stroke-dasharray` arc maths (fraction → filled arc length),
+    - the colour-tier → token mapping, and
+    - the rf2-uv1on `var(--rf-causa-<key>, <hex>)` theming so light +
+      dark both flow through the host's CSS custom-property surface.
+
+  Dual-target via the `_cljs_test.cljc` extension. Pure hiccup —
+  JVM-runnable, no DOM."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.chart.primitives :as prim]))
+
+(defn- circles
+  "All `:circle` elements in a hiccup tree."
+  [tree]
+  (filter (fn [n] (and (vector? n) (= :circle (first n))))
+          (tree-seq (some-fn vector? seq?) seq tree)))
+
+(defn- find-tag
+  [tree tag]
+  (some (fn [n] (when (and (vector? n) (= tag (first n))) n))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+;; ---- structure ----------------------------------------------------------
+
+(deftest countdown-ring-emits-track-and-arc-circles
+  (let [g (prim/countdown-ring {:cx 100 :cy 100 :r 40 :fraction 0.5
+                                :color :green})]
+    (is (= :g (first g)))
+    (is (= "rf-mv-chart-countdown-ring" (:data-testid (second g))))
+    (is (= "green" (:data-color (second g))))
+    (is (= 2 (count (circles g))) "a faded track circle + the arc circle")))
+
+(deftest countdown-ring-testid-override
+  (let [g (prim/countdown-ring {:cx 0 :cy 0 :r 10 :fraction 1.0
+                                :testid "rf-mv-chart-after-ring-idle"})]
+    (is (= "rf-mv-chart-after-ring-idle" (:data-testid (second g))))))
+
+;; ---- arc maths ----------------------------------------------------------
+
+(deftest countdown-ring-dasharray-tracks-fraction
+  (let [r       40
+        circ    (* 2 Math/PI r)
+        arc-of  (fn [frac]
+                  (let [g    (prim/countdown-ring
+                               {:cx 0 :cy 0 :r r :fraction frac})
+                        ;; the arc circle is the SECOND circle (track is first)
+                        arc  (second (circles g))
+                        dash (:stroke-dasharray (second arc))
+                        [a _] (str/split dash #" ")]
+                    (#?(:clj Double/parseDouble :cljs js/parseFloat) a)))]
+    (is (< (Math/abs (- (arc-of 0.5) (* 0.5 circ))) 0.001)
+        "half fraction → half the circumference filled")
+    (is (< (Math/abs (- (arc-of 1.0) circ)) 0.001)
+        "full fraction → whole circumference filled")
+    (is (< (arc-of 0.0) 0.001) "zero fraction → no arc")))
+
+(deftest countdown-ring-nil-fraction-renders-full
+  ;; nil fraction (unresolvable duration) → a faded full ring.
+  (let [g   (prim/countdown-ring {:cx 0 :cy 0 :r 40 :fraction nil})
+        arc (second (circles g))
+        dash (:stroke-dasharray (second arc))
+        [a _] (str/split dash #" ")]
+    (is (< (Math/abs (- (#?(:clj Double/parseDouble :cljs js/parseFloat) a)
+                        (* 2 Math/PI 40)))
+           0.001))))
+
+;; ---- cancelled ----------------------------------------------------------
+
+(deftest countdown-ring-cancelled-draws-cross-line
+  (let [g    (prim/countdown-ring {:cx 100 :cy 100 :r 40 :fraction 0.3
+                                   :cancelled? true})
+        line (find-tag g :line)]
+    (is (= "true" (:data-cancelled (second g))))
+    (is (some? line) "cancelled rings draw a diagonal cross-line")))
+
+(deftest countdown-ring-not-cancelled-has-no-line
+  (let [g (prim/countdown-ring {:cx 0 :cy 0 :r 40 :fraction 0.3})]
+    (is (nil? (find-tag g :line)))))
+
+;; ---- tooltip ------------------------------------------------------------
+
+(deftest countdown-ring-tooltip-emits-title
+  (let [g (prim/countdown-ring {:cx 0 :cy 0 :r 10 :fraction 0.5
+                                :tooltip "idle · 2500ms remaining"})]
+    (is (= [:title "idle · 2500ms remaining"] (find-tag g :title)))))
+
+;; ---- var(--*) theming (rf2-uv1on) --------------------------------------
+
+(deftest countdown-ring-strokes-resolve-through-css-vars
+  (testing "the arc stroke is var(--rf-causa-<tier-token>, <hex>) so
+            light + dark flow through the host's CSS custom-property
+            surface (bead requirement)"
+    (let [g       (prim/countdown-ring {:cx 0 :cy 0 :r 40 :fraction 0.8
+                                        :color :green})
+          [track arc] (circles g)]
+      ;; :green tier → :green token.
+      (is (str/starts-with? (:stroke (second arc)) "var(--rf-causa-green"))
+      (is (str/includes? (:stroke (second arc)) "#4ADE80")
+          "carries the dark-palette hex fallback for standalone embeds")
+      ;; track circle uses the subtle border token.
+      (is (str/starts-with? (:stroke (second track))
+                            "var(--rf-causa-border-subtle")))))
+
+(deftest countdown-ring-cancelled-cross-uses-red-var
+  (let [g    (prim/countdown-ring {:cx 0 :cy 0 :r 40 :fraction 0.2
+                                   :cancelled? true})
+        line (find-tag g :line)]
+    (is (str/starts-with? (:stroke (second line)) "var(--rf-causa-red"))))
+
+(deftest countdown-ring-color-tiers-map-to-tokens
+  (is (str/includes? (-> (prim/countdown-ring {:cx 0 :cy 0 :r 9 :fraction 1
+                                               :color :amber})
+                         circles second second :stroke)
+                     "--rf-causa-yellow")
+      ":amber tier maps to the :yellow token")
+  (is (str/includes? (-> (prim/countdown-ring {:cx 0 :cy 0 :r 9 :fraction 0
+                                               :color :red})
+                         circles second second :stroke)
+                     "--rf-causa-red"))
+  (is (str/includes? (-> (prim/countdown-ring {:cx 0 :cy 0 :r 9 :fraction 1
+                                               :color :gray})
+                         circles second second :stroke)
+                     "--rf-causa-text-tertiary")
+      ":gray tier maps to the :text-tertiary token"))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -4,6 +4,7 @@
    rf2-xfx6l — motion/duration-css)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [clojure.string :as str]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]))
 
 ;; ---- with-alpha (rf2-pyvmr) --------------------------------------------
@@ -79,6 +80,34 @@
     (let [s (tokens/with-alpha :cyan 0.5 tokens/light-palette)]
       ;; Light :cyan is #2A8B96 → rgba(42, 139, 150, 0.5)
       (is (= "rgba(42, 139, 150, 0.5)" s)))))
+
+;; ---- css-var (rf2-uv1on) -----------------------------------------------
+
+(deftest css-var-resolves-to-var-with-hex-fallback
+  (testing "css-var builds var(--rf-causa-<key>, <hex>) so a host that
+            publishes the Causa CSS custom-property surface drives
+            light + dark, while a standalone embed degrades to the
+            dark-palette hex"
+    (is (= "var(--rf-causa-green, #4ADE80)" (tokens/css-var :green)))
+    (is (= "var(--rf-causa-text-tertiary, #8990A0)"
+           (tokens/css-var :text-tertiary)))))
+
+(deftest css-var-name-matches-causa-convention
+  (testing "the variable name mirrors Causa's `var(--rf-causa-<key>)`
+            so the chart + host paint from ONE :root palette"
+    (is (str/starts-with? (tokens/css-var :cyan)
+                          "var(--rf-causa-cyan"))))
+
+(deftest css-var-falls-back-to-supplied-palette-hex
+  (testing "css-var resolves the fallback hex from the supplied palette
+            arg (light theme), not just the dark default"
+    (is (= "var(--rf-causa-cyan, #2A8B96)"
+           (tokens/css-var :cyan tokens/light-palette)))))
+
+(deftest css-var-no-fallback-for-unknown-key
+  (testing "an unknown token has no hex → bare var() (host MUST define
+            it; no garbage fallback)"
+    (is (= "var(--rf-causa-not-a-token)" (tokens/css-var :not-a-token)))))
 
 ;; ---- motion seam (rf2-xfx6l) -------------------------------------------
 


### PR DESCRIPTION
## Summary

Re-implements the `:after`-timer countdown-ring overlay for the xyflow MachineChart (rf2-uv1on · xyflow Phase 2). The rf2-gpzb4 migration moved node positioning into the rendered DOM, so the old SVG-positioned-graph overlay no longer applies.

- **New machines-viz overlay** (`chart/overlays/after_rings.cljs`) — walks the rendered xyflow node DOM by testid (`rf-mv-chart-node-<id>`) with `getBoundingClientRect` and absolute-positions a `countdown-ring` glyph over each bearing node. Pure JVM-testable geometry seam in `after_rings_geometry.cljc` (rect → `{:cx :cy :r}` in overlay-local coords).
- **Causa stays the data owner** — `machine_after_rings.cljs` projects its trace buffer into presentation-ready ring-specs (scrubber-aware retro-replay fraction baked in), drives the single per-chart rAF clock (Lock #8), and delegates positioning + paint to the new overlay. New `timers->ring-specs` helper replaces the SVG-era `state-node-center` / `timers->ring-positions`.
- **Theming via `var(--*)`** — `countdown-ring` strokes now resolve through `var(--rf-causa-<key>, <hex>)` (new `tokens/css-var` helper) so light + dark both flow through the host's CSS custom-property surface, degrading to the dark-palette hex standalone.
- **Wired into `MachineChart`** via `:after-ring-specs` for standalone hosts (viewer/Story); Causa mounts the same overlay via its `machine_canvas` wrapper.
- **Removed** the obsolete viewport-transform alignment path (xyflow lays out in final on-screen coords — no separate viewport to mirror).

## Test plan

- [x] `npm run test:cljs` — 3913 tests / 11882 assertions, 0 failures
- [x] `clojure -M:test` from `tools/machines-viz` — 114 tests, 0 failures (new geometry + primitives + tokens tests)
- [x] `clojure -M:test` from `tools/causa` — 849 tests / 2778 assertions, 0 failures
- [x] `npm run test:bundle-isolation` — PASS (overlay stays tool-isolated)
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures (machine inspector renders)

## Notes

CLJS unit tests pin the overlay shape (no Playwright). `tools/causa/chart/svg.cljc` is now an unused re-export shim (no live consumers of `countdown-ring`/`sparkline` through it) — left for a dedicated cleanup bead to avoid expanding scope into the migration's shared surfaces.

Parallel-safety: coordinated with rf2-yg9he (UIx/Helix adapters) — both touch `chart.cljs`; whoever lands second rebases. This change only adds an `:after-ring-specs` prop path to the wrapper.