### PR TITLE
test(machines): finality predicates + registration-validator conformance fixtures (rf2-vf5cf)

### DIFF
--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -103,6 +103,7 @@
     :fsm/tags
     :fsm/parallel-regions
     :fsm/final-states
+    :fsm/registration-validation                      ;; rf2-vf5cf — registration-error taxonomy via :reg-machine
     :routing/match-url
     :ssr/render-to-string
     :ssr/hydration
@@ -858,6 +859,31 @@
                        "    actual   snapshot: " snap-out "\n"
                        "    expected effects:  " want-fx "\n"
                        "    actual   effects:  " fx-out))})
+
+    ;; pure registration-validation call (rf2-vf5cf). Pins the machine
+    ;; registration-error taxonomy (Spec 009 §The thrown-error shape)
+    ;; against the pure `validate-machine!` validator. `:expect-error
+    ;; <category-kw>` ⇒ the validator must throw an ex-info whose
+    ;; `:rf.error/id` ex-data slot equals the category; absent
+    ;; `:expect-error` ⇒ a well-formed control that must NOT throw.
+    :reg-machine
+    (let [want-error (:expect-error call)
+          thrown     (try (machines/validate-machine! (:definition call)) nil
+                          (catch :default e e))]
+      (if want-error
+        (let [got-id (:rf.error/id (ex-data thrown))
+              ok?    (= want-error got-id)]
+          {:passed? ok?
+           :detail  (when-not ok?
+                      (str "reg-machine\n"
+                           "    expected error :rf.error/id: " want-error "\n"
+                           "    actual   error :rf.error/id: " got-id "\n"
+                           "    thrown:                       " (some-> thrown ex-message)))})
+        {:passed? (nil? thrown)
+         :detail  (when (some? thrown)
+                    (str "reg-machine\n"
+                         "    expected: no error (well-formed machine)\n"
+                         "    thrown:   " (ex-message thrown)))}))
 
     {:passed? false :detail (str "unknown :call form: " (:call call))}))
 

--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -85,6 +85,7 @@
     :fsm/tags                                         ;; rf2-ee0d (Nine States Stage 1)
     :fsm/parallel-regions                             ;; rf2-l67o (Nine States Stage 2)
     :fsm/final-states                                 ;; rf2-gn80 — :final? + :on-done + :output-key
+    :fsm/registration-validation                      ;; rf2-vf5cf — registration-error taxonomy (Spec 009 thrown-error shape) via :reg-machine
     :routing/match-url
     :ssr/render-to-string
     :ssr/hydration
@@ -985,6 +986,34 @@
                        "    actual   snapshot: " snap-out "\n"
                        "    expected effects:  " want-fx "\n"
                        "    actual   effects:  " fx-out))})
+
+    ;; pure registration-validation call (rf2-vf5cf). Pins the machine
+    ;; registration-error taxonomy (Spec 009 §The thrown-error shape)
+    ;; against the pure `validate-machine!` validator — no registrar, no
+    ;; substrate. `:expect-error <category-kw>` ⇒ the validator must throw
+    ;; an ex-info whose `:rf.error/id` ex-data slot equals the category;
+    ;; absent `:expect-error` ⇒ a well-formed control that must NOT throw.
+    :reg-machine
+    (let [validate-machine! (requiring-resolve 're-frame.machines/validate-machine!)
+          want-error (:expect-error call)
+          thrown     (try (validate-machine! (:definition call)) nil
+                          (catch clojure.lang.ExceptionInfo e e)
+                          (catch Throwable e e))]
+      (if want-error
+        (let [got-id (when (instance? clojure.lang.ExceptionInfo thrown)
+                       (:rf.error/id (ex-data thrown)))
+              ok?    (= want-error got-id)]
+          {:passed? ok?
+           :detail  (when-not ok?
+                      (str "reg-machine\n"
+                           "    expected error :rf.error/id: " want-error "\n"
+                           "    actual   error :rf.error/id: " got-id "\n"
+                           "    thrown:                       " (some-> thrown ex-message)))})
+        {:passed? (nil? thrown)
+         :detail  (when (some? thrown)
+                    (str "reg-machine\n"
+                         "    expected: no error (well-formed machine)\n"
+                         "    thrown:   " (ex-message thrown)))}))
 
     ;; unknown call op
     {:passed? false :detail (str "unknown :call form: " (:call call))}))

--- a/implementation/machines/src/re_frame/machines.cljc
+++ b/implementation/machines/src/re_frame/machines.cljc
@@ -28,6 +28,10 @@
   Public surface re-exported from the sub-namespaces:
     - `reg-machine*`, `make-machine-handler` —
       `re-frame.machines.lifecycle-fx.registration`
+    - `validate-machine!` — `re-frame.machines.lifecycle-fx.validation`
+      (the pure registration-time validator; the conformance corpus's
+      `:reg-machine` Mode-B op pins the registration-error taxonomy
+      against it)
     - `machine-transition` — `re-frame.machines.parallel` (the public
       dispatch; flat / compound delegates to
       `re-frame.machines.transition`'s `machine-transition-single`)
@@ -44,6 +48,7 @@
             [re-frame.machines.lifecycle-fx.frame-destroy :as frame-destroy]
             [re-frame.machines.lifecycle-fx.registration :as registration]
             [re-frame.machines.lifecycle-fx.spawn :as spawn]
+            [re-frame.machines.lifecycle-fx.validation :as validation]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.spawn-order :as spawn-order]
             [re-frame.machines.timer :as timer]
@@ -70,6 +75,11 @@
 
 (def reg-machine*           registration/reg-machine*)
 (def make-machine-handler registration/make-machine-handler)
