### PR TITLE
fix(mcp-base): correct validator :where attribution per boundary + drop redundant decode validation (rf2-4ypau + rf2-pfy8e)

### DIFF
--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -192,14 +192,22 @@
   "Validate `patches` against `patches-schema` and throw ex-info on
   mismatch. No-op when Malli is not resolvable on the runtime
   classpath (soft-pass — mirrors `re-frame.schemas.malli`'s default
-  validator). Called by `diff-encode-db-after` at the wire boundary."
-  [patches]
+  validator).
+
+  `where` is the calling-site symbol threaded in by the caller so the
+  ex-info `:where` reflects the ACTUAL wire boundary that tripped
+  (rf2-4ypau): `'mcp-base/diff-encode-db-after` from the encoder,
+  `'mcp-base/apply-patches` from the decoder. Both boundaries call
+  this; hardcoding one side misattributes a decode-side throw to the
+  encoder and misleads operator triage about which side of the wire
+  drifted."
+  [patches where]
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate patches-schema patches)
         (throw (ex-info ":rf.error/bad-diff-patches"
                         {:rf.error/id    :rf.error/bad-diff-patches
-                         :where          'mcp-base/diff-encode-db-after
+                         :where          where
                          :recovery       :no-recovery
                          :reason         "diff-encode patch grammar violated"
                          :schema         patches-schema
@@ -209,15 +217,21 @@
 (defn- validate-sections!
   "Validate `sections` against `sections-schema` and throw ex-info on
   mismatch. Soft-pass when Malli is absent, mirrors
-  `validate-patches!`. Called by `diff-encode-db-after` at the wire
-  boundary after the section-grouping pass (rf2-qeous)."
-  [sections]
+  `validate-patches!`.
+
+  `where` is the calling-site symbol threaded in by the caller so the
+  ex-info `:where` reflects the ACTUAL wire boundary that tripped
+  (rf2-4ypau): `'mcp-base/diff-encode-db-after` from the encoder
+  (after the section-grouping pass, rf2-qeous), `'mcp-base/decode-db-after`
+  from the decoder. Both boundaries call this; hardcoding one side
+  misattributes a decode-side throw to the encoder."
+  [sections where]
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate sections-schema sections)
         (throw (ex-info ":rf.error/bad-diff-sections"
                         {:rf.error/id   :rf.error/bad-diff-sections
-                         :where         'mcp-base/diff-encode-db-after
+                         :where         where
                          :recovery      :no-recovery
                          :reason        "diff-encode section grammar violated"
                          :schema        sections-schema
@@ -302,7 +316,9 @@
   drifted re-frame2 mcp-base, a third-party decoder rolling its own
   shape, a transport corruption). Mirror `diff-encode-db-after`'s
   encoder-boundary gate: validate `patches` against `patches-schema`
-  and throw `:rf.error/bad-diff-patches` ex-info on mismatch.
+  and throw `:rf.error/bad-diff-patches` ex-info on mismatch. The
+  ex-info names `'mcp-base/apply-patches` as the decode-side boundary
+  (rf2-4ypau).
 
   The encoder side already pinned the grammar; this is the symmetric
   decode-side gate so the cross-MCP wire convention surfaces the
@@ -315,7 +331,7 @@
   CLJS `validate-patches?` `goog-define` toggle elides both gates
   together in `:advanced` builds."
   [base patches]
-  (validate-patches! patches)
+  (validate-patches! patches 'mcp-base/apply-patches)
   (reduce
     (fn [acc patch]
       (let [[path op v] patch]
@@ -356,9 +372,9 @@
                (contains? epoch :db-after))
     epoch
     (let [patches  (collect-patches (:db-before epoch) (:db-after epoch) [])
-          _        (validate-patches! patches)
+          _        (validate-patches! patches 'mcp-base/diff-encode-db-after)
           sections (sg/group-patches-into-sections patches)
-          _        (validate-sections! sections)]
+          _        (validate-sections! sections 'mcp-base/diff-encode-db-after)]
       (assoc epoch :db-after
              {vocab/diff-from-key :db-before
               :sections           sections}))))
@@ -383,7 +399,9 @@
   encoder/decoder symmetry per the rf2-8e61v argument: the cross-MCP
   wire convention surfaces drift on the receiving side too, rather
   than silently passing the cosmetic `:section-kind` / `:section-path`
-  slots through to an agent-host UI that paints them as truth.
+  slots through to an agent-host UI that paints them as truth. The
+  ex-info names `'mcp-base/decode-db-after` as the decode-side boundary
+  (rf2-4ypau).
 
   Soft-pass + `goog-define`-elidable by construction — reuses the
   same `validate-sections!` helper as the encoder."
@@ -393,7 +411,7 @@
                  (= :db-before (get da vocab/diff-from-key)))
       epoch
       (let [sections  (:sections da)
-            _         (validate-sections! (or sections []))
+            _         (validate-sections! (or sections []) 'mcp-base/decode-db-after)
             patches   (sg/sections->patches (or sections []))
             db-before (:db-before epoch)
             rebuilt   (apply-patches db-before patches)]

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -303,6 +303,39 @@
   [a b path]
   (collect-patches-into [] a b path))
 
+(defn- apply-patches*
+  "Replay an already-validated patch vector against `base`, returning
+  the reconstructed value. Patches are `[path :assoc v]` or
+  `[path :dissoc]`. Root-path patches (path `[]`) replace `base`
+  outright (for `:assoc`) or are a no-op (for `:dissoc`, by
+  convention).
+
+  This is the non-validating core: callers that have ALREADY validated
+  the patch grammar (e.g. `decode-db-after`, whose `validate-sections!`
+  gate walks each section's nested `:patches` against `patches-schema`
+  via `section-schema`) replay through here directly rather than
+  re-validating the flattened list a second time on the JVM decode hot
+  path (rf2-pfy8e). The public `apply-patches` validates first, then
+  delegates here."
+  [base patches]
+  (reduce
+    (fn [acc patch]
+      (let [[path op v] patch]
+        (cond
+          (empty? path)
+          (if (= op :assoc) v acc)
+          (= op :assoc)
+          (assoc-in acc path v)
+          (= op :dissoc)
+          (let [parent-path (vec (butlast path))
+                k           (last path)]
+            (if (empty? parent-path)
+              (dissoc acc k)
+              (update-in acc parent-path dissoc k)))
+          :else acc)))
+    base
+    patches))
+
 (defn apply-patches
   "Apply a vector of patches to `base`, returning the reconstructed
   value. Patches are `[path :assoc v]` or `[path :dissoc]`. Root-path
@@ -329,26 +362,16 @@
   Soft-pass behaviour mirrors the encoder: when Malli is not
   resolvable on the runtime classpath, validation is skipped. The
   CLJS `validate-patches?` `goog-define` toggle elides both gates
-  together in `:advanced` builds."
+  together in `:advanced` builds.
+
+  Note: `decode-db-after` does NOT route through this fn — it validates
+  `:sections` (whose nested `:patches` are walked against the same
+  `patches-schema`) and replays via the non-validating `apply-patches*`
+  to avoid a redundant second Malli walk of every patch tuple on the
+  JVM decode hot path (rf2-pfy8e)."
   [base patches]
   (validate-patches! patches 'mcp-base/apply-patches)
-  (reduce
-    (fn [acc patch]
-      (let [[path op v] patch]
-        (cond
-          (empty? path)
-          (if (= op :assoc) v acc)
-          (= op :assoc)
-          (assoc-in acc path v)
-          (= op :dissoc)
-          (let [parent-path (vec (butlast path))
-                k           (last path)]
-            (if (empty? parent-path)
-              (dissoc acc k)
-              (update-in acc parent-path dissoc k)))
-          :else acc)))
-    base
-    patches))
+  (apply-patches* base patches))
 
 (defn diff-encode-db-after
   "Replace an epoch's `:db-after` with a path-headed cluster
@@ -394,7 +417,7 @@
   Mirrors the encoder's `validate-sections!` gate. `sections->patches`
   is a permissive `mapcat :patches` — a section with malformed
   `:section-path` / `:section-kind` slots, or extra/missing slots,
-  would slip through to `apply-patches` whose own gate only validates
+  would slip through to a patch replay whose grammar gate only covers
   the flattened `:patches` list. Validating `sections` here gives
   encoder/decoder symmetry per the rf2-8e61v argument: the cross-MCP
   wire convention surfaces drift on the receiving side too, rather
@@ -404,7 +427,17 @@
   (rf2-4ypau).
 
   Soft-pass + `goog-define`-elidable by construction — reuses the
-  same `validate-sections!` helper as the encoder."
+  same `validate-sections!` helper as the encoder.
+
+  ## Single validation pass (rf2-pfy8e)
+
+  `section-schema` nests `patches-schema`, so the `validate-sections!`
+  gate above already Malli-walks every section's `:patches` against the
+  same grammar the public `apply-patches` would re-check. To avoid
+  validating each patch tuple twice on the JVM decode hot path
+  (`watch-epochs` / `trace-window` slices, where Malli is always
+  present), the replay routes through the non-validating
+  `apply-patches*` rather than the public `apply-patches`."
   [epoch]
   (let [da (when (map? epoch) (:db-after epoch))]
     (if-not (and (map? da)
@@ -414,7 +447,7 @@
             _         (validate-sections! (or sections []) 'mcp-base/decode-db-after)
             patches   (sg/sections->patches (or sections []))
             db-before (:db-before epoch)
-            rebuilt   (apply-patches db-before patches)]
+            rebuilt   (apply-patches* db-before patches)]
         (assoc epoch :db-after rebuilt)))))
 
 (defn diff-encode-epochs

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -272,20 +272,35 @@
   ;; encoder entry point.
   (testing "well-formed patches return nil"
     (is (nil? (#'de/validate-patches! [[[:a] :assoc 1]
-                                       [[:b] :dissoc]]))))
+                                       [[:b] :dissoc]]
+                                      'mcp-base/diff-encode-db-after))))
   (testing "malformed patches throw :rf.error/bad-diff-patches"
     (let [bad [[[:a] :replace 1]]]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
             #":rf\.error/bad-diff-patches"
-            (#'de/validate-patches! bad)))
+            (#'de/validate-patches! bad 'mcp-base/diff-encode-db-after)))
       (try
-        (#'de/validate-patches! bad)
+        (#'de/validate-patches! bad 'mcp-base/diff-encode-db-after)
         (is false "expected throw")
         (catch clojure.lang.ExceptionInfo e
           (is (= :rf.error/bad-diff-patches
                  (:rf.error/id (ex-data e)))
-              "ex-info carries the reserved :rf.error/* code"))))))
+              "ex-info carries the reserved :rf.error/* code")))))
+  (testing "the threaded `where` symbol propagates to ex-info :where (rf2-4ypau)"
+    (let [bad [[[:a] :replace 1]]]
+      (try
+        (#'de/validate-patches! bad 'mcp-base/diff-encode-db-after)
+        (is false "expected throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= 'mcp-base/diff-encode-db-after (:where (ex-data e)))
+              "encoder caller threads its own site")))
+      (try
+        (#'de/validate-patches! bad 'mcp-base/apply-patches)
+        (is false "expected throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= 'mcp-base/apply-patches (:where (ex-data e)))
+              "decoder caller threads its own site"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Decoder-boundary validation (rf2-8e61v / F17).
@@ -318,13 +333,16 @@
           clojure.lang.ExceptionInfo
           #":rf\.error/bad-diff-patches"
           (de/apply-patches {} [[:a :assoc 1]]))))
-  (testing "ex-info carries reserved :rf.error/bad-diff-patches code"
+  (testing "ex-info carries reserved :rf.error/bad-diff-patches code + decode-side :where"
     (try
       (de/apply-patches {} [[[:a] :replace 1]])
       (is false "expected throw")
       (catch clojure.lang.ExceptionInfo e
         (is (= :rf.error/bad-diff-patches
-               (:rf.error/id (ex-data e))))))))
+               (:rf.error/id (ex-data e))))
+        (is (= 'mcp-base/apply-patches
+               (:where (ex-data e)))
+            "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)")))))
 
 (deftest apply-patches-well-formed-input-passes-validation
   ;; Soft contract: well-formed patches pass the gate silently and
@@ -397,9 +415,9 @@
           (is (= :rf.error/bad-diff-sections
                  (:rf.error/id (ex-data e)))
               "ex-info carries the reserved :rf.error/* code")
-          (is (= 'mcp-base/diff-encode-db-after
+          (is (= 'mcp-base/decode-db-after
                  (:where (ex-data e)))
-              "ex-info names the validation site"))))))
+              "ex-info names the DECODE-side boundary, not the encoder (rf2-4ypau)"))))))
 
 (deftest decode-db-after-well-formed-sections-round-trip
   ;; The positive companion: well-formed sections decode silently and


### PR DESCRIPTION
## Summary

Two fixes from the mcp-base audit, in `tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc`.

- **rf2-4ypau** — `validate-patches!` / `validate-sections!` hardcoded `:where 'mcp-base/diff-encode-db-after`, but both are also called from the DECODE boundary (`apply-patches`, `decode-db-after`), so a malformed patch/section hitting decode misreported the ENCODER as the failing site. Thread a `where` symbol from each caller; the pinning test now asserts the correct decode-side `:where` per boundary.
- **rf2-pfy8e** — `decode-db-after` Malli-validated each patch tuple twice on the JVM decode hot path (`validate-sections!` walks the nested `:patches` via `section-schema`, then `apply-patches` → `validate-patches!` re-walked the flattened list). Extracted a non-validating `apply-patches*` core; `decode-db-after` — already covered by the sections gate — replays through it, leaving exactly one authoritative validation pass. Public `apply-patches` keeps its own validating gate.

Public encode/decode API signatures are unchanged (downstream story-mcp + re-frame2-pair-mcp consume `apply-patches`/`decode-db-after`/`diff-encode-db-after` — all 2-/1-arg as before); the validator-site threading is internal to the private validators.

## Test plan

- [x] `tools/mcp-base` JVM tests (`clojure -M:test`) — 136 tests, 345 assertions, 0 failures
- [x] `tools/mcp-base` CLJS tests (`npm run test:cljs`) — 5 tests, 18 assertions, 0 failures
- [x] mcp-conformance wire-vocab gate (`clojure -M:test`) — 41 tests, 475 assertions, 0 failures