### PR TITLE
fix(machines): reconcile depth boundary + destroyed/exit trace order + test arity (rf2-r26e2 + rf2-iilco + rf2-jk0hf)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/destroy.cljc
@@ -92,6 +92,11 @@
                            [:rf/spawned parent-id invoke-id])
         children   (when (map? join-state) (:children join-state))]
     (doseq [[child-id spawned-id] children]
+      ;; (rf2-iilco) `destroy-single-actor!` runs the child's `:exit`
+      ;; cascade before teardown; we fire `:rf.machine/destroyed` AFTER it
+      ;; so the trace lands after `:exit` — the same exit-then-destroyed
+      ;; ordering `destroy-single!` and `finalize-machine` use.
+      (destroy-single-actor! frame-id spawned-id)
       ;; rf2-gn80 D6 — `:reason :explicit` discriminates "the parent cascade
       ;; tore the child down" from `:rf.machine/finished` (the auto-destroy
       ;; on `:final?`). Per-child fires omit `:system-id` (the join-state's
@@ -100,8 +105,7 @@
                                :actor-id  spawned-id
                                :parent-id parent-id
                                :spawn-id invoke-id
-                               :child-id  child-id})
-      (destroy-single-actor! frame-id spawned-id))
+                               :child-id  child-id}))
     ;; Clear the join-state slot via the unified projection (slot-only).
     (frame/swap-frame-db! frame-id
                           (fn [db]
@@ -185,17 +189,16 @@
                            (and tracked? (some? slot-id))))]
     (when live?
       (let [released-sid (teardown/find-system-id-for-actor old-db actor-id)]
-        ;; rf2-gn80 D6 — `:reason :explicit` discriminates "an action / fx
-        ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
-        ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
-        ;; the destroyed-trace-shape contract for the `destroy-single!` site.
-        (traces/emit-destroyed! {:frame     frame-id
-                                 :actor-id  actor-id
-                                 :system-id released-sid
-                                 :parent-id parent-id
-                                 :spawn-id invoke-id})
         ;; (rf2-nahfm) Run the active configuration's `:exit` cascade
-        ;; BEFORE the teardown projection clears the snapshot.
+        ;; BEFORE the teardown projection clears the snapshot — and
+        ;; BEFORE the `:rf.machine/destroyed` trace (rf2-iilco). Per Spec
+        ;; 005 §Declarative `:spawn` §Composition with explicit `:entry` /
+        ;; `:exit` (005:2138) the `:exit` action gets to read the actor's
+        ;; final snapshot before the auto-destroy clears it, so a consumer
+        ;; observing the db between `:exit` and `:rf.machine/destroyed`
+        ;; sees the live snapshot. This mirrors `finalize-machine`'s order
+        ;; (exit cascade → teardown → destroyed) so both destroy entry-
+        ;; points share one ordering convention.
         (exit-cascade/run-child-exit! frame-id actor-id)
         (finalize/abort-actor-in-flight-http! actor-id)
         (frame/swap-frame-db! frame-id
@@ -204,6 +207,17 @@
                                          db {:actor-id  actor-id
                                              :parent-id parent-id
                                              :spawn-id invoke-id}))))
