### PR TITLE
fix(routing): popstate honours fragment-only rule + named-splat rank + doc fixes (rf2-8oxj6 + rf2-yjali + rf2-kukj5)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -27,11 +27,13 @@
 
 (defn malformed-url?
   "Public predicate: true when `url`'s percent-encoding is malformed in
-  any of its decode'd portions (path captures via the registered
-  routes' patterns, query keys, query values, or `#fragment`). Used by
-  `:rf.route/transitioned` / `:rf.route/handle-url-change` to discriminate the
-  bare route-miss case (`{:url url}`) from the malformed-URL fail-
-  closed case (`{:url url :reason :malformed-url}`) — both end up at
+  any of its decode'd portions — any non-empty path segment, any query
+  key or value, or the `#fragment`. The scan is purely lexical: it splits
+  the URL into pieces and tries to %-decode each one; no route table or
+  pattern is consulted. Used by `:rf.route/transitioned` /
+  `:rf.route/handle-url-change` to discriminate the bare route-miss case
+  (`{:url url}`) from the malformed-URL fail-closed case
+  (`{:url url :reason :malformed-url}`) — both end up at
   `:rf.route/not-found` but the structured `:reason` lets per-route
   error UIs and SSR projections branch on the cause.
 
@@ -1413,8 +1415,31 @@
 ;; ---- URL-driven navigation: shared full-rewrite path ---------------------
 ;; `:rf.route/transitioned` (forward nav, default scroll `:top`) and
 ;; `:rf.route/handle-url-change` (popstate / initial / SSR, default
-;; scroll `:restore`) share `url-change-fx`. The fragment-only branch is
-;; exclusive to `:rf.route/transitioned`.
+;; scroll `:restore`) share `url-change-fx`. The fragment-only branch
+;; (Spec 012 §Fragments rules 3-4) ALSO lives in `url-change-fx`, so both
+;; events honour it — popstate / Back-Forward to a same-page anchor must
+;; not allocate a new nav-token or re-fire `:on-match` (rf2-8oxj6).
+
+(defn- fragment-only-fx
+  "Spec 012 §Fragments rules 1-4: the new URL differs from the current
+  `:rf/route` slice ONLY in its `#fragment`. Update `:fragment`, emit the
+  `:rf.route/fragment-changed` op trace (rf2-cj9fn), and return the cofx
+  map — WITHOUT allocating a fresh nav-token (rule 3) or re-firing
+  `:on-match` (rule 4). The canonical op-name says what fires it (only a
+  `#fragment` differed) and disambiguates from the runtime event
+  `:rf.route/transitioned`, which fires on every URL transition. The
+  full URL transition path never emits this op and never coincides with
+  a `:rf.route.nav-token/allocated` on the same drain. Consumers carry
+  `:prev-fragment` / `:next-fragment` in `:tags`. Scroll-capture (for the
+  position the user is leaving) still rides along."
+  [db prev next-fragment]
+  (trace/emit! :event :rf.route/fragment-changed
+               {:route-id      (:id prev)
+                :prev-fragment (:fragment prev)
+                :next-fragment next-fragment})
+  (let [capture-fx (capture-scroll-fx-entry db)]
+    (cond-> {:db (assoc-in db [:rf/route :fragment] next-fragment)}
+      capture-fx (assoc :fx [capture-fx]))))
 
 (defn- url-change-fx
   "Pure helper: given db + url + default scroll strategy (+ optional
@@ -1451,6 +1476,22 @@
         ;; Malformed URLs surface no fragment in the slice — the
         ;; fragment was the (or potentially the) decode-fail site.
         fragment          (when-not malformed? (:fragment m))
+        ;; Spec 012 §Fragments rules 3-4: when the new URL differs from
+        ;; the current slice ONLY in its `#fragment` (same route-id,
+        ;; params, query) the runtime updates `:fragment`, emits the
+        ;; `:rf.route/fragment-changed` op trace, and short-circuits
+        ;; BEFORE allocating a fresh nav-token or re-firing `:on-match`.
+        ;; This branch lives in the shared helper so EVERY URL-driven
+        ;; event honours it — both forward nav (`:rf.route/transitioned`)
+        ;; AND popstate / initial / SSR (`:rf.route/handle-url-change`).
+        ;; Back/Forward to a same-page anchor must not re-fetch route
+        ;; data (rf2-8oxj6).
+        prev              (:rf/route db)
+        fragment-only?    (and prev m
+                               (= (:id prev)     (:route-id m))
+                               (= (:params prev) (:params m))
+                               (= (:query prev)  (:query m))
+                               (not= (:fragment prev) fragment))
         matched?          (some? m)
         validation-fail?  (:validation-failed? m)
         fallback?         (or (not matched?) validation-fail?)
@@ -1477,120 +1518,94 @@
                              :saved-pos (when (= :restore strategy)
                                           (lookup-scroll-position db url))
                              :fragment  fragment})]
