### PR TITLE
test(mcp-infra): mcp-base CLJS coverage + cap char-gate + live-emission matrix (rf2-80y2h)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1383,6 +1383,14 @@ jobs:
         with:
           cli: latest
 
+      # rf2-80y2h: mcp-base now carries a CLJS test target (shadow-cljs
+      # :node-test build) covering the `.cljc` `:cljs` reader-conditional
+      # branches the JVM suite cannot reach. Node is required to run it.
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -1406,6 +1414,20 @@ jobs:
       # consumer.
       - name: Run JVM tests (tools/mcp-base artefact)
         run: clojure -M:test
+
+      # rf2-80y2h: the CLJS test target exercises the three `.cljc`
+      # `:cljs`-only branches the JVM suite (Malli always present) can
+      # never reach — the `goog-define` `validate-patches?` default, the
+      # `:cljs` arm of `resolve-malli-validate`, and the
+      # soft-pass-when-Malli-absent no-op in the validation gates. The
+      # :cljs-test alias deliberately omits Malli so the soft-pass branch
+      # actually runs. Both MCP servers consume mcp-base in CLJS; nothing
+      # pinned these paths before.
+      - name: Install Node deps (shadow-cljs for the CLJS test build)
+        run: npm install
+
+      - name: Run CLJS tests (tools/mcp-base artefact)
+        run: npm run test:cljs
 
   jvm-tools-template:
     name: JVM tools/template (clojure -M:test)

--- a/tools/mcp-base/.gitignore
+++ b/tools/mcp-base/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+out/
+.shadow-cljs/
+package-lock.json
+.cpcache/

--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -95,6 +95,40 @@
                        {:mvn/version "0.16.4"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
+  ;; CLJS test build classpath (rf2-80y2h). mcp-base is a `.cljc`
+  ;; library both MCP servers consume in CLJS (re-frame2-pair-mcp is a
+  ;; Node script), yet the JVM `:test` alias above can only exercise the
+  ;; `:clj` reader-conditional arms. Three `.cljc` branches were
+  ;; therefore NEVER executed on any platform: the `goog-define`
+  ;; `validate-patches?` toggle (`diff_encode.cljc`), the `:cljs` arm of
+  ;; `resolve-malli-validate`, and the soft-pass-when-Malli-absent no-op
+  ;; in `validate-patches!` / `validate-sections!`.
+  ;;
+  ;; This alias wires the shadow-cljs `:cljs-test` build (see
+  ;; shadow-cljs.edn) under `:deps true`. Note what is DELIBERATELY
+  ;; ABSENT: metosin/malli. The CLJS test build runs WITHOUT Malli on
+  ;; the classpath so `resolve-malli-validate` returns nil and the
+  ;; validation gates take their soft-pass branch — the exact CLJS-only
+  ;; path the JVM suite (Malli always present) can never reach. The
+  ;; goog-define `validate-patches?` rides its default `true` here
+  ;; (production CLJS bundles flip it to false via :closure-defines; the
+  ;; test build leaves the dev gate on).
+  ;; Classpath-only — shadow-cljs activates this alias via
+  ;; shadow-cljs.edn `:deps {:aliases [:cljs-test]}` and supplies its own
+  ;; `:main`; do NOT add `:main-opts` here or it leaks into the
+  ;; shadow-cljs `clojure` launch and shadows shadow's CLI entry point.
+  ;; Drive the build via `npm run test:cljs` (or `shadow-cljs compile
+  ;; cljs-test`).
+  :cljs-test
+  {:extra-paths ["test"]
+   :extra-deps  {org.clojure/clojurescript {:mvn/version "1.12.145"}
+                 thheller/shadow-cljs      {:mvn/version "3.4.10"}
+                 ;; rf2-try1x — silent-on-success reporter; provides the
+                 ;; `re-frame.test-quiet.shadow-node` :main for the
+                 ;; :node-test build.
+                 day8/re-frame2-test-quiet
+                 {:local/root "../../implementation/test-quiet"}}}
+
   ;; Clojars deploy — mirrors tools/story-mcp/deps.edn.
   :clein {:extra-deps {io.github.noahtheduke/clein
                        {:git/url "https://github.com/day8/clein.git"

--- a/tools/mcp-base/package.json
+++ b/tools/mcp-base/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@day8/re-frame2-mcp-base",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLJS test harness for re-frame2-mcp-base — exercises the .cljc :cljs reader-conditional branches the JVM suite cannot reach (rf2-80y2h).",
+  "license": "MIT",
+  "scripts": {
+    "test:cljs": "shadow-cljs compile cljs-test && node out/cljs-test.js"
+  },
+  "devDependencies": {
+    "shadow-cljs": "3.4.10"
+  }
+}

--- a/tools/mcp-base/shadow-cljs.edn
+++ b/tools/mcp-base/shadow-cljs.edn
@@ -1,0 +1,40 @@
+;; tools/mcp-base — CLJS test build (rf2-80y2h).
+;;
+;; mcp-base is a `.cljc` library: its sources load identically into the
+;; JVM (story-mcp) and CLJS (re-frame2-pair-mcp, a Node script). The
+;; canonical test suite is JVM (`clojure -M:test`, cognitect-labs
+;; test-runner) — the algorithmic content is platform-agnostic and a JVM
+;; round-trip is the cheapest gate.
+;;
+;; But the `.cljc` reader-conditional `:cljs` arms were untested on ANY
+;; platform: the `goog-define`'d `validate-patches?` toggle, the `:cljs`
+;; branch of `resolve-malli-validate`, and the soft-pass no-op in the
+;; validation gates when Malli is absent. Both servers exercise these in
+;; CLJS; nothing pinned them. This build closes that gap.
+;;
+;; `:deps {:aliases [:cljs-test]}` routes classpath resolution through
+;; deps.edn and activates the `:cljs-test` alias (which adds
+;; clojurescript + shadow-cljs + the test-quiet reporter, and pointedly
+;; does NOT add Malli — see deps.edn). Without Malli on the classpath
+;; `resolve-malli-validate` returns nil and the validation gates take
+;; their soft-pass branch — the CLJS-only path the JVM suite cannot
+;; reach.
+;;
+;; The build runs ONLY the `.cljs` test namespaces (`-cljs-test$`
+;; regexp): the existing `.clj` JVM tests use `clojure.lang.ExceptionInfo`
+;; and a JVM Malli dep and cannot compile to CLJS. The CLJS-specific
+;; coverage lives in `re-frame.mcp-base.cljs-branches-cljs-test`.
+{:deps {:aliases [:cljs-test]}
+ :builds
+ {:cljs-test
+  {:target    :node-test
+   :output-to "out/cljs-test.js"
+   ;; Only the dedicated `.cljs` test ns — the `.clj` JVM tests are not
+   ;; CLJS-compilable. The `-cljs-test$` suffix selects exactly the CLJS
+   ;; coverage file and never the JVM `*_test.clj` namespaces.
+   :ns-regexp "-cljs-test$"
+   :autorun   true
+   ;; rf2-try1x — silent-on-success reporter (mirrors re-frame2-pair-mcp's
+   ;; :server-test build). Provided by day8/re-frame2-test-quiet on the
+   ;; :cljs-test alias classpath.
+   :main      re-frame.test-quiet.shadow-node/main}}}

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -172,6 +172,64 @@
   8)
 
 ;; ---------------------------------------------------------------------------
+;; Over-budget decision — extracted from `apply-cap`'s inline `let` so the
+;; two-stage gate is unit-trippable in isolation.
+;;
+;; ## Why the secondary char gate is structurally dominated today
+;;
+;; `apply-cap` derives BOTH sums from the SAME `content-texts` seq:
+;; `tokens = Σ (token-estimate s)`, `chars = Σ (count s)`. With the live
+;; rule `token-estimate = (quot count 4)`, the two sums are not
+;; independent — for a single string of length L, `chars = L` and
+;; `tokens = (quot L 4)`. If `chars > cap*8` (i.e. L > 8·cap), then
+;; `tokens = (quot L 4) > (quot (8·cap) 4) = 2·cap > cap` for any cap ≥ 1.
+;; So whenever the char gate would trip, the primary token gate has
+;; ALREADY tripped — the `(> chars byte-cap)` disjunct can never be the
+;; SOLE reason `over?` is true while `tokens`/`chars` ride the same seq.
+;;
+;; The gate is therefore NOT dead code by accident: it is intentional
+;; defence-in-depth against a FUTURE refinement of `token-estimate` (e.g.
+;; one that recognises base64 / CJK with a much lower per-char token
+;; cost). Under such a rule `chars` and `tokens` decouple and the char
+;; gate becomes load-bearing. To keep the branch from being a silently-
+;; dead inline arm, the decision is extracted here as a pure predicate
+;; over already-summed `tokens`/`chars` — so both disjuncts (and the
+;; `reported` selector) are directly exercised in `cap_test.clj` by
+;; feeding decoupled sums the live `apply-cap` path cannot itself
+;; produce. See `over-cap?` / `reported-count` tests.
+;; ---------------------------------------------------------------------------
+
+(defn over-cap?
+  "Two-stage over-budget predicate (rf2-ih7g4). True when EITHER the
+  token sum exceeds `cap` OR the char sum exceeds `cap *
+  byte-cap-multiplier` (the secondary byte gate).
+
+  Pure over already-summed `tokens` / `chars` so the secondary char
+  gate is trippable in isolation — under the live `token-estimate`
+  rule the char disjunct is structurally dominated (see the ns-level
+  comment above), but the gate guards against a future token-rule
+  refinement that decouples chars from tokens."
+  [tokens chars cap]
+  (or (> tokens cap)
+      (> chars (* cap byte-cap-multiplier))))
+
+(defn reported-count
+  "The `:token-count` reported in the overflow marker. When the
+  secondary char gate is the one that tripped (`chars > cap *
+  byte-cap-multiplier`), report the char count so the agent's overflow
+  handler sees an actionable number reflecting the payload that
+  escaped the token heuristic; otherwise report the token sum.
+
+  Pure over already-summed `tokens` / `chars` (companion to
+  `over-cap?`) — exercised directly in `cap_test.clj` so the char-gate
+  reporting arm is covered even though the live `apply-cap` path cannot
+  reach it under the current `token-estimate` rule."
+  [tokens chars cap]
+  (if (> chars (* cap byte-cap-multiplier))
+    chars
+    tokens))
+
+;; ---------------------------------------------------------------------------
 ;; apply-cap — the wire-boundary enforcement entry point.
 ;; ---------------------------------------------------------------------------
 
@@ -228,15 +286,12 @@
                          {:tokens (+ tokens (overflow/token-estimate s))
                           :chars  (+ chars (count s))}))
                      {:tokens 0 :chars 0}
