### PR TITLE
test(adapters): fold remaining UIx/Helix DOM twins into shared suite via node/browser split (rf2-5or96)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
@@ -1,134 +1,46 @@
 (ns re-frame.adapter.helix-after-render-dom-cljs-test
-  "Behavioural coverage for the Helix adapter's `:adapter/after-render`
-  hook (rf2-334d9). Pre-rf2-334d9 the Helix adapter did not publish
-  `:adapter/after-render`, so `(rf/after-render f)` under a Helix-only
-  app was a silent no-op — closed by Mike's rf2-neiqf decision
-  2026-05-19 to publish via `React.useLayoutEffect`.
+  "Helix DOM/browser entry-point for the after-render twin of the
+  parameterised React-adapter suite (`re-frame.adapter.react-shared-suite`).
 
-  Architecture under test. The spine maintains a per-adapter after-
-  render queue + a sentinel React function component injected at the
-  root of every mounted tree (via `spine/make-render`). The sentinel
-  fires `React.useLayoutEffect` on every commit, draining the queue.
-  When `interop/after-render` is called, the sentinel's stashed
-  `setState` bumps a tick so React schedules a commit, the
-  `useLayoutEffect` fires, and the queue drains in
-  post-commit / pre-paint order — same timing semantics as Reagent's
-  `r/after-render`. A `queueMicrotask` fallback covers the
-  pre-mount / post-unmount call paths.
+  rf2-5or96 folded the UIx/Helix after-render twins (rf2-334d9) into the
+  shared suite. Helix defines its probe component with `helix.core/defnc`
+  + `helix.dom` — substrate macros the suite cannot mint at runtime — so
+  the probe var is built HERE and handed to the suite via the cfg map's
+  `:probe-element` thunk; the orchestration + every assertion lives once
+  in the suite (Approach A: components passed in as elements). A gap on
+  UIx is a gap on Helix by construction.
 
-  Coverage shape mirrors the UIx parity test
-  (`uix_after_render_cljs_test.cljs`):
-    1. The hook is wired at ns-load — calling `interop/after-render`
-       under the Helix adapter returns nil (not a thrown
-       'no hook bound' / silent no-op signal).
-    2. Behaviour. Mount a Helix tree; call `(interop/after-render f)`;
-       verify `f` fired after the next commit (asserted via a side-
-       channel atom).
+  Coverage forwarded (rf2-334d9): the ns-load smoke (node-safe — runs
+  under :node-test) that `interop/after-render` is wired and returns nil,
+  plus the act-driven mount/schedule/drain behaviour (browser-only).
 
-  The behaviour assertion is browser-only — node-runtime has no DOM
-  and `react-dom/client` is unmountable there. Under `:node-test` the
-  ns-load smoke runs and the behaviour test no-ops cleanly.
-
-  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
-  (:require ["react"            :as React]
-            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  (ns-regexp `-dom-cljs-test$`) discovers it for the real DOM assertions;
+  `:node-test`'s `cljs-test$` regex also matches, running the node-safe
+  smoke + the self-gated behaviour no-op."
+  (:require [cljs.test :refer-macros [deftest use-fixtures]]
             [helix.core :refer-macros [$ defnc]]
             [helix.dom  :as d]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.adapter.helix :as helix-adapter]
-            [re-frame.interop :as interop]
+            [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter helix-adapter/adapter}))
 
-(defn- browser? []
-  (and (exists? js/document)
-       (some? (.-createElement js/document))))
-
-(defn- make-mount-node! []
-  (when (browser?)
-    (.createElement js/document "div")))
-
-(defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper."
-  []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
-
-(defn- enable-react-act-env! []
-  (when (browser?)
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
-
-;; ---- ns-load smoke -------------------------------------------------------
-
-(deftest after-render-hook-wired-under-helix
-  (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
-            under the Helix adapter — the hook is wired at ns-load and
-            returns nil (the documented swallow shape) rather than
-            falling through to nil because no adapter published it."
-    ;; Calling with a fn argument should NOT throw and should NOT
-    ;; return a 'no hook bound' sentinel. The hook itself returns nil
-    ;; per the make-after-render-hook contract, and the queueMicrotask
-    ;; fallback drain handles the no-mount case asynchronously.
-    (is (nil? (interop/after-render (fn [] :ok)))
-        "interop/after-render under the Helix adapter returns nil — the
-         spine-built hook is wired through :adapter/after-render via
-         substrate-adapter/route-hook!")))
-
-;; ---- behaviour: mount, schedule, drain after commit ----------------------
-
 (defnc Probe []
   ;; Bare Helix component — the rf2-334d9 sentinel is injected by the
   ;; spine's `make-render`, not by user code.
   (d/div "probe"))
 
+(def ^:private cfg
+  {:adapter       helix-adapter/adapter
+   :name          "Helix"
+   :probe-element (fn [] ($ Probe))})
+
+(deftest after-render-hook-wired-under-helix
+  (suite/assert-after-render-hook-wired cfg))
+
 (deftest after-render-runs-callback-after-next-commit-helix
-  (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
-            after the next mount/render cycle under the Helix adapter.
-            The sentinel injected by the spine's make-render uses
-            React.useLayoutEffect to drain the queue post-commit."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (let [fired      (atom 0)
-                  callback   (fn after-render-cb [] (swap! fired inc))
-                  mount-node (make-mount-node!)
-                  unmount    (atom nil)]
-              (try
-                ;; Mount through `rf/render` so the spine's
-                ;; make-render path injects the after-render sentinel.
-                ;; Direct `react-dom-client/createRoot` + `.render`
-                ;; bypasses the spine wrap and would leave no sentinel
-                ;; in the tree — exactly what the rf2-334d9 design
-                ;; requires under test.
-                (act-fn (fn []
-                          (reset! unmount
-                                  (substrate-adapter/render ($ Probe) mount-node {}))))
-                (is (zero? @fired)
-                    "no after-render fn enqueued yet ⇒ no fires")
-                ;; Enqueue under act so the set-tick bump → re-render
-                ;; → useLayoutEffect drain commits synchronously in
-                ;; the test environment.
-                (act-fn (fn [] (interop/after-render callback)))
-                (is (= 1 @fired)
-                    "after-render fn fired exactly once after the next commit")
-                ;; A second enqueue + drain — the sentinel survives
-                ;; the first drain (its useLayoutEffect runs every
-                ;; commit) so a subsequent after-render also fires.
-                (act-fn (fn [] (interop/after-render callback)))
-                (is (= 2 @fired)
-                    "subsequent after-render fn also fires after its commit")
-                (finally
-                  (when-let [u @unmount]
-                    (try (u) (catch :default _ nil))))))))))))
+  (suite/assert-after-render-runs-after-commit cfg))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -1,32 +1,37 @@
 (ns re-frame.adapter.helix-use-subscribe-dom-cljs-test
-  "Unit coverage for the Helix adapter's `use-subscribe` hook (rf2-518sp).
+  "Helix DOM/browser entry-point for the use-subscribe twin of the
+  parameterised React-adapter suite (`re-frame.adapter.react-shared-suite`).
 
-  Pre-rf2-518sp, `use-subscribe` was published as the canonical Helix
-  subscribe surface (rf2-2qit Decision 1) and exercised only through
-  the Playwright `counter_helix` smoke; no node-runtime headless test
-  asserted that the React.useSyncExternalStore wiring sees post-
-  dispatch values. A regression in `subscribe-fn`'s add-watch keying,
-  `get-snap`'s reaction deref, the use-memo deps vec, or the
-  unsubscribe-on-unmount cleanup (rf2-7g959) would slip past
-  `test:cljs` / `test:browser` and only surface in the smoke.
+  rf2-5or96 folded the UIx/Helix use-subscribe twins (rf2-518sp /
+  rf2-7g959 / rf2-mwft2 / rf2-y0db2 — parity with UIx's rf2-rcgsc) into
+  the shared suite. Helix defines its probe components with
+  `helix.core/defnc` + `$` + `helix.dom` + `helix.hooks` — substrate
+  macros the suite cannot mint at runtime — so the probe vars, their
+  side-channel observation atoms, and the substrate-baked frame/query
+  keywords are built HERE and handed to the suite via the cfg map
+  (Approach A: components passed in as elements + atoms + keywords). The
+  orchestration (reg-frame, dispatch, mount under act, assert) lives once
+  in the suite; a gap on Helix is a gap on UIx by construction.
 
-  Pattern: mirror the Reagent adapter's
-  `scenario-7-concurrent-renders-survive-act-flush` (in
-  `frame_provider_context_cljs_test.cljs`) — gate on `(browser?)`
-  and exit early under `:node-test` where there is no DOM. The
-  browser-test runner exercises the real assertions.
+  Coverage forwarded:
+    - use-subscribe sees post-dispatch values via useSyncExternalStore
+      (rf2-518sp)
+    - 1-arg form resolves through the surrounding frame-provider
+    - 2-arg form pins an explicit frame, no cross-frame leakage (rf2-y0db2)
+    - sub-cache refcount cleanup on unmount (rf2-7g959)
+    - stable-deps-key: one subs/subscribe across N re-renders, unsubscribe
+      unmount-only, spy assertions (rf2-mwft2)
 
-  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require ["react"            :as React]
-            ["react-dom/client" :as react-dom-client]
-            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  (ns-regexp `-dom-cljs-test$`) discovers it for the real DOM assertions;
+  `:node-test`'s `cljs-test$` regex also matches, where every suite fn
+  self-gates on `(browser?)` and no-ops cleanly."
+  (:require [cljs.test :refer-macros [deftest use-fixtures]]
             [helix.core :refer-macros [$ defnc]]
             [helix.dom  :as d]
             [helix.hooks :as helix-hooks]
-            [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.subs :as subs]
             [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
@@ -34,46 +39,57 @@
     {:adapter helix-adapter/adapter}))
 
 ;; ---- side-channel atoms ----------------------------------------------------
-;; Per-test atoms read by the Helix probe components below. The probes
-;; are defnc top-levels (helix `defnc` defines a Var; it cannot sit
-;; inside a `let`) and close over these atoms; each deftest `reset!`s
-;; the atom it cares about at the top of its body.
+;; Read by the Helix probe components below. The probes are defnc
+;; top-levels (helix `defnc` defines a Var; it cannot sit inside a `let`)
+;; and close over these atoms; the suite `reset!`s the atom each assertion
+;; cares about at the top of its body.
 
-(def ^:private probe-observed       (atom []))
-(def ^:private probe-fp-observed    (atom []))
-(def ^:private refcount-target      (atom nil))
+(def ^:private probe-observed    (atom []))
+(def ^:private probe-fp-observed (atom []))
+(def ^:private refcount-target   (atom nil))
+(def ^:private mwft2-set-tick    (atom nil))
 
 (defnc Probe []
   (let [target @refcount-target
-        v (helix-adapter/use-subscribe target
-                                       [:rf.helix-use-subscribe-test/n])]
+        v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/n])]
     (swap! probe-observed conj v)
     (d/div (str "n=" v))))
 
 (defnc ProbeFp []
-  (let [v (helix-adapter/use-subscribe
-            [:rf.helix-use-subscribe-test/k])]
+  (let [v (helix-adapter/use-subscribe [:rf.helix-use-subscribe-test/k])]
     (swap! probe-fp-observed conj v)
     (d/div (str "k=" v))))
 
 (defnc ProbeRc []
   (let [target @refcount-target
-        v (helix-adapter/use-subscribe target
-                                       [:rf.helix-use-subscribe-test/m])]
+        v (helix-adapter/use-subscribe target [:rf.helix-use-subscribe-test/m])]
     (d/div (str "m=" v))))
 
