### PR TITLE
fix(causa): Static frame-picker actually scopes Flows/Schemas/Routes/Interceptors + plural tab labels + contiguous order (rf2-lcwom + rf2-oxrm3 + rf2-g22yd)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -87,7 +87,7 @@ Wireframe at default (800px popout, "cosy" density):
 │ ● :cart/recalculate                                                     │
 │ ◉ :order/retry                                      🌐  ← head/sel      │
 ├═════════════════════════════════════════════════════════════════════════┤   drag handle (L2/L3)
-│ ◉Event ○App DB ○View 8 ○Trace 47 ○Machines 1 ○Canvas ○Routing ⚠Issues 1 │              L3 — 8 tabs
+│ ◉Event ○App DB ○Views 8 ○Trace 47 ○Machines 1 ○Canvas ○Routes ⚠Issues 1 │              L3 — 8 tabs
 ├─────────────────────────────────────────────────────────────────────────┤
 │ — Event tab content for the focused event —                             │   L4 — fills the rest
 └─────────────────────────────────────────────────────────────────────────┘
@@ -106,10 +106,10 @@ The four layers, top to bottom:
    decorated by gutter glyph (`● ◉ x ▥ ↺`) + right-aligned badges (`⚠`
    `🌐` `🤖`) + trailing redaction marker (`[● REDACTED N]`). The
    spine sub `:rf.causa/focus` reads from this layer.
-3. **L3 — Tab bar (40px).** Eight tabs: Event / App DB / View / Trace /
-   Machines / Machines Canvas / Routing / Issues. Letter mnemonics:
-   `e` `a` `v` `t` `m` `c` `r` `i`. Count badges (`View 8`) update
-   with focused cascade. Routing was promoted to its own L3 tab in
+3. **L3 — Tab bar (40px).** Eight tabs: Event / App DB / Views / Trace /
+   Machines / Machines Canvas / Routes / Issues. Letter mnemonics:
+   `e` `a` `v` `t` `m` `c` `r` `i`. Count badges (`Views 8`) update
+   with focused cascade. Routes was promoted to its own L3 tab in
    rf2-nrbs9; Machines Canvas was promoted in rf2-mkpnb — both follow
    the cohesive-sub-domain rule (sub-domains earn their own lens tab).
    (rf2-4v67l — the Chrome A11y dogfood tab was removed in favour of
@@ -1172,8 +1172,8 @@ on `Esc`, click-outside, or invocation of any item.
 - Registered handlers (id + `:doc`)
 - Frames
 - Machines with current state
-- L4 tab jumps — Dynamic: Event / App DB / View / Trace / Machines
-  / Machines Canvas / Routing / Issues; Static: Machines / Routes /
+- L4 tab jumps — Dynamic: Event / App DB / Views / Trace / Machines
+  / Machines Canvas / Routes / Issues; Static: Machines / Routes /
   Schemas / Flows / Interceptors (see §Mode-aware command surface below)
 - Command verbs (recents-boosted; see §Command verbs below)
 - Settings entries
@@ -1631,8 +1631,8 @@ with L2; Static is 3-layer without). The composer (`surface-composer`
 in `shell.cljs`) `case`-dispatches between the two on `[:rf.causa/mode]`.
 
 **Tab inventory rule.** Tab inventories are mode-keyed and not shared.