-                     (content-texts io result))
-          byte-cap (* cap byte-cap-multiplier)
-          over?    (or (> tokens cap) (> chars byte-cap))]
-      (if-not over?
+                     (content-texts io result))]
+      (if-not (over-cap? tokens chars cap)
         result
-        (let [reported (if (> chars byte-cap) chars tokens)
-              marker   (overflow/overflow-payload
-                         {:tool        tool
-                          :token-count reported
-                          :cap         cap
-                          :hint        hint})]
+        (let [marker (overflow/overflow-payload
+                       {:tool        tool
+                        :token-count (reported-count tokens chars cap)
+                        :cap         cap
+                        :hint        hint})]
           (build-overflow-result io marker result))))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cap_test.clj
@@ -186,13 +186,7 @@
 (deftest byte-cap-multiplier-and-char-sum-are-pinned
   ;; Defence-in-depth shape pin (rf2-ih7g4 / rf2-8cpsg / F18). The
   ;; secondary byte cap is `cap * byte-cap-multiplier` and reads from
-  ;; the same `content-texts` seq the token sum does. Under the
-  ;; current `(quot c 4)` token rule the secondary gate is
-  ;; mathematically un-trippable in isolation (token sum ≈ chars/4,
-  ;; so chars > cap*8 ⇒ tokens > cap*2 > cap); the gate is kept
-  ;; wired so a future token-rule refinement (e.g. one that
-  ;; recognises base64 with a much lower per-char cost) cannot
-  ;; silently widen the wire envelope.
+  ;; the same `content-texts` seq the token sum does.
   ;;
   ;; Pin the two shape invariants — `byte-cap-multiplier = 8` and
   ;; `sum-text-chars` and `sum-text-tokens` read the same content-
@@ -201,6 +195,77 @@
   (let [r {:content [{:type "text" :text (big-string 100)}]}]
     (is (= 100 (cap/sum-text-chars map-io r)))
     (is (= 25 (cap/sum-text-tokens map-io r)))))
