### PR TITLE
chore(machines-viz): audit cluster — delete dead migration residue + spec sync + single-source constants (7 beads incl. P1 hk94k)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -39,37 +39,41 @@ UIx / Helix).
 [viz/MachineChart props]
 ```
 
-`props` is a map; the schema below is closed (the chart rejects
-unrecognised keys at registration time).
+`props` is a map. The component destructures the keys below with
+defaults and ignores unrecognised keys; it does not run a closed-
+schema reject. The component is presentation-only — the host pulls
+the definition + the live snapshot and passes them in (this keeps the
+chart testable in isolation and avoids coupling it to a framework
+registry).
 
 ### Props
 
 | Prop | Required | Default | Meaning |
 |---|---|---|---|
-| `:machine-id` | yes | n/a | The id of the registered machine to render. The chart resolves the definition via `(rf/machine-meta machine-id)` and the snapshot via `[:rf/machines machine-id]`. |
-| `:frame-id` | yes | n/a | The frame within which to resolve the registration and the snapshot. Hosts that observe only one frame can hard-code it; multi-frame hosts (Causa, Story) pass the user-selected frame here. |
-| `:on-state-click` | no | `nil` | `(fn [state-id state-meta] ...)`. Fires when the user clicks a state node. Hosts wire this to their click semantics (Causa: jump to source; Story: highlight in chrome; viewer: no-op). |
-| `:on-transition-click` | no | `nil` | `(fn [from-state event-id to-state transition-meta] ...)`. Fires on a transition edge click. |
-| `:on-guard-click` | no | `nil` | `(fn [guard-name source-meta] ...)`. Fires when the user clicks a guard label inside a transition's tooltip. |
-| `:on-action-click` | no | `nil` | `(fn [action-name source-meta] ...)`. Fires when the user clicks an action label inside a state's entry/exit tooltip. |
-| `:read-only?` | no | `false` | If `true`, all `:on-*` callbacks are no-op'd regardless of what the host passes. The viewer page sets this. |
-| `:show-microsteps?` | no | `true` | Whether intermediate `:always` microstep nodes are rendered. |
-| `:show-after-rings?` | no | `true` | Whether `:after` countdown rings render on the source states. |
-| `:show-invoke-all?` | no | `true` | Whether `:spawn-all` children render as a row of mini-machines (vs. a collapsed single icon). |
-| `:show-spawned?` | no | `true` | Whether dynamically `:rf.machine/spawn`-ed children appear in the parent's spawn-tray. |
-| `:height` | no | `nil` (flex) | Fixed height in pixels. Useful for uniform-ribbon layouts. |
-| `:width` | no | `nil` (flex) | Fixed width in pixels. |
-| `:initial-zoom` | no | `1.0` | Starting zoom factor. The user can zoom/pan after mount; the prop only sets the initial value. |
-| `:auto-pan?` | no | `false` | Whether the chart auto-pans on every transition to keep the active state visible. Causa's panel sets this from its localStorage toggle; the viewer page leaves it off. |
-| `:current-state-override` | no | `nil` | A `{:state ... :data ...}` map that overrides the live snapshot. Used by the read-only viewer page to render the shared snapshot — when sourced from a share URL, `:data` is always absent (the share schema carries `:state` only; per [§Share-URL payload schema](#share-url-payload-schema)). Out-of-scope for live charts. |
-| `:direction` | no | `:tb` | Layout axis. `:tb` lays the chart top-to-bottom (rank flows down); `:lr` left-to-right (rank flows right). Promoted from an internal `chart.elk-layout/->elk-graph` arg to a top-level prop per rf2-ikdi3 so wide vs. narrow hosts can pick the axis without forking the file. |
-| `:layout-options` | no | `nil` | ELK `layoutOptions` overrides — a map of string → string keys that merge ON TOP of the canonical defaults (`chart.elk-layout/default-layout-options`). Hosts tighten / widen / swap individual knobs (`"elk.spacing.nodeNode"` for density, `"elk.layered.crossingMinimization.strategy"` for rank-order discipline, etc.) without re-stating the whole map. The `:direction` arg always wins for `"elk.direction"`. Per rf2-ikdi3. |
-| `:layout-engine` | no | `:auto` | Engine selector — `:auto` (cached ELK when available, layered fallback otherwise — the historical behaviour), `:elk` (cached ELK only; returns nothing when not ready so the host can choose 'wait + retry' over 'render the inferior engine'), `:layered` (force the layered fallback — useful for deterministic screenshot tests). Per rf2-ikdi3 — the two-engine reality (layered fallback + ELK) is now surfaced explicitly rather than hidden behind a single entry point. |
-| `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Picks the geometry + typography map from `visual-constants/chart-for-density`; the chart's `corner-radius` lock (rf2-g6cig) is invariant across every density so the chart's visual character stays consistent — only quantity scales. Per [§Density](#density) and rf2-32gw5. |
-| `:spawn-all-join` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready `:spawn-all` join-spec — `{:node-id <string> :join <:all\|:any\|{:n N}\|{:fn _}> :children [{:key <kw> :done? :failed? :cancelled? :note}] :resolved? <bool?> :on-all-complete :on-any-failed}`. When present the chart mounts the `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing state, showing each spawned child + the join state. The host (Causa) projects the spec from its `:rf.machine.spawn-all/*` trace buffer; machines-viz owns only positioning + paint. nil → no inspector. |
+| `:machine-id` | no | `nil` | Identifies the machine. Surfaces as the chart's aria-label and on every per-node `:data` payload (read by tests + hosts). |
+| `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
+| `:current-state` | no | `nil` | The live `:state` keyword/vector for the active-state highlight. `nil` renders no highlight. |
+| `:from-highlight` | no | `nil` | Focused-event lens origin (a `:state` value). |
+| `:to-highlight` | no | `nil` | Focused-event lens landing (a `:state` value). |
+| `:sim?` | no | `nil` | Flips the highlight palette to amber for the simulator path. |
+| `:on-state-click` | no | `nil` | `(fn [path] ...)`. Fires when the user clicks a state node; `path` is the clicked node's path. No-op'd when `:read-only?` is true. |
+| `:read-only?` | no | `nil` | When `true`, all `:on-*` callbacks are no-op'd. The viewer page sets this. |
+| `:direction` | no | `:tb` | Layout axis. `:tb` lays the chart top-to-bottom; `:lr` left-to-right. Fed to elkjs as `elk.direction`. |
+| `:layout-options` | no | `nil` | Host-side elkjs `layoutOptions` overrides merged on top of `default-elk-options` (`chart.cljs/default-elk-options`). The `:direction` arg drives `elk.direction`. |
+| `:density` | no | `:regular` | Density variant — `:compact` / `:regular` / `:cosy`. Resolves the geometry + typography map via `visual-constants/chart-for-density`; the resolved map is threaded through the projector onto every node/edge `:data` so the xyflow node/edge components render at the chosen density. The chart root surfaces the resolved density as `data-density`. `nil` ≡ `:regular`; an unknown density throws at render time. Per [§Density](#density) and rf2-32gw5. |
+| `:height` | no | `"100%"` | Outer wrapper height (CSS string). xyflow requires a non-zero parent height. |
+| `:show-minimap?` | no | `false` | When `true`, render xyflow's built-in MiniMap. |
+| `:show-controls?` | no | `true` | When `true`, render xyflow's built-in zoom/pan/fit Controls. |
+| `:show-background?` | no | `true` | When `true`, render xyflow's dot-pattern Background. |
+| `:after-ring-specs` | no | `nil` | rf2-uv1on. Optional vector of presentation-ready `:after`-timer ring-specs (each `{:node-id :fraction :color :cancelled? :tooltip :testid}`). When non-empty the chart mounts the `chart.overlays.after-rings` overlay as a sibling of the canvas; it walks the rendered node DOM to position each ring. The host owns the trace→spec projection + the scrubber-aware fraction. `nil` / empty → no overlay. |
+| `:after-ring-tick` | no | `nil` | Opaque value the host bumps to force the after-rings overlay to re-measure + repaint (Causa passes `now-ms`; Lock #8 — one rAF clock per chart, owned host-side). |
+| `:on-after-ring-hover` | no | `nil` | `(fn [node-id] ...)`. Hover-enter callback the overlay wires on each ring. |
+| `:on-after-ring-leave` | no | `nil` | `(fn [node-id] ...)`. Hover-leave callback the overlay wires on each ring. |
+| `:spawn-all-join` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready `:spawn-all` join-spec — `{:node-id <string> :join <:all\|:any\|{:n N}\|{:fn _}> :children [{:key <kw> :done? :failed? :cancelled? :note}] :resolved? <bool?> :on-all-complete :on-any-failed}`. When present the chart mounts the `chart.overlays.spawn-all-join` inspector beside the spawn-all-bearing state, showing each spawned child + the join state. The host (Causa) projects the spec from its `:rf.machine.spawn-all/*` trace buffer; machines-viz owns only positioning + paint. `nil` → no inspector. |
 | `:on-spawn-child-click` | no | `nil` | `(fn [child-key] ...)`. Fires on a join-inspector child-row click; Causa pivots to the child instance. |
-| `:cancellation-cascade` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready cascade-spec — `{:node-id <string> :parent-label <string?> :from-state <kw?> :steps [{:kind <:exit\|:destroy\|:abort\|:cleanup> :label <string> :note :delta-ms}]}`. When present (and `:steps` is non-empty) the chart mounts the `chart.overlays.cancellation-cascade` waterfall beneath the parent state, turning the scattered abort/destroy traces into one decision laid out vertically. The host projects the spec from the cancellation trace cluster. nil / no steps → dormant. |
+| `:cancellation-cascade` | no | `nil` | rf2-3ow55 (xyflow Phase 2). A presentation-ready cascade-spec — `{:node-id <string> :parent-label <string?> :from-state <kw?> :steps [{:kind <:exit\|:destroy\|:abort\|:cleanup> :label <string> :note :delta-ms}]}`. When present (and `:steps` is non-empty) the chart mounts the `chart.overlays.cancellation-cascade` waterfall beneath the parent state, turning the scattered abort/destroy traces into one decision laid out vertically. The host projects the spec from the cancellation trace cluster. `nil` / no steps → dormant. |
 | `:overlay-tick` | no | `nil` | rf2-3ow55. Opaque value the host bumps to force the `:spawn-all` + cascade overlays to re-measure + repaint (mirrors `:after-ring-tick`). |
+| `:testid` | no | `"rf-mv-chart"` | Root wrapper `data-testid` so tests + hosts can find the chart. |
 
 ### Parallel-region rendering (rf2-lkwev, xyflow Phase 2)
 
@@ -217,24 +221,27 @@ the SAME key set (asserted by `visual-constants-cljs-test`).
   matching named map via `visual-constants/chart-for-density`.
 - Any other value throws an `ex-info` at render time — picking an
   unknown density is a programmer error, not a runtime fallback.
-- The resolved density surfaces on the root `<svg>` element as
-  `data-density="<compact|regular|cosy>"` so hosts and tests can
+- The resolved density surfaces on the chart's root wrapper element
+  as `data-density="<compact|regular|cosy>"` so hosts and tests can
   read the active density without re-reading the bound prop.
 
 ### Implementation notes
 
-- The render entry-point (`chart.svg/render`) rebinds the dynamic
-  Var `visual-constants/*chart*` to the chosen density's map for
-  the duration of the call. Helpers destructure off `vc/*chart*`,
-  not off the namespace-level `vc/chart` alias.
-- Hiccup construction is eager (`into` over `for`) so every density-
-  resolved constant is captured in the returned data structure;
-  the dynamic binding unwinds before the hiccup is handed to
-  React.
-- Direct hiccup-walking tests that want a non-default density can
-  `binding [vc/*chart* (vc/chart-for-density :compact)] ...` and
-  call helpers directly; production code always goes through the
-  `:density` prop.
+- `MachineChart` resolves the `:density` prop ONCE per render via
+  `visual-constants/chart-for-density` (rf2-k647w). The resolved
+  map is threaded through the projector (`chart.projection/xyflow-
+  graph`) onto every node + edge `:data` as `{:chart <density-map>}`.
+- The xyflow node + edge components recover that map off their
+  `:data` prop (`chart.nodes/chart-constants` does `js->clj` on the
+  `clj->js`-ed `:chart` entry) and read their geometry / typography
+  off it. xyflow invokes these components OUTSIDE any dynamic-binding
+  scope, so the density travels in the data, not in a dynamic Var.
+- A node/edge payload without a `:chart` entry falls back to
+  `visual-constants/chart-regular`, so the regular density stays
+  pixel-identical to the pre-rf2-k647w hardcoded numbers.
+- Direct projection tests that want a non-default density pass it
+  through `xyflow-graph`'s `:chart` option and assert on the emitted
+  `:data`; production code always goes through the `:density` prop.
 
 Per rf2-32gw5 (resolves the `visual-constants.cljc` doc-string's
 'a future density toggle (compact / cosy / comfy) a one-knob change'

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -19,8 +19,6 @@
       payloads carrying the active/from-highlight/to-highlight
       flags, event labels, tags, etc.
     - The elkjs `compute-layout!` async pass + cache.
-    - The substrate-agnostic re-export hook (`MachineChart`
-      registered against the v2 `:view` registration surface).
 
   ## What this does NOT own
 
@@ -212,8 +210,9 @@
 (defn MachineChart
   "Render a state-machine definition as an interactive xyflow chart.
 
-  Args (map — `:closed` schema enforced at registration time per
-  `tools/machines-viz/spec/API.md` §Props):
+  Args (map — see `tools/machines-viz/spec/API.md` §Props; the
+  component destructures the keys below with defaults and ignores
+  unknown keys):
 
     :machine-id        — keyword; identifies the machine. Surfaces as
                          the chart's aria-label and on every per-node

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -501,13 +501,3 @@
                [overlay-cascade/CancellationCascadeOverlay
                 {:cascade-spec cancellation-cascade
                  :tick         overlay-tick}])]))))))
-
-;; ---- empty-graph convenience for callers --------------------------------
-
-(defn render-from-definition
-  "Legacy entry-point — renders the chart from a definition map. Kept
-  for callers still using the pre-migration `render-from-definition`
-  surface; prefer the `MachineChart` component directly."
-  ([definition] (render-from-definition definition {}))
-  ([definition opts]
-   [MachineChart (assoc opts :definition definition)]))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -5,7 +5,7 @@
   ELK+SVG lock. This ns is no longer a layout engine: xyflow + elkjs
   own positioning. What remains is the substrate-agnostic **graph
   parse** — definition → flat list of nodes + edges + per-node /
-  per-edge metadata. The xyflow chart ns (`chart/xyflow.cljs`)
+  per-edge metadata. The xyflow chart ns (`chart.cljs`)
   consumes this projection and hands the nodes/edges to xyflow's
   React renderer; elkjs runs as xyflow's layout backend off the same
   graph.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -43,6 +43,7 @@
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.nodes.parallel-region-node
              :as parallel-region-node]
+            [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.theme.tokens
              :as tokens
              :refer [mono-stack sans-stack]]
@@ -86,25 +87,13 @@
 (def ^:private pos-bottom (.-Bottom Position))
 (def ^:private pos-left   (.-Left Position))
 
-;; ---- visual constants ---------------------------------------------------
-
-(def state-node-min-width
-  "Minimum width in px for a state node body. xyflow lays out nodes
-  based on their measured size; this floor gives every node a
-  consistent rhythm without overflowing labels."
-  140)
-
-(def state-node-min-height
-  "Minimum height in px for a state node body."
-  44)
-
-(def compound-node-min-width
-  "Minimum width for a compound container."
-  220)
-
-(def compound-node-min-height
-  "Minimum height for a compound container."
-  120)
+;; ---- node-size floor constants ------------------------------------------
+;;
+;; rf2-kra7h — single-sourced from `chart.projection`. The elk projection
+;; and these CSS `min-width` / `min-height` floors MUST agree (the
+;; laid-out slot vs. the measured box), so they live in one canonical,
+;; JVM-readable home (`projection`, the pure layer the projection tests
+;; pin) and the renderer reads them via `projection/<name>`.
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -220,8 +209,8 @@
                      :flex-direction   "column"
                      :align-items      "center"
                      :justify-content  "center"
-                     :min-width        (str state-node-min-width "px")
-                     :min-height       (str state-node-min-height "px")
+                     :min-width        (str projection/state-node-min-width "px")
+                     :min-height       (str projection/state-node-min-height "px")
                      :padding          "8px 12px"
                      :background       fill
                      :border           (str stroke-w "px solid " stroke)
@@ -305,8 +294,8 @@
              :style {:position         "relative"
                      :width            "100%"
                      :height           "100%"
-                     :min-width        (str compound-node-min-width "px")
-                     :min-height       (str compound-node-min-height "px")
+                     :min-width        (str projection/compound-node-min-width "px")
+                     :min-height       (str projection/compound-node-min-height "px")
                      :padding-top      (str compound-pad-y "px")
                      :background       (tokens/with-alpha :accent-violet 0.06)
                      :border           (str "1px dashed " (:accent-violet tokens/tokens))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -71,32 +71,21 @@
   (:require [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.primitives :as prim]
             [day8.re-frame2-machines-viz.chart.overlays.after-rings-geometry
-             :as geo]))
+             :as geo]
+            [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
+             :as anchor]))
 
 ;; ---- DOM measurement ----------------------------------------------------
-
-(defn- rect->map
-  "JS DOMRect → the `{:left :top :width :height}` map the geometry
-  helper consumes."
-  [^js dom-rect]
-  (when dom-rect
-    {:left   (.-left dom-rect)
-     :top    (.-top dom-rect)
-     :width  (.-width dom-rect)
-     :height (.-height dom-rect)}))
 
 (defn- query-node-rect
   "Resolve a node-id's bounding rect by walking `root`'s subtree for
   `[data-testid=\"rf-mv-chart-node-<id>\"]`. Returns the rect map or
   nil when the node isn't in the DOM (off-screen / not yet mounted /
-  compound parent without a leaf)."
+  compound parent without a leaf). Uses the shared `overlay-anchor`
+  DOM seam (rf2-ed099)."
   [^js root node-id]
   (when (and root node-id)
-    (when-let [testid (geo/state->node-testid node-id)]
-      (let [sel (str "[data-testid=\"" testid "\"]")
-            el  (.querySelector root sel)]
-        (when el
-          (rect->map (.getBoundingClientRect el)))))))
+    (anchor/query-node-rect-by-testid root (geo/state->node-testid node-id))))
 
 (defn- measure-rings
   "Walk the DOM under `root` for every ring-spec's bearing node and
@@ -108,7 +97,7 @@
   this fn only gathers the DOM rects."
   [^js root ring-specs]
   (when root
-    (let [container-rect (rect->map (.getBoundingClientRect root))
+    (let [container-rect (anchor/rect->map (.getBoundingClientRect root))
           ;; xyflow bakes zoom into the rendered rects, so the
           ;; overlay reads them as-is (zoom 1.0 → no extra scaling of
           ;; the gap; the node's measured size already carries zoom).

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -43,29 +43,16 @@
 
 ;; ---- DOM measurement ----------------------------------------------------
 
-(defn- rect->map
-  [^js dom-rect]
-  (when dom-rect
-    {:left   (.-left dom-rect)
-     :top    (.-top dom-rect)
-     :width  (.-width dom-rect)
-     :height (.-height dom-rect)}))
-
-(defn- query-node-rect
-  [^js root node-id]
-  (when (and root node-id)
-    (when-let [testid (anchor/node->card-testid node-id)]
-      (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
-        (when el (rect->map (.getBoundingClientRect el)))))))
-
 (defn- measure-anchor
   "Walk the DOM under `root` for the cascade-spec's parent node and
   return the overlay-local waterfall anchor (or nil when the node
-  isn't in the DOM). Uses the pure `overlay-anchor/anchor-below`."
+  isn't in the DOM). Uses the shared `overlay-anchor` DOM seam + the
+  pure `overlay-anchor/anchor-below`."
   [^js root node-id]
   (when (and root node-id)
-    (let [container (rect->map (.getBoundingClientRect root))
-          node      (query-node-rect root node-id)]
+    (let [container (anchor/rect->map (.getBoundingClientRect root))
+          node      (anchor/query-node-rect-by-testid
+                      root (anchor/node->card-testid node-id))]
       (anchor/anchor-below node container))))
 
 ;; ---- cascade-step glyph -------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
@@ -38,6 +38,32 @@
   (when (and node-id (not (str/blank? (str node-id))))
     (str "rf-mv-chart-node-" node-id)))
 
+#?(:cljs
+   (defn rect->map
+     "JS `DOMRect` → the `{:left :top :width :height}` map the anchoring
+     helpers consume. Returns nil for a nil rect. CLJS-only (DOM
+     interop); the overlays share this single seam (rf2-ed099)."
+     [^js dom-rect]
+     (when dom-rect
+       {:left   (.-left dom-rect)
+        :top    (.-top dom-rect)
+        :width  (.-width dom-rect)
+        :height (.-height dom-rect)})))
+
+#?(:cljs
+   (defn query-node-rect-by-testid
+     "Walk `root`'s subtree for `[data-testid=\"<testid>\"]` and return
+     the matched element's bounding rect as a `rect->map`, or nil when
+     `root` / `testid` is missing or the node isn't in the DOM
+     (off-screen / not yet mounted / compound parent without a leaf).
+     CLJS-only; the shared DOM-measurement seam for every chart overlay
+     (rf2-ed099)."
+     [^js root testid]
+     (when (and root testid)
+       (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
+         (when el
+           (rect->map (.getBoundingClientRect el)))))))
+
 (defn anchor-right-of
   "Anchor a card to the RIGHT of a bearing node. Takes the node's
   viewport rect + the overlay container's rect; returns

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -42,29 +42,16 @@
 
 ;; ---- DOM measurement ----------------------------------------------------
 
-(defn- rect->map
-  [^js dom-rect]
-  (when dom-rect
-    {:left   (.-left dom-rect)
-     :top    (.-top dom-rect)
-     :width  (.-width dom-rect)
-     :height (.-height dom-rect)}))
-
-(defn- query-node-rect
-  [^js root node-id]
-  (when (and root node-id)
-    (when-let [testid (anchor/node->card-testid node-id)]
-      (let [el (.querySelector root (str "[data-testid=\"" testid "\"]"))]
-        (when el (rect->map (.getBoundingClientRect el)))))))
-
 (defn- measure-anchor
   "Walk the DOM under `root` for the join-spec's bearing node and
   return the overlay-local card anchor (or nil when the node isn't in
-  the DOM). Uses the pure `overlay-anchor/anchor-right-of`."
+  the DOM). Uses the shared `overlay-anchor` DOM seam + the pure
+  `overlay-anchor/anchor-right-of`."
   [^js root node-id]
   (when (and root node-id)
-    (let [container (rect->map (.getBoundingClientRect root))
-          node      (query-node-rect root node-id)]
+    (let [container (anchor/rect->map (.getBoundingClientRect root))
+          node      (anchor/query-node-rect-by-testid
+                      root (anchor/node->card-testid node-id))]
       (anchor/anchor-right-of node container))))
 
 ;; ---- child-row glyph ----------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -37,9 +37,11 @@
 ;;
 ;; The elk projection (`elk-child`) and the node renderers
 ;; (`chart.nodes`) share these floors so a state's measured box and
-;; its laid-out slot agree. They live here (pure, JVM-readable) so the
-;; projection tests can reference them; `chart.nodes` re-exports them
-;; for the renderer's CSS `min-width` / `min-height`.
+;; its laid-out slot agree. This is their single canonical home (pure,
+;; JVM-readable, so the projection tests can reference them); rf2-kra7h
+;; — `chart.nodes` `:require`s this ns and reads them via
+;; `projection/<name>` for the renderer's CSS `min-width` /
+;; `min-height` rather than re-declaring its own copies.
 
 (def state-node-min-width
   "Minimum width in px for a state node body. xyflow lays out nodes

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -144,9 +144,10 @@
   "Backwards-compatible alias for the dark palette — same shape
   Causa's `tokens` map exposes so the chart's `(:bg-1 tokens)` style
   call sites read identically. The light theme is layered on top via
-  the `:palette` render option (rf2-usord); the 200+ inline-style
-  reads in `chart/svg` continue to resolve through this alias until
-  the CSS-variable migration consolidates the indirection."
+  the `:palette` render option (rf2-usord); the inline-style reads in
+  `chart.nodes`, `chart.edges`, `chart.cljs` and the overlays continue
+  to resolve through this alias until the CSS-variable migration
+  consolidates the indirection."
   dark-palette)
 
 ;; ---- font stacks -------------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -246,21 +246,6 @@
   value when `:density` is unspecified."
   chart-regular)
 
-(def ^:dynamic *chart*
-  "The currently-resolved chart visual-constants map. Defaults to
-  `chart-regular`. The `MachineChart` render entry (`chart.svg/render`)
-  rebinds this for the duration of a single render pass to the
-  density picked by `:density`; helpers inside the renderer read
-  their geometry / typography off this dynamic Var instead of off
-  the namespace-level `chart` Var so a single chart instance can
-  render at compact, regular, or cosy without re-wiring the helper
-  graph.
-
-  Test-only, non-public consumers may rebind this directly via
-  `binding`; production callers go through the `:density` prop. Per
-  rf2-32gw5."
-  chart-regular)
-
 (def densities
   "The complete catalogue of density keywords accepted by
   `chart-for-density` (and, transitively, the `MachineChart`

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -284,11 +284,3 @@
     (is (thrown? #?(:clj  Exception
                     :cljs js/Error)
                  (vc/chart-for-density "regular"))))) ;; string, not kw
-
-(deftest dynamic-chart-default-is-regular
-  (testing "rf2-32gw5 — `vc/*chart*` defaults to `chart-regular`
-            outside any `binding`. Helpers that destructure off
-            `vc/*chart*` outside the renderer's binding scope see
-            the same constants the namespace-level alias provided
-            before rf2-32gw5."
-    (is (= vc/chart-regular vc/*chart*))))


### PR DESCRIPTION
## Summary

Seven beads from the `tools/machines-viz` post-xyflow-migration audit. Mostly dead migration residue (deleted cleanly, no back-compat shims), plus a spec/API.md sync to the shipped component and a single-source fix for duplicated geometry constants. The default `MachineChart` render stays pixel-identical (the code changes are dead-code deletion, single-source, and docstrings — no behaviour change).

## Beads

- **rf2-hk94k (P1)** — delete the dead `^:dynamic *chart*` Var + its test. It was the abandoned pre-migration density mechanism (`binding`-ed nowhere; only its own test read it; docstring referenced a non-existent `chart.svg/render`). The shipped rf2-k647w architecture threads the resolved density through node/edge `:data {:chart}`.
- **rf2-qpxho (P2)** — sync `tools/machines-viz/spec/API.md` §Props + §Density impl-notes to the shipped `chart.cljs/MachineChart`. The table documented a pre-migration component (`:frame-id`, `:on-transition-click`, `:current-state-override`, `:layout-engine`…) the shipped component doesn't accept, and §Density referenced dead `chart.svg`/`*chart*`/`chart.elk-layout`. Rewrote both to the actual props + the `:data {:chart}` density-threading mechanism. (Local machines-viz spec, NOT the top-level hot-zone spec/API.md.)
- **rf2-kra7h (P2)** — single-source the node-size floor constants (140/44/220/120). They were declared twice (`projection.cljc` + `nodes.cljs`) with no `projection` require in `nodes`. `nodes` now `:require`s `projection` and reads them via `projection/<name>`; canonical home stays in the pure JVM-readable `projection` ns.
- **rf2-i975g (P3)** — drop the false `:closed` schema "enforced at registration" + `:view` re-export claims in `MachineChart`'s docstrings. The component destructures with `:or` defaults and ignores unknown keys; there is no registration.
- **rf2-rww19 (P3)** — fix stale post-migration ns refs: `tokens.cljc` named deleted `chart/svg` + a dead "200+" count (→ live consumers); `layout.cljc` named non-existent `chart/xyflow.cljs` (→ `chart.cljs`).
- **rf2-i9dz0 (P4)** — delete `render-from-definition` legacy entry-point (zero callers anywhere in the repo).
- **rf2-ed099 (P4)** — lift the copy-pasted overlay DOM-measurement seam (`rect->map` + `query-node-rect-by-testid`, cljs-guarded) into the shared `overlay-anchor.cljc`; the three overlays now share one seam. The form-3 mount/resize scaffold dedup was deferred (a Reagent form-3 factory in a JVM-loaded `.cljc` isn't worth the churn — the bead marks it optional).

## Follow-on filed

- **rf2-idnbw (P3)** — `spec/API.md` §What-renders + §Performance-invariants + §Share-URL still reference pre-migration props (`:show-*`, `:frame-id`, `:auto-pan?`, `:current-state-override`). Larger reconciliation than rf2-qpxho's §Props scope; deferred.

## Test plan

- [x] `npm run test:cljs` — 4096 tests, 12431 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 13 scenarios (incl. deep-machine xyflow canvas render), 0 failures, 13 matrix rows