### PR TITLE
feat(causa): Views panel — three stacked tables (L1 subs · L2+ subs · Views) (rf2-8ve8z)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel.cljs
@@ -8,16 +8,30 @@
   while the sub cascade is the supporting context.
 
   The internal panel-registry key stays `:views` (it was always the
-  internal id, never a user contract). The panel renders the full
-  reactive cascade per spec/021 §3 reorganised into two sections:
+  internal id, never a user contract). Per rf2-8ve8z (phase-B of the
+  Views-tab redesign) the panel renders the reactive cascade as THREE
+  STACKED TABLES, top→bottom mirroring the cascade flowing toward the
+  UI:
 
-      Subs this cascade (count)   ONE table — one row per sub that ran,
-                                  columns sub-id | changed? | cascaded?
-                                  | code. Each sub appears exactly once
-                                  (rf2-isun6 · replaced the prior three
-                                  overlapping ran/changed/cascaded lists)
-      Views re-rendered           entries named via `reg-view :name`,
-                                  `[code] chip` + hover-highlight
+      Level 1 subs (observe app-db)   name | changed | code — the subs
+                                      that read app-db directly
+                                      (`:inputs []` per sub-topology)
+      Level 2+ subs                   name | changed | inputs | code —
+                                      composed subs; inputs lists the
+                                      input-sub names one per line
+      Views:                          name | action | reason — one row
+                                      per view render/unmount. `name` is
+                                      hoverable (pink DOM highlight,
+                                      rf2-8l03l); `action` is mount /
+                                      rerender / unmount; `reason` is the
+                                      changed subs THIS view reads, or
+                                      `← parent re-render` (structural,
+                                      UNNAMED).
+
+  The Level 1 / Level 2+ split + the inputs/code columns come from
+  `re-frame.subs.tooling/sub-topology`; the view action + reason ride
+  phase-A's (rf2-9hoos) `:mount?` / `:deref-subs` fields on
+  `:rf.view/rendered` + the new `:rf.view/unmounted` op.
 
   ## Public surface
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
@@ -1,23 +1,58 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-subs
-  "Subscriptions for the Reactive panel (rf2-wyvf2 · spec/021 §3).
+  "Subscriptions for the Views panel (rf2-wyvf2 / rf2-8ve8z · spec/021 §3).
 
   The panel reads the focused epoch record's normalized structured
   projections — `:sub-runs` and `:renders` — assembled by the
-  substrate on each `:rf/epoch-record` (per spec/018). It does NOT
-  re-derive rows from raw `:trace-events` by op-keyword: the canonical
-  ops are `:sub/run` / `:rf.sub/skip` / `:rf.view/rendered`
-  (Spec 009 §:op-type vocabulary), and the earlier op-keyword path
-  grepped for names the substrate never emits (`:rf.sub/computed` /
-  `:rf.sub/skipped`), pinning subs-ran / subs-skipped to zero
-  regardless of how many subs actually ran.
+  substrate on each `:rf/epoch-record` (per spec/018), plus the
+  view-side capture ops (`:rf.view/rendered` / `:rf.view/unmounted`)
+  off the raw `:trace-events`. It does NOT re-derive sub rows from raw
+  `:trace-events` by op-keyword: the canonical ops are `:sub/run` /
+  `:rf.sub/skip` / `:rf.view/rendered` (Spec 009 §:op-type vocabulary),
+  and the earlier op-keyword path grepped for names the substrate never
+  emits (`:rf.sub/computed` / `:rf.sub/skipped`), pinning subs-ran /
+  subs-skipped to zero regardless of how many subs actually ran.
 
   - `:sub-runs` → subs-ran (`:recomputed?` true) + subs-skipped
-    (memo-hit, `:recomputed?` false)
+    (memo-hit, `:recomputed?` false); each carries `:value-changed?`.
   - `:renders`  → views-rendered (`:render-key` → top-level `:view-id`)
   - flow counts → tallied from `:trace-events` (`:rf.flow/computed` /
     `:rf.flow/skip`), the one slice with no structured projection.
 
-  No new instrumentation — pure consumer over the epoch record.
+  ## phase-B Views redesign (rf2-8ve8z)
+
+  The Views panel is THREE STACKED TABLES mirroring the reactive
+  cascade flowing toward the UI:
+
+    1. Level 1 subs (observe app-db)  — `:inputs []` per `sub-topology`
+    2. Level 2+ subs                  — non-empty `:inputs`
+    3. Views                          — one row per render/unmount, with
+                                        an `action` (mount/rerender/
+                                        unmount) and a `reason`
+
+  The sub-level partition uses `re-frame.subs.tooling/sub-topology` —
+  the static `:<-` dependency graph (`{sub-id {:inputs [...] :ns :line
+  :file}}`). `:inputs []` is Level 1 (reads app-db directly); non-empty
+  is Level 2+. Topology also supplies the `:ns/:line/:file` source coord
+  for the `code` column's jump-to-source chip and the input-sub names
+  for the Level 2+ `inputs` column.
+
+  The view ACTION + REASON ride phase-A's (rf2-9hoos) additions to the
+  view-render trace ops, read off the epoch record's `:trace-events`:
+
+    - `:rf.view/rendered` carries `:mount?` (true → mount, false →
+      rerender) and `:deref-subs` (the `[query-id args]` query-vectors
+      THIS view derefs — its per-view read-set; absent for a structural
+      render that derefs no subs).
+    - `:rf.view/unmounted` is a teardown op → action unmount.
+
+  The REASON is computed by intersecting a render's `:deref-subs`
+  query-ids with the set of subs that `:value-changed?` this cascade:
+  non-empty → reactive (list those changed sub names); empty → the
+  view rendered with no own sub change → structural (`← parent
+  re-render`, deliberately UNNAMED). Unmount rows have no reason.
+
+  No new instrumentation — pure consumer over the epoch record + the
+  static topology snapshot.
 
   ## Public surface
 
@@ -30,12 +65,20 @@
          :has-cascade?    <bool>
          :triggered-by    <event-vec>
          :seed-paths      [<path> ...]
-         :subs-ran        [{:sub-id _ :payload _} ...]   ; rf.sub/computed
-         :subs-skipped    [{:sub-id _ :payload _} ...]   ; rf.sub/skipped
-         :views-rendered  [{:view-id _ :payload _} ...]  ; rf.view/rendered
+         :subs-ran        [{:sub-id _ :value-changed? _ ...} ...]
+         :subs-skipped    [{:sub-id _ ...} ...]
+         :views-rendered  [{:view-id _ ...} ...]      ; legacy count slot
+         :level-1-subs    [{:sub-id _ :changed? _ :coord _} ...]
+         :level-2-subs    [{:sub-id _ :changed? _ :inputs [...] :coord _} ...]
+         :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
          :counts          {:subs-ran N :subs-skipped N
                            :views-rendered N
                            :flows-recomputed N}}
+
+  The `:reason` slot on a `:view-row` is `{:kind :reactive :subs [...]}`
+  | `{:kind :structural}` | `{:kind :none}` (unmount). The view layer
+  truncates the `:subs` list honestly with a `+N more` overflow per the
+  Spec 009 cascade-cap posture.
 
   Per spec/021 §3.4 the panel's 'Show unchanged subs' disclosure is
   view-local (panel UI state); the always-expand override lives in
@@ -45,7 +88,8 @@
 
   `install!` registers `:rf.causa/reactive-data` + the panel-local
   disclosure-toggle state slot. Idempotent."
-  (:require [re-frame.core :as rf]))
+  (:require [re-frame.core :as rf]
+            [re-frame.subs.tooling :as subs-tooling]))
 
 ;; ---- pure helpers (exposed for test) ------------------------------------
 
@@ -67,46 +111,214 @@
   [event]
   (or (:operation event) (:op event)))
 
