### PR TITLE
feat(machines-viz): wire xyflow MachineChart :density prop to single-source visual-constants (rf2-k647w)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -55,7 +55,8 @@
              :as overlay-spawn-all]
             [day8.re-frame2-machines-viz.chart.overlays.cancellation-cascade
              :as overlay-cascade]
-            [day8.re-frame2-machines-viz.theme.tokens :as tokens]))
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- xyflow React-class adapters ----------------------------------------
 
@@ -235,6 +236,19 @@
     :read-only?        — when true all `:on-*` callbacks are no-op'd.
                          The viewer page sets this.
     :direction         — `:tb` (top-to-bottom, default) or `:lr`.
+    :density           — rf2-k647w. `:compact` / `:regular` (default) /
+                         `:cosy`. Resolves the geometry + typography
+                         map via `visual-constants/chart-for-density`;
+                         the resolved map is threaded through the
+                         projector onto every node/edge `:data` so the
+                         xyflow node/edge components render at the
+                         chosen density. The chart root surfaces the
+                         resolved density as `data-density`. nil ≡
+                         `:regular` (pixel-identical to the historical
+                         render). An unknown density throws at render
+                         time (per `spec/API.md` §Density resolution
+                         rules) — picking outside the closed set is a
+                         programmer error, not a runtime fallback.
     :layout-options    — host-side elk.js `layoutOptions` overrides
                          merged on top of `default-elk-options`.
     :height            — outer wrapper height (CSS string; default
@@ -295,7 +309,7 @@
         layout-key    (r/atom nil)]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
                  sim? on-state-click read-only?
-                 direction layout-options
+                 direction layout-options density
                  height show-minimap? show-controls? show-background?
                  after-ring-specs after-ring-tick
                  on-after-ring-hover on-after-ring-leave
@@ -358,7 +372,16 @@
            "Machine has no states to render."]
 
           :else
-          (let [highlight-id      (layout/highlight-id current-state)
+          ;; rf2-k647w — resolve the `:density` prop ONCE per render to
+          ;; its visual-constants map. `chart-for-density` throws on an
+          ;; unknown density (per spec/API.md §Density), maps nil →
+          ;; regular, and returns the closed-set map otherwise. The
+          ;; resolved map threads through the projector onto every
+          ;; node/edge `:data`; the resolved density name surfaces on
+          ;; the root as `data-density`.
+          (let [chart-vc          (vc/chart-for-density density)
+                density-name      (name (or density :regular))
+                highlight-id      (layout/highlight-id current-state)
                 from-highlight-id (layout/highlight-id from-highlight)
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
@@ -369,7 +392,8 @@
                                :from-highlight-id from-highlight-id
                                :to-highlight-id   to-highlight-id
                                :sim?              sim?
-                               :on-state-click    callback})
+                               :on-state-click    callback
+                               :chart             chart-vc})
                 aria-label (str "State machine"
                                 (when machine-id
                                   (str ": " (name machine-id)))
@@ -386,6 +410,11 @@
                    :data-node-count (str n-states)
                    :data-region-count (str n-regions)
                    :data-edge-count (str n-trans)
+                   ;; rf2-k647w — the resolved density surfaces here so
+                   ;; hosts + tests read the active density without
+                   ;; re-reading the bound prop (per spec/API.md
+                   ;; §Density resolution rules).
+                   :data-density density-name
                    :data-highlight-id (or highlight-id "")
                    :data-from-highlight-id (or from-highlight-id "")
                    :data-to-highlight-id (or to-highlight-id "")
@@ -417,9 +446,13 @@
                :maxZoom             4.0
                :proOptions          #js {:hideAttribution true}}
               (when show-background?
+                ;; rf2-k647w — dot-grid spacing + radius track the
+                ;; resolved density (`:dot-grid-spacing-px` /
+                ;; `:dot-grid-radius-px`); regular = 16 / 1.0, the
+                ;; historical hardcoded pair.
                 [:> Background {:variant (.-Dots BackgroundVariant)
-                                :gap 16
-                                :size 1
+                                :gap (:dot-grid-spacing-px chart-vc)
+                                :size (:dot-grid-radius-px chart-vc)
                                 :color (tokens/with-alpha :accent-violet 0.4)}])
               (when show-controls?
                 [:> Controls {:showZoom true

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -43,13 +43,30 @@
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
-             :refer [mono-stack]]))
+             :refer [mono-stack]]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 (def ^:private get-bezier-path (.-getBezierPath xyflow))
 (def ^:private BaseEdge        (.-BaseEdge xyflow))
 (def ^:private EdgeLabelRenderer (.-EdgeLabelRenderer xyflow))
 
 ;; ---- helpers ------------------------------------------------------------
