### PR TITLE
fix(instrumentation): attribute :rf.view/rendered to the causing cascade, not commit-time epoch (rf2-qs6dl)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -499,6 +499,10 @@
     :producer-ns 're-frame.epoch
     :design-bead "rf2-25zo2"
     :description "Walk a frame's in-flight cascade buffer and return {:cause-event-id :cause-subs :rendered-so-far} for :rf.view/rendered attribution. Consumed by re-frame.views at view-render emit time so the Causa Reactive panel can graph cause→effect for re-renders. Returns nil when the epoch artefact is absent."}
+   {:key         :epoch/record-render!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-qs6dl"
+    :description "Attribute a post-settle render emit (a :view/render / :rf.view/rendered op firing at React commit time, after the causing cascade settled) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a render op arrives with no in-flight cascade; back-fills the render into the causing epoch record and re-fans it to epoch listeners so snapshot consumers re-sync. Fixes the one-epoch :renders lag."}
    {:key         :epoch/epoch-history
     :producer-ns 're-frame.epoch
     :description "Return the committed-epoch ring buffer (introspection)."}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -313,6 +313,13 @@
                         (assembly/build-record frame-id db-before db-after
                                                events outcome halt-reason))]
            (state/record! record)
+           ;; Per rf2-qs6dl: mark this as the frame's most-recently-
+           ;; settled epoch so post-settle async render emits (which
+           ;; fire at React commit time, after this cascade settled) are
+           ;; attributed back to THIS cascade rather than buffered into
+           ;; the next one. Set after `record!` so the record is in the
+           ;; ring before any render can back-fill into it.
+           (state/set-last-settled-epoch! frame-id (:epoch-id record))
            ;; Per rf2-931pm — focused-event-only cascade-DAG capture.
            ;; Sticky hook (rf2-f72pd) published by `re-frame.trace.cascade`
            ;; at ns-load; when the trace.cascade ns has not been loaded
@@ -439,6 +446,10 @@
                           :event-id      :rf.epoch/db-replaced
                           :trigger-event [:rf.epoch/db-replaced]))]
       (state/record! record)
+      ;; Per rf2-qs6dl: a `reset-frame-db!` re-renders the views that read
+      ;; the replaced state; attribute those post-settle renders back to
+      ;; this synthetic epoch rather than the next real cascade.
+      (state/set-last-settled-epoch! frame-id (:epoch-id record))
       (trace/emit! :rf.epoch :rf.epoch/db-replaced
                    {:frame    frame-id
                     :epoch-id (:epoch-id record)})
@@ -542,6 +553,15 @@
 ;; consume this via `:epoch/cascade-cause` at render-emit time to stamp
 ;; :cause-event-id + :cause-subs onto the per-render trace.
 (late-bind/set-fn! :epoch/cascade-cause       capture/cascade-cause)
+;; rf2-qs6dl: post-settle render back-fill. `capture-event!` routes a
+;; view-render op that fires with no in-flight cascade (a React-commit-
+;; time async re-render) here so it is attributed to the cascade that
+;; CAUSED it (the frame's most-recently-settled epoch) rather than the
+;; next in-flight cascade. The orchestrator lives in
+;; `re-frame.epoch.listeners` (state back-fill + listener re-notify);
+;; publishing it through late-bind keeps `capture` free of a require on
+;; `listeners` (which would close the assembly→capture cycle).
+(late-bind/set-fn! :epoch/record-render!      listeners/record-render!)
 (late-bind/set-fn! :epoch/epoch-history       epoch-history)
 (late-bind/set-fn! :epoch/restore-epoch       restore-epoch)
 (late-bind/set-fn! :epoch/reset-frame-db!     reset-frame-db!)

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -18,7 +18,8 @@
   + projection trio out of the facade keeps the cascade pipeline a
   single grep target."
   (:require [re-frame.epoch.state :as state]
-            [re-frame.interop :as interop]))
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]))
 
 ;; ---- skip-ops catalogue --------------------------------------------------
 ;;
@@ -66,6 +67,37 @@
     ;; for this frame.
     :rf.warning/epoch-redact-fn-exception})
 
