### PR TITLE
docs(skill): add Storybook-JS mental-model framing to Story references (rf2-8syr6)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -139,7 +139,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **State machines — `references/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`.
 
-**Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play-script`), `story-mcp-loop.md` (agent self-healing loop over MCP), `causa.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open).
+**Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play-script`), `story-mcp-loop.md` (agent self-healing loop over MCP), `causa.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open). For anything Story, the standing bridge is **think in Storybook JS, then map onto Story** — `stories.md` carries the verified concept map.
 
 **Cross-cutting — `references/cross-cutting/`**: `testing.md` (with-frame, dispatch-sync, compute-sub), `api-cheatsheet.md`, `privacy-and-elision.md` (schema `:sensitive?` / `:large?` / `elide-wire-value`), `production-observability.md` (`register-event-listener!` / `register-error-listener!`), `ssr-authoring.md` (`reg-head` / `render-head` / `active-head` / `head-model->html` and the `:rf.ssr/check-version` + `:rf.ssr/check-schema-digest` fxs).
 

--- a/skills/re-frame2/references/tooling/stories.md
+++ b/skills/re-frame2/references/tooling/stories.md
@@ -2,7 +2,31 @@
 
 > Authoring `reg-story` / `reg-variant` (and the five other Story `reg-*` macros). Assumes you already know what a component playground / story is — this leaf only covers re-frame2's specific declarations.
 
-> **Tip**: stuck on how to model a story/variant/workspace shape? Ask *"how would Storybook do it?"* — Storybook is in your training data and re-frame2's primitives map cleanly: `reg-story` ≈ CSF story, `reg-variant` ≈ story export (`Default` / `WithProps` / etc.), `reg-decorator` ≈ Storybook decorator, `reg-story-panel` ≈ addon panel, `:play-script` ≈ Storybook play. Differences worth noting: re-frame2 has **`reg-workspace` as first-class composition** (Storybook doesn't quite — closer to Ladle's compose); `reg-mode` is re-frame2-specific (app-state modes like dark/light, not Storybook themes). Sketch in Storybook mentally, then translate.
+## Mental model: think in Storybook, map onto Story
+
+**Standing advice for all Story work: think about how you'd do it in Storybook JS, then map those ideas onto Story.** Storybook is the widely-known component-playground mental model and it's in your training data — sketch the shape there first ("which story, which args, which controls, which play step?"), then translate to re-frame2's `reg-*` declarations. The primitives line up cleanly, with a few deliberate divergences that are themselves the interesting part.
+
+| Storybook concept | Story equivalent | Notes |
+|---|---|---|
+| **story** (CSF named export `Default` / `WithProps` / …) | `reg-variant` (one variant per scenario); the component-level parent is `reg-story` | A `reg-story` carries the `:component` + shared defaults; each `reg-variant` is one scenario, exactly like a CSF named export. |
+| **args** | `:args` | Same concept, same name. Five layers compose by deep-merge (global → story → mode → variant → live cell-override); vectors replace. Matches Storybook's merge convention. |
+| **argTypes** | `:argtypes` — but rarely written | Story auto-derives the controls panel from the view's **Malli schema**. Write `[:int {:min 0 :max 100}]` once on the view and every story gets the slider. `:argtypes` is only the per-key override channel for what the schema can't say. |
+| **controls** | the controls panel | Schema-derived (see above). `:string`→text, bounded `:int`→slider, `[:enum …]`→select, `[:map …]`→nested group, `[:vector X]`→repeater. |
+| **play function** | `:play-script` (phase 4) | A vector of TAGGED steps (`[:dispatch-sync ev]` / `[:click sel]` / `[:type sel txt]` / `[:wait ms]` / …), NOT a closure. Assertions ride `[:dispatch-sync [:rf.assert/* …]]`. **Key divergence:** `:rf.assert/*` events *record* into `:assertions` and continue — Storybook's play throws on first failure; Story collects every mismatch. |
+| **decorators** (project / component / story) | `reg-decorator` + `:decorators` | Three kinds — `:hiccup` (wrapper), `:frame-setup` (seed app-db / fire init events), `:fx-override` (stub an fx). Project-wide decorators go in `configure! :rf.story/global-decorators` — the `preview.ts` `decorators: […]` parity. Compose order is global → story → variant, same as Storybook. |
+| **globals / globalTypes toolbar** (theme · viewport · locale · backgrounds) **+ Chromatic Modes** | `reg-mode` (saved arg tuples) | One primitive collapses all four Storybook toolbar addons. `(reg-mode :Mode.theme/dark {:axis :theme :args {:theme :dark}})` is the theme switcher; `:viewport` / `:locale` / `:background` axes cover the rest. Each `(variant × mode)` cell is independently snapshot-able — that's the Chromatic-Modes combinatorial-matrix idea, native. |
+| **tags** (`autodocs` / `test` / `dev`, `!`-removal) | `:tags` + `reg-tag` | Same inclusion-and-filter role; same `!`-prefix removal (`:!dev` drops an inherited tag). The seven canonical tags auto-register. |
+| **record-canvas-as-CSF** recorder | `start-recording!` → `gen-play-snippet` → `:play-script` | EDN out, not Testing-Library code — no DOM-event translation layer. See `story-recorder.md`. |
+
+**Where Story deliberately has NO Storybook equivalent (read these as the payoff, not a gap):**
+
+- **CSF itself / the default-export + named-export file format.** Story is EDN-first: the seven `reg-*` macros, pure data, no `:render` fn-slot. The combined Form-B `(reg-story id {:variants {…}})` is the closest *shape* to CSF's default-export-plus-named-exports, but a variant body round-trips as data (over the wire, into the MCP pipeline, to a visual-regression server) in a way CSF's inline-JSX bodies cannot. This restriction is the design centre, not a missing feature.
+- **The render fn / `useArgs()` / `useState()`** — and the hooks-inside-stories re-render gotcha that comes with them. Every variant IS its own re-frame frame with its own `app-db`; stateful stories are the default, driven by `:events` (setup) and `:play-script` (post-render) and read with subs. No render fn means no place for a hook to break.
+- **A first-party visual-regression service** (Chromatic / Percy). Story ships the `snapshot-identity` hook for downstream services to consume; it is not in the pixel-capture/baseline-storage business.
+
+Sketch in Storybook mentally, then translate.
+
+> **One-liner for the next leaf:** the same "think in Storybook, map onto Story" bridge applies to the recorder (`story-recorder.md`) and the agent loop (`story-mcp-loop.md`).
 
 ## When to load this leaf
 