+;;
+;; rf2-k647w — edge typography (label font-size + backplate opacity)
+;; reads off the resolved density's `visual-constants` map, threaded
+;; onto the edge `:data` by the projector. xyflow `clj->js`-es the edge
+;; array, so `chart-constants` recovers the kebab-keyword CLJS map and
+;; falls back to `vc/chart-regular` when absent.
+
+(defn- chart-constants
+  "Recover the resolved visual-constants map off an edge's `:data`
+  (`(.-chart d)`); `vc/chart-regular` when absent so the regular
+  density stays pixel-identical to the pre-rf2-k647w hardcoded values."
+  [^js d]
+  (let [c (.-chart d)]
+    (if (some? c)
+      (js->clj c :keywordize-keys true)
+      vc/chart-regular)))
 
 (defn- edge-stroke
   [{:keys [active? focused?]}]
@@ -59,11 +76,17 @@
     :else    (:border-default tokens/tokens)))
 
 (defn- edge-stroke-width
-  [{:keys [active? focused?]}]
-  (cond
-    focused? 2.5
-    active?  2.0
-    :else    1.5))
+  "rf2-k647w — edge stroke widths read off the resolved density. The
+  active stroke sits midway between default + emphasis; the focused
+  stroke is the emphasis width (preserving the shipped regular
+  relationship 1.5 / 2.0 / 2.5)."
+  [{:keys [active? focused? chart]
+    :or   {chart vc/chart-regular}}]
+  (let [{:keys [stroke-width stroke-width-emphasis]} chart]
+    (cond
+      focused? stroke-width-emphasis
+      active?  (/ (+ stroke-width stroke-width-emphasis) 2.0)
+      :else    stroke-width)))
 
 ;; ---- transition-edge ----------------------------------------------------
 
@@ -81,10 +104,12 @@
         tgt-pos    (.-targetPosition props)
         marker-end (.-markerEnd props)
         d          (.-data props)
+        vc         (chart-constants d)
         label      (or (.-eventLabel d) "")
         active?    (boolean (.-active d))
         focused?   (boolean (.-focused d))
         after-ms   (.-afterMs d)
+        {:keys [edge-label-px edge-label-backplate-opacity]} vc
         ;; xyflow's getBezierPath returns [path-string label-x label-y
         ;; offset-x offset-y]. Use a JS-side destructure via aget.
         bz (get-bezier-path
@@ -98,7 +123,7 @@
         label-x (aget bz 1)
         label-y (aget bz 2)
         stroke  (edge-stroke {:active? active? :focused? focused?})
-        stroke-w (edge-stroke-width {:active? active? :focused? focused?})]
+        stroke-w (edge-stroke-width {:active? active? :focused? focused? :chart vc})]
     (r/as-element
       [:<>
        [:> BaseEdge {:id (.-id props)
@@ -119,10 +144,10 @@
                                             label-x "px," label-y "px)")
                        :pointer-events "auto"
                        :font-family    mono-stack
-                       :font-size      "11px"
+                       :font-size      (str edge-label-px "px")
                        :font-weight    400
                        :color          (:bg-0 tokens/tokens)
-                       :background     (tokens/with-alpha :white 0.85)
+                       :background     (tokens/with-alpha :white edge-label-backplate-opacity)
                        :padding        "1px 5px"
                        :border-radius  "3px"
                        :border         (str "1px solid " (tokens/with-alpha :border-subtle 0.4))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -45,7 +45,30 @@
              :as parallel-region-node]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
-             :refer [mono-stack sans-stack]]))
+             :refer [mono-stack sans-stack]]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
+
+;; ---- density-resolved constants -----------------------------------------
+;;
+;; rf2-k647w — the renderer no longer hardcodes geometry/typography. The
+;; projector threads the resolved density's `visual-constants` map onto
+;; every node payload as `:data {:chart {...}}`; xyflow `clj->js`-es the
+;; node array, so the map arrives as a JS object. `chart-constants`
+;; recovers a kebab-keyword CLJS map (the keys `visual-constants` ships),
+;; falling back to `vc/chart-regular` so a node payload without a `:chart`
+;; entry (legacy / direct construction) still renders the regular default.
+
+(defn- chart-constants
+  "Recover the resolved visual-constants map off a node's `:data`
+  (`(.-chart d)`). The projector emits a CLJS map; xyflow `clj->js`-es
+  it into a JS object, so we `js->clj` it back with keyword keys.
+  Returns `vc/chart-regular` when absent so the regular density stays
+  pixel-identical to the pre-rf2-k647w hardcoded numbers."
+  [^js d]
+  (let [c (.-chart d)]
+    (if (some? c)
+      (js->clj c :keywordize-keys true)
+      vc/chart-regular)))
 
 ;; ---- xyflow Handle adapter ----------------------------------------------
 
