### PR TITLE
feat(causa): single per-cascade subs table in Views panel (rf2-isun6)

### DIFF
--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -328,18 +328,43 @@ the rendered DOM highlights), with the sub cascade as supporting
 context. The internal panel-registry key stays `:views` (never a
 user contract). The L4 tab label renders as `View`.
 
-### §3.1.1 Layout (rf2-e33ad)
+### §3.1.1 Layout (rf2-e33ad · rf2-isun6)
 
-Per Mike-direction 2026-05-21 the panel renders the cascade as four
+Per Mike-direction 2026-05-21 the panel renders the cascade as two
 bare-label pipeline sections (mirroring the rf2-n4ad0 Event panel
 rhythm — thin left rail + downward chevrons):
 
-  1. **SUBS RAN (count)** — entries with `[code]` chip
-  2. **SUBS WHOSE VALUE CHANGED (count)** — entries with `[code]` chip
-  3. **SUBS THAT CASCADED (count)** — entries
-  4. **VIEWS RE-RENDERED (count)** — entries named via the
+  1. **SUBS THIS CASCADE (count)** — **one table**, one row per sub
+     that *ran* this cascade (the union — formerly the "SUBS RAN"
+     set). Columns:
+
+     | column | meaning |
+     | --- | --- |
+     | `sub-id` | the sub's query-id (violet) |
+     | `changed?` | ✓ when the sub's value changed (`sub-changed?` — `:value-changed?` / `:prev-value` ≠ `:value`) |
+     | `cascaded?` | ✓ when an upstream sub drove the recompute (`sub-cascaded?` — `:cascade?` / `:cause-sub`); the upstream `:cause-sub` rides as muted `← :s/foo` secondary text on the ✓ |
+     | `code` | the `[code]` source-coord chip — opens the sub's registration in the editor |
+
+     **Each sub appears EXACTLY once.** The `changed?` / `cascaded?`
+     dimensions are *columns*, not separate lists (rf2-isun6). This
+     replaces the prior three overlapping sections — **SUBS RAN**,
+     **SUBS WHOSE VALUE CHANGED**, **SUBS THAT CASCADED** — in which a
+     sub that ran *and* changed *and* cascaded was repeated in all
+     three (redundant). The dirty-check predicates (`sub-changed?` /
+     `sub-cascaded?`) survive — they now drive the two flag columns
+     rather than `filterv`-splitting the run-set into three lists.
+
+  2. **VIEWS RE-RENDERED (count)** — entries named via the
      `reg-view :name` slot (fallback: var name) + `[code]` chip +
      hover-highlight on the rendered view's root DOM node
+
+**testids.** The table carries `rf-causa-reactive-subs-table`; each
+row is `rf-causa-reactive-sub-row-<slug>` and its code chip
+`rf-causa-reactive-sub-code-<slug>` (slug = sub-id with non-alnum
+flattened to `_`). The empty-but-focused placeholder is
+`rf-causa-reactive-subs-empty`. (The prior per-section
+`rf-causa-reactive-sub-ran` / `…-subs-{ran,changed,cascaded}-empty`
+testids are retired with the three-list layout.)
 
 **Hover-highlight contract.** Hovering a view-row stamps a subtle
 background-only highlight (`var(--bg-3)`) on the rendered view's

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
@@ -9,11 +9,13 @@
 
   The internal panel-registry key stays `:views` (it was always the
   internal id, never a user contract). The panel renders the full
-  reactive cascade per spec/021 §3 reorganised into four sections:
+  reactive cascade per spec/021 §3 reorganised into two sections:
 
-      Subs ran (count)            entries with [code] chip
-      Subs whose value changed    entries
-      Subs that cascaded          entries
+      Subs this cascade (count)   ONE table — one row per sub that ran,
+                                  columns sub-id | changed? | cascaded?
+                                  | code. Each sub appears exactly once
+                                  (rf2-isun6 · replaced the prior three
+                                  overlapping ran/changed/cascaded lists)
       Views re-rendered           entries named via `reg-view :name`,
                                   `[code] chip` + hover-highlight
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -3,13 +3,24 @@
   prior bead: rf2-wyvf2).
 
   Renders the canonical sub-cascade + view-re-render visualisation as
-  four bare-label pipeline sections, mirroring the rf2-n4ad0 Event
+  two bare-label pipeline sections, mirroring the rf2-n4ad0 Event
   panel rhythm (thin left rail + downward chevrons):
 