+;; ---- view action + reason (rf2-8ve8z, phase-A rf2-9hoos contract) ---------
+
+(defn- changed-sub-id-set
+  "Set of sub-ids whose value CHANGED this cascade — `:value-changed?`
+  true on the `:sub-runs` projection. The basis for the per-view
+  reactive-vs-structural reason classification.
+
+  nil-safe: a `:sub-runs` entry without `:value-changed?` (the base-
+  shape `compute-sub` emit omits it) is simply not counted as changed."
+  [sub-runs]
+  (into #{}
+        (comp (filter :value-changed?)
+              (map :sub-id))
+        (or sub-runs [])))
+
+(defn- query-id
+  "Extract the sub-id (query-id) from a `:deref-subs` entry. Entries are
+  `[query-id args]` query-vectors; a bare keyword query-id (no args) is
+  tolerated. Returns nil for any other shape."
+  [qv]
+  (cond
+    (vector? qv)  (first qv)
+    (keyword? qv) qv
+    :else         nil))
+
+(defn compute-view-reason
+  "Classify WHY a view rendered, given its `:deref-subs` query-vectors
+  and the set of subs that `:value-changed?` this cascade.
+
+  Returns a tagged map:
+
+    {:kind :reactive  :subs [<changed-sub-id> ...]}  — the view derefs
+        at least one sub that changed this cascade. `:subs` is the
+        INTERSECTION (the view's own changed reasons), order preserved
+        from the view's deref order so the most-relevant reads lead.
+    {:kind :structural}  — the view rendered but none of the subs it
+        derefs changed (or it derefs no subs at all). The unnamed
+        `← parent re-render` case — we deliberately never name the
+        parent (permanent, per rf2-8ve8z).
+
+  Pure. nil-safe on both args."
+  [deref-subs changed-set]
+  (let [changed   (or changed-set #{})
+        ;; preserve the view's deref order; keep only the changed ones
+        own-changed (into []
+                          (comp (keep query-id)
+                                (filter changed)
+                                (distinct))
+                          (or deref-subs []))]
+    (if (seq own-changed)
+      {:kind :reactive :subs own-changed}
+      {:kind :structural})))
+
+(defn view-rows
+  "Project the focused cascade's view-render + view-unmount trace events
+  into ordered `:view-row` maps for the Views table (rf2-8ve8z).
+
+  Reads `:rf.view/rendered` and `:rf.view/unmounted` ops off the raw
+  `:trace-events` (the phase-A rf2-9hoos additions). The structured
+  `:renders` projection is intentionally NOT used here — it projects
+  from `:view/render` (the render-START marker) and carries neither
+  `:mount?` nor `:deref-subs`. The action/reason data rides the
+  post-render `:rf.view/rendered` op + the `:rf.view/unmounted` op.
+
+  Each row:
+
+    {:view-id   <kw/id>
+     :render-key <[view-id token]>
+     :action    :mount | :rerender | :unmount
+     :reason    {:kind :reactive :subs [...]} | {:kind :structural}
+                | {:kind :none}                 ; unmount}
+
+  `changed-set` is the set of changed sub-ids this cascade (from
+  `changed-sub-id-set`). nil-safe: missing tags / absent fields degrade
+  to a structural reason rather than crashing. Events without a
+  `:view-id` are skipped (they can't anchor a row)."
+  [trace-events changed-set]
+  (into []
+        (keep (fn [ev]
+                (let [op   (op-kw ev)
+                      tags (:tags ev)
+                      view-id (or (:view-id tags) (:view-id ev))]
+                  (cond
+                    (nil? view-id) nil
+
+                    (= :rf.view/rendered op)
+                    (let [mount?     (true? (:mount? tags))
+                          deref-subs (:deref-subs tags)]
+                      {:view-id    view-id
+                       :render-key (:render-key tags)
+                       :action     (if mount? :mount :rerender)
+                       :reason     (compute-view-reason deref-subs changed-set)})
+
+                    (= :rf.view/unmounted op)
+                    {:view-id    view-id
+                     :render-key (:render-key tags)
+                     :action     :unmount
+                     :reason     {:kind :none}}
+
+                    :else nil))))
+        (or trace-events [])))
+
+;; ---- sub-level partition (rf2-8ve8z, sub-topology contract) ---------------
+
+(defn topology-coord
+  "Extract the jump-to-source coord (`{:file :line :ns}`) for a sub from
+  a `sub-topology` entry. Returns nil when the entry carries no `:file`
+  (degrade gracefully — the `code` column simply omits the chip)."
+  [topo-entry]
+  (when-let [file (:file topo-entry)]
+    (when (string? file)
+      {:file file :line (:line topo-entry) :ns (:ns topo-entry)})))
+
+(defn level-1?
+  "True when a sub is a Level 1 sub — it observes app-db DIRECTLY,
+  reported by `sub-topology` as `:inputs []`. A sub MISSING from the
+  topology (not statically registered, e.g. a test-injected literal)
+  is treated as Level 1 by default — the conservative bucket, since a
+  sub with no declared inputs reads app-db."
+  [topo-entry]
+  (empty? (:inputs topo-entry)))
+
+(defn partition-subs-by-level
+  "Partition the cascade's subs into the Level 1 / Level 2+ table rows
+  using the static `sub-topology` snapshot (rf2-8ve8z).
+
+  `subs-ran` is the `:sub-runs` projection slice (each entry carries
+  `:sub-id` + `:value-changed?`). `topology` is the
+  `re-frame.subs.tooling/sub-topology` map (`{sub-id {:inputs [...]
+  :ns :line :file}}`).
+
+  Returns `{:level-1 [row ...] :level-2 [row ...]}` where each row:
+
+    Level 1: {:sub-id _ :changed? bool :coord {...}?}
+    Level 2: {:sub-id _ :changed? bool :inputs [<input-sub-id> ...]
+              :coord {...}?}
+
+  Order preserved from `subs-ran` within each level. nil-safe: a sub
+  absent from the topology degrades to Level 1 with no inputs / no
+  coord. Both args may be nil."
+  [subs-ran topology]
+  (let [topo (or topology {})]
+    (reduce
+      (fn [acc sub-run]
+        (let [sub-id     (:sub-id sub-run)
+              topo-entry (get topo sub-id)
+              changed?   (boolean (:value-changed? sub-run))
+              coord      (topology-coord topo-entry)]
+          (if (level-1? topo-entry)
+            (update acc :level-1 conj
+                    (cond-> {:sub-id sub-id :changed? changed?}
+                      coord (assoc :coord coord)))
+            (update acc :level-2 conj
+                    (cond-> {:sub-id sub-id :changed? changed?
+                             :inputs (vec (:inputs topo-entry))}
+                      coord (assoc :coord coord))))))
+      {:level-1 [] :level-2 []}
+      (or subs-ran []))))
+
+;; ---- record projection ----------------------------------------------------
+
 (defn project-record
-  "Project an epoch record into the Reactive-panel shape. Pure data.
+  "Project an epoch record into the Views-panel shape. Pure data.
 
   Reads the substrate's normalized structured projections — `:sub-runs`
   and `:renders` — directly off the `:rf/epoch-record` (per spec/018),
-  rather than re-deriving rows from raw `:trace-events` by op-keyword.
-  The op-keyword path this replaced grepped for names the substrate
-  never emits (`:rf.sub/computed` / `:rf.sub/skipped`) where the
-  canonical ops are `:sub/run` / `:rf.sub/skip` (Spec 009 §:op-type
-  vocabulary), so subs-ran / subs-skipped were perpetually zero.
+  the view-side capture ops (`:rf.view/rendered` / `:rf.view/unmounted`)
+  off the raw `:trace-events`, and flow counts off `:trace-events`'
+  canonical `:rf.flow/computed` / `:rf.flow/skip` ops.
 
-  `:sub-runs` entries carry `:sub-id` / `:query-v` / `:recomputed?`;
-  the `:recomputed?` flag splits genuine recomputes (subs-ran) from
-  memo-hit skips (subs-skipped). `:renders` entries carry `:render-key`
-  (a `[view-id idx]` vector); `:view-id` is lifted to the top level for
-  the panel's row renderer.
+  `topology` (optional) is the `re-frame.subs.tooling/sub-topology`
+  snapshot used to partition subs into Level 1 / Level 2+ and supply
+  the `inputs` + `code` columns. Absent / nil topology degrades every
+  sub to Level 1 with no inputs / no coord — the panel still renders.
 
-  Flows have no structured projection on the record, so flow counts are
-  tallied from `:trace-events` using the canonical `:rf.flow/computed`
-  / `:rf.flow/skip` op names.
+  `:sub-runs` entries carry `:sub-id` / `:query-v` / `:recomputed?` /
+  `:value-changed?`; `:recomputed?` splits genuine recomputes (subs-ran)
+  from memo-hit skips (subs-skipped). The view rows ride the phase-A
+  rf2-9hoos fields on the view-render ops.
 
   Returns the map shape documented in the ns docstring (sans the
   focus / frame / dispatch-id keys; those come from the spine sub)."
-  [record]
-  (let [sub-runs (vec (:sub-runs record))
-        ran      (filterv :recomputed? sub-runs)
-        skipped  (filterv (complement :recomputed?) sub-runs)
-        renders  (mapv (fn [r] (assoc r :view-id (first (:render-key r))))
-                       (:renders record))
-        grouped  (group-by op-kw (or (:trace-events record) []))
-        flows-comp    (count (get grouped :rf.flow/computed []))
-        flows-skipped (count (get grouped :rf.flow/skip []))]
-    {:subs-ran        ran
-     :subs-skipped    skipped
-     :views-rendered  renders
-     :counts          {:subs-ran         (count ran)
-                       :subs-skipped     (count skipped)
-                       :views-rendered   (count renders)
-                       :flows-recomputed flows-comp
-                       :flows-skipped    flows-skipped}}))
+  ([record] (project-record record nil))
+  ([record topology]
+   (let [sub-runs (vec (:sub-runs record))
+         ran      (filterv :recomputed? sub-runs)
+         skipped  (filterv (complement :recomputed?) sub-runs)
+         renders  (mapv (fn [r] (assoc r :view-id (first (:render-key r))))
+                        (:renders record))
+         trace-events (or (:trace-events record) [])
+         grouped  (group-by op-kw trace-events)
+         flows-comp    (count (get grouped :rf.flow/computed []))
+         flows-skipped (count (get grouped :rf.flow/skip []))
+         changed-set   (changed-sub-id-set ran)
+         {:keys [level-1 level-2]} (partition-subs-by-level ran topology)
+         v-rows        (view-rows trace-events changed-set)]
+     {:subs-ran        ran
+      :subs-skipped    skipped
+      :views-rendered  renders
+      :level-1-subs    level-1
+      :level-2-subs    level-2
+      :view-rows       v-rows
+      :counts          {:subs-ran         (count ran)
+                        :subs-skipped     (count skipped)
+                        :views-rendered   (count renders)
+                        :view-rows        (count v-rows)
+                        :flows-recomputed flows-comp
+                        :flows-skipped    flows-skipped}})))
 
 (defn- triggered-by
   "Reconstruct the triggering event from the epoch record. Reuses the
@@ -141,8 +353,13 @@
     :<- [:rf.causa/focus]
     :<- [:rf.causa/epoch-history]
     (fn [[focus history] _query]
-      (let [record (focused-epoch-record history (:epoch-id focus))
-            proj   (project-record record)]
+      (let [record   (focused-epoch-record history (:epoch-id focus))
+            ;; Static topology snapshot — read once per cascade. Free
+            ;; (registry-only); used to partition L1 / L2+ subs and
+            ;; supply the inputs + code columns. Defensive try so a
+            ;; topology read never crashes the panel.
+            topology (try (subs-tooling/sub-topology) (catch :default _ nil))
+            proj     (project-record record topology)]
         (merge proj
                {:focus        focus
                 :frame        (:frame focus)

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -1,39 +1,58 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-view
-  "Root view for the View panel (rf2-e33ad · Mike-direction 2026-05-21 ·
-  prior bead: rf2-wyvf2).
+  "Root view for the Views panel (rf2-e33ad / rf2-8ve8z · Mike-direction
+  2026-05-21 · prior beads: rf2-wyvf2, rf2-isun6).
 
-  Renders the canonical sub-cascade + view-re-render visualisation as
-  two bare-label pipeline sections, mirroring the rf2-n4ad0 Event
-  panel rhythm (thin left rail + downward chevrons):
+  Renders the reactive cascade flowing toward the UI as THREE STACKED
+  TABLES, top→bottom mirroring the cascade (rf2-8ve8z, phase-B of the
+  Views-tab redesign; phase-A landed the substrate captures in
+  rf2-9hoos):
 
-      Subs this cascade (count)   ONE table — one row per sub that RAN
-                                  this cascade. Columns:
-                                    sub-id | changed? | cascaded? | code
-                                  `changed?` ✓ via `sub-changed?`,
-                                  `cascaded?` ✓ via `sub-cascaded?`
-                                  (the upstream `:cause-sub` rides as
-                                  secondary text on the cascaded ✓).
-                                  Each sub appears EXACTLY once — the
-                                  changed/cascaded dimensions are
-                                  columns, not separate lists
-                                  (rf2-isun6 · replaces the prior three
-                                  overlapping SUBS RAN / SUBS WHOSE
-                                  VALUE CHANGED / SUBS THAT CASCADED
-                                  sections that repeated each sub).
-      Views re-rendered (count)   entries — named via reg-view :name
-                                  slot (fallback: var name) +
-                                  [code] chip + hover-highlight
+      Level 1 subs (observe app-db)   one row per Level 1 sub that ran
+                                      this cascade. Columns:
+                                        name | changed | code
+                                      `changed` is the accent flag from
+                                      the `:value-changed?` projection;
+                                      `code` is a jump-to-source [code]
+                                      chip from the static topology
+                                      coord.
+
+      Level 2+ subs                   one row per composed sub that ran.
+                                      Columns:
+                                        name | changed | inputs | code
+                                      `inputs` lists the input-sub names
+                                      ONE PER LINE (the static `:<-`
+                                      chain from `sub-topology`).
+
+      Views:                          one row per view render / unmount
+                                      this cascade. Columns:
+                                        name | action | reason
+                                      `name` is hoverable (reuses the
+                                      pink diagonal-stripe DOM highlight,
+                                      rf2-8l03l); `action` is mount /
+                                      rerender / unmount; `reason` is the
+                                      changed subs THIS view reads (a
+                                      reactive render) or the literal
+                                      `← parent re-render` (a structural
+                                      render — UNNAMED, permanent).
+
+  The Level 1 / Level 2+ split comes from
+  `re-frame.subs.tooling/sub-topology` (`:inputs []` = Level 1); the
+  view action + reason come from phase-A's `:mount?` / `:deref-subs`
+  fields on `:rf.view/rendered` + the new `:rf.view/unmounted` op. All
+  the data wiring lives in `reactive-panel-subs/project-record` — this
+  ns is pure presentation over the projected `:rf.causa/reactive-data`
+  shape.
 
   ## Hover-highlight (rf2-e33ad / rf2-8l03l)
 
-  Hovering a view row toggles the `.rf-causa-view-highlight` class
-  (rf2-8l03l) onto the rendered view's root DOM node (matched by
-  `data-rf-view` — the attribute the framework already stamps per
-  Spec 006 §View tagging contract). The class (theme/global-styles)
-  paints a translucent PINK DIAGONAL-STRIPE barber-pole via
-  `background-image` — pink-on-fainter-pink so it reads on both light
-  and dark app surfaces, translucent so the view's content shows
-  through. The highlight is background-only — NO border / outline /
+  Hovering a Views-table NAME cell toggles the
+  `.rf-causa-view-highlight` class (rf2-8l03l) onto the rendered view's
+  root DOM node (matched by `data-rf-view` — the attribute the framework
+  already stamps per Spec 006 §View tagging contract). The class
+  (theme/global-styles) paints a translucent PINK DIAGONAL-STRIPE
+  barber-pole via `background-image` — pink-on-fainter-pink so it reads
+  on both light and dark app surfaces, translucent so the view's content
+  shows through. The highlight is background-only — NO border / outline /
   shadow that would perturb layout. Cleared on mouseleave by removing
   the class (no residue).
 
@@ -44,15 +63,36 @@
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
             [day8.re-frame2-causa.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]))
+
+;; ---- truncation budget (rf2-8ve8z · Spec 009 cascade-cap posture) -------
+;;
+;; A full-page cascade can run hundreds of subs / fire hundreds of view
+;; renders. The substrate already caps `:rf.view/rendered` emits at 100
+;; per cascade (re-frame.views/view-rendered-cap). The panel mirrors
+;; that ceiling for table rows and applies a tighter inline budget to
+;; the per-row list columns (inputs / reason subs) so a wide composed
+;; sub or a many-reason render stays a single legible row. Overflow is
+;; surfaced honestly with a muted `+N more` affordance, never silently
+;; dropped.
+
+(def ^:private max-table-rows
+  "Max rows rendered per table before a `+N more` overflow row. Mirrors
+  the substrate's per-cascade view-render cap (100)."
+  100)
+
+(def ^:private max-inline-list
+  "Max items rendered inline in a per-row list column (inputs / reason
+  changed-subs) before a `+N more` suffix. Keeps a wide sub row
+  legible — the full set is in the underlying data."
+  6)
 
 ;; ---- styling primitives -------------------------------------------------
 
 (def ^:private section-label-style
-  "Bare body-text label per Mike-direction 2026-05-21. NOT a large h1/
-  h2 heading; uppercase 11px sans-stack matches the rf2-n4ad0 Event
-  panel section labels."
+  "Bare body-text label preceding each table. NOT a large h1/h2 heading;
+  uppercase 11px sans-stack matches the rf2-n4ad0 Event panel section
+  labels."
   {:padding       "8px 12px 4px 12px"
    :font-family   sans-stack
    :font-size     "11px"
@@ -60,18 +100,6 @@
    :letter-spacing "0.6px"
    :text-transform "uppercase"
    :color         (:text-secondary tokens)})
-
-(def ^:private row-style
-  {:padding     "4px 12px 4px 24px"
-   :font-family mono-stack
-   :font-size   "12px"
-   :color       (:text-primary tokens)
-   :display     "flex"
-   :gap         "8px"
-   :align-items "center"})
-
-(def ^:private dim-row-style
-  (assoc row-style :color (:text-tertiary tokens)))
 
 (def ^:private empty-row-style
   {:padding     "2px 12px 6px 24px"
@@ -89,16 +117,17 @@
    :user-select  "none"
    :opacity      "0.6"})
 
-;; ---- single subs-table styling (rf2-isun6) ----------------------------
+;; ---- table styling (rf2-8ve8z) -----------------------------------------
 
-(def ^:private subs-table-style
+(def ^:private table-style
   {:width          "100%"
    :border-collapse "collapse"
    :margin         "2px 12px 4px 24px"
    :font-family    mono-stack
-   :font-size      "12px"})
+   :font-size      "12px"
+   :table-layout   "auto"})
 
-(def ^:private subs-th-style
+(def ^:private th-style
   "Column header cell. Muted sans label echoing the section-label
   primitive so the table reads as part of the pipeline rhythm."
   {:text-align     "left"
@@ -109,27 +138,68 @@
    :letter-spacing "0.4px"
    :text-transform "uppercase"
    :color          (:text-tertiary tokens)
-   :white-space    "nowrap"})
+   :white-space    "nowrap"
+   :vertical-align "bottom"})
 
