### PR TITLE
fix(machines): normalize single-map :always in guard/action ref validation (rf2-zg579)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/validation.cljc
@@ -457,7 +457,12 @@
               t     (if (vector? t) t [t])]
         (check-guard!  (:guard t)  s)
         (check-action! (:action t) s))
-      (doseq [t (:always state-node)]
+      ;; `:always` admits a single entry map OR a vector of entry maps;
+      ;; normalise via `always-entries` so a single-map `:always`'s
+      ;; guard/action refs are validated (iterating the raw map yields
+      ;; MapEntries, so `(:guard t)`/`(:action t)` would no-op and a
+      ;; dangling ref would slip past fail-fast registration).
+      (doseq [t (always-entries state-node)]
         (check-guard!  (:guard t)  s)
         (check-action! (:action t) s))
       (check-action! (:entry state-node) s)

--- a/implementation/machines/test/re_frame/nested_validation_test.clj
+++ b/implementation/machines/test/re_frame/nested_validation_test.clj
@@ -150,6 +150,78 @@
       (is (some? thrown)
           "nested :always :action misuse SHOULD throw at registration"))))
 
+;; ---- regression (rf2-zg579): single-map :always must be normalised ------
+;; The grammar admits `:always` as a single entry map OR a vector of entry
+;; maps. The guard/action ref-validation loop used to iterate `(:always
+;; state-node)` directly; for a single-map `:always` that yields the map's
+;; MapEntries, so `(:guard t)`/`(:action t)` no-op'd and a dangling ref
+;; slipped past fail-fast registration (surfacing only late, at runtime).
+;; The fix routes the loop through the in-file `always-entries` normaliser.
+;; The vector form (above) was already covered; these pin the single-map
+;; form so both shapes are guarded.
+
+(deftest top-level-always-single-map-guard-keyword-unresolved
+  (testing "Top-level single-map :always with unregistered :guard keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:always {:target :other
+                                       :guard  :no-such-guard}}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-always-singlemap-guard m)]
+      (is (some? thrown)
+          "single-map :always :guard misuse SHOULD throw at registration")
+      (is (= ":rf.error/machine-unresolved-guard" (.getMessage thrown))
+          "error category names the unresolved-guard contract")
+      (is (= :no-such-guard (:guard (ex-data thrown)))
+          "ex-data carries the offending guard keyword"))))
+
+(deftest top-level-always-single-map-action-keyword-unresolved
+  (testing "Top-level single-map :always with unregistered :action keyword fails registration"
+    (let [m {:initial :idle
+             :guards  {}
+             :actions {}
+             :states  {:idle {:always {:target :other
+                                       :action :no-such-action}}
+                       :other {}}}
+          thrown (registration-throws? :rf.nested-validation/top-always-singlemap-action m)]
+      (is (some? thrown)
+          "single-map :always :action misuse SHOULD throw at registration")
+      (is (= ":rf.error/machine-unresolved-action" (.getMessage thrown))
+          "error category names the unresolved-action contract")
+      (is (= :no-such-action (:action (ex-data thrown)))
+          "ex-data carries the offending action keyword"))))
+
+(deftest nested-always-single-map-guard-keyword-unresolved
+  (testing "Nested-state single-map :always with unregistered :guard keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:always {:target :other
+                                                          :guard  :no-such-guard}}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-always-singlemap-guard m)]
+      (is (some? thrown)
+          "nested single-map :always :guard misuse SHOULD throw at registration")
+      (is (= :no-such-guard (:guard (ex-data thrown)))
+          "ex-data carries the offending guard keyword"))))
+
+(deftest nested-always-single-map-action-keyword-unresolved
+  (testing "Nested-state single-map :always with unregistered :action keyword fails registration"
+    (let [m {:initial :outer
+             :guards  {}
+             :actions {}
+             :states  {:outer {:initial :inner
+                               :states  {:inner {:always {:target :other
+                                                          :action :no-such-action}}
+                                         :other {}}}}}
+          thrown (registration-throws? :rf.nested-validation/nested-always-singlemap-action m)]
+      (is (some? thrown)
+          "nested single-map :always :action misuse SHOULD throw at registration")
+      (is (= :no-such-action (:action (ex-data thrown)))
+          "ex-data carries the offending action keyword"))))
+
 ;; ---- gap probe: :entry / :exit action references -------------------------
 
 (deftest top-level-entry-action-keyword-unresolved


### PR DESCRIPTION
## Summary
- `validate-machine!`'s guard/action ref-validation loop iterated `(:always state-node)` directly. The grammar admits `:always` as a single entry map OR a vector of entry maps; for a single-map `:always`, `doseq` iterates the map's MapEntries, so `(:guard t)`/`(:action t)` return nil and both checks no-op. A dangling guard/action ref in single-map `:always` slipped past fail-fast registration and only surfaced late at runtime.
- Fix: route the loop through the existing in-file `always-entries` normaliser (`validation.cljc:314`), the same helper the runtime `pick-always-transition` and the self-loop validator already use. The vector form was already validated correctly; only single-map was affected.

## Tests
- Added 4 regression tests in `nested_validation_test.clj` (top-level + nested, guard + action) for single-map `:always` with a dangling `:guard`/`:action`, asserting `:rf.error/machine-unresolved-guard` / `-action` throws at registration with the offending keyword in ex-data. The vector form was already covered by existing tests.
- Proven to fail before the fix (8 failures, 2 errors with source reverted) and pass after.

## Gates
- `clojure -M:test` (machines artefact): 242 tests, 815 assertions, 0 failures, 0 errors.
- `npm run test:cljs`: 4096 tests, 12426 assertions, 0 failures, 0 errors.