### PR TITLE
fix(docs/cljs): high-contrast result-value color in the playground (rf2-hmod4)

### DIFF
--- a/docs/cljs/playground.css
+++ b/docs/cljs/playground.css
@@ -61,9 +61,13 @@
   color: var(--md-default-fg-color--light, #555);
 }
 
+/* Result value (=> …). A fixed dark green — NOT --md-typeset-ins-color, which
+ * is Material's CriticMarkup inserted-text HIGHLIGHT green (a light green meant
+ * to sit on a tinted background) and renders low-contrast on the light-grey
+ * result panel. #1a5e1a is 7.31:1 on --md-code-bg-color #f4f7f4 (WCAG AAA). */
 .cljs-val {
   font-weight: 600;
-  color: var(--md-typeset-ins-color, #1a5e1a);
+  color: #1a5e1a;
 }
 
 [data-md-color-scheme="slate"] .cljs-val {

--- a/tools/playground/src/playground.css
+++ b/tools/playground/src/playground.css
@@ -61,9 +61,13 @@
   color: var(--md-default-fg-color--light, #555);
 }
 
+/* Result value (=> …). A fixed dark green — NOT --md-typeset-ins-color, which
+ * is Material's CriticMarkup inserted-text HIGHLIGHT green (a light green meant
+ * to sit on a tinted background) and renders low-contrast on the light-grey
+ * result panel. #1a5e1a is 7.31:1 on --md-code-bg-color #f4f7f4 (WCAG AAA). */
 .cljs-val {
   font-weight: 600;
-  color: var(--md-typeset-ins-color, #1a5e1a);
+  color: #1a5e1a;
 }
 
 [data-md-color-scheme="slate"] .cljs-val {


### PR DESCRIPTION
## Summary

The docs/cljs live-playground rendered eval-result values (`=> …`) as light green on the light-grey result panel in the default (light) scheme — hard to read (Mike-reported).

**Root cause.** `tools/playground/src/playground.css` set `.cljs-val`'s light-mode color from `var(--md-typeset-ins-color, #1a5e1a)`. `--md-typeset-ins-color` is Material's CriticMarkup inserted-text HIGHLIGHT green — a light green intended to sit on a tinted background — so it resolves to ~`#2bb324`, giving only ~2.6:1 contrast on the `--md-code-bg-color` result panel. The good `#1a5e1a` fallback never applied because the variable was always defined. Slate mode (`#6ee36e`) was already fine.

**Fix.** Use a fixed dark green `#1a5e1a` for the light-mode result value (not the ins-highlight var). Left the slate `.cljs-val` (`#6ee36e`) and `.cljs-out` (muted fg) unchanged — both verified readable.

**Color / contrast (browser-verified, computed styles via headless Chromium against the built docs page, both schemes):**

| scheme | `.cljs-val` color | result-panel bg | contrast |
|--------|-------------------|-----------------|----------|
| default (light) | `#1a5e1a` `rgb(26,94,26)` | `rgb(245,245,245)` | **7.24:1** (WCAG AAA) |
| slate (dark) | `#6ee36e` `rgb(110,227,110)` | `rgb(39,42,53)` | **8.77:1** (WCAG AAA) |

Both comfortably exceed WCAG AA (4.5:1). Before: ~2.6:1 in light mode.

Propagated to the deployed copy `docs/cljs/playground.css` via the build's `copy-css` step; the source and deployed files are byte-identical.

## Test plan

- [x] `python -m mkdocs build --strict` passes
- [x] `tools/playground` smoke (`node test/smoke.test.mjs`) passes (CSS-unaffected; bundle unchanged)
- [x] `docs/cljs/playground.css` == `tools/playground/src/playground.css`
- [x] Browser-verified computed contrast in both default and slate schemes (table above)