+
+;; ---------------------------------------------------------------------------
+;; Two-stage gate, unit-trippable in isolation (rf2-80y2h).
+;;
+;; The previous test set documented (in a docstring) that the secondary
+;; char gate was un-trippable under the live `(quot c 4)` token rule and
+;; then never executed it — the `(> chars byte-cap)` disjunct and the
+;; `reported = chars` selector inside `apply-cap` had ZERO executing
+;; coverage. A regression that inverted either comparison shipped
+;; unobserved.
+;;
+;; The decision was NOT genuinely reachable through `apply-cap` + a
+;; custom `ResultIO`: `apply-cap` derives BOTH sums from the same
+;; `content-texts` strings inline, so an IO cannot return chars
+;; without proportional tokens — the two are computed by `apply-cap`
+;; itself, not by the IO. The fix extracts the gate into the pure
+;; `over-cap?` / `reported-count` predicates over already-summed
+;; tokens/chars, which ARE trippable in isolation by feeding the
+;; decoupled sums a future `token-estimate` refinement could produce.
+;; ---------------------------------------------------------------------------
+
+(deftest over-cap?-primary-token-gate-trips
+  ;; The common path: token sum exceeds cap, chars well under byte-cap.
+  (is (true?  (cap/over-cap? 5001 6000 5000)) "tokens > cap trips")
+  (is (false? (cap/over-cap? 5000 6000 5000)) "tokens = cap does NOT trip (inclusive-low)")
+  (is (false? (cap/over-cap? 4999 6000 5000)) "tokens < cap does NOT trip"))
+
+(deftest over-cap?-secondary-char-gate-trips-in-isolation
+  ;; The branch the live `apply-cap` path cannot reach: tokens UNDER
+  ;; cap but chars OVER `cap * byte-cap-multiplier`. Reachable only when
+  ;; a future token rule decouples chars from tokens (e.g. base64 / CJK
+  ;; recognised at a lower per-char token cost). `over-cap?` MUST still
+  ;; trip — that is the whole point of the defence-in-depth gate.
+  (let [cap-tokens 100
+        byte-cap   (* cap-tokens cap/byte-cap-multiplier)] ;; 800
+    (is (true? (cap/over-cap? 50 (inc byte-cap) cap-tokens))
+        "tokens under cap but chars > cap*8 ⇒ secondary gate trips")
+    (is (false? (cap/over-cap? 50 byte-cap cap-tokens))
+        "chars = cap*8 does NOT trip (strict >)")
+    (is (false? (cap/over-cap? 50 (dec byte-cap) cap-tokens))
+        "chars < cap*8 and tokens under cap ⇒ no trip")))
+
+(deftest reported-count-selects-chars-when-char-gate-tripped
+  ;; The `reported = (if (> chars byte-cap) chars tokens)` selector. The
+  ;; chars arm is the one the live path never reaches; pin both arms.
+  (let [cap-tokens 100
+        byte-cap   (* cap-tokens cap/byte-cap-multiplier)] ;; 800
+    (is (= 999 (cap/reported-count 50 999 cap-tokens))
+        "char gate tripped (999 > 800) ⇒ report the char count")
+    (is (= 50 (cap/reported-count 50 800 cap-tokens))
+        "char gate NOT tripped (800 = byte-cap, not >) ⇒ report tokens")
+    (is (= 150 (cap/reported-count 150 700 cap-tokens))
+        "only the token gate tripped ⇒ report tokens")))
+
+(deftest over-cap?-and-reported-count-agree-with-apply-cap
+  ;; Consistency pin: the extracted predicates are exactly what
+  ;; `apply-cap` uses. A token-gated over-budget response reports the
+  ;; token count via `reported-count`, and `apply-cap`'s marker carries
+  ;; the same number. (The char-gate arm has no live `apply-cap`
+  ;; counterpart by construction — that asymmetry is the documented
+  ;; structural domination, covered in isolation above.)
+  (let [big (big-string 4000)        ;; 4000 chars ⇒ 1000 tokens
+        r   (ok-text-result {:huge big})
+        cap-tokens 500
+        toks (cap/sum-text-tokens map-io r)
+        chrs (cap/sum-text-chars map-io r)
+        out  (cap/apply-cap map-io r {:tool "snapshot" :cap cap-tokens})
+        body (get-in out [:structuredContent vocab/overflow-key])]
+    (is (true? (cap/over-cap? toks chrs cap-tokens)))
+    (is (= (cap/reported-count toks chrs cap-tokens) (:token-count body))
+        "apply-cap's reported :token-count matches reported-count over the same sums")))
 
 ;; ---------------------------------------------------------------------------
 ;; structuredContent counted toward the budget (rf2-ih7g4) — story-mcp

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -1,0 +1,135 @@
+(ns re-frame.mcp-base.cljs-branches-cljs-test
+  "CLJS-only coverage for re-frame2-mcp-base (rf2-80y2h).
+
+  mcp-base ships as `.cljc` and both MCP servers consume it in CLJS
+  (re-frame2-pair-mcp is a Node script). The canonical JVM suite
+  (`clojure -M:test`) can only exercise the `:clj` reader-conditional
+  arms, AND it always has Malli on the classpath — so three CLJS
+  behaviours had ZERO executing coverage on any platform:
+
+    1. The library actually loads and the diff algorithm round-trips
+       under a CLJS runtime (not just the JVM).
+    2. `diff-encode/validate-patches?` rides its `goog-define` default
+       `true` in dev/test CLJS builds.
+    3. The validation gates SOFT-PASS when Malli is not on the
+       classpath — the `:cljs` arm of `resolve-malli-validate` returns
+       nil, so `validate-patches!` / `validate-sections!` no-op rather
+       than throw. This build runs WITHOUT Malli (see deps.edn
+       `:cljs-test` — Malli is deliberately absent), so a malformed
+       patch / section reaching the public decoder boundary is NOT
+       rejected here, whereas the JVM suite (Malli present) DOES reject
+       it. That observable contrast is the soft-pass branch pin.
+
+  Coverage is via the PUBLIC API: the soft-pass branch is observable as
+  'no throw on malformed input when Malli is absent', so we don't reach
+  into the private helpers — we pin the behaviour the consumers depend
+  on."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.mcp-base.cap :as cap]
+            [re-frame.mcp-base.diff-encode :as de]
+            [re-frame.mcp-base.overflow :as overflow]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; 1. The .cljc library loads and the diff algorithm round-trips in CLJS.
+;;    This is the load-bearing 'it runs on CLJS at all' pin — the JVM
+;;    suite proved the algorithm; this proves the CLJS compile + runtime.
+;; ---------------------------------------------------------------------------
+
+(deftest diff-algorithm-round-trips-under-cljs
+  (testing "collect-patches / apply-patches round-trip"
+    (let [a {:user {:name "ada" :age 30} :session :idle}
+          b {:user {:name "ada" :age 31 :role :admin}}
+          p (de/collect-patches a b [])]
+      (is (= b (de/apply-patches a p)))))
+  (testing "diff-encode-db-after emits the :rf.mcp/diff-from marker"
+    (let [epoch   {:db-before {:a 1 :b 2} :db-after {:a 1 :b 3}}
+          encoded (de/diff-encode-db-after epoch)]
+      (is (= :db-before (get-in encoded [:db-after vocab/diff-from-key])))
+      (is (= epoch (de/decode-db-after encoded))
+          "encode then decode reconstructs the original epoch")))
+  (testing "diff-encode-epochs :full mode passes through"
+    (let [epochs [{:db-before {:a 1} :db-after {:a 2}}]]
+      (is (= epochs (de/diff-encode-epochs epochs :full))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The goog-define toggle rides its default `true` in dev/test builds.
+;;    `validate-patches?` is a public `goog-define` def; pin its default
+;;    so a build that flips it without intent (or a refactor that drops
+;;    the default) trips here. Production bundles override it to false
+;;    via :closure-defines.
+;; ---------------------------------------------------------------------------
+
+(deftest validate-patches?-goog-define-defaults-true
+  (is (true? de/validate-patches?)
+      "dev/test CLJS build leaves the validation toggle at its goog-define default"))
+
+;; ---------------------------------------------------------------------------
+;; 3. Soft-pass when Malli is absent (the :cljs resolve arm). This build
+;;    runs WITHOUT Malli on the classpath, so `resolve-malli-validate`
+;;    returns nil and the validation gates take their no-op branch. The
+;;    JVM suite (Malli present) asserts the SAME inputs THROW; here they
+;;    must NOT. That contrast is the soft-pass branch coverage.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-patches-soft-passes-malformed-when-malli-absent
+  ;; JVM `apply-patches-rejects-malformed-tuples` asserts these throw
+  ;; :rf.error/bad-diff-patches (Malli present). With Malli absent the
+  ;; validate-patches! gate is a no-op; the malformed tuple falls
+  ;; through `apply-patches`'s own `cond` (:else acc) without a throw.
+  (testing "unknown op does not throw (soft-pass) and is dropped by the cond"
+    (is (= {} (de/apply-patches {} [[[:a] :replace 1]]))
+        "no Malli ⇒ no validation throw; :replace falls through to :else acc"))
+  (testing "well-formed patches still apply correctly"
+    (is (= {:a 1 :b 2} (de/apply-patches {:a 1} [[[:b] :assoc 2]])))
+    (is (= {:a 1} (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]])))))
+
+(deftest decode-db-after-soft-passes-malformed-sections-when-malli-absent
+  ;; JVM `decode-db-after-rejects-malformed-sections` asserts this
+  ;; throws :rf.error/bad-diff-sections (Malli present). With Malli
+  ;; absent the validate-sections! gate is a no-op, so decode proceeds
+  ;; through the permissive `sections->patches` mapcat. The malformed
+  ;; :section-kind / :section-path slots are cosmetic and ignored by the
+  ;; replay; the :patches still apply.
+  (let [epoch {:db-before {:a 1}
+               :db-after  {:rf.mcp/diff-from :db-before
+                           :sections [{:section-path :not-a-vector ;; malformed
+                                       :section-kind :renamed       ;; not in enum
+                                       :patches      [[[:a] :assoc 2]]}]}}
+        decoded (de/decode-db-after epoch)]
+    (is (= {:a 2} (:db-after decoded))
+        "no Malli ⇒ no section-validation throw; patches replay regardless")))
+
+;; ---------------------------------------------------------------------------
+;; 4. The cap pipeline (the extracted two-stage gate, rf2-80y2h) runs
+;;    under CLJS too. `over-cap?` / `reported-count` are pure CLJC; pin
+;;    that the secondary char gate trips in isolation on the CLJS side
+;;    as well — both servers cap on the wire.
+;; ---------------------------------------------------------------------------
+
+(def map-io
+  (reify cap/ResultIO
+    (content-texts [_ result] (map :text (:content result)))
+    (build-overflow-result [_ marker _original]
+      {:content           [{:type "text" :text (pr-str marker)}]
+       :structuredContent marker})))
+
+(deftest cap-two-stage-gate-runs-under-cljs
+  (testing "primary token gate"
+    (is (true?  (cap/over-cap? 5001 6000 5000)))
+    (is (false? (cap/over-cap? 5000 6000 5000))))
+  (testing "secondary char gate trips in isolation"
+    (is (true?  (cap/over-cap? 50 801 100)) "chars > cap*8 trips even with tokens under cap")
+    (is (= 801  (cap/reported-count 50 801 100)) "char-gated ⇒ report chars")
+    (is (= 50   (cap/reported-count 50 700 100)) "token-gated ⇒ report tokens"))
+  (testing "apply-cap emits the overflow marker on a real over-budget payload"
+    (let [r   {:content [{:type "text" :text (apply str (repeat 4000 "x"))}]}
+          out (cap/apply-cap map-io r {:tool "snapshot" :cap 500 :hint "narrow scope"})
+          body (get-in out [:structuredContent vocab/overflow-key])]
+      (is (= :reached (:limit body)))
+      (is (= 500 (:cap-tokens body)))
+      (is (> (:token-count body) 500))))
+  (testing "under-budget payload passes through untouched"
+    (let [r   {:content [{:type "text" :text (pr-str {:small :payload})}]}
+          out (cap/apply-cap map-io r {:tool "snapshot" :cap overflow/default-max-tokens})]
+      (is (identical? r out)))))

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -332,9 +332,81 @@
   (is (= {:a 1 :b 2}
          (de/apply-patches {:a 1} [[[:b] :assoc 2]])))
   (is (= {:a 1}
-         (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]])))
-  (is (= []
-         (let [out (de/apply-patches {:a 1} [])]
-           ;; empty patches: identity passthrough
-           (is (= {:a 1} out))
-           []))))
+         (de/apply-patches {:a 1 :b 2} [[[:b] :dissoc]]))))
+
+(deftest apply-patches-empty-patches-is-identity
+  ;; Empty patch list ⇒ base returned unchanged.
+  (is (= {:a 1} (de/apply-patches {:a 1} []))))
+
+;; ---------------------------------------------------------------------------
+;; Decoder-boundary SECTION validation (rf2-j6oay / rf2-80y2h).
+;;
+;; `decode-db-after` validates the `:sections` vector via
+;; `validate-sections!` BEFORE flattening + replaying — encoder/decoder
+;; symmetry per the rf2-8e61v argument. The encoder boundary
+;; (`diff-encode-db-after`) was tested negatively
+;; (`diff-encode-db-after-emits-schema-conformant-sections` +
+;; `validate-patches!` direct), and `validate-sections!` was tested
+;; only positively (it never throws on a real encode). This pins the
+;; SYMMETRIC decode-side gate: a marker carrying malformed `:sections`
+;; reaching `decode-db-after` MUST throw `:rf.error/bad-diff-sections`
+;; rather than slip cosmetic `:section-kind` / `:section-path` slots
+;; through to an agent-host UI that paints them as truth.
+;; ---------------------------------------------------------------------------
+
+(deftest decode-db-after-rejects-malformed-sections
+  (testing "section with a non-vector :section-path throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections [{:section-path :not-a-vector
+                                         :section-kind :modified
+                                         :patches      [[[:a] :assoc 2]]}]}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing "section with an unknown :section-kind throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections [{:section-path [:a]
+                                         :section-kind :renamed     ;; not in the enum
+                                         :patches      [[[:a] :assoc 2]]}]}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing "section missing the :patches slot throws"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections [{:section-path [:a]
+                                         :section-kind :modified}]}}]
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #":rf\.error/bad-diff-sections"
+            (de/decode-db-after epoch)))))
+  (testing "ex-info carries the reserved :rf.error/bad-diff-sections code"
+    (let [epoch {:db-before {:a 1}
+                 :db-after  {:rf.mcp/diff-from :db-before
+                             :sections [{:section-path :bad
+                                         :section-kind :modified
+                                         :patches      []}]}}]
+      (try
+        (de/decode-db-after epoch)
+        (is false "expected throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :rf.error/bad-diff-sections
+                 (:rf.error/id (ex-data e)))
+              "ex-info carries the reserved :rf.error/* code")
+          (is (= 'mcp-base/diff-encode-db-after
+                 (:where (ex-data e)))
+              "ex-info names the validation site"))))))
+
+(deftest decode-db-after-well-formed-sections-round-trip
+  ;; The positive companion: well-formed sections decode silently and
+  ;; reconstruct :db-after — proving the decode gate is a guard, not a
+  ;; blanket reject.
+  (let [epoch   {:db-before {:user {:name "ada" :age 30}}
+                 :db-after  {:user {:name "ada" :age 31}}}
+        encoded (de/diff-encode-db-after epoch)
+        decoded (de/decode-db-after encoded)]
+    (is (= epoch decoded))))

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -238,4 +238,89 @@ async function assertJsonRpcErrorCodes(client) {
   }
 }
 
