### PR TITLE
docs(skill): reconcile re-frame2-setup with deps-new template + version pins (5 beads)

### DIFF
--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -28,7 +28,9 @@ The two routes are complementary, not redundant:
 | You don't care to learn the wiring. | You want the wiring explained as you go, with citations into `spec/` and worked examples. |
 
 Either way you end up at the same canonical shape — the skill walks the
-seven-step path manually; the template performs it for you. After the
+seven-step path manually and lands on the template's day-one scaffold
+(core + Reagent adapter + schemas + Causa, `init` entry symbol); the
+template performs the same steps for you in one command. After the
 counter mounts, the same handoff to `re-frame2` / `re-frame2-pair`
 applies.
 
@@ -36,11 +38,11 @@ applies.
 
 The canonical seven-step greenfield path:
 
-1. Discover the current re-frame2 VERSION (the ten artefacts ship in lockstep).
-2. Add `day8/re-frame2` + `day8/re-frame2-reagent` to `deps.edn`.
+1. Discover the current re-frame2 VERSION (the eleven artefacts ship in lockstep; Causa rides the same line).
+2. Add the day-one deps to `deps.edn` — `day8/re-frame2` + `day8/re-frame2-reagent` + `day8/re-frame2-schemas` + `day8/re-frame2-causa`, plus an explicit `reagent/reagent`.
 3. Add `react`, `react-dom`, `shadow-cljs` to `package.json`. Run `npm install`.
-4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app, plus `public/index.html`.
-5. Write the entry namespace — `(rf/init! reagent-adapter/adapter)`, the Reagent root, `(defn ^:export run [] ...)`.
+4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app (with the Causa `:devtools/preloads` wiring), plus `public/index.html` carrying the `[data-rf-causa-host]` column.
+5. Write the entry namespace — `(rf/init! reagent-adapter/adapter)`, the Reagent root, `(defn ^:export init [] ...)`.
 6. Write the first counter — registered event, registered sub, `reg-view`-defined view, mount.
 7. Run `shadow-cljs watch app`. Visit the dev server. Click the buttons. Done.
 
@@ -50,7 +52,7 @@ The canonical seven-step greenfield path:
 - Live REPL inspection of the running app — that's [`re-frame2-pair`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-pair).
 - Migrating an existing re-frame v1 codebase to v2 — that's a different problem; see [`migration/from-re-frame-v1/README.md`](https://github.com/day8/re-frame2/blob/main/migration/from-re-frame-v1/README.md).
 - Test infrastructure, CI, deployment — out of scope. The author chooses their own.
-- Anything beyond Reagent + shadow-cljs. UIx, Helix, and other build tools are noted only as "swap the adapter ns / pick a different build tool"; the canonical path is Reagent + shadow-cljs.
+- Anything beyond Reagent + shadow-cljs. The canonical path is Reagent + shadow-cljs. For a UIx or Helix greenfield, `references/entry-namespace.md` §UIx / Helix greenfield gives the three adapter substitutions and points at the generator template's complete `_uix/` / `_helix/` variants (`clojure -Tnew create ... :substrate :uix`), which is the fastest non-Reagent path.
 
 ## Status
 
@@ -66,14 +68,20 @@ skills/re-frame2-setup/
 ├── package.json
 ├── .claude-plugin/
 │   └── plugin.json
