### PR TITLE
ci(testing): split Story/Causa gate PR-smoke vs nightly-full + cache testbed compiles (rf2-wa3oo + rf2-og36y)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -44,6 +44,22 @@ jobs:
             ${{ runner.os }}-expensive-implementation-
             ${{ runner.os }}-cljs-
 
+      # rf2-og36y: same keyed shadow-cljs compile cache as the PR-smoke
+      # gate (.shadow-cljs incremental state + .cpcache classpath cache).
+      # Restoring the warm cache here keeps the nightly-full sweep fast
+      # AND keeps the cache primed for the PR-smoke gate (which shares the
+      # `<os>-story-causa-shadow-` restore-keys prefix), so the first PR
+      # of the day still lands a warm partial cache.
+      - name: Cache shadow-cljs compile output (.shadow-cljs / .cpcache)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            implementation/.shadow-cljs
+            implementation/.cpcache
+          key: ${{ runner.os }}-story-causa-shadow-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/deps.edn', 'implementation/package-lock.json', 'implementation/**/deps.edn', 'tools/story/deps.edn', 'tools/causa/deps.edn', 'tools/story/src/**', 'tools/story/testbeds/**', 'tools/causa/src/**', 'tools/causa/testbeds/**', 'implementation/core/src/**') }}
+          restore-keys: |
+            ${{ runner.os }}-story-causa-shadow-
+
       - name: npm install
         run: npm ci
 
@@ -61,6 +77,7 @@ jobs:
           npm run test:reagent-slim:bundle-isolation
           npm run test:examples
           npm run test:story-feature-load
+          npm run test:story-play-scripts
           npm run test:causa-feature-gate
           npm run test:story-static
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1053,7 +1053,7 @@ jobs:
         run: npm run test:examples
 
   story-causa-browser:
-    name: Story/Causa browser gates (targeted)
+    name: Story/Causa browser gates (PR-smoke)
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.story_causa_browser == 'true'
     runs-on: ubuntu-latest
@@ -1092,31 +1092,63 @@ jobs:
             ${{ runner.os }}-story-causa-browser-
             ${{ runner.os }}-cljs-
 
+      # rf2-og36y: cache the shadow-cljs compile output (.shadow-cljs/
+      # incremental state + .cpcache classpath cache) keyed on the build
+      # config + every source path the smoke testbeds pull in. The
+      # testbed compile (400+ files per bundle) is the dominant cost of
+      # this gate; a warm `.shadow-cljs/` cache lets shadow recompile
+      # only changed namespaces instead of the whole graph. The key is
+      # conservative — any change under the Story/Causa src or testbed
+      # trees, the shared implementation source, or the build config
+      # busts it, so a stale cache can never serve wrong output. The
+      # `restore-keys` prefix still gives a warm partial cache on a miss.
+      - name: Cache shadow-cljs compile output (.shadow-cljs / .cpcache)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            implementation/.shadow-cljs
+            implementation/.cpcache
+          key: ${{ runner.os }}-story-causa-shadow-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/deps.edn', 'implementation/package-lock.json', 'implementation/**/deps.edn', 'tools/story/deps.edn', 'tools/causa/deps.edn', 'tools/story/src/**', 'tools/story/testbeds/**', 'tools/causa/src/**', 'tools/causa/testbeds/**', 'implementation/core/src/**') }}
+          restore-keys: |
+            ${{ runner.os }}-story-causa-shadow-
+
       - name: npm install
         run: npm ci
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
-      # PR-time targeted gates for Story/Causa browser regressions. The
-      # classifier keeps this off for unrelated PRs. Story feature-load
-      # runner/testbed/matrix changes must exercise the same live browser
-      # gate here, not only in a worker's local loop.
-      - name: Run Causa feature browser gate
-        run: npm run test:causa-feature-gate
-
-      - name: Run Story static-export browser smoke
-        run: npm run test:story-static
-
-      - name: Run Story feature-load browser gate
-        run: npm run test:story-feature-load
+      # PR-smoke tier (rf2-wa3oo + rf2-og36y). The full feature-load +
+      # full Causa matrix + Story static-export sweep is on the critical
+      # path of every Story/Causa PR at ~700s, and the identical sweep
+      # already runs nightly in expensive-tests.yml — so PR time ran the
+      # full matrix twice over. PR time now runs only the high-signal
+      # subset:
+      #
+      #   - Causa feature gate in --smoke mode: the 3 highest-signal
+      #     scenarios (6-tab shell handoff, deterministic-exception →
+      #     Issues/Trace surfacing, Cmd-K palette) over just 2 staged
+      #     surfaces (counter + deliberate-throw), compiling 2 testbed
+      #     bundles instead of 13.
+      #   - Story :play-script CI-as-test gate (rf2-3qcxk): drives the
+      #     live Story shell over the single counter-with-stories
+      #     testbed and runs every variant's :play-script. This is the
+      #     gate that renders the assertion-strip, so the rf2-5lw9w
+      #     assertion-strip :key fix stays covered on the PR critical
+      #     path.
+      #
+      # The full sweep (test:causa-feature-gate, test:story-feature-load,
+      # test:story-static) runs nightly in expensive-tests.yml.
+      - name: Run Causa feature browser gate (PR-smoke)
+        run: npm run test:causa-feature-gate:smoke
 
       # rf2-3qcxk — every Story variant whose body carries a
       # `:play-script` slot doubles as an automated regression test.
       # The runner discovers them via `re-frame.story.play.ci-runner`,
       # drives each through the live shell, and reports a structured
-      # pass/fail row per variant. Lives in the same Story/Causa job
-      # because it shares the testbed bundle and Playwright stack.
+      # pass/fail row per variant. Kept on the PR critical path: it is a
+      # single-testbed compile and is the live render path that exercises
+      # the assertion-strip (rf2-5lw9w).
       - name: Run Story :play-script CI-as-test gate
         run: npm run test:story-play-scripts
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,8 +20,8 @@ Running everything everywhere makes PRs slow and the dev loop painful. Skipping 
 | **MCP conformance — wire** (`tools/mcp-conformance` suite) | medium | MCP servers honour the strict `CallToolResultSchema`; trusted-PATH + symlink-safe-unlink helpers. |
 | **MCP conformance — live** (`test:re-frame2-pair-live-overflow-hermetic`, `test:re-frame2-pair-live-subscribe`) | expensive | Real re-frame2-pair-mcp behaviour against a real shadow-cljs nREPL; over-budget eval cap; subscribe/unsubscribe lifecycle. |
 | **Example smoke** (`test:examples`, `test:examples:realworld`) | expensive | Whole-example browser smoke for the runnable examples (cart, counter variants, RealWorld). |
-| **Story feature gates** (`test:story-feature-load`, `test:story-play-scripts`) | expensive | Story testbed exercises the feature/load matrix; play-scripts double every story's `:play-script` as a regression test. |
-| **Causa feature gates** (`test:causa-feature-gate`) | expensive | Causa panel-gallery feature matrix (4-layer chrome, tab navigation, modal/popover behaviour). |
+| **Story feature gates** (`test:story-feature-load`, `test:story-play-scripts`) | expensive | Story testbed exercises the feature/load matrix; play-scripts double every story's `:play-script` as a regression test. `test:story-play-scripts` is single-testbed + high-signal (it renders the live shell + assertion-strip) and stays on the PR critical path; `test:story-feature-load` is nightly-full only (see the Story/Causa PR-smoke vs nightly-full split below). |
+| **Causa feature gates** (`test:causa-feature-gate`, `test:causa-feature-gate:smoke`) | expensive (full) / medium (smoke) | Causa feature matrix (4-layer chrome, tab navigation, exception/issue surfacing). The `--smoke` tier runs the 3 highest-signal scenarios over 2 staged surfaces on the PR critical path; the full 14-scenario / 13-surface sweep runs nightly. |
 | **Template emitted-app smoke** (`jvm-tools-template`) | expensive | The emitted app from `tools/template/` boots + passes its own gates — proves the template stays viable. |
 | **Skills structural** (`skills-structural`) | fast | Skill manifests + shared content stay structurally valid against the schema. |
 
@@ -59,9 +59,61 @@ The classifier maps "what files changed" → "which expensive jobs fire on this 
 ## The 4 tier scenarios (outputs of the management approach above)
 
 1. **Agent pre-checkin** — `scripts/test-fast-pr.sh` plus the surface-specific command for files touched. Run the always-on PR spine locally, then add the narrow changed surface: JVM artefact, browser, bundle, tool, template, or skill structural tests.
-2. **PR CI** — `.github/workflows/test.yml`. Always runs lockstep drift, skill/MCP drift, core JVM, CLJS node integration, JS harness self-tests, and docs link validation for docs PRs. Expensive jobs run only when conservative path filters say the owning surface changed.
-3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/examples/bundle matrix, Story/Causa gates, template emitted-app smoke, and live MCP conformance — kept off the PR critical path.
+2. **PR CI** — `.github/workflows/test.yml`. Always runs lockstep drift, skill/MCP drift, core JVM, CLJS node integration, JS harness self-tests, and docs link validation for docs PRs. Expensive jobs run only when conservative path filters say the owning surface changed. The `story-causa-browser` job runs the **PR-smoke tier** (a fast high-signal subset — see the Story/Causa split below), not the full sweep.
+3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/examples/bundle matrix, the **full** Story/Causa sweep, template emitted-app smoke, and live MCP conformance — kept off the PR critical path.
 4. **Release** — `.github/workflows/release.yml` plus the latest green expensive workflow. The core pre-release gate; release is cut only after the scheduled/manual expensive suite is green on the release candidate.
+
+### Story/Causa gate — PR-smoke vs nightly-full split
+
+The `story-causa-browser` Playwright gate used to run the full sweep
+(full Causa feature matrix + Story feature-load + Story static-export +
+Story play-scripts) on the critical path of every Story/Causa PR. That
+made it the single slowest CI gate at ~700s (≈6× the next slowest job),
+and the **identical** sweep already runs nightly in
+`expensive-tests.yml` — so PR time ran the full matrix twice over. The
+dominant cost is shadow-cljs testbed compilation (each bundle is 400+
+files, ~24s; the full Causa gate stages 13 surfaces).
+
+The gate is now split into two tiers:
+
+- **PR tier (`story-causa-browser` in `test.yml`)** — a fast smoke on the
+  critical path. It runs only:
+  - `npm run test:causa-feature-gate:smoke` — the 3 highest-signal Causa
+    scenarios (6-tab shell handoff, deterministic-exception →
+    Issues/Trace surfacing, Cmd-K palette) over just 2 staged surfaces
+    (`counter` + `deliberate-throw`), compiling 2 testbed bundles
+    instead of 13. Scenarios opt into the smoke via `smoke: true` in
+    `tools/causa/testbeds/feature_matrix/scenarios.cjs`; the gate fails
+    loud if the smoke set is ever empty.
+  - `npm run test:story-play-scripts` — single-testbed
+    (`counter-with-stories`), drives the live Story shell, and is the
+    render path that exercises the assertion-strip. Kept on the PR path
+    so the assertion-strip stays covered per-PR.
+
+  Target PR-tier wall-clock: **<180s** (down from ~700s), helped by the
+  keyed `.shadow-cljs/` + `.cpcache` compile cache (next bullet).
+
+- **Nightly tier (`expensive-tests.yml`)** — the full sweep:
+  `test:causa-feature-gate` (all 14 scenarios / 13 surfaces),
+  `test:story-feature-load`, `test:story-play-scripts`, and
+  `test:story-static`. Off the PR critical path; the nightly-full set is
+  a strict superset of the PR-smoke set, so nothing the smoke covers is
+  lost.
+
+Both tiers restore a keyed shadow-cljs compile cache
+(`implementation/.shadow-cljs` + `implementation/.cpcache`), keyed on
+the build config + the Story/Causa src/testbed source hashes + shared
+implementation source. The nightly run repopulates the cache so the
+first PR-smoke of the day lands a warm partial cache (shared
+`<os>-story-causa-shadow-` `restore-keys` prefix). Any change under the
+keyed source trees busts the cache, so a stale cache can never serve
+wrong compile output.
+
+When adding a new Causa scenario, decide its tier: tag it `smoke: true`
+only if it is high-signal enough to earn a slot on every PR's critical
+path **and** it loads one of the already-staged smoke surfaces (or
+accept the extra compile if it must stage a new one). Everything else
+runs nightly by default.
 
 ## Local commands
 
@@ -94,9 +146,10 @@ agent pre-checkin "narrow to the changed surface" workflow.
 | `npm run test:reagent-slim:bundle-isolation` | Reagent Slim invariant: slim advanced bundles exclude stock Reagent impl sentinels and `react-dom/server`, with a stock-Reagent positive control. |
 | `npm run test:examples` | Browser smoke across the runnable examples. |
 | `npm run test:examples:realworld` | Narrow RealWorld (Conduit / Spec 014) smoke only (rf2-h9ut9). The full sweep above is rigorous local / nightly / release; this changed-surface gate compiles and smokes one example end-to-end for cross-artefact runtime changes. Accepts `--filter <substring>` (or `EXAMPLES_FILTER=<substring>`) for ad-hoc narrowing against any single example or testbed. |
-| `npm run test:story-feature-load` | Story full-browser feature-load and resilience gate (`tools/story/test/story_feature_load.cjs`). Occasional / pre-commit until proven stable — not yet default CI. |
-| `npm run test:story-play-scripts` | Story `:play-script` CI-as-test gate (rf2-3qcxk). Discovers every registered variant whose body carries a non-empty `:play-script` slot, navigates the live shell to each, waits for the auto-run's terminal status, and reports per-variant pass/fail. Variants whose id contains `failing` or `expected-fail` invert the assertion (expected `:fail`); everything else asserts `:pass`. Runs in the `story-causa-browser` GH job alongside `test:story-feature-load`. |
-| `npm run test:causa-feature-gate` | Causa browser feature/load gate from `tools/causa/spec/017-Test-Coverage-Matrix.md`. Occasional; not default CI. |
+| `npm run test:story-feature-load` | Story full-browser feature-load and resilience gate (`tools/story/test/story_feature_load.cjs`). **Nightly-full tier** — runs in `expensive-tests.yml`, not on the PR critical path (per the Story/Causa split above). |
+| `npm run test:story-play-scripts` | Story `:play-script` CI-as-test gate (rf2-3qcxk). Discovers every registered variant whose body carries a non-empty `:play-script` slot, navigates the live shell to each, waits for the auto-run's terminal status, and reports per-variant pass/fail. Variants whose id contains `failing` or `expected-fail` invert the assertion (expected `:fail`); everything else asserts `:pass`. **PR-smoke tier** — single-testbed, renders the assertion-strip, runs in the `story-causa-browser` PR job (and nightly). |
+| `npm run test:causa-feature-gate` | Causa browser feature/load gate from `tools/causa/spec/017-Test-Coverage-Matrix.md` — the full 14-scenario / 13-surface sweep. **Nightly-full tier** (`expensive-tests.yml`). |
+| `npm run test:causa-feature-gate:smoke` | PR-smoke tier of the Causa gate (`--smoke`). Runs only the scenarios tagged `smoke: true` over just the surfaces those scenarios load (3 scenarios / 2 surfaces today). On the `story-causa-browser` PR critical path. |
 | `npm run test:story-static` | Static-build contract and deployable-output sanity for the Story export. |
 | `npm run story:build` | Build the Story static artefact. |
 | `npm run test:script-policy` / `npm run test:script-helpers` | Self-tests for the JS harness helpers (path policy, changed-surface classifier port, browser-test report, gate report, local browser harness). |
@@ -286,7 +339,7 @@ PR time; one row per output here so the table stays scannable).
 | `template_expensive` | `jvm-tools-template` (emitted-app smoke) |
 | `mcp_conformance` | MCP conformance ×4 (`mcp-conformance-{story,re-frame2-pair,wire-vocab,...}`) |
 | `mcp_live` | `mcp-conformance-re-frame2-pair` (live + hermetic) |
-| `story_causa_browser` | `story-causa-browser` (feature gates, Playwright — Causa feature-matrix + Story static + Story feature-load + Story play-scripts) |
+| `story_causa_browser` | `story-causa-browser` (PR-smoke, Playwright — Causa feature-matrix `--smoke` + Story play-scripts only; the full Causa matrix, Story feature-load, and Story static run nightly in `expensive-tests.yml` — see the Story/Causa split above) |
 | `skills_structural` | `skills-structural` |
 
 
@@ -319,11 +372,13 @@ the per-tool matrices govern the contract for individual features.
 | Story | [`tools/story/spec/015-Test-Coverage.md`](tools/story/spec/015-Test-Coverage.md) | [`tools/story/test/story_feature_load.cjs`](tools/story/test/story_feature_load.cjs) (browser feature-load + 20-event re-check, run via `npm run test:story-feature-load` from `implementation/`). |
 | Causa | [`tools/causa/spec/017-Test-Coverage-Matrix.md`](tools/causa/spec/017-Test-Coverage-Matrix.md) | [`implementation/scripts/serve-and-run-causa-feature-gate.cjs`](implementation/scripts/serve-and-run-causa-feature-gate.cjs) (browser feature/load matrix slice + 20-event re-check, run via `npm run test:causa-feature-gate` from `implementation/`). |
 
-Both feature gates are deliberately occasional / pre-commit, not
-default CI, while their flake rate and runtime stabilise. A coverage
-row that says `covered` in the per-tool matrix and is gated by the
-feature command above is real; a `partial` or `missing` row is the
-owning team's backlog.
+Both feature gates are split per the Story/Causa PR-smoke vs
+nightly-full tiers above: a high-signal smoke runs on the PR critical
+path (`test:causa-feature-gate:smoke` + `test:story-play-scripts`) and
+the full sweep runs nightly. A coverage row that says `covered` in the
+per-tool matrix and is gated by the feature command above is real (the
+nightly-full sweep is the system of record for matrix coverage); a
+`partial` or `missing` row is the owning team's backlog.
 
 ## Placement decision dimensions
 

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -31,6 +31,7 @@
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
     "test:story-play-scripts": "node ../examples/scripts/serve-and-run-story-play-scripts.cjs",
     "test:causa-feature-gate": "node scripts/serve-and-run-causa-feature-gate.cjs",
+    "test:causa-feature-gate:smoke": "node scripts/serve-and-run-causa-feature-gate.cjs --smoke",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs"

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -96,9 +96,66 @@ test('Mixed Story src + spec change DOES trigger story_causa_browser (rf2-k9ekz)
   assert.equal(result.story_causa_browser, 'true');
 });
 
-test('targeted Story/Causa workflow runs the Story feature-load gate', () => {
-  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
-  assert.match(workflow, /story-causa-browser:[\s\S]*npm run test:story-feature-load/);
+// rf2-wa3oo — the story-causa-browser PR job now runs the PR-SMOKE
+// tier, not the full sweep. It runs the Causa gate in --smoke mode and
+// the single-testbed Story :play-script gate (which renders the
+// assertion-strip, keeping rf2-5lw9w covered per-PR). The full sweep —
+// test:story-feature-load, the non-smoke test:causa-feature-gate, and
+// test:story-static — moved to the nightly expensive-tests.yml workflow.
+const EXPENSIVE_WORKFLOW = path.join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'expensive-tests.yml',
+);
+
+// Narrow the workflow text to the story-causa-browser job block so the
+// per-tier assertions can't accidentally match a step in a sibling job.
+function storyCausaJobBlock(workflow) {
+  const start = workflow.indexOf('\n  story-causa-browser:');
+  assert.notEqual(start, -1, 'story-causa-browser job not found in test.yml');
+  // The next top-level job starts at the next `\n  <name>:` at 2-space
+  // indent. Find it from just after the job header.
+  const rest = workflow.slice(start + 1);
+  const nextJob = rest.search(/\n {2}[A-Za-z0-9_-]+:\n/);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob);
+}
+
+test('PR story-causa-browser job runs the Causa --smoke gate (rf2-wa3oo)', () => {
+  const block = storyCausaJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  assert.match(block, /npm run test:causa-feature-gate:smoke/);
+});
+
+test('PR story-causa-browser job keeps the Story :play-script gate (assertion-strip cover, rf2-5lw9w)', () => {
+  const block = storyCausaJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  assert.match(block, /npm run test:story-play-scripts/);
+});
+
+test('PR story-causa-browser job does NOT run the full sweep (moved to nightly, rf2-wa3oo)', () => {
+  const block = storyCausaJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  assert.doesNotMatch(block, /npm run test:story-feature-load/);
+  assert.doesNotMatch(block, /npm run test:story-static/);
+  // The non-smoke (full-matrix) Causa gate must not run at PR time. The
+  // `:smoke` suffix is intentionally allowed; assert the bare invocation
+  // (followed by end-of-line, not `:smoke`) is absent.
+  assert.doesNotMatch(block, /npm run test:causa-feature-gate(?!:smoke)/);
+});
+
+test('Nightly expensive workflow runs the full Story/Causa sweep (rf2-wa3oo)', () => {
+  const workflow = fs.readFileSync(EXPENSIVE_WORKFLOW, 'utf8');
+  assert.match(workflow, /npm run test:story-feature-load/);
+  assert.match(workflow, /npm run test:causa-feature-gate\b/);
+  assert.match(workflow, /npm run test:story-static/);
+  assert.match(workflow, /npm run test:story-play-scripts/);
+});
+
+test('PR + nightly Story/Causa jobs cache the shadow-cljs compile output (rf2-og36y)', () => {
+  const prBlock = storyCausaJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  assert.match(prBlock, /implementation\/\.shadow-cljs/);
+  assert.match(prBlock, /story-causa-shadow-/);
+  const nightly = fs.readFileSync(EXPENSIVE_WORKFLOW, 'utf8');
+  assert.match(nightly, /implementation\/\.shadow-cljs/);
+  assert.match(nightly, /story-causa-shadow-/);
 });
 
 // rf2-t5slp — the framework-testbeds gate was retired after all four

--- a/implementation/scripts/serve-and-run-causa-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-causa-feature-gate.cjs
@@ -34,6 +34,40 @@ const BASE_URL = process.env.CAUSA_FEATURE_GATE_BASE_URL || `http://127.0.0.1:${
 const TIMEOUT_MS = Number(process.env.CAUSA_FEATURE_GATE_TIMEOUT_MS || 45000);
 const READY_TIMEOUT_MS = 30000;
 const VERBOSE_TESTS = isVerboseTests();
+
+// rf2-wa3oo: PR-smoke vs nightly-full split. With `--smoke` (or
+// RF2_GATE_SMOKE=1) the gate runs only the scenarios tagged
+// `smoke: true` and compiles only the testbed surfaces those scenarios
+// actually load — cutting the 13-surface / 14-scenario nightly sweep
+// down to the 2-surface high-signal subset on the PR critical path.
+// The full sweep keeps running nightly in expensive-tests.yml. The CLI
+// flag is the cross-platform entry point (no cross-env dependency); the
+// env var stays supported for harness composition.
+const SMOKE =
+  process.env.RF2_GATE_SMOKE === '1' || process.argv.includes('--smoke');
+
+// Map a scenario's served URL (e.g. "/counter/" or
+// "/testbeds/deliberate-throw/") back to the STAGED_SURFACES entry that
+// serves it, so smoke mode compiles only what the smoke scenarios need.
+function surfaceForScenario(scenario) {
+  const urlPath = String(scenario.url || '').replace(/^\/+|\/+$/g, '');
+  return STAGED_SURFACES.find((surface) => surface.servedPath === urlPath) || null;
+}
+
+const ACTIVE_SCENARIOS = SMOKE
+  ? SCENARIOS.filter((scenario) => scenario.smoke === true)
+  : SCENARIOS;
+
+const ACTIVE_SURFACES = SMOKE
+  ? (() => {
+      const needed = new Set();
+      for (const scenario of ACTIVE_SCENARIOS) {
+        const surface = surfaceForScenario(scenario);
+        if (surface) needed.add(surface);
+      }
+      return STAGED_SURFACES.filter((surface) => needed.has(surface));
+    })()
+  : STAGED_SURFACES;
 const { chromium } = require(require.resolve('playwright', {
   paths: [IMPL_ROOT],
 }));
@@ -72,7 +106,7 @@ function cleanAndStageRoot() {
 }
 
 function compileSurfaces() {
-  const builds = [...new Set(STAGED_SURFACES.map((surface) => surface.build))];
+  const builds = [...new Set(ACTIVE_SURFACES.map((surface) => surface.build))];
   const isWin = process.platform === 'win32';
   const cmd = isWin ? 'npx.cmd' : 'npx';
   const args = ['shadow-cljs', 'compile', ...builds];
@@ -107,7 +141,7 @@ function stageSharedIfReferenced(surface, outDir) {
 }
 
 function stageSurfaces() {
-  for (const surface of STAGED_SURFACES) {
+  for (const surface of ACTIVE_SURFACES) {
     const bundleSrc = implPath(surface.bundleDir);
     const htmlSrc = relPath(surface.html);
     const outDir = path.join(OUT_ROOT, surface.servedPath);
@@ -324,7 +358,7 @@ async function runScenarios() {
   let anyFailed = false;
 
   try {
-    for (const scenario of SCENARIOS) {
+    for (const scenario of ACTIVE_SCENARIOS) {
       const label = scenario.name;
       const detailLines = [];
       const browserState = {
@@ -404,12 +438,26 @@ async function runScenarios() {
     }
   }
   console.log(
-    `Ran ${results.length} Causa feature scenarios. ${failedCount} failures. Covered ${coveredRows.length} matrix rows.`,
+    `Ran ${results.length} Causa feature scenarios (${SMOKE ? 'PR-smoke tier' : 'nightly-full sweep'}). ` +
+      `${failedCount} failures. Covered ${coveredRows.length} matrix rows.`,
   );
   return anyFailed ? 1 : 0;
 }
 
 async function main() {
+  // Fail loud rather than silently passing a zero-scenario smoke if a
+  // future scenario rename drops the `smoke: true` tag (rf2-wa3oo).
+  if (SMOKE && ACTIVE_SCENARIOS.length === 0) {
+    throw new Error(
+      'RF2_GATE_SMOKE=1 but no scenarios are tagged `smoke: true` in ' +
+        'tools/causa/testbeds/feature_matrix/scenarios.cjs. The PR-smoke ' +
+        'tier must keep at least one high-signal scenario.',
+    );
+  }
+  console.log(
+    `Causa feature gate — ${SMOKE ? 'PR-smoke tier' : 'nightly-full sweep'}: ` +
+      `${ACTIVE_SCENARIOS.length} scenario(s) over ${ACTIVE_SURFACES.length} surface(s).`,
+  );
   cleanAndStageRoot();
   compileSurfaces();
   stageSurfaces();

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -2526,6 +2526,11 @@ const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
     url: '/counter/',
+    // rf2-wa3oo: PR-smoke tier. The 6-tab handoff over the counter
+    // surface is the highest-signal Causa scenario — it boots the shell,
+    // walks every surviving L3 tab, and proves the chrome wiring. Kept
+    // on the PR critical path; the rest of the matrix runs nightly.
+    smoke: true,
     panels: PANEL_HANDOFFS.map(([id]) => id),
     // Post rf2-xy4yb + rf2-y0z5b: coverage narrowed to the 6
     // surviving L3 tabs. Removed surfaces (Time Travel, Causality
@@ -2558,6 +2563,11 @@ const SCENARIOS = [
   {
     name: 'deterministic exceptions and issue/trace surfacing',
     url: '/testbeds/deliberate-throw/',
+    // rf2-wa3oo: PR-smoke tier. The exception → Issues/Trace surfacing
+    // path is the second-highest-signal slice (it proves the error lens
+    // wires up end-to-end against a real thrown handler). Counter +
+    // deliberate-throw are the only two surfaces the smoke compiles.
+    smoke: true,
     panels: ['issues', 'trace'],
     coveredRows: ['Event Detail', 'Trace', 'Issues Ribbon', 'Effects', 'Flows', 'Machines', 'Open in Editor / Source Coordinates'],
     run: runExceptionSchemaHttp,
@@ -2622,6 +2632,11 @@ const SCENARIOS = [
     // recents persist + lead on re-open, Esc closes without dispatch.
     name: 'command palette chord, fuzzy filter, execute verb, and recents round-trip',
     url: '/counter/',
+    // rf2-wa3oo: PR-smoke tier. Reuses the already-staged counter
+    // surface (no extra compile), and exercises the Cmd-K interaction
+    // path — the highest-signal "key interactions" coverage the audit
+    // asked the smoke to keep. Adds no surface to the compile set.
+    smoke: true,
     panels: [],
     coveredRows: [
       'Cmd-K palette',


### PR DESCRIPTION
Closes rf2-wa3oo + rf2-og36y. From the rf2-dmm3t testing audit: the ~700s `story-causa-browser` gate (6.4x the next slowest job) was on every Story/Causa PR's critical path, and the identical full sweep already runs nightly in `expensive-tests.yml` — so PR time ran the full matrix twice over.

## rf2-wa3oo — PR-smoke vs nightly-full split

**PR tier** (`story-causa-browser` in `test.yml`) now runs a high-signal smoke:
- `test:causa-feature-gate:smoke` — the 3 highest-signal Causa scenarios (6-tab shell handoff, deterministic-exception → Issues/Trace surfacing, Cmd-K palette) over just 2 staged surfaces (`counter` + `deliberate-throw`), compiling **2 testbed bundles instead of 13**. Scenarios opt in via `smoke: true`; the gate fails loud if the smoke set is empty.
- `test:story-play-scripts` — single-testbed, drives the live Story shell, and is the render path that exercises the **assertion-strip**, so the in-flight rf2-5lw9w assertion-strip `:key` fix stays covered per-PR.

**Nightly tier** (`expensive-tests.yml`) runs the full sweep — `test:causa-feature-gate` (all 14 scenarios / 13 surfaces), `test:story-feature-load`, `test:story-play-scripts`, `test:story-static`. The nightly-full set is a strict superset of the PR-smoke set; no coverage is lost, only deferred off the critical path.

## rf2-og36y — cache + trim testbed compiles

- **Trim**: smoke mode compiles only the surfaces its scenarios load (2, not 13) — attacks the compile tax directly.
- **Cache**: a keyed `actions/cache` for the shadow-cljs compile output (`implementation/.shadow-cljs` + `.cpcache`), keyed on build config + Story/Causa src/testbed source hashes + shared impl source. Added to both the PR-smoke gate and the nightly job (shared `restore-keys` prefix), so the nightly run primes the cache for the first PR-smoke of the day. Any keyed-source change busts the cache, so it can never serve stale compile output.

## Expected PR-tier time reduction

**~700s → target <180s.** The smoke compiles 3 testbed bundles total (2 Causa surfaces + 1 Story testbed) instead of ~16, and the warm `.shadow-cljs` cache makes those incremental.

## Test plan
- [x] Causa smoke filter resolves to 3 scenarios / 2 surfaces (verified locally)
- [x] `node --check` on the gate script; `--smoke` flag + `RF2_GATE_SMOKE=1` both honored
- [x] Both workflow YAML files parse (PyYAML)
- [x] `package.json` valid JSON
- [x] Harness self-tests pass (22/22), incl. 6 new assertions for the PR-smoke composition + nightly-full superset + shadow cache
- [ ] CI green on this PR (Story/Causa gate runs the new smoke tier)