+;; ---- render ops (rf2-qs6dl) -----------------------------------------------
+;;
+;; The three view-render ops that fire at React COMMIT time — AFTER the
+;; causing cascade settled (Reagent batches re-renders onto a later tick
+;; via `re-frame.interop/after-render`). When one of these arrives with
+;; no in-flight cascade for its frame, it must be attributed back to the
+;; cascade that CAUSED it (the most-recently-settled epoch) rather than
+;; buffered into the next cascade — see `re-frame.epoch.state/back-fill-
+;; render!` and `re-frame.epoch.listeners/record-render!`.
+(def ^:private render-ops
+  #{:view/render
+    :rf.view/rendered
+    :rf.view/rendered-cap-reached})
+
+(defn- in-flight-cascade?
+  "True when the frame's in-flight capture buffer already holds an
+  `:event/run-start` emit — the canonical signal that a cascade has
+  begun draining into this buffer (mirrors the gate
+  `re-frame.epoch.listeners/on-frame-destroyed!` uses for mid-drain
+  detection). A render that fires WITH a cascade in flight (synchronous
+  flush — SSR, a render triggered inside another render's reactive read)
+  genuinely belongs to that cascade and is buffered normally; a render
+  that fires with NO cascade in flight is a post-settle async re-render
+  and is back-filled to the cascade that caused it."
+  [frame-id]
+  (some (fn [ev]
+          (and (= :event (:op-type ev))
+               (= :event (:operation ev))
+               (= :run-start (-> ev :tags :phase))))
+        (state/buffer-for frame-id)))
+
 (defn capture-event!
   "Internal trace-capture entry point published through `re-frame.late-bind`
   under `:epoch/capture-event`. `re-frame.trace/emit!` and
@@ -83,7 +115,17 @@
   tied to a specific cascade. The `:rf.epoch/*` trace events this
   namespace emits OUTSIDE a cascade (catalogued in `skip-ops`) are
   also skipped, so a snapshotted/restored/db-replaced emit cannot leak
-  into the next cascade's harvested record."
+  into the next cascade's harvested record.
+
+  Per rf2-qs6dl: a view-render op (`:view/render` / `:rf.view/rendered`
+  / `:rf.view/rendered-cap-reached`) that arrives with no in-flight
+  cascade for its frame is a post-settle async re-render — it fired at
+  React commit time, AFTER the causing cascade settled. Routing it into
+  the now-empty buffer would mis-attribute it to the NEXT cascade (the
+  one-epoch lag the bead documents). Instead it is back-filled into the
+  cascade that caused it via the `:epoch/record-render!` hook. A render
+  that fires WITH a cascade in flight (synchronous flush) belongs to
+  that cascade and is buffered as before."
   [event]
   (when interop/debug-enabled?
     (let [op       (:operation event)
@@ -91,7 +133,20 @@
           frame-id (or (:frame tags)
                        (:frame event))]
       (when (and frame-id (not (contains? skip-ops op)))
-        (state/buffer-event! frame-id event)))))
+        (if (and (contains? render-ops op)
+                 (not (in-flight-cascade? frame-id)))
+          ;; Post-settle render — attribute to the causing cascade.
+          ;; The orchestrator (state back-fill + listener re-notify)
+          ;; lives in `re-frame.epoch.listeners`; reaching it through
+          ;; late-bind keeps `capture` free of a require on `listeners`
+          ;; (which requires `assembly` → `capture`, a cycle). The hook
+          ;; is published at `re-frame.epoch` ns-load; when absent (the
+          ;; degenerate load-order window before the facade installs it)
+          ;; the render falls through to the normal buffer path.
+          (if-let [record-render! (late-bind/get-fn-cached :epoch/record-render!)]
+            (record-render! frame-id event)
+            (state/buffer-event! frame-id event))
+          (state/buffer-event! frame-id event))))))
 
 ;; ---- cascade-cause (for :rf.view/rendered attribution, rf2-25zo2) --------
 ;;

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -71,6 +71,47 @@
                                            :cljs (.-message ex))
                               :recovery :no-recovery}))))))
 
