### PR TITLE
docs(skills): published pages file gaps via GitHub issues, not bd (rf2-6pjn3)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -23,7 +23,7 @@ The repo's [`SKILL-REDIRECT.md`](https://github.com/day8/re-frame2/blob/main/SKI
 | [**re-frame2-implementor**](re-frame2-implementor.md) | Build a new re-frame2 implementation in a different host language or substrate. Two-phase workflow — Phase 1 locks the decisions; Phase 2 walks the spec corpus with conformance as the acceptance test. |
 | [**re-frame2-causa**](re-frame2-causa.md) | Read-only tour of the **Causa** devtools panel — how to launch it and which tab, across its Dynamic event-spine and Static registry-browse modes, shows X. |
 | [**re-frame2-pair**](re-frame2-pair.md) | Pair-program with a live, running re-frame2 app. Dispatch events, inspect `app-db`, walk epochs, hot-swap handlers — all via Tool-Pair contract. |
-| [**re-frame2-pair-retro**](re-frame2-pair-retro.md) | Retrospect a `re-frame2-pair` session. Surfaces friction; proposes targeted improvements; routes upstream beads to re-frame2 when the cause is framework-shaped. |
+| [**re-frame2-pair-retro**](re-frame2-pair-retro.md) | Retrospect a `re-frame2-pair` session. Surfaces friction; proposes targeted improvements; routes upstream GitHub issues to re-frame2 when the cause is framework-shaped. |
 
 ## Picking the right one
 

--- a/docs/skills/re-frame2-implementor.md
+++ b/docs/skills/re-frame2-implementor.md
@@ -34,7 +34,7 @@ A paste-ready kickoff prompt ships with the skill at [`skills/re-frame2-implemen
 
 Excerpted shape (full text in the kickoff file):
 
-> *I'm implementing a new port of re-frame2 in this repo. Walk the implementation workflow end-to-end per the `re-frame2-implementor` skill. The spec corpus is at `<path-to-re-frame2>/spec/`. Phase 1 — walk me through the decision blocks, capture each choice in `DECISIONS.md`. Phase 2 — walk the EP corpus in dependency order (001 → 002 → 006 → 004 → 009 → optional). The spec is the contract; the CLJS reference is one worked example, not normative. No core.async. JVM-runnability for the test surface. Spec gaps file `bd create` beads; never silent extrapolation. Begin with Phase 1.*
+> *I'm implementing a new port of re-frame2 in this repo. Walk the implementation workflow end-to-end per the `re-frame2-implementor` skill. The spec corpus is at `<path-to-re-frame2>/spec/`. Phase 1 — walk me through the decision blocks, capture each choice in `DECISIONS.md`. Phase 2 — walk the EP corpus in dependency order (001 → 002 → 006 → 004 → 009 → optional). The spec is the contract; the CLJS reference is one worked example, not normative. No core.async. JVM-runnability for the test surface. Spec gaps file GitHub issues against `day8/re-frame2` (ask me before filing); never silent extrapolation. Begin with Phase 1.*
 
 Two common amendments — *"minimum viable port"* (declare every optional capability `no` and ship the core only) and *"reference impl tour first"* (read the CLJS tour before locking decisions, treating the tour as descriptive).
 

--- a/docs/skills/re-frame2-pair-retro.md
+++ b/docs/skills/re-frame2-pair-retro.md
@@ -1,12 +1,12 @@
 # re-frame2-pair-retro
 
-> Turns a `re-frame2-pair` session into a product retrospective. Surfaces friction, classifies root causes, proposes 2–5 concrete improvements, and (only on explicit approval) drafts or files beads against the right repo.
+> Turns a `re-frame2-pair` session into a product retrospective. Surfaces friction, classifies root causes, proposes 2–5 concrete improvements, and (only on explicit approval) drafts or files GitHub issues against the right repo.
 
 ## What it does
 
 The `re-frame2-pair-retro` skill is a **meta-skill** for `re-frame2-pair`. It reads the current or just-finished pair-programming session and turns it into a focused retrospective: what was the user actually trying to do; where did the workflow drag, confuse, or frustrate; which problems were one-off environment issues vs recurring product gaps; and 2–5 concrete improvement ideas, prioritized by leverage, including 1–2 bolder ideas when reshaping the workflow would materially improve it.
 
-The skill is **diagnosis first**, contribution second. It presents friction points before root causes, lets the user steer which ones to dig into, and never files a bead or edits another repo without explicit approval. Improvements are routed to the right layer:
+The skill is **diagnosis first**, contribution second. It presents friction points before root causes, lets the user steer which ones to dig into, and never files a GitHub issue or edits another repo without explicit approval. Improvements are routed to the right layer:
 
 - **`re-frame2-pair`** — friction inside the pair tool itself (SKILL.md, scripts, recipes, structured results, attach/discovery brittleness, cross-platform handling).
 - **`re-frame2`** — friction caused by the framework's Tool-Pair contract (missing trace events, gaps in `epoch-history` or `restore-epoch` failure modes, missing registrar query surfaces, source-coord annotation gaps, schema-reflection shortcomings).
@@ -19,7 +19,7 @@ Load this skill when:
 
 - The user asks how `re-frame2-pair` could better support their workflow.
 - The user wants a retrospective on a debugging or pairing session that just happened.
-- The user wants concrete improvement ideas or bead drafts for `re-frame2-pair`.
+- The user wants concrete improvement ideas or GitHub-issue drafts for `re-frame2-pair`.
 
 Do **not** use this skill for:
 
@@ -37,11 +37,11 @@ The skill auto-triggers on retrospective-shaped questions ("how could re-frame2-
 
 The skill's analysis workflow runs in six steps: reconstruct the session goal, build a short timeline of stalls / restarts / detours, extract a numbered friction list (and ask the user which to dig into), classify root causes through ten lenses (skill structure / skill gap / misleading docs / missing structured op / unreliable op / default or fallback / platform bug / validation gap / upstream limitation / context-window issue), generate improvements at the right layer, and prioritize down to 2–5.
 
-Output is a compact retrospective with sections — `Goal`, `Observed friction`, `Likely root causes`, `Improvement ideas`, optional `Bolder ideas`, optional `Bead candidates`. The skill drafts bead bodies on request, but never files without explicit approval.
+Output is a compact retrospective with sections — `Goal`, `Observed friction`, `Likely root causes`, `Improvement ideas`, optional `Bolder ideas`, optional `Issue candidates`. The skill drafts GitHub-issue bodies on request, but never files without explicit approval.
 
 ## Where the skill lives
 
 - Source: [`skills/re-frame2-pair-retro/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-pair-retro)
 - `SKILL.md`: [`skills/re-frame2-pair-retro/SKILL.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame2-pair-retro/SKILL.md)
-- Reference leaves: [`skills/re-frame2-pair-retro/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-pair-retro/references) — `analysis-lenses.md` (taxonomy when a session has multiple plausible causes), `known-frictions.md` (recurring classes of `re-frame2-pair` pain — useful for sanity-checking whether a friction is one-off or a pattern), `issue-template.md` (bead-body structure).
+- Reference leaves: [`skills/re-frame2-pair-retro/references/`](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-pair-retro/references) — `analysis-lenses.md` (taxonomy when a session has multiple plausible causes), `known-frictions.md` (recurring classes of `re-frame2-pair` pain — useful for sanity-checking whether a friction is one-off or a pattern), `issue-template.md` (GitHub-issue body structure).
 - Companion skill: [`re-frame2-pair`](re-frame2-pair.md) — the skill this one retrospects.


