### PR TITLE
spike(docs/cljs): CM6 + clojure-mode + Scittle eval cell proof (rf2-qk3sh)

### DIFF
--- a/docs/cljs/_spike-qk3sh/.gitignore
+++ b/docs/cljs/_spike-qk3sh/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+cell.bundle.js

--- a/docs/cljs/_spike-qk3sh/README.md
+++ b/docs/cljs/_spike-qk3sh/README.md
@@ -1,0 +1,83 @@
+# Phase 0 spike — CM6 + clojure-mode + Scittle eval cell (rf2-qk3sh)
+
+**Throwaway reference.** Phase 1 (rf2-y99zt, the real `tools/` shadow-cljs
+artefact + instant-nav bootstrap) supersedes this. Kept only as a validated,
+copy-pasteable wiring reference. Not built by CI, not loaded by mkdocs.
+
+Proves: one CodeMirror 6 `EditorView` over a `<pre>`, using
+`@nextjournal/clojure-mode`'s `default_extensions` + `complete_keymap` plus a
+custom **Mod-Enter** eval keymap that calls Scittle's
+`scittle.core.eval_string` and renders the result/printed-output/errors into a
+sibling `<div>`.
+
+## Run it
+
+```bash
+npm install          # CM6 + clojure-mode + esbuild + playwright
+npm run browsers     # one-time: playwright install chromium
+npm run build        # esbuild bundles cell.src.mjs -> cell.bundle.js (IIFE)
+npm run smoke        # headless Chromium: drives 3 cells, asserts output
+# or open index.html in a browser and Ctrl/Cmd-Enter a cell.
+```
+
+## Validated recipe
+
+- **Scittle is a classic `<script>`, NOT an ES module.** Load it via
+  `<script src=".../scittle.js">` (CDN: `cdn.jsdelivr.net/npm/scittle@0.8.31/dist/scittle.js`).
+  It installs the `window.scittle` global; read `window.scittle.core.eval_string`
+  at eval time. Do NOT `import` it.
+- **CM6 + clojure-mode ARE ES modules** — bundle them with esbuild (`--format=iife`).
+  `@nextjournal/clojure-mode` exports `default_extensions` (an array) and
+  `complete_keymap` (an array of keybindings = paredit + builtin).
+- **Eval keymap MUST be `Prec.highest(keymap.of([{key:"Mod-Enter", run, preventDefault:true}]))`.**
+  Without `Prec.highest` the keypress can be swallowed before the handler runs.
+- **`eval_string` returns the actual CLJS value** (numbers as JS numbers, etc.),
+  and **throws a real JS `Error`** (with `.message`) on eval failure.
+- **Capture `*out*` + result together** by evaluating a wrapper that returns a
+  `(clj->js [...])` array (see `evalCljs` in `cell.src.mjs`).
+
+## GOTCHAS for Phase 1
+
+1. **No JVM classes in SCI.** `java.io.StringWriter` does NOT resolve. Use
+   `(with-out-str ...)` to capture printed output, not a StringWriter.
+2. **A CLJS vector returned to JS is a PersistentVector object, NOT a JS array.**
+   `out[0]` / `out[1]` index access returns internal fields (garbage), not
+   elements. Wrap the return value in `(clj->js ...)` to get a real JS `Array`
+   (verified: `clj->js` and `into-array` both yield real arrays).
+3. **`with-out-str` only captures explicit prints, not the body's return value.**
+   Stash the return value in an `(atom)` inside the with-out-str body, then
+   `pr-str` it after. The validated wrapper:
+   ```clojure
+   (clj->js
+     (let [r# (atom nil)
+           o# (with-out-str (reset! r# (do <USER-SRC>)))]
+       [o# (pr-str (deref r#))]))
+   ```
+4. **Scittle logs eval errors to `console.error` AND throws.** The throw is what
+   you catch+render; the console.error noise is expected, not a real page error.
+   Don't treat Scittle's console diagnostics as test failures.
+5. **`pr-str` of maps/sets renders cleanly** (e.g. `{:a 1, :b [1 2], :c #{:x :y}}`)
+   — good enough for the docs cells. For larger structures Phase 1 may want
+   `scittle.pprint.js` (ships in the Scittle dist) for pretty multi-line output.
+6. **esbuild local-binary gotcha:** run the project-local `node_modules/.bin/esbuild`
+   (or `npm run build`). A bare `npx esbuild` pulls a fresh global esbuild that
+   can't resolve the locally-installed `@codemirror/*` packages.
+
+## Resolved dep versions (this spike)
+
+| dep | resolved |
+|---|---|
+| `@nextjournal/clojure-mode` | 0.3.3 |
+| `@nextjournal/lezer-clojure` | 1.0.0 (transitive) |
+| `@codemirror/state` | 6.6.0 |
+| `@codemirror/view` | 6.43.0 |
+| `@codemirror/commands` | 6.10.3 |
+| `@codemirror/language` | 6.12.3 (transitive) |
+| `@codemirror/autocomplete` | 6.20.2 (transitive) |
+| `scittle` (CDN global) | 0.8.31 |
+| esbuild | 0.28.0 |
+| playwright | 1.60.0 |
+
+Bundle size: CM6 + clojure-mode unminified IIFE ≈ **866 KB** (`cell.bundle.js`);
+`--minify` shrinks it substantially. Scittle core ≈ 876 KB raw / 183 KB gzip
+(loaded separately from CDN). Matches the findings doc estimates.

