### PR TITLE
fix(examples/uix): audit cluster — README test-free + namespaced counter key + canonical CSS vars (4 beads)

### DIFF
--- a/examples/uix/README.md
+++ b/examples/uix/README.md
@@ -13,30 +13,32 @@ uix/
   dashboard_uix/  <-- design-led example proving multi-pane layout on UIx
 ```
 
-Each example sits in its own folder with the CLJS source (`core.cljs`), a hand-written `index.html`, and a Playwright smoke spec (`<name>.spec.cjs`). The on-disk folder names carry the `_uix` suffix because the CLJS namespaces (`counter-uix.core`, `login-uix.core`) are deliberately distinct from their Reagent siblings (`counter.core`, `login.core`) — both substrate trees end up on the same shadow-cljs classpath, so the namespaces have to be unique. The folder name follows the namespace convention (`-` becomes `_` on disk).
+Each example sits in its own folder with the CLJS source (`core.cljs`) and a hand-written `index.html`. The `examples/` tree is **test-free** (locked policy, rf2-8cevm): no example ships a Playwright spec — see [Testing](#testing) below for where the real regression coverage lives. The on-disk folder names carry the `_uix` suffix because the CLJS namespaces (`counter-uix.core`, `login-uix.core`) are deliberately distinct from their Reagent siblings (`counter.core`, `login.core`) — both substrate trees end up on the same shadow-cljs classpath, so the namespaces have to be unique. The folder name follows the namespace convention (`-` becomes `_` on disk).
 
 The dataflow — events, subs, schemas, machine, managed-HTTP stub — is **identical** to the Reagent siblings under [`../reagent/`](../reagent/); only the view layer differs. UIx components are written as `defui` and consume subs via the `use-subscribe` hook (Decision 1, UIx-idiomatic).
 
 ## What each example demonstrates
 
 - **`uix/counter_uix/`** ([build id `examples/counter-uix`](../../implementation/shadow-cljs.edn))
-  Same `:counter/initialise` / `:counter/increment` / `:counter/decrement` events as the Reagent counter; the view renders +/- buttons and a count between them. Smoke-spec asserts an initial render of `5` (seeded by `:counter/initialise`), then drives clicks and asserts the count moves.
+  Same `:counter/initialise` / `:counter/inc` / `:counter/dec` events as the Reagent counter; the view renders +/- buttons and a count between them. The count seeds to `5` (via `:counter/initialise`) and moves as the buttons dispatch.
 
 - **`uix/login_uix/`** ([build id `examples/login-uix`](../../implementation/shadow-cljs.edn))
-  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent login example. The view layer is a UIx `defui` form. Smoke-spec drives credentials → submit → asserts the welcome banner appears on success.
+  Same login state machine (`:idle -> :submitting -> :authed`/`:error-shown`), same Malli schemas, same `:rf.http/managed.login-demo` stub fx as the Reagent login example. The view layer is a UIx `defui` form. Entering credentials and submitting drives the machine to `:authed` and the welcome banner appears on success.
 
 - **`uix/dashboard_uix/`** ([build id `examples/dashboard-uix`](../../implementation/shadow-cljs.edn))
   Design-led example proving UIx can drive a substantive multi-pane layout. Shares the `_shared/css/style.css` "Editorial Warm" visual identity with the Reagent notebook and Helix process-monitor counterparts. No state machines, no HTTP — design-led examples exist to prove polished visuals + interaction, not to replay platform features other examples already cover.
 
-## Running
+## Testing
 
-The UIx examples are wired into the same orchestrator as the Reagent set. From `implementation/`:
+The `examples/` tree carries no tests (locked policy, rf2-8cevm). Browser smoke coverage for the UIx substrate lives at the **adapter level**: a single mount + dispatch + assert smoke at [`implementation/adapters/uix/testbed/spec.cjs`](../../implementation/adapters/uix/testbed/) (one each for Reagent, UIx, and Helix). Real regressions are caught by the substrate contract tests (`npm run test:cljs`), the Causa feature-matrix gate (`npm run test:causa-feature-gate`), bundle-isolation, the perf-bundle gate, and mcp-conformance — not by per-example specs.
+
+From `implementation/`, the adapter smokes run via:
 
 ```bash
 npm run test:examples
 ```
 
-That compiles `examples/counter-uix`, `examples/login-uix`, and `examples/dashboard-uix` alongside every Reagent example, stages each `index.html`, serves the lot, and drives the adapter-level smoke specs. The bundle-isolation grep at [`implementation/scripts/check-bundle-isolation.cjs`](../../implementation/scripts/check-bundle-isolation.cjs) runs against the Reagent counter; the per-substrate-per-example shadow-cljs builds let CI verify a Reagent example's `main.js` carries no UIx code and vice versa.
+That compiles the three adapter testbeds (`adapters/reagent-testbed`, `adapters/uix-testbed`, `adapters/helix-testbed`), stages each `index.html`, serves them, and drives the three `spec.cjs` smokes; the example builds in this directory are not staged because nothing tests them. Bundle isolation is verified separately (each per-substrate shadow-cljs build lets CI confirm a Reagent bundle's `main.js` carries no UIx code and vice versa, and likewise for UIx ↔ Helix).
 
 To iterate on one UIx example interactively, from `implementation/`:
 
@@ -44,7 +46,7 @@ To iterate on one UIx example interactively, from `implementation/`:
 shadow-cljs watch examples/counter-uix
 ```
 