-module.exports = { runWithWatchdog, assertJsonRpcErrorCodes };
+// ---------------------------------------------------------------------
+// Tool-descriptor shape gate (rf2-80y2h).
+//
+// Both `end-to-end-re-frame2-pair.cjs` and `end-to-end-story.cjs` ran four
+// near-identical `for (const t of listed.tools)` loops over the
+// catalogue, pinning cross-MCP-convention invariants the SDK's
+// ListToolsResultSchema does NOT model:
+//
+//   1. inputSchema.type === 'object'        (NAMING.md catalogue surface)
+//   2. inputSchema.properties has max-tokens (TOKEN-BUDGETS.md MUST)
+//   3. an :outputSchema map is declared      (rf2-3l3be)
+//   4. an :annotations map with at least one classification hint set
+//      (rf2-94p8q)
+//
+// The two copies (~60 LoC each) differed in EXACTLY one place: the
+// annotations classification set. re-frame2-pair-mcp permits
+// `openWorldHint` as a classifier (its eval-cljs / dispatch tools touch
+// an open world); story-mcp does not (its tools are closed-world reads /
+// fixture writes). Extracting the loops here with an `allowOpenWorld`
+// flag collapses that drift to a single maintained gate; a new
+// invariant is added once, not twice.
+//
+// Throws on the first violation with a descriptive, server-agnostic
+// message (the tool name + the failed invariant). Returns nothing.
+// ---------------------------------------------------------------------
+function assertDescriptorShape(tools, { allowOpenWorld } = {}) {
+  // 1 + 2. inputSchema is a map with type=object and a max-tokens slot.
+  for (const t of tools) {
+    if (!t.inputSchema || typeof t.inputSchema !== 'object') {
+      throw new Error('tool ' + t.name + ' has no inputSchema');
+    }
+    if (t.inputSchema.type !== 'object') {
+      throw new Error(
+        'tool ' + t.name + " inputSchema.type MUST be 'object' (cross-MCP " +
+          'convention; NAMING.md catalogue surface); got: ' +
+          JSON.stringify(t.inputSchema.type),
+      );
+    }
+    const props = t.inputSchema.properties || {};
+    if (!('max-tokens' in props)) {
+      throw new Error(
+        'tool ' + t.name + " inputSchema.properties MUST expose 'max-tokens' " +
+          '(TOKEN-BUDGETS.md §"Per-call override slot": every tool surfaces ' +
+          'the cap-override slot so clients discover it automatically).',
+      );
+    }
+  }
+
+  // 3. outputSchema declared (rf2-3l3be).
+  for (const t of tools) {
+    if (!t.outputSchema || typeof t.outputSchema !== 'object') {
+      throw new Error(
+        'tool ' + t.name + ' MUST declare :outputSchema (rf2-3l3be); got: ' +
+          JSON.stringify(t.outputSchema),
+      );
+    }
+  }
+
+  // 4. annotations map with at least one classification hint (rf2-94p8q).
+  // openWorldHint counts as a classifier only when `allowOpenWorld` is
+  // set — the single per-server difference between the two harnesses.
+  for (const t of tools) {
+    if (!t.annotations || typeof t.annotations !== 'object') {
+      throw new Error(
+        'tool ' + t.name + ' MUST declare :annotations (rf2-94p8q); got: ' +
+          JSON.stringify(t.annotations),
+      );
+    }
+    const a = t.annotations;
+    const classified =
+      a.readOnlyHint === true ||
+      a.destructiveHint === true ||
+      (allowOpenWorld === true && a.openWorldHint === true);
+    if (!classified) {
+      const allowed = allowOpenWorld
+        ? 'readOnlyHint / destructiveHint / openWorldHint'
+        : 'readOnlyHint / destructiveHint';
+      throw new Error(
+        'tool ' + t.name + ' annotations MUST set at least one of ' +
+          allowed + '; got: ' + JSON.stringify(a),
+      );
+    }
+  }
+}
+
+module.exports = { runWithWatchdog, assertJsonRpcErrorCodes, assertDescriptorShape };

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -29,7 +29,11 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
-const { runWithWatchdog, assertJsonRpcErrorCodes } = require('./_runner.cjs');
+const {
+  runWithWatchdog,
+  assertJsonRpcErrorCodes,
+  assertDescriptorShape,
+} = require('./_runner.cjs');
 
 const RE_FRAME2_PAIR_MCP_DIR = path.resolve(__dirname, '..', '..', 're-frame2-pair-mcp');
 const SERVER = path.join(RE_FRAME2_PAIR_MCP_DIR, 'out', 'server.js');
