### PR TITLE
fix(http): warn-on-reflection in transport + drop dead run-accept arm + repeat-key param encoding (3 beads)

### DIFF
--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -48,13 +48,23 @@
      :cljs (js/encodeURIComponent (str s))))
 
 (defn params->query
-  "Encode a `:params` map as a query string (no leading `?`)."
+  "Encode a `:params` map as a query string (no leading `?`).
+
+  Scalar values (string / number / keyword / boolean) encode to a single
+  `k=v` pair. A sequential value (vector / seq / list) encodes as one
+  repeated `k=v` pair per element — `{:tag [\"a\" \"b\"]}` → `tag=a&tag=b`
+  (rf2-mag59). Repeat-key is the conventional HTTP-client idiom for
+  multi-valued query params; Spec 012 §Query strings and fragments does
+  not normatively pin a multi-valued shape, so the client picks the most
+  interoperable one. An empty sequential value contributes no pair. A
+  `nil` value still emits a bare `k=` pair (the key carries no value)."
   [params]
   (->> params
-       (map (fn [[k v]]
-              (str (url-encode (if (keyword? k) (name k) (str k)))
-                   "="
-                   (url-encode v))))
+       (mapcat (fn [[k v]]
+                 (let [k-enc (url-encode (if (keyword? k) (name k) (str k)))]
+                   (if (sequential? v)
+                     (map #(str k-enc "=" (url-encode %)) v)
+                     [(str k-enc "=" (url-encode v))]))))
        (str/join "&")))
 
 (defn merge-params

--- a/implementation/http/src/re_frame/http_encoding.cljc
+++ b/implementation/http/src/re_frame/http_encoding.cljc
@@ -110,13 +110,21 @@
 
   Per rf2-5ijhk + audit finding 3.3 the default-accept shape is
   inlined here (the earlier `default-accept-fn` allocated a fresh
-  closure per response even when the user didn't supply `:accept`)."
-  [accept-fn-or-nil decoded {:keys [status]}]
+  closure per response even when the user didn't supply `:accept`).
+
+  Per rf2-7iji6 the default is unconditionally `{:ok decoded}`. The only
+  call site (`http-transport/handle-response!`) reaches `run-accept`
+  exclusively inside the 2xx branch — status classification (4xx / 5xx /
+  non-2xx-else) runs BEFORE decode per Spec 014 §Failure categories, so
+  the default never sees a non-2xx status. The earlier non-2xx arm was
+  dead on the live cascade and emitted an off-taxonomy `:kind
+  :http-status` (not a member of the closed `:rf.http/*` failure set);
+  it has been removed. `:accept` runs only against a successfully
+  decoded 2xx body, so it needs no status."
+  [accept-fn-or-nil decoded]
   (if accept-fn-or-nil
     (accept-fn-or-nil decoded)
-    (if (and (>= status 200) (< status 300))
-      {:ok decoded}
-      {:failure {:kind :http-status :status status :body decoded}})))
+    {:ok decoded}))
 
 ;; ---- reply addressing -----------------------------------------------------
 

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -720,7 +720,7 @@
                           ;; normalised ctx into the decoder; nil means
                           ;; the reader uses its default.
                           :max-decoded-keys (:max-decoded-keys ctx)})
-              accepted (encoding/run-accept accept decoded {:status status})]
+              accepted (encoding/run-accept accept decoded)]
           (finalise-success! (assoc ctx :decoded decoded) accepted))
         (catch #?(:clj Throwable :cljs :default) e
           (let [d (ex-data e)]

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -37,6 +37,14 @@
                    [java.time Duration]
                    [java.util.concurrent CompletableFuture])))
 
+;; rf2-b45uc — reflection warnings ON in the densest JVM-interop ns of
+;; the http surface (HttpClient, HttpRequest, BodyPublishers, HttpHeaders,
+;; CompletableFuture). The code is type-hinted today; the flag is the
+;; tripwire that catches a future un-hinted interop call compiling to
+;; reflective dispatch — exactly where interop is densest. Mirrors
+;; http_test_support.cljc:86. CLJS ignores the form.
+#?(:clj (set! *warn-on-reflection* true))
+
 ;; ---- platform transport: CLJS Fetch ---------------------------------------
 
 #?(:cljs

