### PR TITLE
fix(ssr): strip event/proto props + streaming fallback + runtime-version (rf2-x7hin + rf2-405ld + rf2-via0g)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
+++ b/implementation/ssr/src/re_frame/ssr/html_helpers.cljc
@@ -102,6 +102,51 @@
                        :attribute k
                        :recovery  :no-recovery})))))
 
+;; Prototype-pollution keys (rf2-dwds9 / security audit §XSS at output
+;; boundaries). These three names, if they reach the underlying host's
+;; `createElement`-equivalent on the client at hydration, can poison
+;; `Object.prototype`. They are dropped at static-markup emission before
+;; they ever land in the wire props map.
+(def ^:private reserved-prop-keys
+  #{"__proto__" "constructor" "prototype"})
+
+;; `on*` event-handler-prop matcher (rf2-dwds9). Matches the two canonical
+;; handler-prop spellings re-frame hiccup and react-dom/server recognise:
+;;
+;;   - camelCase: `on` followed by an UPPERCASE letter — `onClick`,
+;;     `onMouseDown`, `onLoad`. (`on[A-Z]…`)
+;;   - kebab-case: `on-` prefix — `on-click`, `on-mouse-down`. (`on-…`)
+;;
+;; Deliberately NOT a bare `(starts-with? "on")`: that ate innocuous
+;; English-word attribute names like `one`, `once`, `online`, `only`.
+;; A handler is always `on` + uppercase or `on` + hyphen; ordinary words
+;; are `on` + lowercase with no hyphen, so this discriminates cleanly.
+(def ^:private event-handler-name-re
+  #"on(?:[A-Z].*|-.*)")
+
+(defn strip-prop?
+  "True when the attribute `[k v]` MUST be dropped at SSR static-markup
+  emission per Spec 011 rule rf2-dwds9:
+
+    - `on*` event-handler props (`:on-click`, `:onMouseDown`, …). The
+      client-side substrate adapters wire handlers at hydration; the
+      server-rendered string MUST NOT carry them inline. Matched against
+      `event-handler-name-re` (camelCase `on[A-Z]` or kebab `on-`).
+    - function-valued prop values — a fn can only be a handler/callback;
+      it has no HTML-attribute serialisation and must never reach output.
+    - reserved prototype-pollution keys (`__proto__` / `constructor` /
+      `prototype`), dropped before they reach the host createElement.
+
+  Mirrors react-dom/server behaviour. Recognised here are exactly the
+  props that are *safe to silently drop*; malformed keys (breakout chars)
+  are NOT this fn's concern — they surface at the `validate-attr-name!`
+  grammar gate (rf2-vl8ir)."
+  [[k v]]
+  (let [nm (name k)]
+    (or (some? (re-matches event-handler-name-re nm))
+        (fn? v)
+        (contains? reserved-prop-keys (str/lower-case nm)))))
+
 (defn attr-string
   "Render an attribute map as ` k1=\"v1\" k2=\"v2\"` (leading space when
   non-empty; empty string when the map is empty). Boolean `true` emits
@@ -117,19 +162,31 @@
   `\"onclick=alert(1) data-x\"` would otherwise inject an event-handler
   attribute by escaping the attribute-name context. Same gate covers
   the `:html-attrs` / `:body-attrs` flow through the host shell
-  (security audit §P3.1)."
+  (security audit §P3.1).
+
+  Props matching `strip-prop?` — `on*` event-handler props, function-
+  valued props, and reserved prototype-pollution keys — are dropped at
+  emit time per Spec 011 rule rf2-dwds9 (the per-attribute prop-name
+  filter position in the locked emitter composition order). The filter
+  runs ahead of the attribute-key grammar gate so a stripped prop never
+  reaches `validate-attr-name!`."
   [attrs]
-  (if (empty? attrs)
-    ""
-    (str " "
-         (str/join " "
-                   (keep (fn [[k v]]
-                           (cond
-                             (true? v)  (validate-attr-name! k)
-                             (false? v) nil
-                             (nil? v)   nil
-                             :else      (str (validate-attr-name! k)
-                                             "=\""
-                                             (escape-attr v)
-                                             "\"")))
-                         attrs)))))
+  ;; `keep` realises only the surviving attributes; the leading space is
+  ;; added once, conditionally. A map that is non-empty but whose every
+  ;; entry is stripped/omitted (e.g. `{:on-click f}`) must yield `\"\"`,
+  ;; not a stray `\" \"` — so we branch on the rendered seq, not the input
+  ;; map's emptiness.
+  (let [rendered (keep (fn [[k v :as kv]]
+                         (cond
+                           (strip-prop? kv) nil
+                           (true? v)  (validate-attr-name! k)
+                           (false? v) nil
+                           (nil? v)   nil
+                           :else      (str (validate-attr-name! k)
+                                           "=\""
+                                           (escape-attr v)
+                                           "\"")))
+                       attrs)]
+    (if (seq rendered)
+      (str " " (str/join " " rendered))
+      "")))

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -129,8 +129,14 @@
   (atom []))
 
 (defn- record-continuation!
-  [acc id subtree]
-  (swap! acc conj {:id id :subtree subtree}))
+  "Record a continuation entry for one `:rf/suspense-boundary`. The
+  declared `:fallback` hiccup is stored alongside the `:subtree` so the
+  drain path (`render-continuation`) can re-materialise it when the
+  subtree render throws (Spec 011 §Failure semantics — inline fallback).
+  Without it, a FAILED continuation would render `nil` → empty string,
+  silently dropping the author-declared loading state (rf2-405ld)."
+  [acc id subtree fallback]
+  (swap! acc conj {:id id :subtree subtree :fallback fallback}))
 
 ;; ---- duplicate-id detection ----------------------------------------------
 