@@ -105,8 +128,11 @@
     :else           (:border-default tokens/tokens)))
 
 (defn- tag-pill
-  "Render a single state-tag pill. Hiccup."
-  [tag]
+  "Render a single state-tag pill. Hiccup. rf2-k647w — geometry +
+  typography read off the resolved density `vc` map (height / pad-x /
+  px / radius / gap) instead of hardcoded literals."
+  [tag {:keys [tag-pill-height tag-pill-pad-x tag-pill-px
+               tag-pill-radius tag-pill-gap]}]
   (let [label   (if (keyword? tag) (name tag) (str tag))
         token-k (tokens/tag-pill-color tag)
         fill    (tokens/with-alpha token-k 0.18)
@@ -117,14 +143,14 @@
             :data-tag    label
             :style {:display          "inline-flex"
                     :align-items      "center"
-                    :height           "16px"
-                    :padding          "0 6px"
-                    :margin-right     "3px"
+                    :height           (str tag-pill-height "px")
+                    :padding          (str "0 " tag-pill-pad-x "px")
+                    :margin-right     (str tag-pill-gap "px")
                     :background       fill
                     :border           (str "1px solid " stroke)
-                    :border-radius    "8px"
+                    :border-radius    (str tag-pill-radius "px")
                     :font-family      sans-stack
-                    :font-size        "9px"
+                    :font-size        (str tag-pill-px "px")
                     :font-weight      600
                     :color            stroke
                     :line-height      "1"
@@ -150,6 +176,7 @@
     - Final state: doubled border + small check glyph."
   [^js props]
   (let [d              (.-data props)
+        vc             (chart-constants d)
         label          (or (.-label d) "")
         path           (.-path d)
         active?        (boolean (.-active d))
@@ -168,10 +195,16 @@
                         :final?         final?}
         fill           (node-fill styled)
         stroke         (node-stroke styled)
+        ;; rf2-k647w — stroke widths read off the resolved density.
+        ;; The active-affordance stroke sits one notch above the
+        ;; emphasis stroke (active-affordance = emphasis + 0.75,
+        ;; preserving the shipped regular relationship 2.5 → 3.25).
+        {:keys [corner-radius stroke-width stroke-width-emphasis
+                state-label-px final-glyph-px tag-pill-row-gap]} vc
         stroke-w       (cond
-                         active-affordance? 3.25
-                         emphasised?        2.5
-                         :else              1.5)]
+                         active-affordance? (+ stroke-width-emphasis 0.75)
+                         emphasised?        stroke-width-emphasis
+                         :else              stroke-width)]
     (r/as-element
       [:div {:data-testid (str "rf-mv-chart-node-" (.-id props))
              :data-active (str active?)
@@ -192,9 +225,9 @@
                      :padding          "8px 12px"
                      :background       fill
                      :border           (str stroke-w "px solid " stroke)
-                     :border-radius    "6px"
+                     :border-radius    (str corner-radius "px")
                      :font-family      mono-stack
-                     :font-size        "13px"
+                     :font-size        (str state-label-px "px")
                      :font-weight      (if emphasised? 600 400)
                      :color            (if emphasised?
                                          (:text-primary tokens/tokens)
@@ -213,7 +246,8 @@
                        :right         "-3px"
                        :bottom        "-3px"
                        :border        (str "1px solid " (:green tokens/tokens))
-                       :border-radius "7px"
+                       ;; outer ring sits 1px proud of the node corner
+                       :border-radius (str (inc corner-radius) "px")
                        :pointer-events "none"}}])
        ;; State-tag pills
        (when (seq tags)
@@ -223,8 +257,8 @@
                               :flex-direction "row"
                               :justify-content "center"
                               :align-items    "center"
-                              :margin-bottom  "3px"}}]
-               (for [t tags] (tag-pill t))))
+                              :margin-bottom  (str tag-pill-row-gap "px")}}]
+               (for [t tags] (tag-pill t vc))))
        ;; Label
        [:div {:style {:line-height "1.2"}} label]
        ;; Final-state check glyph
@@ -233,7 +267,7 @@
                        :top         "4px"
                        :right       "8px"
                        :font-family mono-stack
-                       :font-size   "13px"
+                       :font-size   (str final-glyph-px "px")
                        :color       (:green tokens/tokens)}}
           "✓"])
        ;; xyflow attachment points (invisible — edges connect here)
@@ -260,8 +294,10 @@
   chrome."
   [^js props]
   (let [d     (.-data props)
+        vc    (chart-constants d)
         label (or (.-label d) "")
-        path  (.-path d)]
+        path  (.-path d)
+        {:keys [compound-pad-y compound-radius compound-title-px]} vc]
     (r/as-element
       [:div {:data-testid (str "rf-mv-chart-compound-" (.-id props))
              :data-node-id (.-id props)
@@ -271,16 +307,16 @@
                      :height           "100%"
                      :min-width        (str compound-node-min-width "px")
                      :min-height       (str compound-node-min-height "px")
-                     :padding-top      "24px"
+                     :padding-top      (str compound-pad-y "px")
                      :background       (tokens/with-alpha :accent-violet 0.06)
                      :border           (str "1px dashed " (:accent-violet tokens/tokens))
-                     :border-radius    "10px"
+                     :border-radius    (str compound-radius "px")
                      :pointer-events   "none"}}
        [:div {:style {:position    "absolute"
                      :top         "4px"
                      :left        "10px"
                      :font-family sans-stack
-                     :font-size   "13px"
+                     :font-size   (str compound-title-px "px")
                      :font-weight 600
                      :color       (:accent-violet tokens/tokens)}}
         label]])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -30,7 +30,8 @@
       tree), and the async `compute-layout!` promise pass stay in
       `chart.cljs`; they touch JS objects and are not portable to the
       JVM.