+;; The pure registration-time validator (Spec 005 §registration validators,
+;; rf2-f9tu). Re-exported so the conformance corpus's `:reg-machine` Mode-B
+;; call op can pin the registration-error taxonomy (Spec 009 §thrown-error
+;; shape) directly against the leaf fn — no registrar/substrate fixture.
+(def validate-machine!      validation/validate-machine!)
 (def spawn-fx               spawn/spawn-fx)
 (def invoke-all-init-fx     spawn/invoke-all-init-fx)
 (def destroy-machine-fx     destroy/destroy-machine-fx)

--- a/implementation/machines/test/re_frame/machine_finality_purity_test.clj
+++ b/implementation/machines/test/re_frame/machine_finality_purity_test.clj
@@ -1,0 +1,182 @@
+(ns re-frame.machine-finality-purity-test
+  "Per rf2-vf5cf §G1. Direct pure-engine (JVM) coverage for the three
+  finality predicates the lifecycle handler recomputes at the macrostep
+  boundary to decide whether to fire `:on-done` + auto-destroy:
+
+    - `transition/final-state-node?` — the per-node `:final? true` flag.
+    - `transition/final-on-leaf?`    — the active LEAF of a snapshot is final.
+    - `finalize/all-regions-final?`  — a parallel machine is final iff
+      EVERY region's active leaf is final.
+
+  Pre-rf2-vf5cf a grep of the machines test tree returned ZERO direct
+  matches for these symbols — they were exercised only TRANSITIVELY via
+  integration dispatch in `final_state_cljs_test.cljc`. The riskiest of
+  the three is the parallel union (`all-regions-final?`,
+  finalize.cljc:69): a partial-final parallel snapshot (some regions
+  final, some not) finalising prematurely would surface only as a
+  downstream dispatch symptom, not a clean predicate failure. These
+  tests pin the predicates at the cheapest-and-most-precise layer — pure
+  fns of their arguments, no frame, no dispatch loop, no app-db.
+
+  Per Spec 005 §Final states (rf2-gn80):
+    - `:final?` is a first-class state-node key (D1), NOT stashed under
+      `:meta`.
+    - A parallel-region machine is `:final?` only when EVERY region's
+      active leaf is `:final?` (§Parallel regions and `:final?`)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.machines.lifecycle-fx.finalize :as finalize]
+            [re-frame.machines.transition :as transition]))
+
+;; ---------------------------------------------------------------------------
+;; final-state-node? — the per-node :final? flag (transition.cljc:914)
+;; ---------------------------------------------------------------------------
+
+(deftest final-state-node?-reads-the-first-class-flag
+  (testing ":final? true on a state-node ⇒ true"
+    (is (true? (transition/final-state-node? {:final? true}))
+        "a node declaring :final? true is final"))
+
+  (testing "absent / false / non-true :final? ⇒ false (strict true? check)"
+    (is (false? (transition/final-state-node? {}))
+        "a node with no :final? key is not final")
+    (is (false? (transition/final-state-node? {:final? false}))
+        ":final? false is explicitly not final")
+    (is (false? (transition/final-state-node? {:on {:go :other}}))
+        "an ordinary transition-bearing node is not final")
+    ;; Per Spec 005 rf2-gn80 D1 the flag is a FIRST-CLASS key. A truthy-
+    ;; but-not-true value (e.g. stashed under :meta, or a non-boolean) is
+    ;; NOT final — the predicate is `(true? ...)`, not `(boolean ...)`.
+    (is (false? (transition/final-state-node? {:meta {:final? true}}))
+        ":final? under :meta is NOT the first-class key (D1) — not final")
+    (is (false? (transition/final-state-node? {:final? :yes}))
+        "a non-true truthy :final? value is not final (strict true? check)")
+    (is (false? (transition/final-state-node? nil))
+        "a nil node (path did not resolve) is not final")))
+
+;; ---------------------------------------------------------------------------
+;; final-on-leaf? — the active leaf of a snapshot is final
+;; (transition.cljc:922; called from commit-or-finalize, registration.cljc:328)
+;; ---------------------------------------------------------------------------
+
+(def flat-final-machine
+  "A flat machine whose :done leaf is :final?."
+  {:initial :running
+   :data    {}
+   :states  {:running {:on {:finish :done}}
+             :done    {:final? true}}})
+
+(def compound-final-machine
+  "A compound machine whose nested [:wrapper :done] leaf is :final?."
+  {:initial :wrapper
+   :data    {}
+   :states  {:wrapper {:initial :running
+                       :states  {:running {:on {:finish :done}}
+                                 :done    {:final? true}}}}})
+
+(deftest final-on-leaf?-flat-state
+  (testing "a flat snapshot whose :state is the :final? leaf ⇒ true"
+    (is (true? (transition/final-on-leaf? flat-final-machine :done))
+        "the :done leaf is :final?")
+    (is (true? (transition/final-on-leaf? flat-final-machine [:done]))
+        "vector-form :state resolves to the same leaf"))
+
+  (testing "a flat snapshot at a non-final leaf ⇒ false"
+    (is (false? (transition/final-on-leaf? flat-final-machine :running))
+        "the :running leaf is not :final?")))
+
+(deftest final-on-leaf?-compound-state
+  (testing "a compound snapshot whose active leaf is :final? ⇒ true"
+    (is (true? (transition/final-on-leaf? compound-final-machine [:wrapper :done]))
+        "the deeply-resolved [:wrapper :done] leaf is :final?"))
+
+  (testing "a compound snapshot at a non-final leaf ⇒ false"
+    (is (false? (transition/final-on-leaf? compound-final-machine [:wrapper :running]))
+        "the [:wrapper :running] leaf is not :final?"))
+
+  (testing "finality keys off the LEAF, not an ancestor"
+    ;; The :wrapper compound node itself carries no :final? — finality is
+    ;; a leaf property. Resolving the parent path (which final-on-leaf?
+    ;; never does for a committed leaf snapshot, but pin the leaf-only
+    ;; contract anyway via node-at) returns the non-final compound node.
+    (is (false? (transition/final-state-node?
+                  (transition/node-at compound-final-machine [:wrapper])))
+        "the compound :wrapper ancestor is not itself :final?")))
+
+;; ---------------------------------------------------------------------------
+;; all-regions-final? — parallel union (finalize.cljc:69)
+;;
+;; THE riskiest predicate (rf2-vf5cf §G1): a partial-final parallel
+;; snapshot must NOT finalise. The fn returns true ONLY when the machine
+;; is :type :parallel, the snapshot :state is a region→leaf map, AND every
+;; region's active leaf is :final?.
+;; ---------------------------------------------------------------------------
+
+(def parallel-machine
+  "A two-region parallel machine. Region :left has a :final? :done leaf;
+  region :right has a :final? :done leaf. Each region also has a
+  non-final :running leaf."
+  {:type    :parallel
+   :data    {}
+   :regions {:left  {:initial :running
+                     :states  {:running {:on {:finish :done}}
+                               :done    {:final? true}}}
+             :right {:initial :running
+                     :states  {:running {:on {:finish :done}}
+                               :done    {:final? true}}}}})
+
+(deftest all-regions-final?-every-region-final
+  (testing "BOTH regions at their :final? leaf ⇒ true"
+    (is (true? (finalize/all-regions-final?
+                 parallel-machine
+                 {:left :done :right :done}))
+        "a parallel machine is final iff EVERY region's leaf is :final?")))
+
+(deftest all-regions-final?-partial-final-is-not-final
+  (testing "ONE region final, the other still running ⇒ false (the risky branch)"
+    ;; This is the premature-finalisation guard: a snapshot where :left has
+    ;; reached :done but :right is still :running must NOT report final.
+    (is (false? (finalize/all-regions-final?
+                  parallel-machine
+                  {:left :done :right :running}))
+        "left-final + right-running must NOT finalise (partial-final guard)")
+    (is (false? (finalize/all-regions-final?
+                  parallel-machine
+                  {:left :running :right :done}))
+        "right-final + left-running must NOT finalise (symmetric)"))
+
+  (testing "NEITHER region final ⇒ false"
+    (is (false? (finalize/all-regions-final?
+                  parallel-machine
+                  {:left :running :right :running}))
+        "both regions running ⇒ not final")))
+
+(deftest all-regions-final?-non-parallel-or-non-map-state
+  (testing "a non-parallel machine ⇒ false regardless of state"
+    (is (false? (finalize/all-regions-final?
+                  flat-final-machine :done))
+        "all-regions-final? short-circuits false for a non-parallel machine"))
+
+  (testing "a parallel machine with a non-map :state ⇒ false"
+    (is (false? (finalize/all-regions-final? parallel-machine :done))
+        "a keyword :state is not a region→leaf map ⇒ not all-regions-final")))
+
+(deftest all-regions-final?-vector-region-leaves
+  (testing "regions whose active leaf is a NESTED (vector) path are resolved"
+    ;; A region whose final leaf is nested under a compound state — the
+    ;; per-region leaf resolution must walk the vector path, not just a
+    ;; top-level keyword.
+    (let [m {:type    :parallel
+             :data    {}
+             :regions {:left  {:initial :wrap
+                               :states  {:wrap {:initial :running
+                                                :states  {:running {:on {:finish :done}}
+                                                          :done    {:final? true}}}}}
+                       :right {:initial :running
+                               :states  {:running {:on {:finish :done}}
+                                         :done    {:final? true}}}}}]
+      (is (true? (finalize/all-regions-final?
+                   m {:left [:wrap :done] :right :done}))
+          "a nested region leaf at [:wrap :done] resolves and is :final?")
+      (is (false? (finalize/all-regions-final?
+                    m {:left [:wrap :running] :right :done}))
+          "a nested NON-final region leaf prevents finalisation"))))

