### PR TITLE
fix(re-frame2-pair): shim papercuts — --build colon, phantom trace API in SKILL.md, port-file resolution (rf2-n3yn6)

### DIFF
--- a/docs/skills/re-frame2-pair.md
+++ b/docs/skills/re-frame2-pair.md
@@ -9,7 +9,7 @@ The `re-frame2-pair` skill is the AI pair-programming companion for a running re
 Three primitives carry the skill's agency, all part of re-frame2's [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md):
 
 1. **The REPL** — ClojureScript forms evaluated against the real app, usually through helpers in the injected `re-frame2-pair.runtime` namespace.
-2. **The trace stream** — `(rf/register-listener! id listener)` for live trace events; `(rf/trace-buffer opts)` for the retain-N ring of recent events.
+2. **The trace stream** — `(rf/register-listener! id listener)` for live trace events; `(re-frame.trace.tooling/trace-buffer opts)` for the retain-N ring of recent events (`rf/trace-buffer` is a JVM-only alias, so CLJS callers use the `re-frame.trace.tooling` ns).
 3. **The epoch history** — `(rf/epoch-history frame-id)` returns the per-frame ring of `:rf/epoch-record` values, each carrying `:db-before`, `:db-after`, `:trace-events`, and the assembled `:sub-runs` / `:renders` / `:effects` projections.
 
 The skill is **multi-frame aware** (Spec 002 — most apps run with one frame, larger apps run several). It registers exactly **one** trace listener (`:re-frame2-pair`) and one epoch listener (`:re-frame2-pair-epoch`) so it coexists with other tools (e.g. `re-frame-10x` v2) on the same bus. Mutating ops refuse with `:ambiguous-frame` when the operating frame is unclear.

--- a/skills/re-frame2-pair/README.md
+++ b/skills/re-frame2-pair/README.md
@@ -15,7 +15,7 @@ A coding agent working with just the **static code** is working with a limited p
 It can:
 
 - use the REPL
-- consume re-frame2's Tool-Pair surfaces directly: the trace stream (`register-trace-listener`), the retain-N trace buffer (`trace-buffer`), the per-frame epoch history (`epoch-history`), the registered handler/sub/fx/machine introspection API (`registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `machines`, `machine-meta`, `app-schemas`, `sub-cache`), and first-class time-travel via `restore-epoch`
+- consume re-frame2's Tool-Pair surfaces directly: the trace stream (`re-frame.trace.tooling/register-listener!`), the retain-N trace buffer (`re-frame.trace.tooling/trace-buffer`), the per-frame epoch history (`epoch-history`), the registered handler/sub/fx/machine introspection API (`registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `machines`, `machine-meta`, `app-schemas`, `sub-cache`), and first-class time-travel via `restore-epoch`
 - use re-frame2's source-coord annotation (`data-rf2-source-coord`) — and re-com's `data-rc-src` as a fallback — to bridge live DOM elements back to source `{:ns :line :file}`
 
 With these capabilities, Claude Code can iteratively perform experiments by patching parts of the system, restoring state to a recorded epoch, retrying events and seeing the results.
@@ -212,7 +212,7 @@ The pieces (design; see *Status* above):
 2. `eval-cljs` (MCP tool `mcp__re-frame2-pair__eval-cljs`) sends short ClojureScript forms over nREPL into the browser runtime and returns edn.
 3. `preload/re_frame2_pair/runtime.cljs` is the `re-frame2-pair.runtime` namespace itself, loaded into the consumer app via shadow-cljs's `:devtools :preloads`. It registers exactly one trace listener (`:re-frame2-pair`) and one epoch listener (`:re-frame2-pair-epoch`), and installs the `js/globalThis.__re_frame2_pair_runtime` marker the connect-flow probes.
 4. `SKILL.md` teaches Claude a verb vocabulary (read / write / trace / watch / hot-reload / time-travel) mapped onto those forms, plus diagnostic recipes composed from them.
-5. All trace and epoch reads come from re-frame2's own surfaces — `register-trace-listener`, `trace-buffer`, `register-epoch-listener!`, `epoch-history`. Render entries are projected by re-frame2 itself in `:renders`, with `:ns` / `:line` / `:file` resolvable through the registrar's source-coord capture (Spec 001).
+5. All trace and epoch reads come from re-frame2's own surfaces — `re-frame.trace.tooling/register-listener!`, `re-frame.trace.tooling/trace-buffer`, `register-epoch-listener!`, `epoch-history`. Render entries are projected by re-frame2 itself in `:renders`, with `:ns` / `:line` / `:file` resolvable through the registrar's source-coord capture (Spec 001).
 
 See [`docs/initial-spec.md`](docs/initial-spec.md) for the full operation catalogue, architecture, error surfaces, versioning, and phased delivery plan.
 

--- a/skills/re-frame2-pair/README.md
+++ b/skills/re-frame2-pair/README.md
@@ -198,7 +198,7 @@ Useful when you want to force the tool, or when the phrasing of your question do
 
 The skill's first op in a session is `discover-app`, which:
 
