### PR TITLE
fix(pair-mcp): real async assertions (no more false-green) + port-discovery/transport coverage (rf2-wnrpi)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -131,7 +131,7 @@
          :session       nil
          :probed-builds #{}}))
 
-(defn- attach-handlers!
+(defn attach-handlers!
   "Wire up `data` / `error` / `close` on the freshly-connected socket.
   Resolves pending requests on matching `:done` status; logs errors;
   marks the conn closed on disconnect.
@@ -141,7 +141,15 @@
   variants left a window where a second `data` callback (or a
   Buffer.concat racing) could observe the freshly-accumulated bytes
   but not yet the trimmed trailer, double-decoding the same frame.
-  One atomic swap closes that window."
+  One atomic swap closes that window.
+
+  Public (not `defn-`) so `nrepl_test.cljs` can drive the data-folding
+  + pending-id dispatch with a fake socket — feeding synthetic chunks
+  and asserting pending handlers fire — without opening a real TCP
+  socket (rf2-wnrpi). The fake socket need only implement an `on`
+  method that records the callback per event name; see the test's
+  `fake-socket` helper. This mirrors the `decode-all-frames`
+  public-for-test precedent above."
   [conn-atom ^js socket]
   (j/call socket :on "data"
     (fn [chunk]

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/cache_test.cljs
@@ -14,6 +14,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [cljs.reader :as edn]
             [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.cache :as cache]))
 
 ;; ---------------------------------------------------------------------------
@@ -36,21 +37,10 @@
   (cond-> #js {:content #js [#js {:type "text" :text text}]}
     error? (j/assoc! :isError true)))
 
-(defn- args-js
-  "Construct a JS args object from a CLJS map (helps the
-  `j/get`-by-name paths in `args->fingerprint`)."
-  [m]
-  (let [o #js {}]
-    (doseq [[k v] m]
-      (j/assoc! o (name k) v))
-    o))
-
-(defn- extract-text
-  "Pull the first text slot off an MCP result."
-  [result]
-  (let [content (j/get result :content)
-        item    (when (array? content) (aget content 0))]
-    (when item (j/get item :text))))
+;; `args-js` + `extract-text` are the shared wire-envelope extractors
+;; (rf2-wnrpi) — one definition in `test-utils`, aliased here.
+(def ^:private args-js tu/args->js)
+(def ^:private extract-text tu/extract-text)
 
 (defn- cache-hit-result?
   "True iff `result` is a `:rf.mcp/cache-hit` marker."

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -270,6 +270,8 @@
     | subscribe              | n/a   | yes         | n/a               |
     | unsubscribe            | n/a   | yes         | n/a               |
     | list-subscriptions     | yes   | n/a         | n/a               |
+    | handler-meta           | yes   | yes         | (short-circuit)   |
+    | list-handlers          | yes   | yes         | (short-circuit)   |
     | get-re-frame2-pair-instructions | yes   | n/a         | n/a               |
     | (pipeline)             | cache-hit (precheck) ; unknown-tool error  |
 
@@ -646,6 +648,58 @@
      ":allow-raw-state? false"]
     :fixture/expect
     {:isError? false}}
