### PR TITLE
refactor(adapters): shared parameterized ratom-spine for Reagent + reagent-slim + gensym/docstring hygiene (rf2-rzex9 + rf2-l4dmr)

### DIFF
--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -19,81 +19,50 @@
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]))
 
-;; ---- container ------------------------------------------------------------
-
-(defn- make-state-container [initial-value]
-  (r/atom initial-value))
-
-(defn- read-container [container]
-  @container)
-
-(defn- replace-container! [container new-value]
-  (reset! container new-value)
-  nil)
-
-(defn- subscribe-container [container on-change]
-  ;; Substrate-scoped gensym prefix so a cross-substrate test bundle / log
-  ;; / inspector can attribute the watch back to the slim adapter rather
-  ;; than confusing it with a stock-Reagent watch (l4dmr / rf2-l4dmr LOW-1).
-  (let [k (gensym "rf-reagent-slim-sub-")]
-    (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
-    (fn unsubscribe [] (remove-watch container k))))
-
-;; ---- derived (reactions) --------------------------------------------------
-
-(defn- make-derived-value [source-containers compute-fn]
-  ;; Arity-specialised recompute closure via `spine/build-recompute-fn`
-  ;; (rf2-eoy63 / rf2-v1nu0 / rf2-fzrav). Pre-rf2-eoy63 this body was a
-  ;; naive `(apply compute-fn (map deref ...))` — paid `apply` + a lazy
-  ;; cons cell per source per recompute on the hot path. Lifted into
-  ;; the spine so reagent-slim shares the same arity-spec as the
-  ;; Reagent, UIx and Helix adapters — single source of truth, same
-  ;; pattern as `spine/dispose-frame-sub-caches!` (rf2-jcjul).
-  (ratom/make-reaction (spine/build-recompute-fn source-containers compute-fn)))
-
-;; ---- render ---------------------------------------------------------------
+;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
-;; Active roots are tracked in a per-adapter atom so `dispose-adapter!`
-;; can drain them (rf2-7v82h; mirrors the Reagent adapter's
-;; rf2-9fdkb tracking). Each mount adds the React-19 root to the active
-;; set; the returned unmount thunk removes itself from the set before
-;; calling `(rdc/unmount root)`.
+;; The container quartet, the React-root renderer, the dispose body and
+;; the SSR emitter helpers are the SAME shape as the bridge adapter
+;; `re-frame.adapter.reagent`, modulo the reactive-atom impl (`reagent2.*`
+;; here, stock `reagent.*` there). They live in
+;; `re-frame.substrate.spine/make-ratom-spine` (rf2-rzex9) — one
+;; implementation, two adapters, zero drift, mirroring the React-hook
+;; `make-react-spine` that backs UIx/Helix.
+;;
+;; CRITICAL — bundle isolation (IMPL-SPEC §1.8 / the
+;; `test:reagent-slim:bundle-isolation` gate). The spine MUST NOT
+;; `:require` stock `reagent.*`; the reactive-atom ops are INJECTED here
+;; so this adapter's `reagent2.*` requires stay confined to this ns and
+;; the spine never names a reactive-atom ns. deps.edn carries zero direct
+;; `reagent.*` requires (the slim framing: a re-implementation, not a
+;; thin wrapper).
 
-(defonce ^:private active-roots (atom #{}))
+(def ^:private spine-fns
+  (spine/make-ratom-spine
+    {:substrate-name    "reagent-slim"
+     ;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
+     ;; test bundle / log / inspector can attribute a watch to the slim
+     ;; adapter rather than confusing it with a stock-Reagent watch.
+     :gensym-prefix-sub "rf-reagent-slim-sub-"
+     ;; Each op is a thin call-through lambda rather than the bare Var
+     ;; value so the spine resolves the namespaced fn at CALL time. This
+     ;; keeps the `with-redefs [rdc/create-root …]` test-observability the
+     ;; slim render / dispose-drain pins rely on (capturing the bare Var
+     ;; value at load time would freeze the original impls past any
+     ;; `with-redefs` rebind). Runtime behaviour is identical.
+     :ratom-ops         {:r/atom              (fn [v] (r/atom v))
+                         :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
+                         :rdc/create-root     (fn [mp] (rdc/create-root mp))
+                         :rdc/render          (fn [root tree] (rdc/render root tree))
+                         :rdc/hydrate-root    (fn [mp tree] (rdc/hydrate-root mp tree))
+                         :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
-(defn- render [render-tree mount-point opts]
-  ;; The bridge mounted into a raw DOM container directly; under the
-  ;; rewrite we explicitly create a React-19 root once and reuse it.
-  ;; The unmount thunk closes over the root to call its .unmount.
-  ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a boolean;
-  ;; no defensive coercion.
-  (let [hydrate? (:hydrate? opts)
-        root     (if hydrate?
-                   (rdc/hydrate-root mount-point render-tree)
-                   (let [r (rdc/create-root mount-point)]
-                     (rdc/render r render-tree)
-                     r))]
-    (swap! active-roots conj root)
-    (fn unmount []
-      (swap! active-roots disj root)
-      (rdc/unmount root))))
-
-(defonce ^:private hiccup-emitter (atom nil))
-
-(defn set-hiccup-emitter!
+(def set-hiccup-emitter!
   "Install the hiccup → HTML fn used by render-to-string. Idempotent.
   Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
   `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
   resolves it at load time without a static :require."
-  [f]
-  (reset! hiccup-emitter f))
-
-(defn- render-to-string [render-tree opts]
-  (if-let [emit @hiccup-emitter]
-    (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason      "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
-                     :render-tree render-tree}))))
+  (:set-hiccup-emitter! spine-fns))
 
 ;; ---- context provider -----------------------------------------------------
 
@@ -102,51 +71,11 @@
   ;; keyword arg is ignored — `build-frame-provider` is 0-arity
   ;; (rf2-4y60); the returned component takes the frame keyword at
   ;; render time. Per IMPL-SPEC §9.4: the views.cljs ns continues to
-  ;; back the frame-provider; the rewrite doesn't replace it.
+  ;; back the frame-provider; the rewrite doesn't replace it. Kept as
+  ;; adapter-side wiring (not in the shared ratom-spine) because it is
+  ;; the Reagent-component-shaped frame-provider, distinct from the
+  ;; React-hook spine's hook-shaped one.
   (views/build-frame-provider))
-
-;; ---- disposal -------------------------------------------------------------
-
-(defn- dispose-adapter! []
-  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
-  ;; rf2-jcjul, rf2-7v82h). The four-MUST list — brought to full parity
-  ;; with the Reagent adapter (reagent.cljs:100-137):
-  ;;
-  ;;   1. Cancel all in-flight reactive subscriptions — walk every live
-  ;;      frame's per-frame sub-cache and dispose each cached Reaction.
-  ;;      The component-unmount-driven path handles the mounted case
-  ;;      (reagent2 reaps Reactions once their last watcher drops) — but
-  ;;      `dispose-adapter!` MUST cover the headless / test-fixture path
-  ;;      where no component unmount fires before the adapter goes away,
-  ;;      and the SSR path where the rendered tree was string-serialised
-  ;;      without ever being mounted. Without the walk, sequential
-  ;;      `init! → dispose-adapter!` cycles in a long-lived process
-  ;;      accumulate per-frame sub-cache entries closed over stale
-  ;;      Reactions forever. Delegated to
-  ;;      `spine/dispose-frame-sub-caches!` (rf2-jcjul): the same helper
-  ;;      backs the Reagent adapter and the spine-built UIx / Helix
-  ;;      adapters so all three substrates share one implementation —
-  ;;      no three-way drift on the lifecycle MUST.
-  ;;
-  ;;   2. Release host-specific resources — drain the active-roots set
-  ;;      (React 19 roots; mounted-but-not-unmounted at process exit /
-  ;;      hot-reload). Swallow per-root throws so one misbehaving root
-  ;;      cannot strand the rest of the drain (rf2-7v82h).
-  ;;
-  ;;   3. Discard internal caches — clear the hiccup-emitter (the SSR
-  ;;      late-bind sink; the registered fn captures `re-frame.ssr`
-  ;;      state that must not survive the adapter) (rf2-7v82h).
-  ;;
-  ;;   4. Make subsequent calls return `:rf.error/adapter-disposed` —
-  ;;      handled one level up by `substrate-adapter/dispose-adapter!`
-  ;;      via the `disposed?` breadcrumb (rf2-6wxys).
-  (spine/dispose-frame-sub-caches!)
-  (doseq [root @active-roots]
-    (try (rdc/unmount root)
-         (catch :default _ nil)))
-  (reset! active-roots #{})
-  (reset! hiccup-emitter nil)
-  nil)
 
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:
@@ -157,17 +86,23 @@
   Drop-in shape-compatible with `re-frame.adapter.reagent/adapter` per
   IMPL-SPEC §2.1 — the only difference is the substrate, not the keys.
   Per Spec 006 §CLJS reference + rf2-agql: there is no default-adapter
-  registry; adapter wiring is explicit at the call site."
+  registry; adapter wiring is explicit at the call site.
+
+  The container quartet, renderer, render-to-string and dispose body
+  come from `spine/make-ratom-spine` (rf2-rzex9, shared with the bridge
+  Reagent adapter under an injected `reagent2.*` op set);
+  `register-context-provider` stays adapter-local (Reagent-component-
+  shaped frame-provider via `re-frame.views`)."
   {:kind                      :rf.adapter/reagent-slim
-   :make-state-container      make-state-container
-   :read-container            read-container
-   :replace-container!        replace-container!
-   :subscribe-container       subscribe-container
-   :make-derived-value        make-derived-value
-   :render                    render
-   :render-to-string          render-to-string
+   :make-state-container      (:make-state-container spine-fns)
+   :read-container            (:read-container       spine-fns)
+   :replace-container!        (:replace-container!   spine-fns)
+   :subscribe-container       (:subscribe-container  spine-fns)
+   :make-derived-value        (:make-derived-value   spine-fns)
+   :render                    (:render               spine-fns)
+   :render-to-string          (:render-to-string     spine-fns)
    :register-context-provider register-context-provider
-   :dispose-adapter!          dispose-adapter!})
+   :dispose-adapter!          (:dispose-adapter!     spine-fns)})
 
 ;; Per rf2-uo7v + IMPL-SPEC §9.2: publish the hiccup-emitter installer
 ;; through the chained late-bind hook table so re-frame.ssr (in

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -32,7 +32,10 @@
   nil)
 
 (defn- subscribe-container [container on-change]
-  (let [k (gensym "rf-sub-")]
+  ;; Substrate-scoped gensym prefix so a cross-substrate test bundle / log
+  ;; / inspector can attribute the watch back to the slim adapter rather
+  ;; than confusing it with a stock-Reagent watch (l4dmr / rf2-l4dmr LOW-1).
+  (let [k (gensym "rf-reagent-slim-sub-")]
     (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
     (fn unsubscribe [] (remove-watch container k))))
 

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -26,7 +26,10 @@
   nil)
 
 (defn- subscribe-container [container on-change]
-  (let [k (gensym "rf-sub-")]
+  ;; Substrate-scoped gensym prefix so a cross-substrate test bundle / log
+  ;; / inspector can attribute the watch back to the Reagent adapter rather
+  ;; than confusing it with a slim watch (l4dmr / rf2-l4dmr LOW-1).
+  (let [k (gensym "rf-reagent-sub-")]
     (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
     (fn unsubscribe [] (remove-watch container k))))
 

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -13,80 +13,46 @@
             [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
-;; ---- container ------------------------------------------------------------
-
-(defn- make-state-container [initial-value]
-  (r/atom initial-value))
-
-(defn- read-container [container]
-  @container)
-
-(defn- replace-container! [container new-value]
-  (reset! container new-value)
-  nil)
-
-(defn- subscribe-container [container on-change]
-  ;; Substrate-scoped gensym prefix so a cross-substrate test bundle / log
-  ;; / inspector can attribute the watch back to the Reagent adapter rather
-  ;; than confusing it with a slim watch (l4dmr / rf2-l4dmr LOW-1).
-  (let [k (gensym "rf-reagent-sub-")]
-    (add-watch container k (fn [_ _ prev nu] (on-change prev nu)))
-    (fn unsubscribe [] (remove-watch container k))))
-
-;; ---- derived (reactions) --------------------------------------------------
-
-(defn- make-derived-value [source-containers compute-fn]
-  ;; Arity-specialised recompute closure (rf2-v1nu0 / rf2-fzrav): the
-  ;; spine helper `build-recompute-fn` builds a 0-arg thunk that skips
-  ;; `apply` + lazy-`map` cost on the dominant 0/1/2-arity paths and
-  ;; falls back to `mapv` + `apply` for ≥3. Pre-rf2-eoy63 this fn
-  ;; carried the case-spec body inline; lifted into the spine so all
-  ;; four adapters (Reagent, reagent-slim, UIx, Helix) share one
-  ;; implementation — same single-source-of-truth pattern as
-  ;; `make-dispose-adapter!` (rf2-jcjul).
-  (ratom/make-reaction (spine/build-recompute-fn source-containers compute-fn)))
-
-;; ---- render ---------------------------------------------------------------
+;; ---- shared ratom-spine wiring --------------------------------------------
 ;;
-;; Active roots are tracked in a per-adapter atom so `dispose-adapter!`
-;; can drain them (rf2-9fdkb). Each mount adds the Reagent Root to the
-;; active set; the returned unmount thunk removes itself from the set
-;; before calling `(rdc/unmount root)`.
+;; The container quartet, the React-root renderer, the dispose body and
+;; the SSR emitter helpers are the SAME shape as reagent-slim, modulo the
+;; reactive-atom impl (stock `reagent.*` here, `reagent2.*` there). They
+;; live in `re-frame.substrate.spine/make-ratom-spine` (rf2-rzex9) — one
+;; implementation, two adapters, zero drift, mirroring the React-hook
+;; `make-react-spine` that backs UIx/Helix. The reactive-atom ops are
+;; INJECTED here so the spine never `:require`s a reactive-atom ns: this
+;; adapter passes its stock `reagent.*` impls; the slim adapter passes
+;; `reagent2.*`. (Load-bearing for reagent-slim bundle isolation — the
+;; slim adapter's deps.edn carries zero direct `reagent.*` requires.)
 
-(defonce ^:private active-roots (atom #{}))
+(def ^:private spine-fns
+  (spine/make-ratom-spine
+    {:substrate-name    "Reagent"
+     ;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
+     ;; test bundle / log / inspector can attribute a watch to the
+     ;; Reagent adapter rather than confusing it with a slim watch.
+     :gensym-prefix-sub "rf-reagent-sub-"
+     ;; Each op is a thin call-through lambda rather than the bare Var
+     ;; value so the spine resolves the namespaced fn at CALL time. This
+     ;; keeps the `with-redefs [rdc/create-root …]` test-observability the
+     ;; adapter-render / dispose-drain pins rely on (capturing the bare
+     ;; Var value at load time would freeze the original impls past any
+     ;; `with-redefs` rebind). Runtime behaviour is identical.
+     :ratom-ops         {:r/atom              (fn [v] (r/atom v))
+                         :ratom/make-reaction (fn [thunk] (ratom/make-reaction thunk))
+                         :rdc/create-root     (fn [mp] (rdc/create-root mp))
+                         :rdc/render          (fn [root tree] (rdc/render root tree))
+                         :rdc/hydrate-root    (fn [mp tree] (rdc/hydrate-root mp tree))
+                         :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
-(defn- render [render-tree mount-point opts]
-  ;; React 18+ Root API: create-root → render → unmount; hydrate-root
-  ;; on the SSR path returns its own Root (rf2-fn5rk + rf2-6hyy slim
-  ;; parity). Pin: `adapter-render-cljs-test`. Per rf2-gwkvr: Spec 006
-  ;; §`render` types `:hydrate?` as a boolean; no defensive coercion.
-  (let [hydrate? (:hydrate? opts)
-        root     (if hydrate?
-                   (rdc/hydrate-root mount-point render-tree)
-                   (let [r (rdc/create-root mount-point)]
-                     (rdc/render r render-tree)
-                     r))]
-    (swap! active-roots conj root)
-    (fn unmount []
-      (swap! active-roots disj root)
-      (rdc/unmount root))))
-
-(defonce ^:private hiccup-emitter (atom nil))
-
-(defn set-hiccup-emitter!
-  "Install the hiccup → HTML fn used by render-to-string. Idempotent."
-  [f]
-  (reset! hiccup-emitter f))
-
-(defn- render-to-string [render-tree opts]
-  ;; Reagent ships server-side rendering via reagent.dom.server — but in
-  ;; CLJS browser builds we don't typically render-to-string. Install
-  ;; the emitter via set-hiccup-emitter! if you need this in CLJS.
-  (if-let [emit @hiccup-emitter]
-    (emit render-tree opts)
-    (throw (ex-info ":rf.error/no-hiccup-emitter-bound"
-                    {:reason "require re-frame.ssr (the SSR ns-load resolves the :reagent/set-hiccup-emitter! late-bind hook automatically), or call set-hiccup-emitter! directly"
-                     :render-tree render-tree}))))
+(def set-hiccup-emitter!
+  "Install the hiccup → HTML fn used by render-to-string. Idempotent.
+  Reagent ships server-side rendering via reagent.dom.server — but in
+  CLJS browser builds we don't typically render-to-string; install the
+  emitter via this fn (or let the SSR seam resolve the late-bind hook)
+  if you need it in CLJS."
+  (:set-hiccup-emitter! spine-fns))
 
 ;; ---- context provider -----------------------------------------------------
 
@@ -95,49 +61,12 @@
   ;; keyword arg is ignored — `build-frame-provider` is 0-arity
   ;; (rf2-4y60); the returned component takes the frame keyword at
   ;; render time. The arg stays in the substrate signature per
-  ;; Spec 006 §Frame-provider via React context.
+  ;; Spec 006 §Frame-provider via React context. Kept as adapter-side
+  ;; wiring (not in the shared ratom-spine) because it is the Reagent-
+  ;; component-shaped frame-provider, distinct from the React-hook
+  ;; spine's hook-shaped one — and so the core spine carries no
+  ;; spine→views dependency edge.
   (views/build-frame-provider))
-
-;; ---- disposal -------------------------------------------------------------
-
-(defn- dispose-adapter! []
-  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
-  ;; rf2-jcjul). The four-MUST list:
-  ;;
-  ;;   1. Cancel all in-flight reactive subscriptions — walk every live
-  ;;      frame's per-frame sub-cache and dispose each cached Reaction.
-  ;;      Delegated to `spine/dispose-frame-sub-caches!` (rf2-jcjul):
-  ;;      the same helper backs reagent-slim and the spine-built UIx /
-  ;;      Helix adapters so all three substrates share one
-  ;;      implementation — no three-way drift on the lifecycle MUST.
-  ;;      Component-unmount-driven disposal handles the mounted case
-  ;;      (Reagent reaps Reactions when their last watcher drops); the
-  ;;      explicit walk covers the test-fixture / headless path where
-  ;;      no component unmount fires before the adapter goes away.
-  ;;      `interop/dispose!` inside the walk routes through
-  ;;      `:adapter/dispose!` which is still wired for this adapter at
-  ;;      this point in the teardown (substrate-adapter clears the
-  ;;      install slot AFTER calling us).
-  ;;
-  ;;   2. Release host-specific resources — drain the active-roots set
-  ;;      (React 18+ Roots; mounted-but-not-unmounted at process exit /
-  ;;      hot-reload). Swallow per-root throws so one misbehaving root
-  ;;      cannot strand the rest of the drain.
-  ;;
-  ;;   3. Discard internal caches — clear hiccup-emitter (the SSR
-  ;;      late-bind sink; the registered fn captures `re-frame.ssr`
-  ;;      state that must not survive the adapter).
-  ;;
-  ;;   4. Make subsequent calls return `:rf.error/adapter-disposed` —
-  ;;      handled one level up by `substrate-adapter/dispose-adapter!`
-  ;;      via the `disposed?` breadcrumb (rf2-6wxys).
-  (spine/dispose-frame-sub-caches!)
-  (doseq [root @active-roots]
-    (try (rdc/unmount root)
-         (catch :default _ nil)))
-  (reset! active-roots #{})
-  (reset! hiccup-emitter nil)
-  nil)
 
 (def adapter
   "The Reagent adapter map. Pass to `(rf/init! ...)` to install:
@@ -147,17 +76,22 @@
 
   See Spec 006 §CLJS reference: Reagent as default adapter for the
   bridging pseudocode. Per rf2-agql there is no default-adapter
-  registry — adapter wiring is explicit at the call site."
+  registry — adapter wiring is explicit at the call site.
+
+  The container quartet, renderer, render-to-string and dispose body
+  come from `spine/make-ratom-spine` (rf2-rzex9, shared with
+  reagent-slim); `register-context-provider` stays adapter-local
+  (Reagent-component-shaped frame-provider via `re-frame.views`)."
   {:kind                      :rf.adapter/reagent
-   :make-state-container      make-state-container
-   :read-container            read-container
-   :replace-container!        replace-container!
-   :subscribe-container       subscribe-container
-   :make-derived-value        make-derived-value
-   :render                    render
-   :render-to-string          render-to-string
+   :make-state-container      (:make-state-container spine-fns)
+   :read-container            (:read-container       spine-fns)
+   :replace-container!        (:replace-container!   spine-fns)
+   :subscribe-container       (:subscribe-container  spine-fns)
+   :make-derived-value        (:make-derived-value   spine-fns)
+   :render                    (:render               spine-fns)
+   :render-to-string          (:render-to-string     spine-fns)
    :register-context-provider register-context-provider
-   :dispose-adapter!          dispose-adapter!})
+   :dispose-adapter!          (:dispose-adapter!     spine-fns)})
 
 ;; Chained SSR emitter install (rf2-4z7bp / parity rf2-cl1qv):
 ;; `re-frame.ssr.emit` invokes `:reagent/set-hiccup-emitter!` at

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1060,3 +1060,156 @@
      ;; rf2-334d9 — :adapter/after-render impl. Each adapter publishes
      ;; this via substrate-adapter/route-hook!.
      :after-render-hook           after-render-hook}))
+
+;; ---- ratom-family spine (Reagent + reagent-slim) --------------------------
+;;
+;; The Reagent and reagent-slim adapters are the SAME shape under a
+;; different reactive-atom impl (stock `reagent.*` vs the `reagent2.*`
+;; rewrite). Pre-rf2-rzex9 each carried a byte-identical (modulo the
+;; ratom ns) copy of the container quartet, the React-root renderer, and
+;; the dispose body. `make-ratom-spine` factors that shared shape exactly
+;; as `make-react-spine` factors the UIx/Helix hook family — one
+;; implementation, two adapters, zero drift.
+;;
+;; CRITICAL — slim bundle isolation (IMPL-SPEC §1.8 / the
+;; `test:reagent-slim:bundle-isolation` gate). This helper lives in
+;; core/substrate and MUST NOT `:require` stock `reagent.*` — the day8/
+;; reagent-slim adapter would otherwise drag the stock-Reagent impl tree
+;; into every slim release bundle. The reactive-atom ops are therefore
+;; INJECTED by each adapter via the `:ratom-ops` map (the HOF
+;; parameterisation): the Reagent adapter passes its stock `reagent.*`
+;; impls, the slim adapter passes its `reagent2.*` impls. The spine never
+;; names either ns. (The same isolation principle as `make-react-spine`,
+;; which calls `react-dom/client` directly but never Reagent.)
+
+(defn make-ratom-spine
+  "Build the per-substrate ratom-family substrate surfaces given the
+  substrate's ratom ops and gensym prefix:
+
+      :substrate-name    — string (currently informational; the ratom
+                           family has no warn-non-dom-root surface, that
+                           lives in re-frame.views for these adapters)
+      :gensym-prefix-sub — gensym prefix for `subscribe-container` watch
+                           keys (substrate-scoped per rf2-l4dmr so logs /
+                           inspectors attribute a watch to its substrate)
+      :ratom-ops         — the injected reactive-atom impls, a map of:
+          :r/atom              — (fn [v]) → reactive atom container
+          :ratom/make-reaction — (fn [thunk]) → reaction over a thunk
+          :rdc/create-root     — (fn [mount-point]) → React root
+          :rdc/render          — (fn [root tree]) → render hiccup into
+                                 root (the substrate's hiccup→element
+                                 walk + `.render`, NOT a bare `.render`)
+          :rdc/hydrate-root    — (fn [mount-point tree]) → React root
+          :rdc/unmount         — (fn [root]) → unmount the root
+
+  The spine MUST NOT `:require` stock `reagent.*`; the ops above are the
+  only path to the substrate's reactive primitive, so each adapter's own
+  `reagent.*` / `reagent2.*` requires stay confined to the adapter ns
+  (load-bearing for reagent-slim bundle isolation — see the section
+  comment above).
+
+  Returns a map of the substrate-contract surfaces (minus
+  `register-context-provider`) plus the SSR helpers each adapter
+  re-exports:
+
+      {:make-state-container       …
+       :read-container             …
+       :replace-container!         …
+       :subscribe-container        …
+       :make-derived-value         …
+       :render                     …
+       :render-to-string           …
+       :dispose-adapter!           …
+       :set-hiccup-emitter!        …
+       :active-roots-cell          …
+       :emitter-cell               …}
+
+  `:register-context-provider` is NOT produced here: for the ratom
+  family it is the Reagent-component-shaped frame-provider from
+  `re-frame.views` (`views/build-frame-provider`), which the React-hook
+  spine's hook-shaped `frame-provider` is not. Keeping it as adapter-side
+  wiring also keeps this core ns free of a spine→views dependency edge.
+
+  Behaviour is byte-for-byte equivalent to the pre-rf2-rzex9 hand-written
+  adapter bodies: container quartet incl. the substrate-scoped gensym;
+  the create-root/hydrate-root render with active-roots tracking + an
+  unmount thunk that drops itself from the set; and the four-MUST dispose
+  body (`dispose-frame-sub-caches!` + active-roots drain w/ per-root
+  throw-swallow + emitter clear)."
+  [{:keys [gensym-prefix-sub ratom-ops]}]
+  (let [{r-atom        :r/atom
+         make-reaction :ratom/make-reaction
+         create-root   :rdc/create-root
+         render-root   :rdc/render
+         hydrate-root  :rdc/hydrate-root
+         unmount-root  :rdc/unmount} ratom-ops
+        active-roots-cell (make-active-roots-cell)
+        emitter-cell      (make-hiccup-emitter-cell)
+        make-state-container
+        (fn make-state-container [initial-value]
+          (r-atom initial-value))
+        read-container
+        (fn read-container [container]
+          @container)
+        replace-container!
+        (fn replace-container! [container new-value]
+          (reset! container new-value)
+          nil)
+        subscribe-container
+        (make-subscribe-container gensym-prefix-sub)
+        ;; Arity-specialised recompute closure via `build-recompute-fn`
+        ;; (rf2-eoy63), wrapped in the substrate's own reaction primitive.
+        make-derived-value
+        (fn make-derived-value [source-containers compute-fn]
+          (make-reaction (build-recompute-fn source-containers compute-fn)))
+        ;; React 18+/19 Root API: create-root → render → unmount; the
+        ;; hydrate branch on the SSR path returns its own Root. Active
+        ;; roots are tracked so `dispose-adapter!` can drain them; the
+        ;; unmount thunk removes itself from the set before unmounting.
+        ;; Per rf2-gwkvr: Spec 006 §`render` types `:hydrate?` as a
+        ;; boolean; no defensive coercion.
+        render
+        (fn render [render-tree mount-point opts]
+          (let [hydrate? (:hydrate? opts)
+                root     (if hydrate?
+                           (hydrate-root mount-point render-tree)
+                           (let [r (create-root mount-point)]
+                             (render-root r render-tree)
+                             r))]
+            (swap! active-roots-cell conj root)
+            (fn unmount []
+              (swap! active-roots-cell disj root)
+              (unmount-root root))))
+        ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
+        ;; rf2-jcjul, rf2-7v82h). The four-MUST list:
+        ;;   1. Cancel in-flight reactive subscriptions — walk every live
+        ;;      frame's per-frame sub-cache (`dispose-frame-sub-caches!`,
+        ;;      shared with the React-hook spine for zero drift).
+        ;;   2. Release host-specific resources — drain active-roots,
+        ;;      swallowing per-root throws so one bad root cannot strand
+        ;;      the rest of the drain.
+        ;;   3. Discard internal caches — clear the hiccup-emitter cell.
+        ;;   4. Subsequent calls return `:rf.error/adapter-disposed` —
+        ;;      enforced one level up by substrate-adapter via the
+        ;;      `disposed?` breadcrumb (rf2-6wxys).
+        dispose-adapter!
+        (fn dispose-adapter! []
+          (dispose-frame-sub-caches!)
+          (doseq [root @active-roots-cell]
+            (try (unmount-root root)
+                 (catch :default _ nil)))
+          (reset! active-roots-cell #{})
+          (reset! emitter-cell nil)
+          nil)]
+    {:make-state-container       make-state-container
+     :read-container             read-container
+     :replace-container!         replace-container!
+     :subscribe-container        subscribe-container
+     :make-derived-value         make-derived-value
+     :render                     render
+     :render-to-string           (make-render-to-string emitter-cell)
+     :dispose-adapter!           dispose-adapter!
+     :set-hiccup-emitter!        (fn set-it! [f]
+                                   (set-hiccup-emitter! emitter-cell f))
+     :active-roots-cell          active-roots-cell
+     :emitter-cell               emitter-cell}))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -652,8 +652,8 @@
 (defn- resolve-act-fn
   "Return React's act() if available, else nil. React 19 hosts act on
   the React namespace directly; React 18 hosts it on react-dom/test-utils.
-  Mirrors the Reagent test harness's act-fn at
-  `adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs:467`."
+  Mirrors the Reagent test harness's act-fn in
+  `adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs`."
   []
   (or (when (exists? (.-act React)) (.-act React))
       (try


### PR DESCRIPTION
## Summary

Two beads, one PR (commit-per-bead, smallest first).

### rf2-l4dmr (P4 — hygiene)
- Substrate-scope the ratom-family `subscribe-container` gensym prefix: both adapters used the literal `(gensym "rf-sub-")` — un-attributed and identical across the two, so a cross-substrate test bundle / log / inspector could not tell a Reagent watch from a slim one. Now `"rf-reagent-sub-"` / `"rf-reagent-slim-sub-"` (mirrors how the React-hook spine parameterizes its gensym prefixes per substrate).
- Drop the brittle `:467` file:line cross-ref in `resolve-act-fn`'s docstring (`spine.cljs`) — the line number drifts on any edit with nothing enforcing it. File cross-ref kept.

### rf2-rzex9 (P3 — the refactor)
The Reagent and reagent-slim adapters carried byte-identical (modulo the reactive-atom ns) copies of the container quartet, the React-root renderer, and the four-MUST dispose body — the same shape under a different reactive-atom impl (stock `reagent.*` vs the `reagent2.*` rewrite). Folded into a shared **ratom-spine HOF** in `re-frame.substrate.spine`, mirroring the existing React-hook `make-react-spine` that backs UIx/Helix.

**The spine HOF + its param map.** `make-ratom-spine` takes:
- `:substrate-name` (informational)
- `:gensym-prefix-sub` — substrate-scoped watch-key prefix
- `:ratom-ops` — the injected reactive-atom impls: `{:r/atom :ratom/make-reaction :rdc/create-root :rdc/render :rdc/hydrate-root :rdc/unmount}`

and produces the container quartet + `make-derived-value` + `render` (active-roots tracking + self-removing unmount thunk) + `render-to-string` + `dispose-adapter!` (the four-MUST body) + `set-hiccup-emitter!`. Each adapter is now wiring + late-bind routing only. `register-context-provider` stays adapter-local — it is the Reagent-component-shaped frame-provider from `re-frame.views`, distinct from the hook-shaped one, and keeping it out avoids a spine→views dependency edge.

> Note: the bead's enumerated op set omitted `:rdc/render`. It is required for byte-for-byte fidelity — `reagent(2).dom.client/render` is a *function* (hiccup→element walk + `.render`), not a bare `.render` method call, so it must be an injected op alongside the others.

**How slim isolation is preserved.** The helper lives in core/substrate and **never `:require`s a reactive-atom ns** — the ratom ops are INJECTED by each adapter (stock `reagent.*` for Reagent, `reagent2.*` for slim). The slim adapter's `deps.edn` keeps its "zero direct `reagent.*` requires" property. The ops are passed as **thin call-through lambdas** so the spine resolves the namespaced fn at *call time*, preserving the `with-redefs [rdc/...]` test-observability the render / dispose-drain pins depend on (capturing bare Var values at load time would have frozen them past any `with-redefs`).

**Behaviour is byte-for-byte equivalent**: container quartet incl. the substrate-scoped gensym (from l4dmr); create-root/hydrate-root render; self-removing unmount thunk; `dispose-frame-sub-caches!` + active-roots drain (per-root throw-swallow) + emitter clear.

**LoC removed.** ~131 lines of duplicated adapter body eliminated (per adapter: 123-124 deleted / 58 added); +153 in the shared helper (mostly docstring + isolation rationale; ~80 executable lines, now single-source).

## Test plan
- [x] `npm run test:cljs` — 4090 tests / 12408 assertions, 0 failures / 0 errors
- [x] `npm run test:reagent-slim:bundle-isolation` (**CRITICAL**) — 3 contracts / 19 sentinel checks PASS; no stock-Reagent leak into the slim bundle, no react-dom/server
- [x] `npm run test:bundle-isolation` — internal-sentinel + budget + uix/helix-reagent-free all PASS
- [x] Reagent + reagent-slim render / dispose-drain `with-redefs` pins pass (in the node `test:cljs` target)