--- a/implementation/machines/test/re_frame/machines_conformance_test.clj
+++ b/implementation/machines/test/re_frame/machines_conformance_test.clj
@@ -69,16 +69,22 @@
       {:fixture/load-error (.getMessage e)
        :fixture/file       (.getName file)})))
 
-(defn- has-machine-transition-call?
-  "True if any `:fixture/calls` entry uses `:call :machine-transition`."
+(def machine-call-ops
+  "The Mode-B `:call` ops this artefact's runner executes:
+  `:machine-transition` (pure transition) and `:reg-machine` (pure
+  registration validation, pinning the registration-error taxonomy)."
+  #{:machine-transition :reg-machine})
+
+(defn- has-machine-call?
+  "True if any `:fixture/calls` entry uses a `:call` this runner executes."
   [fixture]
-  (some (fn [c] (= :machine-transition (:call c)))
+  (some (fn [c] (contains? machine-call-ops (:call c)))
         (or (:fixture/calls fixture) [])))
 
 (defn all-machine-transition-fixtures
   "Every fixture file whose `:fixture/calls` contains at least one
-  `:machine-transition` call. Returns a vector of `[filename fixture]`
-  pairs in stable lex order."
+  `:machine-transition` or `:reg-machine` call. Returns a vector of
+  `[filename fixture]` pairs in stable lex order."
   []
   (->> (file-seq fixtures-dir)
        (filter #(.isFile %))
@@ -87,7 +93,7 @@
        (map (fn [f] [(.getName f) (load-fixture f)]))
        (filter (fn [[_ fx]]
                  (and (not (:fixture/load-error fx))
-                      (has-machine-transition-call? fx))))
+                      (has-machine-call? fx))))
        vec))
 
 ;; ---- claimed capability set -----------------------------------------------
@@ -112,6 +118,10 @@
     :fsm/delayed-after
     :fsm/tags
     :fsm/final-states
+    ;; rf2-vf5cf: the registration-error taxonomy (Spec 009 thrown-error
+    ;; shape) — pinned by the `:reg-machine` Mode-B op against the pure
+    ;; `validate-machine!` validator.
+    :fsm/registration-validation
     :actor/spawn-destroy
     :actor/invoke
     :actor/spawn-and-join
@@ -254,18 +264,64 @@
                      "    expected effects:  " want-fx "\n"
                      "    actual   effects:  " fx-out))}))
 
