### PR TITLE
feat(causa): pink diagonal-stripe view hover-highlight (rf2-8l03l)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -24,13 +24,18 @@
                                   slot (fallback: var name) +
                                   [code] chip + hover-highlight
 
-  ## Hover-highlight (rf2-e33ad)
+  ## Hover-highlight (rf2-e33ad / rf2-8l03l)
 
-  Hovering a view row stamps a subtle `:bg-3`-tinted highlight on the
-  rendered view's root DOM node (matched by `data-rf-view` — the
-  attribute the framework already stamps per Spec 006 §View tagging
-  contract). The highlight is background-only — NO border / outline /
-  shadow that would perturb layout. Cleared on mouseleave.
+  Hovering a view row toggles the `.rf-causa-view-highlight` class
+  (rf2-8l03l) onto the rendered view's root DOM node (matched by
+  `data-rf-view` — the attribute the framework already stamps per
+  Spec 006 §View tagging contract). The class (theme/global-styles)
+  paints a translucent PINK DIAGONAL-STRIPE barber-pole via
+  `background-image` — pink-on-fainter-pink so it reads on both light
+  and dark app surfaces, translucent so the view's content shows
+  through. The highlight is background-only — NO border / outline /
+  shadow that would perturb layout. Cleared on mouseleave by removing
+  the class (no residue).
 
   Pure hiccup — frame isolation via the enclosing
   `[rf/frame-provider {:frame :rf/causa}]` in the shell. Subs read on
@@ -225,22 +230,35 @@
     (when (string? file)
       {:file file :line (:line meta) :column (:column meta) :ns (:ns meta)})))
 
-;; ---- hover-highlight (rf2-e33ad) ---------------------------------------
+;; ---- hover-highlight (rf2-e33ad / rf2-8l03l) --------------------------
 ;;
-;; Hover a view-row → stamp a subtle background-only highlight on the
-;; rendered view's root DOM node (matched via the `data-rf-view`
+;; Hover a view-row → stamp a distinctive background-only highlight on
+;; the rendered view's root DOM node (matched via the `data-rf-view`
 ;; attribute the framework already stamps per Spec 006). Cleared on
 ;; mouseleave.
 ;;
+;; Mechanism (rf2-8l03l): toggle the Causa-namespaced
+;; `.rf-causa-view-highlight` class. The class rule (in
+;; `theme/global-styles` `motion-css`) paints a TRANSLUCENT PINK
+;; DIAGONAL-STRIPE barber-pole via `background-image` over the view's
+;; own background — pink-on-fainter-pink so it reads on BOTH light and
+;; dark app surfaces, translucent so the view's content shows through.
+;; A class toggle is cleaner than the old inline stash/restore: the
+;; `background-image` gradient layers OVER the view's own
+;; `background-color` without destroying it, and `clear-highlight!`
+;; simply removes the class to fully restore the node — no
+;; `data-rf-causa-prior-bg` stash, no residue.
+;;
 ;; Why background-only: NO border / outline / shadow that would
-;; perturb layout. Per Mike-direction 2026-05-21 the hover signal must
-;; be subtle and must NOT shift surrounding pixels.
+;; perturb layout. Per Mike-direction 2026-05-21 (rf2-e33ad) the hover
+;; signal must NOT shift surrounding pixels — a `background-image`
+;; paints inside the existing box with zero reflow.
 
-(def ^:private highlight-bg-color
-  "The hover-highlight tint. `:bg-3` is the canonical subtle
-  surface-3 token; light + dark themes both resolve through the
-  CSS-variable layer (rf2-on4cm landed)."
-  (:bg-3 tokens))
+(def ^:private highlight-class
+  "Causa-namespaced class toggled onto the hovered view's
+  `data-rf-view` node. The matching CSS rule (theme/global-styles)
+  paints the pink diagonal-stripe `background-image`."
+  "rf-causa-view-highlight")
 
 (defn- highlight-selector
   "Build the DOM selector for a view-id. Per Spec 006 the attribute
@@ -249,33 +267,25 @@
   (str "[data-rf-view='" (str view-id) "']"))
 
 (defn- apply-highlight!
-  "Stamp the highlight onto every DOM node matching `view-id`. Stashes
-  the prior inline `background-color` in a custom data attribute so
-  `clear-highlight!` can restore the value. CLJS-only side effect."
-  [view-id]
-  (when (and (exists? js/document) view-id)
-    (let [nodes (.querySelectorAll js/document (highlight-selector view-id))]
-      (.forEach nodes
-                (fn [^js node]
-                  (when-not (.getAttribute node "data-rf-causa-prior-bg")
-                    (let [prior (or (.. node -style -backgroundColor) "")]
-                      (.setAttribute node "data-rf-causa-prior-bg" prior)
-                      (set! (.. node -style -backgroundColor)
-                            highlight-bg-color)))))
-      nil)))
-
-(defn- clear-highlight!
-  "Restore the prior inline `background-color` on every DOM node
+  "Toggle the pink diagonal-stripe highlight class onto every DOM node
   matching `view-id`. CLJS-only side effect."
   [view-id]
   (when (and (exists? js/document) view-id)
     (let [nodes (.querySelectorAll js/document (highlight-selector view-id))]
       (.forEach nodes
                 (fn [^js node]
-                  (let [prior (.getAttribute node "data-rf-causa-prior-bg")]
-                    (when prior
-                      (set! (.. node -style -backgroundColor) prior)
-                      (.removeAttribute node "data-rf-causa-prior-bg")))))
+                  (.add (.-classList node) highlight-class)))
+      nil)))
+
+(defn- clear-highlight!
+  "Remove the highlight class from every DOM node matching `view-id`,
+  fully restoring the node to its original look. CLJS-only side effect."
+  [view-id]
+  (when (and (exists? js/document) view-id)
+    (let [nodes (.querySelectorAll js/document (highlight-selector view-id))]
+      (.forEach nodes
+                (fn [^js node]
+                  (.remove (.-classList node) highlight-class)))
       nil)))
 
 ;; ---- header (outcome line; no h1) --------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -727,6 +727,38 @@
     "[data-testid^=\"rf-causa-edn-widget-browse-\"]:hover .rf-causa-edn-widget-copy,\n"
     "[data-testid^=\"rf-causa-edn-widget-browse-\"]:focus-within .rf-causa-edn-widget-copy {\n"
     "  opacity: 1;\n"
