### PR TITLE
fix(machines): bound transitive self-chaining raise depth (rf2-b88nm)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -1274,12 +1274,25 @@
   recursive machine-transition-single call; non-:raise fx pass through to
   the accumulator. Returns a `result/ok` Result carrying the post-drain
   `[snap accum-fx]`, or a `result/fail` Result if any recursive step
-  failed."
-  [machine snapshot fx-vec depth-limit]
+  failed.
+
+  `start-depth` seeds the loop's raise-depth counter with the count of
+  raises ALREADY processed transitively before this drain — see
+  `machine-transition-single` (rf2-b88nm). Threading it makes the depth
+  bound *transitive*: a self-chaining single-raise (state A raises an
+  event into state B, which itself raises, …) recurses through nested
+  `machine-transition-single` → `drain-raises` frames, and each frame's
+  drain continues counting from where its caller left off. Without the
+  seed every nested drain would restart at 0, so a runaway self-chain
+  would blow the host call stack instead of firing the clean
+  `:rf.error/machine-raise-depth-exceeded`. Breadth (raise siblings in a
+  single fx vector) and transitive depth (nested raise chains) both count
+  toward the same `:raise-depth-limit`."
+  [machine snapshot fx-vec depth-limit start-depth]
   (loop [pending fx-vec
          accum   []
          snap    snapshot
-         depth   0]
+         depth   start-depth]
     (cond
       ;; `>=` (not `>`) so the `:raise` drain permits exactly `depth-limit`
       ;; recursions (depths 0..limit-1) — parity with the `:always` microstep
@@ -1307,7 +1320,10 @@
             rest-pending (rest pending)]
         (case fx-id
           :raise
-          (let [step-result (machine-transition-single machine snap args)]
+          ;; Pass `(inc depth)` as the nested call's transitive seed so a
+          ;; raise that itself raises keeps counting against this drain's
+          ;; budget rather than restarting at 0 (rf2-b88nm).
+          (let [step-result (machine-transition-single machine snap args (inc depth))]
             (if (result/fail? step-result)
               step-result
               (result/with-ok [snap2 fx2] step-result
@@ -1379,8 +1395,19 @@
   `:always-depth-limit` (both default 16). Parallel-region routing lives
   in `re-frame.machines.parallel`'s `machine-transition` — the dispatch
   checks `parallel?` and either broadcasts across regions or falls
-  through to this fn."
-  [machine snapshot event]
+  through to this fn.
+
+  `raise-depth` is the count of `:raise` recursions already consumed
+  before reaching this call. The public entry passes 0; `drain-raises`
+  passes its running count so a self-chaining single-raise accumulates
+  transitive depth against the SAME `:raise-depth-limit` rather than
+  resetting per nested call (rf2-b88nm). It seeds the `:raise` drains
+  below — both the pre-commit drain and the per-`:always`-step drain — so
+  raises emitted anywhere in this macrostep continue counting from the
+  inbound transitive depth."
+  ([machine snapshot event]
+   (machine-transition-single machine snapshot event 0))
+  ([machine snapshot event raise-depth]
   (let [always-limit (get machine :always-depth-limit always-depth-limit-default)
         raise-limit  (get machine :raise-depth-limit  raise-depth-limit-default)
         path             (state-path (:state snapshot))
@@ -1407,7 +1434,7 @@
     (if (result/fail? result-after-event)
       result-after-event
       (result/with-ok [snap-after-event fx-after-event] result-after-event
-        (let [raised (drain-raises machine snap-after-event fx-after-event raise-limit)]
+        (let [raised (drain-raises machine snap-after-event fx-after-event raise-limit raise-depth)]
           (if (result/fail? raised)
             raised
             (result/with-ok [snap-after-raise fx-after-raise] raised
@@ -1450,11 +1477,16 @@
                         (if (result/fail? step-result)
                           step-result
                           (result/with-ok [snap2 fx2] step-result
-                            (let [raised2 (drain-raises machine snap2 fx2 raise-limit)]
+                            ;; Seed the per-`:always`-step drain with the
+                            ;; macrostep's inbound transitive `raise-depth`
+                            ;; (rf2-b88nm) so raises emitted by an `:always`
+                            ;; cascade reached via a raise chain keep counting
+                            ;; against the same `:raise-depth-limit`.
+                            (let [raised2 (drain-raises machine snap2 fx2 raise-limit raise-depth)]
                               (if (result/fail? raised2)
                                 raised2
                                 (result/with-ok [snap3 fx3] raised2
                                   (recur snap3
                                          (vec (concat fx fx3))
                                          (inc depth)
-                                         (conj visited (:state snap3))))))))))))))))))))
+                                         (conj visited (:state snap3)))))))))))))))))))))

--- a/implementation/machines/test/re_frame/machine_transition_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_transition_purity_test.clj
@@ -252,6 +252,66 @@
       (is (= 4 depth)
           ":raise aborts at depth == limit (4) — same boundary as :always (was 5 pre-fix)"))))
 