@@ -82,87 +86,16 @@ runWithWatchdog(
     }
     console.log('OK   tools/list -> ' + names.length + ' tools advertised:', names.join(', '));
 
-    // 2b. Tighten the inputSchema spot-check past "is an object"
-    // (rf2-i3ffz F-GAP-2). The SDK's ListToolsResultSchema already
-    // gates structural JSON-Schema-validity at the SDK layer; this
-    // step pins two cross-MCP-convention invariants the SDK doesn't
-    // model:
-    //
-    //   1. `type === 'object'` — every tool's input shape is a map
-    //      (per NAMING.md §"The verb table"; the catalogue carries
-    //      no scalar-input tools today).
-    //   2. `properties['max-tokens']` is present on every descriptor
-    //      — TOKEN-BUDGETS.md §"Per-call override slot" pins the
-    //      MUST: "The slot surfaces in tools/list on every tool
-    //      descriptor so clients discover it automatically." A
-    //      regression that drops `max-tokens` from a descriptor's
-    //      properties would silently break agent-host budget
-    //      negotiation; that bug now trips here.
-    for (const t of listed.tools) {
-      if (!t.inputSchema || typeof t.inputSchema !== 'object') {
-        throw new Error('tool ' + t.name + ' has no inputSchema');
-      }
-      if (t.inputSchema.type !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " inputSchema.type MUST be 'object' (cross-MCP " +
-            "convention; NAMING.md catalogue surface); got: " +
-            JSON.stringify(t.inputSchema.type),
-        );
-      }
-      const props = t.inputSchema.properties || {};
-      if (!('max-tokens' in props)) {
-        throw new Error(
-          'tool ' + t.name + " inputSchema.properties MUST expose 'max-tokens' " +
-            '(TOKEN-BUDGETS.md §"Per-call override slot": every tool surfaces ' +
-            'the cap-override slot so clients discover it automatically).',
-        );
-      }
-    }
+    // 2b-2d. Descriptor-shape conformance — inputSchema type=object +
+    // max-tokens (rf2-i3ffz F-GAP-2 / TOKEN-BUDGETS.md), :outputSchema
+    // (rf2-3l3be), and an :annotations classification hint (rf2-94p8q).
+    // The shared `assertDescriptorShape` helper pins all three; pair-mcp
+    // permits `openWorldHint` as a classifier (its eval-cljs / dispatch
+    // tools touch an open world), so `allowOpenWorld: true`. See
+    // _runner.cjs for the per-invariant rationale (rf2-80y2h dedup).
+    assertDescriptorShape(listed.tools, { allowOpenWorld: true });
     console.log(
-      'OK   every tool descriptor carries inputSchema with type=object + max-tokens',
-    );
-
-    // 2c. Output-schema conformance (rf2-3l3be). Every descriptor MUST
-    // declare an :outputSchema describing the structuredContent payload
-    // shape. mcp-builder canonical pattern: "Define outputSchema
-    // wherever possible for structured responses."
-    for (const t of listed.tools) {
-      if (!t.outputSchema || typeof t.outputSchema !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " MUST declare :outputSchema (rf2-3l3be); got: " +
-            JSON.stringify(t.outputSchema),
-        );
-      }
-    }
-    console.log(
-      'OK   every tool descriptor carries outputSchema (rf2-3l3be)',
-    );
-
-    // 2d. Tool annotations conformance (rf2-94p8q). Every descriptor
-    // MUST declare an :annotations map advertising the MCP hint slots
-    // (readOnlyHint / destructiveHint / idempotentHint / openWorldHint)
-    // so agent hosts can auto-approve reads + gate destructive ops.
-    for (const t of listed.tools) {
-      if (!t.annotations || typeof t.annotations !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " MUST declare :annotations (rf2-94p8q); got: " +
-            JSON.stringify(t.annotations),
-        );
-      }
-      // At least one of readOnlyHint / destructiveHint / openWorldHint
-      // must be set — that's the load-bearing classification. Other
-      // slots are optional refinements.
-      const a = t.annotations;
-      if (a.readOnlyHint !== true && a.destructiveHint !== true && a.openWorldHint !== true) {
-        throw new Error(
-          'tool ' + t.name + " annotations MUST set at least one of " +
-            "readOnlyHint / destructiveHint / openWorldHint; got: " +
-            JSON.stringify(a),
-        );
-      }
-    }
-    console.log(
-      'OK   every tool descriptor carries annotations with a classification hint (rf2-94p8q)',
+      'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
     );
 
     // 3. Canonical workflow (degraded, since no nREPL is available):

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -28,7 +28,11 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { runWithWatchdog, assertJsonRpcErrorCodes } = require('./_runner.cjs');
+const {
+  runWithWatchdog,
+  assertJsonRpcErrorCodes,
+  assertDescriptorShape,
+} = require('./_runner.cjs');
 const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
 
 const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
