### PR TITLE
docs(mkdocs): OpenGraph social cards via material[imaging] social plugin (rf2-orxjj)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,20 @@ jobs:
           cache: pip
           cache-dependency-path: requirements.txt
 
+      # Cairo + Pango system libraries for Material's `social` plugin (rf2-orxjj).
+      # The plugin's image backend (CairoSVG, pulled in by material[imaging] in
+      # requirements.txt) links against these native libs to rasterise the
+      # OpenGraph/Twitter cards. Without them card generation throws at build
+      # time. This is the load-bearing CI change — it is what lets `CI=true`
+      # actually generate cards (the `social.cards: !ENV [CI, false]` gate in
+      # mkdocs.yml). Package list per Material's "Setting up social cards" docs.
+      - name: Install imaging system libraries (Cairo + Pango)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev \
+            libpng-dev libz-dev libpango-1.0-0 libpangocairo-1.0-0
+
       - name: Install MkDocs + plugins
         run: pip install -r requirements.txt
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,28 @@ theme:
 # in the list, otherwise search silently disappears.
 plugins:
   - search
+  # OpenGraph / Twitter social preview cards (rf2-orxjj). Material's `social`
+  # plugin auto-generates one branded card image per page from the site
+  # metadata + the brand palette below, then injects the `og:image` /
+  # `twitter:image` meta tags — so shared docs URLs render a professional
+  # preview on Slack/Twitter/etc. `site_url` (set at the top of this file) is
+  # required for the absolute image URLs the cards emit.
+  #
+  # Card generation needs the `imaging` extra's system libraries (Cairo +
+  # Pango via material[imaging]). CI installs them (see .github/workflows/
+  # docs.yml) and sets CI=true, so `enabled: !ENV [CI, false]` turns the
+  # plugin on there. A LOCAL `mkdocs build --strict` (where Cairo/Pango may
+  # be absent) sees CI unset → `enabled` is false → the plugin returns from
+  # on_config BEFORE its hard cairosvg dependency check (plugin.py: `cards =
+  # enabled`, then `if not cards: return` precedes the import probe), so the
+  # strict build still passes. Gating on `enabled` (not `cards`) is required:
+  # the plugin overwrites `cards` with `enabled` at on_config time, so a
+  # `cards:`-only gate is ignored and the dependency check still fires.
+  - social:
+      enabled: !ENV [CI, false]
+      cards_layout_options:
+        background_color: "#1976d2"  # Material `blue` primary
+        color: "#ffffff"
 
 # Klipse live-code bootstrap (rf2-zr5r5). Small, site-wide loader that does
 # NOTHING unless the page actually has ```klipse cells (only docs/cljs/index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,11 @@
 # Pinned for reproducibility. Bump deliberately and verify the build still
 # resolves the cross-tree nav (docs/guide + spec/) cleanly.
 mkdocs==1.6.1
-mkdocs-material==9.5.44
+# The [imaging] extra pulls in Pillow + CairoSVG, which the Material `social`
+# plugin (mkdocs.yml) needs to render OpenGraph/Twitter cards (rf2-orxjj).
+# CairoSVG additionally needs the Cairo + Pango *system* libraries — CI
+# apt-get installs those before this pip step (see .github/workflows/docs.yml).
+mkdocs-material[imaging]==9.5.44
 pymdown-extensions==10.11.2
 # Pin pygments below 2.20 (rf2-4jaz). Pygments 2.20.0 added an html.escape()
 # call around the HtmlFormatter `filename` option, which crashes when


### PR DESCRIPTION
## Summary

Enable auto-generated OpenGraph/Twitter social preview cards for the published GH-Pages docs site (rf2-orxjj), so shared docs URLs render a branded preview on Slack/Twitter/etc.

## Changes

- **`mkdocs.yml`** — add the Material `social` plugin (placed after `- search`, keeping the search guard entry first). Card layout uses the existing blue brand palette (`#1976d2` background, white text). `site_url` was already set, which the plugin needs for absolute card image URLs.
- **`requirements.txt`** — pin `mkdocs-material[imaging]==9.5.44`; the `[imaging]` extra pulls in Pillow + CairoSVG (the card image backend).
- **`.github/workflows/docs.yml`** — `apt-get install` the Cairo + Pango system libraries (`libcairo2-dev`, `libfreetype6-dev`, `libffi-dev`, `libjpeg-dev`, `libpng-dev`, `libz-dev`, `libpango-1.0-0`, `libpangocairo-1.0-0`) before the pip step. This is the load-bearing CI change — CairoSVG links against these native libs to rasterise the cards.

## Local-vs-CI gating

Card rasterisation needs Cairo/Pango, which aren't available in every local dev environment. The plugin is gated with `enabled: !ENV [CI, false]`:

- **CI** sets `CI=true` (and installs the imaging libs) → plugin enabled → cards generated and `og:image`/`twitter:image` tags injected.
- **Local** `mkdocs build --strict` (no `CI` env) → `enabled` is false → the plugin returns from `on_config` *before* its hard cairosvg dependency check, so the strict build passes even without the imaging libs.

The gate is on `enabled`, **not** `cards`: Material's social plugin overwrites `cards` with the value of `enabled` at config time (`self.config.cards = self.config.enabled`), so a `cards:`-only gate is silently ignored and the dependency probe still fires. Gating `enabled` is what actually short-circuits.

## Test plan

- [x] `python -m mkdocs build --strict` from repo root with `CI` unset — passes (no warnings/errors; plugin disabled).
- [x] `CI=true python -m mkdocs build` — plugin activates and reaches the cairosvg dependency check (locally errors only because cairosvg isn't installed; in CI with `material[imaging]` + Cairo/Pango installed it generates cards).
- [x] `python scripts/check_doc_slugs.py --self-test --verbose` — all 11 self-tests pass.
- [x] `python scripts/check_doc_slugs.py --verbose` — no broken links.
- [ ] CI docs workflow generates per-page card images (verified once merged / on the PR docs build).

Local card generation could **not** be verified in the worker environment (cairosvg/Cairo absent) — cards are CI-gated by design.