+;; ---- transitive self-chaining raise depth (rf2-b88nm) ---------------------
+;;
+;; The `raise-depth-boundary-matches-always-boundary` test above bounds
+;; BREADTH — N raise siblings drained from a single `:fx` vector through
+;; one `drain-raises` queue. But a SELF-CHAINING single-raise (a state
+;; whose `:raise` re-targets a path that itself raises) recurses through
+;; nested `machine-transition-single` → `drain-raises` frames. Pre-fix
+;; each nested `drain-raises` restarted its depth counter at 0, so the
+;; transitive chain was UNBOUNDED: a runaway self-chain blew the JVM call
+;; stack (StackOverflowError) instead of firing the clean
+;; `:rf.error/machine-raise-depth-exceeded`. The fix threads the
+;; transitive raise-depth across the nested recursion so self-chaining
+;; raises accumulate against the same `:raise-depth-limit`.
+
+(deftest self-chaining-raise-bounded-transitively
+  (testing "an infinitely self-chaining :raise hits :raise-depth-limit cleanly,
+   not a host StackOverflowError (rf2-b88nm)"
+    ;; `:loop` has an internal (no-:target) transition on :tick whose
+    ;; action re-raises [:tick] — an unbounded self-chain. Each raise
+    ;; re-enters machine-transition-single from the same state. With
+    ;; :raise-depth-limit 4 the transitive chain must abort at depth 4
+    ;; (the >= boundary, matching the breadth test above) rather than
+    ;; recursing forever down the JVM stack.
+    (let [spec {:initial :loop
+                :data    {}
+                :raise-depth-limit 4
+                :actions {:reraise (fn [_] {:fx [[:raise [:tick]]]})}
+                :states  {:loop {:on {:tick {:action :reraise}}}}}
+          ;; If the transitive depth were NOT threaded this call would
+          ;; recurse without bound and throw StackOverflowError before
+          ;; producing any Result — so reaching the assertion at all
+          ;; proves the chain terminated.
+          depth (capture-error-depth!
+                  :rf.error/machine-raise-depth-exceeded
+                  spec {:state :loop :data {}} [:tick])]
+      (is (= 4 depth)
+          "self-chaining :raise aborts at depth == limit (4) — the SAME bound
+           the breadth fan-out hits, now reached transitively across nested
+           machine-transition-single calls (was StackOverflowError pre-fix)")))
+
+  (testing "a self-chain shorter than the limit still completes normally (rf2-b88nm)"
+    ;; Three chained internal raises (s0 → s1 → s2 → s3) under the default
+    ;; limit (16) must NOT trip the bound — the transitive counter only
+    ;; fires the error when the chain genuinely exceeds the limit.
+    (let [mk (fn [next-ev]
+               (fn [_] (if next-ev {:fx [[:raise next-ev]]} {})))
+          spec {:initial :s0
+                :data    {}
+                :actions {:r1 (mk [:e2]) :r2 (mk [:e3]) :r3 (mk nil)}
+                :states  {:s0 {:on {:e1 {:target :s1 :action :r1}}}
+                          :s1 {:on {:e2 {:target :s2 :action :r2}}}
+                          :s2 {:on {:e3 {:target :s3 :action :r3}}}
+                          :s3 {}}}
+          {s ::result/snap} (machines/machine-transition
+                              spec {:state :s0 :data {}} [:e1])]
+      (is (= :s3 (:state s))
+          "a 3-deep self-chain under the default limit reaches the terminal
+           state in a single macrostep — transitive bounding does not lower
+           the legitimate chain budget"))))
+
 (deftest machine-raise-pre-commit
   (testing ":raise routes locally pre-commit (does not go to runtime fifo)"
     (let [calls (atom [])


### PR DESCRIPTION
## Root cause

The machine `:raise` drain's depth-limit bounded only **breadth** — raise siblings drained from a single `:fx` vector through one `drain-raises` queue (counted by the loop's `depth` local). But a **self-chaining single-raise** — a state whose `:raise` re-targets a path that itself raises — recurses through nested `machine-transition-single` → `drain-raises` frames, and each nested `drain-raises` restarted its depth counter at `0`. So transitive self-chaining depth was **unbounded**: a runaway self-chain blew the JVM call stack (`StackOverflowError`) instead of producing the clean `:rf.error/machine-raise-depth-exceeded`.

(Discovered while fixing rf2-r26e2 / #1853, which reconciled the drain boundary to `(>= depth depth-limit)`. This builds on that.)

## Fix

`implementation/machines/src/re_frame/machines/transition.cljc`:

- `machine-transition-single` gains an optional `raise-depth` arg. The public 3-arity entry passes `0`; the new 4-arity threads the transitive count.
- `drain-raises` gains a `start-depth` param and seeds its loop counter with it. Each `:raise` recursion now calls `machine-transition-single` with `(inc depth)`, so the nested drain continues counting from where its caller left off.
- Both drains inside `machine-transition-single` (the pre-commit drain and the per-`:always`-step drain) are seeded with the macrostep's inbound `raise-depth`.

Breadth (siblings in one fx vector) and transitive depth (nested raise chains) now both accumulate against the **same** `:raise-depth-limit`. The error shape, the default limit (16), and the breadth-bounded behaviour are unchanged — only self-chaining now counts toward the bound.

## Tests

Added two pure-engine regression tests (`machine_transition_purity_test.clj`, reusing the existing `capture-error-depth!` helper):

- **`self-chaining-raise-bounded-transitively`** — an infinitely self-chaining `:raise` (`:loop` state re-raising `[:tick]`) under `:raise-depth-limit 4` aborts at `depth == 4` and fires the clean error. Reaching the assertion at all proves the chain terminated rather than overflowing the host stack.
- a finite 3-deep self-chain under the default limit (16) still completes to its terminal state — transitive bounding does not lower the legitimate chain budget.

The existing breadth fan-out tests (`raise-depth-boundary-matches-always-boundary`, `raise-depth-exceeded-tag-carries-frame`) and the `:raise`-chain tests pass unchanged.

## Gates

- machines JVM (`clojure -M:test`): 231 tests, 784 assertions, 0 failures, 0 errors
- `npm run test:cljs`: 3998 tests, 12130 assertions, 0 failures, 0 errors
- No `spec/*.md` touched — mkdocs gate N/A