--- a/docs/cljs/_spike-qk3sh/cell.src.mjs
+++ b/docs/cljs/_spike-qk3sh/cell.src.mjs
@@ -1,0 +1,153 @@
+// Spike rf2-qk3sh — Phase 0 proof: one CM6 cell evaluating plain CLJS via Scittle.
+//
+// This is the entry source. It is bundled with esbuild into `cell.bundle.js`
+// (an IIFE) which is what index.html loads. Scittle itself is loaded as a
+// separate classic <script> (CDN/local) that installs the `scittle` global —
+// Scittle is a shadow-cljs :browser build, NOT an ES module, so we do NOT
+// import it; we read `window.scittle.core.eval_string` at eval time.
+//
+// Deps (resolved): @nextjournal/clojure-mode 0.3.3, @codemirror/state 6.6.0,
+//   @codemirror/view 6.43.0, @codemirror/commands 6.x, scittle 0.8.31 (CDN/global).
+
+import { EditorState, Prec } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import {
+  default_extensions,
+  complete_keymap,
+} from "@nextjournal/clojure-mode";
+
+// --- Eval wiring -----------------------------------------------------------
+
+// Capture printed output (*out*) by wrapping the source so that Scittle's
+// with-out-str collects anything the form prints, and we still return the
+// value. We eval TWO things: the printed output and the result value.
+//
+// scittle.core.eval_string(srcString) -> the value of the LAST form in srcString
+// (a JS-visible representation of the CLJS value; SCI returns the actual value).
+// It throws a JS error if the form is invalid / eval fails.
+//
+// To also capture printed side-effects (println etc.) AND pretty-print the
+// result the way the docs cells want, we eval a small wrapper expression.
+function evalCljs(src) {
+  const scittle = window.scittle;
+  if (!scittle || !scittle.core || !scittle.core.eval_string) {
+    throw new Error("Scittle global not loaded (window.scittle.core.eval_string missing)");
+  }
+  // SCI is a JS interpreter — NO JVM classes (java.io.StringWriter is absent).
+  // Capture printed output (*out*) with clojure.core/with-out-str, and pr-str
+  // the result value.
+  //
+  // GOTCHA: a CLJS vector returned from eval_string is a *PersistentVector
+  // object*, NOT a JS array — out[0]/out[1] index access does NOT work. Wrap
+  // the result in (clj->js ...) so Scittle hands JS a real Array.
+  //
+  // We must NOT print the body's value via with-out-str (that only captures
+  // explicit prints). So: capture prints with with-out-str around the body,
+  // stash the body's return value in an atom, then pr-str it separately.
+  const wrapped =
+    "(clj->js" +
+    "  (let [r# (atom nil)" +
+    "        o# (with-out-str (reset! r# (do " + src + "\n)))]" +
+    "    [o# (pr-str (deref r#))]))";
+  const out = scittle.core.eval_string(wrapped); // -> JS array [printed, resultStr]
+  return { printed: out[0] || "", result: out[1] };
+}
+
+function renderResult(targetEl, { printed, result }) {
+  targetEl.classList.remove("err");
+  targetEl.innerHTML = "";
+  if (printed && printed.length) {
+    const pre = document.createElement("div");
+    pre.className = "cljs-out";
+    pre.textContent = printed;
+    targetEl.appendChild(pre);
+  }
+  const val = document.createElement("div");
+  val.className = "cljs-val";
+  val.textContent = "=> " + result;
+  targetEl.appendChild(val);
+}
+
+function renderError(targetEl, err) {
+  targetEl.classList.add("err");
+  targetEl.innerHTML = "";
+  const msg = (err && (err.message || err.toString())) || "unknown error";
+  targetEl.textContent = "ERROR: " + msg;
+}
+
+// Custom eval keymap: Mod-Enter evaluates the whole cell.
+// Wrapped in Prec.highest so it runs BEFORE any default/clojure-mode handler
+// that might also bind Mod-Enter and swallow the event.
+function evalKeymap(getResultEl) {
+  return Prec.highest(
+    keymap.of([
+      {
+        key: "Mod-Enter",
+        preventDefault: true,
+        run: (view) => {
+          const src = view.state.doc.toString();
+          const resultEl = getResultEl();
+          try {
+            renderResult(resultEl, evalCljs(src));
+          } catch (e) {
+            renderError(resultEl, e);
+          }
+          return true; // handled — prevents newline insertion
+        },
+      },
+    ])
+  );
+}
+
+// --- Cell mount ------------------------------------------------------------
+
+function mountCell(preEl) {
+  if (preEl.dataset.cljsMounted) return;
+  const source = preEl.textContent.replace(/\n+$/, "");
+
+  const wrap = document.createElement("div");
+  wrap.className = "cljs-cell";
+  const editorHost = document.createElement("div");
+  editorHost.className = "cljs-editor";
+  const resultEl = document.createElement("div");
+  resultEl.className = "cljs-result";
+  wrap.appendChild(editorHost);
+  wrap.appendChild(resultEl);
+
+  preEl.replaceWith(wrap);
+
+  const state = EditorState.create({
+    doc: source,
+    extensions: [
+      lineNumbers(),
+      history(),
+      ...default_extensions, // clojure-mode: lezer syntax, close/match brackets, etc.
+      keymap.of([...complete_keymap, ...defaultKeymap, ...historyKeymap]),
+      evalKeymap(() => resultEl),
+      EditorView.theme({
+        "&": { fontSize: "14px", border: "1px solid #ccc", borderRadius: "4px" },
+        ".cm-content": { fontFamily: "monospace" },
+      }),
+    ],
+  });
+
+  const view = new EditorView({ state, parent: editorHost });
+  wrap.dataset.cljsMounted = "1";
+  return view;
+}
+
+function mountAll() {
+  document
+    .querySelectorAll("pre.language-cljs:not([data-cljs-mounted])")
+    .forEach(mountCell);
+}
+
+// Expose for the test harness + run on load.
+window.__rf2SpikeMountAll = mountAll;
+window.__rf2SpikeEvalCljs = evalCljs;
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", mountAll);
+} else {
+  mountAll();
+}

