### PR TITLE
fix(core): :after on schema-fail + plain-atom ref-count dispose + subscribe cache re-validate (rf2-i36mm + rf2-uatcy + rf2-7pqe7)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -689,9 +689,16 @@
 
 (defn- run-chain
   "Execute the interceptor chain bracketed in performance marks. When
-  event-payload validation failed the handler is not invoked; per Spec
-  010 §Per-step recovery step 1 the initial context is returned
-  unchanged and the downstream queue continues.
+  event-payload validation failed (`event-ok?` false) the handler is
+  suppressed via `:rf/skip-handler?` on the initial context — the same
+  mechanism the cofx-failure path (Spec 010 step 2) uses — rather than
+  skipping the chain wholesale. Per Spec 010 §Per-step recovery step 1
+  the handler does not run and the downstream queue continues; per Spec
+  002 §Interceptor chain execution rule 2 the chain STILL executes so
+  the `:after` pass always runs in full and cleanup-on-`:after`
+  interceptors (debug pp/snapshot, Story snapshot capturer) fire even
+  on a pre-handler validation failure. Symmetric with the cofx path:
+  both failures keep teardown intact.
 
   Per Spec 009 §Performance instrumentation (rf2-du3i): the
   `performance/mark-and-measure` bracket produces a
@@ -700,10 +707,11 @@
   `re-frame.performance/enabled?=false` the bracket DCEs and the call
   collapses to a plain `execute-chain` invocation."
   [event-id full-chain initial-ctx event-ok?]
-  (if event-ok?
+  (let [ctx (if event-ok?
+              initial-ctx
+              (assoc initial-ctx :rf/skip-handler? true))]
     (performance/mark-and-measure :event event-id
-      (interceptor/execute-chain full-chain initial-ctx))
-    initial-ctx))
+      (interceptor/execute-chain full-chain ctx))))
 
 (defn- commit-and-flow!
   "Settle the cascade: surface any chain exception, commit :db, run

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -355,16 +355,41 @@
            ;; to zero), cancel it: a new subscriber arrived inside the
            ;; grace-period window, so the cached value is reused. Per
            ;; Spec 006 §Reference counting and disposal.
