### PR TITLE
fix(http): redact sensitive failure :cause + honour explicit reply handler + CLJS json-parse guard (rf2-eusm1 + rf2-smqkq + rf2-x1uhu)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -185,6 +185,20 @@
       (and supplied? (vector? value))
       (conj value reply-payload)
 
+      ;; rf2-smqkq — an explicitly supplied non-vector non-nil reply target
+      ;; (e.g. a bare keyword or a map) is malformed: Spec 014 §Reply
+      ;; addressing types `:on-success` / `:on-failure` as "event vector or
+      ;; nil". Earlier this fell into the `:else` default-merge branch and
+      ;; silently re-routed the reply to the originating event-id, dropping
+      ;; the caller's explicit intent. Reject it at the dispatch site rather
+      ;; than swallow the misuse.
+      supplied?
+      (throw (ex-info ":rf.error/http-bad-reply-target"
+                      {:where    :rf.http/managed
+                       :recovery :no-recovery
+                       :value    value
+                       :reason   "`:on-success` / `:on-failure` must be an event vector or nil per Spec 014 §Reply addressing; a non-vector non-nil value cannot be dispatched as an event"}))
+
       ;; default — back to originator with :rf/reply merged into message
       :else
       (let [event-id (first origin-event)

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -143,7 +143,20 @@
                      ;; Accept-failure carries the user's domain failure-map at :detail
                      ;; — opaque to us; redact wholesale when sensitive.
                      (and sensitive? (contains? failure :detail))
-                     (assoc :detail redacted-sentinel))]
+                     (assoc :detail redacted-sentinel)
+
+                     ;; rf2-eusm1 — a string `:cause` is the free-text throw
+                     ;; message from the interceptor/transport path. It is
+                     ;; author-controlled and can echo a secret the
+                     ;; interceptor was handling (e.g. a token-validation
+                     ;; message embedding the token), so it rides the same
+                     ;; sensitive redaction as the response-side slots. The
+                     ;; `string?` guard preserves keyword `:cause`
+                     ;; discriminators (e.g. decode-failure's
+                     ;; `:cause :too-many-keys`) — those are security-relevant
+                     ;; signals, not secret payload (http-decode §too-many-keys).
+                     (and sensitive? (string? (:cause failure)))
+                     (assoc :cause redacted-sentinel))]
       [failure' url-hit?])))
 
 (defn redact-failure

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -86,7 +86,14 @@
                                                     :limit       max-keys}))))
                                (keyword k))]
                   (cheshire/parse-string s key-fn)))
-        :cljs (let [parsed (js/JSON.parse s)
+        :cljs (when (string? s)
+                ;; rf2-x1uhu — mirror the JVM Cheshire branch's
+                ;; `(when (string? s) ...)` guard so both hosts return nil
+                ;; (rather than CLJS throwing inside `js/JSON.parse`) on a
+                ;; non-string input. `util-json` is documented as a
+                ;; shared/promotable helper; the two readers must behave
+                ;; identically.
+                (let [parsed (js/JSON.parse s)
                     ;; rf2-wu1n5 — CLJS path: walk the parsed JS object
                     ;; tree counting unique object-keys BEFORE
                     ;; `js->clj :keywordize-keys true` interns them.
@@ -116,4 +123,4 @@
                                                                 :limit       max-keys})))))
                                          (doseq [k ks] (walk (aget v k))))))]
                              (walk parsed))]
