### PR TITLE
fix(instrumentation): back-fill post-settle :sub/run to the causing cascade (rf2-wi900)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -503,6 +503,10 @@
     :producer-ns 're-frame.epoch
     :design-bead "rf2-qs6dl"
     :description "Attribute a post-settle render emit (a :view/render / :rf.view/rendered op firing at React commit time, after the causing cascade settled) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a render op arrives with no in-flight cascade; back-fills the render into the causing epoch record and re-fans it to epoch listeners so snapshot consumers re-sync. Fixes the one-epoch :renders lag."}
+   {:key         :epoch/record-sub-run!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-wi900"
+    :description "Subs sibling of :epoch/record-render!. Attribute a post-settle sub-run emit (a :sub/run / :rf.sub/skip op firing at React deref time, after the causing cascade settled, because reactions recompute lazily) back to the cascade that caused it — the frame's most-recently-settled epoch. Called by re-frame.epoch.capture/capture-event! when a sub-run op arrives with no in-flight cascade; back-fills the sub-run (and its :value-changed? / :prev-value / :value attribution) into the causing epoch record and re-fans it to epoch listeners. Fixes the one-epoch :sub-runs lag visible in Causa's per-cascade Views subs table."}
    {:key         :epoch/epoch-history
     :producer-ns 're-frame.epoch
     :description "Return the committed-epoch ring buffer (introspection)."}

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -562,6 +562,14 @@
 ;; publishing it through late-bind keeps `capture` free of a require on
 ;; `listeners` (which would close the assembly→capture cycle).
 (late-bind/set-fn! :epoch/record-render!      listeners/record-render!)
+;; rf2-wi900: post-settle sub-run back-fill — the subs sibling of
+;; `:epoch/record-render!`. `capture-event!` routes a `:sub/run` /
+;; `:rf.sub/skip` op that fires with no in-flight cascade (a React-deref-
+;; time async reactive recompute) here so it is attributed to the cascade
+;; that CAUSED it (the frame's most-recently-settled epoch) rather than the
+;; next in-flight cascade — fixing the one-epoch `:sub-runs` /
+;; `:value-changed?` lag visible in Causa's per-cascade Views subs table.
+(late-bind/set-fn! :epoch/record-sub-run!     listeners/record-sub-run!)
 (late-bind/set-fn! :epoch/epoch-history       epoch-history)
 (late-bind/set-fn! :epoch/restore-epoch       restore-epoch)
 (late-bind/set-fn! :epoch/reset-frame-db!     reset-frame-db!)

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -81,6 +81,24 @@
     :rf.view/rendered
     :rf.view/rendered-cap-reached})
 
+;; ---- sub-run ops (rf2-wi900) ----------------------------------------------
+;;
+;; The subs sibling of render-ops. A `:sub/run` (reactive recompute) or
+;; `:sub/skip` (memo hit) fires when a reaction is derefed — and reactions
+;; deref LAZILY at React render time, which Reagent batches onto a later
+;; tick AFTER the causing cascade settled. So like a render, a sub-run
+;; arriving with no in-flight cascade for its frame is a post-settle async
+;; recompute and must be attributed back to the cascade that CAUSED it (the
+;; most-recently-settled epoch), not buffered into the next cascade — see
+;; `re-frame.epoch.state/back-fill-sub-run!` and
+;; `re-frame.epoch.listeners/record-sub-run!`. An in-flight (synchronous)
+;; sub-run — one that recomputes while a cascade is draining (an event
+;; handler that subscribes, an SSR render) — genuinely belongs to that
+;; cascade and is buffered normally.
+(def ^:private sub-run-ops
+  #{:sub/run
+    :rf.sub/skip})
+
 (defn- in-flight-cascade?
   "True when the frame's in-flight capture buffer already holds an
   `:event/run-start` emit — the canonical signal that a cascade has
@@ -125,7 +143,15 @@
   one-epoch lag the bead documents). Instead it is back-filled into the
   cascade that caused it via the `:epoch/record-render!` hook. A render
   that fires WITH a cascade in flight (synchronous flush) belongs to
