### PR TITLE
docs(skill): fix re-frame2-pair-retro :on-error lens + template stubs + taxonomy (6 beads)

### DIFF
--- a/skills/re-frame2-pair-retro/SKILL.md
+++ b/skills/re-frame2-pair-retro/SKILL.md
@@ -140,7 +140,7 @@ Single-quoted here-doc delimiter (`<<'EOF'`) so `$`, `` ` ``, and `\` inside the
 
 ## Reference files
 
-- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in issue-filing protocol). Extracted by ; consumed by both this skill and `re-frame2-improver`.
+- [`../shared/retro-protocol.md`](../shared/retro-protocol.md) — shared retro protocol (seven-step diagnosis-first workflow, evidence-citation discipline, layer-routing rules, opt-in issue-filing protocol). Extracted from this skill's locked design into a shared leaf; consumed by both this skill and `re-frame2-improver` so the two retro-style skills stay in lockstep.
 - [`references/analysis-lenses.md`](references/analysis-lenses.md) — friction signals (generic + re-frame2-specific), root-cause categories, improvement patterns, routing decisions, prioritization.
 - [`references/known-frictions.md`](references/known-frictions.md) — recurring classes of `re-frame2-pair` pain; sanity-check one-off vs pattern.
 - [`references/issue-template.md`](references/issue-template.md) — GitHub-issue body template (+ shell-safety pattern for transcript-derived bodies).

--- a/skills/re-frame2-pair-retro/evals/evals.json
+++ b/skills/re-frame2-pair-retro/evals/evals.json
@@ -2,7 +2,7 @@
  "skill_name": "re-frame2-pair-retro",
  "schema_version": "1",
  "convention": "anthropics/skills/skill-creator evals.json — trigger-only fixture per references/schemas.md. Each entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy.",
- "notes": "Positives target retro-on-a-pair-session prompts (a re-frame2-pair session must have occurred or been recapped). Negatives target vocab-only retros (no pair surface), and adjacent skills (improver = static code, pair = live runtime, etc.).",
+ "notes": "Positives target retro-on-a-pair-session prompts (a re-frame2-pair session must have occurred or been recapped), including the harder post-error branch (ids 4, 17, 18 — the post-mortem AFTER a settled error, not the live firefight). Negatives target vocab-only retros (no pair surface), adjacent skills (improver = static code, pair = live runtime, etc.), the mid-pair error the user wants FIXED (id 19 — stays in re-frame2-pair), and out-of-scope Story-recorder retros (id 20 — routes to re-frame2-pair variant-refinement).",
  "evals": [
  {"id": 1, "name": "explicit-retro", "should_trigger": true, "prompt": "Retro on this re-frame2-pair session: I spent 20 minutes debugging why discover-app refused to attach. Multiple retries, same :reason :runtime-not-preloaded each time."},
  {"id": 2, "name": "review-pair-session", "should_trigger": true, "prompt": "Review my re-frame2-pair session from the last hour. What took longer than it should have?"},
@@ -12,6 +12,8 @@
  {"id": 6, "name": "should-pair-absorb", "should_trigger": true, "prompt": "Which parts of this re-frame2-pair workflow should the pair tool itself absorb?"},
  {"id": 7, "name": "upstream-framework", "should_trigger": true, "prompt": "I think the friction in this re-frame2-pair session is actually a re-frame2 framework gap, not a pair-tool gap. Where would I file an upstream bead?"},
  {"id": 8, "name": "retro-five-rounds", "should_trigger": true, "prompt": "I just finished pairing with Claude on a re-frame2 bug for five rounds. Retro on the session — what wasted effort can we shave?"},
+ {"id": 17, "name": "post-error-onerror-postmortem", "should_trigger": true, "prompt": "That re-frame2-pair session just ended after the frame's :on-error policy fired and the cascade halted. Now that the dust has settled, post-mortem the firefight — what could re-frame2-pair have done to make that error easier to handle?"},
+ {"id": 18, "name": "post-error-restore-failed", "should_trigger": true, "prompt": "We're done debugging — restore-epoch kept failing with :rf.epoch/restore-version-mismatch for ten minutes during that re-frame2-pair session. Retro the post-error scramble and tell me where the friction was."},
  {"id": 9, "name": "neg-generic-retro", "should_trigger": false, "prompt": "What went wrong with my deploy yesterday?", "rationale": "Vocab hit ('what went wrong') with no re-frame2-pair session."},
  {"id": 10, "name": "neg-improve-workflow", "should_trigger": false, "prompt": "How can I improve my git workflow?", "rationale": "Generic workflow improvement, no pair surface."},
  {"id": 11, "name": "neg-static-improver", "should_trigger": false, "prompt": "Audit cart/events.cljs for re-frame2 anti-patterns.", "rationale": "Static code critique is re-frame2-improver."},
@@ -19,6 +21,8 @@
  {"id": 13, "name": "neg-author-code", "should_trigger": false, "prompt": "Write me a re-frame2 reg-event-fx for posting a login form.", "rationale": "Authoring code is re-frame2."},
  {"id": 14, "name": "neg-greenfield", "should_trigger": false, "prompt": "Set up a new re-frame2 project from scratch.", "rationale": "Greenfield is re-frame2-setup."},
  {"id": 15, "name": "neg-causa-tour", "should_trigger": false, "prompt": "Where in Causa do I see machine state?", "rationale": "Causa tour is its own skill."},
- {"id": 16, "name": "neg-routine-pair", "should_trigger": false, "prompt": "Help me dispatch an event into my running app and watch the result.", "rationale": "Routine pair work — not a retro request."}
+ {"id": 16, "name": "neg-routine-pair", "should_trigger": false, "prompt": "Help me dispatch an event into my running app and watch the result.", "rationale": "Routine pair work — not a retro request."},
+ {"id": 19, "name": "neg-mid-pair-error-wants-fix", "should_trigger": false, "prompt": "My re-frame2-pair session just threw a stack trace from the cart/checkout handler — fix it so the dispatch works.", "rationale": "A mid-session error the user wants FIXED stays in re-frame2-pair (live debugging). The retro is for the post-mortem AFTER the firefight, not the firefight itself — SKILL.md disambiguation at the post-error branch."},
+ {"id": 20, "name": "neg-story-recorder-retro", "should_trigger": false, "prompt": "Retro on my recorded play sequence from the Story recorder — what should I refine?", "rationale": "Story Test Codegen recorder retrospectives are explicitly out of scope (SKILL.md §When NOT to use); the recorder output is a :play-script to refine in re-frame2-pair's variant-refinement workflow, not a pair-session friction trace."}
  ]
 }

--- a/skills/re-frame2-pair-retro/references/analysis-lenses.md
+++ b/skills/re-frame2-pair-retro/references/analysis-lenses.md
@@ -34,7 +34,7 @@ These signals are unique to or amplified by re-frame2's Tool-Pair surfaces. Watc
 - `restore-epoch` calls that fail with one of the six named failure modes (`:rf.epoch/restore-unknown-epoch`, `restore-schema-mismatch`, `restore-missing-handler`, `restore-version-mismatch`, `restore-during-drain`, or `:rf.error/no-such-handler`) without a clear next-best-action
 - silent loss of history because `:epoch-history :depth` is too low for the user's workflow, with no warning when the target epoch ages out
 - stale or empty result because the build is `:advanced` (production-elided): the trace surface, schema validation, and epoch machinery are gated by `re-frame.interop/debug-enabled?` and elide entirely
-- source-coordinate workflows that assume `data--coord` is present when the runtime opt is off
+- source-coordinate workflows that assume `data-rf2-source-coord` is present when the runtime opt is off
 - private-namespace reach-through (`re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`) — these are off-contract per Tool-Pair §REPL-eval and may move
 - hot-swap that fired but the user could not tell because `:rf.registry/handler-replaced` was not surfaced
 - dispatch correlation gaps: cascade walks where `:dispatch-id` / `:parent-dispatch-id` were available but the tool did not stitch them
@@ -55,13 +55,13 @@ Friction signals specific to `:on-error`:
 - `:replacement` was set under a `:recovery` value other than `:replaced-with-default` (ignored by the runtime; may emit `:rf.warning/replacement-ignored-on-recovery`)
 - `:replacement` shape did not match the failing operation's normal return (effect-map for `:rf.error/handler-exception`, position-matched value for `:rf.error/schema-validation-failure`, etc.) — runtime rejected it as `:rf.error/bad-on-error-return`
 - `:replacement` was set on a non-substitutable category (registration-time failures, drain-depth-exceeded, `:rf.epoch/restore-*` rejections, `:rf.machine/*` registration-time rejections) — runtime cannot honour it
-- the user expected `:on-error` to fire in a CLJS production build but it didn't — pre- builds gated `:on-error` behind `goog.DEBUG`; surface the dev/prod divergence and route the fix upstream rather than working around it in the policy
+- the agent assumed `:on-error` elides in a CLJS production build and so dismissed a production handler-exception report — but the slot is **always-on**: it rides the `re-frame.error-emit` substrate, is NOT gated by `re-frame.interop/debug-enabled?`, and survives `:advanced` + `goog.DEBUG=false` for the `:rf.error/handler-exception` path (per `spec/009-Instrumentation.md` §Production elision and the posture matrix). Registered policy fns DO fire in prod for handler exceptions. Only the dev-side enrichments elide: `:dispatch-id` / source-coord correlation and the `:rf.error/bad-on-error-return` / `:rf.error/on-error-policy-exception` validation traces ride the dev trace surface, and policy-fn exceptions are caught silently in CLJS prod. Surface that real dev/prod split (recovery fires, validation diagnostics don't) rather than telling the user the slot is gone in production
 - the session reached into `re-frame.events` / `re-frame.registrar` to read the registered policy fn instead of using `(:on-error (rf/frame-meta <frame-id>))` — off-contract private-namespace reach-through per Tool-Pair §REPL-eval
 
 Routing the fix:
 
 - **re-frame2-pair skill** — the friction is that the agent didn't recognise the bad-return / policy-throw trace categories, or the inspection recipe was unclear → tighten `references/on-error.md`, add a recipe, or surface the trace categories more loudly in `references/errors.md`
-- **upstream re-frame2** — the friction is the runtime's behaviour itself (silent fallback, no warning trace, prod-elision of the slot, missing structured `:tags` on the bad-return trace) → file against `re-frame2`, cross-link to `spec/009-Instrumentation.md §Error-handler policy`
+- **upstream re-frame2** — the friction is the runtime's behaviour itself (silent fallback, no warning trace, a category the always-on error-emit substrate does not yet cover beyond `:rf.error/handler-exception`, missing structured `:tags` on the bad-return trace) → file against `re-frame2`, cross-link to `spec/009-Instrumentation.md §Error-handler policy`
 
 When proposing improvements, prefer turning a silent runtime fallback into a louder warning the agent can route to the user, and prefer a recipe over a doc paragraph when the friction is "I didn't know how to inspect the registered policy at the REPL".
 
@@ -106,7 +106,7 @@ Also consider higher-upside redesigns:
 Decide which target repo's GitHub issues the filing lives in before drafting:
 
 - **`day8/re-frame2-pair`** — the friction is in the tool's SKILL.md, scripts, attach logic, recipe selection, structured-result shape, cross-platform handling, or any concern that is not part of the framework's commitment.
-- **`day8/re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself: a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data--coord` shape question, a schema-reflection limitation, or a private-namespace reach-through that should be promoted to public.
+- **`day8/re-frame2`** — the friction is caused by a gap or ambiguity in the Tool-Pair contract itself: a missing trace event category, an under-specified `:rf.epoch/*` failure mode, a missing registrar query, a `data-rf2-source-coord` shape question, a schema-reflection limitation, or a private-namespace reach-through that should be promoted to public.
 - **Both** — sometimes the fastest path is a tool-side workaround now plus an upstream issue for the long-term fix. File both, and reference one from the other.
 
 ## Prioritization

--- a/skills/re-frame2-pair-retro/references/known-frictions.md
+++ b/skills/re-frame2-pair-retro/references/known-frictions.md
@@ -135,7 +135,7 @@ Typical improvements:
 
 Signals:
 - the retrospective is unsure whether a tool the user "should have reached for" was actually exposed by the running re-frame2-pair-mcp build, or whether it was reasoning from stale docs
-- the session reasons about tool availability from `re-frame2-pair/references/ops.md` alone — that doc can drift from the live `tools.cljs` catalogue (see on the drift gate)
+- the session reasons about tool availability from `re-frame2-pair/references/ops.md` alone — that doc can drift from the live `tools.cljs` catalogue (the re-frame2-pair-mcp conformance corpus at `tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs` is the drift gate that pins each tool's wire shape, but it does not catch a recipe citing a tool that the running build never exposed)
 - a "why didn't they use tool X?" thread surfaces with no way to confirm X was actually callable in that session
 
 Typical improvements:
@@ -147,7 +147,7 @@ Typical improvements:
 
 Signals:
 - "where in the source did this come from?" returned nothing
-- `data--coord` annotation is off because it is opt-in
+- `data-rf2-source-coord` annotation is off because it is opt-in
 - the user expected DOM-to-source even though re-frame2 commits to the attribute, not the helpers
 
 Typical improvements:

--- a/skills/re-frame2-pair-retro/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair-retro/spec/authoring-prompt.md
@@ -12,7 +12,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 >
 > *1. `skills/re-frame2-pair-retro/spec/design.md` — the locked design decisions (L1 through L12). Pillars 1-4 in §2 are non-negotiable. L1 (no re-frame-10x routing) and L2 (no bead filing without approval) are cardinal.*
 > *2. `skills/re-frame2-pair-retro/spec/inputs.md` — the canonical inputs the skill leans on.*
-> *3. `skills/re-frame2-pair/SKILL.md` + `skills/re-frame2-pair/references/` — the sibling skill the user just exercised. The improver reads the parent's friction surface (ops, recipes, errors, hot-reload-protocol).*
+> *3. `skills/re-frame2-pair/SKILL.md` + `skills/re-frame2-pair/references/` — the sibling skill the user just exercised. The improver reads the parent's friction surface (ops, recipes, errors, and the hot-reload coordination protocol in `ops.md`).*
 > *4. `skills/re-frame2-pair/spec/design.md` — the sibling's locks. The improver respects these when proposing changes.*
 > *5. `skills/re-frame2/SKILL.md` + `skills/re-frame2/spec/design.md` — the application-authoring sibling (relevant for upstream-routing decisions).*
 > *6. `skills/re-frame-migration/SKILL.md` — the closest structural sibling with an existing `spec/` triad. Voice / shape mirror this.*
@@ -29,7 +29,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > ├── agents/
 > │ └── openai.yaml (alt-host config for non-Claude operation)
 > ├── references/
-> │ ├── analysis-lenses.md (~140 lines; ten root-cause lenses)
+> │ ├── analysis-lenses.md (~140 lines; nine root-cause lenses)
 > │ ├── known-frictions.md (~120 lines; recurring pain patterns)
 > │ └── issue-template.md (~90 lines; bead-body template + redaction)
 > └── spec/
@@ -45,7 +45,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > *1. Reconstruct the session goal.*
 > *2. Build a short timeline of where progress stalled / restarted / detoured.*
 > *3. Extract friction (numbered list; present BEFORE root causes).*
-> *4. Classify the root cause using the ten lenses (briefly; don't force every finding through every lens).*
+> *4. Classify the root cause using the nine lenses (briefly; don't force every finding through every lens).*
 > *5. Generate improvements at the right layer (skill / script / runtime / tests / docs / upstream `re-frame2`).*
 > *6. Prioritise — return 2-5 grounded improvements + 0-2 bolder ideas.*
 >
@@ -94,7 +94,7 @@ A self-contained prompt that re-authors the `re-frame2-pair-retro` skill from th
 > *- Don't claim AI authorship anywhere — commits and PR title/body read as Mike Thompson's work.*
 > *- Don't include bead-ids in user-facing leaves.*
 >
-> *Open the PR with title `feat(skills): re-frame2-pair-retro — pair-session retrospective skill`. PR body lists: the skill structure, the file LoC table, the six-step workflow, the ten lenses, the output format, the relationship to the sibling skills (`re-frame2-pair` — its primary feedback loop; `re-frame2` — for upstream routing).*
+> *Open the PR with title `feat(skills): re-frame2-pair-retro — pair-session retrospective skill`. PR body lists: the skill structure, the file LoC table, the six-step workflow, the nine lenses, the output format, the relationship to the sibling skills (`re-frame2-pair` — its primary feedback loop; `re-frame2` — for upstream routing).*
 
 ## Notes on the reauthoring contract
 

--- a/skills/re-frame2-pair-retro/spec/design.md
+++ b/skills/re-frame2-pair-retro/spec/design.md
@@ -44,7 +44,7 @@ The skill walks a six-step analysis: reconstruct goal → build timeline → ext
 
 ### L5 — Use the analysis-lenses taxonomy
 
-`references/analysis-lenses.md` defines ten root-cause lenses (skill structure / skill gap / misleading docs / missing structured op / unreliable op / default-or-fallback / platform bug / validation gap / upstream limitation / context-window issue). Each lens has a question to ask and a typical improvement shape. The skill walks these lenses **briefly** for each finding; doesn't force every finding through every lens.
+`references/analysis-lenses.md` defines nine root-cause lenses (`docs/discoverability` / `workflow-gap` / `missing-op` / `unreliable-op` / `default/fallback` / `platform-bug` / `validation-gap` / `upstream-gap` / `out-of-scope`). Each lens has a question to ask and a typical improvement shape. The skill walks these lenses **briefly** for each finding; doesn't force every finding through every lens.
 
 ### L6 — Bolder ideas are labelled
 
@@ -58,7 +58,7 @@ When the session has enough evidence, the retro uses these sections:
 - `Likely root causes` (one primary per finding; multiple contributors allowed)
 - `Improvement ideas` (2-5 grounded; bolder ideas separated)
 - `Bolder ideas` (if any)
-- `Bead candidates` (only if user asks)
+- `Issue candidates` (only if user asks)
 - `Other possibilities` (low-priority leftovers)
 
 If the session is too thin, the skill says so plainly and asks for either a recap or permission to use a longer conversation as input.
@@ -96,7 +96,7 @@ Bead drafts redact secrets, tokens, internal URLs, and unnecessary local file pa
 
 - Users finishing a `re-frame2-pair` session who want a structured retrospective.
 - Friction analysis: direct (user complaints) + indirect (repeated commands, fallback to lower-level tools, manual reconstruction).
-- Classification across the ten lenses in `references/analysis-lenses.md`.
+- Classification across the nine lenses in `references/analysis-lenses.md`.
 - Drafting beads against `re-frame2-pair` (tool changes) or `re-frame2` (upstream contract changes).
 - Spotting recurring patterns via `references/known-frictions.md`.
 
@@ -121,7 +121,7 @@ skills/re-frame2-pair-retro/
 ├── agents/
 │ └── openai.yaml (alt-host config — kept for cross-LLM operation)
 ├── references/
-│ ├── analysis-lenses.md (~140 lines; ten root-cause lenses + improvement shapes)
+│ ├── analysis-lenses.md (~140 lines; nine root-cause lenses + improvement shapes)
 │ ├── known-frictions.md (~120 lines; recurring re-frame2-pair pain patterns)
 │ └── issue-template.md (~90 lines; bead-body template, redaction rules)
 └── spec/
@@ -157,12 +157,12 @@ The pillars in §2 govern *what* the skill delivers; the rules below govern *how
 - **Positive gaps too.** What almost worked? What required too much expert knowledge? What capability existed but was undiscoverable? What should have been the default? Negative-space evidence is as load-bearing as failure evidence.
 - **Be creatively ambitious after diagnosis.** Start with grounded fixes; then ask what would make this workflow feel nearly automatic or hard to misuse. Include 1-2 higher-upside ideas when warranted, even if they reshape the workflow rather than patching a local symptom. Operationalises pillar 4 + L6.
 
-SKILL.md cross-links here rather than reciting these rules inline — keeps the orchestrator lean per 's leaf-size ceiling.
+SKILL.md cross-links here rather than reciting these rules inline — keeps the orchestrator lean per `skills/README.md` §Leaf size discipline's per-leaf size ceiling.
 
 ## 9. Why this design diverges from `re-frame2-pair`
 
 - **No structured-op catalogue.** This skill doesn't operate on a live app; it operates on a session transcript.
-- **No `allowed-tools` block in frontmatter.** The skill is conversational; the AI's tools are the default Read/Edit/Write/Grep/Glob set plus `gh issue create` when filing is opt-in (the skill files GitHub issues against the target repo — `bd` is the re-frame2 monorepo's internal tracker and is never invoked from a published skill).
+- **Read-only `allowed-tools` block in frontmatter.** The skill is conversational and diagnose-first, so it ships an explicit allow-list — `Read`, `Grep`, `Glob`, plus `Bash(gh issue list *)` / `Bash(gh issue view *)` / `Bash(gh issue create *)`. It deliberately omits `Edit` and `Write`: the skill never rewrites source, in this repo or another — friction routes to GitHub issues against the target repo, not edits. `gh issue create` is granted but approval-gated (L2). `bd` is the re-frame2 monorepo's internal tracker and is never invoked from a published skill.
 - **No connect-first rule.** No live runtime to connect to.
 - **`agents/openai.yaml` is included.** The skill is portable across LLM hosts; the openai config carries the routing for non-Claude hosts.
 - **No `scripts/` directory.** The skill doesn't ship runtime tooling.

--- a/skills/re-frame2-pair-retro/spec/inputs.md
+++ b/skills/re-frame2-pair-retro/spec/inputs.md
@@ -22,26 +22,25 @@ The sibling skill the user just exercised. The improver reads the parent skill's
 - **`SKILL.md`** — the parent's cardinal rules, primitives, style guidance. Friction often surfaces as "the cardinal rule was right but buried" or "the style guidance didn't fire when it should have".
 - **`references/ops.md` + `references/recipes.md`** — the catalogue the user navigated. Missing ops or missing recipes are first-class findings.
 - **`references/errors.md`** — the error-recovery catalogue. Misleading recovery suggestions are findings.
-- **`references/hot-reload-protocol.md`** — the strict source-edit protocol. Friction here is high-leverage (every source edit triggers it).
+- **`references/ops.md` §Hot-reload coordination** — the strict source-edit protocol (folded into the op catalogue, not a standalone leaf). Friction here is high-leverage (every source edit triggers it).
 - **`scripts/`** + **MCP server** — the transport surface. Brittleness here breaks every session.
 - **`spec/design.md`** (this skill's neighbour) — the locked decisions. The improver respects locks; doesn't propose changes that contradict them.
 
 ## 3. Tertiary input — `references/analysis-lenses.md`
 
-The ten root-cause lenses the skill walks during classification:
+The nine root-cause lenses the skill walks during classification — the canonical names live in `references/analysis-lenses.md §Root-cause categories`; this table mirrors them:
 
 | Lens | Question | Typical improvement |
 |------|----------|---------------------|
-| Skill structure | Was the right guidance present but buried? | Promote to guard rail, shorten, reorder, add examples |
-| Skill gap | Was key guidance missing entirely? | Add a recipe, anti-pattern, decision rule |
-| Misleading docs | Did docs suggest the wrong action or trust model? | Correct wording, add warnings, align contracts |
-| Missing structured op | Did the workflow need a first-class op? | Add a script/runtime op or structured field |
-| Unreliable op | Did an op behave ambiguously or brittlely? | Fix behavior, add warnings, strengthen validation |
-| Default or fallback | Was the default path wrong, silent, or unsafe? | Change defaults or automate the safer fallback |
-| Platform bug | Did the workflow break on a specific shell/OS/browser? | Add platform-aware handling or explicit detection |
-| Validation gap | Did this ship because the right fixture/test is missing? | Add test coverage or fixture support |
-| Upstream limitation | Is `re-frame2-pair` working around the wrong abstraction in `re-frame2`? | File a GitHub issue against `day8/re-frame2` |
-| Context-window issue | Did long context or low-salience guidance cause forgetfulness? | Make the guard rail shorter, earlier, stronger |
+| `docs/discoverability` | The feature or prerequisite existed, but could the user find or trust it? | Promote to guard rail, correct wording, add warnings, align contracts |
+| `workflow-gap` | Did the instructions / recipes guide the user through a common task? | Add a recipe, anti-pattern, decision rule |
+| `missing-op` | Did the workflow need a first-class operation that does not exist? | Add a script/runtime op or structured field |
+| `unreliable-op` | Was an existing operation too brittle or ambiguous? | Fix behavior, add warnings, strengthen validation |
+| `default/fallback` | Was the default behavior wrong, silent, or unsafe? | Change defaults or automate the safer fallback |
+| `platform-bug` | Did the workflow break on a specific OS / shell / browser? | Add platform-aware handling or explicit detection |
+| `validation-gap` | Did this ship because the repo lacks the right smoke test, fixture, or warning? | Add test coverage or fixture support |
+| `upstream-gap` | Does the best fix belong in `re-frame2` itself (Tool-Pair contract, instrumentation, schema reflection, epoch machinery, source-coord)? | File a GitHub issue against `day8/re-frame2` |
+| `out-of-scope` | Did the user want something `re-frame2-pair` should probably not own? | Route elsewhere; decline cleanly |
 
 This is the canonical taxonomy; the improver doesn't invent ad-hoc categories.
 


### PR DESCRIPTION
## Summary

Fixes a correctness/quality cluster in the `re-frame2-pair-retro` skill (retro for pair sessions): one inverted deep-framework lens, three broken template stubs, a mis-spelled DOM attribute, spec/leaf taxonomy drift, a dangling sibling-file reference, and thin eval coverage on the post-error branch.

- **`:on-error` production-elision lens corrected** — `references/analysis-lenses.md` taught the OPPOSITE of the spec. Per `spec/009-Instrumentation.md` §Production elision + the posture matrix, the `:on-error` slot is **always-on**: it rides the `re-frame.error-emit` substrate, is NOT gated by `re-frame.interop/debug-enabled?`, and survives `:advanced` + `goog.DEBUG=false` for the `:rf.error/handler-exception` path. Registered policy fns DO fire in prod; only dev-side enrichments (`:dispatch-id` / source-coord, the bad-on-error-return / policy-exception validation traces) elide. The dangling over-stripped `pre-` fragment on the same line is gone, and the upstream-routing bullet that listed "prod-elision of the slot" as a friction is corrected.
- **Three template stubs filled** — `SKILL.md` reference-files note ("Extracted by ;"), `spec/design.md` leaf-size cross-link ("per 's leaf-size"), and `references/known-frictions.md` drift-gate note ("see on the drift gate", now pointing at the re-frame2-pair-mcp conformance corpus).
- **`data--coord` → `data-rf2-source-coord`** — fixed in all three places (analysis-lenses ×2, known-frictions ×1); canonical per `spec/Tool-Pair.md`.
- **Taxonomy reconciled to shipped reality** — the spec triad (`design.md`, `inputs.md`, `authoring-prompt.md`) claimed TEN lenses; the live leaf lists NINE (`docs/discoverability`, `workflow-gap`, `missing-op`, `unreliable-op`, `default/fallback`, `platform-bug`, `validation-gap`, `upstream-gap`, `out-of-scope`). `design.md §9` now describes the real read-only allowed-tools block (omits Edit/Write); `Bead candidates` → `Issue candidates`.
- **Stale sibling-file ref fixed** — `inputs.md` cited the non-existent `re-frame2-pair/references/hot-reload-protocol.md`; the protocol now lives in `ops.md §Hot-reload coordination`.
- **Eval coverage on the post-error branch** — added two post-error positives (`:on-error` post-mortem, restore-version-mismatch scramble), a "mid-pair error wants a fix not a retro → false" negative, and a "Story-recorder retro → false" negative. Now 10 positives / 10 negatives, valid JSON, unique ids.

All changes confined to `skills/re-frame2-pair-retro/`. No bead refs or AI attribution in user-facing leaves.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exit 0
- [x] `python -m mkdocs build --strict` — exit 0 (skill leaves are outside `docs_dir`; build clean)
- [x] `bb skills/shared/tests/retro_protocol_test.clj` — 24 tests / 37 assertions, 0 failures (SKILL.md still links the shared protocol)
- [x] `python scripts/check_skill_redirect_anchors.py` — no new broken anchors (one pre-existing report in an untouched file)
- [x] `python scripts/check_skill_mcp_drift.py` — exit 0
- [x] `evals.json` validated: 10 pos / 10 neg, unique ids, parses