### PR TITLE
fix(instrumentation): attribute late mount renders to the mount epoch, not the first post-mount cascade (rf2-vh1k3)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -407,6 +407,10 @@
    {:key         :views/clear-plain-fn-warned-pairs!
     :producer-ns 're-frame.views.warn-once
     :description "Clear the warned-pairs cache (test isolation)."}
+   {:key         :views/reading-render-key
+    :producer-ns 're-frame.views
+    :design-bead "rf2-vh1k3"
+    :description "Return the render-key of the view whose render is currently deref-ing a subscription (nil outside a view render). The reactive :sub/run emit stamps it onto its tag so the epoch back-fill can tell a view's genuine re-render (its own input changed) from a mount-burst tail that re-derefs unchanged subs."}
 
    ;; ---- :adapter/* — chained / routed across every CLJS adapter (rf2-0d35) --
    {:key         :adapter/clear-warn-once-caches!

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -216,17 +216,29 @@
         ;; §Privacy for why we MUST NOT elide here.
         (if interop/debug-enabled?
           (let [cascade?  (boolean (seq input-signals))
-                cause-sub (changed-cause-sub prev-in-vals in-vals input-signals)]
+                cause-sub (changed-cause-sub prev-in-vals in-vals input-signals)
+                ;; rf2-vh1k3 — the render-key of the view whose render is
+                ;; deref-ing this reaction (nil outside a view render). The
+                ;; epoch back-fill reads this off the target epoch's
+                ;; `:sub-runs` so a late-arriving render is attributed to
+                ;; the epoch where the rendering view's OWN inputs changed,
+                ;; not whatever cascade is settling when a mount-burst tail
+                ;; commits. Resolved through late-bind so this .cljc subs
+                ;; layer stays free of a require on the CLJS-only views ns.
+                reader-rk (when-let [f (late-bind/get-fn-cached
+                                         :views/reading-render-key)]
+                            (f))]
             (trace/emit! :sub/run :sub/run
-                         {:sub-id         query-id
-                          :query-v        query-v
-                          :frame          frame-id
-                          :value-changed? (not= prev-value validated)
-                          :prev-value     (when-not (= unset prev-value)
-                                            prev-value)
-                          :value          validated
-                          :cascade?       cascade?
-                          :cause-sub      cause-sub}))
+                         (cond-> {:sub-id         query-id
+                                  :query-v        query-v
+                                  :frame          frame-id
+                                  :value-changed? (not= prev-value validated)
+                                  :prev-value     (when-not (= unset prev-value)
+                                                    prev-value)
+                                  :value          validated
+                                  :cascade?       cascade?
+                                  :cause-sub      cause-sub}
+                           reader-rk (assoc :reader-render-key reader-rk))))
           (trace/emit! :sub/run :sub/run
                        {:sub-id  query-id
                         :query-v query-v

--- a/implementation/core/src/re_frame/views.cljs
+++ b/implementation/core/src/re_frame/views.cljs
@@ -75,6 +75,24 @@
   []
   (or *render-key* [:rf.view/anonymous nil]))
 
+(defn reading-render-key
+  "Return the `:render-key` of the view whose render is currently
+  deref-ing a subscription, or nil when no view render is on the stack.
+
+  Distinct from `current-render-key` (which substitutes the anonymous
+  fallback): this returns the RAW `*render-key*` — nil when a sub is
+  computed OUTSIDE any view render (a handler that subscribes, an SSR
+  walk, a direct `compute-sub`). The reactive `:sub/run` emit
+  (`re-frame.subs.memo`) stamps this onto its tag (rf2-vh1k3) so the
+  epoch back-fill can attribute a post-settle render to the epoch in
+  which the rendering view's OWN inputs actually changed — not whatever
+  cascade happens to be settling when the late mount commit lands.
+
+  Published through late-bind under `:views/reading-render-key` so the
+  subs layer reads it without a static require on this CLJS-only ns."
+  []
+  *render-key*)
+
 ;; ---- re-exported public surface ------------------------------------------
 ;;
 ;; Plain `def` aliases (rather than `:refer`-imports) so
@@ -306,3 +324,17 @@
         wrapped    (build-frame-aware-view id render-fn view-scope coord-attr wrap-applied?)]
     (registrar/register! :view id (assoc metadata :handler-fn wrapped))
     wrapped))
+
+;; ---- late-bind publication (rf2-vh1k3) ------------------------------------
+;;
+;; The reactive `:sub/run` emit (`re-frame.subs.memo/validate-and-trace`)
+;; stamps the reading view's render-key onto its tag so the epoch
+;; back-fill can tell a view's GENUINE re-render (its own input changed)
+;; from a mount-burst tail that re-derefs unchanged subs. Reaching
+;; `reading-render-key` through late-bind keeps the subs layer free of a
+;; static require on this CLJS-only views ns (subs is .cljc + must not
+;; hard-couple to the substrate). Sticky-hook shape (rf2-f72pd): set once
+;; at views ns-load, never withdrawn. Whole stamp rides
+;; `interop/debug-enabled?` at the consumer so production DCEs it.
+
+(late-bind/set-fn! :views/reading-render-key reading-render-key)

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -158,6 +158,19 @@
           tags     (:tags event)
           frame-id (or (:frame tags)
                        (:frame event))]
+      ;; rf2-vh1k3 — learn which subs each view reads from the
+      ;; `:reader-render-key` stamp the runtime sets on a `:sub/run`
+      ;; that recomputes SYNCHRONOUSLY inside a view's render (the mount /
+      ;; first-paint deref). A post-settle reactive recompute fires
+      ;; outside any render binding and carries no stamp, so this learns
+      ;; the read-set at mount; a view's sub set is stable across its
+      ;; life. The render back-fill (`state/value-changed-epoch-for`)
+      ;; uses the read-set to tell a view's genuine re-render from a
+      ;; mount-burst tail. Fires regardless of the routing branch below.
+      (when frame-id
+        (when-let [reader-rk (:reader-render-key tags)]
+          (when (= :sub/run op)
+            (state/record-render-deps! frame-id reader-rk (:sub-id tags)))))
       (when (and frame-id (not (contains? skip-ops op)))
         (cond
           ;; Post-settle render — attribute to the causing cascade.

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -89,28 +89,68 @@
 
 (defn record-render!
   "Attribute a post-settle render emit to the cascade that CAUSED it
-  (rf2-qs6dl). A `:view/render` / `:rf.view/rendered` trace fires at
-  React commit time — AFTER the causing cascade settled — so it cannot
-  ride the in-flight cascade buffer (there is none). This back-fills the
-  render into the frame's most-recently-settled epoch record and re-fans
-  the updated record out to epoch listeners so snapshot consumers (Causa
-  Views / Reactive panel, which cache `epoch-history` at settle time)
-  re-sync to the corrected `:renders`.
+  (rf2-qs6dl), refined for the mount-render case (rf2-vh1k3).
+
+  A `:view/render` / `:rf.view/rendered` trace fires at React commit
+  time — AFTER the causing cascade settled — so it cannot ride the
+  in-flight cascade buffer (there is none). rf2-qs6dl back-filled it into
+  the frame's most-recently-settled epoch; that is right for a genuine
+  reactive re-render but wrong for a MOUNT render whose commit lands late
+  (React batches a freshly-mounted component's render onto a later tick,
+  so it can commit AFTER the first user cascade settles). Attributed to
+  last-settled, a mount render leaks spuriously into the first post-mount
+  cascade's `:renders` (the rf2-vh1k3 defect: parallel-frames' title-view
+  appearing in the first counter-inc epoch though its subs never changed).
+
+  `state/resolve-render-epoch` picks the right anchor: the newest epoch
+  where the rendering view's OWN inputs changed (a real re-render rides
+  its causing cascade exactly as rf2-qs6dl intends), else the view's
+  MOUNT epoch (a mount / mount-burst tail anchors where the instance
+  first rendered), else the most-recently-settled epoch (a brand-new
+  instance whose first render commits post-settle — the settling cascade
+  becomes its mount). The chosen epoch is recorded as the render-key's
+  mount epoch on first sighting so subsequent late renders resolve
+  against it.
+
+  A render that resolves back to its mount epoch where it ALREADY landed
+  is de-duped (no second `:renders` row, no re-notify) — that is the
+  mount-burst tail being absorbed rather than re-filed.
+
+  Re-fans the corrected record out to epoch listeners so snapshot
+  consumers (Causa Views / Reactive panel, which cache `epoch-history`
+  at settle time) re-sync to the corrected `:renders`.
 
   No-op when the frame has no settled epoch yet (a render before the
   first cascade) or when the target epoch has been evicted from the ring
   — `back-fill-render!` returns nil and we skip the re-notify."
   [frame-id event]
   (when interop/debug-enabled?
-    (when-let [epoch-id (state/last-settled-epoch-id frame-id)]
-      (when-let [updated (state/back-fill-render! frame-id epoch-id
-                                                  event (render-row event))]
-        ;; Re-fan the corrected record so snapshot consumers re-read the
-        ;; ring. The fan-out is failure-isolated per listener (same
-        ;; contract as the settle-time fan-out); a render-driven Causa
-        ;; pump (`:rf.causa/epoch-recorded`) is `:rf.trace/no-emit?` so
-        ;; it commits no new epoch and cannot loop back into this path.
-        (notify-listeners! updated)))))
+    (when-let [default-epoch (state/last-settled-epoch-id frame-id)]
+      (let [render-key (-> event :tags :render-key)
+            target     (state/resolve-render-epoch frame-id render-key
+                                                    default-epoch)]
+        ;; Record the mount anchor on first sighting; never overwrites.
+        (state/record-mount-epoch! frame-id render-key target)
+        ;; De-dup a mount-burst tail ONLY when it was REDIRECTED away from
+        ;; the settling cascade (`target` ≠ `default-epoch`) back to a
+        ;; mount epoch where the instance already rendered. A genuine
+        ;; re-render resolves to the settling cascade (`target` =
+        ;; `default-epoch`) and is never de-duped — so the paired
+        ;; `:view/render` + `:rf.view/rendered` of one real render both
+        ;; ride their cascade (only the late mount-burst tail is absorbed).
+        (when-not (and render-key
+                       (not= target default-epoch)
+                       (state/render-key-already-in-epoch?
+                         frame-id target render-key))
+          (when-let [updated (state/back-fill-render! frame-id target
+                                                      event (render-row event))]
+            ;; Re-fan the corrected record so snapshot consumers re-read
+            ;; the ring. The fan-out is failure-isolated per listener
+            ;; (same contract as the settle-time fan-out); a render-driven
+            ;; Causa pump (`:rf.causa/epoch-recorded`) is
+            ;; `:rf.trace/no-emit?` so it commits no new epoch and cannot
+            ;; loop back into this path.
+            (notify-listeners! updated)))))))
 
 ;; ---- post-settle sub-run back-fill (rf2-wi900) ----------------------------
 
@@ -253,4 +293,10 @@
     ;; render emit (a torn-down component's final flush) can't back-fill
     ;; into a record belonging to the destroyed frame's history — which
     ;; was just dropped above anyway.
-    (state/drop-last-settled-epoch! frame-id)))
+    (state/drop-last-settled-epoch! frame-id)
+    ;; Per rf2-vh1k3: forget every render-key's mount-epoch anchor AND
+    ;; read-set for the destroyed frame so a re-registration of a
+    ;; same-keyed frame (`reset-frame! :app/main`) re-mints both from
+    ;; scratch.
+    (state/drop-frame-mount-epochs! frame-id)
+    (state/drop-frame-render-deps! frame-id)))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -246,6 +246,193 @@
   (reset! last-settled-epoch {})
   nil)
 
+;; ---- mount-epoch tracking + render-attribution resolution (rf2-vh1k3) ----
+;;
+;; rf2-qs6dl back-fills a post-settle render to the frame's most-recently-
+;; settled epoch — the cascade that ran just before the React commit. That
+;; is correct for a genuine reactive re-render, but WRONG for a MOUNT
+;; render whose commit lands late: React/Reagent batch a freshly-mounted
+;; component's render onto a later tick, so a view's mount render can
+;; commit AFTER the first user interaction settles. Attributed to
+;; last-settled, it shows up spuriously in the first post-mount cascade's
+;; RENDERED list (e.g. parallel-frames' title-view appearing in the first
+;; counter-inc epoch even though its subs never changed).
+;;
+;; The discriminator is the rf2-l1jz8 `:value-changed?` attribution
+;; already on the reactive `:sub/run` trace, plus the rf2-vh1k3
+;; `:reader-render-key` stamp naming the view whose render deref'd the
+;; sub. A render of view K belongs to epoch N iff N's cascade actually
+;; drove K's re-render — i.e. some `:sub/run` with `:reader-render-key K`
+;; AND `:value-changed? true` landed in N. When no recent epoch shows a
+;; value-change for K, the render is a mount (or mount-burst tail) and is
+;; attributed to K's MOUNT epoch (its first-ever attribution) rather than
+;; whatever cascade happens to be settling.
+
+(defonce ^:private mount-epoch-by-render-key
+  ;; frame-id → {render-key → epoch-id} : the epoch a render-key was
+  ;; FIRST attributed to (its mount epoch). Bounds: one entry per live
+  ;; render-key per frame; pruned with the frame on teardown.
+  (atom {}))
+
+;; frame-id → {render-key → #{sub-id ...}} : which subscriptions each
+;; view reads. Learned from the `:reader-render-key` stamp on `:sub/run`
+;; traces — which the runtime only sets when the reaction recomputes
+;; SYNCHRONOUSLY inside the view's render (the mount / first-paint
+;; deref). A post-settle reactive recompute fires during Reagent's
+;; reaction-flush phase with no `*render-key*` bound, so the stamp is
+;; absent there; the mount-time learning is sufficient because a view's
+;; sub set is stable across its life. The index lets the render
+;; back-fill (`value-changed-epoch-for`) decide whether a cascade
+;; actually re-rendered a view by checking value-change on the view's
+;; OWN subs, even when the post-settle sub-run carries no render-key.
+(defonce ^:private render-deps-by-render-key (atom {}))
+
+(defn record-render-deps!
+  "Union `sub-id` into `render-key`'s read-set for `frame-id`. Called for
+  every `:sub/run` that arrives stamped with a `:reader-render-key`
+  (rf2-vh1k3) — the synchronous in-render deref that names the reading
+  view. Idempotent; the set only grows."
+  [frame-id render-key sub-id]
+  (when (and frame-id render-key sub-id)
+    (swap! render-deps-by-render-key
+           update-in [frame-id render-key] (fnil conj #{}) sub-id))
+  nil)
+
+(defn render-deps-for
+  "Return the set of sub-ids `render-key` is known to read in `frame-id`,
+  or nil when none learned yet."
+  [frame-id render-key]
+  (get-in @render-deps-by-render-key [frame-id render-key]))
+
+(defn drop-frame-render-deps!
+  "Forget every render-key's read-set for `frame-id` (frame teardown)."
+  [frame-id]
+  (swap! render-deps-by-render-key dissoc frame-id)
+  nil)
+
+(defn reset-render-deps!
+  "Wipe the render-deps map across all frames (fixture reset)."
+  []
+  (reset! render-deps-by-render-key {})
+  nil)
+
+(defn mount-epoch-for
+  "Return the epoch-id `render-key` was first attributed to in `frame-id`,
+  or nil when never seen."
+  [frame-id render-key]
+  (get-in @mount-epoch-by-render-key [frame-id render-key]))
+
+(defn record-mount-epoch!
+  "Record `epoch-id` as `render-key`'s mount epoch for `frame-id`, but
+  only on the FIRST sighting — later attributions never overwrite the
+  mount epoch (a re-render of an existing instance must not move its
+  mount anchor)."
+  [frame-id render-key epoch-id]
+  (when (and frame-id render-key epoch-id)
+    (swap! mount-epoch-by-render-key
+           (fn [m]
+             (if (get-in m [frame-id render-key])
+               m
+               (assoc-in m [frame-id render-key] epoch-id)))))
+  nil)
+
+(defn drop-frame-mount-epochs!
+  "Forget every render-key's mount epoch for `frame-id` (frame teardown)."
+  [frame-id]
+  (swap! mount-epoch-by-render-key dissoc frame-id)
+  nil)
+
+(defn reset-mount-epochs!
+  "Wipe the mount-epoch map across all frames (fixture reset)."
+  []
+  (reset! mount-epoch-by-render-key {})
+  nil)
+
+(defn- epoch-value-changed-for-view?
+  "True when epoch record `r` carries a value-changed `:sub/run` belonging
+  to the view named by `render-key` — i.e. a `:sub/run` with
+  `:value-changed? true` whose `:reader-render-key` is `render-key`
+  (the synchronous in-render deref, when stamped) OR whose `:sub-id` is
+  in the view's learned read-set `deps` (the post-settle reactive
+  recompute, which carries no render-key). `deps` may be nil when the
+  view's read-set was never learned — then only the render-key match
+  applies."
+  [r render-key deps]
+  (some (fn [ev]
+          (and (= :sub/run (:operation ev))
+               (true? (-> ev :tags :value-changed?))
+               (let [t (:tags ev)]
+                 (or (= render-key (:reader-render-key t))
+                     (and deps (contains? deps (:sub-id t)))))))
+        (:trace-events r)))
+
+(defn- value-changed-epoch-for
+  "Scan `frame-id`'s ring (most-recent first) for the newest epoch in
+  which the view named by `render-key` had a value-changed `:sub/run` —
+  i.e. the cascade that genuinely re-rendered the view. Returns that
+  epoch-id, or nil when no retained epoch shows a value-change for the
+  view (a mount / mount-burst tail).
+
+  A view's subs are matched two ways (see `epoch-value-changed-for-view?`):
+  by the `:reader-render-key` stamp (synchronous in-render deref) and by
+  the view's learned read-set (`render-deps-for`) for post-settle reactive
+  recomputes that carry no render-key. The read-set is learned at mount
+  from the stamped synchronous derefs; a view's sub set is stable across
+  its life, so mount-time learning suffices.
+
+  Reads only `:trace-events`, which the most-recent `:trace-events-keep`
+  records retain — exactly the window a post-settle render can target
+  (the back-fill never reaches older, projection-only records). One pass
+  newest-first; short-circuits at the first matching epoch."
+  [frame-id render-key]
+  (let [history (history-for frame-id)
+        deps    (render-deps-for frame-id render-key)]
+    (loop [i (dec (count history))]
+      (when (>= i 0)
+        (let [r (nth history i)]
+          (if (epoch-value-changed-for-view? r render-key deps)
+            (:epoch-id r)
+            (recur (dec i))))))))
+
+(defn resolve-render-epoch
+  "Resolve the epoch a post-settle render of `render-key` should be
+  attributed to in `frame-id` (rf2-vh1k3). Falls back to
+  `default-epoch-id` (the rf2-qs6dl most-recently-settled epoch) when no
+  better anchor is found, preserving the qs6dl behaviour for genuine
+  reactive re-renders and for the degenerate no-render-key case.
+
+  Resolution order:
+    1. The newest epoch in which the view's OWN inputs changed
+       (`value-changed-epoch-for`) — a genuine reactive re-render rides
+       its causing cascade exactly as rf2-qs6dl intends.
+    2. Otherwise the view's MOUNT epoch (`mount-epoch-for`) — a mount
+       render, or a mount-burst tail that re-deref'd unchanged subs, is
+       anchored to where the instance first rendered rather than leaking
+       into the first post-mount cascade.
+    3. Otherwise `default-epoch-id` — a brand-new instance whose very
+       first render commits post-settle (no mount epoch recorded yet, no
+       value-change scan hit): treat the settling cascade as its mount,
+       which `record-mount-epoch!` then anchors."
+  [frame-id render-key default-epoch-id]
+  (or (when render-key (value-changed-epoch-for frame-id render-key))
+      (when render-key (mount-epoch-for frame-id render-key))
+      default-epoch-id))
+
+(defn render-key-already-in-epoch?
+  "True when `frame-id`'s epoch `epoch-id` record already carries a
+  `:renders` row for `render-key` — used to de-dup a mount-burst tail
+  that resolves back to the mount epoch where the render already landed
+  (rf2-vh1k3). Reads the structured `:renders` projection (always
+  present on a built record), not the optional `:trace-events`."
+  [frame-id epoch-id render-key]
+  (let [history (history-for frame-id)]
+    (boolean
+      (some (fn [r]
+              (and (= epoch-id (:epoch-id r))
+                   (some (fn [row] (= render-key (:render-key row)))
+                         (:renders r))))
+            history))))
+
 (defn back-fill-render!
   "Append `render-event` and its projected `:renders` row into the
   already-committed epoch record identified by `frame-id` + `epoch-id`
@@ -408,11 +595,14 @@
 
 (defn reset-histories!
   "Wipe every frame's recorded epochs. Also clears the last-settled-epoch
-  map (rf2-qs6dl) so a fixture's first cascade can't back-fill a render
-  into a previous fixture's record."
+  map (rf2-qs6dl) and the mount-epoch map (rf2-vh1k3) so a fixture's
+  first cascade can't back-fill a render into a previous fixture's
+  record nor inherit a stale render-key→mount-epoch anchor."
   []
   (reset! histories {})
   (reset-last-settled-epochs!)
+  (reset-mount-epochs!)
+  (reset-render-deps!)
   nil)
 
 ;; ---- listener registry ----------------------------------------------------

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -3014,3 +3014,233 @@
           "no record materialised from an orphan sub-run")
       (is (= [] @seen)
           "no listener fan-out for a sub-run with no causing cascade"))))
+
+;; ---- rf2-vh1k3: late MOUNT render → mount epoch, not the next cascade -----
+;;
+;; THE BUG (P3, confirmed live on parallel-frames :below via headless
+;; Chrome — see the bead's before/after capture): a view's MOUNT render
+;; commits LATE. React/Reagent batch a freshly-mounted component's render
+;; onto a later tick, so a view's mount render can fire at React commit
+;; time AFTER the first user interaction settles. rf2-qs6dl back-fills a
+;; post-settle render to the frame's most-recently-settled epoch — correct
+;; for a genuine reactive re-render, but for a late mount render that means
+;; the view shows up spuriously in the FIRST post-mount cascade's RENDERED
+;; list (parallel-frames: title-view appears in the first counter-inc epoch
+;; though counter-inc cannot change any title sub).
+;;
+;; LIVE REPRO (parallel-frames :below, before fix):
+;;   epoch 2 initialise  RENDERED [frame-panel counter-view title-view]  (mount)
+;;   1st '+' counter-inc RENDERED [counter-view TITLE-VIEW]  ← title-view spurious
+;;   2nd '+' counter-inc RENDERED [counter-view]             (clean thereafter)
+;;
+;; THE DISCRIMINATOR: the rf2-l1jz8 `:value-changed?` attribution on the
+;; reactive `:sub/run` trace, plus the rf2-vh1k3 `:reader-render-key`
+;; stamp naming the view whose render deref'd the sub. A render of view K
+;; belongs to epoch N iff some `:sub/run` with `:reader-render-key K` AND
+;; `:value-changed? true` landed in N. counter-view's first-'+' render is
+;; legit (its ::counter sub changed 0→1); title-view's is a mount-burst
+;; tail (its subs re-deref'd UNCHANGED), so it anchors to the mount epoch
+;; where the instance first rendered.
+;;
+;; WHY THE PRIOR (qs6dl) SUITE MISSED IT: those tests model a render that
+;; fires exactly once per cascade and re-renders a DIFFERENT view each
+;; cascade. None modelled a view that mounts in epoch A and then commits a
+;; late mount-burst render in epoch B with UNCHANGED inputs — the precise
+;; shape that mis-attributes here.
+
+(def ^:private cv-rk
+  "counter-view render-key (a stable [view-id instance-token] tuple)."
+  [:counter-view 6])
+
+(def ^:private tv-rk
+  "title-view render-key."
+  [:title-view 7])
+
+(defn- emit-mount-sub-run!
+  "Emit a `:sub/run` the way a reaction does on its FIRST compute — the
+  SYNCHRONOUS in-render deref at mount/first-paint. `*render-key*` is
+  bound on that path, so the runtime stamps `:reader-render-key` (the
+  rf2-vh1k3 read-set-learning signal). Carries the rf2-l1jz8 value-change
+  attribution; the first recompute always reports value-changed? true."
+  [frame-id sub-id reader-rk prev-value value]
+  (trace/emit! :sub/run :sub/run
+               {:sub-id            sub-id
+                :query-v           [sub-id]
+                :frame             frame-id
+                :value-changed?    (not= prev-value value)
+                :prev-value        prev-value
+                :value             value
+                :cascade?          false
+                :cause-sub         nil
+                :reader-render-key reader-rk}))
+
+(defn- emit-post-settle-reactive-sub-run!
+  "Emit a `:sub/run` the way a reaction does on a POST-SETTLE recompute —
+  Reagent's reaction-flush phase, which fires OUTSIDE any view render, so
+  `*render-key*` is NOT bound and the runtime emits NO `:reader-render-key`
+  stamp (verified live on parallel-frames :below — see the bead's headless
+  capture). The render back-fill must therefore resolve the view's
+  value-change via the read-set learned at mount, NOT a per-event stamp.
+  This is the load-bearing distinction the fix turns on."
+  [frame-id sub-id prev-value value]
+  (trace/emit! :sub/run :sub/run
+               {:sub-id         sub-id
+                :query-v        [sub-id]
+                :frame          frame-id
+                :value-changed? (not= prev-value value)
+                :prev-value     prev-value
+                :value          value
+                :cascade?       false
+                :cause-sub      nil}))
+
+(defn- emit-post-settle-render-rk!
+  "Emit a `:view/render` the way the substrate does at React commit time
+  (post-settle, empty buffer), carrying an explicit `:render-key` tuple."
+  [frame-id render-key]
+  (trace/emit! :view :view/render
+               {:render-key render-key
+                :frame      frame-id}))
+
+(defn- rendered-keys
+  "The render-key tuples present in an epoch record's `:renders`."
+  [record]
+  (->> (:renders record) (map :render-key) set))
+
+(deftest mount-render-attributed-to-mount-epoch-not-next-cascade
+  (testing "rf2-vh1k3 — a late MOUNT render (a freshly-mounted view whose
+            render commits AFTER the next cascade settled, with UNCHANGED
+            inputs) is attributed to its MOUNT epoch, NOT the cascade that
+            happens to be settling. A genuine reactive re-render (inputs
+            changed) still rides its causing cascade."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
+    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+
+    ;; MOUNT epoch: seed settles, then both views mount. Model the mount
+    ;; renders + their first sub recomputes (value-changed? true on the
+    ;; first recompute) IN-FLIGHT-equivalent — here, immediately after the
+    ;; seed cascade so they back-fill into the seed (mount) epoch.
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (let [mount-epoch (last (rf/epoch-history :test/main))]
+      ;; counter-view mounts: render + its ::counter sub first-recompute
+      ;; (SYNCHRONOUS in-render deref → reader-render-key stamped → read-set
+      ;; learned). The mount render commits and back-fills into the seed
+      ;; (mount) epoch.
+      (emit-post-settle-render-rk! :test/main cv-rk)
+      (emit-mount-sub-run! :test/main :counter cv-rk nil 0)
+      ;; title-view mounts: render + its ::title-state sub first-recompute.
+      (emit-post-settle-render-rk! :test/main tv-rk)
+      (emit-mount-sub-run! :test/main :title-state tv-rk nil :idle)
+
+      ;; FIRST '+' : counter-inc settles as the next epoch.
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+      (let [inc-epoch (last (rf/epoch-history :test/main))]
+        ;; Post-settle commit burst after the first '+'. Reactive
+        ;; recomputes here fire OUTSIDE any render → NO reader-render-key
+        ;; stamp (the live shape):
+        ;;   counter-view re-renders — its ::counter sub CHANGED 0 → 1
+        ;;   (a genuine reactive re-render). Resolved via the learned
+        ;;   read-set {::counter} → value-change in THIS epoch → rides it.
+        (emit-post-settle-reactive-sub-run! :test/main :counter 0 1)
+        (emit-post-settle-render-rk! :test/main cv-rk)
+        ;;   title-view's MOUNT render commits LATE — its ::title-state sub
+        ;;   re-derefs UNCHANGED (:idle → :idle), so this is a mount-burst
+        ;;   tail, NOT a counter-inc-driven re-render. No value-change for
+        ;;   title-view's read-set in this epoch → anchors to the mount
+        ;;   epoch where the instance first rendered.
+        (emit-post-settle-reactive-sub-run! :test/main :title-state :idle :idle)
+        (emit-post-settle-render-rk! :test/main tv-rk)
+
+        (let [history (rf/epoch-history :test/main)
+              m       (some #(when (= (:epoch-id mount-epoch) (:epoch-id %)) %) history)
+              i       (some #(when (= (:epoch-id inc-epoch)   (:epoch-id %)) %) history)]
+          (is (= :seed        (:event-id m)))
+          (is (= :counter-inc (:event-id i)))
+
+          ;; THE FIX, pinned: the counter-inc epoch's RENDERED list is
+          ;; [counter-view] ONLY. title-view's late mount render does NOT
+          ;; leak into it (pre-fix it did — the rf2-vh1k3 defect).
+          (is (contains? (rendered-keys i) cv-rk)
+              "counter-inc epoch carries counter-view's GENUINE re-render
+               (its ::counter sub changed 0 → 1)")
+          (is (not (contains? (rendered-keys i) tv-rk))
+              "counter-inc epoch does NOT carry title-view's late mount
+               render — title-view's subs never changed on a counter-inc,
+               so its mount-burst render must NOT leak into this cascade
+               (the rf2-vh1k3 defect: pre-fix it spuriously appeared here)")
+
+          ;; The mount epoch still carries title-view's mount render —
+          ;; the late tail is absorbed into where the instance first
+          ;; rendered, not dropped on the floor.
+          (is (contains? (rendered-keys m) tv-rk)
+              "the mount epoch carries title-view's mount render")
+          (is (contains? (rendered-keys m) cv-rk)
+              "the mount epoch carries counter-view's mount render"))))))
+
+(deftest mount-render-tail-into-mount-epoch-is-deduped
+  (testing "rf2-vh1k3 — a mount-burst tail render that resolves back to its
+            mount epoch (where the instance already rendered) is de-duped:
+            it does not add a second :renders row for the same render-key."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
+    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    ;; title-view mounts in the seed epoch (render + first sub recompute,
+    ;; stamped → read-set learned).
+    (emit-post-settle-render-rk! :test/main tv-rk)
+    (emit-mount-sub-run! :test/main :title-state tv-rk nil :idle)
+
+    (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+    ;; Two late mount-burst tail renders for title-view after the next
+    ;; cascade, each with UNCHANGED subs (post-settle reactive, no stamp)
+    ;; — both must resolve to the mount epoch and be absorbed (no
+    ;; duplicate rows).
+    (emit-post-settle-reactive-sub-run! :test/main :title-state :idle :idle)
+    (emit-post-settle-render-rk! :test/main tv-rk)
+    (emit-post-settle-render-rk! :test/main tv-rk)
+
+    (let [history     (rf/epoch-history :test/main)
+          mount-epoch (first history)
+          tv-rows     (->> (:renders mount-epoch)
+                           (filter #(= tv-rk (:render-key %))))]
+      (is (= :seed (:event-id mount-epoch)))
+      (is (= 1 (count tv-rows))
+          "title-view appears exactly ONCE in its mount epoch's :renders —
+           the late mount-burst tail is de-duped, not appended again"))))
+
+(deftest genuine-re-render-of-mounted-view-rides-its-cascade
+  (testing "rf2-vh1k3 — once a view has mounted, a LATER genuine re-render
+            (its own inputs change in a subsequent cascade) is attributed
+            to THAT cascade, not redirected back to the mount epoch. The
+            mount-epoch anchor only governs mount-burst tails."
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed        (fn [_ _] {:counter 0}))
+    (rf/reg-event-db :counter-inc (fn [db _] (update db :counter inc)))
+
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    ;; counter-view mounts (stamped → read-set {::counter} learned).
+    (emit-post-settle-render-rk! :test/main cv-rk)
+    (emit-mount-sub-run! :test/main :counter cv-rk nil 0)
+
+    ;; First '+'.
+    (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+    (let [inc1 (last (rf/epoch-history :test/main))]
+      (emit-post-settle-reactive-sub-run! :test/main :counter 0 1)
+      (emit-post-settle-render-rk! :test/main cv-rk)
+
+      ;; Second '+'.
+      (rf/dispatch-sync [:counter-inc] {:frame :test/main})
+      (let [inc2 (last (rf/epoch-history :test/main))]
+        (emit-post-settle-reactive-sub-run! :test/main :counter 1 2)
+        (emit-post-settle-render-rk! :test/main cv-rk)
+
+        (let [history (rf/epoch-history :test/main)
+              e1      (some #(when (= (:epoch-id inc1) (:epoch-id %)) %) history)
+              e2      (some #(when (= (:epoch-id inc2) (:epoch-id %)) %) history)]
+          (is (contains? (rendered-keys e1) cv-rk)
+              "the first counter-inc carries counter-view's re-render")
+          (is (contains? (rendered-keys e2) cv-rk)
+              "the second counter-inc ALSO carries counter-view's re-render
+               — a genuine re-render rides its own cascade, never collapses
+               back to the mount epoch"))))))


### PR DESCRIPTION
## Root cause

Follow-up to rf2-qs6dl/#1935. A view's **mount render commits late**:
React/Reagent batch a freshly-mounted component's render onto a later
tick, so it can fire at React commit time *after* the first user cascade
settles. rf2-qs6dl back-fills a post-settle render to the frame's
most-recently-settled epoch — correct for a genuine reactive re-render,
but wrong for a late mount render, which then leaks into the first
post-mount cascade's `RENDERED` list.

Confirmed live on parallel-frames `:below` (headless Chrome): the first
`+` click's `counter-inc` epoch reported `[counter-view title-view]`
though `title-view`'s subs never changed on a counter-inc; it
self-corrected from the 2nd click.

## Fix — option (a): attribute the late mount render to its mount epoch

The bead offered (a) attribute the mount render to its mount epoch, or
(b) blanket de-dup. **(a) was chosen** because empirically the two views
render with **identical render-keys in BOTH epochs** (same instance
tokens — `counter-view#6`, `title-view#7`), so render-key novelty alone
cannot separate `counter-view`'s genuine re-render from `title-view`'s
mount-burst tail. The only signal that does is **value-change per view**:
a render of view K belongs to epoch N iff some sub K reads had
`:value-changed? true` in N (the rf2-l1jz8 attribution).

Mechanism:
- `re-frame.subs.memo` stamps the reactive `:sub/run` with
  `:reader-render-key` — the view whose render synchronously deref'd the
  reaction. Reagent's post-settle reaction-flush fires *outside* any
  render binding, so the stamp is present only on the synchronous
  mount/first-paint deref. That's enough to **learn each view's read-set
  at mount** (a view's sub set is stable across its life). Reached via a
  new `:views/reading-render-key` late-bind hook (no subs→views dep).
- `re-frame.epoch.state/resolve-render-epoch` resolves a post-settle
  render's epoch: the newest epoch where the view's OWN subs
  value-changed (genuine re-render rides its cascade) → else the view's
  mount epoch (mount / mount-burst tail) → else last-settled (brand-new
  instance). A tail resolving back to its mount epoch where it already
  landed is de-duped.

Whole path is dev-only (`interop/debug-enabled?`) and DCEs in production
— confirmed by `test:elision` (35/35 production-absent).

## Regression test (fails without the fix)

`epoch_test.clj` adds three rf2-vh1k3 tests modelling the live
trace shape (mount sub-runs stamped; post-settle reactive recomputes
unstamped):
- a late mount render with unchanged subs lands in the mount epoch ONLY,
  not the settling cascade — **this assertion FAILS without the fix**
  (verified by temporarily reverting the resolver: title-view spuriously
  appears in the counter-inc epoch);
- a genuine re-render rides its own cascade across successive clicks;
- a mount-burst tail is de-duped (no duplicate `:renders` row).

## Before / after (live, parallel-frames `:below`, headless Chrome)

| | epoch (initialise) | 1st `+` (counter-inc) | 2nd `+` |
|---|---|---|---|
| **before** | `[frame-panel counter-view title-view]` | `[counter-view TITLE-VIEW]` ← spurious | `[counter-view]` |
| **after** | `[frame-panel counter-view title-view]` | `[counter-view]` | `[counter-view]` |

## Gates

- JVM epoch: 194 tests, 0 failures (incl. 3 new)
- JVM core: 719 tests, 0 failures (incl. late-bind drift)
- `npm run test:cljs`: 4095 tests, 0 failures
- `npm run test:causa-feature-gate`: 13 scenarios, 0 failures
- `npm run test:elision`: 35/35 production-absent