### PR TITLE
docs(skill): fix re-frame2 invoke->spawn refs + examples-map + test-helpers docs (4 beads)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -137,7 +137,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **Fundamentals — `references/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
 
-**State machines — `references/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `invoke.md` (child machines), `cancellation.md`.
+**State machines — `references/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`.
 
 **Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play-script`), `story-mcp-loop.md` (agent self-healing loop over MCP), `causa.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open).
 

--- a/skills/re-frame2/decision-trees/pick-a-pattern.md
+++ b/skills/re-frame2/decision-trees/pick-a-pattern.md
@@ -111,11 +111,11 @@ If the example contradicts the leaf, **the example wins** — re-frame2's cardin
 | RemoteData | [`patterns/remote-data.md`](../patterns/remote-data.md) | (inline mini-example) |
 | Forms | [`patterns/forms.md`](../patterns/forms.md) | `examples/reagent/login/` |
 | Boot | [`patterns/boot.md`](../patterns/boot.md) | `examples/reagent/boot/` |
-| WebSocket | [`patterns/websocket.md`](../patterns/websocket.md) | (pending) |
+| WebSocket | [`patterns/websocket.md`](../patterns/websocket.md) | `examples/reagent/websocket/` |
 | ManagedHTTP | [`patterns/managed-http.md`](../patterns/managed-http.md) | `examples/reagent/managed_http_counter/` |
 | NineStates | [`patterns/nine-states.md`](../patterns/nine-states.md) | `examples/reagent/nine_states/` |
 | AsyncEffect | [`patterns/async-effect.md`](../patterns/async-effect.md) | (inline mini-example) |
-| LongRunningWork | [`patterns/long-running-work.md`](../patterns/long-running-work.md) | (pending) |
+| LongRunningWork | [`patterns/long-running-work.md`](../patterns/long-running-work.md) | `examples/reagent/long_running_work/` |
 | StaleDetection | [`patterns/stale-detection.md`](../patterns/stale-detection.md) | (inline mini-example) |
 
 Load at most two pattern leaves at a time. If three or more seem necessary, the request probably spans features and should be broken up — author each pattern's leaf in its own pass.

