### PR TITLE
test(story): cover runner→assertion bridge + assertion-helper branches + outer :key meta (rf2-uhq5j)

### DIFF
--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -13,59 +13,167 @@
 
   - The runner's pure state machine (via `runner-test`).
   - The chip + banner label helpers (via `play-status-cljs-test`).
-  - `coerce-script` lifts (verified inline below)."
-  (:require [clojure.test :refer [deftest is testing #?(:clj use-fixtures)]]
+  - The dispatch→assertion outcome-matching bridge (`failed-since` +
+    `dispatch-step-result`, exercised directly below — rf2-uhq5j)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.story.play.runner :as runner]
-            #?@(:clj
-                [[re-frame.core             :as rf]
-                 [re-frame.frame            :as frame]
-                 [re-frame.registrar        :as registrar]
-                 [re-frame.story            :as story]
-                 [re-frame.story.assertions :as assertions]
-                 [re-frame.story.async      :as async]
-                 [re-frame.story.config     :as config]
-                 [re-frame.story.loaders    :as loaders]
-                 [re-frame.story.play       :as legacy-play]
-                 [re-frame.story.play.runner-events :as re]
-                 [re-frame.machines         :as machines]
-                 [re-frame.substrate.plain-atom :as plain-atom]])))
+            [re-frame.core              :as rf]
+            [re-frame.frame             :as frame]
+            [re-frame.story             :as story]
+            [re-frame.story.assertions  :as assertions]
+            [re-frame.story.loaders     :as loaders]
+            [re-frame.story.play        :as legacy-play]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.machines          :as machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.registrar         :as registrar]
+            ;; `re-frame.story.async/deref-blocking` is JVM-only (it
+            ;; blocks a thread) and `config/set-global-args!` is only
+            ;; needed by the JVM `reset-all` lineage — the integration
+            ;; tests below that use them are themselves JVM-gated.
+            #?@(:clj [[re-frame.story.async  :as async]
+                      [re-frame.story.config :as config]])))
+
+;; ---- CLJS+JVM: the dispatch→assertion outcome-matching bridge -----------
+;;
+;; `failed-since` + `dispatch-step-result` (runner_events.cljc) turn a
+;; handler-recorded `:rf.assert/*` failure into a runner `step-fail` so
+;; the play's terminal status flips. Before rf2-uhq5j these were hit only
+;; transitively via the heavy JVM `run-blocking` integration tests below;
+;; this section drives them directly on BOTH runtimes by seeding a known
+;; `:rf.story/assertions` vector on a live frame, then asserting the
+;; step-fail / step-skip shape + `:message`/`:expected`/`:actual`
+;; projection. Both fns are private — reached via var-quote (the
+;; established Story-test seam pattern, e.g. play/listener-for-frame).
+
+(def ^:private failed-since        @#'re/failed-since)
+(def ^:private dispatch-step-result @#'re/dispatch-step-result)
+
+(def ^:private bridge-frame :story.bridge/frame)
+
+(defn- seed-assertions!
+  "Append each record in `recs` to `bridge-frame`'s `:rf.story/assertions`
+  via a real `dispatch-sync`, mirroring how the `:rf.assert/*` handlers
+  land their records. Returns the post-seed assertion count."
+  [recs]
+  (doseq [r recs]
+    (rf/dispatch-sync [::seed r] {:frame bridge-frame}))
+  (count (:rf.story/assertions (rf/get-frame-db bridge-frame))))
+
+(defn- bridge-reset!
+  "Single namespace fixture (rf2-uhq5j unified the prior JVM-only
+  `reset-all`). Resets every Story side-table + the re-frame frame
+  registry, reinstalls the canonical vocabulary, and registers the
+  bridge test frame + its `::seed` event. Runs on both runtimes; the
+  JVM-only `:reload` of machines + `config/set-global-args!` are gated."
+  [test-fn]
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter)
+       (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+  #?(:clj (require 're-frame.machines :reload))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  #?(:clj (config/set-global-args! {}))
+  (reset! assertions/trace-accumulators {})
+  (reset! legacy-play/stepper-state {})
+  (reset! re/run-state {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (frame/reg-frame bridge-frame {:doc "outcome-matching bridge test frame"})
+  (rf/reg-event-db ::seed
+    (fn [db [_ rec]]
+      (update db :rf.story/assertions (fnil conj []) rec)))
+  (test-fn))
+
+(use-fixtures :each bridge-reset!)
+
+(deftest failed-since-filters-to-failures-after-prev-count
+  (testing "failed-since returns only the :passed? false records appended
+            after prev-count — the dispatched event's contribution"
+    (let [prev (seed-assertions! [{:passed? true  :id :rf.assert/path-equals}])
+          _    (seed-assertions! [{:passed? false :id :rf.assert/path-equals
+                                   :expected :loaded :actual :idle :message "boom"}
+                                  {:passed? true  :id :rf.assert/path-equals}])
+          out  (failed-since bridge-frame prev)]
+      (is (= 1 (count out))
+          "only the one new failing record is returned — the earlier pass
+           (before prev-count) and the trailing pass are excluded")
+      (is (= :loaded (:expected (first out))))
+      (is (= :idle   (:actual   (first out)))))))
+
+(deftest failed-since-empty-when-no-new-failures
+  (testing "failed-since is empty when nothing failed since prev-count"
+    (let [prev (seed-assertions! [{:passed? false :id :rf.assert/path-equals}])]
+      ;; prior failure is BEFORE prev-count; a clean pass lands after.
+      (seed-assertions! [{:passed? true :id :rf.assert/path-equals}])
+      (is (empty? (failed-since bridge-frame prev))
+          "the pre-prev failure is excluded; the post-prev pass is filtered"))))
+
+(deftest failed-since-tolerates-prev-count-overshoot
+  (testing "failed-since clamps prev-count to the current length (subvec
+            never throws even if the accumulator shrank)"
+    (seed-assertions! [{:passed? false :id :rf.assert/path-equals}])
+    (is (= [] (failed-since bridge-frame 999))
+        "an out-of-range prev-count yields an empty slice, not an error")))
+
+(deftest dispatch-step-result-projects-failure-to-step-fail
+  (testing "a new failing assertion since prev becomes a runner step-fail
+            carrying the record's :expected / :actual / :message"
+    (let [step [:dispatch-sync [:rf.assert/path-equals [:status] :loaded]]
+          prev (seed-assertions! [])
+          _    (seed-assertions! [{:passed? false :id :rf.assert/path-equals
+                                   :expected :loaded :actual :idle
+                                   :message  "expected :loaded, got :idle"}])
+          out  (dispatch-step-result bridge-frame prev 3 step)]
+      (is (false? (:passed? out)) "the step result flips to fail")
+      (is (= :dispatch-sync (:type out)) "step-type is preserved")
+      (is (= 3 (:idx out)))
+      (is (= step (:step out)))
+      (is (= :loaded (:expected out)))
+      (is (= :idle   (:actual out)))
+      (is (= "expected :loaded, got :idle" (:message out))))))
+
+(deftest dispatch-step-result-synthesizes-message-when-record-has-none
+  (testing "when the failing record carries no :message, the bridge
+            synthesizes one from :id / :payload / :expected / :actual"
+    (let [step [:dispatch [:rf.assert/path-equals [:k] 1]]
+          prev (seed-assertions! [])
+          _    (seed-assertions! [{:passed? false :id :rf.assert/path-equals
+                                   :payload  [[:k] 1] :expected 1 :actual 0}])
+          out  (dispatch-step-result bridge-frame prev 0 step)]
+      (is (false? (:passed? out)))
+      (is (re-find #":rf.assert/path-equals" (:message out))
+          "the synthesized message names the assertion id")
+      (is (re-find #"expected 1" (:message out)))
+      (is (re-find #"actual 0"   (:message out))))))
+
+(deftest dispatch-step-result-skips-when-no-failure
+  (testing "a dispatch that contributed no failing assertion is a
+            step-skip — :passed? nil, so it doesn't count toward failures"
+    (let [step [:dispatch-sync [:some/event]]
+          prev (seed-assertions! [{:passed? true :id :rf.assert/path-equals}])]
+      ;; A clean pass lands after prev — no failures contributed.
+      (seed-assertions! [{:passed? true :id :rf.assert/path-equals}])
+      (let [out (dispatch-step-result bridge-frame prev 1 step)]
+        (is (nil? (:passed? out)) "step-skip leaves :passed? nil")
+        (is (= :dispatch-sync (:type out)))
+        (is (= 1 (:idx out)))
+        (is (= step (:step out)))))))
 
 ;; ---- CLJS-runnable: pure-data coverage of the script lift ---------------
-
-(deftest bare-event-vector-lift-via-coerce
-  (testing "a bare [:event ...] entry in :script lifts to [:dispatch <vec>]"
-    (is (= [[:dispatch [:rt/touch]] [:dispatch [:rt/touch]]]
-           (runner/coerce-script [[:rt/touch] [:rt/touch]])))
-    (let [spec (runner/parse-spec {:auto-run? false
-                                    :script    [[:rt/touch]
-                                                [:wait 0]
-                                                [:assert-db [:k] nil]]})]
-      (is (= [[:dispatch [:rt/touch]]
-              [:wait 0]
-              [:assert-db [:k] nil]]
-             (:script spec))))))
+;;
+;; (rf2-uhq5j) the former `bare-event-vector-lift-via-coerce` test here
+;; was removed: it duplicated the pure `coerce-script` / `parse-spec`
+;; contract already asserted in `runner-test`
+;; (coerce-script-lifts-bare-event-vectors + parse-spec-lifts-bare-
+;; vectors-inside-map). The wrong-layer copy added no signal.
 
 ;; ---- JVM-only: integration tests against a live re-frame frame ----------
-
-#?(:clj
-   (defn reset-all [test-fn]
-     (story/clear-all!)
-     (registrar/clear-all!)
-     (reset! frame/frames {})
-     (try (rf/init! plain-atom/adapter)
-          (catch clojure.lang.ExceptionInfo _ nil))
-     (require 're-frame.machines :reload)
-     (machines/reset-timers!)
-     (loaders/clear-watchers!)
-     (config/set-global-args! {})
-     (reset! assertions/trace-accumulators {})
-     (reset! legacy-play/stepper-state    {})
-     (reset! re/run-state                 {})
-     (story/install-canonical-vocabulary!)
-     (frame/ensure-default-frame!)
-     (test-fn)))
-
-#?(:clj (use-fixtures :each reset-all))
+;;
+;; These reuse the namespace-wide `bridge-reset!` fixture above (which
+;; unified the prior JVM-only `reset-all`).
 
 #?(:clj
    (defn- run-blocking

--- a/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/assertion_strip_cljs_test.cljs
@@ -418,6 +418,63 @@
       (is (= 3 (count (into #{} keys)))
           "keys are unique strip-wide even across groups"))))
 
+;; ---- :key meta on the OUTER group seq (rf2-uhq5j / rf2-5lw9w-one-up) ------
+;;
+;; The strip nests two `for` seqs: outer groups → inner rows. The inner
+;; row keys are pinned above. The OUTER group element's
+;; `^{:key (str "group-" gi)}` (assertion_strip.cljs:468) was never
+;; asserted — a missing/duplicate group key warns in React exactly like
+;; the rf2-5lw9w row-key bug, one level up, and would slip past node-test
+;; the same way. These tests pin `(meta element) :key` on every group
+;; element so a regression there can't go silent.
+
+(defn- collect-group-seq-elements
+  "Walk `hiccup` and collect the outer group elements — the `[:div ...]`
+  vectors the group `for` produces, one per dispatching :event cluster.
+  Each carries `:data-test \"story-canvas-assertion-group\"` in its prop
+  map. Returns them in encounter order so callers can assert per-element
+  `:key` meta."
+  [hiccup]
+  (let [found (atom [])
+        group-element? (fn [x]
+                         (and (vector? x)
+                              (= :div (first x))
+                              (map? (second x))
+                              (= "story-canvas-assertion-group"
+                                 (:data-test (second x)))))]
+    (letfn [(walk [node]
+              (cond
+                (group-element? node) (swap! found conj node)
+                (vector? node)        (run! walk node)
+                (seq? node)           (run! walk node)
+                :else                 nil))]
+      (walk hiccup))
+    @found))
+
+(deftest assertion-strip-group-seq-elements-carry-key-meta
+  (testing "every outer group element carries a unique :key in its
+            metadata so React's GROUP seq is keyed — the rf2-5lw9w
+            failure mode one level up (the outer for over groups)"
+    (let [assertions [{:assertion :rf.assert/path-equals :passed? true
+                       :event [:click] :payload [[:c] 1]}
+                      {:assertion :rf.assert/path-equals :passed? false
+                       :event [:submit] :payload [[:c] 2] :reason "differ"}
+                      {:assertion :rf.assert/path-equals :passed? true
+                       :event [:reset] :payload [[:c] 3]}]
+          hiccup     (render-strip assertions)
+          groups     (collect-group-seq-elements hiccup)
+          keys       (map #(:key (meta %)) groups)]
+      (is (= 3 (count groups))
+          "one group element per dispatching event")
+      (is (every? vector? groups)
+          "group elements are vector literals — the :key sits on the
+           element React receives, not a call form")
+      (is (every? some? keys)
+          "every group element carries a :key in its metadata so React's
+           group seq is keyed (no missing-key warning)")
+      (is (= (count groups) (count (into #{} keys)))
+          ":key values are unique across the group seq"))))
+
 ;; ---- pure: value-display -------------------------------------------------
 
 (deftest value-display-short-no-clamp

--- a/tools/story/test/re_frame/story_assertions_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_assertions_cljs_test.cljs
@@ -17,7 +17,8 @@
             [re-frame.story            :as story]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async-lib]
-            [re-frame.story.loaders    :as loaders]))
+            [re-frame.story.loaders    :as loaders]
+            [re-frame.subs             :as subs]))
 
 (defn reset-all! []
   (story/clear-all!)
@@ -118,3 +119,108 @@
     (is (fn? story/canonical-assertion-ids))
     (is (fn? story/execute-play!))
     (is (= :rf.story/force-fx-stub story/force-fx-stub-id))))
+
+;; ===========================================================================
+;; Internal assertion-helper branches (rf2-uhq5j)
+;;
+;; The seven evaluators are exercised end-to-end via run-variant above +
+;; the JVM ns. The branches below were untested at any layer — reached
+;; directly via var-quote (the established Story-test seam pattern).
+;; ===========================================================================
+
+;; ---- event-matches? — the fn? + bare-keyword? branches ------------------
+;;
+;; story_assertions_test.clj only passes literal event vectors, so the
+;; predicate-needle (`fn?`) and bare-keyword (`keyword?`) branches of
+;; `:rf.assert/dispatched?` (spec/007's `[event-or-pred]`) had no test.
+
+(def ^:private event-matches? @#'assertions/event-matches?)
+
+(deftest cljs-event-matches?-fn-predicate-branch
+  (testing "a fn needle is applied to the observed event vector"
+    (is (true?  (event-matches? [:user/click 7] (fn [ev] (= 7 (second ev)))))
+        "predicate sees the whole observed vector and returns truthy → matched")
+    (is (false? (event-matches? [:user/click 7] (fn [ev] (= 99 (second ev)))))
+        "predicate returns falsey → not matched")
+    (is (false? (event-matches? [:user/click] (constantly nil)))
+        "a nil-returning predicate is coerced to false")))
+
+(deftest cljs-event-matches?-bare-keyword-branch
+  (testing "a bare keyword needle matches on the observed event's head id"
+    (is (true?  (event-matches? [:user/click {:x 1}] :user/click))
+        "head id equals the keyword → matched regardless of payload")
+    (is (false? (event-matches? [:user/submit] :user/click))
+        "different head id → not matched")))
+
+(deftest cljs-event-matches?-vector-and-fallthrough
+  (testing "the literal-vector branch still matches exactly; non-fn/
+            vector/keyword needles fall through to false"
+    (is (true?  (event-matches? [:user/click 1] [:user/click 1])))
+    (is (false? (event-matches? [:user/click 1] [:user/click 2])))
+    (is (false? (event-matches? [:user/click] "not-a-needle"))
+        "a string needle hits the :else branch → false")
+    (is (false? (event-matches? [:user/click] 42))
+        "a number needle hits the :else branch → false")))
+
+;; ---- evaluate-sub-equals — the sub-throws (::compute-error) arm ----------
+;;
+;; Only the clean pass/fail of a well-behaved sub was tested. The
+;; evaluator wraps `subs/compute-sub` in its OWN try/catch and, when
+;; that throws, records :passed? false with :actual :rf.assert/sub-threw
+;; rather than propagating. Note `compute-sub` normally swallows a
+;; throwing sub-body internally (it recovers to nil), so the evaluator's
+;; catch is reachable only when compute-sub ITSELF throws — we force that
+;; here with `with-redefs` so the ::compute-error arm is exercised
+;; directly (the realistic case being a failure inside compute-sub's
+;; input-resolution / registrar-lookup before its own try).
+
+(def ^:private evaluate-sub-equals @#'assertions/evaluate-sub-equals)
+
+(deftest cljs-evaluate-sub-equals-sub-throws
+  (testing "when compute-sub throws, the evaluator records a fail with
+            :actual :rf.assert/sub-threw — never propagates"
+    (with-redefs [subs/compute-sub (fn [_query-v _db]
+                                      (throw (ex-info "kaboom" {})))]
+      (let [out (evaluate-sub-equals :rf/default {} [[:boom] :anything])]
+        (is (false? (:passed? out)))
+        (is (= :rf.assert/sub-threw (:actual out))
+            ":actual is the sentinel, not the raw exception")
+        (is (= :anything (:expected out)))
+        (is (re-find #"threw" (:reason out))
+            ":reason explains the sub threw")))))
+
+;; ---- evaluate-effect-emitted — the pred-rejects-but-present arm ----------
+;;
+;; Only present/absent was tested. When the fx-id WAS emitted but the
+;; optional predicate rejects it, the evaluator must record :passed?
+;; false with the pred-reject reason (and a thrown predicate is treated
+;; as a rejection, never propagated).
+
+(def ^:private evaluate-effect-emitted @#'assertions/evaluate-effect-emitted)
+
+(deftest cljs-evaluate-effect-emitted-pred-rejects-present-fx
+  (testing "fx present but optional predicate returns false → fail with
+            the pred-reject reason"
+    (assertions/record-emitted-fx! :rf/default :http)
+    (let [out (evaluate-effect-emitted :rf/default [:http (constantly false)])]
+      (is (false? (:passed? out)))
+      (is (contains? (:actual out) :http)
+          ":actual still reports the emitted-fx set (the fx WAS present)")
+      (is (re-find #"predicate rejected" (:reason out))))))
+
+(deftest cljs-evaluate-effect-emitted-pred-accepts-present-fx
+  (testing "fx present and predicate accepts → pass (the positive arm of
+            the same branch, for contrast)"
+    (assertions/record-emitted-fx! :rf/default :http)
+    (let [out (evaluate-effect-emitted :rf/default [:http (constantly true)])]
+      (is (true? (:passed? out)))
+      (is (re-find #"emitted during play" (:reason out))))))
+
+(deftest cljs-evaluate-effect-emitted-pred-throws-is-rejection
+  (testing "a predicate that throws is swallowed and treated as a
+            rejection — never propagates"
+    (assertions/record-emitted-fx! :rf/default :http)
+    (let [out (evaluate-effect-emitted :rf/default
+                                       [:http (fn [_] (throw (ex-info "x" {})))])]
+      (is (false? (:passed? out))
+          "thrown predicate → not passed, no exception escapes"))))


### PR DESCRIPTION
## Summary

Closes the internal-seam test-coverage gaps from the 2026-05-21 Story
test-coverage audit (`ai/findings/2026-05-21-testcov-story.md`, bead
rf2-uhq5j). Layering stays correct — all new tests are CLJS-unit (run on
both node-test and the JVM gate where the .cljc seam allows); no new
browser specs.

- **runner→assertion outcome-matching bridge** (`runner_events.cljc`
  `failed-since` + `dispatch-step-result`): the highest-value gap. These
  turn a handler-recorded `:rf.assert/*` failure into a runner
  `step-fail` so a play's terminal status flips, and were previously hit
  only transitively via the heavy JVM `run-blocking` integration. New
  direct units (CLJS + JVM) seed a known `:rf.story/assertions` vector on
  a live frame and pin the step-fail/step-skip shape +
  `:message`/`:expected`/`:actual` projection, message synthesis when the
  record carries none, and the prev-count subvec-clamp tolerance. The
  namespace fixture is unified (folds the prior JVM-only `reset-all`).
- **`event-matches?`**: the `fn?` (predicate), bare-`keyword?`, and
  `:else` branches of `:rf.assert/dispatched?` (only the literal-vector
  branch was covered; spec/007 documents `[event-or-pred]`).
- **`evaluate-sub-equals` `::compute-error` arm**: records `:actual
  :rf.assert/sub-threw` when `compute-sub` throws (the catch was dead in
  tests; `compute-sub` normally swallows a throwing sub-body internally,
  so the arm is forced via `with-redefs`).
- **`evaluate-effect-emitted` pred-reject arm**: fx present but predicate
  rejects → fail; predicate accepts → pass; thrown predicate → rejection.
- **assertion-strip outer group-seq `:key` meta**
  (`assertion_strip.cljs:468`): the rf2-5lw9w failure mode one level up —
  pins `:key` on every group `[:div]` element so a missing/dup group key
  can't slip past node-test.
- Dropped the wrong-layer dup `bare-event-vector-lift-via-coerce` (it
  duplicated `runner-test`'s pure `coerce-script`/`parse-spec` contract).

## Test plan

- [x] `npm run test:cljs` (node-test) — 4083 tests / 12346 assertions / 0 failures / 0 errors
- [x] `clojure -M:test` in `tools/story` — 846 tests / 2504 assertions / 0 failures / 0 errors