### PR TITLE
feat(machines-viz): xyflow Phase-2 bundle — parallel regions + spawn-all/cascade overlays + UIx/Helix adapters + visual-pin tests (4 beads)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -333,7 +333,7 @@ same model.
 | Renderer | Layout | Output | Surface | Status |
 |---|---|---|---|---|
 | Mermaid | Mermaid-internal (Dagre-derived) | static SVG via DSL | docs prose, README, AI-pair chat replies | shipped (`re-frame.machines.mermaid`) |
-| xyflow + elkjs (`MachineChart`) | ELK.js inside `@xyflow/react` | interactive React canvas | Causa panel + user-app drop-in + docs cells | v1.0 commitment (Phase 1 — rf2-gpzb4 xyflow migration; Reagent-only adapter, UIx/Helix substrate adapters follow-on) |
+| xyflow + elkjs (`MachineChart`) | ELK.js inside `@xyflow/react` | interactive React canvas | Causa panel + user-app drop-in + docs cells | v1.0 commitment (Phase 2 COMPLETE — rf2-gpzb4 xyflow migration + rf2-lkwev/rf2-3ow55/rf2-yg9he/rf2-y9j79: full parallel-region rendering, `:spawn-all` join + cancellation-cascade overlays, UIx/Helix substrate adapters, browser-side visual-pin tests) |
 
 ### Alternatives rejected (with reasons)
 
@@ -403,18 +403,32 @@ continuing to lift the hand-rolled stack.
 **Accepted trade-offs** (captured here so future debate doesn't
 re-litigate them — these were knowingly traded, not overlooked):
 
-- **Substrate-agnostic hiccup contract LOST.** xyflow is a React
-  component library; the chart becomes React-component-shaped
-  rather than substrate-agnostic hiccup data. Phase 1 ships
-  Reagent-only; UIx and Helix substrate adapters are follow-on
-  beads. (The chart was always going to bottom out at a React
-  renderer eventually; this just moves the boundary earlier.)
-- **JVM-testability of the rendered output LOST.** The previous
+- **Substrate-agnostic hiccup contract LOST (substrate PARITY
+  restored Phase 2, rf2-yg9he).** xyflow is a React component
+  library; the chart becomes React-component-shaped rather than
+  substrate-agnostic hiccup data. Phase 1 shipped Reagent-only.
+  Phase 2 restored UIx + Helix parity: because xyflow IS React,
+  the Reagent `MachineChart` bottoms out at a React element tree,
+  and `reagent.core/reactify-component` lifts it to a plain React
+  class any host mounts. The shared bridge
+  (`adapters/react_chart.cljs`) reactifies ONCE; thin per-substrate
+  shells (`adapters/uix.cljs`, `adapters/helix.cljs`) present an
+  idiomatic surface. There is no fork of the chart per substrate —
+  all three render the same component through one bridge.
+- **JVM-testability of the rendered output LOST (browser-side CLJS
+  coverage restored Phase 2, rf2-y9j79).** The previous
   `chart/svg.cljc` was `.cljc`-testable from `clojure -M:test`;
   the new `chart.cljs` is CLJS-only because xyflow is a JS lib.
   The **parse layer** (`chart/layout.cljc`) stays JVM-testable —
   pure data → graph map, no xyflow dependency — so the
-  substrate-agnostic graph contract still has JVM coverage.
+  substrate-agnostic graph contract still has JVM coverage. Phase 2
+  added the browser-side visual-pin suite
+  (`test/.../chart/chart_dom_cljs_test.cljs`) — it mounts the chart
+  against a sample machine under headless Chromium and pins node /
+  edge counts, the node/edge class + testid contract, the
+  Controls / MiniMap / Background toggles, and the parallel-region
+  container rendering — restoring the rendered-output coverage the
+  JVM `.cljc` tests carried pre-migration.
 - **Aesthetic coherence requires extensive custom node + edge
   components.** xyflow's default look (rounded-corner default
   nodes, generic edge style) collides with the Causa devtool

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -66,6 +66,52 @@ unrecognised keys at registration time).
 | `:layout-options` | no | `nil` | ELK `layoutOptions` overrides — a map of string → string keys that merge ON TOP of the canonical defaults (`chart.elk-layout/default-layout-options`). Hosts tighten / widen / swap individual knobs (`"elk.spacing.nodeNode"` for density, `"elk.layered.crossingMinimization.strategy"` for rank-order discipline, etc.) without re-stating the whole map. The `:direction` arg always wins for `"elk.direction"`. Per rf2-ikdi3. |
 | `:layout-engine` | no | `:auto` | Engine selector — `:auto` (cached ELK when available, layered fallback otherwise — the historical behaviour), `:elk` (cached ELK only; returns nothing when not ready so the host can choose 'wait + retry' over 'render the inferior engine'), `:layered` (force the layered fallback — useful for deterministic screenshot tests). Per rf2-ikdi3 — the two-engine reality (layered fallback + ELK) is now surfaced explicitly rather than hidden behind a single entry point. |
 | `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Picks the geometry + typography map from `visual-constants/chart-for-density`; the chart's `corner-radius` lock (rf2-g6cig) is invariant across every density so the chart's visual character stays consistent — only quantity scales. Per [§Density](#density) and rf2-32gw5. |
+| `:spawn-all-join` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready `:spawn-all` join-spec — `{:node-id <string> :join <:all\|:any\|{:n N}\|{:fn _}> :children [{:key <kw> :done? :failed? :cancelled? :note}] :resolved? <bool?> :on-all-complete :on-any-failed}`. When present the chart mounts the `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing state, showing each spawned child + the join state. The host (Causa) projects the spec from its `:rf.machine.spawn-all/*` trace buffer; machines-viz owns only positioning + paint. nil → no inspector. |
+| `:on-spawn-child-click` | no | `nil` | `(fn [child-key] ...)`. Fires on a join-inspector child-row click; Causa pivots to the child instance. |
+| `:cancellation-cascade` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready cascade-spec — `{:node-id <string> :parent-label <string?> :from-state <kw?> :steps [{:kind <:exit\|:destroy\|:abort\|:cleanup> :label <string> :note :delta-ms}]}`. When present (and `:steps` is non-empty) the chart mounts the `chart.overlays.cancellation-cascade` waterfall beneath the parent state, turning the scattered abort/destroy traces into one decision laid out vertically. The host projects the spec from the cancellation trace cluster. nil / no steps → dormant. |
+| `:overlay-tick` | no | `nil` | rf2-3ow55. Opaque value the host bumps to force the `:spawn-all` + cascade overlays to re-measure + repaint (mirrors `:after-ring-tick`). |
+
+### Parallel-region rendering (rf2-lkwev, xyflow Phase 2)
+
+A `{:type :parallel :regions {...}}` machine renders EVERY region as a
+distinct orthogonal zone (Stately parity), superseding the Phase 1
+first-region-only projection. Each region surfaces a synthetic
+`:region?` compound container node — `chart.layout/parse-definition`
+mints a `region__<region-id>` node-id for it, tags each region state
+with `:region` + `:parent-id`, and flags the result `:parallel? true`.
+`chart.chart/xyflow-graph` projects the container as a
+`type: "parallel-region"` xyflow node (rendered by
+`chart.nodes.parallel-region-node` with a distinct dashed boundary +
+header label whose colour rotates per region index) and assigns each
+state a `parentNode`/`:extent "parent"` so xyflow's sub-flow mechanic
+nests the states inside the zone; elkjs lays the states out inside
+each region's bounding box via `elk.hierarchyHandling
+INCLUDE_CHILDREN`. The chart root surfaces `data-region-count`; region
+containers are excluded from `data-node-count` + the aria-label state
+count (they are zone chrome, not states).
+
+### Substrate adapters (rf2-yg9he, xyflow Phase 2)
+
+The xyflow `MachineChart` is a Reagent component, but xyflow IS React,
+so the chart bottoms out at a React element tree.
+`reagent.core/reactify-component` lifts it to a plain React class any
+host mounts. The shared bridge `adapters.react-chart` reactifies once
+(`MachineChartReactClass`) + exposes `chart-element` (CLJS props map →
+React element); thin per-substrate shells present an idiomatic surface:
+
+```clojure
+;; UIx host
+(:require [day8.re-frame2-machines-viz.adapters.uix :as mv-uix])
+($ mv-uix/MachineChart {:machine-id :auth/flow :definition defn})
+
+;; Helix host
+(:require [day8.re-frame2-machines-viz.adapters.helix :as mv-helix]
+          [helix.core :refer [$]])
+($ mv-helix/MachineChart {:machine-id :auth/flow :definition defn})
+```
+
+All three substrates render the SAME component through one bridge —
+there is no per-substrate fork of the chart.
 
 The four `:on-*` callback shapes are mirrored from
 [Causa 003 §Source-coord integration](../../causa/spec/003-Machine-Inspector.md#source-coord-integration);
@@ -817,7 +863,11 @@ the AI-generate test ns for examples).
 ## Public CLJS API surface — summary
 
 ```clojure