-    ;; rf2-4ic0f: structured telemetry for the malformed-URL case so
-    ;; SSR error projections, security dashboards, and pair-tools can
-    ;; surface the failure independently of the generic miss trace.
-    ;; Emitted alongside the regular `:rf.error/no-such-handler` event
-    ;; below — the discriminator is the `:reason :malformed-url` slot
-    ;; on the slice's `:params`.
-    (when malformed?
-      (trace/emit! :warning :rf.warning/malformed-url
-                   (cond-> {:url url}
-                     frame (assoc :frame frame))))
-    ;; Spec 012 §Route-not-found §3: emit :rf.warning/no-not-found-route
-    ;; when the unmatched-URL path resolves to :rf.route/not-found AND
-    ;; no such route is registered. Tools / AI scaffolds key off this.
-    (when (and fallback? (nil? route-meta))
-      (trace/emit! :warning :rf.warning/no-not-found-route
-                   {:url url}))
-    ;; :rf.error/no-such-handler discriminates from event / frame
-    ;; handler misses by :kind :route. The :frame tag (present when the
-    ;; caller threads it in — `:rf.route/handle-url-change`) lets the
-    ;; SSR error-projection listener attribute the trace per-frame.
-    ;; rf2-4ic0f: include `:reason :malformed-url` when applicable so
-    ;; the structured error is uniform across the trace + the slice.
-    (when fallback?
-      (trace/emit-error! :rf.error/no-such-handler
-                         (cond-> {:url url
-                                  :kind :route
-                                  :recovery :replaced-with-default}
-                           frame      (assoc :frame frame)
-                           malformed? (assoc :reason :malformed-url))))
-    (trace/emit! :event :rf.route.nav-token/allocated
-                 {:route-id  route-id
-                  :nav-token token})
-    ;; Per rf2-dn26r: route lifecycle pair. Fires after the nav-token
-    ;; allocation so trace consumers see {allocated → deactivated? →
-    ;; activated?} in that order for any cross-route transition.
-    (emit-activation-traces! (get-in db [:rf/route :id]) route-id)
-    {:db (assoc db' :rf/route
-                {:id         route-id
-                 :params     params
-                 :query      query
-                 :fragment   fragment
-                 :transition transition
-                 :error      nil
-                 :nav-token  token})
-     :fx (vec (concat (when capture-fx [capture-fx])
-                      (mapv (fn [ev] [:dispatch ev]) on-match-vec)
-                      ;; Per Spec 012 §Per-route data loading §2:
-                      ;; settle :loading → :idle after the on-match
-                      ;; drain. FIFO order: settle runs after every
-                      ;; on-match event already queued above.
-                      (when (seq on-match-vec)
-                        [[:dispatch [:rf.route.internal/settle-transition token]]])
-                      (when scroll-fx [scroll-fx])))}))
+    (if fragment-only?
+      ;; Spec 012 §Fragments rules 3-4 (rf2-8oxj6): short-circuit BEFORE
+      ;; the nav-token allocation / on-match drain below. Honoured on
+      ;; both `:rf.route/transitioned` and `:rf.route/handle-url-change`
+      ;; (popstate) because the branch lives in the shared helper.
+      (fragment-only-fx db prev fragment)
+      (do
+        ;; rf2-4ic0f: structured telemetry for the malformed-URL case so
+        ;; SSR error projections, security dashboards, and pair-tools can
+        ;; surface the failure independently of the generic miss trace.
+        ;; Emitted alongside the regular `:rf.error/no-such-handler` event
+        ;; below — the discriminator is the `:reason :malformed-url` slot
+        ;; on the slice's `:params`.
+        (when malformed?
+          (trace/emit! :warning :rf.warning/malformed-url
+                       (cond-> {:url url}
+                         frame (assoc :frame frame))))
+        ;; Spec 012 §Route-not-found §3: emit :rf.warning/no-not-found-route
+        ;; when the unmatched-URL path resolves to :rf.route/not-found AND
+        ;; no such route is registered. Tools / AI scaffolds key off this.
+        (when (and fallback? (nil? route-meta))
+          (trace/emit! :warning :rf.warning/no-not-found-route
+                       {:url url}))
+        ;; :rf.error/no-such-handler discriminates from event / frame
+        ;; handler misses by :kind :route. The :frame tag (present when the
+        ;; caller threads it in — `:rf.route/handle-url-change`) lets the
+        ;; SSR error-projection listener attribute the trace per-frame.
+        ;; rf2-4ic0f: include `:reason :malformed-url` when applicable so
+        ;; the structured error is uniform across the trace + the slice.
+        (when fallback?
+          (trace/emit-error! :rf.error/no-such-handler
+                             (cond-> {:url url
+                                      :kind :route
+                                      :recovery :replaced-with-default}
+                               frame      (assoc :frame frame)
+                               malformed? (assoc :reason :malformed-url))))
+        (trace/emit! :event :rf.route.nav-token/allocated
+                     {:route-id  route-id
+                      :nav-token token})
+        ;; Per rf2-dn26r: route lifecycle pair. Fires after the nav-token
+        ;; allocation so trace consumers see {allocated → deactivated? →
+        ;; activated?} in that order for any cross-route transition.
+        (emit-activation-traces! (get-in db [:rf/route :id]) route-id)
+        {:db (assoc db' :rf/route
+                    {:id         route-id
+                     :params     params
+                     :query      query
+                     :fragment   fragment
+                     :transition transition
+                     :error      nil
+                     :nav-token  token})
+         :fx (vec (concat (when capture-fx [capture-fx])
+                          (mapv (fn [ev] [:dispatch ev]) on-match-vec)
+                          ;; Per Spec 012 §Per-route data loading §2:
+                          ;; settle :loading → :idle after the on-match
+                          ;; drain. FIFO order: settle runs after every
+                          ;; on-match event already queued above.
+                          (when (seq on-match-vec)
+                            [[:dispatch [:rf.route.internal/settle-transition token]]])
+                          (when scroll-fx [scroll-fx])))}))))
 
 (events/reg-event-fx :rf.route/transitioned
   (fn [{:keys [db frame]} [_ url opts :as event-vec]]
-    ;; Per Spec 012 §URL changes are events / §Fragments. match-url
-    ;; surfaces the URL's `#fragment` directly on its result; if only
-    ;; the fragment differs from the current slice, update :fragment but
-    ;; DO NOT re-fire :on-match — emit :rf.route/fragment-changed
-    ;; instead (rf2-cj9fn). Otherwise full nav: delegate to
-    ;; `url-change-fx`.
-    ;;
-    ;; Default scroll strategy for forward nav (click / programmatic
-    ;; push) is `:top` per Spec 012 §Scroll restoration; popstate /
-    ;; initial / SSR routes through `:rf.route/handle-url-change` which
-    ;; defaults to `:restore`.
-    (let [opts           (or opts {})
-          blocked        (maybe-block-navigation db (or frame :rf/default)
-                                                event-vec url
-                                                (:bypass-leave-guard? opts))
-          m              (when-not blocked (match-url url))
-          fragment       (:fragment m)
-          prev           (:rf/route db)
-          fragment-only? (and prev m
-                              (= (:id prev)     (:route-id m))
-                              (= (:params prev) (:params m))
-                              (= (:query prev)  (:query m))
-                              (not= (:fragment prev) fragment))]
-      (cond
-        blocked
-        blocked
-
-        fragment-only?
-        ;; Per Spec 009 §:op-type vocabulary and Spec 012 §Fragments
-        ;; (rf2-cj9fn): :rf.route/fragment-changed is the canonical
-        ;; op-name for fragment-only navigation. The op-name says what
-        ;; fires it (only a `#fragment` differed) and disambiguates from
-        ;; the runtime event `:rf.route/transitioned`, which fires on every URL
-        ;; transition. Pre-rf2-cj9fn this emitted `:rf.route/fragment-changed`
-        ;; — one path segment away from the runtime event with very
-        ;; different meaning. The new op-name pairs with the fragment-
-        ;; only branch's contract: full URL transitions never emit it,
-        ;; never coincide with a `:rf.route.nav-token/allocated` on the
-        ;; same drain. Consumers carry `:prev-fragment` / `:next-fragment`
-        ;; in `:tags`.
-        (do (trace/emit! :event :rf.route/fragment-changed
-                         {:route-id      (:id prev)
-                          :prev-fragment (:fragment prev)
-                          :next-fragment fragment})
-            (let [capture-fx (capture-scroll-fx-entry db)]
-              (cond-> {:db (assoc-in db [:rf/route :fragment] fragment)}
-                capture-fx (assoc :fx [capture-fx]))))
-
-        :else
-        (url-change-fx db url :top nil)))))
+    ;; Per Spec 012 §URL changes are events / §Fragments. Forward nav
+    ;; (link click / programmatic push). After the leave-guard check,
+    ;; delegate to the shared `url-change-fx`, which distinguishes a
+    ;; fragment-only change (update :fragment, emit
+    ;; :rf.route/fragment-changed, no nav-token / no :on-match — rf2-cj9fn)
+    ;; from a full slice rewrite. Default scroll strategy for forward nav
+    ;; is `:top` per Spec 012 §Scroll restoration; popstate / initial /
+    ;; SSR routes through `:rf.route/handle-url-change` (default
+    ;; `:restore`).
+    (let [opts    (or opts {})
+          blocked (maybe-block-navigation db (or frame :rf/default)
+                                          event-vec url
+                                          (:bypass-leave-guard? opts))]
+      (or blocked
+          (url-change-fx db url :top nil)))))
 
 (events/reg-event-fx :rf.route/handle-url-change
   (fn [{:keys [db frame]} [_ url opts :as event-vec]]
     ;; Per Spec 012 §URL changes are events — popstate, initial load,
-    ;; SSR. Always a full slice rewrite (the fragment-only branch is
-    ;; exclusive to `:rf.route/transitioned`); default scroll strategy is
-    ;; `:restore` so the saved position trumps. `:frame` is threaded
-    ;; through to `url-change-fx` so the SSR error-projection listener
+    ;; SSR. Delegates to the shared `url-change-fx`, which honours the
+    ;; fragment-only short-circuit (Spec 012 §Fragments rules 3-4): a
+    ;; Back/Forward to a same-page `#fragment` updates :fragment WITHOUT
+    ;; allocating a new nav-token or re-firing :on-match (rf2-8oxj6). The
+    ;; default scroll strategy is `:restore` so the saved position trumps.
+    ;; `:frame` is threaded through so the SSR error-projection listener
     ;; can attribute the :no-such-handler trace per-frame.
     (let [opts    (or opts {})
           blocked (maybe-block-navigation db (or frame :rf/default)

--- a/implementation/routing/src/re_frame/routing/match.cljc
+++ b/implementation/routing/src/re_frame/routing/match.cljc
@@ -261,8 +261,17 @@
            counts  {:static 0 :named 0 :splat 0 :optional 0 :total 0}]
       (if-not (< i n)
         (let [{:keys [static total splat optional named]} counts
+              ;; Spec 012 §Route ranking algorithm rule 4: the catch-all
+              ;; is EXACTLY the bare `/*` pattern — a single unnamed splat
+              ;; with no other segments. A NAMED splat (`/*rest`) is a rest
+              ;; param and out-ranks the catch-all, so it MUST NOT be
+              ;; classified here. The bare splat carries an empty capture
+              ;; name (validate-route-pattern! permits `/*` with empty nm);
+              ;; a named splat records its name, so require the lone
+              ;; captured name to be empty to qualify as catch-all.
               catch-all? (and (= 1 total) (= 1 splat)
-                              (zero? static) (zero? named) (zero? optional))]
+                              (zero? static) (zero? named) (zero? optional)
+                              (= [""] names))]
           {:regex   (re-pattern (apply str (conj parts "$")))
            :names   names
            ;; `:groups` maps each optional-group's opening '{' index to

--- a/implementation/routing/src/re_frame/routing/url.cljc
+++ b/implementation/routing/src/re_frame/routing/url.cljc
@@ -60,20 +60,21 @@
 
 (defn malformed-url?
   "Public predicate: true when `url`'s percent-encoding is malformed in
-  any of its decode'd portions (path captures via the registered
-  routes' patterns, query keys, query values, or `#fragment`). Used by
-  `:rf.route/transitioned` / `:rf.route/handle-url-change` to discriminate the
-  bare route-miss case (`{:url url}`) from the malformed-URL fail-
-  closed case (`{:url url :reason :malformed-url}`) — both end up at
+  any of its decode'd portions — any non-empty path segment, any query
+  key or value, or the `#fragment`. Used by `:rf.route/transitioned` /
+  `:rf.route/handle-url-change` to discriminate the bare route-miss case
+  (`{:url url}`) from the malformed-URL fail-closed case
+  (`{:url url :reason :malformed-url}`) — both end up at
   `:rf.route/not-found` but the structured `:reason` lets per-route
   error UIs and SSR projections branch on the cause.
 
   Per Spec 012 §Routing failure semantics §Malformed percent-encoding
-  (rf2-4ic0f). The check decodes path captures against the registered
-  patterns (so a bare `%` in a non-captured static segment of a path
-  the route doesn't match is not flagged — it's just a normal miss);
-  for the query and fragment the full string is decoded, so any `%`
-  that won't decode anywhere in either flips the predicate.
+  (rf2-4ic0f). The scan is purely lexical and pattern-agnostic: the URL
+  is split into path segments (on `/`), query pairs (on `&`, then `=`),
+  and the `#fragment`, and each piece is run through `safe-url-decode`.
+  Any piece that won't decode flips the predicate — no route table or
+  compiled pattern is consulted, so a bare `%` in any path segment is
+  flagged regardless of whether a route would have captured it.
 
   O(URL-pieces) — runs once per URL-driven nav alongside the regular
   `match-url` walk; the cost is bounded by the URL length, not the

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2080,6 +2080,61 @@
           (is (= "fragments" (-> second-ev :tags :next-fragment))
               "second transition: next-fragment is the new value"))))))
 
+;; ---- rf2-8oxj6: popstate honours the fragment-only rule ----------------
+;;
+;; Spec 012 §Fragments rules 3-4: a fragment-only URL change MUST NOT
+;; allocate a new nav-token and MUST NOT re-fire :on-match. Back/Forward
+;; (popstate) is wired through :rf.route/handle-url-change. Before the
+;; fix the fragment-only short-circuit lived ONLY in
+;; :rf.route/transitioned, so popstate to a same-page #fragment took the
+;; full-rewrite path → fresh nav-token + :on-match re-fire (the exact
+;; data-refetch thrash the rule forbids). The branch now lives in the
+;; shared `url-change-fx`, so BOTH events honour it.
+
+(deftest popstate-fragment-only-change-no-token-no-on-match-refire
+  (testing "rf2-8oxj6: :rf.route/handle-url-change (popstate) to a URL
+            differing ONLY in its #fragment does NOT allocate a new
+            nav-token and does NOT re-fire :on-match (Spec 012 §Fragments
+            rules 3-4)"
+    (let [on-match-calls (atom 0)]
+      (rf/reg-event-db :docs/load
+                       (fn [db _]
+                         (swap! on-match-calls inc)
+                         db))
+      (rf/reg-route :route/docs {:path     "/docs/:page"
+                                 :on-match [[:docs/load]]})
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}}
+                 (fn [_ _] nil))
+      ;; Land on /docs/routing via popstate (handle-url-change). This is
+      ;; a full nav: allocates nav-1 and fires :on-match once.
+      (rf/dispatch-sync [:rf.route/handle-url-change "/docs/routing"])
+      (let [slice (:rf/route (rf/get-frame-db :rf/default))]
+        (is (= :route/docs (:id slice)) "landed on /docs/routing")
+        (is (= "nav-1" (:nav-token slice)) "first nav allocated nav-1")
+        (is (= 1 @on-match-calls) ":on-match fired once on the full nav"))
+
+      (let [traces (atom [])]
+        (rf/register-listener! ::popstate-frag (fn [ev] (swap! traces conj ev)))
+        ;; Back/Forward to the SAME page, only the #fragment differs.
+        ;; This is the popstate path (handle-url-change), the regression
+        ;; site: must short-circuit, NOT full-rewrite.
+        (rf/dispatch-sync [:rf.route/handle-url-change "/docs/routing#section-2"])
+        (rf/unregister-listener! ::popstate-frag)
+        (let [slice (:rf/route (rf/get-frame-db :rf/default))]
+          (is (= "section-2" (:fragment slice))
+              "fragment-only change updates :fragment")
+          (is (= "nav-1" (:nav-token slice))
+              "rule 3: no NEW nav-token allocated on fragment-only popstate")
+          (is (= 1 @on-match-calls)
+              "rule 4: :on-match did NOT re-fire on fragment-only popstate"))
+        ;; The fragment-only branch emits :rf.route/fragment-changed and
+        ;; NEVER a :rf.route.nav-token/allocated on the same drain.
+        (is (some #(= :rf.route/fragment-changed (:operation %)) @traces)
+            "fragment-only popstate emits :rf.route/fragment-changed")
+        (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
+            "fragment-only popstate emits NO :rf.route.nav-token/allocated")))))
+
 ;; ---- T8: :fragment in slice after URL-driven nav -----------------------
 
 (deftest fragment-in-slice-after-url-driven-nav
@@ -2497,6 +2552,47 @@
           "empty splat tail → nil (regex requires non-empty capture)")
       (is (nil? (routing.match/match-against compiled "/files"))
           "missing splat tail → nil"))))