@@ -93,71 +97,16 @@ runWithWatchdog(
     }
     console.log('OK   tools/list -> ' + names.length + ' tools advertised');
 
-    // Tighten the inputSchema spot-check past "is an object" (rf2-i3ffz
-    // F-GAP-2). See `end-to-end-re-frame2-pair.cjs` for the cross-MCP rationale:
-    //   - `type === 'object'` — every tool's input shape is a map.
-    //   - `properties['max-tokens']` — TOKEN-BUDGETS.md MUST.
-    for (const t of listed.tools) {
-      if (!t.inputSchema || typeof t.inputSchema !== 'object') {
-        throw new Error('tool ' + t.name + ' has no inputSchema');
-      }
-      if (t.inputSchema.type !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " inputSchema.type MUST be 'object' (cross-MCP " +
-            "convention; NAMING.md catalogue surface); got: " +
-            JSON.stringify(t.inputSchema.type),
-        );
-      }
-      const props = t.inputSchema.properties || {};
-      if (!('max-tokens' in props)) {
-        throw new Error(
-          'tool ' + t.name + " inputSchema.properties MUST expose 'max-tokens' " +
-            '(TOKEN-BUDGETS.md §"Per-call override slot": every tool surfaces ' +
-            'the cap-override slot so clients discover it automatically).',
-        );
-      }
-    }
+    // Descriptor-shape conformance — inputSchema type=object +
+    // max-tokens (rf2-i3ffz F-GAP-2 / TOKEN-BUDGETS.md), :outputSchema
+    // (rf2-3l3be), and an :annotations classification hint (rf2-94p8q).
+    // Shared `assertDescriptorShape` helper (rf2-80y2h dedup). story-mcp
+    // is closed-world (reads + fixture writes), so openWorldHint does
+    // NOT count as a classifier — `allowOpenWorld` omitted (defaults
+    // false).
+    assertDescriptorShape(listed.tools, { allowOpenWorld: false });
     console.log(
-      'OK   every tool descriptor carries inputSchema with type=object + max-tokens',
-    );
-
-    // 2c. Output-schema conformance (rf2-3l3be). Every descriptor MUST
-    // declare an :outputSchema describing the structuredContent payload
-    // shape. mcp-builder canonical pattern: "Define outputSchema
-    // wherever possible for structured responses."
-    for (const t of listed.tools) {
-      if (!t.outputSchema || typeof t.outputSchema !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " MUST declare :outputSchema (rf2-3l3be); got: " +
-            JSON.stringify(t.outputSchema),
-        );
-      }
-    }
-    console.log(
-      'OK   every tool descriptor carries outputSchema (rf2-3l3be)',
-    );
-
-    // 2d. Tool annotations conformance (rf2-94p8q). Every descriptor
-    // MUST declare an :annotations map advertising the MCP hint slots
-    // (readOnlyHint / destructiveHint / idempotentHint / openWorldHint)
-    // so agent hosts can auto-approve reads + gate destructive ops.
-    for (const t of listed.tools) {
-      if (!t.annotations || typeof t.annotations !== 'object') {
-        throw new Error(
-          'tool ' + t.name + " MUST declare :annotations (rf2-94p8q); got: " +
-            JSON.stringify(t.annotations),
-        );
-      }
-      const a = t.annotations;
-      if (a.readOnlyHint !== true && a.destructiveHint !== true) {
-        throw new Error(
-          'tool ' + t.name + " annotations MUST set at least one of " +
-            "readOnlyHint / destructiveHint; got: " + JSON.stringify(a),
-        );
-      }
-    }
-    console.log(
-      'OK   every tool descriptor carries annotations with a classification hint (rf2-94p8q)',
+      'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
     );
 
     // 3. register-variant — body as an EDN string so JSON's lack of

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -45,5 +45,15 @@
                        day8/re-frame2-test-quiet
                        {:local/root "../../../implementation/test-quiet"}
                        io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                       ;; rf2-80y2h — the canonical `:rf.mcp/diff-from`
