### PR TITLE
chore(template): drop redundant with-story 'story' npm script (rf2-bto1m)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/package_with_story.json
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/package_with_story.json
@@ -6,7 +6,6 @@
   "scripts": {
     "watch":   "shadow-cljs watch app",
     "release": "shadow-cljs release app",
-    "story":   "shadow-cljs watch app",
     "test":    "shadow-cljs compile test && node out/node-test.js"
   },
   "devDependencies": {

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -196,9 +196,9 @@ clojure -Tnew create :template io.github.day8/re-frame2-template \
 
 Adds `day8/re-frame2-story` to `deps.edn` (lockstep with the core
 coord version), emits `stories.cljs` next to `events.cljs` /
-`subs.cljs` / `views.cljs`, swaps `core.cljs` for the hash-routing
-variant, and wires `npm run story` as an alias for `shadow-cljs
-watch app` — visit `#/stories` for the playground, `#/` for the
+`subs.cljs` / `views.cljs`, and swaps `core.cljs` for the hash-routing
+variant. Story serves off the same `:app` build, so `npm run watch`
+covers both — visit `#/stories` for the playground, `#/` for the
 live app.
 
 This is the branching-flag exception called out in

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -357,8 +357,6 @@
             ;; Pin value owned by version_lockstep_test.clj (rf2-5v619, D3).
             (is (some? (get-in deps [:deps 'day8/re-frame2-story :mvn/version]))
                 "story coord carries an :mvn/version pin")
-            (is (.contains pkg-txt "\"story\":")
-                "package.json declares a `story` npm script")
             (is (.contains pkg-txt "\"qrcode-generator\"")
                 "package.json declares the qrcode-generator npm dep
                  (Story's only direct npm dependency — re-frame.story.qr


### PR DESCRIPTION
## Summary
- The with-story `package_with_story.json` declared a `story` npm script (`shadow-cljs watch app`) that was **byte-identical** to `watch`. Story serves off the same `:app` build via the `#/stories` hash route, so `npm run story` did nothing distinct from `npm run watch` and silently landed users on the plain app at `#/` with no hint — misleading cruft.
- Removed the no-op `story` script, its assertion in `template_test.clj`, and corrected the now-inaccurate `npm run story` claim in `spec/DESIGN-RATIONALE.md` (it now says `npm run watch` covers both, with `#/stories` for the playground and `#/` for the live app).
- With-story scaffold otherwise intact.

## Gate results
- `cd tools/template && clojure -M:test` — **21 tests, 296 assertions, 0 failures, 0 errors** (includes the updated `template_test.clj` which generates + inspects the emitted with-story app).
- `package_with_story.json` re-validated as parseable JSON after the edit.
- Verified no other `"story":` / `npm run story` reference remains anywhere in the template tree or its tests.

rf2-bto1m