### PR TITLE
fix(ssr): case-insensitive redirect host + namespaced tag names + JSON-valid JSON-LD numbers (rf2-lgmiw + rf2-77l9w + rf2-8jl26)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -78,11 +78,20 @@
   ;; element-name) require an ASCII-lower first letter + a `-`; the
   ;; conservative grammar admits both standard elements and well-formed
   ;; custom-element names.
-  #"[A-Za-z][A-Za-z0-9-]*")
+  ;;
+  ;; rf2-77l9w — XML-namespaced SVG/MathML tags carry a single colon-
+  ;; separated prefix (e.g. `:svg:rect`, `:xlink:href`-style elements).
+  ;; Admit one optional `prefix:` segment where the prefix follows the
+  ;; same element-name grammar. A single colon only — embedded `<`, `>`,
+  ;; whitespace, `=` (the tag-injection vectors) remain rejected, and a
+  ;; bare/leading/trailing/double colon (`:rect`, `svg:`, `a::b`) still
+  ;; throws because each segment must be a well-formed element name.
+  #"(?:[A-Za-z][A-Za-z0-9-]*:)?[A-Za-z][A-Za-z0-9-]*")
 
 (defn- validate-tag-name!
   "Throw `:rf.error/invalid-tag-name` if `tag-name` does not match the
-  HTML5 / SVG / MathML element-name grammar (`[A-Za-z][A-Za-z0-9-]*`).
+  HTML5 / SVG / MathML element-name grammar (`[A-Za-z][A-Za-z0-9-]*`,
+  optionally prefixed by a single XML namespace segment `prefix:`).
   Per rf2-z7gor — DOM tag-name component of a hiccup keyword was emitted
   without validation, allowing tag-injection through hostile keywords
   like `(keyword \"img src=x onerror=alert(1)\")`."
@@ -96,7 +105,8 @@
                                     " (from hiccup head " (pr-str source-kw) ")"
                                     " does not match the HTML5/SVG/MathML"
                                     " element-name grammar"
-                                    " ([A-Za-z][A-Za-z0-9-]*) — DOM tag-name"
+                                    " ([A-Za-z][A-Za-z0-9-]*, optionally"
+                                    " namespaced prefix:local) — DOM tag-name"
                                     " injection forbidden")
                      :tag-name tag-name
                      :source   source-kw

--- a/implementation/ssr/src/re_frame/ssr/head/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/head/emit.cljc
@@ -70,11 +70,33 @@
   [x]
   #?(:cljs (-> (js/JSON.stringify (clj->js x))
                html/escape-script-body-string)