-  that cascade and is buffered as before."
+  that cascade and is buffered as before.
+
+  Per rf2-wi900: the identical post-settle timing applies to reactive
+  sub-runs (`:sub/run` / `:rf.sub/skip`) — reactions recompute lazily at
+  React deref time, AFTER the causing cascade settled, so a sub-run with
+  no in-flight cascade is back-filled into the causing epoch via the
+  `:epoch/record-sub-run!` hook (sibling of `:epoch/record-render!`). An
+  in-flight sub-run (a handler that subscribes, an SSR render) belongs to
+  the in-flight cascade and is buffered as before."
   [event]
   (when interop/debug-enabled?
     (let [op       (:operation event)
@@ -133,8 +159,7 @@
           frame-id (or (:frame tags)
                        (:frame event))]
       (when (and frame-id (not (contains? skip-ops op)))
-        (if (and (contains? render-ops op)
-                 (not (in-flight-cascade? frame-id)))
+        (cond
           ;; Post-settle render — attribute to the causing cascade.
           ;; The orchestrator (state back-fill + listener re-notify)
           ;; lives in `re-frame.epoch.listeners`; reaching it through
@@ -143,9 +168,22 @@
           ;; is published at `re-frame.epoch` ns-load; when absent (the
           ;; degenerate load-order window before the facade installs it)
           ;; the render falls through to the normal buffer path.
+          (and (contains? render-ops op)
+               (not (in-flight-cascade? frame-id)))
           (if-let [record-render! (late-bind/get-fn-cached :epoch/record-render!)]
             (record-render! frame-id event)
             (state/buffer-event! frame-id event))
+
+          ;; Post-settle sub-run — the subs sibling (rf2-wi900). Same
+          ;; back-fill shape, distinct hook. Falls through to the normal
+          ;; buffer path during the pre-facade-install load-order window.
+          (and (contains? sub-run-ops op)
+               (not (in-flight-cascade? frame-id)))
+          (if-let [record-sub-run! (late-bind/get-fn-cached :epoch/record-sub-run!)]
+            (record-sub-run! frame-id event)
+            (state/buffer-event! frame-id event))
+
+          :else
           (state/buffer-event! frame-id event))))))
 
 ;; ---- cascade-cause (for :rf.view/rendered attribution, rf2-25zo2) --------

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -112,6 +112,52 @@
         ;; it commits no new epoch and cannot loop back into this path.
         (notify-listeners! updated)))))
 
+;; ---- post-settle sub-run back-fill (rf2-wi900) ----------------------------
+
+(defn- sub-run-row
+  "Project a `:sub/run` trace event into its structured `:sub-runs` row,
+  mirroring `capture/project-all`'s `:sub/run` arm VERBATIM (same slot set
+  + same value-change/cascade attribution threading per rf2-l1jz8).
+  Returns nil for `:rf.sub/skip` — `project-all` projects no `:sub-runs`
+  row for a memo hit, so a skip rides only the `:trace-events` slot
+  (symmetric with `render-row` returning nil for `:rf.view/rendered`)."
+  [event]
+  (when (= :sub/run (:operation event))
+    (let [t (:tags event)]
+      {:sub-id         (:sub-id t)
+       :query-v        (:query-v t)
+       :recomputed?    true
+       :value-changed? (:value-changed? t)
+       :prev-value     (:prev-value t)
+       :value          (:value t)
+       :cascade?       (:cascade? t)
+       :cause-sub      (:cause-sub t)})))
+
+(defn record-sub-run!
+  "Attribute a post-settle sub-run emit to the cascade that CAUSED it
+  (rf2-wi900). The subs sibling of `record-render!`: a `:sub/run` /
+  `:rf.sub/skip` trace fires when a reaction recomputes, and reactions
+  recompute lazily at React deref time — AFTER the causing cascade settled
+  — so it cannot ride the in-flight cascade buffer (there is none). This
+  back-fills the sub-run into the frame's most-recently-settled epoch
+  record and re-fans the updated record out to epoch listeners so snapshot
+  consumers (Causa's per-cascade Views subs table, which caches
+  `epoch-history` at settle time) re-sync to the corrected `:sub-runs` +
+  `:value-changed?` attribution.
+
+  No-op when the frame has no settled epoch yet (a sub-run before the
+  first cascade) or when the target epoch has been evicted from the ring
+  — `back-fill-sub-run!` returns nil and we skip the re-notify."
+  [frame-id event]
+  (when interop/debug-enabled?
+    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
+      (when-let [updated (state/back-fill-sub-run! frame-id epoch-id
+                                                   event (sub-run-row event))]
+        ;; Re-fan the corrected record so snapshot consumers re-read the
+        ;; ring. Same failure-isolated fan-out + no-loop contract as the
+        ;; render back-fill above.
+        (notify-listeners! updated)))))
+
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
   and rf2-v0jwt §Outcomes (`:halted-destroy`):

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -289,6 +289,67 @@
                    (assoc history idx r'))))))
     @updated))
 