+
+;; ---- rf2-yjali: named splat out-ranks the bare catch-all ----------------
+;;
+;; Spec 012 §Route ranking algorithm rule 4: "Rest params beat
+;; catch-all/not-found." The catch-all is EXACTLY the bare `/*` pattern
+;; (`is-catch-all? (= pattern "/*")` in the spec pseudocode). A NAMED
+;; splat (`/*rest`) is a rest param, so it must out-rank `/*`. Before the
+;; fix `parse-pattern`'s classifier flagged ANY single-splat-only pattern
+;; as catch-all, so `/*rest` tied with `/*` at rank element 4 instead of
+;; beating it.
+
+(deftest parse-pattern-named-splat-outranks-bare-catch-all
+  (testing "rf2-yjali — only the bare `/*` is catch-all; a named splat
+            `/*rest` ranks above it at rank element 4 (Spec 012 rule 4)"
+    (let [catch-all (:rank (routing.match/parse-pattern "/*"))
+          rest-splat (:rank (routing.match/parse-pattern "/*rest"))]
+      ;; Rank element 3 (0-indexed) is the rule-4 catch-all discriminator:
+      ;; 0 = catch-all (less specific), 1 = not catch-all (more specific).
+      (is (= 0 (nth catch-all 3))
+          "bare `/*` is classified as the catch-all (rank elem 4 = 0)")
+      (is (= 1 (nth rest-splat 3))
+          "named `/*rest` is NOT the catch-all (rank elem 4 = 1)")
+      ;; The two patterns are identical on every other rank element
+      ;; (statics, length, splat, optional) — the catch-all discriminator
+      ;; is the ONLY difference, and it must make `/*rest` win.
+      (is (= (assoc catch-all 3 :x) (assoc rest-splat 3 :x))
+          "the two ranks differ ONLY at the rule-4 catch-all element")
+      (is (pos? (compare rest-splat catch-all))
+          "lexicographic compare: `/*rest` out-ranks `/*` (rule 4)"))))
+
+(deftest match-url-named-splat-wins-over-bare-catch-all
+  (testing "rf2-yjali — when both `/*rest` and `/*` are registered, a
+            multi-segment URL resolves to the named-splat route, not the
+            catch-all (Spec 012 §Route ranking rule 4)"
+    (rf/reg-route :route/catch-all {:path "/*"})
+    (rf/reg-route :route/rest      {:path "/*rest"})
+    (let [m (routing/match-url "/some/deep/path")]
+      (is (= :route/rest (:route-id m))
+          "named-splat route wins the rule-4 tiebreak against bare catch-all")
+      (is (= {:rest "some/deep/path"} (:params m))
+          "the named splat captures the whole tail under :rest"))))
 
 (deftest match-against-root-pattern-matches-root-path
   (testing "rf2-aleg9 — the special `/` pattern matches the root URL

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -87,7 +87,7 @@ Defined per the [009 Error contract](009-Instrumentation.md#error-contract):
 - `:rf.route/activated` / `:rf.route/deactivated` — fire on every cross-route navigation commit, in `deactivated → activated` order. Same-id navigation (path/query change with no route-id shift) emits neither. First-ever navigation emits `:rf.route/activated` only (no prior route). Per rf2-dn26r.
 - `:rf.route.nav-token/allocated` — fresh nav-token cascade begins.
 - `:rf.route.nav-token/stale-suppressed` — async result carrying a now-superseded token.
-- `:rf.route/fragment-changed` — fragment-only URL update (the URL changed only in its `#fragment`; `:on-match` did not re-fire). Distinct from the runtime event `:rf.route/transitioned`, which fires on every URL transition. Renamed from `:rf.route/fragment-changed` per rf2-cj9fn so the trace op-name says what fires it (only a `#fragment` differed) and disambiguates from the runtime event.
+- `:rf.route/fragment-changed` — fragment-only URL update (the URL changed only in its `#fragment`; `:on-match` did not re-fire). Distinct from the runtime event `:rf.route/transitioned`, which fires on every URL transition. The op-name says what fires it (only a `#fragment` differed) and disambiguates from the runtime event (rf2-cj9fn).
 - `:rf.route/navigation-blocked` — `:can-leave` guard rejected a navigation.
 - `:rf.error/can-leave-non-boolean` — `:can-leave` sub returned a non-boolean value; the runtime BLOCKED the navigation. Closed contract per rf2-5pyyl; see [§Navigation blocking — pending-nav protocol](#navigation-blocking--pending-nav-protocol).
 - `:rf.error/duplicate-url-binding` — second frame attempted `:url-bound? true` while another already owns the URL.
@@ -795,7 +795,7 @@ Read it via the `:rf.route/fragment` sub. Fragment is **populated by `match-url`
 When the new URL differs from the current URL **only** in its fragment (same `:route-id`, same `:params`, same `:query`, but different `:fragment`), the runtime:
 
 1. Updates `:fragment` in the `:rf/route` slice.
-2. Emits a `:rf.route/fragment-changed` trace event (rf2-cj9fn; pre-rename `:rf.route/fragment-changed`) with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s>}`.
+2. Emits a `:rf.route/fragment-changed` trace event (rf2-cj9fn) with `:tags {:route-id <id> :prev-fragment <s> :next-fragment <s>}`.
 3. Does **NOT** allocate a new `:nav-token`.
 4. Does **NOT** re-fire `:on-match`.
 


### PR DESCRIPTION
## Summary

Three routing fixes in the `re-frame.routing` artefact:

- **rf2-8oxj6 (P1) — popstate honours the fragment-only rule.** Spec 012 §Fragments rules 3-4 require a fragment-only URL change to NOT allocate a new nav-token and NOT re-fire `:on-match`. The short-circuit lived exclusively in `:rf.route/transitioned`, while popstate / Back-Forward flows through `:rf.route/handle-url-change` → the unconditional full-rewrite `url-change-fx`. So Back to a same-page URL differing only in `#fragment` allocated a fresh nav-token and re-fired the loaders — the exact data-refetch thrash the rule forbids. Fix: the fragment-only branch now lives in the shared `url-change-fx` (factored into `fragment-only-fx`), so BOTH events honour it. This matches the spec's reference handler + prose, which already place the branch in `handle-url-change`.

- **rf2-yjali (P2) — named splat out-ranks the bare catch-all.** `parse-pattern`'s classifier flagged ANY single-splat-only pattern as catch-all, so `/*rest` tied with `/*` at ranking rule 4 instead of out-ranking it. The catch-all is exactly the bare `/*` (unnamed splat) per the spec pseudocode; the classifier now additionally requires the lone splat to be unnamed.

- **rf2-kukj5 (P3, cosmetic) — two doc-smells.** (a) The `:rf.route/fragment-changed` "renamed from itself" note (spec + impl) is removed/reworded. (b) `malformed-url?`'s docstring claimed a pattern-aware path decode it never performs — the scan is purely lexical (split URL into path segments / query pairs / fragment, `safe-url-decode` each); both `routing.cljc` and `routing/url.cljc` docstrings corrected.

## Test plan

- [x] `npm run test:cljs` — 3905 tests / 11871 assertions, 0 failures
- [x] routing artefact JVM: `clojure -M:test` — 111 tests / 503 assertions, 0 failures
- [x] `mkdocs build --strict` — clean (spec edits)
- [x] New regression tests:
  - `popstate-fragment-only-change-no-token-no-on-match-refire` — popstate to a fragment-only URL asserts no new nav-token, no `:on-match` re-fire, emits `:rf.route/fragment-changed`, no `:rf.route.nav-token/allocated`
  - `parse-pattern-named-splat-outranks-bare-catch-all` — rank tuple: `/*rest` rule-4 element beats `/*`
  - `match-url-named-splat-wins-over-bare-catch-all` — end-to-end resolution