### PR TITLE
fix(causa): re-wire downstream-subs popover into current-state inspector (rf2-2lb7z)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -42,9 +42,12 @@
     survives there for the Event tab's diff surface + the MCP exporter;
     this panel reads only `:rf.causa/app-db-state`.
   - `app-db-diff-downstream` — the downstream-subs hover popover
-    (spec/021 §4.4). Its subs/events stay installed; the trigger is no
-    longer injected here now that there are no diff section breadcrumbs
-    to host it (a current-state re-wire is follow-on)."
+    (spec/021 §4.4). Re-wired into the current-state inspector
+    (rf2-2lb7z): the trigger is mounted in each section header by
+    `app-db-diff-state` (one per top-level user-domain key, one per
+    reserved area `[:rf/area]`, one per fan-out instance `[:rf/area
+    id]`). rf2-okvit had dropped the diff breadcrumbs that previously
+    hosted it; this leaf re-injects it onto the section headers."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.app-db-diff-downstream
@@ -79,10 +82,10 @@
   []
   (subs/install!)
   (events/install!)
-  ;; rf2-op9v2 — downstream-subs overlay subs + events. Kept installed
-  ;; so the spec/021 §4.4 feature + its tests stay live; the hover
-  ;; trigger is no longer injected from this panel (rf2-okvit dropped
-  ;; the diff section breadcrumbs that hosted it).
+  ;; rf2-op9v2 — downstream-subs overlay subs + events. rf2-2lb7z
+  ;; re-wired the hover trigger into the current-state inspector's
+  ;; section headers (mounted by `app-db-diff-state`); install! here
+  ;; registers the subs/events those triggers + the popover read.
   (downstream/install!)
   ;; rf2-2moh1 — register the Dynamic app-db tab with the internal L4
   ;; tab registry. rf2-okvit — label is lowercase "app-db" to match the

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
@@ -25,8 +25,25 @@
   home-grown diff engine — this view carries no diff / value-changed
   affordances.
 
+  ## Downstream-subs hover popover (spec/021 §4.4, rf2-2lb7z)
+
+  Each section header hosts the downstream-subs hover trigger
+  (`app-db-diff-downstream/hover-trigger`) keyed to that section's
+  app-db path — hovering it opens the popover listing subs/views
+  downstream of the path. The reserved-area sections key on `[:rf/area]`
+  (or `[:rf/area id]` per instance); the TOP user-domain section fans a
+  trigger out per top-level user-domain key (`[:key]`) since the whole-db
+  root path `[]` is a no-op for the path-filter (per
+  `panels.shared.sub-input-paths/sub-touches-path?`). The popover
+  machinery itself (subs/events/component) is owned by
+  `app-db-diff-downstream`; this ns is just the trigger host (the
+  re-wire after rf2-okvit dropped the diff breadcrumbs that previously
+  hosted it).
+
   Pure hiccup; reuses Causa's theme tokens so light/dark resolve."
