### PR TITLE
test(core): late-bind cache + chain-fn ordering + registrar guards (rf2-0kfd4)

### DIFF
--- a/implementation/core/test/re_frame/core_contract_guards_test.clj
+++ b/implementation/core/test/re_frame/core_contract_guards_test.clj
@@ -1,0 +1,209 @@
+(ns re-frame.core-contract-guards-test
+  "Per rf2-0kfd4 (testcov-core G3 + G4 + G5 + G6) — guard contracts on
+  load-bearing internal seams that previously had no behavioural test.
+
+    G3 — `registrar/register!` unknown-kind throw + `valid-kind?`
+         (registrar.cljc). Registering a kind outside the closed v1 set
+         throws `:rf.error/unknown-registry-kind` with the documented
+         ex-data shape. Spec 001 §Registry model names the closed kind
+         set as a contract; this pins the guard that enforces it.
+
+    G4 — registrar registration/replacement hook isolation
+         (registrar.cljc). `add-registration-hook!` fires on EVERY
+         register! (first-time AND re-registration); `add-replacement-
+         hook!` fires only on re-registration. Both run isolated — a
+         throwing hook is swallowed (try/catch) so a buggy listener
+         can't block the registration.
+
+    G5 — `frame/frame-disposed-for-drain?` (frame.cljc) three branches:
+         destroyed-but-present → true, absent → true, live → false.
+
+    G6 — `subs/reg-sub` malformed-form throw `:rf.error/reg-sub-bad-args`
+         (subs.cljc). reg-event / reg-view bad-args are pinned elsewhere;
+         the reg-sub rejection branch was not.
+
+  Pure JVM unit. A fixture snapshots/restores the (private) registration
+  and replacement hook atoms — there is no public clear for them, so a
+  test-installed hook must be torn down here to keep sibling tests clean.
+  The registrar/frame slots the tests touch are cleared on entry."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.subs :as subs]))
+
+;; ---- fixtures -------------------------------------------------------------
+;;
+;; `registration-hooks` / `replacement-hooks` are private `defonce`
+;; atoms with a public *add* but no public *clear*. Snapshot+restore so a
+;; throwing test hook never leaks into a sibling test (which would, e.g.,
+;; break every subsequent register! call's hook fan-out). Also clear the
+;; registrar + frame slots the tests below write.
+
+(defn isolate-registrar-state [test-fn]
+  (let [reg-hooks-before  @(deref #'registrar/registration-hooks)
+        repl-hooks-before @(deref #'registrar/replacement-hooks)
+        frames-before     @frame/frames]
+    (registrar/clear-kind! :sub)
+    (registrar/clear-kind! :event)
+    (try
+      (test-fn)
+      (finally
+        (reset! (deref #'registrar/registration-hooks) reg-hooks-before)
+        (reset! (deref #'registrar/replacement-hooks)  repl-hooks-before)
+        (reset! frame/frames frames-before)
+        (registrar/clear-kind! :sub)
+        (registrar/clear-kind! :event)))))
+
+(use-fixtures :each isolate-registrar-state)
+
+;; =============================================================================
+;; G3 — unknown-kind throw + valid-kind?
+;; =============================================================================
+
+(deftest valid-kind?-recognises-the-closed-v1-set
+  (testing "valid-kind? is true for each member of the closed v1 kind set"
+    (doseq [k registrar/kinds]
+      (is (registrar/valid-kind? k) (str k " is a valid v1 registry kind"))))
+  (testing "valid-kind? is false for kinds outside the closed set"
+    (is (not (registrar/valid-kind? :not-a-kind)))
+    (is (not (registrar/valid-kind? :machine))
+        "machine guards/actions are machine-scoped, not a registry kind (Spec 005)")
+    (is (not (registrar/valid-kind? nil)))))
+
+(deftest register!-throws-on-an-unknown-kind
+  (testing "register! rejects a kind outside the closed v1 set with the documented error shape"
+    (let [ex (try
+               (registrar/register! :bogus-kind :some/id {:handler-fn identity})
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex)
+          "an unknown kind throws an ex-info")
+      (is (= ":rf.error/unknown-registry-kind" (.getMessage ^Exception ex))
+          "message is the stringified canonical error keyword")
+      (let [data (ex-data ex)]
+        (is (= :rf.error/unknown-registry-kind (:rf.error/id data))
+            ":rf.error/id is the canonical discriminator")
+        (is (= 'rf/register-handler (:where data)) ":where names the user-facing seam")
+        (is (= :fix-registration (:recovery data)) ":recovery is :fix-registration")
+        (is (= :bogus-kind (:kind data)) "ex-data echoes the offending kind")
+        (is (= :some/id (:id data)) "ex-data echoes the id")
+        (is (string? (:reason data)) ":reason is a human-readable string")))))
+
+(deftest register!-throws-before-writing-the-slot
+  (testing "an unknown-kind register! does not mutate the registry"
+    (let [before @(deref #'registrar/kind->id->metadata)]
+      (try (registrar/register! :bogus-kind :x {:handler-fn identity})
+           (catch clojure.lang.ExceptionInfo _ nil))
+      (is (= before @(deref #'registrar/kind->id->metadata))
+          "the registry map is untouched — the throw precedes the swap!"))))
+
+;; =============================================================================
+;; G4 — registration / replacement hook isolation + firing contract
+;; =============================================================================
+
+(deftest registration-hook-fires-on-first-time-and-re-registration
+  (testing "add-registration-hook! fires on BOTH first-time and re-registration"
+    (let [calls (atom [])]
+      (registrar/add-registration-hook!
+        (fn [m] (swap! calls conj (select-keys m [:kind :id :was]))))
+      (registrar/register! :sub :s/one {:handler-fn (fn [] :v1)})
+      (registrar/register! :sub :s/one {:handler-fn (fn [] :v2)})
+      (is (= 2 (count @calls)) "the hook fired on both registrations")
+      (is (nil? (:was (first @calls)))
+          ":was is nil on first-time registration")
+      (is (some? (:was (second @calls)))
+          ":was carries the previous metadata on re-registration"))))
+
+(deftest replacement-hook-fires-only-on-re-registration
+  (testing "add-replacement-hook! fires on re-registration, not first-time"
+    (let [calls (atom [])]
+      (registrar/add-replacement-hook!
+        (fn [m] (swap! calls conj (select-keys m [:kind :id :different-fn?]))))
+      (registrar/register! :sub :s/two {:handler-fn (fn [] :a)})
+      (is (= 0 (count @calls)) "no replacement hook on first-time registration")
+      (registrar/register! :sub :s/two {:handler-fn (fn [] :b)})
+      (is (= 1 (count @calls)) "replacement hook fired on re-registration")
+      (is (true? (:different-fn? (first @calls)))
+          ":different-fn? is true when the handler-fn identity changed"))))
+
+(deftest throwing-registration-hook-is-swallowed
+  (testing "a throwing registration hook does not break register!"
+    (let [reached (atom false)]
+      (registrar/add-registration-hook! (fn [_] (throw (ex-info "bad hook" {}))))
+      ;; A second hook installed AFTER the throwing one — if the throw
+      ;; were not swallowed per-hook, the doseq would abort and this hook
+      ;; would never fire.
+      (registrar/add-registration-hook! (fn [_] (reset! reached true)))
+      (is (= {:was nil :now {:handler-fn :the-fn}}
+             (registrar/register! :sub :s/iso {:handler-fn :the-fn}))
+          "register! returns its normal {:was :now} result despite the throwing hook")
+      (is (true? @reached)
+          "the second hook still fired — per-hook throws are isolated")
+      (is (= {:handler-fn :the-fn} (registrar/lookup :sub :s/iso))
+          "the registration slot was written despite the throwing hook"))))
+
+(deftest throwing-replacement-hook-is-swallowed
+  (testing "a throwing replacement hook does not break a re-registration"
+    (registrar/add-replacement-hook! (fn [_] (throw (ex-info "bad repl hook" {}))))
+    (registrar/register! :sub :s/repl {:handler-fn (fn [] :first)})
+    (let [result (registrar/register! :sub :s/repl {:handler-fn (fn [] :second)})]
+      (is (some? (:was result)) "re-registration completed despite the throwing hook")
+      (is (some? (registrar/lookup :sub :s/repl))
+          "the new slot is in place"))))
+
+;; =============================================================================
+;; G5 — frame/frame-disposed-for-drain? three branches
+;; =============================================================================
+
+(deftest frame-disposed-for-drain?-distinguishes-the-three-branches
+  (testing "live frame → false; destroyed-but-present → true; absent → true"
+    (reset! frame/frames
+            {:f/live      {:lifecycle {:destroyed? false}}
+             :f/destroyed {:lifecycle {:destroyed? true}}})
+    (is (false? (frame/frame-disposed-for-drain? :f/live))
+        "a registered, non-destroyed frame is NOT disposed for drain")
+    (is (true? (frame/frame-disposed-for-drain? :f/destroyed))
+        "a present-but-:destroyed? frame is disposed (post step-3, pre step-6)")
+    (is (true? (frame/frame-disposed-for-drain? :f/never-registered))
+        "an absent id returns true — benign for the drain caller (Spec 002)")))
+
+;; =============================================================================
+;; G6 — subs/reg-sub malformed-form throw
+;; =============================================================================
+
+(deftest reg-sub-rejects-trailing-args-after-the-handler
+  (testing "a layer-1 form with an extra trailing arg throws :rf.error/reg-sub-bad-args"
+    (let [ex (try
+               (subs/reg-sub :sub/malformed (fn [db _] db) :unexpected-extra)
+               (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo ex)
+          "a malformed reg-sub tail throws an ex-info")
+      (is (= ":rf.error/reg-sub-bad-args" (.getMessage ^Exception ex)))
+      (let [data (ex-data ex)]
+        (is (= :rf.error/reg-sub-bad-args (:rf.error/id data)))
+        (is (= 'rf/reg-sub (:where data)))
+        (is (= :fix-registration (:recovery data)))
+        (is (= :sub/malformed (:id data)) "ex-data echoes the sub id"))
+      (is (nil? (registrar/lookup :sub :sub/malformed))
+          "the malformed sub was never registered"))))
+
+(deftest reg-sub-rejects-a-dangling-arrow-without-a-vector
+  (testing "a `:<-` not followed by a vector falls through to the bad-args throw"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #":rf.error/reg-sub-bad-args"
+          (subs/reg-sub :sub/dangling-arrow :<- :not-a-vector (fn [v _] v)))
+        ":<- with a non-vector neighbour is not a valid layer-2 chain")))
+
+(deftest reg-sub-accepts-the-three-valid-shapes
+  (testing "the valid layer-1 / layer-2-single / layer-2-multi shapes parse cleanly"
+    ;; Layer-1.
+    (is (= :sub/l1 (subs/reg-sub :sub/l1 (fn [db _] db))))
+    ;; Layer-2 single.
+    (is (= :sub/l2-single
+           (subs/reg-sub :sub/l2-single :<- [:sub/l1] (fn [up _] up))))
+    ;; Layer-2 multi.
+    (is (= :sub/l2-multi
+           (subs/reg-sub :sub/l2-multi
+                         :<- [:sub/l1] :<- [:sub/l2-single]
+                         (fn [[a b] _] [a b]))))
+    (let [meta (registrar/lookup :sub :sub/l2-multi)]
+      (is (= [[:sub/l1] [:sub/l2-single]] (:input-signals meta))
+          "the :<- chain is parsed into :input-signals in order"))))

--- a/implementation/core/test/re_frame/late_bind_cache_test.clj
+++ b/implementation/core/test/re_frame/late_bind_cache_test.clj
@@ -1,0 +1,215 @@
+(ns re-frame.late-bind-cache-test
+  "Per rf2-0kfd4 (testcov-core G1 + G2) — behavioural coverage for the
+  late-bind sticky resolution cache and the `chain-fn!` runtime
+  composition contract.
+
+  These are rf2-f72pd hot-path machinery: every dispatch / subscribe
+  resolves `:trace/emit!`, `:adapter/current-frame`, `:router/dispatch!`,
+  `:epoch/capture-event`, … through `get-fn-cached`. The documented
+  invariants previously had ZERO assertions:
+
+    G1 — `get-fn-cached` / `invalidate-cache!` (late_bind.cljc):
+      (a) a resolved fn is cached and re-served,
+      (b) nil resolutions are NOT cached — a deferred publication is
+          visible on the next call,
+      (c) `set-fn!` / `chain-fn!` invalidate the slot so hot-reload swaps
+          the fn on the next lookup. A stale slot serving a withdrawn
+          hook is a silent correctness bug; this file pins the guard.
+
+    G2 — `chain-fn!` ordering (late_bind.cljc):
+      step-fn runs FIRST (last-registered = outer wrapper), each previous
+      handler runs after with the same args, per-step throws PROPAGATE
+      (not swallowed), the chained hook returns nil.
+
+  Pure JVM unit — no adapter / frame / trace runtime needed. Every test
+  drives a synthetic `:test/*` hook key so real published hooks are never
+  touched; a fixture snapshots and restores the (private) `hooks` and
+  `fn-cache` atoms regardless."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.late-bind :as late-bind]))
+
+;; ---- fixtures -------------------------------------------------------------
+;;
+;; `hooks` and `fn-cache` are process-global `defonce` atoms; the tests
+;; below mutate them via the public `set-fn!` / `chain-fn!` / public
+;; `invalidate-cache!` API. We snapshot both and restore them after each
+;; test so a synthetic `:test/*` key can never leak into a sibling test
+;; or a real published hook can never be clobbered.
+
+(defn isolate-hook-state [test-fn]
+  (let [hooks-before     @(deref #'late-bind/hooks)
+        fn-cache-before  @(deref #'late-bind/fn-cache)]
+    (try
+      (test-fn)
+      (finally
+        (reset! (deref #'late-bind/hooks)    hooks-before)
+        (reset! (deref #'late-bind/fn-cache) fn-cache-before)))))
+
+(use-fixtures :each isolate-hook-state)
+
+(defn- cached?
+  "True when `hook-key` currently has a populated cache slot."
+  [hook-key]
+  (contains? @(deref #'late-bind/fn-cache) hook-key))
+
+;; =============================================================================
+;; G1 — sticky resolution cache: get-fn-cached / invalidate-cache!
+;; =============================================================================
+
+(deftest get-fn-cached-caches-and-reserves-a-resolved-fn
+  (testing "first hit reads `hooks`, populates the cache slot, returns the fn"
+    (let [k  :test/g1-resolved
+          f  (fn [] :resolved)]
+      (is (not (cached? k)) "precondition: slot empty before any lookup")
+      (late-bind/set-fn! k f)
+      ;; set-fn! invalidates the slot — still uncached until the first read.
+      (is (not (cached? k)) "set-fn! does not pre-warm the cache")
+      (is (identical? f (late-bind/get-fn-cached k))
+          "first get-fn-cached resolves through `hooks`")
+      (is (cached? k) "the resolved fn is now cached/reserved")
+      (is (identical? f (late-bind/get-fn-cached k))
+          "subsequent hit re-serves the same fn"))))
+
+(deftest get-fn-cached-re-serves-the-cached-slot-even-after-hooks-mutates
+  (testing "once cached, get-fn-cached returns the cached slot, not a fresh `hooks` read"
+    ;; This pins the *stickiness*: the cache is the source of truth until
+    ;; explicitly invalidated. A bare `hooks` mutation (no invalidate)
+    ;; must NOT be observed by get-fn-cached — only set-fn!/chain-fn!
+    ;; (which invalidate) flip a cached resolution.
+    (let [k  :test/g1-sticky
+          f1 (fn [] :first)
+          f2 (fn [] :second)]
+      (late-bind/set-fn! k f1)
+      (is (identical? f1 (late-bind/get-fn-cached k)) "warm the slot with f1")
+      ;; Mutate `hooks` directly, bypassing set-fn!/invalidate-cache!.
+      (swap! (deref #'late-bind/hooks) assoc k f2)
+      (is (identical? f1 (late-bind/get-fn-cached k))
+          "cached slot is sticky — a non-invalidating `hooks` write is not seen"))))
+
+(deftest get-fn-cached-does-not-cache-nil-resolutions
+  (testing "an unpublished key returns nil and is NOT cached — deferred publication is visible next call"
+    (let [k :test/g1-deferred]
+      (is (nil? (late-bind/get-fn-cached k)) "unpublished key resolves to nil")
+      (is (not (cached? k))
+          "nil resolution must NOT populate the cache slot")
+      ;; Publish AFTER the first (nil) lookup — a sticky-nil bug would
+      ;; keep returning nil here.
+      (let [f (fn [] :late)]
+        (late-bind/set-fn! k f)
+        (is (identical? f (late-bind/get-fn-cached k))
+            "deferred publication is visible on the next get-fn-cached call")))))
+
+(deftest invalidate-cache!-drops-the-slot-so-the-next-lookup-re-resolves
+  (testing "invalidate-cache! forces re-resolution through `hooks` on the next call"
+    (let [k  :test/g1-invalidate
+          f1 (fn [] :v1)
+          f2 (fn [] :v2)]
+      (late-bind/set-fn! k f1)
+      (is (identical? f1 (late-bind/get-fn-cached k)) "warm the slot")
+      (is (cached? k))
+      ;; Swap the underlying `hooks` value, then invalidate the slot —
+      ;; this is exactly the hot-reload sequence, but with the slot
+      ;; cleared explicitly via the public helper.
+      (swap! (deref #'late-bind/hooks) assoc k f2)
+      (is (nil? (late-bind/invalidate-cache! k)) "invalidate-cache! returns nil")
+      (is (not (cached? k)) "the slot is dropped")
+      (is (identical? f2 (late-bind/get-fn-cached k))
+          "next lookup re-resolves through `hooks` and serves the new fn"))))
+
+(deftest set-fn!-invalidates-the-slot-so-hot-reload-swaps-the-fn
+  (testing "re-publishing via set-fn! drops the cached resolution (hot-reload semantics)"
+    (let [k  :test/g1-hot-reload
+          f1 (fn [] :old)
+          f2 (fn [] :new)]
+      (late-bind/set-fn! k f1)
+      (is (identical? f1 (late-bind/get-fn-cached k)) "warm with the old fn")
+      (is (cached? k))
+      ;; A genuine artefact hot-reload calls set-fn! again with the new fn.
+      (late-bind/set-fn! k f2)
+      (is (not (cached? k)) "set-fn! invalidated the slot")
+      (is (identical? f2 (late-bind/get-fn-cached k))
+          "the very next get-fn-cached serves the newly-published fn — no stale slot"))))
+
+;; =============================================================================
+;; G2 — chain-fn! runtime composition ordering
+;; =============================================================================
+
+(deftest chain-fn!-runs-step-first-then-previous-handler
+  (testing "last-registered step is the OUTER wrapper — step-fn runs before the previous handler"
+    (let [k     :test/g2-order
+          order (atom [])]
+      ;; First step becomes the inner handler.
+      (late-bind/chain-fn! k (fn [_] (swap! order conj :first)))
+      ;; Second step is registered last → runs first.
+      (late-bind/chain-fn! k (fn [_] (swap! order conj :second)))
+      (let [hook (late-bind/get-fn k)]
+        (is (some? hook) "the chained hook is published under the key")
+        (hook :arg))
+      (is (= [:second :first] @order)
+          "step-fn (last-registered) runs FIRST, the previous handler runs after"))))
+
+(deftest chain-fn!-fans-out-the-same-args-to-every-step
+  (testing "every chained step receives the same args"
+    (let [k    :test/g2-args
+          seen (atom [])]
+      (late-bind/chain-fn! k (fn [a b] (swap! seen conj [:inner a b])))
+      (late-bind/chain-fn! k (fn [a b] (swap! seen conj [:outer a b])))
+      ((late-bind/get-fn k) 1 2)
+      (is (= [[:outer 1 2] [:inner 1 2]] @seen)
+          "both steps see identical args; outer (last-registered) first"))))
+
+(deftest chain-fn!-chained-hook-returns-nil
+  (testing "the chained hook is side-effecting — it returns nil regardless of step return values"
+    (let [k :test/g2-return]
+      (late-bind/chain-fn! k (fn [_] :inner-return))
+      (late-bind/chain-fn! k (fn [_] :outer-return))
+      (is (nil? ((late-bind/get-fn k) :arg))
+          "chained hook returns nil — callers do not consume a step value"))))
+
+(deftest chain-fn!-first-step-with-no-previous-runs-alone
+  (testing "the very first chain-fn! step runs with no previous handler (previous is nil)"
+    (let [k   :test/g2-first
+          hit (atom 0)]
+      (late-bind/chain-fn! k (fn [_] (swap! hit inc)))
+      ((late-bind/get-fn k) :arg)
+      (is (= 1 @hit) "the lone step runs exactly once with no previous to chain"))))
+
+(deftest chain-fn!-propagates-per-step-throws
+  (testing "a throwing step is NOT swallowed — the throw propagates out of the chained hook"
+    (let [k          :test/g2-throw-outer
+          inner-ran? (atom false)]
+      (late-bind/chain-fn! k (fn [_] (reset! inner-ran? true)))
+      ;; Outer (last-registered) step throws — it runs first, so the
+      ;; throw escapes before the inner handler ever runs.
+      (late-bind/chain-fn! k (fn [_] (throw (ex-info "boom-outer" {}))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"boom-outer"
+            ((late-bind/get-fn k) :arg))
+          "the outer step's throw propagates")
+      (is (false? @inner-ran?)
+          "outer throws first, so the previous handler never runs — throws are not swallowed"))))
+
+(deftest chain-fn!-propagates-throw-from-a-previous-step
+  (testing "a throw from a previous (inner) step also propagates"
+    (let [k          :test/g2-throw-inner
+          outer-ran? (atom false)]
+      ;; Inner step (registered first) throws.
+      (late-bind/chain-fn! k (fn [_] (throw (ex-info "boom-inner" {}))))
+      ;; Outer step runs first, succeeds, then invokes the throwing inner.
+      (late-bind/chain-fn! k (fn [_] (reset! outer-ran? true)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"boom-inner"
+            ((late-bind/get-fn k) :arg))
+          "the inner step's throw propagates out of the chained hook")
+      (is (true? @outer-ran?)
+          "the outer step ran first (before the inner throw)"))))
+
+(deftest chain-fn!-invalidates-the-cache-slot
+  (testing "chain-fn! re-publishes via set-fn!, so a previously-cached resolution is dropped"
+    (let [k :test/g2-cache-invalidate]
+      ;; Seed an initial direct fn and warm the cache.
+      (late-bind/set-fn! k (fn [_] :seed))
+      (is (some? (late-bind/get-fn-cached k)) "warm the slot")
+      (is (cached? k))
+      ;; chain-fn! wraps it — must invalidate the slot.
+      (late-bind/chain-fn! k (fn [_] nil))
+      (is (not (cached? k))
+          "chain-fn! invalidated the cache slot so the next dispatch sees the chained hook"))))


### PR DESCRIPTION
## Summary

Adds cheap JVM/cljc unit tests for previously-untested but load-bearing internal contracts in `implementation/core/` (rf2-0kfd4, findings G1–G6). No source changes — test-only.

- **G1 — late-bind sticky cache** (`late_bind.cljc`): `get-fn-cached` caches + reserves a resolved fn; **nil resolutions are NOT cached** (a deferred publication is visible on the next call); `invalidate-cache!` and `set-fn!` drop the slot so hot-reload swaps the fn on the next lookup. Pins the guard against a stale slot silently serving a withdrawn hook.
- **G2 — `chain-fn!` ordering** (`late_bind.cljc`): step-fn runs first (last-registered = outer wrapper), identical args fan out to every step, per-step throws **propagate** (not swallowed), the chained hook returns nil, and `chain-fn!` invalidates the cache slot.
- **G3 — unknown-kind throw** (`registrar.cljc`): `register!` rejects a kind outside the closed v1 set with the documented `:rf.error/unknown-registry-kind` ex-data shape, before any slot write; `valid-kind?` recognises the closed set.
- **G4 — hook isolation** (`registrar.cljc`): registration hooks fire on first-time AND re-registration; replacement hooks fire only on re-registration; a throwing hook is swallowed and does not block registration.
- **G5 — `frame-disposed-for-drain?`** (`frame.cljc`): direct 3-branch unit (live → false, destroyed-but-present → true, absent → true).
- **G6 — `reg-sub` bad-args** (`subs.cljc`): malformed forms throw `:rf.error/reg-sub-bad-args`; the three valid shapes still parse.

New deftests use a fixture that snapshots/restores the private late-bind and registrar hook atoms so synthetic `:test/*` keys never leak across tests.

**No real bug found** — every documented invariant behaved as specified, including the critical nil-not-cached and invalidate-on-set semantics.

## Test plan

- [x] core JVM gate (`implementation/core` `clojure -M:test`): 712 tests / 3377 assertions, 0 failures, 0 errors (the 23 new tests / 80 assertions included).
- [x] CLJS gate (`implementation/` `npm run test:cljs`): 4070 tests / 12305 assertions, 0 failures, 0 errors (unchanged — JVM-only additions).