### PR TITLE
feat(causa): Static EDN via shared widget + universal copy-to-clipboard + Static list a11y (rf2-2kwhw + rf2-f026h + rf2-mq8wk)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -46,7 +46,8 @@
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.theme.tokens
              :as t
-             :refer [tokens type-scale mono-stack sans-stack]]))
+             :refer [tokens type-scale mono-stack sans-stack]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -182,8 +183,14 @@
 
 (defn- flow-row
   [{:keys [flow-id frame inputs path doc] :as _row}]
+  ;; rf2-mq8wk — list semantics. Flow rows are non-interactive (no
+  ;; row-level dispatch), so `role=listitem` is the right shape — they
+  ;; are catalogue entries, not buttons. The interactive Static surface
+  ;; that earns keyboard activation is the Routes list (whose rows
+  ;; toggle an expand surface — see static/routes/browse_list.cljs).
   [:li {:data-testid (str "rf-causa-static-flows-row-"
                           (subs (pr-str flow-id) 1))
+        :role        "listitem"
         :style       {:display       "block"
                       :padding       "6px 12px"
                       :font-family   mono-stack
@@ -205,31 +212,41 @@
             :style {:color     (:text-tertiary tokens)
                     :font-size "10px"}}
      (pr-str frame)]]
-   [:div {:style {:margin-left  "12px"
-                  :color        (:text-secondary tokens)
-                  :font-size    "11px"
-                  :line-height  1.4}}
-    [:div
-     [:span {:style {:color (:text-tertiary tokens)
-                     :margin-right "6px"}}
-      "inputs:"]
-     (for [[i input-path] (map-indexed vector inputs)]
-       ^{:key (str "in-" i)}
-       [:code {:style {:color (:cyan tokens)
-                       :margin-right "6px"}}
-        (pr-str input-path)])]
-    [:div
-     [:span {:style {:color (:text-tertiary tokens)
-                     :margin-right "6px"}}
-      "output →"]
-     [:code {:style {:color (:yellow tokens)}}
-      (pr-str path)]]
-    (when doc
-      [:div {:style {:margin-top  "4px"
-                     :color       (:text-secondary tokens)
-                     :font-family sans-stack
-                     :font-style  "italic"}}
-       doc])]])
+   ;; rf2-2kwhw — input + output path values render through the shared
+   ;; cljs-devtools EDN widget (spec 007:119 — "all values rendered via
+   ;; the cljs-devtools-shaped renderer") rather than raw `pr-str` +
+   ;; `[:code]`. `edn/inspect` is the canonical L4 renderer (same call
+   ;; the App-DB segment-inspector uses); each value gets a stable
+   ;; per-flow `node-key` so the widget's per-node expand state + copy
+   ;; affordance (rf2-f026h) ride the same way they do in the App-DB /
+   ;; Trace / Event surfaces.
+   (let [flow-key (subs (pr-str flow-id) 1)]
+     [:div {:style {:margin-left  "12px"
+                    :color        (:text-secondary tokens)
+                    :font-size    "11px"
+                    :line-height  1.4}}
+      [:div {:style {:display "flex" :align-items "baseline" :gap "6px"}}
+       [:span {:style {:color (:text-tertiary tokens)
+                       :flex  "0 0 auto"}}
+        "inputs:"]
+       (into [:span {:style {:display     "inline-flex"
+                             :flex-wrap   "wrap"
+                             :gap         "6px"}}]
+             (for [[i input-path] (map-indexed vector inputs)]
+               ^{:key (str "in-" i)}
+               (edn/inspect input-path
+                            (str "static-flows/" flow-key "/input/" i))))]
+      [:div {:style {:display "flex" :align-items "baseline" :gap "6px"}}
+       [:span {:style {:color (:text-tertiary tokens)
+                       :flex  "0 0 auto"}}
+        "output →"]
+       (edn/inspect path (str "static-flows/" flow-key "/output"))]
+      (when doc
+        [:div {:style {:margin-top  "4px"
+                       :color       (:text-secondary tokens)
+                       :font-family sans-stack
+                       :font-style  "italic"}}
+         doc])])])
 
 ;; ---- empty states --------------------------------------------------------
 