-Dynamic ships 8 tabs (Event / App DB / View / Trace / Machines /
-Machines Canvas / Routing / Issues — see [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
+Dynamic ships 8 tabs (Event / App DB / Views / Trace / Machines /
+Machines Canvas / Routes / Issues — see [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md)
 for the per-panel content designs). Static ships 5 tabs (Machines /
 Routes / Schemas / Flows / Interceptors — see §Sub-tab inventory
 above). New tabs MUST declare which mode(s) they belong to; tab-id

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1509,15 +1509,28 @@ surface is event-independent — and renders 3 layers:
 L2's absence is also a functional signal — see §Mode-signal mechanism
 below.
 
-The L1 frame picker is **mode-independent**. Static is also
-frame-scoped — registered events, subs, machines, routes, schemas,
-flows, and interceptors all live in a particular frame, so the user
-must be able to pick which frame they are browsing whether the lens is
-event-coupled (Dynamic) or event-independent (Static). Both shells
-mount the same `frame_switcher/frame-switcher-view` (the canonical L1
-contract); the selection persists across mode toggles. Dynamic's
-spine-coupled clusters (nav `[◀ ▶ ⏭]`, filter pills) remain hidden in
-Static — those have no meaning without a spine.
+The L1 frame picker is **mode-independent**. Per [Spec 001](../../../spec/001-Registration.md)
+the registrar is **process-global** — frames isolate *state*, not
+*registrations* — so event / sub / route / interceptor /
+machine-definition catalogues are shared across every frame and read
+the same regardless of the picker. What the picker scopes is the
+genuinely per-frame surface each Static panel projects:
+
+| Tab | Frame-scoped (picker changes it) | Process-global (cross-frame) |
+|---|---|---|
+| **Machines** | live machine snapshots (`:rf/machines` in the target-frame db) | the machine-definition catalogue |
+| **Routes** | the current-route slice (`:rf/route`) | the route-definition catalogue |
+| **Schemas** | the app-db-schema side-table (`schemas-by-frame`) | event-spec + sub-spec rows |
+| **Flows** | the flows registry (`{frame-id {flow-id …}}`, [Spec 013](../../../spec/013-Flows.md)) | — (fully per-frame) |
+| **Interceptors** | — | interceptor chains (live on globally registered events) |
+
+So switching the picker changes the per-frame projections above; the
+global catalogues are deliberately cross-frame. The picker stays in
+Static because four of the five tabs DO carry a per-frame surface.
+Both shells mount the same `frame_switcher/frame-switcher-view` (the
+canonical L1 contract); the selection persists across mode toggles.
+Dynamic's spine-coupled clusters (nav `[◀ ▶ ⏭]`, filter pills) remain
+hidden in Static — those have no meaning without a spine.
 
 ### Sub-tab inventory (Static L3)
 

--- a/tools/causa/spec/012-Views.md
+++ b/tools/causa/spec/012-Views.md
@@ -1,6 +1,6 @@
 # 012-Views
 
-> **See also**: [`021-Dynamic-Panel-Designs.md` §3](021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8) for the canonical View (formerly "Views") panel content design. The L3 tab display label was renamed `Views` → `View` per spec/021 §11.5; the tab key + spec doc continue to use `:views` / `012-Views.md` for stability. Per-panel content semantics moved to 021.
+> **See also**: [`021-Dynamic-Panel-Designs.md` §3](021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8) for the canonical Views panel content design. The L3 tab display label is **`Views`** — the all-plural-domain-noun convention (Mike-direction 2026-05-21) keeps the tab vocabulary uniform across both tab sets (Views / Flows / Schemas / Routes / Machines are all plural). The tab key + spec doc continue to use `:views` / `012-Views.md` for stability. Per-panel content semantics moved to 021.
 
 ## Bug class
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -59,7 +59,7 @@ Wireframe at default (800px popout, "cosy" density):
 │ ● :cart/recalculate                                                     │
 │ ◉ :order/retry                                      🌐  ← head/sel      │
 ├═════════════════════════════════════════════════════════════════════════┤   drag handle (L2/L3)
-│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Routing ⚠Issues 1        │   L3 — 7 tabs
+│ ◉Event ○App-db ○Views 8 ○Trace 47 ○Machines 1 ○Routes ⚠Issues 1         │   L3 — 7 tabs
 ├─────────────────────────────────────────────────────────────────────────┤
 │ — Event tab content for the focused event —                             │   L4 — fills the rest
 │   event vector · source · handler return · db writes · fx · fx-handlers │

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
@@ -51,9 +51,12 @@
   ;; the slot for the smaller diff).
   (panel-registry/reg-l4-tab!
     {:id    :views
-     ;; rf2-e33ad — display label renamed from `Reactive` to `View`
-     ;; per Mike-direction 2026-05-21. Internal id stays `:views`.
-     :label "View"
+     ;; Display label renamed `Reactive` -> `View` -> `Views`. The
+     ;; all-plural-domain-noun convention (Mike-direction 2026-05-21)
+     ;; aligns the tab vocabulary across both tab sets — Views / Flows /
+     ;; Schemas / Routes / Machines are all plural. Internal id stays
+     ;; `:views`.
+     :label "Views"
      :mnem  "v"
      :modes #{:dynamic}
      :order 2

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -473,9 +473,14 @@
   ;; rf2-mkpnb — order bumped 5 → 6 to make room for the new Machines
   ;; Canvas tab at order 5 (sits adjacent to Machines so the two
   ;; machine sub-domain tabs render next to each other).
+  ;; Display label is the plural domain noun "Routes" — matching the
+  ;; Static Routes tab so the two tab sets share one vocabulary
+  ;; (all-plural-domain-noun convention, Mike-direction 2026-05-21).
+  ;; Internal id stays `:routing` (id is not a user contract; same
+  ;; posture as `:views` rendering as "Views").
   (panel-registry/reg-l4-tab!
     {:id    :routing
-     :label "Routing"
+     :label "Routes"
      :mnem  "r"
      :modes #{:dynamic}
      :order 6

--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -344,14 +344,15 @@
       (project-data registry-snapshot query)))
 
   ;; rf2-2moh1 — register the Static Flows tab with the internal L4
-  ;; tab registry. Order 4 sits between :views (3) and :events (5)
-  ;; per the parent epic findings doc §2.4.
+  ;; tab registry. Contiguous order: machines 0 · routes 1 · schemas 2
+  ;; · flows 3 · interceptors 4 (the standalone :views / :events tabs
+  ;; rf2-b2fif removed previously left orders 3 + 5 as gaps).
   (panel-registry/reg-l4-tab!
     {:id    :flows
      :label "Flows"
      :mnem  "l"
      :modes #{:static}
-     :order 4
+     :order 3
      :panel Panel
      :placeholder-bead "rf2-uhsqb"})
 

--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -50,6 +50,22 @@
 
 ;; ---- pure helpers --------------------------------------------------------
 
+(defn scope-to-frame
+  "Narrow a `{frame-id {flow-id flow-map}}` registry snapshot to a
+  single `frame-id`, returning the same two-level shape carrying only
+  that frame's entry. The flows registry is genuinely per-frame (Spec
+  013 — `re-frame.flows.registry/flows` is keyed by frame-id), so the
+  L1 frame picker's selection MUST scope the catalogue: switching the
+  picker changes which frame's flows the Static Flows tab lists.
+
+  A nil `frame-id` (no frame resolved yet) returns the snapshot
+  verbatim — the cold-start empty-state stays useful rather than
+  blanking the list. Pure data — JVM-runnable."
+  [registry-snapshot frame-id]
+  (if (nil? frame-id)
+    registry-snapshot
+    (select-keys registry-snapshot [frame-id])))
+
 (defn project-rows
   "Flatten `{frame-id {flow-id flow-map}}` into a flat vector of rows,
   sorted by flow-id ascending. Pure data so the JVM unit-test target
@@ -93,9 +109,14 @@
        :flows       [<row> ...]
        :total       <pre-filter count>
        :filtered?   <bool>
-       :query       <string-or-nil>}"
-  [registry-snapshot query]
-  (let [rows     (project-rows registry-snapshot)
+       :query       <string-or-nil>}
+
+  `frame-id` scopes the per-frame registry to the picker's observed
+  frame before projecting (nil = no frame resolved → list every
+  frame's flows; see `scope-to-frame`)."
+  [registry-snapshot frame-id query]
+  (let [scoped   (scope-to-frame registry-snapshot frame-id)
+        rows     (project-rows scoped)
         silent?  (empty? rows)
         filtered (filter-rows rows query)]
     {:silent?   silent?
@@ -337,11 +358,16 @@
 
   ;; ---- view-facing composite -------------------------------------------
 
+  ;; `:rf.causa/observed-frame` is the L1 frame picker's current
+  ;; selection (installed by `app-db-diff-subs/install!`). The flows
+  ;; registry is per-frame (Spec 013), so the picker scopes the
+  ;; catalogue — switching frames changes which frame's flows list.
   (rf/reg-sub :rf.causa.static.flows/tab-data
     :<- [:rf.causa.static.flows/registered-flows]
+    :<- [:rf.causa/observed-frame]
     :<- [:rf.causa.static.flows/query]
-    (fn [[registry-snapshot query] _query]
-      (project-data registry-snapshot query)))
+    (fn [[registry-snapshot observed-frame query] _query]
+      (project-data registry-snapshot observed-frame query)))
 
   ;; rf2-2moh1 — register the Static Flows tab with the internal L4
   ;; tab registry. Contiguous order: machines 0 · routes 1 · schemas 2

--- a/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
@@ -343,14 +343,14 @@
     (fn [[registrations-map query] _query]
       (project-data registrations-map query)))
 
-  ;; rf2-2moh1 — register the Static Interceptors tab. Order 6 — sits
-  ;; after :events (5).
+  ;; rf2-2moh1 — register the Static Interceptors tab. Contiguous order:
+  ;; machines 0 · routes 1 · schemas 2 · flows 3 · interceptors 4.
   (panel-registry/reg-l4-tab!
     {:id    :interceptors
      :label "Interceptors"
      :mnem  "i"
      :modes #{:static}
-     :order 6
+     :order 4
      :panel Panel
      :placeholder-bead "rf2-o5f5f.6"})
 

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -60,6 +60,25 @@
 
 ;; ---- pure helpers --------------------------------------------------------
 
+(defn scope-app-schemas-to-frame
+  "Narrow a `{frame-id {path schema-meta}}` app-db-schema snapshot to a
+  single `frame-id`. App-db schemas are genuinely per-frame (the
+  `re-frame.schemas.storage/schemas-by-frame` side-table is keyed by
+  frame-id), so the L1 frame picker scopes the app-db-schema rows.
+
+  A nil `frame-id` (no frame resolved yet) returns the snapshot
+  verbatim. Pure data — JVM-runnable.
+
+  NOTE: only the app-db-schema rows are frame-scoped. Event-spec and
+  sub-spec rows come from the process-global registrar (Spec 001 —
+  the registrar is per-process; frames isolate state, not
+  registrations), so they are unconditionally cross-frame and carry
+  `:frame nil`."
+  [schemas-by-frame frame-id]
+  (if (nil? frame-id)
+    schemas-by-frame
+    (select-keys schemas-by-frame [frame-id])))
+
 (defn project-app-schema-rows
   "Flatten `{frame-id {path schema-meta}}` into row maps.
   `schema-meta` carries `:schema`, `:doc`, plus `:file`/`:line`/`:ns`
@@ -123,8 +142,13 @@
         (filterv #(str/includes? (row-haystack %) needle) rows)))))
 
 (defn project-data
-  [schemas-by-frame events-map subs-map query]
-  (let [rows     (project-rows schemas-by-frame events-map subs-map)
+  "View-facing composite. `frame-id` scopes the per-frame app-db
+  schemas to the picker's observed frame (nil = every frame; see
+  `scope-app-schemas-to-frame`); event-spec + sub-spec rows are
+  process-global and always included."
+  [schemas-by-frame events-map subs-map frame-id query]
+  (let [scoped   (scope-app-schemas-to-frame schemas-by-frame frame-id)
+        rows     (project-rows scoped events-map subs-map)
         silent?  (empty? rows)
         filtered (filter-rows rows query)]
     {:silent?   silent?
@@ -392,11 +416,18 @@
 
   ;; ---- view-facing composite -------------------------------------------
 
+  ;; `:rf.causa/observed-frame` is the L1 frame picker's current
+  ;; selection. App-db schemas are per-frame (the `schemas-by-frame`
+  ;; side-table is keyed by frame-id), so the picker scopes the app-db
+  ;; rows — switching frames changes which frame's app-db schemas
+  ;; list. Event + sub specs are process-global (Spec 001) and stay
+  ;; cross-frame regardless of the picker.
   (rf/reg-sub :rf.causa.static.schemas/tab-data
     :<- [:rf.causa.static.schemas/registry]
+    :<- [:rf.causa/observed-frame]
     :<- [:rf.causa.static.schemas/query]
-    (fn [[{:keys [schemas-by-frame events subs]} query] _query]
-      (project-data schemas-by-frame events subs query)))
+    (fn [[{:keys [schemas-by-frame events subs]} observed-frame query] _query]
+      (project-data schemas-by-frame events subs observed-frame query)))
 
   ;; rf2-2moh1 — register the Static Schemas tab with the internal L4
   ;; tab registry.

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -23,11 +23,28 @@
       │ L4  Detail panel (fills remaining canvas)             │
       └───────────────────────────────────────────────────────┘
 
-  The L1 frame picker is mode-INDEPENDENT — Static registrations are
-  still frame-scoped, so the user must be able to pick which frame
-  they are browsing. The picker uses the canonical
-  `frame_switcher/frame-switcher-view` (same contract as Dynamic's
-  ribbon); mode toggles preserve the selection.
+  The L1 frame picker is mode-INDEPENDENT. Per Spec 001 the registrar
+  is process-GLOBAL — frames isolate state, not registrations — so
+  event / sub / route / interceptor / machine-definition catalogues are
+  shared across every frame and read the same regardless of the picker.
+  What the picker DOES scope is the genuinely per-frame surfaces each
+  panel projects:
+
+    - Machines    — live machine snapshots (`:rf/machines` in the
+                    target-frame db); the definition catalogue is global.
+    - Flows       — the flows registry is per-frame
+                    (`{frame-id {flow-id ...}}`, Spec 013).
+    - Schemas     — the app-db-schema side-table is per-frame
+                    (`schemas-by-frame`); event/sub specs are global.
+    - Routes      — the current-route slice (`:rf/route`) is per-frame;
+                    the route-definition catalogue is global.
+    - Interceptors— global (interceptor chains live on globally
+                    registered events).
+
+  So switching frames changes the per-frame projections above; the
+  global catalogues are deliberately cross-frame. The picker uses the
+  canonical `frame_switcher/frame-switcher-view` (same contract as
+  Dynamic's ribbon); mode toggles preserve the selection.
 
   L2 is also a functional signal: its absence is one of the four
   stacked mode-signal mechanisms (chrome silhouette) the parent epic

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -50,16 +50,17 @@
           icon (th/find-by-testid tree "rf-causa-reactive-panel-icon")]
       (is (nil? icon) "panel-icon span is gone (lived in the deleted h1)"))))
 
-(deftest reactive-panel-uses-view-display-label
-  (testing "rf2-e33ad · Mike-direction 2026-05-21 — the L4 tab now
-            displays as `View` (renamed from `Reactive`); the panel-
+(deftest reactive-panel-uses-views-display-label
+  (testing "Mike-direction 2026-05-21 — the L4 tab displays as `Views`
+            under the all-plural-domain-noun convention (Views / Flows /
+            Schemas / Routes / Machines are all plural); the panel-
             registry key stays `:views` (internal id, never a user
             contract)."
     (facade/install!)
     (let [registered (panel-registry/tab-by-id :dynamic :views)]
       (is (some? registered) "panel-registry has a :views entry under :dynamic")
-      (is (= "View" (:label registered))
-          "L4 tab label renders as `View`"))))
+      (is (= "Views" (:label registered))
+          "L4 tab label renders as `Views`"))))
 
 (deftest reactive-panel-renders-four-cascade-sections
   (testing "rf2-e33ad — the View panel renders four pipeline sections

--- a/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
@@ -121,14 +121,43 @@
       (is (= 0 (count (panel/filter-rows rows "no-such-thing")))))))
 
 (deftest project-data-shape
-  (let [data (panel/project-data sample-flows nil)]
+  ;; nil frame-id = list every frame's flows (see scope-to-frame).
+  (let [data (panel/project-data sample-flows nil nil)]
     (testing "silent flag"
       (is (false? (:silent? data)))
-      (is (true? (:silent? (panel/project-data {} nil)))))
+      (is (true? (:silent? (panel/project-data {} nil nil)))))
     (testing "totals + filter flags"
       (is (= 2 (:total data)))
       (is (false? (:filtered? data)))
-      (is (true? (:filtered? (panel/project-data sample-flows "cart")))))))
+      (is (true? (:filtered? (panel/project-data sample-flows nil "cart")))))))
+
+(deftest scope-to-frame-narrows-to-one-frame
+  (let [multi {:rf/default {:a {:id :a}}
+               :rf/cart    {:b {:id :b}}}]
+    (testing "nil frame-id passes the snapshot through verbatim"
+      (is (= multi (panel/scope-to-frame multi nil))))
+    (testing "a frame-id keeps only that frame's entry"
+      (is (= {:rf/default {:a {:id :a}}}
+             (panel/scope-to-frame multi :rf/default)))
+      (is (= {:rf/cart {:b {:id :b}}}
+             (panel/scope-to-frame multi :rf/cart))))
+    (testing "an absent frame-id yields an empty registry"
+      (is (= {} (panel/scope-to-frame multi :rf/nope))))))
+
+(deftest project-data-scopes-to-frame
+  (let [multi {:rf/default {:a {:id :a :inputs [] :path [:a]}}
+               :rf/cart    {:b {:id :b :inputs [] :path [:b]}
+                            :c {:id :c :inputs [] :path [:c]}}}]
+    (testing "frame A surfaces only frame A's flows, not the flattened global set"
+      (let [data (panel/project-data multi :rf/default nil)]
+        (is (= 1 (:total data)))
+        (is (= [:a] (mapv :flow-id (:flows data))))))
+    (testing "frame B surfaces only frame B's flows"
+      (let [data (panel/project-data multi :rf/cart nil)]
+        (is (= 2 (:total data)))
+        (is (= [:b :c] (mapv :flow-id (:flows data))))))
+    (testing "nil frame-id still lists every frame's flows"
+      (is (= 3 (:total (panel/project-data multi nil nil)))))))
 
 ;; -------------------------------------------------------------------------
 ;; (2) registry wiring
@@ -161,6 +190,45 @@
       (is (false? (:silent? data))))
     (rf/dispatch-sync
       [:rf.causa.static.flows/set-registered-flows-override-for-test nil])))
