### PR TITLE
test(ssr): un-mask streaming fallback + prove XSS strip through render-to-string (rf2-usio0)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/head_emit_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/head_emit_cljs_test.cljc
@@ -1,0 +1,73 @@
+(ns re-frame.ssr.head-emit-cljs-test
+  "Node-runtime smoke for the CLJS branch of `head/emit/ld-json-string`.
+  Per rf2-usio0 (testcov audit ai/findings/2026-05-21-testcov-ssr.md
+  §Layer gap).
+
+  `ld-json-string` is a reader-conditional: the JVM side is a hand-rolled
+  JSON printer (exhaustively tested in `ssr_head_test.clj`), while the
+  CLJS side delegates to `js/JSON.stringify` then runs the SAME
+  script-body escape (`html/escape-script-body-string`). Before rf2-usio0
+  the CLJS branch had NO Node test — the hand-rolled JVM printer diverges
+  from the `JSON.stringify` path, and the security-critical `<script>`
+  close-tag escape on the CLJS side was unverified on Node.
+
+  This file ends in `-cljs-test` so the shadow `:node-test` build
+  (`:ns-regexp \"cljs-test$\"`) picks it up. It is `.cljc` so the same
+  assertions also run under the JVM test gate (a free belt-and-braces
+  cross-check that the two `ld-json-string` branches agree on the
+  observable contract: valid JSON envelope + escaped `<`).
+
+  We drive through `head-model->html` — the public surface that composes
+  `ld-json-string` via `emit-json-ld` — rather than the private helper,
+  so the test pins the contract a consumer actually sees."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.ssr.head.emit :as head-emit]))
+
+(deftest ld-json-string-serialises-structured-map
+  (testing "rf2-usio0 — the CLJS JSON-LD path serialises a structured map
+            and rides the <script type=\"application/ld+json\"> envelope
+            (the JSON.stringify branch, on Node)."
+    (let [html (head-emit/head-model->html
+                 {:json-ld [{"@context" "https://schema.org"
+                             "@type"    "Article"
+                             "headline" "Hello"}]})]
+      (is (str/includes? html "type=\"application/ld+json\""))
+      (is (str/includes? html "\"@context\""))
+      (is (str/includes? html "\"@type\":\"Article\"")
+          "JSON.stringify emits compact `key:value` with no spaces")
+      (is (str/includes? html "\"headline\":\"Hello\""))
+      (is (str/ends-with? html "</script>")
+          "the genuine envelope-closing </script> is present"))))
+
+(deftest ld-json-string-escapes-script-close-in-string-values
+  (testing "rf2-usio0 / rf2-m5u23 — the CLJS path escapes every `<` in a
+            string value as `\\u003c` AFTER `JSON.stringify`, so a value
+            carrying `</script>` cannot close the surrounding
+            `<script type=\"application/ld+json\">` envelope. This is the
+            security-critical assertion the CLJS branch lacked."
+    (let [hostile "</script><script>alert(document.cookie)</script>"
+          html    (head-emit/head-model->html
+                    {:json-ld [{"@context" "https://schema.org"
+                                "@type"    "Article"
+                                "headline" hostile}]})]
+      (is (not (str/includes? html "</script><script>alert"))
+          "the closing-tag pattern is broken — no raw </script> survives
+           in the JSON-LD body")
+      (is (str/includes? html "\\u003c/script>\\u003cscript>")
+          "every `<` in the string value is escaped as the JSON `\\u003c`
+           escape — round-trips through the client's JSON.parse")
+      (is (str/ends-with? html "</script>")
+          "the genuine envelope-closing </script> is unaffected"))))
+
+(deftest ld-json-string-escapes-script-close-in-keys
+  (testing "rf2-usio0 / rf2-m5u23 — a `<` inside a JSON-LD KEY is also
+            escaped on the CLJS path (the escape walks the whole
+            stringified payload, keys included)."
+    (let [hostile-key "</script>"
+          html        (head-emit/head-model->html
+                        {:json-ld [{hostile-key "value"}]})]
+      (is (not (str/includes? html "</script>\":"))
+          "</script> as a key cannot close the envelope")
+      (is (str/includes? html "\\u003c/script>")
+          "`<` in keys comes through escaped"))))

--- a/implementation/ssr/test/re_frame/ssr_emit_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_emit_test.clj
@@ -1,0 +1,232 @@
+(ns re-frame.ssr-emit-test
+  "Spec 011 §XSS at output boundaries — the strip-prop rule (rf2-dwds9)
+  driven through the FULL emit composition, not just `attr-string` in
+  isolation. Per rf2-usio0 (testcov audit ai/findings/2026-05-21-testcov-ssr.md
+  §G1).
+
+  `ssr_attr_filter_test.clj` proves the rule at the per-attribute unit
+  level (`html-helpers/attr-string` called directly). That is necessary
+  but not sufficient: the emitter COMPOSES `attr-string` inside
+  `emit-element` (emit.cljc:323-326) and inside the streaming walker
+  (streaming.cljc:225-227), and the strip MUST run AHEAD of the
+  attribute-name grammar gate (html_helpers.cljc:179-189) at that
+  composed callsite. A regression that reorders the emitter composition,
+  or that bypasses `attr-string` for some attr path in `emit-element` /
+  `walk-dom-tag`, would pass every per-attribute test while leaking a
+  hostile `on*` handler / fn-valued prop / prototype-pollution key onto
+  the wire.
+
+  These tests therefore feed hostile props through:
+
+    1. `re-frame.ssr.emit/render-to-string` — the public non-streaming
+       emitter, including the void-element branch, the registered-view
+       branch, fragments, and the root-attrs (`:emit-hash?`) injection.
+    2. `re-frame.ssr.streaming/render-shell` — the streaming shell walk,
+       whose `walk-dom-tag` re-derives attrs via `emit/attr-string`.
+
+  so a reorder/bypass regression at EITHER composed callsite is caught.
+
+  JVM-only — the strip rule is platform-neutral .cljc, but the per-attr
+  proof already runs on both platforms (`ssr_attr_filter_test`); driving
+  the JVM emit composition here is enough to pin the composition order."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.ssr.emit :as emit]
+            [re-frame.ssr.streaming :as streaming]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ===========================================================================
+;; G1 — strip-prop XSS rule through `render-to-string` / `emit-element`
+;; ===========================================================================
+
+(deftest render-to-string-strips-event-handler-props
+  (testing "rf2-usio0 / rf2-dwds9 — an `on*` event-handler prop fed
+            through the FULL `render-to-string` emit composition (not
+            `attr-string` in isolation) is dropped at emit time. Pins
+            that the strip survives `emit-element`'s attr path."
+    (testing ":on-click (kebab) is stripped through render-to-string"
+      (is (= "<div id=\"x\"></div>"
+             (emit/render-to-string [:div {:on-click "alert(1)" :id "x"}] {}))))
+
+    (testing ":onClick (camelCase) is stripped through render-to-string"
+      (is (= "<div id=\"x\"></div>"
+             (emit/render-to-string [:div {:onClick "alert(1)" :id "x"}] {}))))
+
+    (testing "the stripped handler value never appears in the output
+              string — belt-and-braces against a partial-emit leak"
+      (let [html (emit/render-to-string
+                   [:div {:onMouseDown "steal()" :id "x"}] {})]
+        (is (not (str/includes? html "steal"))
+            "the handler body must not survive anywhere in the markup")
+        (is (not (str/includes? html "onMouseDown"))
+            "the handler attribute name must not survive either")))
+
+    (testing "a div whose ONLY attr is a stripped handler emits a clean
+              open tag — no stray space, no bare attr"
+      (is (= "<div></div>"
+             (emit/render-to-string [:div {:on-click "f"}] {}))))))
+
+(deftest render-to-string-strips-function-valued-props
+  (testing "rf2-usio0 / rf2-dwds9 — a function-valued prop has no HTML
+            serialisation and is dropped through the full emit
+            composition."
+    (is (= "<div id=\"x\"></div>"
+           (emit/render-to-string [:div {:title (fn [_] :handler) :id "x"}] {})))
+
+    (testing "fn value is stripped even on an innocuous key name"
+      (is (= "<span></span>"
+             (emit/render-to-string [:span {:data-cb (fn [] nil)}] {}))))))
+
+(deftest render-to-string-drops-prototype-pollution-keys
+  (testing "rf2-usio0 / rf2-dwds9 — reserved prototype-pollution keys
+            (`__proto__` / `constructor` / `prototype`) are dropped
+            through `render-to-string` before they reach the host
+            createElement-equivalent on hydration."
+    (doseq [k ["__proto__" "constructor" "prototype"]]
+      (testing (str "`" k "` is dropped through render-to-string")
+        (is (= "<div id=\"x\"></div>"
+               (emit/render-to-string
+                 [:div {(keyword k) "polluted" :id "x"}] {}))
+            (str k " must not survive to wire output via the emit path"))))
+
+    (testing "the match is case-insensitive at the composed callsite too"
+      (is (= "<div id=\"x\"></div>"
+             (emit/render-to-string
+               [:div {(keyword "Constructor") "polluted" :id "x"}] {}))))))
+
+(deftest render-to-string-strips-props-on-void-element
+  (testing "rf2-usio0 — the strip composes with the VOID-element branch
+            of `emit-element` (emit.cljc:322-323), not just the
+            open/close branch. An `on*` handler on an <input> is dropped
+            and the void tag self-closes cleanly."
+    (is (= "<input id=\"x\">"
+           (emit/render-to-string
+             [:input {:on-change "x()" :id "x"}] {})))
+    (let [html (emit/render-to-string
+                 [:img {:onError "alert(1)" :src "/a.png"}] {})]
+      (is (str/includes? html "src=\"/a.png\"") "the legit attr survives")
+      (is (not (str/includes? html "onError")) "the handler is stripped")
+      (is (not (str/includes? html "alert")) "the handler body is gone"))))
+
+(deftest render-to-string-strips-props-through-registered-view-root
+  (testing "rf2-usio0 — the strip composes with the registered-view
+            resolution branch (emit.cljc:296-311). A view whose ROOT
+            DOM element carries a hostile handler must still emit
+            stripped — the source-coord injection + view-ref indirection
+            must not bypass `attr-string`."
+    (rf/reg-view ^{:rf/id :test/hostile-root} hostile-root-view []
+      [:div {:on-click "alert(document.cookie)" :id "v"}
+       [:p "safe body"]])
+    (let [html (emit/render-to-string [:test/hostile-root] {})]
+      (is (str/includes? html "<p>safe body</p>")
+          "the view body still renders")
+      (is (str/includes? html "id=\"v\"")
+          "the legit root attr survives")
+      (is (not (str/includes? html "on-click"))
+          "the root handler is stripped through the view-ref branch")
+      (is (not (str/includes? html "alert(document.cookie)"))
+          "the handler body never reaches the wire"))))
+
+(deftest render-to-string-strips-props-when-root-attrs-injected
+  (testing "rf2-usio0 — the strip survives the rf2-lxwse root-attrs
+            (`:emit-hash?`) injection path. The injected
+            `data-rf-render-hash` lands while the user's hostile handler
+            on the SAME root element is dropped — `merge-root-attrs`
+            feeds into the same `attr-string` strip."
+    (let [html (emit/render-to-string
+                 [:div {:onClick "alert(1)" :id "root"} [:p "x"]]
+                 {:emit-hash? true})]
+      (is (str/includes? html "data-rf-render-hash=")
+          "the render-hash root attr was injected")
+      (is (str/includes? html "id=\"root\"")
+          "the legit user attr survives alongside the injected hash")
+      (is (not (str/includes? html "onClick"))
+          "the user's handler on the hash-bearing root is still stripped")
+      (is (not (str/includes? html "alert"))
+          "no handler body leaks through the injection composition"))))
+
+(deftest render-to-string-strips-deep-nested-handler
+  (testing "rf2-usio0 — the strip runs at EVERY emit-element descent, not
+            only the root. A handler buried several levels deep is
+            dropped — `emit-children` re-enters `emit-element` per child."
+    (let [html (emit/render-to-string
+                 [:div
+                  [:section
+                   [:ul
+                    [:li {:onClick "deep()" :class "item"} "deep"]]]]
+                 {})]
+      (is (str/includes? html "class=\"item\"") "the deep legit attr survives")
+      (is (str/includes? html ">deep</li>") "the deep text survives")
+      (is (not (str/includes? html "onClick")) "the deep handler is stripped")
+      (is (not (str/includes? html "deep()")) "the deep handler body is gone"))))
+
+;; ===========================================================================
+;; G1 — strip-prop XSS rule through `streaming/render-shell`'s walk
+;; ===========================================================================
+
+(deftest render-shell-strips-event-handler-props
+  (testing "rf2-usio0 / rf2-dwds9 — the streaming shell walker
+            (`walk-dom-tag`, streaming.cljc:225-227) re-derives attrs via
+            `emit/attr-string`, so an `on*` handler on a shell DOM
+            element must be stripped through the shell walk too — not
+            just through the non-streaming `render-to-string`."
+    (let [tree [:div {:on-click "alert(1)" :id "x"}
+                [:p "shell body"]]
+          {:keys [shell-html]} (streaming/render-shell tree)]
+      (is (str/includes? shell-html "<p>shell body</p>")
+          "the shell body renders")
+      (is (str/includes? shell-html "id=\"x\"")
+          "the legit attr survives the walk")
+      (is (not (str/includes? shell-html "on-click"))
+          "the handler is stripped through walk-dom-tag")
+      (is (not (str/includes? shell-html "alert(1)"))
+          "the handler body never reaches the shell HTML"))))
+
+(deftest render-shell-strips-function-and-proto-props
+  (testing "rf2-usio0 / rf2-dwds9 — fn-valued + prototype-pollution
+            props are also stripped through the streaming walk."
+    (let [tree [:div {:title (fn [] nil)
+                      :__proto__ "polluted"
+                      :id "x"}
+                [:span "ok"]]
+          {:keys [shell-html]} (streaming/render-shell tree)]
+      (is (str/includes? shell-html "id=\"x\"") "the legit attr survives")
+      (is (str/includes? shell-html "<span>ok</span>") "body renders")
+      (is (not (str/includes? shell-html "__proto__"))
+          "the prototype-pollution key is stripped through the walk")
+      (is (not (str/includes? shell-html "polluted"))
+          "the prototype-pollution value never reaches the shell"))))
+
+(deftest render-shell-strips-handler-on-void-element
+  (testing "rf2-usio0 — the streaming walk's void-element branch
+            (streaming.cljc:224) also runs the strip. An `on*` handler on
+            an <input> in the shell is dropped."
+    (let [tree [:form
+                [:input {:onChange "steal()" :name "q"}]]
+          {:keys [shell-html]} (streaming/render-shell tree)]
+      (is (str/includes? shell-html "name=\"q\"") "the legit attr survives")
+      (is (not (str/includes? shell-html "onChange")) "the handler is stripped")
+      (is (not (str/includes? shell-html "steal")) "the handler body is gone"))))
+
+(deftest render-shell-strips-handler-buried-near-suspense-boundary
+  (testing "rf2-usio0 — a hostile handler on a shell element that SITS
+            ALONGSIDE a :rf/suspense-boundary is stripped through the
+            walk, while the boundary still registers its continuation.
+            Pins that the strip composes with the suspense-walk path,
+            not only plain DOM descent."
+    (let [tree [:div {:onClick "alert(1)" :id "outer"}
+                [:rf/suspense-boundary
+                 {:id :sb :fallback [:p "loading"]}
+                 [:p "body"]]]
+          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+      (is (= 1 (count continuations))
+          "the boundary still registered its continuation")
+      (is (str/includes? shell-html "id=\"outer\"")
+          "the legit attr on the boundary-bearing element survives")
+      (is (not (str/includes? shell-html "onClick"))
+          "the handler on the boundary-bearing element is stripped")
+      (is (not (str/includes? shell-html "alert(1)"))
+          "the handler body never reaches the shell"))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -80,9 +80,16 @@
           "fallback still materialised in the shell")
       ;; Drain the continuation — the subtree is nil per the n=0 branch;
       ;; emit-element returns "" for nil, so the resolved html is empty.
+      ;; rf2-usio0 — drain the shell-produced entry VERBATIM (no manual
+      ;; `(assoc … :fallback …)`). The entry must already carry its
+      ;; declared :fallback from `record-continuation!`; re-injecting it
+      ;; by hand re-introduces exactly the mask the rf2-405ld fix removed.
       (let [fid    (make-server-frame)
-            entry  (assoc (first continuations) :fallback [:p "loading"])
+            entry  (first continuations)
             result (streaming/render-continuation fid entry)]
+        (is (= [:p "loading"] (:fallback entry))
+            "record-continuation! stored the declared :fallback on the
+             zero-body entry (drained verbatim, not re-injected)")
         (is (not (:failed? result))
             "nil subtree is NOT a failure — render-to-string treats it
              as an empty render per the emit-element nil branch")
@@ -107,9 +114,14 @@
       (is (= 1 (count continuations))
           "multi-child body still registers ONE continuation — the
            fragment wraps all children")
+      ;; rf2-usio0 — drain the entry verbatim; the declared :fallback
+      ;; must ride from `record-continuation!`, not be re-injected here.
       (let [fid    (make-server-frame)
-            entry  (assoc (first continuations) :fallback [:p "loading"])
+            entry  (first continuations)
             result (streaming/render-continuation fid entry)]
+        (is (= [:p "loading"] (:fallback entry))
+            "record-continuation! stored the declared :fallback on the
+             multi-child entry")
         (is (not (:failed? result)))
         (is (= "<p>first</p><p>second</p><p>third</p>" (:html result))
             "all three children resolved — fragment splices them
@@ -159,11 +171,17 @@
       ;; non-streaming emitter, which surfaces an exception on the
       ;; unrecognised :rf/suspense-boundary head — caught as a
       ;; failure and inline-fallback'd. Pin THAT contract.
+      ;; rf2-usio0 — drain the outer entry verbatim; its declared
+      ;; :fallback rides from `record-continuation!`. Re-injecting it by
+      ;; hand masks an empty-fallback regression on the fail-soft path.
       (let [fid    (make-server-frame)
-            entry  (assoc (first continuations) :fallback [:p "outer loading"])
+            entry  (first continuations)
             captured (atom [])
             result (with-trace-capture captured
                      #(streaming/render-continuation fid entry))]
+        (is (= [:p "outer loading"] (:fallback entry))
+            "record-continuation! stored the outer boundary's declared
+             :fallback on the entry")
         ;; The pure render-continuation path (without the ring
         ;; adapter's per-chunk re-walker) DOES fail on the buried
         ;; suspense-boundary keyword — which exercises the
@@ -253,9 +271,15 @@
           "only one continuation survives dedup across three duplicates")
       ;; Drain it — the body should be the LAST registration's body
       ;; (third), confirming last-write-wins.
+      ;; rf2-usio0 — drain verbatim; last-write-wins means the surviving
+      ;; entry carries the THIRD boundary's declared :fallback, threaded
+      ;; through `record-continuation!` (not re-injected by hand).
       (let [fid    (make-server-frame)
-            entry  (assoc (first continuations) :fallback [:p "third fallback"])
+            entry  (first continuations)
             result (streaming/render-continuation fid entry)]
+        (is (= [:p "third fallback"] (:fallback entry))
+            "the surviving entry carries the LAST registration's declared
+             :fallback — last-write-wins applies to :fallback too")
         (is (str/includes? (:html result) "third body")
             "the resolved chunk carries the LAST-registered body — not
              the first or middle. Per Spec 011 §Boundary nesting and
@@ -367,7 +391,12 @@
                 {:id :after-destroy :fallback [:p "loading"]}
                 [:p "body"]]
           {:keys [continuations]} (streaming/render-shell tree)
-          entry (assoc (first continuations) :fallback [:p "loading"])]
+          ;; rf2-usio0 — drain the entry verbatim; the declared :fallback
+          ;; rides from `record-continuation!`. Re-injecting it masks an
+          ;; empty-fallback regression on the fail-soft path.
+          entry (first continuations)]
+      (is (= [:p "loading"] (:fallback entry))
+          "record-continuation! stored the declared :fallback on the entry")
       ;; Destroy the frame.
       (rf/destroy-frame! fid)
       ;; Now drive the continuation against the dead frame-id. The


### PR DESCRIPTION
## Summary

Closes the two real items from the SSR test-coverage audit (`ai/findings/2026-05-21-testcov-ssr.md`, bead rf2-usio0).

### 1. Un-mask the streaming fallback (G5)
`ssr_streaming_corner_test.clj` re-injected `:fallback` onto the shell-produced continuation entry by hand (`(assoc (first continuations) :fallback …)` at ~84/111/163/257/370), re-introducing exactly the mask the rf2-405ld fix removed from `ssr_streaming_test.clj`. These tests would pass even if `record-continuation!` stopped storing `:fallback`.

The corner tests now drain `(first continuations)` **verbatim** and assert the entry already carries its declared `:fallback` from `record-continuation!`, so an empty-fallback regression on the record→fail path would surface here. The deliberate throwing-fallback test (`render-continuation-fallback-render-throw-emits-empty-html`) is left exempt — it intentionally swaps in a throwing fallback.

De-masking revealed **no bug**: the real record→fail path is sound.

### 2. Prove the XSS strip through `render-to-string` (G1, HIGH)
The strip-prop rule (rf2-dwds9 — `on*` / fn-valued / `__proto__`/`constructor`/`prototype`) was tested ONLY against `html-helpers/attr-string` in isolation, never through the full emit composition. A reorder/bypass at the composed callsite (`emit.cljc:323-326` / `streaming.cljc:225-227`) would have passed every test.

New `ssr_emit_test.clj` drives hostile props through:
- `ssr/render-to-string` — open/close, void element, registered-view root, root-attrs (`:emit-hash?`) injection, and deep-nested descent.
- `streaming/render-shell`'s walk — `walk-dom-tag`, void branch, and alongside a `:rf/suspense-boundary`.

### 3. CLJS `ld-json-string` Node smoke (layer gap)
New `ssr/head_emit_cljs_test.cljc` covers the CLJS branch of `head/emit/ld-json-string` (`JSON.stringify` + script-body escape), which had no Node coverage. The security-critical `</script>` close-tag escape is now verified on the CLJS path. `.cljc` so it also cross-checks under the JVM gate.

G2 (namespaced `:svg:rect` emit / malformed `:a::b` throw) was found to be **already covered** in `ssr_end_to_end_test.clj:1418-1460` — no action needed.

## Test plan
- [x] `clojure -M:test` from `implementation/ssr` — 214 tests, 737 assertions, 0 failures
- [x] `clojure -M:test` from `implementation/ssr-ring` — 63 tests, 327 assertions, 0 failures
- [x] `npm run test:cljs` from `implementation/` — 4043 tests, 12244 assertions, 0 failures