### PR TITLE
test(adapters): UIx/Helix data-rf-view elision pin + frame-context-corrupted/clear-warn-once parity (rf2-ihcib + rf2-ovbxk)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_clear_warn_once_chain_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_clear_warn_once_chain_cljs_test.cljs
@@ -1,0 +1,130 @@
+(ns re-frame.adapter.helix-clear-warn-once-chain-cljs-test
+  "Per rf2-ovbxk: exercise the chained `:adapter/clear-warn-once-caches!`
+  hook through the Helix adapter surface.
+
+  The Helix adapter wires its per-adapter `clear-warned-non-dom-roots!`
+  thunk into the chained hook at ns-load via
+  `spine/install-clear-warn-once-step!` (see `helix.cljs:199`). The hook
+  is then invoked by `make-reset-runtime-fixture` after every test to keep
+  warn-once state from leaking across sibling tests.
+
+  The publication test (`helix_late_bind_publication_cljs_test.cljs`)
+  pins that the hook is REGISTERED (i.e. `late-bind/get-fn` returns a
+  non-nil fn). This file goes one step further: it drives the hook end-
+  to-end and asserts the Helix adapter's `warn-cache` actually empties.
+
+  This is the Helix-side counterpart to
+  `re-frame.adapter.uix-clear-warn-once-chain-cljs-test`.
+
+  Strategy. The warn-cache is private to the adapter's spine-fns
+  closure, so we reach it indirectly via the substrate behaviour it
+  governs: `wrap-view` wrapping a user-fn whose output is a non-DOM
+  React element fires the per-id warn-once. After one fire the same id
+  is silenced on subsequent invocations. Invoking the chained hook
+  clears the cache and re-arms the same id.
+
+  Sibling test for the Reagent path:
+  `warn_once_fixture_isolation_cljs_test.cljs` (rf2-4edk).
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require ["react" :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+;; ---- helper: capture console.warn calls -----------------------------------
+
+(defn- with-captured-console-warn
+  "Replace js/console.warn with a recording shim around `thunk`. Returns
+  the vector of joined-message strings observed. Restores the original
+  on the way out, even if thunk throws."
+  [thunk]
+  (let [calls    (atom [])
+        original (.-warn js/console)]
+    (try
+      (set! (.-warn js/console)
+            (fn [& args]
+              (swap! calls conj (apply str args))))
+      (thunk)
+      @calls
+      (finally
+        (set! (.-warn js/console) original)))))
+
+;; ---- helper: non-DOM React element output ---------------------------------
+
+(defn- non-dom-element
+  "Build a React element whose `.-type` is NOT a string — `wrap-view`'s
+  source-coord annotator classifies this as a non-DOM root and routes
+  it to the warn-once path (Spec 006 §Source-coord annotation).
+  React.Fragment is a Symbol on React 18+, so `.-type` is non-string —
+  exactly the shape needed to exercise the warn path."
+  []
+  (React/createElement React/Fragment #js {} "non-dom"))
+
+;; ---- the chained-hook exercise --------------------------------------------
+
+(deftest chained-clear-warn-once-caches-empties-helix-warn-cache
+  (testing "rf2-ovbxk: the chained :adapter/clear-warn-once-caches! hook
+            (registered via spine/install-clear-warn-once-step! at Helix
+            adapter ns-load) clears the Helix adapter's warn-cache. After
+            one warn-once fire the same id is silenced; after the
+            chained hook fires the same id re-warns — proving the
+            adapter's cache participates in the chain."
+    (let [target-id    :rf.helix-clear-warn-once/shared
+          wrapped      (helix-adapter/wrap-view target-id {}
+                                                (fn user-fn [] (non-dom-element)))
+          phase-1-ws   (with-captured-console-warn
+                         (fn []
+                           ;; Three calls in the same phase prove the
+                           ;; warn-once contract within a phase: exactly
+                           ;; one emission for the id.
+                           (dotimes [_ 3] (wrapped))))
+          _            (is (= 1 (count phase-1-ws))
+                           (str "phase-1 sanity: warn-once fires exactly "
+                                "once WITHIN a single phase; got "
+                                (count phase-1-ws) ": " (pr-str phase-1-ws)))
+          chained-hook (late-bind/get-fn :adapter/clear-warn-once-caches!)
+          _            (is (some? chained-hook)
+                           "precondition: the chained hook is registered")
+          _            (chained-hook)
+          phase-2-ws   (with-captured-console-warn
+                         (fn []
+                           ;; Same id, post-chain. Without the chain
+                           ;; clearing the Helix adapter's cache the
+                           ;; emission would be silenced; with the chain
+                           ;; the cache is empty and the warn re-fires.
+                           (wrapped)))]
+      (is (= 1 (count phase-2-ws))
+          (str "phase-2 must re-emit the warning for the same id AFTER "
+               "the chained :adapter/clear-warn-once-caches! hook fires "
+               "(per rf2-ovbxk). Got " (count phase-2-ws) ": "
+               (pr-str phase-2-ws) ". If this is zero, the Helix adapter's "
+               "warn-cache is no longer participating in the chained "
+               "clear-step, defeating the rf2-4edk fixture-isolation "
+               "guarantee under Helix.")))))
+
+;; ---- positive control: direct `clear-warned-non-dom-roots!` works ---------
+
+(deftest clear-warned-non-dom-roots-resets-helix-cache-directly
+  (testing "Calling the Helix adapter's `clear-warned-non-dom-roots!`
+            thunk directly also resets the cache — this is the seam the
+            chained hook invokes. Pin it independently so a future
+            refactor that drops the chain wiring but keeps the fn name
+            is caught here (and vice versa)."
+    (let [target-id :rf.helix-clear-warn-once/direct
+          wrapped   (helix-adapter/wrap-view target-id {}
+                                             (fn user-fn [] (non-dom-element)))
+          ws-1      (with-captured-console-warn
+                      (fn [] (wrapped)))]
+      (is (= 1 (count ws-1)) "first emission fires")
+      (helix-adapter/clear-warned-non-dom-roots!)
+      (let [ws-2 (with-captured-console-warn (fn [] (wrapped)))]
+        (is (= 1 (count ws-2))
+            (str "after `helix-adapter/clear-warned-non-dom-roots!` the "
+                 "same id re-emits. Got " (count ws-2) ": "
+                 (pr-str ws-2)))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_source_coord_dom_elision_prod_test.cljs
@@ -40,6 +40,14 @@
   (when (and el (.-props el))
     (aget (.-props el) "data-rf2-source-coord")))
 
+(defn- react-element-view-attr
+  "Pull `data-rf-view` off a React element's `.-props`, or nil.
+  Defensively returns nil on every branch so the test assertions can
+  use `nil?`."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf-view")))
+
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 
 (deftest reg-view-output-has-no-source-coord-under-prod-helix
@@ -58,7 +66,10 @@
         (is (= "span" (.-type out))
             "root element's type preserved")
         (is (nil? (react-element-source-coord out))
-            "NO data-rf2-source-coord on the rendered root — elision contract holds")))))
+            "NO data-rf2-source-coord on the rendered root — elision contract holds")
+        (is (nil? (react-element-view-attr out))
+            "NO data-rf-view on the rendered root — view-id tagging rides the
+             same interop/debug-enabled? gate and elides too (rf2-ihcib)")))))
 
 (deftest reg-view-with-attrs-has-no-source-coord-under-prod-helix
   (testing "Even with an existing props map on the root, the wrapper does
@@ -78,4 +89,7 @@
         (is (= "card" (aget props "className")) "user className preserved")
         (is (= "x"    (aget props "id")) "user id preserved")
         (is (nil? (aget props "data-rf2-source-coord"))
-            "NO data-rf2-source-coord merged into the props — elision contract holds")))))
+            "NO data-rf2-source-coord merged into the props — elision contract holds")
+        (is (nil? (aget props "data-rf-view"))
+            "NO data-rf-view merged into the props — view-id tagging elides on the
+             same gate (rf2-ihcib)")))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_frame_context_corrupted_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_frame_context_corrupted_cljs_test.cljs
@@ -1,0 +1,117 @@
+(ns re-frame.adapter.uix-frame-context-corrupted-cljs-test
+  "Parity test for `:rf.error/frame-context-corrupted` under the UIx
+  adapter (rf2-ovbxk).
+
+  The corruption-detection + recovery path lives in
+  `re-frame.adapter.context/function-component-current-frame` — the
+  shared impl UIx wires into its `:adapter/current-frame` slot per
+  rf2-d4sf (see `uix.cljs:177-179`). A non-keyword `_currentValue` on
+  the shared frame-context emits `:rf.error/frame-context-corrupted`
+  (rf2-8q66) and falls through to `:rf/default` (recovery
+  `:replaced-with-default`).
+
+  This is the UIx-side counterpart to
+  `re-frame.adapter.helix-frame-context-corrupted-cljs-test`. Both
+  adapters wire through the *same* shared impl, so the path itself is
+  already covered — what this file pins is that the UIx adapter's
+  hook-routing keeps that path live. If the `:adapter/current-frame`
+  Var ever drifts (a refactor of the late-bind hook table, the UIx
+  adapter's `route-hook!` line, or the shared fn's emit path), this
+  parity test breaks the build.
+
+  Implementation note: the test pokes `.-_currentValue` directly. React
+  itself mutates this field as Provider boundaries are entered and
+  exited during render; outside a render frame we are free to set it
+  to test values and restore the original in `finally`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+;; ---- trace helpers --------------------------------------------------------
+
+(defn- collect-traces [k]
+  (let [traces (atom [])]
+    (trace-tooling/register-listener! k (fn [ev] (swap! traces conj ev)))
+    traces))
+
+(defn- corruption-traces [traces]
+  (filter #(= :rf.error/frame-context-corrupted (:operation %)) @traces))
+
+;; ---- direct-call parity ----------------------------------------------------
+;;
+;; The shared `function-component-current-frame` resolves `_currentValue`
+;; off the frame-context. UIx's `:adapter/current-frame` hook (wired
+;; in uix.cljs by `route-hook!`) points at this fn. Probe the fn
+;; directly to assert the emit-and-recover contract under a UIx-
+;; installed runtime.
+
+(deftest direct-call-emits-error-and-recovers-under-uix
+  (testing "function-component-current-frame: corrupted _currentValue under UIx adapter"
+    (let [original (.-_currentValue ^js adapter-context/frame-context)
+          traces   (collect-traces ::direct-uix)]
+      (try
+        (testing "nil _currentValue: error trace fires; resolves to :rf/default"
+          (reset! traces [])
+          (set! (.-_currentValue ^js adapter-context/frame-context) nil)
+          (is (= :rf/default (adapter-context/function-component-current-frame))
+              "falls through to :rf/default (recovery preserved under UIx)")
+          (let [errs (corruption-traces traces)]
+            (is (= 1 (count errs))
+                "one :rf.error/frame-context-corrupted event fired")
+            (is (= :error (:op-type (first errs)))
+                ":op-type is :error per Spec 009 §Error contract")
+            (is (= :replaced-with-default (:recovery (first errs)))
+                ":recovery is :replaced-with-default — fall-through preserved")
+            (is (= :nil (-> errs first :tags :type))
+                ":tags :type names the corrupted shape")))
+        (testing "number _currentValue: error trace fires; resolves to :rf/default"
+          (reset! traces [])
+          (set! (.-_currentValue ^js adapter-context/frame-context) 42)
+          (is (= :rf/default (adapter-context/function-component-current-frame))
+              "falls through to :rf/default")
+          (let [errs (corruption-traces traces)]
+            (is (= 1 (count errs))
+                "one error trace per corrupted read")
+            (is (= :number (-> errs first :tags :type)))
+            (is (= 42 (-> errs first :tags :received))
+                ":tags :received echoes the offending value")))
+        (finally
+          (trace-tooling/unregister-listener! ::direct-uix)
+          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
+
+;; ---- adapter-routed parity -------------------------------------------------
+;;
+;; `rf/current-frame` (-> `frame/resolve-current-frame`) consults the
+;; `:adapter/current-frame` late-bind hook (rf2-d4sf). Under a UIx-
+;; installed runtime, this routes to `function-component-current-frame`.
+;; Corrupting `_currentValue` and calling the public seam exercises the
+;; rf2-d4sf wiring end-to-end: regression in the hook table, the UIx
+;; `route-hook!` line, or the chain-bottom fallback breaks this test.
+
+(deftest current-frame-recovers-under-uix
+  (testing "rf/current-frame: corrupted _currentValue → :rf/default under UIx"
+    (let [original (.-_currentValue ^js adapter-context/frame-context)
+          traces   (collect-traces ::routed-uix)]
+      (try
+        (reset! traces [])
+        (set! (.-_currentValue ^js adapter-context/frame-context) "")
+        (is (= :rf/default (rf/current-frame))
+            "adapter-routed read recovers to :rf/default under UIx")
+        (let [errs (corruption-traces traces)]
+          (is (= 1 (count errs))
+              "one :rf.error/frame-context-corrupted event fired through the UIx-routed path")
+          (is (= :empty-string (-> errs first :tags :type))
+              ":tags :type distinguishes empty-string from a populated string"))
+        (finally
+          (trace-tooling/unregister-listener! ::routed-uix)
+          (set! (.-_currentValue ^js adapter-context/frame-context) original))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_source_coord_dom_elision_prod_test.cljs
@@ -40,6 +40,14 @@
   (when (and el (.-props el))
     (aget (.-props el) "data-rf2-source-coord")))
 
+(defn- react-element-view-attr
+  "Pull `data-rf-view` off a React element's `.-props`, or nil.
+  Defensively returns nil on every branch so the test assertions can
+  use `nil?`."
+  [el]
+  (when (and el (.-props el))
+    (aget (.-props el) "data-rf-view")))
+
 ;; ---- annotation elides under :advanced + goog.DEBUG=false ----------------
 
 (deftest reg-view-output-has-no-source-coord-under-prod-uix
@@ -58,7 +66,10 @@
         (is (= "span" (.-type out))
             "root element's type preserved")
         (is (nil? (react-element-source-coord out))
-            "NO data-rf2-source-coord on the rendered root — elision contract holds")))))
+            "NO data-rf2-source-coord on the rendered root — elision contract holds")
+        (is (nil? (react-element-view-attr out))
+            "NO data-rf-view on the rendered root — view-id tagging rides the
+             same interop/debug-enabled? gate and elides too (rf2-ihcib)")))))
 
 (deftest reg-view-with-attrs-has-no-source-coord-under-prod-uix
   (testing "Even with an existing props map on the root, the wrapper does
@@ -78,4 +89,7 @@
         (is (= "card" (aget props "className")) "user className preserved")
         (is (= "x"    (aget props "id")) "user id preserved")
         (is (nil? (aget props "data-rf2-source-coord"))
-            "NO data-rf2-source-coord merged into the props — elision contract holds")))))
+            "NO data-rf2-source-coord merged into the props — elision contract holds")
+        (is (nil? (aget props "data-rf-view"))
+            "NO data-rf-view merged into the props — view-id tagging elides on the
+             same gate (rf2-ihcib)")))))


### PR DESCRIPTION
## Summary

Two per-substrate test-coverage gaps in the UIx + Helix adapters. Tests only — the impls are shared and unchanged; this restores per-substrate test discipline.

- **rf2-ihcib** — The UIx/Helix `*-source-coord-dom-elision-prod-test` files asserted only `data-rf2-source-coord` absence under `:advanced` + `goog.DEBUG=false`. Both attrs ride the same `interop/debug-enabled?` gate in `spine/make-wrap-view` (`inject-source-coord-attr`), so each prod-elision test now also asserts `data-rf-view` (the Spec 006 §View tagging contract attr, rf2-01il5) is elided.
- **rf2-ovbxk** — Parity-test omissions. Added the missing UIx `uix_frame_context_corrupted` test (mirrors the existing Helix counterpart; pins the `:adapter/current-frame` routing into the shared `function-component-current-frame` impl, emit + recover to `:rf/default`) and the missing Helix `helix_clear_warn_once_chain` test (mirrors the existing UIx counterpart; drives the chained `:adapter/clear-warn-once-caches!` hook end-to-end and asserts the Helix warn-cache empties + re-arms).

## Test plan

- [x] `npm run test:cljs` — 3915 tests / 11912 assertions, 0 failures, 0 errors (picks up the two new `-cljs-test` parity files)
- [x] `npm run test:browser-prod-elision` — 54 tests / 155 assertions, 0 failures, 0 errors (the `:advanced` + `goog.DEBUG=false` build that exercises the extended `data-rf-view` elision assertions)