### PR TITLE
test(adapters): reagent-slim coverage parity + correct adapters README (rf2-yrb8r + rf2-jp4r3)

### DIFF
--- a/implementation/adapters/README.md
+++ b/implementation/adapters/README.md
@@ -11,20 +11,22 @@ This directory groups re-frame2's **substrate adapters** — implementations of 
 | [`reagent/`](reagent/) | Reagent adapter | `day8/re-frame2-reagent` | Reagent 2.x — the canonical CLJS reference adapter |
 | [`uix/`](uix/) | UIx adapter | `day8/re-frame2-uix` | UIx 2.x — modern hooks-based React layer |
 | [`helix/`](helix/) | Helix adapter | `day8/re-frame2-helix` | Helix 0.2.x — minimal React wrapper |
-| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/re-frame2-reagent-slim` (NB: artefact coord is `day8/reagent-slim` per IMPL-SPEC DECISION-1) | Reagent rewrite for React 19 — Stage 4-A landed |
+| [`reagent-slim/`](reagent-slim/) | Reagent-slim adapter | `day8/re-frame2-reagent-slim` (NB: artefact coord is `day8/reagent-slim` per IMPL-SPEC DECISION-1) | Reagent rewrite for React 19 — Stage 4 landed (full `reagent2.*` rewrite) |
 | [`test-react/`](test-react/) | Test-React adapter | `day8/re-frame2-test-react` | Pure-CLJC React class-3 lifecycle simulator — unit-testable lifecycle bug catching (rf2-gqyqv placeholder skeleton) |
 
 A consumer picks one (or more) by adding the matching artefact to their `deps.edn` alongside `day8/re-frame2`. Bundle isolation is **structural** — the wrong adapter is absent from the classpath, not eliminated by dead-code analysis. See [Conventions §Substrate-adapter shipping convention](../../spec/Conventions.md).
 
-The `reagent-slim` adapter is in active development (Stage 4-A landed — reactive primitives only) and does not yet participate in the cross-substrate test matrix.
+The `reagent-slim` adapter has landed Stage 4 (the full `reagent2.*` rewrite — reactive primitives, render scheduler, hiccup translation, and pure-CLJS render-to-string). It now carries its own CLJS test suite (substrate-shape contract, container round-trip, derived-value tracking, the disposal-MUST list, render Root-API call sequence, and source-coord / view-id stamping under the slim adapter) alongside the `reagent2.*` internals tests.
 
 ## What an adapter implements
 
 Each adapter implements the surface defined in [Spec 006 §The adapter API contract](../../spec/006-ReactiveSubstrate.md):
 
-- **Required (6):** `mount-frame`, `dispose-frame!`, `read`, `swap-with!`, `subscribe`, `render`.
-- **Optional (2):** the core falls back when these are absent.
+- **Required (6):** `make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string`.
+- **Optional (2):** `subscribe-container`, `register-context-provider` — the core falls back when these are absent.
 - **Lifecycle (1):** `dispose-adapter!`.
+
+An adapter is a Clojure map carrying these fns under the matching keys plus a `:kind` discriminator keyword (e.g. `:rf.adapter/reagent-slim`). See [`re-frame.substrate.adapter`](../core/src/re_frame/substrate/adapter.cljc) for the live contract.
 
 Plus per-adapter ergonomics — e.g. `use-subscribe` hook (UIx, Helix), source-coord wrapping, `flush-views!` test helper.
 
@@ -46,14 +48,18 @@ adapters/
 │   ├── deps.edn
 │   ├── src/re_frame/adapter/helix.cljs
 │   └── test/...
-└── reagent-slim/
-    ├── deps.edn              ; declares day8/reagent-slim (no re-frame2- prefix per DECISION-1)
-    ├── src/reagent2/...      ; the slim Reagent rewrite (Stage 4-A: reactive primitives)
-    ├── src/re_frame/adapter/reagent_slim.cljs
+├── reagent-slim/
+│   ├── deps.edn              ; declares day8/reagent-slim (no re-frame2- prefix per DECISION-1)
+│   ├── src/reagent2/...      ; the slim Reagent rewrite (Stage 4: full reagent2.* rewrite)
+│   ├── src/re_frame/adapter/reagent_slim.cljs
+│   └── test/...
+└── test-react/
+    ├── deps.edn              ; declares day8/re-frame2-test-react
+    ├── src/re_frame/adapter/test_react.cljc  ; pure-CLJC class-3 lifecycle simulator
     └── test/...
 ```
 