-    - **Topology parsing** — lives in `chart.layout`.")
+    - **Topology parsing** — lives in `chart.layout`."
+  (:require [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- node-size floor constants -----------------------------------------
 ;;
@@ -134,10 +135,24 @@
                            landing state.
     :sim?                — flips the highlight palette to amber.
     :on-state-click      — `(fn [path] ...)` invoked when a state
-                           node is clicked."
+                           node is clicked.
+    :chart               — rf2-k647w. The resolved visual-constants
+                           map for the active `:density`
+                           (`visual-constants/chart-for-density`).
+                           Threaded into every node/edge `:data` as
+                           `:chart` so the xyflow node/edge components
+                           — which React invokes OUTSIDE the render's
+                           dynamic-binding scope — read their geometry
+                           + typography off the payload instead of a
+                           hardcoded literal. Defaults to
+                           `visual-constants/chart-regular` so callers
+                           that omit it (the JVM projection tests, a
+                           density-less host) get the regular density
+                           pixel-identical to pre-rf2-k647w."
   [{:keys [nodes edges]}
    positions
-   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
+   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click chart]
+    :or   {chart vc/chart-regular}}]
   {:nodes
    ;; rf2-lkwev — region container nodes MUST precede their children in
    ;; the xyflow nodes array (xyflow requires a parentNode to appear
@@ -167,6 +182,14 @@
                                      :final          (boolean (:final? n))
                                      :compound       (boolean (:compound? n))
                                      :tags           (vec (:tags n))
+                                     ;; rf2-k647w — the resolved density's
+                                     ;; visual constants ride on every node
+                                     ;; payload so the xyflow node component
+                                     ;; reads geometry/typography off `:data`
+                                     ;; (it is invoked outside the render's
+                                     ;; binding scope, so a dynamic var would
+                                     ;; not be in effect).
+                                     :chart          chart
                                      :onClick        on-state-click}
                               region? (assoc :regionId    (:region n)
                                              :regionIndex (:region-index n)))
@@ -201,5 +224,9 @@
                        :focused    focused?
                        :afterMs    (:after e)
                        :guard      (some-> (:guard e) name)
-                       :action     (some-> (:action e) name)}}))
+                       :action     (some-> (:action e) name)
+                       ;; rf2-k647w — resolved density constants for the
+                       ;; edge-label typography (same rationale as the
+                       ;; node payload above).
+                       :chart      chart}}))
          edges)})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -40,7 +40,21 @@
   active state's static affordance (cyan tint + emphasised stroke)
   carries the 'currently here' signal without a continuous loop;
   the transition glow on event-fire remains for moment-of-cause
-  cueing. `:pulse-stroke-width-add` retired with the animation."
+  cueing. `:pulse-stroke-width-add` retired with the animation.
+
+  rf2-k647w — this ns is now the SINGLE SOURCE of the chart's render
+  geometry/typography. The xyflow `MachineChart` (`chart.nodes` /
+  `chart.edges` / `chart.cljs`) used to HARDCODE the regular-density
+  numbers and had DRIFTED from `chart-regular` (tag-pill height 16 vs.
+  spec'd 12, pad-x 6 vs. 5, px 9 vs. 8, row-gap 3 vs. 4). The
+  reconciliation moves `chart-regular` to the SHIPPED renderer numbers
+  (so wiring `:density` introduces no visual regression at the default)
+  and adds `:compound-radius` + `:tag-pill-radius` — two render
+  constants the renderer hardcoded but `visual-constants` did not yet
+  carry. The renderer now READS every one of these off the resolved
+  density map (threaded through the projector's per-node/per-edge
+  `:data`); switching `:density` changes the render for real and the
+  chart root emits `data-density`."
   {:no-doc true})
 
 (def chart-regular
@@ -73,9 +87,17 @@
     :caption-strip-px         — chart-level caption strip height
                                 (rf2-3zdzw)
     :caption-text-px          — caption strip text font-size
+    :compound-radius          — compound container corner radius
+                                (rf2-k647w — distinct from the
+                                state-node `:corner-radius` lock; the
+                                compound chrome reads as a looser box)
     :tag-pill-height          — state-tag pill height (rf2-m1b88)
     :tag-pill-pad-x           — state-tag pill horizontal padding
     :tag-pill-px              — state-tag pill text font-size
+    :tag-pill-radius          — state-tag pill corner radius
+                                (rf2-k647w — the pill's own rounding;
+                                tracks density, unlike the state-node
+                                `:corner-radius` lock)
     :tag-pill-gap             — horizontal gap between adjacent
                                 pills
     :tag-pill-row-gap         — vertical gap from pill row to
@@ -91,6 +113,7 @@
    :compound-pad-x         16
    :compound-pad-y         24
    :compound-stroke-dash   "4 3"
+   :compound-radius        10
 
    ;; ── typography (rf2-gg7ws — chart-regular floor 13/11) ───────
    :state-label-px         13
@@ -101,12 +124,16 @@
    :caption-strip-px       28
    :caption-text-px        11
 
-   ;; ── state-tag pills (rf2-m1b88) ──────────────────────────────
-   :tag-pill-height        12
-   :tag-pill-pad-x         5
-   :tag-pill-px            8
+   ;; ── state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to
+   ;;    the SHIPPED renderer numbers — height 16 / pad-x 6 / px 9 /
+   ;;    radius 8 / row-gap 3 — so wiring :density introduces NO
+   ;;    visual regression at the regular default) ─────────────────
+   :tag-pill-height        16
+   :tag-pill-pad-x         6
+   :tag-pill-px            9
+   :tag-pill-radius        8
    :tag-pill-gap           3
