### PR TITLE
docs(skill): re-frame-migration :on-create seeding + 560px + metadata (3 beads)

### DIFF
--- a/skills/re-frame-migration/README.md
+++ b/skills/re-frame-migration/README.md
@@ -1,6 +1,6 @@
 # re-frame-migration
 
-> ↑ [`skills/`](../) — index of all six re-frame2 skills.
+> ↑ [`skills/`](../) — index of all eight re-frame2 skills.
 
 A `Skill` that helps `Claude Code` **migrate an existing re-frame v1.x ClojureScript codebase to [re-frame2](https://github.com/day8/re-frame2)** — from `re-frame/re-frame` deps to `day8/re-frame2`, mechanical rewrites applied automatically, judgment-call call sites flagged for human review.
 
@@ -65,7 +65,8 @@ skills/re-frame-migration/
 │   ├── auto-cross-cutting.md      # Type A: cross-cutting renames, views, init, artefacts
 │   ├── guided-handlers-state.md   # Type B: handler / view / db-seeding walkthroughs
 │   ├── guided-interceptors-subs.md# Type B: interceptor / sub / payload walkthroughs
-│   └── output-format.md           # The migration-summary shape
+│   ├── output-format.md           # The migration-summary shape
+│   └── error-events.md            # Pointer to Spec 009's error-event catalogue (single source)
 └── spec/
     ├── design.md                  # Locked design decisions
     ├── inputs.md                  # Canonical inputs the skill leans on

--- a/skills/re-frame-migration/references/causa-replaces-10x.md
+++ b/skills/re-frame-migration/references/causa-replaces-10x.md
@@ -108,7 +108,7 @@ The recommended host CSS reads its `flex-basis` from a single CSS custom propert
 [data-rf-causa-host] { --rf-causa-inline-width: 380px; }
 ```
 
-The default (`420px`) is the same one Causa ships in its config defaults. A 320px floor is built into the recommended CSS (`min-width: 320px`) so the panel never collapses below readable.
+The default (`560px`) is the same one Causa ships in its config defaults. A 320px floor is built into the recommended CSS (`min-width: 320px`) so the panel never collapses below readable.
 
 The custom property is the **only** supported resize knob. Don't fork the `flex-basis` literal; readers (linters, tooling, story-mode chrome) look for the property name. See [`tools/causa/spec/API.md` §Resizing the inline host](../../../tools/causa/spec/API.md) for the full contract.
 

--- a/skills/re-frame-migration/references/guided-handlers-state.md
+++ b/skills/re-frame-migration/references/guided-handlers-state.md
@@ -149,7 +149,7 @@ If the author declines, document the warning in the report.
 **Decision shape**:
 
 1. **Author the `:on-create` event**. `(rf/reg-frame :rf/default {:on-create [[:app/seed initial-state]]})` plus the `[:app/seed initial]` event handler that writes the seed into `app-db`.
-2. **Move the seed to test fixtures only** if the seed is test-specific. (`with-frame` in `re-frame.test-support` accepts an `:initial-db` opt.)
+2. **Move the seed to test fixtures only** if the seed is test-specific. Seed the test frame the same way — via `:on-create` — never a top-level `app-db` poke: `(rf/with-frame [f (rf/make-frame {:on-create [:test/seed initial]})] ...)`.
 
 Present the seed value and the proposed rewrite; confirm with the author; apply both the M-1 require-removal and the M-15 `:on-create` rewrite together.
 

--- a/skills/re-frame-migration/spec/design.md
+++ b/skills/re-frame-migration/spec/design.md
@@ -89,41 +89,43 @@ Per Mike's standing memory rule "Findings is local-only" — any exploration of 
 
 ```
 skills/re-frame-migration/
-├── SKILL.md                       (router; ~190 lines)
-├── README.md                      (human-facing intro; ~70 lines)
+├── SKILL.md                       (router; ~120 lines)
+├── README.md                      (human-facing intro; ~80 lines)
 ├── LICENSE                        (MIT, mirrors re-frame2-setup)
 ├── package.json                   (npm metadata for distribution)
 ├── .claude-plugin/plugin.json     (Claude Code plugin metadata)
 ├── references/
-│   ├── kickoff-prompt.md           (~60 lines)
-│   ├── setup.md                    (~130 lines)
-│   ├── breaking-changes.md         (~180 lines)
-│   ├── sequencing.md               (~100 lines)
-│   ├── auto-call-site-rewrites.md  (~180 lines; Type A — ns / effect-map / dispatch)
-│   ├── auto-cross-cutting.md       (~175 lines; Type A — keywords / interceptors / views / init / artefacts)
-│   ├── guided-handlers-state.md    (~145 lines; Type B — handler / view / db-seeding / error-handler)
-│   ├── guided-interceptors-subs.md (~150 lines; Type B — interceptor / sub / payload / observer)
-│   └── output-format.md            (~110 lines)
+│   ├── kickoff-prompt.md           (~70 lines)
+│   ├── setup.md                    (~170 lines)
+│   ├── causa-replaces-10x.md       (~240 lines; devtools swap — re-frame-10x → Causa)
+│   ├── breaking-changes.md         (~150 lines)
+│   ├── sequencing.md               (~150 lines)
+│   ├── auto-call-site-rewrites.md  (~250 lines; Type A — ns / effect-map / dispatch)
+│   ├── auto-cross-cutting.md       (~290 lines; Type A — keywords / interceptors / views / init / artefacts)
+│   ├── guided-handlers-state.md    (~160 lines; Type B — handler / view / db-seeding / error-handler)
+│   ├── guided-interceptors-subs.md (~155 lines; Type B — interceptor / sub / payload / observer)
+│   ├── output-format.md            (~115 lines)
+│   └── error-events.md             (~95 lines; pointer to Spec 009's error-event catalogue)
 └── spec/
     ├── design.md                  (this file)
     ├── inputs.md                  (the canonical inputs the skill leans on)
     └── authoring-prompt.md        (one-shot reauthor prompt)
 ```
 
-**Totals**: SKILL.md (~190) + 9 reference leaves (~1,130) + 3 spec files (~250) ≈ ~1,570 LoC across 13 files. Every leaf comfortably under the 250-line ceiling; SKILL.md well under the 500-line Anthropic guideline.
+**Totals**: SKILL.md (~120) + 11 reference leaves (~1,850) + 3 spec files (~330) ≈ ~2,300 LoC across 15 markdown files. Most leaves sit under the 250-line soft ceiling; the two Type A catalogues (`auto-call-site-rewrites.md` ~250, `auto-cross-cutting.md` ~290) run to the cap or just over because their shape-catalogue content resists further splitting. SKILL.md is well under the 500-line Anthropic guideline.
 
 **Type A / Type B split into two leaves each.** The 365L `automated-transforms.md` and 300L `guided-checklist.md` originals violated the 250-line soft ceiling. They've been split along natural cluster boundaries: Type A divides into per-call-site rewrites (ns / effect-map / dispatch shapes) and cross-cutting (keyword renames / interceptor cleanup / views / init / artefact adds); Type B divides into handler-state-shaped (M-3, M-5, M-10, M-11, M-12, M-13, M-14, M-15) and interceptor-sub-payload-shaped (M-17, M-18, M-19, M-21, M-23, M-26). All four leaves remain one level deep from SKILL.md — no SKILL → A → B chains.
 
 ## 6. Why the leaf split
 
-The nine reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical migration session loads:
+The eleven reference leaves are sized to load on demand without spending context budget on irrelevant detail. Typical migration session loads:
 
-- **Phase 2 (bump-only success)**: `setup.md` + `output-format.md`. ~240 LoC.
-- **Phase 3 (sweep with Type A only)**: `auto-call-site-rewrites.md` + `auto-cross-cutting.md` + `breaking-changes.md` + `sequencing.md` + `output-format.md`. ~745 LoC.
-- **Phase 3 (sweep with Type A + Type B)**: add the relevant `guided-*.md` (typically one; both for cross-surface migrations). ~890–1,040 LoC.
-- **Full migration (rare)**: all nine reference leaves. ~1,130 LoC.
+- **Phase 2 (bump-only success)**: `setup.md` + `output-format.md`. ~285 LoC.
+- **Phase 3 (sweep with Type A only)**: `auto-call-site-rewrites.md` + `auto-cross-cutting.md` + `breaking-changes.md` + `sequencing.md` + `output-format.md`. ~960 LoC.
+- **Phase 3 (sweep with Type A + Type B)**: add the relevant `guided-*.md` (typically one; both for cross-surface migrations). ~1,120–1,280 LoC.
+- **Full migration (rare)**: all eleven reference leaves. ~1,850 LoC.
 
-Even the worst case is well under any reasonable context budget; the median case is ~25% of the total skill content. The Type A split lets a Phase-3 sweep that only trips per-call-site rules load `auto-call-site-rewrites.md` (~180L) without dragging in the cross-cutting catalogue (and vice versa). Likewise the Type B split lets a sub-only migration load just `guided-interceptors-subs.md`.
+Even the worst case is well under any reasonable context budget; the median case is ~25% of the total skill content. The Type A split lets a Phase-3 sweep that only trips per-call-site rules load `auto-call-site-rewrites.md` (~250L) without dragging in the cross-cutting catalogue (and vice versa). Likewise the Type B split lets a sub-only migration load just `guided-interceptors-subs.md`.
 
 ## 7. Anti-patterns the skill explicitly resists
 


### PR DESCRIPTION
## Summary

Three correctness/metadata fixes to the `re-frame-migration` skill, all grounded against `spec/`, the v1->v2 corpus (`migration/from-re-frame-v1/README.md`), and `tools/causa/spec/API.md`.

- **:on-create seeding (P1)** — `references/guided-handlers-state.md` (M-15) referenced a non-existent `with-frame` `:initial-db` opt. Frames seed via `:on-create` only (`spec/002-Frames.md:111`; corpus M-15) — there is no `:db`/`:initial-db` config key. Replaced with the correct `(rf/with-frame [f (rf/make-frame {:on-create [:test/seed initial]})] ...)` pattern so an author writes a working seed instead of a silent no-op.
- **560px default (P3)** — `references/causa-replaces-10x.md:111` stated a stale `420px` inline-width default that contradicts the canonical `560px` (`tools/causa/spec/API.md`) and the skill's own CSS examples (lines 78, 102). Fixed to `560px`.
- **Metadata refresh (P4)** — `spec/design.md` file-structure block updated to actual line counts and the two leaves added since (`causa-replaces-10x.md`, `error-events.md` -> 11 reference leaves); totals corrected. `README.md` layout block gains the missing `error-events.md` leaf and "six skills" -> "eight skills".

## Test plan

- [x] `python scripts/check_doc_slugs.py` — pass (exit 0)
- [x] `python -m mkdocs build --strict` — pass (exit 0)
- [x] `python scripts/check_skill_redirect_anchors.py` — exit 0 (one pre-existing broken ref in `skills/re-frame2/`, unrelated to this PR)