### PR TITLE
fix(causa): Trace tab 'X / Y in view' denominator is cascade-scoped (rf2-r6d6u)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -634,9 +634,10 @@
   The filter pass still walks the projected-row vector (a single
   reverse-then-filter over rows that are ALREADY projected — no
   per-event `project-row` cost) and stops at `cap` matches so the
-  view never sees more than its render-cap rows. The buffer's full
-  size is reflected by `:total`; the panel's overflow indicator
-  surfaces 'hidden N' from the cap-rows helper downstream.
+  view never sees more than its render-cap rows. `:total` reflects
+  the in-scope, pre-user-filter denominator (see Scoped denominator
+  below); `:buffer-total` carries the whole buffer's size for callers
+  that need it.
 
   ## Cascade-scope (rf2-ycoct)
 
@@ -645,6 +646,21 @@
   belonging to the focused cascade — honouring spec/018 §6 (every L4
   panel is a lens on the spine's focused event, not a global ribbon).
   User chip filters still apply AND-wise on top of the cascade scope.
+
+  ## Scoped denominator (rf2-r6d6u)
+
+  The Trace tab is a per-cascade lens, so its 'X / Y in view' header
+  must report a denominator that lives INSIDE the cascade scope. `Y`
+  (`:total`) is the count of in-scope rows BEFORE user chip filters;
+  `X` (`:rendered`) is the count AFTER user filters. When unscoped
+  (the 2-arity global-ribbon bridge / headless test rigs that pass no
+  `opts`) `:total` is the whole buffer — the global ribbon's
+  denominator IS the buffer. The previous shape always returned the
+  whole-buffer `:total`, so a `:below`-focused cascade with 8 in-scope
+  ops reported '8 / 113 in view' where 113 spanned every recent
+  cascade AND every frame — leaking the unscoped, cross-frame total
+  and violating frame isolation. `:buffer-total` preserves the
+  whole-buffer count for any caller that needs the raw ring size.
 
   Scope semantics:
 
@@ -667,8 +683,13 @@
   only — the cascade-scope is a system-level invariant, not a user
   narrowing.
 
-  Returned shape adds:
+  Returned shape adds / changes:
 
+    :total               — the in-scope, pre-user-filter row count
+                           (the 'Y' of 'X / Y in view'). Equals
+                           `:buffer-total` when unscoped.
+    :buffer-total        — the whole buffer's row count, regardless of
+                           scope (was the prior meaning of `:total`).
     :cascade-dispatch-id — the resolved scope value (nil when
                            unscoped) — the view uses it to label the
                            cascade-scope chip in the header.
@@ -688,10 +709,12 @@
          spine-aware? (some? opts)
          normalised (normalise-filters filters)
          passes?    (trace-bus/build-filter-predicate normalised)
-         total      (:total state)
+         ;; `buffer-total` is the whole ring's size; `total` (returned)
+         ;; is the in-scope, pre-user-filter denominator computed below.
+         buffer-total (:total state)
          no-focus?  (and spine-aware?
                          (nil? cascade-dispatch-id)
-                         (pos? total))
+                         (pos? buffer-total))
          in-scope?  (cond
                       no-focus?
                       (constantly false)
@@ -708,39 +731,53 @@
          no-user-filters? (empty? normalised)
          rows       (:projected-rows state)
          rev-rows   (rseq rows)
-         rendered+rows
+         ;; Single walk produces three numbers + the display vector:
+         ;;   scoped-total — in-scope rows, BEFORE user chip filters
+         ;;                  (the 'Y' of 'X / Y in view').
+         ;;   rendered     — in-scope rows that ALSO pass user filters
+         ;;                  (the 'X').
+         ;;   display-rows — the rendered rows, newest-first.
+         scoped+rendered+rows
          (cond
            ;; Defensive no-focus path: short-circuit to empty rows
            ;; without walking the buffer.
            no-focus?
-           [0 []]
+           [0 0 []]
 
            ;; Fast path: no user filters AND no cascade-scope → every
-           ;; row passes; just reverse the vector.
+           ;; row is in scope and passes; scoped-total = rendered =
+           ;; the full buffer.
            (and no-user-filters? (not scoped?))
-           [(count rows) (vec rev-rows)]
+           [buffer-total buffer-total (vec rev-rows)]
 
            :else
            (loop [remain rev-rows
+                  scoped-total 0
                   rendered 0
                   acc      (transient [])]
              (if (nil? (seq remain))
-               [rendered (persistent! acc)]
+               [scoped-total rendered (persistent! acc)]
                (let [row (first remain)
                      ev  (:raw row)]
-                 (if (and (in-scope? row)
-                          (or no-user-filters? (passes? ev)))
-                   (recur (next remain) (inc rendered) (conj! acc row))
-                   (recur (next remain) rendered acc))))))
-         [rendered display-rows] rendered+rows
+                 (if (in-scope? row)
+                   (if (or no-user-filters? (passes? ev))
+                     (recur (next remain) (inc scoped-total) (inc rendered)
+                            (conj! acc row))
+                     (recur (next remain) (inc scoped-total) rendered acc))
+                   (recur (next remain) scoped-total rendered acc))))))
+         [scoped-total rendered display-rows] scoped+rendered+rows
+         ;; The denominator the view shows: in-scope when scoped, the
+         ;; whole buffer when unscoped (global ribbon).
+         total      (if scoped? scoped-total buffer-total)
          empty-kind (cond
-                      (zero? total)    :no-events
-                      no-focus?        :no-focus
-                      (zero? rendered) :no-matches
-                      :else            nil)
+                      (zero? buffer-total) :no-events
+                      no-focus?            :no-focus
+                      (zero? rendered)     :no-matches
+                      :else                nil)
          active-filters (active-filters-summary normalised (:seen state))]
      {:rows                display-rows
       :total               total
+      :buffer-total        buffer-total
       :rendered            rendered
       :distinct            (effective-distinct (:distinct state)
                                                (:seen state)

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -810,8 +810,13 @@
           state (h/rebuild-feed-state evs)
           ;; Fixture has dispatch-ids 10, 11, 12. Scope to 10 → rows 1, 2, 4.
           feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 10})]
