### PR TITLE
fix(adapters): reagent-slim full dispose + test-react numeric mount order + derived-value note (rf2-7v82h + rf2-ovpl3 + rf2-pyp3n)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -49,6 +49,14 @@
   (ratom/make-reaction (spine/build-recompute-fn source-containers compute-fn)))
 
 ;; ---- render ---------------------------------------------------------------
+;;
+;; Active roots are tracked in a per-adapter atom so `dispose-adapter!`
+;; can drain them (rf2-7v82h; mirrors the Reagent adapter's
+;; rf2-9fdkb tracking). Each mount adds the React-19 root to the active
+;; set; the returned unmount thunk removes itself from the set before
+;; calling `(rdc/unmount root)`.
+
+(defonce ^:private active-roots (atom #{}))
 
 (defn- render [render-tree mount-point opts]
   ;; The bridge mounted into a raw DOM container directly; under the
@@ -56,13 +64,16 @@
   ;; The unmount thunk closes over the root to call its .unmount.
   ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a boolean;
   ;; no defensive coercion.
-  (let [hydrate? (:hydrate? opts)]
-    (if hydrate?
-      (let [root (rdc/hydrate-root mount-point render-tree)]
-        (fn unmount [] (rdc/unmount root)))
-      (let [root (rdc/create-root mount-point)]
-        (rdc/render root render-tree)
-        (fn unmount [] (rdc/unmount root))))))
+  (let [hydrate? (:hydrate? opts)
+        root     (if hydrate?
+                   (rdc/hydrate-root mount-point render-tree)
+                   (let [r (rdc/create-root mount-point)]
+                     (rdc/render r render-tree)
+                     r))]
+    (swap! active-roots conj root)
+    (fn unmount []
+      (swap! active-roots disj root)
+      (rdc/unmount root))))
 
 (defonce ^:private hiccup-emitter (atom nil))
 
@@ -95,21 +106,44 @@
 
 (defn- dispose-adapter! []
   ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
-  ;; rf2-jcjul). The component-unmount-driven path handles the
-  ;; mounted case (reagent2 reaps Reactions once their last watcher
-  ;; drops) — but `dispose-adapter!` MUST cover the headless /
-  ;; test-fixture path where no component unmount fires before the
-  ;; adapter goes away, and the SSR path where the rendered tree was
-  ;; string-serialised without ever being mounted. Without the walk,
-  ;; sequential `init! → dispose-adapter!` cycles in a long-lived
-  ;; process accumulate per-frame sub-cache entries closed over stale
-  ;; Reactions forever.
+  ;; rf2-jcjul, rf2-7v82h). The four-MUST list — brought to full parity
+  ;; with the Reagent adapter (reagent.cljs:100-137):
   ;;
