### PR TITLE
fix(causa): Views panel chrome cleanup — ribbon, chevrons, left rule, count badges (rf2-fhh34)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -1,31 +1,31 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-view
   "Root view for the Views panel (rf2-e33ad / rf2-8ve8z · Mike-direction
-  2026-05-21 · prior beads: rf2-wyvf2, rf2-isun6).
+  2026-05-21 · prior beads: rf2-wyvf2, rf2-isun6 · chrome cleanup
+  rf2-fhh34).
 
   Renders the reactive cascade flowing toward the UI as THREE STACKED
   TABLES, top→bottom mirroring the cascade (rf2-8ve8z, phase-B of the
   Views-tab redesign; phase-A landed the substrate captures in
   rf2-9hoos):
 
-      Level 1 subs (observe app-db)   one row per Level 1 sub that ran
-                                      this cascade. Columns:
-                                        name | changed | code
-                                      `changed` is the accent flag from
-                                      the `:value-changed?` projection;
-                                      `code` is a jump-to-source [code]
-                                      chip from the static topology
-                                      coord.
+      Level 1 Subscriptions   one row per Level 1 sub that ran this
+                              cascade. Columns:
+                                name | changed | code
+                              `changed` is the accent flag from the
+                              `:value-changed?` projection; `code` is a
+                              jump-to-source [code] chip from the static
+                              topology coord.
 
-      Level 2+ subs                   one row per composed sub that ran.
-                                      Columns:
-                                        name | changed | inputs | code
-                                      `inputs` lists the input-sub names
-                                      ONE PER LINE (the static `:<-`
-                                      chain from `sub-topology`).
+      Level 2+ Subscriptions  one row per composed sub that ran.
+                              Columns:
+                                name | changed | inputs | code
+                              `inputs` lists the input-sub names ONE PER
+                              LINE (the static `:<-` chain from
+                              `sub-topology`).
 
-      Views:                          one row per view render / unmount
-                                      this cascade. Columns:
-                                        name | action | reason
+      Views                   one row per view render / unmount this
+                              cascade. Columns:
+                                name | action | reason
                                       `name` is hoverable (reuses the
                                       pink diagonal-stripe DOM highlight,
                                       rf2-8l03l); `action` is mount /
@@ -90,15 +90,14 @@
 ;; ---- styling primitives -------------------------------------------------
 
 (def ^:private section-label-style
-  "Bare body-text label preceding each table. NOT a large h1/h2 heading;
-  uppercase 11px sans-stack matches the rf2-n4ad0 Event panel section
-  labels."
+  "Bare title-case label preceding each table. NOT a large h1/h2 heading;
+  12px sans-stack semibold (rf2-fhh34 chrome cleanup — the titles read as
+  written: `Level 1 Subscriptions` / `Level 2+ Subscriptions` / `Views`,
+  no uppercase transform, no count badge)."
   {:padding       "8px 12px 4px 12px"
    :font-family   sans-stack
-   :font-size     "11px"
+   :font-size     "12px"
    :font-weight   600
-   :letter-spacing "0.6px"
-   :text-transform "uppercase"
    :color         (:text-secondary tokens)})
 
 (def ^:private empty-row-style
@@ -107,15 +106,6 @@
    :font-style  "italic"
    :font-family sans-stack
    :font-size   "11px"})
-
-(def ^:private chevron-style
-  {:padding-left "4px"
-   :color        (:text-tertiary tokens)
-   :font-family  mono-stack
-   :font-size    "10px"
-   :line-height  1
-   :user-select  "none"
-   :opacity      "0.6"})
 
 ;; ---- table styling (rf2-8ve8z) -----------------------------------------
 
@@ -243,15 +233,6 @@
          :style       section-label-style}
    title])
 
