### PR TITLE
test(template): compile+run with-story branch + deps-resolve probe + shared test helper (rf2-5v619)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1492,26 +1492,28 @@ jobs:
       # static parse, AND behavioural compile+run. This is the only
       # PR-time CI surface for this artefact.
       #
-      # The template's `template_test.clj` opportunistically invokes
-      # `clojure -P` against generated deps.edn if `clojure` is on PATH
-      # to confirm the deps parse — the setup-clojure step above ensures
-      # that probe runs. The probe is gated behind
-      # RF2_TEMPLATE_DEPS_RESOLVE=1 (default off for local fast loop,
-      # on for CI) so contributors aren't paying ~2s × 3 substrates on
-      # every local test run for a smoke that's a known-skip until the
-      # alpha artefacts land on Clojars.
-      #
       # `emitted_test_run_test.clj` compiles + runs the emitted
-      # `events_test.cljs` per substrate against the in-repo source
-      # tree (closes rf2-owbpr / rf2-ir6a0). Gated behind
+      # `events_test.cljs` per substrate (and the `:include-story? true`
+      # with-story scaffold's `:app` build) against the in-repo source
+      # tree, with deps rewritten to :local/root (closes rf2-owbpr /
+      # rf2-ir6a0; with-story tier rf2-5v619). Gated behind
       # RF2_TEMPLATE_RUN_EMITTED_TESTS=1 — opt-in because the local
       # fast loop may lack Node and the smoke costs ~30–60 s per
       # substrate cold-cache. The `npm ci` step above primes
       # implementation/node_modules so the emitted bundle's React
       # imports resolve at run time.
+      #
+      # NB: there is deliberately no `clojure -P` deps-resolve probe.
+      # The generated deps.edn pins the alpha-channel :mvn/version coords
+      # (0.0.1.alpha) which are not published anywhere — re-frame2
+      # distributes via git-coord, not Clojars (rf2-dolpf §2.5/§3) — so a
+      # `-P` against the published coords cannot resolve and would always
+      # red. The behavioural tier transitively resolves + compiles the
+      # full deps tree under the :local/root rewrite, which is the
+      # strongest resolve signal achievable pre-publish. A published-coord
+      # resolve probe is a forward concern for the §3 release pipeline.
       - name: Run JVM tests (tools/template artefact)
         env:
-          RF2_TEMPLATE_DEPS_RESOLVE: "1"
           RF2_TEMPLATE_RUN_EMITTED_TESTS: "1"
         run: clojure -M:test
 

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -52,77 +52,20 @@
             [clojure.edn :as edn]
             [clojure.pprint :as pprint]
             [clojure.string :as string]
-            [org.corfield.new :as deps-new])
-  (:import [java.nio.file Files LinkOption Path FileVisitOption]
+            [day8.re-frame2-template.test-support
+             :refer [tmp-dir delete-recursively run-template! repo-root]])
+  ;; java.nio types used directly by `link-node-modules!` below. The
+  ;; tmp-dir / delete-recursively helpers that needed Path / LinkOption /
+  ;; FileVisitOption moved to the shared test-support ns (rf2-5v619).
+  (:import [java.nio.file Files]
            [java.nio.file.attribute FileAttribute]))
 