### PR DESCRIPTION
## Summary

The published docs-site skill pages told external readers to file spec gaps and friction via `bd`/beads — the re-frame2 monorepo's **internal** mayor-method tracker. External skill users never invoke `bd`; the skills themselves file **GitHub issues** against the target repo (`day8/re-frame2` / `day8/re-frame2-pair`), and their own cardinal rules say `bd` is never invoked from a published skill. This is a published-surface hygiene fix that aligns the docs pages with the skills' actual contribution path.

Three published `docs/skills/*.md` pages had the leak:

- **`re-frame2-implementor.md`** — the kickoff-prompt excerpt said `Spec gaps file 'bd create' beads`; now `Spec gaps file GitHub issues against day8/re-frame2 (ask me before filing)`, matching the skill's actual kickoff prompt.
- **`re-frame2-pair-retro.md`** — "drafts or files beads", "never files a bead", "bead drafts", "Bead candidates", "drafts bead bodies", "bead-body structure" → GitHub-issue equivalents; `Bead candidates` corrected to `Issue candidates` to match the skill's real output section name.
- **`index.md`** — the summary row "routes upstream beads to re-frame2" → "routes upstream GitHub issues to re-frame2".

The internal `skills/*` trees already use GitHub-issue language consistently and are out of scope here.

## Test plan

- [x] `python -m mkdocs build --strict` from repo root — exit 0
- [x] `python scripts/check_doc_slugs.py` — exit 0
- [x] Grep sweep of `docs/skills/*.md` for `bd`/`bd create`/`bead` — no matches remain