### PR TITLE
docs(skill): add xstate mental-model framing to State-Machine references (rf2-4surm)

### DIFF
--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -58,7 +58,7 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 
 1. **Implementation is ground truth.** When spec and `implementation/**` disagree, the implementation wins. Recipes here are verified against `implementation/**` and `examples/reagent/**`.
 2. **Recipes over explanations.** Use the canonical shape; do not re-derive from first principles.
-3. **Distinguish orchestration from state.** State machines for *modes* (legal-transitions-depend-on-current-state); slices for *fields*. See [`decision-trees/slice-or-machine.md`](decision-trees/slice-or-machine.md).
+3. **Distinguish orchestration from state.** State machines for *modes* (legal-transitions-depend-on-current-state); slices for *fields*. See [`decision-trees/slice-or-machine.md`](decision-trees/slice-or-machine.md). **For machines, the standing mental model is: think how you'd do it in xstate, then map onto re-frame2** — xstate is the widely-known FSM model in your training data, and most concepts translate cleanly (`:type :parallel`, `:tags`, `:guards`/`:actions`, `:always`, `:after`, final states). A handful of slots re-frame2 deliberately renames or omits (`invoke`→`:spawn`, `context`→`:data`, no `assign`/action-vectors/compound-guard-data); those divergences are the trap. The translation key + divergence flags live in [`references/state-machines/reg-machine.md`](references/state-machines/reg-machine.md).
 4. **Schemas at boundaries.** `reg-app-schema` for paths that cross trust boundaries (HTTP payloads, persisted state, snapshot restores). Do not schema-fence every internal key.
 5. **`examples/reagent/<x>/` is canonical.** When a pattern has a worked example, match its shape.
 6. **Frames before globals.** Talk to a frame via `dispatch` / `subscribe`. Do not import frame internals or bypass to mutate state.