-(def ^:private subs-td-style
-  {:padding     "3px 12px 3px 0"
-   :color       (:text-primary tokens)
+(def ^:private td-style
+  {:padding        "3px 12px 3px 0"
+   :color          (:text-primary tokens)
    :vertical-align "top"})
 
-(def ^:private flag-yes-style
-  "The ✓ cell when a dimension is set."
+(def ^:private name-cell-style
+  "The `name` column — the sub-id / view-id. Violet accent + semibold so
+  the identifier leads the row."
+  (assoc td-style :color (:accent-violet tokens) :font-weight 600
+                  :white-space "nowrap"))
+
+(def ^:private changed-yes-style
+  "The `changed` flag when the sub's value changed this cascade — a clear
+  accent so the eye lands on it."
   {:color (:cyan tokens) :font-weight 600})
 
-(def ^:private flag-no-style
-  "The · placeholder when a dimension is unset — dim so the eye skips it."
+(def ^:private changed-no-style
+  "The `changed` placeholder when unchanged — muted so the eye skips it."
   {:color (:text-tertiary tokens) :opacity "0.5"})
 
-(def ^:private cause-sub-style
-  "Secondary text rendered next to the cascaded ✓ — the upstream
-  `:cause-sub` that triggered the cascade. Dim so the ✓ stays primary."
-  {:color (:text-tertiary tokens)
-   :font-size "10px"
-   :margin-left "6px"})
+(def ^:private overflow-style
+  "Muted `+N more` affordance for honest truncation."
+  {:color       (:text-tertiary tokens)
+   :font-style  "italic"
+   :font-family sans-stack
+   :font-size   "10px"})
+
+;; ---- action / reason styling (rf2-8ve8z) -------------------------------
+
+(def ^:private action->token
+  "Map a view action to its accent token. mount = green (a new thing
+  appears), rerender = cyan (the standard change accent shared with the
+  sub `changed` flag), unmount = red (a thing goes away)."
+  {:mount    :green
+   :rerender :cyan
+   :unmount  :red})
+
+(defn- action-style
+  [action]
+  {:color       (get tokens (get action->token action :text-secondary))
+   :font-weight 600
+   :font-family sans-stack
+   :font-size   "10px"
+   :letter-spacing "0.3px"
+   :text-transform "uppercase"})
+
+(def ^:private structural-reason-style
+  "The literal `← parent re-render` text — muted so a structural render
+  reads as quieter than a reactive one (which carries named subs)."
+  {:color       (:text-tertiary tokens)
+   :font-style  "italic"})
+
+(def ^:private reactive-reason-sub-style
+  "A changed-sub name in a reactive view's reason cell."
+  {:color (:cyan tokens)})
+
+(def ^:private none-reason-style
+  "The em-dash placeholder for an unmount row's empty reason."
+  {:color (:text-tertiary tokens) :opacity "0.5"})
 
 ;; ---- pure formatters ---------------------------------------------------
 
@@ -157,11 +227,16 @@
       :else
       (pr-str view-id))))
 