-└── references/
-    ├── deps-versions.md
-    ├── shadow-cljs.md
-    ├── entry-namespace.md
-    └── first-counter.md
+├── references/
+│   ├── deps-versions.md
+│   ├── shadow-cljs.md
+│   ├── entry-namespace.md
+│   └── first-counter.md
+├── spec/
+│   ├── design.md
+│   ├── inputs.md
+│   └── authoring-prompt.md
+└── evals/
+    └── evals.json
 ```
 
-`SKILL.md` is the router: it walks the seven-step canonical path and links to the leaf in `references/` whenever depth is useful. The four reference files are each one level deep — Claude reads them in full when the corresponding step needs more detail. No leaf depends on another leaf; they can be read in any order.
+`SKILL.md` is the router: it walks the seven-step canonical path and links to the leaf in `references/` whenever depth is useful. The four reference files are each one level deep — Claude reads them in full when the corresponding step needs more detail. No leaf depends on another leaf; they can be read in any order. `spec/` carries skill-internal design/authoring meta-docs (not loaded during normal operation), and `evals/` holds the trigger-accuracy fixture. Both are excluded from the npm `files` array by design.
 
 ## Install the skill in Claude Code
 

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -48,28 +48,29 @@ Any non-setup question → route to the right skill; don't improvise here.
 ## Cardinal rules
 
 1. **Default to the re-frame2 repo's pinned baseline; never silently chase "latest from npm".** The greenfield baseline is the set of versions the re-frame2 repo itself builds against (`implementation/package.json`, `implementation/deps.edn`) at the **author-supplied pin** of `day8/re-frame2`. Treat that pinned baseline as known-good. The author may explicitly opt into "latest from npm" — but the skill never picks `latest` on its behalf. See [`references/deps-versions.md`](references/deps-versions.md).
-2. **All ten artefacts ship at the same VERSION.** Mixing versions across `day8/re-frame2-*` artefacts is unsupported. Use the single `<VERSION>` the author pinned at kickoff.
-3. **Only add per-feature artefacts the author actually uses.** Core + adapter are mandatory; `-schemas` / `-machines` / `-routing` / `-flows` / `-http` / `-ssr` / `-epoch` are pay-as-you-go.
-4. **Reagent adapter is the default reference substrate.** Unless the author explicitly says UIx or Helix, scaffold against Reagent.
+2. **All eleven artefacts ship at the same VERSION** (and the `day8/re-frame2-causa` devtools panel rides the same line). Mixing versions across `day8/re-frame2-*` coordinates is unsupported. Use the single `<VERSION>` the author pinned at kickoff.
+3. **The day-one shape matches the generator template.** Core + Reagent adapter + `-schemas` + `-causa` (plus an explicit `reagent/reagent` pin) are the day-one deps. The remaining per-feature artefacts (`-machines` / `-routing` / `-flows` / `-http` / `-ssr` / `-epoch`) are pay-as-you-go — add them only when the author writes code that uses them.
+4. **Reagent adapter is the default reference substrate.** Unless the author explicitly says UIx or Helix, scaffold against Reagent. For a UIx/Helix greenfield, [`references/entry-namespace.md`](references/entry-namespace.md) §UIx / Helix greenfield gives the three adapter substitutions and points at the generator template's `_uix/` / `_helix/` variants (`clojure -Tnew create ... :substrate :uix`).
 5. **Don't write tests for the author.** This skill stops at "the counter mounts."
 6. **nREPL is dev-only and bound to localhost.** Anywhere this skill mentions nREPL (shadow-cljs's default REPL, `re-frame2-pair` attachment), it must remind the author: nREPL is a remote-evaluation surface — never expose it on `0.0.0.0` or a public interface. shadow-cljs binds to localhost by default; do not override that without an isolated, trusted-network reason.
 
 ## Canonical greenfield path (seven steps)
 
-1. **Discover the current artefact VERSION.** → [`references/deps-versions.md`](references/deps-versions.md). Day-one deps: `day8/re-frame2` + `day8/re-frame2-reagent` only.
-2. **Add the two artefacts to `deps.edn`.** → `references/deps-versions.md` §`deps.edn`.
+1. **Discover the current artefact VERSION.** → [`references/deps-versions.md`](references/deps-versions.md). Day-one deps match the generator template: `day8/re-frame2` + `day8/re-frame2-reagent` + `day8/re-frame2-schemas` + `day8/re-frame2-causa`, plus an explicit `reagent/reagent`.
+2. **Add the day-one artefacts to `deps.edn`.** → `references/deps-versions.md` §`deps.edn`.
 3. **Add `react`, `react-dom`, `shadow-cljs` to `package.json`; run `npm install`.** → `references/deps-versions.md` §`package.json`.
-4. **Write `shadow-cljs.edn` and `index.html`.** One `:target :browser` build, `:init-fn your-app.core/run`, `:source-paths` including `src/`. If Causa is enabled, `index.html` must provide the true-inline `[data-rf-causa-host]` left layout column beside `#app`; Causa auto-opens there on app load. → [`references/shadow-cljs.md`](references/shadow-cljs.md) for the exact shape, the `:devtools` block, and the `index.html`.
-5. **Write the entry namespace.** `your-app/core.cljs` requires `[re-frame.core :as rf]` and `[re-frame.adapter.reagent :as reagent-adapter]`, then calls `(rf/init! reagent-adapter/adapter)` **before any dispatch or render**. → [`references/entry-namespace.md`](references/entry-namespace.md) for the canonical shape, the React-root `defonce` pattern, and the order-of-operations contract.
+4. **Write `shadow-cljs.edn` and `index.html`.** One `:target :browser` build, `:init-fn your-app.core/init`, `:source-paths` including `src/`, and the `:devtools/preloads [day8.re-frame2-causa.preload]` Causa wiring. `index.html` must provide the true-inline `[data-rf-causa-host]` left layout column beside `#app`; Causa auto-opens there on app load. → [`references/shadow-cljs.md`](references/shadow-cljs.md) for the exact shape, the `:devtools` block, and the `index.html`.
+5. **Write the entry namespace.** `your-app/core.cljs` requires `[re-frame.core :as rf]` and `[re-frame.adapter.reagent :as reagent-adapter]`, then calls `(rf/init! reagent-adapter/adapter)` **before any dispatch or render**. The exported entry symbol is `init` (matching the template's `:init-fn ...core/init`). → [`references/entry-namespace.md`](references/entry-namespace.md) for the canonical shape, the React-root `defonce` pattern, and the order-of-operations contract.
 6. **Write the first counter.** A registered event, sub, view (`reg-view`), and mount — end-to-end in one file. → [`references/first-counter.md`](references/first-counter.md).
 7. **Run and verify.** `npx shadow-cljs watch app` → open `http://localhost:<port>/`. Counter visible, `+`/`-` flips the number. **Done.**
 
 ## Done checklist
 
-- [ ] `deps.edn` lists `day8/re-frame2` and `day8/re-frame2-reagent` at the same VERSION.
+- [ ] `deps.edn` lists `day8/re-frame2`, `day8/re-frame2-reagent`, `day8/re-frame2-schemas`, `day8/re-frame2-causa` at the same VERSION, plus an explicit `reagent/reagent`.
 - [ ] `package.json` lists `react`, `react-dom`, `shadow-cljs`.
 - [ ] `npm install` completes without errors.
-- [ ] `shadow-cljs.edn` has one `:builds` entry for the app, `:init-fn` pointing at the entry ns.
+- [ ] `shadow-cljs.edn` has one `:builds` entry for the app, `:init-fn` pointing at the entry ns's `init`, and `:devtools/preloads [day8.re-frame2-causa.preload]`.
+- [ ] `index.html` provides `[data-rf-causa-host]` beside `#app`.
 - [ ] Entry ns calls `(rf/init! reagent-adapter/adapter)` before any render.
 - [ ] `shadow-cljs watch <build-id>` compiles cleanly.
 - [ ] Browser shows the counter and `+`/`-` updates it.
@@ -80,10 +81,10 @@ Hand off: *"Setup is done. Switch to **`re-frame2`** for events/subs/machines/sc
 
 - **`Could not locate re-frame/core.cljs`** — artefact not on classpath. Check `deps.edn` and that `shadow-cljs.edn` reads it (`clj -Stree | grep re-frame2`).
 - **`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` not installed. `npm install react react-dom`. Reagent 2.x needs React 19.
-- **Counter doesn't update, no errors** — `(rf/init! reagent-adapter/adapter)` not called, or called after `rdc/render`. Move it to the top of `run`.
+- **Counter doesn't update, no errors** — `(rf/init! reagent-adapter/adapter)` not called, or called after `rdc/render`. Move it to the top of `init`.
 - **Blank page, no console errors** — `index.html` missing `<main id="app">` / `<div id="app">`, or entry ns looking up a different id.
 - **Causa logs missing layout host** — add the true-inline host markup/CSS from `references/shadow-cljs.md`, or configure `{:rf.causa/layout-host-selector "..."}` before Causa auto-opens. The same actionable diagnostic is available through `window.day8.re_frame2_causa.status()`.
-- **`Uncaught ReferenceError: re_frame is not defined`** — `:init-fn` in `shadow-cljs.edn` doesn't match the entry-ns `run` symbol. Check `(defn ^:export run [] ...)` matches `:init-fn your-app.core/run`.
+- **`Uncaught ReferenceError: re_frame is not defined`** — `:init-fn` in `shadow-cljs.edn` doesn't match the entry-ns `init` symbol. Check `(defn ^:export init [] ...)` matches `:init-fn your-app.core/init`.
 
 Anything else: point at `re-frame2` or `SKILL-REDIRECT.md`.
 

--- a/skills/re-frame2-setup/references/deps-versions.md
+++ b/skills/re-frame2-setup/references/deps-versions.md
@@ -5,7 +5,7 @@ How to choose **which** re-frame2 artefacts to depend on, and **what version** t
 ## Contents
 
 - The lockstep contract
-- The ten artefacts (and which two a greenfield project needs)
+- The eleven artefacts (and which ones a greenfield project needs)
 - Discovering the current VERSION
 - `deps.edn` shape
 - `package.json` shape
@@ -15,11 +15,11 @@ How to choose **which** re-frame2 artefacts to depend on, and **what version** t
 
 ## The lockstep contract
 
-re-frame2 ships **ten Maven artefacts in lockstep**: every artefact at the same VERSION, every release. Mixing versions across artefacts is unsupported — the runtime contract between core, adapters, and the per-feature surfaces is checked at boot time and bound to a single coordinated VERSION.
+re-frame2 ships **eleven Maven artefacts in lockstep** (core + 7 per-feature + 3 per-adapter; see [`spec/Conventions.md` §Packaging conventions](../../../spec/Conventions.md)): every artefact at the same VERSION, every release. The `day8/re-frame2-causa` devtools panel publishes on the same version line too. Mixing versions across artefacts is unsupported — the runtime contract between core, adapters, and the per-feature surfaces is checked at boot time and bound to a single coordinated VERSION.
 
 Picking a re-frame2 VERSION for your project means picking it once and using it everywhere a `day8/re-frame2-*` coordinate appears.
 
-## The ten artefacts
+## The eleven artefacts
 
 | Artefact | Tier | When to add |
 |---|---|---|
@@ -27,7 +27,7 @@ Picking a re-frame2 VERSION for your project means picking it once and using it 
 | `day8/re-frame2-reagent` | substrate | **Always (for a Reagent app).** The Reagent adapter map. |
 | `day8/re-frame2-uix` | substrate | Instead of `-reagent` if you target UIx. |
 | `day8/re-frame2-helix` | substrate | Instead of `-reagent` if you target Helix. |
-| `day8/re-frame2-schemas` | per-feature | When you call `reg-app-schema` or `reg-event-schema`. |
+| `day8/re-frame2-schemas` | per-feature | **Day one** (the template attaches a whole-app-db schema). Required whenever you call `reg-app-schema` / `reg-event-schema`; without it CLJS schema validation soft-passes per Spec 010. |
 | `day8/re-frame2-machines` | per-feature | When you call `reg-machine` or `make-machine-handler`. |
 | `day8/re-frame2-routing` | per-feature | When you dispatch `:rf.route/*` events or register routes. |
 | `day8/re-frame2-flows` | per-feature | When you call `reg-flow`. |
@@ -35,7 +35,11 @@ Picking a re-frame2 VERSION for your project means picking it once and using it 
 | `day8/re-frame2-ssr` | per-feature | When you call `render-to-string` server-side. |
 | `day8/re-frame2-epoch` | per-feature | When you call `epoch-history` or `restore-epoch` (also pulled in transitively by `re-frame2-pair`). |
 
-**Greenfield day-one minimum: just `day8/re-frame2` + `day8/re-frame2-reagent`.** Resist adding the others until the author writes code that actually uses them — they're optional by design so apps that don't use them don't pay the classpath cost.
+The eleven above are the **publishable** lockstep set. Two more local roots ride the same version but sit outside the publishable count: `day8/reagent-slim` (an alternate slim Reagent substrate) and `day8/re-frame2-ssr-ring` (a Ring adaptor over `-ssr`) — niche, not part of greenfield. Separately, the in-app devtools panel `day8/re-frame2-causa` ships on the same version line and is a **day-one** dep in the template (see the day-one shape below); it is tooling, not one of the eleven library artefacts.
+
+**Greenfield day-one shape.** This skill matches the [deps-new generator template](../README.md#relationship-to-the-generator-template) so the manual route and the one-command route land on the same scaffold. The template ships **four** re-frame2 coords on day one — core + the Reagent adapter, plus `day8/re-frame2-schemas` (the starter app attaches a whole-app-db schema; without this artefact CLJS soft-passes per Spec 010) and `day8/re-frame2-causa` (the in-app devtools panel, wired via `:devtools/preloads` and Causa-priority by default) — plus an explicit `reagent/reagent` pin.
+
+The remaining per-feature artefacts (`-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) stay pay-as-you-go: resist adding them until the author writes code that actually uses them, so apps that don't use them don't pay the classpath cost.
 
 ## Discovering the current VERSION
 
@@ -57,17 +61,22 @@ A minimal `deps.edn` for a greenfield re-frame2 project:
 
 ```clojure
 {:paths ["src"]
- :deps  {org.clojure/clojure       {:mvn/version "1.11.1"}
-         org.clojure/clojurescript {:mvn/version "1.11.132"}
+ :deps  {org.clojure/clojure       {:mvn/version "1.12.0"}
+         org.clojure/clojurescript {:mvn/version "1.12.145"}
+
          day8/re-frame2            {:mvn/version "<VERSION>"}
-         day8/re-frame2-reagent    {:mvn/version "<VERSION>"}}}
+         day8/re-frame2-reagent    {:mvn/version "<VERSION>"}
+         day8/re-frame2-schemas    {:mvn/version "<VERSION>"}
+         day8/re-frame2-causa      {:mvn/version "<VERSION>"}
+
+         reagent/reagent           {:mvn/version "2.0.1"}}}
 ```
 
-Replace `<VERSION>` with the VERSION you discovered above. **Both `day8/re-frame2-*` lines get the same value.**
+Replace `<VERSION>` with the VERSION you discovered above. **Every `day8/re-frame2-*` line gets the same value.**
 
-Notes on the Clojure / ClojureScript versions:
-- The Clojure / ClojureScript versions in the example are what the re-frame2 repo's own examples build against (see `implementation/core/deps.edn`). You can use newer versions if shadow-cljs and Reagent support them; you can probably use slightly older ones too. Start with these.
-- Reagent itself is **already declared as a dep of `day8/re-frame2-reagent`**, so you don't need to add `reagent/reagent` to your `:deps`. It'll be pulled in transitively at whatever version the adapter's `deps.edn` pins.
+Notes on the pins:
+- The Clojure / ClojureScript versions match what the re-frame2 repo's own core artefact builds against (`implementation/core/deps.edn`) and what the generator template pins. You can use newer versions if shadow-cljs and Reagent support them; start with these.
+- `reagent/reagent {:mvn/version "2.0.1"}` is pinned **explicitly**, matching the template. The Reagent adapter pulls Reagent in transitively, but pinning the substrate version yourself is the idiomatic choice — it stops a surprise transitive bump from changing your rendering substrate underneath you. Keep the version in lockstep with the adapter's `deps.edn`.
 
 ## `package.json` shape
 
@@ -94,11 +103,10 @@ Then `npm install` (after the author has approved the resolved `package.json`).
 
 ## When to add the optional per-feature artefacts
 
-The seven per-feature artefacts are pay-as-you-go. Add them **at the moment** the author writes code that calls into them — not before.
+`day8/re-frame2-schemas` is **already in the day-one shape** (the template attaches a whole-app-db schema). The remaining six per-feature artefacts are pay-as-you-go. Add them **at the moment** the author writes code that calls into them — not before.
 
 | If the author writes... | Add to `deps.edn`... |
 |---|---|
-| `(rf/reg-app-schema ...)` or any `:schema` key in a `reg-*` opts map | `day8/re-frame2-schemas` |
 | `(rf/reg-machine ...)` or `(rf/make-machine-handler ...)` | `day8/re-frame2-machines` |
 | `(rf/reg-route ...)` or dispatches `:rf.route/handle-url-change` | `day8/re-frame2-routing` |
 | `(rf/reg-flow ...)` | `day8/re-frame2-flows` |

--- a/skills/re-frame2-setup/references/entry-namespace.md
+++ b/skills/re-frame2-setup/references/entry-namespace.md
@@ -30,7 +30,7 @@ The canonical shape of `your-app/core.cljs` — the entry namespace shadow-cljs'
 
 ;; -- entry ------------------------------------------------------------------
 
-(defn ^:export run []
+(defn ^:export init []
   (rf/init! reagent-adapter/adapter)
   (rdc/render react-root [root-view]))
 ```
@@ -39,9 +39,11 @@ That's the whole entry namespace. Events / subs / views go above the mount point
 
 `root-view` is the top-level registered view. See `first-counter.md` for what it looks like.
 
+The entry symbol is `init`, matching the generator template's `:init-fn {{namespace}}.core/init`. (The repo's worked example in `examples/reagent/counter/core.cljs` happens to call its entry fn `run` — same shape, different name. Pick one and keep `shadow-cljs.edn`'s `:init-fn` pointing at whatever you choose; this skill uses `init` so the manual route matches the template.)
+
 ## Order of operations
 
-`run` must do these three things, **in this order**, every time:
+`init` must do these three things, **in this order**, every time:
 
 1. **`(rf/init! reagent-adapter/adapter)`** — install the substrate adapter into the default frame.
 2. **(optional) `(rf/dispatch-sync [:your-app/initialise])`** — seed app-db synchronously before the first render. Most apps want this; some let the views render against an empty app-db and seed on first user interaction.
@@ -58,7 +60,7 @@ re-frame2 splits **the registry** (a process-global handler / sub / fx map) from
 Three consequences:
 
 - **Adapters are values, not magic.** `re-frame.adapter.reagent/adapter` is a regular CLJS var holding a map. `rf/init!` takes that value directly — no global registration, no name-based lookup. Swap it for `re-frame.adapter.uix/adapter` or `re-frame.adapter.helix/adapter` and you have a UIx / Helix app.
-- **`rf/init!` is idempotent in dev but not redundant.** Hot-reload of `core.cljs` will re-invoke `run`; calling `rf/init!` again is safe and resets the default frame's substrate config. Don't try to "guard" it with `defonce` — let it run.
+- **`rf/init!` is idempotent in dev but not redundant.** Hot-reload of `core.cljs` will re-invoke `init`; calling `rf/init!` again is safe and resets the default frame's substrate config. Don't try to "guard" it with `defonce` — let it run.
 - **No implicit boot.** Unlike re-frame v1 (where `re-frame.core` had no boot step), re-frame2 requires the explicit `init!`. The reason: multi-substrate support and the per-frame substrate-config model (Spec 006) need to know *which* adapter you want before any subscription resolves. There is no default.
 
 The adapter map carries the substrate's `state-container`, `read-container`, `replace-container!`, `subscribe`, `render`, and hot-reload hooks. You don't construct it; you require the namespace and pass its `adapter` var.
@@ -75,7 +77,7 @@ Two contractual bits:
 - **`defonce`** — under shadow-cljs hot-reload, `core.cljs` reloads on every save. Without `defonce`, every reload calls `create-root` again on the same DOM node, and React 19 complains loudly (or, worse, silently mounts two roots that fight each other). `defonce` ensures the root is created exactly once per page load.
 - **`(js/document.getElementById "app")`** — must match the `id` in `index.html`. Mismatch here is the most common cause of a blank page with no console error.
 
-In `run`, `rdc/render` is called against `react-root` (not against the DOM node directly). Both `create-root` and `render` come from `reagent.dom.client` — that's the React 19 client-Root entry surface for Reagent 2.x.
+In `init`, `rdc/render` is called against `react-root` (not against the DOM node directly). Both `create-root` and `render` come from `reagent.dom.client` — that's the React 19 client-Root entry surface for Reagent 2.x.
 
 ## Where everything else goes
 
@@ -85,7 +87,7 @@ In a tiny app, all of this fits in `your-app/core.cljs` above the mount point:
 - **Subscriptions** — `(rf/reg-sub ...)`
 - **Effects** — `(rf/reg-fx ...)` (per-app fx)
 - **Views** — `(reg-view <name> [...] <body>)` (via the `reg-view` macro from `re-frame.core`)
-- **`(rf/dispatch-sync [:your-app/initialise])`** in `run` — the initial seed event
+- **`(rf/dispatch-sync [:your-app/initialise])`** in `init` — the initial seed event
 
 For anything beyond the first counter, split:
 
@@ -98,6 +100,16 @@ src/your_app/
 ```
 
 then `(:require [your-app.events] [your-app.subs] [your-app.views :as views])` in `core.cljs` so the registrations happen at load time. Use `[views/root-view]` in `rdc/render`. The folder shape is a convention; re-frame2 has no opinion about it.
+
+## UIx / Helix greenfield
+
+This skill scaffolds against **Reagent** (the default reference substrate). For a UIx or Helix greenfield app the wiring is the same shape with three substitutions:
+
+- **deps.edn** — swap `day8/re-frame2-reagent` for `day8/re-frame2-uix` (or `-helix`), and swap the substrate npm/Maven deps: UIx uses `com.pitch/uix.core` + `com.pitch/uix.dom`; Helix uses `lilactown/helix`. (Drop the `reagent/reagent` pin.)
+- **entry ns** — require `[re-frame.adapter.uix :as uix-adapter]` (or `re-frame.adapter.helix`), pass `uix-adapter/adapter` to `rf/init!`, and mount with the substrate's own root API (`uix.dom/create-root` + `render-root` for UIx) instead of `reagent.dom.client`.
+- everything else (events, subs, schemas, Causa wiring, `dispatch-sync` seed, `:init-fn ...core/init`) is identical across substrates.
+
+The fastest path for a non-Reagent greenfield is the **generator template**, which ships complete `_uix/` and `_helix/` variants — invoke `clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app :substrate :uix` (or `:helix`) and you get a working UIx/Helix counter without hand-wiring the substitutions above. See [the generator-template section](../README.md#relationship-to-the-generator-template).
 
 ## Differences from re-frame v1
 

--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -57,7 +57,7 @@ Use it as the body of `src/your_app/core.cljs`. When it mounts and clicks work, 
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn ^:export init []
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])
   (rdc/render react-root [root-view]))
@@ -94,10 +94,10 @@ The result is regular Reagent hiccup. Reagent renders, the React 19 root commits
 
 `defonce` guards `react-root` against hot-reload. See `entry-namespace.md` for why.
 
-`run`'s three lines (in this order):
+`init`'s three lines (in this order):
 
 1. `(rf/init! reagent-adapter/adapter)` — install the Reagent substrate adapter.
-2. `(rf/dispatch-sync [:counter/initialise])` — seed `app-db` to `{:count 0}` before first render. `dispatch-sync` drains the event synchronously; the `app-db` is committed before `run` returns.
+2. `(rf/dispatch-sync [:counter/initialise])` — seed `app-db` to `{:count 0}` before first render. `dispatch-sync` drains the event synchronously; the `app-db` is committed before `init` returns.
 3. `(rdc/render react-root [root-view])` — mount.
 
 ## Verifying it works
@@ -120,7 +120,7 @@ Click `+` — the number becomes `1`. Click `-` — back to `0`. Refresh the pag
 
 If you see a blank page, open the browser console. Most failures land there with a clear error:
 - `Cannot read property 'getElementById' of undefined` — script ran before DOM was ready; check `index.html` loads `main.js` at the *bottom* of `<body>`.
-- `Could not find frame :rf/default` — `rf/init!` didn't run before render. Check `run` is the `:init-fn` shadow-cljs is calling.
+- `Could not find frame :rf/default` — `rf/init!` didn't run before render. Check `init` is the `:init-fn` shadow-cljs is calling.
 - `No subscription handler registered for: :count` — registrations didn't run. If you split into multiple namespaces, make sure `core.cljs` `:require`s them so they load.
 
 ## What to do next

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -25,16 +25,16 @@ The minimal `shadow-cljs.edn` build for a greenfield re-frame2 Reagent single-pa
   {:target     :browser
    :output-dir "public/js"
    :asset-path "/js"
-   :modules    {:main {:init-fn your-app.core/run}}}}}
+   :modules    {:main {:init-fn your-app.core/init}}}}}
 ```
 
 The smallest greenfield build entry. Three things matter for re-frame2:
 
 1. **`:dependencies []`.** shadow-cljs reads `deps.edn` automatically. Don't duplicate the `day8/re-frame2-*` coordinates here; that's where they'd shadow each other if their VERSION ever drifted.
-2. **`:init-fn your-app.core/run`.** shadow-cljs calls this symbol at bundle-init time. The function must be exported (`(defn ^:export run [] ...)`). This is the entry point that calls `(rf/init! reagent-adapter/adapter)` — see `entry-namespace.md`.
+2. **`:init-fn your-app.core/init`.** shadow-cljs calls this symbol at bundle-init time. The function must be exported (`(defn ^:export init [] ...)`). This is the entry point that calls `(rf/init! reagent-adapter/adapter)` — see `entry-namespace.md`. (`init` matches the generator template; the symbol name is yours to choose, as long as `:init-fn` points at it.)
 3. **One module.** A single-page re-frame2 app needs exactly one `:modules` entry. Code-splitting is possible later but not part of greenfield.
 
-Substitute `your-app.core/run` with whatever your entry namespace + run symbol actually is. If you call your namespace `myapp.core` and your run fn `start`, this becomes `:init-fn myapp.core/start`.
+Substitute `your-app.core/init` with whatever your entry namespace + entry symbol actually is. If you call your namespace `myapp.core` and your entry fn `start`, this becomes `:init-fn myapp.core/start`.
 
 The build id (`:app` above) is the name you give the build for `shadow-cljs watch <build-id>`. Use anything that reads naturally; `:app` is convention.
 
@@ -82,9 +82,9 @@ Four contractual bits:
 - **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows.
 - **`/js/main.js` is an absolute path from site root.** That's correct for shadow-cljs's dev server.
 
-## `:devtools` block (optional, for hot-reload)
+## `:devtools` block (hot-reload + Causa)
 
-Add `:devtools` to enable shadow-cljs's hot-reload + dev server:
+Add `:devtools` to enable shadow-cljs's hot-reload + dev server, and to load the Causa devtools panel — both wired by default in the generator template:
 
 ```clojure
 :builds
@@ -92,19 +92,23 @@ Add `:devtools` to enable shadow-cljs's hot-reload + dev server:
  {:target     :browser
   :output-dir "public/js"
   :asset-path "/js"
-  :modules    {:main {:init-fn your-app.core/run}}
+  :modules    {:main {:init-fn your-app.core/init}}
   :devtools   {:http-port 8020
                :http-root "public"
-               :watch-dir "public"}}}
+               :watch-dir "public"
+               :after-load your-app.core/init
+               :preloads   [day8.re-frame2-causa.preload]}}}
 ```
 
 - `:http-port` — port the dev server listens on. `8020` is convention; pick anything free.
 - `:http-root "public"` — the dev server serves files from this directory. Your `index.html` lives at `public/index.html`.
 - `:watch-dir "public"` — shadow-cljs reloads the browser when any file under here changes (including the compiled `main.js`).
+- `:after-load your-app.core/init` — re-run the entry fn after each hot reload so the freshly-loaded code re-installs the adapter and re-renders.
+- `:preloads [day8.re-frame2-causa.preload]` — loads the Causa in-app devtools panel in dev/watch builds. `:preloads` (and the whole `:devtools` block) are cut from `release` builds automatically, so Causa never ships to production.
 
 With this block in place, `shadow-cljs watch app` starts the dev server. Visit `http://localhost:8020/` and the browser auto-refreshes on every recompile.
 
-re-frame2 itself **does not need a preload** for hot-reload. shadow-cljs's default behaviour is enough. Causa is the devtools exception: if you add `day8.re-frame2-causa.preload`, the page must provide `[data-rf-causa-host]` as shown above. The Causa preload registers listeners/keybindings and auto-opens into that app-provided host after `rf/init!` installs the substrate adapter; there is no lazy/manual-only launch step.
+re-frame2's *core* does not need a preload for hot-reload — shadow-cljs's default behaviour is enough. **Causa is the one default preload:** because Causa is a day-one dep (see `deps-versions.md`), the template wires `day8.re-frame2-causa.preload` here, and the page must provide the `[data-rf-causa-host]` layout column shown above. The Causa preload registers listeners/keybindings and auto-opens into that app-provided host after `rf/init!` installs the substrate adapter; there is no lazy/manual-only launch step. If you genuinely want a Causa-free build, drop the `:preloads` entry and the `day8/re-frame2-causa` dep together.
 
 ## Production build (`release`)
 
@@ -124,7 +128,7 @@ If you want to pin the port explicitly (e.g. for editor integrations), add a top
 
 A few things you might pull in by reflex from other CLJS framework setups that re-frame2 specifically does not require:
 
-- **No framework preload required** — re-frame2 has no preload analogue to re-frame v1. Causa is optional devtools wiring; when enabled, its default is the `[data-rf-causa-host]` true-inline panel on app load. Overlay/body-padding chrome is optional debug tooling, not the default, and pop-out remains available from the mounted panel.
+- **No *framework* preload required** — re-frame2's core has no preload analogue to re-frame v1. The one default preload is Causa's devtools (`day8.re-frame2-causa.preload`, wired in `:devtools/preloads`); its default surface is the `[data-rf-causa-host]` true-inline panel on app load. Overlay/body-padding chrome is optional debug tooling, not the default, and pop-out remains available from the mounted panel.
 - **No `:closure-defines`** for re-frame2 itself in dev. The single exception is opting into the performance-API instrumentation (Spec 009 §Performance instrumentation) — set `re-frame.performance/enabled? true` only if the author asks for it explicitly. Default dev is fine.
 - **No special compiler options** for dev. `{:compiler-options {:warnings {...}}}` is up to the author.
 - **No SSR build entry** unless the author wants SSR. SSR is opt-in via `day8/re-frame2-ssr` (separate per-feature artefact); the SSR build is a separate `:target :node-script` (or `:target :browser` running in a static-render harness). Out of scope for greenfield.

--- a/skills/re-frame2-setup/spec/authoring-prompt.md
+++ b/skills/re-frame2-setup/spec/authoring-prompt.md
@@ -31,10 +31,12 @@ A self-contained prompt that re-authors the `re-frame2-setup` skill from this `s
 > │   ├── shadow-cljs.md             (~100 lines; minimal build shape, index.html)
 > │   ├── entry-namespace.md         (~120 lines; rf/init! + Reagent root contract)
 > │   └── first-counter.md           (~110 lines; end-to-end worked example)
-> └── spec/
->     ├── design.md
->     ├── inputs.md
->     └── authoring-prompt.md
+> ├── spec/
+> │   ├── design.md
+> │   ├── inputs.md
+> │   └── authoring-prompt.md
+> └── evals/
+>     └── evals.json                 (trigger-accuracy fixture)
 > ```
 >
 > *Every reference leaf is ≤250 lines (target ~120). SKILL.md is ~170 lines (under Anthropic's 500-line ceiling). All leaves are one level deep.*
@@ -45,15 +47,15 @@ A self-contained prompt that re-authors the `re-frame2-setup` skill from this `s
 > *2. Add deps to `deps.edn`.*
 > *3. Add npm deps to `package.json`.*
 > *4. Write `shadow-cljs.edn`.*
-> *5. Write the entry namespace with `(rf/init! reagent-adapter/adapter)` before any render.*
+> *5. Write the entry namespace with `(rf/init! reagent-adapter/adapter)` before any render. Exported entry symbol is `init` (matches the generator template).*
 > *6. Write the first counter (event + sub + reg-view + mount).*
 > *7. Run it and verify.*
 >
 > *Cardinal rules to bake in (these go in SKILL.md):*
 >
-> *1. **Never hardcode artefact versions in suggestions written to disk.** Look them up first.*
-> *2. **All ten artefacts ship at the same VERSION.** Mixing is unsupported.*
-> *3. **Only add the per-feature artefacts the author actually uses.** Core + adapter on day one; the rest pay-as-you-go.*
+> *1. **Never hardcode the re-frame2 artefact VERSION in suggestions written to disk.** Look it up first; leave it as `<VERSION>`. (Concrete Clojure/CLJS/Reagent pins matching the template are fine.)*
+> *2. **All eleven artefacts ship at the same VERSION** (and `day8/re-frame2-causa` rides the same line). Mixing is unsupported.*
+> *3. **The day-one shape matches the generator template:** core + Reagent adapter + `-schemas` + `-causa` + explicit `reagent/reagent`. The remaining per-feature artefacts (`-machines`/`-routing`/`-flows`/`-http`/`-ssr`/`-epoch`) are pay-as-you-go.*
 > *4. **The Reagent adapter is the default reference substrate.** Unless the author says UIx or Helix, scaffold Reagent.*
 > *5. **Don't write tests for the author.** This skill stops at "the counter mounts".*
 >
@@ -90,7 +92,7 @@ A self-contained prompt that re-authors the `re-frame2-setup` skill from this `s
 
 ## When to re-author
 
-- A new mandatory artefact ships in lockstep (the ten-artefact set grows) → update `references/deps-versions.md` and the SKILL.md framing.
+- A new mandatory artefact ships in lockstep (the eleven-artefact set grows) → update `references/deps-versions.md` and the SKILL.md framing.
 - The `re-frame.adapter.reagent` contract changes materially → `references/entry-namespace.md` and `references/first-counter.md` need updates.
 - `rf/init!`'s signature changes → all four reference leaves need a sweep.
 - Reagent v3 lands and supplants v2 → re-derive against the v3 counter example.

--- a/skills/re-frame2-setup/spec/design.md
+++ b/skills/re-frame2-setup/spec/design.md
@@ -23,17 +23,17 @@ The same four pillars as the `re-frame2` skill, scoped to greenfield bootstrap:
 
 These are not up for re-litigation. A future authoring pass MUST preserve them unless explicitly unlocked by Mike.
 
-### L1 — Never hardcode artefact versions in suggestions written to disk
+### L1 — Never hardcode the re-frame2 artefact VERSION in suggestions written to disk
 
-re-frame2 ships ten Maven artefacts in lockstep at a single VERSION. Versions change. The skill points the author at `references/deps-versions.md` for lookup; the cardinal rule lives in SKILL.md so it's read on every load. Hardcoded versions in suggestions are a documented anti-pattern.
+re-frame2 ships eleven Maven artefacts in lockstep at a single VERSION (core + 7 per-feature + 3 per-adapter per `spec/Conventions.md`; `day8/re-frame2-causa` rides the same line). The re-frame2 VERSION changes. The skill leaves it as `<VERSION>` and points the author at `references/deps-versions.md` for lookup; the cardinal rule lives in SKILL.md so it's read on every load. Hardcoded re-frame2 VERSIONs in suggestions are a documented anti-pattern. (The non-re-frame2 pins — Clojure/ClojureScript/Reagent — are pinned to concrete versions matching the generator template, since those are slow-moving and the template fixes them.)
 
-### L2 — All ten artefacts ship at the same VERSION
+### L2 — All eleven artefacts ship at the same VERSION
 
-The author picks the VERSION once; every `day8/re-frame2-*` dep gets that same version. Mixing versions across artefacts is unsupported. This rule lands in both SKILL.md and `references/deps-versions.md`.
+The author picks the VERSION once; every `day8/re-frame2-*` dep (including `-causa`) gets that same version. Mixing versions across artefacts is unsupported. This rule lands in both SKILL.md and `references/deps-versions.md`.
 
-### L3 — Only add the per-feature artefacts the author actually uses
+### L3 — Day-one shape matches the generator template; remaining per-feature artefacts are pay-as-you-go
 
-Core (`day8/re-frame2`) and adapter (`day8/re-frame2-reagent`) are mandatory on day one. Per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) come in **only when the author starts using the feature**. The skill resists the temptation to "add them all defensively" — pay-as-you-go is the contract.
+The day-one deps match the deps-new template: core (`day8/re-frame2`), the Reagent adapter (`day8/re-frame2-reagent`), `-schemas` (the starter app attaches a whole-app-db schema), and `-causa` (the in-app devtools panel, Causa-priority by default), plus an explicit `reagent/reagent` pin. The remaining per-feature artefacts (`-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) come in **only when the author starts using the feature**. The skill resists "add them all defensively" — pay-as-you-go is the contract for everything past the day-one shape.
 
 ### L4 — The Reagent adapter is the default reference substrate
 
@@ -95,13 +95,15 @@ skills/re-frame2-setup/
 │   ├── shadow-cljs.md             (~100 lines; build shape, index.html)
 │   ├── entry-namespace.md         (~120 lines; rf/init! + Reagent root contract)
 │   └── first-counter.md           (~110 lines; end-to-end worked example)
-└── spec/
-    ├── design.md                  (this file)
-    ├── inputs.md                  (canonical inputs)
-    └── authoring-prompt.md        (one-shot reauthor prompt)
+├── spec/
+│   ├── design.md                  (this file)
+│   ├── inputs.md                  (canonical inputs)
+│   └── authoring-prompt.md        (one-shot reauthor prompt)
+└── evals/
+    └── evals.json                 (trigger-accuracy fixture)
 ```
 
-SKILL.md (~170) + 4 reference leaves (~450) + 3 spec files (~250) ≈ ~870 LoC across 10 files. Typical greenfield session reads SKILL.md + 2 reference leaves = ~370 LoC.
+SKILL.md (~170) + 4 reference leaves (~450) + 3 spec files (~250) ≈ ~870 LoC across 10 files, plus the `evals/evals.json` trigger fixture. Typical greenfield session reads SKILL.md + 2 reference leaves = ~370 LoC. `spec/` and `evals/` are excluded from the npm `files` array by design.
 
 ## 6. Discovery surface (frontmatter `description`)
 
@@ -110,7 +112,7 @@ The `description` is "pushy" and lists every greenfield-trigger phrase: *"start 
 ## 7. Anti-patterns the skill explicitly resists
 
 - **Hardcoding artefact versions in suggestions** — L1 cardinal rule.
-- **Mixing versions across the ten artefacts** — L2 cardinal rule.
+- **Mixing versions across the eleven artefacts** — L2 cardinal rule.
 - **Adding per-feature artefacts defensively** — L3 cardinal rule + `references/deps-versions.md`'s "pay-as-you-go" framing.
 - **Branching into UIx/Helix at greenfield** — L4. Substrate-switch is a separate conversation.
 - **Writing tests for the author** — L5 cardinal rule.

--- a/skills/re-frame2-setup/spec/inputs.md
+++ b/skills/re-frame2-setup/spec/inputs.md
@@ -8,7 +8,7 @@ The canonical inputs the skill leans on. A re-authoring pass needs these to repr
 
 The skill teaches a four-file scaffolding (`deps.edn`, `package.json`, `shadow-cljs.edn`, `core.cljs`). Each file's shape is derived from:
 
-- **`day8/re-frame2`'s release artefacts** — the ten Maven coords (`day8/re-frame2`, `day8/re-frame2-reagent`, `day8/re-frame2-schemas`, `day8/re-frame2-machines`, `day8/re-frame2-routing`, `day8/re-frame2-flows`, `day8/re-frame2-http`, `day8/re-frame2-ssr`, `day8/re-frame2-epoch`, plus the test-support artefact). All ship in lockstep at a single VERSION; the skill reads that VERSION at discovery time rather than hardcoding it.
+- **`day8/re-frame2`'s release artefacts** — the eleven publishable Maven coords (core + 7 per-feature + 3 per-adapter per `spec/Conventions.md` §Packaging conventions: `day8/re-frame2`, `day8/re-frame2-reagent`, `day8/re-frame2-uix`, `day8/re-frame2-helix`, `day8/re-frame2-schemas`, `day8/re-frame2-machines`, `day8/re-frame2-routing`, `day8/re-frame2-flows`, `day8/re-frame2-http`, `day8/re-frame2-ssr`, `day8/re-frame2-epoch`). The `day8/re-frame2-causa` devtools panel rides the same version line (day-one dep in the generator template). All ship in lockstep at a single VERSION; the skill reads that VERSION at discovery time rather than hardcoding it.
 - **`examples/reagent/counter/`** in the re-frame2 repo — the canonical first-counter shape. `references/first-counter.md` is a trimmed version of this example.
 - **`examples/reagent/counter/shadow-cljs.edn`** — the canonical `shadow-cljs.edn` shape for a single-page browser app.
 - **`examples/reagent/counter/index.html`** — the canonical `index.html` (`<div id="app">`, `<script src="js/main.js">`).
@@ -56,3 +56,4 @@ When the artefact set or the greenfield contract changes:
 5. **`rf/init!` signature changes** → update SKILL.md's Step 5 framing and `references/entry-namespace.md`.
 6. **A new common greenfield failure mode appears** → add a row to SKILL.md's Troubleshooting section (move to a dedicated leaf if it grows past ~30 lines per OQ3).
 7. **The `examples/reagent/counter/` shape changes** → re-derive `references/first-counter.md` from the example.
+8. **The deps-new template's day-one shape changes** (`tools/template/resources/day8/re_frame2_template/_reagent/{deps.edn,shadow-cljs.edn,core.cljs}`) → re-reconcile the skill's day-one deps, `:devtools/preloads`, and entry symbol so the manual route stays aligned with the one-command generator.


### PR DESCRIPTION
## Summary

Realigns the `re-frame2-setup` skill with the deps-new generator template (`tools/template/`, rebuilt 2026-05-20) and current artefact pins. The skill had drifted: it claimed the manual route and the one-command generator land on the same shape, but the template now ships a richer day-one scaffold. Five beads:

- **rf2-5wobl (P1)** — day-one shape now matches the template: four re-frame2 coords (core + `-reagent` + `-schemas` + `-causa`) plus an explicit `reagent/reagent {:mvn/version "2.0.1"}`, entry symbol `init` (was `run`), and `:devtools/preloads [day8.re-frame2-causa.preload]` + `:after-load`. Causa is now wired by default, so the `[data-rf-causa-host]` index.html markup is no longer orphaned. Reconciled across SKILL.md, README.md, deps-versions.md, shadow-cljs.md, entry-namespace.md, first-counter.md, and the spec/ meta-docs.
- **rf2-r37bn (P1)** — bumped stale `clojure 1.11.1 / clojurescript 1.11.132` to `1.12.0 / 1.12.145`, matching `implementation/core/deps.edn` and the template.
- **rf2-khg3t (P2)** — fixed "ten artefacts" -> "eleven" (core + 7 per-feature + 3 per-adapter per `spec/Conventions.md`); noted `reagent-slim` / `ssr-ring` local roots and the Causa devtools panel ride the same version line. (No CHANGELOG in the skill tree, so that note was out of scope.)
- **rf2-g7kvh (P3)** — added `spec/` and `evals/` to the README + design.md layout diagrams (and the authoring-prompt structure block).
- **rf2-z66ap (P3)** — added a UIx/Helix greenfield section to `entry-namespace.md` (three adapter substitutions + the template's `:substrate :uix/:helix` flag) so the `uix-greenfield` eval has a real recipe to back its trigger; pointed README + SKILL.md routing at it.

All dep coords, version pins, entry symbols, and the artefact count were verified against `tools/template/`, `implementation/core/deps.edn`, `implementation/deps.edn`, and `spec/Conventions.md` before editing. No bead refs or AI attribution in user-facing skill content. Top-level `skills/README.md` untouched.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exit 0.
- [x] `python -m mkdocs build --strict` — exit 0.
- [x] `evals.json` parses (16 entries); no dedicated eval validator exists in the repo.
- [x] New relative links (`../../../spec/Conventions.md` from references/ and spec/, README `#relationship-to-the-generator-template` anchor) resolve.
- [x] No remaining `run` entry-symbol refs, `1.11.x` pins, or "ten artefacts" prose in the skill tree.