@@ -137,7 +137,7 @@ Load at most two leaves per task. If a task seems to need three, it likely spans
 
 **Fundamentals — `references/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
 
-**State machines — `references/state-machines/`**: `reg-machine.md`, `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`.
+**State machines — `references/state-machines/`**: `reg-machine.md` (declaration + the xstate→re-frame2 translation key), `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`. Standing mental model across all of these: think in xstate, then map onto re-frame2 — see `reg-machine.md` for the full mapping table and deliberate-divergence flags.
 
 **Tooling — `references/tooling/`**: `stories.md`, `routing.md`, `story-recorder.md` (record canvas interactions as `:play-script`), `story-mcp-loop.md` (agent self-healing loop over MCP), `causa.md` (the devtools panel — mount strategy, launch modes, host-CSS-variable resize contract, popout, suppress-auto-open).
 

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -5,6 +5,8 @@
 
 re-frame2 gives you three places to put state. The right choice usually falls out of one or two questions; this tree walks them in priority order. The four state-machine tells are listed first because if any of them holds, the choice is settled.
 
+> **Mental-model shortcut:** if you can already picture the feature as an xstate machine — distinct states, an `on` transition table, guards gating transitions, maybe an `invoke`d child — that's a strong signal the answer here is **machine**, not slice. xstate is the widely-known FSM model and a good intuition pump for "is this even a machine?" The four tells below formalise that instinct; once you've decided it *is* a machine, [`../references/state-machines/reg-machine.md`](../references/state-machines/reg-machine.md) carries the full xstate→re-frame2 translation key (including where re-frame2 deliberately renames or omits xstate slots).
+
 ## The three shapes
 
 | Shape | What it is | When it fits |

--- a/skills/re-frame2/references/state-machines/cancellation.md
+++ b/skills/re-frame2/references/state-machines/cancellation.md
@@ -4,6 +4,8 @@
 
 Reach for this leaf when a `:spawn`d child issues `:rf.http/managed` requests, holds a websocket, or owns any in-flight side effect — and the parent might decide to leave the `:spawn`-bearing state. The cleanup is automatic; this leaf tells you what is guaranteed and what to add by hand for non-HTTP side effects.
 
+> **Mental model — think in xstate, map onto re-frame2.** In xstate, leaving an `invoke`-bearing state stops the invoked actor; re-frame2 keeps that intuition — leaving a `:spawn`-bearing state destroys the child — but the **abort cascade is richer and the mechanism deliberately diverges**. There is no `ActorRef` to `.stop()` and no per-actor mailbox: the snapshot lives in `app-db`, and a single destroy hook fires across every trigger (state exit, `:after` timeout, `:spawn-all` cancel-on-decision, frame teardown, imperative destroy), automatically aborting the actor's in-flight `:rf.http/managed` requests. And re-frame2 uses **no `core.async`** in the cancellation path — for non-HTTP resources (websocket, timer, external stream) you wire cleanup into the child's `:exit` action, not a channel close. Sketch the lifecycle the xstate way, then lean on the exit cascade rather than an explicit teardown call.
+
 ## The guarantee
 
 When the runtime destroys a spawned actor by **any** trigger, every in-flight `:rf.http/managed` request the actor had issued is aborted. The trigger list (Spec 005 §Cancellation cascade §The contract, `spec/005-StateMachines.md:2034`):

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -4,7 +4,34 @@
 
 Reach for this leaf when authoring a `rf/reg-machine` call: the declaration map's keys, the `:guards` / `:actions` lookup tables, how a machine is dispatched into. For parallel regions, tags, `:spawn`, or cancellation, see the sibling leaves.
 
-> **Tip**: stuck on how to model a state shape? Ask yourself *"how would XState do it?"* — XState is in your training data, and re-frame2's machine primitives map cleanly onto its concepts (`:type :parallel` ≈ XState parallel states, `:tags` ≈ XState tags, `:spawn` ≈ XState invoke, `:guards`/`:actions` ≈ XState named guards/actions). Sketch the shape in XState mentally, then translate.
+## Mental model — think in xstate, then map onto re-frame2
+
+**Standing advice for every machine you author: think about how you'd do it in xstate, then map those ideas onto re-frame2.** xstate is the widely-known JS FSM mental model and it's well-represented in your training data — so the fastest way to model a feature's states is to sketch it the xstate way (states, transitions, guards, actions, `context`, `invoke`, parallel states, final states), then translate each piece into its re-frame2 equivalent.
+
+Most concepts map cleanly. A handful of slots re-frame2 **deliberately renames or omits** — those divergences are intentional (the spec documents each one and why), and they're exactly where xstate-trained intuition will steer you wrong. Treat the table below as the translation key, and watch the flagged divergence rows.
+
+| xstate concept | re-frame2 equivalent | Notes / deliberate divergence |
+|---|---|---|
+| **states** (`state.value`) | `:states` map + the snapshot's `:state` slot | Flat → single keyword; compound → vector path; parallel → region-name→keyword map. Convergence. |
+| **transitions** (`on: { EVENT: ... }`) | `:on {event-keyword transition-spec}` on a state node | Convergence. Bare-target / explicit-map / guarded-vector forms. |
+| **guards** (`guard` / named guards) | `:guard` on a transition + the top-level `:guards` map | Convergence on the *name*. **Divergence:** no `{and: [...]}` compound-guard data form — compose with one fn or one named registered compound. Guards see `:data`, not the whole snapshot. |
+| **actions** (`actions` / named actions) | `:action` / `:entry` / `:exit` + the top-level `:actions` map | Convergence on the *name*. **Divergence:** no action-vector `[a1 a2 a3]` per slot — one fn or one named registered compound. `:entry`/`:exit` are a single fn or single keyword, never vectors. |
+| **`assign({...})`** | action returns `{:data new-data}` (and/or `{:fx [...]}`) | **Divergence (name/shape):** no `[:assign {...}]` form. Symmetric with `reg-event-fx`'s `{:db :fx}`. The invariant matches xstate's `assign` though: callbacks may only update `:data` — they cannot nudge the machine into an undeclared state. |
+| **`context`** (extended state) | `:data` (the machine's private map, distinct from `app-db`) | **Divergence (name):** re-frame2 calls the slot `:data`, tracking FSM / `gen_statem` "state data" vocabulary and avoiding re-frame's already-overloaded "context" (interceptor pipeline + React context). |
+| **`invoke`** (state-bound child actor) | `:spawn` (and `:spawn-all` for fan-out-and-join) | **Divergence (name):** the most semantically-loaded slot is renamed on purpose, to break the "almost-correct xstate code" trap and align with the imperative `:rf.machine/spawn` fx. No `:onError`/`:onSnapshot`/`autoForward`/multiple-`:invoke`-per-state. See `spawn.md`. |
+| **`onDone`** (child→parent completion) | `:final?` leaf + parent `:spawn`'s `:on-done` + `:output-key` | Convergence — re-frame2 ships first-class final-state-with-parent-notification. See `spawn.md`. |
+| **parallel states** (`type: 'parallel'`) | `:type :parallel` + `:regions {...}` | Convergence (name + concept). `:data` shared; `:tags` is the union across active regions. See `regions.md`. |
+| **final states** (`type: 'final'`) | `:final? true` on a leaf state | Convergence on the concept. **Note the divergence:** a `:final?` singleton (or every-region-final parallel machine) **auto-destroys** — "final means final." Omit `:final?` for a persistent terminal state. See `spawn.md`. |
+| **tags** (`tags: [...]`) | `:tags #{...}` on a state node + `machine-has-tag?` | Convergence. See `tags.md`. |
+| **eventless / always transitions** | `:always [{:guard ... :target ...} ...]` | Convergence (re-frame2's term for xstate/SCXML transient transitions). |
+| **delayed transitions** (`after`) | `:after {<ms> transition-spec}` | Convergence on the name. No recurring timers / pause-resume in v1. |
+| **`raise` (self-event)** | `:raise` inside an action's `:fx` | **Divergence:** sugar for atomic self-dispatch — there is no per-actor mailbox to insert in front of. |
+| **`sendTo` / `sender` (reply to a request)** | include the reply event in the request vector | **Divergence:** no new API; the event vector carries its own reply target. |
+| **`ActorRef` runtime objects** | snapshots at `[:rf/machines <id>]` in `app-db` | **Divergence (architecture):** data-oriented, agent-friendly, no live-object leak footguns. Read via `sub-machine`. |
+| **`setup({actors, guards, actions})`** | per-machine `:guards` / `:actions` maps in the spec | **Divergence:** machine-scoped (not globally registered) — each machine has its own guard/action namespace, validated at registration; cross-machine reuse is via plain Clojure vars. |
+| **three creation modes** (`createActor` / `invoke` / `spawn`) | one mechanism, two patterns: singleton via `reg-event-fx`, dynamic via `:spawn` / `[:rf.machine/spawn ...]` | **Divergence:** lifetime is encoded by `app-db` shape + registration lifetime, not by which constructor you call. |
+
+The deliberate-divergence rows are catalogued in Spec 005 §Lessons from xstate and §Deliberate omissions vs xstate (and the full table in CP-5-MachineGuide §Lessons from xstate). When you reach for an xstate slot that isn't in the table — `:onError`, an action vector, `{and: [...]}`, multiple `:invoke` per state — that's a signal to stop and check the divergence rows rather than assume parity.
 
 ## Canonical signature
 

--- a/skills/re-frame2/references/state-machines/spawn.md
+++ b/skills/re-frame2/references/state-machines/spawn.md
@@ -4,6 +4,8 @@
 
 Reach for this leaf when a state hosts an asynchronous activity whose lifetime must match the state's lifetime: an HTTP request, a websocket session, a sub-machine running a sub-flow. For wall-clock guards on that activity, use the parent state's `:after`. For "fan out N children and join when done", see `:spawn-all` below. For the cancellation/cleanup contract, see `cancellation.md`.
 
+> **Mental model — think in xstate, map onto re-frame2.** `:spawn` IS xstate's `invoke` (state-bound child actor), but **this is the one slot re-frame2 deliberately renames** — it's the most semantically-loaded surface, and the rename breaks the "almost-correct xstate code" trap while aligning the declarative key with the imperative `:rf.machine/spawn` fx. So sketch the child-actor flow the xstate `invoke` way, then translate the slot name and watch the divergences: there is no `:onError` (errors flow through `:rf.error/*` + `:on-child-error`), no `:onSnapshot` (read the snapshot via `sub-machine`), no `autoForward` (forward events explicitly with `:fx [[:dispatch ...]]`), and only **one `:spawn` per state** (xstate admits a vector). `onDone` *does* map, to `:final?` + `:on-done` + `:output-key` below. The full divergence list is in Spec 005 §Deliberate name divergence — `:spawn` and §Deliberate omissions vs xstate.
+
 ## Canonical declaration
 
 ```clojure

--- a/skills/re-frame2/references/state-machines/tags.md
+++ b/skills/re-frame2/references/state-machines/tags.md
@@ -4,6 +4,8 @@
 
 Reach for this leaf when a view needs to ask "is the machine in any in-flight state?" or "is the form read-only?" — without naming the specific state-keyword. Tags are how a state declares its **intent** so views can query the intent, not the state name. Pairs with `regions.md` for the parallel-region tag-union story.
 
+> **Mental model — think in xstate, map onto re-frame2.** re-frame2's `:tags` ARE xstate's state `tags` — this is a clean convergence, name and concept. If you know "any active state carrying the tag puts it in the active configuration's tag set" from xstate, that's exactly the rule here (the union runs along the active path for compound machines and across all regions for parallel ones). The re-frame2-specific binding to learn is the query side: `machine-has-tag?` is a **subscription**, so views deref `@(rf/machine-has-tag? id tag)` rather than reading a tag list off an `ActorRef`.
+
 ## Canonical declaration
 
 A state node carries a `:tags` slot whose value is a **set of keywords**. There is no separate registration call; the slot is just a key on the state node, processed by the runtime via `compute-tags` (`implementation/machines/src/re_frame/machines.cljc:311`):


### PR DESCRIPTION
## Directive

In any `/skill` content related to State Machines (FSM), the standing advice is now: **think about how you'd do this in xstate, then map those ideas to re-frame2.** xstate is the widely-known JS FSM mental model and well-represented in agent training data; anchoring re-frame2 machine guidance to it helps users transfer intuition — while explicitly flagging where re-frame2 deliberately diverges.

## Files

- `skills/re-frame2/references/state-machines/reg-machine.md` (PRIMARY) — prominent "Mental model: think in xstate, map onto re-frame2" section + a full concept-mapping table with deliberate-divergence rows flagged.
- `skills/re-frame2/references/state-machines/spawn.md` — pointer anchored to the `invoke`→`:spawn` rename + the spawn-specific omissions.
- `skills/re-frame2/references/state-machines/cancellation.md` — pointer anchored to the automatic exit-cascade (no `ActorRef.stop()`, no per-actor mailbox, no `core.async`).
- `skills/re-frame2/references/state-machines/tags.md` — pointer noting tags are a clean convergence, queried via a subscription.
- `skills/re-frame2/decision-trees/slice-or-machine.md` — a nod into the four machine-tells ("if you can picture it as an xstate machine, it's probably a machine").
- `skills/re-frame2/SKILL.md` — extended cardinal rule 3 + the state-machines reference index with the standing mental model.

(Top-level `skills/README.md` deliberately untouched. No bead refs in skill docs; no AI attribution.)

## Verified xstate → re-frame2 mapping

Verified against `spec/005-StateMachines.md` (§Lessons from xstate, §Deliberate omissions vs xstate, §Deliberate name divergence — `:spawn`), `spec/CP-5-MachineGuide.md` (the full divergence table), and `implementation/machines/` (confirmed no `:invoke` / `:context` / `:assign` keywords exist).

### Clean convergences

| xstate | re-frame2 |
|---|---|
| states (`state.value`) | `:states` + snapshot `:state` (keyword / vector-path / region-map) |
| transitions (`on`) | `:on {event transition-spec}` |
| `onDone` (child→parent completion) | `:final?` leaf + parent `:on-done` + `:output-key` |
| parallel states (`type: 'parallel'`) | `:type :parallel` + `:regions` |
| final states (`type: 'final'`) | `:final? true` |
| tags | `:tags #{...}` + `machine-has-tag?` |
| eventless / transient transitions | `:always` |
| delayed transitions (`after`) | `:after {<ms> ...}` |

### Deliberate divergences (intentional — flagged in the docs)

| xstate | re-frame2 | Why it diverges |
|---|---|---|
| `invoke` (state-bound child) | **`:spawn`** | Most semantically-loaded slot renamed on purpose to break the "almost-correct xstate code" trap and align with the imperative `:rf.machine/spawn` fx (rf2-5r4q2). No `:onError` / `:onSnapshot` / `autoForward` / multiple-per-state. |
| `context` | **`:data`** | Avoids re-frame's overloaded "context" (interceptor pipeline + React context); tracks FSM / `gen_statem` "state data" vocabulary. |
| `assign({...})` | action returns **`{:data ...}`** | Symmetric with `reg-event-fx`'s `{:db :fx}`; one fewer DSL. (Same invariant as `assign`: callbacks may only touch `:data`, never nudge into an undeclared state.) |
| compound guards `{and: [...]}` | one fn or one named registered compound | Imperative composition is fns; named compounds carry semantic content. |
| action-vector `[a1 a2 a3]` per slot | one fn or one named registered compound | Same reason as guards; `:entry`/`:exit` are single fn/keyword, never vectors. |
| `setup({actors,guards,actions})` | per-machine `:guards` / `:actions` maps | Machine-scoped (not global); reuse via Clojure vars. |
| `ActorRef` runtime objects | snapshots at `[:rf/machines <id>]` | Data-oriented, agent-friendly, no live-object leak footguns. |
| per-actor mailboxes | one per-frame router queue | Drain at frame granularity. |
| `raise` (self-event) | `:raise` (atomic self-dispatch sugar) | No per-actor mailbox to front-insert. |
| `sendTo` / `sender` (reply) | reply event carried in the request vector | No new API. |
| three creation modes (`createActor`/`invoke`/`spawn`) | one mechanism, two patterns (singleton via `reg-event-fx`; dynamic via `:spawn`) | Lifetime encoded by `app-db` shape + registration lifetime. |
| final-state persistence | a `:final?` singleton **auto-destroys** | "Final means final" — omit `:final?` for a stable terminal state. |
| cancellation via `ActorRef.stop()` | automatic single destroy-hook across every exit trigger; **no `core.async`** | Non-HTTP cleanup wired into the child's `:exit` action. |
| SCXML / Stately / XState-JSON interop | not in v1 | Deferred to the v1.1+ interop family. |

## Gates

- `python scripts/check_doc_slugs.py` — pass (exit 0)
- `python scripts/check_skill_redirect_anchors.py` — pass (exit 0)
- `python -m mkdocs build --strict` — pass (exit 0, no warnings on the touched files)