### PR TITLE
chore(core+flows): small-misc audit cleanups — no-get-in hot path, redundant private, stale docstring + dead deps flag (4 beads)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -66,7 +66,7 @@
   precedence over the host-wide `interop/platform` marker."
   [frame-id]
   (or (when frame-id
-        (get-in (frame/frame frame-id) [:config :platform]))
+        (-> (frame/frame frame-id) :config :platform))
       interop/platform))
 
 (defn- maybe-validate-cofx!

--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -141,7 +141,7 @@
 ;; This is the SSR-mode production switch. Local dev / tests leave it
 ;; alone (the default is `true`).
 
-(defn- ^:private read-debug-flag
+(defn- read-debug-flag
   "Read the JVM debug gate. System property `re-frame.debug` wins; falls
   back to env var `RE_FRAME_DEBUG`. A nil / absent reading returns
   `true` (dev default). A reading from the conventional false-y

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -579,7 +579,7 @@
   section without a second emit."
   [effects coeffects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
-    (let [active-platform (or (get-in frame-record [:config :platform])
+    (let [active-platform (or (-> frame-record :config :platform)
                               interop/platform)
           event           (:event envelope)]
       (fx/do-fx frame fx-vec active-platform fx-overrides event envelope effects coeffects))))

--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -51,14 +51,7 @@
                        day8/re-frame2-test-quiet {:local/root "../test-quiet"}
                        io.github.cognitect-labs/test-runner
                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         ;; `-e :expected-fail` excludes deftests carrying the
-         ;; `^:expected-fail` metadata from the default test sweep. Such
-         ;; tests pin contracts whose backing fix has not yet landed
-         ;; (e.g. rf2-cdh9h pins the cycle-rollback-on-replacement
-         ;; contract; the sibling fix rf2-7csri is still open). Once the
-         ;; matching fix merges, drop the metadata from the test and the
-         ;; assertion flips back into the default sweep automatically.
-         :main-opts   ["-m" "re-frame.test-quiet.runner" "-e" ":expected-fail"]}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}
 
   ;; Clojars deploy (rf2-r382). Modeled on re-frame v1's release flow.
   ;; The release workflow runs `clojure -M:clein deploy` from this

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -18,9 +18,9 @@
   Surfaces exercised:
 
   - `:rf.flow/registered`  (emitted by `reg-flow` on first-time register)
-  - `:rf.flow/computed`    (emitted by `recompute-flow` on successful run)
-  - `:rf.flow/skip`        (emitted by `recompute-flow` on value-equal inputs)
-  - `:rf.flow/failed`      (emitted by `recompute-flow` when :output throws)
+  - `:rf.flow/computed`    (emitted by `evaluate-flow!` on successful run)
+  - `:rf.flow/skip`        (emitted by `evaluate-flow!` on value-equal inputs)
+  - `:rf.flow/failed`      (emitted by `evaluate-flow!` when :output throws)
   - `:rf.flow/cleared`     (emitted by `clear-flow`)
 
   Naming convention: files ending in `-elision-prod-test.cljs` are


### PR DESCRIPTION
Disjoint-surface small-misc tail bundle — 4 trivial P4 audit cleanups across core + flows. No behaviour change; idiom/cruft only.

- **rf2-77hyq (core)** — `cofx.cljc:69` + `router.cljc:582` replaced `(get-in (frame ...) [:config :platform])` with keyword-invoke threading (`(-> ... :config :platform)`), removing per-dispatch path-vector allocation on the hot path. Aligns with the rf2-mqv4m no-`get-in` hot-path convention (registrar/lookup, frame/frame). Result identical.
- **rf2-1hzsa (core)** — `interop.clj:144` dropped redundant `^:private` metadata on `defn- read-debug-flag` (`defn-` already implies private).
- **rf2-337r8 (flows)** — `flows_trace_emit_elision_prod_test.cljs:21-23` docstring corrected: trace emission credited to the nonexistent `recompute-flow` is now attributed to the real evaluator `evaluate-flow!` (`flows.cljc:58`).
- **rf2-0ttb3 (flows)** — `flows/deps.edn` removed the dead `-e :expected-fail` flag + misleading comment (rf2-7csri landed; zero `^:expected-fail` tags remain in the flows tree, so the flag was a no-op). `:main-opts` now matches the canonical bare `["-m" "re-frame.test-quiet.runner"]` form used by every other artefact.

## Gates
- `npm run test:cljs` — 4090 tests / 12408 assertions, 0 failures / 0 errors
- core JVM `clojure -M:test` — 713 tests / 3381 assertions, 0 failures / 0 errors
- flows JVM `clojure -M:test` — 97 tests / 410 assertions, 0 failures / 0 errors