--- a/docs/cljs/_spike-qk3sh/index.html
+++ b/docs/cljs/_spike-qk3sh/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>rf2-qk3sh spike — CM6 + clojure-mode + Scittle eval cell</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 760px; margin: 2rem auto; padding: 0 1rem; }
+    h1 { font-size: 1.2rem; }
+    .cljs-cell { margin: 1rem 0; }
+    .cljs-result {
+      margin-top: 4px; padding: 6px 10px; border-radius: 4px;
+      background: #f4f7f4; font-family: monospace; white-space: pre-wrap;
+      min-height: 1.4em;
+    }
+    .cljs-result.err { background: #fdecec; color: #a40000; }
+    .cljs-out { color: #555; }
+    .cljs-val { font-weight: 600; color: #1a5e1a; }
+    .hint { color: #777; font-size: 0.85rem; }
+  </style>
+  <!-- Scittle: classic <script>, installs window.scittle. NOT an ES module. -->
+  <script src="https://cdn.jsdelivr.net/npm/scittle@0.8.31/dist/scittle.js"></script>
+</head>
+<body>
+  <h1>rf2-qk3sh spike: CM6 + nextjournal/clojure-mode + Scittle eval cell</h1>
+  <p class="hint">Click into a cell, edit, press <kbd>Ctrl/Cmd-Enter</kbd> to eval.</p>
+
+  <h2>Cell 1 — arithmetic</h2>
+  <pre class="language-cljs">(+ 1 2 3)</pre>
+
+  <h2>Cell 2 — defn + call + println (multi-form, *out* capture)</h2>
+  <pre class="language-cljs">(defn square [x] (* x x))
+(println "computing...")
+{:squares (map square [1 2 3 4]) :set #{:a :b} :nested {:k [1 2]}}</pre>
+
+  <h2>Cell 3 — deliberate error (must render, not crash)</h2>
+  <pre class="language-cljs">(this-var-does-not-exist 1 2)</pre>
+
+  <!-- Bundled CM6 + clojure-mode entry (esbuild IIFE). -->
+  <script src="./cell.bundle.js"></script>
+</body>
+</html>

--- a/docs/cljs/_spike-qk3sh/package.json
+++ b/docs/cljs/_spike-qk3sh/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "rf2-spike-qk3sh-cljs-cell",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Phase 0 spike (rf2-qk3sh): one CM6 + nextjournal/clojure-mode cell evaluating plain CLJS via Scittle. Throwaway reference for Phase 1 (rf2-y99zt).",
+  "type": "commonjs",
+  "scripts": {
+    "build": "esbuild cell.src.mjs --bundle --format=iife --outfile=cell.bundle.js",
+    "build:min": "esbuild cell.src.mjs --bundle --minify --format=iife --outfile=cell.bundle.js",
+    "smoke": "node smoke.test.mjs",
+    "browsers": "playwright install chromium"
+  },
+  "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.0",
+    "@nextjournal/clojure-mode": "0.3.3"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.0",
+    "playwright": "^1.60.0"
+  }
+}

--- a/docs/cljs/_spike-qk3sh/smoke.test.mjs
+++ b/docs/cljs/_spike-qk3sh/smoke.test.mjs
@@ -1,0 +1,113 @@
+// Spike rf2-qk3sh smoke: real headless-chromium run of the proof page.
+// Serves the spike dir over http, loads index.html, drives three cells:
+//   1. arithmetic  -> "=> 6"
+//   2. defn + println + nested map/set -> printed "computing..." + value
+//   3. deliberate error -> error renders, page does NOT crash
+//
+// Run: node smoke.test.mjs   (from this dir)
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { chromium } from "playwright";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    let p = req.url.split("?")[0];
+    if (p === "/") p = "/index.html";
+    const file = join(__dirname, decodeURIComponent(p));
+    const data = await readFile(file);
+    res.writeHead(200, { "content-type": MIME[extname(file)] || "application/octet-stream" });
+    res.end(data);
+  } catch (e) {
+    res.writeHead(404);
+    res.end("not found: " + req.url);
+  }
+});
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("FAIL: " + msg);
+    process.exitCode = 1;
+  } else {
+    console.log("PASS: " + msg);
+  }
+}
+
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+const url = `http://127.0.0.1:${port}/index.html`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+// Only count genuine UNCAUGHT page errors. NOTE (gotcha for Phase 1): Scittle
+// logs eval errors to console.error as a diagnostic AND throws — the throw is
+// what we catch/render, so its console.error noise is expected, not a failure.
+const pageErrors = [];
+page.on("pageerror", (e) => pageErrors.push(e.message));
+
+await page.goto(url, { waitUntil: "networkidle" });
+
+// Wait for Scittle global + cells mounted.
+await page.waitForFunction(() => !!(window.scittle && window.scittle.core && window.scittle.core.eval_string), null, { timeout: 15000 });
+await page.waitForSelector(".cljs-cell .cm-editor", { timeout: 15000 });
+
+const cells = await page.$$(".cljs-cell");
+assert(cells.length === 3, `3 cells mounted (got ${cells.length})`);
+
+async function evalCell(idx) {
+  const cell = cells[idx];
+  const content = await cell.$(".cm-content");
+  await content.click();
+  // Move cursor to end so Mod-Enter evals whole doc.
+  await page.keyboard.press("Control+End");
+  await page.keyboard.press("Control+Enter");
+  // give eval a tick
+  await page.waitForTimeout(200);
+  const result = await cell.$(".cljs-result");
+  const text = (await result.innerText()).trim();
+  const isErr = await result.evaluate((el) => el.classList.contains("err"));
+  return { text, isErr };
+}
+
+// Cell 1: (+ 1 2 3)
+const c1 = await evalCell(0);
+console.log("cell1 result:", JSON.stringify(c1.text));
+assert(!c1.isErr, "cell1 not flagged error");
+assert(c1.text.includes("=> 6"), `cell1 evaluates to 6 (got ${JSON.stringify(c1.text)})`);
+
+// Cell 2: defn + println + nested coll
+const c2 = await evalCell(1);
+console.log("cell2 result:", JSON.stringify(c2.text));
+assert(!c2.isErr, "cell2 not flagged error");
+assert(c2.text.includes("computing..."), `cell2 captures println *out* (got ${JSON.stringify(c2.text)})`);
+assert(c2.text.includes(":squares") && c2.text.includes("(1 4 9 16)"), `cell2 result map renders squares (got ${JSON.stringify(c2.text)})`);
+assert(c2.text.includes("#{") , `cell2 renders set literal (got ${JSON.stringify(c2.text)})`);
+
+// Cell 3: error case
+const c3 = await evalCell(2);
+console.log("cell3 result:", JSON.stringify(c3.text));
+assert(c3.isErr, "cell3 flagged as error");
+assert(/ERROR/i.test(c3.text), `cell3 shows ERROR text (got ${JSON.stringify(c3.text)})`);
+
+// Re-eval cell 1 AFTER the error to prove no crash / state intact.
+const c1again = await evalCell(0);
+assert(c1again.text.includes("=> 6"), `cell1 still evals to 6 after error (got ${JSON.stringify(c1again.text)})`);
+
+assert(pageErrors.length === 0, `no uncaught page errors (saw: ${JSON.stringify(pageErrors)})`);
+
+await browser.close();
+server.close();
+
+console.log(process.exitCode ? "\n=== SMOKE FAILED ===" : "\n=== SMOKE PASSED ===");