-  ;; Delegated to `spine/dispose-frame-sub-caches!` (rf2-jcjul): the
-  ;; same helper backs the Reagent adapter and the spine-built UIx /
-  ;; Helix adapters so all three substrates share one implementation
-  ;; — no three-way drift on the lifecycle MUST.
-  (spine/dispose-frame-sub-caches!))
+  ;;   1. Cancel all in-flight reactive subscriptions — walk every live
+  ;;      frame's per-frame sub-cache and dispose each cached Reaction.
+  ;;      The component-unmount-driven path handles the mounted case
+  ;;      (reagent2 reaps Reactions once their last watcher drops) — but
+  ;;      `dispose-adapter!` MUST cover the headless / test-fixture path
+  ;;      where no component unmount fires before the adapter goes away,
+  ;;      and the SSR path where the rendered tree was string-serialised
+  ;;      without ever being mounted. Without the walk, sequential
+  ;;      `init! → dispose-adapter!` cycles in a long-lived process
+  ;;      accumulate per-frame sub-cache entries closed over stale
+  ;;      Reactions forever. Delegated to
+  ;;      `spine/dispose-frame-sub-caches!` (rf2-jcjul): the same helper
+  ;;      backs the Reagent adapter and the spine-built UIx / Helix
+  ;;      adapters so all three substrates share one implementation —
+  ;;      no three-way drift on the lifecycle MUST.
+  ;;
+  ;;   2. Release host-specific resources — drain the active-roots set
+  ;;      (React 19 roots; mounted-but-not-unmounted at process exit /
+  ;;      hot-reload). Swallow per-root throws so one misbehaving root
+  ;;      cannot strand the rest of the drain (rf2-7v82h).
+  ;;
+  ;;   3. Discard internal caches — clear the hiccup-emitter (the SSR
+  ;;      late-bind sink; the registered fn captures `re-frame.ssr`
+  ;;      state that must not survive the adapter) (rf2-7v82h).
+  ;;
+  ;;   4. Make subsequent calls return `:rf.error/adapter-disposed` —
+  ;;      handled one level up by `substrate-adapter/dispose-adapter!`
+  ;;      via the `disposed?` breadcrumb (rf2-6wxys).
+  (spine/dispose-frame-sub-caches!)
+  (doseq [root @active-roots]
+    (try (rdc/unmount root)
+         (catch :default _ nil)))
+  (reset! active-roots #{})
+  (reset! hiccup-emitter nil)
+  nil)
 
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_drain_roots_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_drain_roots_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.adapter.reagent-slim-dispose-drain-roots-cljs-test
+  "Pins the reagent-slim adapter's `dispose-adapter!` four-MUST list
+  items 2 (release host-specific resources: drain active React roots)
+  and 3 (discard internal caches: clear the hiccup-emitter) — Spec 006
+  §Adapter disposal lifecycle, rf2-7v82h.
+
+  Before rf2-7v82h the slim adapter's `dispose-adapter!` only ran the
+  per-frame sub-cache walk (MUST 1); it never tracked active React
+  roots and never cleared the SSR hiccup-emitter, so an
+  `init! → render → dispose-adapter!` cycle (test fixtures, hot-reload,
+  SSR string-serialise without mount) left React roots mounted and the
+  installed emitter alive across teardown. The Reagent adapter already
+  honoured both MUSTs (reagent.cljs:100-137); this brings slim to
+  parity.
+
+  Strategy mirrors `re-frame.adapter-render-cljs-test`: spy on
+  `reagent2.dom.client`'s create-root / render / unmount via
+  `with-redefs` so the test runs under :node-test with no real DOM.
+  We drive the adapter's private `:render` slot to register stranded
+  roots, install a hiccup-emitter, then call `dispose-adapter!` and
+  assert every stranded root was unmounted and the emitter is nil.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent2.dom.client :as rdc]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+
+;; ---- fixture --------------------------------------------------------------
+;;
+;; Cold-start. The unit under test IS `dispose-adapter!`, so we install
+;; the slim adapter ourselves and let the test body drive render +
+;; dispose. Each test cleans up after itself so a re-run is idempotent.
+;; Frames are wiped so the MUST-1 sub-cache walk inside dispose sees an
+;; empty registry (this file pins MUST 2 + 3, not MUST 1).
+
+(defn fresh-slim [test-fn]
+  (adapter/reset-lifecycle-state-for-tests!)
+  (reset! frame/frames {})
+  (adapter/install-adapter! reagent-slim-adapter/adapter)
+  (test-fn)
+  (reset! frame/frames {})
+  (adapter/reset-lifecycle-state-for-tests!))
+
+(use-fixtures :each fresh-slim)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- mk-fake-root
+  "A fake Root identity — an object carrying an `.unmount` method so
+  `reagent2.dom.client/unmount`'s `(some? (.-unmount root))` guard
+  passes. The spy on `rdc/unmount` records calls; the method body is
+  never reached because we redef the var."
+  [tag]
+  #js {:rf-test-root-tag tag
+       :unmount          (fn [] nil)})
+
+;; ---- MUST 2: drain active roots -------------------------------------------
+
+(deftest dispose-adapter-drains-stranded-active-roots
+  (testing "dispose-adapter! unmounts every root mounted-but-not-unmounted
+            (the headless / hot-reload path) — rf2-7v82h MUST 2"
+    (let [unmount-calls (atom [])
+          root-a        (mk-fake-root :a)
+          root-b        (mk-fake-root :b)
+          root-c        (mk-fake-root :c)
+          roots         (atom [root-a root-b root-c])]
+      (with-redefs [rdc/create-root (fn
+                                      ([_]   (let [[r] @roots] (swap! roots rest) r))
+                                      ([_ _] (let [[r] @roots] (swap! roots rest) r)))
+                    rdc/render      (fn
+                                      ([_ _]     nil)
+                                      ([_ _ _]   nil)
+                                      ([_ _ _ _] nil))
+                    rdc/unmount     (fn [root] (swap! unmount-calls conj root) nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)]
+          ;; Mount three roots; do NOT call the returned unmount thunks
+          ;; — they are now "stranded" (mounted-but-not-unmounted).
+          (render-fn [:div "a"] #js {} nil)
+          (render-fn [:div "b"] #js {} nil)
+          (render-fn [:div "c"] #js {} nil)
+          (is (empty? @unmount-calls)
+              "precondition: no roots unmounted before dispose")
+
+          ;; Drive the drain.
+          (adapter/dispose-adapter!)
+
+          (is (= 3 (count @unmount-calls))
+              "dispose-adapter! unmounted all three stranded roots")
+          (doseq [r [root-a root-b root-c]]
+            (is (some #(identical? r %) @unmount-calls)
+                (str "stranded root " (pr-str r) " was drained by dispose-adapter!"))))))))
+
+(deftest dispose-adapter-does-not-double-unmount-explicitly-unmounted-roots
+  (testing "a root whose unmount thunk already fired is removed from the
+            active set, so dispose-adapter! does NOT unmount it again
+            — rf2-7v82h MUST 2 (the thunk disj's itself before unmount)"
+    (let [unmount-calls (atom [])
+          root-live     (mk-fake-root :live)
+          root-gone     (mk-fake-root :gone)
+          roots         (atom [root-live root-gone])]
+      (with-redefs [rdc/create-root (fn
+                                      ([_]   (let [[r] @roots] (swap! roots rest) r))
+                                      ([_ _] (let [[r] @roots] (swap! roots rest) r)))
+                    rdc/render      (fn ([_ _] nil) ([_ _ _] nil) ([_ _ _ _] nil))
+                    rdc/unmount     (fn [root] (swap! unmount-calls conj root) nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)
+              _live-thunk (render-fn [:div "live"] #js {} nil)
+              gone-thunk  (render-fn [:div "gone"] #js {} nil)]
+          ;; Explicitly unmount the second root via its thunk.
+          (gone-thunk)
+          (is (= [root-gone] @unmount-calls)
+              "precondition: explicit unmount fired exactly once for the gone root")
+
+          ;; Dispose: only the still-live root should be drained.
+          (adapter/dispose-adapter!)
+
+          (is (= 1 (count (filter #(identical? root-gone %) @unmount-calls)))
+              "the explicitly-unmounted root is NOT unmounted a second time")
+          (is (some #(identical? root-live %) @unmount-calls)
+              "the still-live root IS drained by dispose-adapter!"))))))
+
+(deftest dispose-adapter-tolerates-throwing-root
+  (testing "one root whose unmount throws does not strand the rest of
+            the drain — rf2-7v82h MUST 2 (per-root try/catch)"
+    (let [unmount-calls (atom [])
+          bad-root      (mk-fake-root :bad)
+          good-root     (mk-fake-root :good)
+          roots         (atom [bad-root good-root])]
+      (with-redefs [rdc/create-root (fn
+                                      ([_]   (let [[r] @roots] (swap! roots rest) r))
+                                      ([_ _] (let [[r] @roots] (swap! roots rest) r)))
+                    rdc/render      (fn ([_ _] nil) ([_ _ _] nil) ([_ _ _ _] nil))
+                    rdc/unmount     (fn [root]
+                                      (swap! unmount-calls conj root)
+                                      (when (identical? root bad-root)
+                                        (throw (ex-info "boom" {:root root})))
+                                      nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)]
+          (render-fn [:div "bad"] #js {} nil)
+          (render-fn [:div "good"] #js {} nil)
+          ;; Must not propagate the bad root's throw.
+          (is (nil? (adapter/dispose-adapter!))
+              "dispose-adapter! swallows the per-root throw and returns nil")
+          (is (some #(identical? bad-root %) @unmount-calls)
+              "the throwing root's unmount was attempted")
+          (is (some #(identical? good-root %) @unmount-calls)
+              "the good root was still drained despite the earlier throw"))))))
+
+;; ---- MUST 3: clear the hiccup-emitter -------------------------------------
+
+(deftest dispose-adapter-clears-hiccup-emitter
+  (testing "dispose-adapter! resets the SSR hiccup-emitter to nil so the
+            installed fn (which captures re-frame.ssr state) does not
+            survive teardown — rf2-7v82h MUST 3"
+    ;; Install an emitter and prove render-to-string resolves it.
+    (reagent-slim-adapter/set-hiccup-emitter!
+      (fn [tree _opts] (str "EMITTED:" (pr-str tree))))
+    (is (= "EMITTED:[:p \"hi\"]"
+           ((:render-to-string reagent-slim-adapter/adapter) [:p "hi"] nil))
+        "precondition: the installed emitter is live before dispose")
+
+    ;; Dispose drains the emitter.
+    (adapter/dispose-adapter!)
+
+    ;; Post-dispose: render-to-string raises the no-emitter-bound error
+    ;; (the only black-box proof the emitter atom was reset to nil).
+    (is (thrown-with-msg?
+          cljs.core.ExceptionInfo
+          #":rf.error/no-hiccup-emitter-bound"
+          ((:render-to-string reagent-slim-adapter/adapter) [:p "hi"] nil))
+        "after dispose the emitter is nil; render-to-string raises no-emitter-bound")))

--- a/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
+++ b/implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc
@@ -38,6 +38,39 @@
     - React-context provider traversal. Frame-routing under this
       adapter is via the dynamic-var tier; the React-context tier
       is degenerate (no React).
+    - Derived-value disposal / ref-count symmetry under CLJS
+      (rf2-pyp3n). `make-derived-value` reifies `IDeref` ONLY — no
+      `IWatchable`, no disposal protocol. Consequences, split by host:
+        * On the JVM the sub-cache's `interop/add-on-dispose!` works:
+          `re-frame.interop` (interop.clj) implements dispose directly,
+          keyed by reaction identity, and the reify is a valid map key,
+          so the input-ref-count symmetry described in subs.cljc holds.
+        * Under CLJS it is a SILENT no-op: this adapter intentionally
+          does NOT publish the `:adapter/dispose!` /
+          `:adapter/add-on-dispose!` late-bind hooks (see the routing
+          block at the foot of this ns — reactive-substrate hooks are
+          withheld so misconfigured production paths surface rather than
+          paper over), and interop.cljs routes through those late-bind
+          hooks, which no-op when unregistered. So under the CLJS
+          test-react path the per-derived-value dispose hook never fires
+          and ref-count symmetry does NOT hold. This is consistent with
+          the `reactive subscription tracking out of scope` line above
+          but is called out explicitly here because the JVM-works /
+          CLJS-silent split is otherwise surprising.
+      Also masked in practice: `subscribe-container` on a DERIVED value
+      never fires its watch (it watches the source container, not the
+      reified IDeref), but real subs watch the source so no test relies
+      on it.
+    - Per-frame sub-cache teardown on `dispose-adapter!` (rf2-pyp3n).
+      The other four adapters delegate Spec 006 §Adapter disposal
+      lifecycle MUST 1 to `spine/dispose-frame-sub-caches!`; this
+      adapter CANNOT — it is CLJC and the spine is CLJS-only, so
+      reaching for it would break the JVM build. `dispose-adapter!`
+      drains active-mounts (host-resource MUST) but leaves per-frame
+      sub-caches to the host runtime. Acceptable here because the test
+      adapter's `make-derived-value` holds no host resources (it is a
+      plain `IDeref` reify recomputed on deref) — there is nothing for
+      a sub-cache walk to dispose.
 
   Usage skeleton:
 
@@ -84,6 +117,15 @@
 (defn- make-derived-value [source-containers compute-fn]
   ;; Recompute on every deref. No caching: the test surface only ever
   ;; runs a sub a handful of times per test case.
+  ;;
+  ;; rf2-pyp3n: IDeref ONLY — deliberately no IWatchable / no disposal
+  ;; protocol. The sub-cache's dispose/ref-count path therefore works on
+  ;; the JVM (interop.clj implements dispose by reaction identity) but is
+  ;; a SILENT no-op under CLJS (this adapter withholds the
+  ;; :adapter/dispose! / :adapter/add-on-dispose! late-bind hooks, and
+  ;; interop.cljs routes through them — unregistered hooks no-op). See the
+  ;; ns docstring's `Out of scope` list for the full JVM-works /
+  ;; CLJS-silent split and why it is acceptable for the test adapter.
   (reify
     #?(:clj clojure.lang.IDeref :cljs IDeref)
     (#?(:clj deref :cljs -deref) [_]
@@ -95,6 +137,13 @@
 ;; carries:
 ;;
 ;;   :id              — gensym tag (for log readability)
+;;   :seq             — monotonic integer minted from `mount-counter`
+;;                      at construction. The `:id` gensym is NOT a safe
+;;                      sort key: `mount-record-from-unmount-fn` needs
+;;                      the freshest mount, and a lexicographic sort on
+;;                      the gensym suffix ("…mount-10" < "…mount-9")
+;;                      returns a STALE record after the 10th mint
+;;                      (rf2-ovpl3). `:seq` is the numeric ordering key.
 ;;   :render-tree     — atom holding the currently-rendered tree
 ;;   :lifecycle-log   — atom holding a vector of {:phase ... :at ms}
 ;;                      entries; the test driver inspects this to
@@ -110,10 +159,17 @@
 ;;                      or `unmount!` after teardown.
 
 (defrecord ^:no-doc MountedComponent
-  [id render-tree lifecycle-log currently-rendering? mounted?])
+  [id seq render-tree lifecycle-log currently-rendering? mounted?])
 
 ;; All live mounts; `dispose-adapter!` walks this to drain.
 (defonce ^:private active-mounts (atom #{}))
+
+;; Monotonic mount sequence (rf2-ovpl3). `render` mints `(swap! ...
+;; inc)` into each MountedComponent's `:seq`; `mount-record-from-
+;; unmount-fn` sorts on this integer to recover the freshest mount.
+;; The gensym `:id` suffix is NOT monotonic-safe under a lexicographic
+;; sort, so it cannot serve as the ordering key.
+(defonce ^:private mount-counter (atom 0))
 
 (defn- now-ms []
   #?(:clj (System/currentTimeMillis)
@@ -143,6 +199,7 @@
   ;; (no `:hydrate?` semantics).
   (let [mount (->MountedComponent
                 (gensym "test-react-mount-")
+                (swap! mount-counter inc)
                 (atom nil)
                 (atom [])
                 (atom false)
@@ -204,6 +261,13 @@
   ;; mounted? false WITHOUT routing through the public `unmount!`
   ;; (which would throw on a stuck currently-rendering? cell) and log
   ;; a :forced-teardown phase so the test surface can spot drift.
+  ;;
+  ;; rf2-pyp3n: this drains active-mounts (the host-resource MUST) but
+  ;; does NOT walk per-frame sub-caches the way the other four adapters
+  ;; do via `spine/dispose-frame-sub-caches!` — this adapter is CLJC and
+  ;; the spine is CLJS-only. Acceptable because test-react's
+  ;; `make-derived-value` holds no host resources (plain IDeref reify);
+  ;; see the ns docstring's `Out of scope` list.
   (doseq [m @active-mounts]
     (when @(:mounted? m)
       (log-phase! m :forced-teardown)
@@ -258,18 +322,19 @@
   ;; The mount we just added is the only one whose `:mounted?` is
   ;; true AND that closes over `unmount-fn`. Since closures aren't
   ;; introspectable in CLJ, we use the active-mounts order: the
-  ;; most-recently-conj'd is the freshest add for non-empty sets.
+  ;; freshest add is the one with the highest monotonic `:seq`.
   ;; (For unit-test use this is sufficient; tests mount one root at
   ;; a time per scope.)
-  (let [mounts @active-mounts]
-    (when (seq mounts)
-      ;; `set` has no order; we tag each MountedComponent with a
-      ;; monotonic id at construction and pick the max-id mount
-      ;; whose :mounted? is true.
-      (->> mounts
-           (filter (comp deref :mounted?))
-           (sort-by (comp str :id))
-           last))))
+  (let [live (filter (comp deref :mounted?) @active-mounts)]
+    ;; `set` has no order; each MountedComponent carries a monotonic
+    ;; integer `:seq` minted at construction. Pick the max-`:seq` live
+    ;; mount via a NUMERIC reduction. rf2-ovpl3: the pre-fix code sorted
+    ;; lexicographically on the gensym `:id` string, so once >=10 mounts
+    ;; had been minted in a process "…mount-10" sorted BEFORE "…mount-9"
+    ;; and `last` returned a STALE record. `:seq` is a real integer, so
+    ;; the reduction is monotonic for any mount count.
+    (when (seq live)
+      (reduce (fn [a b] (if (> (:seq b) (:seq a)) b a)) live))))
 
 (defn mount!
   "Mount `render-tree` (a hiccup vector or any data the test treats as

--- a/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
+++ b/implementation/adapters/test-react/test/re_frame/adapter/test_react_test.cljc
@@ -91,3 +91,46 @@
           ":forced-teardown phase records the drain so tests can spot leaked mounts")
       ;; Re-install so the fixture's outer dispose call below is a no-op.
       (substrate-adapter/install-adapter! test-react/adapter))))
+
+;; ---- scenario 4: monotonic mount ordering (rf2-ovpl3) ---------------------
+
+(deftest mount-returns-the-freshest-record-past-the-tenth-mint
+  (testing "mount! returns the LATEST mount even after >=10 mounts in one
+            process — rf2-ovpl3. The pre-fix code sorted lexicographically
+            on the gensym :id, so '…mount-10' < '…mount-9' returned a STALE
+            record. The numeric :seq ordering is monotonic for any count."
+    ;; Mount 11 components without unmounting any (they stay live), then
+    ;; mount one more whose render-tree is a unique sentinel. The
+    ;; freshest mount! must return THAT sentinel's record — not a stale
+    ;; mount-9-vs-mount-10 lexicographic loser.
+    (let [_earlier (doall (for [i (range 11)]
+                            (test-react/mount! [:div (str "v" i)])))
+          latest   (test-react/mount! [:div "SENTINEL-LATEST"])]
+      (is (= [:div "SENTINEL-LATEST"] (test-react/current-render-tree latest))
+          "mount! returned the record for the most-recent mount, not a
+           lexicographically-stale one")
+      ;; And the returned record's :seq is the maximum across all live
+      ;; mounts — proves we picked the freshest, not just any live one.
+      (let [max-seq (apply max (map :seq (test-react/mounted-roots)))]
+        (is (= max-seq (:seq latest))
+            "the returned record carries the maximum monotonic :seq"))
+      ;; The unmount thunk on the returned record tears down the SENTINEL
+      ;; mount specifically (not a stale neighbour).
+      (test-react/unmount! latest)
+      (is (nil? (test-react/current-render-tree latest))
+          "unmounting the returned record tore down the correct (latest) mount")
+      ;; Drain the 11 still-live earlier mounts so the fixture's
+      ;; dispose-adapter! has nothing surprising to forcibly tear down.
+      (doseq [m _earlier] (test-react/unmount! m)))))
+
+(deftest mount-seq-is-strictly-increasing
+  (testing "each mount! mints a strictly-greater :seq than the previous —
+            the monotonic ordering invariant rf2-ovpl3 relies on"
+    (let [a (test-react/mount! [:div "a"])
+          b (test-react/mount! [:div "b"])
+          c (test-react/mount! [:div "c"])]
+      (is (< (:seq a) (:seq b) (:seq c))
+          ":seq is strictly increasing across successive mounts")
+      (test-react/unmount! a)
+      (test-react/unmount! b)
+      (test-react/unmount! c))))


### PR DESCRIPTION
## Summary

Three adapter bug/clarity fixes.

- **rf2-7v82h (P1, BUG)** — reagent-slim `dispose-adapter!` violated Spec 006 §Adapter disposal lifecycle MUST 2 (never tracked/drained active React roots) and MUST 3 (never cleared its `hiccup-emitter`). It now tracks each mounted root in a per-adapter `active-roots` atom (the unmount thunk disj's itself before unmounting), drains stranded roots on dispose with a per-root `try/catch`, and resets the emitter to nil — full parity with the stock Reagent adapter (`reagent.cljs:100-137`).
- **rf2-ovpl3 (P2, BUG)** — test-react `mount!` sorted active mounts lexicographically on the gensym `:id` (`(sort-by (comp str :id))`), so once a process minted >=10 mounts `"...mount-10" < "...mount-9"` and `mount!` returned a STALE `MountedComponent`. Each record now carries a monotonic integer `:seq` from a global counter; the lookup picks the max-`:seq` live mount via a numeric reduction.
- **rf2-pyp3n (P3)** — test-react `make-derived-value` is `IDeref`-only, so the sub-cache dispose/ref-count path works on the JVM (interop.clj) but is a silent no-op under CLJS (the adapter deliberately withholds the `:adapter/dispose!` / `:adapter/add-on-dispose!` late-bind hooks). This JVM-works / CLJS-silent split — plus the absent per-frame sub-cache teardown on dispose (the adapter is CLJC; the spine is CLJS-only) — is now documented precisely in the ns docstring's Out-of-scope list and at both call sites. No behaviour change: the test adapter holds no host resources, so there is nothing for a sub-cache walk to dispose. Documentation was the right call rather than wiring reactive-substrate hooks the adapter intentionally withholds.

## Test plan

- [x] New `reagent_slim_dispose_drain_roots_cljs_test.cljs`: stranded roots drained, explicitly-unmounted roots not double-unmounted, throwing root tolerated, emitter cleared (proven via render-to-string raising no-emitter-bound).
- [x] New test-react cases: `mount!` returns the freshest record past the 10th mint; `:seq` is strictly increasing.
- [x] `npm run test:cljs` — 3909 tests / 11884 assertions, 0 failures, 0 errors.
- [x] test-react JVM `clojure -M:test` — 6 tests / 13 assertions, 0 failures, 0 errors.
- [x] No `spec/*.md` edits (no mkdocs build needed).