### PR TITLE
docs(causa): rewrite tour/index to Dynamic/Static IA + reconcile spec 007 tab inventory (rf2-1haya + rf2-tzket)

### DIFF
--- a/docs/causa/02-panel-tour.md
+++ b/docs/causa/02-panel-tour.md
@@ -1,111 +1,144 @@
 # 2. Panel tour
 
-Fourteen panels. You'll use four of them daily, six of them weekly, and the rest the occasional Tuesday afternoon when something exotic breaks.
+Two chromes, thirteen tabs. You'll live in three or four of them daily, reach for the rest the occasional Tuesday afternoon when something exotic breaks.
 
-This chapter is the map. Each panel gets a one-paragraph "when you'd open this" answer; the chapters that follow take the four hero panels — Event detail, Time travel, Trace, Click-to-source — and unpack them depth-first.
+This chapter is the map. First the two chromes — **Dynamic** (the event-coupled spine) and **Static** (the registry browser) — then a one-paragraph "when you'd open this" answer for each tab. The chapters that follow take the hero surfaces — Event detail, time-travel, Trace, Click-to-source, App-DB, Machines — and unpack them depth-first.
 
+![The Causa shell, opened over the live app — the four-layer Dynamic chrome](../images/causa/02-shell-opened.png)
 
-![Causa sidebar — fourteen panels, two bands](../images/causa/02-sidebar-panels.png)
+## The two chromes
 
-The sidebar groups panels into two bands:
+Causa is one tool with two reading postures, toggled with `Cmd-Shift-M`. The mode pill at ribbon-left says which you're in; the chrome silhouette tells you at a glance even if you don't look at the pill.
 
-- **Always-active** (top) — Event detail, Time travel, App-DB, Subscriptions, Effects, Trace, Machines. These render whether you've configured anything or not.
-- **Conditional-with-activity** (bottom) — Flows, Routes, Performance, Issues, Schemas, Hydration. These light up only when the app is using the relevant subsystem (the *Hydration* panel only appears when SSR hydration actually runs, etc.).
+**Dynamic** — four stacked layers:
 
-## Event detail — the landing panel
+```
+┌───────────────────────────────────────────────────────┐
+│ L1  Top ribbon (56px)                                 │  scope controls
+├───────────────────────────────────────────────────────┤
+│ L2  Event list (8 rows default; resizable; min 2)     │  the spine / timeline
+├───────────────────────────────────────────────────────┤
+│ L3  Tab bar (40px) — 8 tabs                           │  projection selector
+├───────────────────────────────────────────────────────┤
+│ L4  Detail panel (fills remaining canvas)             │  per-tab content
+└───────────────────────────────────────────────────────┘
+```
 
-![Event detail showing the most recent epoch](../images/causa/02-event-detail.png)
+Every Dynamic surface orients around **one focused event** — the spine sub `:rf.causa/focus`. You pick an event in the L2 list; every tab below rebinds atomically. The tabs are *lenses on that one event*.
 
-Lands on every open. Renders the *most recent* epoch — the event vector, the `app-db` diff, the inline mini-graph of what cascaded, the subs that recomputed, the views that re-rendered, the fxs that fired, and the duration. If you're answering "what did the user just do?", this is the panel.
+**Static** — three layers (no L2 spine, because Static is event-independent):
 
-Five questions every event answers, all on first paint:
+```
+┌───────────────────────────────────────────────────────┐
+│ L1  Top ribbon — mode pill · frame picker · icons     │
+├───────────────────────────────────────────────────────┤
+│ L3  Tab bar (40px) — 5 tabs                           │
+├───────────────────────────────────────────────────────┤
+│ L4  Detail panel (fills remaining canvas)             │
+└───────────────────────────────────────────────────────┘
+```
 
-1. **What was dispatched?** Event vector, top of the panel.
-2. **What changed?** App-db diff, expanded.
-3. **What rendered?** Render list, keyed by view-id.
-4. **What fxs fired?** Effects list, with `:outcome ∈ {:ok :error :skipped-on-platform}`.
-5. **How long?** Total cascade duration.
+Static reuses Dynamic's full design language — same fonts, same palette, same 56px ribbon and 40px tab-bar. The differences are deliberate signals: a cyan left-edge stripe (violet in Dynamic), a dampened motion profile (continuous pulses dropped, tab swaps instant), and the missing L2 itself. Same surface, quieter key.
 