+        ;; rf2-gn80 D6 — `:reason :explicit` discriminates "an action / fx
+        ;; tore the actor down" from `:rf.machine/finished` (the auto-destroy
+        ;; on `:final?`). Always stamp `:system-id` (nil when not bound) per
+        ;; the destroyed-trace-shape contract for the `destroy-single!` site.
+        ;; `released-sid` was resolved from `old-db` above, before teardown
+        ;; mutated the reverse index — symmetric with `finalize-machine`.
+        (traces/emit-destroyed! {:frame     frame-id
+                                 :actor-id  actor-id
+                                 :system-id released-sid
+                                 :parent-id parent-id
+                                 :spawn-id invoke-id})
         (traces/emit-system-id-released! frame-id released-sid actor-id)
         ;; Unregister the live handler. Last so any in-flight trace emit
         ;; against the actor still resolves before the slot disappears.

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1281,7 +1281,11 @@
          snap    snapshot
          depth   0]
     (cond
-      (> depth depth-limit)
+      ;; `>=` (not `>`) so the `:raise` drain permits exactly `depth-limit`
+      ;; recursions (depths 0..limit-1) — parity with the `:always` microstep
+      ;; loop's `(>= depth always-limit)` bound (rf2-r26e2). Both default 16
+      ;; with identical intent per Spec 005 §Bounded depth (005:1276).
+      (>= depth depth-limit)
       (do (trace/emit-error! :rf.error/machine-raise-depth-exceeded
                              {;; The live runtime spec carries the machine
                               ;; id under `:rf/parent-id`; the spec map forbids

--- a/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
+++ b/implementation/machines/test/re_frame/destroyed_exit_order_test.clj
@@ -1,0 +1,157 @@
+(ns re-frame.destroyed-exit-order-test
+  "Per rf2-iilco — the `:rf.machine/destroyed` trace fires AFTER the
+  child's active-configuration `:exit` cascade on EVERY destroy path.
+
+  Before rf2-iilco the explicit / declarative-`:spawn` destroy
+  (`destroy-single!`) and the `:spawn-all` per-child teardown
+  (`destroy-invoke-all-children!`) emitted `:rf.machine/destroyed`
+  BEFORE running `run-child-exit!`, while the final-state auto-destroy
+  (`finalize-machine`) emitted it AFTER the cascade. A consumer keying
+  on `:rf.machine/destroyed` therefore saw the destroy signal at a
+  different point relative to the `:exit` side-effects depending on
+  which entry-point fired — a latent inconsistency for tools (Causa,
+  re-frame-10x, story-mcp) that key on the trace.
+
+  Spec 005 §Declarative `:spawn` §Composition with explicit `:entry` /
+  `:exit` (005:2138) pins the order: the `:exit` action reads the
+  actor's final snapshot *before* the auto-destroy clears it, so a
+  consumer observing the db between `:exit` and `:rf.machine/destroyed`
+  must see the live snapshot. That makes exit-then-destroyed the
+  spec-correct convention; this file pins it on all three paths.
+
+  Mechanism: a shared ordered log captures both the `:exit` action's
+  fire (the action conjes a marker) and the `:rf.machine/destroyed`
+  trace (a listener conjes a marker). The marker order in the log is
+  the observable ordering."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- record-order!
+  "Register a `:rf.machine/destroyed` listener that conjes `:destroyed`
+  onto `log`; returns an unregister thunk."
+  [log]
+  (let [id ::order-listener]
+    (trace/register-listener!
+      id
+      (fn [ev]
+        (when (= :rf.machine/destroyed (:operation ev))
+          (swap! log conj :destroyed))))
+    #(trace/unregister-listener! id)))
+
+(defn- exit-then-destroyed?
+  "True iff the first `:exit` marker precedes the first `:destroyed`
+  marker in the ordered `log`."
+  [log]
+  (let [v (vec log)]
+    (< (.indexOf v :exit) (.indexOf v :destroyed))))
+
+;; ---- Path 1: explicit / declarative-:spawn destroy (destroy-single!) ------
+
+(deftest destroyed-after-exit-on-explicit-destroy
+  (testing "destroy-single! fires :exit BEFORE :rf.machine/destroyed"
+    (let [log   (atom [])
+          unreg (record-order! log)]
+      (try
+        (rf/reg-machine :eo/standalone
+          {:initial :running
+           :data    {}
+           :states  {:running {:exit (fn [_] (swap! log conj :exit) {})}}})
+        (rf/reg-machine :eo/destroyer
+          {:initial :armed
+           :data    {}
+           :states  {:armed {:on {:fire {:action (fn [_]
+                                                   {:fx [[:rf.machine/destroy :eo/standalone]]})}}}}})
+        (rf/dispatch-sync [:eo/standalone [:rf.machine/noop]])
+        (rf/dispatch-sync [:eo/destroyer [:fire]])
+        (is (= [:exit :destroyed] @log)
+            "explicit destroy emits :exit then :rf.machine/destroyed")
+        (is (exit-then-destroyed? @log)
+            ":exit precedes :rf.machine/destroyed")
+        (finally (unreg))))))
+
+(deftest destroyed-after-exit-on-invoke-exit-cascade
+  (testing "declarative :spawn exit cascade (destroy-single!) fires :exit BEFORE :destroyed"
+    (let [log   (atom [])
+          unreg (record-order! log)]
+      (try
+        (rf/reg-machine :eo/child
+          {:initial :working
+           :data    {}
+           :states  {:working {:exit (fn [_] (swap! log conj :exit) {})}}})
+        (rf/reg-machine :eo/parent
+          {:initial :idle
+           :data    {}
+           :states  {:idle    {:on {:start :working}}
+                     :working {:spawn {:machine-id :eo/child}
+                               :on    {:stop :idle}}}})
+        (rf/dispatch-sync [:eo/parent [:start]])            ;; spawn child
+        (rf/dispatch-sync [:eo/parent [:stop]])             ;; exit :working → destroy child
+        (is (= [:exit :destroyed] @log)
+            "declarative :spawn exit cascade emits :exit then :destroyed")
+        (finally (unreg))))))
+
+;; ---- Path 2: :spawn-all per-child teardown (destroy-invoke-all-children!) --
+
+(deftest destroyed-after-exit-on-invoke-all-teardown
+  (testing ":spawn-all per-child teardown fires each :exit BEFORE its :destroyed"
+    (let [log   (atom [])
+          unreg (record-order! log)]
+      (try
+        (rf/reg-machine :eo/ia-child
+          {:initial :working
+           :data    {}
+           :states  {:working {:exit (fn [_] (swap! log conj :exit) {})}}})
+        (rf/reg-machine :eo/ia-parent
+          {:initial :hydrating
+           :data    {}
+           :states  {:hydrating {:spawn-all
+                                  {:children [{:id :a :machine-id :eo/ia-child}
+                                              {:id :b :machine-id :eo/ia-child}]
+                                   :join            :all
+                                   :on-child-done   :ia/done
+                                   :on-child-error  :ia/failed
+                                   :on-all-complete [:go-done]
+                                   :on-any-failed   [:ia/cancel]}
+                                  :on {:go-done   :done
+                                       :ia/cancel :idle}}
+                     :done {}
+                     :idle {}}})
+        (rf/dispatch-sync [:eo/ia-parent [:rf.machine/spawned]])
+        (rf/dispatch-sync [:eo/ia-parent [:ia/cancel]])     ;; tear children down
+        ;; Two children: each fires :exit then :destroyed. The
+        ;; per-child loop runs them sequentially, so the log is a
+        ;; strict [:exit :destroyed :exit :destroyed].
+        (is (= [:exit :destroyed :exit :destroyed] @log)
+            "each child emits :exit then :destroyed, in per-child order")
+        (finally (unreg))))))
+
+;; ---- Path 3: final-state auto-destroy (finalize-machine) ------------------
+
+(deftest destroyed-after-exit-on-final-state-auto-destroy
+  (testing "finalize-machine fires :exit BEFORE :destroyed (the reference order)"
+    (let [log   (atom [])
+          unreg (record-order! log)]
+      (try
+        (rf/reg-machine :eo/final-child
+          {:initial :running
+           :data    {}
+           :states  {:running {:on {:finish :done}}
+                     :done    {:final? true
+                               :exit   (fn [_] (swap! log conj :exit) {})}}})
+        (rf/reg-machine :eo/final-parent
+          {:initial :working
+           :data    {}
+           :states  {:working {:spawn {:machine-id :eo/final-child}}}})
+        (rf/dispatch-sync [:eo/final-parent [:rf.machine/spawned]])
+        (let [spawned-id (get-in (rf/get-frame-db :rf/default)
+                                 [:rf/spawned :eo/final-parent [:working]])]
+          (rf/dispatch-sync [spawned-id [:finish]]))
+        (is (= [:exit :destroyed] @log)
+            "final-state auto-destroy emits :exit then :destroyed (reference order)")
+        (finally (unreg))))))

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -32,7 +32,8 @@
   "
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.machines :as machines]
-            [re-frame.machines.result :as result]))
+            [re-frame.machines.result :as result]
+            [re-frame.trace :as trace]))
 
 (def auth-flow-spec
   "A tiny declarative-`:spawn` machine. On `[:submit]` from `:idle` it
@@ -171,6 +172,85 @@
           ;; and the guard passes — transition to :authed.
           {s ::result/snap} (machines/machine-transition m {:state :checking :data {:authed? true}} [:noop])]
       (is (= :authed (:state s))))))