--- a/skills/re-frame2/examples-map.md
+++ b/skills/re-frame2/examples-map.md
@@ -61,14 +61,21 @@ The canonical cross-framework benchmark — persistence (localStorage), in-place
 
 A cluster of six small benchmark apps from the [7GUIs](https://eugenkiss.github.io/7guis/) suite — `temperature/`, `flight_booker/`, `timer/`, `crud/`, `circle_drawer/`, `cells/`. Each app is a focused stress on one shape: bidirectional derivations (`temperature`), form-validity-driven button enablement (`flight_booker`), `:dispatch-later` periodic ticks (`timer`), list-CRUD with selection-as-state (`crud`), undo/redo via a snapshot-on-write interceptor and modal-as-state (`circle_drawer`), and a full formula-graph subscription substrate with cycle detection (`cells`). Point at the 7GUIs cluster when picking the right shape for a small focused concern: a controlled input pair, a Book-button-enables-only-when-valid flow, a periodic-tick UI, list operations with selection, undo/redo, or formula-driven cell propagation. Exercises 004 Views, 002 Frames, 006 ReactiveSubstrate, and Pattern-Forms. See `examples/reagent/7Guis/README.md` for the cluster's own narrative.
 
-## In-flight examples (pending)
+## websocket — `examples/reagent/websocket/`
 
-Two examples are listed in `examples/README.md` as **pending** worked examples — they accompany pattern leaves that ship with inline mini-examples until their own `examples/reagent/<x>/` directories land:
+The canonical Pattern-WebSocket worked example — a connection lifecycle machine where a hierarchical compound `:active` state parents `:connecting` / `:authenticating` / `:connected` and owns a `:spawn`d socket actor whose lifetime spans all three child leaves; `:reconnecting` rides `:after` exponential backoff; `:always` flushes the offline send-queue on `:connected`; `:fsm/tags` carry queryable connection-state predicates for the view; the live `:socket-id` doubles as the connection epoch for staleness checks; request/reply correlation is wired end-to-end. Runs against an in-process mock WebSocket — no network needed. Point at this example when authoring any long-lived-connection feature, when verifying the `:spawn`-at-parent-level lifetime idiom, the connection-epoch staleness pattern, or `:after`-backoff reconnection. Source spans `connection.cljs` (the machine), `messages.cljs`, `schema.cljs`, and `views.cljs`. Exercises Pattern-WebSocket, Pattern-StaleDetection, and 005 StateMachines. The worked-source companion to `patterns/websocket.md`.
 
-- **`examples/reagent/websocket/` (pending)** — will become the canonical Pattern-WebSocket example: a state machine that owns the long-lived connection lifecycle (`:disconnected → :connecting → :authenticating → :connected → :reconnecting → :failed`), heartbeat, queued-sends-when-disconnected, re-auth on reconnect, and topic-subscription preservation across reconnects.
-- **`examples/reagent/long_running_work/` (pending)** — will become the canonical Pattern-LongRunningWork example: a CPU-bound batch job (process N items in chunks of 100) running on the main thread via a state machine that yields between chunks with `:after 0`, reports progress through `:data`, and supports user-initiated cancel.
+## long_running_work — `examples/reagent/long_running_work/`
 
-Until these ship, the pattern leaves themselves are the authoritative shape — `patterns/websocket.md`, `patterns/long-running-work.md`.
+The canonical Pattern-LongRunningWork worked example — a `:work/flow` parent coordinator spawns N `:work/processor` worker children via `:spawn-all` and joins on `:all`; each child processes its shard in chunks, yielding between chunks via `:after` so the browser stays responsive, and dispatches a `:progress` event back to the parent on every chunk (the parent's internal self-transition updates `:data :progress`, which the `:work/progress-fraction` sub recomputes). Cooperative cancellation is uniform: every exit path (user `:cancel`, `:on-all-complete`, frame destroy, `:after`) fires one `:rf.machine/destroy` whose cascade tears down every in-flight child timer/request. Point at this example when authoring a CPU-bound batch job, a parent/child fan-out-and-join via `:spawn-all`, progress reporting through `:data`, or the destroy-cascade cancellation contract. Source: `worker.cljs` (the `:work/flow` + `:work/processor` machines), `core.cljs`, `schema.cljs`, `views.cljs`. Exercises Pattern-LongRunningWork and 005 StateMachines. The worked-source companion to `patterns/long-running-work.md`.
+
+## ssr_streaming — `examples/reagent/ssr_streaming/`
+
+The streaming-SSR worked example for [Spec 011 §Streaming](../../spec/011-SSR.md#streaming-ssr) — a dashboard with three slow cards where the page shell + header render immediately on the server, then each card streams its content as its own data fetch resolves. Demonstrates the `:rf/suspense-boundary` hiccup marker, per-card fallback hiccup, inline-fallback failure semantics, and interleaved per-subtree hydration. Point at this example when authoring streaming server-rendered views, suspense boundaries, or per-subtree hydration. Lives in a single `core.cljc` (cross-platform JVM/browser). Exercises 011 SSR §Streaming and 004 Views. The streaming complement to the minimal `ssr/` walkthrough.
+
+## notebook — `examples/reagent/notebook/`
+
+The design-led Reagent example — a three-pane editorial layout (documents tree · markdown editor · live preview) that proves the substrate drives a substantive multi-pane UI. The design-led counterpart to `examples/uix/dashboard_uix/` and `examples/helix/process_monitor_helix/`; all three share the "Editorial Warm" identity from `examples/_shared/css/style.css`. A tiny pure-CLJS markdown parser keeps the bundle small. Point at this example when authoring a multi-pane layout, a master-detail editor shape, or when verifying the shared design-system identity across substrates. Single `core.cljs`. Exercises 002 Frames and 004 Views. Not a pattern-teaching example — read it for layout/identity shape, not for a primitive.
 
 ## Adapter smoke-pairs
 
@@ -91,4 +98,4 @@ Per [Spec 006 §Adapter shipping convention](../../spec/006-ReactiveSubstrate.md
 
 ---
 
-*Derived from `examples/reagent/**` and `examples/README.md` @ main `89bd9c3`. Re-verify whenever a new worked example lands or an in-flight example merges (e.g. `boot/`, `websocket/`, `long_running_work/`).*
+*Derived from `examples/reagent/**` and `examples/README.md` @ main `89bd9c3`. Re-verify whenever a new worked example lands.*

--- a/skills/re-frame2/patterns/boot.md
+++ b/skills/re-frame2/patterns/boot.md
@@ -126,7 +126,7 @@ No parallel `:loading?` flag — the machine's state IS the UI signal.
 
 **Re-boot.** Dispatch a wildcard parent event: `:auth.session/expired {:target :authenticating}`. Most apps reload the page on session expiry.
 
-**Final-state handoff (`:final?` / `:on-done`).** When boot is `:spawn`'d by an outer coordinator (SSR shell, embedding host, test harness), mark `:ready` as `:final?` — parent receives `:on-done` synchronously, with optional `:output-key` carrying e.g. the loaded `:user`. The standalone-singleton form (canonical above) must NOT use `:final?` — auto-destroy takes the snapshot and the `[:app.boot/*]` subs with it. Keep `:ready` as ordinary terminal (`:meta {:terminal? true}`) when the app subscribes to the boot snapshot post-handoff. See `../references/state-machines/invoke.md` §Final states.
+**Final-state handoff (`:final?` / `:on-done`).** When boot is `:spawn`'d by an outer coordinator (SSR shell, embedding host, test harness), mark `:ready` as `:final?` — parent receives `:on-done` synchronously, with optional `:output-key` carrying e.g. the loaded `:user`. The standalone-singleton form (canonical above) must NOT use `:final?` — auto-destroy takes the snapshot and the `[:app.boot/*]` subs with it. Keep `:ready` as ordinary terminal (`:meta {:terminal? true}`) when the app subscribes to the boot snapshot post-handoff. See `../references/state-machines/spawn.md` §Final states.
 
 **Parameters — the canonical seam.** The boot machine is the ONLY place that reads host globals (`/config` endpoint, build-time env vars, restored session). Once captured into `:data :config`, downstream phases thread values forward via Pattern-AsyncEffect (event payload or spawn-spec `:data` fn). Downstream machines never reach into a global.
 
@@ -145,7 +145,7 @@ No parallel `:loading?` flag — the machine's state IS the UI signal.
 
 ## Pointers
 
-SKILL-REDIRECT.md → *Pattern — Boot* (auth-machine retry-ownership, SSR handoff), *EP — Frames (002)* (`:on-create`), *EP — State machines (005)* (substrate), *EP — SSR (011)*, *EP — HTTP requests (014)*. `:final?` / `:on-done` / `:output-key` → `../references/state-machines/invoke.md` §Final states. Retry-ownership boundary → `patterns/managed-http.md`.
+SKILL-REDIRECT.md → *Pattern — Boot* (auth-machine retry-ownership, SSR handoff), *EP — Frames (002)* (`:on-create`), *EP — State machines (005)* (substrate), *EP — SSR (011)*, *EP — HTTP requests (014)*. `:final?` / `:on-done` / `:output-key` → `../references/state-machines/spawn.md` §Final states. Retry-ownership boundary → `patterns/managed-http.md`.
 
 ---
 

--- a/skills/re-frame2/patterns/long-running-work.md
+++ b/skills/re-frame2/patterns/long-running-work.md
@@ -126,7 +126,7 @@ Exiting `:working` fires one `:rf.machine/destroy` fx carrying `:rf/spawn-all tr
 
 **Progress UI from the machine.** Register subs on `[:rf/machine <id>]` and project `:data` fields into the view.
 
-**Final-state child completion (`:final?` / `:output-key`).** Cleaner than hand-rolling `:dispatch-done`: mark the child's `:done` as `:final? true` with `:output-key :shard-result`; `:spawn-all` recognises completion natively, parent receives the result via `:on-child-done`. Singletons supporting `:reset` back to `:idle` must NOT use `:final?` (auto-destroy fires first). See `../references/state-machines/invoke.md` §Final states.
+**Final-state child completion (`:final?` / `:output-key`).** Cleaner than hand-rolling `:dispatch-done`: mark the child's `:done` as `:final? true` with `:output-key :shard-result`; `:spawn-all` recognises completion natively, parent receives the result via `:on-child-done`. Singletons supporting `:reset` back to `:idle` must NOT use `:final?` (auto-destroy fires first). See `../references/state-machines/spawn.md` §Final states.
 
 ## Anti-patterns
 
@@ -139,12 +139,12 @@ Exiting `:working` fires one `:rf.machine/destroy` fx carrying `:rf/spawn-all tr
 
 ## Worked example
 
-`examples/reagent/long_running_work/` — three parallel `:work/processor` children coordinated by `:work/flow`. The Show / Hide wrapper's `r/with-let` cleanup dispatches `[:work/flow [:cancel]]`. Carries a Playwright smoke and `cljs-test`.
+`examples/reagent/long_running_work/` — three parallel `:work/processor` children coordinated by `:work/flow` via `:spawn-all`. The Show / Hide wrapper's `r/with-let` cleanup dispatches `[:work/flow [:cancel]]`. The machines live in `worker.cljs`; `core.cljs` / `schema.cljs` / `views.cljs` complete it; `test/long_running_work/worker_test.cljs` is the CLJS unit test.
 
 ## Pointer to the spec
 
-Full rationale — `:spawn-all` runtime, join-state layout, `:join` modes (`:any`, `:n-of`), v1 migration — lives in *Pattern — Long-running work* and Spec 005. `:final?` surface: `../references/state-machines/invoke.md` §Final states.
+Full rationale — `:spawn-all` runtime, join-state layout, `:join` modes (`:any`, `:n-of`), v1 migration — lives in *Pattern — Long-running work* and Spec 005. `:final?` surface: `../references/state-machines/spawn.md` §Final states.
 
 ---
 
-*Derived from Pattern-LongRunningWork and the in-flight `examples/reagent/long_running_work/` @ main `89bd9c3`.*
+*Derived from Pattern-LongRunningWork and the worked example `examples/reagent/long_running_work/` @ main `89bd9c3`.*

--- a/skills/re-frame2/patterns/websocket.md
+++ b/skills/re-frame2/patterns/websocket.md
@@ -4,7 +4,7 @@ Long-lived bidirectional connection lifecycle (WebSocket / SSE / WebRTC peer) mo
 
 `:rf.ws/*` is one instance of the **managed external effect** umbrella — alongside `:rf.http/managed`, state-machine `:spawn`, `:rf.server/*`, and `:rf.flow/*`. The connection's lifecycle (issuance, reconnect, abort, teardown, structured failures under `:rf.ws/*`, trace-bus observability, wire-value elision) is framework-owned. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the eight-property shared contract; the rest of this leaf is WebSocket-specific.
 
-> **Status of the worked example:** `examples/reagent/websocket/` is in flight. Until it lands, the canonical declaration below is the source of truth.
+> **Worked example:** `examples/reagent/websocket/` ships the canonical Pattern-WebSocket app (`connection.cljs` holds the machine). Read it as ground truth; the canonical declaration below is the leaf-level summary.
 
 ## When to use this pattern
 
@@ -145,7 +145,7 @@ The `:rf.cred/*` family is the recommended sketch — your app's auth slice prov
 
 **SSR.** No-ops server-side: `:spawn` spawn fx is `:platforms #{:client}`; `:after` timers don't schedule under SSR.
 
-**Final-state termination (`:final?` / `:on-done`).** Restricted to the *child* role. When the WS machine is `:spawn`'d by an outer session machine, mark a terminal-failed branch (e.g. `:permanently-failed`, distinct from recoverable `:failed`) `:final? true` — parent receives clean unrecoverable signal via `:on-done` with optional `:output-key`. Child heartbeat / handshake machines reaching `:expired` / `:handshake-failed` can similarly use `:final?` instead of dispatching custom outbound events. The top-level connection machine itself stays recoverable. See `../references/state-machines/invoke.md` §Final states.
+**Final-state termination (`:final?` / `:on-done`).** Restricted to the *child* role. When the WS machine is `:spawn`'d by an outer session machine, mark a terminal-failed branch (e.g. `:permanently-failed`, distinct from recoverable `:failed`) `:final? true` — parent receives clean unrecoverable signal via `:on-done` with optional `:output-key`. Child heartbeat / handshake machines reaching `:expired` / `:handshake-failed` can similarly use `:final?` instead of dispatching custom outbound events. The top-level connection machine itself stays recoverable. See `../references/state-machines/spawn.md` §Final states.
 
 ## Anti-patterns
 
@@ -160,15 +160,15 @@ The `:rf.cred/*` family is the recommended sketch — your app's auth slice prov
 
 ## Worked example
 
-`examples/reagent/websocket/` (pending — in flight). Until merged, treat the canonical declaration above as the source of truth.
+`examples/reagent/websocket/` is the canonical worked example. `connection.cljs` holds the lifecycle machine (compound `:active` parenting `:connecting` / `:authenticating` / `:connected`, a `:spawn`d socket actor, `:after` backoff, `:always` offline-queue flush, connection-epoch staleness, request/reply correlation); `messages.cljs`, `schema.cljs`, and `views.cljs` complete it. Read the source first; the declaration above is the leaf-level summary.
 
 ## Pointers
 
 - Full pattern doc, request-reply correlation worked example, SSR composition → SKILL-REDIRECT.md → *Pattern — WebSocket*.
 - State-machine substrate (`:spawn`, `:after`, `:always`, hierarchical) → SKILL-REDIRECT.md → *EP — State machines (005)*.
-- `:final?` / `:on-done` / `:output-key` → `../references/state-machines/invoke.md` §Final states.
+- `:final?` / `:on-done` / `:output-key` → `../references/state-machines/spawn.md` §Final states.
 - Connection-epoch idiom → SKILL-REDIRECT.md → *Pattern — Stale detection*.
 
 ---
 
-*Derived from Pattern-WebSocket @ main `89bd9c3`. The worked example `examples/reagent/websocket/` is in flight; re-verify and link once it merges.*
+*Derived from Pattern-WebSocket and the worked example `examples/reagent/websocket/` @ main `89bd9c3`. Re-verify after `:rf.ws/*` or connection-machine changes.*

--- a/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
+++ b/skills/re-frame2/references/cross-cutting/api-cheatsheet.md
@@ -82,6 +82,19 @@ Production fx surface: `re-frame.http-managed`. Test surfaces (canned-stub fxs +
 | `ts/assert-path-equals` | `(path expected-val)` / `(path expected-val opts)` — mirrors `:rf.assert/path-equals` |
 | `ts/assert-db-equals` | `(expected-db)` / `(expected-db opts)` — companion full-db form |
 
+## View tests — `re-frame.test-helpers` (see `cross-cutting/testing.md`)
+
+The view-tree assertion axis (commonly aliased `:as h`). Walk hiccup by `:data-testid`; the single-frame e2e trio brackets a fresh frame and stashes the root view.
+
+| Surface | Shape |
+|---|---|
+| `h/with-app-fixture` | macro: `(opts body+)` / `(opts frame-id body+)` — opts `:install` `:root-view` `:root-view-args` `:frame-config`; brackets a fresh single frame |
+| `h/expect-text` | `(testid expected)` (stashed root view) / `(tree testid expected)` — asserts `:data-testid` node text via `clojure.test/is` |
+| `h/wait-until` | `(pred)` / `(pred opts)` / `(testid expected)` / `(testid expected opts)` — bounded poll; opts `:timeout-ms` (2000) `:interval-ms` (5) `:label`. JVM-sync (throws on timeout) / CLJS-Promise (rejects on timeout) |
+| `h/find-by-testid` / `h/find-all-by-testid` / `h/find-by-testid-prefix` | `(tree testid)` → hiccup node(s) |
+| `h/text-content` / `h/invoke-handler` | `(node)` → text · `(node event-key & args)` → calls the handler under `event-key` (e.g. `:on-click`) |
+| `h/testid` | `(testid)` / `(testid attrs)` — attrs-fragment authoring helper for view call sites |
+
 ## SSR — `day8/re-frame2-ssr`
 
 | Surface | Shape |

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -126,6 +126,55 @@ When the test is exercising the live cache (e.g. layer-2 sub on top of a real di
 
 `subscribe-once` materialises the reaction, reads `@`, and unsubscribes — one line, no leaked subscription. Prefer it over `@(rf/subscribe ...)` in tests.
 
+## Asserting the view: `re-frame.test-helpers` (the view-tree axis)
+
+`re-frame.test-support` covers the **runtime-state** axis (events / fx / subs / machines). The sibling namespace `re-frame.test-helpers` covers the **view-tree** axis — call the view-fn, walk the returned hiccup by `:data-testid`, assert on rendered content. Reach for it when "does the screen show the right thing?" or "does the button dispatch the right event?" is the question. A test doing both `:require`s both.
+
+```clojure
+(:require [re-frame.core         :as rf]
+          [re-frame.test-helpers :as h])
+```
+
+### The single-frame e2e trio: `with-app-fixture` / `expect-text` / `wait-until`
+
+This is the dominant shape for an app-developer e2e view test — it compresses the `make-frame` / `with-frame` / `destroy-frame!` bracket to one macro. `with-app-fixture` creates a fresh single frame, runs an `:install` thunk inside its dynamic extent, stashes the root view so `expect-text` / `wait-until` find it without a tree argument, and tears the frame down in a `finally`.
+
+```clojure
+(deftest counter-e2e
+  (h/with-app-fixture
+    {:install   (fn []
+                  (rf/reg-event-db :counter/inc (fn [db _] (update db :n inc)))
+                  (rf/reg-sub      :counter/n   (fn [db _] (:n db)))
+                  (rf/reg-view     :counter/view
+                    (fn [] [:span (h/testid "n") @(rf/subscribe [:counter/n])])))
+     :root-view (fn [] [:counter/view])}
+    (rf/dispatch-sync [:counter/inc])
+    (h/expect-text :n "1")))          ;; uses the stashed root view
+```
+
+`with-app-fixture` opts (all optional): `:install` (zero-arg fn run inside the bound frame — register events/subs/views here; pair with a `make-reset-runtime-fixture` `:each` fixture to roll the registrations back), `:root-view` (hiccup-returning view fn stashed for `expect-text`/`wait-until`), `:root-view-args` (args vector applied to `:root-view`, default `[]` — use when the view takes a props map), `:frame-config` (map merged into `make-frame`/`reg-frame` — `:on-create`, `:fx-overrides`, `:interceptors`, …). Two call shapes: `(with-app-fixture opts body+)` gets an anonymous gensym'd frame id; `(with-app-fixture opts frame-id body+)` names it.
+
+`expect-text` asserts the `:data-testid` node's text equals `expected`, reporting via `clojure.test/is`:
+
+```clojure
+(h/expect-text :n "1")              ;; uses the fixture-stashed root view
+(h/expect-text tree :n "1")         ;; 3-arity — walk an explicit tree, no fixture
+```
+
+`testid` may be a string (`"n"`) or keyword (`:n`). Returns a boolean, but the `is` report has already fired.
+
+`wait-until` is the bounded-deadline poll for async cascades (HTTP, scheduled events, machine `:after` transitions) whose post-condition is observable in the view — the view-test counterpart to `test-support`'s `poll-until`. Two call shapes plus opts:
+
+```clojure
+(h/wait-until #(= "done" (-> (some-tree) (h/find-by-testid "status") h/text-content)))
+(h/wait-until :status "done")                          ;; testid form — polls the stashed root view
+(h/wait-until :status "done" {:timeout-ms 5000 :interval-ms 10 :label "status ready"})
+```
+
+`opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label` (timeout-message tag). **Per-platform shape** (matching `poll-until`): on **JVM** it is synchronous — returns the truthy value, throws `ex-info` (`:rf.error/id :rf.error/wait-until-timeout`) on timeout. On **CLJS** it returns a `js/Promise` — resolves with the truthy value, rejects on timeout; compose with `cljs.test/async`. For sync cascades, `expect-text` after `dispatch-sync` is enough — only reach for `wait-until` when the cascade is genuinely async. It is not a substitute for timer-semantics sleeps (grace-period elapse, throttle/debounce window).
+
+The lower-level walk helpers (`find-by-testid`, `find-all-by-testid`, `text-content`, `invoke-handler`, and the `testid` attrs-authoring helper) are documented in SKILL.md §Testing your views — use them directly when you need the `:on-click`-fires-the-right-event assertion or a tree that no fixture stashed.
+
 ## Machine snapshots and tag queries
 
 A machine's snapshot lives at `(get-in app-db [:rf/machines machine-id])` — a map of `{:state ... :data ... :tags ...}` (`:tags` is absent when the active state-configuration's tag union is empty).
@@ -211,4 +260,4 @@ Per-frame `:fx-overrides` in `reg-frame` accepts the same fn-value form, so a te
 
 ---
 
-*Derived from `implementation/core/src/re_frame/test_support.cljc` (public test-support surface) and `implementation/core/src/re_frame/substrate/plain_atom.cljc` (JVM adapter) @ main `89bd9c3`. Re-verify after test-support surface changes.*
+*Derived from `implementation/core/src/re_frame/test_support.cljc` (public test-support surface), `implementation/core/src/re_frame/test_helpers.cljc` (view-tree assertion surface — `with-app-fixture` / `expect-text` / `wait-until`), and `implementation/core/src/re_frame/substrate/plain_atom.cljc` (JVM adapter) @ main `89bd9c3`. Re-verify after test-support / test-helpers surface changes.*

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -70,8 +70,8 @@ Every state node is a map. Recognised slots (see `implementation/machines/src/re
 - `:entry` / `:exit` — singular action references or fns, fired on entering / leaving the node.
 - `:always` — eventless microstep table (`:always [{:guard ... :target ...} ...]`).
 - `:after` — delayed transition table, `:after {<ms-or-sub-vec-or-fn> <transition-spec>}`.
-- `:spawn` — declarative child spawn (see `invoke.md`).
-- `:spawn-all` — spawn-and-join sugar (see `invoke.md`).
+- `:spawn` — declarative child spawn (see `spawn.md`).
+- `:spawn-all` — spawn-and-join sugar (see `spawn.md`).
 - `:tags` — a set of keywords describing this state's per-axis intent (see `tags.md`).
 - `:states` + `:initial` — nested compound state (deepest-wins resolution).
 

--- a/skills/re-frame2/references/state-machines/spawn.md
+++ b/skills/re-frame2/references/state-machines/spawn.md
@@ -139,4 +139,4 @@ For the full declarative-`:spawn` desugaring rules, composition with hierarchica
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (declarative-`:spawn` desugar, `:spawn-all` join engine, `:on-spawn` stamping) @ main `89bd9c3`, and `spec/conformance/fixtures/invoke-all-*` fixtures. Re-verify after `:spawn`/`:spawn-all` runtime changes.*
+*Derived from `implementation/machines/src/re_frame/machines.cljc` (declarative-`:spawn` desugar, `:spawn-all` join engine, `:on-spawn` stamping) @ main `89bd9c3`, and `spec/conformance/fixtures/spawn-all-*` fixtures. Re-verify after `:spawn`/`:spawn-all` runtime changes.*

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -40,7 +40,7 @@ A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` 
 > │   │   ├── reg-machine.md       (states, initial, guards, actions)
 > │   │   ├── regions.md           (single-region + :type :parallel)
 > │   │   ├── tags.md              (state tags, machine-has-tag?)
-> │   │   ├── invoke.md            (:spawn, :spawn-all, child-machine result)
+> │   │   ├── spawn.md             (:spawn, :spawn-all, child-machine result)
 > │   │   └── cancellation.md      (destroy cascade, cleanup contract)
 > │   ├── tooling/
 > │   │   ├── stories.md           (reg-story, story frames)

--- a/skills/re-frame2/spec/inputs.md
+++ b/skills/re-frame2/spec/inputs.md
@@ -32,8 +32,10 @@ The worked example for each pattern. Used both as a source of truth for canonica
 - `examples/reagent/boot/` — Boot pattern.
 - `examples/reagent/nine_states/` — NineStates pattern.
 - `examples/reagent/managed_http_counter/` — ManagedHTTP pattern.
-- `examples/reagent/long_running_work/` (pending) — LongRunningWork pattern.
-- `examples/reagent/websocket/` (pending) — WebSocket pattern.
+- `examples/reagent/long_running_work/` — LongRunningWork pattern.
+- `examples/reagent/websocket/` — WebSocket pattern.
+- `examples/reagent/ssr_streaming/` — streaming SSR (Spec 011 §Streaming).
+- `examples/reagent/notebook/` — design-led multi-pane layout.
 
 When an example doesn't yet exist, the relevant pattern leaf inlines a mini-declaration and flags "example app pending".
 


### PR DESCRIPTION
## Summary

Skill-doc accuracy fixes for `skills/re-frame2/` (audit-derived, 4 beads). The skill's expertise was already accurate; these are stale cross-refs + an examples-status drift.

- **rf2-uzj8d (P1)** — the state-machine leaf was renamed `invoke.md` -> `spawn.md`, but cross-refs still pointed at the dead file. Repointed every `invoke.md` ref to `spawn.md` (`SKILL.md`, `reg-machine.md`, `boot.md`, `long-running-work.md`, `websocket.md`, `authoring-prompt.md`) and added `spawn.md` to the SKILL.md state-machines leaf list. `slice-or-machine.md` was already correct.
- **rf2-5e579 (P2)** — `examples/reagent/websocket/` and `long_running_work/` now ship with full source; promoted them from the "pending" section of `examples-map.md` to full per-example paragraphs, added `notebook/` and `ssr_streaming/`, and flipped the stale `(pending)` / `in flight` status in `pick-a-pattern.md`, the websocket + long-running-work pattern leaves, and `spec/inputs.md`. Also corrected a "Playwright smoke" claim on the long-running-work example to its actual CLJS unit test.
- **rf2-2q4hx (P2)** — documented the `re-frame.test-helpers` single-frame e2e trio (`with-app-fixture` / `expect-text` / `wait-until`) plus the `find-by-testid` family in `references/cross-cutting/testing.md` and added a cheatsheet block in `api-cheatsheet.md`. Signatures verified against `implementation/core/src/re_frame/test_helpers.cljc`.
- **rf2-0cjrp (P3)** — fixed the `spawn.md` footer's non-existent `invoke-all-*` conformance-fixture citation to the actual `spawn-all-*`.

All claims verified against `spec/`, `implementation/`, and `examples/` before writing.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — pass (exit 0)
- [x] `python -m mkdocs build --strict` — pass (exit 0)
- [x] `python scripts/check_skill_redirect_anchors.py` — no NEW broken anchors introduced (count unchanged at 1; the one broken ref, `stories.md:163`, is pre-existing on `origin/main` and outside this PR's scope/file ownership)
- [x] `python scripts/check_skill_mcp_drift.py` — pass (exit 0)