### PR TITLE
fix(pair-mcp): --port-file flag + send-op! nil-guard (rf2-3dbwh + rf2-av5kl)

### DIFF
--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -67,12 +67,24 @@ Add to your `~/.claude/settings.json` (or per-project `.claude/settings.json`):
 }
 ```
 
-The server auto-discovers the nREPL port from (in order):
+The server auto-discovers the nREPL port from (highest precedence first):
 
-1. `$SHADOW_CLJS_NREPL_PORT` env var
-2. `target/shadow-cljs/nrepl.port`
-3. `.shadow-cljs/nrepl.port`
-4. `.nrepl-port`
+1. `--port-file <path>` launch flag — an explicit, **cwd-independent**
+   path to the port file. See [Launch flags](#launch-flags).
+2. `$SHADOW_CLJS_NREPL_PORT` env var.
+3. `target/shadow-cljs/nrepl.port`
+4. `.shadow-cljs/nrepl.port`
+5. `.nrepl-port`
+
+> **cwd caveat (rf2-3dbwh).** Steps 3–5 are bare *relative* paths,
+> resolved against the server process's current working directory
+> (`process.cwd()`). The MCP server runs as a **subprocess of the agent
+> host** (Claude Code / Cursor / Copilot), whose cwd is frequently **not**
+> your project root. When it isn't, all three file fallbacks miss
+> silently and only the env var (step 2) or `--port-file` (step 1)
+> resolve a port. If discovery fails with no obvious cause, prefer the
+> explicit escape hatches: set `SHADOW_CLJS_NREPL_PORT`, or pass
+> `--port-file <absolute-path-to-nrepl.port>`.
 
 ### Path-drift probe
 
@@ -133,6 +145,30 @@ your editor is the source of truth.
 |-----------------------------|---------|--------------------------------------------------------------------------------------|
 | `--allow-eval`              | OFF     | Enable the `eval-cljs` tool. Default-OFF gate (rf2-cxx5s); see "eval-cljs gate" below. |
 | `--allow-sensitive-reads`   | OFF     | Honour caller-supplied `:include-sensitive true` and `:elision false` on direct-read tools (`snapshot` / `get-path` / `subscribe` / `trace-window` / `watch-epochs`). Default-OFF gate (rf2-c2dtu). Canonical cross-MCP flag name shared with story-mcp (rf2-2x3ql); see "sensitive-reads gate" below. |
+| `--port-file <path>`        | —       | Explicit, **cwd-independent** path to the nREPL port file. Highest precedence in port discovery (rf2-3dbwh); see "port-file flag" below. Accepts `--port-file <path>` and `--port-file=<path>`. |
+
+#### port-file flag (rf2-3dbwh)
+
+The default port-file fallbacks (`target/shadow-cljs/nrepl.port`,
+`.shadow-cljs/nrepl.port`, `.nrepl-port`) are **relative** paths resolved
+against the server's current working directory. Because the MCP server is
+launched as a subprocess of the agent host, that cwd is frequently *not*
+your project root — in which case the relative scan misses and only the
+env var or `--port-file` resolve a port. `--port-file` takes an
+**absolute** path and wins over every other source:
+
+```json
+{
+  "mcpServers": {
+    "re-frame2-pair": {
+      "command": "re-frame2-pair-mcp",
+      "args": ["--port-file", "/abs/path/to/project/.shadow-cljs/nrepl.port"]
+    }
+  }
+}
+```
+
+It is the cwd-independent escape hatch when port auto-discovery fails.
 
 #### eval-cljs gate (rf2-cxx5s)
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -51,20 +51,43 @@
    ".shadow-cljs/nrepl.port"
    ".nrepl-port"])
 
+(defn- read-port-file
+  "Read + parse an nREPL port from a single file `path`. Returns an
+  integer or nil (file absent / unreadable / non-numeric content)."
+  [path]
+  (try
+    (let [content (str/trim (.toString (.readFileSync fs path)))
+          n       (js/parseInt content 10)]
+      (when-not (js/isNaN n) n))
+    (catch :default _ nil)))
+
 (defn read-port-from-fs
   "Read the nREPL port from the standard shadow-cljs / nrepl locations.
-  Returns an integer or nil."
-  []
-  (or (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
-        (let [n (js/parseInt env 10)]
-          (when-not (js/isNaN n) n)))
-      (some (fn [path]
-              (try
-                (let [content (str/trim (.toString (.readFileSync fs path)))
-                      n       (js/parseInt content 10)]
-                  (when-not (js/isNaN n) n))
-                (catch :default _ nil)))
-            port-file-candidates)))
+  Returns an integer or nil.
+
+  ## Precedence (highest first)
+
+    1. `--port-file <path>`   explicit, cwd-independent escape hatch
+                              (rf2-3dbwh). Passed as `explicit-port-file`.
+    2. `$SHADOW_CLJS_NREPL_PORT` env var.
+    3. `target/shadow-cljs/nrepl.port`  ┐
+    4. `.shadow-cljs/nrepl.port`        ├ cwd-relative scan (steps 3-5).
+    5. `.nrepl-port`                    ┘
+
+  The file-scan candidates (steps 3-5) are bare relative paths resolved
+  against `process.cwd()`. An MCP server launched as a subprocess of the
+  agent host (Claude Code / Cursor / Copilot) frequently has a cwd that
+  is NOT the consumer project root — in that case the scan misses
+  silently and only the env var or `--port-file` work. `--port-file`
+  (step 1) is the cwd-independent escape hatch; see the tool README."
+  ([] (read-port-from-fs nil))
+  ([explicit-port-file]
+   (or (when (and explicit-port-file (seq explicit-port-file))
+         (read-port-file explicit-port-file))
+       (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
+         (let [n (js/parseInt env 10)]
+           (when-not (js/isNaN n) n)))
+       (some read-port-file port-file-candidates))))
 
 ;; ---------------------------------------------------------------------------
 ;; bencode framing — handle concatenated frames in one TCP packet.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -302,8 +302,23 @@
                             (resolve @state)))))]
                 (swap! conn-atom assoc-in [:pending id] on-frame)
                 (let [op (j/assoc! (clj->js op-map) "id" id)
+                      ;; rf2-av5kl: re-read `:socket` immediately before the
+                      ;; write. `connect!` guarantees a live socket at resolve
+                      ;; time, but the close/error handlers (attach-handlers!)
+                      ;; can fire in the window between resolve and this write —
+                      ;; `close!` nils `:socket`. A bare `(.write nil ...)` would
+                      ;; throw an opaque native "Cannot read .write of null" in
+                      ;; the Promise executor AND strand the just-registered id
+                      ;; in `:pending`. Guard explicitly: clean up the pending
+                      ;; entry + timer and reject with a structured,
+                      ;; retry-to-reconnect message instead of the native NPE.
                       ^js sock (:socket @conn-atom)]
-                  (.write sock (bencode/encode op))))))))
+                  (if sock
+                    (.write sock (bencode/encode op))
+                    (do
+                      (swap! conn-atom update :pending dissoc id)
+                      (js/clearTimeout timer)
+                      (reject (js/Error. "nREPL socket dropped before write — retry to reconnect"))))))))))
       (.catch (fn [err] (js/Promise.reject err))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -5,11 +5,12 @@
 
   ## Lifecycle
 
-  1. boot: read nREPL port from `SHADOW_CLJS_NREPL_PORT` env or the
-     standard port-files. Open the persistent socket lazily on first
-     tool call (so the server starts cleanly even before shadow-cljs
-     is running — the first tool that needs the socket gets a
-     structured error).
+  1. boot: read nREPL port from the `--port-file <path>` flag, the
+     `SHADOW_CLJS_NREPL_PORT` env var, or the standard cwd-relative
+     port-files (in that precedence — see `nrepl/read-port-from-fs`).
+     Open the persistent socket lazily on first tool call (so the
+     server starts cleanly even before shadow-cljs is running — the
+     first tool that needs the socket gets a structured error).
   2. `initialize`: standard MCP handshake.
   3. `tools/list`: returns the twelve tool descriptors (the seven
      bash-shim-overlap ops `discover-app` / `eval-cljs` / `dispatch` /
@@ -51,19 +52,25 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- resolve-port
-  "Look up the nREPL port. Returns an integer or throws with a hint."
-  []
-  (or (nrepl/read-port-from-fs)
+  "Look up the nREPL port. Returns an integer or throws with a hint.
+
+  `explicit-port-file` (from the `--port-file <path>` launch flag) takes
+  precedence over the env var and the cwd-relative file scan — see
+  `nrepl/read-port-from-fs` and the tool README (rf2-3dbwh)."
+  [explicit-port-file]
+  (or (nrepl/read-port-from-fs explicit-port-file)
       (throw (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
                       {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found
                        :where    'pair-mcp/resolve-port
                        :recovery :no-recovery
                        :reason   (str "nREPL port not found. Start your shadow-cljs dev build "
                                       "(`shadow-cljs watch <build>`), or set "
-                                      "SHADOW_CLJS_NREPL_PORT explicitly.")}))))
+                                      "SHADOW_CLJS_NREPL_PORT explicitly, or pass "
+                                      "`--port-file <absolute-path-to-nrepl.port>` "
+                                      "(the cwd-independent escape hatch).")}))))
 
-(defn- new-conn []
-  (let [port (resolve-port)]
+(defn- new-conn [explicit-port-file]
+  (let [port (resolve-port explicit-port-file)]
     (log! "nREPL port =" port)
     (nrepl/make-conn port "127.0.0.1")))
 
@@ -143,9 +150,35 @@
                                          :text (pr-str payload)}]
              :structuredContent (clj->js payload)}))))
 
+(defn- parse-port-file-flag
+  "Pluck the value of the `--port-file` launch flag out of `argv`.
+  Accepts both the space form `--port-file <path>` and the equals form
+  `--port-file=<path>`. Returns the path string, or nil if absent /
+  given without a value. Last occurrence wins (consistent with argv
+  override semantics). Public-ish (private) — exercised via
+  `parse-launch-flags` in tests."
+  [argv]
+  (loop [items argv
+         found nil]
+    (if-let [item (first items)]
+      (cond
+        ;; --port-file=<path>
+        (str/starts-with? item "--port-file=")
+        (recur (rest items) (subs item (count "--port-file=")))
+
+        ;; --port-file <path>  (value is the next argv element)
+        (= item "--port-file")
+        (let [v (second items)]
+          (if (and v (not (str/starts-with? v "--")))
+            (recur (drop 2 items) v)
+            (recur (rest items) found)))
+
+        :else
+        (recur (rest items) found))
+      found)))
+
 (defn parse-launch-flags
-  "Pluck the named boolean launch flags out of the raw process argv. Two
-  flags today:
+  "Pluck the named launch flags out of the raw process argv. Flags today:
 
     --allow-eval             — opt-in to the `eval-cljs` tool (rf2-cxx5s
                                cascade from rf2-czv3p). Default OFF.
@@ -155,16 +188,22 @@
                                Default OFF. Canonical cross-MCP name
                                (rf2-2x3ql) — matches story-mcp's identically
                                named gate (rf2-g9fje / rf2-uaymx).
+    --port-file <path>       — explicit, cwd-independent nREPL port-file
+                               path (rf2-3dbwh). Highest precedence in the
+                               port-discovery chain — see
+                               `nrepl/read-port-from-fs`. Accepts both
+                               `--port-file <path>` and `--port-file=<path>`.
 
-  Returns `{:allow-eval? bool :allow-raw-state? bool}`. The internal
-  keyword `:allow-raw-state?` is the pair-mcp implementation-side
-  identifier for the gate's state; the CLI flag is the operator-facing
-  name. Unknown flags are ignored — node's shadow-cljs entry passes its
-  own argv prelude (script path), and future flags can land here without
-  breaking older invocations."
+  Returns `{:allow-eval? bool :allow-raw-state? bool :port-file str-or-nil}`.
+  The internal keyword `:allow-raw-state?` is the pair-mcp
+  implementation-side identifier for the gate's state; the CLI flag is the
+  operator-facing name. Unknown flags are ignored — node's shadow-cljs
+  entry passes its own argv prelude (script path), and future flags can
+  land here without breaking older invocations."
   [argv]
   {:allow-eval?      (boolean (some #{"--allow-eval"} argv))
-   :allow-raw-state? (boolean (some #{"--allow-sensitive-reads"} argv))})
+   :allow-raw-state? (boolean (some #{"--allow-sensitive-reads"} argv))
+   :port-file        (parse-port-file-flag argv)})
 
 (defn- apply-launch-flags!
   "Wire launch-flag state into the relevant tool gates. Called once
@@ -195,20 +234,23 @@
                " abuse-window-ms="           (:abuse-window-ms merged)))))
 
 (defn main [& args]
-  (let [argv (vec args)]
-    (apply-launch-flags! (parse-launch-flags argv))
-    (apply-resource-controls! argv))
-  (try
-    (let [conn   (new-conn)
-          server (boot! conn)]
-      (log! "starting stdio transport")
-      (connect-transport! server "ready — awaiting MCP frames on stdin"))
-    (catch :default e
-      (log! "boot failed:" (.-message e))
-      ;; Even on boot failure (e.g. nREPL port missing) we keep the
-      ;; process alive so the MCP client can talk to us, list tools,
-      ;; and surface a structured error from the first tool call. The
-      ;; bash-shim chain had the same semantics — the error came back
-      ;; as `{:ok? false :reason :nrepl-port-not-found}`.
-      (let [server (build-server (degraded-handler e))]
-        (connect-transport! server "ready (degraded — no nREPL port)")))))
+  (let [argv         (vec args)
+        launch-flags (parse-launch-flags argv)]
+    (apply-launch-flags! launch-flags)
+    (apply-resource-controls! argv)
+    (when-let [pf (:port-file launch-flags)]
+      (log! "nREPL port-file (--port-file):" pf))
+    (try
+      (let [conn   (new-conn (:port-file launch-flags))
+            server (boot! conn)]
+        (log! "starting stdio transport")
+        (connect-transport! server "ready — awaiting MCP frames on stdin"))
+      (catch :default e
+        (log! "boot failed:" (.-message e))
+        ;; Even on boot failure (e.g. nREPL port missing) we keep the
+        ;; process alive so the MCP client can talk to us, list tools,
+        ;; and surface a structured error from the first tool call. The
+        ;; bash-shim chain had the same semantics — the error came back
+        ;; as `{:ok? false :reason :nrepl-port-not-found}`.
+        (let [server (build-server (degraded-handler e))]
+          (connect-transport! server "ready (degraded — no nREPL port)"))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -163,6 +163,61 @@
       (fn []
         (is (nil? (nrepl/read-port-from-fs)))))))
 
+;; ---------------------------------------------------------------------------
+;; --port-file explicit override (rf2-3dbwh). The 1-arity `read-port-from-fs`
+;; takes an explicit, cwd-independent path that wins over BOTH the env var and
+;; the relative file-scan candidates. nil/blank ⇒ falls through to the normal
+;; precedence chain.
+;; ---------------------------------------------------------------------------
+
+(deftest port-discovery-explicit-port-file-wins-over-env
+  (testing "an explicit --port-file path beats SHADOW_CLJS_NREPL_PORT"
+    ;; env says 7777, the explicit file says 9001 → explicit wins. The
+    ;; env must NOT short-circuit ahead of the explicit path.
+    (with-fs-stub! "7777"
+      (read-returning "explicit/nrepl\\.port" "9001")
+      (fn []
+        (is (= 9001 (nrepl/read-port-from-fs "explicit/nrepl.port"))
+            "explicit --port-file is highest precedence")))))
+
+(deftest port-discovery-explicit-port-file-wins-over-file-scan
+  (testing "an explicit --port-file path beats the cwd-relative candidates"
+    (with-fs-stub! nil
+      (fn [^js path]
+        (let [p (str path)]
+          (cond
+            (re-find #"explicit[\\/]nrepl\.port" p) "9002"
+            (re-find #"target/shadow-cljs/nrepl\.port" p) "6001"
+            :else (throw (js/Error. "ENOENT")))))
+      (fn []
+        (is (= 9002 (nrepl/read-port-from-fs "explicit/nrepl.port"))
+            "explicit path wins over the relative scan")))))
+
+(deftest port-discovery-explicit-port-file-trimmed-and-parsed
+  (testing "explicit-path content is trimmed + parsed like the candidates"
+    (with-fs-stub! nil
+      (read-returning "explicit/nrepl\\.port" "  9003  \n")
+      (fn []
+        (is (= 9003 (nrepl/read-port-from-fs "explicit/nrepl.port")))))))
+
+(deftest port-discovery-explicit-port-file-missing-falls-through
+  (testing "an absent explicit path falls through to env then file scan"
+    ;; The explicit path throws ENOENT; env (7777) must then resolve.
+    (with-fs-stub! "7777" throwing-read
+      (fn []
+        (is (= 7777 (nrepl/read-port-from-fs "nope/missing.port"))
+            "missing --port-file ⇒ fall through to env")))))
+
+(deftest port-discovery-explicit-port-file-nil-is-normal-chain
+  (testing "nil explicit path behaves exactly like the 0-arity chain"
+    (with-fs-stub! nil
+      (read-returning "target/shadow-cljs/nrepl.port" "6001")
+      (fn []
+        (is (= 6001 (nrepl/read-port-from-fs nil))
+            "nil explicit ⇒ normal env→file precedence")
+        (is (= 6001 (nrepl/read-port-from-fs))
+            "0-arity stays equivalent")))))
+
 ;; ===========================================================================
 ;; Transport data-handler — `attach-handlers!` (rf2-wnrpi, finding G3).
 ;;

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -8,7 +8,7 @@
 
   Tests pin `decode-all-frames` directly from
   `re-frame2-pair-mcp.nrepl` — the source ns is the contract."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing async]]
             [applied-science.js-interop :as j]
             ["bencode" :as bencode]
             ["fs" :as fs]
@@ -348,3 +348,60 @@
       (is (= {} (:pending @conn)) "pending cleared so no stale resolvers")
       (is (= #{} (:probed-builds @conn))
           "probe cache cleared — a fresh connect must re-probe the preload"))))
+
+;; ===========================================================================
+;; `send-op!` connect→write race nil-guard (rf2-av5kl).
+;;
+;; `connect!`'s fast path resolves immediately when a live socket is present,
+;; but the socket close/error handlers can fire in the window between that
+;; resolve and the actual `.write`. If `:socket` got nilled by `close!` in
+;; that window, a bare `(.write nil ...)` would throw an opaque native
+;; "Cannot read .write of null" AND strand the just-registered id in
+;; `:pending`. We simulate the race by nilling `:socket` synchronously after
+;; the send-op! call but before the `.then` microtask runs.
+;; ===========================================================================
+
+(deftest send-op!-nil-socket-rejects-structured-and-cleans-pending
+  (testing "socket dropped between connect-resolve and write → structured reject, no pending leak"
+    (async done
+      (let [writes (atom 0)
+            ;; A fake live socket so connect!'s fast path resolves immediately.
+            sock   (j/lit {:write (fn [_] (swap! writes inc) nil)})
+            conn   (nrepl/make-conn 0 "127.0.0.1")]
+        ;; Pre-seed a healthy connection so connect! returns Promise.resolve.
+        (swap! conn assoc :socket sock :closed? false)
+        (let [p (nrepl/send-op! conn {"op" "eval" "code" "(+ 1 1)"})]
+          ;; Synchronously — before the .then microtask writes — drop the
+          ;; socket exactly as a racing close! would.
+          (swap! conn assoc :socket nil)
+          (-> p
+              (.then (fn [_]
+                       (is false "send-op! must REJECT when the socket is nil at write time")
+                       (done)))
+              (.catch (fn [err]
+                        (is (= "nREPL socket dropped before write — retry to reconnect"
+                               (.-message err))
+                            "structured retry-to-reconnect message, not the native NPE")
+                        (is (zero? @writes) "no write attempted against a nil socket")
+                        (is (= {} (:pending @conn))
+                            "the just-registered id is dissoc'd — no pending leak")
+                        (done)))))))))
+
+(deftest send-op!-live-socket-writes-normally
+  (testing "with a live socket present at write time, send-op! writes the encoded op"
+    (async done
+      (let [writes (atom [])
+            sock   (j/lit {:write (fn [buf] (swap! writes conj buf) nil)})
+            conn   (nrepl/make-conn 0 "127.0.0.1")]
+        (swap! conn assoc :socket sock :closed? false)
+        ;; Don't drop the socket — the write should happen, the op stays
+        ;; pending (no :done frame is ever fed), and we just assert the write
+        ;; landed then resolve the test.
+        (nrepl/send-op! conn {"op" "eval" "code" "(+ 1 1)"})
+        ;; Let the connect! fast-path microtask run before asserting.
+        (js/queueMicrotask
+          (fn []
+            (is (= 1 (count @writes)) "exactly one write against the live socket")
+            (is (= 1 (count (:pending @conn)))
+                "the op is registered as pending awaiting its :done frame")
+            (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -121,6 +121,46 @@
         "Legacy --allow-raw-state must not enable the gate post-rename")))
 
 ;; ---------------------------------------------------------------------------
+;; --port-file launch flag (rf2-3dbwh) — explicit, cwd-independent port file.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-launch-flags-port-file-defaults-nil
+  (let [flags (server/parse-launch-flags [])]
+    (is (nil? (:port-file flags))
+        "absent --port-file ⇒ :port-file nil")))
+
+(deftest parse-launch-flags-port-file-space-form
+  (testing "--port-file <path> reads the value from the next argv element"
+    (let [flags (server/parse-launch-flags ["--port-file" "/abs/path/nrepl.port"])]
+      (is (= "/abs/path/nrepl.port" (:port-file flags)))
+      (is (false? (:allow-eval? flags)) "other flags stay at defaults"))))
+
+(deftest parse-launch-flags-port-file-equals-form
+  (testing "--port-file=<path> reads the inline value"
+    (let [flags (server/parse-launch-flags ["--port-file=/abs/path/nrepl.port"])]
+      (is (= "/abs/path/nrepl.port" (:port-file flags))))))
+
+(deftest parse-launch-flags-port-file-rides-with-other-flags
+  (let [flags (server/parse-launch-flags
+                ["--allow-eval" "--port-file" "/p/nrepl.port" "--allow-sensitive-reads"])]
+    (is (= "/p/nrepl.port" (:port-file flags)))
+    (is (true? (:allow-eval? flags)))
+    (is (true? (:allow-raw-state? flags)))))
+
+(deftest parse-launch-flags-port-file-missing-value-is-nil
+  (testing "a trailing --port-file with no value (or followed by a flag) yields nil"
+    (is (nil? (:port-file (server/parse-launch-flags ["--port-file"])))
+        "trailing --port-file with no value")
+    (is (nil? (:port-file (server/parse-launch-flags ["--port-file" "--allow-eval"])))
+        "--port-file immediately followed by another flag is not a value")))
+
+(deftest parse-launch-flags-port-file-last-occurrence-wins
+  (let [flags (server/parse-launch-flags
+                ["--port-file" "/first/nrepl.port" "--port-file=/second/nrepl.port"])]
+    (is (= "/second/nrepl.port" (:port-file flags))
+        "later --port-file overrides earlier (argv override semantics)")))
+
+;; ---------------------------------------------------------------------------
 ;; signal-runtime! cache — fires once per (build-id, server-lifetime).
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **rf2-3dbwh (P2)** — Port-file discovery's three relative fallbacks (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`) resolve against `process.cwd()`, which is usually not the project root for an agent-host-launched MCP subprocess — so all three miss silently and only the env var worked. Adds a `--port-file <path>` launch flag (highest precedence, ahead of `SHADOW_CLJS_NREPL_PORT`) as a cwd-independent escape hatch, and documents the cwd dependency + the new flag in the README. Existing fallbacks kept.
- **rf2-av5kl (P3)** — `send-op!` wrote to the socket without re-checking `(:socket @conn-atom)` for nil. If `close`/`error` fired between `connect!` resolving and the write, `(.write nil ...)` threw an opaque native NPE and stranded the just-registered id in `:pending`. Adds a nil-guard that dissocs the pending id, clears the timer, and rejects with a structured retry-to-reconnect message.

## Precedence chosen for --port-file

`--port-file <path>` (1) > `$SHADOW_CLJS_NREPL_PORT` (2) > `target/shadow-cljs/nrepl.port` (3) > `.shadow-cljs/nrepl.port` (4) > `.nrepl-port` (5). The explicit flag is the new highest-precedence source, ahead of the env var per the bead. Accepts both `--port-file <path>` and `--port-file=<path>`.

## Test plan

- [x] `npm test` (shadow-cljs `:server-test` + node) — 484 tests / 1277 assertions, 0 failures
- [x] `clojure -M:test` alias — same suite, 0 failures
- Added: `read-port-from-fs` explicit-path precedence tests (wins over env + file scan, trims/parses, falls through when missing, nil ≡ 0-arity); `parse-launch-flags` `--port-file` tests (space form, equals form, missing-value, last-wins, rides with other flags); `send-op!` nil-socket structured-reject + no-pending-leak test + live-socket write test.