### PR TITLE
fix(story-mcp): correct tool-count comment + cache registered-substrates var (rf2-l8e2c + rf2-1shje)

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -67,6 +67,16 @@
   [sym]
   (try (resolve sym) (catch Throwable _ nil)))
 
+#?(:clj
+   ;; `story/registered-substrates` is CLJS-only — resolved once at ns-load
+   ;; (mirrors `tools.dev/registered-substrates-var`, the documented
+   ;; pattern). The substrate set is stable across the process lifetime, so
+   ;; `read-run-opts` (preview/run/snapshot hot path) derefs this cached var
+   ;; rather than re-resolving per call. JVM-standalone deploy reads nil and
+   ;; yields an empty set; the nREPL-attached CLJS deploy reads the var.
+   (defonce ^:private registered-substrates-var
+     (resolve-cljs-var 'story/registered-substrates)))
+
 (defn text-result
   "Build a success result with a single text content item. `structured`
   (optional) lands on the `structuredContent` slot per the spec/2025-06-18
@@ -183,8 +193,8 @@
   CLJS-only (the JVM-standalone deploy reads `nil`); the modes set
   is the registered-mode id set."
   [arguments]
-  (let [substrate-set #?(:clj  (if-let [v (resolve-cljs-var 'story/registered-substrates)]
-                                 (try (set (v)) (catch Throwable _ #{}))
+  (let [substrate-set #?(:clj  (if registered-substrates-var
+                                 (try (set (registered-substrates-var)) (catch Throwable _ #{}))
                                  #{})
                          :cljs (try (set (story/registered-substrates))
                                     (catch :default _ #{})))

--- a/tools/story-mcp/test/stdio-roundtrip.js
+++ b/tools/story-mcp/test/stdio-roundtrip.js
@@ -5,7 +5,7 @@
 //
 //   - initialize                  (negotiate protocolVersion 2025-06-18)
 //   - notifications/initialized   (notification, no response)
-//   - tools/list                  (expect all 17 tools per spec/002)
+//   - tools/list                  (expect all 19 tools per spec/002)
 //   - tools/call list-tags        (read-side smoke; canonical seven present)
 //   - tools/call list-substrates  (returns a vector, possibly empty on JVM)
 //   - tools/call get-story-instructions (text content)


### PR DESCRIPTION
Two LOW-severity story-mcp audit fixes.

- **rf2-l8e2c** — stdio-roundtrip.js header comment said "17 tools"; the registry is 19 (fixture, spec/002, README, src docstrings all agree). The assertion already counts dynamically against the fixture — comment-only fix.
- **rf2-1shje** — read-run-opts re-resolved the CLJS-only `story/registered-substrates` var on every call (preview/run/snapshot hot path). Now cached once at ns-load via `defonce` on the `:clj` branch, mirroring `tools.dev/registered-substrates-var`. Behaviour identical.

Gates: `node test/stdio-roundtrip.js` GREEN (19 tools), `clojure -M:test` 140 tests / 753 assertions, 0 failures.