### PR TITLE
docs(skill): fix re-frame2 stories.md 'Guide — Stories' redirect anchor (rf2-gr5s4)

### DIFF
--- a/skills/re-frame2/references/tooling/stories.md
+++ b/skills/re-frame2/references/tooling/stories.md
@@ -160,7 +160,7 @@ The dev shell's Test pane and recorder ship ergonomic affordances that consume w
 - Args precedence + four-phase lifecycle full detail → `tools/story/spec/002-Runtime.md` §Args resolution precedence, §Four-phase lifecycle.
 - Worked example, every macro at least once → `tools/story/testbeds/counter_with_stories/`.
 - The seven `:rf.assert/*` events, semantics + source-stamping → `SKILL-REDIRECT.md` → *EP — Stories (007)* §Assertions.
-- Render shell, panel placement, multi-substrate pane → `SKILL-REDIRECT.md` → *Guide — Stories*.
+- Render shell, panel placement, multi-substrate pane → `tools/story/spec/003-Render-Shell.md` §UI shell substrate, §Workspace layouts, §Multi-substrate side-by-side rendering.
 - Test Codegen (record canvas interactions as `:play-script`) → `story-recorder.md` (sibling leaf).
 - Agent self-healing loop over MCP (variant authoring → run → assert → refine) → `story-mcp-loop.md` (sibling leaf).
 - MCP write surface (programmatic registration via `reg-*` helpers) → `SKILL-REDIRECT.md` → *EP — Stories (007)* §MCP Surface.


### PR DESCRIPTION
## Summary

`skills/re-frame2/references/tooling/stories.md:163` carried a deep-material bullet that pointed at a `SKILL-REDIRECT.md` bullet label (`*Guide — Stories*`) which does not exist, so `scripts/check_skill_redirect_anchors.py` reported it BROKEN. This was pre-existing on `main` (flagged by multiple skill-fix workers).

Fix (option b — repoint the leaf ref to a real target): the "Render shell, panel placement, multi-substrate pane" material is artefact-source detail, not published-spec material, so a SKILL-REDIRECT bullet was the wrong shape. Repointed it at the accurate artefact-source doc `tools/story/spec/003-Render-Shell.md` with the three relevant sections, mirroring the sibling artefact-path bullets (lines 159–161).

## Anchor-checker result

- Before: `references BROKEN: 1` (exit 1)
- After: 0 broken (exit 0, silent-on-success)

## Test plan

- [x] `python scripts/check_skill_redirect_anchors.py` → exit 0, 0 broken
- [x] `python scripts/check_doc_slugs.py` → exit 0
- [x] `python -m mkdocs build --strict` → exit 0