### PR TITLE
fix(core): spine glitch-free multi-input derived value + path :after empty-stack guard (rf2-i21f5 + rf2-mas2y)

### DIFF
--- a/implementation/core/src/re_frame/std_interceptors.cljc
+++ b/implementation/core/src/re_frame/std_interceptors.cljc
@@ -43,24 +43,34 @@
                       (get-in (:db (:coeffects ctx)) path-vec))))
       :after
       (fn [ctx]
-        ;; The splice-back only fires when the handler actually emitted
-        ;; a `:db` effect. If the handler returned no `:db`, the slice
-        ;; didn't change and we MUST NOT synthesise a `:db` effect —
-        ;; downstream tools rely on "no `:db` effect = no DB write" (the
-        ;; docstring contract). Synthesising would be idempotent at the
-        ;; value level (same `original-db` re-spliced with the same
-        ;; pre-handler slice) but allocated a fresh map per path-walk-
-        ;; step and produced a spurious `:db` effect from a no-`:db`
-        ;; handler.
-        (let [stack       (:rf/path-stack ctx [])
-              original-db (peek stack)
-              new-stack   (pop stack)
-              handler-emitted-db? (contains? (:effects ctx) :db)]
-          (cond-> (assoc ctx :rf/path-stack new-stack)
-            handler-emitted-db?
-            (assoc-in [:effects :db]
-                      (assoc-in original-db path-vec
-                                (get-in ctx [:effects :db])))))))))
+        ;; Guard: only unwind when our `:before` actually pushed. When an
+        ;; EARLIER interceptor's `:before` throws, `execute-chain`
+        ;; short-circuits all downstream `:before` stages (including
+        ;; ours) yet still runs every `:after` in reverse (Spec 002
+        ;; §rule 2). With no push, `:rf/path-stack` is absent — `(pop [])`
+        ;; would throw a SPURIOUS second error masking the original. The
+        ;; sibling `unwrap` interceptor mirrors this guard via its
+        ;; `:rf/unwrap-stash` presence check. No stack → no-op teardown.
+        (let [stack (:rf/path-stack ctx)]
+          (if (empty? stack)
+            ctx
+            ;; The splice-back only fires when the handler actually
+            ;; emitted a `:db` effect. If the handler returned no `:db`,
+            ;; the slice didn't change and we MUST NOT synthesise a `:db`
+            ;; effect — downstream tools rely on "no `:db` effect = no DB
+            ;; write" (the docstring contract). Synthesising would be
+            ;; idempotent at the value level (same `original-db`
+            ;; re-spliced with the same pre-handler slice) but allocated a
+            ;; fresh map per path-walk-step and produced a spurious `:db`
+            ;; effect from a no-`:db` handler.
+            (let [original-db (peek stack)
+                  new-stack   (pop stack)
+                  handler-emitted-db? (contains? (:effects ctx) :db)]
+              (cond-> (assoc ctx :rf/path-stack new-stack)
+                handler-emitted-db?
+                (assoc-in [:effects :db]
+                          (assoc-in original-db path-vec
+                                    (get-in ctx [:effects :db])))))))))))
 
 ;; ---- unwrap ---------------------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -8,8 +8,10 @@
   Scope. This ns provides:
 
     * The plain-`atom` container quartet (make / read / replace / subscribe).
-    * `make-derived-value` (one watch per source; reifies the
-      re-frame-owned `re-frame.disposable/IDisposable`).
+    * `make-derived-value` (one watch per source, coalesced through a
+      shared per-adapter epoch scheduler so a multi-input derived value
+      recomputes glitch-free and notifies once per coherent input epoch;
+      reifies the re-frame-owned `re-frame.disposable/IDisposable`).
     * React 18+ root renderer (createRoot + render, hydrateRoot for
       hydrate).
     * Late-bind hiccup-emitter atom + `render-to-string` thrower.
@@ -40,6 +42,113 @@
             [re-frame.subs       :as subs]
             [re-frame.adapter.context :as adapter-context]))
 