-   :tag-pill-row-gap       4
+   :tag-pill-row-gap       3
 
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
@@ -138,6 +165,7 @@
    :compound-pad-x         10
    :compound-pad-y         18
    :compound-stroke-dash   "3 2"
+   :compound-radius        8           ;; ~25% tighter than regular's 10
 
    ;; ── typography (rf2-gg7ws refused-floor revisited for thumbnails)
    :state-label-px         11
@@ -148,12 +176,13 @@
    :caption-strip-px       22
    :caption-text-px        9
 
-   ;; ── state-tag pills ──────────────────────────────────────────
-   :tag-pill-height        10
-   :tag-pill-pad-x         4
+   ;; ── state-tag pills (tighter than the regular 16/6/9/8) ──────
+   :tag-pill-height        13
+   :tag-pill-pad-x         5
    :tag-pill-px            7
+   :tag-pill-radius        6
    :tag-pill-gap           2
-   :tag-pill-row-gap       3
+   :tag-pill-row-gap       2
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    12
@@ -183,6 +212,7 @@
    :compound-pad-x         20
    :compound-pad-y         30
    :compound-stroke-dash   "5 4"
+   :compound-radius        12          ;; ~25% looser than regular's 10
 
    ;; ── typography (walked up one notch from the regular floor) ──
    :state-label-px         15
@@ -193,12 +223,13 @@
    :caption-strip-px       34
    :caption-text-px        13
 
-   ;; ── state-tag pills ──────────────────────────────────────────
-   :tag-pill-height        14
-   :tag-pill-pad-x         6
-   :tag-pill-px            10
+   ;; ── state-tag pills (looser than the regular 16/6/9/8) ───────
+   :tag-pill-height        19
+   :tag-pill-pad-x         7
+   :tag-pill-px            11
+   :tag-pill-radius        10
    :tag-pill-gap           4
-   :tag-pill-row-gap       5
+   :tag-pill-row-gap       4
 
    ;; ── dot-grid background ──────────────────────────────────────
    :dot-grid-spacing-px    20

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -40,7 +40,8 @@
   (:require ["react"            :as React]
             ["react-dom/client" :as react-dom-client]
             [cljs.test :refer-macros [deftest is testing]]
-            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]))
+            [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- sample machines ----------------------------------------------------
 
@@ -51,6 +52,14 @@
              :loading {:on {:ok :done :err :failed}}
              :done    {:final? true}
              :failed  {:final? true}}})
+
+(def ^:private tagged-machine
+  "A machine whose idle state carries a state-tag, so the tag-pill DOM
+  (whose height/px/radius track the resolved density) is assertable
+  (rf2-k647w density-render pin)."
+  {:initial :idle
+   :states  {:idle    {:tags [:initial-tag] :on {:start :loading}}
+             :loading {:on {:done :idle}}}})
 
 (def ^:private parallel-machine
   "A parallel machine: 2 regions, 2 states each (rf2-lkwev)."
@@ -217,6 +226,82 @@
         (fn [_root node]
           (is (pos? (count-sel node ".react-flow__background"))
               "xyflow Background present by default"))))))