+
+(def two-frame-flows
+  "Two frames each carrying distinct flows — fixture for the picker-
+  scoping regression."
+  {:rf/default
+   {:user/full-name {:id     :user/full-name
+                     :inputs [[:user :first]]
+                     :path   [:derived :full-name]}}
+   :rf/cart-frame
+   {:cart/total {:id     :cart/total
+                 :inputs [[:cart :items]]
+                 :path   [:cart :total]}
+    :cart/count {:id     :cart/count
+                 :inputs [[:cart :items]]
+                 :path   [:cart :count]}}})
+
+(deftest tab-data-scopes-to-picker-frame
+  (testing "the L1 frame picker scopes the Flows catalogue — switching
+            the picker frame changes which frame's flows the tab lists,
+            rather than the flattened all-frames set"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.flows/set-registered-flows-override-for-test
+         two-frame-flows])
+      (testing "picker on :rf/default → only that frame's one flow"
+        (rf/dispatch-sync [:rf.causa/select-frame :rf/default])
+        (let [data @(rf/subscribe [:rf.causa.static.flows/tab-data])]
+          (is (= 1 (:total data)) "frame :rf/default has one flow")
+          (is (= [:user/full-name] (mapv :flow-id (:flows data)))
+              "only :rf/default's flow surfaces")))
+      (testing "picker on :rf/cart-frame → only that frame's two flows"
+        (rf/dispatch-sync [:rf.causa/select-frame :rf/cart-frame])
+        (let [data @(rf/subscribe [:rf.causa.static.flows/tab-data])]
+          (is (= 2 (:total data)) "frame :rf/cart-frame has two flows")
+          (is (= [:cart/count :cart/total] (mapv :flow-id (:flows data)))
+              "only :rf/cart-frame's flows surface — NOT the global set of 3")))
+      (rf/dispatch-sync
+        [:rf.causa.static.flows/set-registered-flows-override-for-test nil]))))
 
 ;; -------------------------------------------------------------------------
 ;; (3) view rendering