-day8.re-frame2-machines-viz.chart/MachineChart    ; component
+day8.re-frame2-machines-viz.chart/MachineChart    ; component (Reagent)
+day8.re-frame2-machines-viz.adapters.react-chart/MachineChartReactClass ; rf2-yg9he — reactified React class
+day8.re-frame2-machines-viz.adapters.react-chart/chart-element          ; rf2-yg9he — CLJS props → React element
+day8.re-frame2-machines-viz.adapters.uix/MachineChart   ; rf2-yg9he — UIx shell ($-mountable)
+day8.re-frame2-machines-viz.adapters.helix/MachineChart ; rf2-yg9he — Helix shell ($-mountable)
 day8.re-frame2-machines-viz.share/encode-share-url
 day8.re-frame2-machines-viz.share/decode-share-url
 day8.re-frame2-machines-viz.mermaid/emit          ; pure fn — definition → string

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/helix.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/helix.cljs
@@ -1,0 +1,49 @@
+(ns day8.re-frame2-machines-viz.adapters.helix
+  "Helix substrate shell for `MachineChart` (rf2-yg9he · xyflow Phase 2).
+
+  ## Why this exists
+
+  The xyflow migration (#1806) shipped `MachineChart` Reagent-only.
+  This shell restores Helix substrate parity: a Helix host renders the
+  SAME xyflow chart through the shared React bridge
+  (`adapters.react-chart`), which reactifies the Reagent component to a
+  plain React class. There is no fork of the chart — only this thin,
+  Helix-idiomatic surface.
+
+  ## Surface
+
+  `MachineChart` is a Helix component (`defnc`). A Helix host mounts it
+  the usual way:
+
+      (:require [day8.re-frame2-machines-viz.adapters.helix :as mv-helix]
+                [helix.core :refer [$]])
+
+      ($ mv-helix/MachineChart {:machine-id  :auth/login-flow
+                                :definition  defn
+                                :current-state :idle})
+
+  Props are the closed map the Reagent `MachineChart` accepts (see
+  `spec/API.md` §Props). The `:props` Helix-feature is enabled so the
+  component receives the raw props as a single map argument (Helix
+  otherwise spreads named props); the shell forwards them to the
+  bridge unchanged.
+
+  ## Bundle isolation
+
+  Tool-jar only; xyflow + elkjs are dev-only. Nothing under
+  `implementation/` may `:require` this. A Helix host opts into the
+  bundle cost deliberately."
+  (:require [helix.core :refer [defnc]]
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]))
+
+(defnc MachineChart
+  "Helix component wrapping the xyflow `MachineChart` via the shared
+  React bridge. With the `:props` feature the whole props object
+  arrives as `props`; the shell forwards it to
+  `react-chart/chart-element` which builds the reactified-Reagent
+  React element. Renders the identical chart a Reagent host renders.
+
+  `:children` is dropped — the chart manages its own subtree."
+  [props]
+  {:helix/features {:check-invalid-hooks-usage false}}
+  (react-chart/chart-element (dissoc props :children)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/react_chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/react_chart.cljs
@@ -1,0 +1,72 @@
+(ns day8.re-frame2-machines-viz.adapters.react-chart
+  "Shared React-component bridge for the `MachineChart` substrate
+  adapters (rf2-yg9he · xyflow Phase 2).
+
+  ## Why this exists
+
+  The xyflow migration (#1806) shipped `MachineChart` Reagent-only —
+  that was the accepted Phase 1 trade-off when the chart went from
+  substrate-agnostic hiccup to a React-component-shaped renderer (xyflow
+  is a React library). This bead restores UIx + Helix substrate parity.
+
+  The lever is that xyflow IS React: the Reagent `MachineChart` bottoms
+  out at a React element tree (via `r/as-element` inside its node + edge
+  components). `reagent.core/reactify-component` lifts the whole Reagent
+  component to a plain React component class that ANY React host — UIx,
+  Helix, or raw React — can mount with `createElement` / `$`. So all
+  three substrates render the SAME chart through one bridge; there is no
+  fork of the chart per substrate, only a thin host-idiomatic shell.
+
+  ## The bridge
+
+  `MachineChartReactClass` is the reactified Reagent `MachineChart`,
+  memoised (reactify-component returns a fresh class each call; React
+  caches component types by reference, so we reactify ONCE at ns-load).
+  `chart-element` builds a React element from a CLJS props map for the
+  per-substrate shells.
+
+  ## Props contract
+
+  Identical to the Reagent `MachineChart` (see `chart/MachineChart`'s
+  docstring + `spec/API.md` §Props). The shells pass a CLJS props map
+  straight through; reactify-component hands it to the Reagent component
+  as its single map argument. Callback props (`:on-state-click`, …)
+  carry through unchanged.
+
+  ## Bundle isolation
+
+  Same contract as the rest of machines-viz — xyflow + elkjs are dev-
+  only; nothing under `implementation/` may `:require` this. The
+  per-substrate shells live here in the tool jar so a UIx / Helix host
+  opts into the bundle cost deliberately (per `000-Vision.md`
+  §Surface set — user-app drop-in)."
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart :as chart]))
+
+(def MachineChartReactClass
+  "The reactified Reagent `MachineChart`, as a plain React component
+  class. Reactified ONCE at ns-load (React caches component types by
+  reference; reactifying per-render would defeat that cache and churn
+  the subtree). Any React host mounts it via `createElement` / `$`
+  with a single CLJS props map."
+  (r/reactify-component chart/MachineChart))
+
+(defn chart-element
+  "Build a React element for `MachineChart` from a CLJS `props` map.
+  The per-substrate shells call this; the returned element is a plain
+  React element so UIx (`$`) and Helix (`$`) — and raw React — all
+  mount it identically.
+
+  `props` is the same closed map the Reagent `MachineChart` accepts
+  (see `spec/API.md` §Props).
+
+  The reactified Reagent component reads its render argument from the
+  React prop `argv` — a Reagent-shaped component vector
+  `[component props & children]`. The render fn is invoked with
+  `(nth argv 1)`, so the props map sits at index 1; index 0 is an
+  ignored placeholder (the component constructor in normal Reagent
+  use). Building the React element directly (rather than via Reagent's
+  `:>` interop) keeps the shells substrate-neutral."
+  [props]
+  (r/create-element MachineChartReactClass
+                    #js {:argv #js [MachineChartReactClass (or props {})]}))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/uix.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/adapters/uix.cljs
@@ -1,0 +1,45 @@
+(ns day8.re-frame2-machines-viz.adapters.uix
+  "UIx substrate shell for `MachineChart` (rf2-yg9he · xyflow Phase 2).
+
+  ## Why this exists
+
+  The xyflow migration (#1806) shipped `MachineChart` Reagent-only.
+  This shell restores UIx substrate parity: a UIx host renders the
+  SAME xyflow chart through the shared React bridge
+  (`adapters.react-chart`), which reactifies the Reagent component to a
+  plain React class. There is no fork of the chart — only this thin,
+  UIx-idiomatic surface.
+
+  ## Surface
+
+  `MachineChart` is a UIx component (`defui`). A UIx host mounts it the
+  usual way:
+
+      (:require [day8.re-frame2-machines-viz.adapters.uix :as mv-uix])
+
+      ($ mv-uix/MachineChart {:machine-id  :auth/login-flow
+                              :definition  defn
+                              :current-state :idle})
+
+  Props are the closed map the Reagent `MachineChart` accepts (see
+  `spec/API.md` §Props); the shell forwards them to the bridge
+  unchanged. `:children` is ignored (the chart owns its subtree).
+
+  ## Bundle isolation
+
+  Tool-jar only; xyflow + elkjs are dev-only. Nothing under
+  `implementation/` may `:require` this. A UIx host opts into the
+  bundle cost deliberately."
+  (:require [uix.core :refer [defui $]]
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]))
+
+(defui MachineChart
+  "UIx component wrapping the xyflow `MachineChart` via the shared
+  React bridge. `props` is a CLJS map matching the Reagent
+  `MachineChart` contract; forwarded to `react-chart/chart-element`
+  which builds the reactified-Reagent React element. Renders the
+  identical chart a Reagent host renders."
+  [props]
+  ;; `defui` already hands us a CLJS map; `:children` (if any) is
+  ;; dropped — the chart manages its own subtree.
+  ($ :<> (react-chart/chart-element (dissoc props :children))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -50,6 +50,10 @@
             [day8.re-frame2-machines-viz.chart.edges :as edges]
             [day8.re-frame2-machines-viz.chart.overlays.after-rings
              :as after-rings]
+            [day8.re-frame2-machines-viz.chart.overlays.spawn-all-join
+             :as overlay-spawn-all]
+            [day8.re-frame2-machines-viz.chart.overlays.cancellation-cascade
+             :as overlay-cascade]
             [day8.re-frame2-machines-viz.theme.tokens :as tokens]))
 
 ;; ---- xyflow React-class adapters ----------------------------------------
@@ -88,26 +92,64 @@
    "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
    "elk.edgeRouting"                            "SPLINES"})
 
+(defn- elk-child
+  "Build a single elk.js child descriptor for a parsed node (a plain
+  CLJS map; `->elk-input` `clj->js`-es the whole tree)."
+  [n]
+  {:id     (:id n)
+   :width  (if (:compound? n) 220 nodes/state-node-min-width)
+   :height (if (:compound? n) 120 nodes/state-node-min-height)
+   :labels [{:text (:label n)}]})
+
+(defn- ->elk-children
+  "Project parsed nodes into elk.js's `children` shape.
+
+  Flat (non-parallel) machines emit one flat child per node. Parallel
+  machines (rf2-lkwev) nest each region's states UNDER their region
+  container node so elkjs lays the states out INSIDE the region's
+  bounding box (xyflow's parentNode sub-flow then renders them inside
+  the dashed region boundary). Region containers carry their own
+  `elk.algorithm`/`elk.padding` so each orthogonal zone gets a clean
+  internal layout, and the regions themselves are laid side-by-side at
+  the root."
+  [{:keys [nodes parallel?]}]
+  (if-not parallel?
+    (mapv elk-child nodes)
+    (let [region-nodes (filterv :region? nodes)
+          ;; Group the non-region (state) nodes by their parent region.
+          by-parent    (group-by :parent-id (remove :region? nodes))]
+      (mapv (fn [rn]
+              (let [children (get by-parent (:id rn) [])]
+                {:id    (:id rn)
+                 :labels [{:text (:label rn)}]
+                 ;; Each region lays out its own states internally;
+                 ;; padding leaves room for the region header strip.
+                 :layoutOptions {"elk.algorithm" "layered"
+                                 "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}
+                 :children (mapv elk-child children)}))
+            region-nodes))))
+
 (defn- ->elk-input
   "Build an elk.js JS-side input graph for the given parsed nodes +
-  edges + direction."
-  [{:keys [nodes edges]} direction layout-options]
+  edges + direction. Parallel machines (rf2-lkwev) get a hierarchical
+  graph (region containers with nested state children) so elkjs sizes
+  + positions each orthogonal zone and its states; flat machines get
+  the original single-level child list."
+  [{:keys [edges] :as parsed} direction layout-options]
   (let [dir-str (case direction
                   :lr "RIGHT"
                   :tb "DOWN"
                   "DOWN")
         opts    (-> default-elk-options
                     (merge (or layout-options {}))
-                    (assoc "elk.direction" dir-str))]
+                    (assoc "elk.direction" dir-str)
+                    ;; Hierarchical layout must descend into region
+                    ;; children for the parallel case (rf2-lkwev).
+                    (cond-> (:parallel? parsed)
+                      (assoc "elk.hierarchyHandling" "INCLUDE_CHILDREN")))]
     #js {:id "root"
          :layoutOptions (clj->js opts)
-         :children (clj->js
-                     (mapv (fn [n]
-                             {:id     (:id n)
-                              :width  (if (:compound? n) 220 nodes/state-node-min-width)
-                              :height (if (:compound? n) 120 nodes/state-node-min-height)
-                              :labels [{:text (:label n)}]})
-                           nodes))
+         :children (clj->js (->elk-children parsed))
          :edges (clj->js
                   (mapv (fn [e]
                           {:id (:id e)
@@ -119,21 +161,29 @@
 (defn- elk-result->positions
   "Adapter: elk.js JS result → `{node-id {:x :y :width :height}}` map.
   Used by `xyflow-graph` to merge xyflow-side node objects with
-  elk-laid-out positions."
+  elk-laid-out positions.
+
+  Walks nested elk children (rf2-lkwev — parallel machines nest each
+  region's states under the region container). elkjs reports a child's
+  `x`/`y` RELATIVE to its parent container, which is exactly what
+  xyflow's parentNode sub-flow wants — so we record each node's
+  position AS elkjs gives it, no re-basing. Region containers get
+  their root-relative position + the size elkjs computed for the zone."
   [elk-result]
-  (let [children (or (.-children elk-result) #js [])
-        n        (alength children)]
-    (loop [i 0
-           acc {}]
-      (if (< i n)
-        (let [c (aget children i)]
-          (recur (inc i)
-                 (assoc acc (.-id c)
-                        {:x      (or (.-x c) 0)
-                         :y      (or (.-y c) 0)
-                         :width  (or (.-width c) nodes/state-node-min-width)
-                         :height (or (.-height c) nodes/state-node-min-height)})))
-        acc))))
+  (let [acc (atom {})]
+    (letfn [(walk! [^js node]
+              (let [children (or (.-children node) #js [])
+                    n        (alength children)]
+                (dotimes [i n]
+                  (let [c (aget children i)]
+                    (swap! acc assoc (.-id c)
+                           {:x      (or (.-x c) 0)
+                            :y      (or (.-y c) 0)
+                            :width  (or (.-width c) nodes/state-node-min-width)
+                            :height (or (.-height c) nodes/state-node-min-height)})
+                    (walk! c)))))]
+      (walk! elk-result))
+    @acc))
 
 (defn compute-layout!
   "Run elk.js layout on `parsed` (the output of
@@ -186,27 +236,51 @@
    positions
    {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
   {:nodes
+   ;; rf2-lkwev — region container nodes MUST precede their children in
+   ;; the xyflow nodes array (xyflow requires a parentNode to appear
+   ;; before any node that references it). Regions are already emitted
+   ;; before their states by `parse-parallel`, but sort defensively so
+   ;; the parent-before-child invariant holds regardless of upstream
+   ;; ordering.
    (mapv (fn [n]
-           (let [pos (get positions (:id n) {:x 0 :y 0})
+           (let [pos     (get positions (:id n) {:x 0 :y 0})
+                 region? (boolean (:region? n))
                  active? (= (:id n) highlight-id)
                  from-hi? (= (:id n) from-highlight-id)
-                 to-hi?   (= (:id n) to-highlight-id)]
-             {:id       (:id n)
-              :type     (if (:compound? n) "compound" "state")
-              :position {:x (:x pos) :y (:y pos)}
-              :data     {:label          (:label n)
-                         :path           (:path n)
-                         :active         active?
-                         :fromHighlight  from-hi?
-                         :toHighlight    to-hi?
-                         :sim            (boolean (and active? sim?))
-                         :final          (boolean (:final? n))
-                         :compound       (boolean (:compound? n))
-                         :tags           (vec (:tags n))
-                         :onClick        on-state-click}
-              :draggable false
-              :selectable false}))
-         nodes)
+                 to-hi?   (= (:id n) to-highlight-id)
+                 base
+                 {:id       (:id n)
+                  :type     (cond
+                              region?         "parallel-region"
+                              (:compound? n)  "compound"
+                              :else           "state")
+                  :position {:x (:x pos) :y (:y pos)}
+                  :data     (cond-> {:label          (:label n)
+                                     :path           (:path n)
+                                     :active         active?
+                                     :fromHighlight  from-hi?
+                                     :toHighlight    to-hi?
+                                     :sim            (boolean (and active? sim?))
+                                     :final          (boolean (:final? n))
+                                     :compound       (boolean (:compound? n))
+                                     :tags           (vec (:tags n))
+                                     :onClick        on-state-click}
+                              region? (assoc :regionId    (:region n)
+                                             :regionIndex (:region-index n)))
+                  :draggable false
+                  :selectable false}]
+             (cond-> base
+               ;; Region containers carry an explicit measured size so
+               ;; xyflow draws the zone box at the elk-computed extent.
+               region? (assoc :style {:width  (:width pos)
+                                      :height (:height pos)})
+               ;; A state inside a region attaches to its parent region
+               ;; via xyflow's parentNode sub-flow; `:extent "parent"`
+               ;; clamps it inside the dashed boundary.
+               (and (not region?) (:parent-id n))
+               (assoc :parentNode (:parent-id n)
+                      :extent     "parent"))))
+         (sort-by #(if (:region? %) 0 1) nodes))
    :edges
    (mapv (fn [e]
            (let [from-active? (or (= (:source e) highlight-id)
@@ -308,6 +382,31 @@
                          one rAF clock per chart, owned host-side).
     :on-after-ring-hover / :on-after-ring-leave — `(fn [node-id] ...)`
                          hover callbacks the overlay wires on each ring.
+    :spawn-all-join    — rf2-3ow55. Optional presentation-ready
+                         `:spawn-all` join-spec (`{:node-id :join
+                         :children :resolved? :on-all-complete
+                         :on-any-failed}`). When present the chart
+                         mounts the `chart.overlays.spawn-all-join`
+                         inspector beside the spawn-all-bearing state;
+                         it shows the spawned children + join state.
+                         The host owns the trace→spec projection from
+                         its `:rf.machine.spawn-all/*` buffer. nil →
+                         no inspector.
+    :on-spawn-child-click — `(fn [child-key] ...)`; fires on a join-
+                         inspector child-row click (Causa pivots to
+                         the child instance).
+    :cancellation-cascade — rf2-3ow55. Optional presentation-ready
+                         cascade-spec (`{:node-id :parent-label
+                         :from-state :steps}`). When present (and the
+                         step list is non-empty) the chart mounts the
+                         `chart.overlays.cancellation-cascade`
+                         waterfall beneath the parent state. The host
+                         owns the trace→spec projection from the
+                         cancellation trace cluster. nil / no steps →
+                         dormant (no overlay).
+    :overlay-tick      — opaque value the host bumps to force the
+                         spawn-all + cascade overlays to re-measure +
+                         repaint (mirrors `:after-ring-tick`).
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
@@ -319,6 +418,8 @@
                  height show-minimap? show-controls? show-background?
                  after-ring-specs after-ring-tick
                  on-after-ring-hover on-after-ring-leave
+                 spawn-all-join on-spawn-child-click
+                 cancellation-cascade overlay-tick
                  testid]
           :or   {direction         :tb
                  height            "100%"
@@ -327,7 +428,11 @@
                  show-background?  true
                  testid            "rf-mv-chart"}}]
       (let [parsed     (layout/parse-definition definition)
-            n-states   (count (:nodes parsed))
+            ;; rf2-lkwev — exclude synthetic parallel-region container
+            ;; nodes from the state count + aria-label (they are zone
+            ;; chrome, not states).
+            n-states   (count (remove :region? (:nodes parsed)))
+            n-regions  (count (filter :region? (:nodes parsed)))
             n-trans    (count (:edges parsed))
             ;; Trigger an elk layout pass when the (definition,
             ;; direction, layout-options) tuple changes. Keep the
@@ -390,10 +495,15 @@
                                 " with " n-states " "
                                 (if (= 1 n-states) "state" "states")
                                 " and " n-trans " "
-                                (if (= 1 n-trans) "transition" "transitions") ".")]
+                                (if (= 1 n-trans) "transition" "transitions")
+                                (when (pos? n-regions)
+                                  (str " across " n-regions " parallel "
+                                       (if (= 1 n-regions) "region" "regions")))
+                                ".")]
             [:div {:data-testid testid
                    :data-machine-id (str machine-id)
                    :data-node-count (str n-states)
+                   :data-region-count (str n-regions)
                    :data-edge-count (str n-trans)
                    :data-highlight-id (or highlight-id "")
                    :data-from-highlight-id (or from-highlight-id "")
@@ -454,7 +564,30 @@
                 {:ring-specs after-ring-specs
                  :tick       after-ring-tick
                  :on-hover   on-after-ring-hover
-                 :on-leave   on-after-ring-leave}])]))))))
+                 :on-leave   on-after-ring-leave}])
+             ;; rf2-3ow55 — `:spawn-all` join inspector. Same
+             ;; sibling-overlay shape as the after-rings overlay: it
+             ;; walks the node DOM to anchor a join-state card beside
+             ;; the spawn-all-bearing state. The host projects the
+             ;; presentation-ready join-spec from its
+             ;; `:rf.machine.spawn-all/*` trace buffer.
+             (when (and spawn-all-join (:node-id spawn-all-join))
+               [overlay-spawn-all/SpawnAllJoinOverlay
+                {:join-spec      spawn-all-join
+                 :tick           overlay-tick
+                 :on-child-click on-spawn-child-click}])
+             ;; rf2-3ow55 — cancellation-cascade visualiser. Dormant
+             ;; unless the host supplies a cascade-spec with steps;
+             ;; when a parent transition cancels children the host
+             ;; projects the cascade from the cancellation trace
+             ;; cluster and the overlay paints the waterfall beneath
+             ;; the parent state.
+             (when (and cancellation-cascade
+                        (:node-id cancellation-cascade)
+                        (seq (:steps cancellation-cascade)))
+               [overlay-cascade/CancellationCascadeOverlay
+                {:cascade-spec cancellation-cascade
+                 :tick         overlay-tick}])]))))))
 
 ;; ---- empty-graph convenience for callers --------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -54,6 +54,21 @@
                       ...]
        :initial-path <vec-of-kw>}            ;; the machine's :initial path
 