-      Subs ran (count)            entries with [code] chip
-      Subs whose value changed    entries with [code] chip
-      Subs that cascaded          entries
-      Views re-rendered           entries — named via reg-view :name
+      Subs this cascade (count)   ONE table — one row per sub that RAN
+                                  this cascade. Columns:
+                                    sub-id | changed? | cascaded? | code
+                                  `changed?` ✓ via `sub-changed?`,
+                                  `cascaded?` ✓ via `sub-cascaded?`
+                                  (the upstream `:cause-sub` rides as
+                                  secondary text on the cascaded ✓).
+                                  Each sub appears EXACTLY once — the
+                                  changed/cascaded dimensions are
+                                  columns, not separate lists
+                                  (rf2-isun6 · replaces the prior three
+                                  overlapping SUBS RAN / SUBS WHOSE
+                                  VALUE CHANGED / SUBS THAT CASCADED
+                                  sections that repeated each sub).
+      Views re-rendered (count)   entries — named via reg-view :name
                                   slot (fallback: var name) +
                                   [code] chip + hover-highlight
 
@@ -72,6 +83,48 @@
    :line-height  1
    :user-select  "none"
    :opacity      "0.6"})
+
+;; ---- single subs-table styling (rf2-isun6) ----------------------------
+
+(def ^:private subs-table-style
+  {:width          "100%"
+   :border-collapse "collapse"
+   :margin         "2px 12px 4px 24px"
+   :font-family    mono-stack
+   :font-size      "12px"})
+
+(def ^:private subs-th-style
+  "Column header cell. Muted sans label echoing the section-label
+  primitive so the table reads as part of the pipeline rhythm."
+  {:text-align     "left"
+   :padding        "2px 12px 4px 0"
+   :font-family    sans-stack
+   :font-size      "10px"
+   :font-weight    600
+   :letter-spacing "0.4px"
+   :text-transform "uppercase"
+   :color          (:text-tertiary tokens)
+   :white-space    "nowrap"})
+
+(def ^:private subs-td-style
+  {:padding     "3px 12px 3px 0"
+   :color       (:text-primary tokens)
+   :vertical-align "top"})
+
+(def ^:private flag-yes-style
+  "The ✓ cell when a dimension is set."
+  {:color (:cyan tokens) :font-weight 600})
+
+(def ^:private flag-no-style
+  "The · placeholder when a dimension is unset — dim so the eye skips it."
+  {:color (:text-tertiary tokens) :opacity "0.5"})
+
+(def ^:private cause-sub-style
+  "Secondary text rendered next to the cascaded ✓ — the upstream
+  `:cause-sub` that triggered the cascade. Dim so the ✓ stays primary."
+  {:color (:text-tertiary tokens)
+   :font-size "10px"
+   :margin-left "6px"})
 
 ;; ---- pure formatters ---------------------------------------------------
 
@@ -246,34 +299,12 @@
             (or (:subs-skipped counts) 0) " skipped · "
             (or (:views-rendered counts) 0) " views rendered"))]))
 