+
+   ;; ---------- handler-meta (rf2-wnrpi, finding G7) ----------------------
+   ;; Previously handler-meta / list-handlers had NO outer-wire-shape pin
+   ;; in the corpus — their unit suite carried error paths only (and even
+   ;; those were silently skipped pre-rf2-wnrpi). These fixtures put both
+   ;; tools inside the "every tool" cross-tool ratchet the corpus promises.
+   {:fixture/id    :handler-meta/happy
+    :fixture/doc   "handler-meta on a registered (kind,id) merges :ok? true + the requested kind/id onto the runtime meta map."
+    :fixture/tool  "handler-meta"
+    :fixture/args  {:kind "event" :id ":user/login"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["registrar-describe"        {:ns "user.app" :line 12 :doc "login event"}]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError?          false
+     :edn-submap        {:ok? true :kind :event :id :user/login}
+     :edn-contains-keys #{:ns :line :doc}}}
+
+   {:fixture/id    :handler-meta/missing-kind
+    :fixture/doc   "handler-meta with no :kind short-circuits on :invalid-kind before any nREPL round-trip."
+    :fixture/tool  "handler-meta"
+    :fixture/args  {:id ":user/login"}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :invalid-kind}}
+
+   ;; ---------- list-handlers (rf2-wnrpi, finding G7) ---------------------
+   {:fixture/id    :list-handlers/happy
+    :fixture/doc   "list-handlers returns the sorted id vector + :count for a kind, wrapped :ok? true."
+    :fixture/tool  "list-handlers"
+    :fixture/args  {:kind "event"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  true]
+     ["registrar-list"            [:user/login :user/logout]]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError?   false
+     :edn-submap {:ok? true :kind :event
+                  :ids [:user/login :user/logout] :count 2}}}
+
+   {:fixture/id    :list-handlers/missing-kind
+    :fixture/doc   "list-handlers with no :kind short-circuits on :invalid-kind."
+    :fixture/tool  "list-handlers"
+    :fixture/args  {}
+    :fixture/eval-script
+    [[:default nil]]
+    :fixture/expect
+    {:isError? true
+     :reason :invalid-kind}}
 
    ;; ---------- pipeline: unknown tool ------------------------------------
    {:fixture/id    :pipeline/unknown-tool

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dispatch_test.cljs
@@ -16,7 +16,7 @@
                               the security gate (rf2-vflrg)"
   (:require [cljs.test :refer-macros [deftest is async]]
             [cljs.reader]
-            [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.dispatch :as dispatch]))
 
@@ -49,17 +49,10 @@
         (.then (fn [_] (body-fn)))
         (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
 
-(defn- read-result-text
-  "Extract the EDN text from a `wire/ok-text` / `wire/err-text` JS
-  envelope and read it back as CLJS data."
-  [result-js]
-  (let [content (j/get result-js :content)
-        item    (when (array? content) (aget content 0))
-        text    (when item (j/get item :text))]
-    (cljs.reader/read-string text)))
-
-(defn- err? [result-js]
-  (true? (j/get result-js :isError)))
+;; `read-result-text` (EDN read of the wire envelope) and `err?` are the
+;; shared extractors (rf2-wnrpi) — aliased from `test-utils`.
+(def ^:private read-result-text tu/extract-edn)
+(def ^:private err? tu/error?)
 
 ;; ---------------------------------------------------------------------------
 ;; Rejection arms — the security gate.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -18,32 +18,22 @@
        kinds; `machine-meta` for `:machine`).
     4. Error envelopes — missing / invalid kind / id arguments surface
        structured `:reason` slots an agent can read."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [applied-science.js-interop :as j]
-            [cljs.reader :as edn]
+            [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.handler-meta :as hm]))
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers.
+;;
+;; The wire-envelope extractors live in `test-utils` (shared across
+;; suites, rf2-wnrpi). `args-js` is aliased to the shared `args->js`.
 ;; ---------------------------------------------------------------------------
 