--- a/implementation/http/src/re_frame/util_json.cljc
+++ b/implementation/http/src/re_frame/util_json.cljc
@@ -38,6 +38,15 @@
   this as `:rf.http/decode-failure`."
   #?(:clj  (:require [cheshire.core :as cheshire])))
 
+;; rf2-b45uc — reflection warnings ON. This ns carries the other
+;; non-trivial JVM interop in the http surface (Cheshire's
+;; `generate-string` / `parse-string` and the `java.util.HashSet`
+;; keyword-cap counter). The HashSet calls are type-hinted; the flag
+;; keeps the tripwire on so a future un-hinted interop call surfaces as
+;; a compile-time reflection warning rather than silent reflective
+;; dispatch. CLJS ignores the form.
+#?(:clj (set! *warn-on-reflection* true))
+
 (def ^:const default-max-decoded-keys
   "Default cap on the number of unique object keys a single `json-parse`
   call may decode. Per rf2-wu1n5 — a defensive ceiling against the

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -280,6 +280,39 @@
   (testing "an empty params map renders an empty string"
     (is (= "" (encoding/params->query {})))))
 
+(deftest params->query-multi-valued-uses-repeat-key
+  (testing "rf2-mag59 — a sequential value (vector / seq / list) encodes
+            as one repeated k=v pair per element (repeat-key idiom),
+            NOT a single (str coll) blob"
+    (is (= "tag=a&tag=b"
+           (encoding/params->query {:tag ["a" "b"]}))
+        "a vector value repeats the key per element — not tag=%5B%22a%22...")
+    (is (= "id=1&id=2&id=3"
+           (encoding/params->query {:id [1 2 3]}))
+        "numeric elements coerce via url-encode like scalar values")
+    (is (= "id=1&id=2"
+           (encoding/params->query {:id (list 1 2)}))
+        "a list (seq) value is treated the same as a vector")
+    (is (= "q=a%20b&q=c%26d"
+           (encoding/params->query {:q ["a b" "c&d"]}))
+        "each element is independently percent-escaped"))
+  (testing "an empty sequential value contributes no pair"
+    (is (= "" (encoding/params->query {:tag []}))
+        "an empty vector value emits nothing")
+    (is (= "page=2"
+           (encoding/params->query {:page 2 :tag []}))
+        "an empty seq value drops out, scalar siblings still encode"))
+  (testing "a single-element sequential still uses the key once"
+    (is (= "tag=only"
+           (encoding/params->query {:tag ["only"]}))))
+  (testing "a set value (also sequential? false) is NOT repeat-keyed — only
+            ordered seqs are; a set falls through to scalar (str ...)"
+    ;; sets are unordered so repeat-key has no stable shape; treat as scalar.
+    (is (clojure.string/starts-with?
+          (encoding/params->query {:tag #{"a"}})
+          "tag=")
+        "a set value encodes via the scalar path (no defined repeat order)")))
+
 ;; ---- merge-params — `?` vs `&` separator selection ------------------------
 
 (deftest merge-params-selects-question-mark-or-ampersand

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -366,40 +366,37 @@
 
 ;; ---- run-accept — Spec 014 §`:accept` default normalisation (G2) ----------
 ;;
-;; The default `:accept` (nil accept-fn) maps 2xx → {:ok decoded} and any
-;; other status → {:failure {:kind :http-status ...}}. The user-fn branch
-;; is exercised end-to-end in http_managed_test (accept-failure round-trip);
-;; here we pin the DEFAULT and the simple user-fn pass-through.
+;; Per rf2-7iji6 the default `:accept` (nil accept-fn) is unconditionally
+;; {:ok decoded}. The only call site (http-transport/handle-response!)
+;; reaches run-accept exclusively inside the 2xx branch — status
+;; classification (4xx / 5xx / non-2xx-else) runs BEFORE decode per Spec
+;; 014 §Failure categories — so the default never sees a non-2xx status.
+;; The earlier non-2xx arm ({:failure {:kind :http-status ...}}) was dead
+;; on the live cascade and off the closed `:rf.http/*` taxonomy; it has
+;; been removed. The user-fn branch is exercised end-to-end in
+;; http_managed_test (accept-failure round-trip); here we pin the DEFAULT
+;; and the simple user-fn pass-through.
 
-(deftest run-accept-default-2xx-is-ok
-  (testing "rf2-ohwgm — with no :accept fn, a 2xx status normalises the
-            decoded value to {:ok decoded}"
+(deftest run-accept-default-is-ok
+  (testing "rf2-7iji6 — with no :accept fn, the decoded value is wrapped
+            unconditionally as {:ok decoded} (run-accept only ever runs
+            against an already-classified 2xx response)"
     (is (= {:ok {:title "hello"}}
-           (encoding/run-accept nil {:title "hello"} {:status 200})))
-    (is (= {:ok {:title "hello"}}
-           (encoding/run-accept nil {:title "hello"} {:status 299}))
-        "the whole 2xx band is :ok")))
-
-(deftest run-accept-default-non-2xx-is-failure
-  (testing "rf2-ohwgm — with no :accept fn, a non-2xx status normalises to
-            {:failure {:kind :http-status :status N :body decoded}}"
-    (is (= {:failure {:kind :http-status :status 404 :body {:error "nope"}}}
-           (encoding/run-accept nil {:error "nope"} {:status 404}))
-        "the default treats any non-2xx as a domain failure carrying the
-         status + decoded body")
-    (is (= {:failure {:kind :http-status :status 500 :body nil}}
-           (encoding/run-accept nil nil {:status 500})))))
+           (encoding/run-accept nil {:title "hello"})))
+    (is (= {:ok nil}
+           (encoding/run-accept nil nil))
+        "a nil decoded body still wraps as {:ok nil}")))
 
 (deftest run-accept-user-fn-overrides-default
   (testing "rf2-ohwgm — a supplied :accept fn is invoked with the decoded
             value and its return ({:ok ..} or {:failure ..}) is used
-            verbatim, overriding the status-based default"
+            verbatim, overriding the default"
     (let [accept (fn [decoded]
                    (if (:valid? decoded)
                      {:ok (:data decoded)}
                      {:failure {:kind :domain :reason :invalid}}))]
       (is (= {:ok 42}
-             (encoding/run-accept accept {:valid? true :data 42} {:status 200})))
+             (encoding/run-accept accept {:valid? true :data 42})))
       (is (= {:failure {:kind :domain :reason :invalid}}
-             (encoding/run-accept accept {:valid? false} {:status 200}))
+             (encoding/run-accept accept {:valid? false}))
           "the user :accept can fail a 2xx response (domain-level rejection)"))))