+(defn- id-slug
+  "Stable testid suffix for a sub-id / view-id — kw/symbol punctuation
+  flattened to `_` so the row + chip testids are CSS-selector safe."
+  [id]
+  (when id (string/replace (str id) #"[^a-zA-Z0-9_]" "_")))
+
 ;; ---- pipeline chrome ---------------------------------------------------
 
 (defn- section-label
-  "Bare label that precedes each pipeline section's body — matches the
-  rf2-n4ad0 Event panel section-label primitive. testid:
+  "Bare label that precedes each table. testid:
   `rf-causa-reactive-section-<id>-label`."
   [id title]
   [:div {:data-testid (str "rf-causa-reactive-section-" id "-label")
@@ -169,8 +244,8 @@
    title])
 
 (defn- pipeline-chevron
-  "Small downward chevron `⋁` separating adjacent pipeline sections.
-  Muted (`:text-tertiary`) so the chevron is rhythm not foreground."
+  "Small downward chevron `⋁` separating adjacent tables. Muted
+  (`:text-tertiary`) so the chevron is rhythm not foreground."
   [from-id]
   [:div {:data-testid (str "rf-causa-reactive-chevron-" from-id)
          :aria-hidden "true"
@@ -178,9 +253,9 @@
    "⋁"])
 
 (defn- empty-row
-  "Render a muted placeholder for an empty section. Per Mike-direction
-  2026-05-21 empty states are ALWAYS visible so the pipeline rhythm
-  holds."
+  "Render a muted placeholder for an empty table. Empty states are
+  ALWAYS visible so the pipeline rhythm holds (Mike-direction
+  2026-05-21)."
   [testid label]
   [:div {:data-testid testid
          :style empty-row-style}
@@ -189,37 +264,37 @@
 ;; ---- [code] open-chip helpers -----------------------------------------
 
 (defn- code-chip
-  "Render an open-in-editor pill matching the Event panel's
-  `coord-chip` shape. Dispatches `:rf.causa/open-in-editor`. Returns
-  nil when there is no usable `:file`."
+  "Render an open-in-editor pill matching the Event panel's `coord-chip`
+  shape — a clickable `ns:line` jump-to-source affordance. Dispatches
+  `:rf.causa/open-in-editor`. Returns nil when there is no usable
+  `:file`."
   [coord testid]
   (when (and (map? coord) (seq (:file coord)))
-    [:button {:data-testid testid
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.causa/open-in-editor
-                                           {:source-coord coord}]
-                                          {:frame :rf/causa}))
-              :style       {:background  "transparent"
-                            :color       (:cyan tokens)
-                            :border      (str "1px solid " (:border-default tokens))
-                            :padding     "1px 6px"
-                            :border-radius "3px"
-                            :margin-left "8px"
-                            :cursor      "pointer"
-                            :font-family mono-stack
-                            :font-size   "10px"}}
-     "[code]"]))
-
-(defn- sub-coord
-  "Look up the source coord for a registered sub id via the registry
-  meta read. Returns the structured coord (`{:file :line ...}`) when
-  the registration carries it. Pure-ish — calls into the registry."
-  [sub-id]
-  (let [meta (rf/handler-meta :sub sub-id)
-        file (:file meta)]
-    (when (string? file)
-      {:file file :line (:line meta) :column (:column meta) :ns (:ns meta)})))
+    (let [ns-seg (some-> (:ns coord) str)
+          line   (:line coord)
+          label  (cond
+                   (and ns-seg line) (str ns-seg ":" line)
+                   ns-seg            ns-seg
+                   line              (str ":" line)
+                   :else             "[code]")]
+      [:button {:data-testid testid
+                :title       (str "Open " (:file coord)
+                                  (when line (str ":" line)))
+                :on-click    (fn [e]
+                               (.stopPropagation e)
+                               (rf/dispatch [:rf.causa/open-in-editor
+                                             {:source-coord coord}]
+                                            {:frame :rf/causa}))
+                :style       {:background  "transparent"
+                              :color       (:cyan tokens)
+                              :border      (str "1px solid " (:border-default tokens))
+                              :padding     "1px 6px"
+                              :border-radius "3px"
+                              :cursor      "pointer"
+                              :font-family mono-stack
+                              :font-size   "10px"
+                              :white-space "nowrap"}}
+       label])))
 
 (defn- view-coord
   "Look up the source coord for a registered view id via the registry
@@ -232,10 +307,10 @@
 
 ;; ---- hover-highlight (rf2-e33ad / rf2-8l03l) --------------------------
 ;;
-;; Hover a view-row → stamp a distinctive background-only highlight on
-;; the rendered view's root DOM node (matched via the `data-rf-view`
-;; attribute the framework already stamps per Spec 006). Cleared on
-;; mouseleave.
+;; Hover a Views-table NAME cell → stamp a distinctive background-only
+;; highlight on the rendered view's root DOM node (matched via the
+;; `data-rf-view` attribute the framework already stamps per Spec 006).
+;; Cleared on mouseleave.
 ;;
 ;; Mechanism (rf2-8l03l): toggle the Causa-namespaced
 ;; `.rf-causa-view-highlight` class. The class rule (in
@@ -255,9 +330,9 @@
 ;; paints inside the existing box with zero reflow.
 
 (def ^:private highlight-class
-  "Causa-namespaced class toggled onto the hovered view's
-  `data-rf-view` node. The matching CSS rule (theme/global-styles)
-  paints the pink diagonal-stripe `background-image`."
+  "Causa-namespaced class toggled onto the hovered view's `data-rf-view`
+  node. The matching CSS rule (theme/global-styles) paints the pink
+  diagonal-stripe `background-image`."
   "rf-causa-view-highlight")
 
 (defn- highlight-selector
@@ -291,9 +366,9 @@
 ;; ---- header (outcome line; no h1) --------------------------------------
 
 (defn- header-block
-  "Compact metadata strip — replaces the large h1 heading per
-  rf2-6xezz. Renders a single line with the frame + cascade counts so
-  the operator has the rhythm without the heading."
+  "Compact metadata strip — replaces the large h1 heading per rf2-6xezz.
+  Renders a single line with the frame + cascade counts so the operator
+  has the rhythm without the heading."
   [data]
   (when (:has-cascade? data)
     [:header {:data-testid "rf-causa-reactive-header-meta"
@@ -307,146 +382,216 @@
        (str "frame " (:frame data)
             " · " (or (:subs-ran counts) 0) " subs ran · "
             (or (:subs-skipped counts) 0) " skipped · "
-            (or (:views-rendered counts) 0) " views rendered"))]))
+            (or (:view-rows counts) (:views-rendered counts) 0) " view renders"))]))
 
-;; ---- subs-this-cascade dimension predicates ---------------------------
-;;
-;; rf2-isun6: a sub that ran may ALSO have changed value and/or cascaded.
-;; These two predicates no longer split the run-set into separate lists
-;; — they drive the `changed?` / `cascaded?` columns of the single
-;; subs table, so each sub appears exactly once.
+;; ---- shared cell renderers --------------------------------------------
 
-(defn- sub-changed?
-  "True when a `:rf.sub/computed` payload represents a value change
-  rather than the (already-equal) re-evaluation. The substrate sets
-  `:reason :input-changed` when the inputs differ; `:value-changed?`
-  may also ride on the payload depending on substrate version. Pure."
-  [payload]
-  (let [reason (:reason payload)]
-    (or (= :value-changed reason)
-        (true? (:value-changed? payload))
-        (and (contains? payload :prev-value)
-             (not= (:prev-value payload) (:value payload))))))
+(defn- changed-cell
+  "The `changed` column — a clear accent ✓ when the sub's value changed
+  this cascade; otherwise a muted · placeholder."
+  [changed?]
+  [:td {:style td-style}
+   (if changed?
+     [:span {:style changed-yes-style} "✓"]
+     [:span {:style changed-no-style} "·"])])
 
-(defn- sub-cascaded?
-  "True when a `:rf.sub/computed` payload represents a cascade (a sub
-  that was triggered by another sub's value change rather than by an
-  app-db write). The substrate stamps `:cause-sub` / `:cascade?` on
-  the payload depending on version. Pure."
-  [payload]
-  (or (true? (:cascade? payload))
-      (some? (:cause-sub payload))
-      (= :sub-cascade (:reason payload))))
+(defn- code-cell
+  "The `code` column — the jump-to-source chip, or a muted em-dash when
+  the topology carries no source coord (nil-safe degrade)."
+  [coord testid]
+  [:td {:style td-style}
+   (or (code-chip coord testid)
+       [:span {:style changed-no-style} "—"])])
 