-  (:require [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+  (:require [day8.re-frame2-causa.panels.app-db-diff-downstream
+             :as downstream]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
@@ -37,26 +54,47 @@
   "A titled card surface used by every current-state section. `title`
   is hiccup (so callers can colour the reserved-area / instance-id
   label); `testid` hooks the section for tests; `body` is the section's
-  content hiccup. Reuses Causa's `:bg-3` card + subtle-border chrome so
-  light/dark resolve via the token CSS variables."
-  [{:keys [testid title body]}]
+  content hiccup. Optional `trigger` is right-aligned hiccup in the
+  header — the downstream-subs hover trigger(s) for this section's
+  path(s) (spec/021 §4.4). Reuses Causa's `:bg-3` card + subtle-border
+  chrome so light/dark resolve via the token CSS variables."
+  [{:keys [testid title body trigger]}]
   [:section {:data-testid testid
              :style       {:margin        "12px"
                            :background    (:bg-3 tokens)
                            :border        (str "1px solid " (:border-subtle tokens))
                            :border-radius "4px"
                            :overflow      "hidden"}}
-   [:header {:style {:padding        "6px 12px"
-                     :border-bottom  (str "1px solid " (:border-subtle tokens))
-                     :font-family    sans-stack
-                     :font-size      "11px"
-                     :font-weight    600
-                     :text-transform "uppercase"
-                     :letter-spacing "0.5px"
-                     :color          (:text-secondary tokens)}}
-    title]
+   [:header {:style {:display         "flex"
+                     :align-items     "center"
+                     :justify-content "space-between"
+                     :gap             "8px"
+                     :padding         "6px 12px"
+                     :border-bottom   (str "1px solid " (:border-subtle tokens))
+                     :font-family     sans-stack
+                     :font-size       "11px"
+                     :font-weight     600
+                     :text-transform  "uppercase"
+                     :letter-spacing  "0.5px"
+                     :color           (:text-secondary tokens)}}
+    [:span {:style {:overflow      "hidden"
+                    :text-overflow "ellipsis"
+                    :white-space   "nowrap"
+                    :flex          1}}
+     title]
+    (when trigger trigger)]
    [:div {:style {:padding "8px 12px"}}
     body]])
+
+(defn- path-trigger
+  "Mount the downstream-subs hover trigger for a single app-db `path`
+  (spec/021 §4.4). Reagent component vector — Reagent renders it under
+  the panel's `reg-view` so its `subscribe` reactivity resolves. The
+  trigger's `:text-transform` is reset so the header's uppercase chrome
+  doesn't bleed into the keyword path label inside the popover."
+  [path]
+  [:span {:style {:text-transform "none"}}
+   [downstream/hover-trigger path]])
 
 (defn- empty-body
   "Empty-state placeholder body for an absent / empty section. `label`
@@ -85,18 +123,41 @@
 
 ;; ---- top (user-domain) section ------------------------------------------
 
+(defn- top-triggers
+  "Downstream-subs hover triggers for the TOP user-domain section: one
+  per top-level user-domain key (`[:key]`). The whole-db root path `[]`
+  is a no-op for the path-filter (per
+  `panels.shared.sub-input-paths/sub-touches-path?` — the root excludes
+  every known layer-1 leaf), so the TOP section fans out per key rather
+  than hosting a single `[]` trigger. Returns nil when `top` carries no
+  user-domain keys (so the empty TOP section shows no triggers). Keys
+  are sorted by `pr-str` for stable render order."
+  [top]
+  (when (and (map? top) (seq top))
+    (into [:span {:data-testid "rf-causa-app-db-state-top-triggers"
+                  :style {:display     "inline-flex"
+                          :align-items "center"
+                          :flex-wrap   "wrap"
+                          :gap         "2px"
+                          :flex        "0 0 auto"}}]
+          (for [k (sort-by pr-str (keys top))]
+            (with-meta (path-trigger [k]) {:key (pr-str k)})))))
+
 (defn top-section
   "The TOP section — the app-db MINUS every reserved `:rf/*` key (the
   user-domain app-db). Renders the whole user-domain value as a
   current-state tree. Empty-state when the user-domain app-db is empty
-  (e.g. boot value / reserved-keys-only db)."
+  (e.g. boot value / reserved-keys-only db). Each top-level user-domain
+  key gets a downstream-subs hover trigger in the header (spec/021
+  §4.4)."
   [top]
   (section-shell
-    {:testid "rf-causa-app-db-state-top"
-     :title  [:span "app-db"]
-     :body   (if (and (map? top) (empty? top))
-               (empty-body "app-db has no user-domain keys yet.")
-               (value-body top "top"))}))
+    {:testid  "rf-causa-app-db-state-top"
+     :title   [:span "app-db"]
+     :trigger (top-triggers top)
+     :body    (if (and (map? top) (empty? top))
+                (empty-body "app-db has no user-domain keys yet.")
+                (value-body top "top"))}))
 
 ;; ---- reserved-area sections ---------------------------------------------
 