+    "}\n"
+    ;; rf2-8l03l — view-row hover-highlight (supersedes the flat grey
+    ;; :bg-3 inline tint). When the operator hovers a view-row in the
+    ;; Views / Reactive panel, `apply-highlight!` toggles this class on
+    ;; the hovered view's rendered DOM node (matched via the framework's
+    ;; `data-rf-view` attribute; Spec 006). The rule layers a translucent
+    ;; PINK DIAGONAL-STRIPE barber-pole (Tailwind pink-500 at two alphas)
+    ;; OVER the view's own background — pink-on-fainter-pink so the
+    ;; signal reads on BOTH light and dark app surfaces (white-on-white
+    ;; would vanish on a light page), and translucent so the view's own
+    ;; content + background show through.
+    ;;
+    ;; LAYOUT-SAFE (rf2-e33ad / Mike-direction 2026-05-21): background
+    ;; ONLY. No border / outline / box-shadow / box-model change → ZERO
+    ;; pixel shift on surrounding content. A `background-image` (gradient)
+    ;; paints inside the existing box without reflow. `!important` beats
+    ;; the per-view inline `background-image` (rare) so the stripe always
+    ;; lands; the class layers over the view's inline `background-color`
+    ;; without destroying it, and `clear-highlight!` simply removes the
+    ;; class to restore the node to its original look (no residue, no
+    ;; stash/restore dance).
+    ;;
+    ;; The selector is intentionally UNSCOPED (no `rf-causa-shell`
+    ;; ancestor) — the `data-rf-view` nodes live in the inspected app's
+    ;; frame, OUTSIDE the Causa shell, so the rule must reach the whole
+    ;; document. The `.rf-causa-view-highlight` class name is Causa-
+    ;; namespaced so it can't collide with host-app classes.
+    ".rf-causa-view-highlight {\n"
+    "  background-image: repeating-linear-gradient(\n"
+    "    45deg,\n"
+    "    rgba(236, 72, 153, 0.30) 0 6px,\n"
+    "    rgba(236, 72, 153, 0.10) 6px 12px) !important;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -353,6 +353,70 @@
         (is (re-find #"Mark\s*!important" block)
             "Mark rule carries !important")))))
 
