### PR TITLE
fix(ssr): daemon-flag the streaming writer thread + drop redundant ^:private (rf2-ekwda + rf2-o2481)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -259,7 +259,13 @@
                 ;; doesn't pin a non-trivial chunk of heap per request.
                 (let [pipe-in  (PipedInputStream. (* 16 1024))
                       pipe-out (PipedOutputStream. pipe-in)]
-                  (.start
+                  ;; Daemon thread (rf2-ekwda): a writer blocked on
+                  ;; `.write` to the bounded 16 KiB pipe of a slow-loris
+                  ;; client must NOT keep the JVM alive at shutdown. The
+                  ;; ns + handler docstrings and both test namespaces
+                  ;; assert daemon semantics; this is what makes that
+                  ;; contract real.
+                  (doto
                     (Thread.
                       ^Runnable
                       (fn writer-thread []
@@ -271,7 +277,9 @@
                             ;; it does NOT block the response close on
                             ;; the slower destroy path.
                             (lifecycle/destroy-frame-quietly! frame-id))))
-                      ^String (str "rf2-ssr-streaming-" (name frame-id))))
+                      ^String (str "rf2-ssr-streaming-" (name frame-id)))
+                    (.setDaemon true)
+                    (.start))
                   ;; Build the Ring response off the response
                   ;; accumulator's status/headers/cookies — no body
                   ;; default-stamp (we pass our own InputStream).

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -465,6 +465,14 @@
               (str "every captured thread name starts with the
                    `rf2-ssr-streaming-` prefix — captured names: "
                    (vec names))))
+        ;; rf2-ekwda: the writer is genuinely a daemon thread, not just
+        ;; named one — a writer blocked on `.write` to a slow-loris
+        ;; client's bounded pipe must NOT pin the JVM open at shutdown.
+        ;; Captured live, this is the only place the daemon flag is
+        ;; observable; assert it for real so a future regression that
+        ;; drops `(.setDaemon true)` fails here.
+        (is (every? (fn [^Thread t] (.isDaemon t)) @observed)
+            "every live streaming writer thread is a daemon thread")
         ;; And of course: the daemon terminates after the request
         ;; completes.
         (let [leaked (await-no-streaming-threads! 5000)]

--- a/implementation/ssr/src/re_frame/ssr/hash.cljc
+++ b/implementation/ssr/src/re_frame/ssr/hash.cljc
@@ -39,7 +39,7 @@
 
 (declare canonical-edn-into)
 
-(defn- ^:private append-children!
+(defn- append-children!
   "Append canonical-EDN of each non-nil child of `xs` into `sb`,
   separated by `sep`. Maps with nil values and sequential children
   that are nil are pruned at the parent per Spec 011 §Hydration-mismatch
@@ -58,7 +58,7 @@
             (canonical-edn-into sb x)
             (recur (next xs) false)))))))
 
-(defn- ^:private member-canonical
+(defn- member-canonical
   "Render one set/seq member's canonical form to a fresh accumulator.
   Used for the set branch where members must be lexicographically
   sorted by their canonical form before appending. Returns nil for
@@ -74,7 +74,7 @@
          (canonical-edn-into sb x)
          (.join sb "")))))
 
-(defn- ^:private append-sorted-set!
+(defn- append-sorted-set!
   "Sets: emit `#{` + sorted-by-canonical-EDN members + `}`. Members can
   be heterogeneous, so we materialise per-member canonical forms,
   sort the strings, then append. The set branch is the only place
@@ -99,7 +99,7 @@
                (recur (next items) false)))
            (.push sb "}")))))
 
-(defn- ^:private append-map!
+(defn- append-map!
   "Maps: emit `{` + sorted key-value pairs (`key value`, comma-joined) + `}`.
   Nil-valued entries pruned per Spec 011 §Hydration-mismatch detection."
   [sb m]


### PR DESCRIPTION
## Summary

Two fixes from the SSR best-practice audit (`ai/findings/ssr-bestpractice-2026-05-21.md`).

- **rf2-ekwda (P2, shutdown-safety bug)** — the per-request streaming writer in `ssr-ring/.../streaming.clj` was started via `(.start (Thread. ...))` with **no** `(.setDaemon true)`, despite the ns docstring, the `stream-handler` docstring, and both test namespaces all asserting daemon semantics. A writer blocked on `.write` to the bounded 16 KiB pipe of a slow-loris client was therefore a live **non-daemon** thread that could keep the JVM from exiting at shutdown. Now constructed with `(doto (Thread. ...) (.setDaemon true) (.start))`, preserving the existing `rf2-ssr-streaming-<frame-id>` thread name. Added a real `(.isDaemon t)` assertion to `daemon-thread-name-is-frame-scoped` (the one test that captures the live writer thread) so the contract is genuinely exercised and a future regression fails loudly.
- **rf2-o2481 (P3, idiom cleanup)** — dropped the redundant `^:private` metadata on four `defn-` helpers in `ssr/.../hash.cljc` (`append-children!`, `member-canonical`, `append-sorted-set!`, `append-map!`); `defn-` already privatises. No behaviour change.

## Test plan

- [x] `clojure -M:test` in `implementation/ssr-ring` — 63 tests, 328 assertions, 0 failures (incl. new `.isDaemon` assertion)
- [x] `clojure -M:test` in `implementation/ssr` — 214 tests, 737 assertions, 0 failures
- [x] `npm run test:cljs` — 4096 tests, 12426 assertions, 0 failures