### PR TITLE
test(schemas): common-prefix narrowing + direct-call shape + elision symmetry (rf2-rbbmt)

### DIFF
--- a/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_failure_paths_test.clj
@@ -41,7 +41,9 @@
             [re-frame.core :as rf]
             [re-frame.schemas :as schemas]
             [re-frame.schemas.malli]
-            [re-frame.schemas.test-fixture :as tf]))
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.schemas.validate :as validate]
+            [re-frame.schemas.validator :as validator]))
 
 (use-fixtures :each tf/reset-runtime)
 
@@ -333,3 +335,115 @@
                   [:auth    [:map [:token {:sensitive? true} :string]]]]]
       (is (false? (schemas/schema-sensitive-at? schema [:public]))
           ":public is on a different branch from :auth/:token"))))
+
+;; ---- G1: multi-error common-prefix narrowing (rf2-rbbmt) -----------------
+;;
+;; Every test above drives a SINGLE failing slot, so the Malli explainer
+;; reports one `:errors` entry and `failing-in-path`'s
+;; `(reduce common-prefix (first paths) (rest paths))` never folds over a
+;; non-empty `(rest paths)`. The tests below drive TWO diverging `:in`
+;; paths under one registered `[:map ...]` schema so the reduce branch
+;; executes and must narrow to the common ancestor — plus direct unit
+;; tests for `common-prefix` and `failing-in-path` (the only non-trivial
+;; private helpers in the validate slice, previously with zero direct
+;; coverage).
+
+(deftest multi-error-path-narrows-to-common-ancestor
+  (testing "rf2-rbbmt — two diverging children of one nested [:map ...]
+            both fail; the Malli explainer reports two `:in` paths
+            ([:root :user :id] + [:root :user :age]) and `failing-in-path`
+            must `reduce common-prefix` them to the parent slot
+            [:user]. :path is then the registered root + that ancestor."
+    (rf/reg-app-schema [:root]
+                       [:map
+                        [:user [:map
+                                [:id  :int]
+                                [:age :int]]]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-schema!
+                      ;; BOTH children fail — :id and :age are strings,
+                      ;; not ints. Two diverging :in paths under one schema.
+                      {:root {:user {:id "bad" :age "also-bad"}}}
+                      :root/bad))]
+      (is (= 1 (count traces))
+          "one trace per registered schema, even with two leaf failures")
+      (let [v (first traces)]
+        (is (= [:root :user] (-> v :tags :path))
+            ":path narrows to the common ancestor [:root :user] — the
+             reduce common-prefix branch collapsed [:user :id] and
+             [:user :age] to [:user], conj'd onto the registered root")
+        (is (= [:root] (-> v :tags :registered-path)))
+        (is (= {:id "bad" :age "also-bad"} (-> v :tags :value))
+            ":value is the ancestor slot's value — both failing children")))))
+
+(deftest multi-error-top-level-map-narrows-to-root
+  (testing "rf2-rbbmt — two diverging children of a top-level [:map ...]
+            registered directly at the path; their `:in` paths
+            ([:id] + [:age]) common-prefix to [] (the map root), so the
+            leaf path collapses to the registered root. Distinguishes the
+            empty-common-prefix fold from the single-error :in [] case."
+    (rf/reg-app-schema [:rec] [:map [:id :int] [:age :int]])
+    (let [traces (capture-trace
+                   #(schemas/validate-app-schema!
+                      {:rec {:id "bad" :age "bad"}}
+                      :rec/bad))]
+      (is (= 1 (count traces)))
+      (let [v (first traces)]
+        (is (= [:rec] (-> v :tags :path))
+            "common-prefix of [:id] and [:age] is [] — leaf path is the
+             registered root [:rec]")
+        (is (= [:rec] (-> v :tags :registered-path)))))))
+
+;; ---- G1: direct unit tests for the private helpers -----------------------
+
+(deftest common-prefix-unit
+  (testing "rf2-rbbmt — common-prefix returns the longest shared leading
+            run of two sequential collections, as a vector"
+    (let [cp #'validate/common-prefix]
+      (is (= [:a :b] (cp [:a :b :c]   [:a :b :d]))
+          "diverge at index 2 → prefix is the first two elements")
+      (is (= []      (cp [:x]         [:y]))
+          "diverge at index 0 → empty prefix")
+      (is (= [:a :b] (cp [:a :b]      [:a :b]))
+          "identical → the whole vector")
+      (is (= [:a]    (cp [:a :b]      [:a]))
+          "one is a strict prefix of the other → the shorter one")
+      (is (= []      (cp []          [:a]))
+          "empty input → empty prefix")
+      (is (= []      (cp [:a]        []))
+          "empty other → empty prefix")
+      (is (= [:a :b :c] (cp [:a :b :c] [:a :b :c :d]))
+          "longer-suffix divergence still stops at the shorter length")
+      (is (vector? (cp [:a] [:a]))
+          "result is a vector (transient→persistent!), not a lazy seq"))))
+
+(deftest failing-in-path-unit
+  (testing "rf2-rbbmt — failing-in-path extracts and narrows the Malli
+            explainer's per-error :in paths; nil when no extractable path"
+    (let [fip #'validate/failing-in-path]
+      (is (nil? (fip nil))
+          "non-map explanation → nil")
+      (is (nil? (fip {}))
+          "no :errors key → nil")
+      (is (nil? (fip {:errors []}))
+          "empty :errors → nil")
+      (is (nil? (fip {:errors [{:path [:x]} {:path [:y]}]}))
+          "errors carry no :in → nil (keep :in drops every entry)")
+      (is (= [:a] (fip {:errors [{:in [:a]}]}))
+          "single error → that error's :in verbatim")
+      (is (= [:user] (fip {:errors [{:in [:user :id]} {:in [:user :age]}]}))
+          "two diverging :in → reduce common-prefix to the ancestor")
+      (is (= [] (fip {:errors [{:in [:id]} {:in [:age]}]}))
+          "fully-divergent :in → empty common prefix (the root)")
+      (is (= [:a :b] (fip {:errors [{:in [:a :b :c]}
+                                    {:in [:a :b :d]}
+                                    {:in [:a :b :e]}]}))
+          "three errors fold left to the shared [:a :b] prefix")))
+  (testing "rf2-rbbmt — failing-in-path agrees with the live Malli
+            explainer on a real two-child divergence"
+    (let [fip #'validate/failing-in-path
+          schema [:map [:user [:map [:id :int] [:age :int]]]]
+          expl   (validator/run-explainer schema {:user {:id "x" :age "y"}})]
+      (is (= [:user] (fip expl))
+          "live Malli explanation with two failing children narrows to
+           the [:user] ancestor"))))

--- a/implementation/schemas/test/re_frame/schemas_storage_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_storage_test.clj
@@ -168,6 +168,67 @@
     (is (= {} (schemas/frame-schema-entries :rf/default)))
     (is (= {} (schemas/frame-schema-entries :tenant/a)))))
 
+;; ---- on-frame-destroyed! (Spec 002 §Destroy / rf2-rbbmt) -----------------
+;;
+;; storage.cljc:361 drops a destroyed frame's schemas so a subsequent
+;; reg-frame of the same id starts with a clean slate (prevents spurious
+;; rollbacks against orphan paths — rf2-wkxng / rf2-6m0se). Previously
+;; covered ONLY indirectly via the conformance runner's destroy cycle;
+;; these are the direct slice-local pins for the dissoc + idempotent
+;; no-op the docstring promises.
+
+(deftest on-frame-destroyed-dissocs-the-frame
+  (testing "rf2-rbbmt — on-frame-destroyed! drops every schema registered
+            against the destroyed frame; sibling frames are untouched"
+    (rf/reg-app-schema [:user] [:map [:id :int]] {:frame :tenant/doomed})
+    (rf/reg-app-schema [:auth] [:string]         {:frame :tenant/doomed})
+    (rf/reg-app-schema [:user] [:map]            {:frame :tenant/survivor})
+    (is (= 2 (count (schemas/frame-schema-entries :tenant/doomed)))
+        "doomed frame has both registrations before destroy")
+    (schemas/on-frame-destroyed! :tenant/doomed)
+    (is (= {} (schemas/frame-schema-entries :tenant/doomed))
+        "destroyed frame's entries are gone")
+    (is (nil? (rf/app-schema-at [:user] :tenant/doomed))
+        "looking up a destroyed frame's schema yields nil")
+    (is (= [:map] (rf/app-schema-at [:user] :tenant/survivor))
+        "sibling frame's registration survives — destroy is frame-scoped")))
+
+(deftest on-frame-destroyed-is-idempotent-no-op-for-missing-frame
+  (testing "rf2-rbbmt — destroying a frame with no registrations (or one
+            already destroyed) is a no-op dissoc — never throws, never
+            disturbs other frames"
+    (rf/reg-app-schema [:user] [:map] {:frame :tenant/keep})
+    ;; Never-registered frame — the swap! dissoc returns the (unchanged)
+    ;; registry value and never throws. The destroyed frame is simply
+    ;; absent from the result.
+    (let [after (schemas/on-frame-destroyed! :tenant/never)]
+      (is (map? after)
+          "swap! dissoc returns the registry value; no throw")
+      (is (not (contains? after :tenant/never))
+          "the never-registered frame is absent from the registry"))
+    ;; Double-destroy is safe.
+    (schemas/on-frame-destroyed! :tenant/keep)
+    (schemas/on-frame-destroyed! :tenant/keep)
+    (is (= {} (schemas/frame-schema-entries :tenant/keep))
+        "second destroy of an already-empty frame is a clean no-op")
+    (is (= {} (schemas/frame-schema-entries :tenant/never)))))
+
+(deftest on-frame-destroyed-allows-clean-re-registration
+  (testing "rf2-rbbmt — after destroy, re-registering the same frame-id
+            starts from a clean slate (the rf2-wkxng rationale: no orphan
+            schemas re-fire against the re-created frame)"
+    (rf/reg-app-schema [:user]   [:map [:id :int]] {:frame :tenant/reuse})
+    (rf/reg-app-schema [:orphan] [:string]         {:frame :tenant/reuse})
+    (schemas/on-frame-destroyed! :tenant/reuse)
+    ;; Re-create with only ONE of the prior schemas.
+    (rf/reg-app-schema [:user] [:vector] {:frame :tenant/reuse})
+    (let [entries (schemas/frame-schema-entries :tenant/reuse)]
+      (is (= #{[:user]} (set (keys entries)))
+          "only the freshly-registered path is present — :orphan did not
+           survive the destroy")
+      (is (= [:vector] (-> entries (get [:user]) :schema))
+          "the re-registration's schema, not the pre-destroy one"))))
+
 ;; ---- registration roundtrip via reg-app-schemas --------------------------
 
 (deftest bulk-registration-visible-from-meta-at

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -42,6 +42,9 @@
             ;; opt-in on both runtimes; without it the default
             ;; validator soft-passes (Spec 010 §Recommended soft-pass).
             [re-frame.schemas.malli]
+            ;; rf2-rbbmt dedup D3 — single-source the empty-set digest
+            ;; literal from the parity fixtures rather than re-pinning it.
+            [re-frame.schemas.digest-parity-fixtures :as digest-fixtures]
             [re-frame.schemas.test-fixture :as tf]
             [re-frame.registrar :as registrar]
             [re-frame.spec :as spec]
@@ -518,6 +521,143 @@
           (is (= {:x "bad"} (-> v :tags :received)))
           (is (= :skipped   (:recovery v))))))))
 
+;; ---- G2 (rf2-rbbmt): direct-call shape for event / cofx / sub ------------
+;;
+;; validate-fx! has a dedicated direct-invocation shape test above
+;; (fx-args-validation-direct-call-shape). The three sibling fns were
+;; exercised ONLY through live dispatch — no direct call asserting the
+;; boolean return contract (true on pass / false on fail / true on the
+;; no-`:schema` soft-pass arm at validate.cljc:250) plus the locked tag
+;; shape. These mirror the fx shape test for symmetry across the four
+;; meta-bearing wrappers.
+
+(deftest event-payload-validation-direct-call-shape
+  (testing "rf2-rbbmt — validate-event! returns true on pass, false on
+            fail, true on the no-:schema soft-pass arm; emits the
+            canonical :where :event trace with the locked tag shape"
+    (let [traces (atom [])]
+      (rf/register-listener! ::evd (fn [ev] (swap! traces conj ev)))
+      (is (true? (schemas/validate-event! :user/strict [:user/strict 7]
+                                          {:schema [:cat [:= :user/strict] :int]}))
+          "well-typed event vector passes")
+      (is (false? (schemas/validate-event! :user/strict [:user/strict "bad"]
+                                           {:schema [:cat [:= :user/strict] :int]}))
+          "malformed event vector fails")
+      (is (true? (schemas/validate-event! :user/strict [:user/strict "bad"] {}))
+          "no :schema on meta → soft pass (validate.cljc:250 true arm)")
+      (rf/unregister-listener! ::evd)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations))
+            "exactly one trace — only the malformed call with a :schema fired")
+        (let [v (first violations)]
+          (is (= :event       (-> v :tags :where)))
+          (is (= :user/strict (-> v :tags :event-id)))
+          (is (= :user/strict (-> v :tags :failing-id)))
+          (is (= :user/strict (-> v :tags :schema-id)))
+          (is (= [:user/strict "bad"] (-> v :tags :value)))
+          (is (= [:user/strict "bad"] (-> v :tags :received)))
+          (is (= :no-recovery (:recovery v))))))))
+
+(deftest cofx-validation-direct-call-shape
+  (testing "rf2-rbbmt — validate-cofx! returns true on pass, false on
+            fail, true on the no-:schema soft-pass arm; emits the
+            canonical :where :cofx trace with the locked tag shape"
+    (let [traces (atom [])]
+      (rf/register-listener! ::cfd (fn [ev] (swap! traces conj ev)))
+      (is (true? (schemas/validate-cofx! :app-version :ev/origin "1.4.5"
+                                         {:schema :string}))
+          "well-typed cofx value passes")
+      (is (false? (schemas/validate-cofx! :app-version :ev/origin 42
+                                          {:schema :string}))
+          "malformed cofx value fails")
+      (is (true? (schemas/validate-cofx! :app-version :ev/origin 42 {}))
+          "no :schema on meta → soft pass (validate.cljc:250 true arm)")
+      (rf/unregister-listener! ::cfd)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations)))
+        (let [v (first violations)]
+          (is (= :cofx        (-> v :tags :where)))
+          (is (= :app-version (-> v :tags :cofx-id)))
+          (is (= :ev/origin   (-> v :tags :event-id)))
+          (is (= :ev/origin   (-> v :tags :failing-id)))
+          (is (= :app-version (-> v :tags :schema-id)))
+          (is (= 42           (-> v :tags :value)))
+          (is (= 42           (-> v :tags :received)))
+          (is (= :no-recovery (:recovery v))))))))
+
+(deftest sub-return-validation-direct-call-shape
+  (testing "rf2-rbbmt — validate-sub! returns true on pass, false on
+            fail, true on the no-:schema soft-pass arm; emits the
+            canonical :where :sub-return trace with the locked tag shape"
+    (let [traces (atom [])]
+      (rf/register-listener! ::sbd (fn [ev] (swap! traces conj ev)))
+      (is (true? (schemas/validate-sub! :items [:items] ["a" "b"]
+                                        {:schema [:vector :string]}))
+          "well-typed sub return passes")
+      (is (false? (schemas/validate-sub! :items [:items] [1 2]
+                                         {:schema [:vector :string]}))
+          "malformed sub return fails")
+      (is (true? (schemas/validate-sub! :items [:items] [1 2] {}))
+          "no :schema on meta → soft pass (validate.cljc:250 true arm)")
+      (rf/unregister-listener! ::sbd)
+      (let [violations (filter #(= :rf.error/schema-validation-failure
+                                   (:operation %))
+                               @traces)]
+        (is (= 1 (count violations)))
+        (let [v (first violations)]
+          (is (= :sub-return  (-> v :tags :where)))
+          (is (= :items       (-> v :tags :sub-id)))
+          (is (= :items       (-> v :tags :failing-id)))
+          (is (= :items       (-> v :tags :schema-id)))
+          (is (= [:items]     (-> v :tags :query-v)))
+          (is (= [1 2]        (-> v :tags :value)))
+          (is (= [1 2]        (-> v :tags :received)))
+          (is (= :replaced-with-default (:recovery v))))))))
+
+;; ---- G3 (rf2-rbbmt): production-elision symmetry for cofx + sub ----------
+;;
+;; debug-enabled?=false elision is pinned for app-db (:75), event (:282),
+;; and fx (:472) but NOT for validate-cofx! / validate-sub!. The bodies
+;; share the outer `(if interop/debug-enabled? ... true)` gate, so a
+;; refactor of one wrapper that broke its gate would slip past the suite.
+;; These direct-call pins close that asymmetry.
+
+(deftest cofx-validation-elides-when-debug-disabled
+  (testing "rf2-rbbmt — validate-cofx! is a no-op (returns true, emits
+            nothing) when debug-enabled? is false (production)"
+    (let [traces (atom [])]
+      (rf/register-listener! ::cfe (fn [ev] (swap! traces conj ev)))
+      (with-redefs [interop/debug-enabled? false]
+        (is (true? (schemas/validate-cofx! :app-version :ev/origin 42
+                                           {:schema :string}))
+            "production gate returns true unconditionally — even on a
+             value that would fail in dev"))
+      (rf/unregister-listener! ::cfe)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure
+                              (:operation %))
+                          @traces))
+          "no validation trace when debug-enabled? is false"))))
+
+(deftest sub-return-validation-elides-when-debug-disabled
+  (testing "rf2-rbbmt — validate-sub! is a no-op (returns true, emits
+            nothing) when debug-enabled? is false (production)"
+    (let [traces (atom [])]
+      (rf/register-listener! ::sbe (fn [ev] (swap! traces conj ev)))
+      (with-redefs [interop/debug-enabled? false]
+        (is (true? (schemas/validate-sub! :items [:items] [1 2]
+                                          {:schema [:vector :string]}))
+            "production gate returns true unconditionally — even on a
+             value that would fail in dev"))
+      (rf/unregister-listener! ::sbe)
+      (is (empty? (filter #(= :rf.error/schema-validation-failure
+                              (:operation %))
+                          @traces))
+          "no validation trace when debug-enabled? is false"))))
+
 (deftest fx-args-validation-redacts-when-sensitive
   (testing "validate-fx! consults the schema tree for `:sensitive?` props
             (the fx-meta `:sensitive?` annotation has been removed); on
@@ -813,9 +953,10 @@
     (let [d (rf/app-schemas-digest :test/empty)]
       (is (string? d))
       (is (re-matches #"sha256:[0-9a-f]{16}" d))
-      ;; SHA-256 of "" is e3b0c44298fc1c14...; first 16 hex chars are
-      ;; e3b0c44298fc1c14.
-      (is (= "sha256:e3b0c44298fc1c14" d)
+      ;; rf2-rbbmt dedup D3 — the empty-set digest literal is single-
+      ;; sourced from the parity fixtures (the namespace's own docstring
+      ;; declares it the source of truth) rather than re-pinned here.
+      (is (= (:expected digest-fixtures/empty-set) d)
           "empty schema set hashes the empty concatenation per Spec 010"))))
 
 (deftest app-schemas-digest-independent-of-registration-order
@@ -884,26 +1025,41 @@
               "exactly one trace fired — for the value the custom validator rejected")
           (is (= "totally-bad" (-> violations first :tags :value))))))))
 