+;; ---- rf2-8l03l — view hover-highlight class ----------------------------
+;;
+;; The view-row hover-highlight (panels/reactive_panel_view
+;; apply-highlight! / clear-highlight!) toggles the
+;; `.rf-causa-view-highlight` class onto the hovered view's
+;; `data-rf-view` DOM node. The class rule lives in `motion-css` and
+;; paints a translucent PINK DIAGONAL-STRIPE barber-pole via
+;; `background-image` — pink-on-fainter-pink so it reads on both light
+;; and dark app surfaces. Layout-safe: background-only (no border /
+;; outline / box-shadow) so hovering shifts ZERO surrounding pixels.
+
+(deftest motion-css-declares-view-highlight-class
+  (testing "rf2-8l03l — the motion stylesheet ships a
+            `.rf-causa-view-highlight` rule (toggled by apply-highlight!
+            / clear-highlight! in reactive_panel_view) that supersedes
+            the old flat grey :bg-3 inline tint."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"\.rf-causa-view-highlight\s*\{" css)
+          "the Causa-namespaced highlight class rule is present"))))
+
+(deftest motion-css-view-highlight-is-pink-diagonal-stripe
+  (testing "rf2-8l03l — the highlight paints a translucent PINK
+            DIAGONAL-STRIPE barber-pole: a 45deg repeating-linear-
+            gradient of Tailwind pink-500 (rgb 236,72,153) at two
+            alphas (0.30 / 0.10). Pink-on-fainter-pink (NOT white) so
+            the signal reads on BOTH light and dark app backgrounds,
+            translucent so the view's own content shows through."
+    (let [css @#'gs/motion-css
+          rule (re-find #"\.rf-causa-view-highlight\s*\{[\s\S]*?\}" css)]
+      (is (some? rule) "highlight rule block found")
+      (when rule
+        (is (re-find #"repeating-linear-gradient" rule)
+            "uses a repeating-linear-gradient (barber-pole stripe)")
+        (is (re-find #"45deg" rule)
+            "the stripes run at 45deg (diagonal)")
+        (is (re-find #"rgba\(236,\s*72,\s*153,\s*0\.30\)" rule)
+            "the brighter pink band is pink-500 at 0.30 alpha")
+        (is (re-find #"rgba\(236,\s*72,\s*153,\s*0\.10\)" rule)
+            "the fainter pink band is pink-500 at 0.10 alpha")
+        (is (not (re-find #"255,\s*255,\s*255" rule))
+            "NOT white — white would vanish on a light app background")))))
+
+(deftest motion-css-view-highlight-is-layout-safe
+  (testing "rf2-8l03l / rf2-e33ad (Mike-direction 2026-05-21) — the
+            highlight is background-ONLY so hovering shifts ZERO
+            surrounding pixels. A `background-image` (gradient) paints
+            inside the existing box without reflow; there must be NO
+            border / outline / box-shadow / box-model property in the
+            rule that could perturb layout."
+    (let [css @#'gs/motion-css
+          rule (re-find #"\.rf-causa-view-highlight\s*\{[\s\S]*?\}" css)]
+      (is (some? rule) "highlight rule block found")
+      (when rule
+        (is (re-find #"background-image:" rule)
+            "paints via background-image (layout-safe)")
+        (is (not (re-find #"(?i)\bborder\b\s*:" rule))
+            "no border declaration (would shift the box)")
+        (is (not (re-find #"(?i)\boutline\b\s*:" rule))
+            "no outline declaration")
+        (is (not (re-find #"(?i)box-shadow\s*:" rule))
+            "no box-shadow declaration")
+        (is (not (re-find #"(?i)\b(margin|padding|width|height)\s*:" rule))
+            "no box-model property that could shift surrounding pixels")))))
+
 ;; ---- rf2-5kfxe.6 — light theme CSS variables ---------------------------
 
 (deftest themes-css-publishes-root-defaults


### PR DESCRIPTION
## Summary

Replaces the flat grey `:bg-3` view hover-highlight with a distinctive, unmistakably-inspector overlay (rf2-8l03l). Hovering a view-row in the Views/Reactive panel now paints a **translucent pink diagonal-stripe barber-pole** on the matching `[data-rf-view]` app node.

### The gradient

```
repeating-linear-gradient(45deg,
  rgba(236, 72, 153, 0.30) 0 6px,
  rgba(236, 72, 153, 0.10) 6px 12px)
```

Tailwind pink-500 at two alphas — **pink-on-fainter-pink (NOT white)** so the signal reads on BOTH light and dark app backgrounds, translucent so the view's own content + background show through.

### Class vs inline — chose the class

Toggle a Causa-namespaced `.rf-causa-view-highlight` class (rule added to `theme/global-styles` `motion-css`) rather than the old inline `backgroundColor` stash/restore. Rationale:

- The class's `background-image` layers OVER the view's own `background-color` without destroying it; `clear-highlight!` just removes the class → full restore, no residue.
- Drops the `data-rf-causa-prior-bg` stash/restore attribute dance and the `highlight-bg-color` def entirely.
- The CSS rule is intentionally **unscoped** (no `rf-causa-shell` ancestor) — the `data-rf-view` nodes live in the inspected app's frame, OUTSIDE the Causa shell, so the rule must reach the whole document. The class name is `rf-causa-`-namespaced so it can't collide with host-app classes.

### Layout-safe (rf2-e33ad / Mike-direction 2026-05-21)

Background-image ONLY. No border / outline / box-shadow / box-model change. A gradient paints inside the existing box with zero reflow → **ZERO pixel shift** on surrounding content.

## Test plan

- [x] `npm run test:cljs` — 4095 tests / 12437 assertions, 0 failures (includes 3 new tests asserting the rule exists, is the pink 45deg gradient at 0.30/0.10 with no white, and is layout-safe — no border/outline/box-shadow/box-model property).
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures, 13 matrix rows.
- [x] **Browser-verified on parallel-frames** (headless Chromium via Playwright): hovered a Views-panel view-row → matching app node (`:parallel-frames.core/counter-view`) gained `.rf-causa-view-highlight` with computed `background-image` = the pink 45deg `repeating-linear-gradient` (236,72,153 at 0.3/0.1); **layout shift = false** (every app-subtree element's bounding rect identical before vs during hover); mouseleave restored `background-image` to `none`, class removed, no `data-rf-causa-prior-bg` residue.