+;; ---- post-settle sub-run back-fill (rf2-wi900) ----------------------------
+;;
+;; The subs sibling of the render back-fill above. A `:sub/run` (or
+;; `:sub/skip`) trace fires when a reaction recomputes — and reactions
+;; recompute LAZILY at React render (deref) time, which Reagent batches
+;; onto a later tick AFTER the causing cascade settled. So a sub-run, like
+;; a render, lands in the now-empty buffer post-settle and — pre-rf2-wi900
+;; — was harvested by the NEXT cascade's settle, mis-attributing every
+;; reactive recompute (and its `:value-changed?` / `:prev-value` / `:value`
+;; attribution) to cascade N+1 (the one-epoch lag the bead documents,
+;; visibly wrong in Causa's per-cascade Views subs table).
+;;
+;; The fix mirrors the render path exactly: a sub-run that fires with no
+;; in-flight cascade for the frame is back-filled into that frame's
+;; most-recently-settled epoch record (the cascade that dirtied the
+;; reaction's inputs and scheduled the recompute), reusing the same
+;; `last-settled-epoch` map the render back-fill tracks.
+
+(defn back-fill-sub-run!
+  "Append `sub-event` and its projected `:sub-runs` row into the
+  already-committed epoch record identified by `frame-id` + `epoch-id`
+  (rf2-wi900). Returns the updated record (so the caller can re-notify
+  listeners), or nil when the target epoch is no longer in the ring
+  (evicted, or the sub-run fired before any cascade settled).
+
+  `sub-run-row` is the structured `:sub-runs` entry (or nil — a `:sub/skip`
+  op carries no `:sub-runs` row, exactly as `project-all` projects no
+  `:sub-runs` row for it; it rides only the `:trace-events` slot). The
+  mutation rewrites the matching record in the frame's history vector
+  under a single `swap!`; the record stays at its original ring position
+  so epoch ordering is preserved. Symmetric with `back-fill-render!`."
+  [frame-id epoch-id sub-event sub-run-row]
+  (let [updated (atom nil)]
+    (swap! histories update frame-id
+           (fn [history]
+             (let [history (or history [])
+                   idx     (some (fn [i]
+                                   (when (= epoch-id (:epoch-id (nth history i)))
+                                     i))
+                                 (range (count history)))]
+               (if (nil? idx)
+                 history
+                 (let [r  (nth history idx)
+                       r' (cond-> r
+                            ;; Only records that retained their raw trace
+                            ;; stream (within :trace-events-keep) carry the
+                            ;; slot; back-fill it when present so raw-trace
+                            ;; consumers see the post-settle sub-run in the
+                            ;; right cascade.
+                            (contains? r :trace-events)
+                            (update :trace-events (fnil conj []) sub-event)
+                            ;; The structured :sub-runs projection is the
+                            ;; primary consumer surface (Causa Views subs
+                            ;; table). Always present on a built record;
+                            ;; append the projected row.
+                            (some? sub-run-row)
+                            (update :sub-runs (fnil conj []) sub-run-row))]
+                   (reset! updated r')
+                   (assoc history idx r'))))))
+    @updated))
+
 ;; ---- per-cascade capture buffer -------------------------------------------
 ;;
 ;; Per Tool-Pair §Per-cascade capture: the drain runs traces through

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -2823,3 +2823,194 @@
           "no record materialised from an orphan render")
       (is (= [] @seen)
           "no listener fan-out for a render with no causing cascade"))))
+
+;; ---- rf2-wi900: post-settle :sub/run attributed to the CAUSING cascade ----
+;;
+;; THE BUG (P1, confirmed live on parallel-frames): the SUBS sibling of
+;; rf2-qs6dl. A `:sub/run` trace fires when a reaction recomputes — and
+;; reactions recompute LAZILY at React deref (render) time, which Reagent
+;; batches onto a later tick AFTER the causing cascade settled. By that
+;; point `settle!` has harvested the cascade buffer and committed the
+;; record, so the sub-run lands in a now-empty buffer and — pre-rf2-wi900
+;; — was harvested by the NEXT cascade's settle, mis-attributing every
+;; reactive recompute (and its `:value-changed?` / `:prev-value` / `:value`
+;; attribution) to cascade N+1 (a one-epoch lag). Causa's per-cascade
+;; Views subs table therefore showed the value-changed checkmark against
+;; the WRONG subs: e.g. a `counter-inc db 1→2` epoch reported the counter
+;; sub `:value 1` (the PRIOR cascade's result) — the tell.
+;;
+;; #1935 (rf2-qs6dl) fixed this for render ops ONLY. This is the IDENTICAL
+;; defect for `:sub/run`, fixed with the same post-settle back-fill.
+;;
+;; WHY THE PRIOR SUITE MISSED IT: the existing sub-run projection tests
+;; drive subs the JVM way — implicitly, INSIDE the synchronous cascade —
+;; and only assert the SHAPE of `:sub-runs`. None modelled the real
+;; browser timing where the sub recompute fires AFTER the cascade settled,
+;; and none asserted cross-cascade attribution (cascade B carries B's
+;; sub-runs and NOT A's). The render counterpart (qs6dl) had this exact
+;; test class; this is the missing subs sibling.
+
+(defn- emit-post-settle-sub-run!
+  "Emit a `:sub/run` trace the way a reaction does at React deref time:
+  op-type `:sub/run`, tags carrying `:sub-id` + `:query-v` + `:frame`
+  plus the rf2-l1jz8 value-change attribution, fired OUTSIDE any cascade
+  (no in-flight buffer). Mirrors `re-frame.subs.memo/validate-and-trace`'s
+  enriched `:sub/run` emit."
+  [frame-id sub-id prev-value value]
+  (trace/emit! :sub/run :sub/run
+               {:sub-id         sub-id
+                :query-v        [sub-id]
+                :frame          frame-id
+                :value-changed? (not= prev-value value)
+                :prev-value     prev-value
+                :value          value
+                :cascade?       false
+                :cause-sub      nil}))
+
+(defn- sub-run-ids
+  "The sub-ids present in an epoch record's `:sub-runs` projection."
+  [record]
+  (->> (:sub-runs record)
+       (map :sub-id)
+       set))
+
+(defn- sub-run-for
+  "The `:sub-runs` entry for `sub-id` in `record`, or nil."
+  [record sub-id]
+  (->> (:sub-runs record)
+       (filter #(= sub-id (:sub-id %)))
+       first))
+
+(deftest post-settle-sub-run-attributed-to-causing-cascade
+  (testing "rf2-wi900 — a sub-run that fires AFTER its cascade settled
+            (React-deref timing) is attributed to the cascade that CAUSED
+            it, not the next in-flight cascade. Two cascades that recompute
+            DIFFERENT subs must each carry their OWN sub-run, with the
+            value-change attribution landing on the right epoch."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed         (fn [_ _] {:title "a" :counter 0}))
+    (rf/reg-event-db :title-loaded (fn [db _] (assoc db :title "loaded")))
+    (rf/reg-event-db :counter-inc  (fn [db _] (update db :counter inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+
+    ;; Cascade A — a title refresh. It settles, THEN (next tick, React
+    ;; deref) the :title sub recomputes "a" → "loaded".
+    (rf/dispatch-sync [:title-loaded] {:frame :test/main})
+    (let [epoch-a (last (rf/epoch-history :test/main))]
+      (emit-post-settle-sub-run! :test/main :title "a" "loaded")
+
+      ;; Cascade B — a counter bump. It settles, THEN (and ONLY) the
+      ;; :counter sub recomputes 0 → 1 post-settle — counter-inc cannot
+      ;; make the :title sub recompute.
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+      (let [epoch-b (last (rf/epoch-history :test/main))]
+        (emit-post-settle-sub-run! :test/main :counter 0 1)
+
+        ;; Re-read the ring — both records were back-filled in place.
+        (let [history (rf/epoch-history :test/main)
+              a       (some #(when (= (:epoch-id epoch-a) (:epoch-id %)) %) history)
+              b       (some #(when (= (:epoch-id epoch-b) (:epoch-id %)) %) history)]
+          (is (= :title-loaded (:event-id a)))
+          (is (= :counter-inc  (:event-id b)))
+
+          ;; The smoking gun, pinned: cascade A carries the :title sub-run
+          ;; and NOT the :counter sub-run; cascade B carries the :counter
+          ;; sub-run and NOT the :title sub-run. Pre-fix, A's :title
+          ;; sub-run leaked into B's epoch (the one-epoch lag), so B would
+          ;; (wrongly) report the :title sub and A would report nothing.
+          (is (contains? (sub-run-ids a) :title)
+              "cascade A's epoch carries its OWN :title sub-run")
+          (is (not (contains? (sub-run-ids a) :counter))
+              "cascade A's epoch does NOT carry cascade B's :counter sub-run")
+          (is (contains? (sub-run-ids b) :counter)
+              "cascade B's epoch carries its OWN :counter sub-run")
+          (is (not (contains? (sub-run-ids b) :title))
+              "cascade B's epoch does NOT carry cascade A's lagged :title
+               sub-run — THE LAG IS GONE")
+
+          ;; The value-change attribution lands on the RIGHT epoch: B's
+          ;; :counter sub-run shows 0 → 1 (the bump this cascade caused),
+          ;; NOT the prior cascade's lagged value. This is the exact
+          ;; defect Mike reproduced: a counter-inc epoch must show the
+          ;; counter's NEW value, not the previous cascade's result.
+          (let [b-counter (sub-run-for b :counter)]
+            (is (= true (:value-changed? b-counter))
+                "B's :counter sub-run is marked value-changed")
+            (is (= 0 (:prev-value b-counter))
+                "B's :counter sub-run's :prev-value is the pre-bump value")
+            (is (= 1 (:value b-counter))
+                "B's :counter sub-run's :value is THIS cascade's result
+                 (1), not the lagged prior value")))))))
+
+(deftest post-settle-sub-run-back-fill-renotifies-listeners
+  (testing "rf2-wi900 — back-filling a post-settle sub-run re-fans the
+            corrected record out to epoch listeners so snapshot consumers
+            (Causa's per-cascade Views subs table, which caches
+            epoch-history at settle time) re-sync to the corrected
+            :sub-runs + :value-changed? attribution"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
+
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:inc]  {:frame :test/main})
+      (let [settle-fanouts (count @seen)]
+        ;; A post-settle sub-run for the :inc epoch fires (React deref).
+        (emit-post-settle-sub-run! :test/main :n 0 1)
+        (is (= (inc settle-fanouts) (count @seen))
+            "the back-fill triggered exactly one additional listener fan-out")
+        (let [renotified (last @seen)]
+          (is (= :inc (:event-id renotified))
+              "the re-fanned record is the :inc cascade's (the causing epoch)")
+          (is (contains? (sub-run-ids renotified) :n)
+              "the re-fanned record carries the back-filled sub-run")
+          (is (= 1 (:value (sub-run-for renotified :n)))
+              "the re-fanned sub-run carries this cascade's value"))))))
+
+(deftest in-flight-sub-run-still-rides-current-cascade
+  (testing "rf2-wi900 — a sub-run that fires WITH a cascade in flight
+            (synchronous deref — a handler that subscribes, an SSR render)
+            belongs to that cascade and is buffered normally, NOT
+            back-filled."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    ;; A handler that emits a :sub/run WHILE the cascade is draining (an
+    ;; in-flight recompute — the buffer already holds :event/run-start).
+    (rf/reg-event-db :sub-during
+      (fn [db _]
+        (trace/emit! :sub/run :sub/run
+                     {:sub-id         :inline-sub
+                      :query-v        [:inline-sub]
+                      :frame          :test/main
+                      :value-changed? true
+                      :prev-value     nil
+                      :value          :computed
+                      :cascade?       false
+                      :cause-sub      nil})
+        (update db :n inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:sub-during] {:frame :test/main})
+
+    (let [epoch (last (rf/epoch-history :test/main))]
+      (is (= :sub-during (:event-id epoch)))
+      (is (contains? (sub-run-ids epoch) :inline-sub)
+          "an in-flight sub-run rides its own cascade's epoch (buffered,
+           not back-filled to a prior settled epoch)"))))
+
+(deftest post-settle-sub-run-before-any-cascade-is-noop
+  (testing "rf2-wi900 — a sub-run that fires before any cascade has settled
+            (no last-settled epoch for the frame) is a silent no-op: no
+            record exists to back-fill, no listener fan-out, no throw."
+    (rf/reg-frame :test/main {})
+    (let [seen (atom [])]
+      (rf/register-epoch-listener! ::watcher (fn [r] (swap! seen conj r)))
+      ;; No cascade has run — last-settled-epoch is empty for the frame.
+      (emit-post-settle-sub-run! :test/main :orphan-sub nil :computed)
+      (is (= [] (rf/epoch-history :test/main))
+          "no record materialised from an orphan sub-run")
+      (is (= [] @seen)
+          "no listener fan-out for a sub-run with no causing cascade"))))


### PR DESCRIPTION
## Root cause

The subs sibling of rf2-qs6dl (#1935). A `:sub/run` trace fires when a reaction recomputes — and reactions recompute **lazily at React deref (render) time**, which Reagent batches onto a later tick AFTER the causing cascade settled. By then `settle!` has already harvested the cascade buffer and committed the record, so the sub-run lands in a now-empty buffer and gets harvested by the **next** cascade's settle — mis-attributing every reactive recompute (and its `:value-changed?` / `:prev-value` / `:value` attribution) to cascade N+1.

This is the one-epoch lag visible in Causa's per-cascade Views subs table: a `counter-inc db 1→2` epoch showed the counter sub `:value 1` (the **prior** cascade's result — Mike's "tell"), and the first cascade after a reload marked every sub `changed? true / prev nil` (the mount recomputes shoved forward by one).

The `:value-changed?` boolean itself is computed correctly in `subs/memo.cljc`; the bug was purely **which epoch** the `:sub/run` was filed under. #1935 fixed this identical defect for render ops only — its back-fill in `epoch/capture.cljc` covers `:view/render` / `:rf.view/rendered` / `:rf.view/rendered-cap-reached` but not `:sub/run`.

## Fix design — back-fill (consistent with #1935), not eager recompute

I went with the **back-fill** (the bead's default): surgical, consistent with #1935, low-risk. Eager-in-cascade sub recompute would be a large recompute-timing change touching the reactive substrate's hot path — out of scope for a P1 attribution fix, and the bead said to stop and report before attempting it. The back-fill is the right call: it mirrors a proven, shipped pattern and is purely a dev-tier trace-attribution change.

The fix mirrors #1935's shape exactly:

- **`capture.cljc`** — `sub-run-ops` set (`:sub/run` / `:rf.sub/skip`); `capture-event!` routes a sub-run arriving with **no in-flight cascade** for its frame through a new `:epoch/record-sub-run!` late-bind hook (sibling of `:epoch/record-render!`). An **in-flight** sub-run (a handler that subscribes, an SSR render) still rides its own cascade, buffered normally.
- **`state.cljc`** — `back-fill-sub-run!` appends the sub-run trace + projected `:sub-runs` row into the frame's most-recently-settled epoch record, reusing the same `last-settled-epoch` map the render back-fill already tracks (and already clears on frame destroy / fixture reset).
- **`listeners.cljc`** — `sub-run-row` (mirrors `project-all`'s `:sub/run` arm verbatim, including the rf2-l1jz8 value-change attribution; returns nil for `:rf.sub/skip` so a memo hit rides only `:trace-events`, symmetric with `render-row`) + `record-sub-run!` orchestrator that back-fills then re-fans the corrected record to listeners so snapshot consumers (Causa) re-sync.
- **`epoch.cljc` + `directory.cljc`** — publish + document the new `:epoch/record-sub-run!` hook.

Dev-only and elidable — DCEs in production exactly like the rest of the trace surface.

## Regression test (the missing test class)

Added the subs counterpart of qs6dl's renders test to `epoch_test.clj`: emit a `:sub/run` **outside any cascade** (post-settle timing) and assert cross-cascade attribution — a sub-run for cascade A lands on A's epoch, not B's, and the value-change attribution lands on the right epoch (B's counter sub-run shows `prev 0 → value 1`, this cascade's result, not the lagged prior value). Plus the three siblings: back-fill re-notifies listeners, in-flight sub-run rides its own cascade, sub-run before any cascade is a no-op.

**Verified it FAILS without the fix** (9 failures) — e.g. `cascade B's epoch does NOT carry cascade A's lagged :title sub-run` failed with `(not (not true))`, and B's counter sub-run `:value` was `nil` instead of `1`.

## Before / after attribution (live browser, parallel-frames `:below` counter)

Drove `:below` counter increments in headless Chromium and read the frame's `epoch-history` `:sub-runs` straight off the live runtime.

**BEFORE (lagged):**

| epoch event | counter sub :prev → :value |
|---|---|
| counter-inc | nil → 0  *(mount recompute mis-filed here)* |
| counter-inc | 0 → 0 |
| counter-inc | 1 → ... *(each one cascade behind)* |

**AFTER (correct):**

| epoch event | counter sub :prev → :value |
|---|---|
| initialise  | nil → 0  *(the genuine mount recompute)* |
| counter-inc | 0 → 1 |
| counter-inc | 1 → 2 |
| counter-inc | 2 → 3 |

Each `:sub/run` is now filed under the cascade that produced it; a `counter-inc 1→2` epoch shows `:value 2 / :prev 1 / changed? true`, and the first-cascade-after-reload no longer marks every sub changed.

## Gates

- `npm run test:cljs` — 4095 tests / 12437 assertions, 0 failures
- JVM core (`clojure -M:test`) — 719 tests (incl. late-bind drift test pinning the new directory entry), 0 failures
- JVM epoch — 191 tests / 701 assertions (incl. the 4 new wi900 tests), 0 failures
- `npm run test:causa-feature-gate` — 13/13 scenarios, 0 failures
- `npm run test:elision` — production 35/35 absent (attribution DCEs)