### PR TITLE
test(epoch): resolve dead :halted-handler-exception + commit-no-epoch invariant (rf2-zymix)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -263,10 +263,14 @@
       buffer is empty (a truly empty cascade — likely a rejected
       dispatch — is degenerate and would emit a misleading record).
     (settle! frame-id db-before db-after outcome halt-reason)
-      Drain-boundary commit with explicit outcome. `outcome` is one of
-      `:ok` / `:halted-depth` / `:halted-destroy` /
-      `:halted-handler-exception`; `halt-reason` is a structured
-      descriptor populated on halt paths (nil on `:ok`). On a buffer
+      Drain-boundary commit with explicit outcome. The runtime commits
+      one of three outcomes: `:ok` / `:halted-depth` / `:halted-destroy`
+      (`:halted-handler-exception` is a schema-reserved value the
+      reference runtime never emits — handler exceptions ride the
+      interceptor error-capture seam and the drain settles `:ok` with the
+      error trace under `:trace-events`; see Spec-Schemas §`:rf/epoch-record`
+      §Outcomes and Spec 009 §register-epoch-listener!). `halt-reason` is
+      a structured descriptor populated on halt paths (nil on `:ok`). On a buffer
       with no recoverable trigger (no `:event/run-start` and no
       `:event-id` tag — e.g. a destroy that races a registration-time
       emit) `build-record` omits `:event-id` / `:trigger-event`

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -264,10 +264,14 @@
    (build-record frame-id db-before db-after events :ok nil))
   ([frame-id db-before db-after events outcome halt-reason]
    ;; Per rf2-v0jwt §Outcomes — :outcome is required and pins the
-   ;; drain-boundary outcome (:ok / :halted-depth / :halted-destroy /
-   ;; :halted-handler-exception); :halt-reason is a structured
-   ;; descriptor populated on halt paths, absent on :ok. The schema
-   ;; in Spec-Schemas §:rf/epoch-record is the canonical pin.
+   ;; drain-boundary outcome. The reference runtime commits one of three:
+   ;; :ok / :halted-depth / :halted-destroy. (:halted-handler-exception
+   ;; is a schema-reserved value the runtime never emits — handler
+   ;; exceptions ride the interceptor error-capture seam and the drain
+   ;; settles :ok with the error trace under :trace-events; see
+   ;; Spec-Schemas §:rf/epoch-record §Outcomes.) :halt-reason is a
+   ;; structured descriptor populated on halt paths, absent on :ok. The
+   ;; schema in Spec-Schemas §:rf/epoch-record is the canonical pin.
    ;;
    ;; Per rf2-kl5p1 (audit r3 §F1): `:event-id` and `:trigger-event`
    ;; are emitted only when `find-trigger-event` resolves them. The

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -196,6 +196,18 @@
             "halted-destroy carries nil :db-after")))))
 
 ;; ---- 2. projected-record ---------------------------------------------------