-(defn- pipeline-chevron
-  "Small downward chevron `⋁` separating adjacent tables. Muted
-  (`:text-tertiary`) so the chevron is rhythm not foreground."
-  [from-id]
-  [:div {:data-testid (str "rf-causa-reactive-chevron-" from-id)
-         :aria-hidden "true"
-         :style       chevron-style}
-   "⋁"])
-
 (defn- empty-row
   "Render a muted placeholder for an empty table. Empty states are
   ALWAYS visible so the pipeline rhythm holds (Mike-direction
@@ -363,27 +344,6 @@
                   (.remove (.-classList node) highlight-class)))
       nil)))
 
-;; ---- header (outcome line; no h1) --------------------------------------
-
-(defn- header-block
-  "Compact metadata strip — replaces the large h1 heading per rf2-6xezz.
-  Renders a single line with the frame + cascade counts so the operator
-  has the rhythm without the heading."
-  [data]
-  (when (:has-cascade? data)
-    [:header {:data-testid "rf-causa-reactive-header-meta"
-              :style {:padding "8px 12px"
-                      :border-bottom (str "1px solid " (:border-subtle tokens))
-                      :background    (:bg-3 tokens)
-                      :font-family   sans-stack
-                      :font-size     "11px"
-                      :color         (:text-tertiary tokens)}}
-     (let [counts (:counts data)]
-       (str "frame " (:frame data)
-            " · " (or (:subs-ran counts) 0) " subs ran · "
-            (or (:subs-skipped counts) 0) " skipped · "
-            (or (:view-rows counts) (:views-rendered counts) 0) " view renders"))]))
-
 ;; ---- shared cell renderers --------------------------------------------
 
 (defn- changed-cell
@@ -431,7 +391,7 @@
   (let [rows (:level-1-subs data)
         n    (count rows)]
     [:<>
-     (section-label "l1" (str "LEVEL 1 SUBS (OBSERVE APP-DB) (" n ")"))
+     (section-label "l1" "Level 1 Subscriptions")
      (if (seq rows)
        [:table {:data-testid "rf-causa-reactive-l1-table"
                 :style       table-style}
@@ -490,7 +450,7 @@
   (let [rows (:level-2-subs data)
         n    (count rows)]
     [:<>
-     (section-label "l2" (str "LEVEL 2+ SUBS (" n ")"))
+     (section-label "l2" "Level 2+ Subscriptions")
      (if (seq rows)
        [:table {:data-testid "rf-causa-reactive-l2-table"
                 :style       table-style}
@@ -574,7 +534,7 @@
   (let [rows (:view-rows data)
         n    (count rows)]
     [:<>
-     (section-label "views" (str "VIEWS: (" n ")"))
+     (section-label "views" "Views")
      (if (seq rows)
        [:table {:data-testid "rf-causa-reactive-views-table"
                 :style       table-style}
@@ -625,7 +585,6 @@
                        :color (:text-primary tokens)
                        :font-family sans-stack
                        :font-size "14px"}}
-     (header-block data)
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond
         (not (:has-cascade? data))
@@ -633,13 +592,8 @@
 
         :else
         [:div {:data-testid "rf-causa-reactive-pipeline"
-               :style {:border-left   (str "1px solid " (:border-subtle tokens))
-                       :margin-left   "16px"
-                       :padding-left  "12px"
-                       :padding-top   "8px"
+               :style {:padding-top   "8px"
                        :padding-bottom "8px"}}
          (level-1-section data)
-         (pipeline-chevron "l1")
          (level-2-section data)
-         (pipeline-chevron "l2")
          (views-section data)])]]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -75,8 +75,9 @@
 
 (deftest reactive-panel-renders-three-tables
   (testing "rf2-8ve8z — a focused cascade renders THREE stacked tables
-            (Level 1 subs · Level 2+ subs · Views) with chevrons between
-            them, top→bottom mirroring the reactive cascade."
+            (Level 1 subs · Level 2+ subs · Views), top→bottom mirroring
+            the reactive cascade. rf2-fhh34 chrome cleanup: NO chevrons
+            between sections."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
@@ -95,8 +96,43 @@
       (is (has-testid? tree "rf-causa-reactive-l1-table")  "Level 1 table renders")
       (is (has-testid? tree "rf-causa-reactive-l2-table")  "Level 2+ table renders")
       (is (has-testid? tree "rf-causa-reactive-views-table") "Views table renders")
-      (is (has-testid? tree "rf-causa-reactive-chevron-l1") "chevron after Level 1")
-      (is (has-testid? tree "rf-causa-reactive-chevron-l2") "chevron after Level 2"))))
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-chevron-l1"))
+          "rf2-fhh34 — no chevron after Level 1")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-chevron-l2"))
+          "rf2-fhh34 — no chevron after Level 2"))))
+
+(deftest reactive-panel-section-titles-are-clean-no-counts
+  (testing "rf2-fhh34 chrome cleanup — section titles read exactly
+            `Level 1 Subscriptions` / `Level 2+ Subscriptions` / `Views`,
+            with NO `(observe app-db)` suffix and NO trailing count badge."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
+    (let [tree (view/reactive-panel)]
+      (is (= "Level 1 Subscriptions"
+             (text-of tree "rf-causa-reactive-section-l1-label"))
+          "Level 1 title is clean — no suffix, no count")
+      (is (= "Level 2+ Subscriptions"
+             (text-of tree "rf-causa-reactive-section-l2-label"))
+          "Level 2+ title is clean — no count")
+      (is (= "Views"
+             (text-of tree "rf-causa-reactive-section-views-label"))
+          "Views title carries no count number"))))
+
+(deftest reactive-panel-omits-summary-ribbon
+  (testing "rf2-fhh34 chrome cleanup — the per-cascade summary ribbon
+            (`frame · N subs ran · …`) is gone."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {:subs-ran 2 :subs-skipped 0 :view-rows 1}
+       :level-1-subs [] :level-2-subs [] :view-rows []})
+    (let [tree (view/reactive-panel)]
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-header-meta"))
+          "summary ribbon header is removed"))))
 
 (deftest level-1-row-renders-name-and-code
   (testing "rf2-8ve8z — a Level 1 sub row carries its name + a code chip


### PR DESCRIPTION
## Summary

Visual polish on the just-shipped three-table Views panel (rf2-8ve8z, PR #1942). Chrome only — table columns and data are untouched.

Six changes (all in the Causa tool, `panels/reactive_panel_view.cljs`):

1. **Vertical left line removed** — dropped `:border-left` on the pipeline container (and the `:margin-left`/`:padding-left` that only existed to space content off the rule).
2. **Summary ribbon removed** — deleted `header-block` (`rf-causa-reactive-header-meta`: `frame :below · 5 subs ran · 0 skipped · 1 view renders`) and its call site.
3. **Level 1 title** → exactly `Level 1 Subscriptions` (dropped the `(observe app-db)` suffix and the `(N)` count badge).
4. **Chevrons removed** — deleted `pipeline-chevron` + `chevron-style`; sections render always-expanded with no `⋁` glyph between them.
5. **Level 2+ title** → exactly `Level 2+ Subscriptions` (dropped the count).
6. **Views title** → `Views` (dropped the trailing count number).

The `section-label-style` lost its `text-transform: uppercase` so the new mixed-case titles render exactly as written; tokens still resolve in light + dark. The view-name hover-highlight and all three tables' columns (L1 = name·changed·code, L2+ = name·changed·inputs·code, Views = name·action·reason) are unchanged.

## Tests

CLJS-first. Updated `reactive_panel_view_cljs_test.cljs`:
- `reactive-panel-renders-three-tables` — chevron assertions inverted to **absence**.
- Added `reactive-panel-section-titles-are-clean-no-counts` — asserts the three exact title strings.
- Added `reactive-panel-omits-summary-ribbon` — asserts the ribbon header is gone.

## Test plan
- [x] `npm run test:cljs` — 4129 tests / 12547 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures, 13 matrix rows