@@ -111,19 +172,21 @@
 (defn instance-section
   "One fan-out sub-section for a single instance of a map-of-instances
   reserved area — section title = the instance id. Used per machine
-  (`:rf/machines`) and per parent (`:rf/spawned`)."
+  (`:rf/machines`) and per parent (`:rf/spawned`). The header hosts the
+  downstream-subs hover trigger keyed to `[area id]` (spec/021 §4.4)."
   [area {:keys [id value]}]
   (section-shell
-    {:testid (str "rf-causa-app-db-state-instance-"
-                  (pr-str area) "-" (pr-str id))
-     :title  [:span
-              (area-label area)
-              [:span {:style {:margin "0 6px" :color (:text-tertiary tokens)}}
-               "›"]
-              [:span {:style {:font-family mono-stack
-                              :color       (:text-primary tokens)}}
-               (pr-str id)]]
-     :body   (value-body value (str (pr-str area) "/" (pr-str id)))}))
+    {:testid  (str "rf-causa-app-db-state-instance-"
+                   (pr-str area) "-" (pr-str id))
+     :title   [:span
+               (area-label area)
+               [:span {:style {:margin "0 6px" :color (:text-tertiary tokens)}}
+                "›"]
+               [:span {:style {:font-family mono-stack
+                               :color       (:text-primary tokens)}}
+                (pr-str id)]]
+     :trigger (path-trigger [area id])
+     :body    (value-body value (str (pr-str area) "/" (pr-str id)))}))
 
 (defn instances-area
   "Render a map-of-instances reserved area (`:rf/machines`,
@@ -133,13 +196,14 @@
   [{:keys [area empty? instances]}]
   (if empty?
     (section-shell
-      {:testid (str "rf-causa-app-db-state-area-" (pr-str area))
-       :title  (area-label area)
-       :body   (empty-body
-                 (case area
-                   :rf/machines "No machines registered."
-                   :rf/spawned  "No spawned actors."
-                   "Empty."))})
+      {:testid  (str "rf-causa-app-db-state-area-" (pr-str area))
+       :title   (area-label area)
+       :trigger (path-trigger [area])
+       :body    (empty-body
+                  (case area
+                    :rf/machines "No machines registered."
+                    :rf/spawned  "No spawned actors."
+                    "Empty."))})
     (into [:div {:data-testid (str "rf-causa-app-db-state-area-" (pr-str area))}]
           (for [{:keys [id] :as inst} instances]
             (with-meta (instance-section area inst)
@@ -152,17 +216,18 @@
   for `:rf/route`). Empty/absent slices render the empty-state body."
   [{:keys [area empty? value]}]
   (section-shell
-    {:testid (str "rf-causa-app-db-state-area-" (pr-str area))
-     :title  (area-label area)
-     :body   (if empty?
-               (empty-body
-                 (case area
-                   :rf/route              "No active route."
-                   :rf/system-ids         "No system-id bindings."
-                   :rf/pending-navigation "No navigation pending."
-                   :rf/elision            "No elision declarations."
-                   "Empty."))
-               (value-body value (pr-str area)))}))
+    {:testid  (str "rf-causa-app-db-state-area-" (pr-str area))
+     :title   (area-label area)
+     :trigger (path-trigger [area])
+     :body    (if empty?
+                (empty-body
+                  (case area
+                    :rf/route              "No active route."
+                    :rf/system-ids         "No system-id bindings."
+                    :rf/pending-navigation "No navigation pending."
+                    :rf/elision            "No elision declarations."
+                    "Empty."))
+                (value-body value (pr-str area)))}))
 
 (defn area-section
   "Dispatch one reserved-area section entry (from

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_state_cljs_test.cljs
@@ -15,6 +15,8 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [cljs.test :refer-macros [use-fixtures]]
+            [day8.re-frame2-causa.panels.app-db-diff-downstream
+             :as downstream]
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]
             [day8.re-frame2-causa.panels.app-db-diff-state :as state]))
 
@@ -36,6 +38,31 @@
 
 (defn- testids [tree]
   (->> (hiccup-seq tree)
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (:data-testid (second node)))))
+       (remove nil?)
+       set))
+
+;; ---- fn-component-expanding walker (for the downstream-subs trigger) -----
+;;
+;; `app-db-diff-state` mounts the downstream-subs hover trigger as a
+;; Reagent fn-component vector `[downstream/hover-trigger path]`. The
+;; plain `hiccup-seq` above doesn't render fn-components, so these
+;; helpers expand them (calling the fn) so the trigger's own testid is
+;; reachable. Mirrors `app_db_diff_cljs_test.cljs`.
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- expanded-hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- expanded-testids [tree]
+  (->> (expanded-hiccup-seq tree)
        (keep (fn [node]
                (when (and (vector? node) (map? (second node)))
                  (:data-testid (second node)))))
@@ -137,3 +164,116 @@
       (let [tree (state/state-body (h/current-state-sections db))]
         (is (some? (find-by-testid tree "rf-causa-app-db-state-top")))
         (is (some? (find-by-testid tree "rf-causa-app-db-state-area-:rf/route")))))))