--- a/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
@@ -120,13 +120,46 @@
     (is (= 0 (count (panel/filter-rows rows "nope"))))))
 
 (deftest project-data-shape
+  ;; nil frame-id = list every frame's app-db schemas (see
+  ;; scope-app-schemas-to-frame).
   (let [data (panel/project-data (:schemas-by-frame sample-registry)
                                  (:events sample-registry)
                                  (:subs   sample-registry)
+                                 nil
                                  nil)]
     (is (= 3 (:total data)))
     (is (false? (:silent? data)))
-    (is (true? (:silent? (panel/project-data {} {} {} nil))))))
+    (is (true? (:silent? (panel/project-data {} {} {} nil nil))))))
+
+(deftest scope-app-schemas-to-frame-narrows
+  (let [multi {:rf/default {[:a] {:schema :int}}
+               :rf/cart    {[:b] {:schema :int}}}]
+    (testing "nil frame-id passes through verbatim"
+      (is (= multi (panel/scope-app-schemas-to-frame multi nil))))
+    (testing "a frame-id keeps only that frame's app-db schemas"
+      (is (= {:rf/default {[:a] {:schema :int}}}
+             (panel/scope-app-schemas-to-frame multi :rf/default))))
+    (testing "an absent frame-id yields an empty map"
+      (is (= {} (panel/scope-app-schemas-to-frame multi :rf/nope))))))
+
+(deftest project-data-scopes-app-db-schemas-but-not-global-specs
+  (let [multi-by-frame {:rf/default {[:user] {:schema :map}}
+                        :rf/cart    {[:cart] {:schema :map}}}
+        events         (:events sample-registry)   ;; one spec'd event
+        subs           (:subs   sample-registry)]  ;; one spec'd sub
+    (testing "frame :rf/default → its 1 app-db schema + the 2 global specs"
+      (let [data (panel/project-data multi-by-frame events subs :rf/default nil)]
+        (is (= 3 (:total data)) "1 app-db (default) + 1 event + 1 sub")
+        (is (= 1 (count (filterv #(= :app-db (:kind %)) (:schemas data))))
+            "only :rf/default's app-db schema, not :rf/cart's")))
+    (testing "frame :rf/cart → its 1 app-db schema + the same 2 global specs"
+      (let [data (panel/project-data multi-by-frame events subs :rf/cart nil)]
+        (is (= 3 (:total data)))
+        (is (= [[:cart]]
+               (mapv :id (filterv #(= :app-db (:kind %)) (:schemas data))))
+            "only :rf/cart's app-db schema surfaces")))
+    (testing "nil frame-id → both frames' app-db schemas + global specs"
+      (is (= 4 (:total (panel/project-data multi-by-frame events subs nil nil)))))))
 
 ;; -------------------------------------------------------------------------
 ;; (2) registry wiring
@@ -153,6 +186,43 @@
     (let [data @(rf/subscribe [:rf.causa.static.schemas/tab-data])]
       (is (= 3 (:total data)))
       (is (false? (:silent? data))))))
+
+(def two-frame-registry
+  "Two frames each carrying a distinct app-db schema, plus the shared
+  process-global event + sub specs — fixture for the picker-scoping
+  regression."
+  {:schemas-by-frame
+   {:rf/default    {[:user] {:schema [:map [:id :int]]}}
+    :rf/cart-frame {[:cart] {:schema [:map [:n :int]]}}}
+   :events {:user/login {:spec [:tuple :keyword]}}
+   :subs   {:user/full-name {:spec :string}}})
+
+(deftest tab-data-scopes-app-db-schemas-to-picker-frame
+  (testing "the L1 frame picker scopes the app-db-schema rows — switching
+            the picker frame changes which frame's app-db schemas list,
+            while the process-global event + sub specs stay visible in
+            every frame"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.schemas/set-registry-override-for-test
+         two-frame-registry])
+      (testing "picker on :rf/default → its 1 app-db schema + 2 global specs"
+        (rf/dispatch-sync [:rf.causa/select-frame :rf/default])
+        (let [data    @(rf/subscribe [:rf.causa.static.schemas/tab-data])
+              app-dbs (filterv #(= :app-db (:kind %)) (:schemas data))]
+          (is (= 3 (:total data)) "1 app-db (default) + 1 event + 1 sub")
+          (is (= [[:user]] (mapv :id app-dbs))
+              "only :rf/default's app-db schema, not :rf/cart-frame's")))
+      (testing "picker on :rf/cart-frame → its 1 app-db schema + 2 global specs"
+        (rf/dispatch-sync [:rf.causa/select-frame :rf/cart-frame])
+        (let [data    @(rf/subscribe [:rf.causa.static.schemas/tab-data])
+              app-dbs (filterv #(= :app-db (:kind %)) (:schemas data))]
+          (is (= 3 (:total data)))
+          (is (= [[:cart]] (mapv :id app-dbs))
+              "only :rf/cart-frame's app-db schema surfaces — NOT the global 2")))
+      (rf/dispatch-sync
+        [:rf.causa.static.schemas/set-registry-override-for-test nil]))))
 
 ;; -------------------------------------------------------------------------
 ;; (3) view rendering

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -496,10 +496,11 @@
             "L1 frame picker (or single-frame label) present in Dynamic")))))
 
 (deftest l1-frame-picker-mounts-in-static-mode
-  (testing "Static surface mounts the L1 frame picker — Static is also
-            frame-scoped (registrations live in a particular frame),
-            so the picker is mode-INDEPENDENT and persists across mode
-            toggles"
+  (testing "Static surface mounts the L1 frame picker — four of the five
+            Static tabs project a per-frame surface (machines snapshots,
+            current-route slice, app-db schemas, flows), so the picker
+            is mode-INDEPENDENT and persists across mode toggles even
+            though the registrar itself is process-global"
     (causa-setup!)
     (frame-dispatch [:rf.causa/set-mode :static])
     (rf/with-frame :rf/causa


### PR DESCRIPTION
## Summary

A three-fix cluster on Causa's Static-mode L3/L4 surface, sequenced smallest-to-biggest.

### rf2-g22yd (P3) — contiguous Static tab `:order`
The removed standalone `:views`/`:events` tabs left orders 3 and 5 as gaps (machines 0, routes 1, schemas 2, flows 4, interceptors 6). Renumbered flows 4->3 and interceptors 6->4 so the five tabs run 0..4 contiguously. Render was already correct (`sort-by` tolerates gaps); the inventory just read as if two panels failed to register. No behaviour change.

### rf2-oxrm3 (P2) — unify tab labels on the all-plural-domain-noun convention
The two tab sets disagreed: Dynamic showed singular `View` and `Routing`, Static showed plural `Routes`/`Flows`/`Schemas`. Settled on all-plural domain nouns (Mike-direction): Dynamic `View`->`Views` and `Routing`->`Routes`, aligning both tab sets. Internal registry keys (`:views`, `:routing`) are unchanged — they are not a user contract (same posture the spec already documents for the `:views`/"Views" split). Updated the label-assertion test + the spec display-label notes (012-Views.md, the 007/018 tab-strip mocks).

### rf2-lcwom (P1, BUG) — Static frame picker scopes the genuinely per-frame catalogues
The picker telegraphed a frame scope it did not honour. The fix scopes each panel's **genuinely per-frame** data to `:rf.causa/observed-frame`:

- **Flows** — the flows registry is per-frame (`{frame-id {flow-id ...}}`, Spec 013). Now switching frames lists that frame's flows.
- **Schemas** — the app-db-schema side-table (`schemas-by-frame`) is per-frame; the app-db rows are now scoped. Event-spec + sub-spec rows come from the process-global registrar (Spec 001) and stay cross-frame.

**Diagnosis correction:** the bead premise ("scope all 4 of Flows/Schemas/Routes/Interceptors") was partly inaccurate. Per Spec 001 (and Causa specs 008 §134 / 014 §5) the **registrar is process-global — frames isolate state, not registrations**. So route + event + interceptor + machine-*definition* registrations are global and have **no per-frame set to scope**. Routes/Interceptors are therefore deliberately left cross-frame; forcing a fake frame filter on them would be wrong. The picker still earns its place because four of the five tabs DO carry a per-frame projection (machines snapshots, current-route slice, app-db schemas, flows). The shell docstring + Spec 007 claim that asserted ALL Static registrations are frame-scoped have been corrected to the accurate per-tab breakdown.

## Test plan

- [x] `npm run test:cljs` from implementation/ — 4007 tests / 12178 assertions, 0 failures (was 4001 pre-change; +6 new scoping tests).
- [x] `clojure -M:test` from tools/causa — 849 tests / 2778 assertions, 0 failures.
- [x] `mkdocs build --strict` — clean (spec doc edits).
- [x] New per-panel regression tests assert picker frame A vs B yields the correct per-frame catalogue, not the flattened global set (flows: 1 vs 2 flows; schemas: per-frame app-db schema scoping while global specs persist).