-                (js->clj parsed :keywordize-keys true))))))
+                  (js->clj parsed :keywordize-keys true)))))))

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -151,3 +151,80 @@
         (is (and (<= 1500 s) (<= s 2500))
             (str "post-clamp jittered sample " s " sits in ±25% window
                   around clamp (1500..2500)"))))))
+
+;; ---- build-reply-event — Spec 014 §Reply addressing -----------------------
+;;
+;; The four branches: explicit nil (silenced), explicit vector (append
+;; payload), default/omitted (back to originator with :rf/reply merged),
+;; and — per rf2-smqkq — an explicitly supplied non-vector non-nil value
+;; (malformed) which must throw rather than silently default-merge.
+
+(def ^:private reply-payload {:kind :success :value 42})
+
+(deftest build-reply-event-explicit-nil-is-silenced
+  (testing "explicit :on-success nil silences the reply"
+    (is (nil? (encoding/build-reply-event
+                {:origin-event  [:items/load {:page 1}]
+                 :explicit-on   {:supplied? true :value nil}
+                 :reply-payload reply-payload})))))
+
+(deftest build-reply-event-explicit-vector-appends-payload
+  (testing "explicit event vector gets the reply payload appended as last arg"
+    (is (= [:items/loaded reply-payload]
+           (encoding/build-reply-event
+             {:origin-event  [:items/load {:page 1}]
+              :explicit-on   {:supplied? true :value [:items/loaded]}
+              :reply-payload reply-payload})))
+    (testing "extra args on the supplied vector are preserved before the payload"
+      (is (= [:items/loaded 7 reply-payload]
+             (encoding/build-reply-event
+               {:origin-event  [:items/load]
+                :explicit-on   {:supplied? true :value [:items/loaded 7]}
+                :reply-payload reply-payload}))))))
+
+(deftest build-reply-event-default-merges-into-originator
+  (testing "omitted handler routes back to the originating event-id with
+            :rf/reply merged into the original message map"
+    (is (= [:items/load {:page 1 :rf/reply reply-payload}]
+           (encoding/build-reply-event
+             {:origin-event  [:items/load {:page 1}]
+              :explicit-on   {:supplied? false :value nil}
+              :reply-payload reply-payload})))
+    (testing "a non-map original message yields a fresh {:rf/reply ...} map"
+      (is (= [:items/load {:rf/reply reply-payload}]
+             (encoding/build-reply-event
+               {:origin-event  [:items/load]
+                :explicit-on   {:supplied? false :value nil}
+                :reply-payload reply-payload}))))))
+
+(deftest build-reply-event-non-vector-explicit-throws
+  (testing "rf2-smqkq — an explicitly supplied non-vector non-nil reply
+            target (keyword / map) is malformed per Spec 014 §Reply
+            addressing ('event vector or nil') and must throw rather than
+            silently fall through to the default-merge branch"
+    ;; bare keyword
+    (let [ex (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #":rf.error/http-bad-reply-target"
+                   (encoding/build-reply-event
+                     {:origin-event  [:items/load {:page 1}]
+                      :explicit-on   {:supplied? true :value :items/loaded}
+                      :reply-payload reply-payload})))]
+      (is (= :items/loaded (:value (ex-data ex)))
+          "the rejected value is surfaced on the ex-data for diagnosis")
+      (is (= :no-recovery (:recovery (ex-data ex)))))
+    ;; map
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/http-bad-reply-target"
+          (encoding/build-reply-event
+            {:origin-event  [:items/load]
+             :explicit-on   {:supplied? true :value {:dispatch :items/loaded}}
+             :reply-payload reply-payload})))
+    (testing "the malformed value is NOT silently re-routed to the originator"
+      (is (not= [:items/load {:page 1 :rf/reply reply-payload}]
+                (try (encoding/build-reply-event
+                       {:origin-event  [:items/load {:page 1}]
+                        :explicit-on   {:supplied? true :value :items/loaded}
+                        :reply-payload reply-payload})
+                     (catch clojure.lang.ExceptionInfo _ ::threw)))))))

--- a/implementation/http/test/re_frame/http_privacy_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_test.clj
@@ -210,6 +210,38 @@
 (deftest redact-failure-tolerates-nil
   (is (nil? (privacy/redact-failure nil true))))
 
+;; rf2-eusm1 — an interceptor-failure trace carries the interceptor's
+;; thrown message at :cause; it is author-controlled free text and can
+;; echo a secret the interceptor was handling. It must ride the same
+;; sensitive redaction as the response-side slots.
+(deftest redact-failure-redacts-string-cause-when-sensitive
+  (testing "free-text :cause (interceptor throw message) redacted when sensitive"
+    (let [f {:kind :rf.error/http-interceptor-failed
+             :interceptor-id :auth/check
+             :cause "token validation failed for Bearer sk-live-abc123"}
+          r (privacy/redact-failure f true)]
+      (is (= :rf/redacted (:cause r))
+          "the interceptor's thrown message must not ride the trace surface verbatim"))))
+
+(deftest redact-failure-preserves-string-cause-when-not-sensitive
+  (testing "free-text :cause preserved when the request is not sensitive"
+    (let [f {:kind :rf.error/http-interceptor-failed
+             :interceptor-id :auth/check
+             :cause "interceptor :auth/check :before threw"}
+          r (privacy/redact-failure f false)]
+      (is (= "interceptor :auth/check :before threw" (:cause r))))))
+
+(deftest redact-failure-preserves-keyword-cause-discriminator
+  (testing "a keyword :cause (e.g. decode-failure's :too-many-keys) is a
+            security-relevant signal, NOT secret payload — preserved even
+            when sensitive"
+    (let [f {:kind :rf.http/decode-failure :cause :too-many-keys :body-text "raw"}
+          r (privacy/redact-failure f true)]
+      (is (= :too-many-keys (:cause r))
+          "the keyword discriminator must survive — it is the signal, not the secret")
+      (is (= :rf/redacted (:body-text r))
+          "the response body still redacts when sensitive"))))
+
 ;; ---- 6. stamp-sensitive --------------------------------------------------
 
 (deftest stamp-sensitive-adds-flag-when-true
@@ -536,3 +568,22 @@
           r (privacy/prepare-emit-failure f true)]
       (is (= "https://api.example.com/x?user_id=:rf/redacted&page=:rf/redacted" (:url r)))
       (is (true? (:sensitive? r))))))