+;;
+;; This section pins the projection emission-site contract from the
+;; privacy angle: per-leaf substitution (sensitive / large), bookkeeping
+;; pass-through, nil-input safety, and history-walk shape. It deliberately
+;; does NOT re-assert projection IDEMPOTENCY (re-projecting an already-
+;; projected record is a no-op at the substitution points) — that
+;; invariant has its authoritative pins in
+;; `epoch_mcp_egress_conformance_test`
+;; (`forwarder-projected-record-is-sensitive-idempotent` :255 +
+;; `forwarder-projected-record-is-large-idempotent` :305), with the
+;; redact×project composition cases in `epoch_redact_fn_projection_test`.
+;; Keep idempotency assertions there; do not duplicate them here (rf2-zymix).
 
 (deftest projected-record-redacts-sensitive-in-db-after
   (testing "schema-declared sensitive path in :db-after lands as

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -918,6 +918,103 @@
           ":rf.epoch/restore-non-ok-record fired so listeners can surface
            the refusal to the user"))))
 
+;; ---- :halted-handler-exception is schema-reserved, never emitted ---------
+;;
+;; Per Spec-Schemas §`:rf/epoch-record` §Outcomes (rf2-v0jwt) and Spec 009
+;; §register-epoch-listener!: the reference runtime commits exactly three
+;; drain-boundary outcomes — :ok / :halted-depth / :halted-destroy.
+;; `:halted-handler-exception` is a SCHEMA-RESERVED enum value held for a
+;; future runtime path that aborts the drain on handler throw; today's
+;; runtime routes handler exceptions through the interceptor error-capture
+;; seam (the drain does NOT abort), so the cascade settles `:ok` with the
+;; `:rf.error/handler-exception` trace under `:trace-events`. This test
+;; pins that contract directly so the dead outcome can't silently start
+;; being emitted (rf2-zymix) — the dual of `depth-exceeded-commits-halted-
+;; record` for the one halt the runtime deliberately does NOT model.
+
+(deftest handler-exception-settles-ok-never-halted-handler-exception
+  (testing "an event handler that throws does NOT halt the drain: the
+            cascade settles with :outcome :ok (the interceptor chain
+            captured the throw via the error-capture seam) and the
+            failure surfaces as a :rf.error/handler-exception trace under
+            :trace-events. The schema-reserved :halted-handler-exception
+            outcome is never committed by the reference runtime."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :boom (fn [_ _] (throw (ex-info "handler blew" {:why :test}))))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    ;; The throw is captured by the chain — dispatch-sync returns normally,
+    ;; the drain does not abort.
+    (rf/dispatch-sync [:boom] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)
+          boom-r  (last history)]
+      (is (= 2 (count history))
+          "the throwing cascade still commits exactly one epoch record")
+      (is (= :boom (:event-id boom-r))
+          "the throwing event is the cascade trigger")
+      (is (= :ok (:outcome boom-r))
+          ":outcome is :ok — the drain settled cleanly despite the throw")
+      (is (not= :halted-handler-exception (:outcome boom-r))
+          ":halted-handler-exception is schema-reserved, never emitted")
+      (is (nil? (:halt-reason boom-r))
+          "no :halt-reason on a clean settle — there was no drain halt")
+      (is (has-error-op? (:trace-events boom-r) :rf.error/handler-exception)
+          "the throw surfaces as a :rf.error/handler-exception trace under
+           :trace-events, not as a halt outcome")
+      (is (not-any? (fn [r] (= :halted-handler-exception (:outcome r)))
+                    history)
+          "no record across the whole ring carries the reserved outcome"))))
+
+;; ---- rejected / aborted dispatch commits no epoch (rf2-zymix) ------------
+;;
+;; Per `settle!`'s empty-buffer policy (epoch.cljc) — a drain boundary
+;; whose capture buffer holds no cascade context is SKIPPED rather than
+;; committing a record with no :event-id / :trigger-event. This is the
+;; "no misleading record on a rejected / aborted dispatch" guard: the
+;; router calls `discard-buffer!` for the routine cascade-abort case
+;; (depth-exceeded mid-flight, dispatch-sync rejection), so when `settle!`
+;; fires at the abort boundary the harvested buffer is empty and no record
+;; is committed. The invariant was only covered indirectly (cross-
+;; contamination / leaked-buffer tests); this names it directly by driving
+;; the empty-buffer settle! seam.
+
+(deftest empty-buffer-settle-commits-no-epoch
+  (testing "settle! at a drain boundary whose capture buffer is empty —
+            the reality after the router has discarded the buffer for a
+            rejected / aborted dispatch — commits NO epoch record. A
+            record with no :event-id / :trigger-event would misrepresent
+            a cascade that never ran; the empty-buffer skip in settle!
+            (epoch.cljc) suppresses it. The ring stays empty for the frame."
+    (rf/reg-frame :test/main {})
+    ;; Start from a known-empty capture buffer for this frame — the
+    ;; post-discard state the router leaves on a rejected/aborted
+    ;; dispatch. (`reg-frame` emits a :frame/created trace that
+    ;; capture-event! would buffer; reset so the buffer is genuinely
+    ;; empty, mirroring discard-buffer!.)
+    (reset! @#'state/capture-buffers {})
+
+    ;; settle! fires at the abort boundary with no buffered cascade
+    ;; context — the empty-buffer skip suppresses the commit.
+    (epoch/settle! :test/main {} {})
+
+    (is (empty? (rf/epoch-history :test/main))
+        "no epoch record committed for an empty-buffer drain boundary —
+         the rejected/aborted-dispatch no-misleading-record guard")
+
+    ;; A real cascade afterwards DOES commit — proving the skip is an
+    ;; empty-buffer policy, not a frame-wide disable.
+    (rf/reg-event-db :real (fn [_ _] {:n 1}))
+    (rf/dispatch-sync [:real] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
+      (is (= 1 (count history))
+          "the subsequent real cascade commits exactly one record")
+      (is (= :real (:event-id (first history)))
+          "the committed record is the real cascade, not the suppressed
+           empty-buffer boundary"))))
+
 ;; ---- recording is gated on debug-enabled? ---------------------------------
 
 (deftest configure-roundtrip


### PR DESCRIPTION
## Summary

Resolves the dead `:halted-handler-exception` epoch outcome flagged in the `implementation/epoch/` test-coverage audit (`ai/findings/2026-05-21-testcov-epoch.md`), plus adds the missing direct pin for the "rejected/aborted dispatch commits no epoch" invariant and trims the projection-idempotency duplication.

## Wire-vs-strike decision: STRIKE (docstrings only)

The spec is **intentional** here — nothing to strike from `spec/`:

- **Spec 009 §register-epoch-listener!** (lines 294, 300) enumerates exactly the two halt outcomes the runtime commits: `:halted-depth`, `:halted-destroy`. It does NOT list `:halted-handler-exception`.
- **Spec-Schemas §`:rf/epoch-record` §Outcomes** documents `:halted-handler-exception` as **Reserved**: "the reference runtime currently routes through the interceptor chain's error-capture seam ... No record carries this outcome under today's CLJS reference. Held for a future runtime path that aborts the drain on handler exception." The schema enum keeps it as a deliberately-reserved value, prose-qualified.
- The runtime confirms this: a handler throw is captured into `:rf/interceptor-error` (NOT rethrown — the drain does not abort), the per-event dispatch outcome is `:error`, and the drain settles the epoch record with `:outcome :ok`, the throw surfacing as a `:rf.error/handler-exception` trace under `:trace-events`. Matches `testbeds/deliberate_throw/README.md`.

What was wrong was the **implementation docstrings** (`epoch.cljc`, `assembly.cljc`), which listed `:halted-handler-exception` flatly as a live outcome with no reserved qualifier — an unqualified enumeration of an unreachable outcome (masterpiece-posture violation). Re-stated both docstrings to the three outcomes the runtime actually commits, noting the reserved value and pointing to the spec.

## Changes

- **Docstring strike** in `epoch.cljc` `settle!` and `assembly.cljc` `build-record`: list the three live outcomes; note `:halted-handler-exception` is schema-reserved + never emitted, with spec pointers.
- **New test** `handler-exception-settles-ok-never-halted-handler-exception`: pins that a throwing handler settles `:outcome :ok`, surfaces the throw as a `:rf.error/handler-exception` trace, and never commits the reserved outcome across the ring. The dual of `depth-exceeded-commits-halted-record` for the halt the runtime deliberately does NOT model.
- **New test** `empty-buffer-settle-commits-no-epoch`: names the `settle!` empty-buffer skip directly (the "rejected/aborted dispatch commits no epoch" invariant — previously only covered indirectly).
- **Idempotency dup trim**: `epoch_privacy_test.clj` now carries a section cross-reference to the authoritative idempotency pins in `epoch_mcp_egress_conformance_test` (`:255`/`:305`), so a future reader won't re-assert idempotency here. Privacy_test had no explicit idempotency assertions to delete; its distinct-intent per-leaf projection coverage is retained (the finding's own verdict was "intentional layering with distinct documented intents", and the bead's "only if clearly safe" guard applies).

## Test plan

- [x] epoch JVM (`implementation/epoch` → `clojure -M:test`): 183 tests, 671 assertions, 0 failures
- [x] CLJS (`implementation` → `npm run test:cljs`): 4100 tests, 12384 assertions, 0 failures
- [x] No `spec/*.md` edited → mkdocs gate not required