### PR TITLE
chore(examples/uix): correct stale dashboard-uix shadow-cljs comment (rf2-zur9c)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -676,8 +676,8 @@
 
   ;; rf2-t7t6f — UIx design-led example. Analytics-dashboard layout
   ;; (status tiles + filter chips + sparkline cards) proving UIx builds
-  ;; substantive UIs. Pairs with the UIx 'Swiss Modern' visual identity
-  ;; (rf2-nfg15) from examples/_shared/css/uix.css.
+  ;; substantive UIs. Pairs with the shared 'Editorial Warm' visual
+  ;; identity (rf2-v4fpe Option 2) from examples/_shared/css/style.css.
   :examples/dashboard-uix
   {:target     :browser
    :output-dir "out/examples/dashboard-uix"


### PR DESCRIPTION
## Summary
- Fixes a stale comment on the `:examples/dashboard-uix` build in `implementation/shadow-cljs.edn` (a hot-zone file).
- The comment referenced a nonexistent `examples/_shared/css/uix.css` and the dead per-substrate "Swiss Modern" identity (rf2-nfg15).
- That identity was superseded by rf2-v4fpe Option 2 — the one shared "Editorial Warm" identity in `examples/_shared/css/style.css`, which `examples/uix/dashboard_uix/index.html` actually loads.
- Comment-only change; the build config itself is unchanged.

## Test plan
- [x] `npx shadow-cljs compile examples/dashboard-uix` — Build completed (153 files, 0 warnings)
- [x] `npm run test:cljs` — 4090 tests / 12408 assertions, 0 failures, 0 errors