-      (is (= 5 (:total feed))
-          ":total reflects entire buffer, not the scoped subset")
+      ;; rf2-r6d6u: the denominator the view shows ('Y' of 'X / Y in
+      ;; view') is the in-scope, pre-user-filter count — NOT the whole
+      ;; buffer. Three rows belong to cascade 10, so :total is 3.
+      (is (= 3 (:total feed))
+          ":total reflects the in-scope subset (cascade 10), not the buffer")
+      (is (= 5 (:buffer-total feed))
+          ":buffer-total still carries the whole ring's size")
       (is (= 3 (:rendered feed))
           "three rows belong to cascade 10")
       (is (= #{1 2 4} (set (mapv :id (:rows feed))))
@@ -829,7 +834,13 @@
                                             {:op-type :error}
                                             {:cascade-dispatch-id 10})]
       (is (= 1 (:rendered feed)))
-      (is (= [2] (mapv :id (:rows feed)))))))
+      (is (= [2] (mapv :id (:rows feed))))
+      ;; rf2-r6d6u: the denominator stays the in-scope, PRE-user-filter
+      ;; count — cascade 10 has 3 rows, so 'X / Y in view' is '1 / 3',
+      ;; NOT '1 / 1'. The user filter narrows X, never Y.
+      (is (= 3 (:total feed))
+          ":total is the in-scope count before the user chip filter")
+      (is (= 5 (:buffer-total feed))))))
 
 (deftest project-feed-from-state-cascade-scope-no-overlap-empty
   (testing "rf2-ycoct: scope on a cascade not in the buffer renders
@@ -838,6 +849,10 @@
           state (h/rebuild-feed-state evs)
           feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 99999})]
       (is (= 0 (:rendered feed)))
+      ;; rf2-r6d6u: no row is in scope → the scoped denominator is 0.
+      (is (= 0 (:total feed))
+          ":total is 0 when no buffered row matches the scope")
+      (is (= 5 (:buffer-total feed)))
       (is (= :no-matches (:empty-kind feed)))
       (is (= 99999 (:cascade-dispatch-id feed))))))
 
@@ -854,7 +869,11 @@
           feed  (h/project-feed-from-state state {} {:cascade-dispatch-id :ungrouped})]
       (is (= 2 (:rendered feed))
           "rows 1 and 3 have no :dispatch-id → they belong to :ungrouped")