+
+;; ---- :density prop (rf2-k647w) ------------------------------------------
+
+(defn- tag-pill-height-px
+  "Read the integer px height off the first state-tag pill's inline
+  style (the pill's height tracks the resolved density per rf2-k647w).
+  Returns nil when no pill is present."
+  [^js node]
+  (when-let [pill (.querySelector node "[data-testid^=\"rf-mv-chart-state-tag-\"]")]
+    (let [h (.. pill -style -height)]            ;; e.g. "16px"
+      (js/parseInt h 10))))
+
+(deftest chart-data-density-defaults-to-regular
+  (testing "rf2-k647w — omitting :density surfaces data-density=\"regular\"
+            on the chart root (nil ≡ regular, the historical default)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [root _node]
+          (is (= "regular" (.getAttribute root "data-density"))
+              "data-density defaults to regular"))))))
+
+(deftest chart-data-density-reflects-prop
+  (testing "rf2-k647w — :density :compact / :cosy surface the matching
+            data-density on the root, so hosts + tests read the active
+            density without re-reading the bound prop"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (do
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done :density :compact}
+          (fn [root _node]
+            (is (= "compact" (.getAttribute root "data-density")))))
+        (with-mounted-chart
+          {:machine-id :test/flow :definition idle-loading-done :density :cosy}
+          (fn [root _node]
+            (is (= "cosy" (.getAttribute root "data-density")))))))))
+
+(deftest chart-density-changes-tag-pill-geometry
+  (testing "rf2-k647w — :density actually changes the RENDER, not just
+            the attr: the state-tag pill height equals the resolved
+            density's :tag-pill-height (regular 16 / compact 13 / cosy
+            19), proving the renderer reads geometry off the threaded
+            visual-constants instead of a hardcoded literal"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (do
+        (with-mounted-chart
+          {:machine-id :test/tags :definition tagged-machine :density :regular}
+          (fn [_root node]
+            (is (= (:tag-pill-height vc/chart-regular) (tag-pill-height-px node))
+                "regular pill height matches chart-regular")))
+        (with-mounted-chart
+          {:machine-id :test/tags :definition tagged-machine :density :compact}
+          (fn [_root node]
+            (is (= (:tag-pill-height vc/chart-compact) (tag-pill-height-px node))
+                "compact pill height matches chart-compact")))
+        (with-mounted-chart
+          {:machine-id :test/tags :definition tagged-machine :density :cosy}
+          (fn [_root node]
+            (is (= (:tag-pill-height vc/chart-cosy) (tag-pill-height-px node))
+                "cosy pill height matches chart-cosy")))))))
+
+(deftest chart-default-tag-pill-is-pixel-identical
+  (testing "rf2-k647w — the DEFAULT (no :density) tag-pill height is the
+            shipped-reality 16px. This is the no-visual-regression pin:
+            a host that never passes :density gets exactly the
+            pre-rf2-k647w chart."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/tags :definition tagged-machine}
+        (fn [_root node]
+          (is (= 16 (tag-pill-height-px node))
+              "default tag-pill height is the shipped 16px"))))))
 
 ;; ---- empty / nil definition placeholders --------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -17,7 +17,8 @@
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-machines-viz.chart.layout :as layout]
-            [day8.re-frame2-machines-viz.chart.projection :as projection]))
+            [day8.re-frame2-machines-viz.chart.projection :as projection]
+            [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- fixtures ----------------------------------------------------------
 
@@ -311,6 +312,59 @@
       (is (= 0 (:regionIndex (:data audio))))
       (is (= 1 (:regionIndex (:data video))))
       (is (not (contains? (:data muted) :regionId))))))
+
+;; ---- :density → threaded visual-constants (rf2-k647w) ------------------
+;;
+;; The xyflow node/edge components render OUTSIDE the chart's render
+;; binding scope (React invokes them lazily), so the projector threads
+;; the resolved density's visual-constants map onto every node/edge
+;; `:data {:chart {...}}`. These pins guard that threading at the cheap
+;; JVM layer — the DOM suite (chart_dom) then pins the rendered effect.
+
+(deftest xyflow-graph-threads-chart-constants-onto-nodes
+  (testing "rf2-k647w — the resolved `:chart` map rides on EVERY node's
+            `:data` so the xyflow node component reads geometry off the
+            payload (it is invoked outside the render binding scope)"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {:chart vc/chart-compact})]
+      (is (seq (:nodes graph)))
+      (is (every? #(= vc/chart-compact (:chart (:data %))) (:nodes graph))
+          "compact density threads chart-compact onto every node"))))
+
+(deftest xyflow-graph-threads-chart-constants-onto-edges
+  (testing "rf2-k647w — the resolved `:chart` map rides on EVERY edge's
+            `:data` so the edge label typography tracks the density"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {:chart vc/chart-cosy})]
+      (is (seq (:edges graph)))
+      (is (every? #(= vc/chart-cosy (:chart (:data %))) (:edges graph))
+          "cosy density threads chart-cosy onto every edge"))))
+
+(deftest xyflow-graph-chart-defaults-to-regular
+  (testing "rf2-k647w — omitting `:chart` (the JVM tests, a density-less
+            caller) defaults to `chart-regular` so the regular density
+            stays pixel-identical to pre-rf2-k647w"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          idle   (node-by-id graph (layout/node-id [:idle]))]
+      (is (= vc/chart-regular (:chart (:data idle)))))))
+
+(deftest xyflow-graph-density-changes-threaded-constants
+  (testing "rf2-k647w — switching the density threads a DIFFERENT
+            constants map: the regular projection's tag-pill height
+            differs from the compact projection's, proving `:density`
+            actually changes what the renderer paints"
+    (let [parsed   (layout/parse-definition idle-loading)
+          idle-id  (layout/node-id [:idle])
+          regular  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-regular})
+                       (node-by-id idle-id) :data :chart)
+          compact  (-> (projection/xyflow-graph parsed {} {:chart vc/chart-compact})
+                       (node-by-id idle-id) :data :chart)]
+      (is (not= (:tag-pill-height regular) (:tag-pill-height compact)))
+      (is (= 16 (:tag-pill-height regular)))
+      (is (= 13 (:tag-pill-height compact)))
+      ;; corner-radius is the locked invariant — identical across both
+      (is (= (:corner-radius regular) (:corner-radius compact) 6)))))
 
 ;; ---- ->elk-children (G3) -----------------------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -22,13 +22,18 @@
   `API.md` §Density** — `MachineChart`'s `:density` prop resolves
   through `visual-constants/chart-for-density`, the three named maps
   share a key set, and the corner-radius lock is density-invariant.