@@ -258,7 +264,7 @@
           ;; render synchronously inline). A `:rf/suspense-boundary`
           ;; INSIDE a fallback is a programmer error; we do not check.
           fallback-html (emit/render-to-string fallback nil)]
-      (record-continuation! acc id subtree)
+      (record-continuation! acc id subtree fallback)
       (fallback-template id fallback-html))))
 
 (defn walk
@@ -409,6 +415,37 @@
            :delta   nil
            :failed? true})))))
 
+(def ^:private default-pattern-protocol-version
+  "The v1 pattern-protocol version stamp (per Spec-Schemas
+  §`:rf/hydration-payload` — \"integer; v1 = 1\"). Terminal fallback in
+  `resolve-version` so the canonical `:rf/version` key is always present
+  (Malli `:int` slot, not `:optional`)."
+  1)
+
+(defn resolve-version
+  "Pick the `:rf/version` value for the streaming hydration payload.
+  Resolution order, identical to the non-streaming
+  `re-frame.ssr.ring.payload/resolve-version`:
+
+    1. an explicit `:version` opt from the caller (host-supplied stamp),
+    2. the framework-global `:rf2/runtime-version` late-bind hook — the
+       same source the client-side `:rf.ssr/check-version` fx reads, so
+       both sides of the wire pin one value with no extra wiring,
+    3. `default-pattern-protocol-version` (v1 = 1) as the terminal
+       numeric fallback (the schema slot is required).
+
+  Audit rf2-asmj1 S8 fixed the non-streaming path; rf2-via0g extends the
+  same fix here. The streaming path previously hard-coded `(or version 1)`
+  inline, which silently disagreed with whatever the client-side
+  `:rf2/runtime-version` hook returned and defeated the
+  `:rf.ssr/version-mismatch` check on every host that hadn't passed
+  `:version` explicitly."
+  [explicit-version]
+  (or explicit-version
+      (when-let [f (late-bind/get-fn :rf2/runtime-version)]
+        (f))
+      default-pattern-protocol-version))
+
 (defn build-final-payload
   "After every continuation has drained, construct the canonical
   `:rf/hydration-payload` for the `__rf_payload` final chunk. The
@@ -417,7 +454,11 @@
 
   Mirrors `re-frame.ssr.ring.payload/build-payload`'s shape so the
   client-side bootstrap can read either streaming or non-streaming
-  payloads with the same code path.
+  payloads with the same code path. Version source-of-truth:
+  `resolve-version` above — caller opt wins, falling back to the
+  `:rf2/runtime-version` late-bind hook so server and client read from
+  the same source (rf2-via0g, mirroring the non-streaming rf2-asmj1 S8
+  fix).
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
   policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
@@ -430,7 +471,7 @@
   [frame-id render-hash {:keys [version schema-digest] :as policy-opts}]
   (let [app-db   (frame/frame-app-db-value frame-id)
         db-slice (payload-policy/apply-policy app-db policy-opts)]
-    (cond-> {:rf/version     (or version 1)
+    (cond-> {:rf/version     (resolve-version version)
              :rf/frame-id    frame-id
              :rf/app-db      db-slice
              :rf/render-hash render-hash}

--- a/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_attr_filter_test.clj
@@ -1,0 +1,92 @@
+(ns re-frame.ssr-attr-filter-test
+  "Spec 011 §XSS at output boundaries — rule rf2-dwds9: the SSR static-
+  markup emitter MUST strip, at attribute-emit time:
+
+    - `on*` event-handler props (matched on the normalised/lower-cased
+      name, so `:on-click` / `:onClick` / `:ONLOAD` all filter out),
+    - function-valued prop values, and
+    - reserved prototype-pollution keys (`__proto__` / `constructor` /
+      `prototype`),
+
+  matching react-dom/server behaviour. The filter is the per-attribute
+  prop-name position in the locked emitter composition order, so it runs
+  ahead of the attribute-name grammar gate (rf2-vl8ir) — a stripped prop
+  never reaches `validate-attr-name!`.
+
+  These exercise `re-frame.ssr.html-helpers/attr-string` directly (the
+  single shared per-attribute emission point used by the main emitter,
+  the head emitter, and the streaming emitter)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.ssr.html-helpers :as html]))
+
+(deftest attr-string-strips-event-handler-props
+  (testing "rf2-dwds9 — `on*` event-handler props are dropped at emit time.
+            Matched forms are the two canonical handler-prop spellings the
+            re-frame hiccup adapters and react-dom/server recognise:
+            camelCase `on[A-Z]…` and kebab `on-…`."
+    (testing ":on-click (kebab) is stripped"
+      (is (= " id=\"x\""
+             (html/attr-string {:on-click "alert(1)" :id "x"}))))
+
+    (testing ":onClick (camelCase) is stripped"
+      (is (= " id=\"x\""
+             (html/attr-string {:onClick "alert(1)" :id "x"}))))
+
+    (testing ":onMouseDown (camelCase, multi-word) is stripped"
+      (is (= " id=\"x\""
+             (html/attr-string {:onMouseDown "alert(1)" :id "x"}))))
+
+    (testing "`true`-valued on* boolean prop is also stripped (no bare attr)"
+      (is (= " id=\"x\""
+             (html/attr-string {:on-load true :id "x"}))))
+
+    (testing "a non-handler attribute starting with the letters `on`
+              survives — only `on[A-Z]` / `on-` discriminate, so innocuous
+              English-word keys like `one` / `once` / `online` are NOT eaten"
+      (let [out (html/attr-string {:data-on "ok" :one "1" :once "2" :online "3"})]
+        (is (str/includes? out "data-on=\"ok\""))
+        (is (str/includes? out "one=\"1\""))
+        (is (str/includes? out "once=\"2\""))
+        (is (str/includes? out "online=\"3\""))))
+
+    (testing "a map whose every entry is a stripped on* prop yields the
+              empty string — no stray leading space"
+      (is (= "" (html/attr-string {:on-click "f" :onScroll "g"}))))))
+
+(deftest attr-string-strips-function-valued-props
+  (testing "rf2-dwds9 — function-valued props have no HTML serialisation
+            and are dropped (a fn can only be a handler/callback)"
+    (is (= " id=\"x\""
+           (html/attr-string {:title (fn [_] :handler) :id "x"})))
+
+    (testing "fn value is stripped even when the key itself is innocuous"
+      (is (= ""
+             (html/attr-string {:data-cb (fn [] nil)}))))))
+
+(deftest attr-string-drops-prototype-pollution-keys
+  (testing "rf2-dwds9 — reserved prototype-pollution keys are dropped
+            before they reach the host createElement-equivalent"
+    (doseq [k ["__proto__" "constructor" "prototype"]]
+      (testing (str "`" k "` is dropped")
+        (is (= " id=\"x\""
+               (html/attr-string {(keyword k) "polluted" :id "x"}))
+            (str k " must not survive to wire output"))))
+
+    (testing "the match is case-insensitive on the normalised name"
+      (is (= " id=\"x\""
+             (html/attr-string {(keyword "Constructor") "polluted" :id "x"}))))))
+
+(deftest attr-string-normal-attrs-still-emit
+  (testing "the filter does not over-reach — ordinary attrs round-trip"
+    (let [out (html/attr-string {:id "main" :class "a b" :data-x "1"})]
+      (is (str/includes? out "id=\"main\""))
+      (is (str/includes? out "class=\"a b\""))
+      (is (str/includes? out "data-x=\"1\""))))
+
+  (testing "stripped props are filtered BEFORE the grammar gate — a prop
+            that would otherwise throw `:rf.error/ssr-invalid-attribute-name`
+            is silently dropped rather than raising"
+    (is (= " id=\"x\""
+           (html/attr-string {(keyword "onClick=alert(1) data-x") "v"
+                              :id "x"})))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -5,6 +5,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
@@ -117,13 +118,22 @@
           tree   [:rf/suspense-boundary {:id :flaky :fallback [:p "Loading…"]}
                   [throws]]
           {:keys [continuations]} (streaming/render-shell tree)
-          entry  (assoc (first continuations) :fallback [:p "Loading…"])
+          ;; rf2-405ld — exercise the REAL record→fail path: the
+          ;; continuation entry must already carry its declared :fallback
+          ;; from `record-continuation!`. Previously this test masked the
+          ;; bug by manually `(assoc … :fallback [:p "Loading…"])`; with
+          ;; the manual assoc removed, an empty fallback on failure (the
+          ;; bug) would surface here as a "" :html.
+          entry  (first continuations)
           captured (atom [])
           result (with-trace-capture captured
                    #(streaming/render-continuation fid entry))]
+      (is (= [:p "Loading…"] (:fallback entry))
+          "record-continuation! stored the declared :fallback on the entry")
       (is (:failed? result) ":failed? truthy")
       (is (nil? (:delta result)) "delta omitted on failure")
-      (is (= "<p>Loading…</p>" (:html result)) "fallback hiccup materialised in place")
+      (is (= "<p>Loading…</p>" (:html result))
+          "declared fallback hiccup materialised in place (not empty)")
       (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
                 @captured)
           ":rf.ssr/suspense-boundary-failed trace emitted"))))
@@ -156,6 +166,46 @@
       (is (= "deadbeef" (:rf/render-hash payload)))
       (is (= "abc123" (:rf/schema-digest payload)))
       (is (= {:articles [{:id "a"}]} (:rf/app-db payload))))))
