### PR TITLE
fix(machines-viz): resolve choose-edge-type spawn arm + retire dead visual-constants test + xyflow-graph projector coverage (rf2-0gmwp)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -79,7 +79,7 @@ first-region-only projection. Each region surfaces a synthetic
 `:region?` compound container node — `chart.layout/parse-definition`
 mints a `region__<region-id>` node-id for it, tags each region state
 with `:region` + `:parent-id`, and flags the result `:parallel? true`.
-`chart.chart/xyflow-graph` projects the container as a
+`chart.projection/xyflow-graph` projects the container as a
 `type: "parallel-region"` xyflow node (rendered by
 `chart.nodes.parallel-region-node` with a distinct dashed boundary +
 header label whose colour rotates per region index) and assigns each

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -46,6 +46,7 @@
             ["elkjs/lib/elk.bundled.js" :as elkjs]
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.chart.nodes :as nodes]
             [day8.re-frame2-machines-viz.chart.edges :as edges]
             [day8.re-frame2-machines-viz.chart.overlays.after-rings
@@ -92,43 +93,6 @@
    "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
    "elk.edgeRouting"                            "SPLINES"})
 
-(defn- elk-child
-  "Build a single elk.js child descriptor for a parsed node (a plain
-  CLJS map; `->elk-input` `clj->js`-es the whole tree)."
-  [n]
-  {:id     (:id n)
-   :width  (if (:compound? n) 220 nodes/state-node-min-width)
-   :height (if (:compound? n) 120 nodes/state-node-min-height)
-   :labels [{:text (:label n)}]})
-
-(defn- ->elk-children
-  "Project parsed nodes into elk.js's `children` shape.
-
-  Flat (non-parallel) machines emit one flat child per node. Parallel
-  machines (rf2-lkwev) nest each region's states UNDER their region
-  container node so elkjs lays the states out INSIDE the region's
-  bounding box (xyflow's parentNode sub-flow then renders them inside
-  the dashed region boundary). Region containers carry their own
-  `elk.algorithm`/`elk.padding` so each orthogonal zone gets a clean
-  internal layout, and the regions themselves are laid side-by-side at
-  the root."
-  [{:keys [nodes parallel?]}]
-  (if-not parallel?
-    (mapv elk-child nodes)
-    (let [region-nodes (filterv :region? nodes)
-          ;; Group the non-region (state) nodes by their parent region.
-          by-parent    (group-by :parent-id (remove :region? nodes))]
-      (mapv (fn [rn]
-              (let [children (get by-parent (:id rn) [])]
-                {:id    (:id rn)
-                 :labels [{:text (:label rn)}]
-                 ;; Each region lays out its own states internally;
-                 ;; padding leaves room for the region header strip.
-                 :layoutOptions {"elk.algorithm" "layered"
-                                 "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}
-                 :children (mapv elk-child children)}))
-            region-nodes))))
-
 (defn- ->elk-input
   "Build an elk.js JS-side input graph for the given parsed nodes +
   edges + direction. Parallel machines (rf2-lkwev) get a hierarchical
@@ -149,7 +113,7 @@
                       (assoc "elk.hierarchyHandling" "INCLUDE_CHILDREN")))]
     #js {:id "root"
          :layoutOptions (clj->js opts)
-         :children (clj->js (->elk-children parsed))
+         :children (clj->js (projection/->elk-children parsed))
          :edges (clj->js
                   (mapv (fn [e]
                           {:id (:id e)
@@ -179,8 +143,8 @@
                     (swap! acc assoc (.-id c)
                            {:x      (or (.-x c) 0)
                             :y      (or (.-y c) 0)
-                            :width  (or (.-width c) nodes/state-node-min-width)
-                            :height (or (.-height c) nodes/state-node-min-height)})
+                            :width  (or (.-width c) projection/state-node-min-width)
+                            :height (or (.-height c) projection/state-node-min-height)})
                     (walk! c)))))]
       (walk! elk-result))
     @acc))
@@ -211,95 +175,12 @@
        (done-fn nil)))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
