### PR TITLE
chore(epoch): drop unused interop require + complete projected-record docstring (rf2-k6l2t + rf2-r9kij)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -487,9 +487,9 @@
   `:rf.size/large-elided` markers per the §Composition rule. The
   record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
   `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
-  `:rf.epoch/sensitive?`) and the cheap structured projections
-  (`:sub-runs`, `:renders`, `:effects`) pass through unchanged —
-  they carry no app-db material.
+  `:rf.epoch/sensitive?`, `:rf.epoch/redacted-modified-paths-count`)
+  and the cheap structured projections (`:sub-runs`, `:renders`,
+  `:effects`) pass through unchanged — they carry no app-db material.
 
   Per Security.md §Epoch privacy posture and rf2-mrsck: this is the
   single normative projection emission site for off-box egress. Tools

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -19,8 +19,7 @@
   Per Phase-1 finding (rf2-0wi86): no two atoms are ever held in a
   single critical section, so a tiny state ns owns all of them with
   zero locking/ordering subtleties — the cross-cutting coupling is
-  cosmetic, not structural."
-  (:require [re-frame.interop :as interop]))
+  cosmetic, not structural.")
 
 ;; ---- configuration --------------------------------------------------------
 


### PR DESCRIPTION
Two P3 fixes from the epoch audit (commit per-bead).

- **rf2-k6l2t** — `epoch/state.cljc`: removed the unused `[re-frame.interop :as interop]` require (dead carryover from the rf2-0wi86 seam-A split; `interop` was never referenced in the ns).
- **rf2-r9kij** — `epoch.cljc`: added `:rf.epoch/redacted-modified-paths-count` to the facade `projected-record` docstring's bookkeeping-passthrough list, matching `write.cljc:421` + `Spec-Schemas.md:2383` (doc-only; behaviour already correct).

Gates: epoch JVM `clojure -M:test` (183 tests / 671 assertions, 0 failures / 0 errors); `npm run test:cljs` (4096 tests / 12426 assertions, 0 failures / 0 errors).