### PR TITLE
test(routing): CLJS malformed-% smoke + query-emit + splat-encode margins (rf2-idvz9)

### DIFF
--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -446,6 +446,47 @@
       (is (= 2 @fired?)
           "removeEventListener stopped further deliveries"))))
 
+;; ---- malformed-% fail-closed (CLJS decode path) --------------------------
+;;
+;; Per Spec 012 §Routing failure semantics §Malformed percent-encoding
+;; (rf2-wbvme + rf2-4ic0f). The JVM suite pins the fail-closed contract
+;; against `URLDecoder/decode` (routing_test.clj:781-808). The CLJS
+;; runtime decodes via `js/decodeURIComponent`, which throws on a
+;; DIFFERENT set of malformed inputs than the JVM decoder — so the
+;; security-critical fail-closed path (hostile / broken URLs → route-miss,
+;; never a runtime crash) needs a smoke on the runtime that actually
+;; ships to browsers. `safe-url-decode` must swallow `js/decodeURIComponent`'s
+;; throw and `match-url` must return nil, exactly as on the JVM.
+(deftest match-url-malformed-percent-fails-closed-cljs
+  (testing "rf2-4ic0f: malformed %-encoding fails closed on the CLJS
+            decodeURIComponent path — match-url returns nil, never throws"
+    (register-routes!)
+    (rf/reg-route :hist/search {:path "/search"})
+    ;; Path segment — bare `%`, incomplete pair, non-hex pair.
+    (is (nil? (routing/match-url "/articles/%"))
+        "bare `%` in path → route-miss (no decodeURIComponent throw escapes)")
+    (is (nil? (routing/match-url "/articles/x%a"))
+        "incomplete %-pair in path → route-miss")
+    (is (nil? (routing/match-url "/articles/x%XX"))
+        "non-hex %-pair in path → route-miss")
+    ;; Query value + key — whole URL fails closed (no partial slice).
+    (is (nil? (routing/match-url "/search?x=%"))
+        "malformed query VALUE → whole URL is a route-miss")
+    (is (nil? (routing/match-url "/search?%=v"))
+        "malformed query KEY → whole URL is a route-miss")
+    ;; Fragment.
+    (is (nil? (routing/match-url "/search#%"))
+        "malformed `#fragment` → route-miss")
+    ;; No registered route: even a bare `%` URL must not throw.
+    (is (nil? (routing/match-url "/%"))
+        "bare `%` with no matching route → route-miss, not an exception"))
+  (testing "well-formed %-encoding still decodes on the CLJS path"
+    (register-routes!)
+    (let [m (routing/match-url "/articles/hello%20world")]
+      (is (some? m) "well-formed %-encoded path segment matches")
+      (is (= "hello world" (get-in m [:params :id]))
+          "decodeURIComponent decodes the well-formed segment into the slice"))))
+
 ;; =========================================================================
 ;; 4. replaceState — no new history entry
 ;; =========================================================================

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -940,6 +940,42 @@
            (routing/route-url :route/docs4 {:page "routing"}))
         "2-arity → no query, no fragment")))
 
+;; ---- route-url query-string emission -------------------------------------
+;;
+;; Per Spec 012 §Bidirectional URL ↔ params. The qs builder
+;; (routing.cljc:725-731) joins `(name k)=url-encode(v)` pairs with `&`.
+;; Coverage elsewhere only hits the single-pair `{:lang "en"}` case
+;; (route-url-4-arity-appends-fragment:918), which can't observe pair
+;; ORDERING or query-VALUE percent-encoding. These are the two behaviours
+;; the multi-pair `&`-join + per-value `url-encode` exist for.
+(deftest route-url-query-string-emission
+  (testing "multi-pair query: pairs joined with `&` in insertion order"
+    (rf/reg-route :route/list {:path "/list"})
+    (is (= "/list?a=1&b=2"
+           (routing/route-url :route/list {} (array-map :a "1" :b "2")))
+        "two query pairs join with `&`, preserving insertion order")
+    (is (= "/list?x=1&y=2&z=3"
+           (routing/route-url :route/list {} (array-map :x "1" :y "2" :z "3")))
+        "three query pairs join with `&` in insertion order"))
+
+  (testing "query VALUES are percent-encoded (encodeURIComponent semantics)"
+    (rf/reg-route :route/search {:path "/search"})
+    (is (= "/search?q=x%20y"
+           (routing/route-url :route/search {} {:q "x y"}))
+        "a space in a query value encodes to %20 (not '+')")
+    (is (= "/search?a=1&b=x%20y"
+           (routing/route-url :route/search {} (array-map :a "1" :b "x y")))
+        "multi-pair ordering AND value %-encoding together")
+    (is (= "/search?filter=a%26b%3Dc"
+           (routing/route-url :route/search {} {:filter "a&b=c"}))
+        "`&` and `=` in a value are encoded so they cannot inject extra pairs"))
+
+  (testing "query KEYS are percent-encoded too"
+    (rf/reg-route :route/k {:path "/k"})
+    (is (= "/k?a%20b=v"
+           (routing/route-url :route/k {} {(keyword "a b") "v"}))
+        "a space in a query key encodes to %20")))
+
 (deftest match-url-route-url-round-trip-with-fragment
   (testing "URL → match-url → route-url 4-arity → URL recovers the original
             (the full bidirectional contract including #fragment). rf2-5ifai:
@@ -2013,6 +2049,35 @@
       (let [built (routing/route-url :route/files {:rest "a/b/c"})]
         (is (= "/files/a/b/c" built)
             "route-url emits the splat segments preserving '/'")))))
