### PR TITLE
chore(mcp-conformance): fix README count/live-server drift + drop phantom causa ref + dead export (3 beads)

### DIFF
--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -40,7 +40,7 @@ Every existing test surface for these servers is **server-side**:
 
 - per-tool unit tests (under each server artefact's `test/`)
 - `stdio-roundtrip.js` — a hand-rolled JSON-RPC wire-format probe
-- `live-{nrepl,server}.js` — workflow tests against a running runtime
+- `live-nrepl.js` — workflow tests against a running runtime
 
 None of these drive a server from the **client** side of MCP — they all
 either hand-roll JSON-RPC framing or skip the protocol layer entirely.
@@ -113,8 +113,9 @@ npm test
 ### `end-to-end-re-frame2-pair.cjs`
 
 1. Connect — full SDK handshake against the freshly spawned bundle
-2. `tools/list` — confirm the twelve advertised tools match the pinned
-   catalogue
+2. `tools/list` — confirm the advertised tools match the pinned
+   catalogue (sourced from re-frame2-pair-mcp's `tool-names.json`
+   fixture — the single source of truth)
 3. Spot-check every descriptor carries an `inputSchema`
 4. Walk degraded-mode `dispatch` / `watch-epochs` / `snapshot` /
    `subscribe` — each call routes through the SDK's

--- a/tools/mcp-conformance/lib/exec-safety.cjs
+++ b/tools/mcp-conformance/lib/exec-safety.cjs
@@ -337,6 +337,4 @@ function safeUnlinkInside(candidatePath, allowedRoot) {
 module.exports = {
   resolveTrustedExe,
   safeUnlinkInside,
-  // Exposed for tests; not part of the public contract.
-  _internals: { isPathInside, pathExtensionsFor },
 };

--- a/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-overflow.cjs
@@ -175,7 +175,7 @@ function parseOverflowMarker(text) {
 
 // Pre-flight SKIP: route through the runner's shared skip helper so we
 // don't spawn a child or install a watchdog. Same posture as the sibling
-// end-to-end-causa.cjs placeholder. The skip helper prints the canonical
+// live-re-frame2-pair-subscribe.cjs. The skip helper prints the canonical
 // `SKIP <reason>` banner and exits 0.
 if (!process.env.SHADOW_CLJS_NREPL_PORT) {
   runWithWatchdog.skip(


### PR DESCRIPTION
## Summary
Audit cluster from the mcp-conformance best-practice review (3 beads):
- **rf2-u4v6f** — drop the hard-coded "twelve advertised tools" count in README (source-of-truth fixture lists more; test already counts dynamically) + correct stale `live-server.js` catalogue refs (removed in #1897).
- **rf2-pwqzl** — remove the last phantom `end-to-end-causa.cjs` reference (causa-mcp was dropped).
- **rf2-a0tkx** — remove the dead `_internals` export from `exec-safety.cjs` (zero importers).

Recovered: the worker committed all three but was cut off before pushing; mayor pushed + opened this PR.