### PR TITLE
docs(mkdocs): Material feature flags + palette toggle + mermaid fence + nav.indexes (rf2-zr5r5 + q0n02 + 9ewbc + qgpkm)

### DIFF
--- a/docs/cljs/index.md
+++ b/docs/cljs/index.md
@@ -1279,28 +1279,24 @@ Three paths forward, depending on what you want next:
   (intentionally not site-wide; the non-minified plugin is ~7 MB).
   Vendored locally in docs/klipse/ rather than CDN-loaded so the chapter
   works even if the upstream Klipse project (dormant since 2022) goes
-  away. Relative paths below resolve from the built /guide/00-.../ URL
-  back up to /klipse/ at the site root.
+  away.
 
-  Why the non-minified klipse_plugin.js and not klipse_plugin.min.js?
-  Both versions of Klipse 7.11.4 throw "Failed to execute 'querySelectorAll'
-  on 'Document': The provided selector is empty." at startup when the
-  user-supplied klipse_settings doesn't list a selector for every one of
-  Klipse's 40+ registered language modes. The non-minified build is the
-  only variant the upstream maintainer tests against, and it does NOT
-  exhibit that bug for ClojureScript cells when only `selector` is
-  configured.
+  The actual loading (CodeMirror CSS + klipse_settings + plugin) lives in
+  docs/klipse/klipse-bootstrap.js, wired via `extra_javascript` in
+  mkdocs.yml. That indirection is required because `navigation.instant` is
+  enabled site-wide: Material does NOT re-execute inline <script> tags in
+  page content on an instant page swap, so a reader reaching this page via
+  an in-site link would get dead cells. `extra_javascript` modules ARE
+  re-run by Material on every instant navigation, so the bootstrap fires
+  reliably and mounts the cells. The bootstrap is guarded — it does nothing
+  on pages without ```klipse cells, keeping the heavy plugin off every
+  other page. See that file's header for the full rationale, including the
+  reasons for the non-minified klipse_plugin.js and the `selector` setting.
 
-  Why `selector` (no suffix) and not `selector_eval_clojure`?
-  ClojureScript is Klipse's default mode; `selector` is the documented
-  setting key (every clojure-demo.html in the upstream repo uses it).
-  `selector_eval_clojure` is NOT a real Klipse setting — Klipse's
-  registered-mode table contains only OTHER languages (eval-javascript,
-  eval-ocaml, eval-python, …). ClojureScript is the language Klipse uses
-  for its own internals, so it has no separate mode-registration.
+  The <style> block below is plain CSS and stays inline: browsers apply
+  page-content <style> as the DOM is inserted (no script execution needed),
+  so it survives instant navigation.
 -->
-
-<link rel="stylesheet" type="text/css" href="../../klipse/codemirror.css">
 
 <style>
   /* Match Material theme: keep cells visually distinct from the static
@@ -1322,24 +1318,3 @@ Three paths forward, depending on what you want next:
     white-space: pre-wrap;
   }
 </style>
-
-<script>
-  // Material/pymdownx-superfences renders ```klipse fences as
-  // <pre class="language-klipse"><code>...</code></pre>
-  // (via the custom_fences entry in mkdocs.yml). Klipse's `selector`
-  // setting walks down from <pre> to find the <code> child, replaces
-  // it with a CodeMirror editor, and evaluates the cell contents as
-  // ClojureScript.
-  window.klipse_settings = {
-    selector: '.language-klipse',
-    codemirror_options_in: {
-      lineWrapping: true,
-      autoCloseBrackets: true,
-      matchBrackets: true
-    },
-    codemirror_options_out: {
-      lineWrapping: true
-    }
-  };
-</script>
-<script src="../../klipse/klipse_plugin.js"></script>