+
+;; ---- downstream-subs hover trigger re-wire (spec/021 §4.4, rf2-2lb7z) ---
+;;
+;; After rf2-okvit redesigned this tab into a current-state inspector,
+;; the §4.4 downstream-subs popover lost its host (the diff breadcrumbs).
+;; rf2-2lb7z re-wires the trigger into the current-state section headers:
+;; one trigger per top-level user-domain key in the TOP section, one per
+;; reserved area `[:rf/area]`, and one per fan-out instance `[:rf/area
+;; id]`. The popover subs/events/component are unchanged — these tests
+;; assert the trigger is now INJECTED, threading the section's path.
+
+(defn- trigger-testid
+  "The downstream-subs trigger's path-keyed testid (mirrors
+  `app-db-diff-downstream/hover-trigger`)."
+  [path]
+  (str "rf-causa-app-db-downstream-trigger-" (pr-str path)))
+
+(defn- find-expanded-by-testid
+  "Find the (fn-expanded) node carrying `testid`, walking through
+  fn-components so containers whose children are fn-component vectors
+  are reachable."
+  [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (expanded-hiccup-seq tree)))
+
+(deftest top-section-hosts-per-user-domain-key-trigger
+  (testing "the TOP section fans a downstream-subs trigger out per
+            top-level user-domain key (path `[:key]`) — the whole-db
+            root `[]` is a path-filter no-op so we key per top-level key"
+    (downstream/install!)
+    (let [model (h/current-state-sections {:counter 5 :user {:name "ada"}
+                                           :rf/route {:id :home}})
+          tree  (state/state-body model)
+          ids   (expanded-testids tree)
+          ;; Scope the negative assertion to the TOP-triggers container
+          ;; only — reserved-area sections DO host their own
+          ;; `[:rf/route]` trigger elsewhere in the tree (correct), so
+          ;; the whole-tree id set legitimately contains it.
+          top-triggers (find-expanded-by-testid
+                         tree "rf-causa-app-db-state-top-triggers")
+          top-ids      (expanded-testids top-triggers)]
+      (is (contains? ids "rf-causa-app-db-state-top-triggers")
+          "TOP section carries the trigger group container")
+      (is (contains? top-ids (trigger-testid [:counter]))
+          "a trigger keyed to the user-domain key [:counter]")
+      (is (contains? top-ids (trigger-testid [:user]))
+          "a trigger keyed to the user-domain key [:user]")
+      (is (not (contains? top-ids (trigger-testid [:rf/route])))
+          "reserved keys are NOT in the user-domain TOP triggers"))))
+
+(deftest top-section-no-triggers-when-no-user-domain-keys
+  (testing "a reserved-keys-only db → TOP section renders no triggers
+            (no user-domain keys to host one)"
+    (downstream/install!)
+    (let [model (h/current-state-sections {:rf/route {:id :home}})
+          tree  (state/state-body model)
+          ids   (expanded-testids tree)]
+      (is (not (contains? ids "rf-causa-app-db-state-top-triggers"))
+          "no trigger group when the user-domain app-db is empty"))))
+
+(deftest machine-instance-section-hosts-path-trigger
+  (testing "each machine fan-out section hosts a trigger keyed to its
+            `[:rf/machines id]` path"
+    (downstream/install!)
+    (let [model (h/current-state-sections
+                  {:rf/machines {:title/flow {:state :playing}
+                                 :auth       {:state :idle}}})
+          tree  (state/state-body model)
+          ids   (expanded-testids tree)]
+      (is (contains? ids (trigger-testid [:rf/machines :title/flow]))
+          "trigger keyed to [:rf/machines :title/flow]")
+      (is (contains? ids (trigger-testid [:rf/machines :auth]))
+          "trigger keyed to [:rf/machines :auth]"))))
+
+(deftest singleton-area-section-hosts-path-trigger
+  (testing ":rf/route singleton section hosts a trigger keyed to
+            `[:rf/route]`"
+    (downstream/install!)
+    (let [model (h/current-state-sections
+                  {:rf/route {:id :app/article :params {:id "A"}}})
+          tree  (state/state-body model)
+          ids   (expanded-testids tree)]
+      (is (contains? ids (trigger-testid [:rf/route]))
+          "trigger keyed to the [:rf/route] area path"))))
+
+(deftest empty-reserved-area-section-still-hosts-path-trigger
+  (testing "an absent/empty reserved area's empty-state section STILL
+            hosts its `[:rf/area]` trigger — the path is meaningful even
+            with no live value (the popover degrades to its empty-state)"
+    (downstream/install!)
+    (let [model (h/current-state-sections {:counter 1})
+          tree  (state/state-body model)
+          ids   (expanded-testids tree)]
+      (is (contains? ids (trigger-testid [:rf/machines]))
+          "empty :rf/machines area still hosts a [:rf/machines] trigger")
+      (is (contains? ids (trigger-testid [:rf/route]))
+          "empty :rf/route area still hosts a [:rf/route] trigger"))))
+
+(deftest trigger-rewire-nil-safe
+  (testing "nil / empty db still renders the triggers (where applicable)
+            without throwing"
+    (downstream/install!)
+    (doseq [db [nil {}]]
+      (let [tree (state/state-body (h/current-state-sections db))
+            ids  (expanded-testids tree)]
+        ;; No user-domain keys → no TOP triggers; reserved areas still
+        ;; host theirs.
+        (is (not (contains? ids "rf-causa-app-db-state-top-triggers")))
+        (is (contains? ids (trigger-testid [:rf/route])))))))