+                       ;; encoder so the wire-vocab gate can assert LIVE
+                       ;; emission (the real encoder actually producing
+                       ;; the marker), not only fixture+grep coverage.
+                       ;; The grep pin only checks the literal exists in
+                       ;; `mcp-base/vocab.cljc`; without a live-emission
+                       ;; gate a tool that stopped diff-encoding
+                       ;; `:db-after` would pass every conformance check.
+                       day8/re-frame2-mcp-base
+                       {:local/root "../../mcp-base"}}
          :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -81,6 +81,8 @@
             [clojure.test    :refer [deftest is testing]]
             [malli.core      :as m]
             [malli.error     :as me]
+            [re-frame.mcp-base.diff-encode :as de]
+            [re-frame.mcp-base.overflow :as mcp-overflow]
             [re-frame.mcp-conformance.fixtures :as fx]))
 
 ;; ---------------------------------------------------------------------------
@@ -559,6 +561,118 @@
                            :cap-tokens 5000
                            :hint       "..."}}))
         "re-frame2-pair-shape emit missing :token-count must fail")))
+
+;; ---------------------------------------------------------------------------
+;; LIVE marker emission (rf2-80y2h).
+;;
+;; ## The gap this closes
+;;
+;; Pre-rf2-80y2h, only `:rf.mcp/overflow` had a LIVE emission assertion
+;; (`test/live-re-frame2-pair-overflow.cjs`, gated on a real nREPL +
+;; Playwright, hermetic on CI). Every other marker was pinned by exactly
+;; two layers:
+;;
+;;   1. an authored fixture validated against the canonical schema
+;;      (`every-fixture-conforms-to-its-canonical-schema`); and
+;;   2. a source-text grep that the marker LITERAL appears in
+;;      `mcp-base/vocab.cljc` (`marker-literal-appears-...-emit-source`).
+;;
+;; Neither layer observes the actual ENCODER producing the marker. The
+;; grep checks only that the literal is DECLARED in vocab.cljc — not that
+;; `diff-encode-db-after` still WRITES it into a real epoch. A regression
+;; that made `diff-encode-db-after` pass `:db-after` through unchanged
+;; (or emit a different key) would: leave the vocab literal in place
+;; (grep passes), leave the authored fixture untouched (fixture passes),
+;; and ship a tool that silently stopped diff-encoding. Every gate green.
+;;
+;; ## What this adds
+;;
+;; A live-emission gate for `:rf.mcp/diff-from`: drive the CANONICAL
+;; encoder (`re-frame.mcp-base.diff-encode/diff-encode-db-after`, the
+;; same fn re-frame2-pair-mcp's wire pipeline calls) over a real epoch
+;; and assert the emitted `:db-after` (a) carries the `:rf.mcp/diff-from`
+;; marker key and (b) validates against the canonical `DiffFromBody`
+;; schema pinned above. If the encoder stops emitting the marker — the
+;; exact regression the fixture+grep layers miss — this gate fails.
+;;
+;; ## Per-marker live-vs-fixture policy (Axis 4 of the rf2-80y2h audit)
+;;
+;; Only markers whose EMITTER is JVM-reachable from this pure-JVM gate
+;; get a live-emission assertion:
+;;
+;;   - :rf.mcp/diff-from   — LIVE here. Emitter is mcp-base
+;;                           `diff-encode-db-after` (`.cljc`, on the JVM
+;;                           classpath via the `:test` alias).
+;;   - :rf.mcp/overflow    — LIVE in `live-re-frame2-pair-overflow.cjs`
+;;                           (hermetic CI). Emitter is the re-frame2-pair-mcp
+;;                           CLJS wire boundary; the marker SHAPE builder
+;;                           (`mcp-base/overflow.cljc/overflow-payload`)
+;;                           is additionally exercised live below since
+;;                           it too is JVM-reachable.
+;;   - :rf.mcp/summary     — FIXTURE+grep only. Emitter is re-frame2-pair-mcp
+;;     :rf.mcp/dedup-table   CLJS (`tools/*.cljs`) with no JVM-reachable
+;;     :rf.mcp/cache-hit     counterpart; a pure-JVM live probe is
+;;     :rf.size/large-elided impossible. Their bodies are pure data
+;;                           transforms already unit-tested in mcp-base /
+;;                           re-frame2-pair-mcp; a live SDK probe for each
+;;                           is tracked as future work (it requires the
+;;                           heavyweight nREPL+Playwright orchestrator the
+;;                           overflow path uses).
+;; ---------------------------------------------------------------------------
+
+(deftest diff-from-marker-emitted-live-by-canonical-encoder
+  ;; The load-bearing live-emission gate. Drive the real encoder and
+  ;; assert the marker is actually written — not just declared in vocab.
+  (let [epoch    {:db-before {:cart {:items [{:sku "abc"}]}
+                              :checkout {:state :idle}
+                              :tmp 42}
+                  :db-after  {:cart {:items [{:sku "abc"} {:sku "xyz"}]}
+                              :checkout {:state :review}}
+                  :event     [:cart/add-item {:sku "xyz"}]}
+        encoded  (de/diff-encode-db-after epoch)
+        db-after (:db-after encoded)]
+    (testing "the encoder writes the :rf.mcp/diff-from marker"
+      (is (= :db-before (get db-after :rf.mcp/diff-from))
+          (str "diff-encode-db-after MUST emit the :rf.mcp/diff-from "
+               "marker. If this fails, the encoder stopped diff-encoding "
+               ":db-after — the regression the fixture+grep gates miss. "
+               "Got :db-after = " (pr-str db-after))))
+    (testing "the emitted body validates against the canonical DiffFromBody schema"
+      (is (m/validate DiffFromBody db-after)
+          (str "Live-emitted :db-after failed DiffFromBody validation:\n"
+               (me/humanize (m/explain DiffFromBody db-after)))))
+    (testing "the emitted marker decodes back to the original :db-after"
+      (is (= epoch (de/decode-db-after encoded))
+          "live encode → decode round-trips the epoch"))))
+
+(deftest diff-from-marker-absent-when-encoder-disabled
+  ;; The contrapositive: `:full` mode passes :db-after through unchanged,
+  ;; so the marker MUST be absent. This pins that the marker's presence
+  ;; is genuinely tied to the encoder running — proving the live test
+  ;; above isn't accidentally green because something else writes the key.
+  (let [epoch  {:db-before {:a 1} :db-after {:a 2}}
+        passed (first (de/diff-encode-epochs [epoch] :full))]
+    (is (not (contains? (:db-after passed) :rf.mcp/diff-from))
+        ":full mode must NOT carry the diff-from marker")
+    (is (= {:a 2} (:db-after passed))
+        ":full mode passes :db-after through verbatim")))
+
+(deftest overflow-marker-shape-emitted-live-by-canonical-builder
+  ;; `:rf.mcp/overflow`'s wire emission is live-tested in
+  ;; `live-re-frame2-pair-overflow.cjs`, but its SHAPE builder
+  ;; (`mcp-base/overflow.cljc/overflow-payload`) is also JVM-reachable.
+  ;; Drive it directly and assert the built marker validates against the
+  ;; canonical Overflow schema — a live counterpart to the authored
+  ;; overflow fixtures, catching a builder change that drifts the body
+  ;; shape without touching the fixtures.
+  (let [marker (mcp-overflow/overflow-payload
+                 {:tool "snapshot" :token-count 6250 :cap 5000
+                  :hint "Narrow the scope."})]
+    (is (= :rf.mcp/overflow (first (keys marker)))
+        "builder emits the canonical top-level :rf.mcp/overflow key")
+    (is (m/validate Overflow marker)
+        (str "Live-built overflow marker failed Overflow validation:\n"
+             (me/humanize (m/explain Overflow marker))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-text vocabulary pin. The literal marker key MUST appear in


### PR DESCRIPTION
## Summary

Closes the narrow coverage gaps in the MCP-infra slice (`tools/mcp-base` + `tools/mcp-conformance`) identified by the rf2-80y2h audit (`ai/findings/2026-05-21-testcov-mcp-infra.md`).

- **cap char-gate (gap 1)** — the secondary char-byte gate in `apply-cap` was a silently-dead inline branch (the test set documented it un-trippable and never executed it). It is **genuinely un-trippable** through `apply-cap` + a custom `ResultIO`: `apply-cap` derives BOTH the token and char sums from the same `content-texts` strings inline, so an IO cannot return chars without proportional tokens. Extracted the decision into pure `over-cap?` / `reported-count` predicates over already-summed tokens/chars — both disjuncts and the reported-count selector are now trippable and tested in isolation, with the structural domination documented in source as intentional defence-in-depth against a future token-rule refinement.
- **mcp-base CLJS test target (gap 2)** — mcp-base is a `.cljc` library both servers consume in CLJS but had a JVM-only suite. Added a shadow-cljs `:node-test` build (the `:cljs-test` alias deliberately omits Malli so the soft-pass branch actually runs) covering the `goog-define` `validate-patches?` default, the `:cljs` `resolve-malli-validate` arm, and the soft-pass-when-Malli-absent no-op. Wired into the `jvm-tools-mcp-base` CI job (Node setup + `npm run test:cljs`).
- **decode-gate negative test (gap 3)** — added the symmetric decode-side negative for `decode-db-after`'s `validate-sections!` gate.
- **live-emission matrix (gap 4)** — added a live-emission gate driving the canonical mcp-base encoder so a tool that stopped diff-encoding `:db-after` fails (fixture+grep layers miss it), plus a live overflow-builder shape gate, and documented the per-marker live-vs-fixture policy (the other 4 markers emit from CLJS-only sites with no JVM-reachable counterpart).
- **descriptor-shape dedup** — extracted the four near-identical descriptor-shape loops duplicated across `end-to-end-{re-frame2-pair,story}.cjs` into a shared `_runner.cjs` `assertDescriptorShape(tools, {allowOpenWorld})` helper.

### cap char-gate decision

**Genuinely un-trippable** under the current architecture, not just the current rule. `apply-cap` computes `tokens` and `chars` from the same `content-texts` seq inline, so no `ResultIO` can decouple them; for any string of length L, `chars > cap*8` implies `tokens = (quot L 4) > 2*cap > cap`, so the primary token gate always trips first. Rather than leave a dead inline arm, the gate is extracted into named pure predicates so both disjuncts and the `reported` selector are directly exercised — guarding a future `token-estimate` refinement (e.g. base64/CJK at lower per-char cost) that decouples the sums.

## Test plan

- [x] `clojure -M:test` from `tools/mcp-base` — 136 tests / 342 assertions, 0 failures
- [x] `clojure -M:test` from `tools/mcp-conformance/wire-vocab` — 41 tests / 475 assertions, 0 failures
- [x] `npm run test:cljs` from `tools/mcp-base` (new build) — 5 tests / 18 assertions, 0 failures, 0 warnings
- [x] `node test/end-to-end-re-frame2-pair.cjs` — GREEN (shared `assertDescriptorShape`, `allowOpenWorld: true`)
- [x] `node test/end-to-end-story.cjs` — GREEN (shared `assertDescriptorShape`, `allowOpenWorld: false`)