--- a/skills/re-frame2/references/tooling/story-mcp-loop.md
+++ b/skills/re-frame2/references/tooling/story-mcp-loop.md
@@ -2,6 +2,8 @@
 
 > The agent loop pattern: write a variant → run it via story-mcp → assert via `:rf.assert/*` → refine on failure. Assumes you already know what MCP is — this leaf covers the four-step loop and the story-mcp tools that wire each step.
 
+> **Mental model: think in Storybook, map onto Story.** When authoring a variant in step 1, sketch it as a Storybook story first (which args, which play steps?), then translate to the EDN `reg-variant` body — see `stories.md` §Mental model for the full concept map. The loop's distinctive twist over a Storybook play function: `:rf.assert/*` events *record* (they don't throw), so `read-failures` returns **every** mismatch in one pass — the agent refines against the complete failure set, not just the first thrown assertion.
+
 ## When to load this leaf
 
 - An agent (Claude Code, Cursor, Copilot) is generating variants against a re-frame2 codebase and needs to iterate against the running Story library.

--- a/skills/re-frame2/references/tooling/story-recorder.md
+++ b/skills/re-frame2/references/tooling/story-recorder.md
@@ -2,6 +2,8 @@
 
 > Recording canvas interactions and pasting the captured trace into a `:play-script` body. Assumes you already know what record-and-save UX is (Storybook 9's marquee feature) — this leaf covers re-frame2's specific recorder surface and the canvas-as-fixture pattern that makes it work.
 
+> **Mental model: think in Storybook, map onto Story.** The recorder is Story's answer to Storybook 9's "record canvas interactions → CSF" feature. The difference is the output shape: Storybook emits a Testing-Library code translation; Story emits a pure-EDN `:play-script` step sequence with no DOM-event capture and no page-object layer. Picture the Storybook record-and-save flow, then map: `REC` toggle → `start-recording!` / `stop-recording!`; the generated CSF story → a `(reg-variant …)` form with an `:extends` link and a `:play-script` body. Full concept table in `stories.md` §Mental model.
+
 ## When to load this leaf
 
 - A variant's `:play-script` body needs to grow but you'd rather drive the canvas than hand-author the event vectors.


### PR DESCRIPTION
## Directive

Standing advice for any /skill content related to Story: *"think about how I would do this in Storybook JS, and map those ideas onto Story."* Storybook JS is the widely-known mental model; anchoring Story guidance to it lets users transfer intuition. Added as a recurring mental-model framing (not a throwaway line).

## Files

- `skills/re-frame2/references/tooling/stories.md` (PRIMARY) — prominent "Mental model: think in Storybook, map onto Story" section near the top, with a verified Storybook→Story concept table and an explicit list of where Story deliberately has NO equivalent.
- `skills/re-frame2/references/tooling/story-recorder.md` — shorter pointer to the same bridge (record-canvas-as-CSF → `start-recording!`/`gen-play-snippet`/`:play-script`).
- `skills/re-frame2/references/tooling/story-mcp-loop.md` — shorter pointer (sketch as a Storybook story, then translate; record-don't-throw → `read-failures` returns every mismatch).
- `skills/re-frame2/SKILL.md` — one-line nod in the Tooling reference list.

## Verified concept mapping (against `tools/story/spec/` + `tools/story/src/`)

| Storybook | Story | Source |
|---|---|---|
| story (CSF named export) | `reg-variant`; parent is `reg-story` | 001-Authoring §three pillars |
| args | `:args` (5-layer deep-merge) | 001 §Args |
| argTypes | `:argtypes` — but controls auto-derive from the view's Malli schema; `:argtypes` is the override channel | 001 §Schema→controls |
| controls | the controls panel (schema-derived) | 001 §Controls |
| play function | `:play-script` (phase 4) — **DIVERGENCE:** `:rf.assert/*` events record, don't throw | 004-Assertions §record-don't-throw |
| decorators (project/component/story) | `reg-decorator` (`:hiccup`/`:frame-setup`/`:fx-override`); `:rf.story/global-decorators` = `preview.ts` decorators; global→story→variant order | 001 §Global decorators |
| globals/globalTypes toolbar (theme·viewport·locale·backgrounds) + Chromatic Modes | `reg-mode` (saved tuples) — one primitive collapses all four | Feature-Parity-Audit:106; 010-Toolbar §addon mappings |
| tags (`autodocs`/`test`/`dev`, `!`-removal) | `:tags` + `reg-tag` (same `!`-prefix removal) | 001 §reg-tag |
| record-canvas-as-CSF | `start-recording!` → `gen-play-snippet` → `:play-script` (EDN, no Testing-Library translation) | Feature-Parity-Audit:124 |

**Deliberately NO Story equivalent:**
- **CSF / the default-export+named-export file format** — Story is EDN-first, no `:render` fn-slot; Form-B `(reg-story {:variants {…}})` is the closest *shape*. (DESIGN-RATIONALE §Rejected: CSF Factories)
- **render fn / `useArgs` / `useState`** (and the hooks-inside-stories gotcha) — every variant IS a frame; pure-data body. (001 §Frame-as-isolation)
- **first-party visual-regression service** (Chromatic/Percy) — Story ships only the `snapshot-identity` hook. (DESIGN-RATIONALE §Rejected)

Also corrects the prior tip line's inaccurate claim that `reg-mode` is "re-frame2-specific … not Storybook themes" — `reg-mode` is in fact the direct counterpart of Storybook's globals/globalTypes toolbar plus Chromatic Modes.

## Gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_skill_redirect_anchors.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0)