### PR DESCRIPTION
## Summary

Follow-on from rf2-okvit (PR #1944). That redesign turned the App-DB tab from a diff view into a current-state cljs-devtools inspector sectioned by reserved `:rf/*` area, dropping the diff breadcrumbs that hosted the **spec/021 §4.4 downstream-subs hover popover**. The popover's subs / events / component stayed installed but the trigger was no longer injected — the feature was orphaned.

This PR re-injects the trigger onto the current-state section headers, threading each section's app-db path into the existing `:rf.causa.app-db/show-downstream` event. **No popover rebuild** — the subs/events/`popover-body`/`hover-trigger` in `app-db-diff-downstream` are reused unchanged.

## How the path is threaded

`app-db-diff-state/section-shell` gained an optional `:trigger` header slot; a small `path-trigger` helper mounts `[downstream/hover-trigger path]` keyed to a section's path. Granularity per section type:

- **TOP user-domain section** — one trigger per top-level user-domain key (`[:key]`). The whole-db root `[]` is a no-op for the path-filter (per `panels.shared.sub-input-paths/sub-touches-path?`, which excludes every known layer-1 leaf at root), so fanning out per key is the meaningful granularity. No user-domain keys → no triggers.
- **Reserved singleton areas** (`:rf/route`, `:rf/system-ids`, …) — one `[:rf/area]` trigger each, including the empty-state sections so the path stays reachable.
- **Map-of-instances fan-out** (`:rf/machines`, `:rf/spawned`) — one `[:rf/area id]` trigger per instance section.

Hovering a trigger opens the existing popover listing subs (recomputed / skipped) + views downstream of that path, with the `⤴ jump to Reactive panel` affordance. nil-safe: hovering a path with no downstream subs shows the popover's existing empty-state, not a crash.

## Tests

CLJS-first (no Playwright). Extended `app_db_diff_state_cljs_test.cljs` with an fn-component-expanding hiccup walker and 6 new tests asserting the trigger is now injected at each section type (TOP per-key, machine instances, route singleton, empty-area, nil-safety). The existing `app_db_diff_downstream_cljs_test.cljs` already covers the popover's own behaviour and still passes unchanged.

## Test plan

- [x] `npm run test:cljs` — 4133 tests / 12557 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — exit 0 (full: 13 scenarios / 12 surfaces; smoke: exit 0)
- [x] Causa JVM `clojure -M:test` — 854 tests / 2780 assertions, 0 failures, 0 errors