-           (let [pending (:pending-dispose entry)]
+           (let [pending  (:pending-dispose entry)
+                 reaction (:reaction entry)]
              (when pending
                (try (interop/clear-timeout! pending)
                     (catch #?(:clj Throwable :cljs :default) _ nil)))
-             (swap! cache update k
-                    (fn [e]
-                      (-> e
-                          (update :ref-count (fnil inc 0))
-                          (assoc :pending-dispose nil))))
-             (:reaction entry))
+             ;; Re-validate the slot AFTER cancelling the timer (rf2-7pqe7).
+             ;; The `clear-timeout!` is best-effort: on a concurrent host a
+             ;; grace timer can fire `dispose-entry-now!` on another thread
+             ;; between the `(get @cache k)` snapshot above and this point,
+             ;; dissoc-ing the slot and disposing `reaction`. A blind
+             ;; `(update k inc-ref-count)` would then resurrect a phantom
+             ;; entry with no `:reaction` AND hand back the now-disposed
+             ;; reaction. The pure-swap-fn only bumps when the slot is still
+             ;; present holding the SAME reaction; reading `[old new]` from
+             ;; the snapshot pair tells us whether the bump landed. If the
+             ;; slot was concurrently evicted (or rebuilt under a different
+             ;; reaction), fall through to a fresh build — the same
+             ;; CAS-after-snapshot discipline `re-frame.subs.cache` uses.
+             ;; On single-threaded CLJS the re-check always succeeds (the
+             ;; timer callback and `subscribe` cannot interleave), so the
+             ;; rebuild branch is concurrency-host-only.
+             (let [[_old new]
+                   (swap-vals! cache
+                               (fn [m]
+                                 (if (identical? reaction
+                                                 (get-in m [k :reaction]))
+                                   (update m k
+                                           (fn [e]
+                                             (-> e
+                                                 (update :ref-count (fnil inc 0))
+                                                 (assoc :pending-dispose nil))))
+                                   m)))]
+               (if (identical? reaction (get-in new [k :reaction]))
+                 reaction
+                 (compute-and-cache! frame-id query-v))))
            (compute-and-cache! frame-id query-v)))))))
 
 (defn subscribe-once

--- a/implementation/core/src/re_frame/substrate/plain_atom.cljc
+++ b/implementation/core/src/re_frame/substrate/plain_atom.cljc
@@ -9,7 +9,33 @@
   There is no default-adapter registry and no ns-load side-effect.
   Consumers (JVM tests, headless SSR hosts, any process that wants the
   plain-atom path on CLJS) call `(rf/init! plain-atom/adapter)`
-  explicitly. The `adapter` var below is the public surface.")
+  explicitly. The `adapter` var below is the public surface.
+
+  ## Disposal / ref-count participation (rf2-uatcy)
+
+  The sub-cache wires symmetric input-release through
+  `re-frame.interop/add-on-dispose!` at slot construction (Spec 006
+  §Reference counting and disposal) and `re-frame.interop/dispose!` at
+  slot evict — so a layer-2+ sub's `:<-` inputs lose their reader when
+  the parent reaction disposes. Both runtimes must honour that contract
+  or input ref-counts leak monotonically until `clear-sub-cache!`.
+
+    - **JVM.** `re-frame.interop` (the `.clj`) implements
+      `add-on-dispose!` / `dispose!` directly, keyed by the reaction
+      object in a process-wide callback registry — so the plain-atom
+      JVM derived value (a bare `IDeref` reify) participates without
+      reifying any disposal protocol.
+
+    - **CLJS.** `re-frame.interop` (the `.cljs`) routes those calls
+      through the `:adapter/add-on-dispose!` / `:adapter/dispose!`
+      late-bind hooks, which dispatch on the derived value reifying a
+      disposal protocol. The plain-atom CLJS derived value therefore
+      reifies `re-frame.disposable/IDisposable` (mirroring the spine),
+      and this ns publishes the two hooks via `substrate-adapter/
+      route-hook!` so a CLJS-plain-atom host (rather than a leak)
+      releases inputs symmetrically on slot evict."
+  #?(:cljs (:require [re-frame.disposable :as rf-disposable]
+                     [re-frame.substrate.adapter :as substrate-adapter])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -32,10 +58,36 @@
   ;; No caching: derived values recompute on every deref. SSR runs each
   ;; sub at most a handful of times per request; caching would add
   ;; complexity for negligible gain.
-  (reify
-    #?(:clj clojure.lang.IDeref :cljs IDeref)
-    (#?(:clj deref :cljs -deref) [_]
-      (apply compute-fn (map deref source-containers)))))
+  ;;
+  ;; JVM: a bare `IDeref` reify suffices — `re-frame.interop` (the .clj)
+  ;; keys its `add-on-dispose!` / `dispose!` callback registry by this
+  ;; object's identity, so disposal participation needs no protocol on
+  ;; the value itself.
+  ;;
+  ;; CLJS (rf2-uatcy): `re-frame.interop` (the .cljs) routes
+  ;; `add-on-dispose!` / `dispose!` through the `:adapter/*` hooks, which
+  ;; dispatch on the derived value reifying `IDisposable`. Reify it here
+  ;; (mirroring `re-frame.substrate.spine`) so the sub-cache's symmetric
+  ;; input-release callback is registered at slot construction and fires
+  ;; at slot evict — otherwise layer-2+ input ref-counts never decrement
+  ;; on the CLJS-plain-atom path. The plain-atom derived value owns no
+  ;; source watches (it recomputes on deref), so `-dispose` only fires
+  ;; the registered on-dispose callbacks.
+  #?(:clj
+     (reify
+       clojure.lang.IDeref
+       (deref [_] (apply compute-fn (map deref source-containers))))
+     :cljs
+     (let [on-dispose-fns (atom [])]
+       (reify
+         IDeref
+         (-deref [_] (apply compute-fn (map deref source-containers)))
+         rf-disposable/IDisposable
+         (-add-on-dispose [_ f]
+           (swap! on-dispose-fns conj f))
+         (-dispose [_]
+           (doseq [f @on-dispose-fns] (f))
+           (reset! on-dispose-fns []))))))
 
 (defn- render [_ _ _]
   ;; SSR uses render-to-string exclusively. Calling render on the JVM is
@@ -88,3 +140,31 @@
    :render-to-string          render-to-string
    :register-context-provider register-context-provider
    :dispose-adapter!          dispose-adapter!})