+;; ---- single :reg-machine call ---------------------------------------------
+;;
+;; The `:reg-machine` Mode-B op pins the registration-error taxonomy
+;; (Spec 009 §The thrown-error shape — the :rf.error/id ex-data contract)
+;; against the pure registration validator `validate-machine!`. A
+;; well-formed `:definition` validates silently; a malformed one throws an
+;; ex-info whose `:rf.error/id` ex-data slot names the category the
+;; fixture's `:expect-error` pins. No registrar, no substrate, no app-db —
+;; the validator is a pure leaf fn of the machine map.
+
+(defn- run-reg-machine-call
+  "Execute one `:reg-machine` call. Returns `{:passed? bool :detail msg}`.
+
+  Validates `(:definition call)` via `re-frame.machines/validate-machine!`.
+  - With `:expect-error <category-kw>`: passes iff the validator throws an
+    ex-info whose `(:rf.error/id (ex-data e))` equals the category.
+  - With `:expect-valid? true` (or no `:expect-error`): passes iff the
+    validator does NOT throw (a well-formed control case)."
+  [call]
+  (let [definition (:definition call)
+        want-error (:expect-error call)
+        thrown     (try (machines/validate-machine! definition) nil
+                        (catch clojure.lang.ExceptionInfo e e)
+                        (catch Throwable e e))]
+    (if want-error
+      (let [got-id (when (instance? clojure.lang.ExceptionInfo thrown)
+                     (:rf.error/id (ex-data thrown)))
+            ok?    (= want-error got-id)]
+        {:passed? ok?
+         :detail  (when-not ok?
+                    (str "reg-machine\n"
+                         "    expected error :rf.error/id: " want-error "\n"
+                         "    actual   error :rf.error/id: " got-id "\n"
+                         "    thrown:                       " (some-> thrown ex-message)))})
+      ;; control: must NOT throw
+      {:passed? (nil? thrown)
+       :detail  (when (some? thrown)
+                  (str "reg-machine\n"
+                       "    expected: no error (well-formed machine)\n"
+                       "    thrown:   " (ex-message thrown)))})))
+
 ;; ---- fixture-level pass/fail ----------------------------------------------
 
 (defn- run-fixture
-  "Run every `:machine-transition` call in the fixture; return
-  `{:fixture-id ... :passed? bool :failures [detail ...]}`. Non-
-  `:machine-transition` calls in the same fixture are ignored — they
-  belong to other primitives that don't ship in this artefact."
+  "Run every `:machine-transition` and `:reg-machine` call in the fixture;
+  return `{:fixture-id ... :passed? bool :failures [detail ...]}`. Other
+  `:call` ops in the same fixture are ignored — they belong to primitives
+  that don't ship in this artefact."
   [fixture]
   (let [realised   (realise-machine-handlers fixture)
-        calls      (filter #(= :machine-transition (:call %))
-                           (or (:fixture/calls fixture) []))
-        results    (mapv #(run-machine-transition-call % realised) calls)
+        calls      (or (:fixture/calls fixture) [])
+        results    (->> calls
+                        (keep (fn [c]
+                                (case (:call c)
+                                  :machine-transition (run-machine-transition-call c realised)
+                                  :reg-machine        (run-reg-machine-call c)
+                                  nil)))
+                        vec)
         failures   (filterv (complement :passed?) results)]
     {:fixture-id (:fixture/id fixture)
      :calls-run  (count results)

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -135,7 +135,33 @@ Routing and SSR pure-call fixtures use the same shape with different `:call` ops
   {:call :round-trip :url "/articles/intro"}]}
 ```
 
-The reserved `:call` operators currently used by the corpus are `:machine-transition`, `:match-url`, `:route-url`, `:round-trip`, `:assert-rank-greater`, and `:render-to-string`. The set is additive — new pure primitives may register a new `:call` op in subsequent fixture spec versions; existing ops cannot be redefined.
+The reserved `:call` operators currently used by the corpus are `:machine-transition`, `:reg-machine`, `:match-url`, `:route-url`, `:round-trip`, `:assert-rank-greater`, and `:render-to-string`. The set is additive — new pure primitives may register a new `:call` op in subsequent fixture spec versions; existing ops cannot be redefined.
+
+#### The `:reg-machine` op — registration-error taxonomy
+
+The `:reg-machine` op pins the machine **registration-error taxonomy** (the [009 §thrown-error shape](../009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract) — the `:rf.error/id` ex-data contract) at the conformance layer. A re-frame2 machine spec is validated at registration time by a pure leaf fn (`validate-machine!` in the CLJS reference); each malformed spec throws an `ex-info` whose `:rf.error/id` ex-data slot names a `:rf.error/machine-*` category. The taxonomy is a spec-normative contract surface — consumers (Causa's error widget, the pair-tool overlay, `:on-error` policies) `case` on `:rf.error/id`, never the message string — so it deserves a corpus pin independent of any host's full registration machinery.
+
+A `:reg-machine` call carries the candidate `:definition` and either an `:expect-error` (the `:rf.error/<category>` keyword the validator must throw) or no `:expect-error` (a well-formed control that must validate silently):
+
+```clojure
+;; Excerpt — full file at fixtures/machine-reg-error-compound-state-missing-initial.edn
+{:fixture/id           :machine/reg-error-compound-state-missing-initial
+ :fixture/capabilities #{:fsm/hierarchical :fsm/registration-validation}
+ :fixture/calls
+ [;; A compound state declaring :states but no :initial is rejected.
+  {:call         :reg-machine
+   :definition   {:initial :authenticated
+                  :states  {:authenticated {:states {:dashboard {} :settings {}}}}}
+   :expect-error :rf.error/machine-compound-state-missing-initial}
+
+  ;; Control: a compound state that DOES declare :initial validates silently.
+  {:call       :reg-machine
+   :definition {:initial :authenticated
+                :states  {:authenticated {:initial :dashboard
+                                          :states  {:dashboard {} :settings {}}}}}}]}
+```
+
+The host runs the call by invoking its registration-time validator on `:definition` and comparing the thrown `:rf.error/id` against `:expect-error` (pass iff equal); a control call (no `:expect-error`) passes iff the validator does not throw. Fixtures using `:reg-machine` declare the `:fsm/registration-validation` capability alongside the FSM/actor capability the malformed shape exercises (`:fsm/hierarchical`, `:fsm/final-states`, `:actor/spawn-and-join`, …). A host that does not implement registration-time validation (e.g. a port that validates lazily) declares `:fsm/registration-validation` in its `known-skipped-capabilities` allowlist.
 
 ### Capability tagging
 
@@ -144,7 +170,7 @@ Per [Goal 6 — Hierarchical FSM substrate with implementor-chosen capabilities]
 Capability tag conventions:
 
 - `:core/*` — pattern-required basics every conformant port supports (event handler, frame, dispatch envelope, sub, trace, fx, error).
-- `:fsm/*` — FSM-richness axis (`:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`).
+- `:fsm/*` — FSM-richness axis (`:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`, `:fsm/final-states`, `:fsm/registration-validation`).
 - `:actor/*` — actor-model axis (`:actor/own-state`, `:actor/spawn-destroy`, `:actor/cross-actor-fx`, `:actor/invoke`, `:actor/spawn-and-join`, `:actor/system-id`).
 - `:routing/*`, `:ssr/*`, `:schemas/*` — per-spec capabilities for ports that ship them.
 
@@ -265,7 +291,7 @@ Each fixture defines an **invariant the implementation upholds**. The harness:
 2. **Realises handler bodies** — for each `:fixture/handlers` entry, interpret the DSL ops into a host-native closure and bind it to the id under the kind.
 3. **Creates the frame** — apply `:fixture/frame-config` via `make-frame` (or the host equivalent); this fires `:on-create` and any `:on-create` events seeded into the frame.
 4. **Runs `:fixture/dispatches`** — one event vector per call, each via `dispatch-sync`. Each settles to fixed point before the next.
-5. **Runs `:fixture/calls`** (if present) — direct invocations of pure primitives (`machine-transition`, `match-url`, `route-url`, `render-to-string`, `round-trip`, `assert-rank-greater`). Each call carries its own expectation; mismatches surface as fixture-level failures.
+5. **Runs `:fixture/calls`** (if present) — direct invocations of pure primitives (`machine-transition`, `reg-machine`, `match-url`, `route-url`, `render-to-string`, `round-trip`, `assert-rank-greater`). Each call carries its own expectation; mismatches surface as fixture-level failures.
 6. **Captures observables** (Mode A) — final `app-db`, sub values (per `:fixture/expect :sub-values`), trace events emitted, effects routed.
 7. **Compares** (Mode A) — partial-match per assertion. `:trace-emissions` partial-matches each trace event by its specified keys; absent keys are ignored. `:final-app-db` is a literal compare. `:effects-routed` matches the routed-fx pairs in declaration order.
 
@@ -288,7 +314,7 @@ Each fixture is **a single file** of <200 lines including registrations and expe
       - Compare actuals against `:fixture/expect`.
    d. **If `:fixture/calls` is present (Mode B):**
       - For each call record, invoke the named primitive with the supplied arguments.
-      - Compare the result against the call-local expectation (`:expect`, or operation-specific keys like `:expect-next-snapshot` + `:expect-effects`).
+      - Compare the result against the call-local expectation (`:expect`, or operation-specific keys like `:expect-next-snapshot` + `:expect-effects` for `:machine-transition`, or `:expect-error` for `:reg-machine`).
 3. Report pass/fail per fixture; total conformance score.
 
 The harness is small (~300 lines per host).
@@ -339,6 +365,10 @@ See `fixtures/` for the actual files. Each fixture is one EDN file; each exercis
 | `after-single-delay.edn` | `:machine/after-single-delay` | Single `:after` entry fires after the configured delay; verifies `:rf.machine.timer/scheduled` at state entry, `:rf.machine.timer/fired` at expiry, and the snapshot transitions to the target after the test-clock advances past the delay. |
 | `after-stale-detection.edn` | `:machine/after-stale-detection` | A real `:on` event arrives before the `:after` timer expires; the machine transitions out of the state; the epoch advances; the eventual timer firing is detected as stale (`:rf.machine.timer/stale-after`) and silently ignored. The "real event beats the timer" race the epoch mechanism handles. |
 | `after-hierarchy.edn` | `:machine/after-hierarchy` | `:after` on a parent compound state remains active while the snapshot is in any child; sibling-leaf transitions inside the parent do NOT cancel the parent's `:after`. Exiting the parent advances the epoch and the parent-level timer's eventual firing is stale. |
+| `machine-reg-error-compound-state-missing-initial.edn` | `:machine/reg-error-compound-state-missing-initial` | `:reg-machine` Mode-B: a compound state-node declaring `:states` but no `:initial` is rejected at registration with `:rf.error/machine-compound-state-missing-initial`; the `:initial`-bearing control validates silently. |
+| `machine-reg-error-always-self-loop.edn` | `:machine/reg-error-always-self-loop` | `:reg-machine` Mode-B: an `:always` entry whose keyword/vector `:target` resolves to its own declaring state throws `:rf.error/machine-always-self-loop`; an internal (no-`:target`) `:always` and a sibling-target `:always` validate silently. |
+| `machine-reg-error-final-state-shape.edn` | `:machine/reg-error-final-state-shape` | `:reg-machine` Mode-B: a compound `:final?` state, a transition-bearing `:final?` state, and a non-final `:output-key` state throw `:rf.error/machine-final-state-compound` / `-final-state-has-transitions` / `-output-key-without-final` respectively; well-formed `:final?` leaves (with `:output-key` / `:entry` / `:exit`) validate silently. |
+| `machine-reg-error-spawn-all-shape.edn` | `:machine/reg-error-spawn-all-shape` | `:reg-machine` Mode-B: a node declaring both `:spawn` and `:spawn-all` throws `:rf.error/machine-spawn-all-with-spawn`; two `:spawn-all` children sharing an `:id` throw `:rf.error/machine-spawn-all-duplicate-id`; the distinct-`:id` control validates silently. |
 | `routing-match-url.edn` | `:routing/match-url` | Bidirectional URL ↔ params; round-trip property |
 | `routing-navigate.edn` | `:routing/navigate` | `:rf.route/navigate` updates `app-db` + emits `:rf.nav/push-url` fx |
 | `route-ranking-precedence.edn` | `:routing/ranking-precedence` | Deterministic 6-rule ranking cascade resolves overlapping routes; equal-score warning |

--- a/spec/conformance/fixtures/machine-reg-error-always-self-loop.edn
+++ b/spec/conformance/fixtures/machine-reg-error-always-self-loop.edn
@@ -1,0 +1,59 @@
+;; Conformance fixture: machine/reg-error-always-self-loop
+;;
+;; Per [005 §Self-loop forbidden at registration](../../005-StateMachines.md#self-loop-forbidden-at-registration)
+;; and rf2-hh1pi: a state whose `:always` targets ITSELF is rejected at
+;; construction time. An eventless self-loop either fires repeatedly to
+;; depth-exceeded (guard stays true) or is a no-op (guard flips on first
+;; hit) — in both cases the author intended something else, so the bug is
+;; caught at registration rather than late at runtime via the
+;; depth-exceeded backstop.
+;;
+;; A keyword `:target` self-loops when it equals the declaring state's own
+;; key; a vector `:target` self-loops when it equals the declaring state's
+;; absolute path. An `:always` entry with NO `:target` is an INTERNAL
+;; eventless transition (the canonical action-microstep pattern) and is
+;; NOT a self-loop — the control case below pins that distinction.
+;;
+;; Mode-B `:reg-machine` fixture pinning the registration-error taxonomy
+;; (Spec 009 §The thrown-error shape). The `:rf.error/id` discriminator is
+;; `:rf.error/machine-always-self-loop`.
+
+{:fixture/id           :machine/reg-error-always-self-loop
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/eventless-always :fsm/registration-validation}
+ :fixture/doc          "An :always entry whose :target resolves to its own declaring state is rejected at registration with :rf.error/machine-always-self-loop. Keyword and vector self-targets both throw; an internal (no-:target) :always and a sibling-target :always validate silently."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) Keyword :target naming the declaring state — self-loop, rejected.
+  {:call         :reg-machine
+   :definition   {:initial :checking
+                  :guards  {:ready? :always/true?}
+                  :states  {:checking {:always [{:guard :ready? :target :checking}]}}}
+   :expect-error :rf.error/machine-always-self-loop}
+
+  ;; (2) Vector :target equal to the declaring leaf's absolute path — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :outer
+                  :guards  {:p? :always/true?}
+                  :states  {:outer {:initial :inner
+                                    :states  {:inner {:always [{:guard  :p?
+                                                                :target [:outer :inner]}]}}}}}
+   :expect-error :rf.error/machine-always-self-loop}
+
+  ;; (3) Control: internal :always (no :target, just :action) is the
+  ;; canonical action-microstep pattern — NOT a self-loop, validates silently.
+  {:call       :reg-machine
+   :definition {:initial :working
+                :guards  {:more? :always/false?}
+                :actions {:step :identity}
+                :states  {:working {:always [{:guard :more? :action :step}]}}}}
+
+  ;; (4) Control: an :always targeting a DIFFERENT sibling validates silently.
+  {:call       :reg-machine
+   :definition {:initial :asking
+                :guards  {:enough? :always/true?}
+                :states  {:asking {:always [{:guard :enough? :target :winner}]}
+                          :winner {}}}}]}

--- a/spec/conformance/fixtures/machine-reg-error-compound-state-missing-initial.edn
+++ b/spec/conformance/fixtures/machine-reg-error-compound-state-missing-initial.edn
@@ -1,0 +1,49 @@
+;; Conformance fixture: machine/reg-error-compound-state-missing-initial
+;;
+;; Per [005 §Initial-state cascading](../../005-StateMachines.md#initial-state-cascading)
+;; and rf2-boryv: every COMPOUND state-node (one that declares `:states`)
+;; MUST declare `:initial` — the substate to enter when control reaches
+;; the compound state without a deeper target. Without it the cascade has
+;; no entry-point and would silently yield a non-leaf `:state` snapshot
+;; instead of failing registration, so the validator rejects it at
+;; construction time.
+;;
+;; This is a Mode-B `:reg-machine` fixture: it pins the registration-error
+;; taxonomy (Spec 009 §The thrown-error shape — the `:rf.error/id` ex-data
+;; contract) at the conformance layer. The thrown error's `:rf.error/id`
+;; discriminator is `:rf.error/machine-compound-state-missing-initial`.
+;; Per [009 §The thrown-error shape](../../009-Instrumentation.md#the-thrown-error-shape--the-rferrorid-ex-data-contract):
+;; consumers (Causa's error widget, the pair-tool overlay) `case` on
+;; `:rf.error/id`, never the message string.
+
+{:fixture/id           :machine/reg-error-compound-state-missing-initial
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/hierarchical :fsm/registration-validation}
+ :fixture/doc          "A compound state-node declaring :states but no :initial is rejected at registration with :rf.error/machine-compound-state-missing-initial. The control case — a compound state that DOES declare :initial — validates silently."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) Top-level compound state missing :initial — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :authenticated
+                  :states  {:authenticated
+                            {:states {:dashboard {}
+                                      :settings  {}}}}}    ;; no :initial
+   :expect-error :rf.error/machine-compound-state-missing-initial}
+
+  ;; (2) Deeply-nested compound state missing :initial — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :outer
+                  :states  {:outer {:initial :mid
+                                    :states  {:mid {:states {:leaf {}}}}}}}  ;; :mid compound, no :initial
+   :expect-error :rf.error/machine-compound-state-missing-initial}
+
+  ;; (3) Control: a compound state that declares :initial validates silently.
+  {:call       :reg-machine
+   :definition {:initial :authenticated
+                :states  {:authenticated
+                          {:initial :dashboard
+                           :states  {:dashboard {}
+                                     :settings  {}}}}}}]}

--- a/spec/conformance/fixtures/machine-reg-error-final-state-shape.edn
+++ b/spec/conformance/fixtures/machine-reg-error-final-state-shape.edn
@@ -1,0 +1,68 @@
+;; Conformance fixture: machine/reg-error-final-state-shape
+;;
+;; Per [005 §Final states](../../005-StateMachines.md#final-states-final--on-done--output-key)
+;; and rf2-gn80 §`:final?` constraints. A `:final?` state-node's shape is
+;; constrained at registration:
+;;
+;;   - A `:final?` state MUST NOT be compound (no `:states`, no `:initial`)
+;;     — `:rf.error/machine-final-state-compound`.
+;;   - A `:final?` state MUST NOT declare `:on` / `:always` / `:after` /
+;;     `:spawn` / `:spawn-all` — final means final, no transitions out —
+;;     `:rf.error/machine-final-state-has-transitions`. (`:entry` / `:exit`
+;;     ARE permitted.)
+;;   - A NON-final state declaring `:output-key` is a registration error
+;;     — `:rf.error/machine-output-key-without-final` (D3: `:output-key`
+;;     is only meaningful on a `:final?` state).
+;;
+;; Mode-B `:reg-machine` fixture pinning three members of the
+;; registration-error taxonomy (Spec 009 §The thrown-error shape). Each
+;; call's `:expect-error` names the `:rf.error/id` discriminator.
+
+{:fixture/id           :machine/reg-error-final-state-shape
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:fsm/final-states :fsm/registration-validation}
+ :fixture/doc          "A compound :final? state, a transition-bearing :final? state, and a non-final state declaring :output-key each throw their distinct registration-error category. The control cases — a well-formed :final? leaf with :output-key, and a :final? leaf with :entry/:exit — validate silently."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) A :final? state that is ALSO compound (declares :states) — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :running
+                  :states  {:running {:on {:finish :done}}
+                            :done    {:final? true
+                                      :states {:sub {}}}}}    ;; final + compound
+   :expect-error :rf.error/machine-final-state-compound}
+
+  ;; (2) A :final? state declaring an outbound :on transition — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :running
+                  :states  {:running {:on {:finish :done}}
+                            :done    {:final? true
+                                      :on     {:restart :running}}}}  ;; final + :on
+   :expect-error :rf.error/machine-final-state-has-transitions}
+
+  ;; (3) A NON-final state declaring :output-key — rejected (D3).
+  {:call         :reg-machine
+   :definition   {:initial :running
+                  :states  {:running    {:output-key :result   ;; non-final + :output-key
+                                         :on {:finish :done}}
+                            :done       {:final? true}}}
+   :expect-error :rf.error/machine-output-key-without-final}
+
+  ;; (4) Control: a well-formed :final? leaf carrying :output-key validates silently.
+  {:call       :reg-machine
+   :definition {:initial :running
+                :states  {:running {:on {:finish :done}}
+                          :done    {:final?     true
+                                    :output-key :phase}}}}
+
+  ;; (5) Control: a :final? leaf MAY declare :entry / :exit — validates silently.
+  {:call       :reg-machine
+   :definition {:initial :running
+                :actions {:log :identity}
+                :states  {:running {:on {:finish :done}}
+                          :done    {:final? true
+                                    :entry  :log
+                                    :exit   :log}}}}]}

--- a/spec/conformance/fixtures/machine-reg-error-spawn-all-shape.edn
+++ b/spec/conformance/fixtures/machine-reg-error-spawn-all-shape.edn
@@ -1,0 +1,55 @@
+;; Conformance fixture: machine/reg-error-spawn-all-shape
+;;
+;; Per [005 §Spawn-and-join via `:spawn-all`](../../005-StateMachines.md#spawn-and-join-via-spawn-all)
+;; and rf2-6vmw. A `:spawn-all`-bearing state node is shape-validated at
+;; registration:
+;;
+;;   - A state node MUST NOT declare BOTH `:spawn` and `:spawn-all` (they
+;;     are mutually exclusive) — `:rf.error/machine-spawn-all-with-spawn`.
+;;   - Two children inside one `:spawn-all` block MUST NOT share an `:id`
+;;     keyword — `:rf.error/machine-spawn-all-duplicate-id`.
+;;
+;; Mode-B `:reg-machine` fixture pinning two members of the
+;; registration-error taxonomy (Spec 009 §The thrown-error shape). Each
+;; call's `:expect-error` names the `:rf.error/id` discriminator.
+
+{:fixture/id           :machine/reg-error-spawn-all-shape
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:actor/spawn-and-join :fsm/registration-validation}
+ :fixture/doc          "A state node declaring both :spawn and :spawn-all throws :rf.error/machine-spawn-all-with-spawn; two :spawn-all children sharing an :id throw :rf.error/machine-spawn-all-duplicate-id. The control case — a well-formed :spawn-all with distinct child :ids — validates silently."
+
+ :fixture/registry {}
+ :fixture/handlers  {}
+
+ :fixture/calls
+ [;; (1) A state declaring BOTH :spawn and :spawn-all — mutually exclusive, rejected.
+  {:call         :reg-machine
+   :definition   {:initial :gathering
+                  :states  {:gathering
+                            {:spawn     {:machine-id :worker/solo}
+                             :spawn-all {:children        [{:id :a :machine-id :worker/a}]
+                                         :on-child-done   :child/done
+                                         :on-child-error  :child/error
+                                         :on-all-complete [:all/done]}}}}
+   :expect-error :rf.error/machine-spawn-all-with-spawn}
+
+  ;; (2) Two :spawn-all children sharing an :id keyword — rejected.
+  {:call         :reg-machine
+   :definition   {:initial :gathering
+                  :states  {:gathering
+                            {:spawn-all {:children        [{:id :dup :machine-id :worker/a}
+                                                           {:id :dup :machine-id :worker/b}]
+                                         :on-child-done   :child/done
+                                         :on-child-error  :child/error
+                                         :on-all-complete [:all/done]}}}}
+   :expect-error :rf.error/machine-spawn-all-duplicate-id}
+
+  ;; (3) Control: a well-formed :spawn-all with distinct child :ids validates silently.
+  {:call       :reg-machine
+   :definition {:initial :gathering
+                :states  {:gathering
+                          {:spawn-all {:children        [{:id :a :machine-id :worker/a}
+                                                         {:id :b :machine-id :worker/b}]
+                                       :on-child-done   :child/done
+                                       :on-child-error  :child/error
+                                       :on-all-complete [:all/done]}}}}}]}


### PR DESCRIPTION
## Summary

Closes the two MED-priority coverage gaps from the `implementation/machines/` test-coverage audit (rf2-vf5cf): finality predicates with no direct pure-engine test, and the registration-error taxonomy un-pinned at the conformance layer.

- **Finality predicates (G1)** — new `machine_finality_purity_test.clj` (JVM) drives the three predicates directly, instead of only transitively via integration dispatch:
  - `transition/final-state-node?` — the first-class `:final? true` flag (D1; strict `true?`, so `:meta`-stashed / truthy-non-true / nil all read non-final).
  - `transition/final-on-leaf?` — flat and compound active-leaf finality, leaf-not-ancestor.
  - `finalize/all-regions-final?` — the parallel union, including **the risky partial-final branch** (one region `:done`, the other still `:running` must NOT finalise), non-parallel / non-map short-circuits, and nested vector region leaves.

- **Registration-error taxonomy (G2/G3)** — new `:reg-machine` Mode-B conformance call op pins the Spec 009 thrown-error shape (`:rf.error/id`) for the registration validators, which had **zero** conformance fixtures. Four fixtures (15 `:reg-machine` calls) cover all seven distinctive categories — `compound-state-missing-initial`, `always-self-loop`, `final-state-compound` / `-has-transitions` / `output-key-without-final`, `spawn-all-with-spawn` / `-duplicate-id` — each with well-formed control cases.

- The op is wired into all three conformance runners (machines JVM, core JVM, core CLJS), gated on a new `:fsm/registration-validation` capability, and documented in `spec/conformance/README.md`. `validate-machine!` is re-exported from `re-frame.machines` so the op pins the pure leaf fn directly — no registrar/substrate fixture.

## Test plan

- [x] machines JVM (`clojure -M:test`): 238 tests / 805 assertions, 0 failures (+7 finality deftests; conformance fixtures run inside the existing corpus deftest)
- [x] core JVM (`clojure -M:test`): 689 tests / 3297 assertions, 0 failures
- [x] CLJS node (`npm run test:cljs`): 4070 tests / 12305 assertions, 0 failures (full clean rebuild)
- [x] Verified each runner actually executes the new fixtures via deliberate wrong-`:expect-error` probes that turned the suite red on JVM and CLJS, then reverted.

## Notes

- No real bug found — the audit verdict held (gaps were refinements). All malformed-spec fixtures threw the exact expected `:rf.error/id`, and the parallel partial-final guard behaves correctly.
- Harness note (pre-existing): the CLJS corpus inlines fixtures via a compile-time macro that does NOT track `.edn`-only changes; an incremental `npm run test:cljs` after a fixture-only edit can serve stale data. A full clean (`rm -rf .shadow-cljs/builds out/node-test.js`) forces the macro to re-run. CI builds clean, so this is local-iteration only.
- Skipped the LOW cosmetic destroy-fixture extraction (item 3) — the five destroy files pin distinct contracts and the shared-helper refactor is out of this change's scope.