-  That is a normative spec surface in a spec-first project, so the
-  contract is real even while the xyflow renderer's `:density`
-  consumption is still being re-wired (the xyflow `MachineChart`
-  currently hardcodes the regular-density numbers rather than reading
-  `chart-for-density`; closing that renderer gap — including
-  reconciling the drifted tag-pill values — is tracked separately).
-  This suite pins the data contract the renderer rewire must satisfy."
+
+  rf2-k647w — the renderer gap is now CLOSED. `visual-constants` is
+  the SINGLE SOURCE of the chart's render geometry/typography: the
+  xyflow `MachineChart` (`chart.nodes` / `chart.edges` / `chart.cljs`)
+  reads every constant off the resolved density map (threaded through
+  the projector's per-node/per-edge `:data`) instead of hardcoding.
+  The drifted tag-pill values were reconciled to the shipped renderer
+  numbers (so wiring `:density` introduced no visual regression), and
+  two render constants the renderer hardcoded — `:compound-radius`,
+  `:tag-pill-radius` — were promoted into the maps. This suite now
+  guards live render code, not just the spec data-contract it pinned
+  before."
   (:require
     #?(:clj  [clojure.test :refer [deftest is testing]]
        :cljs [cljs.test    :refer-macros [deftest is testing]])
@@ -51,6 +56,7 @@
     :compound-pad-x
     :compound-pad-y
     :compound-stroke-dash
+    :compound-radius                ;; rf2-k647w — render constant promoted
     ;; typography (rf2-gg7ws — lifted 11/9 → 13/11)
     :state-label-px
     :edge-label-px
@@ -59,10 +65,11 @@
     :compound-title-px
     :caption-strip-px
     :caption-text-px
-    ;; state-tag pills (rf2-m1b88)
+    ;; state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to shipped)
     :tag-pill-height
     :tag-pill-pad-x
     :tag-pill-px
+    :tag-pill-radius                ;; rf2-k647w — render constant promoted
     :tag-pill-gap
     :tag-pill-row-gap
     ;; dot-grid background (rf2-m4nj4)
@@ -124,6 +131,28 @@
             floor fails CI."
     (is (= 13 (:state-label-px vc/chart)))
     (is (= 11 (:edge-label-px vc/chart)))))
+
+(deftest chart-regular-tag-pill-matches-shipped-render
+  (testing "rf2-k647w — `chart-regular`'s tag-pill geometry/typography
+            equals the values the xyflow renderer SHIPPED before this
+            bead (height 16 / pad-x 6 / px 9 / radius 8 / row-gap 3).
+            Pre-bead the renderer hardcoded these while `chart-regular`
+            carried the older 12/5/8/-/4. The reconciliation moved
+            `chart-regular` to the shipped reality so wiring `:density`
+            introduces NO visual regression at the default. Pin so a
+            future edit can't silently re-open the drift."
+    (is (= 16 (:tag-pill-height vc/chart)))
+    (is (= 6  (:tag-pill-pad-x vc/chart)))
+    (is (= 9  (:tag-pill-px vc/chart)))
+    (is (= 8  (:tag-pill-radius vc/chart)))
+    (is (= 3  (:tag-pill-row-gap vc/chart)))))
+
+(deftest chart-regular-compound-radius-matches-shipped-render
+  (testing "rf2-k647w — `chart-regular`'s `:compound-radius` equals the
+            10px the compound-node chrome shipped. Distinct from the
+            state-node `:corner-radius` lock (6); the compound box reads
+            as a looser container."
+    (is (= 10 (:compound-radius vc/chart)))))
 
 (deftest chart-edge-label-backplate-opacity-is-fractional
   (testing "rf2-gg7ws — edge-label backplate opacity is in (0, 1).
@@ -204,6 +233,25 @@
     (is (< (:dot-grid-spacing-px vc/chart-compact)
            (:dot-grid-spacing-px vc/chart-regular)
            (:dot-grid-spacing-px vc/chart-cosy)))))
