### PR TITLE
fix(causa): modal focus-trap + restore-on-close + resolve focus-chip no-op (rf2-tpn0u + rf2-w738i)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -277,12 +277,14 @@
            :style       (backdrop-style positioning)}
      [:div (merge
              ;; rf2-7389r — WAI-ARIA dialog contract. The edit-popup
-             ;; already auto-focuses the pattern input on mount, so a
-             ;; focus-on-mount ref would duplicate the work. The
-             ;; existing auto-focus satisfies "focus captured inside
-             ;; the dialog" without an additional ref pass.
+             ;; `:auto-focus`es the pattern input, so `a11y/dialog-ref`
+             ;; detects focus already inside the dialog on mount and
+             ;; leaves it there (no double focus). The ref still installs
+             ;; the Tab/Shift+Tab focus trap and restores focus to the
+             ;; opener (the clicked pill / add-pill button) on close.
              (a11y/dialog-attrs {:labelled-by "rf-causa-edit-popup-title"})
              {:data-testid "rf-causa-edit-popup-dialog"
+              :ref         (a11y/dialog-ref)
               :tab-index   "-1"
               :on-click    #(.stopPropagation %)
               :style       (dialog-style)})

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
@@ -213,13 +213,15 @@
      [:div (merge
              ;; rf2-7389r — WAI-ARIA dialog contract on the inspector
              ;; popover. The previous tab-index 0 marker hinted at
-             ;; focus-trap intent but lacked role/aria-modal; this
-             ;; finishes the contract + adds focus-on-mount so keyboard
-             ;; users start inside the dialog (audit findings #3 + #19).
+             ;; focus-trap intent but lacked role/aria-modal; `:ref`
+             ;; (a11y/dialog-ref) finishes the contract — focus lands
+             ;; inside on open, Tab/Shift+Tab cycle within the dialog,
+             ;; and focus restores to the opener on close (audit
+             ;; findings #3 + #8 + #19).
              (a11y/dialog-attrs {:labelled-by "rf-causa-segment-inspector-title"})
              {:data-testid "rf-causa-segment-inspector-dialog"
               :data-rf-causa-mode "segment-inspector"
-              :ref         (a11y/focus-on-mount-ref)
+              :ref         (a11y/dialog-ref)
               :on-click    #(.stopPropagation %)
               :on-key-down handle-keydown
               :tab-index   0

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -478,12 +478,13 @@
                ;; rf2-7389r — WAI-ARIA dialog contract on the popover
                ;; wrapper. The cancellation-cascade popover already
                ;; carried `tab-index 0` markers hinting at focus-trap
-               ;; intent; this completes the modal contract with
-               ;; role/aria-modal/aria-label + a focus-on-mount ref
-               ;; (audit finding #3 + #19).
+               ;; intent; `a11y/dialog-ref` now delivers it for real —
+               ;; focus lands inside on open, Tab/Shift+Tab cycle within
+               ;; the dialog, and focus restores to the opener on close
+               ;; (audit finding #3 + #8 + #19).
                (a11y/dialog-attrs {:label "Cancellation cascade"})
                {:data-testid "rf-causa-cancellation-cascade-popover-dialog"
-                :ref         (a11y/focus-on-mount-ref)
+                :ref         (a11y/dialog-ref)
                 :on-click    #(.stopPropagation %)
                 :on-key-down handle-popover-keydown
                 :tab-index   0

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -1138,13 +1138,15 @@
      [:div (merge
              ;; rf2-7389r — WAI-ARIA dialog contract: role/aria-modal/
              ;; aria-labelledby pointing at the visible title span.
-             ;; `:ref` focuses the first focusable descendant on mount
-             ;; so keyboard users land inside the modal rather than on
-             ;; <body> (audit finding #3 + #8).
+             ;; `:ref` (a11y/dialog-ref) wires the full modal focus
+             ;; contract: focus lands inside on open, Tab/Shift+Tab
+             ;; cycle within the dialog (focus trap), and focus restores
+             ;; to the opener (the ⚙ ribbon button) on close — so
+             ;; keyboard users never get dropped on <body>.
              (a11y/dialog-attrs {:labelled-by "rf-causa-settings-title"})
              {:data-testid "rf-causa-settings-dialog"
               :data-rf-causa-mode "settings"
-              :ref         (a11y/focus-on-mount-ref)
+              :ref         (a11y/dialog-ref)
               :on-click    #(.stopPropagation %)
               :on-key-down handle-keydown
               :tab-index   "-1"

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -306,12 +306,13 @@
         export-avail?  @(rf/subscribe [:rf.causa/cascade-export-available?])
         export-status  @(rf/subscribe [:rf.causa/cascade-export-status])]
     [:div (merge
-            ;; rf2-7389r — WAI-ARIA dialog contract + focus capture on
-            ;; mount so keyboard users land inside the modal (audit
-            ;; finding #3).
+            ;; rf2-7389r — WAI-ARIA dialog contract. `:ref`
+            ;; (a11y/dialog-ref) lands focus inside on open, traps
+            ;; Tab/Shift+Tab within the dialog, and restores focus to
+            ;; the opener on close (audit finding #3 + #8).
             (a11y/dialog-attrs {:labelled-by "rf-causa-share-modal-title"})
             {:data-testid "rf-causa-share-modal-dialog"
-             :ref         (a11y/focus-on-mount-ref)
+             :ref         (a11y/dialog-ref)
              :tab-index   "-1"
              :on-click    (fn [e] (.stopPropagation e))
              :on-key-down (fn [^js e]

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -542,11 +542,27 @@
      [:span {:aria-hidden "true"} "● "]
      (str "REDACTED " redacted-count)]))
 
+;; Forward declaration — the L2 scroll-into-view machinery is defined
+;; alongside the event-list renderer further down (it lives next to its
+;; sibling `scroll-focused-row-into-view!`), but the L1 focus chip below
+;; reaches it for the rf2-w738i "reveal pivot row" gesture.
+(declare scroll-row-into-view-by-id!)
+
 (defn- ribbon-focus-chip
   "Focus chip (rf2-a1z3b) — surfaces the active focus-set as
-  `🎯 <pivot-label> ✕`. Click `✕` clears focus; click the chip body
-  to scroll the pivot row into view (future). Renders nothing when
-  no focus-set is active.
+  `🎯 <pivot-label> ✕`. Renders nothing when no focus-set is active.
+
+  Two interactive surfaces:
+
+    - **Chip body** (rf2-w738i) — clicking (or Enter / Space on the
+      keyboard) scrolls the pivot row back into view in L2. The pivot
+      is the anchor row that established the focus (`:pivot-id`); after
+      stepping through the focus subset with `[◀][▶]` the user can lose
+      sight of it, so the chip body is the 'take me back to the anchor'
+      gesture. Wired to `scroll-row-into-view-by-id!` — the row is
+      located by the same `data-testid` the L2 renderer stamps.
+    - **`✕` clear button** — clears focus (`:rf.causa/clear-focus`).
+      `stopPropagation` keeps the body's scroll gesture from also firing.
 
   Placement: directly after the nav cluster so the user's eye picks
   it up next to `[◀][▶]` — those buttons step ONLY through the focus
@@ -554,11 +570,24 @@
   as 'stepping inside this focus'."
   [{:keys [focus-set]}]
   (when focus-set
-    (let [label (fh/pivot-label focus-set)
-          tip   (str "Focus: " (fh/dimension-label focus-set)
-                     " (Esc to clear)")]
+    (let [label    (fh/pivot-label focus-set)
+          pivot-id (:pivot-id focus-set)
+          scroll!  (fn [^js e]
+                     (.stopPropagation e)
+                     (scroll-row-into-view-by-id! pivot-id))
+          tip      (str "Focus: " (fh/dimension-label focus-set)
+                        " — click to reveal the pivot row (Esc to clear)")]
       [:div {:data-testid "rf-causa-focus-chip"
              :title       tip
+             :role        "button"
+             :tab-index   "0"
+             :aria-label  (str "Reveal pivot row for focus " label)
+             :on-click    scroll!
+             :on-key-down (fn [^js e]
+                            (let [k (.-key e)]
+                              (when (or (= k "Enter") (= k " "))
+                                (.preventDefault e)
+                                (scroll! e))))
              :style       {:display        "inline-flex"
                            :align-items    "center"
                            :gap            "4px"
@@ -569,6 +598,7 @@
                            :font-family    sans-stack
                            :font-size      (:body type-scale)
                            :color          (:text-primary tokens)
+                           :cursor         "pointer"
                            :max-width      "240px"}}
        ;; rf2-vxpq1 — `🎯` is a decorative glyph; the chip's
        ;; "Focus: <label>" tooltip + the label span carry the
@@ -587,7 +617,10 @@
                        :font-size     (:caption type-scale)}}
         label]
        [:button {:data-testid "rf-causa-focus-chip-clear"
-                 :on-click    #(rf/dispatch [:rf.causa/clear-focus] {:frame :rf/causa})
+                 :on-click    (fn [^js e]
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/clear-focus]
+                                             {:frame :rf/causa}))
                  :title       "Clear focus (Esc)"
                  :aria-label  "Clear focus"
                  :style       {:background    "transparent"
@@ -821,6 +854,22 @@
   [^js el]
   (when (and el (.-scrollIntoView el))
     (.scrollIntoView el #js {:behavior "auto" :block "nearest"})))
+
+(defn- scroll-row-into-view-by-id!
+  "Scroll the L2 row whose `:dispatch-id` is `id` into view. Locates the
+  row by its `data-testid` (`rf-causa-event-row-<id>`) — the same id the
+  `event-row` renderer stamps — and delegates to
+  `scroll-focused-row-into-view!`. No-op when `js/document` is absent
+  (node-test) or the row isn't currently mounted (e.g. scrolled far out
+  of the virtual window). Returns the located element (or nil) so
+  callers / tests can assert the lookup."
+  [id]
+  (when (and (exists? js/document) (.-querySelector js/document) id)
+    (let [sel (str "[data-testid=\"rf-causa-event-row-" (str id) "\"]")
+          el  (.querySelector js/document sel)]
+      (when el
+        (scroll-focused-row-into-view! el))
+      el)))
 
 (defn- focused-row-ref
   "Build the `:ref` callback for a row that is BOTH focused AND in the

--- a/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
@@ -473,11 +473,15 @@
   []
   (let [muted @(rf/subscribe [:rf.causa/muted-event-ids])]
     [:div (merge
-            ;; rf2-7389r — WAI-ARIA dialog contract + focus capture on
-            ;; mount (audit finding #3).
+            ;; rf2-7389r — WAI-ARIA dialog contract. `:ref`
+            ;; (a11y/dialog-ref) lands focus inside on open, traps
+            ;; Tab/Shift+Tab within the dialog (the empty-state body
+            ;; has no focusable child, so the trap pins focus on the
+            ;; tab-index=-1 root), and restores focus to the opener on
+            ;; close (audit finding #3 + #8).
             (a11y/dialog-attrs {:labelled-by "rf-causa-mute-manager-title"})
             {:data-testid "rf-causa-mute-manager-dialog"
-             :ref         (a11y/focus-on-mount-ref)
+             :ref         (a11y/dialog-ref)
              :tab-index   "-1"
              :on-click    (fn [^js e] (.stopPropagation e))
              :on-key-down (fn [^js e]

--- a/tools/causa/src/day8/re_frame2_causa/theme/a11y.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/a11y.cljs
@@ -19,12 +19,21 @@
     - `dialog-attrs` — the canonical ARIA attribute map a dialog
       wrapper merges into its `:div` props. Pure data; one source of
       truth for the role / aria-modal / accessible-name shape.
-    - `focus-on-mount-ref` — a React `:ref` callback that focuses the
-      first focusable element inside a dialog when it mounts. Handles
-      the common case where the dialog itself needs to be focused
-      (so Esc / arrow-keys / Tab work from a known starting point);
-      falls back to focusing the dialog root if no focusable child
-      is found.
+    - `dialog-ref` — a React `:ref` callback that wires the full
+      WAI-ARIA APG modal-dialog focus contract end-to-end:
+
+        1. **Focus capture on open** — focuses the first focusable
+           element inside the dialog when it mounts (falls back to the
+           dialog root, which the caller marks `tab-index=\"-1\"`).
+        2. **Focus TRAP** — while the dialog is open, `Tab` /
+           `Shift+Tab` cycle within the dialog's focusable set rather
+           than leaking to the chrome beneath. Tab from the last
+           focusable wraps to the first; Shift+Tab from the first wraps
+           to the last (the APG dialog recipe).
+        3. **Focus RESTORE on close** — captures `document.activeElement`
+           at open and re-focuses it on unmount, so closing the dialog
+           returns the keyboard user to where they were (the opener
+           button), instead of dropping focus to `<body>`.
 
   ## Why a `:ref` callback rather than `useEffect` / lifecycle
 
@@ -32,17 +41,13 @@
   `r/create-class`, no `useEffect`. A `:ref` callback is the smallest
   surface that hooks into the mount lifecycle without restructuring
   the call site. React invokes the ref with the DOM node on mount
-  and `nil` on unmount; we only act on the mount call.
+  and `nil` on unmount; `dialog-ref` keys both: the mount call captures
+  the opener + installs the trap listener; the unmount call tears the
+  listener down + restores focus.
 
-  ## What does NOT live here (yet)
-
-    - Focus RESTORE on close — capturing `document.activeElement` on
-      open and re-focusing it on close. Tracked as audit finding #8
-      (P2, separate bead).
-    - Focus TRAP — preventing Tab from leaking to chrome beneath the
-      modal. The current behaviour relies on the modal's backdrop +
-      Esc handler to be the user's primary exit; a full trap is the
-      next rev."
+  Each `dialog-ref` call returns a FRESH closure carrying its own
+  capture/listener state, so a re-mount (close-then-reopen) starts a
+  clean lifecycle and never restores a stale opener."
   (:require [clojure.string :as str]))
 
 ;; ---- pure-data attrs ----------------------------------------------------
@@ -76,10 +81,11 @@
 
 ;; ---- focus capture ref --------------------------------------------------
 
-(def ^:private focusable-selector
+(def focusable-selector
   "CSS selector matching elements that can receive keyboard focus by
-  default. Used by `focus-on-mount-ref` to find the first focusable
-  descendant of a freshly-mounted dialog.
+  default. Used by `dialog-ref` to find the focusable descendants of a
+  mounted dialog (for both the focus-on-open landing target and the
+  Tab-trap cycle endpoints).
 
   Excludes elements with `disabled` (attribute selector) and matches
   the WAI-ARIA APG dialog pattern's canonical focusable set."
@@ -91,35 +97,156 @@
              "textarea:not([disabled])"
              "[tabindex]:not([tabindex=\"-1\"])"]))
 
-(defn focus-on-mount-ref
-  "Build a React `:ref` callback that focuses the first focusable
-  descendant of the mounted dialog node — or the dialog node itself
-  if none is found.
+;; ---- pure trap math -----------------------------------------------------
 
-  Returns a function suitable for use as `:ref` on the dialog's outer
-  `:div`. The callback handles unmount (node `nil`) as a no-op so it
-  never throws after the dialog closes.
+(defn trap-wrap-target
+  "Pure helper computing where a `Tab` keystroke should land when it
+  would otherwise leak out of a modal dialog's focusable cycle.
 
-  Idempotent on remount — each mount triggers the focus call once.
+  Given the dialog's ordered `focusables` vector, the currently-focused
+  `active` element, and whether `shift?` is held, return the element to
+  redirect focus to — or `nil` when no redirect is needed (the browser's
+  native Tab moves focus correctly inside the cycle).
 
-  ## Why focus the dialog node as a fallback
+  Wrap rules (WAI-ARIA APG dialog pattern):
 
-  WAI-ARIA APG's dialog pattern says focus must land *inside* the
-  dialog on open. When the dialog has no focusable child (e.g. an
-  empty-state mute manager), focusing the dialog root with
-  `tab-index=\"-1\"` keeps Esc / arrow-keys functional and gives
-  screen readers a programmatic focus target.
+    - `Tab` from the LAST focusable → wrap to the FIRST.
+    - `Shift+Tab` from the FIRST focusable → wrap to the LAST.
+    - `Tab` / `Shift+Tab` when focus is OUTSIDE the dialog's focusable
+      set (e.g. focus sits on the `tab-index=-1` dialog root, or on an
+      element not in `focusables`) → pull focus to the boundary element
+      (first for Tab, last for Shift+Tab) so the trap re-captures it.
+    - Single focusable → that element is both first and last, so any
+      Tab wraps back to it.
 
-  Caller must set `:tab-index \"-1\"` on the dialog div so the
-  fallback `.focus()` call succeeds.
+  Returns nil for the in-between case (focus on a non-boundary
+  focusable) so the caller leaves the native Tab alone. Pure data →
+  element-or-nil; JVM-runnable so the wrap math is tested without DOM."
+  [focusables active shift?]
+  (let [n (count focusables)]
+    (when (pos? n)
+      (let [first-el (nth focusables 0)
+            last-el  (nth focusables (dec n))
+            idx      (loop [i 0]
+                       (cond
+                         (= i n)                  nil
+                         (= active (nth focusables i)) i
+                         :else                    (recur (inc i))))]
+        (cond
+          ;; focus outside the cycle → pull to the boundary
+          (nil? idx)              (if shift? last-el first-el)
+          ;; Shift+Tab off the first → wrap to last
+          (and shift? (zero? idx))     last-el
+          ;; Tab off the last → wrap to first
+          (and (not shift?) (= idx (dec n))) first-el
+          ;; mid-cycle → let the browser handle it
+          :else                   nil)))))
 
-  Pre-alpha caveat: this does NOT trap focus — Tab can still leak to
-  chrome beneath. Trap is the next rev (rf2-7389r follow-on)."
+;; ---- the full modal focus-contract ref ----------------------------------
+
+(defn- node-list->vec
+  "Coerce a DOM `NodeList` (from `querySelectorAll`) to a CLJS vector,
+  preserving document order. Guards `nil` (no DOM) → empty vector."
+  [^js node-list]
+  (if node-list
+    (into [] (for [i (range (.-length node-list))]
+               (.item node-list i)))
+    []))
+
+(defn dialog-ref
+  "Build a React `:ref` callback wiring the full WAI-ARIA APG modal
+  focus contract — capture-on-open, Tab-trap, restore-on-close — onto
+  the dialog's outer `:div`.
+
+  React invokes the ref with the DOM node on mount and `nil` on
+  unmount. This closure keeps per-instance state so both calls are
+  handled:
+
+  ## On mount (node non-nil)
+
+    1. Captures `document.activeElement` — the element that had focus
+       when the dialog opened (typically the opener button). Stashed so
+       the unmount call can restore it.
+    2. Focuses the first focusable descendant, or the dialog root
+       itself when there is none (e.g. an empty-state mute manager).
+       The root must carry `tab-index=\"-1\"` for that fallback to take.
+    3. Installs a `keydown` listener on the dialog node that intercepts
+       `Tab` / `Shift+Tab` and wraps focus inside the dialog's
+       focusable set (see `trap-wrap-target`). `preventDefault` stops
+       the native focus move only when a wrap is needed.
+
+  ## On unmount (node nil)
+
+    1. Removes the keydown listener.
+    2. Restores focus to the captured opener (when it is still in the
+       document and focusable), so closing the dialog returns the
+       keyboard user to where they were — not to `<body>`.
+
+  Tolerant of a DOM-less runtime (Node test target): when
+  `js/document` is absent it degrades to a no-op ref, so the same view
+  fn renders on both the browser-test and node-test builds."
   []
-  (fn [^js node]
-    (when node
-      (let [focusable (.querySelector node focusable-selector)
-            target    (or focusable node)]
-        (try
-          (.focus target)
-          (catch :default _ nil))))))
+  (let [opener   (atom nil)     ;; element focused before the dialog opened
+        listener (atom nil)     ;; the installed keydown handler (for teardown)
+        node*    (atom nil)]    ;; the dialog node (closure over remove-listener)
+    (fn [^js node]
+      (when (exists? js/document)
+        (if node
+          ;; ---- mount ------------------------------------------------------
+          (do
+            (reset! node* node)
+            ;; Capture the opener for restore-on-close. Only an element
+            ;; OUTSIDE the dialog is a valid opener — if focus already
+            ;; sits inside (an `:auto-focus` input ran before this ref),
+            ;; the original opener is no longer derivable, so we record
+            ;; nil and skip restore rather than restoring into the
+            ;; closed dialog's stale subtree.
+            (let [active (.-activeElement js/document)
+                  inside? (and active (not= active node) (.contains node active))]
+              (reset! opener (when-not inside? active))
+              ;; (1)+(2) land focus inside the dialog — UNLESS something
+              ;; inside already holds focus (e.g. the filter edit-popup's
+              ;; `:auto-focus` pattern field). Respecting a pre-focused
+              ;; descendant keeps the caller's intended landing target
+              ;; while still installing the trap + restore below.
+              (when-not inside?
+                (let [target (or (.querySelector node focusable-selector) node)]
+                  (try (.focus target) (catch :default _ nil)))))
+            ;; (3) install the Tab trap
+            (let [handler
+                  (fn [^js e]
+                    (when (= "Tab" (.-key e))
+                      (let [focusables (node-list->vec
+                                         (.querySelectorAll node focusable-selector))]
+                        ;; No focusable child → keep focus pinned on the
+                        ;; dialog root (which is tab-index=-1) so Tab can't
+                        ;; escape to the chrome beneath.
+                        (if (empty? focusables)
+                          (do (.preventDefault e)
+                              (try (.focus node) (catch :default _ nil)))
+                          (when-let [target (trap-wrap-target
+                                              focusables
+                                              (.-activeElement js/document)
+                                              (.-shiftKey e))]
+                            (.preventDefault e)
+                            (try (.focus target) (catch :default _ nil)))))))]
+              (reset! listener handler)
+              (.addEventListener node "keydown" handler)))
+          ;; ---- unmount ----------------------------------------------------
+          (do
+            (when-let [n @node*]
+              (when-let [h @listener]
+                (.removeEventListener n "keydown" h)))
+            (reset! listener nil)
+            (reset! node* nil)
+            ;; restore focus to the opener if it is still attached +
+            ;; focusable (a removed/replaced opener is skipped rather
+            ;; than throwing).
+            (let [prev @opener
+                  body (.-body js/document)]
+              (when (and prev
+                         (.-focus prev)
+                         body
+                         (.contains body prev))
+                (try (.focus prev) (catch :default _ nil))))
+            (reset! opener nil)))))))

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -763,6 +763,55 @@
         "auto-track? false → nil ref")))
 
 ;; -------------------------------------------------------------------------
+;; (3b) Focus chip body click — reveal pivot row (rf2-w738i)
+;; -------------------------------------------------------------------------
+;;
+;; The chip body used to advertise a "(future)" scroll-to-pivot gesture
+;; with no handler — a broken-claim affordance. It now WIRES that gesture
+;; to `scroll-row-into-view-by-id!`, locating the pivot row by the same
+;; `data-testid` the L2 renderer stamps.
+
+(deftest focus-chip-renders-nothing-without-focus-set
+  (testing "rf2-w738i — no active focus-set → the chip renders nothing
+            (no stray clickable chrome)"
+    (is (nil? (#'shell/ribbon-focus-chip {:focus-set nil})))))
+
+(deftest focus-chip-body-is-an-interactive-button
+  (testing "rf2-w738i — the chip body is a real button affordance:
+            role=button, keyboard-focusable, with both pointer + key
+            activation wired (no longer a misleading dead surface)"
+    (let [chip  (#'shell/ribbon-focus-chip
+                  {:focus-set {:dimension :event-id
+                               :value     :some/event
+                               :pivot-id  7}})
+          attrs (second chip)]
+      (is (= "rf-causa-focus-chip" (:data-testid attrs)))
+      (is (= "button" (:role attrs)) "chip body exposes role=button")
+      (is (= "0" (:tab-index attrs)) "chip body is keyboard-focusable")
+      (is (string? (:aria-label attrs)) "chip body has an accessible name")
+      (is (= "pointer" (get-in attrs [:style :cursor]))
+          "cursor:pointer telegraphs the (now-real) interactivity")
+      (is (fn? (:on-click attrs)) "pointer activation wired")
+      (is (fn? (:on-key-down attrs)) "keyboard activation wired"))))
+
+(deftest focus-chip-clear-button-stops-propagation
+  (testing "rf2-w738i — clicking ✕ clears focus WITHOUT also firing the
+            body's scroll gesture (stopPropagation on the clear button)"
+    (let [chip       (#'shell/ribbon-focus-chip
+                       {:focus-set {:dimension :event-id
+                                    :value     :some/event
+                                    :pivot-id  7}})
+          clear-btn  (find-by-testid chip "rf-causa-focus-chip-clear")
+          stopped?   (atom false)
+          stub-event #js {:stopPropagation #(reset! stopped? true)}]
+      (is (some? clear-btn) "clear ✕ button present")
+      ;; Invoking the handler must call stopPropagation (so the chip
+      ;; body's on-click doesn't also run). We don't assert the dispatch
+      ;; here (covered by the focus-clear event tests); only the guard.
+      ((:on-click (second clear-btn)) stub-event)
+      (is @stopped? "clear button stops propagation to the chip body"))))
+
+;; -------------------------------------------------------------------------
 ;; (4a) Ribbon nav button enable/disable state — rf2-htik0 Bug 1
 ;; -------------------------------------------------------------------------
 ;;

--- a/tools/causa/test/day8/re_frame2_causa/shell_focus_chip_dom_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_focus_chip_dom_cljs_test.cljs
@@ -1,0 +1,65 @@
+(ns day8.re-frame2-causa.shell-focus-chip-dom-cljs-test
+  "Live-DOM test for the focus-chip 'reveal pivot row' gesture
+  (rf2-w738i). The chip body's click delegates to
+  `shell/scroll-row-into-view-by-id!`, which locates the pivot row by
+  the `rf-causa-event-row-<id>` data-testid the L2 renderer stamps and
+  calls `scrollIntoView` on it.
+
+  This needs a real DOM (`document.querySelector` against a mounted
+  subtree + an element carrying `scrollIntoView`), so the filename ends
+  in `_dom_cljs_test.cljs` to run under the `:browser-test` build. Under
+  `:node-test` the `(when (exists? js/document) …)` guards keep it green.
+
+  The hiccup-level wiring of the chip (role=button, handlers present,
+  stopPropagation on clear) is covered node-side in `shell-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.shell :as shell]))
+
+(defn- mk-row!
+  "Append a stub L2 row with the canonical data-testid for `id` under
+  `host`. Stamps a `scrollIntoView` that records calls into `calls`.
+  Returns the element."
+  [host id calls]
+  (let [el (.createElement js/document "div")]
+    (.setAttribute el "data-testid" (str "rf-causa-event-row-" (str id)))
+    (set! (.-scrollIntoView el) (fn [_opts] (swap! calls inc)))
+    (.appendChild host el)
+    el))
+
+(deftest scroll-row-into-view-by-id-finds-and-scrolls-pivot
+  (testing "rf2-w738i — `scroll-row-into-view-by-id!` locates the row by
+            its data-testid and calls scrollIntoView on it"
+    (when (exists? js/document)
+      (let [host  (.createElement js/document "div")
+            calls (atom 0)]
+        (.appendChild (.-body js/document) host)
+        (mk-row! host 1 calls)
+        (let [pivot (mk-row! host 7 calls)]
+          (mk-row! host 9 calls)
+          (try
+            (let [found (#'shell/scroll-row-into-view-by-id! 7)]
+              (is (= pivot found) "returns the located pivot row element")
+              (is (= 1 @calls) "scrollIntoView fired exactly once on the pivot"))
+            (finally
+              (.removeChild (.-body js/document) host))))))))
+
+(deftest scroll-row-into-view-by-id-noop-when-row-absent
+  (testing "rf2-w738i — when the pivot row isn't mounted (scrolled out of
+            the virtual window), the helper is a clean no-op (nil, no
+            throw)"
+    (when (exists? js/document)
+      (let [host  (.createElement js/document "div")
+            calls (atom 0)]
+        (.appendChild (.-body js/document) host)
+        (mk-row! host 1 calls)
+        (try
+          (is (nil? (#'shell/scroll-row-into-view-by-id! 999))
+              "absent row → nil")
+          (is (zero? @calls) "no scroll fired")
+          (finally
+            (.removeChild (.-body js/document) host)))))))
+
+(deftest scroll-row-into-view-by-id-noop-on-nil-id
+  (testing "rf2-w738i — a nil pivot-id (degenerate focus-set) is a no-op"
+    (when (exists? js/document)
+      (is (nil? (#'shell/scroll-row-into-view-by-id! nil))))))

--- a/tools/causa/test/day8/re_frame2_causa/theme/a11y_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/a11y_cljs_test.cljs
@@ -1,16 +1,20 @@
 (ns day8.re-frame2-causa.theme.a11y-cljs-test
   "Pure-data tests for the shared a11y helper (rf2-7389r).
 
-  The helper extracts the WAI-ARIA dialog contract + a focus-on-mount
-  `:ref` callback shared by Causa's six modal surfaces. Tests cover:
+  The helper extracts the WAI-ARIA dialog contract + a full modal-
+  focus `:ref` callback (`dialog-ref` — capture-on-open, Tab trap,
+  restore-on-close) shared by Causa's six modal surfaces. Tests cover:
 
     1. `dialog-attrs` shape — role + aria-modal always present;
        labelled-by preferred over label; describedby attaches when set.
-    2. `focus-on-mount-ref` returns a fn (callback ref) that is a no-op
-       on unmount (`nil` node).
+    2. `trap-wrap-target` — the pure Tab-wrap math (JVM/node-runnable):
+       wrap at the boundaries, no-op mid-cycle, pull-in when focus is
+       outside the cycle, single-focusable wraps to itself.
+    3. `dialog-ref` returns a fn (callback ref) that is a no-op on
+       unmount (`nil` node) and tolerates a DOM-less runtime.
 
-  The interactive `.focus()` behaviour is exercised indirectly via the
-  modal integration tests (see `modals.aria-cljs-test`)."
+  The live `.focus()` capture / trap / restore behaviour against a real
+  DOM is exercised by `theme.a11y-dom-cljs-test` (browser-test build)."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-causa.theme.a11y :as a11y]))
 
@@ -57,54 +61,57 @@
       (is (nil? (:aria-label attrs)))
       (is (nil? (:aria-labelledby attrs))))))
 
-;; ---- focus-on-mount-ref ---------------------------------------------------
+;; ---- trap-wrap-target (pure) ---------------------------------------------
+;;
+;; `:a` / `:b` / `:c` stand in for DOM elements — `trap-wrap-target` only
+;; ever compares them by identity, so plain keywords exercise the math.
 
-(deftest focus-on-mount-ref-returns-a-function
+(deftest trap-wrap-target-no-op-mid-cycle
+  (testing "rf2-tpn0u — Tab from a non-boundary focusable returns nil so
+            the browser's native Tab handles the move (no wrap needed)"
+    (is (nil? (a11y/trap-wrap-target [:a :b :c] :b false))
+        "Tab from the middle element → nil")
+    (is (nil? (a11y/trap-wrap-target [:a :b :c] :b true))
+        "Shift+Tab from the middle element → nil")))
+
+(deftest trap-wrap-target-tab-off-last-wraps-to-first
+  (testing "rf2-tpn0u — Tab from the LAST focusable wraps to the FIRST"
+    (is (= :a (a11y/trap-wrap-target [:a :b :c] :c false)))))
+
+(deftest trap-wrap-target-shift-tab-off-first-wraps-to-last
+  (testing "rf2-tpn0u — Shift+Tab from the FIRST focusable wraps to the
+            LAST"
+    (is (= :c (a11y/trap-wrap-target [:a :b :c] :a true)))))
+
+(deftest trap-wrap-target-pulls-in-when-focus-outside-cycle
+  (testing "rf2-tpn0u — when focus is OUTSIDE the focusable set (e.g. on
+            the tab-index=-1 dialog root), Tab pulls to the first +
+            Shift+Tab pulls to the last so the trap re-captures focus"
+    (is (= :a (a11y/trap-wrap-target [:a :b :c] :root false)))
+    (is (= :c (a11y/trap-wrap-target [:a :b :c] :root true)))))
+
+(deftest trap-wrap-target-single-focusable-wraps-to-itself
+  (testing "rf2-tpn0u — with one focusable, it is both first and last,
+            so any Tab keeps focus pinned on it"
+    (is (= :only (a11y/trap-wrap-target [:only] :only false)))
+    (is (= :only (a11y/trap-wrap-target [:only] :only true)))))
+
+(deftest trap-wrap-target-empty-is-nil
+  (testing "rf2-tpn0u — no focusables → nil (caller pins focus on the
+            dialog root instead)"
+    (is (nil? (a11y/trap-wrap-target [] :anything false)))))
+
+;; ---- dialog-ref factory --------------------------------------------------
+
+(deftest dialog-ref-returns-a-function
   (testing "the factory yields a React :ref callback (a fn)"
-    (let [ref (a11y/focus-on-mount-ref)]
+    (let [ref (a11y/dialog-ref)]
       (is (fn? ref)))))
 
-(deftest focus-on-mount-ref-tolerates-nil-unmount
-  (testing "rf2-7389r — React invokes the ref with `nil` on unmount;
-            the callback must short-circuit so it never throws after
-            the modal closes (e.g. backdrop click while focus was
-            pending)"
-    (let [ref (a11y/focus-on-mount-ref)]
+(deftest dialog-ref-tolerates-nil-unmount
+  (testing "rf2-tpn0u — React invokes the ref with `nil` on unmount;
+            the callback must short-circuit so it never throws after the
+            modal closes (e.g. backdrop click before any mount)"
+    (let [ref (a11y/dialog-ref)]
       (is (nil? (ref nil))
           "calling with nil returns nil and does not throw"))))
-
-(deftest focus-on-mount-ref-focuses-first-focusable-child
-  (testing "rf2-7389r — when a real DOM node mounts, the ref focuses
-            the first focusable descendant (matches the WAI-ARIA APG
-            dialog pattern: focus lands inside the dialog)"
-    (when (exists? js/document)
-      (let [host (.createElement js/document "div")
-            input (.createElement js/document "input")
-            btn   (.createElement js/document "button")]
-        (set! (.-tabIndex host) -1)
-        (.appendChild host input)
-        (.appendChild host btn)
-        (.appendChild (.-body js/document) host)
-        (try
-          (let [ref (a11y/focus-on-mount-ref)]
-            (ref host)
-            (is (= input (.-activeElement js/document))
-                "first focusable child receives focus (the <input>)"))
-          (finally
-            (.removeChild (.-body js/document) host)))))))
-
-(deftest focus-on-mount-ref-falls-back-to-root-when-no-focusable
-  (testing "rf2-7389r — when the dialog has no focusable child (e.g.
-            empty-state mute manager), the dialog root itself receives
-            focus via tabindex=-1. Keeps Esc / arrow-keys functional."
-    (when (exists? js/document)
-      (let [host (.createElement js/document "div")]
-        (set! (.-tabIndex host) -1)
-        (.appendChild (.-body js/document) host)
-        (try
-          (let [ref (a11y/focus-on-mount-ref)]
-            (ref host)
-            (is (= host (.-activeElement js/document))
-                "the dialog root receives focus as fallback"))
-          (finally
-            (.removeChild (.-body js/document) host)))))))

--- a/tools/causa/test/day8/re_frame2_causa/theme/a11y_dom_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/a11y_dom_cljs_test.cljs
@@ -1,0 +1,206 @@
+(ns day8.re-frame2-causa.theme.a11y-dom-cljs-test
+  "Live-DOM tests for the modal focus contract `a11y/dialog-ref`
+  (rf2-tpn0u): focus capture on open, the Tab/Shift+Tab focus TRAP, and
+  focus RESTORE to the opener on close.
+
+  These exercise behaviour Node can't fake — `document.activeElement`,
+  real `addEventListener('keydown', …)` on a DOM node, and synthetic
+  `KeyboardEvent` dispatch. The filename ends in `_dom_cljs_test.cljs`
+  so it runs under the `:browser-test` build (real DOM via Chromium) per
+  `implementation/shadow-cljs.edn` (rf2-2hrj8). Under the `:node-test`
+  build the `cljs-test$` regex also matches this ns, but every test
+  short-circuits via `(when (exists? js/document) …)` so the suite stays
+  green on Node and runs fully under Chromium.
+
+  The pure Tab-wrap math (`trap-wrap-target`) and the no-throw factory
+  contracts live in the DOM-free `theme.a11y-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.theme.a11y :as a11y]))
+
+;; ---- DOM scaffolding -----------------------------------------------------
+
+(defn- mk
+  "Create an element of `tag`; return it (not yet attached)."
+  [tag]
+  (.createElement js/document tag))
+
+(defn- mk-dialog!
+  "Build a dialog host with `n` <button> children (labelled b0..b(n-1)),
+  a tab-index=-1 root, attached under document.body. Also creates +
+  attaches a sibling `opener` <button> outside the dialog and focuses
+  it (simulating the ribbon button that opened the modal).
+
+  Returns `{:dialog dialog :buttons [..] :opener opener :cleanup fn}`."
+  [n]
+  (let [opener  (mk "button")
+        dialog  (mk "div")
+        buttons (vec (for [i (range n)]
+                       (let [b (mk "button")]
+                         (set! (.-textContent b) (str "b" i))
+                         b)))]
+    (set! (.-tabIndex dialog) -1)
+    (doseq [b buttons] (.appendChild dialog b))
+    (.appendChild (.-body js/document) opener)
+    (.appendChild (.-body js/document) dialog)
+    (.focus opener)
+    {:dialog  dialog
+     :buttons buttons
+     :opener  opener
+     :cleanup (fn []
+                (when (.contains (.-body js/document) opener)
+                  (.removeChild (.-body js/document) opener))
+                (when (.contains (.-body js/document) dialog)
+                  (.removeChild (.-body js/document) dialog)))}))
+
+(defn- press-tab!
+  "Dispatch a synthetic Tab (or Shift+Tab) keydown on `el`. The bubbling
+  flag is true so the dialog node's listener (installed by dialog-ref)
+  catches it the same way a real Tab does."
+  ([el] (press-tab! el false))
+  ([el shift?]
+   (let [ev (js/KeyboardEvent. "keydown"
+                               #js {:key      "Tab"
+                                    :shiftKey shift?
+                                    :bubbles  true
+                                    :cancelable true})]
+     (.dispatchEvent el ev))))
+
+;; ---- focus capture on open -----------------------------------------------
+
+(deftest dialog-ref-focuses-first-focusable-on-open
+  (testing "rf2-tpn0u — mounting the dialog ref lands focus on the first
+            focusable descendant (WAI-ARIA APG dialog pattern)"
+    (when (exists? js/document)
+      (let [{:keys [dialog buttons cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (is (= (nth buttons 0) (.-activeElement js/document))
+              "first <button> receives focus on open")
+          (finally (ref nil) (cleanup)))))))
+
+(deftest dialog-ref-falls-back-to-root-when-no-focusable
+  (testing "rf2-tpn0u — an empty-state dialog (no focusable child) lands
+            focus on the tab-index=-1 root so Esc / arrow-keys still work"
+    (when (exists? js/document)
+      (let [{:keys [dialog cleanup]} (mk-dialog! 0)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (is (= dialog (.-activeElement js/document))
+              "dialog root receives focus as fallback")
+          (finally (ref nil) (cleanup)))))))
+
+(deftest dialog-ref-respects-pre-focused-descendant
+  (testing "rf2-tpn0u — when a child already holds focus on mount (an
+            :auto-focus input like the edit-popup pattern field), the ref
+            leaves it there rather than stealing focus to the first
+            focusable"
+    (when (exists? js/document)
+      (let [{:keys [dialog buttons cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          ;; pre-focus the SECOND button (stand-in for :auto-focus)
+          (.focus (nth buttons 1))
+          (ref dialog)
+          (is (= (nth buttons 1) (.-activeElement js/document))
+              "pre-focused descendant keeps focus on open")
+          (finally (ref nil) (cleanup)))))))
+
+;; ---- focus trap ----------------------------------------------------------
+
+(deftest dialog-ref-traps-tab-off-last-to-first
+  (testing "rf2-tpn0u — Tab from the LAST focusable wraps to the FIRST
+            instead of leaking to the chrome beneath"
+    (when (exists? js/document)
+      (let [{:keys [dialog buttons cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (.focus (nth buttons 2))           ;; last
+          (press-tab! (nth buttons 2) false) ;; Tab
+          (is (= (nth buttons 0) (.-activeElement js/document))
+              "Tab off the last button wraps to the first")
+          (finally (ref nil) (cleanup)))))))
+
+(deftest dialog-ref-traps-shift-tab-off-first-to-last
+  (testing "rf2-tpn0u — Shift+Tab from the FIRST focusable wraps to the
+            LAST"
+    (when (exists? js/document)
+      (let [{:keys [dialog buttons cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (.focus (nth buttons 0))          ;; first
+          (press-tab! (nth buttons 0) true) ;; Shift+Tab
+          (is (= (nth buttons 2) (.-activeElement js/document))
+              "Shift+Tab off the first button wraps to the last")
+          (finally (ref nil) (cleanup)))))))
+
+(deftest dialog-ref-empty-dialog-pins-tab-on-root
+  (testing "rf2-tpn0u — with no focusable child, Tab cannot escape: the
+            trap pins focus back on the tab-index=-1 dialog root"
+    (when (exists? js/document)
+      (let [{:keys [dialog cleanup]} (mk-dialog! 0)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (.focus dialog)
+          (press-tab! dialog false)
+          (is (= dialog (.-activeElement js/document))
+              "Tab keeps focus on the empty dialog root")
+          (finally (ref nil) (cleanup)))))))
+
+;; ---- focus restore on close ----------------------------------------------
+
+(deftest dialog-ref-restores-focus-to-opener-on-close
+  (testing "rf2-tpn0u — unmounting (ref nil) restores focus to the
+            element that had it before the dialog opened (the opener),
+            not <body>"
+    (when (exists? js/document)
+      (let [{:keys [dialog opener cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          ;; opener already focused by mk-dialog!
+          (is (= opener (.-activeElement js/document))
+              "precondition: opener holds focus before open")
+          (ref dialog)                        ;; open → focus moves inside
+          (is (not= opener (.-activeElement js/document))
+              "focus moved into the dialog on open")
+          (ref nil)                           ;; close
+          (is (= opener (.-activeElement js/document))
+              "focus restored to the opener on close")
+          (finally (cleanup)))))))
+
+(deftest dialog-ref-skips-restore-when-opener-detached
+  (testing "rf2-tpn0u — if the opener was removed from the document while
+            the dialog was open, close must not throw (and must not
+            re-focus a detached node)"
+    (when (exists? js/document)
+      (let [{:keys [dialog opener cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          ;; opener leaves the document while the modal is open
+          (.removeChild (.-body js/document) opener)
+          (is (nil? (ref nil))
+              "close with a detached opener returns nil and does not throw")
+          (finally (cleanup)))))))
+
+(deftest dialog-ref-teardown-removes-trap-listener
+  (testing "rf2-tpn0u — after close, the keydown trap listener is gone:
+            a Tab on the (now-detached) former dialog node does not move
+            focus via the trap"
+    (when (exists? js/document)
+      (let [{:keys [dialog buttons opener cleanup]} (mk-dialog! 3)
+            ref (a11y/dialog-ref)]
+        (try
+          (ref dialog)
+          (ref nil)                           ;; close → listener removed
+          ;; opener is focused again post-restore; a Tab dispatched on
+          ;; the old dialog node must not be intercepted by a stale trap.
+          (.focus opener)
+          (press-tab! dialog false)
+          (is (= opener (.-activeElement js/document))
+              "no stale trap listener fires after close")
+          (finally (cleanup)))))))


### PR DESCRIPTION
## Summary

Two Causa a11y/interaction fixes.

### (1) rf2-tpn0u — modal focus-trap + restore-on-close

`theme/a11y.cljs` previously self-documented two missing pieces of the WAI-ARIA APG modal-dialog contract (focus-trap and focus-restore-on-close). Both are now implemented in a single `a11y/dialog-ref` `:ref` callback that supersedes the old `focus-on-mount-ref`:

- **Focus capture on open** — lands focus on the first focusable descendant (or the `tab-index=-1` root for empty-state dialogs). Respects an `:auto-focus` descendant already inside the dialog (the filter edit-popup pattern field) instead of stealing focus.
- **Focus TRAP** — a `keydown` listener intercepts `Tab` / `Shift+Tab` and wraps focus inside the dialog's focusable set (Tab off the last → first; Shift+Tab off the first → last; pulls focus back in when it sits on the `-1` root). Pure wrap math lives in `trap-wrap-target` (JVM/node-runnable).
- **Focus RESTORE on close** — captures `document.activeElement` at open and restores it on unmount, so closing returns the keyboard user to the opener button rather than dropping to `<body>`. Skips a detached/removed opener without throwing.

All six modal call sites now consume `dialog-ref`: settings popup, share modal, mute manager, filter edit-popup, cancellation-cascade popover, app-db segment inspector.

### (2) rf2-w738i — focus-chip body no-op

**Chosen path: WIRED it** (intent was clear from the docstring + the existing scroll-into-view machinery). The chip body's `(future)` claim is gone; clicking the chip body (or Enter / Space) now scrolls the focus **pivot row** back into view in L2, located by the same `rf-causa-event-row-<id>` data-testid the L2 renderer stamps. The body is now a real `role="button"` with `cursor:pointer`, an accessible name, and keyboard activation. The clear `✕` button stops propagation so it never also fires the reveal gesture.

## Test plan

- [x] `npm run test:cljs` (node) — 4020 tests / 12172 assertions, 0 failures. Adds pure `trap-wrap-target` math, `dialog-ref` factory contracts, and focus-chip hiccup-wiring tests.
- [x] `npm run test:browser` (real DOM via Chromium) — 104 tests / 294 assertions, 0 failures. Adds live focus capture/trap/restore tests (`theme.a11y-dom-cljs-test`) and the focus-chip scroll-into-view lookup (`shell-focus-chip-dom-cljs-test`).
- [x] `tools/causa` JVM gate (`clojure -M:test`) — 849 tests / 2778 assertions, 0 failures.
- [x] node-test + browser-test builds compile with 0 warnings.