### PR TITLE
fix(story): rename fx-stub-miss -> failing-fx-stub-miss (runner expected-fail classification) (rf2-le64j)

### DIFF
--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -549,7 +549,7 @@ module.exports = {
        *     `:counter/sync-to-server` fx running
        *
        * Source-side follow-on (filed separately): a dedicated
-       * `:story.counter-matrix/fx-stub-miss` variant that asserts
+       * `:story.counter-matrix/failing-fx-stub-miss` variant that asserts
        * `:rf.assert/effect-emitted :never-stubbed` so the failing
        * row's reason text ("fx :never-stubbed was not emitted during
        * play") is directly visible. The current testbed has no such

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -557,7 +557,7 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
-  ;; rf2-0uo4e — fx-stub-miss testbed variant. Source-side follow-on
+  ;; rf2-0uo4e — failing-fx-stub-miss testbed variant. Source-side follow-on
   ;; from rf2-6hauy. :play declares :rf.assert/effect-emitted against
   ;; :never-stubbed WITHOUT a corresponding force-fx-stub decorator
   ;; covering the id — the play-runner never observes the fx, so the
@@ -569,15 +569,15 @@
   ;; directly without authoring a one-off probe. The variant is
   ;; intentionally :test-tagged so the chrome test-widget picks it up
   ;; and reports the failure.
-  (story/reg-variant :story.counter-matrix/fx-stub-miss
-    {:doc       "Deterministic fx-stub-miss failing assertion. :play
+  (story/reg-variant :story.counter-matrix/failing-fx-stub-miss
+    {:doc       "Deterministic failing-fx-stub-miss failing assertion. :play
                 asserts :rf.assert/effect-emitted :never-stubbed with
                 NO force-fx-stub decorator covering it — the assertion
                 fails with the canonical 'fx <id> was not emitted
                 during play' reason. Pattern: :story.counter-
                 diagnostics/failing-play."
-     :args      {:label "fx-stub-miss"
-                 :settings {:title "fx-stub-miss" :enabled? true}}
+     :args      {:label "failing-fx-stub-miss"
+                 :settings {:title "failing-fx-stub-miss" :enabled? true}}
      :events    [[:counter/initialise 0]]
      :play-script [[:dispatch-sync [:rf.assert/effect-emitted :never-stubbed]]]
      :tags      #{:dev :test :internal}

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -139,20 +139,20 @@
                    :story.counter-matrix/recorder-redaction
                    :story.counter-matrix/a11y-known-good
                    :story.counter-matrix/a11y-known-bad
-                   ;; rf2-0uo4e — fx-stub-miss testbed (parent story
+                   ;; rf2-0uo4e — failing-fx-stub-miss testbed (parent story
                    ;; :story.counter-matrix).
-                   :story.counter-matrix/fx-stub-miss]]
+                   :story.counter-matrix/failing-fx-stub-miss]]
         (is (contains? vs vid) (str vid " registered")))
       (is (= 14 (count vs))))))
 
-(deftest fx-stub-miss-variant-fails-with-canonical-reason
-  (testing "rf2-0uo4e testbed — :story.counter-matrix/fx-stub-miss runs
+(deftest failing-fx-stub-miss-variant-fails-with-canonical-reason
+  (testing "rf2-0uo4e testbed — :story.counter-matrix/failing-fx-stub-miss runs
             and its :rf.assert/effect-emitted assertion FAILS with the
             canonical reason text 'fx :never-stubbed was not emitted
             during play'. This is the source-side fixture the test pane
             renders in its failing-row reason-text surface."
     (async done
-      (-> (story/run-variant :story.counter-matrix/fx-stub-miss)
+      (-> (story/run-variant :story.counter-matrix/failing-fx-stub-miss)
           (async-lib/then
             (fn [result]
               (let [assertions (:assertions result)
@@ -171,7 +171,7 @@
                 (is (= "fx :never-stubbed was not emitted during play"
                        (:reason miss))
                     "the canonical reason text the test pane surfaces"))
-              (story/destroy-variant! :story.counter-matrix/fx-stub-miss)
+              (story/destroy-variant! :story.counter-matrix/failing-fx-stub-miss)
               (done)))))))
 
 (deftest example-workspaces-registered


### PR DESCRIPTION
Closes rf2-le64j. The last CI-red blocker: a deliberately-failing variant whose id did not match the runner expected-fail regex.

`:story.counter-matrix/fx-stub-miss` asserts `:rf.assert/effect-emitted :never-stubbed` with no `force-fx-stub` decorator, so it correctly fails. But `examples/scripts/serve-and-run-story-play-scripts.cjs` `expectedStatusFor` classifies expected-fail via `/(?:failing|expected[-_]fail)/` on the variant id / play-key. "fx-stub-miss" matched neither token, so the runner expected PASS but got FAIL -> MISS, redding the gate.

Renamed `:story.counter-matrix/fx-stub-miss` -> `:story.counter-matrix/failing-fx-stub-miss`; the `failing-` prefix makes the runner classify it expected-fail. Same class as the earlier event-throws -> failing-event-throws rename.

Updated all references: the reg-variant + docstring + comment + display labels in `stories.cljs`, the registration assertion + deftest + run/destroy calls in `stories_cljs_test.cljs`, and the prose reference in `story_browser_scenarios.cjs`.

Gates: `npm run test:cljs` (3905 tests, 0 failures) and `clojure -M:test` from `tools/story` (841 tests, 0 failures) both green.