### PR TITLE
docs(guide): interactive re-frame2 tutorial foundation + worked counter template (rf2-w29b5)

### DIFF
--- a/docs/guide/interactive-counter.md
+++ b/docs/guide/interactive-counter.md
@@ -1,0 +1,208 @@
+# Interactive: the counter
+
+> **What this is.** The [first-app counter](03-first-app.md) — the canonical re-frame2 teaching example — but *live*. Every code cell below is a real, editable, runnable re-frame2 program in your browser. Read the explanation, run the cell, then change it and run it again.
+>
+> **You'll need.** Nothing but this page. The code runs in your browser; there's no toolchain to install. The first live cell takes a moment to come alive while the re-frame2 engine loads — after that it's instant.
+>
+> **What you'll learn.** The same five primitives the static chapter covers — `reg-event-db`, `reg-sub`, a view, `dispatch`, `subscribe` — except here you build the counter up one live cell at a time and prove each piece works by clicking it.
+
+This is the **template** for re-frame2's interactive tutorials. It's deliberately short: it walks one small program — the counter — end to end, with live cells the reader edits inline. Future interactive chapters follow this same shape; the authoring conventions are written up in [Writing interactive tutorials](interactive-tutorials.md).
+
+If you've read [03 — Your first app](03-first-app.md), this covers the same ground with your hands on the wheel. If you haven't, you can start here — the explanations stand alone — and read the static chapter afterwards for the deeper *why* behind each step.
+
+A note on running cells: click inside any cell to edit it, then press `Ctrl-Enter` (or `Cmd-Enter` on macOS) to evaluate. Each cell below is a complete program — the live counter rebuilds from scratch every time you evaluate.
+
+## The whole counter, running
+
+Here's the entire counter — events, a subscription, a view — in one live cell. Run it (`Ctrl-Enter`), then click the buttons. The number goes up and down, starting at `5`.
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+;; Events — pure functions of (db, event) -> db
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :counter/value inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :counter/value dec)))
+
+;; Subscription — a derivation from app-db
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
+
+;; View — hiccup, with explicit rf/dispatch and rf/subscribe
+(defn counter []
+  [:div
+   [:button {:on-click #(rf/dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em"}} @(rf/subscribe [:counter/value])]
+   [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]])
+
+;; Seed app-db, then hand the view back to be rendered
+(rf/dispatch-sync [:counter/initialise])
+[counter]
+```
+
+That's the complete program. Every line is load-bearing and every line is on the page — there's no hidden setup. The rest of this tutorial takes it apart one piece at a time, and at each step you have a live cell to experiment with.
+
+> **One difference from the static chapter.** Chapter 03 registers its view with `reg-view`, which auto-injects `dispatch` and `subscribe` into the view body. `reg-view` is a macro, and these live cells run in a functions-only environment — so here we write a plain `defn` view and call `rf/dispatch` / `rf/subscribe` explicitly. It's the same component; `reg-view` is just sugar over this shape. See [Writing interactive tutorials](interactive-tutorials.md#one-difference-from-the-static-listings-reg-view) for the why.
+
+## Events: describing what happened
+
+An **event handler** is a pure function from the current state and an event to the *next* state. Nothing more. Here are the counter's three handlers, with a cell that calls one *directly* and shows what it returns:
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :counter/value inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :counter/value dec)))
+
+;; A handler is just a function: look it up and call it directly, with no
+;; browser, no buttons, no app-db. Pass in a state and an event; read the
+;; counter value out of the returned state.
+(defn handler-demo []
+  (let [handler (:handler-fn (rf/handler-meta :event :counter/inc))
+        before  {:counter/value 5}
+        after   (handler before [:counter/inc])]
+    [:div
+     [:div "before :counter/value = " (:counter/value before)]
+     [:div "after  :counter/value = " (:counter/value after)]]))
+
+[handler-demo]
+```
+
+Run that. The cell looks up the registered `:counter/inc` handler and *calls it like the function it is* — passing in `{:counter/value 5}` and the event vector — then reads `:counter/value` out of the state before and after. Before is `5`; after is `6`. No clicking, no rendering of a real counter — a handler is a function from a value to a value, and you can exercise it that way.
+
+Three things to notice in the handlers:
+
+1. **The ids are namespaced.** `:counter/initialise`, not `:initialise`. Every event id starts with the feature it belongs to. The habit matters more as an app grows; it starts here.
+2. **The handlers are pure.** `(fn [db _event] (update db :counter/value inc))` reads a state, returns a new state. No side effects, no DOM, no network. The runtime applies the returned value.
+3. **`update` returns a new map.** `(update db :counter/value inc)` leaves `db` untouched and returns a fresh map with the incremented value. Immutability everywhere.
+
+> **Try it.** Change the `inc` in `:counter/inc` to `(partial + 10)`, then re-evaluate. The `after` line now reads `15` — the handler adds ten. You just changed the program's behaviour by editing one function.
+
+## Subscriptions: deriving what to show
+
+A **subscription** is a derivation: a function from `app-db` to some value a view can read. The counter's is the simplest possible — it just reads the stored value. This cell *computes* it against a state value and shows the result:
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
+
+;; compute-sub runs the registered sub against any state you hand it —
+;; no view, no React, no rendering. Pure data in, data out.
+(defn sub-demo []
+  (let [db    {:counter/value 5}
+        value (rf/compute-sub [:counter/value] db)]
+    [:div "for a db whose :counter/value is "
+     (:counter/value db) ", the :counter/value sub computes " value]))
+
+[sub-demo]
+```
+
+Run it. `compute-sub` runs the `:counter/value` subscription against the state `{:counter/value 5}` and the cell shows `5`. Like a handler, a subscription is just data-in, data-out — `compute-sub` runs it against any state you hand it.
+
+Why name a derivation this trivial? Because once it's a registered, queryable thing:
+
+- A view subscribes to it without knowing where the value lives in `app-db`. Move the value into a richer slice later and only the subscription changes.
+- Tooling can list every derivation in the app — useful for inspection and for AI code generation.
+- Tests compute it against any state value, as the cell above just did.
+
+Subscriptions also chain. A doubled-counter sub built *on top of* `:counter/value`:
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
+
+(rf/reg-sub :counter/doubled
+  :<- [:counter/value]
+  (fn [count _query] (* 2 count)))
+
+(defn doubled-demo []
+  [:div "doubled: " (rf/compute-sub [:counter/doubled] {:counter/value 5})])
+
+[doubled-demo]
+```
+
+The `:<-` declares an input: `:counter/doubled` depends on `:counter/value`. Run it and the cell shows `10`. The framework builds a dependency graph from these declarations — when `:counter/value` changes, `:counter/doubled` recomputes, but only while something is reading it. Cheap when nobody's looking, fast when they are.
+
+## The view: hiccup that subscribes and dispatches
+
+The view is the only piece with substantive shape. It's a function returning **hiccup** — a Clojure data structure that describes a DOM tree:
+
+```cljs-rf2
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
+
+(rf/reg-event-db :counter/inc
+  (fn [db _event] (update db :counter/value inc)))
+
+(rf/reg-event-db :counter/dec
+  (fn [db _event] (update db :counter/value dec)))
+
+(rf/reg-sub :counter/value
+  (fn [db _query] (:counter/value db)))
+
+(defn counter []
+  [:div
+   [:button {:on-click #(rf/dispatch [:counter/dec])} "-"]
+   [:span {:style {:margin "0 1em"}} @(rf/subscribe [:counter/value])]
+   [:button {:on-click #(rf/dispatch [:counter/inc])} "+"]])
+
+(rf/dispatch-sync [:counter/initialise])
+[counter]
+```
+
+This is the full counter again — run it and click the buttons. Reading the view:
+
+- `[:div ...]` is a `<div>`; `[:button {:on-click ...} "-"]` is a `<button>` with a click handler and the text `-`.
+- `@(rf/subscribe [:counter/value])` reads the current value of the subscription. The `@` unwraps the reactive value to its current contents — it's how the view re-renders when the value changes.
+- `#(rf/dispatch [:counter/dec])` is a click handler that puts the `:counter/dec` event on the queue. The handler runs, `app-db` updates, the subscription notices, the view re-renders. That's the whole cycle.
+
+The view never imperatively touches a DOM node. It declares *what the screen should look like given the current state*, and the runtime makes the DOM match.
+
+> **Try it.** Add a third button between the existing two:
+> `[:button {:on-click #(rf/dispatch [:counter/initialise])} "reset"]`
+> Re-evaluate, click `+` a few times, then click `reset` — the counter snaps back to `5`. You added a feature by dispatching an event that already existed; no new handler needed.
+
+## What just happened
+
+When you ran the full cell and clicked `+`, here's the cascade:
+
+1. The button's `:on-click` fired `(rf/dispatch [:counter/inc])`. The event joined the queue.
+2. The runtime popped the event and ran the `:counter/inc` handler: it read `{:counter/value 5}`, returned `{:counter/value 6}`. The runtime updated `app-db`.
+3. The `:counter/value` subscription noticed `app-db` changed and recomputed to `6`.
+4. The view re-rendered. The `<span>` now shows `6`.
+
+Five named steps, no surprises — the same cascade every re-frame2 event runs through, whether the app is a counter or a trading desk.
+
+## Where this goes
+
+You've now built and run every load-bearing primitive: pure event handlers, a subscription (including a chained one), a view that subscribes and dispatches, and the seed-before-render mount. You tested handlers and subscriptions as plain functions, and you changed the program's behaviour by editing live code.
+
+This is the template interactive tutorial. The same *why → live cell → what to try* rhythm scales to the rest of the framework:
+
+- **Effects that aren't state changes** — HTTP, navigation, storage. Static chapter: [04 — Events](04-events.md).
+- **Subscriptions, in depth** — the graph, caching, layered derivations. Static chapter: [07 — Views](07-views.md).
+- **State machines** — for flows where "what's the next state?" is the load-bearing question. Static chapter: [11 — Machines](11-machines.md).
+
+For the full *why* behind the counter — `dispatch-sync` at the mount boundary, why views are registered, the testing story in depth — read the static companion, [03 — Your first app](03-first-app.md). To write the next interactive tutorial, start from [Writing interactive tutorials](interactive-tutorials.md).

--- a/docs/guide/interactive-tutorials.md
+++ b/docs/guide/interactive-tutorials.md
@@ -1,0 +1,94 @@
+# Writing interactive tutorials
+
+> **Who this is for.** Authors adding *interactive* chapters to the guide — pages where the reader edits live re-frame2 code in the browser and watches it run. This is a contributor note, not a reader chapter. If you're here to *learn* re-frame2, you want [03 — Your first app](03-first-app.md) or its live companion, [Interactive: the counter](interactive-counter.md).
+>
+> **What it covers.** The three playground cell kinds, when to reach for each, the conventions for an editable-and-evaluable teaching cell, and the gotchas that bite the first time. There is one worked, end-to-end template tutorial — [Interactive: the counter](interactive-counter.md) — and this note explains the pattern it follows so you can write the next one.
+
+The guide's prose teaches by reading. Static code blocks show the shape; the surrounding sentences explain *why it's shaped that way*. That's enough for most chapters and it's the right default — a reader skimming on a phone shouldn't need a JavaScript runtime to follow the argument.
+
+But some ideas land harder when the reader can *change them and see what happens*. "Dispatch increments the counter" is a sentence. A live counter the reader clicks — then edits the handler to add two instead of one, re-evaluates, and clicks again — is an experience. The playground ([built under `tools/playground`](https://github.com/day8/re-frame2/tree/main/tools/playground)) makes that possible inside an ordinary mkdocs page: fenced code blocks become editable CodeMirror editors that evaluate in the browser.
+
+This page is the **foundation** for that track. The [counter tutorial](interactive-counter.md) is the **template** the first interactive chapter follows. More interactive tutorials will follow the same shape; extend or redirect from here.
+
+## The three cell kinds
+
+A live cell is a fenced code block whose *info string* selects one of three behaviours. The fence text is the only difference between a static block and a live one:
+
+| Fence | What the reader gets | When to use it |
+|---|---|---|
+| ` ```cljs ` | **Plain eval.** Evaluates the forms and prints the last form's value below the editor. No DOM, no re-frame. | Teaching ClojureScript itself — data literals, evaluation rules, builtins. The whole of [the CLJS reading guide](../cljs/index.md) is this kind. |
+| ` ```cljs-render ` | **Stock live component.** Mounts the last form as a live Reagent component, backed by **stock** Reagent + re-frame (the original libraries). | Demonstrating something that's identical between stock re-frame and re-frame2, or where the stock surface is genuinely what you mean. Rare in this guide — the guide teaches re-frame2's own API. |
+| ` ```cljs-rf2 ` | **Live re-frame2 component.** Same as above, but evaluated against re-frame2's **own public API** (`re-frame.core` v2) and rendered through reagent2. | Every interactive *re-frame2* tutorial. This is the one you almost always want. |
+
+For a guide chapter, the answer is almost always ` ```cljs-rf2 `. You're teaching re-frame2; the live cells should run re-frame2. Reach for ` ```cljs ` only when the lesson is pure ClojureScript with no framework in sight, and for ` ```cljs-render ` essentially never — it exists for the rare stock-comparison case.
+
+## The editable-and-evaluable convention
+
+A teaching cell is not a screenshot. It's an invitation to experiment. Three conventions keep that invitation honest:
+
+**1. The cell must run as written.** Whatever you put between the fences is what the reader sees, edits, and evaluates. There's no hidden setup. If the counter needs its `app-db` seeded before the view renders, the seeding form is *in the cell* where the reader can see it. A cell that only works because of state left behind by an earlier cell is a trap — write each interactive cell to stand alone.
+
+**2. Tell the reader what to change.** After a cell, name the edit you want them to try and what they should expect. "Change `inc` to `(partial + 10)`, press the eval shortcut, and click `+` — the counter now jumps by ten." A live cell with no suggested experiment is just a slow screenshot.
+
+**3. Name the eval shortcut once per page.** The reader evaluates a cell with `Ctrl-Enter` (or `Cmd-Enter` on macOS). Say so the first time a page asks them to evaluate, the same way [the CLJS reading guide](../cljs/index.md) does. After that you can just say "re-evaluate."
+
+The shape of a good interactive section is: a sentence of *why*, the live cell, then a sentence of *what to try*. The reader reads the claim, sees it running, then makes it their own by changing it.
+
+## What a `cljs-rf2` cell can call
+
+A `cljs-rf2` cell evaluates against re-frame2's real public API. The names that resolve inside a cell:
+
+- **Registrations** — `reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, and the rest of the `reg-*` family. (In compiled code these are plain functions; the macro forms only add source-location capture, which a browser cell doesn't need.)
+- **Runtime verbs** — `dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`. (On the real public surface these are macros; the cell environment binds the same names to their underlying functions, so you write them exactly as in real code.)
+- **The view substrate** — `reagent2.core` (require it `:as r`).
+
+A cell's standard preamble is therefore:
+
+```
+(require '[reagent2.core :as r]
+         '[re-frame.core :as rf])
+```
+
+and from there `rf/reg-event-db`, `rf/reg-sub`, `rf/dispatch`, `rf/subscribe` all work as you'd expect.
+
+### One difference from the static listings: `reg-view`
+
+The static chapters register views with `reg-view`, which auto-injects `dispatch` and `subscribe` as lexical bindings inside the view body (see [07 — Views](07-views.md)). `reg-view` is a macro, and the live-cell environment is functions-only — so **inside a `cljs-rf2` cell you write plain `defn` views and call `rf/dispatch` / `rf/subscribe` explicitly**:
+
+```
+;; In a static chapter (macro available):
+(rf/reg-view counter []
+  [:button {:on-click #(dispatch [:counter/inc])} "+"])
+
+;; In a live cell (plain defn, explicit rf/ verbs):
+(defn counter []
+  [:button {:on-click #(rf/dispatch [:counter/inc])} "+"])
+```
+
+This is the same component — `reg-view` is sugar over exactly this shape. When you port a static chapter to an interactive one, expand the `reg-view` forms into `defn` views and the injected `dispatch`/`subscribe` into qualified `rf/dispatch`/`rf/subscribe`. Mention the equivalence in prose so a reader who's seen the static chapter isn't tripped by the difference; the [counter tutorial](interactive-counter.md) does exactly this.
+
+## Gotchas
+
+A few things bite the first time you author a `cljs-rf2` cell.
+
+**Top-level forms only — never wrap the cell in `(do …)`.** The cell's source is evaluated form-by-form at the top level. A leading `(require …)` only makes its aliases (`rf`, `r`) visible to its *sibling* top-level forms. Wrap the whole body in one `(do …)` and the `require`'s aliases stop resolving for everything inside — `rf/reg-event-db` becomes an "unresolved symbol" error. Keep every form at the top level.
+
+**A `cljs-rf2` cell always renders — its last form must be hiccup.** There is no plain-eval path for a `cljs-rf2` cell; it *mounts* the value of its last form as a component. End every cell with a component vector — `[counter]` — or a literal hiccup vector (`[:div …]`). If the last form is a registration, a `dispatch-sync`, or a bare value like `{:counter/value 6}`, there's nothing renderable to mount and the cell renders blank (or errors). To *show* a computed value — a handler's return, a `compute-sub` result — wrap it in a tiny view that displays it: `(defn demo [] [:div "result: " (str the-value)])` then `[demo]`. (For a pure value-printing cell with no framework, that's what the plain ` ```cljs ` fence is for — but those run stock ClojureScript, not re-frame2.)
+
+**Seed `app-db` before the view reads it.** Inside the cell, `(rf/dispatch-sync [:counter/initialise])` runs synchronously, so by the time the final `[counter]` form mounts, `app-db` already holds the seeded value. Use `dispatch-sync` for this seed-before-render step (same reasoning as [the static counter's mount](03-first-app.md#initialisation)); plain `dispatch` would queue the event and the first render would race an empty `app-db`.
+
+**The re-frame2 engine loads on demand.** The page only pulls the re-frame2 evaluation bundle when it actually contains a `cljs-rf2` cell. Pages with no live re-frame2 cells never pay that cost — but it also means the bundle downloads on first visit to an interactive page, so the first cell may take a moment to come alive. That's expected; subsequent cells on the same page are instant.
+
+**One registry per page, shared across cells.** Every `cljs-rf2` cell on a page evaluates into the *same* re-frame2 runtime. Two cells that both `reg-event-db :counter/inc` will clobber each other's handler, and `app-db` persists across cells on the page. For a linear tutorial that's usually fine — later cells build on earlier ones. But if you want two independent demos on one page, give them distinct, namespaced ids (`:demo-a/inc`, `:demo-b/inc`) so they don't collide. This is the same id-namespacing discipline the framework asks for everywhere; it just matters sooner in a multi-cell page.
+
+## Writing the next interactive tutorial
+
+The [counter tutorial](interactive-counter.md) is the template. To write another:
+
+1. Pick an idea that *rewards being changed* — where the reader editing the code and re-running it teaches more than reading would. If a static block would do the job, write a static chapter.
+2. Build each interactive section as *why → live cell → what to try*.
+3. Make every `cljs-rf2` cell self-contained (require, registrations, seed, view, final renderable), with namespaced ids.
+4. Add the page to `mkdocs.yml` under the Guide nav, next to its static sibling.
+5. Build with `mkdocs build --strict` and load the page in a browser to confirm the cells mount and respond to clicks — a cell that compiles but doesn't render is worse than a static block.
+
+Keep them tight. An interactive tutorial earns its keep with one or two well-chosen live cells, not a wall of them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
     - guide/README.md
     - "02 — app-db": guide/02-app-db.md
     - "03 — First app": guide/03-first-app.md
+    - "Interactive: the counter": guide/interactive-counter.md
     - "04 — Events": guide/04-events.md
     - "05 — Schemas": guide/05-schemas.md
     - "06 — Coeffects": guide/06-coeffects.md


### PR DESCRIPTION
## Summary

The **foundation** for interactive re-frame2 tutorials, built on the docs/cljs playground's live component cells (`cljs-rf2`), plus **one worked end-to-end template tutorial**. Conservative scope: a reviewable starting point Mike can extend or redirect — not a full curriculum.

### The authoring pattern — `docs/guide/interactive-tutorials.md`

A contributor note (sibling to `AUTHORING.md`, out of nav). Covers:
- The three cell kinds and when to use each: ` ```cljs ` (plain eval), ` ```cljs-render ` (stock reagent/re-frame), ` ```cljs-rf2 ` (live re-frame2 own-API) — and that for a re-frame2 guide chapter the answer is almost always `cljs-rf2`.
- The editable-and-evaluable teaching-cell convention: *why → live cell → what to try*; cells must run as written; name the eval shortcut once.
- The `cljs-rf2` API surface (the `reg-*` family, `dispatch`/`dispatch-sync`/`subscribe`/`inject-cofx`, `reagent2.core`), and the one difference from the static chapters: **`reg-view` is macro-only**, so live cells use plain `defn` views with explicit `rf/dispatch`/`rf/subscribe`.
- The gotchas: top-level forms only (no `(do …)` wrap); a `cljs-rf2` cell **always renders** so its last form must be hiccup (wrap a computed value in a tiny view to display it); seed `app-db` with `dispatch-sync`; the rf2 bundle loads on demand; one shared registry per page → namespace ids.

### The template tutorial — `docs/guide/interactive-counter.md`

The canonical counter (an interactive port of `examples/reagent/counter`), live. Five editable `cljs-rf2` cells walk `reg-event-db` → `reg-sub` (incl. a chained `:<-` sub) → a view, each in the *why → live cell → what to try* rhythm. Wired into the Guide nav next to its static sibling (03 — First app). Marked in prose as the template future interactive tutorials follow.

## Browser-verified live cells (headless chromium)

Loaded the built page in chromium and asserted:
- on-demand re-frame2 SCI bundle (`window.rf2sci`) auto-loads
- all 5 `cljs-rf2` cells mount + render live DOM (no errors, non-blank)
- counter seeds to **5**; clicking **+** twice → **7**; **-** once → **6**
- handler-demo shows before=5 / after=6; sub-demo shows 5; doubled-demo shows 10
- no uncaught page errors

## Foundation note

This is the starting point. The authoring note's "Writing the next interactive tutorial" section and the counter's "Where this goes" section both invite extension — Mike can grow the interactive track or redirect its shape from here.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] `scripts/check_doc_slugs.py` passes (no broken links/anchors)
- [x] Headless-chromium verification of all `cljs-rf2` cells (mount + eval + click)