+  ## Parallel regions (rf2-lkwev — xyflow Phase 2)
+
+  A `{:type :parallel :regions {...}}` definition projects EVERY
+  region (Phase 1 deferred all but the first). Each region becomes a
+  synthetic `:region?` compound node — an orthogonal-zone container
+  the `chart.nodes/parallel-region-node` paints with a distinct
+  dashed boundary (Stately parity). Every state inside a region
+  carries `:region <region-id>` + `:parent-id <region-node-id>` so
+  the chart projector can hand xyflow a `parentNode`/sub-flow
+  grouping; edges stay region-local (a transition declared inside a
+  region never crosses into a sibling region — orthogonality).
+
+  Region node-ids are prefixed `region__<region-id>` so they never
+  collide with a real state's `node-id`.
+
   ## What this does NOT do (pre-migration, this ns DID do)
 
   - **Positioning** (`bfs-ranks`, `place-nodes`, `route-edge`) —
@@ -183,6 +198,18 @@
        (str/join "__")
        (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
 
+(defn region-node-id
+  "Stable string id for a parallel region's synthetic compound node.
+  Prefixed `region__` so it never collides with a state `node-id`
+  (rf2-lkwev). `region-id` is the region's key in the `:regions` map."
+  [region-id]
+  (str "region__"
+       (if (keyword? region-id)
+         (if-let [ns (namespace region-id)]
+           (str ns "_" (name region-id))
+           (name region-id))
+         (str region-id))))
+
 (defn- name-of
   "Render a guard/action symbol-like value as a short string. Keywords
   use `ns/name` when namespaced, plain `name` otherwise. Non-keywords
@@ -250,48 +277,100 @@
 
 ;; ---- public projection --------------------------------------------------
 
+(defn- parse-flat
+  "Project a non-parallel machine definition into `{:nodes :edges
+  :initial-path}`. The shared single-machine walker; `parse-definition`
+  calls this for plain machines AND once per region of a `:parallel`
+  machine (the per-region nodes/edges then get tagged with their
+  region + parent-id)."
+  [definition]
+  (let [{:keys [initial states]} definition
+        base-nodes (vec (collect-nodes [] states))
+        initial-path (when initial [initial])
+        nodes (mapv (fn [n]
+                      (let [n' (if (= (:path n) initial-path)
+                                 (assoc n :initial? true)
+                                 n)]
+                        (assoc n' :id (node-id (:path n')))))
+                    base-nodes)
+        raw-edges (vec (mapcat (fn [[state-id state-node]]
+                                 (collect-state-edges [state-id] state-node))
+                               states))
+        edges (vec (map (fn [e]
+                          (assoc e
+                            :id          (edge-id (:from e) (:to e) e)
+                            :source      (node-id (:from e))
+                            :target      (node-id (:to e))
+                            :from-path   (:from e)
+                            :to-path     (:to e)
+                            :event-label (edge-label e)))
+                        raw-edges))]
+    {:nodes        nodes
+     :edges        edges
+     :initial-path initial-path}))
+
+(defn- parse-parallel
+  "Project a `{:type :parallel :regions {...}}` definition into the
+  flat graph, projecting EVERY region (rf2-lkwev — Phase 1 deferred
+  all but the first). Each region becomes a synthetic `:region?`
+  compound node whose `node-id` is `region-node-id`; each region's
+  states carry `:region <region-id>` + `:parent-id <region-node-id>`
+  so the chart projector can hand xyflow a `parentNode`/sub-flow
+  grouping. Region order is preserved (regions are an ordered map in
+  practice; we keep insertion order via `:regions`)."
+  [definition]
+  (let [regions (:regions definition)
+        per-region
+        (map-indexed
+          (fn [idx [region-id region-def]]
+            (let [rid       (region-node-id region-id)
+                  parsed    (parse-flat region-def)
+                  ;; Tag every state node with its region + parent so
+                  ;; the projector emits xyflow parentNode grouping.
+                  tagged-nodes
+                  (mapv (fn [n]
+                          (assoc n
+                            :region    region-id
+                            :parent-id rid))
+                        (:nodes parsed))
+                  ;; The synthetic region container node.
+                  region-node
+                  {:id        rid
+                   :path      [region-id]
+                   :label     (name region-id)
+                   :depth     0
+                   :region?   true
+                   :region    region-id
+                   :region-index idx
+                   :compound? true}]
+              {:nodes (into [region-node] tagged-nodes)
+               :edges (:edges parsed)}))
+          regions)]
+    {:nodes        (vec (mapcat :nodes per-region))
+     :edges        (vec (mapcat :edges per-region))
+     :initial-path nil
+     :parallel?    true}))
+
 (defn parse-definition
   "Project a machine definition into a flat `{:nodes :edges
   :initial-path}` graph. Pure fn — JVM-runnable.
 
-  For parallel definitions (`{:type :parallel :regions {...}}`) v1
-  projects the first region only; a follow-on bead handles full
-  parallel layout (xyflow exposes a `parentNode` mechanism that maps
-  cleanly onto regions; deferred to keep the migration tight)."
+  Parallel definitions (`{:type :parallel :regions {...}}`) project
+  EVERY region as an orthogonal zone (rf2-lkwev — xyflow Phase 2 full
+  parallel-region rendering; supersedes the Phase 1 first-region-only
+  projection). Each region surfaces a synthetic `:region?` compound
+  node and its states carry `:region` + `:parent-id` for xyflow
+  parentNode grouping; the result also carries `:parallel? true`."
   [definition]
   (cond
     (nil? definition)
     {:nodes [] :edges [] :initial-path nil}
 
     (= :parallel (:type definition))
-    (let [[_region-id region] (first (:regions definition))]
-      (parse-definition region))
+    (parse-parallel definition)
 
     :else
-    (let [{:keys [initial states]} definition
-          base-nodes (vec (collect-nodes [] states))
-          initial-path (when initial [initial])
-          nodes (mapv (fn [n]
-                        (let [n' (if (= (:path n) initial-path)
-                                   (assoc n :initial? true)
-                                   n)]
-                          (assoc n' :id (node-id (:path n')))))
-                      base-nodes)
-          raw-edges (vec (mapcat (fn [[state-id state-node]]
-                                   (collect-state-edges [state-id] state-node))
-                                 states))
-          edges (vec (map (fn [e]
-                            (assoc e
-                              :id          (edge-id (:from e) (:to e) e)
-                              :source      (node-id (:from e))
-                              :target      (node-id (:to e))
-                              :from-path   (:from e)
-                              :to-path     (:to e)
-                              :event-label (edge-label e)))
-                          raw-edges))]
-      {:nodes        nodes
-       :edges        edges
-       :initial-path initial-path})))
+    (parse-flat definition)))
 
 (defn highlight-id
   "Resolve a snapshot `:state` value to the node-id used in the

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -41,6 +41,8 @@
   substrate-specific shim."
   (:require ["@xyflow/react" :as xyflow]
             [reagent.core :as r]
+            [day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
+             :as parallel-region-node]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
              :refer [mono-stack sans-stack]]))
@@ -331,7 +333,8 @@
   callers SHOULD memoise this map at component-construction time
   to avoid re-render churn."
   []
-  #js {"state"          state-node
-       "compound"       compound-node
-       "initial-marker" initial-marker
-       "final-marker"   final-marker})
+  #js {"state"           state-node
+       "compound"        compound-node
+       "parallel-region" parallel-region-node/parallel-region-node
+       "initial-marker"  initial-marker
+       "final-marker"    final-marker})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -1,0 +1,124 @@
+(ns day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
+  "xyflow node component for a parallel-region (orthogonal-zone)
+  container (rf2-lkwev · xyflow Phase 2).
+
+  ## Why this exists
+
+  xyflow Phase 1 (#1806) projected only the FIRST region of a
+  `{:type :parallel :regions {...}}` machine — full parallel layout
+  was deferred. This component completes the deferral: every region
+  renders as a distinct orthogonal zone with its own dashed boundary
+  (Stately Studio parity — Stately paints parallel regions as
+  side-by-side panes separated by a dashed divider).
+
+  ## How it works with xyflow
+
+  `chart.layout/parse-parallel` mints a synthetic `:region?` compound
+  node per region; `chart.chart/xyflow-graph` projects it as a
+  `type: \"parallel-region\"` xyflow node and assigns every state in
+  the region a `parentNode` pointing at the region node (xyflow's
+  sub-flow mechanic). This component renders the region's CHROME — a
+  large translucent box with a dashed border + the region label in
+  the header strip. The child state nodes sit inside via xyflow's
+  parentNode positioning; this component only paints the surround.
+
+  ## Distinct boundary per region
+
+  Each region gets a deterministic accent colour from
+  `region-boundary-color` (a rotation over the token palette) so two
+  adjacent regions read as visually distinct zones — the dashed
+  border + the header label both pick up the region's colour. This is
+  the Stately-parity affordance: a reader sees N orthogonal regions
+  at a glance, each clearly delineated.
+
+  ## Token integration
+
+  All colours read from `theme/tokens`; no hex literals. The dashed
+  boundary uses the region's rotation colour; the body uses a faint
+  tint of the same so the zone reads as a unit."
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.theme.tokens
+             :as tokens
+             :refer [sans-stack]]))
+
+;; ---- region boundary palette --------------------------------------------
+
+(def region-boundary-palette
+  "Deterministic colour rotation for parallel-region boundaries
+  (rf2-lkwev). Distinct from the tag-pill palette: regions are
+  structural zones (not per-state badges), so the rotation leads with
+  `:accent-violet` (the structural-container colour the compound-node
+  chrome already uses) and spreads across cool/warm so adjacent
+  regions read as distinct orthogonal zones."
+  [:accent-violet :cyan :orange :green :magenta :yellow])
+
+(defn region-boundary-color-key
+  "Map a region's index to a stable token key from
+  `region-boundary-palette`. Deterministic — region 0 is always the
+  violet structural colour, region 1 the next, wrapping past the end.
+  Pure data → keyword."
+  [region-index]
+  (nth region-boundary-palette
+       (mod (or region-index 0) (count region-boundary-palette))))
+
+;; ---- parallel-region node ----------------------------------------------
+
+(defn parallel-region-node
+  "Reagent component for a parallel-region container. xyflow invokes
+  this via `nodeTypes={:parallel-region parallel-region-node}`. Reads
+  `:data {:label :regionIndex :regionId ...}` off the xyflow props.
+
+  Renders a translucent zone with a distinct dashed boundary (the
+  region's rotation colour) + a header strip carrying the region
+  label. xyflow's parentNode mechanic places the region's child state
+  nodes inside; this component renders only the surrounding chrome."
+  [^js props]
+  (let [d            (.-data props)
+        label        (or (.-label d) "")
+        region-index (.-regionIndex d)
+        color-key    (region-boundary-color-key region-index)
+        border-color (get tokens/tokens color-key)
+        body-tint    (tokens/with-alpha color-key 0.05)
+        header-tint  (tokens/with-alpha color-key 0.12)]
+    (r/as-element
+      [:div {:data-testid    (str "rf-mv-chart-region-" (.-id props))
+             :data-node-id    (.-id props)
+             :data-region-id  (when-let [rid (.-regionId d)] (str rid))
+             :data-region-index (when (some? region-index) (str region-index))
+             :style {:position       "relative"
+                     :width          "100%"
+                     :height         "100%"
+                     :padding-top    "26px"
+                     :background     body-tint
+                     ;; Distinct DASHED boundary per region — the
+                     ;; Stately-parity orthogonal-zone delineation.
+                     :border         (str "1.5px dashed " border-color)
+                     :border-radius  "12px"
+                     :pointer-events "none"}}
+       ;; Header strip — the region label, tinted to the region colour.
+       [:div {:data-testid (str "rf-mv-chart-regionhdr-" (.-id props))
+              :style {:position       "absolute"
+                      :top            0
+                      :left           0
+                      :right          0
+                      :height         "22px"
+                      :display        "flex"
+                      :align-items    "center"
+                      :padding        "0 10px"
+                      :background     header-tint
+                      :border-bottom  (str "1px dashed " border-color)
+                      :border-top-left-radius  "11px"
+                      :border-top-right-radius "11px"
+                      :font-family    sans-stack
+                      :font-size      "11px"
+                      :font-weight    700
+                      :letter-spacing "0.04em"
+                      :text-transform "uppercase"
+                      :color          border-color}}
+        ;; A small orthogonal-region glyph (parallel bars) precedes the
+        ;; label so the zone reads as "parallel region" at a glance.
+        [:span {:style {:margin-right "6px"
+                        :opacity 0.85
+                        :font-family tokens/mono-stack}}
+         "∥"]
+        label]])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -1,0 +1,220 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.cancellation-cascade
+  "xyflow cancellation-cascade visualiser overlay (rf2-3ow55 · xyflow
+  Phase 2).
+
+  ## Why this exists
+
+  xyflow Phase 1 (#1806) deferred the cross-cutting Causa machine
+  surfaces. This overlay restores the cancellation-cascade visualiser
+  (Causa 003 §M.3 — cancellation cascade ambiguity): when a parent
+  transition cancels child machines, the scattered abort/destroy
+  traces become ONE decision laid out vertically — the parent's exit
+  → each destroyed child / aborted request, indented as a waterfall
+  beneath the parent state.
+
+  ## Pure-presentation, host-projected (mirrors after-rings)
+
+  machines-viz is bundle-isolated from Causa — it cannot read Causa's
+  trace buffer. The overlay's input is a flat, presentation-ready
+  `cascade-spec` the host projects from the cancellation-related trace
+  cluster (`:rf.machine.lifecycle/destroyed`,
+  `:rf.http/aborted-on-actor-destroy`, …). The overlay walks the chart
+  DOM (`rf-mv-chart-node-<id>`) to anchor the waterfall beneath the
+  parent state; the anchoring math is the pure `overlay-anchor` helper
+  so it is JVM-testable end-to-end without a DOM.
+
+  ## Waterfall content
+
+  Header: the parent state + the exited child + a count summary
+  (`Destroyed N actors, aborted M requests`). Body: one indented row
+  per cascade step (destroy / abort / cleanup), each with a kind glyph
+  + a label + an optional `+Δms` relative-time stamp, drawn beneath a
+  vertical spine that visually ties them to the parent decision.
+
+  ## Theming
+
+  Colours resolve through `theme/tokens/css-var` so light + dark both
+  flow through the host's CSS custom-property surface (per the
+  `var(--*)` requirement)."
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
+             :as anchor]))
+
+;; ---- DOM measurement ----------------------------------------------------
+
+(defn- rect->map
+  [^js dom-rect]
+  (when dom-rect
+    {:left   (.-left dom-rect)
+     :top    (.-top dom-rect)
+     :width  (.-width dom-rect)
+     :height (.-height dom-rect)}))
+
+(defn- query-node-rect
+  [^js root node-id]
+  (when (and root node-id)
+    (when-let [testid (anchor/node->card-testid node-id)]
+      (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
+        (when el (rect->map (.getBoundingClientRect el)))))))
+
+(defn- measure-anchor
+  "Walk the DOM under `root` for the cascade-spec's parent node and
+  return the overlay-local waterfall anchor (or nil when the node
+  isn't in the DOM). Uses the pure `overlay-anchor/anchor-below`."
+  [^js root node-id]
+  (when (and root node-id)
+    (let [container (rect->map (.getBoundingClientRect root))
+          node      (query-node-rect root node-id)]
+      (anchor/anchor-below node container))))
+
+;; ---- cascade-step glyph -------------------------------------------------
+
+(defn- step-glyph
+  "Kind glyph + colour-token for a cascade step. `:kind` ∈
+  `:destroy` / `:abort` / `:cleanup` / `:exit`."
+  [{:keys [kind]}]
+  (case kind
+    :exit    ["⏏" :accent-violet]
+    :destroy ["✖" :red]
+    :abort   ["⊘" :orange]
+    :cleanup ["⌫" :text-tertiary]
+    ["•" :text-secondary]))
+
+(defn- cascade-step-row
+  [idx {:keys [label note delta-ms] :as step}]
+  (let [[glyph color-key] (step-glyph step)]
+    [:div {:key         (str idx)
+           :data-testid  (str "rf-mv-chart-cascade-step-" idx)
+           :data-kind    (name (or (:kind step) :other))
+           :style {:display     "flex"
+                   :align-items "baseline"
+                   :gap         "6px"
+                   :padding     "2px 0 2px 14px"
+                   :font-family tokens/mono-stack
+                   :font-size   "11px"
+                   :color       (tokens/css-var :text-secondary)}}
+     [:span {:style {:color (tokens/css-var color-key) :width "12px"}} glyph]
+     [:span {:style {:color (tokens/css-var :text-primary)}} (str label)]
+     (when note
+       [:span {:style {:color (tokens/css-var :text-tertiary)}} note])
+     (when (some? delta-ms)
+       [:span {:style {:margin-left "auto"
+                       :color (tokens/css-var :text-tertiary)}}
+        (str "+" delta-ms "ms")])]))
+
+;; ---- cascade waterfall card ---------------------------------------------
+
+(defn- cascade-card
+  [{:keys [x y node-id parent-label from-state steps] :as spec}]
+  [:div {:data-testid    (str "rf-mv-chart-cascade-" node-id)
+         :data-node-id    node-id
+         :data-step-count (str (count steps))
+         :style {:position       "absolute"
+                 :left           (str x "px")
+                 :top            (str y "px")
+                 :min-width      "200px"
+                 :max-width      "300px"
+                 :padding        "8px 10px"
+                 :pointer-events "auto"
+                 :background     (tokens/css-var :bg-2)
+                 :border         (str "1px solid " (tokens/css-var :red))
+                 :border-radius  "8px"
+                 :box-shadow     "0 4px 14px rgba(0,0,0,0.35)"
+                 :font-family    tokens/sans-stack}}
+   ;; Header
+   [:div {:style {:display "flex" :align-items "center" :gap "6px"
+                  :margin-bottom "2px"
+                  :font-size "11px" :font-weight 700
+                  :color (tokens/css-var :red)}}
+    [:span {:style {:font-family tokens/mono-stack}} "⏏"]
+    "cancellation cascade"]
+   [:div {:data-testid (str "rf-mv-chart-cascade-header-" node-id)
+          :style {:font-family tokens/mono-stack :font-size "10px"
+                  :color (tokens/css-var :text-secondary)
+                  :margin-bottom "2px"}}
+    (str (or parent-label node-id)
+         (when from-state (str " exited " from-state)))]
+   [:div {:data-testid (str "rf-mv-chart-cascade-summary-" node-id)
+          :style {:font-family tokens/mono-stack :font-size "10px"
+                  :color (tokens/css-var :text-tertiary)
+                  :margin-bottom "6px"}}
+    (anchor/cascade-summary-line spec)]
+   ;; Vertical-spine waterfall of steps
+   (into [:div {:data-testid (str "rf-mv-chart-cascade-steps-" node-id)
+                :style {:border-left (str "1px solid " (tokens/css-var :border-default))
+                        :margin-left "5px"}}]
+         (map-indexed cascade-step-row steps))])
+
+;; ---- overlay component --------------------------------------------------
+
+(defn CancellationCascadeOverlay
+  "Absolute-positioned overlay that anchors a cancellation-cascade
+  waterfall beneath the parent state by walking the rendered chart
+  DOM. Reagent form-3 component.
+
+  Props (single map):
+
+    :cascade-spec — `{:node-id <string>        ;; parent state id
+                      :parent-label <string?>  ;; display label
+                      :from-state <kw?>        ;; the exited child state
+                      :steps [{:kind <:exit|:destroy|:abort|:cleanup>
+                               :label <string> :note <string?>
+                               :delta-ms <int?>} ...]}` — the
+                     presentation-ready cascade projection (host
+                     computes from the cancellation trace cluster).
+                     `:node-id` is the string `chart.layout/node-id`
+                     mints from the parent state's path. nil → overlay
+                     drops out (dormant when no cancellation lands).
+    :tick    — opaque value the host bumps to force a re-measure.
+    :testid  — overlay root data-testid; defaults to
+               `\"rf-mv-chart-cancellation-cascade-overlay\"`."
+  [_initial-props]
+  (let [root-ref   (r/atom nil)
+        anchored   (r/atom nil)
+        latest     (r/atom nil)
+        remeasure! (fn []
+                     (when-let [root @root-ref]
+                       (when-let [spec @latest]
+                         (reset! anchored
+                                 (measure-anchor root (:node-id spec))))))
+        resize-fn  (fn [_] (remeasure!))]
+    (r/create-class
+      {:display-name "MachinesViz.CancellationCascadeOverlay"
+
+       :component-did-mount
+       (fn [_this]
+         (when (exists? js/window)
+           (.addEventListener js/window "resize" resize-fn))
+         (remeasure!))
+
+       :component-did-update
+       (fn [_this _prev] (remeasure!))
+
+       :component-will-unmount
+       (fn [_this]
+         (when (exists? js/window)
+           (.removeEventListener js/window "resize" resize-fn)))
+
+       :reagent-render
+       (fn [{:keys [cascade-spec tick testid]
+             :or   {testid "rf-mv-chart-cancellation-cascade-overlay"}}]
+         (reset! latest cascade-spec)
+         (when (and cascade-spec (:node-id cascade-spec)
+                    (seq (:steps cascade-spec)))
+           (let [pos @anchored]
+             [:div {:data-testid testid
+                    :data-node-id (:node-id cascade-spec)
+                    :data-tick (when (some? tick) (str tick))
+                    :ref (fn [el]
+                           (reset! root-ref (when el (.-offsetParent el))))
+                    :style {:position       "absolute"
+                            :top            0
+                            :left           0
+                            :width          "100%"
+                            :height         "100%"
+                            :pointer-events "none"
+                            :overflow       "visible"
+                            :z-index        4}}
+              (when pos
+                (cascade-card (merge cascade-spec pos)))])))})))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
@@ -1,0 +1,147 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
+  "Pure anchoring geometry shared by the xyflow chart's HTML/SVG
+  overlays (rf2-3ow55 · xyflow Phase 2 — the `:spawn-all` join
+  inspector + the cancellation-cascade visualiser).
+
+  ## Why a separate .cljc
+
+  Each overlay walks the rendered chart DOM to find a bearing node's
+  bounding rect, then anchors a card / waterfall next to it. The DOM
+  walk + ref plumbing is CLJS-only (lives in each overlay's `.cljs`),
+  but the math that turns a node's viewport rect + the overlay
+  container's rect into the card's overlay-local `{:x :y}` anchor is
+  pure data → data, so it lives here where the JVM test corpus can
+  pin it. Same split as `after_rings_geometry.cljc`.
+
+  ## Coordinate model
+
+  `getBoundingClientRect` returns viewport-relative rects (`{:left
+  :top :width :height}`). An overlay `<div>`/`<svg>` is absolutely
+  positioned at the chart wrapper's top-left, so a node anchor in
+  overlay-local space is the node's viewport position MINUS the
+  container's viewport origin. xyflow bakes pan/zoom into the rendered
+  rects so no separate viewport transform is needed (same posture as
+  `after_rings_geometry`)."
+  (:require [clojure.string :as str]))
+
+(def card-gap-px
+  "Gap (px) between the bearing node's bounding box and the anchored
+  overlay card so the card sits clear of the node + its affordance."
+  12)
+
+(defn node->card-testid
+  "The xyflow node `data-testid` an overlay queries for a bearing
+  node-id. Mirrors `chart.nodes/state-node`'s `(str \"rf-mv-chart-node-
+  <id>\")` contract. Returns nil for a nil / blank node-id so the
+  overlay skips rather than querying a garbage selector."
+  [node-id]
+  (when (and node-id (not (str/blank? (str node-id))))
+    (str "rf-mv-chart-node-" node-id)))
+
+(defn anchor-right-of
+  "Anchor a card to the RIGHT of a bearing node. Takes the node's
+  viewport rect + the overlay container's rect; returns
+  `{:x :y :node-cx :node-cy}` in overlay-local coordinates (the card's
+  top-left + the node's centre for the connector line), or nil when
+  either rect is missing / degenerate.
+
+  Pure fn — JVM-runnable. Used by the `:spawn-all` join inspector
+  (the card sits beside the spawn-all-bearing state)."
+  [node-rect container-rect]
+  (when (and node-rect container-rect
+             (pos? (or (:width node-rect) 0))
+             (pos? (or (:height node-rect) 0)))
+    (let [cx-origin (or (:left container-rect) 0)
+          cy-origin (or (:top container-rect) 0)
+          nl        (- (or (:left node-rect) 0) cx-origin)
+          nt        (- (or (:top node-rect) 0) cy-origin)
+          nw        (double (or (:width node-rect) 0))
+          nh        (double (or (:height node-rect) 0))]
+      {:x       (+ nl nw card-gap-px)
+       :y       nt
+       :node-cx (+ nl (/ nw 2.0))
+       :node-cy (+ nt (/ nh 2.0))})))
+
+(defn anchor-below
+  "Anchor a card/waterfall BELOW a bearing node. Same inputs as
+  `anchor-right-of`; returns `{:x :y :node-cx :node-cy}` with the
+  anchor at the node's bottom edge + the gap. Used by the
+  cancellation-cascade waterfall (which flows downward from the
+  parent's exit). Pure fn — JVM-runnable."
+  [node-rect container-rect]
+  (when (and node-rect container-rect
+             (pos? (or (:width node-rect) 0))
+             (pos? (or (:height node-rect) 0)))
+    (let [cx-origin (or (:left container-rect) 0)
+          cy-origin (or (:top container-rect) 0)
+          nl        (- (or (:left node-rect) 0) cx-origin)
+          nt        (- (or (:top node-rect) 0) cy-origin)
+          nw        (double (or (:width node-rect) 0))
+          nh        (double (or (:height node-rect) 0))]
+      {:x       nl
+       :y       (+ nt nh card-gap-px)
+       :node-cx (+ nl (/ nw 2.0))
+       :node-cy (+ nt (/ nh 2.0))})))
+
+(defn join-resolved?
+  "Pure resolution check for a `:spawn-all` join given the join
+  condition + the set of done child keys + total child count. Mirrors
+  Spec 005 §`:spawn-all` join semantics (`:all` / `:any` / `{:n N}`).
+  A `{:fn ...}` condition is opaque to the overlay (the host decides),
+  so this returns the host-supplied `:resolved?` verbatim when present.
+
+  Used by the join inspector to colour the 'Resolved' line + compute
+  the 'waiting for K of N' remainder. Pure data → boolean."
+  [{:keys [join children resolved?]}]
+  (let [done   (count (filter :done? children))
+        failed (count (filter :failed? children))
+        total  (count children)]
+    (cond
+      (some? resolved?) (boolean resolved?)
+      (= join :all)     (= done total)
+      (= join :any)     (pos? done)
+      (and (map? join)
+           (:n join))   (>= done (:n join))
+      ;; {:fn ...} or unknown — the host owns truth; default false.
+      :else             (boolean (and (pos? total) (zero? failed)
+                                      (= done total))))))
+
+(defn join-summary
+  "A short `\"K/N done\"` (+ failed/cancelled when present) summary
+  string for a join spec's children. Pure data → string."
+  [{:keys [children]}]
+  (let [total     (count children)
+        done      (count (filter :done? children))
+        failed    (count (filter :failed? children))
+        cancelled (count (filter :cancelled? children))]
+    (str done "/" total " done"
+         (when (pos? failed)    (str " · " failed " failed"))
+         (when (pos? cancelled) (str " · " cancelled " cancelled")))))
+
+;; ---- cancellation-cascade summary (pure, JVM-runnable) -----------------
+
+(defn cascade-counts
+  "Pure summary of a cancellation cascade's steps →
+  `{:destroyed :aborted :cleaned}`. Used in the cascade card's header
+  line. `:kind` ∈ `:exit` / `:destroy` / `:abort` / `:cleanup`.
+  JVM-runnable."
+  [steps]
+  {:destroyed (count (filter #(= :destroy (:kind %)) steps))
+   :aborted   (count (filter #(= :abort   (:kind %)) steps))
+   :cleaned   (count (filter #(= :cleanup (:kind %)) steps))})
+
+(defn cascade-summary-line
+  "Pure header summary string for a cascade-spec (`{:steps [...]}`),
+  e.g. `\"destroyed 1 actor · aborted 3 requests\"`. JVM-runnable."
+  [{:keys [steps]}]
+  (let [{:keys [destroyed aborted cleaned]} (cascade-counts steps)
+        parts (cond-> []
+                (pos? destroyed) (conj (str "destroyed " destroyed
+                                            (if (= 1 destroyed) " actor" " actors")))
+                (pos? aborted)   (conj (str "aborted " aborted
+                                            (if (= 1 aborted) " request" " requests")))
+                (pos? cleaned)   (conj (str cleaned " cleanup"
+                                            (if (= 1 cleaned) "" "s"))))]
+    (if (seq parts)
+      (str/join " · " parts)
+      "no cascade steps")))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -1,0 +1,256 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.spawn-all-join
+  "xyflow `:spawn-all` join-inspector overlay (rf2-3ow55 · xyflow
+  Phase 2).
+
+  ## Why this exists
+
+  xyflow Phase 1 (#1806) deferred the cross-cutting Causa machine
+  surfaces. This overlay restores the `:spawn-all` join inspector
+  (Causa 003 §M.4 — `:spawn-all` never joins): when a state declares
+  `:spawn-all`, the inspector shows the N spawned children + their
+  per-child join state (done / running / failed) and whether the join
+  condition has resolved, anchored beside the spawn-all-bearing state.
+
+  ## Pure-presentation, host-projected (mirrors after-rings)
+
+  machines-viz is bundle-isolated from Causa — it cannot `:require`
+  Causa's trace-buffer subs. So the overlay's input is a flat,
+  presentation-ready `join-spec` the host projects from its trace
+  buffer (`:rf.machine.spawn-all/*` events). The overlay walks the
+  chart's node DOM (`rf-mv-chart-node-<id>`) to anchor the card; the
+  resolution math is the pure `overlay-anchor` helper so it is
+  JVM-testable end-to-end without a DOM.
+
+  ## Card content
+
+  Header: `:spawn-all` + the join condition (`:all` / `:any` /
+  `{:n N}` / `{:fn ...}`). A `Resolved ✓/✗` line with the `waiting
+  for K of N` remainder. One row per child: a glyph (`✓` done /
+  `⧖` running / `✗` failed / `⊘` cancelled), the child key, and an
+  optional status note. Click a child row → the host's
+  `:on-child-click` (Causa pivots to the child instance).
+
+  ## Theming
+
+  Colours resolve through `theme/tokens/css-var` so light + dark both
+  flow through the host's CSS custom-property surface (per the
+  `var(--*)` requirement)."
+  (:require [reagent.core :as r]
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
+             :as anchor]))
+
+;; ---- DOM measurement ----------------------------------------------------
+
+(defn- rect->map
+  [^js dom-rect]
+  (when dom-rect
+    {:left   (.-left dom-rect)
+     :top    (.-top dom-rect)
+     :width  (.-width dom-rect)
+     :height (.-height dom-rect)}))
+
+(defn- query-node-rect
+  [^js root node-id]
+  (when (and root node-id)
+    (when-let [testid (anchor/node->card-testid node-id)]
+      (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
+        (when el (rect->map (.getBoundingClientRect el)))))))
+
+(defn- measure-anchor
+  "Walk the DOM under `root` for the join-spec's bearing node and
+  return the overlay-local card anchor (or nil when the node isn't in
+  the DOM). Uses the pure `overlay-anchor/anchor-right-of`."
+  [^js root node-id]
+  (when (and root node-id)
+    (let [container (rect->map (.getBoundingClientRect root))
+          node      (query-node-rect root node-id)]
+      (anchor/anchor-right-of node container))))
+
+;; ---- child-row glyph ----------------------------------------------------
+
+(defn- child-glyph
+  "Status glyph + colour-token for a child row."
+  [{:keys [done? failed? cancelled?]}]
+  (cond
+    failed?    ["✗" :red]
+    cancelled? ["⊘" :text-tertiary]
+    done?      ["✓" :green]
+    :else      ["⧖" :yellow]))
+
+(defn- child-key->str
+  "Render a child key as a plain string for testids + display.
+  Namespaced keywords keep their ns segment."
+  [k]
+  (cond
+    (nil? k)     ""
+    (keyword? k) (if-let [n (namespace k)] (str n "/" (name k)) (name k))
+    :else        (str k)))
+
+(defn- child-row
+  [{:keys [key note] :as child} on-child-click]
+  (let [[glyph color-key] (child-glyph child)
+        ck (or key "")
+        ck-str (child-key->str ck)]
+    [:div {:key            ck-str
+           :data-testid     (str "rf-mv-chart-spawn-all-child-" ck-str)
+           :data-child-key  ck-str
+           :data-done       (str (boolean (:done? child)))
+           :data-failed     (str (boolean (:failed? child)))
+           :data-cancelled  (str (boolean (:cancelled? child)))
+           :on-click        (when on-child-click
+                              (fn [_] (on-child-click ck)))
+           :style {:display        "flex"
+                   :align-items    "baseline"
+                   :gap            "6px"
+                   :padding        "2px 0"
+                   :cursor         (if on-child-click "pointer" "default")
+                   :font-family    tokens/mono-stack
+                   :font-size      "11px"
+                   :color          (tokens/css-var :text-secondary)}}
+     [:span {:style {:color (tokens/css-var color-key) :width "12px"}} glyph]
+     [:span {:style {:color (tokens/css-var :text-primary)}} ck-str]
+     (when note
+       [:span {:style {:color (tokens/css-var :text-tertiary)}} note])]))
+
+;; ---- join card ----------------------------------------------------------
+
+(defn- join-card
+  "The anchored join-inspector card. `spec` carries the join-spec +
+  the measured `{:x :y}` anchor."
+  [{:keys [x y node-id join children on-all-complete on-any-failed
+           on-child-click] :as spec}]
+  (let [resolved? (anchor/join-resolved? spec)
+        total     (count children)
+        done      (count (filter :done? children))
+        waiting   (max 0 (- total done))
+        join-str  (cond
+                    (keyword? join) (str join)
+                    (map? join)     (pr-str join)
+                    :else           (str join))]
+    [:div {:data-testid     (str "rf-mv-chart-spawn-all-join-" node-id)
+           :data-node-id     node-id
+           :data-join        join-str
+           :data-resolved    (str resolved?)
+           :data-child-count (str total)
+           :style {:position       "absolute"
+                   :left           (str x "px")
+                   :top            (str y "px")
+                   :min-width      "180px"
+                   :max-width      "260px"
+                   :padding        "8px 10px"
+                   :pointer-events "auto"
+                   :background     (tokens/css-var :bg-2)
+                   :border         (str "1px solid " (tokens/css-var :accent-violet))
+                   :border-radius  "8px"
+                   :box-shadow     "0 4px 14px rgba(0,0,0,0.35)"
+                   :font-family    tokens/sans-stack}}
+     ;; Header
+     [:div {:style {:display "flex" :align-items "center" :gap "6px"
+                    :margin-bottom "4px"
+                    :font-size "11px" :font-weight 700
+                    :color (tokens/css-var :accent-violet)}}
+      [:span {:style {:font-family tokens/mono-stack}} "∷"]
+      ":spawn-all"]
+     ;; Join condition + resolution
+     [:div {:data-testid (str "rf-mv-chart-spawn-all-condition-" node-id)
+            :style {:font-family tokens/mono-stack :font-size "10px"
+                    :color (tokens/css-var :text-secondary)
+                    :margin-bottom "2px"}}
+      (str "join " join-str)]
+     [:div {:data-testid (str "rf-mv-chart-spawn-all-resolved-" node-id)
+            :style {:font-family tokens/mono-stack :font-size "10px"
+                    :margin-bottom "6px"
+                    :color (tokens/css-var (if resolved? :green :yellow))}}
+      (if resolved?
+        (str "resolved ✓  (" (anchor/join-summary spec) ")")
+        (str "resolved ✗  (waiting for " waiting " of " total ")"))]
+     ;; Child rows
+     (into [:div {:data-testid (str "rf-mv-chart-spawn-all-children-" node-id)}]
+           (for [c children] (child-row c on-child-click)))
+     ;; Join-target footers
+     (when on-all-complete
+       [:div {:style {:margin-top "6px" :font-family tokens/mono-stack
+                      :font-size "10px" :color (tokens/css-var :text-tertiary)}}
+        (str ":on-all-complete → " (pr-str on-all-complete))])
+     (when on-any-failed
+       [:div {:style {:font-family tokens/mono-stack :font-size "10px"
+                      :color (tokens/css-var :text-tertiary)}}
+        (str ":on-any-failed → " (pr-str on-any-failed))])]))
+
+;; ---- overlay component --------------------------------------------------
+
+(defn SpawnAllJoinOverlay
+  "Absolute-positioned overlay that anchors a `:spawn-all` join-
+  inspector card beside the spawn-all-bearing state by walking the
+  rendered chart DOM. Reagent form-3 component (needs a ref +
+  lifecycle to read the DOM after xyflow lays out).
+
+  Props (single map):
+
+    :join-spec  — `{:node-id <string>           ;; bearing state id
+                    :join <:all|:any|{:n N}|{:fn _}>
+                    :children [{:key <kw> :done? :failed? :cancelled?
+                                :note <string?>} ...]
+                    :resolved? <bool?>           ;; host override
+                    :on-all-complete <target?>   ;; join-resolved target
+                    :on-any-failed   <target?>}` — the presentation-
+                   ready join projection (host computes from its
+                   `:rf.machine.spawn-all/*` trace buffer). `:node-id`
+                   is the string `chart.layout/node-id` mints from the
+                   spawn-all state's path. nil → overlay drops out.
+    :tick       — opaque value the host bumps to force a re-measure +
+                   repaint (the join state changes as children resolve).
+    :testid     — overlay root data-testid; defaults to
+                   `\"rf-mv-chart-spawn-all-join-overlay\"`.
+    :on-child-click — `(fn [child-key] ...)`; fires on a child-row
+                   click (Causa pivots to the child instance)."
+  [_initial-props]
+  (let [root-ref   (r/atom nil)
+        anchored   (r/atom nil)
+        latest     (r/atom nil)
+        remeasure! (fn []
+                     (when-let [root @root-ref]
+                       (when-let [spec @latest]
+                         (reset! anchored
+                                 (measure-anchor root (:node-id spec))))))
+        resize-fn  (fn [_] (remeasure!))]
+    (r/create-class
+      {:display-name "MachinesViz.SpawnAllJoinOverlay"
+
+       :component-did-mount
+       (fn [_this]
+         (when (exists? js/window)
+           (.addEventListener js/window "resize" resize-fn))
+         (remeasure!))
+
+       :component-did-update
+       (fn [_this _prev] (remeasure!))
+
+       :component-will-unmount
+       (fn [_this]
+         (when (exists? js/window)
+           (.removeEventListener js/window "resize" resize-fn)))
+
+       :reagent-render
+       (fn [{:keys [join-spec tick testid on-child-click]
+             :or   {testid "rf-mv-chart-spawn-all-join-overlay"}}]
+         (reset! latest join-spec)
+         (when (and join-spec (:node-id join-spec))
+           (let [pos @anchored]
+             [:div {:data-testid testid
+                    :data-node-id (:node-id join-spec)
+                    :data-tick (when (some? tick) (str tick))
+                    :ref (fn [el]
+                           (reset! root-ref (when el (.-offsetParent el))))
+                    :style {:position       "absolute"
+                            :top            0
+                            :left           0
+                            :width          "100%"
+                            :height         "100%"
+                            :pointer-events "none"
+                            :overflow       "visible"
+                            :z-index        4}}
+              (when pos
+                (join-card (merge join-spec pos
+                                  {:on-child-click on-child-click})))])))})))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/adapters/react_chart_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/adapters/react_chart_cljs_test.cljs
@@ -1,0 +1,70 @@
+(ns day8.re-frame2-machines-viz.adapters.react-chart-cljs-test
+  "Smoke tests for the substrate-adapter React bridge + the UIx /
+  Helix shells (rf2-yg9he · xyflow Phase 2).
+
+  These pin the substrate-parity contract WITHOUT a DOM: the bridge
+  reactifies the Reagent `MachineChart` to a plain React class once,
+  and `chart-element` builds a valid React element from a CLJS props
+  map that any React host (UIx / Helix / raw React) can mount. The
+  full mount-and-assert visual-pin coverage lives in the browser-side
+  `*_dom_cljs_test.cljs` suites.
+
+  CLJS-only (`.cljs`) because the bridge requires reagent + the UIx /
+  Helix component macros, none of which load on the JVM. Runs under
+  `:node-test` (the `cljs-test$` regex matches this file)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            ["react" :as react]
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]
+            [day8.re-frame2-machines-viz.adapters.uix :as mv-uix]
+            [day8.re-frame2-machines-viz.adapters.helix :as mv-helix]))
+
+(def ^:private sample-machine
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done}}
+             :done    {:final? true}}})
+
+;; ---- shared React bridge ------------------------------------------------
+
+(deftest reactified-class-is-stable-by-reference
+  (testing "the Reagent MachineChart is reactified ONCE (React caches
+            component types by reference; a per-render reactify would
+            churn the subtree)"
+    (is (some? react-chart/MachineChartReactClass))
+    (is (identical? react-chart/MachineChartReactClass
+                    react-chart/MachineChartReactClass))))
+
+(deftest chart-element-builds-a-react-element
+  (testing "chart-element returns a valid React element for the bridge"
+    (let [el (react-chart/chart-element
+               {:machine-id :auth/flow :definition sample-machine})]
+      (is (react/isValidElement el)
+          "the bridge produces a mountable React element")
+      (is (identical? react-chart/MachineChartReactClass (.-type el))
+          "the element's type is the reactified MachineChart class"))))
+
+(deftest chart-element-carries-props-through-argv
+  (testing "props ride on the Reagent `argv` prop at index 1 (the
+            reactified Reagent component reads its render arg there)"
+    (let [props {:machine-id :auth/flow :definition sample-machine
+                 :current-state :loading}
+          el    (react-chart/chart-element props)
+          argv  (.. el -props -argv)]
+      (is (= props (aget argv 1))
+          "the props map sits at argv[1]"))))
+
+(deftest chart-element-tolerates-nil-props
+  (is (react/isValidElement (react-chart/chart-element nil))
+      "nil props degrade to an empty map, still a valid element"))
+
+;; ---- substrate shells ---------------------------------------------------
+
+(deftest uix-shell-is-defined
+  (testing "the UIx shell exposes a MachineChart component"
+    (is (some? mv-uix/MachineChart)
+        "UIx MachineChart shell is present")))
+
+(deftest helix-shell-is-defined
+  (testing "the Helix shell exposes a MachineChart component"
+    (is (some? mv-helix/MachineChart)
+        "Helix MachineChart shell is present")))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -1,0 +1,266 @@
+(ns day8.re-frame2-machines-viz.chart.chart-dom-cljs-test
+  "Browser-side CLJS visual-pin tests for the xyflow `MachineChart`
+  (rf2-y9j79 · xyflow Phase 2).
+
+  ## Why this exists
+
+  xyflow Phase 1 (#1806) DELETED the JVM-side `.cljc` renderer tests
+  (the JVM can't load xyflow). This suite restores that coverage as
+  browser-side CLJS: it mounts the chart against a sample machine spec
+  and pins the rendered DOM — node count, edge count, the custom
+  node/edge class + testid contract, and the Controls / MiniMap /
+  Background presence toggles. Per the saved-memory rule
+  (feedback_causa_story_cljs_unit_tests_not_playwright) these are
+  browser CLJS tests, NOT Playwright.
+
+  ## Mounting
+
+  The chart is a Reagent component; we mount it through the substrate-
+  adapter React bridge (`adapters.react-chart/chart-element`) so the
+  mount path is substrate-neutral — the same element a UIx / Helix
+  host would mount. `react-dom/client createRoot` + React `act()`
+  drives the render; assertions read the real DOM via querySelector.
+
+  ## Async-layout note
+
+  elkjs layout is async (returns a Promise); node POSITIONS arrive
+  after it resolves. But xyflow renders the node DOM immediately (at
+  the initial {x 0 y 0}), so node/edge COUNT, class names, and the
+  control toggles are all assertable synchronously after the first
+  commit — none of these depend on the layout pass. The tests
+  therefore do not race the elk Promise.
+
+  ## Target
+
+  ns ends in `-dom-cljs-test` so it runs under the `:browser-test`
+  build (real DOM + headless Chromium) per `shadow-cljs.edn`
+  (rf2-2hrj8). Under `:node-test` (no DOM) every test short-circuits
+  via `(browser?)` and asserts a trivial truth so the suite stays
+  green on both targets."
+  (:require ["react"            :as React]
+            ["react-dom/client" :as react-dom-client]
+            [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]))
+
+;; ---- sample machines ----------------------------------------------------
+
+(def ^:private idle-loading-done
+  "Canonical small machine: 4 states, 3 transitions."
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(def ^:private parallel-machine
+  "A parallel machine: 2 regions, 2 states each (rf2-lkwev)."
+  {:type :parallel
+   :regions {:audio   {:initial :playing
+                       :states {:playing {:on {:pause :paused}}
+                                :paused  {:on {:play :playing}}}}
+             :display {:initial :on
+                       :states {:on  {:on {:dim :off}}
+                                :off {:on {:lit :on}}}}}})
+
+;; ---- DOM mount helpers --------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- get-act []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- mount-node! []
+  (let [el (.createElement js/document "div")]
+    ;; xyflow needs a non-zero parent height to lay out; give the host
+    ;; an explicit box so the chart wrapper's "100%" resolves.
+    (set! (.. el -style -width) "800px")
+    (set! (.. el -style -height) "600px")
+    (.appendChild (.-body js/document) el)
+    el))
+
+(defn- count-sel [^js node sel]
+  (.-length (.querySelectorAll node sel)))
+
+(defn- with-mounted-chart
+  "Mount `MachineChart` with `props` via the React bridge under act(),
+  call `(f root-el node)` with the chart's root DOM element + the host
+  node, then unmount. Returns nil when no DOM / no act() (the caller
+  asserts the skip).
+
+  Note: the assertions here read DOM that mounts on the FIRST commit
+  (node DOM, control toggles, root data-attrs) — none depend on the
+  async elkjs layout pass, which only repositions already-mounted
+  nodes. We deliberately do NOT await the elk Promise (returning a
+  Promise from React's act() makes it async, which the synchronous
+  test runner cannot await and would corrupt the act environment for
+  subsequent tests)."
+  [props f]
+  (let [act-fn (get-act)]
+    (when (and (browser?) act-fn)
+      (enable-react-act-env!)
+      (let [node (mount-node!)
+            root (react-dom-client/createRoot node)]
+        (try
+          (act-fn (fn [] (.render root (react-chart/chart-element props))))
+          (let [el (.querySelector node "[data-testid=\"rf-mv-chart\"]")]
+            (f el node))
+          (finally
+            (try (act-fn (fn [] (.unmount root))) (catch :default _ nil))
+            (try (.removeChild (.-body js/document) node) (catch :default _ nil))))))))
+
+;; ---- node / edge count --------------------------------------------------
+
+(deftest chart-renders-a-node-per-state
+  (testing "rf2-y9j79 — the chart mounts one xyflow node per state"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [root node]
+          (is (some? root) "chart root element mounted")
+          ;; Each state node carries the `rf-mv-chart-node-<id>` testid
+          ;; (the chart.nodes/state-node contract).
+          (is (= 4 (count-sel node "[data-testid^=\"rf-mv-chart-node-\"]"))
+              "one node per state (idle/loading/done/failed)")
+          ;; The root surfaces the count as a data-attr too.
+          (is (= "4" (.getAttribute root "data-node-count"))
+              "data-node-count reflects the state count"))))))
+
+(deftest chart-renders-an-edge-per-transition
+  (testing "rf2-y9j79 — the chart's edge count reflects the transitions.
+
+            The edge LABEL DOM (`rf-mv-chart-edge-<id>`) mounts via
+            xyflow's EdgeLabelRenderer only AFTER the async elkjs
+            layout positions the edges, so we pin the count via the
+            layout-independent `data-edge-count` root attr (the
+            projector emits one edge per transition before layout)."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [root _node]
+          ;; 3 transitions: start, ok, err.
+          (is (= "3" (.getAttribute root "data-edge-count"))
+              "data-edge-count reflects the transition count"))))))
+
+;; ---- final-state affordance ---------------------------------------------
+
+(deftest chart-marks-final-states
+  (testing "rf2-y9j79 — final states render with their state-tags
+            scaffolding + final glyph (checkmark)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          ;; The check glyph ✓ is painted inside each :final? node.
+          (let [text (.-textContent node)]
+            (is (re-find #"✓" text) "a final-state checkmark glyph renders")))))))
+
+;; ---- Controls / MiniMap / Background presence ---------------------------
+
+(deftest chart-shows-controls-by-default
+  (testing "rf2-y9j79 — xyflow Controls render by default"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          (is (pos? (count-sel node ".react-flow__controls"))
+              "xyflow Controls present by default"))))))
+
+(deftest chart-hides-controls-when-disabled
+  (testing "rf2-y9j79 — :show-controls? false drops the Controls"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :show-controls? false}
+        (fn [_root node]
+          (is (zero? (count-sel node ".react-flow__controls"))
+              "no Controls when :show-controls? false"))))))
+
+(deftest chart-shows-minimap-when-enabled
+  (testing "rf2-y9j79 — :show-minimap? true mounts the MiniMap (off by
+            default)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (do
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done}
+          (fn [_root node]
+            (is (zero? (count-sel node ".react-flow__minimap"))
+                "MiniMap off by default")))
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done
+           :show-minimap? true}
+          (fn [_root node]
+            (is (pos? (count-sel node ".react-flow__minimap"))
+                "MiniMap present when :show-minimap? true")))))))
+
+(deftest chart-shows-background-by-default
+  (testing "rf2-y9j79 — the dot-grid Background renders by default"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          (is (pos? (count-sel node ".react-flow__background"))
+              "xyflow Background present by default"))))))
+
+;; ---- empty / nil definition placeholders --------------------------------
+
+(deftest chart-renders-no-definition-placeholder
+  (testing "rf2-y9j79 — a nil definition renders the placeholder, not a
+            canvas"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (let [act-fn (get-act)]
+        (when (and (browser?) act-fn)
+          (enable-react-act-env!)
+          (let [node (mount-node!)
+                root (react-dom-client/createRoot node)]
+            (try
+              (act-fn (fn [] (.render root
+                                      (react-chart/chart-element
+                                        {:machine-id :test/flow :definition nil}))))
+              (is (some? (.querySelector node "[data-testid=\"rf-mv-chart-no-definition\"]"))
+                  "no-definition placeholder renders")
+              (is (nil? (.querySelector node "[data-testid=\"rf-mv-chart\"]"))
+                  "no canvas for a nil definition")
+              (finally
+                (try (act-fn (fn [] (.unmount root))) (catch :default _ nil))
+                (try (.removeChild (.-body js/document) node) (catch :default _ nil))))))))))
+
+;; ---- parallel-region rendering (rf2-lkwev visual-pin) -------------------
+
+(deftest chart-renders-parallel-region-containers
+  (testing "rf2-y9j79 + rf2-lkwev — a parallel machine renders one
+            dashed region container per region, with its child states
+            inside"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/parallel :definition parallel-machine}
+        (fn [root node]
+          ;; Two region containers (audio + display).
+          (is (= 2 (count-sel node "[data-testid^=\"rf-mv-chart-region-\"]"))
+              "one region container per parallel region")
+          (is (= "2" (.getAttribute root "data-region-count"))
+              "data-region-count reflects the region count")
+          ;; Four states total (2 per region) — region containers are
+          ;; NOT counted as states.
+          (is (= 4 (count-sel node "[data-testid^=\"rf-mv-chart-node-\"]"))
+              "all four region states render")
+          (is (= "4" (.getAttribute root "data-node-count"))
+              "data-node-count excludes the region containers"))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -85,18 +85,84 @@
     (is (some :compound? top)
         "the compound parent carries the :compound? flag")))
 
