### PR TITLE
test(causa): de-dup control-axes + cover Hydration/segment-inspector/modal-focus-ref (rf2-dkmnm)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/modals_aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/modals_aria_cljs_test.cljs
@@ -116,6 +116,33 @@
                 points at a heading id rendered in the same tree, or
                 aria-label carries a non-empty string")))))
 
+(defn- assert-dialog-focus-ref!
+  "rf2-dkmnm (audit finding #3 follow-on) — assert the dialog node
+  actually ATTACHES the focus-trap ref + the `tab-index=\"-1\"`
+  fallback target.
+
+  `assert-dialog-contract!` proves the modal is *labelled*, but a
+  labelled dialog with NO focus trap passes that gate. `dialog-ref`
+  (the WAI-ARIA APG capture/trap/restore closure) is wired via the
+  dialog node's `:ref`. Each `dialog-ref` call returns a FRESH closure
+  so identity comparison is impossible — instead we assert the dialog
+  node carries a `:ref` that is a function, plus the
+  `tab-index=\"-1\"` (or `0`) the ref's focus-on-open fallback
+  requires. A renderer that shipped role/aria-modal but dropped the
+  `:ref` would now fail here rather than staying green."
+  [tree dialog-testid label]
+  (let [dialog (find-by-testid tree dialog-testid)
+        attrs  (props dialog)]
+    (is (some? dialog) (str label ": dialog wrapper renders"))
+    (is (fn? (:ref attrs))
+        (str label ": dialog node attaches a :ref (the a11y/dialog-ref
+              focus-trap callback) — a labelled modal with no trap is
+              an a11y regression"))
+    (is (contains? attrs :tab-index)
+        (str label ": dialog node carries :tab-index so dialog-ref's
+              focus-on-open fallback (focus the root when there is no
+              focusable child) has a target"))))
+
 ;; -------------------------------------------------------------------------
 ;; (1) Settings popup
 ;; -------------------------------------------------------------------------
@@ -209,3 +236,69 @@
           tree
           "rf-causa-segment-inspector-dialog"
           "Segment inspector popover")))))