+
+;; ---- depth-limit boundary parity (rf2-r26e2) ------------------------------
+;;
+;; Per Spec 005 §Bounded depth (005:1276) the `:always` microstep loop and
+;; the `:raise` drain share the same default (16) and the same intent: a
+;; limit of N permits exactly N steps before the cascade aborts uncommitted.
+;; The `:always` loop bounds on `(>= depth limit)`; pre-rf2-r26e2 the
+;; `:raise` drain bounded on `(> depth limit)`, which silently permitted one
+;; extra recursion (N+1). These two tests pin the boundary to N on BOTH
+;; paths so the operators can never drift apart again.
+;;
+;; The boundary is a pure-engine property, observed here via the `:depth`
+;; tag the depth-exceeded error trace carries: with the `>=` boundary the
+;; abort fires at `depth == limit`, so the trace's `:depth` equals the limit
+;; (not limit+1).
+
+(defn- capture-error-depth!
+  "Drive a pure `machine-transition` while a tooling listener records traces,
+  returning the `:depth` tag of the first error trace whose `:operation`
+  matches `error-op` (or nil if none fired)."
+  [error-op definition snapshot event]
+  (let [seen (atom [])]
+    (trace/register-listener! ::depth-probe (fn [ev] (swap! seen conj ev)))
+    (try
+      (machines/machine-transition definition snapshot event)
+      (finally (trace/unregister-listener! ::depth-probe)))
+    (->> @seen
+         (filter #(= error-op (:operation %)))
+         first
+         :tags
+         :depth)))
+
+(deftest always-depth-boundary-permits-exactly-limit-microsteps
+  (testing ":always loop with :always-depth-limit N aborts at depth N
+   (>= boundary) — permits exactly N microsteps"
+    ;; Two states ping-pong via always-true `:always` guards. With the
+    ;; limit set to 4 the loop runs microsteps at depths 0..3, then aborts
+    ;; at depth 4. The error trace's `:depth` is therefore 4 (== the limit).
+    (let [spec {:initial :start
+                :data    {}
+                :always-depth-limit 4
+                :guards  {:p? (fn [_] true)}
+                :states  {:start {:on {:go {:target :a}}}
+                          :a     {:always [{:guard :p? :target :b}]}
+                          :b     {:always [{:guard :p? :target :a}]}}}
+          depth (capture-error-depth!
+                  :rf.error/machine-always-depth-exceeded
+                  spec {:state :start :data {}} [:go])]
+      (is (= 4 depth)
+          ":always aborts at depth == limit (4), permitting exactly 4 microsteps"))))
+
+(deftest raise-depth-boundary-matches-always-boundary
+  (testing ":raise drain with :raise-depth-limit N aborts at depth N
+   (>= boundary, rf2-r26e2) — parity with the :always loop, not N+1"
+    ;; The `drain-raises` depth counts raises drained from the queue. A
+    ;; fanned-out batch of more raises than the limit feeds the loop past
+    ;; the bound (same shape as raise-depth-exceeded-tag-carries-frame).
+    ;; With :raise-depth-limit 4 and 6 raises in one batch the drain
+    ;; processes raises at depths 0..3 then aborts at depth 4 — the SAME
+    ;; boundary the :always loop above hits at its limit. Pre-rf2-r26e2
+    ;; (`> depth limit`) the abort fired at depth 5 (N+1), one past parity.
+    (let [spec {:initial :idle
+                :data    {}
+                :raise-depth-limit 4
+                :actions {:fan-out (fn [_]
+                                     {:fx [[:raise [:noop]]
+                                           [:raise [:noop]]
+                                           [:raise [:noop]]
+                                           [:raise [:noop]]
+                                           [:raise [:noop]]
+                                           [:raise [:noop]]]})}
+                :states  {:idle    {:on {:start {:target :running :action :fan-out}
+                                         :noop  :idle}}
+                          :running {:on {:noop :idle}}}}
+          depth (capture-error-depth!
+                  :rf.error/machine-raise-depth-exceeded
+                  spec {:state :idle :data {}} [:start])]
+      (is (= 4 depth)
+          ":raise aborts at depth == limit (4) — same boundary as :always (was 5 pre-fix)"))))
 
 (deftest machine-raise-pre-commit
   (testing ":raise routes locally pre-commit (does not go to runtime fifo)"

--- a/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_hierarchical_cljs_test.cljs
@@ -44,7 +44,7 @@
   (testing "compound state — sibling-leaf transition fires only the leaf exit/entry"
     ;; Tracks which entry/exit hooks fired so we can assert the LCA cascade.
     (let [log (atom [])
-          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
           machine
           {:initial :authenticated
            :data    {}
@@ -88,7 +88,7 @@
 
   (testing "deepest-wins — leaf overrides parent for same event id"
     (let [log (atom [])
-          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
           machine
           {:initial :authenticated
            :data    {}
@@ -128,7 +128,7 @@
 (deftest machine-hierarchical-wildcard-precedence-cljs
   (testing "leaf :* shadows parent's explicit handler for the same event"
     (let [log (atom [])
-          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
           machine
           {:initial :authenticated
            :data    {}
@@ -153,7 +153,7 @@
 
   (testing "parent fallthrough still works when leaf has neither explicit nor :*"
     (let [log (atom [])
-          tag (fn [k] (fn [_ _] (swap! log conj k) {}))
+          tag (fn [k] (fn [_] (swap! log conj k) {}))
           machine
           {:initial :authenticated
            :data    {}

--- a/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_spawn_cljs_test.cljs
@@ -47,11 +47,12 @@
           {:initial :idle
            :data    {:credentials {:user "alice" :pass "secret"}}
            :on-spawn-actions
-           ;; Per Spec 005 §Declarative :spawn (rf2-een2 / rf2-smba):
-           ;; on-spawn callback signature is (fn [data spawned-id] new-data).
-           ;; The runtime patches the returned data back into the snapshot.
-           {:auth/record-actor (fn [data actor-id]
-                                 (assoc data :pending actor-id))}
+           ;; Per Spec 005 §Declarative :spawn (rf2-grw4i / rf2-v0rrr):
+           ;; on-spawn callback takes a single context-map and returns the
+           ;; new data. The callback is advisory — the runtime tracks the
+           ;; spawned id at [:rf/spawned <parent> <invoke-id>] regardless.
+           {:auth/record-actor (fn [{data :data id :id}]
+                                 (assoc data :pending id))}
            :states
            {:idle
             {:on {:submit :authenticating}}


### PR DESCRIPTION
## Summary

A cluster of three machines smells, all P3, found in the rf2-2ukxv-style audit.

- **rf2-r26e2 — depth-limit boundary off-by-one.** The `:always` microstep loop aborts on `(>= depth always-limit)` (exactly N microsteps for limit N), while the `:raise` drain aborted on `(> depth depth-limit)` (N+1 recursions). Spec 005 §Bounded depth (005:1276) names both default 16 with identical intent, and the `always-depth-exceeded` conformance fixture pins the `>=` boundary (limit 5 → depth 5). Reconciled the `:raise` drain to `(>= depth depth-limit)` so both operators share one boundary.

- **rf2-iilco — `:rf.machine/destroyed` ordering relative to `:exit`.** `destroy-single!` (explicit / declarative `:spawn`) and `destroy-invoke-all-children!` (`:spawn-all` per-child) emitted `:rf.machine/destroyed` BEFORE the child's `:exit` cascade, while `finalize-machine` (final-state auto-destroy) emitted it AFTER. Spec 005 §Composition with explicit `:entry` / `:exit` (005:2138) pins exit-then-destroyed (the `:exit` action reads the live snapshot before teardown clears it). Reordered both bugged paths to match `finalize-machine`.

- **rf2-jk0hf — stale 2-arg test callback signatures.** The hierarchical CLJS test's `tag` actions used `(fn [_ _] ...)` and the spawn CLJS test's `:on-spawn` used `(fn [data actor-id] ...)`, predating the unified single-context-map contract (rf2-grw4i / rf2-v0rrr). They passed only because JS ignores extra arity; on the JVM they would throw ArityException. Updated to single-ctx-map form. Test-only.

## Test plan

- [x] `clojure -M:test` from `implementation/machines` — 230 tests, 782 assertions, 0 failures (includes 2 new boundary tests + the new `destroyed_exit_order_test` pinning the order on all 3 destroy paths)
- [x] `npm run test:cljs` from `implementation/` — 3998 tests, 12130 assertions, 0 failures
- [x] No `spec/*.md` files touched — mkdocs gate not required