+;; ---- post-settle render back-fill (rf2-qs6dl) -----------------------------
+
+(defn- render-row
+  "Project a `:view/render` trace event into its structured `:renders`
+  row, mirroring `capture/project-all`'s `:view/render` arm. Returns nil
+  for non-`:view/render` render ops (`:rf.view/rendered` /
+  `:rf.view/rendered-cap-reached`) — those ride only the `:trace-events`
+  slot, exactly as `project-all` already treats them (it projects no
+  `:renders` row for them)."
+  [event]
+  (when (= :view/render (:operation event))
+    (let [t (:tags event)]
+      {:render-key   (or (:render-key t) [:rf.view/anonymous nil])
+       :triggered-by (:triggered-by t)
+       :elapsed-ms   (:elapsed-ms t)})))
+
+(defn record-render!
+  "Attribute a post-settle render emit to the cascade that CAUSED it
+  (rf2-qs6dl). A `:view/render` / `:rf.view/rendered` trace fires at
+  React commit time — AFTER the causing cascade settled — so it cannot
+  ride the in-flight cascade buffer (there is none). This back-fills the
+  render into the frame's most-recently-settled epoch record and re-fans
+  the updated record out to epoch listeners so snapshot consumers (Causa
+  Views / Reactive panel, which cache `epoch-history` at settle time)
+  re-sync to the corrected `:renders`.
+
+  No-op when the frame has no settled epoch yet (a render before the
+  first cascade) or when the target epoch has been evicted from the ring
+  — `back-fill-render!` returns nil and we skip the re-notify."
+  [frame-id event]
+  (when interop/debug-enabled?
+    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
+      (when-let [updated (state/back-fill-render! frame-id epoch-id
+                                                  event (render-row event))]
+        ;; Re-fan the corrected record so snapshot consumers re-read the
+        ;; ring. The fan-out is failure-isolated per listener (same
+        ;; contract as the settle-time fan-out); a render-driven Causa
+        ;; pump (`:rf.causa/epoch-recorded`) is `:rf.trace/no-emit?` so
+        ;; it commits no new epoch and cannot loop back into this path.
+        (notify-listeners! updated)))))
+
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
   and rf2-v0jwt §Outcomes (`:halted-destroy`):
@@ -161,4 +202,9 @@
     ;; explicitly clear here so the next cascade against a same-keyed
     ;; frame starts from an empty buffer. Symmetric to the ring-buffer
     ;; drop above.
-    (state/drop-frame-buffer! frame-id)))
+    (state/drop-frame-buffer! frame-id)
+    ;; Per rf2-qs6dl: forget the last-settled epoch-id so a post-destroy
+    ;; render emit (a torn-down component's final flush) can't back-fill
+    ;; into a record belonging to the destroyed frame's history — which
+    ;; was just dropped above anyway.
+    (state/drop-last-settled-epoch! frame-id)))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -196,6 +196,99 @@
   (swap! histories dissoc frame-id)
   nil)
 