-(deftest parse-definition-supports-parallel-projects-first-region
-  (let [parallel {:type :parallel
-                  :regions {:r1 {:initial :a :states {:a {:on {:go :b}}
-                                                      :b {}}}
-                            :r2 {:initial :x :states {:x {:on {:go :y}}
-                                                      :y {}}}}}
-        {:keys [nodes]} (layout/parse-definition parallel)
-        paths (set (map :path nodes))]
-    (is (contains? paths [:a]))
-    (is (contains? paths [:b]))
-    (is (not (contains? paths [:x]))
-        "v1 projects only the first region — :r2's nodes do not surface")))
+(deftest parse-definition-projects-every-parallel-region
+  (testing "rf2-lkwev xyflow Phase 2 — full parallel-region rendering:
+            EVERY region projects (Phase 1 deferred all but the first)"
+    (let [parallel {:type :parallel
+                    :regions {:r1 {:initial :a :states {:a {:on {:go :b}}
+                                                        :b {}}}
+                              :r2 {:initial :x :states {:x {:on {:go :y}}
+                                                        :y {}}}}}
+          {:keys [nodes edges parallel?]} (layout/parse-definition parallel)
+          paths (set (map :path (remove :region? nodes)))]
+      (is parallel? "the projection flags itself as parallel")
+      (is (contains? paths [:a]))
+      (is (contains? paths [:b]))
+      (is (contains? paths [:x])
+          "rf2-lkwev — :r2's nodes NOW surface (full parallel layout)")
+      (is (contains? paths [:y]))
+      ;; Both regions' edges surface.
+      (is (= #{:go} (set (map :event edges)))
+          "edges from both regions project")
+      (is (= 2 (count edges)) "one :go edge per region"))))
+
+(deftest parse-definition-emits-region-container-nodes
+  (testing "rf2-lkwev — each parallel region surfaces a synthetic
+            :region? compound container node with a region-prefixed id"
+    (let [parallel {:type :parallel
+                    :regions {:audio   {:initial :playing
+                                        :states {:playing {:on {:pause :paused}}
+                                                 :paused  {:on {:play :playing}}}}
+                              :display {:initial :on
+                                        :states {:on  {:on {:dim :off}}
+                                                 :off {:on {:lit :on}}}}}}
+          {:keys [nodes]} (layout/parse-definition parallel)
+          regions (filter :region? nodes)]
+      (is (= 2 (count regions)) "one container node per region")
+      (is (every? :compound? regions) "region containers are compound")
+      (is (= #{(layout/region-node-id :audio)
+               (layout/region-node-id :display)}
+             (set (map :id regions)))
+          "region node-ids are region-prefixed")
+      (is (= #{0 1} (set (map :region-index regions)))
+          "region containers carry their ordinal index for boundary colour"))))
+
+(deftest parse-definition-tags-region-states-with-parent
+  (testing "rf2-lkwev — every state inside a region carries :region +
+            :parent-id so the chart projector emits xyflow parentNode
+            sub-flow grouping"
+    (let [parallel {:type :parallel
+                    :regions {:r1 {:initial :a :states {:a {} :b {}}}
+                              :r2 {:initial :x :states {:x {} :y {}}}}}
+          {:keys [nodes]} (layout/parse-definition parallel)
+          states (remove :region? nodes)]
+      (is (every? :parent-id states) "every state has a parent region id")
+      (is (every? :region states)    "every state knows its region")
+      (let [r1-states (filter #(= :r1 (:region %)) states)]
+        (is (every? #(= (layout/region-node-id :r1) (:parent-id %)) r1-states)
+            ":r1 states point at the :r1 container")))))
+
+(deftest parse-definition-region-edges-stay-region-local
+  (testing "rf2-lkwev — orthogonality: a region's edges never reference
+            a sibling region's node (regions are independent zones)"
+    (let [parallel {:type :parallel
+                    :regions {:r1 {:initial :a :states {:a {:on {:go :b}} :b {}}}
+                              :r2 {:initial :x :states {:x {:on {:go :y}} :y {}}}}}
+          {:keys [nodes edges]} (layout/parse-definition parallel)
+          r1-ids (set (map :id (filter #(= :r1 (:region %)) (remove :region? nodes))))
+          r2-ids (set (map :id (filter #(= :r2 (:region %)) (remove :region? nodes))))]
+      (doseq [e edges]
+        (is (or (and (contains? r1-ids (:source e)) (contains? r1-ids (:target e)))
+                (and (contains? r2-ids (:source e)) (contains? r2-ids (:target e))))
+            "each edge stays within one region")))))
+
+(deftest region-node-id-is-prefixed-and-distinct
+  (testing "rf2-lkwev — region node-ids are region__-prefixed so they
+            never collide with a state node-id"
+    (is (= "region__r1" (layout/region-node-id :r1)))
+    (is (= "region__auth_main" (layout/region-node-id :auth/main)))
+    (is (not= (layout/region-node-id :r1) (layout/node-id [:r1]))
+        "a region container id differs from the same-named state id")))
 
 ;; ---- highlight-id ------------------------------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
@@ -1,0 +1,118 @@
+(ns day8.re-frame2-machines-viz.chart.overlays.overlay-anchor-cljs-test
+  "Pure-data tests for the overlay anchoring + join/cascade helpers
+  shared by the `:spawn-all` join inspector + the cancellation-cascade
+  visualiser overlays (rf2-3ow55 · xyflow Phase 2).
+
+  The overlays walk the rendered DOM to find a bearing node's bounding
+  rect; these helpers turn that rect + the overlay container's rect
+  into the card's overlay-local `{:x :y}` anchor, and resolve the join
+  state. Pure → JVM-runnable, so the math is pinned without a DOM.
+
+  Dual-target via `_cljs_test.cljc` — same pattern every machines-viz
+  helper test uses."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
+             :as anchor]))
+
+;; ---- node->card-testid --------------------------------------------------
+
+(deftest node-card-testid-matches-state-node-contract
+  (is (= "rf-mv-chart-node-idle" (anchor/node->card-testid "idle")))
+  (is (= "rf-mv-chart-node-auth_login__hydrating"
+         (anchor/node->card-testid "auth_login__hydrating"))))
+
+(deftest node-card-testid-nil-on-blank
+  (is (nil? (anchor/node->card-testid nil)))
+  (is (nil? (anchor/node->card-testid "")))
+  (is (nil? (anchor/node->card-testid "   "))))
+
+;; ---- anchor-right-of (join inspector) -----------------------------------
+
+(def ^:private container {:left 20 :top 10 :width 900 :height 400})
+
+(deftest anchor-right-of-positions-card-beside-node
+  ;; Node at viewport (100,100) 140×48; container origin (20,10) →
+  ;; overlay-local node left = 80, top = 90; card sits at x = 80 + 140 +
+  ;; gap(12) = 232, y = 90.
+  (let [a (anchor/anchor-right-of {:left 100 :top 100 :width 140 :height 48}
+                                  container)]
+    (is (= 232.0 (double (:x a))))
+    (is (= 90.0  (double (:y a))))
+    ;; node centre for a connector line: cx = 80 + 70 = 150, cy = 90+24.
+    (is (= 150.0 (:node-cx a)))
+    (is (= 114.0 (:node-cy a)))))
+
+(deftest anchor-right-of-nil-on-missing-or-degenerate
+  (is (nil? (anchor/anchor-right-of nil container)))
+  (is (nil? (anchor/anchor-right-of {:left 0 :top 0 :width 10 :height 10} nil)))
+  (is (nil? (anchor/anchor-right-of {:left 0 :top 0 :width 0 :height 48} container))))
+
+;; ---- anchor-below (cascade waterfall) -----------------------------------
+
+(deftest anchor-below-positions-card-beneath-node
+  ;; Same node; card sits at x = 80 (node left), y = 90 + 48 + gap(12) = 150.
+  (let [a (anchor/anchor-below {:left 100 :top 100 :width 140 :height 48}
+                               container)]
+    (is (= 80.0  (double (:x a))))
+    (is (= 150.0 (double (:y a))))
+    (is (= 150.0 (:node-cx a)))
+    (is (= 114.0 (:node-cy a)))))
+
+(deftest anchor-below-nil-on-degenerate
+  (is (nil? (anchor/anchor-below {:left 0 :top 0 :width 10 :height 0} container))))
+
+;; ---- join-resolved? -----------------------------------------------------
+
+(deftest join-resolved-all
+  (testing ":all resolves only when every child is done"
+    (is (true?  (anchor/join-resolved?
+                  {:join :all :children [{:done? true} {:done? true}]})))
+    (is (false? (anchor/join-resolved?
+                  {:join :all :children [{:done? true} {:done? false}]})))))
+
+(deftest join-resolved-any
+  (testing ":any resolves once one child is done"
+    (is (true?  (anchor/join-resolved?
+                  {:join :any :children [{:done? true} {:done? false}]})))
+    (is (false? (anchor/join-resolved?
+                  {:join :any :children [{:done? false} {:done? false}]})))))
+
+(deftest join-resolved-n
+  (testing "{:n N} resolves when N children are done"
+    (is (true?  (anchor/join-resolved?
+                  {:join {:n 2} :children [{:done? true} {:done? true} {:done? false}]})))
+    (is (false? (anchor/join-resolved?
+                  {:join {:n 3} :children [{:done? true} {:done? true} {:done? false}]})))))
+
+(deftest join-resolved-host-override-wins
+  (testing "an explicit :resolved? from the host wins over the computed value"
+    (is (true? (anchor/join-resolved?
+                 {:join :all :resolved? true :children [{:done? false}]})))
+    (is (false? (anchor/join-resolved?
+                  {:join :any :resolved? false :children [{:done? true}]})))))
+
+;; ---- join-summary -------------------------------------------------------
+
+(deftest join-summary-counts
+  (is (= "1/3 done · 1 failed · 1 cancelled"
+         (anchor/join-summary
+           {:children [{:done? true} {:failed? true} {:cancelled? true}]})))
+  (is (= "2/2 done"
+         (anchor/join-summary
+           {:children [{:done? true} {:done? true}]}))))
+
+;; ---- cascade-counts + summary -------------------------------------------
+
+(deftest cascade-counts-by-kind
+  (let [steps [{:kind :exit} {:kind :destroy} {:kind :abort}
+               {:kind :abort} {:kind :cleanup}]]
+    (is (= {:destroyed 1 :aborted 2 :cleaned 1} (anchor/cascade-counts steps)))))
+
+(deftest cascade-summary-line-pluralises
+  (is (= "destroyed 1 actor · aborted 3 requests"
+         (anchor/cascade-summary-line
+           {:steps [{:kind :destroy}
+                    {:kind :abort} {:kind :abort} {:kind :abort}]})))
+  (is (= "no cascade steps"
+         (anchor/cascade-summary-line {:steps []}))))


### PR DESCRIPTION
Closes rf2-lkwev + rf2-3ow55 + rf2-yg9he + rf2-y9j79. Completes the Stately-quality xyflow migration.

## Stacked on #1837
This PR is **stacked on `worker/mviz-after-rings` (#1837)** — it builds on the `:after-ring-specs` prop path that #1837 adds to `chart.cljs`. The diff here shows only the Phase-2 changes; GitHub auto-retargets the base to `main` when #1837 merges. (#1837 is currently blocked on the flaky "Story/Causa browser gates" check that #1836/#1838 address — not an after-rings regression.)

## What landed (4 beads, layered on chart.cljs — bundled, not parallel)

- **rf2-lkwev — full parallel-region rendering.** `parse-definition` now projects EVERY region (was first-region-only) as a synthetic `:region?` compound container; each region's states carry `:region` + `:parent-id` for xyflow `parentNode` sub-flow grouping; elkjs lays states out inside each region via `INCLUDE_CHILDREN`. New `chart.nodes.parallel-region-node` paints a distinct dashed boundary per region (rotation colour by region index) — Stately parity.
- **rf2-3ow55 — `:spawn-all` join inspector + cancellation-cascade overlays.** Same host-projected, DOM-walking, pure-geometry shape as the after-rings overlay. `chart.overlays.overlay-anchor.cljc` carries the JVM-testable anchoring + join-resolution + cascade-summary math; `spawn_all_join.cljs` + `cancellation_cascade.cljs` are the Reagent overlays.
- **rf2-yg9he — UIx + Helix substrate adapters.** Shared `adapters.react-chart` bridge reactifies the Reagent `MachineChart` once (xyflow IS React); thin `$`-mountable per-substrate shells (`adapters.uix`, `adapters.helix`) restore the substrate parity Phase 1 traded away. One bridge, no per-substrate fork.
- **rf2-y9j79 — browser-side CLJS visual-pin tests.** `chart_dom_cljs_test.cljs` mounts the chart under headless Chromium and pins node/edge counts, the node/edge class + testid contract, the Controls/MiniMap/Background toggles, the no-definition placeholder, and parallel-region containers. Restores (as CLJS) the JVM `.cljc` renderer coverage #1806 deleted.

Spec `000-Vision.md` + `API.md` updated to record Phase-2 completion.

## Gates (all green locally)
- [x] `npm run test:cljs` — 3945 tests, 0 failures
- [x] `clojure -M:test` — machines-viz (131) + causa (849)
- [x] `npm run test:browser` — 85 tests, 0 failures (incl. new visual-pin DOM suite)
- [x] `npm run test:bundle-isolation` — PASS (xyflow/elkjs stay dev-only)
- [x] `npm run test:perf-bundle` — PASS
- [x] clj-kondo — errors 0, warnings 0

## Posture
Pre-alpha · Stately-quality bar · no bead refs in source · `var(--*)` theming · CLJS unit/browser tests (no Playwright).