+
+;; ---- late-bind hook routing (CLJS only, rf2-uatcy) ------------------------
+;;
+;; On CLJS `re-frame.interop`'s `add-on-dispose!` / `dispose!` route
+;; through these `:adapter/*` hooks (the JVM `re-frame.interop` implements
+;; both directly, so this block is CLJS-only). Each routes into the
+;; `re-frame.disposable/IDisposable` protocol the CLJS `make-derived-value`
+;; reifies above, so a CLJS-plain-atom host participates in the sub-cache's
+;; ref-count / disposal contract symmetrically with the React-shaped
+;; adapters (see `re-frame.substrate.spine`'s identical routing). Routed
+;; through `substrate-adapter/route-hook!` so a test bundle that also loads
+;; a React adapter only runs the plain-atom impl while plain-atom is the
+;; `(rf/init!)`-installed adapter (per Spec 006 §adapter routing).
+;;
+;; The `add-on-dispose!` / `dispose!` dispatch tolerates a value that does
+;; NOT satisfy the protocol (e.g. a foreign reaction inherited through a
+;; cross-substrate test bundle) by no-op'ing — mirroring the Reagent
+;; adapter's fall-through dispatch.
+#?(:cljs
+   (do
+     (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+       (fn add-on-dispose!-dispatch [a f]
+         (when (satisfies? rf-disposable/IDisposable a)
+           (rf-disposable/-add-on-dispose a f))))
+     (substrate-adapter/route-hook! adapter :adapter/dispose!
+       (fn dispose!-dispatch [a]
+         (when (satisfies? rf-disposable/IDisposable a)
+           (rf-disposable/-dispose a))))))