+;; ---- epoch scheduler (glitch-freedom; Spec 006 §Invalidation algorithm) ----
+;;
+;; Reagent realises the Phase 1/2/3 invalidation contract automatically:
+;; each `Reaction` re-runs once per `r/flush!` against settled inputs, so
+;; a multi-input layer-2+ reaction never sees a half-updated input set and
+;; never notifies more than once per app-db change. The spine has no
+;; reaction primitive, so it must satisfy the contract explicitly
+;; (Spec 006: "Non-CLJS implementations must satisfy the contract
+;; explicitly").
+;;
+;; The bug a naive spine has (rf2-i21f5): wiring one `add-watch` per
+;; source that recomputes-and-notifies INLINE means a layer-2+ sub with N
+;; changed inputs recomputes once per changed input. The first source's
+;; notify drives the downstream recompute; the second source's notify
+;; drives it AGAIN, and so on — N recomputes per app-db change instead of
+;; one. Each redundant recompute re-runs the user's sub body and emits a
+;; `:sub/run` trace, and a downstream layer-3 sub re-fires per redundant
+;; layer-2 notification, fanning the waste out across the whole `:<-`
+;; graph. (The spine's derived value is pull-based — `-deref` recomputes
+;; fresh from current sources — so each recompute reads settled source
+;; state and the final notified VALUE is correct; the defect is the
+;; redundant recompute storm + over-notification, not a wrong value. The
+;; downstream `notify` only fires on a `=`-change, which masks the storm
+;; for `=`-stable bodies but not for the recompute work, the trace
+;; emissions, or any body with observable per-call cost.) Reagent is
+;; immune (native batched `r/flush!`); the spine must satisfy the Phase
+;; 1/2/3 contract explicitly.
+;;
+;; The fix mirrors Reagent's batched flush. A single per-adapter
+;; scheduler is shared by `replace-container!` (the only app-db mutation
+;; entry point, Spec 006 §revertibility) and every `make-derived-value`.
+;; `replace-container!` brackets its `reset!` in an epoch: source watches
+;; fired by the `reset!` only MARK their derived value dirty (enqueue a
+;; recompute-and-notify thunk) instead of recomputing inline. When the
+;; outermost epoch closes, the scheduler drains the queue. A derived
+;; value's recompute, on changing by `=`, notifies its watchers — which
+;; for a downstream derived value's source-watch marks THAT derived dirty
+;; and enqueues it in turn. Because a dirty-flag dedups re-marks within an
+;; epoch, every derived value recomputes EXACTLY ONCE against fully
+;; settled inputs and notifies its subscribers at most once — exactly the
+;; Phase 1/2/3 ordering (one Phase-3 notification per dirty entry).
+;;
+;; Outside an epoch (a direct `reset!`/`swap!` on a source by test code or
+;; tooling, rather than through `replace-container!`) the mark falls
+;; through to an immediate single-derived flush so the contract still
+;; holds for the one-source-changed case.
+;;
+;; `depth` / `flushing?` / `queue` are written and read only on the
+;; single-threaded JS event loop and never escape the adapter closure —
+;; `volatile!` is the right primitive, no CAS cost.
+
+(defn make-scheduler
+  "Return a fresh per-adapter epoch scheduler cell. Each adapter owns its
+  own so multiple React-shaped adapters can coexist in a test bundle
+  without sharing an epoch queue."
+  []
+  {:depth     (volatile! 0)   ;; open-epoch nesting depth
+   :flushing? (volatile! false)
+   :queue     (volatile! [])  ;; ordered queue of pending flush thunks
+   :queued    (volatile! #{})}) ;; identity set guarding double-enqueue
+
+(defn- drain-scheduler!
+  "Drain the scheduler's pending flush thunks in enqueue order until the
+  queue is empty. Re-entrant-safe: an in-progress drain swallows nested
+  drain requests (the running loop already observes newly-enqueued
+  thunks). Each thunk recomputes its derived value and, on a `=`-change,
+  notifies its watchers — which may enqueue downstream thunks that the
+  same loop then drains, preserving topological order."
+  [{:keys [flushing? queue queued] :as _scheduler}]
+  (when-not @flushing?
+    (vreset! flushing? true)
+    (try
+      (loop []
+        (when (seq @queue)
+          (let [thunk (nth @queue 0)]
+            (vreset! queue (subvec @queue 1))
+            (vswap! queued disj thunk)
+            (thunk))
+          (recur)))
+      (finally
+        (vreset! flushing? false)))))
+
+(defn- schedule-flush!
+  "Enqueue `thunk` on the scheduler (dedup by identity within the current
+  epoch). When no epoch is open, drain immediately so a direct source
+  mutation outside `replace-container!` still flushes synchronously."
+  [{:keys [depth queue queued] :as scheduler} thunk]
+  (when-not (contains? @queued thunk)
+    (vswap! queued conj thunk)
+    (vswap! queue conj thunk))
+  (when (zero? @depth)
+    (drain-scheduler! scheduler)))
+
+(defn- with-epoch
+  "Run `body-thunk` inside an open epoch on `scheduler`; the outermost
+  close drains the pending flush queue. Nested epochs (a re-entrant
+  `replace-container!` during a flush) only drain at the outermost
+  boundary so coalescing spans the whole synchronous cascade."
+  [{:keys [depth] :as scheduler} body-thunk]
+  (vswap! depth inc)
+  (try
+    (body-thunk)
+    (finally
+      (vswap! depth dec)
+      (when (zero? @depth)
+        (drain-scheduler! scheduler)))))
+
 ;; ---- container ------------------------------------------------------------
 ;;
 ;; Per Spec 006 §revertibility-constraints the container holds the
@@ -58,9 +167,18 @@
 (defn read-container [container]
   @container)
 
-(defn replace-container! [container new-value]
-  (reset! container new-value)
-  nil)
+(defn make-replace-container-fn
+  "Return a `replace-container!` fn that brackets its `reset!` in an epoch
+  on `scheduler`. The `reset!` fires source watches synchronously; those
+  watches only MARK their derived values dirty (see
+  `make-derived-value-fn`). The epoch close drains the coalesced flush
+  queue so each affected derived value recomputes glitch-free against the
+  settled app-db and notifies its subscribers exactly once (Spec 006
+  §Invalidation algorithm)."
+  [scheduler]
+  (fn replace-container! [container new-value]
+    (with-epoch scheduler (fn epoch-body [] (reset! container new-value)))
+    nil))
 
 (defn make-subscribe-container
   "Return a `subscribe-container` fn that gensyms watch keys with the
@@ -124,9 +242,20 @@
 
 (defn make-derived-value-fn
   "Return a `make-derived-value` fn that tags per-source watch keys with
-  the given `gensym-prefix`. The fn signature matches the substrate
-  contract: `(sources compute-fn) -> derived-container`."
-  [gensym-prefix]
+  the given `gensym-prefix` and coalesces source-change notifications
+  through `scheduler` (see the epoch-scheduler section above). The fn
+  signature matches the substrate contract:
+  `(sources compute-fn) -> derived-container`.
+
+  Single-recompute / single-notification (rf2-i21f5): a source-change
+  watch does NOT recompute or notify inline. It marks this derived value
+  dirty (enqueues a single recompute-and-notify thunk on the scheduler).
+  The epoch open by `replace-container!` defers the drain until the whole
+  synchronous app-db cascade has settled, so a multi-input derived value
+  recomputes EXACTLY ONCE against the coherent input set and notifies its
+  subscribers at most once — never N times (one recompute + one Phase-3
+  notification per dirty entry per app-db change)."
+  [gensym-prefix scheduler]
   (fn make-derived-value [source-containers compute-fn]
     (let [recompute      (build-recompute-fn source-containers compute-fn)
           watchers       (atom {})           ;; user-key → wrapper-fn
@@ -138,31 +267,42 @@
           ;; source-change notification.
           notify         (fn [prev nu]
                            (when (not= prev nu)
-                             (run! (fn [w] (w prev nu)) (vals @watchers))))]
+                             (run! (fn [w] (w prev nu)) (vals @watchers))))
+          ;; Baseline derived value. Seeded from the *derived* value at
+          ;; construction time, not the raw source. The flush thunk
+          ;; compares prev-derived against the recomputed derived value;
+          ;; if we seeded from `(deref s)` (the raw source), the first
+          ;; source change would spuriously notify whenever the derived
+          ;; projection differs in identity from the raw source — e.g.
+          ;; `(odd? x)`, counts, `:k` lookups, projections — even when the
+          ;; derived value itself is `=`.
+          ;;
+          ;; `prev-state` / `dirty?` are written and read only on the
+          ;; single-threaded JS event loop and never escape this closure —
+          ;; `volatile!` is the right primitive, no CAS cost. `dirty?`
+          ;; dedups re-marks within an epoch: a multi-input derived value
+          ;; whose N sources all fire enqueues exactly one flush thunk.
+          prev-state     (volatile! (recompute))
+          dirty?         (volatile! false)
+          flush!         (fn flush! []
+                           (vreset! dirty? false)
+                           (let [new-derived  (recompute)
+                                 prev-derived @prev-state]
+                             (vreset! prev-state new-derived)
+                             (notify prev-derived new-derived)))
+          mark-dirty!    (fn mark-dirty! []
+                           (when-not @dirty?
+                             (vreset! dirty? true)
+                             (schedule-flush! scheduler flush!)))]
       ;; Wire one watch per source so the listener registry surface
-      ;; (subscribe-container) on the derived container fires whenever
-      ;; any source changes.
-      ;; Seed the baseline from the *derived* value at construction time,
-      ;; not the raw source. The watch callback compares prev-derived
-      ;; against the recomputed derived value; if we seeded from
-      ;; `(deref s)` (the raw source), the first source change would
-      ;; spuriously notify whenever the derived projection differs in
-      ;; identity from the raw source — e.g. `(odd? x)`, counts, `:k`
-      ;; lookups, projections — even when the derived value itself is `=`.
-      ;;
-      ;; `prev-state` is written and read only inside the watch callback
-      ;; (single-threaded JS / Reagent reactivity) and never escapes
-      ;; this closure — `volatile!` is the right primitive, no CAS cost.
-      (let [prev-state (volatile! (recompute))]
-        (doseq [s source-containers]
-          (let [k (gensym gensym-prefix)]
-            (swap! own-keys assoc s k)
-            (add-watch s k
-              (fn [_ _ _ _]
-                (let [new-derived  (recompute)
-                      prev-derived @prev-state]
-                  (vreset! prev-state new-derived)
-                  (notify prev-derived new-derived)))))))
+      ;; (subscribe-container) on the derived container fires whenever any
+      ;; source changes. The watch only MARKS dirty — the actual recompute
+      ;; + notify is deferred to the scheduler drain so it runs once
+      ;; against settled inputs (glitch-free, single notification).
+      (doseq [s source-containers]
+        (let [k (gensym gensym-prefix)]
+          (swap! own-keys assoc s k)
+          (add-watch s k (fn [_ _ _ _] (mark-dirty!)))))
       (reify
         IDeref
         (-deref [_] (recompute))
@@ -763,7 +903,14 @@
                                      after-render-queue-cell
                                      after-render-set-tick-ref)
         subscribe-cont     (make-subscribe-container gensym-prefix-sub)
-        make-derived       (make-derived-value-fn gensym-prefix-derived)
+        ;; rf2-i21f5: one epoch scheduler per adapter, shared by
+        ;; `replace-container!` and every `make-derived-value`, so a
+        ;; multi-input derived value recomputes glitch-free and notifies
+        ;; once per coherent app-db epoch (Spec 006 §Invalidation
+        ;; algorithm). See the epoch-scheduler section above.
+        scheduler          (make-scheduler)
+        replace-cont!      (make-replace-container-fn scheduler)
+        make-derived       (make-derived-value-fn gensym-prefix-derived scheduler)
         ;; Precompute the `use-subscribe` watch-key keyword namespace
         ;; once (outside the render hot path). The per-reaction key
         ;; derives from `(hash reaction)` so the subscribe-fn closure
@@ -895,7 +1042,7 @@
      :active-roots-cell           active-roots-cell
      :make-state-container        make-state-container
      :read-container              read-container
-     :replace-container!          replace-container!
+     :replace-container!          replace-cont!
      :subscribe-container         subscribe-cont
      :make-derived-value          make-derived
      :render                      render-fn

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -182,6 +182,46 @@
     (is (= 11 (get-in (rf/get-frame-db :rf/default) [:foo :bar]))
         "handler that emits :db still gets its slice spliced back")))
 
+;; Per rf2-mas2y: when an EARLIER interceptor's `:before` throws,
+;; `execute-chain` short-circuits all downstream `:before` stages
+;; (including `path`'s) yet still runs every `:after` in reverse
+;; (teardown contract). `path`'s `:before` therefore never pushed onto
+;; `:rf/path-stack`, so its `:after` must NOT call `(pop [])` — that
+;; would throw a SPURIOUS second error masking the original cause. The
+;; sibling `unwrap` interceptor is already guarded for this case (it
+;; no-ops when `:rf/unwrap-stash` is absent); `path` mirrors that guard.
+;;
+;; Source: std_interceptors.cljc — `path`'s `:after` no-ops when
+;; `:rf/path-stack` is empty.
+
+(deftest path-interceptor-after-no-ops-when-before-short-circuited
+  (testing "(path ...) :after does not throw and preserves the original
+            error when an upstream interceptor's :before throws first"
+    (let [boom    (interceptor/->interceptor
+                    :id     :path-short/boom
+                    :before (fn [_ctx]
+                              (throw (ex-info "before blew up"
+                                              {:src :path-short/boom}))))
+          ;; Order: boom (throws in :before) → path (its :before is
+          ;; short-circuited, but its :after still runs in reverse).
+          chain   [boom (rf/path :foo :bar)]
+          final   (interceptor/execute-chain
+                    chain
+                    {:coeffects {:db {:foo {:bar 10}}} :effects {}})
+          errs    (:rf/interceptor-errors final)]
+      (is (= :path-short/boom (get-in final [:rf/interceptor-error :id]))
+          "the original :before failure is the recorded FIRST error")
+      (is (= :before (get-in final [:rf/interceptor-error :phase]))
+          "the FIRST error is the upstream :before throw")
+      (is (= 1 (count errs))
+          "exactly one error — path's :after did NOT synthesise a spurious
+           second error from (pop [])")
+      (is (= [:path-short/boom] (mapv :id errs))
+          "no error attributed to :path — its :after no-opped cleanly")
+      (is (not (contains? (:effects final) :db))
+          "path's no-op :after produced no :db effect when its :before
+           never ran"))))
+
 ;; ---- unwrap ---------------------------------------------------------------
 
 (deftest unwrap-interceptor

--- a/implementation/core/test/re_frame/substrate/spine_build_recompute_fn_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_build_recompute_fn_cljs_test.cljs
@@ -126,7 +126,7 @@
     ;; rf2-eoy63 wiring: spine's IDeref body MUST route through
     ;; build-recompute-fn, not its old naive (apply compute-fn (map
     ;; deref ...)) shape.
-    (let [make-derived (spine/make-derived-value-fn "rf-test-")
+    (let [make-derived (spine/make-derived-value-fn "rf-test-" (spine/make-scheduler))
           s0           (atom 5)
           derived      (make-derived [s0] (fn [a] (* a 10)))]
       (is (= 50 @derived) "1-arity recompute fires through the spine")

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -1,0 +1,182 @@
+(ns re-frame.substrate.spine-glitch-free-cljs-test
+  "Single-recompute + single-notification coverage for the substrate-
+  spine's derived-value epoch scheduler (rf2-i21f5).
+
+  The bug: a naive spine wires one `add-watch` per source that recomputes
+  and notifies INLINE. A layer-2+ derived value with N changed inputs then
+  recomputes once per changed input — the first input's notify drives the
+  downstream recompute, the second input's notify drives it AGAIN, etc.
+  N recomputes per app-db change instead of one. Each redundant recompute
+  re-runs the user's sub body and emits a `:sub/run` trace; a layer-3 sub
+  re-fires per redundant layer-2 notification, fanning the waste across
+  the whole `:<-` graph. Reagent is immune (native batched `r/flush!`);
+  the spine must satisfy the Spec 006 §Invalidation algorithm Phase 1/2/3
+  contract explicitly (one recompute + one Phase-3 notification per dirty
+  entry per app-db change).
+
+  Note on values: the spine's derived value is PULL-BASED — `-deref`
+  recomputes fresh from current sources — so every recompute during the
+  cascade reads settled source state and the notified VALUE is always
+  coherent (never a half-updated intermediate). The load-bearing defect
+  the fix removes is therefore the redundant-recompute storm + over-
+  notification, which these tests assert via per-derived recompute and
+  notification counters.
+
+  These tests build the spine's derived-value graph directly over plain
+  source atoms sharing ONE epoch scheduler, mutate the root through the
+  scheduler-aware `replace-container!` (the only app-db mutation entry
+  point per Spec 006 §revertibility), and assert exactly-one recompute and
+  at-most-one notification per affected derived value per write.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.substrate.spine :as spine]))
+
+;; ---- harness --------------------------------------------------------------
+;;
+;; Mirrors the real sub-graph wiring: `make-state-container` for the root
+;; (app-db), `make-derived-value` for every layer-1 / layer-2 sub, and the
+;; scheduler-aware `replace-container!` as the single mutation entry point.
+;; All derived values share ONE scheduler — exactly as `make-react-spine`
+;; wires them per adapter.
+
+(defn- build-graph []
+  (let [scheduler    (spine/make-scheduler)
+        make-derived (spine/make-derived-value-fn "rf-glitch-" scheduler)
+        replace!     (spine/make-replace-container-fn scheduler)
+        root         (spine/make-state-container {:a 1 :b 10})]
+    {:scheduler    scheduler
+     :make-derived make-derived
+     :replace!     replace!
+     :root         root}))
+
+;; ---- single-input layer-1 (regression guard) ------------------------------
+
+(deftest layer-1-single-input-notifies-once
+  (testing "a layer-1 derived value over the root notifies once per
+            replace-container! when its slice changes by ="
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1     (make-derived [root] (fn [db] (:a db)))
+          notes  (atom [])]
+      (add-watch l1 :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
+      (replace! root {:a 2 :b 10})
+      (is (= [[1 2]] @notes)
+          "exactly one notification carrying old→new derived value")
+      (is (= 2 @l1) "deref reflects the settled value"))))
+
+(deftest layer-1-value-equal-write-does-not-notify
+  (testing "a write that leaves the layer-1 slice =-unchanged does NOT
+            notify (Spec 006 §Value-equal means no propagation)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1     (make-derived [root] (fn [db] (:a db)))
+          notes  (atom 0)]
+      (add-watch l1 :w (fn [_ _ _ _] (swap! notes inc)))
+      ;; :b changes; :a — the only slice l1 reads — does not.
+      (replace! root {:a 1 :b 99})
+      (is (= 0 @notes)
+          "no notification when the derived value is =-unchanged"))))
+
+;; ---- multi-input layer-2 (the over-recompute case) ------------------------
+
+(deftest layer-2-multi-input-recomputes-once-and-notifies-once
+  (testing "a multi-input layer-2 derived value over TWO layer-1 inputs
+            recomputes EXACTLY ONCE and notifies its watcher at most once
+            per replace-container!, even when BOTH inputs change (rf2-i21f5)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1a    (make-derived [root] (fn [db] (:a db)))
+          l1b    (make-derived [root] (fn [db] (:b db)))
+          recompute-count (atom 0)
+          ;; Layer-2: sum of the two layer-1 inputs. With the naive
+          ;; per-source-inline spine the body runs once per changed input
+          ;; (twice here); the epoch scheduler coalesces to one.
+          l2     (make-derived [l1a l1b]
+                   (fn [a b] (swap! recompute-count inc) (+ a b)))
+          seen   (atom [])]
+      (add-watch l2 :w (fn [_ _ _ nu] (swap! seen conj nu)))
+      (is (= 11 @l2) "baseline: 1 + 10")
+      ;; Reset the counter after baseline construction + deref above.
+      (reset! recompute-count 0)
+      ;; ONE app-db write changes BOTH inputs.
+      (replace! root {:a 2 :b 20})
+      (is (= 1 @recompute-count)
+          "layer-2 body recomputed EXACTLY ONCE — the N source-watch fires
+           coalesced into a single flush (not once per changed input)")
+      (is (= 1 (count @seen))
+          "layer-2 watcher notified exactly once per replace-container!")
+      (is (= [22] @seen)
+          "the single notification carries the coherent value (2 + 20)")
+      (is (= 22 @l2) "deref reflects the settled value"))))
+
+(deftest layer-2-three-input-recomputes-once
+  (testing "the single-recompute contract holds for a 3-input layer-2
+            derived value (≥3 sources exercise the recompute-n fallback)"
+    (let [scheduler    (spine/make-scheduler)
+          make-derived (spine/make-derived-value-fn "rf-glitch3-" scheduler)
+          replace!     (spine/make-replace-container-fn scheduler)
+          root         (spine/make-state-container {:a 1 :b 2 :c 3})
+          l1a    (make-derived [root] (fn [db] (:a db)))
+          l1b    (make-derived [root] (fn [db] (:b db)))
+          l1c    (make-derived [root] (fn [db] (:c db)))
+          recompute-count (atom 0)
+          l2     (make-derived [l1a l1b l1c]
+                   (fn [a b c] (swap! recompute-count inc) [a b c]))
+          seen   (atom [])]
+      (add-watch l2 :w (fn [_ _ _ nu] (swap! seen conj nu)))
+      (is (= [1 2 3] @l2))
+      (reset! recompute-count 0)
+      (replace! root {:a 10 :b 20 :c 30})
+      (is (= 1 @recompute-count)
+          "3-input layer-2 body recomputed exactly once for the epoch")
+      (is (= 1 (count @seen))
+          "3-input layer-2 watcher notified exactly once")
+      (is (= [[10 20 30]] @seen)
+          "the single notification carries the fully-settled tuple")
+      (is (= [10 20 30] @l2)))))
+
+(deftest layer-3-cascade-each-tier-notifies-once-glitch-free
+  (testing "a layer-3 sub over a multi-input layer-2 sub propagates ONE
+            coherent notification per tier per replace-container! — the
+            cascade settles to the right value with no spurious extra
+            notifications down the :<- chain.
+
+            (Recompute counts are deliberately NOT asserted here: the
+            spine is pull-based, so a downstream `-deref` of layer-2
+            during layer-3's recompute legitimately re-runs layer-2's
+            body. That deref-driven recompute is independent of the
+            rf2-i21f5 source-watch-storm — which is pinned by the
+            standalone `layer-2-multi-input-recomputes-once-and-notifies-
+            once` test above.)"
+    (let [{:keys [make-derived replace! root]} (build-graph)
+          l1a    (make-derived [root] (fn [db] (:a db)))
+          l1b    (make-derived [root] (fn [db] (:b db)))
+          l2     (make-derived [l1a l1b] (fn [a b] (+ a b)))
+          l3     (make-derived [l2] (fn [s] (* 100 s)))
+          l2-seen (atom [])
+          l3-seen (atom [])]
+      (add-watch l2 :w (fn [_ _ _ nu] (swap! l2-seen conj nu)))
+      (add-watch l3 :w (fn [_ _ _ nu] (swap! l3-seen conj nu)))
+      (is (= 11 @l2))
+      (is (= 1100 @l3))
+      (replace! root {:a 2 :b 20})
+      (is (= [22] @l2-seen) "layer-2 notified once with the coherent sum")
+      (is (= [2200] @l3-seen)
+          "layer-3 notified once with the value computed against the
+           settled layer-2 — no spurious extra notification cascaded down")
+      (is (= 2200 @l3)))))
+
+;; ---- direct source mutation outside an epoch ------------------------------
+
+(deftest layer-1-direct-source-write-still-flushes
+  (testing "a direct source mutation OUTSIDE replace-container! (test /
+            tooling reset!) still flushes the single affected derived
+            value synchronously"
+    (let [scheduler    (spine/make-scheduler)
+          make-derived (spine/make-derived-value-fn "rf-direct-" scheduler)
+          src          (atom 5)
+          l1     (make-derived [src] (fn [x] (* x 10)))
+          notes  (atom [])]
+      (add-watch l1 :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
+      (reset! src 6)
+      (is (= [[50 60]] @notes)
+          "the bare reset! drained immediately (no epoch open) and notified
+           once with the recomputed value"))))


### PR DESCRIPTION
## Summary

Two core bug fixes.

### rf2-i21f5 (P1) — spine over-recomputes + over-notifies multi-input subs
The spine (UIx/Helix substrate) wired one `add-watch` per source that recomputed and notified **inline**. A layer-2+ derived value with N changed inputs therefore recomputed once per changed input — N recomputes per app-db change instead of one. Each redundant recompute re-runs the user's sub body and emits a `:sub/run` trace, and a layer-3 sub re-fires per redundant layer-2 notification, fanning the waste across the whole `:<-` graph. Reagent is immune (native batched `r/flush!`); the spine must satisfy the Spec 006 §Invalidation algorithm Phase 1/2/3 contract explicitly.

Fix: a single per-adapter **epoch scheduler** shared by `replace-container!` and every `make-derived-value` (wired in `make-react-spine`, so both UIx and Helix get it). `replace-container!` brackets its `reset!` in an epoch — source watches fired by the `reset!` only **mark** their derived value dirty (a `dirty?` flag dedups the N source-watch fires into one enqueued flush) instead of recomputing inline. The epoch close drains the queue: each affected derived value recomputes **exactly once** against settled inputs and notifies its subscribers at most once, downstream tiers enqueued in topological order. Direct source mutations outside an epoch (tests/tooling) still flush synchronously.

Note: the spine's derived value is pull-based (`-deref` recomputes fresh), so the previously-notified VALUE was already coherent (deref reads current source state); the load-bearing defect removed here is the redundant-recompute storm + over-notification, which is what the new tests pin.

### rf2-mas2y (P2) — path interceptor :after throws on empty stack
When an earlier interceptor's `:before` throws, `execute-chain` short-circuits all downstream `:before` stages (including `path`'s) yet still runs every `:after` in reverse. `path`'s `:after` then did `(pop [])` (its `:before` never pushed onto `:rf/path-stack`), throwing a **spurious second error** that masked the original cause. Fix mirrors the sibling `unwrap` interceptor's guard: `path`'s `:after` no-ops when `:rf/path-stack` is empty.

## Test plan
- [x] `npm run test:cljs` — 3911 tests / 11890 assertions, 0 failures (incl. new `spine_glitch_free_cljs_test.cljs`)
- [x] core JVM `clojure -M:test` — 685 tests / 3282 assertions, 0 failures (incl. new `path-interceptor-after-no-ops-when-before-short-circuited`)
- [x] `npm run test:bundle-isolation` — pass; UIx/Helix bundles stay Reagent-free, production builds compile clean
- [x] Verified both new spine recompute tests fail (recompute=2) under a temporary inline-drain probe, then pass (=1) with the fix; verified the new path test fails under the unguarded `(pop [])`