+
+;; rf2-eusm1 — end-to-end: a sensitive request whose interceptor throws.
+;; The composed failure trace (the shape `run-interceptor-chain!` hands to
+;; `prepare-emit-failure`) must surface :cause redacted, not verbatim.
+(deftest prepare-emit-failure-redacts-interceptor-cause-when-sensitive
+  (testing "interceptor-failure :cause is redacted on a sensitive request"
+    (let [failure {:where          'run-http-interceptor-chain!
+                   :recovery       :no-recovery
+                   :frame          :app
+                   :interceptor-id :auth/check
+                   :url            "https://api.example.com/login"
+                   :cause          "validation failed: token sk-live-abc123 rejected"}
+          r       (privacy/prepare-emit-failure failure true)]
+      (is (= :rf/redacted (:cause r))
+          "the interceptor's thrown message rides redacted, not verbatim")
+      (is (true? (:sensitive? r)))
+      ;; non-secret locators are still useful for debugging — kept.
+      (is (= :auth/check (:interceptor-id r)))
+      (is (= :app (:frame r))))))

--- a/implementation/http/test/re_frame/util_json_cljs_test.cljs
+++ b/implementation/http/test/re_frame/util_json_cljs_test.cljs
@@ -10,17 +10,22 @@
 
   - `js/JSON.parse('')` throws SyntaxError — does NOT return nil like
     Cheshire does. Empty input is malformed under V8/SpiderMonkey/
-    JavaScriptCore. The `:rf.http/managed` decode site catches.
+    JavaScriptCore. The `:rf.http/managed` decode site catches. NOTE:
+    `\"\"` IS a string, so the `(string? s)` guard added per rf2-x1uhu
+    does NOT short-circuit it — the empty-string throw is preserved.
   - `js/JSON.parse('{not-json')` throws SyntaxError.
-  - `js/JSON.parse(nil)` is `JSON.parse('null')` (JS coercion) →
-    returns `null` (JS) → `(js->clj nil :keywordize-keys true)` is nil.
-    Counter-intuitive but consistent with the JS spec.
+  - non-string input (nil, keyword, number, map, vector) returns nil per
+    rf2-x1uhu: the CLJS branch now opens with the same `(when (string? s)
+    ...)` guard as the JVM Cheshire branch, so a non-string short-circuits
+    to nil on both hosts. Earlier the CLJS path called `js/JSON.parse`
+    directly — nil coerced to `\"null\"` → nil, but a keyword/number/map
+    THREW where the JVM returned nil. That host asymmetry is the bug
+    rf2-x1uhu closed.
 
   These per-platform differences matter for the `:rf.http/managed`
   cascade: the CLJS decode site MUST classify the SyntaxError throws
   as `:rf.http/decode-failure`. Pin the branch's behaviour directly
-  so a future runtime upgrade (or a refactor that adds a string-guard
-  wrapper around the CLJS branch) doesn't silently change the contract.
+  so a future runtime upgrade doesn't silently change the contract.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -56,17 +61,26 @@
           (str "empty-string input must throw on CLJS — got "
                (pr-str thrown))))))
 