-(deftest nil-validator-disables-validation-everywhere
-  (testing "Per Spec 010 §Non-Malli validators — passing nil to
-            set-schema-validator! disables validation entirely; every
-            validate-* fn returns true without inspecting the schema."
+(deftest nil-validator-disables-validation-on-every-surface
+  (testing "Per Spec 010 §Non-Malli validators (rf2-rbbmt dedup D1) —
+            passing nil to set-schema-validator! disables validation
+            entirely; every meta-bearing validate-*! fn AND the app-db
+            walker return true without inspecting the schema, and no
+            trace fires. Parameterised over the surfaces that previously
+            duplicated the no-op assertion as separate deftests."
     (rf/set-schema-validator! nil)
-    (rf/reg-app-schema [:n] [:int])
     (let [traces (atom [])]
       (rf/register-listener! ::nilv (fn [ev] (swap! traces conj ev)))
-      ;; Malformed value would normally fire a trace; with nil
-      ;; validator the call site short-circuits.
-      (schemas/validate-app-schema! {:n "definitely-not-an-int"} :test/h)
+      (rf/reg-app-schema [:n] [:int])
+      ;; Each malformed value would fire a trace under the default
+      ;; (Malli) validator; with nil installed every call short-circuits
+      ;; to true and emits nothing.
+      (is (true? (schemas/validate-app-schema! {:n "bad"} :test/h))
+          "app-db walk: nil validator → true, no trace")
+      (is (true? (schemas/validate-event! :ev/x [:ev/x "bad"]
+                                          {:schema [:cat [:= :ev/x] :int]}))
+          "event: nil validator → true")
+      (is (true? (schemas/validate-cofx! :cf/x :ev/o 42 {:schema :string}))
+          "cofx: nil validator → true")
+      (is (true? (schemas/validate-sub! :sub/x [:sub/x] [1] {:schema [:vector :string]}))
+          "sub-return: nil validator → true")
+      (is (true? (schemas/validate-fx! :fx/x :ev/o {:x "bad"} {:schema [:map [:x :int]]}))
+          "fx-args: nil validator → true")
       (rf/unregister-listener! ::nilv)
       (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
                           @traces))
-          "nil validator: no validation, no trace, no surprise"))))
+          "nil validator: no validation, no trace, no surprise — on any surface"))))
 