-
-(defn- choose-edge-type
-  [edge]
-  (cond
-    (:after edge)  "after"
-    :else          "transition"))
-
-(defn xyflow-graph
-  "Project the parsed graph + a `{node-id position}` map into the
-  xyflow `:nodes` + `:edges` arrays. Pure fn (no DOM, no React).
-
-  Options:
-
-    :highlight-id        — node-id of the active state.
-    :from-highlight-id   — node-id of the focused-event lens's
-                           origin state.
-    :to-highlight-id     — node-id of the focused-event lens's
-                           landing state.
-    :sim?                — flips the highlight palette to amber.
-    :on-state-click      — `(fn [path] ...)` invoked when a state
-                           node is clicked."
-  [{:keys [nodes edges]}
-   positions
-   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
-  {:nodes
-   ;; rf2-lkwev — region container nodes MUST precede their children in
-   ;; the xyflow nodes array (xyflow requires a parentNode to appear
-   ;; before any node that references it). Regions are already emitted
-   ;; before their states by `parse-parallel`, but sort defensively so
-   ;; the parent-before-child invariant holds regardless of upstream
-   ;; ordering.
-   (mapv (fn [n]
-           (let [pos     (get positions (:id n) {:x 0 :y 0})
-                 region? (boolean (:region? n))
-                 active? (= (:id n) highlight-id)
-                 from-hi? (= (:id n) from-highlight-id)
-                 to-hi?   (= (:id n) to-highlight-id)
-                 base
-                 {:id       (:id n)
-                  :type     (cond
-                              region?         "parallel-region"
-                              (:compound? n)  "compound"
-                              :else           "state")
-                  :position {:x (:x pos) :y (:y pos)}
-                  :data     (cond-> {:label          (:label n)
-                                     :path           (:path n)
-                                     :active         active?
-                                     :fromHighlight  from-hi?
-                                     :toHighlight    to-hi?
-                                     :sim            (boolean (and active? sim?))
-                                     :final          (boolean (:final? n))
-                                     :compound       (boolean (:compound? n))
-                                     :tags           (vec (:tags n))
-                                     :onClick        on-state-click}
-                              region? (assoc :regionId    (:region n)
-                                             :regionIndex (:region-index n)))
-                  :draggable false
-                  :selectable false}]
-             (cond-> base
-               ;; Region containers carry an explicit measured size so
-               ;; xyflow draws the zone box at the elk-computed extent.
-               region? (assoc :style {:width  (:width pos)
-                                      :height (:height pos)})
-               ;; A state inside a region attaches to its parent region
-               ;; via xyflow's parentNode sub-flow; `:extent "parent"`
-               ;; clamps it inside the dashed boundary.
-               (and (not region?) (:parent-id n))
-               (assoc :parentNode (:parent-id n)
-                      :extent     "parent"))))
-         (sort-by #(if (:region? %) 0 1) nodes))
-   :edges
-   (mapv (fn [e]
-           (let [from-active? (or (= (:source e) highlight-id)
-                                  (= (:target e) highlight-id))
-                 focused?     (and (some? from-highlight-id)
-                                   (some? to-highlight-id)
-                                   (= (:source e) from-highlight-id)
-                                   (= (:target e) to-highlight-id))]
-             {:id     (:id e)
-              :source (:source e)
-              :target (:target e)
-              :type   (choose-edge-type e)
-              :data   {:eventLabel (:event-label e)
-                       :active     from-active?
-                       :focused    focused?
-                       :afterMs    (:after e)
-                       :guard      (some-> (:guard e) name)
-                       :action     (some-> (:action e) name)}}))
-         edges)})
+;;
+;; rf2-0gmwp — the pure projector (`xyflow-graph` / `choose-edge-type`
+;; / the elk `children` shape) moved to `chart.projection` so the JVM
+;; test corpus can pin it without loading xyflow/elkjs. `chart.cljs`
+;; retains only the JS-interop layout glue above + the React component
+;; below.
 
 ;; ---- inline keyframes ---------------------------------------------------
 
@@ -482,7 +363,7 @@
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
                 {:keys [nodes edges]}
-                (xyflow-graph parsed
+                (projection/xyflow-graph parsed
                               @positions
                               {:highlight-id      highlight-id
                                :from-highlight-id from-highlight-id

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -16,11 +16,17 @@
       edge but renders the label as `after(<ms>)` and exposes a
       `:data-after-ms` attr so a host-side overlay can find the
       ring's bearing node.
-    - `spawn-edge` — invocation edge to spawned children. Renders
-      with a dashed stroke + a tiny ⤳ glyph on the label so a
-      reader at-a-glance distinguishes 'invocation' from
-      'transition'. (Reserved — Phase 1 surfaces the path; full
-      spawn-all join inspector is a follow-on bead per the scope.)
+
+  rf2-0gmwp — there is no `spawn` edge type. Per Spec 005 `:spawn` /
+  `:spawn-all` are state-entry actions that bring CHILD actor machines
+  into existence; they are NOT same-machine transitions, so the parse
+  (`chart.layout`) emits no spawn edge and `chart.projection/`
+  `choose-edge-type` has no `spawn` arm to classify into. Spawned
+  children surface through the `chart.overlays.spawn-all-join`
+  inspector (anchored beside the spawn-bearing state), not as an edge
+  in this chart. The previously-registered `spawn-edge` component was
+  dead registration — never reachable from any parsed edge — and was
+  removed.
 
   ## Substrate posture
 
@@ -139,67 +145,17 @@
   `:data {:after-ms}` attr; the rendering shape is the same."
   transition-edge)
 
-;; ---- spawn-edge ---------------------------------------------------------
-
-(defn spawn-edge
-  "Reagent component for a spawn / spawn-all invocation edge. Renders
-  with a dashed stroke and a tiny ⤳ glyph on the label so a reader
-  at-a-glance distinguishes 'invocation' from 'transition'.
-
-  Phase 1 — the visual is in place; the full `:spawn-all` parallel-
-  child viz + join inspector is a follow-on bead per the bead's
-  scope §Overlays."
-  [^js props]
-  (let [src-x      (.-sourceX props)
-        src-y      (.-sourceY props)
-        tgt-x      (.-targetX props)
-        tgt-y      (.-targetY props)
-        src-pos    (.-sourcePosition props)
-        tgt-pos    (.-targetPosition props)
-        marker-end (.-markerEnd props)
-        d          (.-data props)
-        label      (or (.-eventLabel d) "")
-        bz (get-bezier-path
-             #js {:sourceX        src-x
-                  :sourceY        src-y
-                  :sourcePosition src-pos
-                  :targetX        tgt-x
-                  :targetY        tgt-y
-                  :targetPosition tgt-pos})
-        path  (aget bz 0)
-        label-x (aget bz 1)
-        label-y (aget bz 2)]
-    (r/as-element
-      [:<>
-       [:> BaseEdge {:id (.-id props)
-                     :path path
-                     :markerEnd marker-end
-                     :style #js {:stroke (:accent-violet tokens/tokens)
-                                 :strokeWidth 1.5
-                                 :strokeDasharray "5 3"}}]
-       [:> EdgeLabelRenderer
-        [:div {:data-testid (str "rf-mv-chart-spawn-edge-" (.-id props))
-               :style {:position       "absolute"
-                       :transform      (str "translate(-50%, -50%) translate("
-                                            label-x "px," label-y "px)")
-                       :pointer-events "auto"
-                       :font-family    mono-stack
-                       :font-size      "11px"
-                       :color          (:accent-violet tokens/tokens)
-                       :background     (tokens/with-alpha :white 0.85)
-                       :padding        "1px 5px"
-                       :border-radius  "3px"
-                       :white-space    "nowrap"
-                       :user-select    "none"}}
-         "⤳ " label]]])))
-
 ;; ---- edge-types map -----------------------------------------------------
 
 (defn edge-types
   "The `edgeTypes` prop value for `<ReactFlow>`. Returns a fresh
   plain-JS object on every call; callers SHOULD memoise this map at
-  component-construction time to avoid re-render churn."
+  component-construction time to avoid re-render churn.
+
+  Only `transition` + `after` are registered — every parsed edge maps
+  to one of those two via `chart.projection/choose-edge-type`. There
+  is no `spawn` type (rf2-0gmwp): spawns are state-entry actions, not
+  edges (see the ns docstring)."
   []
   #js {"transition" transition-edge
-       "after"      after-edge
-       "spawn"      spawn-edge})
+       "after"      after-edge})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -14,7 +14,7 @@
   ## How it works with xyflow
 
   `chart.layout/parse-parallel` mints a synthetic `:region?` compound