-;; ---- single subs-this-cascade table (rf2-isun6) -----------------------
+(defn- overflow-line
+  "Render a `+N more` line when `total` exceeds `shown`. Returns nil
+  otherwise."
+  [shown total]
+  (when (> total shown)
+    [:div {:style overflow-style} (str "+" (- total shown) " more")]))
 
-(defn- sub-id-slug
-  "Stable testid suffix for a sub-id — kw/symbol punctuation flattened
-  to `_` so the row + code-chip testids are CSS-selector safe."
-  [sub-id]
-  (when sub-id (string/replace (str sub-id) #"[^a-zA-Z0-9_]" "_")))
+;; ---- table 1: Level 1 subs --------------------------------------------
 
-(defn- flag-cell
-  "A ✓ / · column cell. Renders the cyan ✓ when `on?`; otherwise a dim
-  placeholder. `secondary` (optional) rides as muted text after the ✓
-  (used to surface the upstream `:cause-sub` on the cascaded column)."
-  [on? secondary]
-  [:td {:style subs-td-style}
-   (if on?
-     [:span
-      [:span {:style flag-yes-style} "✓"]
-      (when (seq secondary)
-        [:span {:style cause-sub-style} secondary])]
-     [:span {:style flag-no-style} "·"])])
-
-(defn- subs-table-row
-  "One row per sub that ran this cascade. `changed?` / `cascaded?`
-  columns carry the dimensions; the sub appears exactly once.
+(defn- level-1-row
+  "One Level 1 sub row: name | changed | code.
 
   testids:
-    row       `rf-causa-reactive-sub-row-<slug>`
-    code chip `rf-causa-reactive-sub-code-<slug>`"
-  [payload]
-  (let [sub-id   (or (:sub-id payload) (:id payload))
-        slug     (sub-id-slug sub-id)
-        coord    (when sub-id (sub-coord sub-id))
-        changed? (sub-changed? payload)
-        cause    (when (sub-cascaded? payload)
-                   (let [c (:cause-sub payload)]
-                     (when c (str "← " (format-id c)))))]
-    [:tr {:data-testid (str "rf-causa-reactive-sub-row-" slug)
+    row       `rf-causa-reactive-l1-row-<slug>`
+    code chip `rf-causa-reactive-l1-code-<slug>`"
+  [{:keys [sub-id changed? coord]}]
+  (let [slug (id-slug sub-id)]
+    [:tr {:data-testid (str "rf-causa-reactive-l1-row-" slug)
           :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
-     [:td {:style (assoc subs-td-style :color (:accent-violet tokens)
-                         :font-weight 600)}
-      (format-id sub-id)]
-     (flag-cell changed? nil)
-     (flag-cell (sub-cascaded? payload) cause)
-     [:td {:style subs-td-style}
-      (code-chip coord (str "rf-causa-reactive-sub-code-" slug))]]))
+     [:td {:style name-cell-style} (format-id sub-id)]
+     (changed-cell changed?)
+     (code-cell coord (str "rf-causa-reactive-l1-code-" slug))]))
 
-(defn- subs-table-section
-  "ONE 'SUBS THIS CASCADE' table replacing the prior three overlapping
-  SUBS RAN / SUBS WHOSE VALUE CHANGED / SUBS THAT CASCADED sections.
-  One row per sub that RAN (the union); `changed?` / `cascaded?` are
-  columns, so each sub appears exactly once (rf2-isun6)."
+(defn- level-1-section
   [data]
-  (let [subs-ran (:subs-ran data)
-        n        (count subs-ran)]
+  (let [rows (:level-1-subs data)
+        n    (count rows)]
     [:<>
-     (section-label "subs" (str "SUBS THIS CASCADE (" n ")"))
-     (if (seq subs-ran)
-       [:table {:data-testid "rf-causa-reactive-subs-table"
-                :style       subs-table-style}
+     (section-label "l1" (str "LEVEL 1 SUBS (OBSERVE APP-DB) (" n ")"))
+     (if (seq rows)
+       [:table {:data-testid "rf-causa-reactive-l1-table"
+                :style       table-style}
         [:thead
          [:tr
-          [:th {:style subs-th-style} "sub-id"]
-          [:th {:style subs-th-style} "changed?"]
-          [:th {:style subs-th-style} "cascaded?"]
-          [:th {:style subs-th-style} "code"]]]
+          [:th {:style th-style} "name"]
+          [:th {:style th-style} "changed"]
+          [:th {:style th-style} "code"]]]
         (into [:tbody]
-              (for [[i p] (map-indexed vector subs-ran)]
-                (with-meta (subs-table-row p) {:key i})))]
-       (empty-row "rf-causa-reactive-subs-empty" "(no subs ran)"))]))
+              (concat
+                (for [[i r] (map-indexed vector (take max-table-rows rows))]
+                  (with-meta (level-1-row r) {:key i}))
+                (when (> n max-table-rows)
+                  [[:tr {:data-testid "rf-causa-reactive-l1-overflow"}
+                    [:td {:colSpan 3 :style (assoc td-style :padding-left "0")}
+                     (overflow-line max-table-rows n)]]])))]
+       (empty-row "rf-causa-reactive-l1-empty" "(no Level 1 subs ran)"))]))
 
-;; ---- views re-rendered section ---------------------------------------
+;; ---- table 2: Level 2+ subs -------------------------------------------
 
-(defn- view-rendered-row
-  "Single view-rendered row. Hover triggers a subtle background-only
-  highlight on the rendered view's root DOM (matched via
-  `data-rf-view`). Click [code] opens the registered source. Per
-  Mike-direction 2026-05-21."
-  [payload]
-  (let [view-id    (or (:view-id payload) (:id payload))
-        meta       (when view-id (rf/handler-meta :view view-id))
-        coord      (when view-id (view-coord view-id))
-        disp-name  (view-display-name view-id meta)
-        on-enter   (fn [_e] (apply-highlight! view-id))
-        on-leave   (fn [_e] (clear-highlight! view-id))]
-    [:div {:data-testid (str "rf-causa-reactive-view-rendered")
-           :data-rf-causa-view-id (str view-id)
+(defn- inputs-cell
+  "The `inputs` column — input-sub names ONE PER LINE, honestly
+  truncated with `+N more`. Muted em-dash when there are no inputs
+  (defensive — a Level 2+ row always has at least one)."
+  [inputs]
+  (let [n     (count inputs)
+        shown (take max-inline-list inputs)]
+    [:td {:style td-style}
+     (if (seq inputs)
+       (into [:div {:style {:display "flex" :flex-direction "column"
+                            :gap "1px"}}]
+             (concat
+               (for [[i input] (map-indexed vector shown)]
+                 ^{:key i} [:span {:style {:color (:text-secondary tokens)}}
+                            (format-id input)])
+               [(overflow-line max-inline-list n)]))
+       [:span {:style changed-no-style} "—"])]))
+
+(defn- level-2-row
+  "One Level 2+ sub row: name | changed | inputs | code.
+
+  testids:
+    row       `rf-causa-reactive-l2-row-<slug>`
+    code chip `rf-causa-reactive-l2-code-<slug>`"
+  [{:keys [sub-id changed? inputs coord]}]
+  (let [slug (id-slug sub-id)]
+    [:tr {:data-testid (str "rf-causa-reactive-l2-row-" slug)
+          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
+     [:td {:style name-cell-style} (format-id sub-id)]
+     (changed-cell changed?)
+     (inputs-cell inputs)
+     (code-cell coord (str "rf-causa-reactive-l2-code-" slug))]))
+
+(defn- level-2-section
+  [data]
+  (let [rows (:level-2-subs data)
+        n    (count rows)]
+    [:<>
+     (section-label "l2" (str "LEVEL 2+ SUBS (" n ")"))
+     (if (seq rows)
+       [:table {:data-testid "rf-causa-reactive-l2-table"
+                :style       table-style}
+        [:thead
+         [:tr
+          [:th {:style th-style} "name"]
+          [:th {:style th-style} "changed"]
+          [:th {:style th-style} "inputs"]
+          [:th {:style th-style} "code"]]]
+        (into [:tbody]
+              (concat
+                (for [[i r] (map-indexed vector (take max-table-rows rows))]
+                  (with-meta (level-2-row r) {:key i}))
+                (when (> n max-table-rows)
+                  [[:tr {:data-testid "rf-causa-reactive-l2-overflow"}
+                    [:td {:colSpan 4 :style (assoc td-style :padding-left "0")}
+                     (overflow-line max-table-rows n)]]])))]
+       (empty-row "rf-causa-reactive-l2-empty" "(no Level 2+ subs ran)"))]))
+
+;; ---- table 3: Views ----------------------------------------------------
+
+(defn- reason-cell
+  "The `reason` column for a Views-table row.
+
+    :reactive   → the changed subs THIS view reads (cyan names, honestly
+                  truncated with `+N more`).
+    :structural → the literal `← parent re-render` — UNNAMED. We never
+                  name the parent (permanent, rf2-8ve8z).
+    :none       → unmount row → a muted em-dash."
+  [reason]
+  (let [kind (:kind reason)]
+    [:td {:style td-style}
+     (case kind
+       :reactive
+       (let [subs  (:subs reason)
+             n     (count subs)
+             shown (take max-inline-list subs)]
+         (into [:div {:style {:display "flex" :flex-direction "column"
+                              :gap "1px"}}]
+               (concat
+                 (for [[i s] (map-indexed vector shown)]
+                   ^{:key i} [:span {:style reactive-reason-sub-style}
+                              (format-id s)])
+                 [(overflow-line max-inline-list n)])))
+
+       :structural
+       [:span {:data-testid "rf-causa-reactive-view-reason-structural"
+               :style structural-reason-style}
+        "← parent re-render"]
+
+       ;; :none / unknown
+       [:span {:style none-reason-style} "—"])]))
+
+(defn- view-row
+  "One Views-table row: name | action | reason. Hover the NAME cell to
+  highlight the rendered view's DOM (rf2-8l03l). Each render/unmount of
+  a view yields one row.
+
+  testid: `rf-causa-reactive-view-row-<slug>` (index-suffixed so repeat
+  renders of the same view stay unique)."
+  [idx {:keys [view-id action reason]}]
+  (let [meta      (when view-id (rf/handler-meta :view view-id))
+        disp-name (view-display-name view-id meta)
+        slug      (id-slug view-id)
+        on-enter  (fn [_e] (apply-highlight! view-id))
+        on-leave  (fn [_e] (clear-highlight! view-id))]
+    [:tr {:data-testid (str "rf-causa-reactive-view-row-" slug "-" idx)
+          :data-rf-causa-view-id (str view-id)
+          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
+     [:td {:data-testid (str "rf-causa-reactive-view-name-" slug "-" idx)
            :on-mouse-enter on-enter
            :on-mouse-leave on-leave
-           :style (assoc row-style :cursor "default")}
-     [:span {:style {:color (:accent-violet tokens)
-                     :font-weight 600}}
+           :style (assoc name-cell-style :cursor "default")}
       disp-name]
-     (code-chip coord
-                (str "rf-causa-reactive-view-code-"
-                     (when view-id (string/replace (str view-id)
-                                                    #"[^a-zA-Z0-9_]"
-                                                    "_"))))]))
+     [:td {:style td-style}
+      [:span {:style (action-style action)} (name action)]]
+     (reason-cell reason)]))
 
-(defn- views-rendered-section
+(defn- views-section
   [data]
-  (let [views (:views-rendered data)
-        n     (count views)]
+  (let [rows (:view-rows data)
+        n    (count rows)]
     [:<>
-     (section-label "views-rendered" (str "VIEWS RE-RENDERED (" n ")"))
-     (if (seq views)
-       (into [:div]
-             (for [[i v] (map-indexed vector views)]
-               (with-meta (view-rendered-row v) {:key i})))
-       (empty-row "rf-causa-reactive-views-empty" "(none re-rendered)"))]))
+     (section-label "views" (str "VIEWS: (" n ")"))
+     (if (seq rows)
+       [:table {:data-testid "rf-causa-reactive-views-table"
+                :style       table-style}
+        [:thead
+         [:tr
+          [:th {:style th-style} "name"]
+          [:th {:style th-style} "action"]
+          [:th {:style th-style} "reason"]]]
+        (into [:tbody]
+              (concat
+                (for [[i r] (map-indexed vector (take max-table-rows rows))]
+                  (with-meta (view-row i r) {:key i}))
+                (when (> n max-table-rows)
+                  [[:tr {:data-testid "rf-causa-reactive-views-overflow"}
+                    [:td {:colSpan 3 :style (assoc td-style :padding-left "0")}
+                     (overflow-line max-table-rows n)]]])))]
+       (empty-row "rf-causa-reactive-views-empty" "(no views rendered)"))]))
 
 ;; ---- empty state ------------------------------------------------------
 
@@ -466,7 +611,10 @@
 (defn reactive-panel
   "Plain Reagent fn — invoked from `reactive-panel/Panel` (the public
   facade reg-view) via a function call so the React-context frame tier
-  resolves to `:rf/causa` inside the leaf's subscribes."
+  resolves to `:rf/causa` inside the leaf's subscribes.
+
+  Renders the three stacked tables (rf2-8ve8z) top→bottom mirroring the
+  reactive cascade: Level 1 subs → Level 2+ subs → Views."
   []
   (let [data @(rf/subscribe [:rf.causa/reactive-data])]
     [:section {:data-testid "rf-causa-reactive"
@@ -490,6 +638,8 @@
                        :padding-left  "12px"
                        :padding-top   "8px"
                        :padding-bottom "8px"}}
-         (subs-table-section data)
-         (pipeline-chevron "subs")
-         (views-rendered-section data)])]]))
+         (level-1-section data)
+         (pipeline-chevron "l1")
+         (level-2-section data)
+         (pipeline-chevron "l2")
+         (views-section data)])]]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
@@ -138,3 +138,169 @@
       (is (= 2 (-> p :counts :views-rendered)))
       (is (= 1 (-> p :counts :flows-recomputed)))
       (is (= [:v-x :v-y] (mapv :view-id (:views-rendered p)))))))
