### PR TITLE
docs(skill): correct re-frame2-implementor registrar kinds + layout + phase-1 ids (5 beads)

### DIFF
--- a/skills/re-frame2-implementor/README.md
+++ b/skills/re-frame2-implementor/README.md
@@ -1,6 +1,6 @@
 # re-frame2-implementor
 
-> ↑ [`skills/`](../) — index of all six re-frame2 skills.
+> ↑ [`skills/`](../) — index of all seven re-frame2 skills.
 
 A `Skill` that helps `Claude Code` (or any Anthropic-skill-compatible agent) guide an engineer **building a new re-frame2 implementation** — a port to a different host language or substrate, not an application built on the existing CLJS reference.
 

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -49,10 +49,11 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 8. **Spec gap → draft a GitHub issue against `day8/re-frame2` and ask before filing.** Don't paper, don't invent, don't extrapolate from the reference — but don't auto-file either. Show the engineer the drafted title + body, restrict the body to public spec-quoted evidence (no private port source), and wait for explicit OK before running `gh issue create`. The skill runs in the engineer's port repo; spec gaps reach the framework maintainers via the upstream repo's GitHub issues — never via `bd` (re-frame2's internal tracker, never invoked from a published skill).
 9. **Per-issue approval gate for any cross-repo side effect.** Before running `gh issue create` against a repo other than the one the engineer is working in, show the full draft (title, target repo, label set, body) and wait for explicit "yes" / "go" / "file it". Invoking the skill is consent to the workflow, not to each cross-repo write. See [`references/cardinal-rules.md` §9](references/cardinal-rules.md).
 10. **Pin the spec corpus.** The kickoff prompt names a specific `day8/re-frame2` commit/tag; verify the checkout's HEAD and origin before reading the spec, and record the pinned hash in `DECISIONS.md` (preamble before D1). An unverified checkout is not the contract.
+11. **Honour the reserved `:rf/*` scheme.** Framework-owned ids live under the single root namespace `:rf/*` (and its sub-namespaces); user code MUST NOT register under `:rf/*`. Reserved fx-ids and reserved app-db keys (`:rf/machines`, `:rf/route`, …) are part of the contract. A port that ignores the scheme fails conformance fixtures that assert `:rf.*` operation ids. Per [`spec/Conventions.md`](../../spec/Conventions.md); the "where does each surface live" map is [`spec/Ownership.md`](../../spec/Ownership.md).
 
 ## Phase 1 — lock the decisions
 
-Walk [`references/phase-1-decisions.md`](references/phase-1-decisions.md) and produce a locked-decision record using the [`references/decision-record.md`](references/decision-record.md) template. The seven decision blocks (D1 target language, D2 substrate, D3 scope, D4 foundation choices, D5 schema mechanism, D6 integration story, D7 capability tag set) are detailed there; the canonical option matrices live in [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md).
+Walk [`references/phase-1-decisions.md`](references/phase-1-decisions.md) and produce a locked-decision record using the [`references/decision-record.md`](references/decision-record.md) template. The seven decision blocks (D1 target language, D2 substrate, D3 scope, D4 the always-required realisation decisions — Implementor-Checklist Part 2's F1–F6 / S1–S3 / Sub1–Sub2 / V1–V3 / T1–T3 / E1–E2, sub-numbered 1:1 with the checklist, D5 schema mechanism, D6 integration story, D7 capability tag set) are detailed there; the canonical option matrices live in [`spec/Implementor-Checklist.md`](../../spec/Implementor-Checklist.md).
 
 Output of Phase 1: a single dated decision record committed to the port's own repo.
 
@@ -92,7 +93,7 @@ The corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic da
 
 ## Reference files (all one level deep)
 
-- [`references/cardinal-rules.md`](references/cardinal-rules.md) — the eight rules in prose + anti-pattern corollaries.
+- [`references/cardinal-rules.md`](references/cardinal-rules.md) — the eleven rules in prose + anti-pattern corollaries.
 - [`references/phase-1-decisions.md`](references/phase-1-decisions.md) — Phase 1 walkthrough, seven decision blocks.
 - [`references/decision-record.md`](references/decision-record.md) — fill-in template for the locked-decision record.
 - [`references/phase-2-impl-order.md`](references/phase-2-impl-order.md) — EP-by-EP implementation order.

--- a/skills/re-frame2-implementor/references/cardinal-rules.md
+++ b/skills/re-frame2-implementor/references/cardinal-rules.md
@@ -71,6 +71,16 @@ Filing a GitHub issue against `day8/re-frame2` from inside the engineer's port r
 
 Invoking the skill is consent to the *workflow*, not consent to each *cross-repo write*. Treat the two as separate gates.
 
+## 10. Pin the spec corpus before reading it
+
+The kickoff prompt names a specific `day8/re-frame2` commit/tag. Verify the checkout's HEAD and origin before reading the spec, and record the pinned hash in `DECISIONS.md` (the preamble before D1). Confirm `git -C <path-to-re-frame2> rev-parse HEAD` matches the pin and that the origin is `https://github.com/day8/re-frame2`. An unpinned or unverified checkout is not the contract — it is whatever happens to be on the filesystem. (This restates, as a standalone rule, the pinning discipline also threaded through rule 1.)
+
+## 11. Honour the reserved `:rf/*` namespace scheme
+
+re-frame2 reserves **one root keyword namespace** for framework-owned ids: `:rf/*` (and its sub-namespaces — `:rf.fx/*`, `:rf.machine/*`, `:rf.error/*`, `:rf.registry/*`, …). Every framework runtime id — events, fx, cofx, app-db keys (`:rf/machines`, `:rf/route`), trace operations, error categories, warnings, registrar mutations, the default frame id (`:rf/default`) — lives under that root. **User code MUST NOT register handlers, fx, subs, or frames under `:rf/*`.** Your port must (a) emit framework ids under the reserved scheme and (b) leave the scheme free for the framework, never user code.
+
+This is a conformance surface, not a style preference. Fixtures assert `:rf.*` operation ids on the trace stream and reserved app-db keys at known paths; a port that invents its own framework-id namespace, or lets app code squat `:rf/*`, fails them. The reserved set, reserved fx-ids, and reserved app-db keys are catalogued in [`spec/Conventions.md`](../../../spec/Conventions.md). The "which spec owns this surface" map — the single most useful index for a port author asking "where does X live?" — is [`spec/Ownership.md`](../../../spec/Ownership.md). Consult [`spec/API.md`](../../../spec/API.md) for the consolidated public signatures when wiring each EP's surface.
+
 ---
 
 ## Anti-patterns (rule corollaries)

--- a/skills/re-frame2-implementor/references/decision-record.md
+++ b/skills/re-frame2-implementor/references/decision-record.md
@@ -49,38 +49,109 @@ Every spec citation in this record (and in subsequent code) is against the pinne
 | **Q6 — Tool-Pair adapters** | <yes / no> | |
 | **Q7 — AI-Audit grading** | <yes / no> | |
 
-## D4. Foundation choices
+## D4. Always-required realisation decisions
 
-### D4.1 Identity primitive
+> Sub-ids mirror Implementor-Checklist Part 2 1:1 — Foundation F1–F6, State storage S1–S3, Subscriptions Sub1–Sub2, Views V1–V3, Tracing T1–T3, Errors E1–E2. Fill in every block; all are always required (T2's bridge may be omitted — record the choice).
+
+### Foundation (F1–F6)
+
+#### F1 Identity primitive
 
 - **Mechanism:** <e.g. "branded string types with naming convention" / "polymorphic variants" / "sealed-class hierarchies">
 - **Required properties verified:** stable / namespaceable / value-equal / cheap / serialisable / human-readable / reflective — <confirm all seven, name the helper(s) that provide each>
 
-### D4.2 Persistent data structures
+#### F2 Persistent data structures
 
-- **Library:** <e.g. "Immer" / "im (Rust)" / "pyrsistent" / "native Clojure persistent collections">
+- **Library:** <e.g. "Immer" / "Immutable.js" / "native Clojure persistent collections" / "native F# Map/Set">
 - **Snapshot mechanism:** <e.g. "pointer swap" / "Immer's `produce` drafts" / "deep-copy fallback for X cases">
 
-### D4.3 Reactive substrate
+#### F3 Reactive substrate
 
 - (Locked in D2.)
 
-### D4.4 Effect-handling primitive
+#### F4 Effect-handling primitive
 
 - **Sync default:** <yes — fx run inline when the handler returns / no — different model>
-- **Async re-entry:** <e.g. "Promise.then → :dispatch" / "asyncio task → schedule_dispatch" / "tokio spawn → mpsc sender">
+- **Async re-entry:** <e.g. "Promise.then → :dispatch" / "queueMicrotask → schedule dispatch">
 - **Standard fx the port ships:** <e.g. ":dispatch / :dispatch-later / :http">
 
-### D4.5 Concurrency model
+#### F5 Concurrency model
 
-- **Model:** <e.g. "single-threaded JS event loop" / "single-threaded asyncio" / "single-threaded tokio">
+- **Model:** <e.g. "single-threaded JS event loop (browser / Node main thread)">
 - **Cross-frame serialisation:** <how dispatch is serialised per frame in multi-frame setups>
 - **No core.async confirmation:** <confirm the directive — no channels in the public dispatch contract>
 
-### D4.6 Hot-reload primitive
+#### F6 Hot-reload primitive
 
-- **Mechanism:** <e.g. "Vite HMR module boundary at reg-* call sites" / "watch + reimport via importlib.reload" / "compile-replace via dynamic library swap">
+- **Mechanism:** <e.g. "Vite HMR module boundary at reg-* call sites" / "figwheel/shadow-cljs reload">
 - **State-preservation contract:** <how frame state survives re-registration of `reg-frame`>
+
+### State storage (S1–S3)
+
+#### S1 App-db container
+
+- **Container:** <e.g. "Reagent ratom" / "useSyncExternalStore-backed atom store" / "MutableStateFlow-shaped cell">
+- **Revertibility check:** <confirm no non-derivable adapter state lives outside the container>
+
+#### S2 Snapshot/restore mechanism
+
+- **Mechanism:** <e.g. "pointer swap (persistent collections)" / "value capture + replace-container!"> — depends on F2.
+
+#### S3 Path-access primitive
+
+- **Mechanism:** <e.g. "native assoc-in/update-in/get-in" / "Immer produce + lodash.get" / "lens helpers over Belt.Map">
+
+### Subscriptions (Sub1–Sub2)
+
+#### Sub1 Signal graph + caching
+
+- **Graph backing:** <e.g. "Reagent reactions" / "Solid createMemo" / "hand-rolled signal DAG">
+- **Cache key:** <confirm `=`-by-value equality for invalidation; identity-only equality is out>
+
+#### Sub2 Lifecycle (when to dispose)
+
+- **Disposal policy:** <e.g. "last-deref-disposes after a delay (Reagent)" / "explicit subscribe/unsubscribe ref-count">
+
+### Views (V1–V3)
+
+#### V1 Render-tree shape
+
+- **Shape:** <e.g. "hiccup" / "JSX-as-data / snabbdom vnodes" / "Feliz Html.div DSL"> — must serialise for SSR + tooling.
+
+#### V2 Render trigger
+
+- **Trigger:** <how a subscribed-value change re-renders the view> — falls out of F3.
+
+#### V3 Mount/unmount
+
+- **Lifecycle hooks:** <how mount fires `:on-create` / unmount fires `:on-destroy` on the surrounding frame>
+
+### Tracing & instrumentation (T1–T3)
+
+#### T1 Trace-event delivery
+
+- **Registry shape:** <e.g. "single listener-registry atom + separate ring-buffer atom">
+- **Ring buffer:** <retain-N for tools that attach after events fired; N = ?>
+
+#### T2 Performance API equivalent
+
+- **Bridge:** <ships the perf bridge (`performance.mark`/`measure`) / omits it — the bridge is optional; T1 is the contract>
+
+#### T3 Production elision
+
+- **Mechanism:** <e.g. "Closure DCE via debug-enabled?" / "Vite define + tree-shake" / "#if !DEBUG">
+- **CI verifier:** <sentinel-string scan asserting dev-only strings absent from production bundles>
+
+### Errors (E1–E2)
+
+#### E1 Error capture / recover
+
+- **Capture sites:** <try/catch around handler bodies / fx invocations / sub computations>
+- **No-silent-swallow:** <confirm every catch fires `:operation :rf.error/<category>` + `:op-type :error`>
+
+#### E2 Error reporting to tools
+
+- **Policy slot:** <the per-frame `:on-error` slot in `reg-frame` metadata> — errors flow through the trace stream (T1).
 
 ## D5. Schema mechanism
 

--- a/skills/re-frame2-implementor/references/output-format.md
+++ b/skills/re-frame2-implementor/references/output-format.md
@@ -31,9 +31,9 @@ Produced at the end of the Phase 1 walkthrough. The decision record is committed
   - Q5 stories: <yes / no>
   - Q6 Tool-Pair: <yes / no>
   - Q7 AI-Audit: <yes / no>
-- **Identity primitive:** <D4.1 mechanism>
-- **Persistent data structures:** <D4.2 library>
-- **Concurrency model:** <D4.5>
+- **Identity primitive:** <F1 mechanism>
+- **Persistent data structures:** <F2 library>
+- **Concurrency model:** <F5>
 - **Schema mechanism:** <D5>
 - **Decision record:** committed to `DECISIONS.md` at <commit-hash>.
 

--- a/skills/re-frame2-implementor/references/phase-1-decisions.md
+++ b/skills/re-frame2-implementor/references/phase-1-decisions.md
@@ -10,12 +10,14 @@ Every decision in Phase 1 propagates through every line of Phase 2 code. Spendin
 - D1. Target host language
 - D2. Substrate / view layer
 - D3. Scope — which EPs ship now
-- D4. Foundation choices (identity, persistent data, reactive, effect, concurrency, hot-reload)
+- D4. Always-required realisation decisions (the checklist's Part 2 always-required blocks: Foundation F1–F6, State storage S1–S3, Subscriptions Sub1–Sub2, Views V1–V3, Tracing T1–T3, Errors E1–E2)
 - D5. Schema mechanism
 - D6. Integration story
 - D7. Conformance capability tag set
 
 For each block: the question, what's at stake, options, how to choose, where the spec speaks to it.
+
+**Id scheme — this skill mirrors the checklist's.** D4 below is sub-numbered with the **exact** Part 2 ids from [`spec/Implementor-Checklist.md`](https://day8.github.io/re-frame2/spec/Implementor-Checklist/) — F1–F6, S1–S3, Sub1–Sub2, V1–V3, T1–T3, E1–E2 — so the decision record cross-walks 1:1 with the checklist. (Earlier drafts numbered these D4.1–D4.6 and silently dropped the State storage / extra Views / extra Tracing blocks; the ids and the missing blocks are now reconciled to the spec.)
 
 ---
 
@@ -117,11 +119,15 @@ The [Implementor-Checklist](https://day8.github.io/re-frame2/spec/Implementor-Ch
 
 ---
 
-## D4. Foundation choices
+## D4. Always-required realisation decisions
 
-Six sub-decisions, all required, all from [Implementor-Checklist Part 2 §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required). Each propagates through every line of Phase 2 code.
+The checklist's Part 2 splits the always-required realisation decisions into six groups: **Foundation (F1–F6)**, **State storage (S1–S3)**, **Subscriptions (Sub1–Sub2)**, **Views (V1–V3)**, **Tracing & instrumentation (T1–T3)**, and **Errors (E1–E2)**. Every block below is **always required** (T2 Performance API is required-but-may-omit-the-bridge; see its note) and each propagates through Phase 2 code. The sub-ids match [Implementor-Checklist Part 2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#part-2--how-achieved) exactly.
 
-### D4.1 Identity primitive
+### Foundation (F1–F6)
+
+From [Implementor-Checklist §Foundation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#foundation-always-required).
+
+#### F1 Identity primitive
 
 **The question.** What represents an id?
 
@@ -135,7 +141,7 @@ Six sub-decisions, all required, all from [Implementor-Checklist Part 2 §Founda
 
 **Where the spec speaks.** [`spec/000-Vision.md` §The identity primitive — required properties](https://day8.github.io/re-frame2/spec/000-Vision/#the-identity-primitive--required-properties) and the per-host realisation table.
 
-### D4.2 Persistent data structures
+#### F2 Persistent data structures
 
 **The question.** What does `app-db` (and every snapshot of it) physically live in?
 
@@ -145,11 +151,11 @@ Six sub-decisions, all required, all from [Implementor-Checklist Part 2 §Founda
 
 **Where the spec speaks.** [Implementor-Checklist §F2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f2-persistent-data-structures).
 
-### D4.3 Reactive substrate
+#### F3 Reactive substrate
 
-Already locked in D2.
+Already locked in D2 (the substrate / view-layer choice). Recorded here for cross-walk completeness with the checklist; no separate answer needed.
 
-### D4.4 Effect-handling primitive
+#### F4 Effect-handling primitive
 
 **The question.** How does the runtime invoke registered effects? Sync vs async?
 
@@ -159,7 +165,7 @@ Already locked in D2.
 
 **Where the spec speaks.** [Implementor-Checklist §F4](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f4-effect-handling-primitive).
 
-### D4.5 Concurrency model
+#### F5 Concurrency model
 
 **The question.** Single-threaded event loop vs multi-threaded vs actor-shaped?
 
@@ -169,15 +175,147 @@ Already locked in D2.
 
 **Where the spec speaks.** [`spec/002-Frames.md` §Run-to-completion dispatch drain semantics](https://day8.github.io/re-frame2/spec/002-Frames/). [Implementor-Checklist §F5](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f5-concurrency-model).
 
-### D4.6 Hot-reload primitive
+#### F6 Hot-reload primitive
 
 **The question.** How does re-registration surgically replace registry entries without restarting the runtime?
 
-**Options.** figwheel/shadow-cljs (CLJS); Vite HMR (JS/TS); watch+reimport (Python); compile-replace cycle with `dlopen` (Rust); recompile-and-rerun for compiled-only hosts.
+**Options.** figwheel/shadow-cljs (CLJS); Vite HMR (JS/TS) — and the analogous Vite-HMR-compatible source-build pipeline for each in-scope host (Squint, Fable, Scala.js, PureScript, Kotlin/JS, Melange / ReScript / Reason).
 
 **Constraint.** Re-registration emits `:rf.registry/handler-replaced` per [`spec/001-Registration.md` §Hot-reload semantics](https://day8.github.io/re-frame2/spec/001-Registration/). Frame state preserved across re-registration of `reg-frame`.
 
 **Where the spec speaks.** [Implementor-Checklist §F6](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f6-hot-reload-primitive).
+
+### State storage (S1–S3)
+
+From [Implementor-Checklist §State storage](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#state-storage-always-required). All three are always required.
+
+#### S1 App-db container
+
+**The question.** What container physically holds the frame's `app-db` value?
+
+**What's at stake.** The container's *value* is the frame's `app-db`; all reads/writes go through `read-container` / `replace-container!`. The container's value is what's restored on revert; its identity is stable.
+
+**Options.** Usually the same library that supplies F3's reactive substrate (Reagent ratom / `clojure.core/atom` in the CLJS reference; a `useSyncExternalStore`-backed atom-shaped store, a signal-library cell, or a `MutableStateFlow`-shaped cell per host).
+
+**Constraint.** Adapters MUST NOT hold non-derivable state outside the container (per [`spec/006-ReactiveSubstrate.md` §Revertibility constraints on adapters](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#revertibility-constraints-on-adapters)).
+
+**Where the spec speaks.** [Implementor-Checklist §S1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#s1-app-db-container).
+
+#### S2 Snapshot/restore mechanism
+
+**The question.** How is full-frame-state captured and restored as a value swap?
+
+**What's at stake.** Test fixtures, epoch history (`epoch/restore-epoch` + `epoch/reset-frame-db!`), and time-travel all depend on snapshot/restore being a value swap. With persistent collections (F2) a snapshot is a pointer and restore is `replace-container!`; without them, snapshot is deep-copy and expensive — this is why F2 is pattern-required.
+
+**Where the spec speaks.** [Implementor-Checklist §S2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#s2-snapshotrestore-mechanism).
+
+#### S3 Path-access primitive
+
+**The question.** What provides `assoc-in` / `update-in` / `get-in` over the frame's app-db?
+
+**What's at stake.** Used by handlers, the `path` standard interceptor, registered subs that read paths, and `(rf/snapshot-of path)`. Path operations are hot — choose a fast implementation.
+
+**Options.** Native `assoc-in` / `update-in` / `get-in` (CLJS, Squint); Immer `produce` / `lodash.set`-immutably (TS); lens helpers over the host's immutable map (Belt / F# `Map` / Monocle / `purescript-profunctor-lenses` / Arrow Optics) per host.
+
+**Where the spec speaks.** [Implementor-Checklist §S3](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#s3-path-access-primitive).
+
+### Subscriptions (Sub1–Sub2)
+
+From [Implementor-Checklist §Subscriptions](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#subscriptions-always-required). Both fall out of F3 + S1, but record them explicitly.
+
+#### Sub1 Signal graph + caching
+
+**The question.** What backs the subscription DAG, and how is the per-query cache keyed?
+
+**What's at stake.** Subscriptions form a DAG over `app-db`; values cache per `=`-equality. Layer-1 subs read `app-db` directly; layer-2+ compose via `:<-`. **Equality-by-value is required** for cache invalidation — identity-only equality breaks the contract.
+
+**Where the spec speaks.** [Implementor-Checklist §Sub1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#sub1-signal-graph--caching). [`spec/006-ReactiveSubstrate.md` §Subscription cache](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-cache--contract-and-operational-semantics).
+
+#### Sub2 Lifecycle (when to dispose)
+
+**The question.** When is a sub no view is reading torn down?
+
+**What's at stake.** Subs unread by any view should dispose to release resources; the mechanism varies by reactive substrate (Reagent: last-deref-disposes after a delay). Pick a policy and document it.
+
+**Where the spec speaks.** [Implementor-Checklist §Sub2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#sub2-lifecycle-when-to-dispose).
+
+### Views (V1–V3)
+
+From [Implementor-Checklist §Views](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#views-always-required). All three always required.
+
+#### V1 Render-tree shape
+
+**The question.** What is the serialisable data form of the render-tree?
+
+**What's at stake.** Pure `(state, props) → render-tree`; the render-tree must be serialisable data for SSR (011) and inspectable for view-tree tooling. Closed component trees that don't serialise (raw React elements with closures) break SSR + inspection.
+
+**Options.** Hiccup (CLJS, Squint); JSX-as-data / snabbdom-style vnodes (TS); Feliz `Html.div [...]` (Fable); `R.div [] [...]` (PureScript); `<.div(...)` (Scala.js); `div { ... }` (Kotlin/JS) — every in-scope host targets React + VDOM, so the shape is the host's idiomatic data-form over `createElement`.
+
+**Where the spec speaks.** [Implementor-Checklist §V1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#v1-render-tree-shape). [`spec/004-Views.md`](https://day8.github.io/re-frame2/spec/004-Views/).
+
+#### V2 Render trigger
+
+**The question.** When does the view re-render?
+
+**What's at stake.** Falls out of F3; signal libraries trigger re-render on subscribed-value change. The trigger must be observably equivalent to "change in `app-db` → recompute affected subs → re-render dependent views".
+
+**Where the spec speaks.** [Implementor-Checklist §V2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#v2-render-trigger).
+
+#### V3 Mount/unmount
+
+**The question.** How do component lifecycle hooks fire frame events?
+
+**What's at stake.** Lifecycle should fire `:on-create` (mount-time) and `:on-destroy` (unmount-time) events on the surrounding frame, integrating with the run-to-completion drain.
+
+**Where the spec speaks.** [Implementor-Checklist §V3](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#v3-mountunmount).
+
+### Tracing & instrumentation (T1–T3)
+
+From [Implementor-Checklist §Tracing & instrumentation](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#tracing--instrumentation-always-required).
+
+#### T1 Trace-event delivery
+
+**The question.** What delivers each emitted trace map to every registered listener?
+
+**What's at stake.** Synchronous, in-order, event-at-a-time delivery on the runtime's emit call stack, plus a retain-N ring buffer for tools that attach after events have fired. Listener-invocation **order is not** contract; "every listener, exactly once, synchronously" is. Hot path — listener invocation must short-circuit when no listeners are registered.
+
+**Where the spec speaks.** [Implementor-Checklist §T1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#t1-trace-event-delivery). [`spec/009-Instrumentation.md` §Listener invocation rules](https://day8.github.io/re-frame2/spec/009-Instrumentation/#listener-invocation-rules).
+
+#### T2 Performance API equivalent
+
+**The question.** Does the port bridge to a profiling/perf-marking API?
+
+**What's at stake.** The CLJS reference ships a Chrome Performance API bridge (`performance.mark` / `performance.measure`) for DevTools cross-correlation. Every in-scope host targets the browser, so the Performance API is uniformly available; the **bridge itself is optional** — the underlying trace surface (T1) is the contract. Record explicitly whether the port ships the bridge or omits it.
+
+**Where the spec speaks.** [Implementor-Checklist §T2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#t2-performance-api-equivalent). [`spec/009-Instrumentation.md` §Performance instrumentation](https://day8.github.io/re-frame2/spec/009-Instrumentation/#performance-instrumentation).
+
+#### T3 Production elision
+
+**The question.** How does every emit site, the listener registry, the trace buffer, and the perf bridge elide in production?
+
+**What's at stake.** All tracing is dev-only; production builds must elide it entirely. Mechanism is host-discretion (Closure DCE for CLJS via `re-frame.interop/debug-enabled?`; Vite `define` + tree-shake for TS/Squint; `#if !DEBUG` + tree-shake for Fable; link-time-`if` for Scala.js; release-variant module omission for Kotlin/JS). Copy the CLJS reference's CI sentinel-string verifier pattern.
+
+**Where the spec speaks.** [Implementor-Checklist §T3](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#t3-production-elision). [`spec/009-Instrumentation.md` §Production builds](https://day8.github.io/re-frame2/spec/009-Instrumentation/#production-builds-zero-overhead-zero-code).
+
+### Errors (E1–E2)
+
+From [Implementor-Checklist §Errors](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#errors-always-required).
+
+#### E1 Error capture / recover
+
+**The question.** How are handler / fx / sub exceptions, schema-validation failures, and drain-depth-exceeded caught, classified, and reported?
+
+**What's at stake.** Try/catch around handler bodies, fx invocations, sub computations. Capture must NOT swallow errors silently — every catch fires a structured trace event with `:operation :rf.error/<category>` and `:op-type :error`.
+
+**Where the spec speaks.** [Implementor-Checklist §E1](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#e1-error-capture--recover). [`spec/009-Instrumentation.md` §Recovery contract](https://day8.github.io/re-frame2/spec/009-Instrumentation/#recovery-contract).
+
+#### E2 Error reporting to tools
+
+**The question.** How do tools consume errors, and where does error policy live?
+
+**What's at stake.** Errors are emitted as structured trace events (falls out of T1); tools branch on `:op-type :error` and `:operation` prefix. The per-frame `:on-error` slot in `reg-frame` metadata is the policy mechanism. Strings-as-errors are out — every error has an `:operation` namespaced keyword and a `:tags` map.
+
+**Where the spec speaks.** [Implementor-Checklist §E2](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#e2-error-reporting-to-tools). [`spec/009-Instrumentation.md` §Error contract](https://day8.github.io/re-frame2/spec/009-Instrumentation/#error-contract).
 
 ---
 

--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -4,6 +4,12 @@ The EP-by-EP implementation walk for Phase 2. Each section names: what to read f
 
 The walking order is dependency-driven. Earlier EPs are foundations for later ones; do not skip ahead.
 
+**Three cross-cutting anchors to keep open for every EP below:**
+
+- [`spec/Ownership.md`](https://day8.github.io/re-frame2/spec/Ownership/) — the canonical "where does X live" contract-surface map. When an EP touches a surface and you're unsure which spec owns it, this is the index. Read it once before EP 001 and consult it per-EP.
+- [`spec/Conventions.md`](https://day8.github.io/re-frame2/spec/Conventions/) — the reserved `:rf/*` single-root namespace scheme, reserved fx-ids, reserved app-db keys, the `reg-*` macro inventory. Every framework id your port emits lands under `:rf/*`; honour the scheme from EP 001 onward (cardinal rule 11). Conformance fixtures assert `:rf.*` operation ids.
+- [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/) — the consolidated public signature list. Read the relevant entries first whenever an EP's "The contract" names a public surface (`reg-*`, `dispatch`, `subscribe`, the fx/cofx surface, …).
+
 ## Walking order
 
 1. EP 001 — Registration
@@ -21,12 +27,12 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 ## EP 001 — Registration
 
-**Read first.** [`spec/001-Registration.md`](https://day8.github.io/re-frame2/spec/001-Registration/). Plus [Implementor-Checklist §F6 Hot-reload primitive](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f6-hot-reload-primitive) for the re-registration contract.
+**Read first.** [`spec/001-Registration.md`](https://day8.github.io/re-frame2/spec/001-Registration/). Plus [Implementor-Checklist §F6 Hot-reload primitive](https://day8.github.io/re-frame2/spec/Implementor-Checklist/#f6-hot-reload-primitive) for the re-registration contract, [`spec/Conventions.md`](https://day8.github.io/re-frame2/spec/Conventions/) for the reserved `:rf/*` scheme the registrar must honour, and the `reg-*` entries in [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/) for the public registration signatures.
 
 **The contract.**
 
 - A single registrar — a `(kind, id) → metadata-bearing entry` map.
-- Closed kinds: `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:frame`, `:route`, `:machine-action`, `:machine-guard`, plus any kinds gated by optional EPs (e.g. `:story` if Q5 yes).
+- Closed kinds (the v1 set): `:event`, `:sub`, `:fx`, `:cofx`, `:view`, `:frame`, `:route`, `:app-schema`, `:head`, `:error-projector`, `:flow`. Always implement the core five (`:event`, `:sub`, `:fx`, `:cofx`, `:view`) plus `:frame`; the rest (`:route`, `:app-schema`, `:head`, `:error-projector`, `:flow`) are written only as their optional EPs come into scope (Routing 012, Schemas 010, SSR 011, error projection, Flows 013). Adding a kind outside this set is a spec change, not a port choice. There is **no** `:machine`, `:machine-action`, or `:machine-guard` kind — a machine registers as an ordinary `:event` entry; its guards/actions are machine-scoped, not registry kinds. Per [`spec/001-Registration.md` §Registry model](https://day8.github.io/re-frame2/spec/001-Registration/#registry-model--the-canonical-kind-keyword-set) (`there is no :machine, :machine-action, or :machine-guard registry kind`) and the CLJS reference's closed set in `implementation/core/src/re_frame/registrar.cljc` (`kinds`).
 - Public `reg-*` surface — one per kind. Each `reg-*` takes id + metadata + handler-or-spec.
 - Registration metadata — `:doc`, source coords (`:ns`/`:line`/`:file` if the host supports source-coord capture), `:tags`, kind-specific keys.
 - Hot-reload semantics: re-registration replaces the entry atomically and emits `:rf.registry/handler-replaced`.
@@ -45,7 +51,7 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 ## EP 002 — Frames + events + effects + subscriptions
 
-**Read first.** [`spec/002-Frames.md`](https://day8.github.io/re-frame2/spec/002-Frames/) — this is the spec's biggest chapter and most load-bearing. Plan two reads: one for the frame contract, one for the drain semantics.
+**Read first.** [`spec/002-Frames.md`](https://day8.github.io/re-frame2/spec/002-Frames/) — this is the spec's biggest chapter and most load-bearing. Plan two reads: one for the frame contract, one for the drain semantics. Keep the `reg-event-*` / `reg-sub` / `reg-fx` / `reg-cofx` / `dispatch` / `subscribe` / `reg-frame` entries in [`spec/API.md`](https://day8.github.io/re-frame2/spec/API/) open for the exact public signatures.
 
 **The contract.**
 
@@ -66,8 +72,8 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 - **Closed effect-map shape.** New top-level keys do NOT go in `:db` or `:fx` peer position — they go inside `:fx`. The v1→v2 migration walks this rule under M-8; your port enforces it from the start. Per [`spec/002-Frames.md`](https://day8.github.io/re-frame2/spec/002-Frames/) and the M-8 entry in [`migration/from-re-frame-v1/README.md`](https://day8.github.io/re-frame2/migration/from-re-frame-v1/).
 - **Run-to-completion vs sync vs async fx.** Sync fx run inline; async fx schedule via host's promise/timeout and re-enter through `:dispatch` after the side effect completes. Async fx must NOT call back into the runtime during the current drain — that would violate run-to-completion.
-- **Sub cache invalidation.** The cache invalidates by value equality on inputs. Identity-only equality (`===` in JS without deep compare; `eq?` in Lisp; reference equality in Java) breaks the contract. Your persistent data structure choice (D4.2) must provide cheap value-equality.
-- **Frame revertibility.** The frame's full state — `app-db` plus any per-frame registry tier — must be revertible by value swap. This propagates the D4.2 (persistent data structures) requirement.
+- **Sub cache invalidation.** The cache invalidates by value equality on inputs. Identity-only equality (`===` in JS without deep compare; reference equality in general) breaks the contract. Your persistent data structure choice (F2) must provide cheap value-equality.
+- **Frame revertibility.** The frame's full state — `app-db` plus any per-frame registry tier — must be revertible by value swap. This propagates the F2 (persistent data structures) requirement.
 
 ---
 
@@ -84,7 +90,7 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 - **Revertibility constraint on adapters.** Adapter-internal state must be derivable from the frame value. No "shadow state" inside the adapter that the frame value can't reproduce on revert. Per [`spec/006-ReactiveSubstrate.md` §Revertibility constraints on adapters](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#revertibility-constraints-on-adapters).
 - **Subscription cache invalidation contract.** Per [`spec/006-ReactiveSubstrate.md` §Subscription cache — contract and operational semantics](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-cache--contract-and-operational-semantics).
 
-**What the CLJS reference did (example).** Two adapters in-tree: `re-frame2-reagent` (browser; atop Reagent + React) and a plain-atom adapter (JVM / SSR). The Reagent adapter uses Reagent's reaction primitive for subs; the plain-atom adapter uses a hand-rolled signal graph. Mount/unmount hook into Reagent's component lifecycle.
+**What the CLJS reference did (example).** The substrate contract lives inside core (`implementation/core/src/re_frame/substrate/`): `adapter.cljc` defines the contract, `plain_atom.cljc` provides a dependency-free reference substrate (a plain-atom signal graph, used for JVM / non-browser / SSR paths). On top of that, the React-binding adapters ship as sibling artefacts under `implementation/adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters use Reagent's reaction primitive for subs and hook mount/unmount into React's component lifecycle; the in-core plain-atom substrate uses a hand-rolled signal graph. None of this layout is normative — the split between an in-core reference substrate and per-binding adapters is one worked example.
 
 **Conformance fixtures.** `:core/substrate` family. Verify: replace-container fires the invalidation hook; subscription cache evicts on input change; revert by container swap restores prior view state.
 

--- a/skills/re-frame2-implementor/references/reference-impl-tour.md
+++ b/skills/re-frame2-implementor/references/reference-impl-tour.md
@@ -27,10 +27,19 @@ implementation/
 │       ├── router.cljc      EP 002 — dispatch routing + drain
 │       ├── views.cljs       EP 004 — view registration
 │       ├── spec.cljc        EP 010 — schema hooks + validation
+│       ├── trace.cljc       EP 009 — trace listener registry + ring buffer
+│       ├── emit.cljc        EP 009 — trace emit sites
+│       ├── error.cljc       EP 009 — structured error contract
+│       ├── substrate/       EP 006 — substrate contract + reference substrate
+│       │   ├── adapter.cljc   the six-function substrate contract
+│       │   └── plain_atom.cljc plain-atom reference substrate (JVM / SSR / headless)
 │       └── test_support.cljc EP 008 — test fixtures + helpers
-├── adapters/
-│   ├── reagent/             EP 006 — Reagent + React substrate adapter
-│   └── plain-atom/          EP 006 — JVM / SSR / headless substrate adapter
+├── adapters/                EP 006 — React-binding substrate adapters
+│   ├── reagent/             Reagent + React adapter
+│   ├── reagent-slim/        slim Reagent variant (no stock Reagent / react-dom)
+│   ├── uix/                 UIx + React adapter
+│   ├── helix/               Helix + React adapter
+│   └── test-react/          test-only React harness adapter
 ├── epoch/                   EP 009 — epoch history for time-travel
 ├── flows/                   EP 013 — flows (separate artefact)
 ├── http/                    EP 014 — Managed HTTP (separate artefact)
@@ -62,14 +71,14 @@ The per-feature directories ship as **separate artefacts** in the published libr
 **What's CLJS-specific.**
 
 - Interceptors as the implementation strategy for the six-step pipeline. They're an internal implementation detail per [`spec/Cross-Spec-Interactions.md`](https://day8.github.io/re-frame2/spec/Cross-Spec-Interactions/); your port can use a different mechanism (a monadic computation, a coroutine, a state machine over the dispatch envelope) so long as the observable contract from EP 002 is preserved.
-- Reagent ratom + auto-tracked subscriptions. Your reactive substrate (D2 / D4.3) decides how this works.
+- Reagent ratom + auto-tracked subscriptions. Your reactive substrate (D2 / F3) decides how this works.
 - `defmulti` for fx resolution. A simple lookup table works too.
 
 **What's pattern-required.** Frame as `{state, queue, sub-cache, id}`; event handler is pure `(state, event) → effects-map`; closed effect-map; run-to-completion drain per frame; subscription cache invalidates by value-equality.
 
-### EP 006 — Reactive substrate (`adapters/{reagent,plain-atom}/`)
+### EP 006 — Reactive substrate (`core/src/re_frame/substrate/` + `adapters/`)
 
-**What you'll find.** Two adapters in-tree. The Reagent adapter is browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The plain-atom adapter is JVM-facing — `clojure.core/atom`, hand-rolled signal graph, no render trigger (SSR / headless). Both adapters implement the same six-function contract.
+**What you'll find.** The substrate contract is defined in-core at `core/src/re_frame/substrate/adapter.cljc`, with a dependency-free reference substrate alongside it at `core/src/re_frame/substrate/plain_atom.cljc` — `clojure.core/atom`, hand-rolled signal graph, no render trigger (JVM / SSR / headless). The React-binding adapters then ship as sibling artefacts under `adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters are browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The in-core plain-atom substrate and every adapter implement the same six-function contract.
 
 **What's CLJS-specific.**
 
@@ -90,9 +99,9 @@ The per-feature directories ship as **separate artefacts** in the published libr
 
 **What's pattern-required.** Pure `(state, props) → render-tree`. Render-tree is serialisable data. `reg-view` is the registry-aware entry point. Frame propagation is supported.
 
-### EP 009 — Instrumentation (`core/src/re_frame/trace.cljc` and related)
+### EP 009 — Instrumentation (`core/src/re_frame/{trace,emit,error}.cljc`)
 
-**What you'll find.** A listener-registry atom + a ring-buffer atom. Emit walks the registry inline. Production elision via `goog-define :debug-enabled?` + Closure DCE. A CI script (`scripts/check-elision.cjs`) scans production bundles for dev-only sentinel strings; the build fails if any are found.
+**What you'll find.** A listener-registry + ring buffer in `trace.cljc`, the emit sites in `emit.cljc`, and the structured error contract in `error.cljc`. Emit walks the registry inline. Production elision via `goog-define :debug-enabled?` + Closure DCE. A CI script (`implementation/scripts/check-elision.cjs`) scans production bundles for dev-only sentinel strings; the build fails if any are found.
 
 **What's CLJS-specific.**
 
@@ -140,7 +149,7 @@ EP 011 implementation. Pure hiccup → HTML emitter (~200 lines) for the server 
 
 ## When to consult the tour
 
-- **Phase 1.** As a sanity check on Phase 1 decisions — "the CLJS reference picked X for D4.5; I'm picking Y because my host gives me Z." The tour grounds the choice.
+- **Phase 1.** As a sanity check on Phase 1 decisions — "the CLJS reference picked X for F5; I'm picking Y because my host gives me Z." The tour grounds the choice.
 - **Phase 2, per EP.** As a starting point for "where would I look to see how to handle the awkward case in EP N?" Open the matching directory above; read the corresponding source file.
 - **Spec gaps.** When a spec section is ambiguous and the tour shows the reference made a specific choice — that's not the spec's choice, that's the reference's. Draft a GitHub issue against `day8/re-frame2` asking for the spec to clarify, show the engineer the draft, wait for explicit OK before filing (see [`cardinal-rules.md` §§8–9](cardinal-rules.md) for the filing pattern and the per-issue approval gate).
 

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -147,7 +147,7 @@ The bead surfaced three open questions; the skill resolves them as follows.
 
 **Resolved: prose walkthrough.** `phase-1-decisions.md` is a structured walkthrough — one section per decision block, each section with question / what's at stake / options / how to choose / where the spec speaks. Not a yes/no decision tree.
 
-**Why**: yes/no trees over-simplify the decisions (D4.1 identity primitive has 8+ options per host, not 2; D3 scope has 7 independent questions). A prose walkthrough that names the options + their trade-offs respects the engineer's expertise. The walkthrough is *structured* (consistent block shape per decision) so it's predictable, but the decision is made in prose, not by walking a binary tree.
+**Why**: yes/no trees over-simplify the decisions (F1 identity primitive has 8+ options per host, not 2; D3 scope has 7 independent questions). A prose walkthrough that names the options + their trade-offs respects the engineer's expertise. The walkthrough is *structured* (consistent block shape per decision) so it's predictable, but the decision is made in prose, not by walking a binary tree.
 
 ### OQ2 — Granularity of Phase 2 — one EP at a time, or clusters?
 

--- a/skills/re-frame2-implementor/spec/inputs.md
+++ b/skills/re-frame2-implementor/spec/inputs.md
@@ -21,7 +21,9 @@ The most load-bearing files for the skill:
 - **`spec/009-Instrumentation.md`** — EP 009. Trace event stream, error contract, production elision.
 - **`spec/005-StateMachines.md`** — EP 005. Walked in Phase 2 only if D3 Q1 = yes; the spec's largest EP (~2,900 lines).
 - **`spec/conformance/README.md`** — the acceptance test. Capability tagging, the harness shape, the fixture format. The skill's `references/conformance.md` is the operational walk of this doc.
-- **`spec/API.md`** — the consolidated signatures. Reference target in the SKILL.md done checklist.
+- **`spec/API.md`** — the consolidated signatures. A per-EP "read first" anchor in `references/phase-2-impl-order.md` wherever the public surface matters, plus the SKILL.md done checklist.
+- **`spec/Ownership.md`** — the canonical "where does X live" contract-surface map. A port author's single most useful index for "which spec owns this surface". A Phase-2 reading anchor in `references/phase-2-impl-order.md`.
+- **`spec/Conventions.md`** — the reserved `:rf/*` single-root namespace scheme, reserved fx-ids, reserved app-db keys, the `reg-*` macro inventory. A port that ignores the reserved-namespace scheme fails conformance fixtures asserting `:rf.*` operation ids. A Phase-2 reading anchor and a cardinal rule.
 
 The skill cites every spec file by URL (the published docs URL: `https://day8.github.io/re-frame2/spec/<file>/`). Cross-references to specific sections use anchor links.
 
@@ -33,8 +35,8 @@ Path: `implementation/` in the re-frame2 repo.
 
 The most load-bearing directories for the tour:
 
-- **`implementation/core/src/re_frame/`** — public API + the heart of EP 001 / 002 / 009.
-- **`implementation/adapters/{reagent,plain-atom}/`** — EP 006's two adapter realisations.
+- **`implementation/core/src/re_frame/`** — public API + the heart of EP 001 / 002 / 009; also `core/src/re_frame/substrate/` (the substrate contract `adapter.cljc` + the in-core plain-atom reference substrate `plain_atom.cljc`).
+- **`implementation/adapters/{reagent,reagent-slim,uix,helix,test-react}/`** — EP 006's React-binding adapter realisations (plain-atom is NOT here; it lives in core's `substrate/`).
 - **`implementation/{epoch,flows,http,machines,routing,schemas,ssr}/`** — the per-feature artefacts (per the pay-as-you-go split).
 
 The tour names what's in each directory, calls out CLJS-specific choices, and names pattern-required behaviour. The tour does not transcribe source.


### PR DESCRIPTION
## Summary

Corrects five audit findings in the `skills/re-frame2-implementor/` skill (audit: `ai/findings/2026-05-21-skill-implementor-audit.md`). The host-scope mismatch (rf2-mvthg) is intentionally untouched — it is held for a Mike decision.

- **rf2-chqmo (P1/HIGH)** — `phase-2-impl-order.md` invented `:machine-action`/`:machine-guard` registrar kinds. Replaced with the real closed v1 set `:event :sub :fx :cofx :view :frame :route :app-schema :head :error-projector :flow` per `spec/001-Registration.md` §Registry model and `implementation/core/src/re_frame/registrar.cljc`. A machine registers as an ordinary `:event` entry; its guards/actions are machine-scoped, not registry kinds.
- **rf2-rff5o (P2)** — added `spec/Ownership.md` + `spec/Conventions.md` as Phase-2 reading anchors, `spec/API.md` to per-EP read-first, a new cardinal rule (11) honouring the reserved `:rf/*` scheme + reserved fx/app-db keys, and threaded all three into `spec/inputs.md` §1.
- **rf2-4f54s (P2)** — `reference-impl-tour.md` + `inputs.md` mislocated `plain-atom` as a sibling adapter. Corrected: it lives at `implementation/core/src/re_frame/substrate/plain_atom.cljc`. Fixed the adapter inventory (reagent / reagent-slim / uix / helix / test-react) and the layout tree (added the substrate subtree, helix/uix/reagent-slim).
- **rf2-u1u8k (P2)** — renumbered Phase-1 D4 sub-ids to the checklist's `F1-F6 / S1-S3 / Sub1-Sub2 / V1-V3 / T1-T3 / E1-E2` scheme (1:1 cross-walk) and added the always-required S1-S3, Sub1-Sub2, V1-V3, T1-T3, E1-E2 blocks the checklist mandates, in both `phase-1-decisions.md` and the `decision-record.md` template.
- **rf2-vbu7j (P3)** — "eight rules" → "ten/eleven rules" (now eleven after the new reserved-namespace rule); skill README "six skills" → "seven" (this skill's own README only; top-level `skills/README.md` untouched); split `trace.cljc` into `trace/emit/error.cljc` and corrected the `check-elision.cjs` path to `implementation/scripts/`.

All facts verified against `spec/` and `implementation/` before writing. Spec-site anchors cross-checked against existing repo usages.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — pass (exit 0)
- [x] `mkdocs build --strict` — pass (exit 0; only pre-existing unrelated INFO warnings)
- [x] `python scripts/check_skill_mcp_drift.py` — pass (exit 0)
- [x] `evals.json` JSON valid (unchanged)
- [x] No stale `D4.x` / `machine-action` / `machine-guard` / `adapters/plain-atom` references remain in the skill
- [x] No AI attribution; no bead refs in user-facing skill content; top-level `skills/README.md` untouched