-All four depend on `day8/re-frame2 {:local/root "../../core"}`. None depend on each other.
+All five depend on `day8/re-frame2 {:local/root "../../core"}`. None depend on each other.
 
 ## Per-feature artefacts vs adapters
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_render_cljs_test.cljs
@@ -1,0 +1,176 @@
+(ns re-frame.adapter.reagent-slim-render-cljs-test
+  "reagent-slim render-path coverage parity with the Reagent adapter's
+  `re-frame.adapter-render-cljs-test` (rf2-yrb8r). The slim adapter's
+  `render` slot must follow the React 18+ Root API exactly as the bridge
+  does — `(rdc/create-root mount-point)` first, then `(rdc/render root
+  render-tree)` — NOT `(rdc/render mount-point tree)` directly. The same
+  bug the bridge guards against (rf2-fn5rk: `TypeError: root.render is
+  not a function`) would bite slim too, because slim is positioned as a
+  drop-in Reagent replacement and routes through `reagent2.dom.client`
+  with the identical Root-API shape.
+
+  This pins the call sequence by spying through `with-redefs` on
+  `reagent2.dom.client`'s `create-root` / `render` / `hydrate-root` /
+  `unmount` fns. It does NOT touch a real DOM (no jsdom in :node-test);
+  it asserts the slim adapter wires the Root API correctly.
+
+  Test surface — the private `:render` slot on the slim adapter map plus
+  the spy stubs confirm:
+
+    1. Non-hydrate path: create-root is called exactly once with the
+       mount-point; render is called exactly once with the resulting
+       Root + the render-tree (in that order).
+    2. The returned unmount thunk calls unmount with the Root (not the
+       mount-point).
+    3. Hydrate path: hydrate-root is called once with the mount-point +
+       render-tree; create-root + render are NOT called; the unmount
+       thunk calls unmount with the Root returned by hydrate-root.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [reagent2.dom.client :as rdc]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- mk-fake-root
+  "A fake Root identity — just an object with a marker tag. The spy
+  replaces `rdc/unmount` so its real method is never invoked. Using
+  `#js {...}` keeps the value JS-shaped without depending on React being
+  present in the :node-test runtime."
+  [tag]
+  #js {:rf-test-root-tag tag})
+
+;; ---- non-hydrate path ------------------------------------------------------
+
+(deftest render-uses-create-root-then-render
+  (testing "non-hydrate render: (rdc/create-root mount-point) is called
+            first; (rdc/render root render-tree) follows; the unmount
+            thunk closes over the Root (parity with the bridge's
+            rf2-fn5rk pin)"
+    (let [calls      (atom [])
+          fake-root  (mk-fake-root :non-hydrate)
+          fake-mount #js {:rf-test-mount :non-hydrate}
+          fake-tree  [:div "tree"]]
+      ;; Stubs are multi-arity to mirror reagent2.dom.client's published
+      ;; API (create-root: 1/2, render: 2, hydrate-root: 2/3). Only the
+      ;; lowest arities are exercised by the slim adapter today, but
+      ;; covering the published arities keeps the stubs robust.
+      (with-redefs [rdc/create-root  (fn
+                                       ([mp]   (swap! calls conj [:create-root mp])
+                                               fake-root)
+                                       ([mp _] (swap! calls conj [:create-root mp])
+                                               fake-root))
+                    rdc/render       (fn [root tree]
+                                       (swap! calls conj [:render root tree])
+                                       nil)
+                    rdc/hydrate-root (fn
+                                       ([_ _]
+                                        (swap! calls conj [:hydrate-root])
+                                        (throw (ex-info "hydrate-root must not be called on non-hydrate path" {})))
+                                       ([_ _ _]
+                                        (swap! calls conj [:hydrate-root])
+                                        (throw (ex-info "hydrate-root must not be called on non-hydrate path" {}))))
+                    rdc/unmount      (fn [arg]
+                                       (swap! calls conj [:unmount arg])
+                                       nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)
+              unmount   (render-fn fake-tree fake-mount nil)]
+          (is (fn? unmount)
+              "render returns an unmount thunk")
+          ;; Pre-unmount: exactly create-root + render, in order.
+          (is (= 2 (count @calls))
+              (str "expected 2 calls after render, got " (count @calls)
+                   " — " (pr-str @calls)))
+          (let [[c1 c2] @calls]
+            (is (= [:create-root fake-mount] c1)
+                "first call is (create-root mount-point)")
+            (is (= :render (first c2))
+                "second call is (render …)")
+            (is (identical? fake-root (second c2))
+                "render's first arg is the Root from create-root,
+                NOT the mount-point — the React 18 contract")
+            (is (= fake-tree (nth c2 2))
+                "render's second arg is the render-tree"))
+          ;; Unmount: the thunk calls (rdc/unmount root) — NOT the
+          ;; mount-point.
+          (unmount)
+          (let [last-call (last @calls)]
+            (is (= :unmount (first last-call))
+                "unmount thunk invoked rdc/unmount")
+            (is (identical? fake-root (second last-call))
+                "unmount thunk passed the Root to rdc/unmount,
+                NOT the mount-point")))))))
+
+;; ---- hydrate path ----------------------------------------------------------
+
+(deftest render-hydrate-uses-hydrate-root
+  (testing "hydrate render: (rdc/hydrate-root mount-point render-tree)
+            returns the Root; create-root / render are NOT called; the
+            unmount thunk closes over the Root from hydrate-root (parity
+            with the bridge's rf2-fn5rk pin)"
+    (let [calls      (atom [])
+          fake-root  (mk-fake-root :hydrate)
+          fake-mount #js {:rf-test-mount :hydrate}
+          fake-tree  [:section "ssr-tree"]]
+      (with-redefs [rdc/create-root  (fn
+                                       ([_]   (swap! calls conj [:create-root])
+                                              (throw (ex-info "create-root must not be called on hydrate path" {})))
+                                       ([_ _] (swap! calls conj [:create-root])
+                                              (throw (ex-info "create-root must not be called on hydrate path" {}))))
+                    rdc/render       (fn [_ _]
+                                       (swap! calls conj [:render])
+                                       (throw (ex-info "render must not be called on hydrate path" {})))
+                    rdc/hydrate-root (fn
+                                       ([mp tree]
+                                        (swap! calls conj [:hydrate-root mp tree])
+                                        fake-root)
+                                       ([mp tree _]
+                                        (swap! calls conj [:hydrate-root mp tree])
+                                        fake-root))
+                    rdc/unmount      (fn [arg]
+                                       (swap! calls conj [:unmount arg])
+                                       nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)
+              unmount   (render-fn fake-tree fake-mount {:hydrate? true})]
+          (is (fn? unmount))
+          (is (= 1 (count @calls))
+              (str "expected exactly 1 call (hydrate-root) before unmount, got "
+                   (count @calls) " — " (pr-str @calls)))
+          (is (= [:hydrate-root fake-mount fake-tree] (first @calls))
+              "hydrate-root called once with (mount-point render-tree)")
+          (unmount)
+          (let [last-call (last @calls)]
+            (is (= :unmount (first last-call)))
+            (is (identical? fake-root (second last-call))
+                "unmount thunk passes the Root returned by hydrate-root")))))))
+
+;; ---- regression pin --------------------------------------------------------
+
+(deftest render-does-not-pass-mount-point-to-rdc-render
+  (testing "regression pin (parity with rf2-fn5rk) — the slim render slot
+            must NEVER call `(rdc/render mount-point render-tree)`; the
+            mount-point may only reach create-root / hydrate-root, never
+            rdc/render's first arg"
+    (let [render-calls (atom [])
+          fake-root    (mk-fake-root :regression)
+          fake-mount   #js {:rf-test-mount :regression}]
+      (with-redefs [rdc/create-root  (fn
+                                       ([_]   fake-root)
+                                       ([_ _] fake-root))
+                    rdc/render       (fn [root tree]
+                                       (swap! render-calls conj [root tree]))
+                    rdc/hydrate-root (fn
+                                       ([_ _]   fake-root)
+                                       ([_ _ _] fake-root))
+                    rdc/unmount      (fn [_] nil)]
+        (let [render-fn (:render reagent-slim-adapter/adapter)]
+          (render-fn [:div] fake-mount nil)
+          (is (= 1 (count @render-calls)))
+          (let [[root tree] (first @render-calls)]
+            (is (not (identical? fake-mount root))
+                "rdc/render's first arg is NEVER the raw mount-point")
+            (is (identical? fake-root root)
+                "rdc/render's first arg is the Root from create-root")
+            (is (= [:div] tree)
+                "the render-tree is passed through unchanged")))))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_source_coord_dom_cljs_test.cljs
@@ -1,0 +1,162 @@
+(ns re-frame.adapter.reagent-slim-source-coord-dom-cljs-test
+  "reagent-slim parity for the source-coord stamping contract (rf2-yrb8r;
+  mirrors `re-frame.source-coord-dom-cljs-test` for the Reagent bridge).
+
+  Per Spec 006 §Source-coord annotation: when `interop/debug-enabled?`
+  is true, a registered view's rendered root DOM element MUST carry
+  `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"`. The stamping is
+  driven through `re-frame.views` under the *installed* adapter — so this
+  file installs the slim adapter via the reset-runtime fixture and proves
+  slim participates in the same stamping contract the bridge does. slim
+  is positioned as a drop-in Reagent replacement; the cross-substrate
+  matrix gap (zero stamping coverage under slim) is the gap this closes.
+
+  Coverage mirrors the bridge's shape where it applies to slim:
+
+    - DOM-keyword root with no attrs map: attrs map spliced in.
+    - DOM-keyword root WITH an existing attrs map: coord merged in
+      alongside the user's attrs.
+    - User-supplied data-rf2-source-coord wins (don't overwrite).
+    - Form-2 (render-fn returns a fn): inner-fn output gets annotated.
+    - React Fragment root (`:<>`): root is exempt; no attribute injected.
+    - Programmatic reg-view* without source-coords: degrades to
+      `<ns>:<sym>:?:?`.
+    - Format: the attribute value matches `<ns>:<sym>:<line>:<col>`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- root-attr
+  "Pull the :data-rf2-source-coord value from the root attrs map of a
+  hiccup vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf2-source-coord (second hiccup))))
+
+;; ---- DOM-keyword root, no existing attrs map ------------------------------
+
+(deftest annotates-dom-root-without-attrs
+  (testing "a reg-view'd component with [:tag children…] gets a spliced
+            attrs map carrying :data-rf2-source-coord under slim"
+    (rf/reg-view ^{:rf/id :rf.slim-src-coord/no-attrs} no-attrs-view []
+      [:span "hi"])
+    (let [render (rf/view :rf.slim-src-coord/no-attrs)
+          out    (render)
+          attr   (root-attr out)]
+      (is (vector? out))
+      (is (= :span (first out)) "root tag preserved")
+      (is (string? attr) ":data-rf2-source-coord present")
+      (is (re-find #"^rf\.slim-src-coord:no-attrs:\d+:\d+$" attr)
+          (str ":data-rf2-source-coord matches <ns>:<sym>:<line>:<col>; got "
+               (pr-str attr))))))
+
+;; ---- DOM-keyword root with attrs map --------------------------------------
+
+(deftest annotates-dom-root-with-existing-attrs
+  (testing "a reg-view'd component with [:tag {:class …} children…] has
+            :data-rf2-source-coord merged into the existing attrs map"
+    (rf/reg-view ^{:rf/id :rf.slim-src-coord/with-attrs} with-attrs-view []
+      [:div {:class "card" :id "x"} "body"])
+    (let [render (rf/view :rf.slim-src-coord/with-attrs)
+          out    (render)
+          attrs  (second out)]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (is (map? attrs))
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (= "x"    (:id    attrs)) "user :id preserved")
+      (is (string? (:data-rf2-source-coord attrs))
+          ":data-rf2-source-coord merged in"))))
+
+;; ---- user-supplied coord wins ---------------------------------------------
+
+(deftest user-supplied-data-rf2-source-coord-wins
+  (testing "a render-fn that already set :data-rf2-source-coord is not
+            overwritten — composability with hand-stamped tools"
+    (rf/reg-view ^{:rf/id :rf.slim-src-coord/user-stamped} user-stamped-view []
+      [:p {:data-rf2-source-coord "stamped:by-user"} "ok"])
+    (let [render (rf/view :rf.slim-src-coord/user-stamped)
+          out    (render)]
+      (is (= "stamped:by-user" (:data-rf2-source-coord (second out)))
+          "user-supplied attribute survives the wrapper's merge"))))
+
+;; ---- Form-2: render-fn returns a fn --------------------------------------
+
+(deftest annotates-form-2-inner-output
+  (testing "Form-2 render-fns return a fn; the wrapper recurses on the
+            inner fn's output so annotation lands on the eventual
+            rendered DOM root, not the outer fn"
+    (rf/reg-view* :rf.slim-src-coord/form-2
+      (fn []
+        (fn inner-render []
+          [:section.f2 "form-2 body"])))
+    (let [wrapper (rf/view :rf.slim-src-coord/form-2)
+          out     (wrapper)]
+      (is (fn? out) "outer wrapper returns a fn (Form-2 shape preserved)")
+      (let [inner-out (out)]
+        (is (vector? inner-out) "inner fn returns hiccup")
+        (is (= :section.f2 (first inner-out)))
+        (is (string? (root-attr inner-out))
+            ":data-rf2-source-coord landed on the inner output's root")))))
+
+;; ---- React Fragment / non-DOM root: skip ----------------------------------
+
+(deftest fragment-root-is-exempt
+  (testing "a render-fn that returns a React Fragment :<> at the root is
+            exempt — no attribute injected"
+    (rf/reg-view ^{:rf/id :rf.slim-src-coord/fragment} fragment-view []
+      [:<> [:p "a"] [:p "b"]])
+    (let [render (rf/view :rf.slim-src-coord/fragment)
+          out    (render)]
+      (is (= :<> (first out)) "fragment marker preserved")
+      (is (not (and (map? (second out))
+                    (contains? (second out) :data-rf2-source-coord)))
+          "no :data-rf2-source-coord on fragment root"))))
+
+;; ---- programmatic registration without macro source-coords ---------------
+
+(deftest programmatic-registration-degrades-gracefully
+  (testing "a programmatic reg-view* (no macro coords) still annotates
+            with the id-derived <ns>:<sym> portion; line/col are `?`"
+    (rf/reg-view* :rf.slim-src-coord/programmatic
+      (fn [] [:p "p"]))
+    (let [render (rf/view :rf.slim-src-coord/programmatic)
+          out    (render)
+          attr   (root-attr out)]
+      (is (string? attr))
+      (is (= "rf.slim-src-coord:programmatic:?:?" attr)
+          "format degrades to <ns>:<sym>:?:? when coords are absent"))))
+
+;; ---- attribute format -----------------------------------------------------
+
+(deftest attribute-format-shape
+  (testing "the attribute value is exactly <ns>:<sym>:<line>:<col>"
+    (rf/reg-view ^{:rf/id :rf.slim-src-coord/format-shape} format-shape-view []
+      [:i "x"])
+    (let [out  ((rf/view :rf.slim-src-coord/format-shape))
+          attr (root-attr out)]
+      (is (string? attr))
+      (let [parts (str/split attr #":")]
+        (is (= 4 (count parts))
+            "exactly four colon-separated segments")
+        (is (= "rf.slim-src-coord" (first parts))
+            "first segment is the id keyword's namespace")
+        (is (= "format-shape" (second parts))
+            "second segment is the id keyword's name")
+        (is (re-matches #"\d+" (nth parts 2))
+            "third segment is the line integer")
+        (is (re-matches #"\d+" (nth parts 3))
+            "fourth segment is the column integer")))))

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_view_id_attr_cljs_test.cljs
@@ -1,0 +1,154 @@
+(ns re-frame.adapter.reagent-slim-view-id-attr-cljs-test
+  "reagent-slim parity for the view-id tagging contract (rf2-yrb8r;
+  mirrors `re-frame.view-id-attr-cljs-test` for the Reagent bridge).
+
+  Per Spec 006 §View tagging contract: when `interop/debug-enabled?` is
+  true, a registered view's rendered root DOM element MUST carry
+  `data-rf-view=\"<id>\"` ALONGSIDE `data-rf2-source-coord`. The view-id
+  attribute is the FALLBACK data source for the runtime view-hierarchy
+  walker when the Fiber-walker primary path is unavailable. The tagging
+  is driven through `re-frame.views` under the *installed* adapter — so
+  this file installs the slim adapter via the reset-runtime fixture and
+  proves slim participates in the same tagging contract the bridge does.
+
+  Coverage mirrors the bridge's shape where it applies to slim:
+
+    - DOM-keyword root with no attrs map: BOTH data-rf2-source-coord
+      AND data-rf-view spliced in.
+    - DOM-keyword root WITH an existing attrs map: both merged in
+      alongside the user's attrs.
+    - User-supplied data-rf-view wins (don't overwrite).
+    - Form-2 (render-fn returns a fn): inner-fn output gets BOTH attrs.
+    - React Fragment root: exempt; no attribute injected.
+    - Format: the attribute value is `(str id)` — i.e. `\":ns/sym\"`.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-slim-adapter/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- root-view-attr
+  "Pull the :data-rf-view value from the root attrs map of a hiccup
+  vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf-view (second hiccup))))
+
+(defn- root-coord-attr
+  "Pull the :data-rf2-source-coord value from the root attrs map of a
+  hiccup vector, if any."
+  [hiccup]
+  (and (vector? hiccup)
+       (map? (second hiccup))
+       (:data-rf2-source-coord (second hiccup))))
+
+;; ---- DOM-keyword root, no existing attrs map ------------------------------
+
+(deftest tags-dom-root-without-attrs
+  (testing "a reg-view'd component with [:tag children…] gets BOTH
+            :data-rf2-source-coord AND :data-rf-view spliced in under slim"
+    (rf/reg-view ^{:rf/id :rf.slim-view-id/no-attrs} no-attrs-view []
+      [:span "hi"])
+    (let [render (rf/view :rf.slim-view-id/no-attrs)
+          out    (render)
+          view   (root-view-attr out)
+          coord  (root-coord-attr out)]
+      (is (vector? out))
+      (is (= :span (first out)) "root tag preserved")
+      (is (string? view) ":data-rf-view present alongside :data-rf2-source-coord")
+      (is (string? coord) ":data-rf2-source-coord present (parity)")
+      (is (= ":rf.slim-view-id/no-attrs" view)
+          "view attribute value is (str id) — leading-colon preserved"))))
+
+;; ---- DOM-keyword root with attrs map --------------------------------------
+
+(deftest tags-dom-root-with-existing-attrs
+  (testing "a reg-view'd component with [:tag {:class …} children…] has
+            :data-rf-view merged into the existing attrs map alongside
+            user attrs (without disturbing them)"
+    (rf/reg-view ^{:rf/id :rf.slim-view-id/with-attrs} with-attrs-view []
+      [:div {:class "card" :id "x"} "body"])
+    (let [render (rf/view :rf.slim-view-id/with-attrs)
+          out    (render)
+          attrs  (second out)]
+      (is (vector? out))
+      (is (= :div (first out)))
+      (is (map? attrs))
+      (is (= "card" (:class attrs)) "user :class preserved")
+      (is (= "x"    (:id    attrs)) "user :id preserved")
+      (is (= ":rf.slim-view-id/with-attrs" (:data-rf-view attrs))
+          ":data-rf-view merged in alongside user attrs")
+      (is (string? (:data-rf2-source-coord attrs))
+          ":data-rf2-source-coord still merged in (parity)"))))
+
+;; ---- user-supplied data-rf-view wins --------------------------------------
+
+(deftest user-supplied-data-rf-view-wins
+  (testing "a render-fn that already set :data-rf-view is not overwritten
+            — composability with hand-stamped tools"
+    (rf/reg-view ^{:rf/id :rf.slim-view-id/user-stamped} user-stamped-view []
+      [:p {:data-rf-view "stamped:by-user"} "ok"])
+    (let [render (rf/view :rf.slim-view-id/user-stamped)
+          out    (render)]
+      (is (= "stamped:by-user" (:data-rf-view (second out)))
+          "user-supplied attribute survives the wrapper's merge"))))
+
+;; ---- Form-2: render-fn returns a fn --------------------------------------
+
+(deftest tags-form-2-inner-output
+  (testing "Form-2 render-fns return a fn; the wrapper recurses on the
+            inner fn's output so :data-rf-view lands on the eventual
+            rendered DOM root, not the outer fn"
+    (rf/reg-view* :rf.slim-view-id/form-2
+      (fn []
+        (fn inner-render []
+          [:section.f2 "form-2 body"])))
+    (let [wrapper (rf/view :rf.slim-view-id/form-2)
+          out     (wrapper)]
+      (is (fn? out) "outer wrapper returns a fn (Form-2 shape preserved)")
+      (let [inner-out (out)]
+        (is (vector? inner-out) "inner fn returns hiccup")
+        (is (= :section.f2 (first inner-out)))
+        (is (= ":rf.slim-view-id/form-2" (root-view-attr inner-out))
+            ":data-rf-view landed on the inner output's root")))))
+
+;; ---- React Fragment / non-DOM root: skip ----------------------------------
+
+(deftest fragment-root-is-exempt-for-view-id
+  (testing "a render-fn that returns a React Fragment :<> at the root is
+            exempt for :data-rf-view (same exemption as source-coord)"
+    (rf/reg-view ^{:rf/id :rf.slim-view-id/fragment} fragment-view []
+      [:<> [:p "a"] [:p "b"]])
+    (let [render (rf/view :rf.slim-view-id/fragment)
+          out    (render)]
+      (is (= :<> (first out)) "fragment marker preserved")
+      (is (not (and (map? (second out))
+                    (contains? (second out) :data-rf-view)))
+          "no :data-rf-view on fragment root"))))
+
+;; ---- attribute format -----------------------------------------------------
+
+(deftest attribute-format-is-str-id
+  (testing "the :data-rf-view value is exactly (str id) — preserving the
+            leading colon so a walker can disambiguate keyword ids from
+            raw strings"
+    (rf/reg-view ^{:rf/id :rf.slim-view-id/format-check} format-check-view []
+      [:i "x"])
+    (let [out  ((rf/view :rf.slim-view-id/format-check))
+          attr (root-view-attr out)]
+      (is (string? attr))
+      (is (= ":rf.slim-view-id/format-check" attr)
+          "format is (str :ns/sym) — leading-colon preserved")
+      (is (= :rf.slim-view-id/format-check
+             (keyword (subs attr 1)))
+          "walker round-trips ':<ns>/<sym>' → keyword cleanly"))))


### PR DESCRIPTION
## Summary

Two adapters items in distinct files.

**rf2-yrb8r — reagent-slim test coverage parity.** The slim adapter was the test-coverage outlier (it had shape/container/derived/dispose/late-bind tests but zero render-path and zero stamping coverage). Added the genuinely-missing, meaningful tests that mirror the stock Reagent adapter's shapes where they apply to slim:

- **render Root-API call sequence** (`reagent_slim_render_cljs_test.cljs`): non-hydrate path calls `create-root` then `render` in order; hydrate path calls `hydrate-root` only; the unmount thunk closes over the Root (not the mount-point); plus a regression pin that the raw mount-point never reaches `rdc/render`'s first arg. Mirrors the bridge's rf2-fn5rk pin, spying on `reagent2.dom.client` via `with-redefs` (no jsdom needed).
- **source-coord stamping under slim** (`reagent_slim_source_coord_dom_cljs_test.cljs`): `data-rf2-source-coord` on the rendered view root, driven through `re-frame.views` with the slim adapter installed.
- **view-id stamping under slim** (`reagent_slim_view_id_attr_cljs_test.cljs`): `data-rf-view` alongside `data-rf2-source-coord`, proving slim participates in the cross-substrate stamping/tagging contract.

No real slim bug surfaced — the Root-API wiring and stamping contracts are honoured.

**rf2-jp4r3 — adapters README correction.** `implementation/adapters/README.md` was stale on three counts, all fixed:

- The "Required (6)" list named non-existent fns (`mount-frame`, `swap-with!`, …). Corrected to the actual contract per `re_frame/substrate/adapter.cljc`: `make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string` (and Optional-2 `subscribe-container`, `register-context-provider`). Every name verified against source.
- The layout tree and "All four depend on…" prose omitted the shipping `test-react` adapter — now five adapters with `test-react` added to the tree and the dependency sentence.
- The slim-staging line understated the now-landed Stage 4 rewrite and its existing test suite; rewritten to describe both accurately.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 3927 tests / 11959 assertions, 0 failures (baseline was 3911 / 11895; +16 tests, +64 assertions from the new slim files).
- [x] `clojure -M:test` from `adapters/reagent-slim/` (JVM `reagent2.*` macro suite) — 11 tests, 0 failures (unaffected; new tests are CLJS).
- [x] README is not under `docs_dir: docs`, so mkdocs does not pick it up — no mkdocs build needed.