-That's the daily answer set. Anything deeper, you click through to a peer panel.
+---
 
-## Time travel — the bottom rail
+## Dynamic mode — the eight tabs
 
-The scrubber is always visible at the bottom of the shell — even when you're on a different panel. Drag it backwards to *passively* re-render against a prior epoch's `:db-after`; click *restore* to make it sticky (the runtime calls `restore-epoch` and the live app rewinds).
+### L1 — the ribbon
 
-See the dedicated [chapter 3](03-time-travel.md).
+The scope band, fixed at the top in both modes. Four clusters, left to right:
 
-## App-DB — slice-centric
+- **Nav** (`◀ ▶ ⏭`) — step focus back / forward through the spine, or `⏭` to snap to the live head.
+- **Frame picker** — single-select over the distinct frames in the cascade list. Every tab scopes to the picked frame; the `:rf/causa` frame is excluded by default.
+- **Filter pills** — IN (green, `+`) and OUT (magenta, `×`) pills over the event list, plus a trailing `[+]` to add one. Click any pill to edit it.
+- **Right icons** — settings `⚙` and close `✕`. (Pop-out is a programmatic API, `(causa/popout!)` — no ribbon affordance yet.)
 
-Not a full `app-db` tree dump. **The slices that changed in the current epoch**, plus any slices you've pinned with a *watch* gesture. Read-only — Causa never writes to `app-db` for you (use `re-frame2-pair` for that, or dispatch a real event).
+### L2 — the event list (the spine)
 
-See [chapter 9](09-app-db-diff.md).
+Single-line rows, latest-on-bottom, eight visible by default and vertically resizable (drag the L2/L3 boundary; min two rows). Each row carries a gutter glyph (`● ◉ x ▥`), the event-id, a right-aligned badge cluster (`⚠` exception · `🌐` managed-HTTP · `🤖` machine activity), and a trailing redaction marker when sensitive data was suppressed.
 
-## Subscriptions
+This *is* the timeline. Click a row → focus it (the spine flips to RETRO) and every tab rebinds in one frame. This is also where time-travel lives — there is no bottom rail; you scrub by walking the spine. See [chapter 3](03-time-travel.md).
 
-Every registered sub: id, layer (extractor / derivation), current value, hit-rate badge (TanStack-style — stale / fresh / inflight), and the recompute count this session. Click an edge to walk to a parent sub. Click an id to jump to its `reg-sub`.
+### L3 / L4 — the eight tabs
 
-The TanStack-style badge is unusual for a re-frame tool — it's there because sub recomputation cost is one of the four canonical performance hot-spots, and the panel surfaces it where you'd reach for it anyway.
+Selection lives on `:rf.causa/selected-tab` and drives the L4 detail panel. Mnemonic letters in brackets.
 
-## Effects
+#### Event (`e`) — the landing tab
 