@@ -284,6 +301,7 @@
         (if (empty? flows)
           (empty-filtered query)
           (into [:ul {:data-testid "rf-causa-static-flows-list"
+                      :role        "list"
                       :style       {:list-style     "none"
                                     :margin         "8px 0 0 0"
                                     :padding        "0 8px"

--- a/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
@@ -160,7 +160,11 @@
         row-id  (if (and (> (count id-text) 0) (= \: (first id-text)))
                   (subs id-text 1)
                   id-text)]
+    ;; rf2-mq8wk — list semantics. Interceptor rows are non-interactive
+    ;; catalogue entries (no row-level dispatch), so `role=listitem` is
+    ;; the right shape rather than `role=button`.
     [:li {:data-testid (str "rf-causa-static-interceptors-row-" row-id)
+          :role        "listitem"
           :style       {:display       "block"
                         :padding       "6px 12px"
                         :font-family   mono-stack
@@ -273,6 +277,7 @@
         (if (empty? interceptors)
           (empty-filtered query)
           (into [:ul {:data-testid "rf-causa-static-interceptors-list"
+                      :role        "list"
                       :style       {:list-style     "none"
                                     :margin         "8px 0 0 0"
                                     :padding        "0 8px"

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
@@ -112,6 +112,7 @@
    {:keys [expanded? sim-open? routes-map on-toggle]}]
   [:li {:data-testid (str "rf-causa-static-routes-row-"
                           (subs (pr-str route-id) 1))
+        :role        "listitem"
         :style       {:display       "block"
                       :padding       "0"
                       :font-family   mono-stack
@@ -123,14 +124,33 @@
                                        "2px solid transparent")
                       :border-radius "2px"
                       :line-height   "20px"}}
-   [:div {:style    {:display     "flex"
+   ;; rf2-mq8wk — keyboard a11y. The route row's clickable body toggles
+   ;; the inline expand surface, so it carries the L2 event-row recipe
+   ;; (shell.cljs:1068 `role=button` + `tab-index=0` + `aria-label` +
+   ;; Enter/Space activation). `aria-expanded` mirrors the open state so
+   ;; assistive tech announces the toggle's disclosure semantics.
+   [:div {:role         "button"
+          :tab-index    "0"
+          :aria-expanded (if expanded? "true" "false")
+          :aria-label   (str "Route " (str route-id)
+                             (when path (str " (" path ")"))
+                             (if expanded? " — collapse" " — expand"))
+          :style    {:display     "flex"
                      :align-items "center"
                      :gap         "8px"
                      :padding     "3px 8px"
                      :cursor      "pointer"
                      :white-space "nowrap"
                      :overflow    "hidden"}
-          :on-click on-toggle}
+          :on-click on-toggle
+          :on-key-down (fn [^js e]
+                         ;; Enter / Space fire the same row toggle the
+                         ;; pointer-click path uses, so keyboard-only
+                         ;; users can open/close the expand surface.
+                         (let [k (.-key e)]
+                           (when (or (= k "Enter") (= k " "))
+                             (.preventDefault e)
+                             (on-toggle e))))}
     [:span {:data-testid (str "rf-causa-static-routes-chevron-"
                               (subs (pr-str route-id) 1))
             :style       {:color       (:text-tertiary tokens)
@@ -208,6 +228,7 @@
      (if (empty? routes)
        (empty-filtered query)
        (into [:ul {:data-testid "rf-causa-static-routes-list"
+                   :role        "list"
                    :style       {:list-style     "none"
                                  :margin         "8px 0 0 0"
                                  :padding        "0 8px"

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
@@ -33,7 +33,8 @@
             [day8.re-frame2-causa.static.routes.simulate-nav :as sim-nav]
             [day8.re-frame2-causa.theme.tokens
              :as t
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 (defn- section-label
   [label]
@@ -45,10 +46,16 @@
                  :margin         "8px 0 2px 0"}}
    label])
 
-(defn- code-block
-  "Render a mono block with `pr-str` text."
-  [testid value]
-  [:pre {:data-testid testid
+(defn- value-block
+  "Render an EDN value through the shared cljs-devtools EDN widget
+  (rf2-2kwhw — spec 007:119 'all values rendered via the cljs-devtools-
+  shaped renderer'). Replaces the prior raw-`pr-str` `[:pre]` block so
+  the schema / meta values gain expand/collapse, syntax-colouring
+  parity, and the per-node copy host (rf2-f026h). The `testid` wrapper
+  is preserved so existing per-block selectors still resolve; the
+  `node-key` is stable per block so expand state survives reloads."
+  [testid node-key value]
+  [:div {:data-testid testid
          :style       {:margin        "0"
                        :padding       "6px 8px"
                        :background    (:bg-1 tokens)
@@ -56,11 +63,10 @@
                        :color         (:text-primary tokens)
                        :font-family   mono-stack
                        :font-size     "11px"
-                       :white-space   "pre-wrap"
                        :max-height    "200px"
                        :overflow-y    "auto"
                        :overflow-x    "auto"}}
-   (with-out-str (binding [*print-length* nil] (println (pr-str value))))])
+   (edn/inspect value node-key)])
 
 (defn- chip
   [text colour]
@@ -199,29 +205,34 @@
                                 (subs (pr-str route-id) 1))
               :style       {:margin "4px 0"}}
         (section-label "Matched keys")
+        ;; rf2-2kwhw — matched-keys vector through the shared widget's
+        ;; inline current-state renderer (cljs-devtools one-liner).
         [:div {:style {:font-family mono-stack
                        :font-size   "11px"
                        :color       (:text-secondary tokens)}}
-         (pr-str (vec keys))]])
+         (edn/inspect-inline (vec keys))]])
      (when params
        [:div {:data-testid (str "rf-causa-static-routes-params-schema-"
                                 (subs (pr-str route-id) 1))
               :style       {:margin "4px 0"}}
         (section-label ":params schema")
-        (code-block (str "rf-causa-static-routes-params-schema-block-"
-                         (subs (pr-str route-id) 1))
-                    params)])
+        (value-block (str "rf-causa-static-routes-params-schema-block-"
+                          (subs (pr-str route-id) 1))
+                     (str "static-routes/" (subs (pr-str route-id) 1) "/params")
+                     params)])
      (when query
        [:div {:data-testid (str "rf-causa-static-routes-query-schema-"
                                 (subs (pr-str route-id) 1))
               :style       {:margin "4px 0"}}
         (section-label ":query schema")
-        (code-block (str "rf-causa-static-routes-query-schema-block-"
-                         (subs (pr-str route-id) 1))
-                    query)])
+        (value-block (str "rf-causa-static-routes-query-schema-block-"
+                          (subs (pr-str route-id) 1))
+                     (str "static-routes/" (subs (pr-str route-id) 1) "/query")
+                     query)])
      (section-label "Registrar meta")
-     (code-block (str "rf-causa-static-routes-meta-"
-                      (subs (pr-str route-id) 1))
-                 meta)
+     (value-block (str "rf-causa-static-routes-meta-"
+                       (subs (pr-str route-id) 1))
+                  (str "static-routes/" (subs (pr-str route-id) 1) "/meta")
+                  meta)
      (when sim-open?
        [sim-nav/preview routes-map route-id nil])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -56,7 +56,8 @@
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.theme.tokens
              :as t
-             :refer [tokens type-scale mono-stack sans-stack]]))
+             :refer [tokens type-scale mono-stack sans-stack]]
+            [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
 ;; ---- pure helpers --------------------------------------------------------
 
@@ -241,7 +242,12 @@
   [{:keys [kind id frame schema doc source-coord] :as _row}]
   (let [id-text (pr-str id)
         row-id  (str (name kind) "-" id-text)]
+    ;; rf2-mq8wk — list semantics. Schema rows are non-interactive
+    ;; catalogue entries (the only row-level affordance is the
+    ;; `open-chip` jump-to-source, which is itself focusable), so
+    ;; `role=listitem` is the correct shape rather than `role=button`.
     [:li {:data-testid (str "rf-causa-static-schemas-row-" row-id)
+          :role        "listitem"
           :style       {:display       "block"
                         :padding       "6px 12px"
                         :font-family   mono-stack
@@ -266,13 +272,21 @@
          (pr-str frame)])
       (when (and source-coord (:file source-coord))
         [open-in-editor/open-chip source-coord])]
-     [:div {:style {:margin-left "20px"
+     ;; rf2-2kwhw — the Malli schema EDN renders through the shared
+     ;; cljs-devtools EDN widget (spec 007:119 — "all values rendered
+     ;; via the cljs-devtools-shaped renderer") rather than raw
+     ;; `pr-str` + `[:code]`, so it gains expand/collapse, syntax-
+     ;; colouring parity, and the per-node copy host (rf2-f026h). The
+     ;; `node-key` is stable per (kind,id) so expand state survives
+     ;; reloads and doesn't collide across rows.
+     [:div {:data-testid (str "rf-causa-static-schemas-schema-" row-id)
+            :style {:margin-left "20px"
                     :margin-top  "2px"
                     :color       (:text-secondary tokens)
                     :font-size   "11px"
                     :white-space "pre-wrap"
                     :word-break  "break-word"}}
-      [:code (pr-str schema)]]
+      (edn/inspect schema (str "static-schemas/" row-id))]
      (when doc
        [:div {:style {:margin-left "20px"
                       :margin-top  "2px"
@@ -334,6 +348,7 @@
         (if (empty? schemas)
           (empty-filtered query)
           (into [:ul {:data-testid "rf-causa-static-schemas-list"
+                      :role        "list"
                       :style       {:list-style     "none"
                                     :margin         "8px 0 0 0"
                                     :padding        "0 8px"

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -711,6 +711,22 @@
     "[data-rf-force-colors=\"active\"] [data-testid=\"rf-causa-shell\"] a,\n"
     "[data-rf-force-colors=\"active\"] [data-testid=\"rf-causa-static-shell\"] a {\n"
     "  color: LinkText !important;\n"
+    "}\n"
+    ;; rf2-f026h — universal EDN-widget copy affordance hover-reveal. The
+    ;; `⎘` copy button (widget/copy-affordance) rides on every browse /
+    ;; inspect render's `position:relative` root. It paints recessed
+    ;; (low opacity) at rest so it doesn't clutter the dense value tree,
+    ;; and lifts to full opacity when the operator hovers the value
+    ;; container or tabs into the button (`:focus-within` covers the
+    ;; keyboard path). Like re-frame-10x, the copy gesture is present on
+    ;; every value but stays out of the way until reached for.
+    "[data-testid^=\"rf-causa-edn-widget-browse-\"] .rf-causa-edn-widget-copy {\n"
+    "  opacity: 0.18;\n"
+    "  transition: opacity 120ms ease-out;\n"
+    "}\n"
+    "[data-testid^=\"rf-causa-edn-widget-browse-\"]:hover .rf-causa-edn-widget-copy,\n"
+    "[data-testid^=\"rf-causa-edn-widget-browse-\"]:focus-within .rf-causa-edn-widget-copy {\n"
+    "  opacity: 1;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -59,6 +59,7 @@
   cljs-devtools dep is Causa-only; the `:devtools/preloads` gate keeps
   it out of production bundles per the contract in `tools/README.md`."
   (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [day8.re-frame2-causa.data-display.render :as data-display]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
@@ -71,6 +72,64 @@
 ;; delegate to `browse` / `mini`, which are defined further down — forward
 ;; declare so the facade can sit at the top of the file where callers look.
 (declare browse mini)
+
+;; ---- universal copy-to-clipboard affordance (rf2-f026h) ------------------
+;;
+;; re-frame-10x makes every value copyable. Pre-f026h the only copy
+;; gesture in Causa lived on the App-DB diff panel's section headers
+;; (`diff/render.cljs` → `:rf.causa/copy-{path,value}-to-clipboard`);
+;; the Event lens, Trace, segment-inspector, and the Static panels —
+;; 7 of 8 EDN surfaces — had none. Rather than thread a copy button
+;; into each panel, the affordance rides on the WIDGET ROOT so it
+;; lands on every `browse` (and therefore `inspect`) call — Trace's
+;; `edn/browse`, the segment-inspector + Event lens + Static panels'
+;; `edn/inspect`, all at once.
+;;
+;; The `:rf.causa/copy-value-to-clipboard` event + the
+;; `:rf.causa.fx/copy-to-clipboard` fx are registered process-globally
+;; by `app-db-diff-events/install!` (always called from
+;; `registry.cljs`), so the dispatch resolves on every surface. The
+;; dispatch carries `{:frame :rf/causa}` for the same reason the
+;; segment-inspector's affordances do: `:on-click` fires after React
+;; pops the frame context, so without the explicit envelope the
+;; dispatch would land on `:rf/default`.
+
+(defn copy-affordance
+  "A hover-revealed `⎘` copy button that copies `value` to the
+  clipboard via `:rf.causa/copy-value-to-clipboard`. Pure hiccup —
+  positioned `absolute` top-right of a `position:relative` parent. The
+  `testid` is derived from the widget's render container id so tests can
+  target the per-render affordance. The `⎘` glyph is the same
+  click-to-copy mark spec 007:668 uses for the namespace-fade keyword
+  copy."
+  [value testid]
+  [:button {:data-testid testid
+            :aria-label  "Copy value to clipboard"
+            :title       "Copy value"
+            :on-click    (fn [^js e]
+                           (.stopPropagation e)
+                           (rf/dispatch [:rf.causa/copy-value-to-clipboard value]
+                                        {:frame :rf/causa}))
+            :class       "rf-causa-edn-widget-copy"
+            :style       {:position      "absolute"
+                          :top           "2px"
+                          :right         "2px"
+                          :z-index       1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-secondary tokens)
+                          :border        (str "1px solid " (:border-subtle tokens))
+                          :border-radius "3px"
+                          :cursor        "pointer"
+                          :font-family   mono-stack
+                          :font-size     "11px"
+                          :line-height   1
+                          :padding       "2px 5px"
+                          ;; Recede until the parent is hovered. The
+                          ;; in-bundle stylesheet (theme/css) reveals it
+                          ;; on `:hover` / `:focus-within`; tests assert
+                          ;; on presence + dispatch, not the CSS reveal.
+                          :opacity       0.55}}
+   "⎘"])
 
 ;; ---- panel-facing facade — inspect / inspect-inline ----------------------
 ;;
@@ -166,17 +225,28 @@
   ;; routes through cljs-devtools. Collections expand into the nested
   ;; tree; scalars render as a single coloured span. The home-grown
   ;; render-tree is now diff-only.
-  [:div {:data-testid (str "rf-causa-edn-widget-browse-"
-                           (name (or panel-id :unknown))
-                           "-"
-                           (str (or render-id "")))
-         :style {:font-family mono-stack
-                 :font-size   "12px"
-                 :color       (:text-primary tokens)
-                 :line-height 1.4}}
-   (if (some? max-depth)
-     (cdt/value->tree-hiccup value max-depth)
-     (cdt/value->tree-hiccup value))])
+  ;;
+  ;; rf2-f026h — the universal copy affordance rides on this root, so
+  ;; every browse/inspect surface (Trace, segment-inspector, Event
+  ;; lens, Static panels) gets a copy-to-clipboard gesture. The
+  ;; container is `position:relative` to anchor the absolutely-
+  ;; positioned `⎘` button at its top-right; padding-right reserves
+  ;; the gutter so the button never overlaps a wide value's first line.
+  (let [container-id (str "rf-causa-edn-widget-browse-"
+                          (name (or panel-id :unknown))
+                          "-"
+                          (str (or render-id "")))]
+    [:div {:data-testid container-id
+           :style {:position    "relative"
+                   :font-family mono-stack
+                   :font-size   "12px"
+                   :color       (:text-primary tokens)
+                   :line-height 1.4
+                   :padding-right "26px"}}
+     (copy-affordance value (str container-id "-copy"))
+     (if (some? max-depth)
+       (cdt/value->tree-hiccup value max-depth)
+       (cdt/value->tree-hiccup value))]))
 
 ;; ---- variant: diff -------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
@@ -265,3 +265,68 @@
     (let [tree (panel/Panel)]
       (is (some? (find-by-testid tree "rf-causa-static-flows-empty-filtered"))
           "empty-filtered surface mounts when query removes every row"))))
+
+;; -------------------------------------------------------------------------
+;; (4) a11y list semantics (rf2-mq8wk)
+;; -------------------------------------------------------------------------
+
+(defn- find-by-role [tree role]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= role (:role (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(deftest panel-list-carries-list-semantics
+  (testing "rf2-mq8wk — the flows <ul> is role=list, rows are role=listitem"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.flows/set-registered-flows-override-for-test
+         sample-flows])
+      (let [tree (panel/Panel)
+            list-node (find-by-testid tree "rf-causa-static-flows-list")
+            rows      (find-all-by-testid-prefix
+                        tree "rf-causa-static-flows-row-")]
+        (is (= "list" (:role (second list-node))) "<ul> carries role=list")
+        (is (seq rows) "rows rendered")
+        (is (every? #(= "listitem" (:role (second %))) rows)
+            "every row carries role=listitem")))))
+
+;; -------------------------------------------------------------------------
+;; (5) EDN values render through the shared widget (rf2-2kwhw + rf2-f026h)
+;; -------------------------------------------------------------------------
+
+(deftest input-output-render-through-edn-widget
+  (testing "rf2-2kwhw — input + output paths render via the shared EDN
+            widget (cljs-devtools browse container), not raw pr-str"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.flows/set-registered-flows-override-for-test
+         sample-flows])
+      (let [tree (panel/Panel)
+            widget-nodes (find-all-by-testid-prefix
+                           tree "rf-causa-edn-widget-browse-inspect-")]
+        (is (seq widget-nodes)
+            "at least one cljs-devtools browse container present")))))
+
+(deftest edn-widget-values-carry-copy-affordance
+  (testing "rf2-f026h — the universal copy button rides on the Static
+            flows EDN renders"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.flows/set-registered-flows-override-for-test
+         sample-flows])
+      (let [tree (panel/Panel)
+            copy-buttons (filterv
+                           (fn [node]
+                             (and (vector? node)
+                                  (map? (second node))
+                                  (= "rf-causa-edn-widget-copy"
+                                     (:class (second node)))))
+                           (hiccup-seq tree))]
+        (is (seq copy-buttons)
+            "copy affordance present on the widget-rendered values")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/interceptors/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/interceptors/panel_cljs_test.cljs
@@ -176,3 +176,23 @@
     (rf/dispatch-sync [:rf.causa.static.interceptors/set-query "no-such-id"])
     (let [tree (panel/Panel)]
       (is (some? (find-by-testid tree "rf-causa-static-interceptors-empty-filtered"))))))
+
+;; -------------------------------------------------------------------------
+;; (4) a11y list semantics (rf2-mq8wk)
+;; -------------------------------------------------------------------------
+
+(deftest panel-list-carries-list-semantics
+  (testing "rf2-mq8wk — the interceptors <ul> is role=list, rows role=listitem"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.interceptors/set-registry-override-for-test
+         sample-events-with-chains])
+      (let [tree (panel/Panel)
+            list-node (find-by-testid tree "rf-causa-static-interceptors-list")
+            rows (find-all-by-testid-prefix
+                   tree "rf-causa-static-interceptors-row-")]
+        (is (= "list" (:role (second list-node))) "<ul> carries role=list")
+        (is (seq rows) "rows rendered")
+        (is (every? #(= "listitem" (:role (second %))) rows)
+            "every row carries role=listitem")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
@@ -344,3 +344,110 @@
             "Static Routes panel mounted via the shell's :routes branch")
         (is (nil? (find-by-testid tree "rf-causa-static-placeholder-routes"))
             "the :routes placeholder card is no longer rendered")))))
+
+;; ---- (10) a11y list semantics + keyboard operability (rf2-mq8wk) -------
+
+(defn- find-by-role [tree role]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= role (:role (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-role [tree role]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (= role (:role (second node)))))
+          (hiccup-seq tree)))
+
+(deftest routes-list-rows-keyboard-operable
+  (testing "rf2-mq8wk — the routes <ul> is role=list, rows are
+            role=listitem, and the clickable body is a keyboard-operable
+            role=button (tab-index 0 + aria-expanded + Enter/Space)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree      (panel/Panel)
+            list-node (find-by-testid tree "rf-causa-static-routes-list")
+            listitems (find-all-by-role tree "listitem")
+            buttons   (find-all-by-role tree "button")]
+        (is (= "list" (:role (second list-node))) "<ul> carries role=list")
+        (is (= (count cart-routes) (count listitems))
+            "one role=listitem per route row")
+        ;; Each interactive row body is a role=button with the keyboard
+        ;; contract — tab-index 0, aria-expanded, on-key-down handler.
+        (let [row-buttons (filter #(= "0" (:tab-index (second %))) buttons)]
+          (is (= (count cart-routes) (count row-buttons))
+              "one keyboard-focusable button body per row")
+          (is (every? #(contains? (second %) :aria-expanded) row-buttons)
+              "row buttons expose aria-expanded")
+          (is (every? #(fn? (:on-key-down (second %))) row-buttons)
+              "row buttons handle keyboard activation"))))))
+
+(deftest routes-row-enter-key-activates-toggle
+  (testing "rf2-mq8wk — Enter / Space on a row body consume the key and fire
+            the row toggle; other keys are ignored (bubble through)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree     (panel/Panel)
+            ;; the cart row's clickable body is the role=button whose
+            ;; aria-label mentions the cart route.
+            row-body (some (fn [node]
+                             (when (and (vector? node)
+                                        (map? (second node))
+                                        (= "button" (:role (second node)))
+                                        (let [al (:aria-label (second node))]
+                                          (and al (.includes al ":route/cart"))))
+                               node))
+                           (hiccup-seq tree))
+            on-key   (:on-key-down (second row-body))
+            mk-ev    (fn [k prevented?]
+                       #js {:key k
+                            :preventDefault (fn [] (reset! prevented? true))})]
+        (is (some? on-key) "row body has a keydown handler")
+        (testing "Enter is consumed (preventDefault called)"
+          (let [prevented (atom false)]
+            (on-key (mk-ev "Enter" prevented))
+            (is (true? @prevented))))
+        (testing "Space is consumed (preventDefault called)"
+          (let [prevented (atom false)]
+            (on-key (mk-ev " " prevented))
+            (is (true? @prevented))))
+        (testing "an unrelated key is NOT consumed (bubbles for global keys)"
+          (let [prevented (atom false)]
+            (on-key (mk-ev "a" prevented))
+            (is (false? @prevented))))))))
+
+;; ---- (11) expand-surface EDN renders via the shared widget (2kwhw+f026h) --
+
+(deftest expand-meta-renders-through-edn-widget-with-copy
+  (testing "rf2-2kwhw + rf2-f026h — the registrar-meta block routes through
+            the shared cljs-devtools EDN widget and carries a copy button"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)
+            ;; the meta block wrapper still carries its legacy testid;
+            ;; inside it the widget's browse container + copy button ride.
+            widget (find-all-by-testid-prefix
+                     tree "rf-causa-edn-widget-browse-")
+            copy   (filter (fn [node]
+                             (and (vector? node)
+                                  (map? (second node))
+                                  (= "rf-causa-edn-widget-copy"
+                                     (:class (second node)))))
+                           (hiccup-seq tree))]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-meta-route/cart"))
+            "meta block wrapper preserved")
+        (is (seq widget)
+            "registrar meta renders through the cljs-devtools browse widget")
+        (is (seq copy)
+            "the meta value carries the universal copy affordance")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
@@ -259,3 +259,46 @@
       ;; have an open chip resolved through the editor config.
       (is (pos? (count chips))
           "at least one jump-to-source chip rendered"))))
+
+;; -------------------------------------------------------------------------
+;; (4) a11y list semantics (rf2-mq8wk)
+;; -------------------------------------------------------------------------
+
+(deftest panel-list-carries-list-semantics
+  (testing "rf2-mq8wk — the schemas <ul> is role=list, rows role=listitem"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.schemas/set-registry-override-for-test
+         sample-registry])
+      (let [tree (panel/Panel)
+            list-node (find-by-testid tree "rf-causa-static-schemas-list")
+            rows (find-all-by-testid-prefix tree "rf-causa-static-schemas-row-")]
+        (is (= "list" (:role (second list-node))) "<ul> carries role=list")
+        (is (seq rows) "rows rendered")
+        (is (every? #(= "listitem" (:role (second %))) rows)
+            "every row carries role=listitem")))))
+
+;; -------------------------------------------------------------------------
+;; (5) schema EDN renders through the shared widget (rf2-2kwhw + rf2-f026h)
+;; -------------------------------------------------------------------------
+
+(deftest schema-edn-renders-through-widget-with-copy
+  (testing "rf2-2kwhw + rf2-f026h — the Malli schema renders via the shared
+            cljs-devtools EDN widget and carries the universal copy button"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync
+        [:rf.causa.static.schemas/set-registry-override-for-test
+         sample-registry])
+      (let [tree (panel/Panel)
+            widget (find-all-by-testid-prefix
+                     tree "rf-causa-edn-widget-browse-")
+            copy   (filterv (fn [node]
+                              (and (vector? node)
+                                   (map? (second node))
+                                   (= "rf-causa-edn-widget-copy"
+                                      (:class (second node)))))
+                            (hiccup-seq tree))]
+        (is (seq widget) "schema values render through the browse widget")
+        (is (seq copy) "each schema value carries the copy affordance")))))

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -18,9 +18,21 @@
      attributes are set; long pr-str gets truncated in `:data-pr`.
 
   Pure-data scope — no DOM mount; hiccup-shape assertions only."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.app-db-diff-events :as diff-events]
             [day8.re-frame2-causa.views.edn-widget.widget :as w]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+
+;; A plain-atom runtime fixture so the copy-affordance dispatch test
+;; (rf2-f026h) can fire the registered `:rf.causa/copy-value-to-
+;; clipboard` event end-to-end. The pure-data tests below don't need
+;; it but are unaffected by its presence.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -114,6 +126,84 @@
       (is (some? (find-by-testid out
                                  "rf-causa-edn-widget-browse-test-scalar-1")))
       (is (contains-text? out ":foo/bar")))))