-     :clj  (letfn [(emit [v]
+     :clj  (letfn [(emit-number [v]
+                     ;; rf2-8jl26 — `(str v)` produces non-JSON for two
+                     ;; numeric shapes the JVM admits but JSON.parse rejects:
+                     ;;   • Ratios print as `1/3` — coerce to a double so the
+                     ;;     wire form is `0.3333333333333333`.
+                     ;;   • Non-finite doubles/floats (`##Inf` / `##-Inf` /
+                     ;;     `##NaN`) have no JSON representation — fail-fast,
+                     ;;     same posture as the tag-name / header-value gates.
+                     (cond
+                       (ratio? v) (str (double v))
+                       (and (or (instance? Double v) (instance? Float v))
+                            (not (Double/isFinite (double v))))
+                       (throw (ex-info ":rf.error/invalid-json-ld-number"
+                                       {:rf.error/id :rf.error/invalid-json-ld-number
+                                        :where    'rf.ssr.head/emit
+                                        :reason   (str "JSON-LD number " (pr-str v)
+                                                       " is non-finite — JSON has no"
+                                                       " representation for ##Inf /"
+                                                       " ##-Inf / ##NaN")
+                                        :value    v
+                                        :recovery :no-recovery}))
+                       :else (str v)))
+                   (emit [v]
                      (cond
                        (nil? v)     "null"
                        (boolean? v) (if v "true" "false")
-                       (number? v)  (str v)
+                       (number? v)  (emit-number v)
                        (string? v)  (str "\""
                                          (-> v
                                              (str/replace "\\" "\\\\")

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -592,10 +592,14 @@
                                           :host     host
                                           :reason   :relative-only-violation})
 
-              ;; Step 4: :allow [...] allowlist
+              ;; Step 4: :allow [...] allowlist. DNS hostnames are
+              ;; case-insensitive (RFC 1035 §2.3.3), so lower-case both
+              ;; sides — matching the header/cookie token-grammar treatment
+              ;; elsewhere in this file.
               (and (seq allow)
                    host
-                   (not (contains? (set allow) host)))
+                   (not (contains? (into #{} (map clojure.string/lower-case) allow)
+                                   (clojure.string/lower-case host))))
               (emit-safe-redirect-error! :rf.error/safe-redirect-host-disallowed
                                          {:frame    frame
                                           :location location

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -1295,6 +1295,25 @@
              (-> resp :redirect :location))
           ":location lands on the response :redirect slot"))))
 
+(deftest safe-redirect-allowlist-host-match-is-case-insensitive
+  (testing "rf2-lgmiw step 4: DNS hostnames are case-insensitive (RFC 1035
+            §2.3.3) — a mixed-case host matches a lowercase :allow entry and
+            the redirect succeeds with no trace"
+    (rf/reg-event-fx :sr/in-allow-mixed-case
+      (fn [_ _]
+        {:fx [[:rf.server/safe-redirect
+               {:location "https://APP.Example.COM/dashboard"
+                :allow    ["app.example.com" "alt.example.com"]}]]}))
+    (let [f      (rf/make-frame {:platform :server})
+          traces (capture-safe-redirect-traces!
+                   (fn [] (rf/dispatch-sync [:sr/in-allow-mixed-case] {:frame f})))
+          resp   (get-response f)]
+      (is (empty? traces)
+          "no :rf.error/safe-redirect-* trace — case-folded host matches allow")
+      (is (= "https://APP.Example.COM/dashboard"
+             (-> resp :redirect :location))
+          ":location passes through unchanged (only the COMPARISON folds case)"))))
+
 ;; --- Validation order: parse runs before scheme runs before policy --------
 
 (deftest safe-redirect-validation-order-parse-precedes-scheme
@@ -1394,7 +1413,20 @@
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo #":rf\.error/invalid-tag-name"
             (rf/render-to-string [hostile] {}))
-          (str "hostile tag-name " (pr-str hostile))))))
+          (str "hostile tag-name " (pr-str hostile)))))
+
+  (testing "rf2-77l9w — admitting one namespaced colon segment does NOT
+            admit malformed colon shapes: a bare/leading/trailing/double
+            colon or an empty/ill-formed segment still throws"
+    (doseq [hostile [(keyword ":rect")        ; leading colon — empty prefix
+                     (keyword "svg:")         ; trailing colon — empty local
+                     (keyword "a:b:c")        ; two colons — not a single ns
+                     (keyword "svg::rect")    ; double colon — empty segment
+                     (keyword "svg:rect onload=x")]] ; injection after colon
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo #":rf\.error/invalid-tag-name"
+            (rf/render-to-string [hostile] {}))
+          (str "malformed namespaced tag-name " (pr-str hostile))))))
 
 (deftest ssr-render-accepts-legit-tag-keywords
   (testing "rf2-z7gor — regression guard: HTML / SVG / MathML / custom
@@ -1413,7 +1445,19 @@
         ":tag#id.cls sugar still parses (validator runs on the tag fragment)")
     (is (= "<p>a</p><p>b</p>"
            (rf/render-to-string [:<> [:p "a"] [:p "b"]] {}))
-        ":<> fragment renders children with no wrapper")))
+        ":<> fragment renders children with no wrapper"))
+
+  (testing "rf2-77l9w — XML-namespaced SVG/MathML tags carry a single colon
+            segment and are admitted by the grammar"
+    (is (= "<svg:rect></svg:rect>"
+           (rf/render-to-string [:svg:rect] {}))
+        "namespaced SVG tag `:svg:rect` is accepted")
+    (is (= "<xlink:href>a</xlink:href>"
+           (rf/render-to-string [:xlink:href "a"] {}))
+        "xlink-namespaced tag is accepted")
+    (is (= "<svg:rect id=\"r\" class=\"c\"></svg:rect>"
+           (rf/render-to-string [:svg:rect#r.c] {}))
+        "namespaced tag still composes with the #id.cls sugar")))
 
 (deftest ssr-set-header-rejects-invalid-name
   (testing "rf2-z7gor — :rf.server/set-header with CRLF in :name surfaces

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -279,6 +279,28 @@
         (is (str/includes? html "\"@type\":\"schema/Article\""))
         (is (str/includes? html "\"my.app/headline\":\"my.app/hello\""))))))
 