-;; ---- rf2-mwft2 regression probes ------------------------------------------
-;; A parent that owns a tick state (used to force re-renders) plus a child
-;; that reads a fixed query-v via use-subscribe. The literal `[:rf.helix-mwft2/p]`
-;; vector evaluates to a fresh JS object each render — *exactly* the shape
-;; the bug-without-fix walks into. The parent stashes its set-tick fn into
-;; a side-channel atom so the test can drive forced re-renders from outside.
+;; ---- rf2-y0db2 2-arg explicit-pin probes ----------------------------------
 
-(def ^:private mwft2-set-tick      (atom nil))
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defnc Probe2ArgA []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    (d/div (str "a=" v))))
+
+(defnc Probe2ArgB []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    (d/div (str "b=" v))))
+
+;; ---- rf2-mwft2 stable-deps-key probes -------------------------------------
+;; A parent that owns a tick state (used to force re-renders) plus a child
+;; that reads a fixed query-v via use-subscribe. The literal
+;; `[:rf.helix-mwft2/p]` vector evaluates to a fresh JS object each render —
+;; exactly the shape the bug-without-fix walks into. The parent stashes its
+;; set-tick fn into a side-channel atom so the suite can drive forced
+;; re-renders from outside.
 
 (defnc ProbeMwft2Child []
-  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame
-                                       [:rf.helix-mwft2/p])]
+  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame [:rf.helix-mwft2/p])]
     (d/div (str "p=" v))))
 
 (defnc ProbeMwft2Parent []
@@ -89,332 +105,51 @@
     (d/div {:data-tick tick}
            ($ ProbeMwft2Child))))
 
-;; ---- browser gate ---------------------------------------------------------
+;; ---- cfg + forwarded deftests ---------------------------------------------
 