--- a/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
+++ b/implementation/core/test/re_frame/plain_atom_dispose_cljs_test.cljs
@@ -1,0 +1,137 @@
+(ns re-frame.plain-atom-dispose-cljs-test
+  "CLJS coverage for the plain-atom adapter's participation in the
+  sub-cache disposal / ref-count contract (rf2-uatcy).
+
+  On the JVM the plain-atom adapter rides `re-frame.interop`'s (the .clj)
+  direct `add-on-dispose!` / `dispose!` implementation, so the layer-2+
+  input-release path already works (pinned by the JVM
+  `re-frame.sub-cache-test`). On CLJS `re-frame.interop` routes those calls
+  through the `:adapter/add-on-dispose!` / `:adapter/dispose!` late-bind
+  hooks — which the plain-atom adapter did NOT publish, and its derived
+  value reified no disposal protocol. The consequence was a monotonic
+  leak: a layer-2+ sub's `:<-` input ref-counts never decremented on slot
+  evict, pinning the inputs in the cache until `clear-sub-cache!`.
+
+  These tests run a CLJS-plain-atom host (the SSR / headless-on-CLJS
+  shape) and pin the symmetric input-release contract per Spec 006
+  §Reference counting and disposal. ns ends in -cljs-test so shadow-cljs's
+  :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; A single `use-fixtures :each` (cljs.test REPLACES on repeat calls, it
+;; does not compose) that (a) resets the runtime + installs plain-atom and
+;; (b) restores the default grace-period afterwards — the tests set
+;; grace-period 0 for synchronous disposal, and a sibling suite sharing the
+;; JS heap must not inherit that.
+(def ^:private reset-runtime
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(use-fixtures :each
+  (fn [test-fn]
+    (reset-runtime
+      (fn []
+        (try (test-fn)
+             (finally (subs-cache/configure! {:grace-period-ms 50})))))))
+
+(defn- cache-keys []
+  (set (keys @(:sub-cache (frame/frame :rf/default)))))
+
+(defn- entry-ref-count [query-v]
+  (get-in @(:sub-cache (frame/frame :rf/default)) [query-v :ref-count]))
+
+(deftest layer-2-disposal-decrements-input-ref-counts-on-cljs-plain-atom
+  (testing "rf2-uatcy — disposing a layer-2 sub on the CLJS-plain-atom
+            adapter decrements ref-counts on every :<- input and cascades
+            their disposal, mirroring the JVM contract"
+    (subs-cache/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :sum
+      :<- [:a]
+      :<- [:b]
+      (fn [[a b] _] (+ a b)))
+    (rf/dispatch-sync [:init])
+
+    ;; Subscribe to the parent layer-2 sub — recursively subscribes both
+    ;; inputs, bumping each to ref-count 1. Use the explicit-frame
+    ;; `subs/subscribe` so the test drives the reactive cache path
+    ;; directly (the macro `rf/subscribe` resolves a render-time frame
+    ;; context that headless node tests do not establish).
+    (let [r (subs/subscribe :rf/default [:sum])]
+      (is (= 5 @r))
+      (is (= 1 (entry-ref-count [:sum])) "parent ref-count = 1")
+      (is (= 1 (entry-ref-count [:a])) "input :a ref-count = 1 after layer-2 build")
+      (is (= 1 (entry-ref-count [:b])) "input :b ref-count = 1 after layer-2 build"))
+
+    ;; Dispose the parent (sole subscriber drops → grace=0 sync dispose).
+    ;; Pre-fix the input-release callback never registered (no published
+    ;; :adapter/dispose! hook, no IDisposable on the derived value) so
+    ;; :a / :b leaked here.
+    (subs/unsubscribe :rf/default [:sum])
+
+    (is (not (contains? (cache-keys) [:sum])) "parent disposed")
+    (is (not (contains? (cache-keys) [:a]))
+        "input :a disposed via cascade (ref-count → 0) — no leak")
+    (is (not (contains? (cache-keys) [:b]))
+        "input :b disposed via cascade (ref-count → 0) — no leak")))
+
+(deftest layer-2-disposal-respects-shared-inputs-on-cljs-plain-atom
+  (testing "rf2-uatcy — a shared input is decremented by exactly one when
+            one of its layer-2 holders disposes; it survives while another
+            holder remains"
+    (subs-cache/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3 :c 4}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :b (fn [db _] (:b db)))
+    (rf/reg-sub :c (fn [db _] (:c db)))
+    (rf/reg-sub :ab :<- [:a] :<- [:b] (fn [[a b] _] (+ a b)))
+    (rf/reg-sub :ac :<- [:a] :<- [:c] (fn [[a c] _] (+ a c)))
+    (rf/dispatch-sync [:init])
+
+    (subs/subscribe :rf/default [:ab])
+    (subs/subscribe :rf/default [:ac])
+    (is (= 2 (entry-ref-count [:a])) "shared input :a has ref-count 2")
+    (is (= 1 (entry-ref-count [:b])))
+    (is (= 1 (entry-ref-count [:c])))
+
+    (subs/unsubscribe :rf/default [:ab])
+    (is (not (contains? (cache-keys) [:ab])) ":ab disposed")
+    (is (contains? (cache-keys) [:a]) ":a survives — still referenced by :ac")
+    (is (= 1 (entry-ref-count [:a]))
+        "shared input ref-count dropped by exactly 1 (now 1)")
+    (is (not (contains? (cache-keys) [:b]))
+        ":b was held only by :ab — disposed via cascade")
+
+    (subs/unsubscribe :rf/default [:ac])
+    (is (not (contains? (cache-keys) [:a]))
+        ":a finally disposed after the last layer-2 holder dropped")
+    (is (not (contains? (cache-keys) [:c]))
+        ":c disposed via cascade")))
+
+(deftest layer-3-disposal-cascades-on-cljs-plain-atom
+  (testing "rf2-uatcy — disposal cascades recursively through a layer-3
+            chain on the CLJS-plain-atom adapter"
+    (subs-cache/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :init (fn [_ _] {:a 2}))
+    (rf/reg-sub :a (fn [db _] (:a db)))
+    (rf/reg-sub :a*2 :<- [:a]   (fn [a _] (* 2 a)))
+    (rf/reg-sub :a*4 :<- [:a*2] (fn [a2 _] (* 2 a2)))
+    (rf/dispatch-sync [:init])
+
+    (let [r (subs/subscribe :rf/default [:a*4])]
+      (is (= 8 @r))
+      (is (= 1 (entry-ref-count [:a*4])))
+      (is (= 1 (entry-ref-count [:a*2])))
+      (is (= 1 (entry-ref-count [:a]))))
+
+    (subs/unsubscribe :rf/default [:a*4])
+    (is (not (contains? (cache-keys) [:a*4])))
+    (is (not (contains? (cache-keys) [:a*2])))
+    (is (not (contains? (cache-keys) [:a])))))

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -275,3 +275,66 @@
                  "disposes. Sample: " (vec (take 20 under)))))
       (is (= n-trials (count @per-trial))
           "all trials accounted for"))))