-  node per region; `chart.chart/xyflow-graph` projects it as a
+  node per region; `chart.projection/xyflow-graph` projects it as a
   `type: \"parallel-region\"` xyflow node and assigns every state in
   the region a `parentNode` pointing at the region node (xyflow's
   sub-flow mechanic). This component renders the region's CHROME — a

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -1,0 +1,205 @@
+(ns day8.re-frame2-machines-viz.chart.projection
+  "Pure-data projection layer for the MachineChart — the parsed graph
+  → xyflow `:nodes` / `:edges` arrays + the elk.js `children` shape.
+
+  rf2-0gmwp (2026-05-21) — extracted from `chart.cljs` so the pure
+  projector is JVM-runnable. `chart.cljs` `:require`s `@xyflow/react`
+  + `elkjs`, which makes the WHOLE ns JVM-unloadable; the projection
+  itself is pure CLJS data → data with no DOM, React, or JS-interop,
+  so it lives here where the JVM test corpus can pin it directly
+  (mirroring the `chart.layout` parse split).
+
+  ## What this owns
+
+    - `xyflow-graph` — the central projector that turns
+      `chart.layout/parse-definition` output + a `{node-id position}`
+      map into the xyflow `:nodes` + `:edges` shape, carrying the
+      per-node / per-edge `:data` payloads (active / from-highlight /
+      to-highlight / sim flags, event labels, tags).
+    - `choose-edge-type` — maps a parsed edge to its registered
+      xyflow edge-type id.
+    - `->elk-children` — the elk.js `children` projection (flat for
+      plain machines, nested region containers for parallel ones).
+    - The node-size floor constants the elk projection + the node
+      renderers share.
+
+  ## What this does NOT own
+
+    - **JS-interop glue** — `->elk-input` (`clj->js` / `#js`),
+      `elk-result->positions` (`aget` walk over the elk.js result
+      tree), and the async `compute-layout!` promise pass stay in
+      `chart.cljs`; they touch JS objects and are not portable to the
+      JVM.
+    - **Topology parsing** — lives in `chart.layout`.")
+
+;; ---- node-size floor constants -----------------------------------------
+;;
+;; The elk projection (`elk-child`) and the node renderers
+;; (`chart.nodes`) share these floors so a state's measured box and
+;; its laid-out slot agree. They live here (pure, JVM-readable) so the
+;; projection tests can reference them; `chart.nodes` re-exports them
+;; for the renderer's CSS `min-width` / `min-height`.
+
+(def state-node-min-width
+  "Minimum width in px for a state node body. xyflow lays out nodes
+  based on their measured size; this floor gives every node a
+  consistent rhythm without overflowing labels."
+  140)
+
+(def state-node-min-height
+  "Minimum height in px for a state node body."
+  44)
+
+(def compound-node-min-width
+  "Minimum width for a compound container."
+  220)
+
+(def compound-node-min-height
+  "Minimum height for a compound container."
+  120)
+
+;; ---- elk.js children projection ----------------------------------------
+
+(defn elk-child
+  "Build a single elk.js child descriptor for a parsed node (a plain
+  CLJS map; `chart`'s `->elk-input` `clj->js`-es the whole tree)."
+  [n]
+  {:id     (:id n)
+   :width  (if (:compound? n) compound-node-min-width state-node-min-width)
+   :height (if (:compound? n) compound-node-min-height state-node-min-height)
+   :labels [{:text (:label n)}]})
+
+(defn ->elk-children
+  "Project parsed nodes into elk.js's `children` shape.
+
+  Flat (non-parallel) machines emit one flat child per node. Parallel
+  machines (rf2-lkwev) nest each region's states UNDER their region
+  container node so elkjs lays the states out INSIDE the region's
+  bounding box (xyflow's parentNode sub-flow then renders them inside
+  the dashed region boundary). Region containers carry their own
+  `elk.algorithm`/`elk.padding` so each orthogonal zone gets a clean
+  internal layout, and the regions themselves are laid side-by-side at
+  the root."
+  [{:keys [nodes parallel?]}]
+  (if-not parallel?
+    (mapv elk-child nodes)
+    (let [region-nodes (filterv :region? nodes)
+          ;; Group the non-region (state) nodes by their parent region.
+          by-parent    (group-by :parent-id (remove :region? nodes))]
+      (mapv (fn [rn]
+              (let [children (get by-parent (:id rn) [])]
+                {:id    (:id rn)
+                 :labels [{:text (:label rn)}]
+                 ;; Each region lays out its own states internally;
+                 ;; padding leaves room for the region header strip.
+                 :layoutOptions {"elk.algorithm" "layered"
+                                 "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}
+                 :children (mapv elk-child children)}))
+            region-nodes))))
+
+;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
+
+(defn choose-edge-type
+  "Map a parsed edge to its registered xyflow edge-type id (one of the
+  keys in `chart.edges/edge-types`).
+
+  `:after`-timer edges render via the dedicated `after` type (it adds
+  the `after(<ms>)` label + `data-after-ms` attr the ring overlay
+  reads). Every other edge — plain `:on` transitions AND `:always`
+  eventless transitions — renders via the canonical `transition` type;
+  `:always` carries no distinct edge type (its `always` label segment
+  is composed upstream in `chart.layout/edge-label`).
+
+  Note there is deliberately NO `spawn` arm: per Spec 005 `:spawn` /
+  `:spawn-all` are state-entry actions that bring CHILD actor machines
+  into existence — they are not same-machine transitions, so the parse
+  emits no spawn edge for `choose-edge-type` to classify. Spawned
+  children surface through the `chart.overlays.spawn-all-join`
+  inspector, not as an edge in this chart."
+  [edge]
+  (cond
+    (:after edge) "after"
+    :else         "transition"))
+
+(defn xyflow-graph
+  "Project the parsed graph + a `{node-id position}` map into the
+  xyflow `:nodes` + `:edges` arrays. Pure fn (no DOM, no React).
+
+  Options:
+
+    :highlight-id        — node-id of the active state.
+    :from-highlight-id   — node-id of the focused-event lens's
+                           origin state.
+    :to-highlight-id     — node-id of the focused-event lens's
+                           landing state.
+    :sim?                — flips the highlight palette to amber.
+    :on-state-click      — `(fn [path] ...)` invoked when a state
+                           node is clicked."
+  [{:keys [nodes edges]}
+   positions
+   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
+  {:nodes
+   ;; rf2-lkwev — region container nodes MUST precede their children in
+   ;; the xyflow nodes array (xyflow requires a parentNode to appear
+   ;; before any node that references it). Regions are already emitted
+   ;; before their states by `parse-parallel`, but sort defensively so
+   ;; the parent-before-child invariant holds regardless of upstream
+   ;; ordering.
+   (mapv (fn [n]
+           (let [pos     (get positions (:id n) {:x 0 :y 0})
+                 region? (boolean (:region? n))
+                 active? (= (:id n) highlight-id)
+                 from-hi? (= (:id n) from-highlight-id)
+                 to-hi?   (= (:id n) to-highlight-id)
+                 base
+                 {:id       (:id n)
+                  :type     (cond
+                              region?         "parallel-region"
+                              (:compound? n)  "compound"
+                              :else           "state")
+                  :position {:x (:x pos) :y (:y pos)}
+                  :data     (cond-> {:label          (:label n)
+                                     :path           (:path n)
+                                     :active         active?
+                                     :fromHighlight  from-hi?
+                                     :toHighlight    to-hi?
+                                     :sim            (boolean (and active? sim?))
+                                     :final          (boolean (:final? n))
+                                     :compound       (boolean (:compound? n))
+                                     :tags           (vec (:tags n))
+                                     :onClick        on-state-click}
+                              region? (assoc :regionId    (:region n)
+                                             :regionIndex (:region-index n)))
+                  :draggable false
+                  :selectable false}]
+             (cond-> base
+               ;; Region containers carry an explicit measured size so
+               ;; xyflow draws the zone box at the elk-computed extent.
+               region? (assoc :style {:width  (:width pos)
+                                      :height (:height pos)})
+               ;; A state inside a region attaches to its parent region
+               ;; via xyflow's parentNode sub-flow; `:extent "parent"`
+               ;; clamps it inside the dashed boundary.
+               (and (not region?) (:parent-id n))
+               (assoc :parentNode (:parent-id n)
+                      :extent     "parent"))))
+         (sort-by #(if (:region? %) 0 1) nodes))
+   :edges
+   (mapv (fn [e]
+           (let [from-active? (or (= (:source e) highlight-id)
+                                  (= (:target e) highlight-id))
+                 focused?     (and (some? from-highlight-id)
+                                   (some? to-highlight-id)
+                                   (= (:source e) from-highlight-id)
+                                   (= (:target e) to-highlight-id))]
+             {:id     (:id e)
+              :source (:source e)
+              :target (:target e)
+              :type   (choose-edge-type e)
+              :data   {:eventLabel (:event-label e)
+                       :active     from-active?
+                       :focused    focused?
+                       :afterMs    (:after e)
+                       :guard      (some-> (:guard e) name)
+                       :action     (some-> (:action e) name)}}))
+         edges)})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -43,11 +43,11 @@
   fire) interpolates its `animation-duration` through the same
   `--rf-causa-motion-scale` CSS custom property Causa publishes at
   `:root`. The chart's host (Causa today) ensures the variable is
-  set; when machines-viz ships standalone the chart's own SVG
+  set; when machines-viz ships standalone the chart's own inline
   `<style>` block declares the variable + the
   `prefers-reduced-motion` override so the chart honours the user's
-  setting without a host-side install. See `chart/svg`
-  `inline-stylesheet`. The heartbeat-pulse animation was retired
+  setting without a host-side install. See `chart`
+  `chart-stylesheet`. The heartbeat-pulse animation was retired
   2026-05-20 (rf2-2sez0) — only `:glow-duration-ms` remains in the
   motion catalogue.
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -1,0 +1,364 @@
+(ns day8.re-frame2-machines-viz.chart.projection-cljs-test
+  "Pure-data tests for the MachineChart projection layer (rf2-0gmwp).
+
+  `chart.projection` is the central parsed-graph → xyflow nodes/edges
+  projector plus the elk.js `children` shape + the edge-type chooser.
+  It was extracted from `chart.cljs` (which `:require`s xyflow/elkjs
+  and so is JVM-unloadable) precisely so this corpus can pin it at the
+  cheap JVM layer instead of the slow browser-DOM layer.
+
+  Fixtures lean on `chart.layout/parse-definition` (itself pure +
+  JVM-runnable) so the projection is exercised against the SAME parsed
+  shape the live chart feeds it — no hand-mocked node maps drifting
+  from the parser's contract.
+
+  Dual-target via the `_cljs_test.cljc` extension — same pattern every
+  machines-viz helper test uses."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.projection :as projection]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(def idle-loading
+  "Flat machine with a plain `:on` transition + an `:after` timer + an
+  `:always` eventless transition, so every `choose-edge-type` arm is
+  represented in one parse."
+  {:initial :idle
+   :states  {:idle    {:on    {:start :loading}}
+             :loading {:after {1000 {:target :timeout}}
+                       :always {:target :ready :guard :loaded?}}
+             :ready   {:final? true}
+             :timeout {:final? true}}})
+
+(def compound-machine
+  "One compound parent so the `\"compound\"` node-type arm fires."
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(def parallel-machine
+  "Two-region parallel machine — exercises the region container
+  node-type, the parentNode/extent sub-flow wiring, and the
+  parent-before-child sort."
+  {:type    :parallel
+   :regions {:audio {:initial :muted
+                     :states  {:muted   {:on {:unmute :playing}}
+                               :playing {:on {:mute :muted}}}}
+             :video {:initial :hidden
+                     :states  {:hidden  {:on {:show :shown}}
+                               :shown   {:on {:hide :hidden}}}}}})
+
+(defn- edge-by-id
+  "Pluck an edge from a projected graph by xyflow id."
+  [graph id]
+  (first (filter #(= id (:id %)) (:edges graph))))
+
+(defn- node-by-id
+  [graph id]
+  (first (filter #(= id (:id %)) (:nodes graph))))
+
+;; ---- choose-edge-type (G2) ---------------------------------------------
+
+(deftest choose-edge-type-plain-transition
+  (testing "a plain `:on` edge → the canonical `transition` type"
+    (is (= "transition"
+           (projection/choose-edge-type {:event :start})))))
+
+(deftest choose-edge-type-after-timer
+  (testing "an `:after`-timer edge → the dedicated `after` type"
+    (is (= "after"
+           (projection/choose-edge-type {:after 1000 :event :after-1000})))))
+
+(deftest choose-edge-type-always-falls-to-transition
+  (testing "an `:always` eventless edge has no distinct edge type — it
+            renders via `transition` (its `always` label segment is
+            composed upstream in chart.layout/edge-label, not here)"
+    (is (= "transition"
+           (projection/choose-edge-type {:always? true :event :always})))))
+
+(deftest choose-edge-type-after-wins-over-always
+  (testing "an edge carrying BOTH `:after` and `:always?` is an
+            `:after`-timer first — the `after` arm precedes the
+            transition fall-through"
+    (is (= "after"
+           (projection/choose-edge-type {:after 500 :always? true})))))
+
+(deftest choose-edge-type-has-no-spawn-arm
+  (testing "rf2-0gmwp — `choose-edge-type` NEVER returns `spawn`.
+            Per Spec 005 `:spawn` / `:spawn-all` are state-entry
+            actions (they spawn child actor machines), not same-machine
+            transitions, so the parser emits no spawn edge and there is
+            no spawn arm to classify into. The dead `spawn-edge`
+            registration was removed. Even an edge map with a stray
+            `:spawn` key falls through to `transition`."
+    (is (not= "spawn" (projection/choose-edge-type {:event :foo})))
+    (is (= "transition" (projection/choose-edge-type {:spawn true :event :foo})))))
+
+(deftest choose-edge-type-matches-live-parsed-edges
+  (testing "every edge a real parse emits classifies to a type that is
+            actually registered in chart.edges/edge-types (transition |
+            after) — pins choose-edge-type against the parser's output"
+    (let [{:keys [edges]} (layout/parse-definition idle-loading)]
+      (is (seq edges))
+      (is (every? #{"transition" "after"}
+                  (map projection/choose-edge-type edges))))))
+
+;; ---- xyflow-graph node :type dispatch (G1) -----------------------------
+
+(deftest xyflow-graph-state-node-type
+  (testing "a leaf state projects as a `state`-type node"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          idle   (node-by-id graph (layout/node-id [:idle]))]
+      (is (= "state" (:type idle))))))
+
+(deftest xyflow-graph-compound-node-type
+  (testing "a compound parent projects as a `compound`-type node; its
+            leaf children stay `state`"
+    (let [parsed (layout/parse-definition compound-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          parent (node-by-id graph (layout/node-id [:authenticated]))
+          child  (node-by-id graph (layout/node-id [:authenticated :browsing]))]
+      (is (= "compound" (:type parent)))
+      (is (= "state" (:type child))))))
+
+(deftest xyflow-graph-region-node-type
+  (testing "a parallel-region container projects as a
+            `parallel-region`-type node"
+    (let [parsed (layout/parse-definition parallel-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          region (node-by-id graph (layout/region-node-id :audio))]
+      (is (= "parallel-region" (:type region))))))
+
+;; ---- xyflow-graph parentNode / extent sub-flow wiring (G1) --------------
+
+(deftest xyflow-graph-region-children-wire-parent-node
+  (testing "rf2-lkwev — every state inside a region carries
+            `:parentNode` (the region container id) + `:extent
+            \"parent\"` so xyflow's sub-flow nests + clamps it; the
+            region container itself carries NEITHER"
+    (let [parsed (layout/parse-definition parallel-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          region (node-by-id graph (layout/region-node-id :audio))
+          muted  (node-by-id graph (layout/node-id [:muted]))]
+      (is (= (layout/region-node-id :audio) (:parentNode muted)))
+      (is (= "parent" (:extent muted)))
+      (is (nil? (:parentNode region)) "region container is not nested")
+      (is (nil? (:extent region))))))
+
+(deftest xyflow-graph-flat-state-has-no-parent-node
+  (testing "a state in a non-parallel machine carries no parentNode /
+            extent — those wire ONLY for region children"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          idle   (node-by-id graph (layout/node-id [:idle]))]
+      (is (nil? (:parentNode idle)))
+      (is (nil? (:extent idle))))))
+
+;; ---- xyflow-graph parent-before-child sort (G1) ------------------------
+
+(deftest xyflow-graph-sorts-regions-before-children
+  (testing "rf2-lkwev — xyflow requires a parentNode to appear in the
+            nodes array BEFORE any node that references it. Every
+            region container must precede its first child in the
+            projected order."
+    (let [parsed   (layout/parse-definition parallel-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          ids      (mapv :id (:nodes graph))
+          index-of (fn [id] (.indexOf ids id))]
+      (doseq [n (:nodes graph)
+              :let [parent (:parentNode n)]
+              :when parent]
+        (is (< (index-of parent) (index-of (:id n)))
+            (str "parent " parent " must precede child " (:id n)))))))
+
+(deftest xyflow-graph-region-sort-is-stable-against-shuffle
+  (testing "the sort is defensive — even if upstream emits a child
+            before its region, the projector re-orders regions first"
+    (let [parsed   (layout/parse-definition parallel-machine)
+          ;; Reverse the node order to simulate hostile upstream output.
+          shuffled (update parsed :nodes (comp vec reverse))
+          graph    (projection/xyflow-graph shuffled {} {})
+          ids      (mapv :id (:nodes graph))
+          index-of (fn [id] (.indexOf ids id))]
+      (doseq [n (:nodes graph)
+              :let [parent (:parentNode n)]
+              :when parent]
+        (is (< (index-of parent) (index-of (:id n))))))))
+
+;; ---- xyflow-graph :data flag derivation (G1) ---------------------------
+
+(deftest xyflow-graph-active-flag
+  (testing "the node whose id == highlight-id gets `:active true`; all
+            others `:active false`"
+    (let [parsed   (layout/parse-definition idle-loading)
+          hi       (layout/node-id [:loading])
+          graph    (projection/xyflow-graph parsed {} {:highlight-id hi})
+          loading  (node-by-id graph hi)
+          idle     (node-by-id graph (layout/node-id [:idle]))]
+      (is (true?  (:active (:data loading))))
+      (is (false? (:active (:data idle)))))))
+
+(deftest xyflow-graph-from-and-to-highlight-flags
+  (testing "from-highlight-id / to-highlight-id flip the matching
+            node's `:fromHighlight` / `:toHighlight` flags"
+    (let [parsed (layout/parse-definition idle-loading)
+          from   (layout/node-id [:idle])
+          to     (layout/node-id [:loading])
+          graph  (projection/xyflow-graph parsed {}
+                                          {:from-highlight-id from
+                                           :to-highlight-id   to})]
+      (is (true? (:fromHighlight (:data (node-by-id graph from)))))
+      (is (true? (:toHighlight   (:data (node-by-id graph to)))))
+      (is (false? (:toHighlight  (:data (node-by-id graph from))))))))
+
+(deftest xyflow-graph-sim-flag-is-active-and-sim
+  (testing ":sim is the conjunction of active? AND the sim? option —
+            an active node with sim? true gets `:sim true`; the same
+            node with sim? false gets `:sim false`; an inactive node
+            never gets `:sim` regardless of sim?"
+    (let [parsed   (layout/parse-definition idle-loading)
+          hi       (layout/node-id [:loading])
+          sim      (projection/xyflow-graph parsed {} {:highlight-id hi :sim? true})
+          no-sim   (projection/xyflow-graph parsed {} {:highlight-id hi :sim? false})
+          inactive (projection/xyflow-graph parsed {} {:highlight-id hi :sim? true})]
+      (is (true?  (:sim (:data (node-by-id sim hi)))))
+      (is (false? (:sim (:data (node-by-id no-sim hi)))))
+      (is (false? (:sim (:data (node-by-id inactive (layout/node-id [:idle])))))))))
+
+(deftest xyflow-graph-edge-active-when-endpoint-highlighted
+  (testing "an edge is `:active` when EITHER endpoint is the
+            highlighted node"
+    (let [parsed (layout/parse-definition idle-loading)
+          hi     (layout/node-id [:loading])
+          graph  (projection/xyflow-graph parsed {} {:highlight-id hi})
+          ;; idle --start--> loading : target is highlighted
+          e      (first (filter #(= (:source %) (layout/node-id [:idle]))
+                                (:edges graph)))]
+      (is (true? (:active (:data e)))))))
+
+(deftest xyflow-graph-edge-focused-when-source-and-target-match-lens
+  (testing "an edge is `:focused` ONLY when source==from-highlight AND
+            target==to-highlight (the focused-event lens). A partial
+            match is not focused."
+    (let [parsed (layout/parse-definition idle-loading)
+          from   (layout/node-id [:idle])
+          to     (layout/node-id [:loading])
+          graph  (projection/xyflow-graph parsed {}
+                                          {:from-highlight-id from
+                                           :to-highlight-id   to})
+          focused-edge (first (filter #(and (= (:source %) from)
+                                            (= (:target %) to))
+                                      (:edges graph)))
+          other-edges  (remove #(and (= (:source %) from)
+                                      (= (:target %) to))
+                               (:edges graph))]
+      (is (true? (:focused (:data focused-edge))))
+      (is (every? false? (map (comp :focused :data) other-edges))))))
+
+(deftest xyflow-graph-edge-not-focused-without-both-lens-ends
+  (testing "with only ONE lens end set, no edge is focused (the
+            some?/some? guard requires both)"
+    (let [parsed (layout/parse-definition idle-loading)
+          from   (layout/node-id [:idle])
+          graph  (projection/xyflow-graph parsed {} {:from-highlight-id from})]
+      (is (every? false? (map (comp :focused :data) (:edges graph)))))))
+
+;; ---- xyflow-graph misc payload + style ---------------------------------
+
+(deftest xyflow-graph-region-style-from-measured-position
+  (testing "a region container's `:style {:width :height}` comes from
+            its measured position entry"
+    (let [parsed    (layout/parse-definition parallel-machine)
+          rid       (layout/region-node-id :audio)
+          positions {rid {:x 0 :y 0 :width 320 :height 180}}
+          graph     (projection/xyflow-graph parsed positions {})
+          region    (node-by-id graph rid)]
+      (is (= {:width 320 :height 180} (:style region))))))
+
+(deftest xyflow-graph-position-defaults-to-origin
+  (testing "a node with no entry in the positions map defaults to
+            {:x 0 :y 0} (the pre-layout placeholder)"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          idle   (node-by-id graph (layout/node-id [:idle]))]
+      (is (= {:x 0 :y 0} (:position idle))))))
+
+(deftest xyflow-graph-edge-carries-after-ms-and-event-label
+  (testing "edge `:data` surfaces the after-ms duration + the composed
+            event label from the parsed edge"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          after  (first (filter #(:afterMs (:data %)) (:edges graph)))]
+      (is (some? after) "the :after edge surfaces an :afterMs")
+      (is (= 1000 (:afterMs (:data after))))
+      (is (string? (:eventLabel (:data after)))))))
+
+(deftest xyflow-graph-region-data-carries-region-id-and-index
+  (testing "a region container's `:data` carries `:regionId` +
+            `:regionIndex`; a plain state's does not"
+    (let [parsed (layout/parse-definition parallel-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          audio  (node-by-id graph (layout/region-node-id :audio))
+          video  (node-by-id graph (layout/region-node-id :video))
+          muted  (node-by-id graph (layout/node-id [:muted]))]
+      (is (= :audio (:regionId (:data audio))))
+      (is (= 0 (:regionIndex (:data audio))))
+      (is (= 1 (:regionIndex (:data video))))
+      (is (not (contains? (:data muted) :regionId))))))
+
+;; ---- ->elk-children (G3) -----------------------------------------------
+
+(deftest elk-children-flat-is-one-per-node
+  (testing "a flat machine projects one elk child per parsed node, each
+            with id + width/height floors + a label"
+    (let [parsed   (layout/parse-definition idle-loading)
+          children (projection/->elk-children parsed)]
+      (is (= (count (:nodes parsed)) (count children)))
+      (is (every? :id children))
+      (is (every? #(pos? (:width %)) children))
+      (is (every? #(pos? (:height %)) children)))))
+
+(deftest elk-children-compound-uses-compound-floor
+  (testing "a compound node gets the compound size floor; a leaf gets
+            the state floor"
+    (let [parsed   (layout/parse-definition compound-machine)
+          children (projection/->elk-children parsed)
+          by-id    (into {} (map (juxt :id identity)) children)
+          parent   (get by-id (layout/node-id [:authenticated]))
+          leaf     (get by-id (layout/node-id [:unauth]))]
+      (is (= projection/compound-node-min-width  (:width parent)))
+      (is (= projection/compound-node-min-height (:height parent)))
+      (is (= projection/state-node-min-width  (:width leaf)))
+      (is (= projection/state-node-min-height (:height leaf))))))
+
+(deftest elk-children-parallel-nests-states-under-regions
+  (testing "rf2-lkwev — a parallel machine projects ONE elk child per
+            region (not per state); each region carries its own
+            layoutOptions + nests its states as :children so elkjs lays
+            them out inside the zone"
+    (let [parsed   (layout/parse-definition parallel-machine)
+          children (projection/->elk-children parsed)]
+      ;; two regions → two top-level elk children
+      (is (= 2 (count children)))
+      (is (every? #(contains? % :layoutOptions) children))
+      (is (every? #(seq (:children %)) children))
+      ;; the audio region nests its two states
+      (let [audio (first (filter #(= (layout/region-node-id :audio) (:id %))
+                                 children))]
+        (is (= 2 (count (:children audio))))))))
+
+(deftest elk-children-region-padding-leaves-header-room
+  (testing "each region's elk.padding leaves top room for the header
+            strip the parallel-region-node paints"
+    (let [parsed   (layout/parse-definition parallel-machine)
+          children (projection/->elk-children parsed)]
+      (is (every? #(= "layered" (get-in % [:layoutOptions "elk.algorithm"]))
+                  children))
+      (is (every? #(re-find #"top=" (get-in % [:layoutOptions "elk.padding"]))
+                  children)))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -1,13 +1,6 @@
 (ns day8.re-frame2-machines-viz.visual-constants-cljs-test
-  "Roundtrip / shape pin for the chart visual constants (rf2-hz3tj).
-
-  Per audit `ai/findings/2026-05-20-tools-testing-posture-audit.md`
-  Gap-4, `visual_constants.cljc` was the only src file in
-  `tools/machines-viz/src/` without a test companion. The constants
-  themselves don't drift silently — but the dependents (chart/svg,
-  chart/layout, chart/controls) destructure specific keys from
-  `vc/chart`, and a typo in a key rename would surface as a runtime
-  nil through every chart consumer.
+  "Shape + density-contract pin for the chart visual constants
+  (rf2-hz3tj).
 
   This file pins the SHAPE of `vc/chart`: the expected key set, the
   types each value resolves to, and the no-nil invariant. Cheap —
@@ -21,7 +14,21 @@
   holds across every density, and `chart-for-density` resolves the
   closed catalogue + throws on unknown densities.
 
-  Cites audit Gap-4."
+  rf2-0gmwp — what this guards, post-xyflow-migration. The
+  pre-migration consumers (`chart/svg`, `chart/controls`) were
+  DELETED in rf2-gpzb4; the docstring above used to name them. What
+  `visual-constants` (and therefore this suite) actually guards now is
+  the **`:density` contract specified in `tools/machines-viz/spec/`
+  `API.md` §Density** — `MachineChart`'s `:density` prop resolves
+  through `visual-constants/chart-for-density`, the three named maps
+  share a key set, and the corner-radius lock is density-invariant.
+  That is a normative spec surface in a spec-first project, so the
+  contract is real even while the xyflow renderer's `:density`
+  consumption is still being re-wired (the xyflow `MachineChart`
+  currently hardcodes the regular-density numbers rather than reading
+  `chart-for-density`; closing that renderer gap — including
+  reconciling the drifted tag-pill values — is tracked separately).
+  This suite pins the data contract the renderer rewire must satisfy."
   (:require
     #?(:clj  [clojure.test :refer [deftest is testing]]
        :cljs [cljs.test    :refer-macros [deftest is testing]])
@@ -29,7 +36,9 @@
 
 ;; ---- the expected key catalogue ----------------------------------------
 ;;
-;; The chart's renderer destructures every one of these. A key
+;; The `:density` contract (spec/API.md §Density) requires every named
+;; density map to carry exactly this key set; the renderer rewire that
+;; threads `chart-for-density` destructures every one. A key
 ;; disappearing here (rename, accidental dissoc, late edit) would
 ;; surface as a runtime nil in the chart hiccup — silently. This set
 ;; is the load-bearing inventory.


### PR DESCRIPTION
## Summary

Closes the three rf2-0gmwp items (a likely bug, a dead test, and missing projector coverage) for the xyflow MachineChart.

**1. choose-edge-type spawn arm (decision: remove the dead registration).**
The `spawn-edge` component + its `"spawn"` entry in `edge-types` was dead registration — `choose-edge-type` could never produce `"spawn"` and no parsed edge carried a spawn marker. Per Spec 005, `:spawn` / `:spawn-all` are **state-entry actions** that bring CHILD actor machines into existence; they are NOT same-machine transitions, so `chart.layout` emits no spawn edge for `choose-edge-type` to classify. (Spawned children surface through the `spawn-all-join` overlay, anchored beside the spawn-bearing state — not as an edge.) Removed the component + registration; pinned the absence with a test.

**2. visual_constants dead coverage (decision: keep + refresh, file the renderer rewire).**
The test's docstring named deleted consumers (`chart/svg`, `chart/controls`). But `visual-constants` is not orphaned-by-design dead code — the `:density` prop it backs is **specified in `machines-viz/spec/API.md` §Density** (a normative surface in this spec-first project). The xyflow migration regressed the *renderer's* consumption (it now hardcodes the regular-density numbers); deleting the module would diverge the impl from the spec. Refreshed the docstring to state what the suite actually guards (the `:density` data-contract), and filed **rf2-k647w** to re-wire the renderer through `visual-constants/chart-for-density` (incl. reconciling drifted tag-pill values), which is a feature build beyond a test-coverage bead.

**3. xyflow-graph projector coverage (G1/G2/G3).**
Extracted the pure projector (`xyflow-graph`, `choose-edge-type`, `->elk-children` + node-size floors) from `chart.cljs` (JVM-unloadable — requires xyflow/elkjs) into `chart/projection.cljc`, then added `chart/projection_cljs_test.cljc` covering: node `:type` dispatch (state/compound/parallel-region), the `parentNode`/`:extent "parent"` sub-flow wiring, the parent-before-child sort (incl. a defensive re-sort against shuffled input), the `:data` flag derivation (active / from-/to-highlight / sim / edge `:focused`), region `:style` from measured position, and the flat + nested `->elk-children` projections. JS-interop glue (`->elk-input`, `elk-result->positions`, `compute-layout!`) stays in `chart.cljs`.

## Test plan
- [x] `clojure -M:test` from `tools/machines-viz` — 158 tests, 362 assertions, 0 failures/errors
- [x] `npm run test:cljs` from `implementation/` — 4067 tests, 12295 assertions, 0 failures/errors (confirms `chart.cljs` / `edges.cljs` compile after the extraction + spawn-edge removal)
- [x] `npm run test:bundle-isolation` — PASS (machines-viz stays bundle-isolated)