-(deftest cljs-json-parse-nil-input-returns-nil
-  (testing "rf2-mih7n — `(util-json/json-parse nil)` returns nil on
-            CLJS. The JS engine coerces `nil` → `\"null\"` →
-            `js/JSON.parse` returns `null` → `js->clj` produces nil.
-            Counter-intuitive but spec-consistent. The JVM branch
-            short-circuits via `(when (string? s) ...)` and also
-            returns nil — the two branches produce the SAME observable
-            result for a nil input despite taking very different
-            paths."
+(deftest cljs-json-parse-non-string-input-returns-nil
+  (testing "rf2-x1uhu — non-string inputs return nil (not a throw) on
+            CLJS, mirroring the JVM Cheshire branch. The CLJS branch now
+            opens with the SAME `(when (string? s) ...)` guard as JVM, so
+            both hosts produce nil for nil / keyword / number / map /
+            vector input. Earlier the CLJS path called `js/JSON.parse`
+            directly: nil coerced to nil, but a keyword/number/map/vector
+            THREW where the JVM returned nil — the host asymmetry this
+            bead closed."
     (is (nil? (util-json/json-parse nil))
-        "nil input → nil (cross-platform consistent for this slot)")))
+        "nil input → nil (string? guard short-circuits, cross-host)")
+    (is (nil? (util-json/json-parse :keyword))
+        "keyword input → nil (was a throw before rf2-x1uhu)")
+    (is (nil? (util-json/json-parse 42))
+        "number input → nil (was a throw before rf2-x1uhu)")
+    (is (nil? (util-json/json-parse {:already :clojure}))
+        "map input → nil — caller passed an already-parsed value by
+         mistake (was a throw before rf2-x1uhu)")
+    (is (nil? (util-json/json-parse [1 2 3]))
+        "vector input → nil (was a throw before rf2-x1uhu)")))
 
 (deftest cljs-json-stringify-happy-path
   (testing "rf2-mih7n — sanity-check `json-stringify` on CLJS uses

--- a/implementation/http/test/re_frame/util_json_test.clj
+++ b/implementation/http/test/re_frame/util_json_test.clj
@@ -135,7 +135,9 @@
 ;; guard means a non-string `s` (nil, keyword, number, map, vector)
 ;; returns nil cleanly rather than throwing — protecting the
 ;; `:rf.http/managed` decode pipeline from a programmer error in the
-;; transport layer.
+;; transport layer. Per rf2-x1uhu the CLJS branch now carries the same
+;; guard, so the two hosts agree on non-string input (see the CLJS
+;; counterpart `cljs-json-parse-non-string-input-returns-nil`).
 ;;
 ;; The empty-string case `""` flows through Cheshire's `parse-string`
 ;; which returns nil (Jackson's end-of-stream → nil for an empty


### PR DESCRIPTION
## Summary

Three HTTP-effect bugs in `implementation/http`.

- **rf2-eusm1 (P3, BUG, security-adjacent)** — On a `:before` throw,
  `run-interceptor-chain!` emits `:rf.error/http-interceptor-failed` through
  `privacy/prepare-emit-failure`, which redacted `:url`/`:headers`/`:body`/
  `:body-text`/`:decoded`/`:detail` but NOT `:cause`. `:cause` is the
  interceptor's author-controlled thrown message and can echo a secret it was
  handling (e.g. a token-validation message embedding the token), riding the
  trace surface un-redacted on a sensitive request. Fix: redact a **string**
  `:cause` in `redact-failure-with-flag` (the shared composer behind
  `prepare-emit-failure`). The `string?` guard intentionally preserves
  **keyword** `:cause` discriminators (decode-failure's `:too-many-keys`) — a
  security-relevant signal, not secret payload.

- **rf2-smqkq (P3, BUG)** — `build-reply-event` treated an explicit
  `:on-success`/`:on-failure` as an event vector only when `(vector? value)`.
  A supplied **non-vector non-nil** value (keyword/map) fell into the `:else`
  default-merge branch and silently re-routed the reply to the originating
  event-id, dropping the caller's explicit intent. Spec 014 §Reply addressing
  types these as "event vector or nil"; we now throw a structured
  `:rf.error/http-bad-reply-target` (same shape as `:rf.error/http-bad-retry-on`)
  rather than swallow the misuse.

- **rf2-x1uhu (P4, BUG)** — `util-json/json-parse` JVM path guards
  `(when (string? s) ...)` (nil on non-string); the CLJS path called
  `js/JSON.parse` directly and threw on a keyword/number/map/vector. Added the
  same guard to the CLJS branch so both hosts return nil. `""` is still a
  string, so the empty-string SyntaxError behaviour is preserved.

No spec edits.

## Test plan

- [x] http JVM: `clojure -M:test` from `implementation/http` — 225 tests, 1265 assertions, 0 failures
- [x] CLJS: `npm run test:cljs` from `implementation` — 3905 tests, 11875 assertions, 0 failures
- [x] New tests:
  - `http_privacy_test.clj` — string `:cause` redacted when sensitive; preserved when not; keyword `:cause` discriminator preserved; end-to-end interceptor-failure shape via `prepare-emit-failure`.
  - `http_encoding_test.clj` — `build-reply-event` all branches + the non-vector explicit throw (keyword + map), asserting it is NOT silently re-routed.
  - `util_json_cljs_test.cljs` — non-string inputs (nil/keyword/number/map/vector) return nil on CLJS; stale nil-coercion rationale updated.