+;; ---- post-settle render back-fill (rf2-qs6dl) -----------------------------
+;;
+;; A `:view/render` / `:rf.view/rendered` trace fires at React COMMIT
+;; time, which lands AFTER the causing cascade's run-to-completion has
+;; settled (Reagent batches re-renders onto a later tick — see
+;; `re-frame.interop/after-render`). By commit time `settle!` has already
+;; harvested the cascade buffer and committed the record, so the render
+;; emit lands in a now-empty buffer and — pre-rf2-qs6dl — was harvested
+;; by the NEXT cascade's settle, mis-attributing every render to cascade
+;; N+1 (the one-epoch lag the bead documents).
+;;
+;; The fix attributes the render to the cascade that CAUSED it: when a
+;; render fires with no in-flight cascade for the frame, it is back-filled
+;; into that frame's most-recently-settled epoch record (the cascade that
+;; dirtied the view's inputs and scheduled the re-render). `last-settled-
+;; epoch` tracks frame-id → epoch-id so the back-fill targets the right
+;; record without re-walking the whole ring.
+
+(defonce ^:private last-settled-epoch
+  ;; frame-id → epoch-id of the most-recently-committed :ok-shaped epoch.
+  (atom {}))
+
+(defn set-last-settled-epoch!
+  "Record `epoch-id` as the most-recently-settled epoch for `frame-id`.
+  Called from `settle!` after the record lands in the ring so post-settle
+  render emits can be attributed back to this cascade (rf2-qs6dl)."
+  [frame-id epoch-id]
+  (when (and frame-id epoch-id)
+    (swap! last-settled-epoch assoc frame-id epoch-id))
+  nil)
+
+(defn last-settled-epoch-id
+  "Return the most-recently-settled epoch-id for `frame-id`, or nil."
+  [frame-id]
+  (get @last-settled-epoch frame-id))
+
+(defn drop-last-settled-epoch!
+  "Forget the most-recently-settled epoch for `frame-id` (frame teardown
+  / fixture reset)."
+  [frame-id]
+  (swap! last-settled-epoch dissoc frame-id)
+  nil)
+
+(defn reset-last-settled-epochs!
+  "Wipe the last-settled-epoch map across all frames. Test fixtures call
+  this in lockstep with `reset-histories!` / `reset-capture-buffers!`."
+  []
+  (reset! last-settled-epoch {})
+  nil)
+
+(defn back-fill-render!
+  "Append `render-event` and its projected `:renders` row into the
+  already-committed epoch record identified by `frame-id` + `epoch-id`
+  (rf2-qs6dl). Returns the updated record (so the caller can re-notify
+  listeners), or nil when the target epoch is no longer in the ring
+  (evicted, or the render fired before any cascade settled).
+
+  `render-row` is the structured `:renders` entry (or nil — a non-
+  `:view/render` render op such as `:rf.view/rendered` rides only the
+  `:trace-events` slot). The mutation rewrites the matching record in
+  the frame's history vector under a single `swap!`; the record stays at
+  its original ring position so epoch ordering is preserved."
+  [frame-id epoch-id render-event render-row]
+  (let [updated (atom nil)]
+    (swap! histories update frame-id
+           (fn [history]
+             (let [history (or history [])
+                   idx     (some (fn [i]
+                                   (when (= epoch-id (:epoch-id (nth history i)))
+                                     i))
+                                 (range (count history)))]
+               (if (nil? idx)
+                 history
+                 (let [r  (nth history idx)
+                       r' (cond-> r
+                            ;; Only records that retained their raw
+                            ;; trace stream (within :trace-events-keep)
+                            ;; carry the slot; back-fill it when present
+                            ;; so the Reactive panel's flow tally and any
+                            ;; raw-trace consumer see the post-settle
+                            ;; render in the right cascade.
+                            (contains? r :trace-events)
+                            (update :trace-events (fnil conj []) render-event)
+                            ;; The structured :renders projection is the
+                            ;; primary consumer surface (Causa Views /
+                            ;; Reactive panel). Always present on a built
+                            ;; record; append the projected row.
+                            (some? render-row)
+                            (update :renders (fnil conj []) render-row))]
+                   (reset! updated r')
+                   (assoc history idx r'))))))
+    @updated))
+
 ;; ---- per-cascade capture buffer -------------------------------------------
 ;;
 ;; Per Tool-Pair §Per-cascade capture: the drain runs traces through
@@ -253,9 +346,12 @@
   nil)
 
 (defn reset-histories!
-  "Wipe every frame's recorded epochs."
+  "Wipe every frame's recorded epochs. Also clears the last-settled-epoch
+  map (rf2-qs6dl) so a fixture's first cascade can't back-fill a render
+  into a previous fixture's record."
   []
   (reset! histories {})
+  (reset-last-settled-epochs!)
   nil)
 
 ;; ---- listener registry ----------------------------------------------------

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2662,3 +2662,164 @@
             :trace-events-keep 5; the older absent-default behaviour
             (unbounded) is gone (pre-alpha — no back-compat)"
     (is (= 5 (:trace-events-keep (epoch/current-config))))))
+
+;; ---- rf2-qs6dl: post-settle render attributed to the CAUSING cascade -----
+;;
+;; THE BUG (P1, confirmed live on parallel-frames): a `:view/render` /
+;; `:rf.view/rendered` trace fires at React COMMIT time, which lands
+;; AFTER the causing cascade's run-to-completion has settled (Reagent
+;; batches re-renders onto a later tick — `re-frame.interop/after-render`).
+;; By commit time `settle!` has already harvested the cascade buffer and
+;; committed the record, so the render emit landed in a now-empty buffer
+;; and was harvested by the NEXT cascade's settle — mis-attributing every
+;; render to cascade N+1 (a one-epoch lag). Causa's Views/Reactive panel
+;; therefore showed the wrong cascade's re-renders: e.g. a `counter-inc`
+;; epoch reported `title-view` rendered, which is IMPOSSIBLE (title-view
+;; reads no counter sub) — it was the previous title cascade's lagged
+;; render.
+;;
+;; WHY THE PRIOR SUITE MISSED IT: every existing render-projection test
+;; (`record-shape-canonical`, the depth/keep tests, the projection
+;; tests) drives renders the JVM way — implicitly, INSIDE the synchronous
+;; `dispatch-sync` cascade — and only asserts the SHAPE of `:renders`
+;; (`vector?`, slot present). None modelled the real browser timing where
+;; the render emit fires AFTER the cascade settled, and none asserted
+;; cross-cascade attribution (cascade B carries B's renders and NOT A's).
+;; The lag is invisible to any test that emits the render inside the
+;; cascade or never checks WHICH epoch a render lands in.
+;;
+;; The two tests below model the React-commit timing explicitly: a
+;; `:view/render` is emitted OUTSIDE any cascade (no `*handler-scope*`,
+;; empty in-flight buffer) — exactly what `capture-event!` sees when
+;; Reagent flushes a batched re-render after the drain. Pre-fix the
+;; render leaks into the next cascade; post-fix it is back-filled into
+;; the cascade that caused it.
+
+(defn- emit-post-settle-render!
+  "Emit a `:view/render` trace the way the substrate does at React commit
+  time: op-type `:view`, tags carrying `:render-key` + `:frame`, fired
+  OUTSIDE any cascade (no in-flight buffer). Mirrors
+  `re-frame.views/emit-render-trace!`'s `:view/render` emit."
+  [frame-id view-id]
+  (trace/emit! :view :view/render
+               {:render-key [view-id 0]
+                :frame      frame-id}))
+
+(defn- rendered-view-ids
+  "The view-ids present in an epoch record's `:renders` projection."
+  [record]
+  (->> (:renders record)
+       (map (comp first :render-key))
+       set))
+
+(deftest post-settle-render-attributed-to-causing-cascade
+  (testing "rf2-qs6dl — a render that fires AFTER its cascade settled
+            (React-commit timing) is attributed to the cascade that
+            CAUSED it, not the next in-flight cascade. Two cascades that
+            re-render DIFFERENT views must each carry their OWN render."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed         (fn [_ _] {:title "a" :counter 0}))
+    (rf/reg-event-db :title-loaded (fn [db _] (assoc db :title "loaded")))
+    (rf/reg-event-db :counter-inc  (fn [db _] (update db :counter inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    ;; Cascade A — a title refresh. It settles, THEN (next tick, React
+    ;; commit) title-view re-renders. Model the post-settle render.
+    (rf/dispatch-sync [:title-loaded] {:frame :test/main})
+    (let [epoch-a (last (rf/epoch-history :test/main))]
+      (emit-post-settle-render! :test/main :title-view)
+
+      ;; Cascade B — a counter bump. It settles, THEN counter-view (and
+      ;; ONLY counter-view — counter-inc cannot make title-view re-render)
+      ;; re-renders post-settle.
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+      (let [epoch-b (last (rf/epoch-history :test/main))]
+        (emit-post-settle-render! :test/main :counter-view)
+
+        ;; Re-read the ring — both records were back-filled in place.
+        (let [history (rf/epoch-history :test/main)
+              a       (some #(when (= (:epoch-id epoch-a) (:epoch-id %)) %) history)
+              b       (some #(when (= (:epoch-id epoch-b) (:epoch-id %)) %) history)]
+          (is (= :title-loaded (:event-id a)))
+          (is (= :counter-inc  (:event-id b)))
+
+          ;; The smoking gun, pinned: cascade A carries title-view and
+          ;; NOT counter-view; cascade B carries counter-view and NOT
+          ;; title-view. Pre-fix, A's title-view render leaked into B's
+          ;; epoch (the one-epoch lag), so B would (wrongly) report
+          ;; title-view and A would report nothing.
+          (is (contains? (rendered-view-ids a) :title-view)
+              "cascade A's epoch carries its OWN title-view render")
+          (is (not (contains? (rendered-view-ids a) :counter-view))
+              "cascade A's epoch does NOT carry cascade B's counter-view render")
+          (is (contains? (rendered-view-ids b) :counter-view)
+              "cascade B's epoch carries its OWN counter-view render")
+          (is (not (contains? (rendered-view-ids b) :title-view))
+              "cascade B's epoch does NOT carry cascade A's lagged
+               title-view render — THE LAG IS GONE (a counter-inc cannot
+               make title-view re-render)"))))))
+
+(deftest post-settle-render-back-fill-renotifies-listeners
+  (testing "rf2-qs6dl — back-filling a post-settle render re-fans the
+            corrected record out to epoch listeners so snapshot consumers
+            (Causa Views/Reactive panel, which cache epoch-history at
+            settle time) re-sync to the corrected :renders"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (let [settle-fanouts (count @seen)]
+        ;; A post-settle render for the :inc epoch fires (React commit).
+        (emit-post-settle-render! :test/main :counter-view)
+        (is (= (inc settle-fanouts) (count @seen))
+            "the back-fill triggered exactly one additional listener fan-out")
+        (let [renotified (last @seen)]
+          (is (= :inc (:event-id renotified))
+              "the re-fanned record is the :inc cascade's (the causing epoch)")
+          (is (contains? (rendered-view-ids renotified) :counter-view)
+              "the re-fanned record carries the back-filled render"))))))
+
+(deftest in-flight-render-still-rides-current-cascade
+  (testing "rf2-qs6dl — a render that fires WITH a cascade in flight
+            (synchronous flush — SSR / a render inside the cascade)
+            belongs to that cascade and is buffered normally, NOT
+            back-filled. Renders emitted during dispatch-sync land in
+            their own epoch."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    ;; A handler that emits a :view/render WHILE the cascade is draining
+    ;; (an in-flight render — the buffer already holds :event/run-start).
+    (rf/reg-event-db :render-during
+      (fn [db _]
+        (trace/emit! :view :view/render
+                     {:render-key [:inline-view 0] :frame :test/main})
+        (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:render-during] {:frame :test/main})
+
+    (let [epoch (last (rf/epoch-history :test/main))]
+      (is (= :render-during (:event-id epoch)))
+      (is (contains? (rendered-view-ids epoch) :inline-view)
+          "an in-flight render rides its own cascade's epoch (buffered,
+           not back-filled to a prior settled epoch)"))))
+
+(deftest post-settle-render-before-any-cascade-is-noop
+  (testing "rf2-qs6dl — a render that fires before any cascade has
+            settled (no last-settled epoch for the frame) is a silent
+            no-op: no record exists to back-fill, no listener fan-out,
+            no throw."
+    (rf/reg-frame :test/main {})
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
+      ;; No cascade has run — last-settled-epoch is empty for the frame.
+      (emit-post-settle-render! :test/main :orphan-view)
+      (is (= [] (rf/epoch-history :test/main))
+          "no record materialised from an orphan render")
+      (is (= [] @seen)
+          "no listener fan-out for a render with no causing cascade"))))


### PR DESCRIPTION
## Root cause (confirmed, falsifiable prediction held)

A `:view/render` / `:rf.view/rendered` trace fires at **React commit time**, which lands AFTER the causing cascade's run-to-completion has settled — Reagent batches re-renders onto a later tick (`re-frame.interop/after-render`). By commit time `re-frame.epoch/settle!` has already `harvest-buffer!`'d the cascade buffer and committed the epoch record, so the render emit lands in a now-empty per-frame buffer and gets harvested by the **next** cascade's settle. Result: each epoch's `:renders` projection lists the renders caused by the PREVIOUS cascade — a one-epoch lag. (Same timing that makes `dispatch-and-collect` return `:n-trace 0`.)

## The fix

`re-frame.epoch.capture/capture-event!` now detects a view-render op arriving with **no in-flight cascade** for its frame (no `:event/run-start` buffered — the same gate `on-frame-destroyed!` uses for mid-drain detection) and routes it to a back-fill instead of the next-cascade buffer:

- `settle!` records `last-settled-epoch[frame] = epoch-id` after `record!`.
- A post-settle render is attributed to that epoch — the cascade that dirtied the view's inputs and scheduled the re-render — via `state/back-fill-render!`, which appends the render's `:renders` row (and `:trace-events` entry when the slot is retained) into the already-committed record in place.
- The corrected record is re-fanned through `notify-listeners!` so snapshot consumers (Causa Views/Reactive panel, which cache `epoch-history` at settle time via `:rf.causa/epoch-recorded`) re-sync. The Causa pump is `:rf.trace/no-emit?` so it commits no new epoch and cannot loop.
- A render that fires **with** a cascade in flight (synchronous flush — SSR, a render triggered inside another render's reactive read) still belongs to that cascade and is buffered as before.

Orchestrator lives in `re-frame.epoch.listeners/record-render!` (has both `state` + `notify-listeners!`); `capture` reaches it through the `:epoch/record-render!` late-bind hook to avoid the `assembly → capture` require cycle. Dev-only/elidable — the whole path is under `interop/debug-enabled?` and DCEs in production (`npm run test:elision` 35/35 absent).

## Regression test + why prior tests missed it

`implementation/epoch/test/re_frame/epoch_test.clj` adds four tests. The headline two-cascade test emits a `:view/render` **outside any cascade** (modelling the React-commit timing) and asserts cross-cascade attribution: cascade A (title) carries `title-view` and NOT `counter-view`; cascade B (counter-inc) carries `counter-view` and NOT A's lagged `title-view`.

Prior tests missed it because every existing render-projection test drives renders the JVM way — **inside** the synchronous `dispatch-sync` cascade — and only asserts the *shape* of `:renders` (`vector?`, slot present). None modelled the post-settle React timing, and none asserted **which** epoch a render lands in. The lag is invisible to any test that emits the render inside the cascade or never checks attribution.

Verified the test FAILS without the fix: with the back-fill disabled, `cascade B's epoch carries cascade A's lagged title-view render` and `cascade B's epoch carries its OWN counter-view render` both fail — exactly the documented symptom.

