### PR TITLE
spec(epoch): align :rf/epoch-record owner doc + schema to epoch-per-event (rf2-msxmi)

### DIFF
--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2332,7 +2332,7 @@ The serialisable artefact contract for a story variant (post-v1 library; see [00
 > **Status:** dev-tier (gated on `re-frame.interop/debug-enabled?`; production builds elide entirely)
 > **Conformance:** `spec/conformance/fixtures/epoch-*.edn` + `implementation/epoch/test/re_frame/epoch_*.clj` (build / restore / privacy / redact-fn / jvm-prod-gate)
 
-Per-frame epoch snapshot, recorded on each drain-completion in dev builds. Used by Tool-Pair for time-travel and post-mortem analysis. Production builds elide entirely (no schema validation needed in prod).
+Per-frame epoch snapshot, recorded **per dequeued event** in dev builds — one record per event, not per drain (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)). A drain that settles several events back-to-back yields one record per settled event. Used by Tool-Pair for time-travel and post-mortem analysis. Production builds elide entirely (no schema validation needed in prod).
 
 ```clojure
 (def EpochRecord
@@ -2344,7 +2344,7 @@ Per-frame epoch snapshot, recorded on each drain-completion in dev builds. Used 
    [:trigger-event [:vector :any]]                                          ;; the full event vector
    [:db-before     :any]                                                    ;; app-db before the cascade
    [:db-after      :any]                                                    ;; app-db the runtime settled to (see :outcome)
-   [:outcome       [:enum :ok                                               ;; (rf2-v0jwt) drain reached empty queue cleanly
+   [:outcome       [:enum :ok                                               ;; (rf2-v0jwt) the event's own cascade settled cleanly
                           :halted-depth                                     ;; drain-depth limit tripped; atomic rollback
                           :halted-destroy                                   ;; frame destroyed mid-drain
                           :halted-handler-exception]]                       ;; reserved — current impl does not halt the drain on handler-exception, see §Outcomes below
@@ -2400,11 +2400,11 @@ The `:db-before` / `:db-after` pair lets pair tools display diffs cheaply.
 
 #### Outcomes (rf2-v0jwt)
 
-The runtime commits an epoch record on every drain boundary — both clean settles and halted drains. `:outcome` discriminates so devtools (Causa, re-frame2-pair) can render failing cascades with the partial-information shape they actually carry.
+The runtime commits one epoch record per dequeued event (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)) — both clean per-event settles and the terminal record for an event whose drain halted. `:outcome` discriminates so devtools (Causa, re-frame2-pair) can render failing cascades with the partial-information shape they actually carry.
 
 | `:outcome` | When the runtime commits | `:db-before` | `:db-after` |
 |---|---|---|---|
-| `:ok` | Drain reached an empty queue cleanly. The traditional record. | Pre-cascade snapshot. | Post-cascade snapshot. |
+| `:ok` | The dequeued event's own six-domino cascade settled cleanly. The traditional record — one per dequeued event. | Pre-cascade snapshot. | Post-cascade snapshot. |
 | `:halted-depth` | Drain hit the configured depth limit; the runtime performed an atomic rollback per [Spec 002 §Run-to-completion dispatch](002-Frames.md#run-to-completion-dispatch-drain-semantics). | Pre-cascade snapshot. | Equal to `:db-before` (the rolled-back state). |
 | `:halted-destroy` | A handler called `destroy-frame!` on its own frame mid-cascade; the drain interrupts and drops remaining queued events per [Spec 002 §Edge cases worth pinning §Frame disposal mid-drain](002-Frames.md). | Pre-cascade snapshot. | The state at destroy-time — the partial cascade's writes survive in the recorded value, but the frame is gone so the live container can no longer be read. |
 | `:halted-handler-exception` | **Reserved.** Spec 010 §Per-step recovery line 140 describes "cascade halts" on handler exception, but the reference runtime currently routes through the interceptor chain's error-capture seam: the failing handler's `:db` / `:fx` / flows do **not** apply (the chain caught the exception before `:effects` were populated), but the drain itself continues with the next queued event. No record carries this outcome under today's CLJS reference. Held for a future runtime path that aborts the drain on handler exception. | — | — |

--- a/spec/Tool-Pair.md
+++ b/spec/Tool-Pair.md
@@ -66,9 +66,9 @@ The capability that requires *new* commitments is **time-travel**, addressed bel
 
 The runtime contract for time-travel:
 
-**Recording.** Every event-cascade settle (drain reaching empty queue) marks an epoch boundary. The runtime records, per frame, an `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) consisting of `:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, and (optionally) `:trace-events`, plus the structured per-epoch projections `:sub-runs`, `:renders`, and `:effects` (each pre-derived from `:trace-events`; see [Spec-Schemas §`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record) for shapes). Pair tools route diagnostics off the structured slots — cache-hit-vs-rerun analysis (`:sub-runs[*].:recomputed?`), render-key attribution (`:renders[*].:render-key`, the tuple `[<view-id> <instance-token>]` per [004 §Render-tree primitives](004-Views.md#render-tree-primitives) — rf2-t5tx Option C / rf2-piag), and fx cascade outcome (`:effects[*].:outcome`) — without re-folding the raw trace stream each epoch.
+**Recording.** Each **dequeued event** marks an epoch boundary — one `:rf/epoch-record` per dequeued event, not per drain (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)). The unit is `process-event!`: every dequeued envelope runs its own full six-domino cascade and yields its own epoch, irrespective of how it arrived — a UI `(rf/dispatch …)`, an `:fx [[:dispatch …]]` child queued by another handler, or the frame-creation `:on-create` event each open a fresh epoch. A drain that processes a parent event and the child it `:fx`-dispatched therefore produces **two** epoch records, not one, even though both settle inside the same drain. (A machine's `:raise` sub-events and `:always` microsteps are intra-macrostep — they ride the triggering event's epoch and do **not** open a new one, per [005 §Drain semantics](005-StateMachines.md#drain-semantics).) The runtime records, per frame, an `:rf/epoch-record` (per [Spec-Schemas](Spec-Schemas.md#rfepoch-record)) consisting of `:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:trigger-event`, `:db-before`, `:db-after`, and (optionally) `:trace-events`, plus the structured per-epoch projections `:sub-runs`, `:renders`, and `:effects` (each pre-derived from `:trace-events`; see [Spec-Schemas §`:rf/epoch-record`](Spec-Schemas.md#rfepoch-record) for shapes). Pair tools route diagnostics off the structured slots — cache-hit-vs-rerun analysis (`:sub-runs[*].:recomputed?`), render-key attribution (`:renders[*].:render-key`, the tuple `[<view-id> <instance-token>]` per [004 §Render-tree primitives](004-Views.md#render-tree-primitives) — rf2-t5tx Option C / rf2-piag), and fx cascade outcome (`:effects[*].:outcome`) — without re-folding the raw trace stream each epoch.
 
-**Ordering.** Epochs within a frame are totally ordered by drain-completion time. Across frames, ordering is per-frame only — there is no global epoch sequence.
+**Ordering.** Epochs within a frame are totally ordered by event settle-order — the order in which dequeued events complete their cascades. (A drain that settles several events back-to-back yields one epoch per event, in dequeue order.) Across frames, ordering is per-frame only — there is no global epoch sequence.
 
 **Bounded history.** The runtime keeps the last *N* epochs per frame (default 50, configurable via `(rf/configure :epoch-history {:depth N})`). Older epochs are discarded.
 
@@ -443,7 +443,7 @@ The full attachment surface, from the tool's point of view:
 | Need | Surface | Spec |
 |---|---|---|
 | Receive live trace events | `(rf/register-listener! :my-tool callback)` | [009 §The listener API](009-Instrumentation.md#the-listener-api) |
-| Receive per-drain assembled epoch records | `(rf/register-epoch-listener! :my-tool callback)` | [009 §The listener API](009-Instrumentation.md#the-listener-api) |
+| Receive per-event assembled epoch records | `(rf/register-epoch-listener! :my-tool callback)` | [009 §The listener API](009-Instrumentation.md#the-listener-api) |
 | Read recent trace history (events that already fired) | `(rf/trace-buffer)` (with optional filter map) | [009 §Retain-N trace ring buffer](009-Instrumentation.md#retain-n-trace-ring-buffer-dev-only) |
 | Read epoch history per frame | `(rf/epoch-history frame-id)` | [§Time-travel](#time-travel-epoch-snapshots-and-undo) |
 | Restore an epoch | `(rf/restore-epoch frame-id epoch-id)` | [§Time-travel](#time-travel-epoch-snapshots-and-undo) |
@@ -469,7 +469,7 @@ The consumption pattern is therefore:
 
 > **A pair-shaped tool registers as a trace listener (and/or as an epoch listener for assembled per-cascade records), reads recent history from the trace buffer, queries the registrar for shape, walks the epoch history for time-travel, and dispatches into frames to drive experiments. That's the entire surface.**
 
-Two listener shapes coexist by design: `register-listener!` is the **raw** stream — every event the runtime emits, fine-grained — used by tools that need per-emit detail (custom recorders, error-monitor forwarders, timing aggregators). `register-epoch-listener!` is the **assembled** stream — one fully-shaped `:rf/epoch-record` per drain-settle, with the structured `:sub-runs` / `:renders` / `:effects` projections already computed — used by tools that route diagnostics off "what just happened in this cascade" rather than reconstructing it from the raw trace each time. Pair-shaped tools typically prefer the assembled stream for routing and reach for the raw stream only when they need detail the projection drops.
+Two listener shapes coexist by design: `register-listener!` is the **raw** stream — every event the runtime emits, fine-grained — used by tools that need per-emit detail (custom recorders, error-monitor forwarders, timing aggregators). `register-epoch-listener!` is the **assembled** stream — one fully-shaped `:rf/epoch-record` per dequeued event (per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)), with the structured `:sub-runs` / `:renders` / `:effects` projections already computed — used by tools that route diagnostics off "what just happened in this cascade" rather than reconstructing it from the raw trace each time. Pair-shaped tools typically prefer the assembled stream for routing and reach for the raw stream only when they need detail the projection drops.
 
 This is **dev-only** end-to-end — every primitive listed above elides in production builds (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)). Pair-shaped tools do not ship in production binaries.
 
@@ -504,11 +504,11 @@ For per-cascade structured projections (sub-cache hit/miss, render attribution, 
 
 ### Subscribing to assembled epoch records
 
-`register-epoch-listener!` callbacks fire **once per drain-settle**, with the cascade's `:sub-runs` / `:renders` / `:effects` projections already computed. Pair-shaped tools, post-mortem dashboards, and "what just happened?" probes typically consume this shape rather than re-folding the raw trace stream:
+`register-epoch-listener!` callbacks fire **once per dequeued event** (one per epoch, per [002 §Drain versus event](002-Frames.md#drain-versus-event--the-epoch-unit)), with the cascade's `:sub-runs` / `:renders` / `:effects` projections already computed. A drain that settles several events back-to-back therefore fires the callback once per settled event, in dequeue order. Pair-shaped tools, post-mortem dashboards, and "what just happened?" probes typically consume this shape rather than re-folding the raw trace stream:
 
 ```clojure
 ;; A pair-tool dashboard routing diagnostics off the assembled per-cascade record.
-;; - One callback per drain-settle (NOT per emitted trace event).
+;; - One callback per dequeued event / epoch (NOT per drain, NOT per emitted trace event).
 ;; - The record is fully shaped: :db-before, :db-after, :sub-runs, :renders, :effects.
 ;; - The record has already been appended to (rf/epoch-history (:frame ev)).
 
@@ -540,7 +540,7 @@ Edge-case behaviour the example does not exercise but consumers should know abou
 
 - **Listener exceptions are caught.** A throw inside the callback does not propagate to the framework or other listeners (per [009 §register-epoch-listener! invocation rules](009-Instrumentation.md#register-epoch-listener--assembled-epoch-listener)). The framework does **not** auto-evict the throwing listener — repeated throws keep the registration in place; eviction is the consumer's call.
 - **Re-entrant dispatch from a callback.** A callback that calls `(rf/dispatch …)` enqueues the new event; the new dispatch's drain begins on stack-unwind from the current callback fan-out, not before. Other registered epoch listeners still receive the *current* record before the re-entrant dispatch begins.
-- **`(rf/configure :epoch-history {:depth 0})` and listeners.** Setting depth to 0 disables the per-frame ring buffer (so `(rf/epoch-history frame-id)` returns `[]`) but does **not** stop epoch listeners from firing — `register-epoch-listener!` callbacks continue to receive the assembled record on every drain-settle. Tools that need the assembled stream without retaining history should set depth `0` and consume via `register-epoch-listener!` only.
+- **`(rf/configure :epoch-history {:depth 0})` and listeners.** Setting depth to 0 disables the per-frame ring buffer (so `(rf/epoch-history frame-id)` returns `[]`) but does **not** stop epoch listeners from firing — `register-epoch-listener!` callbacks continue to receive the assembled record once per dequeued event. Tools that need the assembled stream without retaining history should set depth `0` and consume via `register-epoch-listener!` only.
 - **Frame-destroyed mid-observation.** Tool-Pair surface behaviour against destroyed frames (epoch-history reads, in-flight epoch-cb deliveries, restore against a now-destroyed frame, listener silencing) is closed in [§Surface behaviour against destroyed frames](#surface-behaviour-against-destroyed-frames). Read-shaped surfaces return empty shapes; mutating-shaped surfaces raise `:rf.error/no-such-handler` (kind `:frame`); a previously-firing callback whose observed frame is destroyed receives a one-shot `:rf.epoch.cb/silenced-on-frame-destroy` trace.
 
 ### Implications for downstream tools


### PR DESCRIPTION
## Summary

PR #1948 (rf2-u6jsj) corrected the epoch unit to **one `:rf/epoch-record` per dequeued event** in `spec/002-Frames.md` (§Drain versus event) and `spec/009-Instrumentation.md` (§Dispatch correlation). But the **canonical owner** of `:rf/epoch-record` is `Tool-Pair.md` (per `Ownership.md`), and it plus the schema projection `Spec-Schemas.md` still asserted the **old per-drain boundary** — directly contradicting the corrected invariant. This brings them into line.

The invariant they now match: one `:dispatch-id` = one dequeued event = one `:rf/epoch-record`; ordering by event settle-order; `:fx [[:dispatch …]]` children and the `:on-create` frame-creation event each open their own epoch; `:raise`/`:always` microsteps ride the triggering event's epoch (intra-macrostep, no new epoch — Spec 005).

## Changes

**`spec/Tool-Pair.md` §Time-travel**
- **Recording** (~L69): "Every event-cascade settle (drain reaching empty queue) marks an epoch boundary" -> "Each **dequeued event** marks an epoch boundary — one `:rf/epoch-record` per dequeued event, not per drain". Adds the every-origin enumeration (UI dispatch / `:fx :dispatch` child / `:on-create`), the "parent + `:fx`-child = two records" example, and the `:raise`/`:always` intra-macrostep carve-out.
- **Ordering** (~L71): "totally ordered by drain-completion time" -> "totally ordered by event settle-order — the order in which dequeued events complete their cascades."
- Attach-surface table row (~L446): "Receive per-drain assembled epoch records" -> "per-event".
- Two-listener-shapes prose (~L472): "one fully-shaped `:rf/epoch-record` per drain-settle" -> "per dequeued event".
- `register-epoch-listener!` cadence — 3 spots (~L507 prose, ~L511 code comment, ~L543 depth-0 note): "once per drain-settle" / "on every drain-settle" -> "once per dequeued event".

**`spec/Spec-Schemas.md` §`:rf/epoch-record`**
- Prose (~L2335): "recorded on each drain-completion" -> "recorded **per dequeued event** … one record per event, not per drain".
- `:outcome :ok` enum comment (~L2347): "drain reached empty queue cleanly" -> "the event's own cascade settled cleanly".
- Outcomes table lead (~L2403): "commits an epoch record on every drain boundary" -> "commits one epoch record per dequeued event".
- `:ok` outcome row (~L2407): "Drain reached an empty queue cleanly" -> "The dequeued event's own six-domino cascade settled cleanly. … one per dequeued event."
- Drain-level `:halted-depth` / `:halted-destroy` mechanics left intact (genuinely drain-level: depth limit, atomic rollback, destroy-mid-drain).

**`spec/Ownership.md`** — verified consistent; carries no per-drain epoch-unit claim (the time-travel row at L60 names the slice/artefact only). No edit needed.

All new cross-refs reuse the exact `002 §Drain versus event` and `005 §Drain semantics` anchor forms already used in the merged 009.

## Notes
- Spec-only; no code/tests.
- Spec 005 macrostep rule preserved — nothing written contradicts `:raise`/`:always` being intra-macrostep with no new epoch.
- `mkdocs` not installed locally; CI validates `--strict`. Diff reviewed: tables / code fences / anchor links intact.