+(deftest head-model->html-json-ld-emits-json-valid-numbers
+  (testing "rf2-8jl26 — the JVM JSON-LD emitter must produce JSON-valid
+            numbers. A Clojure ratio is coerced to a double (so the wire
+            form is a JSON number, not `1/3`); JSON.parse never sees a
+            ratio literal."
+    (let [html (rf/head-model->html
+                 {:json-ld [{"@type" "Rating"
+                             "ratingValue" 1/3}]})]
+      (is (str/includes? html "\"ratingValue\":0.3333333333333333")
+          "the ratio 1/3 is emitted as its double value, not `1/3`")
+      (is (not (str/includes? html "1/3"))
+          "no raw ratio literal survives into the JSON-LD body")))
+  (testing "rf2-8jl26 — non-finite doubles (##Inf / ##-Inf / ##NaN) have no
+            JSON representation; the emitter fails fast rather than emitting
+            `Infinity` / `NaN`, which JSON.parse rejects"
+    (doseq [bad [##Inf ##-Inf ##NaN]]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo #":rf\.error/invalid-json-ld-number"
+            (rf/head-model->html
+              {:json-ld [{"@type" "Rating" "ratingValue" bad}]}))
+          (str "non-finite JSON-LD number " (pr-str bad) " is rejected")))))
+
 (deftest head-model->html-json-ld-escapes-script-close-in-string-values
   (testing "rf2-m5u23 / security audit 2026-05-14 §P1.1 — a string value
             containing `</script>` MUST NOT close the surrounding


### PR DESCRIPTION
## Summary

Three SSR correctness smells in `implementation/ssr`:

- **rf2-lgmiw (P3, BUG)** — `safe-redirect-fx`'s `:allow` allowlist host match was case-sensitive, so `https://APP.Example.COM/` was rejected even when `app.example.com` was allowlisted (fail-closed usability false-negative). DNS hostnames are case-insensitive (RFC 1035 §2.3.3); the comparison now lower-cases both the host and each allow entry, matching the header/cookie token-grammar treatment already used in the file. Path/scheme handling and the persisted `:location` are unchanged — only the comparison folds case.
- **rf2-77l9w (P4, BUG)** — the tag-name grammar (`[A-Za-z][A-Za-z0-9-]*`) rejected colon-bearing namespaced SVG/MathML tag heads (`:svg:rect`, `:xlink:href`-style elements). The grammar now admits one optional `prefix:` namespace segment where each segment is a well-formed element name. Single colon only — embedded `<`/`>`/whitespace/`=` (the tag-injection vectors) and bare/leading/trailing/double colons still throw `:rf.error/invalid-tag-name`.
- **rf2-8jl26 (P4, BUG)** — the JVM JSON-LD emitter stringified numbers via `(str v)`, so Clojure ratios printed as `1/3` and non-finite doubles as `Infinity`/`NaN` — both rejected by client `JSON.parse`. The JVM emitter now coerces ratios to double and fails fast on non-finite doubles (`##Inf`/`##-Inf`/`##NaN`). The CLJS path (`js/JSON.stringify`) is already JSON-valid and is unchanged.

No spec edits — Spec 011 pins none of these (casing, namespaced tags, JSON-LD numeric edge cases).

## Test plan

- [x] `npm run test:cljs` — 3907 tests / 11878 assertions, 0 failures, 0 errors
- [x] `ssr` JVM `clojure -M:test` — 200 tests / 680 assertions, 0 failures, 0 errors
- [x] `ssr-ring` JVM `clojure -M:test` — 63 tests / 327 assertions, 0 failures, 0 errors
- [x] New regression tests:
  - `safe-redirect-allowlist-host-match-is-case-insensitive` — mixed-case host matches lowercase allow
  - `ssr-render-accepts-legit-tag-keywords` — namespaced `:svg:rect` / `:xlink:href` / `:svg:rect#r.c` accepted
  - `ssr-render-rejects-hostile-tag-keywords` — `:rect`, `svg:`, `a:b:c`, `svg::rect`, `svg:rect onload=x` still throw
  - `head-model->html-json-ld-emits-json-valid-numbers` — ratio coerced to double; `##Inf`/`##-Inf`/`##NaN` rejected