-Every fx the app has issued in the current session, keyed by `fx-id`, with `:outcome` chips and full `:tags` payload. Errors get red rows; aborts get yellow. Click a row to see the full trace event.
+![Event tab showing the focused event's full six-domino story](../images/causa/02-event-detail.png)
 
-## Trace — the raw stream
+Lands on every open and on every focus change. The whole story of one event: the event vector + arg-map + dispatch site, the coefficients and interceptor chain, the handler return, the `:db` writes, the `:fx` vector, and the fx-handlers that actually ran (with their results). If you're answering "what did this event *do*?", this is the tab. Effects are folded in here — the "effects handlers ran" block covers what a standalone Effects panel used to.
 
-Every emitted trace event, in order. Filterable by `:op-type`, by tag, by free-text. The Trace panel is what you'd write yourself with `register-listener!` if Causa didn't exist — it's the bus's most direct rendering.
+#### App DB (`a`) — slice-centric diff
 
-See [chapter 4](04-trace-stream.md).
+Not a full `app-db` tree dump. **The diff of `:db-before` vs `:db-after`** for the focused event — slice-first, with clickable path segments, path-origin chips, and a full-tree disclosure when you want the whole picture. Read-only; Causa never writes to `app-db` for you (use `re-frame2-pair` for that, or dispatch a real event). See [chapter 9](09-app-db-diff.md).
 
-## Machines — Stately-grade state-charts
+#### View (`v`) — why these views rendered
 
-For every registered machine, the panel renders a Stately-quality state-diagram: nodes for states, edges for transitions, guards on edges, actions on entry/exit, parallel regions as side-by-side boxes, hierarchical states nested. The current state is highlighted live; transitions paint as they fire. (Screenshot in [chapter 8](08-machine-inspector.md).)
+Per-view rows — mounted / re-rendered / unmounted — each listing the subs it used and those subs' return values, isolation-scoped to the selected frame. Subscriptions are folded in here: they nest under each view row rather than living in a separate tab, because the question you actually have is "why did *this view* re-render?", and the answer is the sub-invalidation chain underneath it.
 
-Embedded under the hood is [`tools/machines-viz/`](https://github.com/day8/re-frame2/tree/main/tools/machines-viz) — a separate visualiser library that Causa composes in.
+#### Trace (`t`) — the raw stream
 
-See [chapter 8](08-machine-inspector.md).
+The raw multi-axis trace stream, filtered to the focused cascade (`:dispatch-id = <focus>`). A trace-type toggle row sits at the top with IN/OUT pills and sensible defaults. This tab is what you'd write yourself with `register-listener!` if Causa didn't exist — the bus's most direct rendering. See [chapter 4](04-trace-stream.md).
 
-## Flows
+#### Machines (`m`) — event-driven state-charts
 
-Registered [flows](../guide/20-migration.md#flows--the-replacement-for-on-changes) — re-frame2's reactive-derivation primitive. Per-flow status, last value, the inputs it watches, the last few recomputes. Only lights up if your app registers any.
+The event-driven machine lens. **Blank when the focused event touched no machine.** When it did, one section per affected machine: topology with the transition highlighted, the guards and actions that ran, the cancellation cascade, and `:after` rings. This is the "what did *this event* do to my machines?" view — for browsing a machine's full shape cold, use Machines Canvas (next) or Static mode. See [chapter 8](08-machine-inspector.md).
 
-## Routes
+#### Machines Canvas (`c`) — the topology browser
 
-Static route table, plus the current route, plus the per-frame route history. Useful when "the URL changed and the page didn't" or vice versa.
+A **spine-independent** canvas browser — it does *not* couple to the focused event. Master-detail: a picker on the left (one row per registered machine), an interactive Chart adapter on the right (zoom / pan / fit + keyboard shortcuts). The canvas always shows the picked machine's full topology, regardless of where the spine is. It earned its own tab — sibling to the event-driven Machines inspector — under the cohesive-sub-domain rule.
 
-## Performance
+#### Routing (`r`) — the focused-event route lens
 
-The `rf:`-prefixed User Timing entries (event / sub / fx / render) plotted on a millisecond scale. Off by default — it's the channel covered in [Guide 16 — Performance](../guide/17-performance.md). Turn it on when you're looking at a specific slow render.
+A flat focused-event lens: the currently matched route with its params / query / fragment, plus a **Simulate-URL** input that ranks every registered route via the six-rule `:rf.route/rank` tuple with the rank explainer inline. Per-event glyphs (`◆ HERE` / `◆ FROM` / `◆ TO`) mark the route's role in the focused cascade. Silent when no routes are registered.
 
-## Issues
+#### Issues (`i`) — the unified feed
 
-The unified feed: errors, warnings, schema violations, hydration mismatches. One row per issue, with severity chip, source coord, and the underlying trace event one click away. This is where you check first when "something looks off."
+The catch-all health feed: JS exceptions, schema violations, sensitive-data warnings, hydration mismatches, perf-budget overruns, and app console errors/warns. One row per issue, with a severity gutter (`⚠`), source coord, and the underlying trace event one click away. This is where you check first when "something looks off" — and where the [schema timeline](06-schema-timeline.md) and [hydration debugger](07-hydration.md) surface their findings.
 
-## Schemas
+**Three diagnostics folded away, not dropped.** Effects fold into Event, Subscriptions fold into View, and Performance is delegated to Chrome DevTools' Timings track — the framework emits `rf:event:*`, `rf:sub:*`, `rf:fx:*`, `rf:render:*` User-Timing entries that DevTools renders natively. No separate Causa tab competes with the browser's own profiler.
 
-The schema-violation timeline. One row per registered schema (`app-db` slot, sub return, event payload, cofx). Coloured dots per failure with recovery mode. Lit up only if you've registered any Malli schemas — see [Guide 04a — Schemas](../guide/05-schemas.md).
+---
 
-See [chapter 6](06-schema-timeline.md).
+## Static mode — the five tabs
 
-## Hydration
+Flip to Static (`Cmd-Shift-M`) to browse the registry cold. No spine, no focused event — these tabs answer questions about the *shape* of the app, not a particular cascade.
 
-The server-vs-client hydration debugger. Only visible when SSR hydration actually runs in the page. Side-by-side render trees with the diff highlighted.
+#### Machines (`m`, default)
 
-See [chapter 7](07-hydration.md).
+The registered-machine browser plus topology and a sub-strip of browse modes. Lands here by default — it's the densest Static surface.
+
+#### Routes (`r`)
+
+The full registered-route table plus the Simulate-URL ranker. The cold counterpart to Dynamic's Routing tab: there you see the route a cascade matched; here you browse every route and test how an arbitrary URL would rank.
+
+#### Schemas (`c`)
+
+Every registered Malli schema — `app-db` slot, sub return, event payload, cofx — with sample data and jump-to-source. Lit up only if your app registers schemas; see [Guide 04a — Schemas](../guide/05-schemas.md).
+
+#### Flows (`l`)
+
+The registered [flows](../guide/20-migration.md#flows--the-replacement-for-on-changes) catalogue — re-frame2's reactive-derivation primitive. Each flow's inputs, its derivation, its current value. Only populated if your app registers any.
+
+#### Interceptors (`i`)
+
+A pure-browse lens over the registered interceptor chains — useful when "an interceptor is mutating something I didn't expect" and you want to read the chain cold.
 
 ---
 
 ## Resizing Causa
 
-Drag the left edge of the Causa panel to resize horizontally. Width persists across reloads (per-Causa-instance, stored in localStorage). Double-click the handle to reset to default width.
+Drag the left edge of the Causa panel to resize horizontally. Width persists across reloads (per-Causa-instance, stored in localStorage). Within Dynamic, drag the L2/L3 boundary handle to grow or shrink the event list; the detail panel takes the remainder.
 
 For full-screen inspection, change `Settings → General → Panel position` to `fullscreen`. For an out-of-window view, change it to `popout` — the browser's window controls then govern size.
 
-## How the panels share state
+## How the tabs share state
 
-Every panel reads the same store. Selecting an event in *Event detail* highlights the corresponding row in *Trace* and pins the *App-DB* diff to that epoch. Dragging the time-travel scrubber retargets every panel at the historical epoch. Clicking a sub in *Subscriptions* opens its source in your editor (next chapter), pins it in *App-DB*, and highlights its incoming edge in the static sub-graph.
+In Dynamic, every tab reads the same spine. Selecting an event in L2 pins the App DB diff to that epoch, filters Trace to that cascade, scopes View to that frame's renders, and lights up Machines / Routing / Issues with that event's activity — all in one frame. The two modes keep separate tab selections, so flipping to Static and back never clobbers where you were.
 
-The state is **one big sub-graph rooted at Causa's app-db** — a separate frame from your app's. That separation is what lets Causa survive `restore-epoch` on the host frame: the historical view is a projection over the rewound host, not a rewound Causa.
+The state is **one big sub-graph rooted at Causa's app-db** — a separate frame (`:rf/causa`) from your app's. That separation is what lets Causa survive `restore-epoch` on the host frame: the historical view is a projection over the rewound host, not a rewound Causa.
 
-You don't have to know any of this to use the tool. But it's how the panel composition is so cheap to extend — adding a fifteenth panel is "register one slot, render one view"; the substrate is already there.
+You don't have to know any of this to use the tool. But it's how the tab composition is so cheap to extend — adding a tab is "register one slot with `reg-l4-tab!`, render one view"; the substrate is already there.
 
-Next: [time-travel scrubbing](03-time-travel.md) — the rail at the bottom of every panel.
+Next: [time-travel scrubbing](03-time-travel.md) — walking the spine into RETRO.

--- a/docs/causa/index.md
+++ b/docs/causa/index.md
@@ -2,11 +2,16 @@
 
 **The cascade you can see.**
 
-Causa is the in-app devtools panel for re-frame2. It auto-opens in a right-side `[data-rf-causa-host]` layout column in your dev build, toggles with `Ctrl+Shift+C`, and renders fourteen panels over a single observation surface — the framework's own trace bus and epoch buffer. No bespoke recorder, no shadow runtime, no second substrate. The runtime knows what happened; Causa is what knows knows.
+Causa is the in-app devtools panel for re-frame2. It auto-opens in a right-side `[data-rf-causa-host]` layout column in your dev build, toggles with `Ctrl+Shift+C`, and renders one of two chromes over a single observation surface — the framework's own trace bus and epoch buffer. No bespoke recorder, no shadow runtime, no second substrate. The runtime knows what happened; Causa is what knows it.
 
-Where the v1-era [`re-frame-10x`](https://github.com/day8/re-frame-10x) was a sidecar with its own recorder, Causa is a *renderer* of an already-structured surface. Same panels — events, subs, renders, fxs, app-db diff, time-travel — different substrate. The framework moved the observation contract into the runtime; Causa moved with it.
+Where the v1-era [`re-frame-10x`](https://github.com/day8/re-frame-10x) was a sidecar with its own recorder, Causa is a *renderer* of an already-structured surface. Same diagnostics — events, subs, renders, fxs, app-db diff, machines, routes — different substrate. The framework moved the observation contract into the runtime; Causa moved with it.
 
-This is the welcome page. The chapters that follow are a walkthrough — install, panel tour, the hero scenarios — designed to read top-to-bottom. If you want a single sentence to take away first: **the runtime emits trace events, Causa renders them; everything else is composition.**
+The chrome is two modes, one toggle (`Cmd-Shift-M`):
+
+- **Dynamic** — the event-coupled spine. Four stacked layers: an L1 ribbon of scope controls, the L2 event list (the timeline), an L3 strip of eight tabs, and the L4 detail panel. You pick one event in L2; every tab rebinds to that one focal point. This is where you live when you're chasing *what just happened*.
+- **Static** — the registry browser. Three layers (no L2 spine, because Static is event-independent): the same L1 ribbon, an L3 strip of five tabs, and the L4 detail panel. This is where you browse *what is registered* — machines, routes, schemas, flows, interceptors — without a running cascade.
+
+The §[Dynamic vs Static](#dynamic-vs-static-two-chromes-one-surface) section below unpacks the split. If you want a single sentence to take away first: **the runtime emits trace events, Causa renders them; everything else is composition.**
 
 ---
 
@@ -23,7 +28,7 @@ The Causa loop is different. You haven't opened Causa yet. You're just looking a
    <span data-rf2-source-coord="parallel-frames.core:title-view:198:4">No title yet…</span>
    ```
 2. The `data-rf2-source-coord` attribute is on **every** rendered DOM element in dev mode. Four segments, colon-separated: `<ns>:<sym>:<line>:<col>`. You're already at the line in your editor.
-3. You read the function. It subscribes to `::title-status` and `::title-text`. You open the running app, press `Ctrl+Shift+C`, click the L1 frame picker, switch from `:above` to `:below`. The Views panel now scopes every sub-recompute to the `:below` frame.
+3. You read the function. It subscribes to `::title-status` and `::title-text`. You open the running app, press `Ctrl+Shift+C`, click the L1 frame picker, switch from `:above` to `:below`. The View tab now scopes every sub-recompute to the `:below` frame.
 4. You click *Refresh* in `:above` only. The frame picker is still on `:below`. The Trace tab is empty for `:below` — no `:title/flow` transition, no HTTP-shaped row, no sub recompute. Flip the picker back to `:above`: a single `:title/flow` machine-transition row, one in-flight HTTP row, and the title-status sub recomputing on a single frame. Frames are isolated. The design holds.
 5. The Machines tab confirms it from the other direction: `[:rf/machines :title/flow]` reads `:loading` under `:above` and `:idle` under `:below`. Two machines, two app-dbs, one source.
 
@@ -36,14 +41,40 @@ This is the loop the rest of the tutorial unpacks. Source coords on the wire. Fr
 The chapters:
 
 - [1. Installation](01-installation.md) — get Causa running against your app in five minutes.
-- [2. Panel tour](02-panel-tour.md) — the fourteen panels, what each is for, when you'd open it.
-- [3. Time-travel scrubbing](03-time-travel.md) — walk the epoch buffer; rewind; replay.
-- [4. Trace stream](04-trace-stream.md) — every fx, every sub, every render, filtered.
-- [5. Click-to-source](05-click-to-source.md) — the hero feature: any DOM element back to its line.
-- [6. Schema-violation timeline](06-schema-timeline.md) — Malli failures over time.
+- [2. Panel tour](02-panel-tour.md) — the two chromes, the thirteen tabs, what each is for, when you'd reach for it.
+- [3. Time-travel scrubbing](03-time-travel.md) — walk the spine into RETRO; rewind; replay.
+- [4. Trace stream](04-trace-stream.md) — the Trace tab: every fx, every sub, every render, filtered.
+- [5. Click-to-source](05-click-to-source.md) — the hero gesture: any DOM element back to its line.
+- [6. Schema-violation timeline](06-schema-timeline.md) — Malli failures, surfaced on the Issues tab.
 - [7. Hydration debugger](07-hydration.md) — server vs client render diff.
-- [8. Machine inspector](08-machine-inspector.md) — Stately-grade state-chart per machine.
-- [9. App-DB diff](09-app-db-diff.md) — slice-centric diff per epoch.
+- [8. Machine inspector](08-machine-inspector.md) — the Machines tab + the spine-independent Machines Canvas.
+- [9. App-DB diff](09-app-db-diff.md) — the App DB tab: slice-centric diff per epoch.
+
+---
+
+## Dynamic vs Static: two chromes, one surface
+
+Causa is one tool with two reading postures. The same trace bus and the same registries feed both; what changes is whether the surface is **coupled to a cascade** or **browsing the registry cold**. Flip between them with `Cmd-Shift-M`; the mode pill at ribbon-left shows which you're in, and the chrome silhouette tells you at a glance even if you don't look at the pill — Dynamic has the L2 event list, Static does not.
+
+| | **Dynamic** | **Static** |
+|---|---|---|
+| Question | "What just happened?" | "What is registered?" |
+| Coupled to | one focused event (the spine sub `:rf.causa/focus`) | nothing — event-independent |
+| Layers | 4 (L1 ribbon · L2 event list · L3 tabs · L4 detail) | 3 (L1 ribbon · L3 tabs · L4 detail — no spine) |
+| Tabs | 8: Event · App DB · View · Trace · Machines · Machines Canvas · Routing · Issues | 5: Machines · Routes · Schemas · Flows · Interceptors |
+| Edge stripe | violet | cyan |
+| Motion | LIVE pulse + tab fade | dampened — pulses off, instant tab swaps |
+
+**Dynamic is the load-bearing mode.** Four layers stack top-to-bottom:
+
+- **L1 — ribbon.** Scope controls: the nav cluster (`◀ ▶ ⏭` — back / forward / snap-to-head), the frame picker, the IN/OUT filter pills, and the right-icons (settings `⚙`, close `✕`).
+- **L2 — event list.** The spine. Single-line rows, latest-on-bottom, eight visible by default and user-resizable. This *is* the timeline — clicking a row focuses it (flips to RETRO) and rebinds every tab below; pressing `⏭` snaps focus back to the live head. Time-travel is reached here, not on a bottom rail (see [chapter 3](03-time-travel.md)).
+- **L3 — tab bar.** Eight tabs, each a lens on the one focused event. Mnemonic letters: Event `e` · App DB `a` · View `v` · Trace `t` · Machines `m` · Machines Canvas `c` · Routing `r` · Issues `i`. Count badges (`View 8`, `Trace 47`) update as focus moves.
+- **L4 — detail panel.** The active tab's projection of the focused event, filling the remaining canvas.
+
+**Static is Causa-in-a-quieter-key.** It drops the L2 spine — there is no "focused event" to couple to — and renders the same ribbon and tab-bar over five registry-browse tabs: Machines (default), Routes, Schemas, Flows, Interceptors. Use it to answer "what machines exist and what do they look like?", "which routes are registered and how do they rank?", "what schemas guard which slots?" — questions about the *shape* of the app, not a particular cascade.
+
+The two modes keep separate tab selections, so flipping back and forth never clobbers where you were.
 
 ---
 
@@ -57,7 +88,7 @@ This is what *first-class tooling* means in re-frame2: not "we shipped a devtool
 
 The integration is *deep*, not bolt-on. The trace events aren't a sidecar log file — they're emitted inline from the pipeline that the runtime is already walking. The epoch records aren't a recording made by a plugin — they're the same records the runtime uses internally to drive `restore-epoch`. There's no second substrate, no shadow runtime, no "make sure devtools is installed first." When the framework knows something happened, the trace bus knows. When the trace bus knows, every attached tool knows.
 
-Causa is just the most *complete* listener — fourteen panels deep, lazily mounted. Pair tools and the Story playground consume the same surfaces with different presentations. Your project's bespoke debug panel can too, in fifteen lines (we'll show it in [chapter 4](04-trace-stream.md)).
+Causa is just the most *complete* listener — two chromes and thirteen tabs deep, lazily mounted. Pair tools and the Story playground consume the same surfaces with different presentations. Your project's bespoke debug panel can too, in fifteen lines (we'll show it in [chapter 4](04-trace-stream.md)).
 
 ## What you get for free
 
@@ -119,7 +150,7 @@ Subscriptions chain — `:count-doubled` depends on `:count`. The framework know
 ;;    :edges #{[:count-doubled :count] ...}}
 ```
 
-This is **static** — no runtime, no live cache, no Reagent. It reads off the registry. Use it to render a graph of "everything derived," find the leaves (subs nothing else depends on), find the roots (subs that read `app-db` directly), and spot dead subs (registered but no consumers). Causa's Subscriptions panel uses this directly.
+This is **static** — no runtime, no live cache, no Reagent. It reads off the registry. Use it to render a graph of "everything derived," find the leaves (subs nothing else depends on), find the roots (subs that read `app-db` directly), and spot dead subs (registered but no consumers). Causa's View tab (Dynamic) reads it to explain why a view re-rendered, and the Schemas tab (Static) browses the registry the same way.
 
 ## What re-frame2 does not ship
 

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -87,7 +87,7 @@ Wireframe at default (800px popout, "cosy" density):
 │ ● :cart/recalculate                                                     │
 │ ◉ :order/retry                                      🌐  ← head/sel      │
 ├═════════════════════════════════════════════════════════════════════════┤   drag handle (L2/L3)
-│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 │              L3 — 8 tabs
+│ ◉Event ○App DB ○View 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 │              L3 — 8 tabs
 ├─────────────────────────────────────────────────────────────────────────┤
 │ — Event tab content for the focused event —                             │   L4 — fills the rest
 └─────────────────────────────────────────────────────────────────────────┘
@@ -106,9 +106,9 @@ The four layers, top to bottom:
    decorated by gutter glyph (`● ◉ x ▥ ↺`) + right-aligned badges (`⚠`
    `🌐` `🤖`) + trailing redaction marker (`[● REDACTED N]`). The
    spine sub `:rf.causa/focus` reads from this layer.
-3. **L3 — Tab bar (40px).** Eight tabs: Event / App-db / Views / Trace /
+3. **L3 — Tab bar (40px).** Eight tabs: Event / App DB / View / Trace /
    Machines / Machines Canvas / Routing / Issues. Letter mnemonics:
-   `e` `a` `v` `t` `m` `c` `r` `i`. Count badges (`Views 8`) update
+   `e` `a` `v` `t` `m` `c` `r` `i`. Count badges (`View 8`) update
    with focused cascade. Routing was promoted to its own L3 tab in
    rf2-nrbs9; Machines Canvas was promoted in rf2-mkpnb — both follow
    the cohesive-sub-domain rule (sub-domains earn their own lens tab).
@@ -1172,9 +1172,9 @@ on `Esc`, click-outside, or invocation of any item.
 - Registered handlers (id + `:doc`)
 - Frames
 - Machines with current state
-- L4 tab jumps — Dynamic: Event / App-db / Views / Trace / Machines
-  / Routing / Issues; Static: Machines / Routes / Schemas / Views /
-  Events (see §Mode-aware command surface below)
+- L4 tab jumps — Dynamic: Event / App DB / View / Trace / Machines
+  / Machines Canvas / Routing / Issues; Static: Machines / Routes /
+  Schemas / Flows / Interceptors (see §Mode-aware command surface below)
 - Command verbs (recents-boosted; see §Command verbs below)
 - Settings entries
 - Pinned cascades (pin chips live in the palette as a "Pinned
@@ -1631,8 +1631,8 @@ with L2; Static is 3-layer without). The composer (`surface-composer`
 in `shell.cljs`) `case`-dispatches between the two on `[:rf.causa/mode]`.
 
 **Tab inventory rule.** Tab inventories are mode-keyed and not shared.
-Dynamic ships 7 tabs (Event / App-DB / Views / Trace / Machines /
-Routing / Issues — see [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
+Dynamic ships 8 tabs (Event / App DB / View / Trace / Machines /
+Machines Canvas / Routing / Issues — see [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
 for the per-panel content designs). Static ships 5 tabs (Machines /
 Routes / Schemas / Flows / Interceptors — see §Sub-tab inventory
 above). New tabs MUST declare which mode(s) they belong to; tab-id

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -315,7 +315,7 @@
 
     ;; ---- 4-layer chrome events (rf2-xy4yb / spec/018) -------------
 
-    ;; L3 tab bar — flip the active tab. Six valid ids per spec/018 §5:
+    ;; L3 tab bar — flip the active tab. Eight valid ids per spec/018 §5:
     ;; :event :app-db :views :trace :machines :machines-canvas :routing :issues
     ;; (rf2-2moh1 registry-driven; new tab requires only a reg-l4-tab! call).
     (rf/reg-event-db :rf.causa/select-tab


### PR DESCRIPTION
## Summary

Two documentation/inventory reconciliations so docs match the shipped Causa IA.

**rf2-1haya — docs/causa rewritten to the current chrome.** `index.md` and `02-panel-tour.md` still described the deleted IA: "fourteen panels" in a two-band sidebar, a bottom-rail time-travel scrubber, standalone Subscriptions/Effects panels. They are rewritten to the shipped tool:

- **Dynamic chrome** — 4 layers (L1 ribbon · L2 event list / spine · L3 8-tab strip · L4 detail), where every tab is a lens on one focused event.
- **Static chrome** — 3 layers (no L2 spine), 5 registry-browse tabs.
- New **"Dynamic vs Static"** section in the index, with a comparison table; the panel tour now walks all 8 Dynamic tabs (Event / App DB / View / Trace / Machines / Machines Canvas / Routing / Issues) and 5 Static tabs (Machines / Routes / Schemas / Flows / Interceptors).
- Time-travel is reframed as walking the L2 spine into RETRO (not a bottom rail); Effects/Subs/Performance documented as folded-away, not separate panels. Existing chapter cross-links and screenshots retained.

**rf2-tzket — spec 007 + registry comment reconciled to spec/018 §5 and the shipped labels.**

- `007-UX-IA.md`: the L3 ASCII strip and prose now read `App DB` / `View` / `Machines Canvas` (was `App-db` / `Views` / `Canvas`); the "Tab inventory rule" and command-palette tab list corrected from 7 → 8 Dynamic tabs (Machines Canvas was missing) and from the removed Static `Views / Events` sub-tabs to the shipped `Flows / Interceptors`.
- `registry.cljs`: the comment that said "Six valid ids" while listing eight is corrected to "Eight" (comment-only).

Docs and spec now match the shipped IA.

## Test plan

- [x] `mkdocs build --strict` — clean (exit 0, no warnings).
- [x] `python scripts/check_doc_slugs.py` — exit 0.
- [x] registry.cljs change is comment-only (no test run required).