+
+(deftest build-final-payload-version-honours-runtime-version-hook
+  (testing "rf2-via0g — streaming payload :rf/version reads the
+            :rf2/runtime-version late-bind hook (mirroring the non-
+            streaming rf2-asmj1 S8 fix), not a hard-coded 1. The prior
+            `(or version 1)` silently disagreed with the client-side
+            hook and defeated the :rf.ssr/version-mismatch check."
+    (let [fid (make-frame {:db {:k 1}})]
+      (testing "hook present + no explicit :version → hook value wins (not 1)"
+        (late-bind/set-fn! :rf2/runtime-version (constantly "9.9.9"))
+        (try
+          (let [payload (streaming/build-final-payload
+                          fid "hash"
+                          {:payload-policy :rf.ssr.payload/whole-app-db})]
+            (is (= "9.9.9" (:rf/version payload))
+                "runtime-version hook value lands in :rf/version")
+            (is (not= 1 (:rf/version payload))
+                "the hard-coded 1 must NOT win when the hook is registered"))
+          (finally
+            (swap! late-bind/hooks dissoc :rf2/runtime-version))))
+
+      (testing "explicit :version opt wins over the hook"
+        (late-bind/set-fn! :rf2/runtime-version (constantly "9.9.9"))
+        (try
+          (let [payload (streaming/build-final-payload
+                          fid "hash"
+                          {:version        42
+                           :payload-policy :rf.ssr.payload/whole-app-db})]
+            (is (= 42 (:rf/version payload))
+                "caller-supplied :version is the highest-priority source"))
+          (finally
+            (swap! late-bind/hooks dissoc :rf2/runtime-version))))
+
+      (testing "no hook + no explicit :version → terminal v1 fallback"
+        (swap! late-bind/hooks dissoc :rf2/runtime-version)
+        (let [payload (streaming/build-final-payload
+                        fid "hash"
+                        {:payload-policy :rf.ssr.payload/whole-app-db})]
+          (is (= 1 (:rf/version payload))
+              "absent hook + absent opt → v1 pattern-protocol stamp"))))))
 
 (deftest late-bind-hooks-published
   (testing "All three :ssr.streaming/* late-bind hooks resolve to the streaming fns"


### PR DESCRIPTION
## Summary

Three SSR correctness bugs in `implementation/ssr`:

- **rf2-x7hin (P1, SECURITY)** — The SSR emitter never implemented Spec 011 rule **rf2-dwds9**. `attr-string` happily emitted `on-click="…"`. It now strips, at attribute-emit time:
  - `on*` event-handler props — matched on the two canonical handler-prop spellings re-frame hiccup adapters and react-dom/server recognise: camelCase `on[A-Z]…` and kebab `on-…` (so innocuous keys like `one` / `once` / `online` are NOT eaten);
  - function-valued prop values;
  - reserved prototype-pollution keys (`__proto__` / `constructor` / `prototype`).

  The drop runs ahead of the `validate-attr-name!` grammar gate so the three reserved keys fail-soft (dropped) while malformed/breakout keys still throw `:rf.error/ssr-invalid-attribute-name` (rf2-vl8ir preserved). A non-empty attrs map whose every entry is stripped now yields `""` rather than a stray leading space.

- **rf2-405ld (P1)** — Streaming: a FAILED continuation rendered an EMPTY fallback. Root cause: `record-continuation!` never stored `:fallback`, so the real streaming path always saw `nil` → `render-to-string` of nil → `""`. `record-continuation!` now stores the declared `:fallback`; the failure path already destructures and renders it. The existing unit test was masking the bug by manually `(assoc … :fallback …)` onto the entry — that manual assoc is removed, so the test now exercises the real record→fail path.

- **rf2-via0g (P2)** — Streaming `build-final-payload` hard-coded `(or version 1)`, ignoring the `:rf2/runtime-version` hook and silently defeating `:rf.ssr/version-mismatch` detection — the exact bug the non-streaming path fixed under rf2-asmj1 S8. A `resolve-version` mirror now reads the hook (caller `:version` opt wins, then the `:rf2/runtime-version` late-bind hook, then the terminal v1 stamp).

## Test plan

- [x] `npm run test:cljs` — 3905 tests / 11871 assertions, 0 failures
- [x] ssr artefact JVM `clojure -M:test` — 198 tests / 665 assertions, 0 failures (includes new `ssr_attr_filter_test.clj` + the de-masked streaming fallback test + the new runtime-version test)
- [x] ssr-ring artefact JVM `clojure -M:test` — 63 tests / 327 assertions, 0 failures
- [x] No `spec/*.md` edits, so `mkdocs build --strict` not required