+
+;; ---- 4. cache-hit re-validates after cancelling the grace-dispose timer ----
+
+;; The race (rf2-7pqe7): on a cache hit with a pending grace-dispose,
+;; `subscribe` reads the entry, cancels the timer, then bumps the
+;; ref-count. On a concurrent host the grace timer can fire
+;; `dispose-entry-now!` on another thread between the `(get @cache k)`
+;; snapshot and the `clear-timeout!` — dissoc-ing the slot and disposing
+;; the reaction. The `clear-timeout!` is best-effort (the cancel races a
+;; fire that already started). Pre-fix, `subscribe` then blindly
+;; `(update k inc-ref-count)`-ed the (now absent) slot — resurrecting a
+;; PHANTOM entry with no `:reaction` and handing the caller back the
+;; already-DISPOSED reaction.
+;;
+;; The fix re-validates after the cancel: the bump only lands when the slot
+;; still holds the SAME reaction; otherwise `subscribe` falls through to a
+;; fresh build. We simulate the concurrent eviction deterministically by
+;; redef-ing `clear-timeout!` to evict the slot at exactly the cancel
+;; point (the worst-case interleave). This single-threaded simulation
+;; drives the same code path the concurrent race would.
+(deftest cache-hit-revalidates-when-slot-evicted-during-timer-cancel
+  (testing "a cache hit whose slot is concurrently evicted during the
+            grace-timer cancel rebuilds a fresh reaction rather than
+            returning the disposed one or pinning a phantom entry"
+    (subs-cache/configure! {:grace-period-ms 50})  ;; grace > 0 so a timer is stashed
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed])
+
+    (let [cache (:sub-cache (frame/frame :rf/default))
+          ;; First subscribe builds + caches the reaction (ref-count 1).
+          r1    (rf/subscribe [:n])]
+      (is (= 7 @r1) "first subscribe yields the seeded value")
+      (let [k (first (keys @cache))]
+        ;; Drop to zero → schedules a grace-period dispose, stashing a
+        ;; pending-dispose timer handle on the slot.
+        (rf/unsubscribe [:n])
+        (is (some? (get-in @cache [k :pending-dispose]))
+            "a grace-dispose timer is pending after the 1→0 drop")
+
+        ;; Simulate the concurrent grace-fire winning the cancel race:
+        ;; `clear-timeout!` evicts the slot (as `dispose-entry-now!` would
+        ;; have on another thread) at exactly the cancel point.
+        (let [evicted-reaction (get-in @cache [k :reaction])]
+          (with-redefs [interop/clear-timeout!
+                        (fn [_handle]
+                          ;; The grace timer "fired" on another thread:
+                          ;; slot gone, reaction disposed.
+                          (swap! cache dissoc k)
+                          nil)]
+            (let [r2 (rf/subscribe [:n])]
+              (is (some? r2) "subscribe returns a live reaction, not nil")
+              (is (= 7 @r2)
+                  "the rebuilt reaction computes the current value")
+              (is (not (identical? evicted-reaction r2))
+                  "subscribe rebuilt a FRESH reaction — it did NOT hand back
+                   the reaction the concurrent grace-fire disposed")
+              ;; The slot must hold a real reaction (the rebuild), never a
+              ;; phantom entry resurrected with no :reaction.
+              (is (some? (get-in @cache [(first (keys @cache)) :reaction]))
+                  "the cache slot holds a real reaction, not a phantom entry")
+              (is (= 1 (get-in @cache [(first (keys @cache)) :ref-count]))
+                  "the rebuilt slot starts at ref-count 1"))))))))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -241,6 +241,44 @@
             (is (= :user/register (-> v :tags :failing-id)))
             (is (= :user/register (-> v :tags :schema-id)))))))))
 
