### PR TITLE
fix(story): audit cluster — snapshot-hash play-script bug (P1) + identity cleanups (3 beads)

### DIFF
--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -427,8 +427,9 @@ The same data drives every consumer. No artefact duplication.
 
 Every variant has a stable **snapshot identity** comprising its `:variant-id` plus a content hash of its serialised body. The hash includes:
 
-- `:events` and `:play` event vectors (in order),
+- `:events` setup dispatches and the `:play-script` / `:plays` play surfaces (in order) — the legacy `:play` slot was removed (rf2-0wrud),
 - the resolved (post-`:extends`-merge) args, decorators, and tags,
+- the variant's `:viewport` / `:background` visual chrome (they land in the screenshot),
 - the parent story's component id (`:component`) and decorators,
 - the *registered* schema digest of the view (per [011 §`:rf/schema-digest`](011-SSR.md)) — so a schema change invalidates the snapshot identity.
 

--- a/tools/story/src/re_frame/story/canonical.cljc
+++ b/tools/story/src/re_frame/story/canonical.cljc
@@ -127,8 +127,8 @@
   branch of `ensure-installed!` and don't recurse."
   []
   (reset! installed? true)
-  (doseq [install! canonical-installers]
-    (install!)))
+  (doseq [installer canonical-installers]
+    (installer)))
 
 ;; Register the auto-install hook at canonical-ns load time. The
 ;; registrar consults this hook from each `reg-*!` runtime helper —

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -264,6 +264,17 @@
       :story                 story
       :effective-args        effective
       :view-schema-digest    schema-digest
+      ;; rf2-z86vu — `:active-modes` already perturbs identity via
+      ;; `:effective-args` (mode args are merged in by `resolve-args`),
+      ;; so this top-level slot is intentionally belt-and-braces: it
+      ;; keeps the mode-id SET part of the identity so two distinct modes
+      ;; that happen to register identical args (and therefore identical
+      ;; `:effective-args`) still produce DIFFERENT snapshot hashes. The
+      ;; visual-regression baseline is keyed per active-mode context, so
+      ;; the mode id — not just its resolved args — is identity-bearing.
+      ;; Do not "simplify" this away. (Contrast `:cell-overrides`, which
+      ;; perturbs identity only via `:effective-args` — overrides carry
+      ;; no id, so there is no analogous collision risk.)
       :active-modes          (vec (or active-modes []))
       :substrate             substrate})))
 

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -15,11 +15,15 @@
   includes:
 
   - Variant id
-  - `:events` and `:play` event vectors (in order)
-  - `:loaders` (in declared order; canonicalised)
+  - `:events` setup dispatches and the `:play-script` / `:plays` play
+    surfaces (in order) — rf2-0wrud removed the legacy `:play` slot
+  - `:loaders` / `:loaders-complete-when` / `:loaders-teardown`
+    (in declared order; canonicalised)
   - Effective `:args` (post-`:extends`-merge with story + active modes)
   - Variant `:decorators` id sequence + their ref-args
   - Variant `:tags` set
+  - Variant `:viewport` / `:background` visual chrome
+  - Variant `:args->events`, `:platforms`, `:substrates` targeting
   - Parent story `:component` id
   - Parent story `:decorators`
   - Parent story `:tags`
@@ -156,13 +160,52 @@
 
   Per spec/007 §Variant snapshot identity the variant-level `:decorators`
   participate in the hash — watch-mode auto-rerun keys off this identity
-  so a decorator-only edit MUST perturb it."
+  so a decorator-only edit MUST perturb it.
+
+  ## Slice membership (rf2-bgwnf)
+
+  A key belongs in the slice iff editing it changes the variant's
+  *settled rendered/tested state* — the thing a visual-regression
+  baseline or watch-mode rerun must invalidate on. Audited 2026-05-21:
+
+  Included:
+  - `:play-script` / `:plays` — the post-render interaction sequences.
+    A play edit changes the asserted/driven state, so it MUST perturb
+    the hash. (rf2-0wrud removed the legacy `:play` slot; this slice
+    tracked `:play`, which silently no longer existed — the bug
+    rf2-bgwnf fixes.)
+  - `:events` — pre-render setup dispatches.
+  - `:loaders` / `:loaders-complete-when` / `:loaders-teardown` — async
+    setup + the symmetric teardown; both shape the frame's settled state.
+  - `:decorators` / `:tags` — composition + classification.
+  - `:viewport` / `:background` — visual chrome that lands IN the
+    screenshot, so a baseline must invalidate when they change.
+  - `:args->events` / `:platforms` / `:substrates` — derivation +
+    targeting that change what is rendered.
+
+  Excluded (documented, not an oversight):
+  - `:args` — captured via `:effective-args` in `snapshot-tuple` (post-
+    `:extends`-merge + active-mode merge), so reproducing it here would
+    double-count.
+  - `:argtypes` — controls-panel metadata only; it shapes the controls
+    UI, not the rendered snapshot. The args it constrains are already
+    captured via `:effective-args`.
+  - `:modes` — the variant's *available* mode refs. The *active* mode
+    context is captured by `snapshot-tuple` (`:active-modes` slot +
+    merged into `:effective-args`); the available-mode SET does not
+    change the snapshot for a given active-mode context.
+  - `:dispatch-console?` / `:causa` — dev-tooling affordances; no effect
+    on the settled rendered state.
+  - `:doc` / `:source` — prose + coords; runtime-environmental.
+  - `:extends` — resolved away into `:effective-args` before hashing."
   [variant-id]
   (let [body (registrar/handler-meta :variant variant-id)]
     (when body
       (select-keys body
-                   [:events :play :loaders :loaders-complete-when
-                    :tags :decorators :args->events :platforms :substrates]))))
+                   [:events :play-script :plays
+                    :loaders :loaders-complete-when :loaders-teardown
+                    :tags :decorators :args->events :platforms :substrates
+                    :viewport :background]))))
 
 (defn- story-body-slice
   "Story-level slice that the variant inherits for identity purposes.

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -443,6 +443,53 @@
             (is (not= h-empty h-with)
                 "appending a decorator must produce a fresh hash")))))))
 