-;; ---- subs ran section -------------------------------------------------
-
-(defn- sub-ran-row
-  [payload]
-  (let [sub-id (or (:sub-id payload) (:id payload))
-        coord  (when sub-id (sub-coord sub-id))]
-    [:div {:data-testid "rf-causa-reactive-sub-ran"
-           :style row-style}
-     [:span {:style {:color (:accent-violet tokens)
-                     :font-weight 600}}
-      (format-id sub-id)]
-     (code-chip coord
-                (str "rf-causa-reactive-sub-ran-code-"
-                     (when sub-id (string/replace (str sub-id) #"[^a-zA-Z0-9_]" "_"))))]))
-
-(defn- subs-ran-section
-  [data]
-  (let [subs-ran (:subs-ran data)
-        n        (count subs-ran)]
-    [:<>
-     (section-label "subs-ran" (str "SUBS RAN (" n ")"))
-     (if (seq subs-ran)
-       (into [:div]
-             (for [[i p] (map-indexed vector subs-ran)]
-               (with-meta (sub-ran-row p) {:key i})))
-       (empty-row "rf-causa-reactive-subs-ran-empty" "(none ran)"))]))
-
-;; ---- subs whose value changed section --------------------------------
+;; ---- subs-this-cascade dimension predicates ---------------------------
+;;
+;; rf2-isun6: a sub that ran may ALSO have changed value and/or cascaded.
+;; These two predicates no longer split the run-set into separate lists
+;; — they drive the `changed?` / `cascaded?` columns of the single
+;; subs table, so each sub appears exactly once.
 
 (defn- sub-changed?
   "True when a `:rf.sub/computed` payload represents a value change
@@ -287,21 +318,6 @@
         (and (contains? payload :prev-value)
              (not= (:prev-value payload) (:value payload))))))
 
-(defn- subs-changed-section
-  [data]
-  (let [subs-ran     (:subs-ran data)
-        changed-subs (filterv sub-changed? subs-ran)
-        n            (count changed-subs)]
-    [:<>
-     (section-label "subs-changed" (str "SUBS WHOSE VALUE CHANGED (" n ")"))
-     (if (seq changed-subs)
-       (into [:div]
-             (for [[i p] (map-indexed vector changed-subs)]
-               (with-meta (sub-ran-row p) {:key i})))
-       (empty-row "rf-causa-reactive-subs-changed-empty" "(none changed)"))]))
-
-;; ---- subs that cascaded section --------------------------------------
-
 (defn- sub-cascaded?
   "True when a `:rf.sub/computed` payload represents a cascade (a sub
   that was triggered by another sub's value change rather than by an
@@ -312,18 +328,75 @@
       (some? (:cause-sub payload))
       (= :sub-cascade (:reason payload))))
 
-(defn- subs-cascaded-section
+;; ---- single subs-this-cascade table (rf2-isun6) -----------------------
+
+(defn- sub-id-slug
+  "Stable testid suffix for a sub-id — kw/symbol punctuation flattened
+  to `_` so the row + code-chip testids are CSS-selector safe."
+  [sub-id]
+  (when sub-id (string/replace (str sub-id) #"[^a-zA-Z0-9_]" "_")))
+
+(defn- flag-cell
+  "A ✓ / · column cell. Renders the cyan ✓ when `on?`; otherwise a dim
+  placeholder. `secondary` (optional) rides as muted text after the ✓
+  (used to surface the upstream `:cause-sub` on the cascaded column)."
+  [on? secondary]
+  [:td {:style subs-td-style}
+   (if on?
+     [:span
+      [:span {:style flag-yes-style} "✓"]
+      (when (seq secondary)
+        [:span {:style cause-sub-style} secondary])]
+     [:span {:style flag-no-style} "·"])])
+
+(defn- subs-table-row
+  "One row per sub that ran this cascade. `changed?` / `cascaded?`
+  columns carry the dimensions; the sub appears exactly once.
+
+  testids:
+    row       `rf-causa-reactive-sub-row-<slug>`
+    code chip `rf-causa-reactive-sub-code-<slug>`"
+  [payload]
+  (let [sub-id   (or (:sub-id payload) (:id payload))
+        slug     (sub-id-slug sub-id)
+        coord    (when sub-id (sub-coord sub-id))
+        changed? (sub-changed? payload)
+        cause    (when (sub-cascaded? payload)
+                   (let [c (:cause-sub payload)]
+                     (when c (str "← " (format-id c)))))]
+    [:tr {:data-testid (str "rf-causa-reactive-sub-row-" slug)
+          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
+     [:td {:style (assoc subs-td-style :color (:accent-violet tokens)
+                         :font-weight 600)}
+      (format-id sub-id)]
+     (flag-cell changed? nil)
+     (flag-cell (sub-cascaded? payload) cause)
+     [:td {:style subs-td-style}
+      (code-chip coord (str "rf-causa-reactive-sub-code-" slug))]]))
+
+(defn- subs-table-section
+  "ONE 'SUBS THIS CASCADE' table replacing the prior three overlapping
+  SUBS RAN / SUBS WHOSE VALUE CHANGED / SUBS THAT CASCADED sections.
+  One row per sub that RAN (the union); `changed?` / `cascaded?` are
+  columns, so each sub appears exactly once (rf2-isun6)."
   [data]
-  (let [subs-ran      (:subs-ran data)
-        cascaded-subs (filterv sub-cascaded? subs-ran)
-        n             (count cascaded-subs)]
+  (let [subs-ran (:subs-ran data)
+        n        (count subs-ran)]
     [:<>
-     (section-label "subs-cascaded" (str "SUBS THAT CASCADED (" n ")"))
-     (if (seq cascaded-subs)
-       (into [:div]
-             (for [[i p] (map-indexed vector cascaded-subs)]
-               (with-meta (sub-ran-row p) {:key i})))
-       (empty-row "rf-causa-reactive-subs-cascaded-empty" "(none cascaded)"))]))
+     (section-label "subs" (str "SUBS THIS CASCADE (" n ")"))
+     (if (seq subs-ran)
+       [:table {:data-testid "rf-causa-reactive-subs-table"
+                :style       subs-table-style}
+        [:thead
+         [:tr
+          [:th {:style subs-th-style} "sub-id"]
+          [:th {:style subs-th-style} "changed?"]
+          [:th {:style subs-th-style} "cascaded?"]
+          [:th {:style subs-th-style} "code"]]]
+        (into [:tbody]
+              (for [[i p] (map-indexed vector subs-ran)]
+                (with-meta (subs-table-row p) {:key i})))]
+       (empty-row "rf-causa-reactive-subs-empty" "(no subs ran)"))]))
 
 ;; ---- views re-rendered section ---------------------------------------
 
@@ -407,10 +480,6 @@
                        :padding-left  "12px"
                        :padding-top   "8px"
                        :padding-bottom "8px"}}
-         (subs-ran-section data)
-         (pipeline-chevron "subs-ran")
-         (subs-changed-section data)
-         (pipeline-chevron "subs-changed")
-         (subs-cascaded-section data)
-         (pipeline-chevron "subs-cascaded")
+         (subs-table-section data)
+         (pipeline-chevron "subs")
          (views-rendered-section data)])]]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -5,6 +5,7 @@
   structural data-testid hooks ship: panel root, header, the two
   step sections, and the unchanged-subs toggle when applicable."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
@@ -62,24 +63,78 @@
       (is (= "Views" (:label registered))
           "L4 tab label renders as `Views`"))))
 
