### PR TITLE
fix(http): reconcile Spec 014 :sensitive?/denylist + CLJS binary decode (rf2-gvm39 + rf2-wz0rh + rf2-5zj6t)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -75,6 +75,31 @@
       (and ct (str/starts-with? ct "text/"))         :text
       :else                                          :blob)))
 
+(def ^:private binary-decode-kinds
+  "Decode modes whose result is a native binary/structured Fetch body
+  rather than a string. These resolve the response via `.blob()` /
+  `.arrayBuffer()` / `.formData()` instead of `.text()` (rf2-5zj6t)."
+  #{:blob :array-buffer :form-data})
+
+(defn binary-read-kind
+  "Resolve the user-supplied `:decode` (+ response `headers` for the
+  `:auto` sniff) to the binary Fetch body-read kind (`:blob` /
+  `:array-buffer` / `:form-data`) or `nil` when the resolved decoder is
+  text-based (`:json` / `:text` / a fn / a Malli schema / any other
+  keyword). Mirrors the resolution `decode-response-body` performs so
+  the CLJS transport can choose the right Fetch reader BEFORE the body
+  is consumed (a Response body may only be read once). `:auto` over a
+  non-text / non-JSON Content-Type sniffs to `:blob`, so an image
+  fetched without an explicit `:decode` still reads as binary (rf2-5zj6t)."
+  [decode headers]
+  (let [resolved (cond
+                   (fn? decode)        nil
+                   (nil? decode)       (sniff-decoder (content-type-of headers))
+                   (= :auto decode)    (sniff-decoder (content-type-of headers))
+                   :else               decode)]
+    (when (contains? binary-decode-kinds resolved)
+      resolved)))
+
 ;; Memoised resolves (per rf2-tja2y). The Malli vars never rebind at
 ;; runtime; resolving once per JVM / once per CLJS runtime is enough,
 ;; and the deref asymmetry (JVM `requiring-resolve` returns a Var,
@@ -140,8 +165,8 @@
   (`:cause :too-many-keys`) is a security-relevant signal and must
   surface as `:rf.http/decode-failure`, not be masked behind a malli
   rejection."
-  [{:keys [body-text headers decode decode-supplied? request-id url sensitive?
-           max-decoded-keys]}]
+  [{:keys [body-text body-binary headers decode decode-supplied? request-id url
+           sensitive? max-decoded-keys]}]
   (let [content-type (content-type-of headers)
         decoder      (cond
                        (nil? decode)        :auto
@@ -176,14 +201,20 @@
       (= :text resolved)
       body-text
 
+      ;; rf2-5zj6t — binary decode modes return the native Fetch body
+      ;; the transport already read via `.blob()` / `.arrayBuffer()` /
+      ;; `.formData()`. On hosts that have no binary body (the JVM
+      ;; transport reads `.body` as a String) `body-binary` is absent and
+      ;; we fall back to the raw `body-text` so the value is at least the
+      ;; payload, not nil.
       (= :blob resolved)
-      body-text
+      (if (some? body-binary) body-binary body-text)
 
       (= :array-buffer resolved)
-      body-text
+      (if (some? body-binary) body-binary body-text)
 
       (= :form-data resolved)
-      body-text
+      (if (some? body-binary) body-binary body-text)
 
       ;; Malli schema (or anything keyword-like that isn't recognised above).
       ;; rf2-wu1n5 — re-raise a `:rf.error/malformed-json` ex-info

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -111,9 +111,9 @@
         ;; handlers' dispatches yield nil and are not tracked.
         actor-id     (registry/compute-actor-id frame origin-event)
         ;; rf2-bma05 — compute the effective :sensitive? flag once and
-        ;; thread it through the attempt-and-retry loop. Three sources
-        ;; (OR-reduced): per-call args, per-request, and the originating
-        ;; handler's registration metadata. The flag rides every
+        ;; thread it through the attempt-and-retry loop. Two sources
+        ;; (OR-reduced): per-call args and per-request (handler-meta
+        ;; :sensitive? was removed per rf2-hjs2d). The flag rides every
         ;; :rf.http/* trace event emitted within the cascade so
         ;; consumers honour the privacy contract per Spec 009 §Privacy.
         sensitive?   (privacy/request-sensitive? args-map origin-event)

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -66,7 +66,7 @@
      The single `signal` Fetch accepts is always our internal one; any
      caller signal funnels through `addEventListener` for cancellation."
      [{:keys [method url headers body credentials mode redirect cache referrer
-              integrity timeout-ms abort-signal internal-controller]}]
+              integrity timeout-ms abort-signal internal-controller decode]}]
      (let [init     #js {}
            _        (do (aset init "method" (str/upper-case (name method)))
                         (when (seq headers)
@@ -122,13 +122,43 @@
                                                  timeout-ms)))))])
                (.then (fn [resp]
                         (when-let [h @timeout-handle] (js/clearTimeout h))
-                        (-> (.text resp)
-                            (.then (fn [body-text]
-                                     {:ok? (.-ok resp)
-                                      :status (.-status resp)
-                                      :status-text (.-statusText resp)
-                                      :headers (fetch-headers->map (.-headers resp))
-                                      :body-text body-text}))))))]
+                        (let [ok?     (.-ok resp)
+                              headers (fetch-headers->map (.-headers resp))
+                              base    {:ok?         ok?
+                                       :status      (.-status resp)
+                                       :status-text (.-statusText resp)
+                                       :headers     headers}
+                              ;; rf2-5zj6t — a Fetch Response body may be
+                              ;; consumed only once, so the body-reader is
+                              ;; chosen up front from the resolved `:decode`
+                              ;; mode (mirroring `decode-response-body`).
+                              ;; Binary modes (`:blob` / `:array-buffer` /
+                              ;; `:form-data`) read the native body and ride
+                              ;; under `:body-binary`; everything else (and
+                              ;; every non-2xx response, whose raw text is
+                              ;; what the 4xx/5xx failure paths carry) reads
+                              ;; `.text()` into `:body-text`. Decode runs
+                              ;; only on 2xx, so a non-OK response always
+                              ;; takes the text path regardless of `:decode`.
+                              bin-kind (when ok?
+                                         (decode/binary-read-kind decode headers))]
+                          (case bin-kind
+                            :blob
+                            (-> (.blob resp)
+                                (.then (fn [b] (assoc base :body-binary b))))
+
+                            :array-buffer
+                            (-> (.arrayBuffer resp)
+                                (.then (fn [b] (assoc base :body-binary b))))
+
+                            :form-data
+                            (-> (.formData resp)
+                                (.then (fn [b] (assoc base :body-binary b))))
+
+                            ;; nil / text-based decode → read text.
+                            (-> (.text resp)
+                                (.then (fn [body-text]
+                                         (assoc base :body-text body-text)))))))))]
        promise)))
 
 #?(:cljs
@@ -644,7 +674,7 @@
   the failure category is `:rf.http/decode-failure`."
   [ctx result]
   (let [{:keys [decode decode-supplied? accept request-id url]} ctx
-        {:keys [ok? status status-text headers body-text]} result]
+        {:keys [ok? status status-text headers body-text body-binary]} result]
     (cond
       (and (>= status 400) (< status 500))
       (maybe-retry! ctx
@@ -666,6 +696,12 @@
       (try
         (let [decoded  (decode/decode-response-body
                          {:body-text        body-text
+                          ;; rf2-5zj6t — the CLJS transport reads a native
+                          ;; Blob / ArrayBuffer / FormData for binary decode
+                          ;; modes and rides it here; `decode-response-body`
+                          ;; returns it verbatim for `:blob` / `:array-buffer`
+                          ;; / `:form-data`. Absent on the text path / on JVM.
+                          :body-binary      body-binary
                           :headers          headers
                           :decode           decode
                           :decode-supplied? decode-supplied?
@@ -877,7 +913,12 @@
                         :integrity           (:integrity request)
                         :timeout-ms          timeout-ms
                         :abort-signal        abort-signal
-                        :internal-controller internal-controller})
+                        :internal-controller internal-controller
+                        ;; rf2-5zj6t — the transport picks the Fetch
+                        ;; body-reader (`.text()` vs `.blob()` /
+                        ;; `.arrayBuffer()` / `.formData()`) from the
+                        ;; resolved decode mode; pass it through.
+                        :decode              (:decode ctx)})
            (.then (fn [result] (handle-response! ctx' result)))
            ;; rf2-r40km — pass `url` so `classify-cljs-error` can
            ;; distinguish `:rf.http/cors` from `:rf.http/transport`

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -9,7 +9,7 @@
 
   Also covers rf2-r40km — the CLJS-only `:rf.http/cors` classification
   branch of `re-frame.http-transport/classify-cljs-error`."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [re-frame.http :as rf.http]
             [re-frame.http-transport :as transport]))
 
@@ -17,6 +17,12 @@
 ;; transport's public surface for one CLJS-only branch.
 (def ^:private classify-cljs-error
   @#'transport/classify-cljs-error)
+
+;; rf2-5zj6t — reach the private CLJS Fetch transport so we can assert it
+;; reads the correct response body type per `:decode` (a Fetch Response
+;; body may be consumed only once, so the reader is chosen up front).
+(def ^:private cljs-fetch
+  @#'transport/cljs-fetch)
 
 (deftest get-helper-shape
   (testing "(rf.http/get url) produces [:rf.http/managed {:request {:method :get :url url}}]"
@@ -124,3 +130,120 @@
           out (classify-cljs-error err "https://other.invalid/x")]
       (is (= :rf.http/transport (:kind out))
           "non-TypeError stays at :rf.http/transport regardless of URL"))))
+
+;; ---- rf2-5zj6t — binary decode reads the native Fetch body ---------------
+
+(defn- fake-response
+  "A minimal Fetch `Response` stand-in. Each body-reader resolves to a
+  distinct sentinel so the test can prove which reader the transport
+  picked. `.text` returns a string; the binary readers return native
+  stand-in objects."
+  [{:keys [status content-type blob-val ab-val fd-val text-val]}]
+  #js {:ok          (and (>= status 200) (< status 300))
+       :status      status
+       :statusText  ""
+       ;; A Fetch-`Headers`-like object: `forEach (v k)` per `fetch-headers->map`.
+       :headers     #js {:forEach (fn [cb]
+                                    (when content-type (cb content-type "content-type")))}
+       :text        (fn [] (js/Promise.resolve text-val))
+       :blob        (fn [] (js/Promise.resolve blob-val))
+       :arrayBuffer (fn [] (js/Promise.resolve ab-val))
+       :formData    (fn [] (js/Promise.resolve fd-val))})
+
+(defn- with-stub-fetch
+  "Run `f` with `js/fetch` stubbed to resolve `resp`, restoring the
+  original afterwards. Returns the Promise `f` produces."
+  [resp f]
+  (let [orig (.-fetch js/globalThis)]
+    (set! (.-fetch js/globalThis) (fn [_url _init] (js/Promise.resolve resp)))
+    (-> (f)
+        (.finally (fn [] (set! (.-fetch js/globalThis) orig))))))
+
+(deftest binary-decode-reads-native-blob
+  (testing "rf2-5zj6t — `:decode :blob` reads the response via `.blob()`,
+  riding the native Blob under `:body-binary` (NOT the lossy `.text()`
+  string under `:body-text`). The pre-fix transport always read `.text`,
+  so a `:blob` decode resolved to the body-TEXT string."
+    (async done
+      (let [blob (js-obj "__kind" "blob")
+            resp (fake-response {:status       200
+                                 :content-type "image/png"
+                                 :blob-val     blob
+                                 :text-val     "lossy-utf8-text"})]
+        (-> (with-stub-fetch resp
+              #(cljs-fetch {:method  :get
+                            :url     "/img.png"
+                            :headers {}
+                            :decode  :blob
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is (identical? blob (:body-binary result))
+                         ":body-binary carries the native Blob from `.blob()`")
+                     (is (nil? (:body-text result))
+                         "the lossy `.text()` string is NOT read for a `:blob` decode")
+                     (is (true? (:ok? result)))
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
+(deftest array-buffer-and-form-data-read-native-bodies
+  (testing "rf2-5zj6t — `:array-buffer` reads via `.arrayBuffer()` and
+  `:form-data` reads via `.formData()`, each riding `:body-binary`."
+    (async done
+      (let [ab (js-obj "__kind" "ab")
+            fd (js-obj "__kind" "fd")]
+        (-> (with-stub-fetch (fake-response {:status 200 :content-type "application/octet-stream"
+                                             :ab-val ab :text-val "txt"})
+              #(cljs-fetch {:method :get :url "/x" :headers {} :decode :array-buffer
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is (identical? ab (:body-binary result))
+                         ":array-buffer rides the native ArrayBuffer")
+                     (is (nil? (:body-text result)))))
+            (.then (fn [_]
+                     (with-stub-fetch (fake-response {:status 200 :content-type "multipart/form-data"
+                                                      :fd-val fd :text-val "txt"})
+                       #(cljs-fetch {:method :get :url "/y" :headers {} :decode :form-data
+                                     :internal-controller (js/AbortController.)}))))
+            (.then (fn [result]
+                     (is (identical? fd (:body-binary result))
+                         ":form-data rides the native FormData")
+                     (is (nil? (:body-text result)))
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
+(deftest text-and-auto-text-still-read-body-text
+  (testing "rf2-5zj6t — non-binary decodes (`:text`, `:json`, omitted/`:auto`
+  over a text Content-Type) still read `.text()` into `:body-text`. The
+  binary-reader change must not regress the common path."
+    (async done
+      (let [resp (fake-response {:status 200 :content-type "application/json"
+                                 :text-val "{\"ok\":true}" :blob-val (js-obj)})]
+        (-> (with-stub-fetch resp
+              #(cljs-fetch {:method :get :url "/api" :headers {} :decode :auto
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is (= "{\"ok\":true}" (:body-text result))
+                         ":auto over application/json reads `.text()`")
+                     (is (nil? (:body-binary result))
+                         "no binary body is read for a text/JSON decode")
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
+(deftest non-2xx-binary-decode-still-reads-text
+  (testing "rf2-5zj6t — a non-OK response (e.g. 404) ALWAYS reads `.text()`
+  regardless of `:decode`, because decode never runs on non-2xx and the
+  4xx/5xx failure paths carry the raw body-text."
+    (async done
+      (let [resp (fake-response {:status 404 :content-type "image/png"
+                                 :blob-val (js-obj "__kind" "blob")
+                                 :text-val "Not Found"})]
+        (-> (with-stub-fetch resp
+              #(cljs-fetch {:method :get :url "/missing.png" :headers {} :decode :blob
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is (= "Not Found" (:body-text result))
+                         "a 404 reads `.text()` even when `:decode :blob`")
+                     (is (nil? (:body-binary result)))
+                     (is (false? (:ok? result)))
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -342,6 +342,78 @@
               (str "non-canonical Content-Type casing " (pr-str ct-key)
                    " must sniff to :json, not :blob")))))))
 
+;; ---- 5e. binary decode reads the native body, not body-text (rf2-5zj6t) ---
+;;
+;; Spec 014 §Decoding lists `:blob` / `:array-buffer` / `:form-data` as
+;; distinct binary decode shapes. The CLJS transport used to always
+;; pre-read the Fetch response via `(.text resp)`, so the binary decode
+;; branches resolved to the body-TEXT string — a caller asking
+;; `:decode :blob` for an image got a lossy UTF-8 string. The fix routes
+;; the resolved decode mode into the transport, which now picks the
+;; correct Fetch reader (`.blob()` / `.arrayBuffer()` / `.formData()`)
+;; and rides the native body under `:body-binary`; `decode-response-body`
+;; returns it verbatim for the binary branches.
+;;
+;; `binary-read-kind` is the pure resolution helper the transport calls
+;; BEFORE consuming the body (a Fetch Response body may be read once).
+;; These JVM unit tests exercise it and the `decode-response-body`
+;; binary-return path directly with stand-in binary values — they fail
+;; deterministically against the pre-fix code (which returned the text
+;; string for every binary mode).
+
+(deftest binary-read-kind-resolves-binary-decode-modes
+  (testing "explicit binary modes resolve to themselves"
+    (is (= :blob         (http-decode/binary-read-kind :blob {})))
+    (is (= :array-buffer (http-decode/binary-read-kind :array-buffer {})))
+    (is (= :form-data    (http-decode/binary-read-kind :form-data {}))))
+  (testing "text-based / structured modes resolve to nil (read .text)"
+    (is (nil? (http-decode/binary-read-kind :json {})))
+    (is (nil? (http-decode/binary-read-kind :text {})))
+    (is (nil? (http-decode/binary-read-kind (fn [_ _] :decoded) {})))
+    (is (nil? (http-decode/binary-read-kind [:map] {}))
+        "a Malli schema is a text (JSON-parse) mode, not binary"))
+  (testing ":auto sniffs the Content-Type — binary type → :blob (rf2-5zj6t)"
+    (is (= :blob (http-decode/binary-read-kind :auto {"content-type" "image/png"}))
+        ":auto over a binary Content-Type reads as a Blob, not lossy text")
+    (is (= :blob (http-decode/binary-read-kind nil {"content-type" "application/octet-stream"}))
+        "omitted :decode (== :auto) over a binary Content-Type also reads binary"))
+  (testing ":auto sniffs the Content-Type — text/JSON → nil (read .text)"
+    (is (nil? (http-decode/binary-read-kind :auto {"content-type" "application/json"})))
+    (is (nil? (http-decode/binary-read-kind :auto {"content-type" "text/plain"})))
+    (is (nil? (http-decode/binary-read-kind nil  {"content-type" "text/html"})))))
+
+(deftest decode-response-body-returns-native-binary-for-binary-modes
+  (testing "binary decode modes return the pre-read :body-binary verbatim"
+    ;; Stand-in for the native Blob / ArrayBuffer / FormData the CLJS
+    ;; transport reads. The decode pipeline must return THIS value, not
+    ;; the body-text string (the pre-fix bug).
+    (let [native (Object.)]
+      (doseq [mode [:blob :array-buffer :form-data]]
+        (testing (str "mode: " mode)
+          (is (identical? native
+                          (http-decode/decode-response-body
+                            {:body-text   "lossy-utf8-text"
+                             :body-binary native
+                             :headers     {}
+                             :decode      mode
+                             :decode-supplied? true
+                             :request-id  :test/req
+                             :url         "/test"
+                             :sensitive?  false}))
+              (str mode " must return the native binary body, not body-text"))))))
+  (testing "binary mode with no :body-binary (e.g. JVM transport) falls back to body-text"
+    (doseq [mode [:blob :array-buffer :form-data]]
+      (is (= "raw-payload"
+             (http-decode/decode-response-body
+               {:body-text        "raw-payload"
+                :headers          {}
+                :decode           mode
+                :decode-supplied? true
+                :request-id       :test/req
+                :url              "/test"
+                :sensitive?       false}))
+          (str mode " with absent :body-binary returns the raw body-text payload")))))
+
 ;; ---- 6. retry exhaustion --------------------------------------------------
 
 (deftest jvm-retry-exhaustion

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -1090,30 +1090,22 @@ Apps extend the denylist for app-specific tokens (e.g. `shop_token` for Shopify,
 
 Names stored lower-cased; matching is case-insensitive. The default denylist is fixed at boot; the app-extended set is mutable and clearable for test ergonomics via `(rf.http/clear-sensitive-query-params!)`.
 
-A query-param denylist hit **alone** (no per-handler / per-call `:sensitive?`) **stamps `:sensitive? true`** on the resulting trace event — the presence of a denylisted parameter name is itself a signal that the request carries an auth secret, and downstream privacy-honouring consumers should treat the event accordingly. This is the analogue of the header denylist contract: the name is the signal.
+A query-param denylist hit **alone** (no per-request / per-call `:sensitive?`) **stamps `:sensitive? true`** on the resulting trace event — the presence of a denylisted parameter name is itself a signal that the request carries an auth secret, and downstream privacy-honouring consumers should treat the event accordingly. This is the analogue of the header denylist contract: the name is the signal.
 
-### 3. Per-call / per-request / per-handler `:sensitive?`
+### 3. Per-request / per-call `:sensitive?`
 
-Three OR-reduced sources contribute the request-side `:sensitive?` flag for a given `:rf.http/managed` invocation:
+Two OR-reduced sources contribute the request-side `:sensitive?` flag for a given `:rf.http/managed` invocation:
 
-1. **Handler-level** — `:sensitive? true` on the originating event handler's `:rf/registration-metadata` map (per [Spec 009 §The `:sensitive?` registration metadata key](009-Instrumentation.md#the-sensitive-registration-metadata-key)). The conventional site: the event handler that owns the request. Every `:rf.http/managed` dispatched from within a `:sensitive?`-marked handler inherits the flag.
+1. **Per-request** — `:sensitive? true` under the `:request` map of the `:rf.http/managed` args. The conventional site for opting a single request in (e.g. a generic POST handler that becomes sensitive only when posting to `/auth/login`). Composes with `:request-content-type`, `:body`, etc. unchanged.
 
-2. **Per-request** — `:sensitive? true` under the `:request` map of the `:rf.http/managed` args. For requests where the handler itself is not sensitive but **this specific call** is (e.g. a generic POST handler that becomes sensitive only when posting to `/auth/login`). Composes with `:request-content-type`, `:body`, etc. unchanged.
+2. **Per-call** — `:sensitive? true` at the top level of the `:rf.http/managed` args map. Pragmatic sugar for callers that prefer the flag alongside `:on-success` / `:on-failure` rather than nested under `:request`. Semantically identical to per-request.
 
-3. **Per-call** — `:sensitive? true` at the top level of the `:rf.http/managed` args map. Pragmatic sugar for callers that prefer the flag alongside `:on-success` / `:on-failure` rather than nested under `:request`. Semantically identical to per-request.
+Either source set to `true` makes the request sensitive; both sources defaulting to `false`/absent means not sensitive. The runtime resolves the effective flag once at fx-invocation time and threads it through the attempt-and-retry loop so every `:rf.http/*` trace event the cascade emits sees the same flag (no per-emit re-resolution).
 
-Any source set to `true` makes the request sensitive; all sources defaulting to `false`/absent means not sensitive. The runtime resolves the effective flag once at fx-invocation time and threads it through the attempt-and-retry loop so every `:rf.http/*` trace event the cascade emits sees the same flag (no per-emit re-resolution).
+Handler-meta `:sensitive?` is **not** a source — the handler-level `:rf/registration-metadata` annotation has been removed (per rf2-hjs2d, see [Spec 009 §The `:sensitive?` registration metadata key](009-Instrumentation.md#the-sensitive-registration-metadata-key)). Sensitivity is now declared per-request / per-call (the request-side opt-ins here) and, on the trace surface, schema-derived (Spec 009 §Schema-installed redaction). A query-param denylist hit ([§2](#2-query-param-denylist-always-on-rf2-2p8wr)) is a third, automatic stamping signal independent of these opt-ins.
 
 ```clojure
-;; Handler-level (Spec 009 §Privacy — the inherited form):
-(rf/reg-event-fx :auth/sign-in
-  {:doc        "Verify credentials and start a session."
-   :sensitive? true}
-  (fn [_ [_ creds]]
-    {:fx [[:rf.http/managed
-           {:request {:method :post :url "/auth" :body creds}}]]}))
-
-;; Per-request — a non-sensitive handler with one sensitive call:
+;; Per-request — opt a single request in:
 (rf/reg-event-fx :api/proxy
   (fn [_ [_ {:keys [target body]}]]
     {:fx [[:rf.http/managed
@@ -1137,9 +1129,9 @@ For every `:rf.http/*` trace event the runtime emits (`:rf.http/retry-attempt`, 
 3. **Redact body / body-text / decoded / detail** slots when the effective `:sensitive?` is true. Specifically: `:body` (request and response), `:body-text` (decode-failure raw text), `:decoded` (the pre-`:accept` decoded value carried by `:rf.http/accept-failure`), and `:detail` (the user-supplied failure map carried by `:rf.http/accept-failure`). All slot values become `:rf/redacted`.
 4. **Redact `:params`** (the structured query-string params map on the request side) when the effective `:sensitive?` is true. The whole `:params` map value becomes `:rf/redacted`.
 5. **Redact ALL `:url` query-string param values** when the effective `:sensitive?` is true (broader rule than the always-on denylist) — when the request is sensitive, anything that rides the wire is. Non-denylisted params (e.g. `user_id=42`) are scrubbed alongside denylisted ones.
-6. **Stamp `:sensitive?`** on the trace event per [Spec 009 §Trace-event field](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level). The canonical contract is that the flag rides at the top level of the trace envelope (consumers consult `(:sensitive? ev)` for a one-keyword read). The HTTP layer stamps `:sensitive? true` on the tags map passed to `trace/emit!` / `trace/emit-error!`. A **query-param denylist hit alone** (no per-handler / per-call `:sensitive?`) also stamps `:sensitive? true` — the denylisted name is itself the signal. If the core trace surface implements the [rf2-isdwf](#) hoist (Spec 009 §Privacy core-stamping), the flag is moved from tags to top-level by the emit walker; if core does not yet hoist, the flag stays under `:tags`. Once core lands the hoist universally, the tags-slot becomes redundant but harmless. Absent (NOT `false`) when not sensitive — per Spec 009 line 1176 "Consumers treat absent as false."
+6. **Stamp `:sensitive?`** on the trace event per [Spec 009 §Trace-event field](009-Instrumentation.md#trace-event-field-sensitive-at-the-top-level). The canonical contract is that the flag rides at the top level of the trace envelope (consumers consult `(:sensitive? ev)` for a one-keyword read). The HTTP layer stamps `:sensitive? true` on the tags map passed to `trace/emit!` / `trace/emit-error!`. A **query-param denylist hit alone** (no per-request / per-call `:sensitive?`) also stamps `:sensitive? true` — the denylisted name is itself the signal. If the core trace surface implements the [rf2-isdwf](#) hoist (Spec 009 §Privacy core-stamping), the flag is moved from tags to top-level by the emit walker; if core does not yet hoist, the flag stays under `:tags`. Once core lands the hoist universally, the tags-slot becomes redundant but harmless. Absent (NOT `false`) when not sensitive — per Spec 009 line 1176 "Consumers treat absent as false."
 
-The cascade-wide stamping uses the **innermost in-scope handler** rule from [Spec 009 §Privacy](009-Instrumentation.md#the-sensitive-registration-metadata-key): each handler in a cascade contributes its own `:sensitive?` reading. A sensitive handler dispatching a non-sensitive child event does NOT transitively widen the flag — the HTTP fx fired inside the child handler's scope reflects the child's flag. The OR-reduce-by-cascade rollup is the consumer's responsibility (group by `:dispatch-id`).
+The `:sensitive?` flag a `:rf.http/*` trace event carries is the one resolved for **that specific request** from its per-request / per-call opt-ins (plus any automatic query-param-denylist stamp). Sensitivity does not transitively propagate across a dispatch cascade — a request fired from a non-sensitive call stays non-sensitive even when an ancestor handler in the cascade fired a sensitive request, and vice versa. The OR-reduce-by-cascade rollup, if a consumer wants one, is the consumer's responsibility (group by `:dispatch-id`).
 
 ### Composition
 
@@ -1150,7 +1142,7 @@ The cascade-wide stamping uses the **innermost in-scope handler** rule from [Spe
 | × Spec 014 §Middleware | Request-side interceptors run **before** the privacy machinery reads `:sensitive?` (the interceptor chain may itself attach an `Authorization` header). Headers added by interceptors are subject to the same denylist. |
 | × Spec 014 §Failure categories | Every category that carries body-side payload (`:rf.http/http-4xx`, `:rf.http/http-5xx`, `:rf.http/decode-failure`, `:rf.http/accept-failure`) gets the redaction treatment when sensitive. `:rf.http/aborted` carries no body so no body redaction; headers (the denylist) still apply. |
 | × Spec 005 actor-destroy abort | The in-flight handle propagates the effective `:sensitive?` flag, so the `:rf.http/aborted-on-actor-destroy` emit (issued from the registry namespace, distant from the originating fx ctx) still stamps correctly. |
-| × WebSockets (future) | When `:rf.ws/*` (per [Pattern-WebSocket](Pattern-WebSocket.md)) lands, it inherits the same denylist + per-handler / per-call `:sensitive?` machinery; the per-message frame-stamping rule is its own affair, but the request-side concerns are shared. |
+| × WebSockets (future) | When `:rf.ws/*` (per [Pattern-WebSocket](Pattern-WebSocket.md)) lands, it inherits the same denylist + per-request / per-call `:sensitive?` machinery; the per-message frame-stamping rule is its own affair, but the request-side concerns are shared. |
 
 ### Production elision
 
@@ -1179,15 +1171,11 @@ Adjacent surfaces that are first-class re-frame2 commitments but live in their o
 
 ## Open questions
 
-> **SA-4 classification (rf2-p6xyh).** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): all four items classify as **`:post-v1 tracked`** — additive surfaces that do not block v1.
+> **SA-4 classification (rf2-p6xyh).** Per [SPEC-AUTHORING §SA-4](SPEC-AUTHORING.md): all three items classify as **`:post-v1 tracked`** — additive surfaces that do not block v1.
 
 ### Response-side middleware composition (post-v1, rf2-ean6m)
 
 Per [§Middleware](#middleware) (rf2-6y3q) v1 ships request-side middleware only. A response-side `:after` slot — composing additively with `:accept` and `:before` — would let apps project / log / retry on response paths without per-event boilerplate. Deferred to rf2-ean6m until the request-side surface settles in practice and the composition order with `:accept` is decided.
-
-### App-extensible query-param denylist (post-v1, rf2-j3nfp)
-
-Per [§2. Query-param denylist (always-on)](#2-query-param-denylist-always-on-rf2-2p8wr) (rf2-2p8wr) the always-on query-string denylist is a fixed framework-owned set. An extensible registration surface (`rf.http/declare-sensitive-query-param!` parallel to the header denylist) is a natural addition — deferred to rf2-j3nfp until a real app surfaces a query-param-auth pattern outside the default set.
 
 ### Streaming responses (`:rf.http/streaming`) (post-v1, rf2-jg6by)
 
@@ -1225,7 +1213,7 @@ Per [§Aborts](#aborts) (rf2-wvkn) `:rf.http/managed` requests issued from insid
 
 ### Privacy honoured via `:sensitive?` on HTTP trace events (rf2-bma05)
 
-Per [§Privacy](#privacy) (rf2-bma05) the `:rf.http/*` trace events honour the [Spec 009 §`:sensitive?`](009-Instrumentation.md#privacy--sensitive-data-in-traces) contract: per-call, per-request, and per-handler `:sensitive?` flags OR-reduce; the framework redacts request/response bodies and a 12-name header denylist (`authorization`, `cookie`, `set-cookie`, etc.). Headers were chosen as the always-on default surface because they carry the highest-value secrets (auth tokens) across the largest fraction of apps. Apps register their own sensitive headers via `rf.http/declare-sensitive-header!`.
+Per [§Privacy](#privacy) (rf2-bma05) the `:rf.http/*` trace events honour the [Spec 009 §`:sensitive?`](009-Instrumentation.md#privacy--sensitive-data-in-traces) contract: per-call and per-request `:sensitive?` flags OR-reduce (handler-meta `:sensitive?` is no longer a source per rf2-hjs2d); the framework redacts request/response bodies and a 12-name header denylist (`authorization`, `cookie`, `set-cookie`, etc.). Headers were chosen as the always-on default surface because they carry the highest-value secrets (auth tokens) across the largest fraction of apps. Apps register their own sensitive headers via `rf.http/declare-sensitive-header!`.
 
 ### Query-string denylist is always-on (rf2-2p8wr)
 

--- a/spec/Pattern-FormAction.md
+++ b/spec/Pattern-FormAction.md
@@ -181,7 +181,7 @@ The `:tempfile` is host-specific (Ring exposes a `java.io.File`; other adapters 
 
 - File contents MUST NOT appear in trace events. Implementations MUST treat the `:tempfile` slot as opaque and emit only the metadata fields (`:filename`, `:content-type`, `:size`) in trace events.
 - The header denylist ([014 §Header denylist](014-HTTPRequests.md#1-header-denylist-always-on)) applies unchanged for multipart requests: `Authorization`, `Cookie`, etc. remain redacted.
-- When the form is sensitive (`:sensitive? true` on the action handler per [014 §Per-call / per-request / per-handler `:sensitive?`](014-HTTPRequests.md#3-per-call--per-request--per-handler-sensitive)), implementations MUST redact the entire `:form-params` map in trace events — file metadata included, because filenames can themselves leak (`/tmp/passport.pdf`).
+- When the form is sensitive (`:sensitive? true` on the action's request per [014 §Per-request / per-call `:sensitive?`](014-HTTPRequests.md#3-per-request--per-call-sensitive)), implementations MUST redact the entire `:form-params` map in trace events — file metadata included, because filenames can themselves leak (`/tmp/passport.pdf`).
 
 Apps that need fine-grained file-vs-field privacy (sensitive password field + non-sensitive avatar file in the same form) split into two separate POSTs.
 
@@ -258,7 +258,7 @@ A form-action implementation conforms to this convention when:
 - [010-Schemas.md §Validation timing](010-Schemas.md#validation-timing) — the `:spec` boundary check that runs on every dispatched event.
 - [010-Schemas.md §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces-rf2-kj51z) — how `:sensitive?` propagates through schema-validation error reporting.
 - [014-HTTPRequests.md §Header denylist (always-on)](014-HTTPRequests.md#1-header-denylist-always-on) — the canonical sensitive-header set, including `X-CSRF-Token` / `X-XSRF-Token`.
-- [014-HTTPRequests.md §Per-call / per-request / per-handler `:sensitive?`](014-HTTPRequests.md#3-per-call--per-request--per-handler-sensitive) — how the action handler's `:sensitive? true` flag propagates to the request-side cascade for the JS-fetch path.
+- [014-HTTPRequests.md §Per-request / per-call `:sensitive?`](014-HTTPRequests.md#3-per-request--per-call-sensitive) — how the action's per-request / per-call `:sensitive? true` flag propagates to the request-side cascade for the JS-fetch path.
 - [Pattern-Forms.md](Pattern-Forms.md) — the form-slice shape, the seven standard events, the per-field-error-visibility rule, and `:_form` form-level errors. This pattern reuses all of it on the server side.
 - [Pattern-SSR-Loaders.md](Pattern-SSR-Loaders.md) — the sibling pattern for the GET path: parallel data fetch during the drain. A page may use both — Loaders for the initial render, FormAction for subsequent POSTs.
 - [012-Routing.md](012-Routing.md) — the route-table that the action-event registry keys against.


### PR DESCRIPTION
## Summary

Three HTTP items — two Spec 014 reconciliations and one CLJS transport bug fix.

- **rf2-gvm39 (spec)** — Spec 014 §3 still listed handler-level `:sensitive?` registration metadata as an OR-reduced sensitivity source, contradicting both the impl (which dropped it per rf2-hjs2d) and the spec's own §Production-elision note. Reconciled §3 (heading, intro, examples) and the dependent §Privacy / §Composition / Resolved-decisions text to the two-source reality: **per-request** and **per-call** only. Fixed the matching stale comment in `http_handlers/normalise-args` and the two cross-references in `Pattern-FormAction.md`.
- **rf2-wz0rh (spec)** — `declare-sensitive-query-param!` / `clear-sensitive-query-params!` ship in the impl and §2 documents them as shipping, but §Open-questions still deferred them to post-v1. Struck the stale deferral; dropped the SA-4 item count from four to three.
- **rf2-5zj6t (bug)** — the CLJS Fetch transport always pre-read `(.text resp)`, so `:decode :blob` / `:array-buffer` / `:form-data` resolved to the body-TEXT string instead of a native binary body (lossy for images, etc.). `:auto` over a binary Content-Type sniffs to `:blob`, so the omitted-`:decode` path was lossy too. A Fetch Response body may be read only once, so the reader is now chosen up front from the resolved decode mode: `cljs-fetch` reads `.blob()` / `.arrayBuffer()` / `.formData()` for binary 2xx responses (riding `:body-binary`) and `.text()` otherwise. Non-2xx always reads text (decode never runs on non-2xx; the 4xx/5xx paths carry raw body-text). `decode-response-body` returns the native binary verbatim for the binary branches, falling back to `body-text` when absent (the JVM path, which reads `.body` as a String).

## Test plan

- [x] `mkdocs build --strict` passes (no dangling anchors after the §3 rename)
- [x] http JVM `clojure -M:test` — 227 tests / 1283 assertions / 0 failures (incl. new `binary-read-kind` + `decode-response-body` binary unit tests)
- [x] `npm run test:cljs` — 3915 tests / 11907 assertions / 0 failures (incl. new async `cljs-fetch` tests stubbing `js/fetch` to prove the correct body reader per `:decode`)