-(defn- args-js [m]
-  (let [o #js {}]
-    (doseq [[k v] m]
-      (j/assoc! o (name k) v))
-    o))
-
-(defn- extract-text [result]
-  (let [content (j/get result :content)
-        item    (when (array? content) (aget content 0))]
-    (when item (j/get item :text))))
-
-(defn- extract-edn [result]
-  (some-> (extract-text result) edn/read-string))
-
-(defn- is-error? [result]
-  (true? (j/get result :isError)))
+(def ^:private args-js tu/args->js)
+(def ^:private extract-edn tu/extract-edn)
+(def ^:private is-error? tu/error?)
 
 (defn- find-descriptor [name]
   (some #(when (= name (:name %)) %) tools/tool-descriptors))
@@ -106,42 +96,59 @@
 ;;
 ;; The tool short-circuits on bad args BEFORE reaching `probe/ensure-runtime!`.
 ;; A nil conn never gets touched on these paths.
+;;
+;; rf2-wnrpi: these six tests used to call `(.then p (fn [r] (is ...)))`
+;; from a SYNCHRONOUS deftest body — the deftest returned before the
+;; Promise resolved, so cljs.test recorded each as passed with ZERO
+;; assertions. The error-envelope contract for both tools was therefore
+;; effectively untested (a flipped `:invalid-kind` reason or an NPE on
+;; the nil conn would have passed green). Each now wraps the `.then` in
+;; `(async done ...)` so the assertions actually run before the test
+;; completes — mirroring `dispatch_test` / `probe_test`.
 ;; ---------------------------------------------------------------------------
 
 (deftest handler-meta-rejects-missing-kind
   (testing "handler-meta with no :kind surfaces :invalid-kind"
-    (let [p (hm/handler-meta-tool nil (args-js {:id ":user/login"}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :invalid-kind (:reason edn)))))))))
+    (async done
+      (-> (hm/handler-meta-tool nil (args-js {:id ":user/login"}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :invalid-kind (:reason edn))))
+                   (done)))))))
 
 (deftest handler-meta-rejects-unknown-kind
   (testing "handler-meta with an out-of-vocab :kind surfaces :invalid-kind"
-    (let [p (hm/handler-meta-tool nil (args-js {:kind "not-a-kind"
-                                                 :id   ":user/login"}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :invalid-kind (:reason edn)))
-                   (is (= "not-a-kind" (:kind edn)))))))))
+    (async done
+      (-> (hm/handler-meta-tool nil (args-js {:kind "not-a-kind"
+                                              :id   ":user/login"}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :invalid-kind (:reason edn)))
+                     (is (= "not-a-kind" (:kind edn))))
+                   (done)))))))
 
 (deftest handler-meta-rejects-missing-id
   (testing "handler-meta with kind but no :id surfaces :missing-id"
-    (let [p (hm/handler-meta-tool nil (args-js {:kind "event"}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :missing-id (:reason edn)))))))))
+    (async done
+      (-> (hm/handler-meta-tool nil (args-js {:kind "event"}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :missing-id (:reason edn))))
+                   (done)))))))
 
 (deftest handler-meta-rejects-invalid-id-edn
   (testing "handler-meta with unreadable :id surfaces :invalid-id-edn"
-    (let [p (hm/handler-meta-tool nil (args-js {:kind "event"
-                                                 :id   "{:unclosed"}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :invalid-id-edn (:reason edn)))))))))
+    (async done
+      (-> (hm/handler-meta-tool nil (args-js {:kind "event"
+                                              :id   "{:unclosed"}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :invalid-id-edn (:reason edn))))
+                   (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; list-handlers-tool — error envelopes.
@@ -149,19 +156,23 @@
 
 (deftest list-handlers-rejects-missing-kind
   (testing "list-handlers with no :kind surfaces :invalid-kind"
-    (let [p (hm/list-handlers-tool nil (args-js {}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :invalid-kind (:reason edn)))))))))
+    (async done
+      (-> (hm/list-handlers-tool nil (args-js {}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :invalid-kind (:reason edn))))
+                   (done)))))))
 
 (deftest list-handlers-rejects-unknown-kind
   (testing "list-handlers with an out-of-vocab :kind surfaces :invalid-kind"
-    (let [p (hm/list-handlers-tool nil (args-js {:kind "ghost"}))]
-      (.then p (fn [result]
-                 (is (is-error? result))
-                 (let [edn (extract-edn result)]
-                   (is (= :invalid-kind (:reason edn)))))))))
+    (async done
+      (-> (hm/list-handlers-tool nil (args-js {:kind "ghost"}))
+          (.then (fn [result]
+                   (is (is-error? result))
+                   (let [edn (extract-edn result)]
+                     (is (= :invalid-kind (:reason edn))))
+                   (done)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Name + descriptor kind-vocab consistency.

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -11,6 +11,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [applied-science.js-interop :as j]
             ["bencode" :as bencode]
+            ["fs" :as fs]
             [re-frame2-pair-mcp.nrepl :as nrepl]))
 
 (defn- decode-all
@@ -58,3 +59,237 @@
         [fs rst] (decode-all twice)]
     (is (= 3 (count fs)))
     (is (zero? (.-length rst)))))