### PR DESCRIPTION
HTTP audit cluster — 3 P4 beads from the `implementation/http` audit.

## Beads

- **rf2-b45uc** — Enable `*warn-on-reflection*` in `http_transport.cljc` (the densest JVM-interop ns: HttpClient/HttpRequest/BodyPublishers/HttpHeaders/CompletableFuture) and `util_json.cljc` (Cheshire + java.util.HashSet). Both compile clean — 0 reflection warnings; existing type hints already cover every interop site. The flag is the tripwire for future un-hinted interop.
- **rf2-7iji6** — Drop the dead non-2xx arm from `run-accept`. `handle-response!` only calls `run-accept` inside the 2xx branch (status classification runs before decode per Spec 014 §Failure categories), so the arm was dead on the live cascade and its `:kind :http-status` was off the closed `:rf.http/*` taxonomy. Default is now unconditionally `{:ok decoded}`; the now-unused `status` arg is removed (call site updated).
- **rf2-mag59** — Repeat-key encoding for multi-valued `:params`. `params->query` did `(str v)` per value, so `{:tag ["a" "b"]}` stringified to `"[\"a\" \"b\"]"`. Sequential values now encode as `tag=a&tag=b` (conventional HTTP-client idiom; Spec 012 §Query strings is silent on multi-valued shape). Scalars/sets keep the scalar path; empty seqs contribute no pair.

## Test plan

- [x] JVM http tests (`clojure -M:test` in `implementation/http`): 259 tests / 1375 assertions / 0 failures / 0 errors
- [x] **0 reflection warnings** after rf2-b45uc (grep-verified on compile output)
- [x] CLJS gate (`npm run test:cljs`): 4090 tests / 12408 assertions / 0 failures / 0 errors