+
+;; -------------------------------------------------------------------------
+;; Per-modal focus-ref wiring (rf2-dkmnm — audit finding #3 follow-on)
+;; -------------------------------------------------------------------------
+;;
+;; The contract tests above prove each of the six modals is LABELLED
+;; (role + aria-modal + accessible name). They do NOT prove the modal
+;; actually attaches the focus-trap. A renderer could ship a perfectly
+;; labelled dialog with no `a11y/dialog-ref` and every contract test
+;; would stay green while keyboard users fell out of the trap. These
+;; six tests close that hole by asserting each dialog node carries a
+;; function `:ref` (the dialog-ref closure) + the tab-index its
+;; focus-on-open fallback needs — one assertion per surface so a
+;; regression names the exact modal that lost its trap.
+
+(deftest settings-popup-attaches-focus-ref
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/settings-open]))
+  (let [tree (rf/with-frame :rf/causa (settings-view/popup-view))]
+    (assert-dialog-focus-ref! tree "rf-causa-settings-dialog"
+                              "Settings popup")))
+
+(deftest share-modal-attaches-focus-ref
+  (causa-setup!)
+  (let [tree (rf/with-frame :rf/causa (share-modal/share-dialog))]
+    (assert-dialog-focus-ref! tree "rf-causa-share-modal-dialog"
+                              "Share modal")))
+
+(deftest mute-manager-attaches-focus-ref
+  (causa-setup!)
+  (let [tree (rf/with-frame :rf/causa (spine-filters/dialog))]
+    (assert-dialog-focus-ref! tree "rf-causa-mute-manager-dialog"
+                              "Mute manager")))
+
+(deftest filter-edit-popup-attaches-focus-ref
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/open-edit-popup
+                       {:source :add :mode :in :pill {}}]))
+  (let [tree (rf/with-frame :rf/causa (edit-popup/popup-view))]
+    (assert-dialog-focus-ref! tree "rf-causa-edit-popup-dialog"
+                              "Filter edit-popup")))
+
+(deftest cancellation-cascade-popover-attaches-focus-ref
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/cancellation-cascade-open
+                       {:dispatch-id :test-dispatch-id}]))
+  (let [tree (rf/with-frame :rf/causa (cancellation-cascade/Popover))]
+    (is (some? tree) "Popover renders when open")
+    (when tree
+      (assert-dialog-focus-ref!
+        tree "rf-causa-cancellation-cascade-popover-dialog"
+        "Cancellation-cascade popover"))))
+
+(deftest segment-inspector-popover-attaches-focus-ref
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/open-segment-inspector []]))
+  (let [tree (rf/with-frame :rf/causa (segment-inspector/Popup))]
+    (is (some? tree) "Popup renders when open")
+    (when tree
+      (assert-dialog-focus-ref!
+        tree "rf-causa-segment-inspector-dialog"
+        "Segment inspector popover"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_segment_inspector_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_segment_inspector_cljs_test.cljs
@@ -1,0 +1,171 @@
+(ns day8.re-frame2-causa.panels.app-db-segment-inspector-cljs-test
+  "Content-projection guard for the App-DB segment inspector popup
+  (rf2-dkmnm — closes the gap flagged in
+  ai/findings/2026-05-21-testcov-causa.md §Axis 1.2).
+
+  Before this file the inspector (`panels/app-db-segment-inspector`)
+  was exercised only for its ARIA SHAPE (`modals-aria-cljs-test`) and
+  indirectly for the breadcrumb-open dispatch
+  (`diff/render-cljs-test`). Its OWN content projection — the
+  path-prefix slice the value sub computes + the value the body
+  renders — had no focused test. This is that test.
+
+  ## Wiring
+
+  `:rf.causa/segment-inspector-value` chains off
+  `:rf.causa/target-frame-db`, which derives the *observed* frame
+  (default `:rf/default`) and reads `get-frame-db` on it. So seeding
+  the host `:rf/default` frame's db drives the projection through the
+  exact production sub-chain — no stubbed seam."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector
+             :as segment-inspector]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- frame + host-db setup ----------------------------------------------
+
+(def host-db
+  "A nested host app-db so the inspector's path-prefix slice has
+  something to project at each depth."
+  {:cart {:items [{:id 7 :qty 1} {:id 22 :qty 3}]
+          :gross 42}
+   :user {:name "ada" :prefs {:theme :dark}}})
+
+(defn- setup!
+  "Register Causa's handler graph + the `:rf/causa` and host `:rf/default`
+  frames, then seed the host db so the value sub projects from it."
+  []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (frame/reg-frame :rf/default {})
+  ;; A one-off host event to plant a known db on the observed frame.
+  (rf/reg-event-db :test/seed-host-db (fn [_ [_ db]] db))
+  (rf/with-frame :rf/default
+    (rf/dispatch-sync [:test/seed-host-db host-db])))
+
+;; ---- hiccup walk helpers ------------------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- text-content
+  "Flatten all string leaves of a hiccup subtree into one string —
+  enough to assert the rendered value text shows up."
+  [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+(defn- read-value-sub []
+  (rf/with-frame :rf/causa
+    @(rf/subscribe [:rf.causa/segment-inspector-value])))
+
+;; ---- value-sub: path-prefix slice --------------------------------------
+
+(deftest value-sub-empty-path-projects-whole-db
+  (testing "rf2-e9tb0 — an empty path (the root breadcrumb) projects
+            the whole observed-frame db"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector []]))
+    (is (= host-db (read-value-sub))
+        "empty path did not project the whole db")))
+
+(deftest value-sub-projects-path-prefix-slice
+  (testing "rf2-e9tb0 — a non-empty path projects `get-in db path` —
+            the slice AT the clicked prefix, not the whole db"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart]]))
+    (is (= (:cart host-db) (read-value-sub))
+        "[:cart] did not slice to the cart map")
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart :gross]]))
+    (is (= 42 (read-value-sub))
+        "[:cart :gross] did not slice to the leaf value")
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:user :prefs :theme]]))
+    (is (= :dark (read-value-sub))
+        "[:user :prefs :theme] did not slice to the deep leaf")))
+
+(deftest value-sub-tracks-reopened-path
+  (testing "rf2-e9tb0 — reopening at a new path re-projects (the slot
+            is overwritten; the value sub re-fires for the new prefix)"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart]]))
+    (let [v0 (read-value-sub)]
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/open-segment-inspector [:user]]))
+      (let [v1 (read-value-sub)]
+        (is (not= v0 v1)
+            "value sub did not re-project on reopen at a new path")
+        (is (= (:user host-db) v1)
+            "reopened value sub did not slice to the new prefix")))))
+
+;; ---- popup-view: header + body content ---------------------------------
+
+(deftest popup-renders-value-and-path-in-body-and-header
+  (testing "rf2-e9tb0 — the open popup renders the inspected path in
+            the header title and the sliced VALUE in the body (the
+            content projection the breadcrumb click ultimately
+            surfaces). This is the gap the ARIA-only test left open."
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:user]]))
+    (let [tree   (rf/with-frame :rf/causa (segment-inspector/Popup))
+          title  (find-by-testid tree "rf-causa-segment-inspector-title")
+          body   (find-by-testid tree "rf-causa-segment-inspector-body")]
+      (is (some? tree) "Popup renders when open")
+      (is (some? title) "header title node renders")
+      (is (some? body) "body node renders")
+      ;; The header echoes the inspected path so the user knows what
+      ;; they are looking at.
+      (let [title-text (text-content title)]
+        (is (re-find #":user" title-text)
+            "header title did not echo the inspected path"))
+      ;; The body renders the sliced value — the user's name appears
+      ;; somewhere in the projected tree.
+      (let [body-text (text-content body)]
+        (is (re-find #"ada" body-text)
+            "body did not render the sliced value's content")))))
+
+(deftest popup-root-path-header-says-root
+  (testing "rf2-e9tb0 — an empty path inspects the whole db; the
+            header title reads '(root)' so the user isn't left guessing
+            what scope they are inspecting"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector []]))
+    (let [tree  (rf/with-frame :rf/causa (segment-inspector/Popup))
+          title (find-by-testid tree "rf-causa-segment-inspector-title")]
+      (is (re-find #"root" (text-content title))
+          "root-path header title did not read '(root)'"))))
+
+(deftest popup-closed-renders-nothing
+  (testing "rf2-e9tb0 — the closed-state body short-circuits to nil
+            (the single-subscribe + `when` cheapness contract)"
+    (setup!)
+    (is (nil? (rf/with-frame :rf/causa (segment-inspector/Popup)))
+        "closed segment inspector did not render nil")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_pane_render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_pane_render_cljs_test.cljs
@@ -1,0 +1,201 @@
+(ns day8.re-frame2-causa.panels.hydration-pane-render-cljs-test
+  "Unit guard for the Hydration Debugger per-pane renderer (rf2-dkmnm
+  — closes the gap flagged in ai/findings/2026-05-21-testcov-causa.md
+  §Axis 1.1).
+
+  Before this file the Hydration panel
+  (`panels/hydration-pane-render`) rested on the browser feature gate
+  alone — `scenarios.cjs:runHydration`. This is the millisecond-fast
+  unit backstop for the SSR-mismatch projection: the per-side
+  (`:server` / `:client`) rendering that flips `:added` ↔ `:removed`
+  semantics per perspective (rf2-1mcax Phase 4 of rf2-abts7).
+
+  Each test feeds REAL before/after hiccup through the Phase 3 diff
+  engine (`diff.hiccup/diff-hiccup-node`) and asserts the per-pane
+  renderer projects the divergence correctly from each perspective —
+  the contract a structural-diff regression would break."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.panels.hydration-pane-render :as hp]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- hiccup-tree introspection helpers ---------------------------------
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(defn- any-testid-prefix? [tree prefix]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (let [tid (:data-testid (second node))]
+                 (and (string? tid) (.startsWith tid prefix)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+;; ---- perspective root --------------------------------------------------
+
+(deftest render-pane-tags-the-perspective-root
+  (testing "render-pane emits a perspective-scoped root testid so the
+            two panes are independently addressable in the layout"
+    (let [n (hd/diff-hiccup-node [:div {:class "a"} "k"]
+                                 [:div {:class "b"} "k"])]
+      (is (has-testid? (hp/render-pane n :server "hydration-view")
+                       "rf-causa-hydration-pane-render-server")
+          "server pane root testid missing")
+      (is (has-testid? (hp/render-pane n :client "hydration-view")
+                       "rf-causa-hydration-pane-render-client")
+          "client pane root testid missing"))))
+
+;; ---- no-diff chip ------------------------------------------------------
+
+(deftest render-pane-shows-no-diff-chip-when-trees-match
+  (testing "identical server+client hiccup → the 'no structural
+            difference' chip renders (the green-light state of a
+            successful hydration)"
+    (let [n (hd/diff-hiccup-node [:div {:class "x"} "same"]
+                                 [:div {:class "x"} "same"])]
+      (is (has-testid? (hp/render-pane n :server "hydration-view")
+                       "rf-causa-hydration-pane-no-diff-server")
+          "no-diff chip missing on a matching tree")
+      (is (not (any-testid-prefix? (hp/render-pane n :server "hydration-view")
+                                   "rf-causa-hydration-pane-element-"))
+          "an element subtree rendered for a no-diff tree"))))
+
+;; ---- SSR mismatch: client-only node (added) ----------------------------
+
+(deftest added-node-projects-absent-on-server-present-on-client
+  (testing "rf2-1mcax — a client-only node (`:added`) renders as an
+            'absent on this side' ghost on the SERVER pane and a
+            present (green) row on the CLIENT pane. This is the
+            headline SSR-mismatch projection: the client rendered an
+            extra node the server markup lacked."
+    (let [before [:ul [:li "a"]]
+          after  [:ul [:li "a"] [:li "b"]]   ; client added a second <li>
+          n      (hd/diff-hiccup-node before after)
+          server (hp/render-pane n :server "hydration-view")
+          client (hp/render-pane n :client "hydration-view")]
+      (is (has-testid? server "rf-causa-hydration-pane-server-absent")
+          "client-only node not shown as absent on the server pane")
+      (is (has-testid? client "rf-causa-hydration-pane-only-here")
+          "client-only node not shown as present-only on the client pane")
+      (is (not (has-testid? client "rf-causa-hydration-pane-client-absent"))
+          "client pane wrongly marked its own added node absent"))))
+
+;; ---- SSR mismatch: server-only node (removed) --------------------------
+
+(deftest removed-node-projects-present-on-server-absent-on-client
+  (testing "rf2-1mcax — a server-only node (`:removed`) renders as a
+            present (red) row on the SERVER pane and an 'absent on
+            this side' ghost on the CLIENT pane — the mirror of the
+            added case (server markup carried a node the client did
+            not hydrate)."
+    (let [before [:ul [:li "a"] [:li "b"]]   ; server had two <li>
+          after  [:ul [:li "a"]]             ; client dropped the second
+          n      (hd/diff-hiccup-node before after)
+          server (hp/render-pane n :server "hydration-view")
+          client (hp/render-pane n :client "hydration-view")]
+      (is (has-testid? server "rf-causa-hydration-pane-only-here")
+          "server-only node not shown as present-only on the server pane")
+      (is (has-testid? client "rf-causa-hydration-pane-client-absent")
+          "server-only node not shown as absent on the client pane")
+      (is (not (has-testid? server "rf-causa-hydration-pane-server-absent"))
+          "server pane wrongly marked its own removed node absent"))))
+
+;; ---- SSR mismatch: divergent leaf value (modified) ---------------------
+
+(deftest modified-leaf-shows-each-sides-value-per-perspective
+  (testing "rf2-1mcax — a divergent text leaf (`:modified`) shows the
+            pane's OWN value highlighted, with the other side's value
+            as a faint annotation. The classic hydration-mismatch
+            row (e.g. server rendered a timestamp, client re-computed
+            a different one)."
+    (let [before [:span "server-value"]
+          after  [:span "client-value"]
+          n      (hd/diff-hiccup-node before after)]
+      (is (has-testid? (hp/render-pane n :server "hydration-view")
+                       "rf-causa-hydration-pane-modified-server")
+          "server-perspective modified row missing")
+      (is (has-testid? (hp/render-pane n :client "hydration-view")
+                       "rf-causa-hydration-pane-modified-client")
+          "client-perspective modified row missing"))))
+
+;; ---- SSR mismatch: divergent attribute --------------------------------
+
+(deftest modified-attr-renders-per-perspective-attr-row
+  (testing "rf2-1mcax — an attribute whose value diverges
+            server↔client renders a per-perspective modified-attr row
+            (e.g. server `:class \"a\"`, client `:class \"b\"`)."
+    (let [before [:div {:class "a"} "k"]
+          after  [:div {:class "b"} "k"]
+          n      (hd/diff-hiccup-node before after)]
+      (is (any-testid-prefix? (hp/render-pane n :server "hydration-view")
+                              "rf-causa-hydration-attr-modified-")
+          "server pane did not render the modified-attr row")
+      (is (any-testid-prefix? (hp/render-pane n :client "hydration-view")
+                              "rf-causa-hydration-attr-modified-")
+          "client pane did not render the modified-attr row"))))
+
+;; ---- server-only / client-only attribute -------------------------------
+
+(deftest added-attr-projects-absent-server-present-client
+  (testing "rf2-1mcax — an attribute present on the client only
+            (`:added`) renders absent on the server pane and present
+            (client-only) on the client pane."
+    (let [before [:div {} "k"]
+          after  [:div {:title "tip"} "k"]   ; client added :title
+          n      (hd/diff-hiccup-node before after)]
+      (is (any-testid-prefix? (hp/render-pane n :server "hydration-view")
+                              "rf-causa-hydration-attr-server-absent-")
+          "client-only attr not shown absent on the server pane")
+      (is (any-testid-prefix? (hp/render-pane n :client "hydration-view")
+                              "rf-causa-hydration-attr-client-only-")
+          "client-only attr not shown present-only on the client pane"))))
+
+;; ---- fn-prop opaque rule flows through (rf2-1mcax §opts passthrough) ----
+
+(deftest fn-ref-change-surfaces-only-when-toggle-on
+  (testing "rf2-1mcax — the opts map flows straight through to the
+            diff engine: an anonymous-fn prop whose ref changed is
+            opaque-by-default (NO fn-ref row) and surfaces a per-
+            perspective fn-ref row ONLY when :highlight-fn-ref-changes?
+            is on. Guards the per-render-noise suppression."
+    (let [f1     (fn [_e] :one)
+          f2     (fn [_e] :two)
+          before [:button {:on-click f1} "Go"]
+          after  [:button {:on-click f2} "Go"]
+          quiet  (hd/diff-hiccup-node before after)
+          loud   (hd/diff-hiccup-node before after {:highlight-fn-ref-changes? true})]
+      (is (not (any-testid-prefix? (hp/render-pane quiet :server "hydration-view")
+                                   "rf-causa-hydration-attr-fn-ref-changed-"))
+          "opaque fn-ref change leaked a row with the toggle OFF")
+      (is (any-testid-prefix? (hp/render-pane loud :server "hydration-view")
+                              "rf-causa-hydration-attr-fn-ref-changed-")
+          "fn-ref row missing with :highlight-fn-ref-changes? ON"))))
+
+;; ---- expand-state key isolation per perspective ------------------------
+
+(deftest panes-do-not-share-expand-state-keys
+  (testing "rf2-1mcax — the node-key folds the perspective in so the
+            server and client panes hold INDEPENDENT expand state for
+            the same path. A renderer that dropped the perspective
+            from the key would collapse the two panes' expand state
+            into one — assert the rendered trees differ in their
+            per-perspective testids (a proxy for distinct keying)."
+    (let [n      (hd/diff-hiccup-node [:span "server-value"]
+                                      [:span "client-value"])
+          server (hp/render-pane n :server "hydration-view")
+          client (hp/render-pane n :client "hydration-view")]
+      (is (has-testid? server "rf-causa-hydration-pane-modified-server"))
+      (is (not (has-testid? server "rf-causa-hydration-pane-modified-client"))
+          "server pane leaked the client-perspective testid")
+      (is (has-testid? client "rf-causa-hydration-pane-modified-client"))
+      (is (not (has-testid? client "rf-causa-hydration-pane-modified-server"))
+          "client pane leaked the server-perspective testid"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/density_radio_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/density_radio_reactivity_cljs_test.cljs
@@ -1,40 +1,21 @@
 (ns day8.re-frame2-causa.panels.reactivity.density-radio-reactivity-cljs-test
-  "Sub-reactivity guard for the Settings density radio (rf2-dhoc9
-  per-control-action test).
+  "Sub-reactivity guard for the density-control slots NOT already
+  pinned by the e2e harness (rf2-dhoc9 per-control-action test).
 
-  `:rf.causa/settings-update :general :density <value>` writes the
-  settings slot; `:rf.causa/density` (the convenience sub Views row
-  padding + App-db diff row line-height read) re-fires. The DOM
-  side-effect (CSS-var mutation via `effects/apply-density-font-
-  size!`) is best-effort under node-test (no DOM), but the sub-chain
-  to the CSS-var-equivalent surface IS what we test here — mirroring
-  rf2-rwhat Phase 3's browser flow."
+  De-dup note (rf2-dkmnm): the `:cosy`→`:compact`→`:cosy` round-trip
+  of `:rf.causa/density` via `:rf.causa/settings-update` (plus the
+  CSS-var-equivalent px helper and the wrong-frame
+  `*-survives-host-dispatch` assertion) is owned by
+  `control-axes-e2e/density-radio-e2e-cljs-test`. This file keeps
+  only the slots that harness does NOT cover:
+
+    - the parameterised `:rf.causa/setting` read sub, and
+    - the `:comfy` → `:cosy` normalisation step (rf2-ttnst dropped
+      the `:comfy` tier)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
 (use-fixtures :each h/fixture)
-
-(deftest density-sub-tracks-settings-update
-  (testing "rf2-dhoc9 — `:rf.causa/settings-update :general :density`
-            writes the slot; the convenience sub `:rf.causa/density`
-            re-fires with the new value (normalised to the two-tier
-            enum `:cosy` / `:compact` per rf2-ttnst)."
-    (h/setup-causa-frame!)
-    (let [density-0 (h/read-sub :rf.causa/density)]
-      (is (= :cosy density-0)
-          "default density is :cosy")
-      (h/dispatch-causa! [:rf.causa/settings-update :general :density :compact])
-      (let [density-1 (h/read-sub :rf.causa/density)]
-        (is (= :compact density-1)
-            "density flipped to :compact")
-        (is (not= density-0 density-1)
-            "density sub re-fired on settings-update")
-        (h/dispatch-causa! [:rf.causa/settings-update :general :density :cosy])
-        (let [density-2 (h/read-sub :rf.causa/density)]
-          (is (= :cosy density-2)
-              "density flipped back to :cosy")
-          (is (not= density-1 density-2)
-              "density sub re-fired on second settings-update"))))))
 
 (deftest setting-sub-parameterised-read-tracks-write
   (testing "rf2-dhoc9 — the parameterised `:rf.causa/setting` sub

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_filter_pill_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_filter_pill_reactivity_cljs_test.cljs
@@ -1,11 +1,16 @@
-(ns day8.re-frame2-causa.panels.reactivity.event-mute-reactivity-cljs-test
-  "Sub-reactivity guard for the right-click → mute-event-id action
+(ns day8.re-frame2-causa.panels.reactivity.event-filter-pill-reactivity-cljs-test
+  "Sub-reactivity guard for the IN/OUT filter-pill mechanism
   (rf2-dhoc9 per-control-action test).
 
-  `:rf.causa/add-filter :out <pill>` adds an `:out`-bucket pill to
-  `:rf.causa/active-filters`; `:rf.causa/filtered-cascades` recomposes
-  and the L2 event list re-renders without the muted event. This is
-  the unit-level mirror of rf2-rwhat Phase 3's right-click flow."
+  Renamed from `event-mute-reactivity` (rf2-dkmnm): this file is NOT
+  about event-id muting — that distinct mechanism
+  (`:rf.causa/mute-event-id` → the `:rf.causa/muted-event-ids` set)
+  is owned by `control-axes-e2e/event-id-mute-e2e-cljs-test`. Here we
+  cover the pattern-based pill filter: `:rf.causa/add-filter :out
+  <pill>` adds an `:out`-bucket pill to `:rf.causa/active-filters`;
+  `:rf.causa/filtered-cascades` recomposes and the L2 event list
+  re-renders without the filtered event. This is the unit-level
+  mirror of rf2-rwhat Phase 3's right-click flow."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
@@ -15,7 +20,7 @@
   ;; NOTE: `seed-cascades!` derives each cascade's `:event` slot from
   ;; its `:dispatch-id` as `[(keyword "evt" <name>)]`, so the matcher
   ;; sees event-id `:evt/inc` / `:evt/cart` rather than the raw
-  ;; dispatch-id keyword. We mute on the derived event-id to mirror
+  ;; dispatch-id keyword. We filter on the derived event-id to mirror
   ;; the production matcher's input.
   [(h/cascade :counter/inc :rf/default)
    (h/cascade :nav/cart :rf/default)])
@@ -35,40 +40,40 @@
         (is (= 1 (count (:out filters-1)))
             "one pill added to :out bucket")
         (is (= :evt/inc (-> filters-1 :out first :pattern))
-            "pill carries the mute pattern")
+            "pill carries the filter pattern")
         (is (not= filters-0 filters-1)
             "active-filters sub re-fired on add-filter")))))
 
-(deftest filtered-cascades-sub-tracks-mute
+(deftest filtered-cascades-sub-tracks-out-pill
   (testing "rf2-dhoc9 — `:rf.causa/filtered-cascades` recomposes when
-            an `:out` pill is added. The muted event-id's cascade
+            an `:out` pill is added. The filtered event-id's cascade
             falls out of the projected list."
     (h/setup-causa-frame!)
     (h/seed-cascades! cascades)
     (let [cascades-before (h/read-sub :rf.causa/filtered-cascades)]
       (is (= 2 (count cascades-before))
-          "both cascades present before mute")
+          "both cascades present before filter")
       (h/dispatch-causa!
         [:rf.causa/add-filter :out
          {:pattern :evt/inc :scope #{:event-id}}])
       (let [cascades-after (h/read-sub :rf.causa/filtered-cascades)]
         (is (= 1 (count cascades-after))
-            "muted cascade dropped from filtered list")
+            "filtered cascade dropped from list")
         (is (not= cascades-before cascades-after)
-            "filtered-cascades sub re-fired on mute")))))
+            "filtered-cascades sub re-fired on filter")))))
 
 (deftest remove-filter-restores-cascade
   (testing "rf2-dhoc9 — `:rf.causa/remove-filter` deletes a pill; the
-            previously-muted cascade returns to `:rf.causa/filtered-
-            cascades`. Closes the round-trip mute → unmute reactivity
-            contract."
+            previously-filtered cascade returns to `:rf.causa/filtered-
+            cascades`. Closes the round-trip filter → unfilter
+            reactivity contract."
     (h/setup-causa-frame!)
     (h/seed-cascades! cascades)
     (h/dispatch-causa!
       [:rf.causa/add-filter :out
        {:pattern :evt/inc :scope #{:event-id}}])
     (is (= 1 (count (h/read-sub :rf.causa/filtered-cascades)))
-        "mute is active")
+        "filter is active")
     (h/dispatch-causa! [:rf.causa/remove-filter :out 0])
     (is (= 2 (count (h/read-sub :rf.causa/filtered-cascades)))
-        "unmute → cascade returns to the filtered list")))
+        "unfilter → cascade returns to the filtered list")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/mode_toggle_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/mode_toggle_reactivity_cljs_test.cljs
@@ -1,36 +1,21 @@
 (ns day8.re-frame2-causa.panels.reactivity.mode-toggle-reactivity-cljs-test
-  "Sub-reactivity guard for the Cmd-Shift-M mode toggle (rf2-dhoc9
-  per-control-action test).
+  "Sub-reactivity guard for the mode-control slots NOT already pinned
+  by the e2e harness (rf2-dhoc9 per-control-action test).
 
-  `:rf.causa/toggle-mode` flips between `:dynamic` and `:static`. The
-  `:rf.causa/mode` sub the shell's chrome reads MUST re-fire so the
-  L3 tab bar / silhouette switch in lockstep. This is the unit-level
-  mirror of rf2-rwhat Phase 3's browser interaction; runs in millis."
+  De-dup note (rf2-dkmnm): the `:dynamic`→`:static`→`:dynamic`
+  round-trip via `:rf.causa/toggle-mode` is owned by
+  `control-axes-e2e/mode-toggle-e2e-cljs-test` (which also pins the
+  wrong-frame `*-survives-host-dispatch` assertion). This file keeps
+  only the slots that harness does NOT cover:
+
+    - `:rf.causa/set-mode` (the per-segment pill click writes a
+      specific mode, not a toggle).
+    - `:rf.causa.static/select-tab` (the Static-scoped tab lives on
+      its own slot)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
 (use-fixtures :each h/fixture)
-
-(deftest toggle-mode-flips-mode-sub
-  (testing "rf2-dhoc9 — `:rf.causa/toggle-mode` flips `:rf.causa/mode`
-            from `:dynamic` (default) to `:static` and back. The
-            mode sub re-fires on each toggle."
-    (h/setup-causa-frame!)
-    (let [mode-0 (h/read-sub :rf.causa/mode)]
-      (is (= :dynamic mode-0)
-          "default mode is :dynamic per spec/007-UX-IA.md §Static mode")
-      (h/dispatch-causa! [:rf.causa/toggle-mode])
-      (let [mode-1 (h/read-sub :rf.causa/mode)]
-        (is (= :static mode-1)
-            "first toggle flips to :static")
-        (is (not= mode-0 mode-1)
-            "mode sub re-fired on toggle")
-        (h/dispatch-causa! [:rf.causa/toggle-mode])
-        (let [mode-2 (h/read-sub :rf.causa/mode)]
-          (is (= :dynamic mode-2)
-              "second toggle flips back to :dynamic")
-          (is (not= mode-1 mode-2)
-              "mode sub re-fired on second toggle"))))))
 
 (deftest set-mode-writes-specific-mode
   (testing "rf2-dhoc9 — `:rf.causa/set-mode` writes a specific mode

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/palette_invoke_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/palette_invoke_reactivity_cljs_test.cljs
@@ -1,47 +1,20 @@
 (ns day8.re-frame2-causa.panels.reactivity.palette-invoke-reactivity-cljs-test
-  "Sub-reactivity guard for Cmd-K palette open / invoke (rf2-dhoc9
-  per-control-action test).
+  "Sub-reactivity guard for the palette-invoke routing slot NOT
+  already pinned by the e2e harness (rf2-dhoc9 per-control-action
+  test).
 
-  `:rf.causa/palette-open` / `:rf.causa/palette-close` / `:rf.causa/
-  palette-toggle` flip the `:palette-open?` slot; the sub re-fires so
-  the modal mounts / unmounts. `:rf.causa/palette-invoke` with a
-  `:palette/select-tab` action lowers into a `:rf.causa/select-tab`
-  dispatch, which flips the tab sub. This mirrors rf2-rwhat Phase 3's
-  Cmd-K browser flow."
+  De-dup note (rf2-dkmnm): the `:rf.causa/palette-open` /
+  `:rf.causa/palette-close` / `:rf.causa/palette-toggle` open-slot
+  round-trips (plus query-update, the `:toggle-theme` invoke path and
+  the wrong-frame `*-survives-host-dispatch` assertion) are owned by
+  `control-axes-e2e/palette-invoke-e2e-cljs-test`. This file keeps
+  only the slot that harness does NOT cover: `:rf.causa/palette-invoke`
+  with a `:palette/select-panel` action lowering into a
+  `:rf.causa/select-tab` dispatch that flips the selected-tab sub."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
 (use-fixtures :each h/fixture)
-
-(deftest palette-open-sub-tracks-open-event
-  (testing "rf2-dhoc9 — `:rf.causa/palette-open` flips the
-            `:rf.causa/palette-open?` slot; the sub re-fires."
-    (h/setup-causa-frame!)
-    (is (false? (h/read-sub :rf.causa/palette-open?))
-        "default closed")
-    (h/dispatch-causa! [:rf.causa/palette-open])
-    (is (true? (h/read-sub :rf.causa/palette-open?))
-        "palette-open → sub re-fired with true")
-    (h/dispatch-causa! [:rf.causa/palette-close])
-    (is (false? (h/read-sub :rf.causa/palette-open?))
-        "palette-close → sub re-fired with false")))
-
-(deftest palette-toggle-flips-open-sub
-  (testing "rf2-dhoc9 — the Cmd-K key binding fires `:rf.causa/
-            palette-toggle`, which flips the open slot. Two toggles
-            return to the original state."
-    (h/setup-causa-frame!)
-    (let [open-0 (h/read-sub :rf.causa/palette-open?)]
-      (h/dispatch-causa! [:rf.causa/palette-toggle])
-      (let [open-1 (h/read-sub :rf.causa/palette-open?)]
-        (is (= true open-1)
-            "first toggle opens the palette")
-        (is (not= open-0 open-1))
-        (h/dispatch-causa! [:rf.causa/palette-toggle])
-        (let [open-2 (h/read-sub :rf.causa/palette-open?)]
-          (is (= false open-2)
-              "second toggle closes the palette")
-          (is (not= open-1 open-2)))))))
 
 (deftest palette-invoke-select-tab-flips-selected-tab-sub
   (testing "rf2-dhoc9 — `:rf.causa/palette-invoke` with action


### PR DESCRIPTION
## Summary

De-duplicates the `control_axes_e2e/` <-> `panels/reactivity/` overlap and closes the three real coverage gaps from the test-coverage audit (`ai/findings/2026-05-21-testcov-causa.md`). All CLJS-unit (correct layer); no Playwright added.

### De-dup (worst finding)
mode-toggle / density / palette round-trips were covered ~3x (e2e CLJS + reactivity CLJS + browser gate). Keep ONE harness per axis:
- **e2e files keep** the round-trip + the wrong-frame `*-survives-host-dispatch` assertion (rf2-83d4x class) — genuine value the sub-reactivity harness lacks.
- **reactivity files keep only** the slots the e2e harness does NOT cover: `set-mode`, `static-select-tab`, the parameterised `:rf.causa/setting` sub, the `:comfy`->`:cosy` normalisation, and the palette `:palette/select-panel` tab routing. The verbatim round-trip duplicates are removed.
- **Renamed** `event_mute_reactivity_cljs_test` -> `event_filter_pill_reactivity_cljs_test`: it tests IN/OUT pill filtering (`:rf.causa/add-filter`), NOT event-id muting (`:rf.causa/mute-event-id` — owned by `event_id_mute_e2e`). The old name was a maintenance hazard the audit flagged.

### Gaps closed
1. **Hydration panel** (`panels/hydration_pane_render.cljs` had zero unit test, rested on the browser gate). New `hydration_pane_render_cljs_test` feeds real before/after hiccup through the diff engine and pins the per-side (server/client) SSR-mismatch projection: added/removed/modified nodes + attrs, the fn-prop opaque-rule passthrough (toggle off = no fn-ref row; on = row), and per-perspective expand-key isolation.
2. **Segment-inspector content** (`panels/app_db_segment_inspector.cljs` — only ARIA shape was tested). New `app_db_segment_inspector_cljs_test` drives `:rf.causa/segment-inspector-value` through the production `target-frame-db` chain and asserts the path-prefix slice (`[:cart]`, `[:cart :gross]`, deep leaf) + header/body content render + closed-state nil.
3. **Per-modal focus-ref** — `modals_aria_cljs_test` now asserts each of the 6 modals attaches a function `:ref` (the `a11y/dialog-ref` focus trap) + `tab-index`, so a correctly-labelled modal that dropped its trap fails the gate instead of staying green.

## Test plan
- [x] `npm run test:cljs` — 4087 tests / 12343 assertions / 0 failures (Causa CLJS node-test build)
- [x] `tools/causa` `clojure -M:test` — 849 tests / 2778 assertions / 0 failures
- [x] node-test build: 1018 files compiled, 0 warnings (renamed ns picked up by the `cljs-test$` regex)