-(defn- browser? []
-  (and (exists? js/document)
-       (some? (.-createElement js/document))))
-
-(defn- make-mount-node! []
-  (when (browser?)
-    (.createElement js/document "div")))
-
-(defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper."
-  []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
-
-(defn- enable-react-act-env!
-  "React's act() helper warns / behaves as a no-op unless the runner
-  opts in by setting the global `IS_REACT_ACT_ENVIRONMENT` flag. The
-  Playwright browser runner doesn't set this by default; set it
-  inside each test that needs act() so concurrent-renderer pending
-  work commits synchronously."
-  []
-  (when (browser?)
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
-
-;; ---- assertions ------------------------------------------------------------
-;;
-;; The probe component reads the sub via `use-subscribe` and pushes the
-;; observed value into a side-channel atom. After a dispatch we
-;; re-render under `act` and assert the side-channel reflects the new
-;; value. The 2-arg form pins the frame explicitly; the 1-arg form
-;; resolves through the surrounding `frame-provider`.
+(def ^:private cfg
+  {:adapter               helix-adapter/adapter
+   :name                  "Helix"
+   :frame-provider        helix-adapter/frame-provider
+   ;; tracks-app-db
+   :probe-element         (fn [] ($ Probe))
+   :probe-observed        probe-observed
+   :refcount-target       refcount-target
+   :us-frame              :rf.helix-use-subscribe-test/probe-frame
+   :us-query              :rf.helix-use-subscribe-test/n
+   ;; frame-provider 1-arg
+   :probe-fp-element      (fn [] ($ ProbeFp))
+   :probe-fp-observed     probe-fp-observed
+   :fp-frame              :rf.helix-use-subscribe-test/fp-frame
+   :fp-query              :rf.helix-use-subscribe-test/k
+   ;; 2-arg explicit pin
+   :probe-2arg-element    (fn [] ($ :div ($ Probe2ArgA) ($ Probe2ArgB)))
+   :probe-2arg-a-observed probe-2arg-a-observed
+   :probe-2arg-b-observed probe-2arg-b-observed
+   :tenant-a-frame        :rf.helix-rcgsc/tenant-a
+   :tenant-b-frame        :rf.helix-rcgsc/tenant-b
+   :rcgsc-query           :rf.helix-rcgsc/n
+   ;; refcount cleanup
+   :probe-rc-element      (fn [] ($ ProbeRc))
+   :rc-frame              :rf.helix-use-subscribe-test/refcount-frame
+   :rc-query              :rf.helix-use-subscribe-test/m
+   ;; stable deps key
+   :probe-mwft2-element   (fn [] ($ ProbeMwft2Parent))
+   :mwft2-set-tick        mwft2-set-tick
+   :mwft2-frame           :rf.helix-mwft2/probe-frame
+   :mwft2-query           :rf.helix-mwft2/p})
 
 (deftest use-subscribe-tracks-app-db-changes
-  (testing "Helix use-subscribe sees post-dispatch values via useSyncExternalStore"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/probe-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-observed [])
-            (reset! refcount-target target)
-            (rf/reg-frame target {:doc "use-subscribe probe frame"})
-            (rf/reg-event-db :seed-helix-us (fn [_ _] {:n 1}))
-            (rf/reg-event-db :inc-helix-us  (fn [db _] (update db :n inc)))
-            (rf/dispatch-sync [:seed-helix-us] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/n
-                        (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn [] (.render root ($ Probe))))
-                (is (some #{1} @probe-observed)
-                    "first render observed the seeded value n=1")
-                ;; Wrap dispatch in act so React commits the forceUpdate
-                ;; the spine's add-watch → on-change path schedules.
-                ;; Plain `dispatch-sync` outside act emits the
-                ;; "update was not wrapped in act" warning AND fails to
-                ;; flush the resulting render in the test environment.
-                (act-fn (fn [] (rf/dispatch-sync [:inc-helix-us] {:frame target})))
-                (is (some #{2} @probe-observed)
-                    "post-dispatch re-render observed the incremented value n=2")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
+  (suite/assert-use-subscribe-tracks-app-db-changes cfg))
 
 (deftest use-subscribe-frame-provider-resolution
-  (testing "Helix use-subscribe 1-arg form resolves through the surrounding frame-provider"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/fp-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-fp-observed [])
-            (rf/reg-frame target {:doc "use-subscribe fp probe frame"})
-            (rf/reg-event-db :seed-helix-us-fp (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [:seed-helix-us-fp] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/k
-                        (fn [db _] (:k db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn
-                  (fn []
-                    ;; frame-provider is a plain CLJS fn returning a
-                    ;; React element (NOT a React-component head), so
-                    ;; invoke it directly rather than via `($ ...)`.
-                    (.render root
-                      (helix-adapter/frame-provider
-                        {:frame target :children [($ ProbeFp)]}))))
-                (is (some #{:wrapped} @probe-fp-observed)
-                    "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- sub-cache refcount cleanup (rf2-7g959) -------------------------------
-;;
-;; Pre-rf2-7g959, `use-subscribe` only removed the add-watch on
-;; unmount; the sub-cache ref-count for the (frame, query) pair was
-;; never decremented, so the entry stayed pinned at 1 for the process
-;; lifetime. With the rf2-7g959 cleanup in the spine, an explicit
-;; `subs/unsubscribe` fires from a useEffect cleanup so the cache
-;; entry's ref-count returns to 0 after the deferred-dispose grace
-;; period.
-
-(deftest use-subscribe-cleanup-decrements-sub-cache-refcount
-  (testing "Helix use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/refcount-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! refcount-target target)
-            (rf/reg-frame target {:doc "refcount probe frame"})
-            (rf/reg-event-db :seed-helix-us-rc (fn [_ _] {:m 0}))
-            (rf/dispatch-sync [:seed-helix-us-rc] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/m
-                        (fn [db _] (:m db)))
-            (let [cache-key-v [:rf.helix-use-subscribe-test/m]
-                  cache       (:sub-cache (frame/frame target))
-                  mount-node  (make-mount-node!)
-                  root        (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn [] (.render root ($ ProbeRc))))
-                (is (pos? (or (get-in @cache [cache-key-v :ref-count])
-                              0))
-                    "mounted probe pinned a cache entry with ref-count > 0")
-                (act-fn (fn [] (.unmount root)))
-                ;; After unmount the useEffect cleanup fires
-                ;; subs/unsubscribe; the entry's deferred-dispose
-                ;; either races a 0 ref-count or schedules grace-period
-                ;; teardown. Either way the ref-count is no longer
-                ;; pinned at >0 — the regression rf2-7g959 named.
-                (is (or (nil? (get @cache cache-key-v))
-                        (zero? (or (get-in @cache [cache-key-v :ref-count])
-                                   0)))
-                    "post-unmount ref-count is zero (or entry already dropped) — rf2-7g959 cleanup fired")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- 2-arg form: explicit frame-id wins over context (rf2-y0db2) ----------
-;;
-;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
-;; bypass the React-context tier and read from the named frame's
-;; app-db directly. Although the existing Probe defnc above uses the
-;; 2-arg form, no deftest explicitly pinned that two different
-;; frame-ids in the SAME render tree (no surrounding provider) see
-;; distinct values. Parity with UIx's `use-subscribe-2-arg-pins-
-;; explicit-frame` (rf2-rcgsc).
-
-(def ^:private probe-2arg-a-observed (atom []))
-(def ^:private probe-2arg-b-observed (atom []))
-
-(defnc Probe2ArgA []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a
-                                       [:rf.helix-rcgsc/n])]
-    (swap! probe-2arg-a-observed conj v)
-    (d/div (str "a=" v))))
-
-(defnc Probe2ArgB []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b
-                                       [:rf.helix-rcgsc/n])]
-    (swap! probe-2arg-b-observed conj v)
-    (d/div (str "b=" v))))
+  (suite/assert-use-subscribe-frame-provider-resolution cfg))
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
-  (testing "rf2-y0db2 (parity with UIx rf2-rcgsc): use-subscribe's 2-arg
-            form `(use-subscribe frame-kw query-v)` reads from the named
-            frame's app-db, bypassing the React-context tier. Two
-            probes pinning two different frames in the same render
-            tree must see each frame's distinct seed value."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-2arg-a-observed [])
-            (reset! probe-2arg-b-observed [])
-            (rf/reg-frame :rf.helix-rcgsc/tenant-a {:doc "tenant-a"})
-            (rf/reg-frame :rf.helix-rcgsc/tenant-b {:doc "tenant-b"})
-            (rf/reg-event-db :rf.helix-rcgsc/seed (fn [_ [_ n]] {:n n}))
-            (rf/dispatch-sync [:rf.helix-rcgsc/seed 10] {:frame :rf.helix-rcgsc/tenant-a})
-            (rf/dispatch-sync [:rf.helix-rcgsc/seed 100] {:frame :rf.helix-rcgsc/tenant-b})
-            (rf/reg-sub :rf.helix-rcgsc/n (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn []
-                          (.render root
-                            ($ :div
-                              ($ Probe2ArgA)
-                              ($ Probe2ArgB)))))
-                (is (some #{10} @probe-2arg-a-observed)
-                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
-                (is (some #{100} @probe-2arg-b-observed)
-                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
-                (is (not (some #{100} @probe-2arg-a-observed))
-                    "tenant-a probe did NOT leak tenant-b's value")
-                (is (not (some #{10} @probe-2arg-b-observed))
-                    "tenant-b probe did NOT leak tenant-a's value")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
+  (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
 
-;; ---- stable structural-equality deps key (rf2-mwft2) ----------------------
-;;
-;; Pre-rf2-mwft2, `use-subscribe-2` passed the CLJS query-v vector
-;; directly into useMemo / useCallback / useEffect deps arrays.
-;; CLJS persistent vectors are =-equal across renders for the same
-;; literal but produce a *fresh JS object* per render, so React's
-;; Object.is deps comparison fired every render — useMemo re-ran
-;; `subs/subscribe` (cache-hit ref-count churn), useEffect tore down
-;; and rebuilt subscribe/unsubscribe pairs.
-;;
-;; With the fix the deps element is JS-ref-stable across renders
-;; (useRef + = compare), so a stable-literal query-v causes exactly
-;; one subs/subscribe call across N forced re-renders, and the
-;; useEffect cleanup fires only on unmount. Parity with UIx's
-;; `use-subscribe-stable-deps-key` (rf2-mwft2).
+(deftest use-subscribe-cleanup-decrements-sub-cache-refcount
+  (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
 
 (deftest use-subscribe-stable-deps-key
-  (testing "rf2-mwft2 (parity with UIx): stable-literal query-v across N
-            re-renders ⇒ one subs/subscribe call"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-mwft2/probe-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! mwft2-set-tick nil)
-            (rf/reg-frame target {:doc "rf2-mwft2 Helix probe frame"})
-            (rf/reg-event-db :rf.helix-mwft2/seed (fn [_ _] {:p 0}))
-            (rf/dispatch-sync [:rf.helix-mwft2/seed] {:frame target})
-            (rf/reg-sub :rf.helix-mwft2/p (fn [db _] (:p db)))
-            (let [subscribe-calls   (atom 0)
-                  unsubscribe-calls (atom 0)
-                  real-subscribe    subs/subscribe
-                  real-unsubscribe  subs/unsubscribe
-                  cache-key-v       [:rf.helix-mwft2/p]
-                  cache             (:sub-cache (frame/frame target))
-                  mount-node        (make-mount-node!)
-                  root              (react-dom-client/createRoot mount-node)]
-              ;; Spies preserve the multi-arity shape of subs/subscribe
-              ;; (`[query-v]` and `[frame-id query-v]`) so spine call
-              ;; sites that bind the arity-2 invoke-slot resolve. A bare
-              ;; `[& args]` variadic spy compiles only the variadic
-              ;; slot and trips `…cljs$core$IFn$_invoke$arity$2 is not
-              ;; a function` at the spine's `subs/subscribe` call.
-              ;;
-              ;; `unsubscribe`'s 1- and 2-arity bodies recur into the
-              ;; 3-arity through the Var — so without bypassing, a single
-              ;; logical unsubscribe would trip the spy twice (once on
-              ;; entry, once on the recursive 3-arity tail). Each spy
-              ;; arity therefore calls the 3-arity REAL directly,
-              ;; resolving the canonical default-arg shape itself instead
-              ;; of routing back through the Var.
-              (with-redefs [subs/subscribe
-                            (fn spy-subscribe
-                              ([query-v]
-                               (swap! subscribe-calls inc)
-                               (real-subscribe (frame/resolve-current-frame) query-v))
-                              ([frame-id query-v]
-                               (swap! subscribe-calls inc)
-                               (real-subscribe frame-id query-v)))
-                            subs/unsubscribe
-                            (fn spy-unsubscribe
-                              ([query-v]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe (frame/resolve-current-frame)
-                                                 query-v nil))
-                              ([frame-id query-v]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe frame-id query-v nil))
-                              ([frame-id query-v opts]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe frame-id query-v opts)))]
-                (try
-                  ;; Mount the probe — one subs/subscribe for the
-                  ;; useMemo factory.
-                  (act-fn (fn [] (.render root ($ ProbeMwft2Parent))))
-                  (let [mounted-subs @subscribe-calls]
-                    (is (= 1 mounted-subs)
-                        "mount triggered exactly one subs/subscribe call")
-                    (is (zero? @unsubscribe-calls)
-                        "no subs/unsubscribe fires during initial mount")
-                    ;; Force five re-renders by bumping the parent's
-                    ;; tick state. Each parent render also re-renders
-                    ;; the child probe with a freshly-allocated CLJS
-                    ;; vector for [:rf.helix-mwft2/p] — without the fix
-                    ;; the deps mismatch would re-run useMemo (extra
-                    ;; subs/subscribe) and useEffect (extra
-                    ;; subs/unsubscribe) each render.
-                    (dotimes [_ 5]
-                      (act-fn (fn [] (when-let [set-tick @mwft2-set-tick]
-                                       (set-tick inc)))))
-                    (is (= 1 @subscribe-calls)
-                        "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
-                    (is (zero? @unsubscribe-calls)
-                        "subs/unsubscribe never fired across re-renders — useEffect cleanup is unmount-only")
-                    (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
-                        "sub-cache ref-count remains pinned at 1 across re-renders"))
-                  ;; Unmount must fire exactly one unsubscribe — the
-                  ;; rf2-7g959 cleanup pairing must survive the
-                  ;; rf2-mwft2 rewrite.
-                  (act-fn (fn [] (.unmount root)))
-                  (is (= 1 @unsubscribe-calls)
-                      "unmount fired exactly one subs/unsubscribe (rf2-7g959 cleanup survives the rf2-mwft2 rewrite)")
-                  (is (or (nil? (get @cache cache-key-v))
-                          (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
-                      "post-unmount cache entry dropped or ref-count at zero")
-                  (finally
-                    (try (.unmount root) (catch :default _ nil))))))))))))
+  (suite/assert-use-subscribe-stable-deps-key cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -1,132 +1,44 @@
 (ns re-frame.adapter.uix-after-render-dom-cljs-test
-  "Behavioural coverage for the UIx adapter's `:adapter/after-render`
-  hook (rf2-334d9). Pre-rf2-334d9 the UIx adapter did not publish
-  `:adapter/after-render`, so `(rf/after-render f)` under a UIx-only
-  app was a silent no-op — closed by Mike's rf2-neiqf decision
-  2026-05-19 to publish via `React.useLayoutEffect`.
+  "UIx DOM/browser entry-point for the after-render twin of the
+  parameterised React-adapter suite (`re-frame.adapter.react-shared-suite`).
 
-  Architecture under test. The spine maintains a per-adapter after-
-  render queue + a sentinel React function component injected at the
-  root of every mounted tree (via `spine/make-render`). The sentinel
-  fires `React.useLayoutEffect` on every commit, draining the queue.
-  When `interop/after-render` is called, the sentinel's stashed
-  `setState` bumps a tick so React schedules a commit, the
-  `useLayoutEffect` fires, and the queue drains in
-  post-commit / pre-paint order — same timing semantics as Reagent's
-  `r/after-render`. A `queueMicrotask` fallback covers the
-  pre-mount / post-unmount call paths.
+  rf2-5or96 folded the UIx/Helix after-render twins (rf2-334d9) into the
+  shared suite. UIx defines its probe component with `uix.core/defui` +
+  `$` — a substrate macro the suite cannot mint at runtime — so the probe
+  var is built HERE and handed to the suite via the cfg map's
+  `:probe-element` thunk; the orchestration + every assertion lives once
+  in the suite (Approach A: components passed in as elements).
 
-  Coverage shape. Two assertions:
-    1. The hook is wired at ns-load — calling `interop/after-render`
-       under the UIx adapter returns nil (not a thrown
-       'no hook bound' / silent no-op signal).
-    2. Behaviour. Mount a UIx tree; call `(interop/after-render f)`;
-       verify `f` fired after the next commit (asserted via a side-
-       channel atom).
+  Coverage forwarded (rf2-334d9): the ns-load smoke (node-safe — runs
+  under :node-test) that `interop/after-render` is wired and returns nil,
+  plus the act-driven mount/schedule/drain behaviour (browser-only).
 
-  The behaviour assertion is browser-only — node-runtime has no DOM
-  and `react-dom/client` is unmountable there. Under `:node-test` the
-  ns-load smoke runs and the behaviour test no-ops cleanly.
-
-  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
-  (:require ["react"            :as React]
-            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  (ns-regexp `-dom-cljs-test$`) discovers it for the real DOM assertions;
+  `:node-test`'s `cljs-test$` regex also matches, running the node-safe
+  smoke + the self-gated behaviour no-op."
+  (:require [cljs.test :refer-macros [deftest use-fixtures]]
             [uix.core :as uix :refer-macros [defui $]]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.adapter.uix :as uix-adapter]
-            [re-frame.interop :as interop]
+            [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter}))
 
-(defn- browser? []
-  (and (exists? js/document)
-       (some? (.-createElement js/document))))
-
-(defn- make-mount-node! []
-  (when (browser?)
-    (.createElement js/document "div")))
-
-(defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper."
-  []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
-
-(defn- enable-react-act-env! []
-  (when (browser?)
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
-
-;; ---- ns-load smoke -------------------------------------------------------
-
-(deftest after-render-hook-wired-under-uix
-  (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
-            under the UIx adapter — the hook is wired at ns-load and
-            returns nil (the documented swallow shape) rather than
-            falling through to nil because no adapter published it."
-    ;; Calling with a fn argument should NOT throw and should NOT
-    ;; return a 'no hook bound' sentinel. The hook itself returns nil
-    ;; per the make-after-render-hook contract, and the queueMicrotask
-    ;; fallback drain handles the no-mount case asynchronously.
-    (is (nil? (interop/after-render (fn [] :ok)))
-        "interop/after-render under the UIx adapter returns nil — the
-         spine-built hook is wired through :adapter/after-render via
-         substrate-adapter/route-hook!")))
-
-;; ---- behaviour: mount, schedule, drain after commit ----------------------
-
 (defui Probe []
   ;; Bare UIx component — the rf2-334d9 sentinel is injected by the
   ;; spine's `make-render`, not by user code.
   ($ :div "probe"))
 
+(def ^:private cfg
+  {:adapter       uix-adapter/adapter
+   :name          "UIx"
+   :probe-element (fn [] ($ Probe))})
+
+(deftest after-render-hook-wired-under-uix
+  (suite/assert-after-render-hook-wired cfg))
+
 (deftest after-render-runs-callback-after-next-commit-uix
-  (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
-            after the next mount/render cycle under the UIx adapter.
-            The sentinel injected by the spine's make-render uses
-            React.useLayoutEffect to drain the queue post-commit."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (let [fired      (atom 0)
-                  callback   (fn after-render-cb [] (swap! fired inc))
-                  mount-node (make-mount-node!)
-                  unmount    (atom nil)]
-              (try
-                ;; Mount through `rf/render` so the spine's
-                ;; make-render path injects the after-render sentinel.
-                ;; Direct `react-dom-client/createRoot` + `.render`
-                ;; bypasses the spine wrap and would leave no sentinel
-                ;; in the tree — exactly what the rf2-334d9 design
-                ;; requires under test.
-                (act-fn (fn []
-                          (reset! unmount
-                                  (substrate-adapter/render ($ Probe) mount-node {}))))
-                (is (zero? @fired)
-                    "no after-render fn enqueued yet ⇒ no fires")
-                ;; Enqueue under act so the set-tick bump → re-render
-                ;; → useLayoutEffect drain commits synchronously in
-                ;; the test environment.
-                (act-fn (fn [] (interop/after-render callback)))
-                (is (= 1 @fired)
-                    "after-render fn fired exactly once after the next commit")
-                ;; A second enqueue + drain — the sentinel survives
-                ;; the first drain (its useLayoutEffect runs every
-                ;; commit) so a subsequent after-render also fires.
-                (act-fn (fn [] (interop/after-render callback)))
-                (is (= 2 @fired)
-                    "subsequent after-render fn also fires after its commit")
-                (finally
-                  (when-let [u @unmount]
-                    (try (u) (catch :default _ nil))))))))))))
+  (suite/assert-after-render-runs-after-commit cfg))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -1,30 +1,34 @@
 (ns re-frame.adapter.uix-use-subscribe-dom-cljs-test
-  "Unit coverage for the UIx adapter's `use-subscribe` hook (rf2-518sp).
+  "UIx DOM/browser entry-point for the use-subscribe twin of the
+  parameterised React-adapter suite (`re-frame.adapter.react-shared-suite`).
 
-  Pre-rf2-518sp, `use-subscribe` was published as the canonical UIx
-  subscribe surface (rf2-3yij Decision 1) and exercised only through
-  the Playwright `counter_uix` smoke; no node-runtime headless test
-  asserted that the React.useSyncExternalStore wiring sees post-
-  dispatch values. A regression in `subscribe-fn`'s add-watch keying,
-  `get-snap`'s reaction deref, the use-memo deps vec, or the
-  unsubscribe-on-unmount cleanup (rf2-7g959) would slip past
-  `test:cljs` / `test:browser` and only surface in the smoke.
+  rf2-5or96 folded the UIx/Helix use-subscribe twins (rf2-518sp /
+  rf2-7g959 / rf2-mwft2 / rf2-rcgsc) into the shared suite. UIx defines
+  its probe components with `uix.core/defui` + `$` + uix hooks —
+  substrate macros the suite cannot mint at runtime — so the probe vars,
+  their side-channel observation atoms, and the substrate-baked
+  frame/query keywords are built HERE and handed to the suite via the cfg
+  map (Approach A: components passed in as elements + atoms + keywords).
+  The orchestration (reg-frame, dispatch, mount under act, assert) lives
+  once in the suite; a gap on UIx is a gap on Helix by construction.
 
-  Pattern: mirror the Reagent adapter's
-  `scenario-7-concurrent-renders-survive-act-flush` (in
-  `frame_provider_context_cljs_test.cljs`) — gate on `(browser?)`
-  and exit early under `:node-test` where there is no DOM. The
-  browser-test runner exercises the real assertions.
+  Coverage forwarded:
+    - use-subscribe sees post-dispatch values via useSyncExternalStore
+      (rf2-518sp)
+    - 1-arg form resolves through the surrounding frame-provider
+    - 2-arg form pins an explicit frame, no cross-frame leakage (rf2-rcgsc)
+    - sub-cache refcount cleanup on unmount (rf2-7g959)
+    - stable-deps-key: one subs/subscribe across N re-renders, unsubscribe
+      unmount-only, spy assertions (rf2-mwft2)
 
-  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require ["react"            :as React]
-            ["react-dom/client" :as react-dom-client]
-            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  ns ends in `-dom-cljs-test` so shadow-cljs's `:browser-test`
+  (ns-regexp `-dom-cljs-test$`) discovers it for the real DOM assertions;
+  `:node-test`'s `cljs-test$` regex also matches, where every suite fn
+  self-gates on `(browser?)` and no-ops cleanly."
+  (:require [cljs.test :refer-macros [deftest use-fixtures]]
             [uix.core :as uix :refer-macros [defui $]]
-            [re-frame.core :as rf]
-            [re-frame.frame :as frame]
-            [re-frame.subs :as subs]
             [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.react-shared-suite :as suite]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
@@ -32,46 +36,57 @@
     {:adapter uix-adapter/adapter}))
 
 ;; ---- side-channel atoms ----------------------------------------------------
-;; Per-test atoms read by the UIx probe components below. The probes
-;; are defui top-levels (uix `defui` defines a Var; it cannot sit
-;; inside a `let`) and close over these atoms; each deftest `reset!`s
-;; the atom it cares about at the top of its body.
+;; Read by the UIx probe components below. The probes are defui top-levels
+;; (uix `defui` defines a Var; it cannot sit inside a `let`) and close
+;; over these atoms; the suite `reset!`s the atom each assertion cares
+;; about at the top of its body.
 
-(def ^:private probe-observed       (atom []))
-(def ^:private probe-fp-observed    (atom []))
-(def ^:private refcount-target      (atom nil))
+(def ^:private probe-observed    (atom []))
+(def ^:private probe-fp-observed (atom []))
+(def ^:private refcount-target   (atom nil))
+(def ^:private mwft2-set-tick    (atom nil))
 
 (defui Probe []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target
-                                      [:rf.uix-use-subscribe-test/n])]
+        v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/n])]
     (swap! probe-observed conj v)
     ($ :div (str "n=" v))))
 
 (defui ProbeFp []
-  (let [v (uix-adapter/use-subscribe
-            [:rf.uix-use-subscribe-test/k])]
+  (let [v (uix-adapter/use-subscribe [:rf.uix-use-subscribe-test/k])]
     (swap! probe-fp-observed conj v)
     ($ :div (str "k=" v))))
 
 (defui ProbeRc []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target
-                                      [:rf.uix-use-subscribe-test/m])]
+        v (uix-adapter/use-subscribe target [:rf.uix-use-subscribe-test/m])]
     ($ :div (str "m=" v))))
 
-;; ---- rf2-mwft2 regression probes ------------------------------------------
-;; A parent that owns a tick state (used to force re-renders) plus a child
-;; that reads a fixed query-v via use-subscribe. The literal `[:rf.uix-mwft2/p]`
-;; vector evaluates to a fresh JS object each render — *exactly* the shape
-;; the bug-without-fix walks into. The parent stashes its set-tick fn into
-;; a side-channel atom so the test can drive forced re-renders from outside.
+;; ---- rf2-rcgsc 2-arg explicit-pin probes ----------------------------------
 
-(def ^:private mwft2-set-tick      (atom nil))
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defui Probe2ArgA []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    ($ :div (str "a=" v))))
+
+(defui Probe2ArgB []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    ($ :div (str "b=" v))))
+
+;; ---- rf2-mwft2 stable-deps-key probes -------------------------------------
+;; A parent that owns a tick state (used to force re-renders) plus a child
+;; that reads a fixed query-v via use-subscribe. The literal
+;; `[:rf.uix-mwft2/p]` vector evaluates to a fresh JS object each render —
+;; exactly the shape the bug-without-fix walks into. The parent stashes its
+;; set-tick fn into a side-channel atom so the suite can drive forced
+;; re-renders from outside.
 
 (defui ProbeMwft2Child []
-  (let [v (uix-adapter/use-subscribe :rf.uix-mwft2/probe-frame
-                                      [:rf.uix-mwft2/p])]
+  (let [v (uix-adapter/use-subscribe :rf.uix-mwft2/probe-frame [:rf.uix-mwft2/p])]
     ($ :div (str "p=" v))))
 
 (defui ProbeMwft2Parent []
@@ -86,330 +101,51 @@
     ($ :div {:data-tick tick}
        ($ ProbeMwft2Child))))
 
-;; ---- browser gate ---------------------------------------------------------
+;; ---- cfg + forwarded deftests ---------------------------------------------
 
-(defn- browser? []
-  (and (exists? js/document)
-       (some? (.-createElement js/document))))
-
-(defn- make-mount-node! []
-  (when (browser?)
-    (.createElement js/document "div")))
-
-(defn- get-act
-  "Return React's act() if available, else nil. React 18 ships act in
-  react-dom/test-utils; React 19 promotes it to the React namespace
-  proper."
-  []
-  (or (when (exists? (.-act React)) (.-act React))
-      (try
-        (let [test-utils (js/require "react-dom/test-utils")]
-          (.-act test-utils))
-        (catch :default _ nil))))
-
-(defn- enable-react-act-env!
-  "React's act() helper warns / behaves as a no-op unless the runner
-  opts in by setting the global `IS_REACT_ACT_ENVIRONMENT` flag. The
-  Playwright browser runner doesn't set this by default; set it
-  inside each test that needs act() so concurrent-renderer pending
-  work commits synchronously."
-  []
-  (when (browser?)
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
-
-;; ---- assertions ------------------------------------------------------------
-;;
-;; The probe component reads the sub via `use-subscribe` and pushes the
-;; observed value into a side-channel atom. After a dispatch we
-;; re-render under `act` and assert the side-channel reflects the new
-;; value. The 2-arg form pins the frame explicitly; the 1-arg form
-;; resolves through the surrounding `frame-provider`.
+(def ^:private cfg
+  {:adapter               uix-adapter/adapter
+   :name                  "UIx"
+   :frame-provider        uix-adapter/frame-provider
+   ;; tracks-app-db
+   :probe-element         (fn [] (uix/$ Probe))
+   :probe-observed        probe-observed
+   :refcount-target       refcount-target
+   :us-frame              :rf.uix-use-subscribe-test/probe-frame
+   :us-query              :rf.uix-use-subscribe-test/n
+   ;; frame-provider 1-arg
+   :probe-fp-element      (fn [] (uix/$ ProbeFp))
+   :probe-fp-observed     probe-fp-observed
+   :fp-frame              :rf.uix-use-subscribe-test/fp-frame
+   :fp-query              :rf.uix-use-subscribe-test/k
+   ;; 2-arg explicit pin
+   :probe-2arg-element    (fn [] (uix/$ :div (uix/$ Probe2ArgA) (uix/$ Probe2ArgB)))
+   :probe-2arg-a-observed probe-2arg-a-observed
+   :probe-2arg-b-observed probe-2arg-b-observed
+   :tenant-a-frame        :rf.uix-rcgsc/tenant-a
+   :tenant-b-frame        :rf.uix-rcgsc/tenant-b
+   :rcgsc-query           :rf.uix-rcgsc/n
+   ;; refcount cleanup
+   :probe-rc-element      (fn [] (uix/$ ProbeRc))
+   :rc-frame              :rf.uix-use-subscribe-test/refcount-frame
+   :rc-query              :rf.uix-use-subscribe-test/m
+   ;; stable deps key
+   :probe-mwft2-element   (fn [] (uix/$ ProbeMwft2Parent))
+   :mwft2-set-tick        mwft2-set-tick
+   :mwft2-frame           :rf.uix-mwft2/probe-frame
+   :mwft2-query           :rf.uix-mwft2/p})
 
 (deftest use-subscribe-tracks-app-db-changes
-  (testing "UIx use-subscribe sees post-dispatch values via useSyncExternalStore"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/probe-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-observed [])
-            (reset! refcount-target target)
-            (rf/reg-frame target {:doc "use-subscribe probe frame"})
-            (rf/reg-event-db :seed-uix-us (fn [_ _] {:n 1}))
-            (rf/reg-event-db :inc-uix-us  (fn [db _] (update db :n inc)))
-            (rf/dispatch-sync [:seed-uix-us] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/n
-                        (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn [] (.render root (uix/$ Probe))))
-                (is (some #{1} @probe-observed)
-                    "first render observed the seeded value n=1")
-                ;; Wrap dispatch in act so React commits the forceUpdate
-                ;; the spine's add-watch → on-change path schedules.
-                ;; Plain `dispatch-sync` outside act emits the
-                ;; "update was not wrapped in act" warning AND fails to
-                ;; flush the resulting render in the test environment.
-                (act-fn (fn [] (rf/dispatch-sync [:inc-uix-us] {:frame target})))
-                (is (some #{2} @probe-observed)
-                    "post-dispatch re-render observed the incremented value n=2")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
+  (suite/assert-use-subscribe-tracks-app-db-changes cfg))
 
 (deftest use-subscribe-frame-provider-resolution
-  (testing "UIx use-subscribe 1-arg form resolves through the surrounding frame-provider"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/fp-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-fp-observed [])
-            (rf/reg-frame target {:doc "use-subscribe fp probe frame"})
-            (rf/reg-event-db :seed-uix-us-fp (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [:seed-uix-us-fp] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/k
-                        (fn [db _] (:k db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn
-                  (fn []
-                    ;; frame-provider is a plain CLJS fn returning a
-                    ;; React element (NOT a React-component head), so
-                    ;; invoke it directly rather than via `(uix/$ ...)`.
-                    (.render root
-                      (uix-adapter/frame-provider
-                        {:frame target :children [(uix/$ ProbeFp)]}))))
-                (is (some #{:wrapped} @probe-fp-observed)
-                    "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- 2-arg form: explicit frame-id wins over context (rf2-rcgsc) ----------
-;;
-;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
-;; bypass the React-context tier and read from the named frame's
-;; app-db directly. Pre-rf2-rcgsc only the 1-arg context-resolved form
-;; was tested under a frame-provider; the 2-arg explicit-pin shape was
-;; exercised indirectly via the Probe component above but no test
-;; pinned that two different frame-ids in the SAME render tree (no
-;; surrounding provider) see distinct values.
-
-(def ^:private probe-2arg-a-observed (atom []))
-(def ^:private probe-2arg-b-observed (atom []))
-
-(defui Probe2ArgA []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a
-                                     [:rf.uix-rcgsc/n])]
-    (swap! probe-2arg-a-observed conj v)
-    ($ :div (str "a=" v))))
-
-(defui Probe2ArgB []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b
-                                     [:rf.uix-rcgsc/n])]
-    (swap! probe-2arg-b-observed conj v)
-    ($ :div (str "b=" v))))
+  (suite/assert-use-subscribe-frame-provider-resolution cfg))
 
 (deftest use-subscribe-2-arg-pins-explicit-frame
-  (testing "rf2-rcgsc: use-subscribe's 2-arg form
-            `(use-subscribe frame-kw query-v)` reads from the named
-            frame's app-db, bypassing the React-context tier. Two
-            probes pinning two different frames in the same render
-            tree must see each frame's distinct seed value."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-2arg-a-observed [])
-            (reset! probe-2arg-b-observed [])
-            (rf/reg-frame :rf.uix-rcgsc/tenant-a {:doc "tenant-a"})
-            (rf/reg-frame :rf.uix-rcgsc/tenant-b {:doc "tenant-b"})
-            (rf/reg-event-db :rf.uix-rcgsc/seed (fn [_ [_ n]] {:n n}))
-            (rf/dispatch-sync [:rf.uix-rcgsc/seed 10] {:frame :rf.uix-rcgsc/tenant-a})
-            (rf/dispatch-sync [:rf.uix-rcgsc/seed 100] {:frame :rf.uix-rcgsc/tenant-b})
-            (rf/reg-sub :rf.uix-rcgsc/n (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn []
-                          (.render root
-                            (uix/$ :div
-                              (uix/$ Probe2ArgA)
-                              (uix/$ Probe2ArgB)))))
-                (is (some #{10} @probe-2arg-a-observed)
-                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
-                (is (some #{100} @probe-2arg-b-observed)
-                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
-                (is (not (some #{100} @probe-2arg-a-observed))
-                    "tenant-a probe did NOT leak tenant-b's value")
-                (is (not (some #{10} @probe-2arg-b-observed))
-                    "tenant-b probe did NOT leak tenant-a's value")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- sub-cache refcount cleanup (rf2-7g959) -------------------------------
-;;
-;; Pre-rf2-7g959, `use-subscribe` only removed the add-watch on
-;; unmount; the sub-cache ref-count for the (frame, query) pair was
-;; never decremented, so the entry stayed pinned at 1 for the process
-;; lifetime. With the rf2-7g959 cleanup in the spine, an explicit
-;; `subs/unsubscribe` fires from a useEffect cleanup so the cache
-;; entry's ref-count returns to 0 after the deferred-dispose grace
-;; period.
+  (suite/assert-use-subscribe-2-arg-pins-explicit-frame cfg))
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
-  (testing "UIx use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/refcount-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! refcount-target target)
-            (rf/reg-frame target {:doc "refcount probe frame"})
-            (rf/reg-event-db :seed-uix-us-rc (fn [_ _] {:m 0}))
-            (rf/dispatch-sync [:seed-uix-us-rc] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/m
-                        (fn [db _] (:m db)))
-            (let [cache-key-v [:rf.uix-use-subscribe-test/m]
-                  cache       (:sub-cache (frame/frame target))
-                  mount-node  (make-mount-node!)
-                  root        (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn [] (.render root (uix/$ ProbeRc))))
-                (is (pos? (or (get-in @cache [cache-key-v :ref-count])
-                              0))
-                    "mounted probe pinned a cache entry with ref-count > 0")
-                (act-fn (fn [] (.unmount root)))
-                ;; After unmount the useEffect cleanup fires
-                ;; subs/unsubscribe; the entry's deferred-dispose
-                ;; either races a 0 ref-count or schedules grace-period
-                ;; teardown. Either way the ref-count is no longer
-                ;; pinned at >0 — the regression rf2-7g959 named.
-                (is (or (nil? (get @cache cache-key-v))
-                        (zero? (or (get-in @cache [cache-key-v :ref-count])
-                                   0)))
-                    "post-unmount ref-count is zero (or entry already dropped) — rf2-7g959 cleanup fired")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- stable structural-equality deps key (rf2-mwft2) ----------------------
-;;
-;; Pre-rf2-mwft2, `use-subscribe-2` passed the CLJS query-v vector
-;; directly into useMemo / useCallback / useEffect deps arrays.
-;; CLJS persistent vectors are =-equal across renders for the same
-;; literal but produce a *fresh JS object* per render, so React's
-;; Object.is deps comparison fired every render — useMemo re-ran
-;; `subs/subscribe` (cache-hit ref-count churn), useEffect tore down
-;; and rebuilt subscribe/unsubscribe pairs.
-;;
-;; With the fix the deps element is JS-ref-stable across renders
-;; (useRef + = compare), so a stable-literal query-v causes exactly
-;; one subs/subscribe call across N forced re-renders, and the
-;; useEffect cleanup fires only on unmount.
+  (suite/assert-use-subscribe-cleanup-decrements-refcount cfg))
 
 (deftest use-subscribe-stable-deps-key
-  (testing "rf2-mwft2: stable-literal query-v across N re-renders ⇒ one subs/subscribe call"
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-mwft2/probe-frame
-            act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! mwft2-set-tick nil)
-            (rf/reg-frame target {:doc "rf2-mwft2 probe frame"})
-            (rf/reg-event-db :rf.uix-mwft2/seed (fn [_ _] {:p 0}))
-            (rf/dispatch-sync [:rf.uix-mwft2/seed] {:frame target})
-            (rf/reg-sub :rf.uix-mwft2/p (fn [db _] (:p db)))
-            (let [subscribe-calls   (atom 0)
-                  unsubscribe-calls (atom 0)
-                  real-subscribe    subs/subscribe
-                  real-unsubscribe  subs/unsubscribe
-                  cache-key-v       [:rf.uix-mwft2/p]
-                  cache             (:sub-cache (frame/frame target))
-                  mount-node        (make-mount-node!)
-                  root              (react-dom-client/createRoot mount-node)]
-              ;; Spies preserve the multi-arity shape of subs/subscribe
-              ;; (`[query-v]` and `[frame-id query-v]`) so spine call
-              ;; sites that bind the arity-2 invoke-slot resolve. A bare
-              ;; `[& args]` variadic spy compiles only the variadic
-              ;; slot and trips `…cljs$core$IFn$_invoke$arity$2 is not
-              ;; a function` at the spine's `subs/subscribe` call.
-              ;;
-              ;; `unsubscribe`'s 1- and 2-arity bodies recur into the
-              ;; 3-arity through the Var — so without bypassing, a single
-              ;; logical unsubscribe would trip the spy twice (once on
-              ;; entry, once on the recursive 3-arity tail). Each spy
-              ;; arity therefore calls the 3-arity REAL directly,
-              ;; resolving the canonical default-arg shape itself instead
-              ;; of routing back through the Var.
-              (with-redefs [subs/subscribe
-                            (fn spy-subscribe
-                              ([query-v]
-                               (swap! subscribe-calls inc)
-                               (real-subscribe (frame/resolve-current-frame) query-v))
-                              ([frame-id query-v]
-                               (swap! subscribe-calls inc)
-                               (real-subscribe frame-id query-v)))
-                            subs/unsubscribe
-                            (fn spy-unsubscribe
-                              ([query-v]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe (frame/resolve-current-frame)
-                                                 query-v nil))
-                              ([frame-id query-v]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe frame-id query-v nil))
-                              ([frame-id query-v opts]
-                               (swap! unsubscribe-calls inc)
-                               (real-unsubscribe frame-id query-v opts)))]
-                (try
-                  ;; Mount the probe — one subs/subscribe for the
-                  ;; useMemo factory.
-                  (act-fn (fn [] (.render root (uix/$ ProbeMwft2Parent))))
-                  (let [mounted-subs @subscribe-calls]
-                    (is (= 1 mounted-subs)
-                        "mount triggered exactly one subs/subscribe call")
-                    (is (zero? @unsubscribe-calls)
-                        "no subs/unsubscribe fires during initial mount")
-                    ;; Force five re-renders by bumping the parent's
-                    ;; tick state. Each parent render also re-renders
-                    ;; the child probe with a freshly-allocated CLJS
-                    ;; vector for [:rf.uix-mwft2/p] — without the fix
-                    ;; the deps mismatch would re-run useMemo (extra
-                    ;; subs/subscribe) and useEffect (extra
-                    ;; subs/unsubscribe) each render.
-                    (dotimes [_ 5]
-                      (act-fn (fn [] (when-let [set-tick @mwft2-set-tick]
-                                       (set-tick inc)))))
-                    (is (= 1 @subscribe-calls)
-                        "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
-                    (is (zero? @unsubscribe-calls)
-                        "subs/unsubscribe never fired across re-renders — useEffect cleanup is unmount-only")
-                    (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
-                        "sub-cache ref-count remains pinned at 1 across re-renders"))
-                  ;; Unmount must fire exactly one unsubscribe — the
-                  ;; rf2-7g959 cleanup pairing must survive the
-                  ;; rf2-mwft2 rewrite.
-                  (act-fn (fn [] (.unmount root)))
-                  (is (= 1 @unsubscribe-calls)
-                      "unmount fired exactly one subs/unsubscribe (rf2-7g959 cleanup survives the rf2-mwft2 rewrite)")
-                  (is (or (nil? (get @cache cache-key-v))
-                          (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
-                      "post-unmount cache entry dropped or ref-count at zero")
-                  (finally
-                    (try (.unmount root) (catch :default _ nil))))))))))))
+  (suite/assert-use-subscribe-stable-deps-key cfg))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -51,13 +51,37 @@
     - frame-context corrupted `_currentValue` emit + recover (G4)
     - warn-once fires EXACTLY once per id across renders, per-id, not
       global (G5)
-    - write-after-destroy nil-container guard"
+    - write-after-destroy nil-container guard
+
+  DOM/BROWSER TWINS (rf2-5or96 — the DOM-split remainder of rf2-p4736).
+  Two twin clusters defined substrate-specific component vars (UIx
+  `defui`/`$`/uix-hooks; Helix `defnc`/`$`/helix.dom/helix.hooks) that
+  the suite cannot mint at runtime. Approach A — the substrate-specific
+  components are built in each entry file and handed in via the cfg map
+  (`:render-element`, the probe vars, observation atoms, frame keywords),
+  while the orchestration + every assertion lives here as one source:
+
+    - after-render: ns-load smoke (node-safe) + mount/schedule/drain
+      act-driven behaviour (rf2-334d9)
+    - use-subscribe: useSyncExternalStore post-dispatch values
+      (rf2-518sp), frame-provider 1-arg resolution, 2-arg explicit-frame
+      pinning (rf2-rcgsc / rf2-y0db2), refcount cleanup on unmount
+      (rf2-7g959), stable-deps-key one-subscribe-across-N-renders spy
+      assertions (rf2-mwft2)
+
+  These DOM assertions self-gate on `(browser?)` — under :node-test
+  (which discovers the `-dom-cljs-test` entry files via `cljs-test$`)
+  they no-op cleanly; the real assertions run under :browser-test
+  (`-dom-cljs-test$`)."
   (:require ["react" :as React]
+            ["react-dom/client" :as react-dom-client]
             [cljs.test :refer-macros [is testing async]]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.disposable :as rf-disposable]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.subs :as subs]
             [re-frame.late-bind :as late-bind]
             [re-frame.late-bind.directory :as directory]
             [re-frame.machines :as machines]
@@ -1766,3 +1790,374 @@
               (done))
             10))
         10))))
+
+;; ===========================================================================
+;; DOM / browser twins (rf2-5or96 — DOM-split remainder of rf2-p4736)
+;;
+;; UIx and Helix both define substrate-specific component vars via
+;; `defui`/`defnc` + `$` (and, for use-subscribe, the substrate's hooks).
+;; The suite cannot mint those at runtime, so each entry file builds the
+;; probe components + their observation atoms + a `:render-element` thunk
+;; (the substrate's `$`) and hands them in. The orchestration (reg-frame,
+;; dispatch, mount under act, assert) lives here as a single source — a
+;; gap on one substrate is a gap on both by construction.
+;;
+;; These functions self-gate on `(browser?)`; under :node-test they no-op
+;; cleanly (the entry files still load — the after-render ns-load smoke
+;; runs there). The real assertions run under :browser-test.
+;; ===========================================================================
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(defn- get-act
+  "Return React's act() if available, else nil. React 18 ships act in
+  react-dom/test-utils; React 19 promotes it to the React namespace
+  proper."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- enable-react-act-env!
+  "React's act() helper warns / behaves as a no-op unless the runner
+  opts in by setting the global `IS_REACT_ACT_ENVIRONMENT` flag. The
+  Playwright browser runner doesn't set this by default; set it inside
+  each test that needs act() so concurrent-renderer pending work commits
+  synchronously."
+  []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+(defn- with-browser-act
+  "Run the standard DOM-twin gate ladder: skip under :node-test (no DOM)
+  and skip if act() is unreachable from this runner; otherwise enable the
+  act env and call `(f act-fn)`. A plain HOF (not a macro) — this is a
+  .cljs file, so a same-file macro is not available at runtime."
+  [f]
+  (if-not (browser?)
+    (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+    (let [act-fn (get-act)]
+      (if (nil? act-fn)
+        (is true "act() not reachable from this runner; skipping")
+        (do (enable-react-act-env!)
+            (f act-fn))))))
+
+;; ---- after-render hook (rf2-334d9) ----------------------------------------
+
+(defn assert-after-render-hook-wired
+  "rf2-334d9: `interop/after-render` no longer silent-no-ops under the
+  React adapter — the hook is wired at ns-load and returns nil (the
+  documented swallow shape) rather than falling through to nil because no
+  adapter published it. Node-safe (no DOM): runs under :node-test too."
+  [{:keys [name]}]
+  (testing (str name " — after-render hook wired at ns-load (rf2-334d9)")
+    (is (nil? (interop/after-render (fn [] :ok)))
+        "interop/after-render under the adapter returns nil — the
+         spine-built hook is wired through :adapter/after-render via
+         substrate-adapter/route-hook!")))
+
+(defn assert-after-render-runs-after-commit
+  "rf2-334d9: `(interop/after-render f)` schedules `f` to run after the
+  next mount/render cycle. The sentinel injected by the spine's
+  make-render uses React.useLayoutEffect to drain the queue post-commit.
+
+  cfg keys:
+    :probe-element  a thunk returning a fresh substrate probe ELEMENT
+                    (e.g. `#(uix/$ Probe)` / `#($ Probe)`). Built in the
+                    entry file because `$` is a substrate macro."
+  [{:keys [name probe-element]}]
+  (testing (str name " — after-render runs callback after next commit (rf2-334d9)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [fired      (atom 0)
+            callback   (fn after-render-cb [] (swap! fired inc))
+            mount-node (make-mount-node!)
+            unmount    (atom nil)]
+        (try
+          ;; Mount through the substrate adapter's render so the spine's
+          ;; make-render path injects the after-render sentinel. Direct
+          ;; createRoot + .render bypasses the spine wrap and would leave
+          ;; no sentinel in the tree — exactly what rf2-334d9 requires.
+          (act-fn (fn []
+                    (reset! unmount
+                            (substrate-adapter/render (probe-element) mount-node {}))))
+          (is (zero? @fired)
+              "no after-render fn enqueued yet ⇒ no fires")
+          ;; Enqueue under act so the set-tick bump → re-render →
+          ;; useLayoutEffect drain commits synchronously in the test env.
+          (act-fn (fn [] (interop/after-render callback)))
+          (is (= 1 @fired)
+              "after-render fn fired exactly once after the next commit")
+          ;; A second enqueue + drain — the sentinel survives the first
+          ;; drain (its useLayoutEffect runs every commit) so a
+          ;; subsequent after-render also fires.
+          (act-fn (fn [] (interop/after-render callback)))
+          (is (= 2 @fired)
+              "subsequent after-render fn also fires after its commit")
+          (finally
+            (when-let [u @unmount]
+              (try (u) (catch :default _ nil))))))))))
+
+;; ---- use-subscribe (rf2-518sp / rf2-7g959 / rf2-mwft2 / rf2-rcgsc) --------
+;;
+;; The probe components read the sub via `use-subscribe` and push the
+;; observed value into a side-channel atom owned by the entry file. After
+;; a dispatch we re-render under `act` and assert the side-channel
+;; reflects the new value. The 2-arg form pins the frame explicitly; the
+;; 1-arg form resolves through the surrounding `frame-provider`. All
+;; substrate-baked keywords (frame-ids, query-vs) are passed in cfg so
+;; they line up with what the entry file's probe vars closed over at
+;; compile time.
+
+(defn assert-use-subscribe-tracks-app-db-changes
+  "rf2-518sp: use-subscribe sees post-dispatch values via
+  useSyncExternalStore.
+
+  cfg keys:
+    :probe-element     thunk → the 2-arg-form Probe element
+    :probe-observed    atom the Probe pushes observed values into
+    :refcount-target   atom the Probe reads its target frame-id from
+    :us-frame          frame-id keyword the Probe's query resolves under
+    :us-query          query-v keyword the Probe subscribes to"
+  [{:keys [name probe-element probe-observed refcount-target us-frame us-query]}]
+  (testing (str name " — use-subscribe sees post-dispatch values (rf2-518sp)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! probe-observed [])
+      (reset! refcount-target us-frame)
+      (rf/reg-frame us-frame {:doc "use-subscribe probe frame"})
+      (rf/reg-event-db ::us-seed (fn [_ _] {:n 1}))
+      (rf/reg-event-db ::us-inc  (fn [db _] (update db :n inc)))
+      (rf/dispatch-sync [::us-seed] {:frame us-frame})
+      (rf/reg-sub us-query (fn [db _] (:n db)))
+      (let [mount-node (make-mount-node!)
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-element))))
+          (is (some #{1} @probe-observed)
+              "first render observed the seeded value n=1")
+          ;; Wrap dispatch in act so React commits the forceUpdate the
+          ;; spine's add-watch → on-change path schedules. Plain
+          ;; dispatch-sync outside act emits the "not wrapped in act"
+          ;; warning AND fails to flush the render in the test env.
+          (act-fn (fn [] (rf/dispatch-sync [::us-inc] {:frame us-frame})))
+          (is (some #{2} @probe-observed)
+              "post-dispatch re-render observed the incremented value n=2")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-frame-provider-resolution
+  "rf2-518sp: use-subscribe 1-arg form resolves through the surrounding
+  frame-provider.
+
+  cfg keys:
+    :frame-provider     the adapter's frame-provider fn
+    :probe-fp-element    thunk → the 1-arg-form ProbeFp element
+    :probe-fp-observed   atom the ProbeFp pushes observed values into
+    :fp-frame            frame-id keyword for the wrapped frame
+    :fp-query            query-v keyword ProbeFp subscribes to"
+  [{:keys [name frame-provider probe-fp-element probe-fp-observed fp-frame fp-query]}]
+  (testing (str name " — use-subscribe 1-arg resolves via frame-provider (rf2-518sp)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! probe-fp-observed [])
+      (rf/reg-frame fp-frame {:doc "use-subscribe fp probe frame"})
+      (rf/reg-event-db ::us-fp-seed (fn [_ _] {:k :wrapped}))
+      (rf/dispatch-sync [::us-fp-seed] {:frame fp-frame})
+      (rf/reg-sub fp-query (fn [db _] (:k db)))
+      (let [mount-node (make-mount-node!)
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn
+            (fn []
+              ;; frame-provider is a plain CLJS fn returning a React
+              ;; element (NOT a React-component head), so invoke it
+              ;; directly rather than via the substrate's `$`.
+              (.render root
+                (frame-provider
+                  {:frame fp-frame :children [(probe-fp-element)]}))))
+          (is (some #{:wrapped} @probe-fp-observed)
+              "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-2-arg-pins-explicit-frame
+  "rf2-rcgsc / rf2-y0db2: use-subscribe's 2-arg form
+  `(use-subscribe frame-kw query-v)` reads from the named frame's app-db,
+  bypassing the React-context tier. Two probes pinning two different
+  frames in the same render tree must see each frame's distinct seed
+  value.
+
+  cfg keys:
+    :probe-2arg-element  thunk → an element wrapping Probe2ArgA + Probe2ArgB
+    :probe-2arg-a-observed / :probe-2arg-b-observed   the probes' atoms
+    :tenant-a-frame / :tenant-b-frame   the two pinned frame-ids
+    :rcgsc-query         query-v keyword both probes subscribe to"
+  [{:keys [name probe-2arg-element probe-2arg-a-observed probe-2arg-b-observed
+           tenant-a-frame tenant-b-frame rcgsc-query]}]
+  (testing (str name " — use-subscribe 2-arg pins explicit frame (rf2-rcgsc)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! probe-2arg-a-observed [])
+      (reset! probe-2arg-b-observed [])
+      (rf/reg-frame tenant-a-frame {:doc "tenant-a"})
+      (rf/reg-frame tenant-b-frame {:doc "tenant-b"})
+      (rf/reg-event-db ::rcgsc-seed (fn [_ [_ n]] {:n n}))
+      (rf/dispatch-sync [::rcgsc-seed 10]  {:frame tenant-a-frame})
+      (rf/dispatch-sync [::rcgsc-seed 100] {:frame tenant-b-frame})
+      (rf/reg-sub rcgsc-query (fn [db _] (:n db)))
+      (let [mount-node (make-mount-node!)
+            root       (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-2arg-element))))
+          (is (some #{10} @probe-2arg-a-observed)
+              "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
+          (is (some #{100} @probe-2arg-b-observed)
+              "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
+          (is (not (some #{100} @probe-2arg-a-observed))
+              "tenant-a probe did NOT leak tenant-b's value")
+          (is (not (some #{10} @probe-2arg-b-observed))
+              "tenant-b probe did NOT leak tenant-a's value")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-cleanup-decrements-refcount
+  "rf2-7g959: use-subscribe pairs subscribe with subs/unsubscribe on
+  unmount so the sub-cache ref-count for the (frame, query) pair returns
+  to 0 (or the entry is dropped) after unmount.
+
+  cfg keys:
+    :probe-rc-element  thunk → the ProbeRc element (2-arg form, no observe)
+    :refcount-target   atom the ProbeRc reads its target frame-id from
+    :rc-frame          frame-id keyword for the refcount probe
+    :rc-query          query-v keyword ProbeRc subscribes to"
+  [{:keys [name probe-rc-element refcount-target rc-frame rc-query]}]
+  (testing (str name " — use-subscribe cleanup decrements sub-cache refcount (rf2-7g959)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target rc-frame)
+      (rf/reg-frame rc-frame {:doc "refcount probe frame"})
+      (rf/reg-event-db ::rc-seed (fn [_ _] {:m 0}))
+      (rf/dispatch-sync [::rc-seed] {:frame rc-frame})
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [cache-key-v [rc-query]
+            cache       (:sub-cache (frame/frame rc-frame))
+            mount-node  (make-mount-node!)
+            root        (react-dom-client/createRoot mount-node)]
+        (try
+          (act-fn (fn [] (.render root (probe-rc-element))))
+          (is (pos? (or (get-in @cache [cache-key-v :ref-count]) 0))
+              "mounted probe pinned a cache entry with ref-count > 0")
+          (act-fn (fn [] (.unmount root)))
+          ;; After unmount the useEffect cleanup fires subs/unsubscribe;
+          ;; the entry's deferred-dispose either races a 0 ref-count or
+          ;; schedules grace-period teardown. Either way the ref-count is
+          ;; no longer pinned at >0 — the regression rf2-7g959 named.
+          (is (or (nil? (get @cache cache-key-v))
+                  (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+              "post-unmount ref-count is zero (or entry already dropped) — rf2-7g959 cleanup fired")
+          (finally
+            (try (.unmount root) (catch :default _ nil)))))))))
+
+(defn assert-use-subscribe-stable-deps-key
+  "rf2-mwft2: stable-literal query-v across N re-renders ⇒ exactly one
+  subs/subscribe call (the deps element is JS-ref-stable across renders),
+  and the useEffect cleanup (rf2-7g959) fires only on unmount.
+
+  cfg keys:
+    :probe-mwft2-element  thunk → the ProbeMwft2Parent element. The parent
+                          owns a tick state + stashes its set-tick fn into
+                          :mwft2-set-tick on mount; the child reads a
+                          fixed query-v via use-subscribe.
+    :mwft2-set-tick       atom the parent stashes its setter into
+    :mwft2-frame          frame-id keyword the child resolves under
+    :mwft2-query          query-v keyword the child subscribes to"
+  [{:keys [name probe-mwft2-element mwft2-set-tick mwft2-frame mwft2-query]}]
+  (testing (str name " — use-subscribe stable deps key: one subscribe across N renders (rf2-mwft2)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! mwft2-set-tick nil)
+      (rf/reg-frame mwft2-frame {:doc "rf2-mwft2 probe frame"})
+      (rf/reg-event-db ::mwft2-seed (fn [_ _] {:p 0}))
+      (rf/dispatch-sync [::mwft2-seed] {:frame mwft2-frame})
+      (rf/reg-sub mwft2-query (fn [db _] (:p db)))
+      (let [subscribe-calls   (atom 0)
+            unsubscribe-calls (atom 0)
+            real-subscribe    subs/subscribe
+            real-unsubscribe  subs/unsubscribe
+            cache-key-v       [mwft2-query]
+            cache             (:sub-cache (frame/frame mwft2-frame))
+            mount-node        (make-mount-node!)
+            root              (react-dom-client/createRoot mount-node)]
+        ;; Spies preserve the multi-arity shape of subs/subscribe
+        ;; (`[query-v]` and `[frame-id query-v]`) so spine call sites that
+        ;; bind the arity-2 invoke-slot resolve. A bare `[& args]`
+        ;; variadic spy compiles only the variadic slot and trips
+        ;; `…cljs$core$IFn$_invoke$arity$2 is not a function` at the
+        ;; spine's subs/subscribe call.
+        ;;
+        ;; unsubscribe's 1- and 2-arity bodies recur into the 3-arity
+        ;; through the Var — so without bypassing, a single logical
+        ;; unsubscribe would trip the spy twice (once on entry, once on
+        ;; the recursive 3-arity tail). Each spy arity therefore calls the
+        ;; 3-arity REAL directly, resolving the canonical default-arg
+        ;; shape itself instead of routing back through the Var.
+        (with-redefs [subs/subscribe
+                      (fn spy-subscribe
+                        ([query-v]
+                         (swap! subscribe-calls inc)
+                         (real-subscribe (frame/resolve-current-frame) query-v))
+                        ([frame-id query-v]
+                         (swap! subscribe-calls inc)
+                         (real-subscribe frame-id query-v)))
+                      subs/unsubscribe
+                      (fn spy-unsubscribe
+                        ([query-v]
+                         (swap! unsubscribe-calls inc)
+                         (real-unsubscribe (frame/resolve-current-frame) query-v nil))
+                        ([frame-id query-v]
+                         (swap! unsubscribe-calls inc)
+                         (real-unsubscribe frame-id query-v nil))
+                        ([frame-id query-v opts]
+                         (swap! unsubscribe-calls inc)
+                         (real-unsubscribe frame-id query-v opts)))]
+          (try
+            ;; Mount — one subs/subscribe for the useMemo factory.
+            (act-fn (fn [] (.render root (probe-mwft2-element))))
+            (let [mounted-subs @subscribe-calls]
+              (is (= 1 mounted-subs)
+                  "mount triggered exactly one subs/subscribe call")
+              (is (zero? @unsubscribe-calls)
+                  "no subs/unsubscribe fires during initial mount")
+              ;; Force five re-renders by bumping the parent's tick state.
+              ;; Each parent render also re-renders the child probe with a
+              ;; freshly-allocated CLJS vector for the query-v — without
+              ;; the fix the deps mismatch would re-run useMemo (extra
+              ;; subscribe) and useEffect (extra unsubscribe) each render.
+              (dotimes [_ 5]
+                (act-fn (fn [] (when-let [set-tick @mwft2-set-tick]
+                                 (set-tick inc)))))
+              (is (= 1 @subscribe-calls)
+                  "subs/subscribe still called only once after 5 re-renders (no per-render churn)")
+              (is (zero? @unsubscribe-calls)
+                  "subs/unsubscribe never fired across re-renders — useEffect cleanup is unmount-only")
+              (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                  "sub-cache ref-count remains pinned at 1 across re-renders"))
+            ;; Unmount must fire exactly one unsubscribe — the rf2-7g959
+            ;; cleanup pairing must survive the rf2-mwft2 rewrite.
+            (act-fn (fn [] (.unmount root)))
+            (is (= 1 @unsubscribe-calls)
+                "unmount fired exactly one subs/unsubscribe (rf2-7g959 cleanup survives the rf2-mwft2 rewrite)")
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                "post-unmount cache entry dropped or ref-count at zero")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))


### PR DESCRIPTION
## Summary

DOM-split remainder of rf2-p4736. Folds the two remaining UIx/Helix twin pairs — `*_after_render_dom` (rf2-334d9) and `*_use_subscribe_dom` (rf2-518sp / rf2-7g959 / rf2-mwft2 / rf2-rcgsc / rf2-y0db2) — into `re-frame.adapter.react-shared-suite`. These were the twins the earlier dedup (PR #1895) could not fold because they define substrate-specific component vars the suite cannot mint at runtime.

## Approach: A (component-element parameterisation)

The substrate-specific component vars (UIx `defui`/`$`/uix-hooks; Helix `defnc`/`$`/`helix.dom`/`helix.hooks`) are macros that must be expanded where the substrate is in scope — i.e. in the entry files. So each entry file builds its probe components, their side-channel observation atoms, and the substrate-baked frame/query keywords, then hands them to the suite through the cfg map (`:probe-element` thunks, `:probe-observed`/`:refcount-target`/`:mwft2-set-tick` atoms, `:us-frame`/`:rc-query`/… keywords, plus the adapter's `:frame-provider`). The orchestration — reg-frame, dispatch, mount under `act`, and every `is` assertion — lives **once** in the suite. A gap on one substrate is now a gap on both by construction.

Approach A was chosen over B (node/browser deftest split) because the DOM bodies already self-gate on `(browser?)` and no-op under :node-test — there was no separate node-only part worth splitting out beyond the after-render ns-load smoke, which the gate ladder already handles inline. A keeps a single source of orchestration AND a single source of assertions; B would have left the assertion bodies duplicated.

A same-file `defmacro` is not usable at runtime in a `.cljs` file, so the shared gate ladder is a plain HOF (`with-browser-act`) rather than a macro.

## LoC delta

`5 files changed, 655 insertions(+), 965 deletions(-)` — **net −310 lines**. The four entry files collapsed from ~134–416 lines each to thin forwarders (44 / 46 / 151 / 155 lines); the suite gained ~397 lines of single-source DOM orchestration.

## Coverage preserved (all 6 behaviours)

- [x] after_render mount/schedule/drain (act-driven) — `assert-after-render-runs-after-commit`
- [x] use-subscribe useSyncExternalStore post-dispatch values — `assert-use-subscribe-tracks-app-db-changes`
- [x] frame-provider 1-arg resolution — `assert-use-subscribe-frame-provider-resolution`
- [x] 2-arg explicit-frame pinning (no cross-frame leak) — `assert-use-subscribe-2-arg-pins-explicit-frame`
- [x] rf2-7g959 refcount cleanup on unmount — `assert-use-subscribe-cleanup-decrements-refcount`
- [x] rf2-mwft2 stable-deps-key spy assertions (one subscribe across N renders, unsubscribe unmount-only) — `assert-use-subscribe-stable-deps-key`

Plus the after-render ns-load smoke (`assert-after-render-hook-wired`, node-safe).

## Browser ns-suffix discovery intact

All four entry files keep the `-dom-cljs-test` ns suffix, so `:browser-test` (ns-regexp `-dom-cljs-test$`) still discovers them — confirmed by inspecting the compiled `out/browser-test/js/cljs-runtime/` output (all four `*_dom_cljs_test.js` present) and by the green browser run.

## Test plan

- [x] `npm run test:browser` — Ran 108 tests / 301 assertions, 0 failures, 0 errors (load-bearing gate for the DOM twins).
- [x] `npm run test:cljs` — Ran 4100 tests / 12469 assertions, 0 failures, 0 errors (node-side smoke + self-gated no-ops).

The one `:infer-warning` at `react_shared_suite.cljs:1050` is pre-existing (in `assert-sub-exception-recovers-to-nil`, untouched by this change); line number only shifted from the added DOM section.