-;; --- Helpers (local copies, kept independent of the sibling test ns to
-;; avoid accidental state sharing via top-level defs) -----------------------
-
-(defn- tmp-dir [prefix]
-  (Files/createTempDirectory
-    prefix
-    (into-array FileAttribute [])))
-
-(defn- delete-recursively [^Path path]
-  (when (Files/exists path (into-array LinkOption []))
-    (with-open [stream (Files/walk path (into-array FileVisitOption []))]
-      (->> stream
-           .iterator
-           iterator-seq
-           reverse
-           (run! #(try
-                    (Files/deleteIfExists ^Path %)
-                    (catch java.io.IOException _ nil)))))))
-
-(defn- template-resource-dir []
-  (let [cwd (io/file (System/getProperty "user.dir"))]
-    (loop [d cwd]
-      (cond
-        (nil? d)
-        (throw (ex-info "Couldn't locate tools/template/resources above cwd"
-                        {:cwd cwd}))
-
-        (.isDirectory (io/file d "tools/template/resources"))
-        (.getCanonicalPath (io/file d "tools/template/resources"))
-
-        (.isDirectory (io/file d "resources/day8/re_frame2_template"))
-        (.getCanonicalPath (io/file d "resources"))
-
-        :else
-        (recur (.getParentFile d))))))
-
-(defn- run-template! [tmp project-name substrate]
-  (let [dir-str  (.toString ^Path tmp)
-        proj-name (-> project-name name (string/replace #"^.*?/" ""))
-        proj-dir (io/file dir-str proj-name)
-        opts     (cond-> {:template   'day8/re-frame2-template
-                          :name       (symbol project-name)
-                          :target-dir (.getCanonicalPath proj-dir)
-                          :src-dirs   [(template-resource-dir)]
-                          :overwrite  :delete}
-                   substrate (assoc :substrate substrate))]
-    (deps-new/create opts)
-    proj-dir))
-
-(defn- repo-root
-  "Walk up from `user.dir` until we find a sibling
-  `implementation/core/src/re_frame/` directory. The template test JVM
-  is launched from `tools/template/` (the `:test` alias's working dir),
-  but the same lookup keeps working under a manual repo-root
-  invocation. Mirrors the shape in `template_emission_test.clj`."
-  []
-  (loop [d (io/file (System/getProperty "user.dir"))]
-    (cond
-      (nil? d)
-      (throw (ex-info "Couldn't locate repo root (no implementation/core/src/re_frame above cwd)"
-                      {:cwd (System/getProperty "user.dir")}))
-
-      (.isDirectory (io/file d "implementation/core/src/re_frame"))
-      d
-
-      :else
-      (recur (.getParentFile d)))))
+;; --- Helpers ---------------------------------------------------------------
+;;
+;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
+;; repo-root live in the shared `test-support` ns (rf2-5v619, D1). The
+;; shared `run-template!` takes an optional 4th `include-story?` arg, so
+;; the with-story behavioural tier below reuses it directly.
 
 ;; --- Gating ----------------------------------------------------------------
 
@@ -147,15 +90,22 @@
                        (string/replace "\\" "/")))
         adapter-coord (symbol "day8" (str "re-frame2-" (name substrate)))
         rewritten
-        (-> deps
-            (assoc-in [:deps 'day8/re-frame2]
-                      {:local/root (rel-of "implementation/core")})
-            (assoc-in [:deps adapter-coord]
-                      {:local/root (rel-of (str "implementation/adapters/" (name substrate)))})
-            (assoc-in [:deps 'day8/re-frame2-causa]
-                      {:local/root (rel-of "tools/causa")})
-            (assoc-in [:deps 'day8/re-frame2-schemas]
-                      {:local/root (rel-of "implementation/schemas")}))]
+        (cond-> (-> deps
+                    (assoc-in [:deps 'day8/re-frame2]
+                              {:local/root (rel-of "implementation/core")})
+                    (assoc-in [:deps adapter-coord]
+                              {:local/root (rel-of (str "implementation/adapters/" (name substrate)))})
+                    (assoc-in [:deps 'day8/re-frame2-causa]
+                              {:local/root (rel-of "tools/causa")})
+                    (assoc-in [:deps 'day8/re-frame2-schemas]
+                              {:local/root (rel-of "implementation/schemas")}))
+          ;; The with-story scaffold adds day8/re-frame2-story
+          ;; (re-frame.story + re-frame.story.* live under tools/story/).
+          ;; Rewrite it the same way so the with-story behavioural tier
+          ;; resolves + compiles against the in-repo Story source.
+          (contains? (:deps deps) 'day8/re-frame2-story)
+          (assoc-in [:deps 'day8/re-frame2-story]
+                    {:local/root (rel-of "tools/story")}))]
     (spit deps-file (with-out-str (pprint/pprint rewritten)))))
 
 ;; --- node_modules symlink --------------------------------------------------
@@ -231,71 +181,103 @@
 
 ;; --- The orchestration -----------------------------------------------------
 
+(defn- variant-label
+  "A short human label distinguishing the default scaffold from the
+  with-story scaffold, for tmp-dir prefixes + assertion messages."
+  [substrate include-story?]
+  (str (name substrate) (when include-story? "-with-story")))
+
 (defn- compile-and-run-emitted-test!
-  "For one substrate: generate tmp app, rewrite deps.edn → :local/root,
-  link node_modules, run `clojure -M:shadow compile test`, then
+  "For one substrate (optionally with-story): generate a tmp app,
+  rewrite deps.edn → :local/root, link node_modules, run
+  `clojure -M:shadow compile <targets>` (the with-story variant adds
+  the `:app` build to the default `:test` build), then
   `node out/node-test.js`. Asserts both processes exit 0 and the
   expected cljs.test summary line is present.
 
+  When `include-story?` is true the generated project is the with-story
+  scaffold (`core_with_stories.cljs`, `deps_with_story.edn` with the
+  extra day8/re-frame2-story coord, `stories.cljs`). The with-story
+  variant additionally compiles the `:app` build — the only tier that
+  actually shadow-compiles the with-story branch's distinctive code.
+  `events_test.cljs` requires only events + subs, so the `:test` build
+  alone never pulls `core_with_stories.cljs` / `stories.cljs` /
+  re-frame.story onto the compile classpath; the `:app` build's
+  `:init-fn` is `core/init`, which transitively requires all three.
+  A broken with-story compile (re-frame.story API drift, a malformed
+  deps_with_story.edn, a stories.cljs that won't load) therefore fails
+  here rather than shipping green from string-presence / static-parse
+  alone (rf2-5v619, G1; this also closes the `:app`-build half of L1).
+
   Caller is responsible for the env-var gate — this fn always runs."
-  [substrate]
-  (let [root (repo-root)
-        tmp  (tmp-dir (str "rf2-template-run-" (name substrate) "-"))]
-    (try
-      (let [proj (run-template! tmp "acme/my-app" substrate)]
-        (rewrite-deps-for-local-run! root proj substrate)
-        (let [linked? (link-node-modules! root proj)
-              ;; Node's module-resolution walks parent dirs for
-              ;; node_modules, so an unlinked emitted project can still
-              ;; resolve React if implementation/node_modules sits on a
-              ;; parent path. Belt-and-braces: set NODE_PATH so the
-              ;; lookup is unambiguous either way.
-              node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
-              env-over  {"NODE_PATH" node-path}]
-          (is (or linked? (.isDirectory (io/file node-path)))
-              (str "implementation/node_modules must exist for `node` to "
-                   "resolve React (run `npm install` in implementation/ first)"))
+  ([substrate] (compile-and-run-emitted-test! substrate false))
+  ([substrate include-story?]
+   (let [root  (repo-root)
+         label (variant-label substrate include-story?)
+         ;; Default path: compile only the node-test build (fast). The
+         ;; with-story variant also compiles `:app`, the only build that
+         ;; transitively pulls the with-story core + stories + Story
+         ;; coord onto the classpath.
+         compile-targets (if include-story? ["app" "test"] ["test"])
+         tmp   (tmp-dir (str "rf2-template-run-" label "-"))]
+     (try
+       (let [proj (run-template! tmp "acme/my-app" substrate include-story?)]
+         (rewrite-deps-for-local-run! root proj substrate)
+         (let [linked? (link-node-modules! root proj)
+               ;; Node's module-resolution walks parent dirs for
+               ;; node_modules, so an unlinked emitted project can still
+               ;; resolve React if implementation/node_modules sits on a
+               ;; parent path. Belt-and-braces: set NODE_PATH so the
+               ;; lookup is unambiguous either way.
+               node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
+               env-over  {"NODE_PATH" node-path}]
+           (is (or linked? (.isDirectory (io/file node-path)))
+               (str "implementation/node_modules must exist for `node` to "
+                    "resolve React (run `npm install` in implementation/ first)"))
 
-          ;; --- compile -----------------------------------------------------
-          (testing (str substrate " — shadow-cljs compile test")
-            (let [{:keys [exit out]}
-                  (run-process! ["clojure" "-M:shadow" "compile" "test"]
-                                proj env-over)]
-              (is (zero? exit)
-                  (str "`clojure -M:shadow compile test` exited " exit
-                       " for substrate " substrate ". Output:\n" out))))
+           ;; --- compile -----------------------------------------------------
+           (testing (str label " — shadow-cljs compile "
+                         (string/join " " compile-targets))
+             (let [{:keys [exit out]}
+                   (run-process! (into ["clojure" "-M:shadow" "compile"]
+                                       compile-targets)
+                                 proj env-over)]
+               (is (zero? exit)
+                   (str "`clojure -M:shadow compile "
+                        (string/join " " compile-targets) "` exited " exit
+                        " for " label ". Output:\n" out))))
 
-          ;; --- run ---------------------------------------------------------
-          (testing (str substrate " — node out/node-test.js")
-            (let [bundle (io/file proj "out/node-test.js")]
-              (is (.isFile bundle)
-                  (str "Compile step produced out/node-test.js for " substrate))
-              (when (.isFile bundle)
-                (let [{:keys [exit out]}
-                      (run-process! ["node" "out/node-test.js"] proj env-over)]
-                  (is (zero? exit)
-                      (str "`node out/node-test.js` exited " exit
-                           " for substrate " substrate ". Output:\n" out))
-                  ;; cljs.test's default reporter prints
-                  ;;   "Ran N tests containing M assertions."
-                  ;;   "0 failures, 0 errors."
-                  ;; on a green run. Pin both lines so a silent zero-exit
-                  ;; (no tests discovered) doesn't false-green.
-                  (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
-                      (str "expected 'Ran N tests' summary line in output. Got:\n" out))
-                  (is (re-find #"0 failures, 0 errors" out)
-                      (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))))
-      (finally
-        (delete-recursively tmp)))))
+           ;; --- run ---------------------------------------------------------
+           (testing (str label " — node out/node-test.js")
+             (let [bundle (io/file proj "out/node-test.js")]
+               (is (.isFile bundle)
+                   (str "Compile step produced out/node-test.js for " label))
+               (when (.isFile bundle)
+                 (let [{:keys [exit out]}
+                       (run-process! ["node" "out/node-test.js"] proj env-over)]
+                   (is (zero? exit)
+                       (str "`node out/node-test.js` exited " exit
+                            " for " label ". Output:\n" out))
+                   ;; cljs.test's default reporter prints
+                   ;;   "Ran N tests containing M assertions."
+                   ;;   "0 failures, 0 errors."
+                   ;; on a green run. Pin both lines so a silent zero-exit
+                   ;; (no tests discovered) doesn't false-green.
+                   (is (re-find #"Ran \d+ tests? containing \d+ assertions" out)
+                       (str "expected 'Ran N tests' summary line in output. Got:\n" out))
+                   (is (re-find #"0 failures, 0 errors" out)
+                       (str "expected '0 failures, 0 errors' line in output. Got:\n" out))))))))
+       (finally
+         (delete-recursively tmp))))))
 
 (defn- skip-if-disabled!
   "When the gate is off, record a passing assertion that documents the
   skip — so the green-run line count is stable across enabled/disabled
   modes and CI's grep doesn't have to special-case the gated path."
-  [substrate]
+  [label]
   (is true
       (str "RF2_TEMPLATE_RUN_EMITTED_TESTS unset — skipping behavioural "
-           "compile+run for " substrate
+           "compile+run for " label
            ". Static-parse coverage still applies "
            "(template_emission_test.clj).")))
 
@@ -333,3 +315,23 @@
               "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
           (when (and @clojure-cli-available? @node-available?)
             (compile-and-run-emitted-test! :helix))))))
+
+(deftest reagent-with-story-emitted-tests-run-test
+  ;; G1 (rf2-5v619) — the only tier that actually shadow-compiles +
+  ;; node-runs the `:include-story? true` scaffold. Reagent-only because
+  ;; with-story is Reagent-only in v1 (hooks.clj data-fn guard). Same
+  ;; events_test.cljs as the default path runs; the value here is that
+  ;; the with-story core (`core_with_stories.cljs` requiring
+  ;; re-frame.story + the stories ns), `deps_with_story.edn`, and
+  ;; `stories.cljs` are all on the compile classpath — a broken
+  ;; with-story compile fails the build before `node` ever runs.
+  (testing "the emitted with-story Reagent app compiles (story scaffold
+            on the classpath) + events_test.cljs runs green"
+    (if-not @enabled?
+      (skip-if-disabled! "reagent-with-story")
+      (do (is @clojure-cli-available?
+              "`clojure` CLI must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (is @node-available?
+              "`node` must be on PATH when RF2_TEMPLATE_RUN_EMITTED_TESTS=1")
+          (when (and @clojure-cli-available? @node-available?)
+            (compile-and-run-emitted-test! :reagent true))))))

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -110,38 +110,71 @@
 
 ;; --- node_modules symlink --------------------------------------------------
 
+(defn- junction-node-modules!
+  "Windows fall-back when a symlink can't be created: a directory
+  *junction* (`mklink /J`) reparse-points `dst` → `src` and — unlike a
+  symbolic link — needs no `SeCreateSymbolicLinkPrivilege`, so it works
+  on a stock Windows box without Developer Mode. Returns true on
+  success. No-op (false) off Windows, where the symlink path already
+  succeeded."
+  [^java.io.File src ^java.io.File dst]
+  (when (string/starts-with? (string/lower-case (System/getProperty "os.name")) "windows")
+    (try
+      ;; `cmd /c mklink /J <link> <target>` — both paths are passed as
+      ;; native Windows paths (backslashes); ProcessBuilder doesn't run
+      ;; the args through cmd's own parser, so no extra quoting needed.
+      (let [pb (ProcessBuilder.
+                 ^java.util.List ["cmd" "/c" "mklink" "/J"
+                                  (.getPath dst)
+                                  (.getCanonicalPath src)])]
+        (.redirectErrorStream pb true)
+        (let [p (.start pb)]
+          (slurp (.getInputStream p))
+          (zero? (.waitFor p))))
+      (catch Throwable _ false))))
+
 (defn- link-node-modules!
-  "Create a directory symlink from the emitted project's `node_modules`
-  to `<repo>/implementation/node_modules` so React + its peers resolve
-  when `node` runs the compiled bundle. On platforms without symlink
-  privileges (rare on Windows without dev-mode), falls back to a
-  best-effort directory-junction or — last resort — Files/copy. Returns
-  true if `node_modules` is now available inside `proj-dir`."
+  "Make `<repo>/implementation/node_modules` available inside the
+  emitted project as `node_modules`, so npm deps (React + peers)
+  resolve. Two consumers need this:
+
+    - the shadow-cljs `:browser` (`:app`) build resolves JS deps at
+      *compile* time and searches ONLY the project-local `node_modules`
+      — it does not honour `NODE_PATH`. The with-story tier compiles the
+      `:app` build, so a real project-local `node_modules` is mandatory,
+      not belt-and-braces.
+    - `node` running the compiled `:node-test` bundle resolves React at
+      *run* time, where `NODE_PATH` (set by the caller) is also honoured.
+
+  Strategy: a directory symlink first; on Windows without
+  `SeCreateSymbolicLinkPrivilege` (no Developer Mode) that fails, so we
+  fall back to a directory *junction* (`mklink /J`), which needs no
+  privilege. Returns true once `node_modules/react` resolves inside
+  `proj-dir` — the caller asserts on it, because the `:browser` compile
+  has no `NODE_PATH` safety net."
   [^java.io.File root ^java.io.File proj-dir]
-  (let [src   (io/file root "implementation/node_modules")
-        dst   (io/file proj-dir "node_modules")]
+  (let [src         (io/file root "implementation/node_modules")
+        dst         (io/file proj-dir "node_modules")
+        resolvable? #(.isDirectory (io/file dst "react"))]
     (cond
       (not (.isDirectory src))
       false
 
       (.exists dst)
-      true
+      (resolvable?)
 
       :else
-      (try
-        (Files/createSymbolicLink (.toPath dst)
-                                  (.toPath (.getCanonicalFile src))
-                                  (into-array FileAttribute []))
-        true
-        (catch Throwable _
-          ;; Symlink-create requires SeCreateSymbolicLinkPrivilege on
-          ;; Windows without Developer Mode. The shadow-cljs :node-test
-          ;; bundle's React imports resolve via Node's module-resolution
-          ;; algorithm, which walks parent directories looking for
-          ;; node_modules — set the NODE_PATH env var instead at run
-          ;; time. Caller still asserts true here because the run-time
-          ;; resolution covers the fall-back.
-          false)))))
+      (do
+        (try
+          (Files/createSymbolicLink (.toPath dst)
+                                    (.toPath (.getCanonicalFile src))
+                                    (into-array FileAttribute []))
+          (catch Throwable _
+            ;; Symlink-create requires SeCreateSymbolicLinkPrivilege on
+            ;; Windows without Developer Mode. Fall back to a junction,
+            ;; which doesn't.
+            (junction-node-modules! src dst)))
+        (resolvable?)))))
 
 ;; --- Process invocation ----------------------------------------------------
 
@@ -224,16 +257,25 @@
        (let [proj (run-template! tmp "acme/my-app" substrate include-story?)]
          (rewrite-deps-for-local-run! root proj substrate)
          (let [linked? (link-node-modules! root proj)
-               ;; Node's module-resolution walks parent dirs for
-               ;; node_modules, so an unlinked emitted project can still
-               ;; resolve React if implementation/node_modules sits on a
-               ;; parent path. Belt-and-braces: set NODE_PATH so the
-               ;; lookup is unambiguous either way.
+               ;; NODE_PATH covers the `node` *run* step (Node honours it
+               ;; at module-resolution time) and the `:node-test` *compile*
+               ;; (shadow's node target falls back to it). The `:browser`
+               ;; (`:app`) compile does NOT honour NODE_PATH — it searches
+               ;; only the project-local node_modules — so the with-story
+               ;; tier hard-requires `linked?` (a real symlink/junction).
                node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
                env-over  {"NODE_PATH" node-path}]
-           (is (or linked? (.isDirectory (io/file node-path)))
-               (str "implementation/node_modules must exist for `node` to "
-                    "resolve React (run `npm install` in implementation/ first)"))
+           (if include-story?
+             (is linked?
+                 (str "project-local node_modules must resolve for the "
+                      "`:app` (:browser) compile — it ignores NODE_PATH. "
+                      "Symlink/junction into " (.getPath proj)
+                      " failed; ensure implementation/node_modules exists "
+                      "(`npm install` in implementation/) and the OS allows "
+                      "a symlink or `mklink /J` junction."))
+             (is (or linked? (.isDirectory (io/file node-path)))
+                 (str "implementation/node_modules must exist for `node` to "
+                      "resolve React (run `npm install` in implementation/ first)")))
 
            ;; --- compile -----------------------------------------------------
            (testing (str label " — shadow-cljs compile "

--- a/tools/template/test/day8/re_frame2_template/template_emission_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_emission_test.clj
@@ -36,88 +36,15 @@
             [clojure.walk :as walk]
             [clojure.tools.reader :as tr]
             [clojure.tools.reader.reader-types :as rt]
-            [org.corfield.new :as deps-new]))
+            [day8.re-frame2-template.test-support
+             :refer [tmp-dir delete-recursively run-template! repo-root]]))
 
-;; --- Helpers (mirror template_test.clj — kept local so the two test
-;; ns-es don't accidentally share state via top-level defs) -----------------
-
-(defn- tmp-dir [prefix]
-  (let [f (java.nio.file.Files/createTempDirectory
-            prefix
-            (into-array java.nio.file.attribute.FileAttribute []))]
-    (.toAbsolutePath f)))
-
-(defn- delete-recursively [^java.nio.file.Path path]
-  (when (java.nio.file.Files/exists path (into-array java.nio.file.LinkOption []))
-    (with-open [stream (java.nio.file.Files/walk
-                         path
-                         (into-array java.nio.file.FileVisitOption []))]
-      (->> stream
-           .iterator
-           iterator-seq
-           reverse
-           (run! #(try
-                    (java.nio.file.Files/deleteIfExists ^java.nio.file.Path %)
-                    (catch java.io.IOException _ nil)))))))
-
-(defn- template-resource-dir []
-  (let [cwd (io/file (System/getProperty "user.dir"))]
-    (loop [d cwd]
-      (cond
-        (nil? d)
-        (throw (ex-info "Couldn't locate tools/template/resources above cwd"
-                        {:cwd cwd}))
-
-        (.isDirectory (io/file d "tools/template/resources"))
-        (.getCanonicalPath (io/file d "tools/template/resources"))
-
-        (.isDirectory (io/file d "resources/day8/re_frame2_template"))
-        (.getCanonicalPath (io/file d "resources"))
-
-        :else
-        (recur (.getParentFile d))))))
-
-(defn- run-template!
-  ([tmp project-name substrate]
-   (run-template! tmp project-name substrate nil))
-  ([tmp project-name substrate include-story?]
-   (let [dir-str   (.toString ^java.nio.file.Path tmp)
-         proj-name (-> project-name name (string/replace #"^.*?/" ""))
-         proj-dir  (io/file dir-str proj-name)
-         opts      (cond-> {:template   'day8/re-frame2-template
-                            :name       (symbol project-name)
-                            :target-dir (.getCanonicalPath proj-dir)
-                            :src-dirs   [(template-resource-dir)]
-                            :overwrite  :delete}
-                     substrate              (assoc :substrate substrate)
-                     (some? include-story?) (assoc :include-story? include-story?))]
-     (deps-new/create opts)
-     proj-dir)))
+;; --- Helpers ---------------------------------------------------------------
+;;
+;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
+;; repo-root live in the shared `test-support` ns (rf2-5v619, D1).
 
 ;; --- Static-parse machinery ----------------------------------------------
-
-(defn- repo-root
-  "Absolute path of the repo root, derived from the JVM's `user.dir`. The
-  template test JVM is launched from `tools/template/`, so the framework
-  source tree we read for ground-truth lives at `../../implementation/`."
-  []
-  (let [cwd (io/file (System/getProperty "user.dir"))]
-    ;; Walk up until we find a sibling `implementation/core/src/re_frame/`
-    ;; directory. This makes the test robust to either:
-    ;;   a) test JVM launched from tools/template/ (the clein default)
-    ;;   b) test JVM launched from the repo root (manual `clojure
-    ;;      -X:test` invocation)
-    (loop [d cwd]
-      (cond
-        (nil? d)
-        (throw (ex-info "Couldn't locate repo root (no implementation/core/src/re_frame above cwd)"
-                        {:cwd cwd}))
-
-        (.isDirectory (io/file d "implementation/core/src/re_frame"))
-        d
-
-        :else
-        (recur (.getParentFile d))))))
 
 (defn- read-cljs-forms
   "Read every top-level form from a .cljs file. Each form is returned in

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -23,80 +23,13 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
-            [clojure.string :as string]
-            [org.corfield.new :as deps-new]))
+            [day8.re-frame2-template.test-support
+             :refer [tmp-dir delete-recursively run-template!]]))
 
 ;; --- Test helpers ----------------------------------------------------------
-
-(defn- tmp-dir
-  "Create a fresh temp directory and return its absolute path. Caller is
-  responsible for cleanup."
-  [prefix]
-  (let [f (java.nio.file.Files/createTempDirectory
-            prefix
-            (into-array java.nio.file.attribute.FileAttribute []))]
-    (.toAbsolutePath f)))
-
-(defn- delete-recursively
-  "Recursively delete a directory."
-  [^java.nio.file.Path path]
-  (when (java.nio.file.Files/exists path (into-array java.nio.file.LinkOption []))
-    (with-open [stream (java.nio.file.Files/walk
-                         path
-                         (into-array java.nio.file.FileVisitOption []))]
-      (->> stream
-           .iterator
-           iterator-seq
-           reverse
-           (run! #(try
-                    (java.nio.file.Files/deleteIfExists ^java.nio.file.Path %)
-                    (catch java.io.IOException _ nil)))))))
-
-(defn- template-resource-dir
-  "Absolute path of the deps-new template-source root
-  (`tools/template/resources/`). The deps-new resolver walks the
-  classpath; passing `:src-dirs [this]` makes it deterministic even when
-  the test JVM is launched from a non-standard cwd."
-  []
-  (let [cwd (io/file (System/getProperty "user.dir"))]
-    (loop [d cwd]
-      (cond
-        (nil? d)
-        (throw (ex-info "Couldn't locate tools/template/resources above cwd"
-                        {:cwd cwd}))
-
-        (.isDirectory (io/file d "tools/template/resources"))
-        (.getCanonicalPath (io/file d "tools/template/resources"))
-
-        (.isDirectory (io/file d "resources/day8/re_frame2_template"))
-        (.getCanonicalPath (io/file d "resources"))
-
-        :else
-        (recur (.getParentFile d))))))
-
-(defn- run-template!
-  "Drive `org.corfield.new/create` to scaffold an app inside `tmp`.
-  Returns the emitted project root as a `java.io.File`. Equivalent to
-  shelling out to `clojure -Tnew create :template … :name … …`, minus
-  the JVM start-up cost.
-
-  Mirrors the entry-fn shape the clj-new template's test suite used
-  (`test/clj/new/re_frame2_test.clj`, removed in rf2-40vmd / §2.5)."
-  ([tmp project-name substrate]
-   (run-template! tmp project-name substrate nil))
-  ([tmp project-name substrate include-story?]
-   (let [dir-str   (.toString ^java.nio.file.Path tmp)
-         proj-name (-> project-name name (string/replace #"^.*?/" ""))
-         proj-dir  (io/file dir-str proj-name)
-         opts      (cond-> {:template   'day8/re-frame2-template
-                            :name       (symbol project-name)
-                            :target-dir (.getCanonicalPath proj-dir)
-                            :src-dirs   [(template-resource-dir)]
-                            :overwrite  :delete}
-                     substrate              (assoc :substrate substrate)
-                     (some? include-story?) (assoc :include-story? include-story?))]
-     (deps-new/create opts)
-     proj-dir)))
+;;
+;; tmp-dir / delete-recursively / template-resource-dir / run-template!
+;; live in the shared `test-support` ns (rf2-5v619, D1).
 
 (defn- read-edn [^java.io.File f]
   (edn/read-string (slurp f)))
@@ -164,9 +97,12 @@
               "deps.edn references day8/re-frame2 core")
           (is (contains? (:deps deps) (substrate-coord substrate))
               (str "deps.edn references " (substrate-coord substrate)))
-          (let [version (get-in deps [:deps 'day8/re-frame2 :mvn/version])]
-            (is (= "0.0.1.alpha" version)
-                "core coord pinned to alpha-channel version")))
+          ;; The literal pin VALUE is owned by version_lockstep_test.clj
+          ;; (reads repo-root VERSION on disk); asserting a hard-coded
+          ;; "0.0.1.alpha" here would duplicate it and false-fail the
+          ;; moment VERSION bumps (rf2-5v619, D3). Present-check only.
+          (is (some? (get-in deps [:deps 'day8/re-frame2 :mvn/version]))
+              "core coord carries an :mvn/version pin"))
 
         ;; -- shadow-cljs.edn structure --
         (let [scs  (read-edn (io/file root "shadow-cljs.edn"))
@@ -190,9 +126,9 @@
         (let [deps (read-edn (io/file root "deps.edn"))]
           (is (contains? (:deps deps) 'day8/re-frame2-causa)
               "deps.edn references day8/re-frame2-causa")
-          (is (= "0.0.1.alpha"
-                 (get-in deps [:deps 'day8/re-frame2-causa :mvn/version]))
-              "Causa coord lockstep with core version"))
+          ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+          (is (some? (get-in deps [:deps 'day8/re-frame2-causa :mvn/version]))
+              "Causa coord carries an :mvn/version pin"))
 
         ;; -- Schemas coord in deps.edn (rf2-48mij) --
         (let [deps (read-edn (io/file root "deps.edn"))]
@@ -200,9 +136,9 @@
               "deps.edn references day8/re-frame2-schemas (best-practice
                whole-app-db schema needs the artefact on the classpath
                for CLJS validation to fire)")
-          (is (= "0.0.1.alpha"
-                 (get-in deps [:deps 'day8/re-frame2-schemas :mvn/version]))
-              "schemas coord lockstep with core version"))
+          ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+          (is (some? (get-in deps [:deps 'day8/re-frame2-schemas :mvn/version]))
+              "schemas coord carries an :mvn/version pin"))
 
         ;; -- Best-practice surface in events.cljs + schema.cljs (rf2-48mij) --
         (let [events-text (slurp (io/file root "src/acme/my_app/events.cljs"))
@@ -232,21 +168,6 @@
           (is (.contains schema-text "CounterDb")
               "schema.cljs ships the CounterDb Malli schema"))
 
-        ;; -- README best-practice + naming sections (rf2-48mij) --
-        (let [readme-text (slurp (io/file root "README.md"))]
-          (is (.contains readme-text "Best practices baked into the scaffold")
-              "README has a Best practices section")
-          (is (.contains readme-text "Errors are events too")
-              "README documents the errors-are-events-too posture")
-          (is (.contains readme-text "Typed app-db boundaries")
-              "README documents the typed-at-boundaries posture")
-          (is (.contains readme-text "closed failure-category set")
-              "README documents the closed :rf.http/* failure-category set")
-          (is (.contains readme-text "Naming conventions")
-              "README documents the naming-conventions rules")
-          (is (.contains readme-text "spec/Conventions.md")
-              "README links to spec/Conventions.md for the normative catalogue"))
-
         ;; -- package.json sanity --
         (let [pj-text (slurp (io/file root "package.json"))]
           (is (.contains pj-text "\"shadow-cljs\"")
@@ -264,62 +185,97 @@
             :helix   (is (.contains views-text "defnc")
                          "Helix views.cljs uses defnc")))
 
-        ;; -- README badges block (rf2-sufwn) --
+        ;; -- Per-substrate README badge (rf2-sufwn) --
+        ;;
+        ;; The badge LINE varies by substrate, so it stays in the
+        ;; per-substrate shape test. The substrate-INVARIANT README/CI/
+        ;; security text moved to `root-content-test` below — it comes
+        ;; from `root/` and was needlessly re-run 3× (rf2-5v619, L3).
         (let [readme-text (slurp (io/file root "README.md"))]
-          (is (.contains readme-text "img.shields.io/badge/built")
-              "README ships a 'built with re-frame2' badge")
           (is (.contains readme-text
                          (case substrate
                            :reagent "substrate-Reagent"
                            :uix     "substrate-UIx"
                            :helix   "substrate-Helix"))
-              "README ships the per-substrate badge")
-          (is (.contains readme-text "License-MIT")
-              "README ships a License badge"))
-
-        ;; -- Baseline CI workflow (rf2-k2z79) --
-        (let [ci-text (slurp (io/file root ".github/workflows/ci.yml"))]
-          (is (.contains ci-text "name: ci")
-              ".github/workflows/ci.yml declares the ci workflow")
-          (is (.contains ci-text "node-version: '22'")
-              "ci.yml pins Node 22 LTS")
-          (is (.contains ci-text "java-version: '21'")
-              "ci.yml pins JDK 21 (matches re-frame2 reference build)")
-          (is (.contains ci-text "actions/checkout@")
-              "ci.yml uses actions/checkout with a SHA pin")
-          (is (.contains ci-text "actions/setup-java@")
-              "ci.yml uses actions/setup-java with a SHA pin")
-          (is (.contains ci-text "actions/setup-node@")
-              "ci.yml uses actions/setup-node with a SHA pin")
-          (is (.contains ci-text "DeLaGuardo/setup-clojure@")
-              "ci.yml uses DeLaGuardo/setup-clojure with a SHA pin")
-          (is (.contains ci-text "npm test")
-              "ci.yml runs `npm test` (delegates to shadow-cljs :node-test
-               per the emitted package.json)")
-          (is (.contains ci-text "# acme/my-app")
-              "ci.yml header substitutes {{name}}"))
-
-        ;; -- Security baseline (rf2-sh3l8) --
-        (let [index-text  (slurp (io/file root "resources/public/index.html"))
-              readme-text (slurp (io/file root "README.md"))]
-          (is (.contains index-text "Content-Security-Policy")
-              "index.html ships a CSP meta tag")
-          (is (.contains index-text "default-src 'self'")
-              "index.html CSP uses default-src 'self'")
-          (is (.contains index-text "frame-ancestors 'none'")
-              "index.html CSP forbids framing (anti-clickjacking)")
-          (is (.contains index-text "object-src 'none'")
-              "index.html CSP forbids plugin objects")
-          (is (.contains index-text "data-rf-causa-host")
-              "index.html provides Causa's default true-inline layout host")
-          (is (.contains readme-text "Production hardening")
-              "README documents Production hardening")
-          (is (.contains readme-text "X-Content-Type-Options")
-              "README covers nosniff header")
-          (is (.contains readme-text "Referrer-Policy")
-              "README covers Referrer-Policy header")))
+              "README ships the per-substrate badge")))
       (finally
         (delete-recursively tmp)))))
+
+(deftest root-content-test
+  (testing "substrate-invariant root/ content (README best-practice +
+            naming + badges, baseline CI workflow, security baseline) —
+            generated once. These files come from root/ and are
+            substrate-agnostic, so re-running them per substrate (the
+            old assert-shape! shape) was 3× redundant + mislayered
+            (rf2-5v619, L3)."
+    (let [tmp (tmp-dir "rf2-template-root-content-")]
+      (try
+        (let [root (run-template! tmp "acme/my-app" :reagent)]
+          ;; -- README best-practice + naming sections (rf2-48mij) --
+          (let [readme-text (slurp (io/file root "README.md"))]
+            (is (.contains readme-text "Best practices baked into the scaffold")
+                "README has a Best practices section")
+            (is (.contains readme-text "Errors are events too")
+                "README documents the errors-are-events-too posture")
+            (is (.contains readme-text "Typed app-db boundaries")
+                "README documents the typed-at-boundaries posture")
+            (is (.contains readme-text "closed failure-category set")
+                "README documents the closed :rf.http/* failure-category set")
+            (is (.contains readme-text "Naming conventions")
+                "README documents the naming-conventions rules")
+            (is (.contains readme-text "spec/Conventions.md")
+                "README links to spec/Conventions.md for the normative catalogue"))
+
+          ;; -- README substrate-invariant badges (rf2-sufwn) --
+          (let [readme-text (slurp (io/file root "README.md"))]
+            (is (.contains readme-text "img.shields.io/badge/built")
+                "README ships a 'built with re-frame2' badge")
+            (is (.contains readme-text "License-MIT")
+                "README ships a License badge"))
+
+          ;; -- Baseline CI workflow (rf2-k2z79) --
+          (let [ci-text (slurp (io/file root ".github/workflows/ci.yml"))]
+            (is (.contains ci-text "name: ci")
+                ".github/workflows/ci.yml declares the ci workflow")
+            (is (.contains ci-text "node-version: '22'")
+                "ci.yml pins Node 22 LTS")
+            (is (.contains ci-text "java-version: '21'")
+                "ci.yml pins JDK 21 (matches re-frame2 reference build)")
+            (is (.contains ci-text "actions/checkout@")
+                "ci.yml uses actions/checkout with a SHA pin")
+            (is (.contains ci-text "actions/setup-java@")
+                "ci.yml uses actions/setup-java with a SHA pin")
+            (is (.contains ci-text "actions/setup-node@")
+                "ci.yml uses actions/setup-node with a SHA pin")
+            (is (.contains ci-text "DeLaGuardo/setup-clojure@")
+                "ci.yml uses DeLaGuardo/setup-clojure with a SHA pin")
+            (is (.contains ci-text "npm test")
+                "ci.yml runs `npm test` (delegates to shadow-cljs :node-test
+                 per the emitted package.json)")
+            (is (.contains ci-text "# acme/my-app")
+                "ci.yml header substitutes {{name}}"))
+
+          ;; -- Security baseline (rf2-sh3l8) --
+          (let [index-text  (slurp (io/file root "resources/public/index.html"))
+                readme-text (slurp (io/file root "README.md"))]
+            (is (.contains index-text "Content-Security-Policy")
+                "index.html ships a CSP meta tag")
+            (is (.contains index-text "default-src 'self'")
+                "index.html CSP uses default-src 'self'")
+            (is (.contains index-text "frame-ancestors 'none'")
+                "index.html CSP forbids framing (anti-clickjacking)")
+            (is (.contains index-text "object-src 'none'")
+                "index.html CSP forbids plugin objects")
+            (is (.contains index-text "data-rf-causa-host")
+                "index.html provides Causa's default true-inline layout host")
+            (is (.contains readme-text "Production hardening")
+                "README documents Production hardening")
+            (is (.contains readme-text "X-Content-Type-Options")
+                "README covers nosniff header")
+            (is (.contains readme-text "Referrer-Policy")
+                "README covers Referrer-Policy header")))
+        (finally
+          (delete-recursively tmp))))))
 
 (deftest reagent-default-substrate-test
   (testing "default (no :substrate arg) produces Reagent variant"
@@ -398,9 +354,9 @@
                 pkg-txt (slurp (io/file root "package.json"))]
             (is (contains? (:deps deps) 'day8/re-frame2-story)
                 "deps.edn references day8/re-frame2-story")
-            (is (= "0.0.1.alpha"
-                   (get-in deps [:deps 'day8/re-frame2-story :mvn/version]))
-                "story coord lockstep with the core version")
+            ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
+            (is (some? (get-in deps [:deps 'day8/re-frame2-story :mvn/version]))
+                "story coord carries an :mvn/version pin")
             (is (.contains pkg-txt "\"story\":")
                 "package.json declares a `story` npm script")
             (is (.contains pkg-txt "\"qrcode-generator\"")

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -1,0 +1,109 @@
+(ns day8.re-frame2-template.test-support
+  "Shared harness for the tools/template JVM test suite (rf2-5v619, D1).
+
+   The four sibling test files
+   (`template_test.clj` / `template_emission_test.clj` /
+   `emitted_test_run_test.clj` / `version_lockstep_test.clj`) each used
+   to carry their own copies of `tmp-dir` / `delete-recursively` /
+   `template-resource-dir` / `run-template!` / `repo-root` — ~250 lines
+   of duplicated, stateless harness with three slightly-different
+   `repo-root` impls that drifted independently. These are pure
+   functions with no top-level mutable state, so the earlier
+   'kept-independent-to-avoid-state-sharing' rationale didn't hold;
+   they belong in one place.
+
+   `repo-root` is unified to a single walk-up that anchors on
+   `implementation/core/src/re_frame` (the strongest, deepest marker
+   the old impls used). The version-lockstep test previously anchored
+   on `implementation/package.json`; both files live under the same
+   repo root, so the deeper marker subsumes it."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as string]
+            [org.corfield.new :as deps-new])
+  (:import [java.nio.file Files LinkOption Path FileVisitOption]
+           [java.nio.file.attribute FileAttribute]))
+
+;; --- tmp dirs --------------------------------------------------------------
+
+(defn tmp-dir
+  "Create a fresh temp directory and return its absolute `java.nio.file.Path`.
+  Caller is responsible for cleanup (see `delete-recursively`)."
+  [prefix]
+  (.toAbsolutePath
+    (Files/createTempDirectory prefix (into-array FileAttribute []))))
+
+(defn delete-recursively
+  "Recursively delete a directory tree (depth-first, deepest entries
+  first). Swallows per-entry IO failures so a partially-removed tree on
+  a locked OS file (Windows) doesn't fail the enclosing `finally`."
+  [^Path path]
+  (when (Files/exists path (into-array LinkOption []))
+    (with-open [stream (Files/walk path (into-array FileVisitOption []))]
+      (->> stream
+           .iterator
+           iterator-seq
+           reverse
+           (run! #(try
+                    (Files/deleteIfExists ^Path %)
+                    (catch java.io.IOException _ nil)))))))
+
+;; --- repo-root + template-resource-dir -------------------------------------
+
+(defn repo-root
+  "Absolute repo-root `java.io.File`, derived from the JVM's `user.dir`.
+
+  The template test JVM is launched from `tools/template/` (the clein
+  default working dir for the `:test` alias), but a manual repo-root
+  `clojure -X:test` invocation must also work — so we walk up from
+  `user.dir` until we find a directory with a
+  `implementation/core/src/re_frame` child (the deepest, most
+  unambiguous repo marker the old per-file impls used)."
+  []
+  (loop [d (io/file (System/getProperty "user.dir"))]
+    (cond
+      (nil? d)
+      (throw (ex-info (str "Couldn't locate repo root "
+                           "(no implementation/core/src/re_frame above cwd)")
+                      {:cwd (System/getProperty "user.dir")}))
+
+      (.isDirectory (io/file d "implementation/core/src/re_frame"))
+      d
+
+      :else
+      (recur (.getParentFile d)))))
+
+(defn template-resource-dir
+  "Absolute path of the deps-new template-source root
+  (`tools/template/resources/`). The deps-new resolver walks the
+  classpath; passing `:src-dirs [this]` makes it deterministic even when
+  the test JVM is launched from a non-standard cwd."
+  []
+  (.getCanonicalPath (io/file (repo-root) "tools/template/resources")))
+
+;; --- run-template! ---------------------------------------------------------
+
+(defn run-template!
+  "Drive `org.corfield.new/create` to scaffold an app inside `tmp`.
+  Returns the emitted project root as a `java.io.File`. Equivalent to
+  shelling out to `clojure -Tnew create :template … :name … …`, minus
+  the JVM start-up cost.
+
+  `substrate` may be nil (exercises the default-substrate path).
+  `include-story?` is optional; when supplied (non-nil) it is passed
+  through as the `:include-story?` deps-new arg — `true` selects the
+  with-story scaffold, `false` forces the default path explicitly."
+  ([tmp project-name substrate]
+   (run-template! tmp project-name substrate nil))
+  ([tmp project-name substrate include-story?]
+   (let [dir-str   (.toString ^Path tmp)
+         proj-name (-> project-name name (string/replace #"^.*?/" ""))
+         proj-dir  (io/file dir-str proj-name)
+         opts      (cond-> {:template   'day8/re-frame2-template
+                            :name       (symbol project-name)
+                            :target-dir (.getCanonicalPath proj-dir)
+                            :src-dirs   [(template-resource-dir)]
+                            :overwrite  :delete}
+                     substrate              (assoc :substrate substrate)
+                     (some? include-story?) (assoc :include-story? include-story?))]
+     (deps-new/create opts)
+     proj-dir)))

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -20,7 +20,8 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
             [org.corfield.new :as deps-new])
-  (:import [java.nio.file Files LinkOption Path FileVisitOption]
+  (:import [java.nio.file Files LinkOption Path
+            FileVisitResult SimpleFileVisitor]
            [java.nio.file.attribute FileAttribute]))
 
 ;; --- tmp dirs --------------------------------------------------------------
@@ -32,20 +33,64 @@
   (.toAbsolutePath
     (Files/createTempDirectory prefix (into-array FileAttribute []))))
 
+(defn- reparse-point?
+  "True when `path` is a symbolic link OR a Windows directory *junction*.
+  `Files/isSymbolicLink` catches the former but NOT junctions — a junction
+  is a distinct reparse-point type that the JDK reports as a plain
+  directory. We detect it the only portable way: a junction's
+  `BasicFileAttributes` reports `isDirectory` true AND `isOther` true
+  (the reparse-point bit), whereas a real directory reports `isOther`
+  false. (On non-Windows this simply never matches, which is correct —
+  there are no junctions there.)"
+  [^Path path]
+  (or (Files/isSymbolicLink path)
+      (try
+        (let [attrs (Files/readAttributes
+                      path
+                      java.nio.file.attribute.BasicFileAttributes
+                      (into-array LinkOption [LinkOption/NOFOLLOW_LINKS]))]
+          (and (.isDirectory attrs) (.isOther attrs)))
+        (catch java.io.IOException _ false))))
+
 (defn delete-recursively
   "Recursively delete a directory tree (depth-first, deepest entries
   first). Swallows per-entry IO failures so a partially-removed tree on
-  a locked OS file (Windows) doesn't fail the enclosing `finally`."
+  a locked OS file (Windows) doesn't fail the enclosing `finally`.
+
+  CRITICAL: deletes symlinks and Windows *junctions* as a single unit —
+  it never descends THROUGH them. The behavioural emitted-test tier
+  junctions the project's `node_modules` to the shared
+  `implementation/node_modules`; a naive `Files/walk` (which follows
+  junctions, since the JDK treats them as plain directories) would walk
+  into that junction and delete the shared React install. We use
+  `walkFileTree` with a visitor that, on entering a reparse-point
+  directory, deletes the link and skips its subtree."
   [^Path path]
-  (when (Files/exists path (into-array LinkOption []))
-    (with-open [stream (Files/walk path (into-array FileVisitOption []))]
-      (->> stream
-           .iterator
-           iterator-seq
-           reverse
-           (run! #(try
-                    (Files/deleteIfExists ^Path %)
-                    (catch java.io.IOException _ nil)))))))
+  (when (Files/exists path (into-array LinkOption [LinkOption/NOFOLLOW_LINKS]))
+    (Files/walkFileTree
+      path
+      (proxy [SimpleFileVisitor] []
+        (preVisitDirectory [dir attrs]
+          (if (reparse-point? dir)
+            ;; A junction/symlinked dir: unlink it (removes only the
+            ;; reparse point, never the target's contents) and do not
+            ;; descend.
+            (do (try (Files/deleteIfExists ^Path dir)
+                     (catch java.io.IOException _ nil))
+                FileVisitResult/SKIP_SUBTREE)
+            FileVisitResult/CONTINUE))
+        (visitFile [file attrs]
+          (try (Files/deleteIfExists ^Path file)
+               (catch java.io.IOException _ nil))
+          FileVisitResult/CONTINUE)
+        (visitFileFailed [file _exc]
+          ;; Couldn't stat/open the entry — keep going; the postVisit
+          ;; delete below sweeps what it can.
+          FileVisitResult/CONTINUE)
+        (postVisitDirectory [dir _exc]
+          (try (Files/deleteIfExists ^Path dir)
+               (catch java.io.IOException _ nil))
+          FileVisitResult/CONTINUE)))))
 
 ;; --- repo-root + template-resource-dir -------------------------------------
 

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -22,31 +22,16 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
             [clojure.string :as string]
+            [day8.re-frame2-template.test-support
+             :refer [tmp-dir delete-recursively repo-root template-resource-dir]]
             [org.corfield.new :as deps-new]))
 
-;; --- Repo-root discovery (same pattern as template_emission_test) -------
-
-(defn- repo-root
-  "Absolute path of the repo root. The template test JVM is launched
-  from `tools/template/` (clein default), but a manual `clojure -X:test`
-  may launch from the repo root — walk up from `user.dir` until we find
-  a sibling `implementation/package.json`."
-  []
-  (let [cwd (io/file (System/getProperty "user.dir"))]
-    (loop [d cwd]
-      (cond
-        (nil? d)
-        (throw (ex-info "Couldn't locate repo root (no implementation/package.json above cwd)"
-                        {:cwd cwd}))
-
-        (.isFile (io/file d "implementation/package.json"))
-        d
-
-        :else
-        (recur (.getParentFile d))))))
-
-(defn- template-resource-dir []
-  (.getCanonicalPath (io/file (repo-root) "tools/template/resources")))
+;; --- Helpers ---------------------------------------------------------------
+;;
+;; repo-root / template-resource-dir / tmp-dir / delete-recursively live
+;; in the shared `test-support` ns (rf2-5v619, D1). repo-root anchors on
+;; `implementation/core/src/re_frame` — the same repo root that holds
+;; VERSION + implementation/package.json read below.
 
 ;; --- Source-of-truth readers --------------------------------------------
 
@@ -97,25 +82,6 @@
 ;; package.json + deps.edn. This tests the literals as actually-consumed
 ;; (the same value that flows into a generated app), not the source
 ;; string parsed out of the .clj.
-
-(defn- tmp-dir [prefix]
-  (let [f (java.nio.file.Files/createTempDirectory
-            prefix
-            (into-array java.nio.file.attribute.FileAttribute []))]
-    (.toAbsolutePath f)))
-
-(defn- delete-recursively [^java.nio.file.Path path]
-  (when (java.nio.file.Files/exists path (into-array java.nio.file.LinkOption []))
-    (with-open [stream (java.nio.file.Files/walk
-                         path
-                         (into-array java.nio.file.FileVisitOption []))]
-      (->> stream
-           .iterator
-           iterator-seq
-           reverse
-           (run! #(try
-                    (java.nio.file.Files/deleteIfExists ^java.nio.file.Path %)
-                    (catch java.io.IOException _ nil)))))))
 
 (defn- emit-reagent! [tmp]
   (let [dir-str  (.toString ^java.nio.file.Path tmp)


### PR DESCRIPTION
Recovers and ships stranded work for **rf2-5v619** (a prior worker did the work but died before committing), then fixes a real npm-resolution gap the new tier exposed.

## What the recovered work does

- **G1 — with-story branch is now compiled + run.** Adds `reagent-with-story-emitted-tests-run-test`, the only tier that shadow-compiles + node-runs the `:include-story? true` scaffold. It compiles the `:app` (`:browser`) build whose `:init-fn` (`core/init`) transitively pulls `core_with_stories.cljs`, `stories.cljs`, and `re-frame.story` onto the compile classpath, plus the `:test` build. The deps rewrite now also maps `day8/re-frame2-story` to `:local/root`. A broken with-story compile now fails the build instead of shipping green from string-presence + static-parse alone.
- **G3 — stale deps-resolve probe removed.** Drops the dead `RF2_TEMPLATE_DEPS_RESOLVE` CI env var and the comment claiming a `clojure -P` probe that never existed. The alpha-channel `:mvn/version` coords are unpublished (git-coord distribution per rf2-dolpf), so `-P` could never resolve; the comment now documents that the `:local/root` behavioural tier is the strongest pre-publish resolve signal.
- **D1 — shared test helper.** Extracts the ~250 lines of duplicated `tmp-dir` / `delete-recursively` / `template-resource-dir` / `run-template!` / `repo-root` (three drifting `repo-root` impls) into a single `test_support.clj`.
- **D3 — version literal de-dup.** Replaces hard-coded `0.0.1.alpha` asserts with present-checks; the pin value is owned by `version_lockstep_test.clj` (reads VERSION on disk).
- **L3 — god-test split.** Moves substrate-invariant README/CI/security text out of the per-substrate `assert-shape!` into a single `root-content-test` (was re-run 3x).

## npm-resolution fix (exposed by the new :app tier)

The `:browser` build's npm resolver searches only the project-local `node_modules` and ignores `NODE_PATH`. The harness only attempted a symlink, which needs `SeCreateSymbolicLinkPrivilege` (unavailable on stock Windows without Developer Mode), so the `:app` compile red'd with "react not available".

- `link-node-modules!` now falls back to a directory **junction** (`mklink /J`, no privilege required) and asserts `node_modules/react` actually resolves. On Linux CI the symlink path still wins; the junction is a Windows-only fallback.
- `delete-recursively` is now **reparse-point-aware**. A Windows junction is not a symbolic link, so `Files/walk` descends THROUGH it — a naive recursive delete would follow the `node_modules` junction and wipe the shared `implementation/node_modules`. It now uses `walkFileTree` and unlinks symlink/junction directories as a unit (`SKIP_SUBTREE`) without descending.

The with-story scaffold compile itself was **sound** (552 files, 0 warnings) — the only failure was the harness npm-resolution gap.

## test.yml rebase resolution

The base was stale and #1891 (mcp-infra) had merged additions into `test.yml`. The rebase was a clean **union**: #1891's changes are in the `jvm-tools-mcp-base` job (mcp-base CLJS `:node-test` build), while this work's change is in the separate `jvm-tools-template` job (drop the stale env var). Both additive CI changes coexist — verified the mcp-base CLJS step and the template `RF2_TEMPLATE_RUN_EMITTED_TESTS` step are both present post-rebase.

## Gate results

- `tools/template` JVM, gate ON (`RF2_TEMPLATE_RUN_EMITTED_TESTS=1`): **21 tests / 325 assertions / 0 failures, 0 errors** — includes the with-story `:app`+`:test` compile + node-run.
- `tools/template` JVM, gate OFF (fast loop): **21 tests / 297 assertions / 0 failures, 0 errors**.
- Confirmed the shared `implementation/node_modules` survives the harness cleanup (junction-safe).