--- a/docs/klipse/klipse-bootstrap.js
+++ b/docs/klipse/klipse-bootstrap.js
@@ -1,0 +1,126 @@
+/*
+ * Klipse bootstrap — instant-navigation-safe loader (rf2-zr5r5).
+ *
+ * Background: the live-code ClojureScript page (docs/cljs/index.md) renders
+ * ```klipse fences as <pre class="language-klipse">…</pre> and turns each into
+ * an in-browser CodeMirror cell evaluated by the (vendored, ~7 MB) Klipse
+ * plugin. Klipse used to be wired by an inline <script> at the bottom of that
+ * page. With `navigation.instant` enabled, Material swaps page <main> content
+ * via fetch without a full reload — and it does NOT re-execute inline <script>
+ * tags in page content. So an inline-script bootstrap silently stops working
+ * the moment a reader reaches the cljs page via an in-site (instant) link.
+ *
+ * Fix: move the bootstrap into `extra_javascript`. Material RE-RUNS every
+ * `extra_javascript` module on each instant navigation, so this file fires on
+ * the initial load and on every subsequent instant page swap. It is:
+ *
+ *   - Guarded: it does nothing on pages with no `.language-klipse` cells, so
+ *     the heavy plugin loads ONLY on the cljs page (the deliberate decision
+ *     from the mkdocs audit — Klipse must NOT be site-wide).
+ *   - Idempotent: it injects the CSS, the klipse_settings, and the plugin at
+ *     most once per full document; on later instant navs back to the cljs page
+ *     it asks the already-loaded plugin to re-scan the freshly swapped DOM.
+ */
+(function () {
+  "use strict";
+
+  // Resolve sibling-asset URLs relative to THIS file's own location.
+  // MkDocs emits no <base> tag and pages reference assets with relative
+  // paths, so we can't rely on a site root. But this bootstrap and the
+  // Klipse assets (codemirror.css, klipse_plugin.js) all live together in
+  // <root>/klipse/, and Material loads this script with a correctly-pathed
+  // <script src>. `document.currentScript` is the bootstrap's own element
+  // during initial parse — capture its absolute URL once, then resolve
+  // siblings against it. Works on GitHub Pages' /re-frame2/ sub-path and at
+  // the domain root alike.
+  var selfUrl = (document.currentScript && document.currentScript.src) ||
+    (function () {
+      var scripts = document.getElementsByTagName('script');
+      for (var i = scripts.length - 1; i >= 0; i--) {
+        if (scripts[i].src && scripts[i].src.indexOf('klipse-bootstrap.js') !== -1) {
+          return scripts[i].src;
+        }
+      }
+      return '';
+    })();
+
+  function asset(path) {
+    // selfUrl ends in ".../klipse/klipse-bootstrap.js"; siblings share its
+    // directory. `new URL(name, selfUrl)` resolves name against that dir.
+    return new URL(path, selfUrl).href;
+  }
+
+  function hasCells() {
+    return document.querySelector('.language-klipse') !== null;
+  }
+
+  function injectOnce(id, build) {
+    if (document.getElementById(id)) return false;
+    build(id);
+    return true;
+  }
+
+  function loadKlipse() {
+    if (!hasCells()) return;
+
+    // 1. CodeMirror stylesheet for the live cells (once per document).
+    injectOnce('klipse-codemirror-css', function (id) {
+      var link = document.createElement('link');
+      link.id = id;
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = asset('codemirror.css');
+      document.head.appendChild(link);
+    });
+
+    // 2. Klipse settings — must exist before the plugin script runs.
+    //    `selector` keys off the .language-klipse class pymdownx.superfences
+    //    emits; Klipse walks <pre> down to its <code> child and replaces it
+    //    with a CodeMirror editor evaluating the cell as ClojureScript.
+    if (!window.klipse_settings) {
+      window.klipse_settings = {
+        selector: '.language-klipse',
+        codemirror_options_in: {
+          lineWrapping: true,
+          autoCloseBrackets: true,
+          matchBrackets: true
+        },
+        codemirror_options_out: {
+          lineWrapping: true
+        }
+      };
+    }
+
+    // 3. The plugin itself. First arrival on the cljs page loads the (heavy)
+    //    vendored plugin, which scans the DOM and mounts the cells. On a
+    //    later instant nav back to the page the plugin is already present, so
+    //    we just ask it to re-scan the freshly swapped content.
+    var injected = injectOnce('klipse-plugin-js', function (id) {
+      var script = document.createElement('script');
+      script.id = id;
+      script.src = asset('klipse_plugin.js');
+      document.body.appendChild(script);
+    });
+
+    if (!injected && window.klipse && typeof window.klipse.plugin === 'function') {
+      // Already loaded earlier this session — re-mount cells in the new DOM.
+      window.klipse.plugin(window.klipse_settings);
+    }
+  }
+
+  // Material exposes the `document$` observable, which emits on the initial
+  // load AND after every instant navigation. Subscribe ONCE when it's
+  // available (Material may re-execute this module on instant nav, so a
+  // global guard prevents stacking duplicate subscribers); otherwise fall
+  // back to a one-shot DOMContentLoaded (the no-instant case).
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    if (!window.__klipseBootstrapSubscribed) {
+      window.__klipseBootstrapSubscribed = true;
+      window.document$.subscribe(loadKlipse);
+    }
+  } else if (document.readyState !== 'loading') {
+    loadKlipse();
+  } else {
+    document.addEventListener('DOMContentLoaded', loadKlipse);
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,9 @@ nav:
   - Home: index.md
 
   - Guide:
-    - Overview: guide/README.md
+    # navigation.indexes: the section label IS the Guide overview page (no
+    # redundant "Overview" child) — see theme.features (rf2-qgpkm).
+    - guide/README.md
     - "02 — app-db": guide/02-app-db.md
     - "03 — First app": guide/03-first-app.md
     - "04 — Events": guide/04-events.md
@@ -143,7 +145,8 @@ nav:
     - "ClojureScript for non-Clojurians": cljs/index.md
 
   - Story:
-    - "Welcome": story/index.md
+    # Section label IS the Story welcome page (navigation.indexes, rf2-qgpkm).
+    - story/index.md
     - "1. Your first story": story/01-first-story.md
     - "2. Mode tabs": story/02-mode-tabs.md
     - "3. Recorder + Test Codegen": story/03-recorder-codegen.md
@@ -152,7 +155,8 @@ nav:
     - "6. Time-travel in Story": story/06-time-travel.md
     - "7. Multi-substrate side-by-side": story/07-multi-substrate.md
     - "API reference":
-      - "Overview": story/api/index.md
+      # Sub-section label IS its overview (navigation.indexes, rf2-qgpkm).
+      - story/api/index.md
       - "Registration": story/api/registration.md
       - "Play scripts": story/api/play-script.md
       - "Runtime": story/api/runtime.md
@@ -160,7 +164,8 @@ nav:
       - "Reference": story/api/reference.md
 
   - Causa:
-    - "Welcome": causa/index.md
+    # Section label IS the Causa welcome page (navigation.indexes, rf2-qgpkm).
+    - causa/index.md
     - "1. Installation": causa/01-installation.md
     - "2. Panel tour": causa/02-panel-tour.md
     - "3. Time-travel scrubbing": causa/03-time-travel.md
@@ -171,14 +176,16 @@ nav:
     - "8. Machine inspector": causa/08-machine-inspector.md
     - "9. App-DB diff": causa/09-app-db-diff.md
     - "API reference":
-      - "Overview": causa/api/index.md
+      # Sub-section label IS its overview (navigation.indexes, rf2-qgpkm).
+      - causa/api/index.md
       - "Mount control": causa/api/mount-control.md
       - "Configuration keys": causa/api/config-keys.md
       - "Runtime seam": causa/api/runtime-seam.md
       - "Reference": causa/api/reference.md
 
   - Skills:
-    - Overview: skills/index.md
+    # Section label IS the Skills overview page (navigation.indexes, rf2-qgpkm).
+    - skills/index.md
     - "re-frame2 (authoring)": skills/re-frame2.md
     - re-frame2-improver: skills/re-frame2-improver.md
     - re-frame2-setup: skills/re-frame2-setup.md
@@ -189,7 +196,8 @@ nav:
     - re-frame2-pair-retro: skills/re-frame2-pair-retro.md
 
   - API:
-    - Overview: api/README.md
+    # Section label IS the API overview page (navigation.indexes, rf2-qgpkm).
+    - api/README.md
     - "01 — Core": api/01-core.md
     - "02 — Views": api/02-views.md
     - "03 — Effects": api/03-effects.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,9 +30,26 @@ theme:
     logo: material/home
     repo: fontawesome/brands/git-alt
   language: en
+  # Light/dark palette toggle (rf2-q0n02). Two schemes share the existing
+  # blue brand colour; `media` seeds the initial scheme from the reader's OS
+  # preference, and each `toggle` adds a manual switch in the header. The
+  # blue primary/accent reads cleanly against both `default` (light) and
+  # `slate` (dark) — Material darkens the primary surface automatically.
   palette:
-    primary: blue
-    accent: blue
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
   font:
     text: IBM Plex Sans
     code: Source Code Pro

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,6 +201,14 @@ markdown_extensions:
         - name: klipse
           class: language-klipse
           format: !!python/name:pymdownx.superfences.fence_code_format
+        # Mermaid diagrams (rf2-9ewbc). Material renders ```mermaid fences
+        # natively (it ships Mermaid and wires the renderer when this fence
+        # is declared) — no extra plugin needed. Enables architecture,
+        # six-domino, state-machine, and routing-flow diagrams in the guide
+        # and spec as fenced blocks.
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.inlinehilite
   - pymdownx.details
   - pymdownx.tabbed:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,30 @@ theme:
   features:
     - navigation.tabs
     - navigation.sections
+    # navigation.indexes lets a section's own index/landing page BE the
+    # clickable section label (see the folded sections in `nav:` below)
+    # instead of a redundant "Overview"/"Welcome" first child (rf2-zr5r5,
+    # rf2-qgpkm).
+    - navigation.indexes
+    # SPA-style instant page loads + link prefetch — makes a corpus this
+    # large (26-chapter guide + multi-thousand-line spec) feel instant
+    # (rf2-zr5r5). The Klipse live-code page (docs/cljs/index.md) keeps
+    # working under instant nav: its bootstrap is an `extra_javascript`
+    # entry (see below) that Material re-runs on every instant navigation,
+    # rather than an inline <script> (which instant nav does NOT re-run).
+    - navigation.instant
+    - navigation.instant.prefetch
+    # Back-to-top affordance on long pages (spec chapters run thousands of
+    # lines).
+    - navigation.top
+    # Keep the TOC sidebar scrolled to the active heading on long pages.
+    - toc.follow
+    # Richer search — search is load-bearing for this corpus (see the
+    # `plugins:` comment). suggest = inline autocomplete, highlight = mark
+    # matches on the landed page, share = deep-link a search query.
+    - search.suggest
+    - search.highlight
+    - search.share
     - content.code.annotate
     - content.code.copy
 
@@ -67,6 +91,16 @@ theme:
 # in the list, otherwise search silently disappears.
 plugins:
   - search
+
+# Klipse live-code bootstrap (rf2-zr5r5). Small, site-wide loader that does
+# NOTHING unless the page actually has ```klipse cells (only docs/cljs/index.md
+# does), at which point it injects the CodeMirror CSS + the vendored ~7 MB
+# Klipse plugin once and re-mounts cells on later instant navigations. Lives
+# here (re-run by Material on every instant page swap) rather than as an inline
+# <script> on the page (which `navigation.instant` does NOT re-execute). The
+# heavy plugin is still loaded ONLY on the cljs page — see the file's header.
+extra_javascript:
+  - klipse/klipse-bootstrap.js
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Modernises the MkDocs Material config per the 2026-05-21 usage audit. One bundle (all four beads touch `mkdocs.yml`), sequenced smallest→biggest.

- **rf2-q0n02** — Light/dark palette toggle. Replaces the static blue palette with two Material schemes (`default` + `slate`) sharing the existing blue brand colour, each with a `prefers-color-scheme` media seed and a header toggle.
- **rf2-9ewbc** — Mermaid diagrams via a `pymdownx.superfences` custom fence (`name: mermaid`). No extra plugin; Material renders ` ```mermaid ` blocks natively. Verified rendering to `<pre class="mermaid">` via a throwaway probe page (removed).
- **rf2-zr5r5** — Cheap high-value `theme.features`: `navigation.instant` (+ `instant.prefetch`), `navigation.top`, `navigation.indexes`, `toc.follow`, `search.suggest`/`highlight`/`share`.
- **rf2-qgpkm** — Uses `navigation.indexes` to fold each section's Overview/Welcome index page into its section label (Guide, Story, Causa, API, Skills, and the Story/Causa "API reference" sub-sections). No more redundant "Overview"/"Welcome" child entries.

## Klipse vs `navigation.instant` — verification result

The audit flagged the risk: `navigation.instant` swaps `<main>` via fetch and does **not** re-execute inline `<script>` tags in page content, which would silently break the Klipse live-code page (`docs/cljs/index.md`) whenever a reader reaches it via an in-site link.

**Fix shipped (Klipse kept working under instant):** moved the Klipse bootstrap (CodeMirror CSS + `klipse_settings` + the vendored ~7 MB plugin) out of inline page scripts into an `extra_javascript` module (`docs/klipse/klipse-bootstrap.js`). Material re-runs `extra_javascript` modules and emits `document$` on every instant navigation, so the bootstrap fires reliably on initial load and on each instant swap. The bootstrap is:

- **Guarded** — does nothing on pages without `.language-klipse` cells, so the heavy plugin still loads **only** on the cljs page (the deliberate "not site-wide" decision from the audit).
- **Idempotent** — on a later instant nav back to the page it re-mounts cells via `klipse.plugin()` rather than re-injecting the 7 MB plugin.
- **Sub-path safe** — resolves sibling assets against its own script URL (MkDocs emits no `<base>`), so it works on the GitHub Pages `/re-frame2/` sub-path and at the domain root.

Verified via (a) built-HTML inspection — 87 `.language-klipse` cells render, the bootstrap is wired, no static `klipse_plugin.js` script tag on any page; and (b) a node DOM-mock smoke test of the loader logic — single `document$` subscription, correct sub-path URL resolution, no-op on non-Klipse pages, idempotent re-mount on revisit. All flags shipped (no need to drop `navigation.instant`).

## Gates

- `python -m mkdocs build --strict` — passes, **0 warnings**.
- `python scripts/check_doc_slugs.py` — passes.

## Test plan

- [ ] Verify light/dark toggle appears in the header and respects OS preference.
- [ ] Load the CLJS page directly and via an in-site (instant) link; confirm Klipse cells mount and evaluate in both cases.
- [ ] Confirm section labels (Guide/Story/Causa/API/Skills) are clickable and land on their index page.
- [ ] Drop a ` ```mermaid ` block on a page and confirm it renders as a diagram.