+
+;; ---- universal copy-to-clipboard affordance (rf2-f026h) ------------------
+;;
+;; Every `browse` (and therefore `inspect`) render carries a `⎘` copy
+;; button on its `position:relative` root so the copy gesture rides to
+;; Trace, the segment-inspector, the Event lens, and the Static panels
+;; at once. The button's testid is the render container id + "-copy",
+;; its aria-label is set, and its on-click dispatches
+;; `:rf.causa/copy-value-to-clipboard` with the rendered value.
+
+(deftest browse-exposes-copy-affordance
+  (let [out (w/browse {:value     {:a 1}
+                       :panel-id  :test
+                       :render-id "copy-1"})]
+    (testing "the copy button rides on the browse root"
+      (let [btn (find-by-testid
+                  out "rf-causa-edn-widget-browse-test-copy-1-copy")]
+        (is (some? btn) "copy affordance present")
+        (is (= :button (first btn)))
+        (is (= "Copy value to clipboard" (:aria-label (second btn)))
+            "aria-label set for screen readers")
+        (is (fn? (:on-click (second btn)))
+            "on-click is wired")))
+    (testing "the browse root is position:relative so the button anchors"
+      (let [root (find-by-testid out "rf-causa-edn-widget-browse-test-copy-1")]
+        (is (= "relative" (-> root second :style :position)))))))
+
+(deftest inspect-exposes-copy-affordance
+  (let [out (w/inspect {:a 1} "node-copy")]
+    (testing "inspect (the panel-facing facade) also carries the copy button"
+      (is (some? (find-by-testid
+                   out "rf-causa-edn-widget-browse-inspect-node-copy-copy"))))))
+
+(deftest copy-affordance-helper-dispatches-copy-value
+  ;; `copy-affordance` is public; assert its shape directly. The
+  ;; on-click stops propagation (so a row-toggle click underneath
+  ;; doesn't fire) and dispatches the value-copy event — the same
+  ;; event the App-DB diff panel's Copy-value button uses.
+  (let [btn (w/copy-affordance {:k :v} "some-testid")]
+    (is (= :button (first btn)))
+    (is (= "some-testid" (:data-testid (second btn))))
+    (is (= "rf-causa-edn-widget-copy" (:class (second btn)))
+        "carries the hover-reveal class the global stylesheet targets")))
+
+(deftest copy-affordance-onclick-dispatches-copy-event
+  ;; End-to-end: install the diff-events leaf (which registers
+  ;; `:rf.causa/copy-value-to-clipboard` + `:rf.causa.fx/copy-to-
+  ;; clipboard`), stub the clipboard fx to capture the payload, then
+  ;; invoke the copy button's on-click with a stub event. The captured
+  ;; text must be the pr-str of the rendered value — proving the
+  ;; widget's copy gesture is wired to the shared copy machinery.
+  (diff-events/install!)
+  (frame/reg-frame :rf/causa {})
+  (let [captured (atom nil)]
+    (rf/reg-fx :rf.causa.fx/copy-to-clipboard
+      (fn [_ {:keys [text]}] (reset! captured text)))
+    (let [btn      (w/copy-affordance {:k :v} "t")
+          on-click (:on-click (second btn))
+          stop?    (atom false)
+          stub-ev  #js {:stopPropagation (fn [] (reset! stop? true))}]
+      (rf/with-frame :rf/causa
+        (on-click stub-ev))
+      ;; flush the queued dispatch
+      (rf/dispatch-sync [:rf.causa/copy-value-to-clipboard {:k :v}])
+      (is (true? @stop?) "on-click stops propagation so a row-toggle won't fire")
+      (is (= (pr-str {:k :v}) @captured)
+          "clipboard fx received the pr-str of the value"))))
+
+(deftest redacted-sentinel-has-no-copy-affordance
+  ;; Security posture: `:rf/redacted` keeps the bespoke chip chrome and
+  ;; never routes through `browse`, so it gets NO copy gesture — a
+  ;; redacted value must never be copyable. (spec/015 + 007 §Sentinel)
+  (let [out (w/inspect :rf/redacted "node-redacted")]
+    (testing "no copy button on a redacted sentinel"
+      (let [ids (->> (walk-hiccup out)
+                     (keep #(some-> (second %) :data-testid))
+                     (filter string?))]
+        (is (not-any? #(.endsWith % "-copy") ids))))))
 
 ;; ---- variant: diff -------------------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

A three-item Causa Static-panel polish cluster (re-frame-10x quality bar), all sharing the Static panels + the shared cljs-devtools EDN widget. Sequenced smallest → biggest.

- **rf2-mq8wk (P3) — Static list a11y.** The Interceptors + Routes browse lists rendered bare `<ul>/<li>` with no `role=list` / `role=listitem`, and the interactive Routes rows (which toggle an inline expand) were not keyboard-focusable. Added list semantics everywhere; the Routes row body now carries the L2 event-row recipe (`role=button` + `tab-index=0` + `aria-expanded` + `aria-label` + Enter/Space activation, mirroring `shell.cljs:1068`). Flows + Schemas rows are non-interactive catalogue entries → `role=listitem`. Machines browse list already had `role=listbox`/`role=option`, left as-is.

- **rf2-2kwhw (P2) — Static EDN through the shared widget.** Zero Static panels used the cljs-devtools EDN widget (App-DB / Event / Trace / segment-inspector all do); they rendered values via raw `pr-str` + `[:code]`, violating spec 007:119. Routed every Static value render through `edn/inspect` (the canonical L4 renderer the segment-inspector uses), with stable per-render node-keys: Flows input/output paths, Schemas Malli EDN, Routes `:params`/`:query`/registrar-meta blocks (legacy per-block testids preserved) + matched-keys. This was the largest visual-consistency gap from the rf2-fnphk audit.

- **rf2-f026h (P1) — universal copy-to-clipboard.** Copy existed only on the App-DB diff panel. Added a hover-revealed `⎘` copy button on the **widget root** (`browse` → `inspect`), so the gesture rides to Trace, the segment-inspector, the Event lens, and the Static panels (now widget-routed) at once. Dispatches the existing process-global `:rf.causa/copy-value-to-clipboard` event with `{:frame :rf/causa}`; stops propagation so a row-toggle underneath doesn't fire. `:rf/redacted` / `:rf/large` sentinels keep their bespoke chip chrome and never route through `browse`, so a redacted value stays non-copyable — the correct security posture.

## Test plan

- [x] `npm run test:cljs` (from `implementation/`): **4040 tests, 12234 assertions, 0 failures, 0 errors** (12233 → 12234, new tests running).
- [x] `clojure -M:test` (from `tools/causa/`, JVM pure-data subset): **849 tests, 2778 assertions, 0 failures, 0 errors**.
- [x] No spec/*.md touched → no `mkdocs build --strict` needed.
- [x] Tests are pure-hiccup shape assertions (browser-independent) → no `test:browser` needed.

New regression coverage:
- Widget: copy affordance present on `browse`/`inspect`, on-click dispatches `:rf.causa/copy-value-to-clipboard` end-to-end (clipboard fx stubbed, captures the pr-str), redacted sentinel has NO copy button.
- Static panels: `role=list`/`role=listitem` present; Routes row body keyboard contract (Enter/Space consume + activate, unrelated keys bubble); values render through the widget browse container + carry the copy button.