+(deftest event-payload-validation-failure-still-runs-after-pass
+  (testing "Per Spec 002 §Interceptor chain execution rule 2 (rf2-i36mm):
+            a schema-validation failure on the event vector (Spec 010 step
+            1) suppresses the HANDLER but the interceptor chain STILL runs,
+            so every :after stage fires — symmetric with the cofx-failure
+            path (step 2) which uses :rf/skip-handler?. The :after pass
+            must run regardless of the pre-handler failure so cleanup-on-
+            :after interceptors (debug pp, Story snapshot capturer) are not
+            leaked."
+    (let [handler-calls (atom 0)
+          before-calls  (atom 0)
+          after-calls   (atom 0)
+          probe         (rf/->interceptor
+                          :id     ::after-probe
+                          :before (fn [ctx] (swap! before-calls inc) ctx)
+                          :after  (fn [ctx] (swap! after-calls inc) ctx))]
+      (rf/reg-event-db :user/probe
+        {:schema [:cat [:= :user/probe] :int]}
+        [probe]
+        (fn [db _] (swap! handler-calls inc) db))
+      (let [traces (atom [])]
+        (rf/register-listener! ::after-ev (fn [ev] (swap! traces conj ev)))
+        ;; Malformed payload — event-vector validation fails pre-handler.
+        (rf/dispatch-sync [:user/probe "not-an-int"])
+        (rf/unregister-listener! ::after-ev)
+        (is (= 1 (count (filter #(= :rf.error/schema-validation-failure
+                                    (:operation %))
+                                @traces)))
+            "the schema-validation failure fired")
+        (is (zero? @handler-calls)
+            "the handler was suppressed via :rf/skip-handler?")
+        (is (= 1 @after-calls)
+            "the :after pass STILL ran in full on the validation failure")
+        (is (= 1 @before-calls)
+            "the :before pass ran too — the chain executes end-to-end, the
+            handler-wrapper :before is the only stage that honours
+            :rf/skip-handler?")))))
+
 (deftest event-payload-validation-elides-when-debug-disabled
   (testing "validate-event! is a no-op when debug-enabled? is false (production)"
     (let [calls (atom 0)]


### PR DESCRIPTION
## Summary

Three core correctness fixes (cluster), smallest → biggest, each with a regression test.

1. **rf2-i36mm (P2)** — An event-vector schema-validation failure (Spec 010 step 1) skipped `run-chain` wholesale, bypassing the interceptor `:after` pass and leaving cleanup-on-`:after` interceptors (debug pp, Story snapshot capturer) stranded. This violated Spec 002 §Interceptor chain execution rule 2 (`:after` ALWAYS runs) and was asymmetric with the cofx-failure path (step 2). `run-chain` now mirrors the cofx mechanism: on a validation failure it sets `:rf/skip-handler?` on the context and executes the chain, so the handler is suppressed but every `:after` stage fires.

2. **rf2-uatcy (P3)** — On CLJS, `re-frame.interop`'s `add-on-dispose!` / `dispose!` route through the `:adapter/*` late-bind hooks, which dispatch on the derived value reifying a disposal protocol. The plain-atom adapter published neither hook and its derived value reified no `IDisposable`, so on a CLJS-plain-atom host (SSR / headless-on-CLJS) the sub-cache's symmetric input-release callback never registered or fired — layer-2+ input ref-counts leaked monotonically until `clear-sub-cache!` (Spec 006 §Reference counting and disposal). The CLJS `make-derived-value` now reifies `re-frame.disposable/IDisposable` (mirroring the React-shaped spine) and the adapter publishes the two hooks via `route-hook!`. JVM is unchanged — `re-frame.interop` (the `.clj`) implements the callbacks directly, keyed by reaction identity.

3. **rf2-7pqe7 (P4)** — A `subscribe` cache-hit cancelled the grace-dispose timer then blindly bumped the ref-count. On a concurrent host a grace timer firing on another thread between the cache snapshot and `clear-timeout!` would dissoc the slot and dispose the reaction, after which the blind `(update k inc-ref-count)` resurrected a phantom entry with no `:reaction` and handed back the disposed reaction. `subscribe` now re-validates after the cancel (swap-vals!-after-snapshot, the discipline `re-frame.subs.cache` already uses): the bump lands only when the slot still holds the same reaction; otherwise it rebuilds. CLJS-safe today (single-threaded); closes the latent concurrent-host gap.

## Test plan

- [x] `npm run test:cljs` — 4001 tests, 12153 assertions, 0 failures / 0 errors
- [x] core JVM `clojure -M:test` — 686 tests, 3289 assertions, 0 failures / 0 errors
- [x] schemas JVM `clojure -M:test` — 166 tests, 18140 assertions, 0 failures / 0 errors
- [x] Each regression test verified to FAIL with its source fix reverted (stash) and PASS with it applied
- [x] No `spec/*.md` edits — mkdocs gate not required