### PR TITLE
ci(docs): build with --strict so nav/orphan/plugin warnings fail (rf2-eq90w)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,8 +105,14 @@ jobs:
           rm -rf docs/migration
           cp -r migration docs/migration
 
-      - name: Build site
-        run: mkdocs build
+      # --strict escalates MkDocs WARNINGs to a non-zero exit (rf2-eq90w):
+      # nav entries pointing at missing files (nav.not_found), unresolved
+      # internal links MkDocs can see, and plugin warnings now fail the
+      # build instead of slipping through. This is complementary to the
+      # check_doc_slugs.py gate above, which validates markdown-link
+      # target+anchor drift the WARNING set does not cover.
+      - name: Build site (strict)
+        run: mkdocs build --strict
 
       - name: Upload Pages artifact
         # v5 (transitively pins actions/upload-artifact to a SHA, which v3 did not — see rf2-xmmh).


### PR DESCRIPTION
## The bug

CI ran plain `mkdocs build` (`.github/workflows/docs.yml`), but `CLAUDE.md:102` and the `mkdocs_hooks.py` comment block both assert the site builds under `mkdocs build --strict`. The claim was **false**, and it masked a real coverage gap: MkDocs WARNINGs — nav entries pointing at missing files (`nav.not_found`), unresolved internal links MkDocs can see, and plugin warnings — did **not** fail the build. `scripts/check_doc_slugs.py` only validates markdown-link target+anchor drift, which is complementary to `--strict`, not a superset.

## The fix

Switch the build step to `mkdocs build --strict`. The deploy job only consumes the build artifact, so there is a single build command to change.

## Strict build was already clean

Ran `python -m mkdocs build --strict` from repo root (relying on the `on_pre_build` staging hook, the same path CI takes):

- Exit code **0**, **zero** WARNING/ERROR lines.
- No pre-existing strict warnings to sweep.

The remaining `INFO`-level messages ("exist in the docs directory, but are not included in nav", "unrecognized relative link") are **not** escalated by `--strict` (they are INFO under MkDocs 1.6 default validation). They are intentional: the staged `spec/*.md` files are reachable via the API → "Normative reference" link rather than separate nav entries. No change required, and elevating `nav.omitted_files` to a warning would be a separate, larger structural decision.

The now-true `--strict` claims in `CLAUDE.md` and `mkdocs_hooks.py` are left as-is — they describe the failure mode accurately and are aligned now that CI is genuinely strict.

## Gates

- `python -m mkdocs build --strict` (repo root) — PASS (exit 0, no warnings)
- `python scripts/check_doc_slugs.py --self-test --verbose` — PASS (11/11)
- `python scripts/check_doc_slugs.py --verbose` — PASS (362 files, no broken links)