-(deftest nil-validator-also-disables-event-validation
-  (testing "Per Spec 010 §Non-Malli validators — nil validator covers every
-            validation site, not just app-db. The event-validation site
-            short-circuits too."
+(deftest nil-validator-disables-validation-end-to-end-via-dispatch
+  (testing "Per Spec 010 §Non-Malli validators — the nil-validator no-op
+            also holds through a live dispatch: the handler runs even on
+            a payload that would fail the registered :schema, and no
+            pre-handler validation trace fires."
     (rf/set-schema-validator! nil)
     (let [calls (atom 0)]
       (rf/reg-event-db :user/strict
@@ -911,8 +1067,6 @@
         (fn [db _] (swap! calls inc) db))
       (let [traces (atom [])]
         (rf/register-listener! ::nile (fn [ev] (swap! traces conj ev)))
-        ;; A wildly malformed payload — but with no validator the
-        ;; check is skipped and the handler runs anyway.
         (rf/dispatch-sync [:user/strict "not-an-int"])
         (rf/unregister-listener! ::nile)
         (is (= 1 @calls)


### PR DESCRIPTION
## Summary

Closes the targeted coverage gaps from the schemas test-coverage audit (`ai/findings/2026-05-21-testcov-schemas.md`, bead rf2-rbbmt). Test-only — no source touched. The schemas slice was already among the strongest in the tree; these are the last seams.

- **G1 (highest)** — multi-error common-prefix narrowing. Two integration tests drive **two diverging `:in` paths under one registered `[:map ...]`** so the `(reduce common-prefix ...)` branch in `failing-in-path` actually folds: nested `[:map [:user [:map ...]]]` narrows to the `[:user]` ancestor; a top-level `[:map ...]` narrows to `[]` (root). Plus direct unit tests for `common-prefix` and `failing-in-path` — the only non-trivial private helpers in the validate slice, previously with zero direct coverage.
- **G2** — direct-call shape tests for `validate-event!` / `validate-cofx!` / `validate-sub!` mirroring `fx-args-validation-direct-call-shape`: `true`/`false` return contract, locked tag shape, and the no-`:schema` soft-pass arm (`validate.cljc:250`).
- **G3** — `debug-enabled? false` production-elision pins for `validate-cofx!` and `validate-sub!`, closing the asymmetry (app-db/event/fx already pinned).
- **G5** — slice-local `on-frame-destroyed!` unit tests: frame-scoped dissoc, idempotent missing-frame no-op, clean re-registration.

### Dedup
- **D1** — replaced the duplicated JVM nil-validator-disables pair with one parameterised test over all five validation surfaces (app-db/event/cofx/sub/fx) + an end-to-end dispatch variant.
- **D3** — single-sourced the empty-set digest literal (`sha256:e3b0c44298fc1c14`) from `digest-parity-fixtures/empty-set` instead of re-pinning it.

No real source bug found. One test-authoring correction during development: `on-frame-destroyed!` returns the registry value from `swap! ... dissoc` (not `nil`) — expected per its `swap!` shape; the assertion was adjusted to match the documented no-op contract.

## Test plan
- [x] schemas JVM: `clojure -M:test` from `implementation/schemas` — 178 tests / 18218 assertions, 0 failures (was 166 / 18140; +12 tests, +78 assertions)
- [x] `npm run test:cljs` from `implementation/` — 4100 tests / 12384 assertions, 0 failures