+
+;; ===========================================================================
+;; Port discovery — `read-port-from-fs` (rf2-wnrpi, finding G2).
+;;
+;; The fn has a four-way precedence: the `SHADOW_CLJS_NREPL_PORT` env var
+;; wins; failing that, three port-file candidates are tried in order; a
+;; non-numeric value at any source is rejected via the `isNaN` guard; an
+;; all-miss returns nil. None of this was pinned — only `decode-all-frames`
+;; was. We stub `fs.readFileSync` + `process.env.SHADOW_CLJS_NREPL_PORT`
+;; to exercise every branch without touching the real filesystem.
+;; ===========================================================================
+
+(def ^:private env-key "SHADOW_CLJS_NREPL_PORT")
+
+(defn- set-env! [v]
+  (if (nil? v)
+    (js-delete (.-env js/process) env-key)
+    (j/assoc-in! js/process [:env env-key] v)))
+
+(defn- with-fs-stub!
+  "Run `body` with `fs.readFileSync` replaced by `stub-fn` (path → string,
+  or throw to simulate ENOENT) and `process.env.SHADOW_CLJS_NREPL_PORT`
+  set to `env-val` (nil = unset). Restores both afterwards. Returns the
+  value of `body`."
+  [env-val stub-fn body]
+  (let [orig-read (.-readFileSync fs)
+        orig-env  (j/get-in js/process [:env env-key])]
+    (set! (.-readFileSync fs) stub-fn)
+    (set-env! env-val)
+    (try
+      (body)
+      (finally
+        (set! (.-readFileSync fs) orig-read)
+        (set-env! orig-env)))))
+
+(defn- throwing-read
+  "A `readFileSync` stub that always throws — simulates every candidate
+  file being absent."
+  [_path]
+  (throw (js/Error. "ENOENT")))
+
+(defn- read-returning
+  "Build a `readFileSync` stub that returns `content` for `wanted-path`
+  (a substring match) and throws for every other path."
+  [wanted-path content]
+  (fn [^js path]
+    (if (re-find (re-pattern wanted-path) (str path))
+      content
+      (throw (js/Error. "ENOENT")))))
+
+(deftest port-discovery-env-var-wins
+  (testing "SHADOW_CLJS_NREPL_PORT takes precedence over any port file"
+    ;; A port file would resolve to 1234, but the env (7777) wins — the
+    ;; file stub must never be consulted on this path.
+    (with-fs-stub! "7777"
+      (read-returning "nrepl.port" "1234")
+      (fn []
+        (is (= 7777 (nrepl/read-port-from-fs)))))))
+
+(deftest port-discovery-env-numeric-only
+  (testing "a non-numeric env value is rejected by the isNaN guard, fall through to files"
+    (with-fs-stub! "not-a-number"
+      (read-returning "target/shadow-cljs/nrepl.port" "5555")
+      (fn []
+        (is (= 5555 (nrepl/read-port-from-fs))
+            "non-numeric env must NOT short-circuit; the file fallback fires")))))
+
+(deftest port-discovery-first-file-candidate
+  (testing "no env → first candidate (target/shadow-cljs/nrepl.port) is read"
+    (with-fs-stub! nil
+      (read-returning "target/shadow-cljs/nrepl.port" "  6001  \n")
+      (fn []
+        (is (= 6001 (nrepl/read-port-from-fs))
+            "leading/trailing whitespace is trimmed before parse")))))
+
+(deftest port-discovery-fallback-ordering
+  (testing "first candidate absent → second (.shadow-cljs/nrepl.port) wins over third"
+    (with-fs-stub! nil
+      ;; Only the .shadow-cljs candidate (and the .nrepl-port one) exist;
+      ;; the .shadow-cljs one is earlier in the list so it must win.
+      (fn [^js path]
+        (let [p (str path)]
+          (cond
+            (re-find #"\.shadow-cljs[\\/]nrepl\.port" p) "6002"
+            (re-find #"\.nrepl-port" p)                  "6003"
+            :else (throw (js/Error. "ENOENT")))))
+      (fn []
+        (is (= 6002 (nrepl/read-port-from-fs))
+            "earlier candidate in the list wins the ordering contract")))))
+
+(deftest port-discovery-isnan-file-rejected
+  (testing "a port file with non-numeric content is rejected, not returned as NaN"
+    (with-fs-stub! nil
+      (read-returning "nrepl.port" "garbage")
+      (fn []
+        (is (nil? (nrepl/read-port-from-fs))
+            "isNaN guard must reject; never surface a NaN port")))))
+
+(deftest port-discovery-all-miss-is-nil
+  (testing "no env + every candidate absent → nil"
+    (with-fs-stub! nil throwing-read
+      (fn []
+        (is (nil? (nrepl/read-port-from-fs)))))))
+
+;; ===========================================================================
+;; Transport data-handler — `attach-handlers!` (rf2-wnrpi, finding G3).
+;;
+;; The persistent-socket `data` handler folds each chunk into the conn's
+;; `:buf` and splits off complete frames in a SINGLE swap! (the framing-
+;; race fix), then dispatches every complete frame to its pending-id
+;; handler. That logic carried heavy rationale comments but no automated
+;; regression in the default gate (only the opt-in live-nrepl.js). It is
+;; pure buffer logic over a fed chunk — unit-testable with a fake socket
+;; that records its event callbacks rather than a real TCP connection.
+;; ===========================================================================
+
+(defn- fake-socket
+  "A minimal stand-in for a `net.Socket`: `on` records each event's
+  callback into `cbs*` keyed by event name. `emit-data!`/`emit!` below
+  invoke a recorded callback the way Node's EventEmitter would."
+  [cbs*]
+  (j/lit {:on (fn [event cb] (swap! cbs* assoc event cb))}))
+
+(defn- emit-data! [cbs* ^js chunk]
+  ((get @cbs* "data") chunk))
+
+(defn- frame-buf
+  "bencode-encode a CLJS map into a Buffer the data-handler can fold."
+  [m]
+  (bencode/encode (clj->js m)))
+
+(deftest data-handler-dispatches-complete-frame-to-pending
+  (testing "a single complete frame resolves its pending-id handler"
+    (let [cbs*    (atom {})
+          conn    (nrepl/make-conn 0 "127.0.0.1")
+          got*    (atom nil)]
+      (swap! conn assoc :buf (js/Buffer.alloc 0) :pending {"id-1" #(reset! got* %)})
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      (emit-data! cbs* (frame-buf {"id" "id-1" "value" "42"}))
+      (is (some? @got*) "the pending handler fired")
+      (is (= "42" (j/get @got* "value")))
+      (is (zero? (.-length (:buf @conn))) "complete frame leaves no trailer"))))
+
+(deftest data-handler-buffers-partial-frame
+  (testing "a partial frame is held in :buf and dispatched once completed"
+    (let [cbs*  (atom {})
+          conn  (nrepl/make-conn 0 "127.0.0.1")
+          got*  (atom nil)
+          full  (frame-buf {"id" "id-2" "value" "7"})
+          mid   (js/Math.floor (/ (.-length full) 2))
+          head  (.slice full 0 mid)
+          tail  (.slice full mid)]
+      (swap! conn assoc :buf (js/Buffer.alloc 0) :pending {"id-2" #(reset! got* %)})
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      ;; First chunk: incomplete — must NOT dispatch, must retain bytes.
+      (emit-data! cbs* head)
+      (is (nil? @got*) "partial frame must not dispatch")
+      (is (pos? (.-length (:buf @conn))) "partial bytes retained in :buf")
+      ;; Second chunk completes the frame.
+      (emit-data! cbs* tail)
+      (is (some? @got*) "completed frame dispatches")
+      (is (= "7" (j/get @got* "value")))
+      (is (zero? (.-length (:buf @conn)))))))
+
+(deftest data-handler-splits-two-frames-in-one-chunk
+  (testing "two concatenated frames in one chunk each reach their pending handler"
+    (let [cbs*  (atom {})
+          conn  (nrepl/make-conn 0 "127.0.0.1")
+          a*    (atom nil)
+          b*    (atom nil)
+          chunk (js/Buffer.concat #js [(frame-buf {"id" "a" "value" "1"})
+                                       (frame-buf {"id" "b" "value" "2"})])]
+      (swap! conn assoc :buf (js/Buffer.alloc 0)
+             :pending {"a" #(reset! a* %) "b" #(reset! b* %)})
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      (emit-data! cbs* chunk)
+      (is (= "1" (j/get @a* "value")) "first frame dispatched to id a")
+      (is (= "2" (j/get @b* "value")) "second frame dispatched to id b")
+      (is (zero? (.-length (:buf @conn)))))))
+
+(deftest data-handler-ignores-unknown-id
+  (testing "a frame for an id with no pending handler is dropped, not thrown"
+    (let [cbs*  (atom {})
+          conn  (nrepl/make-conn 0 "127.0.0.1")]
+      (swap! conn assoc :buf (js/Buffer.alloc 0) :pending {})
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      ;; Must not throw even though no pending entry matches.
+      (emit-data! cbs* (frame-buf {"id" "ghost" "value" "x"}))
+      (is (zero? (.-length (:buf @conn))) "frame consumed, no trailer left"))))
+
+(deftest close-handler-marks-conn-closed
+  (testing "the close event flips :closed?"
+    (let [cbs* (atom {})
+          conn (nrepl/make-conn 0 "127.0.0.1")]
+      (swap! conn assoc :closed? false)
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      ((get @cbs* "close") nil)
+      (is (true? (:closed? @conn))))))
+
+(deftest error-handler-marks-conn-closed
+  (testing "a socket error flips :closed? (so the next call reconnects)"
+    (let [cbs*      (atom {})
+          conn      (nrepl/make-conn 0 "127.0.0.1")
+          orig-err  (.-error js/console)]
+      (swap! conn assoc :closed? false)
+      (nrepl/attach-handlers! conn (fake-socket cbs*))
+      ;; The error handler logs to stderr via `log!`; silence it so the
+      ;; otherwise-quiet test run stays clean (the log is the SUT's
+      ;; behaviour, not a test failure).
+      (set! (.-error js/console) (fn [& _] nil))
+      (try
+        ((get @cbs* "error") (js/Error. "boom"))
+        (finally
+          (set! (.-error js/console) orig-err)))
+      (is (true? (:closed? @conn))))))
+
+;; ===========================================================================
+;; `close!` — reconnect / probe-cache reset (rf2-wnrpi, finding G3).
+;; ===========================================================================
+
+(deftest close!-resets-probe-cache-and-pending
+  (testing "close! drops :probed-builds, :pending, :socket and marks closed"
+    (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+      (swap! conn assoc
+             :socket #js {:end (fn [] nil)}
+             :closed? false
+             :pending {"id-1" identity}
+             :probed-builds #{:app})
+      (nrepl/close! conn)
+      (is (true? (:closed? @conn)))
+      (is (nil? (:socket @conn)))
+      (is (= {} (:pending @conn)) "pending cleared so no stale resolvers")
+      (is (= #{} (:probed-builds @conn))
+          "probe cache cleared — a fresh connect must re-probe the preload"))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/registry_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/registry_test.cljs
@@ -1,0 +1,46 @@
+(ns re-frame2-pair-mcp.registry-test
+  "Structural completeness of the single tool registry (rf2-47g8l;
+  ratchet added by rf2-wnrpi).
+
+  The whole point of the single `registry/tools` source (rf2-47g8l) is
+  that the three derived views — `tool-descriptors`, `handler-for`, and
+  `cacheable?` — cannot drift, because each is generated from the one
+  vector. `cache_test` already pins `cacheable?` for the named tools;
+  this suite pins the OTHER derived view that the dispatcher relies on:
+  every descriptor name resolves to a handler, and vice versa.
+
+  Without this ratchet a tool added to the descriptor list (or renamed)
+  without a matching handler entry would ship green from every unit
+  suite and surface only as a `:reason :unknown-tool` at the post-
+  compile stdio layer. This pins the contract at the source."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame2-pair-mcp.tools.registry :as registry]))
+
+(deftest handler-for-keys-match-descriptor-names
+  (testing "every descriptor name resolves to exactly one handler — no drift"
+    (let [descriptor-names (set (map :name registry/tool-descriptors))
+          handler-keys     (set (keys registry/handler-for))]
+      (is (= descriptor-names handler-keys)
+          "handler-for keys MUST equal descriptor names — the rf2-47g8l guarantee"))))
+
+(deftest every-handler-is-a-fn
+  (testing "each registered handler is callable (the 3-arity dispatch shape)"
+    (doseq [[name handler] registry/handler-for]
+      (is (fn? handler) (str "handler for " name " must be a fn")))))
+
+(deftest registry-names-are-unique
+  (testing "no duplicate :name in the catalogue — a dup would silently shadow"
+    (let [names (map :name registry/tools)]
+      (is (= (count names) (count (set names)))
+          "duplicate tool name in registry/tools"))))
+
+(deftest catalogue-size-matches-derived-views
+  (testing "all three derived views enumerate the same tool count"
+    (let [n (count registry/tools)]
+      (is (= n (count registry/tool-descriptors)))
+      (is (= n (count registry/handler-for))))))
+
+(deftest cacheable-only-names-registered-tools
+  (testing "cacheable? is false for any name not in the catalogue"
+    (is (not (registry/cacheable? "definitely-not-a-tool")))
+    (is (not (registry/cacheable? "")))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/test_utils.cljs
@@ -1,19 +1,102 @@
 (ns re-frame2-pair-mcp.test-utils
-  "Shared test helpers (rf2-ambfv).
+  "Shared test helpers (rf2-ambfv, rf2-wnrpi).
 
   Home for fns that only the test corpus uses but that conceptually
-  sit alongside the production code. Today's resident is
-  `dedup-expand` — the inverse of `tools.dedup/dedup-value`, useful
-  to assert round-trip exactness against an MCP-shaped wire payload
-  without growing the production surface.
+  sit alongside the production code.
 
-  Why not in `tools.dedup`: the agent host receives the deduped
-  payload and reconstructs locally via `de-dupe.core/expand` directly
-  — the MCP server never calls the inverse. Moving the helper here
-  keeps the production ns minimal and signals \"test-only\" by
-  location."
-  (:require [de-dupe.core :as dedup]
+  ## Wire-envelope extractors (rf2-wnrpi)
+
+  The MCP tools return a `#js {:content #js [#js {:text \"...edn...\"}]}`
+  envelope (with an optional `:isError true`). Four trivial extractors
+  used to walk that shape were copy-pasted privately across at least
+  five suites (`conformance_test`, `handler_meta_test`, `invoke_test`,
+  `cache_test`, `dispatch_test`). They are hoisted here so a wire-shape
+  change touches one definition rather than five drifting copies:
+
+    - `args->js`     — CLJS arg map → the `#js {}` object tools read.
+    - `extract-text` — pull the first content item's `:text` string.
+    - `extract-edn`  — `extract-text` then `edn/read-string`.
+    - `error?`       — truthy `:isError` slot.
+
+  ## Stub installer (rf2-wnrpi)
+
+  `with-stubbed-eval!` installs a Promise-returning stub over
+  `nrepl/cljs-eval-value` and restores it in `.finally` so cleanup
+  outlives async resolution. Two suites (`probe_test`, `dispatch_test`)
+  hand-rolled near-identical copies; the corpus driver in
+  `conformance_test` keeps its own richer `eval-script`/`forms-seen`
+  variant (different contract), and `invoke_test` keeps its
+  fixture-scoped restore (rf2-wb06a race) deliberately — neither is
+  collapsed here.
+
+  ## `dedup-expand`
+
+  The inverse of `tools.dedup/dedup-value`, useful to assert round-trip
+  exactness against an MCP-shaped wire payload without growing the
+  production surface. The agent host reconstructs locally via
+  `de-dupe.core/expand`; the MCP server never calls the inverse, so the
+  helper lives here, signalling \"test-only\" by location."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [de-dupe.core :as dedup]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Wire-envelope extractors — one definition, shared across suites.
+;; ---------------------------------------------------------------------------
+
+(defn args->js
+  "Coerce a CLJS arg map into the `#js {}` object the tools read via
+  `wire/arg`. Keyword keys are `name`d; string keys pass through."
+  [m]
+  (let [o #js {}]
+    (doseq [[k v] m]
+      (j/assoc! o (if (keyword? k) (name k) k) v))
+    o))
+
+(defn extract-text
+  "Pull the first content item's `:text` string from an MCP result
+  envelope, or nil if the shape isn't present."
+  [^js result]
+  (let [content (j/get result :content)
+        item    (when (array? content) (aget content 0))]
+    (when item (j/get item :text))))
+
+(defn extract-edn
+  "`extract-text` then EDN-read the string back to CLJS data."
+  [^js result]
+  (some-> (extract-text result) edn/read-string))
+
+(defn error?
+  "True when the result envelope carries `:isError true`."
+  [^js result]
+  (true? (j/get result :isError)))
+
+;; ---------------------------------------------------------------------------
+;; Stub installer — async-safe `cljs-eval-value` override.
+;; ---------------------------------------------------------------------------
+
+(defn with-stubbed-eval!
+  "Install a stub `nrepl/cljs-eval-value` that resolves to `canned-value`
+  on every call (both the 3- and 4-arity), then run `body-fn` (which
+  returns a Promise) and restore the original in `.finally` so cleanup
+  outlives async resolution.
+
+  This is the simple, value-returning variant used by suites that don't
+  need to inspect the emitted form. Suites that need to capture / match
+  the form string keep their own richer installer."
+  [canned-value body-fn]
+  (let [orig nrepl/cljs-eval-value
+        stub (fn
+               ([_conn _build-id _form-str]
+                (js/Promise.resolve canned-value))
+               ([_conn _build-id _form-str _opts]
+                (js/Promise.resolve canned-value)))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
 
 (defn dedup-expand
   "Reverse `tools.dedup/dedup-value`. Given a value possibly wrapped in


### PR DESCRIPTION
## The false-green bug

Six `handler_meta_test` error-envelope tests called `(.then p (fn [r] (is ...)))` from a **synchronous** `deftest` body with no `(async done)`. The deftest returned before the Promise resolved, so cljs.test recorded each as **passed with ZERO assertions**. Both `handler-meta` and `list-handlers` error paths were effectively untested — a flipped `:invalid-kind` reason or an NPE on the nil conn would have shipped green.

All six now wrap their `.then` body in `(async done ...)` (mirroring `dispatch_test` / `probe_test`), so the assertions actually run. Proven by injecting a deliberate wrong expectation: pre-fix it passed green; post-fix the suite fails with a real diff. Reverted, of course. Swept the rest of the suite — no other `.then`-without-`async` remained.

## What now actually runs (and new coverage)

- **handler-meta / list-handlers error envelopes** — the six tests that were vacuous now execute 13 real assertions (`:invalid-kind`, `:missing-id`, `:invalid-id-edn`, unknown-kind echo).
- **nREPL port discovery** (`read-port-from-fs`) — env-wins precedence, non-numeric-env fall-through, file-fallback ordering, `isNaN` reject, all-miss → nil (stubbing `fs.readFileSync` + `process.env`). Previously only `decode-all-frames` was tested.
- **Persistent-socket transport** (`attach-handlers!`, made public for test like `decode-all-frames`) — single-swap buffer fold, partial-frame buffering, two-frames-in-one-chunk split, unknown-id drop, close/error → `:closed?`, plus `close!` reconnect/probe-cache reset. Driven with a fake socket; no live nREPL. Previously only the opt-in `live-nrepl.js` exercised this.
- **Registry completeness ratchet** — `handler-for` keys == descriptor names (the rf2-47g8l "drift is structurally impossible" guarantee), every handler is a fn, names unique, derived views agree on count.
- **Conformance corpus** — `handler-meta` + `list-handlers` happy + missing-arg fixtures; both tools were entirely outside the cross-tool ratchet before.

## Dedup

Hoisted the wire-envelope extractors (`args->js` / `extract-text` / `extract-edn` / `error?`) and a simple stub installer into `test_utils.cljs`; adopted in `handler_meta_test`, `cache_test`, `dispatch_test`. `invoke_test`'s fixture-scoped restore (rf2-wb06a) and `conformance_test`'s eval-script driver keep their distinct variants.

## Gate

`npm test` (pair-mcp `:server-test`): **453 tests / 1212 assertions → 471 / 1256, 0 failures, 0 errors, 0 warnings.**

Source change is tool-side only (`nrepl.cljs` `attach-handlers!` privacy) — does not touch `implementation/`, bundle isolation preserved.