-1. Finds the running shadow-cljs nREPL (from `target/shadow-cljs/nrepl.port`, falling back to `.shadow-cljs/nrepl.port` or the `SHADOW_CLJS_NREPL_PORT` env var — the exact location depends on shadow-cljs version and config).
+1. Finds the running shadow-cljs nREPL. The `SHADOW_CLJS_NREPL_PORT` env var is a CWD-independent override that wins outright; otherwise the shim scans the standard port files (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`) at both the CWD and under `implementation/`, and picks the **most-recently-modified** one — so a freshly (re)started build always beats a stale leftover port file.
 2. Verifies a browser runtime is attached to that build.
 3. Checks that `re-frame.core` is loaded and `re-frame.interop/debug-enabled?` is true.
 4. Probes the `re-frame2-pair.runtime` preload marker; refuses with `:reason :runtime-not-preloaded` and a setup hint when absent.

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -63,7 +63,7 @@ This is a **router skill**. The trigger-time guard rails live below; the operati
 Your agency runs through three coupled primitives, all part of re-frame2's own [Tool-Pair contract](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md):
 
 1. **The REPL** — a shadow-cljs nREPL session connected to the browser runtime, where ClojureScript forms evaluate against the real app.
-2. **The trace stream** — `(rf/register-trace-listener id cb)` for live trace events; `(rf/trace-buffer opts)` for the retain-N ring of recent events. This skill registers exactly *one* trace listener (under id `:re-frame2-pair`) so multiple tools can coexist.
+2. **The trace stream** — `(re-frame.trace.tooling/register-listener! id cb)` for live trace events; `(re-frame.trace.tooling/trace-buffer opts)` for the retain-N ring of recent events. (`register-listener!` is re-exported on `rf/`, but `trace-buffer` is a **JVM-only** alias on `rf/` — CLJS callers, including this shim's `cljs-eval`, must reach for `re-frame.trace.tooling/trace-buffer` directly or the form silently returns nil.) This skill registers exactly *one* trace listener (under id `:re-frame2-pair`) so multiple tools can coexist.
 3. **The epoch history** — `(rf/epoch-history frame-id)` returns the per-frame ring of `:rf/epoch-record` values, each carrying the cascade's `:db-before`, `:db-after`, `:trace-events`, and the structured `:sub-runs` / `:renders` / `:effects` projections. `(rf/register-epoch-listener! id cb)` is the assembled-stream listener.
 
 Every operation eventually becomes a short ClojureScript form evaluated through the REPL, usually against a helper function in the `re-frame2-pair.runtime` namespace that the consumer app preloads (see §Setup below).
@@ -181,7 +181,7 @@ Load at most two references for a single task. If you find yourself wanting thre
   - The preload's `app-db-reset!` taps default-elide both `:previous` and `:next` payloads through `re-frame.core/elide-wire-value` before any registered tap consumer sees them.
   - The streaming subscription dispatch additionally drops `:sensitive? true` trace events at source (the preload's `streaming-drop?` filter).
 
-  Operators who need raw state for offline debug pass `--allow-sensitive-reads` at server launch — then the per-call MCP args win again (`:include-sensitive? true` and `:elision false` ride through). The retain-N ring buffer reached via `(rf/trace-buffer)` is a separate, explicit read surface — direct CLJS callers see everything regardless of the gate. Same architecture as the `--allow-eval` gate on `eval-cljs` and the canonically-named `--allow-sensitive-reads` gate on story-mcp. See [references/vocabulary.md §Privacy posture](references/vocabulary.md#privacy-posture--sensitive-and-the-streaming-surface).
+  Operators who need raw state for offline debug pass `--allow-sensitive-reads` at server launch — then the per-call MCP args win again (`:include-sensitive? true` and `:elision false` ride through). The retain-N ring buffer reached via `(re-frame.trace.tooling/trace-buffer)` is a separate, explicit read surface — direct CLJS callers see everything regardless of the gate. Same architecture as the `--allow-eval` gate on `eval-cljs` and the canonically-named `--allow-sensitive-reads` gate on story-mcp. See [references/vocabulary.md §Privacy posture](references/vocabulary.md#privacy-posture--sensitive-and-the-streaming-surface).
 
 ---
 

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -123,6 +123,12 @@ This locates the shadow-cljs nREPL port, connects, switches the session to `:clj
 
 If any precondition fails, the script returns a structured edn error like `{:ok? false :reason :runtime-not-preloaded}`. Report the failing check to the user verbatim; do *not* guess at workarounds. See [references/errors.md](references/errors.md) for the common error reasons and the recovery each one calls for.
 
+**Port discovery (bash-shim transport).** The shim finds the nREPL port by scanning shadow-cljs's standard port-file locations (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`) at both the shell CWD *and* under `implementation/`, then picks the **most-recently-modified** file — so a freshly (re)started dev build always wins over a stale leftover port file. If discovery still resolves the wrong port (`connection refused` / wrong build) — e.g. multiple builds running, or a port file living somewhere non-standard — set **`SHADOW_CLJS_NREPL_PORT`** to the live port; it is a CWD-independent override that bypasses file discovery entirely:
+
+```
+SHADOW_CLJS_NREPL_PORT=51708 scripts/discover-app.sh
+```
+
 Between user turns, the nREPL session persists. A full page refresh in the browser drops the runtime, but the preload re-installs it on the next bundle load — no manual reconnect step is needed. Every op checks the load-time marker (`js/globalThis.__re_frame2_pair_runtime`) before proceeding; if it's missing the op refuses with the structured `:runtime-not-preloaded` hint above.
 
 If you want a refresher on the MCP surface before the first real op, optionally call `get-re-frame2-pair-instructions` (formal name `mcp__re-frame2-pair__get-re-frame2-pair-instructions`) — it returns inline onboarding text (tool catalogue, EDN posture, tagged-mutation conventions, streaming-subscribe semantics, the wire pipeline) with no nREPL round-trip.

--- a/skills/re-frame2-pair/STATUS.md
+++ b/skills/re-frame2-pair/STATUS.md
@@ -35,7 +35,7 @@ truth on demand. Still pre-alpha — see *Known unknowns* below.
 |---|---|---|---|
 | 0 | `eval-cljs.sh` round-trips a form | **Coded, not yet run** | `scripts/eval-cljs.sh` + `ops.clj` implement it; needs a live nREPL to verify. |
 | 1 | Read surface (§4.1) | **Coded** | `app-db/snapshot`, `app-db/get`, `app-db/schemas`, `registrar/list`, `registrar/describe`, `subs/cache`, `subs/sample`, `machines/*` — all over `rf/get-frame-db`, `rf/snapshot-of`, `rf/registrations`, `rf/handler-meta`, `rf/sub-cache`, `rf/machines`, `rf/machine-meta`, `rf/app-schemas`. |
-| 2 | Dispatch + trace (§4.2–§4.3) | **Coded** | `pair-dispatch!` / `pair-dispatch-sync!` / `dispatch-and-collect`; trace consumed via `rf/register-trace-listener`, `rf/trace-buffer`, `rf/register-epoch-listener!`, `rf/epoch-history`. No 10x dependency. |
+| 2 | Dispatch + trace (§4.2–§4.3) | **Coded** | `pair-dispatch!` / `pair-dispatch-sync!` / `dispatch-and-collect`; trace consumed via `re-frame.trace.tooling/register-listener!`, `re-frame.trace.tooling/trace-buffer`, `rf/register-epoch-listener!`, `rf/epoch-history`. No 10x dependency. |
 | 3 | Live watch (§4.4) | **Coded, pull-mode only** | `scripts/watch-epochs.sh` runs repeated short evals at 100ms cadence against `epochs-since`; assembled-stream listener feeds an internal stash. Streaming-via-`:out` deferred. |
 | 4 | Hot-swap (REPL) | **Coded** | Delivered by `reg-event-fx`/`reg-sub`/`reg-fx`/`reg-machine` via `eval-cljs.sh`. Re-registration emits `:rf.registry/handler-replaced` per Spec 001 §Hot-reload semantics. |
 | 5 | Hot-reload coordination (§4.5) | **Coded** | `tail-build.sh` implements the probe-based protocol — preferred probes target `(rf/handler-meta ...)` since the meta map's `:line` / `:column` / `:handler-fn` change after re-registration. |
@@ -79,7 +79,7 @@ Four colon-separated segments, where `<ns>` and `<handler-id>` derive from the r
 
 ## What's genuinely verified
 
-- `re-frame.core` exposes the Tool-Pair surfaces this skill consumes — `register-trace-listener`, `trace-buffer`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `configure`, `registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `get-frame-db`, `snapshot-of`, `sub-cache`, `machines`, `machine-meta`, `app-schemas` — confirmed in `re-frame2/implementation/src/re_frame/core.cljc`.
+- `re-frame.core` exposes the Tool-Pair surfaces this skill consumes — `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `configure`, `registrations`, `handler-meta`, `frame-ids`, `frame-meta`, `get-frame-db`, `snapshot-of`, `sub-cache`, `machines`, `machine-meta`, `app-schemas` — confirmed in `implementation/core/src/re_frame/core.cljc`. The `trace-buffer` reader lives in `re-frame.trace.tooling` (re-exported on `rf/` JVM-side only); CLJS callers use the `re-frame.trace.tooling` ns directly.
 - Epoch records carry the documented `:rf/epoch-record` shape — confirmed in `re-frame2/implementation/src/re_frame/epoch.cljc` (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, `:trace-events`, `:sub-runs`, `:renders`, `:effects`).
 - `restore-epoch` implements the six documented failure modes per Tool-Pair §Time-travel.
 - shadow-cljs nREPL accepts JVM `(shadow.cljs.devtools.api/cljs-eval ...)` calls (well-known).

--- a/skills/re-frame2-pair/STATUS.md
+++ b/skills/re-frame2-pair/STATUS.md
@@ -53,7 +53,7 @@ Three things need to be proven against a fixture before calling this beyond pre-
 
 `scripts/discover-app.sh` needs to actually connect against a real re-frame2 app. Specific unknowns:
 
-- nREPL port location across shadow-cljs versions (we try `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`, and `$SHADOW_CLJS_NREPL_PORT` in that order).
+- nREPL port location across shadow-cljs versions. `$SHADOW_CLJS_NREPL_PORT` (a CWD-independent override) wins outright; otherwise we scan `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port` at both the CWD and under `implementation/`, and pick the most-recently-modified file (so a live build's freshly-written port file beats a stale leftover).
 - CLJS-mode switch — does `(shadow.cljs.devtools.api/cljs-eval <build-id> <form-str> {})` return the `:value` in a parseable edn form, or wrapped in a shadow-specific result map?
 - `re-frame.interop/debug-enabled?` — verify the symbol is reachable post-init. The current health check reads the var directly, which works in CLJS but may need adjustment if the symbol is moved.
 

--- a/skills/re-frame2-pair/docs/LOCAL_DEV.md
+++ b/skills/re-frame2-pair/docs/LOCAL_DEV.md
@@ -105,13 +105,19 @@ Restart the shell (and Claude Code) so the new `PATH` takes effect.
 
 ### `:nrepl-port-not-found`
 
-`discover-app.sh` couldn't locate `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, or `$SHADOW_CLJS_NREPL_PORT`. Start your dev build:
+`discover-app.sh` couldn't locate a port file (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, or `.nrepl-port` — probed at the CWD and under `implementation/`) and `$SHADOW_CLJS_NREPL_PORT` is unset. Start your dev build:
 
 ```bash
 npx shadow-cljs watch <build-id>
 ```
 
 ...and make sure nREPL is enabled for the build.
+
+If a build *is* running but discovery picks the wrong port (`connection refused`, or it attaches to a stale build), set the override explicitly — it bypasses file discovery entirely and is independent of the shell's working directory:
+
+```bash
+SHADOW_CLJS_NREPL_PORT=<live-port> scripts/discover-app.sh
+```
 
 ### `:debug-disabled`
 

--- a/skills/re-frame2-pair/docs/capabilities.md
+++ b/skills/re-frame2-pair/docs/capabilities.md
@@ -73,7 +73,7 @@ What re-frame2-pair can see inside a live re-frame2 app.
 | List recorded epochs per frame | *done* | `epoch/history` over `rf/epoch-history` |
 | Restore an epoch | *done* | `epoch/restore` over `rf/restore-epoch` |
 | Step back one epoch | *done* | `undo/step-back` (sugar) |
-| Restore failure surfaces | *done* | Six modes, all documented (Tool-Pair §Time-travel); `(rf/trace-buffer {:op-type :error})` carries the structured tags |
+| Restore failure surfaces | *done* | Six modes, all documented (Tool-Pair §Time-travel); `(re-frame.trace.tooling/trace-buffer {:op-type :error})` carries the structured tags |
 | Configure ring depth | *done* | `(rf/configure :epoch-history {:depth N})` |
 | Reverse side effects | *guardrail* | Restore rewinds `app-db` only; SKILL.md asks Claude to enumerate non-pure effects from the cascade and warn before restoring |
 

--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -36,7 +36,7 @@ re-frame2-pair itself contributes **zero** additional host-project configuration
 
 ### Terminology
 
-- **Trace stream** — `(rf/register-trace-listener)` listeners + `(rf/trace-buffer)` retain-N ring. The fine-grained, per-emit stream (Spec 009).
+- **Trace stream** — `(re-frame.trace.tooling/register-listener!)` listeners + `(re-frame.trace.tooling/trace-buffer)` retain-N ring. The fine-grained, per-emit stream (Spec 009). (`register-listener!` is also on `rf/`; `trace-buffer` is a JVM-only `rf/` alias, so CLJS callers use the `re-frame.trace.tooling` form.)
 - **Assembled epoch** — one `:rf/epoch-record` per drain-settle, with structured `:sub-runs` / `:renders` / `:effects` projections plus `:trace-events`. Consumed via `(rf/register-epoch-listener!)` and `(rf/epoch-history frame-id)`.
 - **Frame** — a re-frame2 isolated runtime instance (Spec 002). Most apps have one (`:rf/default`); larger apps have several.
 - **Origin** — the Spec 002 §Dispatch origin tagging keyword on every dispatch (`:app`, `:pair`, `:story`, `:ui`, `:timer`, `:http`...). The skill stamps `:pair` on its own dispatches.
@@ -74,9 +74,9 @@ shadow-cljs nREPL into the connected browser runtime. Same as v1.
 
 Where v1 reached into re-frame-10x's internal epoch buffer, v2 consumes re-frame2's own surfaces:
 
-- `(rf/register-trace-listener :re-frame2-pair cb)` — raw trace stream. The skill's listener id is fixed (one listener per skill per Spec 009).
-- `(rf/register-epoch-listener! :re-frame2-pair-epoch cb)` — assembled-epoch stream. Mirrors `register-trace-listener`'s contract.
-- `(rf/trace-buffer opts)` — retain-N trace ring (default 200, configurable via `(rf/configure :trace-buffer {:depth N})`).
+- `(re-frame.trace.tooling/register-listener! :re-frame2-pair cb)` — raw trace stream (also re-exported on `rf/`). The skill's listener id is fixed (one listener per skill per Spec 009).
+- `(rf/register-epoch-listener! :re-frame2-pair-epoch cb)` — assembled-epoch stream. Mirrors `register-listener!`'s contract.
+- `(re-frame.trace.tooling/trace-buffer opts)` — retain-N trace ring (default 200, configurable via `(rf/configure :trace-buffer {:depth N})`). CLJS callers must use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is a JVM-only alias and returns nil in the browser runtime.
 - `(rf/epoch-history frame-id)` — per-frame epoch ring (default 50, configurable via `(rf/configure :epoch-history {:depth N})`).
 - `(rf/restore-epoch frame-id epoch-id)` — first-class time-travel with six documented failure modes (Tool-Pair §Time-travel).
 

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -305,7 +305,7 @@
        {:ok?    false
         :frame  frame-id
         :reason :reset-rejected
-        :hint   "rf/reset-frame-db! returned false. Inspect (rf/trace-buffer {:op-type :error}) and {:op-type :rf.epoch} for the structured reason — :rf.error/no-such-handler, :rf.epoch/reset-frame-db-during-drain, or :rf.epoch/reset-frame-db-schema-mismatch."})
+        :hint   "rf/reset-frame-db! returned false. Inspect (re-frame.trace.tooling/trace-buffer {:op-type :error}) and {:op-type :rf.epoch} for the structured reason — :rf.error/no-such-handler, :rf.epoch/reset-frame-db-during-drain, or :rf.epoch/reset-frame-db-schema-mismatch. (rf/trace-buffer is JVM-only; CLJS callers use the re-frame.trace.tooling ns.)"})
      (catch :default e
        (let [{:keys [reason] :as data} (ex-data e)]
          {:ok?     false
@@ -629,7 +629,8 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The framework already maintains a retain-N ring buffer accessible via
-;; `(rf/trace-buffer opts)`. We register one listener here for callers
+;; `(re-frame.trace.tooling/trace-buffer opts)` (the `rf/` alias is
+;; JVM-only). We register one listener here for callers
 ;; that want a programmatic side-channel (e.g. a watch loop's idle
 ;; detector); the buffer remains the canonical query surface.
 
@@ -654,7 +655,7 @@
 
 (defn last-trace-event-id
   "Last trace event id observed by the skill's listener. Useful as a
-   `:since` cursor for `(rf/trace-buffer {:since N})`."
+   `:since` cursor for `(re-frame.trace.tooling/trace-buffer {:since N})`."
   []
   @last-trace-id)
 
@@ -708,7 +709,7 @@
 ;;
 ;; Topic semantics:
 ;;   :trace  — every event in the raw trace stream matching `:filter`
-;;             (filter map mirrors `(rf/trace-buffer)` filter vocab —
+;;             (filter map mirrors `(re-frame.trace.tooling/trace-buffer)` filter vocab —
 ;;             see the trace-buffer surface). One event per delivered trace event.
 ;;   :epoch  — every assembled `:rf/epoch-record` matching `:filter`
 ;;             (filter map mirrors `epoch-matches?` — see watch-epochs).
@@ -752,7 +753,7 @@
 ;; happens in re-frame2-pair: the MCP server registers a subscription, polls
 ;; `drain-subscription!`, and forwards every drained event back to the
 ;; agent as a `notifications/progress` payload. The retain-N ring buffer
-;; reached via `(rf/trace-buffer)` is a separate, explicit read surface;
+;; reached via `(re-frame.trace.tooling/trace-buffer)` is a separate, explicit read surface;
 ;; agents asking for it are making a deliberate request and the filter
 ;; vocabulary already exposes `:sensitive? false` for tools that want to
 ;; pre-filter (see Spec 009 §Filter vocabulary).
@@ -764,7 +765,7 @@
 ;; The flag is consulted at `on-trace-streaming` entry — before any
 ;; subscription's queue sees the event. Dropped events still update the
 ;; `last-trace-id` cursor (so `last-trace-event-id` keeps incrementing
-;; monotonically) and still ride `(rf/trace-buffer)` unchanged — only
+;; monotonically) and still ride `(re-frame.trace.tooling/trace-buffer)` unchanged — only
 ;; the streaming dispatch is gated.
 
 (defonce ^:private privacy-config
@@ -821,7 +822,7 @@
 
 (defn- trace-matches?
   "Test a raw trace event against a filter map. Mirrors the filter
-   vocabulary of `(rf/trace-buffer opts)` — composes
+   vocabulary of `(re-frame.trace.tooling/trace-buffer opts)` — composes
    AND-wise, absent key means no constraint on that axis."
   [filter-map ev]
   (let [{:keys [operation op-type frame severity
@@ -1214,7 +1215,7 @@
 (defn restore-epoch
   "(rf/restore-epoch frame-id epoch-id). Returns true on success, false
    on any failure mode. Failure traces fire under :rf.epoch/* — read
-   them with `(rf/trace-buffer {:op-type :error})`."
+   them with `(re-frame.trace.tooling/trace-buffer {:op-type :error})`."
   ([epoch-id] (restore-epoch epoch-id (current-frame)))
   ([epoch-id frame-id]
    (rf/restore-epoch frame-id epoch-id)))

--- a/skills/re-frame2-pair/references/errors.md
+++ b/skills/re-frame2-pair/references/errors.md
@@ -11,7 +11,7 @@ Every script returns structured edn like `{:ok? false :reason ...}` rather than 
 - `:ns-not-loaded :missing :re-frame2` → re-frame2 isn't loaded; check the user's deps.
 - `:no-frames-registered` → no frame is up yet. Tell the user to call `(rf/init!)` (or wait for app boot).
 - `:ambiguous-frame` → multiple frames; ask the user to `frames/select` or pass `--frame :foo`.
-- `:handler-error` inside an epoch → the user's handler threw; surface the `:rf.error/handler-exception` trace event from `(rf/trace-buffer {:op-type :error})`.
+- `:handler-error` inside an epoch → the user's handler threw; surface the `:rf.error/handler-exception` trace event from `(re-frame.trace.tooling/trace-buffer {:op-type :error})`. (Use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is JVM-only and returns nil in the browser runtime.)
 
 ## Pointing the user at the offending handler
 
@@ -22,7 +22,7 @@ Every `:rf.error/*` trace event carries `:rf.trace/trigger-handler` — `{:kind 
 
 ## `:on-error` policy violations
 
-Two error categories surface when a frame's `:on-error` policy violates its return-map contract. Both ride the trace stream like any other `:rf.error/*` event — pull them with `(rf/trace-buffer {:op-type :error})` and surface to the user verbatim. For the full contract (closed return shape, the `:recovery` enum, why `:retry-count` is gone), see [on-error.md](on-error.md).
+Two error categories surface when a frame's `:on-error` policy violates its return-map contract. Both ride the trace stream like any other `:rf.error/*` event — pull them with `(re-frame.trace.tooling/trace-buffer {:op-type :error})` and surface to the user verbatim. For the full contract (closed return shape, the `:recovery` enum, why `:retry-count` is gone), see [on-error.md](on-error.md).
 
 - `:rf.error/bad-on-error-return` (`:recovery :logged-and-skipped`) → the policy returned a map with a `:recovery` outside the closed enum (commonly the now-removed `:retried`), or set `:replacement` malformed or on a category that has no substitutable value. The runtime falls back to the original error's category default. `:tags {:received <map> :reason <str>}` names the offending shape — quote it to the user; the fix is almost always "drop `:retry-count` and pick a real `:recovery` keyword".
 - `:rf.error/on-error-policy-exception` (`:recovery :no-recovery`) → the policy fn itself threw. The runtime does NOT recursively invoke the policy on its own exception — it emits this trace and falls back to the original error's category default. `:tags {:original <input-error-event> :exception-message <str>}` carries the original error the policy was handling plus the throw message. Cascade halts; the policy's exception does not propagate to user code. Surface both the original op and the throw site to the user.

--- a/skills/re-frame2-pair/references/on-error.md
+++ b/skills/re-frame2-pair/references/on-error.md
@@ -58,7 +58,7 @@ mcp__re-frame2-pair__eval-cljs {form: "(:on-error (rf/frame-meta :rf/default))"}
 mcp__re-frame2-pair__eval-cljs {
   form: "(filter #(#{:rf.error/bad-on-error-return
                      :rf.error/on-error-policy-exception} (:operation %))
-                 (rf/trace-buffer {:op-type :error}))"
+                 (re-frame.trace.tooling/trace-buffer {:op-type :error}))"
 }
 
 ;; Hot-swap a policy (ephemeral; survives until full page reload):

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -62,7 +62,7 @@ Read-only from the trace stream + epoch history.
 
 | Op | Invocation | Returns |
 |---|---|---|
-| `trace/buffer` | `mcp__re-frame2-pair__eval-cljs {form: "(rf/trace-buffer)"}` | Recent N trace events from the retain-N ring (Spec 009 §Retain-N trace ring buffer). Optional `{:operation _ :op-type _ :since _ :frame _}` filter. |
+| `trace/buffer` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame.trace.tooling/trace-buffer)"}` | Recent N trace events from the retain-N ring (Spec 009 §Retain-N trace ring buffer). Optional `{:operation _ :op-type _ :since _ :frame _}` filter. **CLJS callers must use the `re-frame.trace.tooling` ns** — `rf/trace-buffer` is a JVM-only alias and silently returns nil in the browser runtime this skill drives. |
 | `trace/last-epoch` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/last-epoch)"}` | Most recent `:rf/epoch-record` for the operating frame |
 | `trace/last-pair-epoch` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/last-pair-epoch)"}` | Most recent epoch whose `:trigger-event`'s top-level dispatch carried `:origin :pair` (i.e. *this skill* fired it) |
 | `trace/epoch` | `mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/epoch-by-id <id>)"}` | The named epoch from the frame's history |
@@ -144,7 +144,7 @@ mcp__re-frame2-pair__tail-build {wait-ms: 5000, probe: "(some/probe-form)"}
 - After editing a view or helper: pick a CLJS form that derefs the view's namespace var (e.g. `(some-ns/my-view)` or `(meta #'some-ns/my-view)`).
 - If you don't know a good probe, omit `probe` and the tool falls back to a 300ms timer; the result includes `:soft? true` so you know it's timer-based.
 
-A successful probe-flip also coincides with a `:rf.registry/handler-replaced` trace event arriving in the buffer, so an alternative confirmation is `(filter #(= :rf.registry/handler-replaced (:operation %)) (rf/trace-buffer {:since <pre-edit-id>}))`. Use whichever fits — they're not exclusive.
+A successful probe-flip also coincides with a `:rf.registry/handler-replaced` trace event arriving in the buffer, so an alternative confirmation is `(filter #(= :rf.registry/handler-replaced (:operation %)) (re-frame.trace.tooling/trace-buffer {:since <pre-edit-id>}))`. Use whichever fits — they're not exclusive.
 
 ## Time-travel (epoch restore)
 
@@ -169,7 +169,7 @@ re-frame2 ships first-class time-travel as part of the Tool-Pair contract — no
 | Version mismatch | `:rf.epoch/restore-version-mismatch` | Recorded `:rf/snapshot-version` of an active machine is incompatible with the currently-loaded definition (hot-reload bumped it) |
 | Concurrent drain | `:rf.epoch/restore-during-drain` | Called while the frame's run-to-completion drain is in flight |
 
-When `restore-epoch` returns `false`, read the matching trace event from `(rf/trace-buffer {:op-type :error})` to get the structured `:tags`, then report to the user.
+When `restore-epoch` returns `false`, read the matching trace event from `(re-frame.trace.tooling/trace-buffer {:op-type :error})` to get the structured `:tags`, then report to the user.
 
 **Caveat (always tell the user before restoring):** restore rewinds `app-db` only. Side effects that already fired (HTTP requests sent, navigation pushed, localStorage written, `:dispatch-later` already landed) are *not* undone.
 

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -87,7 +87,7 @@ Given a component name or render key, find the latest epoch whose `:renders` inc
 
 ## "Explain this error" / "What caused this error?"
 
-1. Pull recent error traces: `(rf/trace-buffer {:op-type :error})`. Each entry is an `:rf.error/*` op with `:rf.error/data`.
+1. Pull recent error traces: `(re-frame.trace.tooling/trace-buffer {:op-type :error})`. Each entry is an `:rf.error/*` op with `:rf.error/data`. (Use the `re-frame.trace.tooling` ns — `rf/trace-buffer` is JVM-only and returns nil in the browser runtime this skill drives.)
 2. Read `:rf.trace/trigger-handler` on the error event — `{:kind :event :id :user/save :source-coord {:ns ... :file ... :line ... :column ...}}`. This is the **handler that was executing when the error fired**, not the throw site inside the framework. Report it as `<kind> :<id> at <file>:<line>` so the user can jump straight to the source — works in production builds (the field is not elided like `:rf.assert/*`).
 3. If the error sits inside a known epoch, cross-check `:trigger-event` and walk the cascade via `:parent-dispatch-id` — the upstream event that queued the offending handler is often the real culprit.
 4. If `:rf.trace/trigger-handler` is **absent**, the error fired at dispatch-time before any handler ran (e.g. `:rf.error/no-such-event` because the registered id is misspelt). The `:rf.error/data` payload — the failing id, the lookup map — is then the only handle; offer to `registrar/list` the matching kind to find a near match.
@@ -135,7 +135,7 @@ Canonical procedure:
 
 1. `trace/dispatch-and-collect [:foo ...]` → observe baseline. Capture the `:epoch-id` from the resulting record.
 2. **Tell the user** which side effects in the cascade can't be rewound. Walk `:trace-events` for `:event/do-fx` involving non-pure fx (`:http`, navigation, localStorage, `:dispatch-later` that already landed) and warn before restoring.
-3. `epoch/restore <epoch-id>` → rewind `app-db`. Watch for `false` return + check `(rf/trace-buffer {:op-type :error})` for the failure reason.
+3. `epoch/restore <epoch-id>` → rewind `app-db`. Watch for `false` return + check `(re-frame.trace.tooling/trace-buffer {:op-type :error})` for the failure reason.
 4. **Modify the part of the system you're iterating on.**
    - *Handlers / subs / fx:* `(rf/reg-event-fx :foo ...)` / `(rf/reg-sub :bar ...)` / `(rf/reg-fx :baz ...)` via `repl/eval`. The registrar replaces; `:rf.registry/handler-replaced` fires.
    - *Machines:* `(rf/reg-machine :auth ...)` — bumps the machine's `:version` if one is supplied. Old snapshots may now `:rf.epoch/restore-version-mismatch` against this machine.

--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -51,7 +51,7 @@ The filter map is `nil` (no filter) or a topic-specific map. Server-side normali
 
 ### `:trace` / `:fx` / `:error` — trace-buffer filter vocab
 
-Mirrors `(rf/trace-buffer)` per Spec 009. Recognised keys:
+Mirrors `(re-frame.trace.tooling/trace-buffer)` per Spec 009. Recognised keys:
 
 - `:operation` — exact trace operation keyword (e.g. `:event/dispatched`)
 - `:op-type` — broad category: `:event` `:sub` `:fx` `:render` `:cofx` `:error` `:registry` `:internal`

--- a/skills/re-frame2-pair/references/vocabulary.md
+++ b/skills/re-frame2-pair/references/vocabulary.md
@@ -29,8 +29,11 @@ wrong skill — close this and answer from the spec corpus directly.
 - **reg-machine** — state-machine handler registrations (Spec 005).
 - **interceptor** — the cascade middleware contract; introspectable via
   `handler-meta`.
-- **trace-buffer** / **register-trace-listener** — the raw trace stream and its
-  listener registration (Spec 009).
+- **trace-buffer** / **register-listener!** — the raw trace stream's retain-N
+  ring and its listener registration (Spec 009). Both live in
+  `re-frame.trace.tooling`; `register-listener!` is re-exported on `rf/`,
+  `trace-buffer` is a JVM-only `rf/` alias (CLJS callers use the
+  `re-frame.trace.tooling` form).
 - **register-epoch-listener!** / **epoch-history** / **restore-epoch** — the
   assembled-stream listener, the per-frame ring of epoch records, and the
   time-travel entry point.
@@ -63,8 +66,8 @@ This skill honours that contract. The preload's streaming dispatch
 (`on-trace-streaming` → `dispatch-trace-to-subs!`, fed by every
 `subscribe!`) drops `:sensitive? true` events before any subscription
 queue sees them. The retain-N ring buffer reached via
-`(rf/trace-buffer)` is unaffected — agents asking for it are making a
-deliberate request and can pre-filter with `(rf/trace-buffer {:sensitive? false})`.
+`(re-frame.trace.tooling/trace-buffer)` is unaffected — agents asking for it are making a
+deliberate request and can pre-filter with `(re-frame.trace.tooling/trace-buffer {:sensitive? false})`.
 
 ### What gets dropped, what doesn't
 
@@ -73,7 +76,7 @@ deliberate request and can pre-filter with `(rf/trace-buffer {:sensitive? false}
   cursor still advances over them so `:since`-based ring-buffer reads
   remain monotonic.
 - **Not dropped**: events with `:sensitive? false` or no `:sensitive?`
-  key, the underlying `rf/trace-buffer` ring, and `:rf/epoch-record`
+  key, the underlying `re-frame.trace.tooling/trace-buffer` ring, and `:rf/epoch-record`
   values surfaced via `epoch-history` / the `:epoch` streaming topic.
   Epoch records do not carry a top-level `:sensitive?` stamp per spec;
   schema-sensitive slots are redacted by the app-side elision walker

--- a/skills/re-frame2-pair/scripts/discover-app.sh
+++ b/skills/re-frame2-pair/scripts/discover-app.sh
@@ -8,7 +8,9 @@
 # `@day8/re-frame2-pair-mcp` (tools/re-frame2-pair-mcp/). Kept for back-compat.
 #
 # Usage:
-#   scripts/discover-app.sh [--build=:app]
+#   scripts/discover-app.sh [--build=app]
+# (--build accepts both `app` and `:app`; default build is `app` or
+#  $SHADOW_CLJS_BUILD_ID.)
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 command -v bb >/dev/null 2>&1 || {

--- a/skills/re-frame2-pair/scripts/eval-cljs.sh
+++ b/skills/re-frame2-pair/scripts/eval-cljs.sh
@@ -9,8 +9,10 @@
 # sessions where the MCP server isn't configured.
 #
 # Usage:
-#   scripts/eval-cljs.sh '(+ 1 2)' [--build=:app]
+#   scripts/eval-cljs.sh '(+ 1 2)' [--build=app]
 #   scripts/eval-cljs.sh '(re-frame2-pair.runtime/snapshot)'
+# (--build accepts both `app` and `:app`; default build is `app` or
+#  $SHADOW_CLJS_BUILD_ID.)
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 command -v bb >/dev/null 2>&1 || {

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -176,19 +176,54 @@
 (def default-build-id
   (keyword (or (System/getenv "SHADOW_CLJS_BUILD_ID") "app")))
 
-(def port-file-candidates
+;; Relative port-file locations shadow-cljs may write to. We probe each
+;; both at the shell CWD *and* under an `implementation/` subdir, because
+;; the canonical re-frame2 dev build runs from `implementation/` while a
+;; shell often sits at the repo root. A stale repo-root
+;; `.shadow-cljs/nrepl.port` from an old run must not shadow the live
+;; `implementation/.shadow-cljs/nrepl.port`.
+(def port-file-rel-candidates
   ["target/shadow-cljs/nrepl.port"
    ".shadow-cljs/nrepl.port"
    ".nrepl-port"])
 
-(defn- read-port []
+;; Subdir prefixes searched relative to CWD, "" meaning CWD itself.
+;; `implementation/` is the re-frame2 reference-build root.
+(def port-file-dir-prefixes
+  ["" "implementation/"])
+
+(defn- candidate-port-files
+  "Every existing port file reachable from CWD across the rel-candidate ×
+   dir-prefix matrix, as a seq of java.io.File."
+  []
+  (for [prefix port-file-dir-prefixes
+        rel    port-file-rel-candidates
+        :let   [f (io/file (str prefix rel))]
+        :when  (.exists f)]
+    f))
+
+(defn- read-port
+  "Resolve the live shadow-cljs nREPL port. Resolution order:
+
+     1. $SHADOW_CLJS_NREPL_PORT  — explicit, CWD-independent override.
+        Set this to bypass file discovery entirely (e.g. when running
+        the shim from an unusual CWD, or to pin a specific build).
+     2. Otherwise scan every candidate port file (the standard
+        shadow-cljs locations, probed at both CWD and under
+        `implementation/`) and pick the **most-recently-modified** one.
+
+   Picking by mtime — rather than first-in-list — is what makes this
+   robust: the live dev build rewrites its port file on every (re)start,
+   so the freshest file is the live one. A stale repo-root
+   `.shadow-cljs/nrepl.port` left over from an earlier run can no longer
+   shadow the live `implementation/.shadow-cljs/nrepl.port`."
+  []
   (or (when-let [p (System/getenv "SHADOW_CLJS_NREPL_PORT")]
         (Integer/parseInt p))
-      (some (fn [path]
-              (let [f (io/file path)]
-                (when (.exists f)
-                  (Integer/parseInt (str/trim (slurp f))))))
-            port-file-candidates)))
+      (when-let [f (->> (candidate-port-files)
+                        (sort-by (fn [^java.io.File f] (.lastModified f)) >)
+                        first)]
+        (Integer/parseInt (str/trim (slurp f))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Output helpers

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -265,8 +265,13 @@
            :hint "Start your shadow-cljs dev build (`shadow-cljs watch <build>`).")))
 
 (defn- build-id-from-args [args]
+  ;; --build=:app -or- --build=app — both yield :app. We strip a leading
+  ;; colon before `keyword` so the documented `:app` form doesn't produce
+  ;; the malformed `::app` (a namespaced keyword in the `user` ns) and
+  ;; probe a build that doesn't exist (false :runtime-not-preloaded).
   (or (some-> (some #(when (str/starts-with? % "--build=") %) args)
               (str/replace-first "--build=" "")
+              (str/replace-first #"^:" "")
               keyword)
       default-build-id))
 
@@ -356,7 +361,7 @@
 
 (defn- eval-op [args]
   (ensure-port!)
-  (when (empty? args) (die :missing-form :hint "usage: eval '<form>' [--build :app]"))
+  (when (empty? args) (die :missing-form :hint "usage: eval '<form>' [--build=app]"))
   (let [form     (first args)
         build-id (build-id-from-args (rest args))]
     (try

--- a/skills/re-frame2-pair/spec/authoring-prompt.md
+++ b/skills/re-frame2-pair/spec/authoring-prompt.md
@@ -46,12 +46,12 @@ A self-contained prompt that re-authors the `re-frame2-pair` skill from this `sp
 >
 > *Every reference is ≤250 lines. SKILL.md is ~130 lines (well under Anthropic's 500-line ceiling). All references one level deep — no SKILL → A → B chains.*
 >
-> *Frontmatter — `allowed-tools` lists every MCP tool the skill uses (`mcp__re-frame2-pair__discover-app`, `eval-cljs`, `inject-runtime`, `dispatch`, `trace-window`, `watch-epochs`, `tail-build`) plus every bash shim (`Bash(scripts/discover-app.sh *)` etc.) plus the editor tools (`Read`, `Edit`, `Write`, `Grep`, `Glob`). The `description` is "pushy" and lists every re-frame2 surface: `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-trace-listener`, `register-epoch-listener!`, `restore-epoch`, plus toolchain (`re-com`, `shadow-cljs`).*
+> *Frontmatter — `allowed-tools` lists every MCP tool the skill uses (`mcp__re-frame2-pair__discover-app`, `eval-cljs`, `inject-runtime`, `dispatch`, `trace-window`, `watch-epochs`, `tail-build`) plus every bash shim (`Bash(scripts/discover-app.sh *)` etc.) plus the editor tools (`Read`, `Edit`, `Write`, `Grep`, `Glob`). The `description` is "pushy" and lists every re-frame2 surface: `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-listener!`, `register-epoch-listener!`, `restore-epoch`, plus toolchain (`re-com`, `shadow-cljs`).*
 >
 > *Cardinal rules to bake in (SKILL.md):*
 >
 > *1. **Three primitives, no more** — REPL, trace stream, epoch history. All in re-frame2's Tool-Pair contract.*
-> *2. **No re-frame-10x dependency** — time-travel and trace consumption ride on `register-trace-listener` / `register-epoch-listener!` / `epoch-history` / `restore-epoch`.*
+> *2. **No re-frame-10x dependency** — time-travel and trace consumption ride on `register-listener!` / `register-epoch-listener!` / `epoch-history` / `restore-epoch`.*
 > *3. **Connect first, every session** — `discover-app` before any op. Failures return structured edn; report verbatim, don't improvise workarounds.*
 > *4. **Two modes of changing the app** — REPL changes ephemeral; source edits permanent (must `hot-reload/wait` after).*
 > *5. **Multi-frame model** — mutating ops refuse with `:ambiguous-frame` if more than one frame is registered and none selected. Read ops fall back to `:rf/default` after warning.*
@@ -69,7 +69,7 @@ A self-contained prompt that re-authors the `re-frame2-pair` skill from this `sp
 > *- **L11 — Resolve UI references to source first.** Style-guidance rule in SKILL.md.*
 > *- **L12 — Surface restore limits.** Style-guidance rule in SKILL.md.*
 >
-> *Voice: tight, declarative, op-shaped. Use tables for op catalogues and routing. Use code blocks for canonical forms. Cite Tool-Pair surfaces (`(rf/register-trace-listener ...)`, `(rf/epoch-history :rf/default)`) verbatim — these are the contract.*
+> *Voice: tight, declarative, op-shaped. Use tables for op catalogues and routing. Use code blocks for canonical forms. Cite Tool-Pair surfaces (`(re-frame.trace.tooling/register-listener! ...)`, `(rf/epoch-history :rf/default)`) verbatim — these are the contract.*
 >
 > *Don't:*
 >

--- a/skills/re-frame2-pair/spec/design.md
+++ b/skills/re-frame2-pair/spec/design.md
@@ -26,7 +26,7 @@ These are not up for re-litigation. A future authoring pass MUST preserve them u
 Agency runs through three primitives, all in re-frame2's Tool-Pair contract:
 
 1. **The REPL** — a shadow-cljs nREPL session connected to the browser runtime.
-2. **The trace stream** — `(rf/register-trace-listener id cb)` for live events; `(rf/trace-buffer opts)` for the retain-N ring.
+2. **The trace stream** — `(re-frame.trace.tooling/register-listener! id cb)` for live events; `(re-frame.trace.tooling/trace-buffer opts)` for the retain-N ring. (`register-listener!` is also on `rf/`; `trace-buffer` is a JVM-only `rf/` alias, so CLJS callers use the `re-frame.trace.tooling` form.)
 3. **The epoch history** — `(rf/epoch-history frame-id)`, `(rf/register-epoch-listener! id cb)`, and `(rf/restore-epoch ...)`.
 
 Every op the skill teaches eventually becomes a ClojureScript form evaluated through the REPL, usually against a helper in the `re-frame2-pair.runtime` namespace the consumer app preloads via shadow-cljs `:devtools :preloads` (see `SKILL.md` §Setup).
@@ -130,7 +130,7 @@ SKILL.md (~175) + references (~1,100) + spec (~300) ≈ ~1,575 LoC. Typical sess
 
 ## 6. Discovery surface (frontmatter `description`)
 
-The `description` is "pushy" and lists every surface the live-app workflow exposes: `re-frame2`, `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-trace-listener`, `register-epoch-listener!`, `restore-epoch`, plus the toolchain (`re-com`, `shadow-cljs`). The framing is *"pair-program with a live re-frame2 application"* — discriminates against the authoring-only `re-frame2` skill (which triggers on the same surfaces but in code-writing prose).
+The `description` is "pushy" and lists every surface the live-app workflow exposes: `re-frame2`, `app-db`, `dispatch`, `subscribe`, `reg-event`, `reg-sub`, `reg-fx`, `reg-machine`, `frame`, `epoch`, `interceptor`, `sub-cache`, `trace-buffer`, `register-listener!`, `register-epoch-listener!`, `restore-epoch`, plus the toolchain (`re-com`, `shadow-cljs`). The framing is *"pair-program with a live re-frame2 application"* — discriminates against the authoring-only `re-frame2` skill (which triggers on the same surfaces but in code-writing prose).
 
 ## 7. Anti-patterns the skill explicitly resists
 

--- a/skills/re-frame2-pair/spec/inputs.md
+++ b/skills/re-frame2-pair/spec/inputs.md
@@ -10,7 +10,7 @@ Path: `spec/Tool-Pair.md` (the contract specification) + `spec/009-Instrumentati
 
 **This is the source of truth.** Every op the skill teaches is a structured call against one of the Tool-Pair surfaces:
 
-- `(rf/register-trace-listener id cb)` / `(rf/trace-buffer opts)` — the trace stream.
+- `(re-frame.trace.tooling/register-listener! id cb)` / `(re-frame.trace.tooling/trace-buffer opts)` — the trace stream. (`register-listener!` is also re-exported on `rf/`; `trace-buffer` is a JVM-only `rf/` alias, so CLJS callers use the `re-frame.trace.tooling` form.)
 - `(rf/register-epoch-listener! id cb)` / `(rf/epoch-history frame-id)` — the assembled epoch stream and per-frame ring.
 - `(rf/restore-epoch ...)` — first-class time-travel.
 - `(rf/frame-ids)` / `(rf/frame-meta id)` — multi-frame inspection.
@@ -23,7 +23,7 @@ The skill is one of the principal downstream consumers of these surfaces.
 
 For verifying that the public surface in `spec/Tool-Pair.md` is wired up in the reference impl:
 
-- `implementation/core/src/re_frame/core.cljc` — the public single-import API; `register-trace-listener`, `trace-buffer`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `frame-ids`, `frame-meta`, `app-schemas`, `handler-meta`, `configure`.
+- `implementation/core/src/re_frame/core.cljc` — the public single-import API; `register-listener!`, `register-epoch-listener!`, `epoch-history`, `restore-epoch`, `frame-ids`, `frame-meta`, `app-schemas`, `handler-meta`, `configure`. (`trace-buffer` lives in `re-frame.trace.tooling`; `core.cljc` re-exports it on `rf/` JVM-side only.)
 - `implementation/core/src/re_frame/trace.cljc` — the trace stream's internals; what op-types are emitted, how `:op-type :error` filtering works.
 - `implementation/core/src/re_frame/epoch.cljc` — the per-frame epoch ring; what fields a `:rf/epoch-record` carries; the structured `:sub-runs` / `:renders` / `:effects` projections.
 - `implementation/core/src/re_frame/frame.cljc` — frame lifecycle; `:rf/default` registration; per-frame router queues.


### PR DESCRIPTION
Fixes three independent papercuts in the `skills/re-frame2-pair/` bash shim (the legacy/fallback transport — distinct from `tools/re-frame2-pair-mcp`), all hit live while debugging Causa. Bead: rf2-n3yn6.

## 1. `--build` leading-colon parsing
`ops.clj` `build-id-from-args` ran `(keyword stripped)` on the `--build=` value without stripping a leading colon, so the documented `--build=:app` produced the malformed `::app` keyword (namespaced in the `user` ns) → probed a build that doesn't exist → false `:runtime-not-preloaded`. Now strips a leading `:` before `keyword`, so **both** `--build=:app` and `--build=app` yield `:app` (internal slashes like `examples/parallel-frames` are preserved). Aligned the `.sh` usage docs and the `eval` die-hint to the `--build=app` form.

## 2. Phantom trace API names
Docs cited `rf/register-trace-listener` and `rf/trace-buffer`:
- `register-trace-listener` is a **phantom** — the real var is `register-listener!` (the `-trace-` infix was dropped because the namespace already says `trace`; it's re-exported on `rf/` for both JVM and CLJS).
- `trace-buffer` is real but a **JVM-only** alias on `rf/`. CLJS callers — including this shim's `cljs-eval` against the browser runtime — must use `re-frame.trace.tooling/trace-buffer` or the form **silently returns nil** (the "looks like no data" trap).

Corrected the SKILL.md trace-stream section plus every other occurrence across the re-frame2-pair skill tree (references, spec/, docs/, STATUS, README, the preload runtime.cljs docstrings/hints, and the mkdocs-published skill page). Left the `re-frame-migration` M-66 rename table untouched — it deliberately documents the old names as part of the v1→v2 rename history.

**Verified** the real names against `implementation/core/src/re_frame/trace/tooling.cljc` (`register-listener!`, `unregister-listener!`, `clear-listeners!`, `trace-buffer`, `clear-trace-buffer!`, `configure-trace-buffer!`) and `implementation/core/src/re_frame/core.cljc` (the `rf/` re-export table, which makes `trace-buffer` JVM-only).

## 3. CWD-relative port-file resolution
`read-port` resolved `.shadow-cljs/nrepl.port` relative to the shell CWD and took the first existing candidate, so a stale repo-root `.shadow-cljs/nrepl.port` shadowed the live `implementation/.shadow-cljs/nrepl.port` (connection refused / wrong build).

**Approach chosen:** `$SHADOW_CLJS_NREPL_PORT` (CWD-independent override) wins outright; otherwise scan the standard port files (`target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`, `.nrepl-port`) at **both** the CWD and under `implementation/`, and pick the **most-recently-modified** file. Mtime selection — rather than first-in-list — is what makes it robust: a live dev build rewrites its port file on every (re)start, so the freshest file is always the live one; a stale leftover can no longer shadow it. Documented the env override prominently in SKILL.md (Connect-first section) plus README / STATUS / docs/LOCAL_DEV.

## Gates
- `bb tests/shim/shim_test.clj` — 7 tests / 28 assertions, 0 failures.
- `bash -n` on the edited `.sh` scripts — clean (shellcheck not installed in this env).
- `python scripts/check_skill_redirect_anchors.py`, `check_skill_mcp_drift.py`, `check_doc_slugs.py` — all exit 0.
- Manual `bb` verification of both the colon-parse matrix and the mtime port-resolution (stale repo-root vs live `implementation/`, plus env-override precedence).