### PR DESCRIPTION
## Summary

Phase 0 de-risking spike for epic rf2-yao33 (roll-your-own CLJS playground to replace Klipse). **Throwaway reference** — Phase 1 (rf2-y99zt) supersedes this with the real `tools/` shadow-cljs artefact + instant-nav bootstrap. Not built by CI, not loaded by mkdocs; lives under `docs/cljs/_spike-qk3sh/` purely as a validated, copy-pasteable wiring reference.

Proves the inline-cell eval wiring works: one CodeMirror 6 `EditorView` over a `<pre>`, using `@nextjournal/clojure-mode` `default_extensions` + `complete_keymap` plus a `Prec.highest` **Mod-Enter** eval keymap that calls Scittle's `scittle.core.eval_string` and renders the result / `*out*` / errors into a sibling `<div>`.

- Scittle loaded as a classic `<script>` global (CDN); CM6 + clojure-mode bundled with esbuild (IIFE).
- `README.md` captures the validated recipe, exact resolved dep versions, and gotchas for Phase 1.
- `cell.bundle.js`, `node_modules/`, `package-lock.json` are gitignored (regenerable via `npm run build`).

## Validated end-to-end in headless Chromium (12/12 assertions)

- `(+ 1 2 3)` → `=> 6`
- `defn` + `println` + nested coll → `*out*` captured (`computing...`) + `=> {:squares (1 4 9 16), :set #{:a :b}, :nested {:k [1 2]}}`
- deliberate error → `ERROR: Unable to resolve symbol: ...` rendered, no crash, cell still works after

## Resolved versions

`@nextjournal/clojure-mode` 0.3.3 · `scittle` 0.8.31 (CDN global) · `@codemirror/state` 6.6.0 · `@codemirror/view` 6.43.0 · `@codemirror/commands` 6.10.3 · esbuild 0.28.0 · playwright 1.60.0

## Test plan

- [x] `npm install && npm run build && npm run smoke` → SMOKE PASSED (reproducible from clean install)
- [ ] (Phase 1) port wiring into the `tools/` shadow-cljs artefact + instant-nav bootstrap