-(Run `npm run test:examples` once first so `out/examples/counter-uix/index.html` is staged.)
+The build emits `main.js` into `out/examples/counter-uix/`; copy the example's hand-written [`counter_uix/index.html`](counter_uix/index.html) (and the shared assets it references under [`../_shared/`](../_shared/)) alongside it to load the watched build in a browser.
 
 ## Cross-references
 

--- a/examples/uix/counter_uix/core.cljs
+++ b/examples/uix/counter_uix/core.cljs
@@ -31,17 +31,17 @@
 
 (rf/reg-event-fx :counter/initialise
   (fn [_ctx _event]
-    {:db {:count 5}
+    {:db {:counter/value 5}
      :fx [[:counter/log :initialised]]}))
 
 (rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :count inc)))
+  (fn [db _event] (update db :counter/value inc)))
 
 (rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :count dec)))
+  (fn [db _event] (update db :counter/value dec)))
 
-(rf/reg-sub :count
-  (fn [db _query] (:count db)))
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
 
 ;; -- Views -------------------------------------------------------------------
 ;;
@@ -51,7 +51,7 @@
 ;; explicitly.
 
 (defui counter-buttons []
-  (let [count    (uix-adapter/use-subscribe [:count])
+  (let [count    (uix-adapter/use-subscribe [:counter/value])
         dispatch (rf/dispatcher)]
     ($ :div
        ($ :button {:on-click #(dispatch [:counter/dec])} "-")

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -20,7 +20,7 @@
    The shared 'Editorial Warm' visual identity comes from
    examples/_shared/css/style.css (rf2-v4fpe Option 2 — one identity
    across all three substrates)."
-  (:require [uix.core :as uix :refer [$ defui]]
+  (:require [uix.core :refer [$ defui]]
             [uix.dom  :as uix-dom]
             [re-frame.core            :as rf]
             [re-frame.adapter.uix     :as uix-adapter]))

--- a/examples/uix/dashboard_uix/index.html
+++ b/examples/uix/dashboard_uix/index.html
@@ -15,8 +15,7 @@
   <link rel="stylesheet" href="_shared/css/style.css">
   <style>
     /* Per-example layout — Atlas dashboard grid. Tokens come from
-       _shared/css/style.css (--ux-* aliases for --ex-* tokens remain
-       after rf2-v4fpe Option 2). */
+       _shared/css/style.css (the canonical --ex-* design-system tokens). */
     .dash-shell {
       max-width: 1180px;
       margin: 0 auto;
@@ -30,20 +29,20 @@
       gap: 2em;
       margin-bottom: 2.5em;
       padding-bottom: 1.5em;
-      border-bottom: 1.5px solid var(--ux-ink);
+      border-bottom: 1.5px solid var(--ex-ink);
     }
     .dash-shell-head h1 { font-size: 3rem; margin: 0 0 0.3rem; }
     .dash-tagline {
       margin: 0;
-      font-family: var(--ux-mono);
+      font-family: var(--ex-mono);
       text-transform: uppercase;
       letter-spacing: 0.12em;
       font-size: 0.78rem;
-      color: var(--ux-ink-mute);
+      color: var(--ex-ink-muted);
     }
     .dash-substrate-tag {
-      color: var(--ux-ink);
-      background: var(--ux-yellow);
+      color: var(--ex-ink);
+      background: var(--ex-accent-soft);
       padding: 1px 6px;
       margin-left: 6px;
     }
@@ -51,35 +50,35 @@
     .dash-chips { display: flex; gap: 10px; flex-wrap: wrap; }
     .dash-chip {
       display: inline-flex; align-items: center; gap: 8px;
-      font-family: var(--ux-mono);
+      font-family: var(--ex-mono);
       text-transform: uppercase;
       letter-spacing: 0.1em;
       font-size: 0.74rem;
       font-weight: 700;
       padding: 8px 12px;
-      background: var(--ux-bg-raised);
-      color: var(--ux-ink-mute);
-      border: 1.5px solid var(--ux-rule);
-      box-shadow: 3px 3px 0 var(--ux-rule);
+      background: var(--ex-bg-raised);
+      color: var(--ex-ink-muted);
+      border: 1.5px solid var(--ex-rule);
+      box-shadow: 3px 3px 0 var(--ex-rule);
       cursor: pointer;
       border-radius: 0;
       transition: transform 80ms ease, box-shadow 80ms ease, color 100ms ease;
     }
     .dash-chip:hover {
       transform: translate(-1px, -1px);
-      box-shadow: 4px 4px 0 var(--ux-rule);
+      box-shadow: 4px 4px 0 var(--ex-rule);
     }
     .dash-chip.is-on {
-      color: var(--ux-ink);
-      border-color: var(--ux-ink);
-      box-shadow: 3px 3px 0 var(--ux-ink);
+      color: var(--ex-ink);
+      border-color: var(--ex-ink);
+      box-shadow: 3px 3px 0 var(--ex-ink);
     }
     .dash-chip-dot {
       width: 8px; height: 8px; display: inline-block;
     }
-    .dash-chip-dot.tag-money { background: var(--ux-mint); }
-    .dash-chip-dot.tag-perf  { background: var(--ux-cyan-deep); }
-    .dash-chip-dot.tag-usage { background: var(--ux-yellow); }
+    .dash-chip-dot.tag-money { background: var(--ex-success); }
+    .dash-chip-dot.tag-perf  { background: var(--ex-accent-deep); }
+    .dash-chip-dot.tag-usage { background: var(--ex-accent-soft); }
 
     .dash-grid {
       display: grid;
@@ -88,9 +87,9 @@
     }
 
     .dash-card {
-      background: var(--ux-bg-raised);
-      border: 1.5px solid var(--ux-ink);
-      box-shadow: 5px 5px 0 var(--ux-ink);
+      background: var(--ex-bg-raised);
+      border: 1.5px solid var(--ex-ink);
+      box-shadow: 5px 5px 0 var(--ex-ink);
       padding: 1.4em 1.5em;
       display: flex;
       flex-direction: column;
@@ -102,53 +101,53 @@
       justify-content: space-between;
     }
     .dash-eyebrow {
-      font-family: var(--ux-mono);
+      font-family: var(--ex-mono);
       text-transform: uppercase;
       letter-spacing: 0.1em;
       font-size: 0.7rem;
-      color: var(--ux-ink-mute);
+      color: var(--ex-ink-muted);
     }
     .dash-delta {
-      font-family: var(--ux-mono);
+      font-family: var(--ex-mono);
       font-size: 0.78rem;
       font-weight: 700;
       padding: 2px 6px;
     }
-    .dash-delta.is-good { background: var(--ux-mint); color: var(--ux-ink); }
-    .dash-delta.is-bad  { background: var(--ux-coral); color: var(--ux-bg-raised); }
+    .dash-delta.is-good { background: var(--ex-success); color: var(--ex-ink); }
+    .dash-delta.is-bad  { background: var(--ex-error); color: var(--ex-bg-raised); }
 
     .dash-card-value {
       display: flex; align-items: baseline; gap: 4px;
       margin-top: 0.4em;
-      font-family: var(--ux-sans);
-      color: var(--ux-ink);
+      font-family: var(--ex-sans);
+      color: var(--ex-ink);
     }
     .dash-value { font-size: 2.4rem; font-weight: 700; letter-spacing: -0.025em; }
-    .dash-unit  { font-size: 1.2rem; color: var(--ux-ink-mute); font-weight: 500; }
+    .dash-unit  { font-size: 1.2rem; color: var(--ex-ink-muted); font-weight: 500; }
 
     .dash-card-label {
-      font-family: var(--ux-mono);
+      font-family: var(--ex-mono);
       text-transform: uppercase;
       letter-spacing: 0.06em;
       font-size: 0.84rem;
-      color: var(--ux-ink-mute);
+      color: var(--ex-ink-muted);
     }
 
     .dash-sparkline {
       width: 100%; height: 42px;
-      color: var(--ux-cyan-deep);
+      color: var(--ex-accent-deep);
       margin-top: 0.6em;
     }
 
     .dash-shell-foot {
       margin-top: 3em;
       padding-top: 1em;
-      border-top: 1px solid var(--ux-rule);
-      font-family: var(--ux-mono);
+      border-top: 1px solid var(--ex-rule);
+      font-family: var(--ex-mono);
       text-transform: uppercase;
       letter-spacing: 0.1em;
       font-size: 0.74rem;
-      color: var(--ux-ink-faint);
+      color: var(--ex-ink-faint);
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

UIx examples audit cluster — 4 beads. (rf2-zur9c, `implementation/shadow-cljs.edn`, was **excluded** as a hot-zone file and is handled separately.)

- **rf2-ogzge (P2)** — `examples/uix/README.md`: struck the Playwright/`<name>.spec.cjs` smoke-spec claims and per-example "Smoke-spec asserts…" sentences; reframed the Running section into a `## Testing` section attributing smoke coverage to `implementation/adapters/uix/testbed/spec.cjs` (not per-example specs); corrected stale event names (`:counter/increment`/`:counter/decrement` → `:counter/inc`/`:counter/dec`). Mirrors the examples/helix fix (#1902).
- **rf2-974uq (P3)** — `counter_uix/core.cljs`: aligned the counter to the namespaced `:counter/value` key (matching the Reagent exemplar), eliminating the bare unqualified `:count` key so "counter across substrates" teaches an identical dataflow.
- **rf2-c6j3m (P3)** — `dashboard_uix/index.html`: switched the inline CSS from the back-compat `--ux-*` aliases to the canonical `--ex-*` design-system tokens (no back-compat shims).
- **rf2-nu2b0 (P4)** — `dashboard_uix/core.cljs`: removed the unused `:as uix` require alias.

Scope note: rf2-c6j3m's bead also suggests deleting the shared legacy-alias block in `examples/_shared/css/style.css` once all 3 design-led examples are swept — that cross-example sweep is out of scope for this UIx-only cluster (the shared file also feeds notebook + process_monitor_helix).

## Test plan

- [x] `npx shadow-cljs compile examples/counter-uix examples/dashboard-uix` — both bundles compile clean (152 files, 0 warnings each).
- [x] `npm run test:examples` compile phase — all three adapter testbeds build clean (0 warnings). The browser/Playwright stage cannot run in the worker sandbox (port-bind EACCES on :8030); examples are test-free, so the load-bearing check is compilation.