### PR TITLE
docs(impl): reconcile stale :spec→:schema in reference-impl docstrings (rf2-y0whf)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -399,15 +399,15 @@
           (rf/reg-cofx cofx-id (assoc meta :handler-fn handler) handler))))
     (doseq [[id steps] (get handlers-map :event)]
       (let [[kind handler] (conformance/realise-event-handler steps)
-            ;; Per Spec 010 §step 1 (rf2-jwm4): pull :spec / :doc from
+            ;; Per Spec 010 §step 1 (rf2-jwm4): pull :schema / :doc from
             ;; the fixture's :fixture/registry :event meta and pass it
             ;; through to reg-event-* so validate-event! can find it.
             event-meta (get event-registry id {})
             ;; Per rf2-g25p: scan the body for [:cofx-key K] references;
             ;; for each K, auto-wire (inject-cofx C) for every C whose
             ;; namespace matches K (the conformance-corpus convention
-            ;; for the schemas/cofx fixture). With no :spec to flag,
-            ;; non-spec'd cofx still wire so the handler can read them.
+            ;; for the schemas/cofx fixture). With no :schema to flag,
+            ;; non-schema'd cofx still wire so the handler can read them.
             ks            (collect-cofx-keys steps)
             cofx-ids      (vec
                             (mapcat (fn [k]
@@ -428,7 +428,7 @@
                   (rf/reg-event-fx id handler))))))
     (doseq [[id steps] (get handlers-map :sub)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)
-            ;; Per Spec 010 §step 6 (rf2-wcam): pull :spec from the
+            ;; Per Spec 010 §step 6 (rf2-wcam): pull :schema from the
             ;; sub's registry meta so validate-sub! sees it.
             sub-meta (get sub-registry id {})]
         (case kind
@@ -449,7 +449,7 @@
     ;; app-db, or :dispatch a follow-up event (e.g. http stubs).
     ;;
     ;; Two sources combine: :fixture/handlers :fx (bodies) and
-    ;; :fixture/registry :fx (metadata, including :platforms / :spec).
+    ;; :fixture/registry :fx (metadata, including :platforms / :schema).
     ;;
     ;; Per rf2-yhfgf: an id with NO body in :fixture/handlers but a meta
     ;; in :fixture/registry is "declare the dependency, leave the framework

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -168,7 +168,7 @@
   all belong to one frame.
 
   Required keys on the flow map: :id :inputs :output :path.
-  Optional: :doc :spec.
+  Optional: :doc :schema.
 
   The frame to register against comes from the optional :frame opt;
   default is (frame/current-frame) — usually :rf/default unless

--- a/implementation/http/src/re_frame/http_middleware.cljc
+++ b/implementation/http/src/re_frame/http_middleware.cljc
@@ -35,7 +35,7 @@
 (defonce
   ^{:doc "frame-id → vector of `:rf/http-interceptor-meta` slots — each a map
   carrying `:id`, `:before`, and the captured registration-metadata
-  (`:doc`, `:spec`, `:tags`, `:sensitive?`, flat source-coord keys
+  (`:doc`, `:schema`, `:tags`, `:sensitive?`, flat source-coord keys
   `:ns`/`:line`/`:column`/`:file`). Per-frame so each frame's HTTP
   middleware chain is isolated. Order is registration-order; clearing an
   id and re-registering re-appends to the end."}

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -61,7 +61,7 @@
   (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:advanced`
             + `goog.DEBUG=false` the boundary interceptor takes its
             production validation branch. A malformed event against the
-            handler's `:spec` causes `:rf/skip-handler?` to be set on
+            handler's `:schema` causes `:rf/skip-handler?` to be set on
             the context, and the handler is NOT invoked.
 
             Under the same gate, the router's step-1 `validate-event!`
@@ -80,7 +80,7 @@
 (deftest boundary-passes-valid-event-through-in-prod
   (testing "Per Spec 010 §Production builds (rf2-r2uh): under `:advanced`
             + `goog.DEBUG=false` a valid event against the handler's
-            `:spec` flows through the boundary interceptor unchanged.
+            `:schema` flows through the boundary interceptor unchanged.
             The handler runs exactly once."
     (let [calls (atom 0)]
       (rf/reg-event-fx :api/strict

--- a/implementation/schemas/test/re_frame/schemas_conformance_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_conformance_test.clj
@@ -263,7 +263,7 @@
                           (assoc acc k (mapv first pairs)))
                         {}))]
     ;; ---- cofx ----------------------------------------------------------
-    ;; Per Spec 010 §step 2 (rf2-7leq): cofx registrations carry :spec
+    ;; Per Spec 010 §step 2 (rf2-7leq): cofx registrations carry :schema
     ;; metadata; the runtime calls `:schemas/validate-cofx!` after
     ;; injection. We register both bodies AND any registry-only entries.
     (let [all-cofx-ids (into #{} (concat (keys cofx-bodies) (keys cofx-registry)))]
@@ -273,7 +273,7 @@
               handler (realise-cofx-handler cofx-id body)]
           (rf/reg-cofx cofx-id (assoc meta :handler-fn handler) handler))))
     ;; ---- events --------------------------------------------------------
-    ;; Per Spec 010 §step 1 (rf2-jwm4): event meta carries :spec; the
+    ;; Per Spec 010 §step 1 (rf2-jwm4): event meta carries :schema; the
     ;; runtime calls `:schemas/validate-event!` before the handler runs.
     ;; Per rf2-g25p: scan the body for [:cofx-key K]; for each K,
     ;; auto-wire (inject-cofx C) for every C whose namespace matches K.
@@ -298,7 +298,7 @@
                   (rf/reg-event-fx id interceptors handler)
                   (rf/reg-event-fx id handler))))))
     ;; ---- subs ----------------------------------------------------------
-    ;; Per Spec 010 §step 6 (rf2-wcam): sub meta carries :spec; the
+    ;; Per Spec 010 §step 6 (rf2-wcam): sub meta carries :schema; the
     ;; runtime calls `:schemas/validate-sub!` after each compute.
     (doseq [[id steps] (:sub hmap)]
       (let [{:keys [kind inputs body]} (conformance/realise-sub steps)

--- a/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_sensitive_test.clj
@@ -317,7 +317,7 @@
             "structural :cofx-id survives")))))
 
 (deftest cofx-validation-redacts-when-schema-container-sensitive
-  (testing "A container-level :sensitive? on the cofx :spec also triggers
+  (testing "A container-level :sensitive? on the cofx :schema also triggers
             redaction even when the cofx-meta doesn't carry the flag"
     (rf/reg-cofx :secret-blob
       {:schema [:string {:sensitive? true}]}

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -304,7 +304,7 @@
 
 (deftest sub-return-validation-fires-and-replaces-with-default
   (testing "Per Spec 010 §step 6 (rf2-wcam): a sub whose return value fails
-            its :spec emits :rf.error/schema-validation-failure :where :sub-return
+            its :schema emits :rf.error/schema-validation-failure :where :sub-return
             and the caller sees nil (default :replaced-with-default recovery)"
     (rf/reg-event-db :items/init (fn [_ _] {:items ["a" "b" "c"]}))
     (rf/reg-event-db :items/break (fn [db _] (assoc db :items [1 2 3])))
@@ -332,7 +332,7 @@
           (is (= :replaced-with-default (:recovery v))))))))
 
 (deftest compute-sub-validates-return-value
-  (testing "compute-sub validates the return against :spec — the pure
+  (testing "compute-sub validates the return against :schema — the pure
             test-time path mirrors the live reactive path"
     (rf/reg-sub :nums
       {:schema [:vector :int]}
@@ -353,7 +353,7 @@
 
 (deftest cofx-validation-fires-and-skips-handler
   (testing "Per Spec 010 §step 2 (rf2-7leq): a cofx whose injected value
-            fails its :spec emits :rf.error/schema-validation-failure
+            fails its :schema emits :rf.error/schema-validation-failure
             :where :cofx and the handler is NOT invoked"
     (rf/reg-cofx :app-version/bad
       {:schema :string}
@@ -370,7 +370,7 @@
         (rf/dispatch-sync [:cap/seed])
         (rf/unregister-listener! ::cf)
         (is (= 0 @calls)
-            "handler was skipped because the cofx :spec failed")
+            "handler was skipped because the cofx :schema failed")
         (let [violations (filter #(= :rf.error/schema-validation-failure
                                      (:operation %))
                                  @traces)]
@@ -408,7 +408,7 @@
 ;; ---- rf2-xp2o3 — fx-args validation (Spec 010 step 5) --------------------
 
 (deftest fx-args-validation-fires-and-skips-only-the-offending-fx
-  (testing "Per Spec 010 §step 5 (rf2-xp2o3): an fx whose args fail its :spec
+  (testing "Per Spec 010 §step 5 (rf2-xp2o3): an fx whose args fail its :schema
             emits :rf.error/schema-validation-failure :where :fx-args; the
             offending fx is skipped, sibling fx in the same :fx vector
             continue to run (recovery: :skipped)"
@@ -504,7 +504,7 @@
       (is (false? (schemas/validate-fx! :my/fx :ev/origin {:x "bad"} {:schema [:map [:x :int]]}))
           "malformed args fail")
       (is (true? (schemas/validate-fx! :my/fx :ev/origin {:x 1} {}))
-          "no :spec → soft pass")
+          "no :schema → soft pass")
       (rf/unregister-listener! ::fxv4)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
@@ -1265,7 +1265,7 @@
 
 (deftest boundary-interceptor-passes-valid-event-through
   (testing "Per Spec 010 §Production builds (rf2-r2uh) — a valid event
-            against the handler's :spec passes through, the handler runs."
+            against the handler's :schema passes through, the handler runs."
     (let [calls (atom 0)]
       (rf/reg-event-fx :api/response
         {:schema [:cat [:= :api/response]
@@ -1293,7 +1293,7 @@
 
 (deftest boundary-interceptor-skips-handler-on-invalid-event
   (testing "Per Spec 010 §Production builds (rf2-r2uh) — an invalid event
-            against the handler's :spec causes the handler to be
+            against the handler's :schema causes the handler to be
             skipped. Under genuine `:advanced` + `goog.DEBUG=false` the
             router's step-1 validate-event! body elides and the
             boundary path is the only validation site; on the JVM

--- a/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
@@ -4,7 +4,7 @@
   `reg-app-schemas` when the registered schema is NOT a Malli vector
   form (rf2-jsokn / rf2-ycqtv finding #12).
 
-  Background — Spec 010 §The `:spec` value is opaque to re-frame: the
+  Background — Spec 010 §The `:schema` value is opaque to re-frame: the
   schemas-walker (`re-frame.schemas.walker`) is pure data and handles
   only vector-form Malli EDN. Compiled `m/schema` values and registry
   refs (`:my/user-schema`) are treated as opaque leaves; per-slot


### PR DESCRIPTION
## Summary

Follow-up to rf2-aa2wq (PR #1874, which fixed the spec tree). The v1 registration-metadata key `:spec` was renamed to the canonical `:schema` (rf2-ieu0i); the implementation reads `:schema`. Several reference-impl docstrings and test-file prose still described the metadata key as `:spec`. This reconciles the prose. **Doc-comment only — no behaviour change.**

Reconciled (registration-metadata-key sense only):
- `implementation/flows/src/re_frame/flows/registry.cljc` — `reg-flow` docstring (`Optional: :doc :schema`)
- `implementation/http/src/re_frame/http_middleware.cljc` — `interceptors` docstring (captured registration-metadata key list)
- `implementation/schemas/test/re_frame/schemas_test.clj` — 8 `testing`-string / assertion-message references
- `implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs` — 2 `testing`-string references
- `implementation/schemas/test/re_frame/schemas_conformance_test.clj` — 3 comment references
- `implementation/schemas/test/re_frame/schemas_sensitive_test.clj` — 1 `testing`-string reference
- `implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj` — 1 ns-docstring reference
- `implementation/core/test/re_frame/conformance_test.clj` — 4 comment references

Intentionally left intact (out of scope per the bead):
- The machine `:spec` map-key (transition / spawn / join lifecycle-fx)
- `:spec-version` keys
- The Reagent component `:spec` (reagent-slim)
- Deliberate historical references to the v1 name and the renamed `:spec/at-boundary` interceptor-id (`schemas_test.clj:1684`, `core/src/re_frame/spec.cljc:114`, `schemas_boundary_prod_test.cljs:3`)

## Test plan

- [x] `implementation/flows` `clojure -M:test` — 97 tests / 410 assertions, 0 failures
- [x] `implementation/http` `clojure -M:test` — 259 tests / 1369 assertions, 0 failures
- [x] `implementation/` `npm run test:cljs` — 4120 tests / 12465 assertions, 0 failures