-(deftest reactive-panel-renders-four-cascade-sections
-  (testing "rf2-e33ad — the View panel renders four pipeline sections
-            (SUBS RAN · SUBS WHOSE VALUE CHANGED · SUBS THAT CASCADED ·
-            VIEWS RE-RENDERED) wrapped in a left-rail container with
-            chevrons between adjacent sections. Empty states are
-            ALWAYS visible per Mike-direction 2026-05-21."
+(deftest reactive-panel-renders-two-cascade-sections
+  (testing "rf2-isun6 — the View panel renders TWO pipeline sections
+            (SUBS THIS CASCADE · VIEWS RE-RENDERED) wrapped in a left-
+            rail container with a chevron between them. The prior three
+            overlapping subs sections (SUBS RAN / SUBS WHOSE VALUE
+            CHANGED / SUBS THAT CASCADED) collapsed into one table whose
+            `changed?` / `cascaded?` columns carry those dimensions, so
+            each sub appears exactly once. Empty states are ALWAYS
+            visible per Mike-direction 2026-05-21."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
-    ;; The empty-state path doesn't render the sections; we exercise the
-    ;; section names directly via a synthetic cascade injection through
-    ;; the standard install + a fixture-shaped data map. The
-    ;; pipeline-shape test asserts the labels render only when a
-    ;; cascade is focused; we cannot drive that here without a full
-    ;; spine/epoch dispatch. Instead, the labels are pure-data — the
-    ;; section-label keys map 1:1 to the testid pattern, so we assert
-    ;; the helper produces the expected testids by calling the panel
-    ;; directly with a synthetic data map via the namespace fn.
+    ;; The empty-state path doesn't render the sections; the table
+    ;; shape is exercised directly in the focused-cascade test below
+    ;; (which seeds `:rf.causa/reactive-data`). Here we confirm the
+    ;; empty branch holds when no cascade fires.
     (let [tree (view/reactive-panel)]
-      ;; Confirm the empty-state branch is taken when no cascade fires.
       (is (has-testid? tree "rf-causa-reactive-empty")
           "empty branch holds when no cascade is focused"))))
+
+(defn- seed-reactive-data!
+  "Re-register the composite `:rf.causa/reactive-data` to return a
+  literal so the panel view renders its focused-cascade body. The view
+  is the unit under test here — the composite's projection logic is
+  covered by reactive-panel-subs-cljs-test."
+  [data]
+  (rf/reg-sub :rf.causa/reactive-data (fn [_db _q] data)))
+
+(deftest reactive-panel-subs-table-one-row-per-sub
+  (testing "rf2-isun6 — one row per sub that RAN; changed? / cascaded?
+            are columns (each sub appears exactly once). A sub that ran
+            AND changed AND cascaded yields a SINGLE row carrying both
+            ✓ flags, not three rows across three sections."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true
+       :frame        :rf/app
+       :focus        {:current :ep-1}
+       :counts       {:subs-ran 3 :subs-skipped 0 :views-rendered 0}
+       ;; :a ran only · :b ran + changed · :c ran + changed + cascaded
+       :subs-ran     [{:sub-id :a/plain}
+                      {:sub-id :b/changed :value-changed? true
+                       :prev-value 1 :value 2}
+                      {:sub-id :c/cascaded :value-changed? true
+                       :prev-value 3 :value 4 :cascade? true
+                       :cause-sub [:b/changed]}]
+       :views-rendered []})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-subs-table")
+          "the single subs table renders")
+      ;; Exactly one row per sub — no triple-repeat across sections.
+      (is (has-testid? tree "rf-causa-reactive-sub-row-_a_plain"))
+      (is (has-testid? tree "rf-causa-reactive-sub-row-_b_changed"))
+      (is (has-testid? tree "rf-causa-reactive-sub-row-_c_cascaded"))
+      ;; The legacy per-section row testid is gone (collapsed into rows).
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-sub-ran"))
+          "the old per-section row testid no longer ships"))))
+
+(deftest reactive-panel-subs-table-empty-when-no-subs
+  (testing "rf2-isun6 — empty subs placeholder when a cascade is focused
+            but no subs ran."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true
+       :frame        :rf/app
+       :focus        {:current :ep-1}
+       :counts       {:subs-ran 0 :subs-skipped 0 :views-rendered 0}
+       :subs-ran     []
+       :views-rendered []})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-subs-empty")
+          "empty subs placeholder renders")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-subs-table"))
+          "no table when no subs ran"))))