+
+;; ---- url-encode-splat per-segment encoding -------------------------------
+;;
+;; Per Spec 012 §Bidirectional URL ↔ params §Splat. `url-encode-splat`
+;; (url.cljc:27-31) splits on `/`, encodes EACH segment with
+;; encodeURIComponent semantics, and re-joins with literal `/`. The
+;; ASCII-safe round-trip ("a/b/c") above can't observe the encode step
+;; at all — it only proves `/` is preserved. This pins the actual reason
+;; the per-segment join exists: a segment that needs encoding is encoded,
+;; while the `/` separators between segments stay literal (NOT %2F).
+(deftest splat-segment-percent-encoding
+  (testing "a splat segment needing encoding is encoded; literal '/' is preserved"
+    (rf/reg-route :route/files {:path "/files/*rest"})
+    (is (= "/files/a/b%20c"
+           (routing/route-url :route/files {:rest "a/b c"}))
+        "the space inside a segment encodes to %20; the segment '/' stays literal")
+    (is (= "/files/a%20b/c%20d"
+           (routing/route-url :route/files {:rest "a b/c d"}))
+        "every segment is encoded individually; both '/' separators stay literal")
+    (is (= "/files/x%26y/z"
+           (routing/route-url :route/files {:rest "x&y/z"}))
+        "an `&` inside a segment is encoded so it cannot leak into a query"))
+
+  (testing "splat encode round-trips back through match-url (decode is the inverse)"
+    (rf/reg-route :route/files2 {:path "/files/*rest"})
+    (let [built (routing/route-url :route/files2 {:rest "a/b c"})]
+      (is (= "/files/a/b%20c" built))
+      (is (= "a/b c" (get-in (routing/match-url built) [:params :rest]))
+          "match-url decodes each segment back, recovering the original splat value"))))
 
 ;; ---- T6: :on-match dispatches AND :transition :loading observable ----
 


### PR DESCRIPTION
## Summary

Closes routing test-coverage margin gaps from the 2026-05-21 audit (`ai/findings/2026-05-21-testcov-routing.md`, bead rf2-idvz9). Verify-vs-source margins only; no source changes.

- **CLJS malformed-% fail-closed smoke** (`routing_history_cljs_test.cljs`). The fail-closed contract (rf2-wbvme + rf2-4ic0f) was JVM-only. JVM `URLDecoder/decode` and CLJS `decodeURIComponent` throw on *different* malformed inputs, so the security-critical browser-runtime path was untested. New `match-url-malformed-percent-fails-closed-cljs` covers path / query-value / query-key / fragment / no-route, plus a well-formed control.
- **`route-url` query-string emission** (`routing_test.clj`). Previously only single-pair `{:lang "en"}` was hit incidentally. New `route-url-query-string-emission` pins multi-pair `&`-join ordering and key+value `%`-encoding (space → `%20`, `&`/`=` escaped so they can't inject pairs).
- **`url-encode-splat` per-segment encoding** (`routing_test.clj`). The ASCII-safe round-trip only proved `/` preservation. New `splat-segment-percent-encoding` pins encode-while-preserving-`/` with a non-ASCII-safe splat plus a `match-url` decode round-trip.

### Skipped (per audit guidance)
- Ranking rules 1/2/3/5 slice mirror — already conformance-locked cross-host (JVM+CLJS) in `route-ranking-precedence.edn`; not a real hole.
- Fragment-only de-dup — the JVM `:transitioned` payload test carries a unique `prev->next` two-hop `:prev-fragment`/`:next-fragment` assertion not covered by the CLJS single-hop test; folding would net-delete coverage, so kept.

## Test plan

- [x] routing JVM: `clojure -M:test` from `implementation/routing` — 113 tests, 514 assertions, 0 failures/0 errors (was 111 / 503).
- [x] `npm run test:cljs` from `implementation/` — 4121 tests, 12474 assertions, 0 failures/0 errors.