-      (is (= #{1 3} (set (mapv :id (:rows feed))))))))
+      (is (= #{1 3} (set (mapv :id (:rows feed)))))
+      ;; rf2-r6d6u: the :ungrouped bucket has 2 in-scope rows → :total 2.
+      (is (= 2 (:total feed))
+          ":total counts the in-scope (:ungrouped) rows")
+      (is (= 3 (:buffer-total feed))))))
 
 (deftest project-feed-from-state-no-focus-defensive-empty-state
   (testing "rf2-ycoct defensive: opts passed with nil :cascade-dispatch-id
@@ -866,8 +885,13 @@
       (is (= :no-focus (:empty-kind feed)))
       (is (= 0 (:rendered feed)))
       (is (= [] (:rows feed)))
-      (is (= 5 (:total feed))
-          ":total reflects the buffer (the state is broken, not the data)"))))
+      ;; rf2-r6d6u: no focused cascade → nothing is in scope → the
+      ;; scoped denominator is 0. The raw ring is still surfaced via
+      ;; :buffer-total (the state is broken, not the data).
+      (is (= 0 (:total feed))
+          ":total is 0 — no focused cascade means nothing is in view")
+      (is (= 5 (:buffer-total feed))
+          ":buffer-total reflects the buffer (the state is broken, not the data)"))))
 
 (deftest project-feed-from-state-2-arity-preserves-global-ribbon-shape
   (testing "rf2-ycoct: the 2-arity (no opts) keeps the pre-rf2-ycoct
@@ -879,6 +903,11 @@
           feed  (h/project-feed-from-state state {})]
       (is (= 5 (:rendered feed))
           "every buffered row renders — no cascade-scope applied")
+      ;; rf2-r6d6u: unscoped → the global ribbon's denominator IS the
+      ;; whole buffer, so :total = :buffer-total = 5.
+      (is (= 5 (:total feed))
+          "unscoped :total is the whole buffer")
+      (is (= 5 (:buffer-total feed)))
       (is (nil? (:empty-kind feed)))
       (is (nil? (:cascade-dispatch-id feed))
           "the scope key is nil (no scope was passed)"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -848,10 +848,14 @@
       ;; Focus cascade A.
       (rf/dispatch-sync [:rf.causa/focus-cascade 100])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 5 (:total feed))
-            ":total reflects the ENTIRE buffer (unscoped count) —
-             cascade-scope narrows what RENDERS, not what's in the
-             buffer")
+        ;; rf2-r6d6u: the 'X / Y in view' denominator is cascade-scoped
+        ;; — :total is cascade A's 2 in-scope events, NOT the 5-event
+        ;; buffer. The raw ring is surfaced via :buffer-total.
+        (is (= 2 (:total feed))
+            ":total is the in-scope (cascade A) count — the per-cascade
+             lens denominator, not the whole buffer")
+        (is (= 5 (:buffer-total feed))
+            ":buffer-total carries the whole ring's size")
         (is (= 2 (:rendered feed))
             "only the two events in cascade A are rendered")
         (is (= #{1 2} (set (mapv :id (:rows feed))))
@@ -863,6 +867,9 @@
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 3 (:rendered feed))
             "rendered count flips to cascade B's three events")
+        (is (= 3 (:total feed))
+            ":total flips to cascade B's 3 in-scope events")
+        (is (= 5 (:buffer-total feed)))
         (is (= #{3 4 5} (set (mapv :id (:rows feed))))
             "rows are exactly cascade B's events")
         (is (= 200 (:cascade-dispatch-id feed)))))))
@@ -956,8 +963,12 @@
       (is (= :no-focus (:empty-kind feed)))
       (is (= 0 (:rendered feed))
           "no rows render in the no-focus defensive branch")
-      (is (= 1 (:total feed))
-          ":total still reflects the buffer (the state is broken,
+      ;; rf2-r6d6u: no focused cascade → nothing is in scope → :total 0.
+      ;; The raw ring is still surfaced via :buffer-total.
+      (is (= 0 (:total feed))
+          ":total is 0 — no focused cascade means nothing is in view")
+      (is (= 1 (:buffer-total feed))
+          ":buffer-total still reflects the buffer (the state is broken,
            not the data)"))))
 
 (deftest panel-spine-auto-snap-guards-against-no-focus-in-production

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -764,6 +764,26 @@ async function readTraceDomBudget(page) {
   });
 }
 
