### PR TITLE
fix(schemas): publish app-schema-meta-at via late-bind + re-frame.core re-export (rf2-mg6ya)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -469,6 +469,16 @@
   ships in `day8/re-frame2-schemas`."}
   app-schema-at          rf-schemas/app-schema-at)
 
+(def ^{:doc "Return the full registration-metadata map at `path` for a
+  frame, or `nil` — `:path` / `:schema` / `:frame` plus source-coords
+  `:ns` / `:line` / `:file`. The source-coord introspection surface
+  pair-tools and 10x read (e.g. click-back-to-code); `app-schema-at` is
+  the lighter call when only the schema value is needed. Per Spec 010
+  §Schemas as a tooling and agent surface. Returns `nil` when the
+  schemas artefact is not on the classpath. Implementation ships in
+  `day8/re-frame2-schemas`."}
+  app-schema-meta-at     rf-schemas/app-schema-meta-at)
+
 (def ^{:doc "Return every registered `app-schema-at` declaration for a
   frame as a `{path -> schema}` map. Per Spec 010 §Per-frame schemas.
   Returns `{}` when the schemas artefact is not on the classpath.

--- a/implementation/core/src/re_frame/core_schemas.cljc
+++ b/implementation/core/src/re_frame/core_schemas.cljc
@@ -25,6 +25,19 @@
   ([path]      [path {}])
   ([path opts] :delegate))
 
+(defwrapper app-schema-meta-at
+  "Return the full registration-metadata map for a path in a frame, or
+  nil. Unlike `app-schema-at` (which returns just the `:schema` value),
+  this returns the meta stamped at `reg-app-schema` — `:path`,
+  `:schema`, `:frame`, and the source-coords `:ns` / `:line` / `:file`.
+  The source-coord introspection surface pair-tools and 10x read when
+  they need the registration anchor (e.g. click-back-to-code). Per Spec
+  010 §Schemas as a tooling and agent surface. Returns nil when the
+  schemas artefact is not on the classpath."
+  {:hook :schemas/app-schema-meta-at :artefact schemas-artefact :on-absent :nil}
+  ([path]      [path {}])
+  ([path opts] :delegate))
+
 (defwrapper app-schemas
   "Return every registered `app-schema-at` declaration for a frame as a
   `{path → schema}` map. Per Spec 010 §Per-frame schemas. Returns `{}`

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -153,6 +153,10 @@
    {:key         :schemas/app-schema-at
     :producer-ns 're-frame.schemas
     :description "Look up the schema registered at a path (introspection)."}
+   {:key         :schemas/app-schema-meta-at
+    :producer-ns 're-frame.schemas
+    :design-bead "rf2-mg6ya"
+    :description "Return the full registration-metadata map (source-coords + :path/:schema/:frame) for a path, or nil. The source-coord introspection surface pair-tools / 10x read; the lighter app-schema-at returns only the schema value."}
    {:key         :schemas/app-schemas
     :producer-ns 're-frame.schemas
     :description "Return all path → schema registrations (introspection)."}

--- a/implementation/schemas/src/re_frame/schemas.cljc
+++ b/implementation/schemas/src/re_frame/schemas.cljc
@@ -143,6 +143,7 @@
 (late-bind/set-fn! :schemas/reg-app-schema        reg-app-schema)
 (late-bind/set-fn! :schemas/reg-app-schemas       reg-app-schemas)
 (late-bind/set-fn! :schemas/app-schema-at         app-schema-at)
+(late-bind/set-fn! :schemas/app-schema-meta-at    app-schema-meta-at)
 (late-bind/set-fn! :schemas/app-schemas           app-schemas)
 (late-bind/set-fn! :schemas/app-schemas-digest    app-schemas-digest)
 (late-bind/set-fn! :schemas/set-schema-validator! set-schema-validator!)


### PR DESCRIPTION
## Summary

`app-schema-meta-at` is re-exported public from `re-frame.schemas` and is the canonical source-coord introspection query (per `storage.cljc:283-285` + `registrar.cljc:21`) — yet, unlike EVERY sibling query fn (`app-schema-at` / `app-schemas` / `app-schemas-digest` / `reg-app-schema` / `reg-app-schemas`), it was missing from the `:schemas/*` late-bind table and not re-exported through `re-frame.core` / `core-schemas`. Bundle-isolated pair-tools / 10x could therefore only reach it by statically requiring the OPTIONAL schemas artefact — a Tool-Pair contract violation (the seam the `rf2-p7va` per-feature split exists to avoid).

This was an accidental half-export: public-looking + docstring-canonical, but unreachable through the documented seams its siblings all use. Spec 010 (§Schemas as a tooling and agent surface) and `spec/API.md` (lines 25 + 407) already list `app-schema-meta-at` on the public schemas surface, so option (1) from the bead — wire the public seam — is the correct fix.

Changes, mirroring the `app-schema-at` pattern precisely:

- `schemas.cljc` — add `(late-bind/set-fn! :schemas/app-schema-meta-at app-schema-meta-at)`.
- `late_bind/directory.cljc` — add the matching `:schemas/app-schema-meta-at` directory entry (required by the late-bind drift gate, which pins both directions).
- `core_schemas.cljc` — add `defwrapper app-schema-meta-at` (two arities, `:on-absent :nil`).
- `core.cljc` — add the `(def app-schema-meta-at rf-schemas/app-schema-meta-at)` re-export.

## Test plan

- [x] JVM schemas: `clojure -M:test` — 178 tests / 18218 assertions, 0 failures
- [x] JVM core (incl. late-bind-drift gate): `clojure -M:test` — 712 tests / 3380 assertions, 0 failures
- [x] CLJS node: `npm run test:cljs` — 4096 tests / 12426 assertions, 0 failures
- [x] Bundle isolation: `npm run test:bundle-isolation` — PASS