### PR DESCRIPTION
## Summary

The Views/Reactive panel's three overlapping subs sections — **SUBS RAN**, **SUBS WHOSE VALUE CHANGED**, **SUBS THAT CASCADED** — repeated every sub that ran *and* changed *and* cascaded across all three lists. This collapses them into **one** table:

```
SUBS THIS CASCADE (N)
| sub-id | changed? | cascaded? | code |
```

- One row per sub that **ran** this cascade (the union — formerly the "SUBS RAN" set).
- `changed?` ✓ via `sub-changed?` (`:value-changed?` / `:prev-value` ≠ `:value`).
- `cascaded?` ✓ via `sub-cascaded?` (`:cascade?` / `:cause-sub`); the upstream `:cause-sub` rides as muted `← :s/foo` secondary text on the ✓.
- `code` column reuses the existing source-coord `[code]` chip (`:rf.causa/open-in-editor`), one per row.
- **Each sub appears exactly once.** The `sub-changed?` / `sub-cascaded?` predicates survive — they now drive the two flag columns instead of `filterv`-splitting the run-set into three lists.
- The RENDERS section (`views-rendered`) is untouched (qs6dl's concurrent surface).

## testids

- **New:** table `rf-causa-reactive-subs-table`; per-row `rf-causa-reactive-sub-row-<slug>`; per-row chip `rf-causa-reactive-sub-code-<slug>`; empty-but-focused `rf-causa-reactive-subs-empty`.
- **Retired** (no test consumers): `rf-causa-reactive-sub-ran`, `rf-causa-reactive-section-subs-{ran,changed,cascaded}-label`, `…-subs-{ran,changed,cascaded}-empty`.
- **Preserved:** `rf-causa-reactive` (panel root — feature-gate contract), `rf-causa-reactive-section-subs-label`, `rf-causa-reactive-pipeline`, the RENDERS testids.

## Spec

`tools/causa/spec/021-Dynamic-Panel-Designs.md` §3.1.1 rewritten — the four-section list becomes two sections (single subs table + views), with a columns table and a testids note.

## Verification

- `npm run test:cljs` — **4092 tests / 12424 assertions, 0 failures**. Includes new `reactive_panel_view_cljs_test` cases: one-row-per-sub (a sub that ran+changed+cascaded yields a single row with both ✓), empty-subs placeholder, and the old per-section testid is gone.
- `npm run test:causa-feature-gate` (nightly-full sweep) — **13 scenarios, 0 failures**. (`http-server exited unexpectedly` is a harmless post-pass teardown race.)
- **Browser-verified** against the parallel-frames testbed (fresh local build). Drove a cascade in the followed frame (`:below`), opened the Views tab. Observed:

  ```
  SUBS THIS CASCADE (4)
  | sub-id                                | changed? | cascaded? | code   |
  | :parallel-frames.core/counter         |    ·     |     ·     | [code] |
  | :parallel-frames.core/title-state     |    ✓     |     ·     | [code] |
  | :parallel-frames.core/title-data      |    ·     |     ·     | [code] |
  | :parallel-frames.core/title-requests  |    ✓     |     ·     | [code] |
  ```

  Each sub appears exactly once (no triple-repeat); `changed?` ✓ on the subs whose value moved; clicking a `[code]` chip dispatched `:rf.causa/open-in-editor` → `core.cljs:130:1`.

## Test plan

- [x] CLJS unit suite green
- [x] Causa feature gate green
- [x] Browser-verified single table renders one row per sub with correct flags + working code chip