+// rf2-r6d6u: the trace header's 'X / Y in view' denominator is now
+// cascade-scoped (Y = in-scope, pre-user-filter count), so it is NO
+// LONGER a proxy for the whole ring's depth. The buffer-cap invariant
+// ('still capped at 1000') is read straight from the trace bus — the
+// canonical source of truth for ring depth, independent of which
+// cascade the spine has in focus.
+async function readTraceBufferDepth(page) {
+  return page.evaluate(() => {
+    const cljs = window.cljs && window.cljs.core;
+    const bus = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.trace_bus;
+    if (!cljs || !bus || typeof bus.buffer !== 'function') return null;
+    // `bus.buffer()` is the live ring; its count is the actual number of
+    // retained events (vs `current_depth`, which is only the configured
+    // capacity). The 1000-cap saturation invariant needs the live count.
+    return cljs.count(bus.buffer());
+  });
+}
+
 async function pushSyntheticTraceEvents(page, count) {
   const result = await page.evaluate((eventCount) => {
     const cljs = window.cljs && window.cljs.core;
@@ -1765,11 +1785,14 @@ async function runTraceBudgetSaturation(page, state) {
   await clearTrace(page);
   const start = Date.now();
   const pushed = await pushSyntheticTraceEvents(page, 1000);
-  const saturated = await waitForValue(
-    () => readTraceCounts(page),
-    (counts) => counts.total === 1000,
+  // rf2-r6d6u: assert ring saturation against the BUS depth, not the
+  // header denominator (the latter is now cascade-scoped, not the ring).
+  const saturatedDepth = await waitForValue(
+    () => readTraceBufferDepth(page),
+    (depth) => depth === 1000,
     { timeoutMs: 10000, description: 'trace buffer saturation at 1000 rows' },
   );
+  const saturated = await readTraceCounts(page);
   const saturatedDom = await waitForValue(
     () => readTraceDomBudget(page),
     (budget) => budget.rowCount === 200 && budget.overflowPresent,
@@ -1786,26 +1809,32 @@ async function runTraceBudgetSaturation(page, state) {
   for (let i = 0; i < 20; i += 1) {
     await clickHostButtonByLabel(page, i % 2 === 0 ? '+' : '-');
   }
+  // rf2-r6d6u: 'still capped' is a RING invariant — assert the bus depth
+  // stays at 1000 (host dispatches evict synthetic rows but never grow
+  // the ring) and the DOM budget stays ≤ 200. The header denominator is
+  // now cascade-scoped, so it no longer equals the ring depth.
   const after = await waitForValue(
     async () => ({
+      depth: await readTraceBufferDepth(page),
       counts: await readTraceCounts(page),
       dom: await readTraceDomBudget(page),
       events: await readTrace(page),
     }),
     (snapshot) =>
-      snapshot.counts.total === 1000 &&
+      snapshot.depth === 1000 &&
       snapshot.dom.rowCount <= 200 &&
       snapshot.events.some((event) => event.includes(':counter/inc')) &&
       snapshot.events.some((event) => event.includes(':counter/dec')),
     { timeoutMs: 10000, description: 'trace budget still capped after 20 host dispatches' },
   );
   state.loadStats = {
-    eventCountBefore: saturated.total,
-    eventCountAfter: after.counts.total,
-    traceBufferDepth: after.counts.total,
+    eventCountBefore: saturatedDepth,
+    eventCountAfter: after.depth,
+    traceBufferDepth: after.depth,
+    scopedDenominator: after.counts.total,
     visibleRowCount: after.dom.rowCount,
     renderDurationMs: Date.now() - start,
-    bufferEvictionCount: Math.max(0, saturated.total + 20 - after.counts.total),
+    bufferEvictionCount: Math.max(0, saturatedDepth + 20 - after.depth),
     overflowText: after.dom.overflowText,
     syntheticEventsPushed: pushed.pushed,
   };


### PR DESCRIPTION
## Summary

The Trace tab is a per-cascade lens, but its header denominator (`Y` in `X / Y in view`) escaped the cascade scope — it read the **whole** trace-bus buffer. That buffer spans every recent cascade AND every frame, so a `:below`-focused view with 8 in-scope ops rendered `8 / 113 in view`, where 113 mixed in `:above` / `:rf/default` / `nil`-frame events. That leaks an unscoped, cross-frame, multi-cascade total and violates frame isolation.

## What changed

- **`trace_helpers.cljc` — `project-feed-from-state`**: `:total` is now scope-aware. When the panel is cascade-scoped, `:total` (Y) is the count of in-scope rows **before** user chip filters; `:rendered` (X) is the count **after**. When unscoped (the 2-arity global-ribbon bridge / headless test rigs), `:total` stays the whole buffer — the global ribbon's denominator *is* the buffer. The raw ring size is preserved as a new `:buffer-total` key for any caller that needs it. Computed in the existing single reverse-walk (one extra counter), nil-safe (no focus → `0`, no crash).
- **Epoch-indicator consistency**: the `epoch #N · X ops` indicator already reads the scoped `:rendered`, so the header now tells one consistent scoped story. No epoch-resolution logic touched (that is rf2-48nsi's concern).
- **Tests**: `trace_helpers_cljs_test.cljc` + `trace_view_cljs_test.cljs` updated to pin the scoped-total semantics — scoped `:total` reflects the in-scope subset, `:buffer-total` carries the ring size, user filters narrow `X` never `Y`.
- **Feature-matrix scenario** (`scenarios.cjs`): the 1000-event row-budget scenario asserted ring saturation via the header denominator; since that denominator is now cascade-scoped it no longer proxies ring depth, so the scenario reads the trace-bus buffer count directly for the cap invariant.

Causa tool only — no `implementation/` changes.

## Before / after

The `X / Y in view` denominator (`Y`) used to be the whole unscoped, cross-frame, multi-cascade buffer (e.g. `8 / 113`); it now reflects the focused cascade's in-scope, pre-user-filter window (e.g. `8 / 8`).

## Test plan

- [x] `npm run test:cljs` — 4115 tests, 12521 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures, 13 matrix rows