+(deftest snapshot-identity-changes-with-play-script
+  (testing "Per spec/007 §Variant snapshot identity — a variant-level
+            :play-script change MUST perturb the content-hash. Closes
+            rf2-bgwnf: variant-body-slice selected the legacy :play key
+            (removed by rf2-0wrud), so play-script edits were silently
+            dropped from the hash — breaking watch-mode auto-rerun and
+            visual-regression baseline invalidation."
+    (story/reg-story :story.id-ps
+      {:component :app/v})
+    (story/reg-variant :story.id-ps/v
+      {:events      []
+       :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
+    (let [h1 (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+      (story/reg-variant :story.id-ps/v
+        {:events      []
+         :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 2]]]})
+      (let [h2 (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+        (is (not= h1 h2)
+            "editing the play-script must produce a fresh hash"))
+      (testing "adding a play-script to a previously play-less variant also perturbs the hash"
+        (story/reg-variant :story.id-ps/v {:events []})
+        (let [h-none (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+          (story/reg-variant :story.id-ps/v
+            {:events      []
+             :play-script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]})
+          (let [h-with (-> (story/snapshot-identity :story.id-ps/v) :content-hash)]
+            (is (not= h-none h-with)
+                "appending a play-script must produce a fresh hash")))))))
+
+(deftest snapshot-identity-changes-with-plays
+  (testing "Per spec/007 §Variant snapshot identity — the multi-play
+            :plays surface (rf2-tl7zk) also participates in the hash.
+            Companion to rf2-bgwnf: both play surfaces (:play-script and
+            :plays) must perturb snapshot identity."
+    (story/reg-story :story.id-plays
+      {:component :app/v})
+    (story/reg-variant :story.id-plays/v
+      {:events []
+       :plays  [{:name "happy" :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]}]})
+    (let [h1 (-> (story/snapshot-identity :story.id-plays/v) :content-hash)]
+      (story/reg-variant :story.id-plays/v
+        {:events []
+         :plays  [{:name "happy" :script [[:dispatch-sync [:rf.assert/path-equals [:n] 2]]]}]})
+      (let [h2 (-> (story/snapshot-identity :story.id-plays/v) :content-hash)]
+        (is (not= h1 h2)
+            "editing a play's script must produce a fresh hash")))))
+
 (deftest snapshot-identity-changes-with-view-schema-digest
   (testing "Per spec/007 §Variant snapshot identity (line 429) — the
             *registered* schema digest of the view (per spec/011


### PR DESCRIPTION
## Summary

Three beads from the `tools/story` best-practice audit.

- **rf2-bgwnf (P1, REAL BUG)** — `variant-body-slice` selected the legacy `:play` key, removed by rf2-0wrud. The current play surfaces (`:play-script`, `:plays`) were in neither the slice nor the schema, so a play edit did **not** change the snapshot content-hash — silently breaking watch-mode auto-rerun and visual-regression baseline invalidation (both promised by the `identity.cljc` docstring + spec/007 §Variant snapshot identity). Fix replaces `:play` with `:play-script` + `:plays`, additionally adds the visual-bearing `:loaders-teardown`/`:viewport`/`:background` slots, documents the full include/exclude membership so the allow-list stops drifting, and corrects the stale `:play` wording in the docstring and spec/007. **Adds the regression tests that were missing** (`snapshot-identity-changes-with-play-script`, `-with-plays`) — proving a play-script edit now changes the hash.
- **rf2-9hf1c (P3)** — `canonical.cljc`: renamed the `doseq` loop binding from `install!` (which shadowed the enclosing `defn install!` and read as accidental recursion) to `installer`. Pure readability.
- **rf2-z86vu (P4)** — `snapshot-tuple`: documented the belt-and-braces top-level `:active-modes` slot. It is kept on purpose — two distinct modes registering identical args would otherwise collide to the same snapshot hash despite being different visual-regression contexts. Added a comment so it is not "simplified" away.

### bgwnf proof

Before (legacy `:play` slice): two variants differing only by `:play-script` → identical slices → identical hashes (bug). After (`:play-script`/`:plays` in slice): different slices → different hashes. The new tests assert this `not=`.

> Note: this PR edits `spec/007-Stories.md`, which is **not** a top-level hot-zone spec file (the hot-zone list covers spec/009, spec/006, spec/005, spec/002, plus Conventions/API/Tool-Pair/Spec-Schemas).

## Test plan

- [x] `tools/story` JVM tests (`clojure -M:test`) — 848 tests / 2507 assertions, 0 failures (incl. 2 new play-surface regression tests)
- [x] `npm run test:cljs` — 4096 tests / 12426 assertions, 0 failures
- [x] `npm run story:build` — bundle build completed, 0 warnings