### PR TITLE
test(http): cover Malli schema-decode + accept-failure + request-encoding data-path (rf2-ohwgm)

### DIFF
--- a/implementation/http/test/re_frame/http_decode_test.clj
+++ b/implementation/http/test/re_frame/http_decode_test.clj
@@ -1,0 +1,271 @@
+(ns re-frame.http-decode-test
+  "Direct unit coverage for the response-body decode pipeline in
+  `re-frame.http-decode` (rf2-ohwgm; follow-on from the http test-coverage
+  audit `ai/findings/2026-05-21-testcov-http.md`).
+
+  Per Spec 014 §Decoding / §`:auto`, schema-driven decode is the
+  canonical form. Before this file the entire Malli decode + coerce +
+  validate path (`malli-decode`, the schema branch of
+  `decode-response-body`) had ZERO test coverage, the keyword-cap was
+  never threaded through the decoder end-to-end as a thrown
+  `:too-many-keys`, and the `:rf.warning/decode-defaulted` dev emission
+  (Spec 014 §`:auto`) was never asserted to actually fire.
+
+  These fns are pure / host-agnostic, so they belong on the fast JVM
+  `clojure -M:test` layer. Malli is on the http test classpath via the
+  `day8/re-frame2-schemas` test-dep (its transitive `metosin/malli`),
+  so `requiring-resolve` of `malli.core/decode` / `malli.core/validate`
+  / `malli.transform/json-transformer` succeeds at runtime — the
+  schema branch exercises the real Malli decode + coerce + validate."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.http-decode :as decode]
+            [re-frame.trace :as trace]))
+
+;; `decode-response-body` is public; `malli-decode` is private — reach it
+;; via #' so we can pin the lowest-level decode+validate behaviour without
+;; widening the public surface.
+(def ^:private malli-decode @#'decode/malli-decode)
+
+;; Sanity-pin: Malli really is resolvable on this test classpath. If a
+;; future deps change drops the schemas test-dep, every schema test below
+;; would silently degrade to the Malli-absent no-op fall-through
+;; (`malli-decode` returns the parsed value un-coerced, un-validated) and
+;; the coerce / validation-failure assertions would mislead. This guard
+;; turns that into an explicit failure.
+(deftest malli-is-on-the-test-classpath
+  (testing "rf2-ohwgm — the schema-decode tests below require Malli to be
+            resolvable; assert the precondition so a deps regression that
+            removes it fails loudly rather than degrading to the no-op
+            Malli-absent branch"
+    (is (some? (requiring-resolve 'malli.core/decode)))
+    (is (some? (requiring-resolve 'malli.core/validate)))
+    (is (some? (requiring-resolve 'malli.transform/json-transformer)))))
+
+;; ---- G1: malli-decode — coerce success ------------------------------------
+
+(deftest malli-decode-coerces-with-json-transformer
+  (testing "rf2-ohwgm — malli-decode runs the schema's decode with the
+            JSON transformer, applying the canonical JSON coercions (the
+            classic case is string→keyword and string→enum, since JSON
+            has no keyword type) — proving the transformer arg is actually
+            wired (a plain validate-only path would reject the string)
+            (Spec 014 §Decoding 'the canonical form')"
+    ;; The json-transformer coerces a JSON string into a keyword against a
+    ;; :keyword schema, and into an enum member against an [:enum ...]
+    ;; schema. This is the JSON-shaped coercion (numbers already arrive as
+    ;; numbers from the JSON parse, so :int coercion is a no-op).
+    (is (= :foo (malli-decode :keyword "foo"))
+        "JSON string coerced to keyword via the json-transformer")
+    (is (= :a (malli-decode [:enum :a :b] "a"))
+        "JSON string coerced to an enum member via the json-transformer")
+    (testing "a map schema coerces nested string values and keeps numbers as-is"
+      (is (= {:id 7 :status :ok}
+             (malli-decode [:map [:id :int] [:status :keyword]]
+                           {:id 7 :status "ok"}))
+          "string :status coerced to keyword; numeric :id kept (JSON
+           already parsed it to a number)"))))
+
+(deftest malli-decode-passes-through-already-valid-value
+  (testing "rf2-ohwgm — a value that already matches the schema decodes to
+            itself and validates clean"
+    (is (= {:title "hello" :id 42}
+           (malli-decode [:map [:title :string] [:id :int]]
+                         {:title "hello" :id 42})))))
+
+;; ---- G1: malli-decode — validation failure --------------------------------
+
+(deftest malli-decode-throws-canonical-ex-info-on-validation-failure
+  (testing "rf2-ohwgm — when the coerced value still fails the schema,
+            malli-decode throws an ex-info carrying the canonical
+            discriminator `:rf.error/id :rf.error/http-schema-validation-failed`
+            (Spec 009) so the transport classifies it as
+            :rf.http/decode-failure :schema-validation-failure? true"
+    (let [ex (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #":rf.error/http-schema-validation-failed"
+                   ;; :int schema, value is a non-coercible string — the
+                   ;; json-transformer can't turn \"notanumber\" into an int,
+                   ;; so validate fails.
+                   (malli-decode :int "notanumber")))
+          d  (ex-data ex)]
+      (is (= :rf.error/http-schema-validation-failed (:rf.error/id d))
+          "carries the canonical discriminator the transport keys on")
+      (is (= :no-recovery (:recovery d)))
+      (is (= 'rf.http/decode-response-body (:where d)))
+      (is (= :int (:schema d))
+          "the offending schema rides the ex-data for diagnosis")
+      (is (contains? d :value)
+          "the rejected (decoded) value rides the ex-data for diagnosis"))))
+
+(deftest malli-decode-map-schema-missing-required-key-throws
+  (testing "rf2-ohwgm — a map missing a required key fails validation"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/http-schema-validation-failed"
+          (malli-decode [:map [:id :int] [:name :string]]
+                        {:id 1})))))
+
+;; ---- G1: decode-response-body — schema branch end-to-end ------------------
+
+(deftest decode-response-body-schema-success-parses-then-coerces
+  (testing "rf2-ohwgm — passing a Malli schema as :decode JSON-parses the
+            body-text then runs the schema decode+coerce, returning the
+            coerced Clojure value (Spec 014 §Decoding). The JSON parse
+            yields a number for id (no coercion needed) and a string for
+            status which the json-transformer coerces to a keyword."
+    (is (= {:title "hello" :id 42 :status :active}
+           (decode/decode-response-body
+             {:body-text "{\"title\":\"hello\",\"id\":42,\"status\":\"active\"}"
+              :headers   {"content-type" "application/json"}
+              :decode    [:map [:title :string] [:id :int] [:status :keyword]]
+              :decode-supplied? true}))
+        "string :status \"active\" is coerced to keyword :active by the schema decode")))
+
+(deftest decode-response-body-schema-validation-failure-throws-canonical
+  (testing "rf2-ohwgm — a body that parses as JSON but fails schema
+            validation surfaces the canonical
+            `:rf.error/http-schema-validation-failed` ex-info, which the
+            transport maps to :rf.http/decode-failure
+            :schema-validation-failure? true (http_transport.cljc:721-726)"
+    (let [ex (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #":rf.error/http-schema-validation-failed"
+                   (decode/decode-response-body
+                     {:body-text "{\"id\":\"not-an-int\"}"
+                      :headers   {"content-type" "application/json"}
+                      :decode    [:map [:id :int]]
+                      :decode-supplied? true})))]
+      (is (= :rf.error/http-schema-validation-failed
+             (:rf.error/id (ex-data ex)))))))
+
+;; ---- G1: keyword-cap threaded e2e through the schema branch ----------------
+;;
+;; The audit (G1) calls out that the :rf.http/max-decoded-keys cap is
+;; tested at the JSON-reader layer (util_json_test.clj:33) but NOT threaded
+;; end-to-end through the decoder as a thrown :too-many-keys. The schema
+;; branch is the critical path: per rf2-wu1n5 it must RE-RAISE the
+;; cap-throw rather than swallow it behind a Malli rejection.
+
+(deftest decode-response-body-schema-branch-reraises-too-many-keys
+  (testing "rf2-ohwgm / rf2-wu1n5 — the schema branch threads
+            :max-decoded-keys into json-parse and re-raises the
+            `:rf.error/malformed-json :cause :too-many-keys` cap-throw
+            rather than masking it behind a Malli rejection. This is the
+            security-relevant signal the transport classifies as
+            :rf.http/decode-failure."
+    (let [ex (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #":rf.error/malformed-json"
+                   (decode/decode-response-body
+                     ;; three unique object keys, cap of 2 — the JSON
+                     ;; reader throws :too-many-keys before any Malli work.
+                     {:body-text "{\"a\":1,\"b\":2,\"c\":3}"
+                      :headers   {"content-type" "application/json"}
+                      :decode    [:map-of :keyword :int]
+                      :decode-supplied? true
+                      :max-decoded-keys 2})))
+          d  (ex-data ex)]
+      (is (= :rf.error/malformed-json (:rf.error/id d))
+          "the malformed-json discriminator survives — NOT remapped to a
+           schema-validation failure")
+      (is (= :too-many-keys (:cause d))
+          "the keyword-interning DoS cause is preserved end-to-end")
+      (is (= 2 (:limit d))
+          "the per-call cap is threaded through to the reader"))))
+
+(deftest decode-response-body-json-branch-also-reraises-too-many-keys
+  (testing "rf2-ohwgm — the plain :json branch likewise threads the cap
+            (the cap-throw originates in the reader, so :json surfaces it
+            directly without a re-raise wrapper)"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf.error/malformed-json"
+          (decode/decode-response-body
+            {:body-text "{\"a\":1,\"b\":2,\"c\":3}"
+             :headers   {"content-type" "application/json"}
+             :decode    :json
+             :decode-supplied? true
+             :max-decoded-keys 2})))))
+
+;; ---- G4: :rf.warning/decode-defaulted dev emission ------------------------
+;;
+;; Spec 014 §`:auto`. The warning fires when the user did NOT supply
+;; `:decode` and the decoder fell back to auto-sniffing. The audit (G4)
+;; flags that only the prod-elision *absence* test referenced it; no
+;; dev-mode test asserted it actually fires with its tags.
+
+(defn- with-trace-capture [body-fn]
+  (let [captured (atom [])
+        cb-id    ::http-decode-test-cap]
+    (try
+      (trace/register-listener! cb-id (fn [ev] (swap! captured conj ev)))
+      (body-fn captured)
+      (finally
+        (trace/unregister-listener! cb-id)))))
+
+(deftest decode-defaulted-warning-fires-when-decode-omitted
+  (testing "rf2-ohwgm — when :decode is omitted (`:decode-supplied? false`)
+            and the decoder falls back to :auto, `decode-response-body`
+            emits `:rf.warning/decode-defaulted` carrying the resolved
+            decoder + content-type tags (Spec 014 §`:auto`)"
+    (with-trace-capture
+      (fn [captured]
+        (let [v (decode/decode-response-body
+                  {:body-text        "{\"ok\":true}"
+                   :headers          {"content-type" "application/json"}
+                   :decode           nil
+                   :decode-supplied? false
+                   :request-id       :req-1
+                   :url              "https://example.test/x"})
+              warns (filter #(= :rf.warning/decode-defaulted (:operation %))
+                            @captured)]
+          (is (= {:ok true} v)
+              "the auto-sniffed :json path still decodes the body")
+          (is (seq warns)
+              (str "expected a :rf.warning/decode-defaulted trace; captured: "
+                   (pr-str (mapv :operation @captured))))
+          (let [w (first warns)]
+            (is (= :warning (:op-type w)))
+            (let [tags (:tags w)]
+              (is (= :json (:resolved-decoder tags))
+                  "the resolved decoder (sniffed from the JSON content-type) rides the tags")
+              (is (= "application/json" (:content-type tags))
+                  "the response content-type rides the tags")
+              (is (= :req-1 (:request-id tags))
+                  "the request-id rides the tags for correlation")
+              (is (= "https://example.test/x" (:url tags))
+                  "the (privacy-prepared) url rides the tags"))))))))
+
+(deftest decode-defaulted-warning-not-fired-when-decode-supplied
+  (testing "rf2-ohwgm — when the user explicitly supplies :decode the
+            warning is suppressed (the default-to-auto signal only fires
+            on omission)"
+    (with-trace-capture
+      (fn [captured]
+        (decode/decode-response-body
+          {:body-text        "{\"ok\":true}"
+           :headers          {"content-type" "application/json"}
+           :decode           :json
+           :decode-supplied? true
+           :request-id       :req-2
+           :url              "https://example.test/y"})
+        (is (empty? (filter #(= :rf.warning/decode-defaulted (:operation %))
+                            @captured))
+            "an explicit :decode must NOT emit decode-defaulted")))))
+
+(deftest decode-defaulted-warning-resolved-decoder-text-for-text-ct
+  (testing "rf2-ohwgm — the :resolved-decoder tag reflects the sniffed
+            decoder, e.g. :text for a text/* content-type"
+    (with-trace-capture
+      (fn [captured]
+        (decode/decode-response-body
+          {:body-text        "plain words"
+           :headers          {"content-type" "text/plain"}
+           :decode           :auto
+           :decode-supplied? false
+           :request-id       :req-3
+           :url              "https://example.test/z"})
+        (let [w (first (filter #(= :rf.warning/decode-defaulted (:operation %))
+                               @captured))]
+          (is (= :text (get-in w [:tags :resolved-decoder]))
+              "text/* content-type sniffs to :text"))))))

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -2,6 +2,11 @@
   "Direct unit coverage for the pure-fn helpers in `re-frame.http-encoding`
   (rf2-9dro2; follow-on from rf2-q1z1u F2).
 
+  Extended under rf2-ohwgm (http test-coverage audit) with the request-side
+  encoding pipeline — `url-encode`, `params->query`, `merge-params`,
+  `encode-body` — and the default `run-accept` normalisation. These run on
+  every request / response yet had no direct test before.
+
   Specifically pins `compute-backoff-ms` against Spec 014 §Retry and
   backoff at the function boundary. The fn is currently exercised
   only indirectly via the managed-HTTP retry integration tests in
@@ -15,8 +20,10 @@
    - clamp: raw is clamped to :max-ms before any jitter
    - jitter (when true): ±25% offset uniformly distributed,
      floor of zero (never negative)"
-  (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.http-encoding :as encoding]))
+  (:require [clojure.string]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.http-encoding :as encoding]
+            [re-frame.util-json :as util-json]))
 
 ;; ---- attempt → delay (deterministic, jitter off) -------------------------
 
@@ -228,3 +235,171 @@
                         :explicit-on   {:supplied? true :value :items/loaded}
                         :reply-payload reply-payload})
                      (catch clojure.lang.ExceptionInfo _ ::threw)))))))
+
+;; ===========================================================================
+;; rf2-ohwgm — request-side encoding pipeline (G3) + default `run-accept` (G2)
+;;
+;; Per the http test-coverage audit (ai/findings/2026-05-21-testcov-http.md):
+;; `encode-body` / `params->query` / `merge-params` / `url-encode` run on
+;; EVERY request via `run-attempt!` (http_transport.cljc:749,754) yet had
+;; zero direct test. The default `:accept` (`run-accept` with a nil
+;; accept-fn) was likewise only exercised incidentally. Both are pure /
+;; host-agnostic → the fast JVM layer.
+;; ===========================================================================
+
+;; ---- url-encode — Spec 014 §Body encoding (query escaping) ----------------
+
+(deftest url-encode-escapes-reserved-characters
+  (testing "rf2-ohwgm — url-encode percent-escapes reserved query
+            characters so a value never breaks out of its key=value slot"
+    (is (= "hello%20world" (encoding/url-encode "hello world"))
+        "JVM maps the URLEncoder `+` to `%20` (space) per the source")
+    (is (= "a%26b" (encoding/url-encode "a&b"))
+        "ampersand escaped so it can't be read as a param separator")
+    (is (= "a%3Db" (encoding/url-encode "a=b"))
+        "equals escaped so it can't be read as a key/value delimiter")
+    (is (= "a%2Bb" (encoding/url-encode "a+b"))
+        "literal plus escaped to %2B (not collapsed with the space encoding)"))
+  (testing "non-string args are coerced via (str ...) before encoding"
+    (is (= "42" (encoding/url-encode 42)))
+    (is (= "true" (encoding/url-encode true)))))
+
+;; ---- params->query — keyword keys, escaping, joining ----------------------
+
+(deftest params->query-encodes-keyword-keys-and-escapes-values
+  (testing "rf2-ohwgm — params->query renders keyword keys via `name`,
+            escapes values, and joins pairs with `&` (no leading `?`)"
+    (is (= "page=2" (encoding/params->query {:page 2}))
+        "keyword key → name; numeric value coerced via url-encode")
+    (is (= "q=a%20b" (encoding/params->query {:q "a b"}))
+        "value with a space is percent-escaped")
+    (is (= "q=a%26b" (encoding/params->query {:q "a&b"}))
+        "value with an ampersand is escaped so it can't forge a new param"))
+  (testing "string keys pass through, keyword keys lose their colon"
+    (is (= "limit=10" (encoding/params->query {"limit" 10}))))
+  (testing "an empty params map renders an empty string"
+    (is (= "" (encoding/params->query {})))))
+
+;; ---- merge-params — `?` vs `&` separator selection ------------------------
+
+(deftest merge-params-selects-question-mark-or-ampersand
+  (testing "rf2-ohwgm — merge-params appends the query string with `?`
+            when the URL has none, and `&` when the URL already carries a
+            `?` (http_encoding.cljc:60-67)"
+    (is (= "/items?page=2"
+           (encoding/merge-params "/items" {:page 2}))
+        "no existing `?` → join with `?`")
+    (is (= "/items?sort=asc&page=2"
+           (encoding/merge-params "/items?sort=asc" {:page 2}))
+        "existing `?` → join with `&`"))
+  (testing "no params (empty or nil) returns the URL unchanged"
+    (is (= "/items" (encoding/merge-params "/items" {})))
+    (is (= "/items" (encoding/merge-params "/items" nil)))))
+
+;; ---- encode-body — Spec 014 §Body encoding --------------------------------
+;;
+;; Returns a tuple [encoded-body content-type]; content-type may be nil
+;; (the caller decides whether to set the header). One assertion per
+;; branch (nil / :json / :form / :text / explicit-MIME / coll-heuristic /
+;; pass-through).
+
+(deftest encode-body-nil-body-emits-no-content-type
+  (testing "rf2-ohwgm — a nil body encodes to [nil nil] (no body, no
+            Content-Type header)"
+    (is (= [nil nil] (encoding/encode-body nil :json))
+        "nil body short-circuits regardless of the requested content-type")
+    (is (= [nil nil] (encoding/encode-body nil nil)))))
+
+(deftest encode-body-json-request-content-type
+  (testing "rf2-ohwgm — :request-content-type :json JSON-stringifies the
+            body and returns application/json"
+    (let [[body ct] (encoding/encode-body {:a 1 :b "two"} :json)]
+      (is (= "application/json" ct))
+      (is (= {:a 1 :b "two"} (util-json/json-parse body))
+          "the body round-trips through json-parse (stable across key order)"))))
+
+(deftest encode-body-form-request-content-type
+  (testing "rf2-ohwgm — :request-content-type :form URL-encodes the map as
+            a form body and returns application/x-www-form-urlencoded"
+    (let [[body ct] (encoding/encode-body {:q "a b" :page 2} :form)]
+      (is (= "application/x-www-form-urlencoded" ct))
+      ;; form body is `params->query` of the map — assert each escaped pair
+      ;; is present (map iteration order is not guaranteed).
+      (is (clojure.string/includes? body "q=a%20b")
+          "form value space-escaped")
+      (is (clojure.string/includes? body "page=2")))))
+
+(deftest encode-body-text-request-content-type
+  (testing "rf2-ohwgm — :request-content-type :text stringifies the body
+            and returns text/plain"
+    (is (= ["hello" "text/plain"] (encoding/encode-body "hello" :text)))
+    (is (= ["42" "text/plain"] (encoding/encode-body 42 :text))
+        "non-string body coerced via (str ...)")))
+
+(deftest encode-body-explicit-mime-string-request-content-type
+  (testing "rf2-ohwgm — an explicit MIME-string :request-content-type
+            stringifies the body and returns that exact MIME unchanged"
+    (is (= ["<x/>" "application/xml"]
+           (encoding/encode-body "<x/>" "application/xml")))))
+
+(deftest encode-body-coll-heuristic-defaults-to-json
+  (testing "rf2-ohwgm — with no explicit :request-content-type, a raw
+            Clojure coll (map / sequential / set) is JSON-encoded and
+            tagged application/json (the heuristic at http_encoding.cljc:97)"
+    (let [[mbody mct] (encoding/encode-body {:a 1} nil)]
+      (is (= "application/json" mct))
+      (is (= {:a 1} (util-json/json-parse mbody))))
+    (let [[vbody vct] (encoding/encode-body [1 2 3] nil)]
+      (is (= "application/json" vct))
+      (is (= [1 2 3] (util-json/json-parse vbody))))
+    (let [[_ sct] (encoding/encode-body #{1 2 3} nil)]
+      (is (= "application/json" sct)
+          "a set also trips the coll heuristic"))))
+
+(deftest encode-body-passthrough-string-no-content-type
+  (testing "rf2-ohwgm — a non-coll body with no :request-content-type (a
+            pre-encoded string / opaque value) passes through unchanged
+            with a nil content-type (the caller sets no header)"
+    (is (= ["already-encoded" nil]
+           (encoding/encode-body "already-encoded" nil))
+        "a bare string is pass-through: body kept, content-type nil")))
+
+;; ---- run-accept — Spec 014 §`:accept` default normalisation (G2) ----------
+;;
+;; The default `:accept` (nil accept-fn) maps 2xx → {:ok decoded} and any
+;; other status → {:failure {:kind :http-status ...}}. The user-fn branch
+;; is exercised end-to-end in http_managed_test (accept-failure round-trip);
+;; here we pin the DEFAULT and the simple user-fn pass-through.
+
+(deftest run-accept-default-2xx-is-ok
+  (testing "rf2-ohwgm — with no :accept fn, a 2xx status normalises the
+            decoded value to {:ok decoded}"
+    (is (= {:ok {:title "hello"}}
+           (encoding/run-accept nil {:title "hello"} {:status 200})))
+    (is (= {:ok {:title "hello"}}
+           (encoding/run-accept nil {:title "hello"} {:status 299}))
+        "the whole 2xx band is :ok")))
+
+(deftest run-accept-default-non-2xx-is-failure
+  (testing "rf2-ohwgm — with no :accept fn, a non-2xx status normalises to
+            {:failure {:kind :http-status :status N :body decoded}}"
+    (is (= {:failure {:kind :http-status :status 404 :body {:error "nope"}}}
+           (encoding/run-accept nil {:error "nope"} {:status 404}))
+        "the default treats any non-2xx as a domain failure carrying the
+         status + decoded body")
+    (is (= {:failure {:kind :http-status :status 500 :body nil}}
+           (encoding/run-accept nil nil {:status 500})))))
+
+(deftest run-accept-user-fn-overrides-default
+  (testing "rf2-ohwgm — a supplied :accept fn is invoked with the decoded
+            value and its return ({:ok ..} or {:failure ..}) is used
+            verbatim, overriding the status-based default"
+    (let [accept (fn [decoded]
+                   (if (:valid? decoded)
+                     {:ok (:data decoded)}
+                     {:failure {:kind :domain :reason :invalid}}))]
+      (is (= {:ok 42}
+             (encoding/run-accept accept {:valid? true :data 42} {:status 200})))
+      (is (= {:failure {:kind :domain :reason :invalid}}
+             (encoding/run-accept accept {:valid? false} {:status 200}))
+          "the user :accept can fail a 2xx response (domain-level rejection)"))))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -8,8 +8,10 @@
 
   Per Spec 014 §Implementation status — JVM transport is part of the
   CLJS reference implementation's claim."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.util-json :as util-json]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -1096,4 +1098,246 @@
               ":reason is NOT :request-id-superseded (this is the regression guard)"))
 
         (.countDown latch)
+        (finally (stop-server! srv))))))
+
+;; ===========================================================================
+;; rf2-ohwgm — end-to-end coverage for the three untested spec contracts the
+;; http test-coverage audit (ai/findings/2026-05-21-testcov-http.md) flagged:
+;;   G1  — Malli schema decode failure → :rf.http/decode-failure
+;;          :schema-validation-failure? true (and too-many-keys e2e)
+;;   G2  — :accept returning {:failure ..} → :rf.http/accept-failure reply
+;;          carrying :detail + :decoded
+;;   G3  — request-side encoding (params query-string + :request-content-type
+;;          body) and the Content-Type clash guard, observed at a real server
+;; These ride the real java.net.http.HttpClient transport + in-process server
+;; so the WHOLE managed cascade (transport → decode → accept → classify →
+;; reply addressing) is exercised, not just the pure helpers.
+;; ===========================================================================
+
+;; ---- G1: Malli schema decode — validation failure e2e ---------------------
+
+(deftest jvm-schema-validation-failure-classifies-as-decode-failure
+  (testing "rf2-ohwgm — a 200 JSON response that parses but FAILS a Malli
+            :decode schema classifies as :rf.http/decode-failure with
+            :schema-validation-failure? true (Spec 014 §Classification
+            order step 3; http_transport.cljc:721-726)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; id arrives as a JSON string; the schema requires :int and
+              ;; the json-transformer can't coerce "oops" → int, so
+              ;; validation fails.
+              (write-response! ex 200 "application/json" "{\"id\":\"oops\"}")))]
+      (try
+        (rf/reg-event-fx :thing/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/thing")}
+                      :decode  [:map [:id :int]]}]]})))
+        (rf/dispatch-sync [:thing/load])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/decode-failure (:kind failure))
+              "schema validation failure is a decode failure")
+          (is (true? (:schema-validation-failure? failure))
+              "the :schema-validation-failure? slot is set true (Spec 014 line 410)"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-schema-decode-success-coerces-value
+  (testing "rf2-ohwgm — a 200 JSON response that satisfies the Malli
+            :decode schema returns the coerced value as the :success reply
+            (string status coerced to keyword by the json-transformer)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json"
+                               "{\"id\":7,\"status\":\"active\"}")))]
+      (try
+        (rf/reg-event-fx :thing/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/thing")}
+                      :decode  [:map [:id :int] [:status :keyword]]}]]})))
+        (rf/dispatch-sync [:thing/load])
+        (let [db (await-reply! #(some? (:reply %)) 5000)]
+          (is (= :success (get-in db [:reply :kind])))
+          (is (= {:id 7 :status :active} (get-in db [:reply :value]))
+              "the schema coerces the string status to a keyword e2e"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-too-many-keys-cap-classifies-as-decode-failure
+  (testing "rf2-ohwgm — the :rf.http/max-decoded-keys cap threaded into the
+            schema-branch decode surfaces a :too-many-keys throw as
+            :rf.http/decode-failure end-to-end (NOT masked behind a schema
+            rejection; rf2-wu1n5)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (write-response! ex 200 "application/json"
+                               "{\"a\":1,\"b\":2,\"c\":3}")))]
+      (try
+        (rf/reg-event-fx :thing/load
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request                  {:url (str "http://127.0.0.1:" port "/thing")}
+                      :decode                   [:map-of :keyword :int]
+                      :rf.http/max-decoded-keys 2}]]})))
+        (rf/dispatch-sync [:thing/load])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/decode-failure (:kind failure))
+              "an over-cap payload classifies as a decode failure")
+          ;; The cap-throw is :rf.error/malformed-json, NOT a schema
+          ;; validation, so :schema-validation-failure? must be falsey.
+          (is (not (true? (:schema-validation-failure? failure)))
+              "too-many-keys is a malformed-json cap-throw, not a schema rejection"))
+        (finally (stop-server! srv))))))
+
+;; ---- G2: :accept returning {:failure ..} → :rf.http/accept-failure --------
+
+(deftest jvm-accept-failure-classifies-and-carries-detail-and-decoded
+  (testing "rf2-ohwgm — an :accept fn that returns {:failure ..} on a 2xx
+            response produces a :rf.http/accept-failure reply carrying the
+            user :detail and the pre-accept :decoded value
+            (http_transport.cljc:523-530; Spec 014 §`:accept` +
+            §Classification order step 4)"
+    (let [{:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; 200 OK, but the domain payload says the operation failed —
+              ;; the :accept fn turns a transport-success into a domain
+              ;; failure.
+              (write-response! ex 200 "application/json"
+                               "{\"ok\":false,\"reason\":\"quota\"}")))]
+      (try
+        (rf/reg-event-fx :op/run
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url (str "http://127.0.0.1:" port "/op")}
+                      :decode  :json
+                      :accept  (fn [decoded]
+                                 (if (:ok decoded)
+                                   {:ok decoded}
+                                   {:failure {:kind   :domain-rejected
+                                              :reason (:reason decoded)}}))}]]})))
+        (rf/dispatch-sync [:op/run])
+        (let [db      (await-reply! #(some? (:reply %)) 5000)
+              failure (get-in db [:reply :failure])]
+          (is (= :failure (get-in db [:reply :kind])))
+          (is (= :rf.http/accept-failure (:kind failure))
+              "an :accept-rejected 2xx classifies as :rf.http/accept-failure")
+          (is (= {:kind :domain-rejected :reason "quota"} (:detail failure))
+              "the user :failure map rides through verbatim as :detail")
+          (is (= {:ok false :reason "quota"} (:decoded failure))
+              "the pre-accept decoded value rides through as :decoded"))
+        (finally (stop-server! srv))))))
+
+;; ---- G3: request-side encoding observed at the server ---------------------
+
+(deftest jvm-request-params-encoded-into-query-string
+  (testing "rf2-ohwgm — :params is encoded onto the request URL as a query
+            string (keyword keys → name, values escaped) and arrives at
+            the server (http_encoding.cljc:50-67 via run-attempt!)"
+    (let [seen-query (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; getRawQuery preserves the percent-encoding produced by
+              ;; the client; getQuery would decode it back, hiding whether
+              ;; the value was escaped on the wire.
+              (reset! seen-query (.getRawQuery (.getRequestURI ex)))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :search/run
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:url    (str "http://127.0.0.1:" port "/search")
+                                :params {:q "a b" :page 2}}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:search/run])
+        (await-reply! #(some? (:reply %)) 5000)
+        (let [q @seen-query]
+          (is (some? q) "the server saw a query string")
+          (is (clojure.string/includes? q "q=a%20b")
+              "the space-bearing value is percent-escaped in the query")
+          (is (clojure.string/includes? q "page=2")
+              "the keyword key is rendered via name; numeric value coerced"))
+        (finally (stop-server! srv))))))
+
+(deftest jvm-request-content-type-encodes-body-and-sets-header
+  (testing "rf2-ohwgm — :request-content-type :json encodes the body and
+            sets the Content-Type header; the server observes both
+            (http_encoding.cljc:76-102 + the header-set in run-attempt!)"
+    (let [seen-ct   (atom nil)
+          seen-body (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              (reset! seen-ct (.getFirst (.getRequestHeaders ex) "Content-Type"))
+              (reset! seen-body (slurp (.getRequestBody ex)))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :item/create
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:method               :post
+                                :url                  (str "http://127.0.0.1:" port "/items")
+                                :body                 {:name "widget"}
+                                :request-content-type :json}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:item/create])
+        (await-reply! #(some? (:reply %)) 5000)
+        (is (= "application/json" @seen-ct)
+            ":request-content-type :json sets the Content-Type header")
+        (is (= {:name "widget"} (util-json/json-parse @seen-body))
+            "the body is JSON-encoded and round-trips at the server")
+        (finally (stop-server! srv))))))
+
+(deftest jvm-explicit-content-type-header-wins-clash-guard
+  (testing "rf2-ohwgm — when the request already carries a Content-Type
+            header, run-attempt! does NOT overwrite it with the
+            encode-body content-type (the clash guard at
+            http_transport.cljc:755-757)"
+    (let [seen-cts (atom nil)
+          {:keys [port] :as srv}
+          (start-server!
+            (fn [^HttpExchange ex]
+              ;; Capture ALL Content-Type header values so a double-set
+              ;; (guard regression) would show up as >1 entry.
+              (reset! seen-cts (vec (.get (.getRequestHeaders ex) "Content-Type")))
+              (write-response! ex 200 "application/json" "{\"ok\":true}")))]
+      (try
+        (rf/reg-event-fx :item/create
+          (fn [{:keys [db]} [_ msg]]
+            (if-let [reply (:rf/reply msg)]
+              {:db (assoc db :reply reply)}
+              {:fx [[:rf.http/managed
+                     {:request {:method               :post
+                                :url                  (str "http://127.0.0.1:" port "/items")
+                                ;; Caller pre-sets Content-Type; encode-body
+                                ;; would otherwise also propose application/json.
+                                :headers              {"Content-Type" "application/vnd.custom+json"}
+                                :body                 {:name "widget"}
+                                :request-content-type :json}
+                      :decode  :json}]]})))
+        (rf/dispatch-sync [:item/create])
+        (await-reply! #(some? (:reply %)) 5000)
+        (let [cts @seen-cts]
+          (is (= ["application/vnd.custom+json"] cts)
+              "the caller's explicit Content-Type is preserved and NOT
+               supplemented by the encode-body content-type (clash guard)"))
         (finally (stop-server! srv))))))


### PR DESCRIPTION
## Summary

Closes the three first-class Spec 014 coverage gaps surfaced by the http test-coverage audit (`ai/findings/2026-05-21-testcov-http.md`, bead rf2-ohwgm). All additions live on the fast JVM `clojure -M:test` layer (the surfaces are pure / host-agnostic). **No source changes — coverage only.**

- **G1 (Malli schema decode):** new `http_decode_test.clj` covers `malli-decode` coerce-success (JSON string→keyword/enum via the json-transformer) + validation-failure throwing the canonical `:rf.error/http-schema-validation-failed` ex-info; the `decode-response-body` schema branch incl. the `:too-many-keys` cap re-raise (rf2-wu1n5, NOT masked behind a schema rejection). End-to-end via the real `HttpClient` transport: schema-validation-failure → `:rf.http/decode-failure :schema-validation-failure? true`; too-many-keys → `:rf.http/decode-failure`; success → coerced `:value`.
- **G2 (`:rf.http/accept-failure`):** default + user-fn `run-accept` unit tests, plus an e2e round-trip where `:accept` returns `{:failure ..}` and the reply carries `:detail` (user map) + `:decoded` (pre-accept value).
- **G3 (request encoding):** `url-encode` / `params->query` / `merge-params` / `encode-body` across every branch, plus e2e observation at an in-process server of `:params` query-string escaping, `:request-content-type :json` body encoding + Content-Type header, and the Content-Type clash guard (caller's explicit header preserved, not double-set).
- **G4 (`:rf.warning/decode-defaulted`):** asserts the dev-mode warning actually fires (with `:resolved-decoder` / `:content-type` / `:request-id` / `:url` tags) when `:decode` is omitted, and is suppressed when supplied.

## Gate counts

- http JVM (`clojure -M:test`): 227 → **259 tests**, 1283 → **1369 assertions**, 0 failures / 0 errors (+32 tests, +86 assertions).
- `npm run test:cljs`: 4040 tests / 12234 assertions, 0 failures / 0 errors (unchanged — additions are JVM-only; confirms no regression).

## Notes / findings (no bugs)

Two test-authoring corrections, both confirming the code is correct:
- Malli's `json-transformer` does NOT coerce string→int (numbers already arrive typed from the JSON parse); the canonical JSON coercion is string→keyword/enum. Tests use realistic coercions.
- `URI.getQuery()` returns the *decoded* query (hiding wire-escaping); the param test asserts on `getRawQuery()` to verify `%20` escaping on the wire.

## Test plan

- [x] `clojure -M:test` from `implementation/http` green
- [x] `npm run test:cljs` from `implementation/` green