## Before / after epoch -> renders (browser, parallel-frames `:below`)

**BEFORE (buggy)** — each epoch carries the PREVIOUS cascade's renders:
```
epoch 13  counter-inc    -> [title-view]    <- IMPOSSIBLE (counter-inc can't render title-view); 11's lag
epoch 16  counter-inc    -> [counter-view]  <- 13's lagged counter render
epoch 19  title-refresh  -> [counter-view]  <- lagged
```

**AFTER (fixed)** — each epoch carries its OWN cascade's renders:
```
epoch 12  :title/flow (reply->loaded) -> [title-view]
epoch 14  counter-inc                 -> [counter-view]
epoch 17  counter-inc                 -> [counter-view]
epoch 20  title-refresh               -> [title-view]
epoch 23  :title/flow (reply->loaded) -> [title-view]
```

## Gates

- `npm run test:cljs` — 4090 tests, 0 failures
- JVM core (`clojure -M:test`) — 719 tests, 0 failures (added the `:epoch/record-render!` late-bind directory entry the drift test requires)
- JVM epoch (`clojure -M:test`) — 187 tests, 0 failures (incl. 4 new)
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- `npm run test:elision` — production 35/35 absent
- Browser-verify on parallel-frames `:below` — PASS (mapping above)

No spec files touched (mkdocs not required).