+
+(deftest density-tag-pill-and-compound-render-constants-monotonic
+  (testing "rf2-k647w — the render constants the renderer now reads off
+            the resolved density (tag-pill height/radius, compound
+            radius) track the density axis monotonically too. The
+            corner-radius lock (6) is the ONLY geometry that does not
+            scale; everything the renderer paints by quantity does."
+    (is (< (:tag-pill-height vc/chart-compact)
+           (:tag-pill-height vc/chart-regular)
+           (:tag-pill-height vc/chart-cosy)))
+    (is (< (:tag-pill-radius vc/chart-compact)
+           (:tag-pill-radius vc/chart-regular)
+           (:tag-pill-radius vc/chart-cosy)))
+    (is (< (:tag-pill-px vc/chart-compact)
+           (:tag-pill-px vc/chart-regular)
+           (:tag-pill-px vc/chart-cosy)))
+    (is (< (:compound-radius vc/chart-compact)
+           (:compound-radius vc/chart-regular)
+           (:compound-radius vc/chart-cosy)))))
 
 (deftest densities-catalogue-is-closed
   (testing "rf2-32gw5 — the `densities` Var enumerates the closed


### PR DESCRIPTION
## Summary

`tools/machines-viz/spec/API.md` §Density normatively specs a `:density` prop (`:compact`/`:regular`/`:cosy`) resolving through `visual-constants/chart-for-density`, plus a `data-density` attr. But the xyflow migration (rf2-gpzb4) dropped the consumer: the new MachineChart **hardcoded** the regular-density numbers across `nodes.cljs`/`edges.cljs`/`chart.cljs`, the values had **drifted** from `chart-regular`, and `visual_constants.cljc` was consumed by nothing in `src`. The specced `:density` feature was unimplemented. (Surfaced by the rf2-0gmwp testcov worker.)

This wires `:density` for real and makes `visual-constants` the single source of the chart's render geometry/typography.

## Value reconciliation (regular = shipped, no visual regression)

The drifted values were reconciled **toward shipped reality** so the default render is pixel-identical to today:

| Constant | `chart-regular` (was) | renderer shipped | reconciled to |
|---|---|---|---|
| `:tag-pill-height` | 12 | 16 | **16** |
| `:tag-pill-pad-x` | 5 | 6 | **6** |
| `:tag-pill-px` | 8 | 9 | **9** |
| `:tag-pill-row-gap` | 4 | 3 | **3** |
| `:tag-pill-radius` | (absent) | 8 | **8** (key promoted) |
| `:compound-radius` | (absent) | 10 | **10** (key promoted) |

Compact/cosy derive proportionally and stay monotonic (`compact < regular < cosy`). `corner-radius` stays locked at 6 across every density (rf2-g6cig).

## How `:density` switches

- `MachineChart` resolves the prop **once per render** via `chart-for-density` (`nil` -> regular; unknown density **throws** at render time per spec §Resolution rules).
- The resolved map threads through the projector onto **every node/edge `:data`**. This is the load-bearing detail: xyflow invokes node/edge components **outside** the render's dynamic-binding scope, so a dynamic `*chart*` var would not be in effect — the payload survives React's deferred invocation. The node/edge components read geometry/typography off the threaded map; the dot-grid background spacing/radius track it too.
- The chart root emits **`data-density`** so hosts + tests read the active density without re-reading the bound prop.

## Tests

- **projection** (JVM): the resolved `:chart` rides on every node/edge `:data`; regular vs compact threaded constants differ; corner-radius is the locked invariant; omitting `:chart` defaults to `chart-regular`.
- **visual-constants** (JVM+node): pins `chart-regular`'s tag-pill geometry at the **shipped-reality** numbers + the two promoted keys' monotonicity.
- **chart_dom** (browser): `data-density` default/`:compact`/`:cosy`; `:density` actually changes the rendered tag-pill height (regular=16/compact=13/cosy=19); the **no-regression default** (no `:density` prop -> 16px).

## Gates (all green)

- `clojure -M:test` from tools/machines-viz: 165 tests, 383 assertions, 0 failures
- `npm run test:cljs`: 4131 tests, 12490 assertions, 0 failures
- `npm run test:browser`: 108 tests, 301 assertions, 0 failures
- `npm run test:bundle-isolation`: PASS (machines-viz stays isolated)
- mkdocs not required (no `*.md` touched; tools/machines-viz/spec is outside the mkdocs tree)