+
+;; ===========================================================================
+;; phase-B Views redesign — three-table data layer (rf2-8ve8z)
+;; ===========================================================================
+
+;; ---- helpers -----------------------------------------------------------
+
+(defn- sub-run+ [sub-id recomputed? changed?]
+  {:sub-id sub-id :query-v [sub-id]
+   :recomputed? recomputed? :value-changed? changed?})
+
+(defn- rendered-ev
+  "A captured `:rf.view/rendered` trace event — tags carry the phase-A
+  rf2-9hoos fields."
+  [view-id mount? deref-subs]
+  {:operation :rf.view/rendered
+   :tags (cond-> {:view-id view-id :render-key [view-id 0] :mount? mount?}
+           (some? deref-subs) (assoc :deref-subs deref-subs))})
+
+(defn- unmounted-ev [view-id]
+  {:operation :rf.view/unmounted
+   :tags {:view-id view-id :render-key [view-id 0]}})
+
+;; ---- changed-vs-structural classifier ---------------------------------
+
+(deftest compute-view-reason-reactive-when-own-sub-changed
+  (testing "rf2-8ve8z — a view that derefs a sub that changed this cascade
+            gets a :reactive reason listing the INTERSECTION (its own
+            changed reads), in deref order."
+    (let [reason (subs/compute-view-reason [[:cart/total] [:cart/count]]
+                                           #{:cart/total})]
+      (is (= :reactive (:kind reason)))
+      (is (= [:cart/total] (:subs reason))
+          "only the changed sub the view reads lands in the reason"))))
+
+(deftest compute-view-reason-structural-when-no-own-sub-changed
+  (testing "rf2-8ve8z — a view that derefs subs but NONE changed → the
+            structural (`← parent re-render`) reason, UNNAMED."
+    (let [reason (subs/compute-view-reason [[:cart/total]] #{:other/sub})]
+      (is (= :structural (:kind reason)))
+      (is (nil? (:subs reason))))))
+
+(deftest compute-view-reason-structural-when-no-derefs
+  (testing "rf2-8ve8z — a pure structural render (no :deref-subs) → the
+            structural reason. nil-safe on the deref-subs arg."
+    (is (= :structural (:kind (subs/compute-view-reason nil #{:cart/total}))))
+    (is (= :structural (:kind (subs/compute-view-reason [] #{:cart/total}))))))
+
+(deftest compute-view-reason-preserves-deref-order-and-dedupes
+  (testing "rf2-8ve8z — reason :subs follow deref order and de-duplicate."
+    (let [reason (subs/compute-view-reason
+                   [[:b] [:a] [:a] [:c]] #{:a :b :c})]
+      (is (= [:b :a :c] (:subs reason))))))
+
+;; ---- view-rows projection ---------------------------------------------
+
+(deftest view-rows-maps-mount-rerender-unmount
+  (testing "rf2-8ve8z — :mount? true → :mount, false → :rerender, the
+            :rf.view/unmounted op → :unmount."
+    (let [events [(rendered-ev :v/a true  [[:s1]])
+                  (rendered-ev :v/b false [[:s1]])
+                  (unmounted-ev :v/c)]
+          rows   (subs/view-rows events #{:s1})]
+      (is (= [:mount :rerender :unmount] (mapv :action rows)))
+      (is (= [:v/a :v/b :v/c] (mapv :view-id rows))))))
+
+(deftest view-rows-reactive-vs-structural-reason
+  (testing "rf2-8ve8z — a render whose deref'd sub changed → :reactive
+            reason; a render whose deref'd sub did NOT change → structural."
+    (let [events [(rendered-ev :v/reactive   false [[:changed]])
+                  (rendered-ev :v/structural false [[:unchanged]])
+                  (rendered-ev :v/no-derefs  false nil)]
+          rows   (subs/view-rows events #{:changed})
+          by-id  (into {} (map (juxt :view-id identity)) rows)]
+      (is (= :reactive   (-> by-id :v/reactive :reason :kind)))
+      (is (= [:changed]  (-> by-id :v/reactive :reason :subs)))
+      (is (= :structural (-> by-id :v/structural :reason :kind)))
+      (is (= :structural (-> by-id :v/no-derefs :reason :kind))))))
+
+(deftest view-rows-unmount-reason-is-none
+  (testing "rf2-8ve8z — an unmount row carries no reason (:none)."
+    (let [rows (subs/view-rows [(unmounted-ev :v/gone)] #{})]
+      (is (= :none (-> rows first :reason :kind))))))
+
+(deftest view-rows-skips-events-without-view-id-and-non-view-ops
+  (testing "rf2-8ve8z — nil-safe: events without a :view-id and non-view
+            ops are skipped, never crash."
+    (let [events [{:operation :rf.view/rendered :tags {:mount? true}} ; no view-id
+                  {:operation :sub/run :tags {:sub-id :s1}}           ; not a view op
+                  (rendered-ev :v/ok true nil)]
+          rows   (subs/view-rows events #{})]
+      (is (= 1 (count rows)))
+      (is (= :v/ok (-> rows first :view-id))))))
+
+;; ---- Level 1 / Level 2+ partition -------------------------------------
+
+(def ^:private topology
+  "A static sub-topology snapshot: :inputs [] = Level 1; non-empty =
+  Level 2+. Carries :ns/:line/:file so the code coord resolves."
+  {:cart/state {:inputs [] :ns 'cart :line 10 :file "cart.cljs"}
+   :cart/items {:inputs [] :ns 'cart :line 14 :file "cart.cljs"}
+   :cart/total {:inputs [:cart/state :cart/items]
+                :ns 'cart :line 22 :file "cart.cljs"}})
+
+(deftest partition-splits-by-inputs-empty
+  (testing "rf2-8ve8z — :inputs [] subs land in Level 1; non-empty land
+            in Level 2+, carrying their input-sub names + coord."
+    (let [{:keys [level-1 level-2]}
+          (subs/partition-subs-by-level
+            [(sub-run+ :cart/state true true)
+             (sub-run+ :cart/total true true)]
+            topology)]
+      (is (= [:cart/state] (mapv :sub-id level-1)))
+      (is (= [:cart/total] (mapv :sub-id level-2)))
+      (is (= [:cart/state :cart/items] (-> level-2 first :inputs))
+          "Level 2+ row carries its declared input-sub names")
+      (is (= "cart.cljs" (-> level-1 first :coord :file))
+          "Level 1 row carries the topology source coord"))))
+
+(deftest partition-carries-changed-flag
+  (testing "rf2-8ve8z — :value-changed? rides onto each row's :changed?."
+    (let [{:keys [level-1]}
+          (subs/partition-subs-by-level
+            [(sub-run+ :cart/state true true)
+             (sub-run+ :cart/items true false)]
+            topology)]
+      (is (= [true false] (mapv :changed? level-1))))))
+
+(deftest partition-missing-from-topology-defaults-level-1
+  (testing "rf2-8ve8z — nil-safe: a sub absent from the topology defaults
+            to Level 1 with no inputs / no coord (degrade, never crash)."
+    (let [{:keys [level-1 level-2]}
+          (subs/partition-subs-by-level
+            [(sub-run+ :mystery/sub true false)] nil)]
+      (is (= [:mystery/sub] (mapv :sub-id level-1)))
+      (is (empty? level-2))
+      (is (nil? (-> level-1 first :coord))
+          "no coord when topology absent"))))
+
+;; ---- project-record composes the phase-B slots ------------------------
+
+(deftest project-record-emits-level-and-view-slots
+  (testing "rf2-8ve8z — project-record composes :level-1-subs /
+            :level-2-subs (from topology) + :view-rows (from
+            :trace-events view ops) alongside the legacy slots."
+    (let [record {:sub-runs [(sub-run+ :cart/state true true)
+                             (sub-run+ :cart/total true true)]
+                  :trace-events [(rendered-ev :cart/Summary false [[:cart/total]])
+                                 (unmounted-ev :cart/Gone)]}
+          p (subs/project-record record topology)]
+      (is (= [:cart/state] (mapv :sub-id (:level-1-subs p))))
+      (is (= [:cart/total] (mapv :sub-id (:level-2-subs p))))
+      (is (= 2 (count (:view-rows p))))
+      (is (= :reactive (-> p :view-rows first :reason :kind))
+          ":cart/Summary derefs :cart/total which changed → reactive")
+      (is (= [:cart/total] (-> p :view-rows first :reason :subs)))
+      (is (= :unmount (-> p :view-rows second :action)))
+      (is (= 2 (-> p :counts :view-rows))))))
+
+(deftest project-record-degrades-without-topology
+  (testing "rf2-8ve8z — nil topology: every sub falls to Level 1; the
+            panel still renders (no crash)."
+    (let [record {:sub-runs [(sub-run+ :a true true) (sub-run+ :b true false)]}
+          p (subs/project-record record)]
+      (is (= [:a :b] (mapv :sub-id (:level-1-subs p))))
+      (is (empty? (:level-2-subs p))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -1,9 +1,13 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-view-cljs-test
-  "Smoke tests for `reactive-panel-view` (rf2-wyvf2 · spec/021 §3).
+  "Tests for `reactive-panel-view` — the three-stacked-tables Views panel
+  (rf2-8ve8z, phase-B of the Views-tab redesign · prior: rf2-wyvf2 /
+  rf2-isun6 · spec/021 §3).
 
   Mounts `reactive-panel` (the plain Reagent fn) and asserts the
-  structural data-testid hooks ship: panel root, header, the two
-  step sections, and the unchanged-subs toggle when applicable."
+  structural data-testid hooks ship: panel root, header, the three
+  tables (Level 1 subs · Level 2+ subs · Views), their empty states,
+  the action / reason rendering, and the reactive-vs-structural reason
+  classifier surfaced via the seeded `:rf.causa/reactive-data`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -17,12 +21,16 @@
 (defn- has-testid? [tree testid]
   (some? (th/find-by-testid tree testid)))
 
+(defn- text-of
+  "Concatenated text content under the node matching `testid`."
+  [tree testid]
+  (some-> (th/find-by-testid tree testid) th/text-content))
+
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 (deftest reactive-panel-mounts-with-root-testid
-  (testing "rf2-wyvf2 — the panel root surfaces `rf-causa-reactive`
-            data-testid + the panel installs the L4 tab"
+  (testing "the panel root surfaces `rf-causa-reactive` data-testid"
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (let [tree (view/reactive-panel)]
@@ -38,13 +46,8 @@
           "empty-state surfaces when no cascade exists"))))
 
 (deftest reactive-panel-omits-large-h1-heading
-  (testing "rf2-6xezz · Mike-direction 2026-05-21 — the View panel
-            (renamed from Reactive per rf2-e33ad) NO LONGER renders a
-            large h1 heading at its top. The tab strip is the panel-
-            name source-of-truth; the panel body starts immediately
-            under the optional metadata strip. The previous panel-icon
-            element (`rf-causa-reactive-panel-icon`) is also removed
-            because it lived inside the deleted h1."
+  (testing "rf2-6xezz — the Views panel renders NO large h1 heading; the
+            tab strip is the panel-name source-of-truth."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (let [tree (view/reactive-panel)
@@ -52,35 +55,13 @@
       (is (nil? icon) "panel-icon span is gone (lived in the deleted h1)"))))
 
 (deftest reactive-panel-uses-views-display-label
-  (testing "Mike-direction 2026-05-21 — the L4 tab displays as `Views`
-            under the all-plural-domain-noun convention (Views / Flows /
-            Schemas / Routes / Machines are all plural); the panel-
-            registry key stays `:views` (internal id, never a user
-            contract)."
+  (testing "the L4 tab displays as `Views` under the all-plural-domain-
+            noun convention; the panel-registry key stays `:views`."
     (facade/install!)
     (let [registered (panel-registry/tab-by-id :dynamic :views)]
       (is (some? registered) "panel-registry has a :views entry under :dynamic")
       (is (= "Views" (:label registered))
           "L4 tab label renders as `Views`"))))
-
-(deftest reactive-panel-renders-two-cascade-sections
-  (testing "rf2-isun6 — the View panel renders TWO pipeline sections
-            (SUBS THIS CASCADE · VIEWS RE-RENDERED) wrapped in a left-
-            rail container with a chevron between them. The prior three
-            overlapping subs sections (SUBS RAN / SUBS WHOSE VALUE
-            CHANGED / SUBS THAT CASCADED) collapsed into one table whose
-            `changed?` / `cascaded?` columns carry those dimensions, so
-            each sub appears exactly once. Empty states are ALWAYS
-            visible per Mike-direction 2026-05-21."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    ;; The empty-state path doesn't render the sections; the table
-    ;; shape is exercised directly in the focused-cascade test below
-    ;; (which seeds `:rf.causa/reactive-data`). Here we confirm the
-    ;; empty branch holds when no cascade fires.
-    (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-empty")
-          "empty branch holds when no cascade is focused"))))
 
 (defn- seed-reactive-data!
   "Re-register the composite `:rf.causa/reactive-data` to return a
@@ -90,51 +71,155 @@
   [data]
   (rf/reg-sub :rf.causa/reactive-data (fn [_db _q] data)))
 
-(deftest reactive-panel-subs-table-one-row-per-sub
-  (testing "rf2-isun6 — one row per sub that RAN; changed? / cascaded?
-            are columns (each sub appears exactly once). A sub that ran
-            AND changed AND cascaded yields a SINGLE row carrying both
-            ✓ flags, not three rows across three sections."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    (seed-reactive-data!
-      {:has-cascade? true
-       :frame        :rf/app
-       :focus        {:current :ep-1}
-       :counts       {:subs-ran 3 :subs-skipped 0 :views-rendered 0}
-       ;; :a ran only · :b ran + changed · :c ran + changed + cascaded
-       :subs-ran     [{:sub-id :a/plain}
-                      {:sub-id :b/changed :value-changed? true
-                       :prev-value 1 :value 2}
-                      {:sub-id :c/cascaded :value-changed? true
-                       :prev-value 3 :value 4 :cascade? true
-                       :cause-sub [:b/changed]}]
-       :views-rendered []})
-    (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-subs-table")
-          "the single subs table renders")
-      ;; Exactly one row per sub — no triple-repeat across sections.
-      (is (has-testid? tree "rf-causa-reactive-sub-row-_a_plain"))
-      (is (has-testid? tree "rf-causa-reactive-sub-row-_b_changed"))
-      (is (has-testid? tree "rf-causa-reactive-sub-row-_c_cascaded"))
-      ;; The legacy per-section row testid is gone (collapsed into rows).
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-sub-ran"))
-          "the old per-section row testid no longer ships"))))
+;; ---- three-table structure (rf2-8ve8z) --------------------------------
 
-(deftest reactive-panel-subs-table-empty-when-no-subs
-  (testing "rf2-isun6 — empty subs placeholder when a cascade is focused
-            but no subs ran."
+(deftest reactive-panel-renders-three-tables
+  (testing "rf2-8ve8z — a focused cascade renders THREE stacked tables
+            (Level 1 subs · Level 2+ subs · Views) with chevrons between
+            them, top→bottom mirroring the reactive cascade."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true
        :frame        :rf/app
        :focus        {:current :ep-1}
-       :counts       {:subs-ran 0 :subs-skipped 0 :views-rendered 0}
-       :subs-ran     []
-       :views-rendered []})
+       :counts       {:subs-ran 2 :subs-skipped 0 :view-rows 1}
+       :level-1-subs [{:sub-id :cart/state :changed? true
+                       :coord {:file "cart.cljs" :line 10 :ns 'cart}}]
+       :level-2-subs [{:sub-id :cart/total :changed? true
+                       :inputs [:cart/state :cart/items]
+                       :coord {:file "cart.cljs" :line 22 :ns 'cart}}]
+       :view-rows    [{:view-id :cart/Summary :action :rerender
+                       :reason {:kind :reactive :subs [:cart/total]}}]})
     (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-subs-empty")
-          "empty subs placeholder renders")
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-subs-table"))
-          "no table when no subs ran"))))
+      (is (has-testid? tree "rf-causa-reactive-l1-table")  "Level 1 table renders")
+      (is (has-testid? tree "rf-causa-reactive-l2-table")  "Level 2+ table renders")
+      (is (has-testid? tree "rf-causa-reactive-views-table") "Views table renders")
+      (is (has-testid? tree "rf-causa-reactive-chevron-l1") "chevron after Level 1")
+      (is (has-testid? tree "rf-causa-reactive-chevron-l2") "chevron after Level 2"))))
+
+(deftest level-1-row-renders-name-and-code
+  (testing "rf2-8ve8z — a Level 1 sub row carries its name + a code chip
+            from the topology coord."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-2-subs [] :view-rows []
+       :level-1-subs [{:sub-id :cart/state :changed? true
+                       :coord {:file "cart.cljs" :line 10 :ns 'cart}}]})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-l1-row-_cart_state")
+          "the Level 1 row renders with a slug testid")
+      (is (has-testid? tree "rf-causa-reactive-l1-code-_cart_state")
+          "the code chip renders from the topology coord"))))
+
+(deftest level-2-row-renders-inputs-one-per-line
+  (testing "rf2-8ve8z — a Level 2+ sub row carries name + inputs (one per
+            line) + code. The inputs column lists every input-sub name."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :view-rows []
+       :level-2-subs [{:sub-id :cart/total :changed? false
+                       :inputs [:cart/state :cart/items]
+                       :coord {:file "cart.cljs" :line 22 :ns 'cart}}]})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-l2-row-_cart_total")
+          "the Level 2+ row renders")
+      (let [row-text (text-of tree "rf-causa-reactive-l2-row-_cart_total")]
+        (is (re-find #":cart/state" row-text) "input :cart/state listed")
+        (is (re-find #":cart/items" row-text) "input :cart/items listed")))))
+
+;; ---- view action + reason (rf2-8ve8z) ---------------------------------
+
+(deftest view-row-reactive-reason-lists-changed-subs
+  (testing "rf2-8ve8z — a reactive render's reason lists the changed subs
+            THIS view reads (the reactive classifier)."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Summary :action :rerender
+                    :reason {:kind :reactive :subs [:cart/total :cart/count]}}]})
+    (let [tree (view/reactive-panel)
+          row-text (text-of tree "rf-causa-reactive-view-row-_cart_Summary-0")]
+      (is (some? row-text) "the view row renders")
+      (is (re-find #"rerender" row-text) "action reads 'rerender'")
+      (is (re-find #":cart/total" row-text) "reason lists :cart/total")
+      (is (re-find #":cart/count" row-text) "reason lists :cart/count")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-view-reason-structural"))
+          "a reactive render shows named subs, not the structural text"))))
+
+(deftest view-row-structural-reason-shows-parent-rerender-unnamed
+  (testing "rf2-8ve8z — a structural render (no own sub changed) shows the
+            literal `← parent re-render` — UNNAMED, never names the parent."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Wrapper :action :rerender
+                    :reason {:kind :structural}}]})
+    (let [tree (view/reactive-panel)
+          reason (text-of tree "rf-causa-reactive-view-reason-structural")]
+      (is (some? reason) "the structural reason node renders")
+      (is (= "← parent re-render" reason)
+          "the structural reason is the literal unnamed text"))))
+
+(deftest view-row-action-mount-and-unmount
+  (testing "rf2-8ve8z — action renders mount / unmount; an unmount row's
+            reason is empty (no own subs to attribute)."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Added :action :mount
+                    :reason {:kind :reactive :subs [:cart/items]}}
+                   {:view-id :cart/Gone :action :unmount
+                    :reason {:kind :none}}]})
+    (let [tree (view/reactive-panel)
+          mount-text (text-of tree "rf-causa-reactive-view-row-_cart_Added-0")
+          unmount-text (text-of tree "rf-causa-reactive-view-row-_cart_Gone-1")]
+      (is (re-find #"mount" mount-text) "mount action renders")
+      (is (re-find #"unmount" unmount-text) "unmount action renders"))))
+
+(deftest view-name-cell-carries-hover-handlers
+  (testing "rf2-8ve8z / rf2-8l03l — the Views-table NAME cell carries the
+            hover handlers driving the pink DOM highlight."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs []
+       :view-rows [{:view-id :cart/Summary :action :rerender
+                    :reason {:kind :structural}}]})
+    (let [tree (view/reactive-panel)
+          name-cell (th/find-by-testid tree
+                                       "rf-causa-reactive-view-name-_cart_Summary-0")]
+      (is (some? name-cell) "the name cell renders")
+      (is (fn? (th/extract-handler name-cell :on-mouse-enter))
+          "name cell has an :on-mouse-enter handler (apply-highlight!)")
+      (is (fn? (th/extract-handler name-cell :on-mouse-leave))
+          "name cell has an :on-mouse-leave handler (clear-highlight!)"))))
+
+;; ---- empty states (always visible) ------------------------------------
+
+(deftest each-table-shows-empty-state-when-section-empty
+  (testing "rf2-8ve8z — empty states are ALWAYS visible so the pipeline
+            rhythm holds; a focused cascade with no activity shows all
+            three empty placeholders."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-l1-empty")    "Level 1 empty placeholder")
+      (is (has-testid? tree "rf-causa-reactive-l2-empty")    "Level 2+ empty placeholder")
+      (is (has-testid? tree "rf-causa-reactive-views-empty") "Views empty placeholder")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-l1-table"))
+          "no Level 1 table when no Level 1 subs ran"))))


### PR DESCRIPTION
## Summary

Phase-B of the Causa Views-tab redesign (rf2-8ve8z). Rebuilds the Views panel into **three stacked tables**, top→bottom mirroring the reactive cascade flowing toward the UI. The substrate captures it consumes landed in phase-A (rf2-9hoos / #1941); this PR is a pure **consumer** — no `implementation/` substrate touched.

### The three tables

1. **Level 1 subs (observe app-db)** — `name` · `changed` · `code`
2. **Level 2+ subs** — `name` · `changed` · `inputs` (input-sub names, one per line) · `code`
3. **Views:** — `name` (hoverable → pink DOM highlight) · `action` (mount / rerender / unmount) · `reason`

### Data sources

- **Sub topology** — `re-frame.subs.tooling/sub-topology` (`{sub-id {:inputs [...] :ns :line :file}}`). `:inputs []` = Level 1; non-empty = Level 2+. `:ns/:line/:file` → the jump-to-source `[code]` chip (rendered as a clickable `ns:line` label dispatching `:rf.causa/open-in-editor`). `:inputs` → the inputs column.
- **`changed`** — `:value-changed?` off the `:sub-runs` projection.
- **View action + reason** — phase-A's `:mount?` / `:deref-subs` on `:rf.view/rendered` and the new `:rf.view/unmounted` op, read off the epoch record's `:trace-events`. (The structured `:renders` projection is **not** used for the view table — it projects from `:view/render` and carries neither `:mount?` nor `:deref-subs`.)
- **reason** — intersect a view's `:deref-subs` with the cascade's changed-sub set. Non-empty → reactive (list those changed sub names). Empty → structural → the literal `← parent re-render` (**UNNAMED**, permanent). Unmount → no reason.

### Design notes

- The reactive-vs-structural classifier, the L1/L2+ partition, and the action mapping are **pure helpers** in `reactive-panel-subs` (`project-record` takes an optional topology snapshot), covered by CLJS unit tests.
- **nil-safe throughout**: absent topology degrades every sub to Level 1; missing phase-A fields degrade a render to a structural reason; the panel never crashes.
- **Honest truncation**: `+N more` at the Spec 009 cascade cap (100 rows per table) and a tighter inline budget (6) for the list columns.
- Reuses the existing pink diagonal-stripe DOM hover-highlight (rf2-8l03l) on the Views-table name cell and Causa's token/styling layer (light/dark both resolve via CSS variables).

## Test plan

CLJS-first posture (no Playwright). All run from the worktree.

- [x] `npm run test:cljs` (from `implementation/`) — **4122 tests / 12516 assertions, 0 failures, 0 errors, 0 warnings**. Execution of the new tests verified via a temporary sentinel assertion (asserted +1 failure, then reverted).
- [x] `npm run test:causa-feature-gate` (from `implementation/`) — **13 scenarios, 0 failures**.
- [x] `npm run test:bundle-isolation` (from `implementation/`) — PASS (the new `re-frame.subs.tooling` require stays tool-only; production bundles clean).

New CLJS unit tests cover: L1/L2+ partition by `:inputs`, the changed flag, topology-coord, missing-from-topology degrade; the reactive-vs-structural-vs-none reason classifier (order-preserving + dedup); `view-rows` action mapping (mount/rerender/unmount) + nil-safety; `project-record` composing the new slots with and without topology; and the view layer's three tables, code chips, inputs-one-per-line, action/reason rendering, structural unnamed text, hover handlers, and always-visible empty states.