### PR TITLE
feat(causa testbed): odd/even counter parity pill in parallel-frames (cascade fixture, rf2-frz16)

### DIFF
--- a/tools/causa/testbeds/parallel_frames/core.cljs
+++ b/tools/causa/testbeds/parallel_frames/core.cljs
@@ -129,6 +129,14 @@
 
 (rf/reg-sub ::counter (fn [db _] (:counter db)))
 
+;; Layer-2 derived sub — cascades ← ::counter. Recomputes whenever the
+;; counter value changes (every +/- click), giving Causa's Views panel
+;; live `cascaded?` data: ::counter is L1 (app-db input, cascaded ✗);
+;; ::counter-parity is L2 (sub input, cascaded ✓ ← ::counter).
+(rf/reg-sub ::counter-parity
+  :<- [::counter]
+  (fn [counter _] (if (even? counter) "even" "odd")))
+
 ;; ============================================================================
 ;; TITLE (HTTP) — :title/flow state machine + mock-HTTP fx
 ;; ============================================================================
@@ -273,7 +281,13 @@
 ;; identical to the single monolithic panel it replaced.
 
 (reg-view counter-view [frame-label]
-  (let [counter @(subscribe [::counter])]
+  ;; Subscribing `::counter-parity` is what makes the L2 chain run — a
+  ;; sub only recomputes when a rendered view reads it. The pill below
+  ;; is therefore both a feature display AND the fixture that gives
+  ;; Causa's Views `cascaded?` column live data on every +/- click.
+  (let [counter @(subscribe [::counter])
+        parity  @(subscribe [::counter-parity])
+        even?    (= parity "even")]
     [:div {:style {:margin "0.75em 0 0.5em 0"
                    :display "flex" :gap "8px" :align-items "center"}}
      [:strong "Counter:"]
@@ -288,7 +302,18 @@
       counter]
      [:button {:data-testid (str frame-label "-counter-inc")
                :on-click    #(dispatch [::counter-inc])}
-      "+"]]))
+      "+"]
+     [:span {:data-testid (str frame-label "-counter-parity")
+             :style {:font-size "11px"
+                     :font-weight "bold"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.04em"
+                     :padding "1px 8px"
+                     :border-radius "999px"
+                     :color      (if even? "#1a5" "#a40")
+                     :background  (if even? "#e6f7ee" "#fdece6")
+                     :border      (str "1px solid " (if even? "#bfe6cf" "#f3cab8"))}}
+      parity]]))
 
 (reg-view title-view [frame-label]
   (let [state    @(subscribe [::title-state])


### PR DESCRIPTION
## Summary

`parallel-frames` had only **layer-1** subs, so Causa's Views `cascaded?` column never had standing coverage (nothing had an upstream-sub input). This adds a layer-2 derived sub plus a display so the flag has both standing coverage and a live demo.

**The layer-2 sub** (after `::counter`):

```clojure
(rf/reg-sub ::counter-parity
  :<- [::counter]
  (fn [counter _] (if (even? counter) "even" "odd")))
```

**The pill** in `counter-view` — subscribes `::counter-parity` (this is what makes the L2 chain actually run; a sub only recomputes when a rendered view reads it) and renders a compact rounded `:span` next to the counter value with `:data-testid (str frame-label "-counter-parity")`, the text `even`/`odd`, and a parity-tinted background (green for even, peach for odd). Consistent with the testbed's existing inline-style aesthetic; `counter-view` is otherwise unchanged.

## The cascade it produces

Clicking +/- now drives two recomputes, giving Causa's Views `cascaded?` column live data:

- `::counter` — changed ✓, cascaded ✗ (L1, app-db input)
- `::counter-parity` — cascaded ✓ ← `::counter`, changed ✓ on each parity flip

Note: cascaded *attribution correctness* itself rides rf2-wi900 (the `:sub/run` lag fix, in flight) — this bead exercises the flag; correct attribution lands with wi900.

## Browser-verify (Playwright, headless, against a static build of this branch)

`:below` frame, clicking the counter:

| value | pill | bg |
|-------|------|-----|
| 0 | even | green `#e6f7ee` |
| 1 | odd | peach `#fdece6` |
| 2 | even | green |
| 1 | odd | peach |

`:above` frame stayed isolated at `0` / `even` throughout (frame isolation intact). No console errors.

## Test plan

- [x] `npx shadow-cljs compile :examples/parallel-frames` — 0 warnings
- [x] `npx shadow-cljs compile node-test` + `node out/node-test.js` — 4095 tests, 0 failures
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures (parallel-frames change is in `parallel_frames/core.cljs`; the e2e test uses its own local counter handlers, unaffected)
- [x] Browser-verify pill renders + flips even/odd correctly, per table above