### PR TITLE
impl(epoch): bind the epoch to the dequeued event, not the drain (rf2-nj6p7)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -501,7 +501,12 @@
    ;; ---- re-frame.epoch (rf2-lt4e Tool-Pair surface) -------------------------
    {:key         :epoch/settle!
     :producer-ns 're-frame.epoch
-    :description "Settle the current in-flight epoch (commit to history)."}
+    :design-bead "rf2-nj6p7"
+    :description "Settle one DEQUEUED EVENT's epoch (commit to history). Per Spec 002 §Drain versus event the epoch boundary is the dequeued event, not the drain — the router calls this once per process-event! (incl. each :fx-dispatched child), harvesting that one event's cascade buffer. Skips an empty buffer (rejected/aborted dispatch)."}
+   {:key         :epoch/commit-halt-record!
+    :producer-ns 're-frame.epoch
+    :design-bead "rf2-nj6p7"
+    :description "Commit a :halted-* epoch record for a drain halt whose halting event never ran (the per-event depth-exceed boundary). Unlike :epoch/settle! it does NOT skip an empty buffer — under per-event epochs the already-settled events each harvested their own buffer, so the buffer is empty at halt; this synthesises the halting event's :halted-depth record from an explicit trigger. Already-settled siblings are durable (no whole-drain rollback)."}
    {:key         :epoch/discard-buffer!
     :producer-ns 're-frame.epoch
     :description "Discard the in-flight epoch buffer without committing."}

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -949,57 +949,92 @@
   100)
 
 (defn- handle-depth-exceeded!
-  "Tail-path for the depth-limit branch of `drain!`. Atomic rollback per
-  Spec 002 §Run-to-completion §Rules rule 3: restore the pre-drain
-  `:db` BEFORE emitting the error so any trace listener that reads
-  app-db sees the rolled-back value, not a misleading partial cascade.
+  "Tail-path for the depth-limit branch of `drain!`. Per Spec 002
+  §Drain versus event — the epoch unit (rf2-u6jsj/rf2-nj6p7): the epoch
+  boundary is the dequeued EVENT, so the events that already ran in this
+  drain each settled their own DURABLE `:ok` epoch (and their own db
+  write) as they completed — there is NO whole-drain rollback under
+  per-event epochs. The depth limit stops processing the NEXT event (the
+  halting event, still at the head of the queue); the work that already
+  ran is a sequence of complete, individually-atomic events.
 
-  Per rf2-v0jwt §Outcomes: a depth-exceeded drain is a *partial*
-  drain — commit a `:halted-depth` epoch record so devtools (Causa,
-  re-frame2-pair) receive the cascade context. The record's `:db-after`
-  equals `db-before` (the rolled-back state) and `:halt-reason` carries
-  the structured descriptor of the depth-exceed. Listeners receive the
-  record like any other; `restore-epoch` refuses non-`:ok` targets."
-  [frame-id router db-before depth last-event]
+  Per rf2-v0jwt §Outcomes: commit a `:halted-depth` epoch record so
+  devtools (Causa, re-frame2-pair) get a clear 'drain halted here'
+  marker following the runaway `:ok` epochs. The halting event never ran,
+  so its record's `:db-before` / `:db-after` both equal the current
+  (last-settled) db value and its buffer is empty — `commit-halt-record!`
+  synthesises the record from the halting event's trigger. Listeners
+  receive it like any other; `restore-epoch` refuses non-`:ok` targets.
+
+  ## Reconcile with Spec 002 rule 3 (NOTED for spec-tightening, rf2-nj6p7)
+
+  Rule 3 (and the `drain-depth-limit.edn` conformance fixture) describe
+  WHOLE-DRAIN atomic rollback to a pre-drain snapshot, written for the
+  pre-rf2-u6jsj per-drain epoch model. The merged spec PR #1948 redefined
+  the epoch as per-event but did NOT update rule 3 / the fixture
+  (\"impl follow-up rf2-nj6p7\"). Under per-event epochs, whole-drain
+  rollback is incoherent — each settled event is independently atomic and
+  durable. This impl follows the per-event model the merged spec defines:
+  already-settled siblings are durable; only the halting event (which
+  never ran) gets a `:halted-depth` marker. Rule 3's pre-drain-rollback
+  text and the fixture need tightening to the per-event boundary."
+  [frame-id router depth last-event]
   (let [{:keys [queue]} @router
         queue-size      (count queue)
-        container       (frame/get-frame-db frame-id)
+        ;; The halting event — the next one that would have been dequeued.
+        ;; It never runs; its event vector pins the `:halted-depth` marker.
+        ;; The queue holds ENVELOPES (`build-envelope` maps), so reach the
+        ;; raw `[event-id …]` vector through `:event`. Falls back to
+        ;; `last-event` (the most-recently-run event) if the queue is empty
+        ;; at the halt seam (defensive — the depth-exceed path always has a
+        ;; pending child under the runaway-cascade pattern that trips it).
+        halting-event   (or (:event (peek queue)) last-event)
+        ;; Current durable db value — the state the last-settled event
+        ;; left behind. The halting event makes no write, so :db-before
+        ;; equals :db-after on its record.
+        db-now          (frame/frame-app-db-value frame-id)
         halt-reason     {:operation  :rf.error/drain-depth-exceeded
                          :depth      depth
                          :queue-size queue-size
                          :last-event last-event}]
-    (when container
-      (adapter/replace-container! container db-before))
     (trace/emit-error! :rf.error/drain-depth-exceeded
                        {:frame      frame-id
                         :depth      depth
                         :queue-size queue-size
                         :last-event last-event
-                        :rollback?  true
+                        ;; Per rf2-nj6p7: no whole-drain rollback under
+                        ;; per-event epochs — the already-settled events
+                        ;; are durable. `:rollback? false` reflects that.
+                        :rollback?  false
                         :recovery   :no-recovery})
     (swap! router assoc :queue interop/empty-queue :scheduled? false)
-    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
-      ;; :db-after equals :db-before — atomic rollback semantics. The
-      ;; record carries the cascade's :trace-events / :sub-runs /
-      ;; :renders / :effects up to the halt point so devtools can
-      ;; render the partial cascade with the failure highlighted.
-      (settle! frame-id db-before db-before :halted-depth halt-reason))))
+    (when-let [commit-halt! (late-bind/get-fn-cached :epoch/commit-halt-record!)]
+      ;; The halting event never ran, so the capture buffer is empty and
+      ;; `settle!` would skip; `commit-halt-record!` commits regardless,
+      ;; pinning the halting event's trigger. :db-before equals :db-after
+      ;; — the halting event made no write.
+      (commit-halt! frame-id db-now db-now :halted-depth halt-reason
+                    halting-event))))
 
-(defn- handle-drain-settled!
-  "Tail-path for the empty-queue branch of `drain!`. If at least one event
-  was processed, commit the epoch record per Tool-Pair §Time-travel.
+(defn- settle-event-epoch!
+  "Commit the just-completed event's epoch (Tool-Pair §Time-travel). Per
+  Spec 002 §Drain versus event — the epoch unit (rf2-u6jsj/rf2-nj6p7):
+  the epoch boundary is the dequeued EVENT, not the drain-settle. Called
+  by `run-one-pass!` after each `process-event!` returns, with that one
+  event's own pre-/post-cascade db snapshot pair. The epoch surface
+  harvests the in-flight capture buffer — which, within a frame's
+  single-threaded run-to-completion drain, holds exactly this event's
+  six-domino cascade (the previous event already harvested its own at its
+  settle). A machine macrostep ran inside `process-event!` and rides this
+  one event's buffer / epoch (Spec 005 §macrostep), so `:raise` /
+  `:always` microsteps do not allocate a new epoch.
 
-  Per rf2-ynk7 §single-drainer invariant: `:scheduled?` is no longer
-  cleared here. The drain loop's outer `finally` clears `:scheduled?`
-  AND releases `:drain-lock` under a single `locking router` block so
-  any concurrent submitter's `ensure-drain-scheduled!` check serializes
-  against the release. Splitting the two would re-open the
-  enqueue-after-empty-check race that motivated this bead."
-  [frame-id _router db-before depth]
-  (when (pos? depth)
-    (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
-      (let [db-after (frame/frame-app-db-value frame-id)]
-        (settle! frame-id db-before db-after)))))
+  `settle!` itself skips an empty buffer (a rejected/aborted dispatch that
+  never fired `:event/run-start`), so a no-handler / frame-destroyed early
+  exit commits no misleading record."
+  [frame-id db-before db-after]
+  (when-let [settle! (late-bind/get-fn-cached :epoch/settle!)]
+    (settle! frame-id db-before db-after)))
 
 ;; ---- drain-loop! phases ---------------------------------------------------
 ;;
@@ -1113,15 +1148,22 @@
   `:rf.frame/drain-interrupted` lifecycle trace emitted carrying the
   dropped count.
 
-  Each pass takes its pre-cascade `db-before` snapshot from the caller
-  so the epoch settle callback (Tool-Pair §Time-travel) sees the right
-  state for THIS pass."
-  [frame-id router db-before drain-depth]
+  Per rf2-u6jsj/rf2-nj6p7 §Drain versus event — the epoch unit: the epoch
+  boundary is the dequeued EVENT, not the drain. Each event takes its OWN
+  pre-cascade `db-before` snapshot immediately before `process-event!` and
+  its OWN post-cascade `db-after` immediately after; `settle-event-epoch!`
+  commits one `:rf/epoch-record` per event. A drain that processes a
+  parent and an `:fx [[:dispatch …]]` child it queued therefore commits
+  TWO records — one per event — even though both settled in the same
+  drain. (The frame-level `db-before` the caller passes is retained only
+  for the destroy-interrupt path, which reads it as a fallback when the
+  destroyed frame's container is no longer readable.)"
+  [frame-id router drain-db-before drain-depth]
   (loop [depth      0
          last-event nil]
     (cond
       (>= depth drain-depth)
-      (do (handle-depth-exceeded! frame-id router db-before depth last-event)
+      (do (handle-depth-exceeded! frame-id router depth last-event)
           ::halt)
 
       ;; Per rf2-68kok: destroyed-frame check fires BEFORE the next
@@ -1132,24 +1174,28 @@
       ;; lifecycle event, halt.
       ;;
       ;; Per rf2-v0jwt: the just-completed event already ran in full
-      ;; (run-to-completion), so the partial-cascade record commits
-      ;; with `:outcome :halted-destroy`. Devtools (Causa, re-frame-
-      ;; re-frame2-pair) need the cascade context for the failing/interrupted
-      ;; drain — silently discarding the record (the pre-rf2-v0jwt
-      ;; behaviour) hid exactly the cascades developers most need to
-      ;; inspect. `restore-epoch` refuses these records, preserving
+      ;; (run-to-completion) AND already settled its own per-event epoch
+      ;; (rf2-nj6p7) — that record is durable. Devtools (Causa, re-frame-
+      ;; re-frame2-pair) also receive a `:halted-destroy` record for the
+      ;; interrupted drain from the destroy hook / `handle-drain-
+      ;; interrupted!`. `restore-epoch` refuses these records, preserving
       ;; the original "time-travel never lands in a misleading state"
       ;; invariant.
       (frame/frame-disposed-for-drain? frame-id)
-      (do (handle-drain-interrupted! frame-id router db-before)
+      (do (handle-drain-interrupted! frame-id router drain-db-before)
           ::halt)
 
       :else
       (if-let [envelope (take-event! router)]
-        (do (process-event! envelope)
-            (recur (inc depth) (:event envelope)))
-        (do (handle-drain-settled! frame-id router db-before depth)
-            ::settled)))))
+        ;; Per rf2-nj6p7: per-event epoch boundary. Snapshot this event's
+        ;; OWN db-before, run it to completion, snapshot its db-after, and
+        ;; settle its epoch — before the next event is dequeued.
+        (let [db-before (frame/frame-app-db-value frame-id)]
+          (process-event! envelope)
+          (let [db-after (frame/frame-app-db-value frame-id)]
+            (settle-event-epoch! frame-id db-before db-after))
+          (recur (inc depth) (:event envelope)))
+        ::settled))))
 
 (defn- force-release-on-halt!
   "Release the drain-lock after a `::halt` outcome. The depth-exceeded
@@ -1196,8 +1242,10 @@
 
   Outer loop re-enters whenever `try-release-on-empty!` reports a
   submitter raced in between the inner empty-check and the lock-protected
-  release window. Each pass takes a fresh `db-before` snapshot so the
-  epoch settle callback sees the right pre-cascade state for that pass."
+  release window. Each pass snapshots a frame-level `db-before` that the
+  destroy-interrupt path uses as a fallback; per-event epoch snapshots
+  (rf2-nj6p7) are taken inside `run-one-pass!` per dequeued event, not
+  here."
   [frame-id router drain-lock drain-depth]
   (loop []
     (let [db-before (frame/frame-app-db-value frame-id)

--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -136,18 +136,20 @@
         (is (false? (:scheduled? @router))
             ":scheduled? is reset so future dispatches re-engage drain")))))
 
-(deftest drain-depth-exceeded-rolls-back-app-db
-  ;; Spec 002 §Run-to-completion §Rules rule 3 (atomic rollback): when
-  ;; the drain trips its depth limit, the runtime restores app-db to
-  ;; its pre-drain snapshot before emitting :rf.error/drain-depth-
-  ;; exceeded. Partial writes from the failed cascade are reverted —
-  ;; no caller observes a state no single completed event would
-  ;; produce. Discovered via rf2-8hi7.
-  (testing "a 4-deep chain that overflows leaves :db at the pre-drain value"
-    ;; Frame seeded via :on-create so the pre-drain snapshot is non-empty.
-    ;; If rollback regressed (partial writes preserved), :step would
-    ;; advance to whatever the bound caught — the assertion would fail
-    ;; loudly with the depth count so the regression is obvious.
+(deftest drain-depth-exceeded-keeps-durable-per-event-writes
+  ;; Per rf2-u6jsj/rf2-nj6p7 (Spec 002 §Drain versus event — the epoch
+  ;; unit): the epoch boundary is the dequeued EVENT, so each event that
+  ;; ran before the depth limit tripped settled its own durable epoch AND
+  ;; its own db write. There is NO whole-drain rollback under per-event
+  ;; epochs — each settled event is independently atomic. The depth limit
+  ;; stops the NEXT (halting) event; the work that already ran survives.
+  ;;
+  ;; SUPERSEDES the pre-rf2-u6jsj per-drain atomic-rollback behaviour
+  ;; (Spec 002 rule 3's "restore app-db to its pre-drain snapshot"), which
+  ;; was written for the per-drain epoch model. Rule 3 needs tightening to
+  ;; the per-event boundary — see rf2-nj6p7.
+  (testing "a chain that overflows leaves :db with the durable per-event writes"
+    ;; Frame seeded via :on-create so the baseline is non-empty.
     (rf/reg-event-db :seed/init
       (fn [_ _] {:step :pre-drain :counter 0}))
     (rf/reg-frame :drain.rollback/main
@@ -155,21 +157,23 @@
        :drain-depth 4})
     (let [traces (atom [])]
       (rf/register-listener! ::rollback (fn [ev] (swap! traces conj ev)))
-      ;; A handler that COMMITS a :db write (advancing :step and bumping
-      ;; :counter) AND re-dispatches itself. Without rollback, the final
-      ;; :db carries the partial writes from depth-1..depth-4. With
-      ;; rollback, the final :db is exactly what :seed/init produced.
+      ;; A handler that COMMITS a :db write (advancing :step, bumping
+      ;; :counter) AND re-dispatches itself. Each iteration is its own
+      ;; dequeued event = its own durable epoch + db write. After the
+      ;; 4-event limit, :counter == 4 and :step == :mid-drain survive.
       (rf/reg-event-fx :overflow
         (fn [{:keys [db]} _]
           {:db {:step :mid-drain :counter (inc (:counter db 0))}
            :fx [[:dispatch [:overflow]]]}))
       (rf/dispatch-sync [:overflow] {:frame :drain.rollback/main})
       (rf/unregister-listener! ::rollback)
-      ;; Atomic rollback: app-db is exactly what :seed/init produced.
-      (is (= {:step :pre-drain :counter 0}
+      ;; Per-event durability: the four completed events' writes survive —
+      ;; NO whole-drain rollback.
+      (is (= {:step :mid-drain :counter 4}
              (rf/get-frame-db :drain.rollback/main))
-          "app-db is restored to the pre-drain snapshot; partial writes are reverted")
-      ;; Sanity: the depth-exceeded trace did fire and tags :rollback? true.
+          "the durable per-event writes survive; there is no whole-drain rollback")
+      ;; Sanity: the depth-exceeded trace fired and tags :rollback? false
+      ;; (no rollback under per-event epochs).
       (let [hit (some (fn [ev]
                         (when (= :rf.error/drain-depth-exceeded
                                  (:operation ev))
@@ -177,36 +181,34 @@
                       @traces)]
         (is (some? hit) "drain-depth-exceeded trace was emitted")
         (when hit
-          (is (true? (get-in hit [:tags :rollback?]))
-              ":rollback? true tag flags the atomic rollback per Spec 002")))))
+          (is (false? (get-in hit [:tags :rollback?]))
+              ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback")))))
 
-  (testing "rollback target is the snapshot at drain entry, not :on-create"
-    ;; A drain that has already settled cleanly once and then is re-
-    ;; engaged with a self-dispatching event must roll back to the
-    ;; *post-first-drain* state, not all the way back to :on-create.
-    ;; This pins the contract: rollback boundary is the drain, not the
-    ;; lifetime of the frame.
-    (rf/reg-event-db :seed2/init (fn [_ _] {:phase :seeded}))
+  (testing "earlier clean drains stay durable; an overflow keeps prior-event writes"
+    ;; A drain that has already settled cleanly once, then is re-engaged
+    ;; with a self-dispatching event: the earlier clean drain stays
+    ;; durable AND the overflow drain's own per-event writes stay durable
+    ;; (no rollback).
+    (rf/reg-event-db :seed2/init (fn [_ _] {:phase :seeded :n 0}))
     (rf/reg-frame :drain.rollback/two
       {:on-create   [:seed2/init]
        :drain-depth 3})
-    ;; First drain: a clean settle that mutates :phase. After this, the
-    ;; pre-drain snapshot for any FUTURE drain is {:phase :first-settled}.
+    ;; First drain: a clean settle that mutates :phase.
     (rf/reg-event-db :advance (fn [db _] (assoc db :phase :first-settled)))
     (rf/dispatch-sync [:advance] {:frame :drain.rollback/two})
-    (is (= {:phase :first-settled}
+    (is (= {:phase :first-settled :n 0}
            (rf/get-frame-db :drain.rollback/two))
         "first drain settled cleanly; that's the new baseline")
-    ;; Second drain: trip the depth limit. Rollback target is the
-    ;; baseline above, not :seed2/init's output.
+    ;; Second drain: trip the depth limit. Per rf2-nj6p7 the three events
+    ;; that ran each made a durable :n write — no rollback.
     (rf/reg-event-fx :overflow2
-      (fn [_ _]
-        {:db {:phase :poisoned}
+      (fn [{:keys [db]} _]
+        {:db (assoc db :phase :poisoned :n (inc (:n db 0)))
          :fx [[:dispatch [:overflow2]]]}))
     (rf/dispatch-sync [:overflow2] {:frame :drain.rollback/two})
-    (is (= {:phase :first-settled}
+    (is (= {:phase :poisoned :n 3}
            (rf/get-frame-db :drain.rollback/two))
-        "rollback restored the *drain-entry* snapshot, not :on-create's output")))
+        "the overflow drain's per-event writes are durable — no whole-drain rollback")))
 
 ;; ---- 3. dispatch-sync-in-handler ------------------------------------------
 
@@ -403,11 +405,13 @@
 
 ;; ---- rf2-6guf: drain-depth-exceeded preserves OTHER frames' app-db --------
 ;;
-;; Per test-coverage-review-2026-05-12 P3-25: the existing
-;; `drain-depth-exceeded-rolls-back-app-db` only exercises :rf/default. The
-;; broader contract is "rollback is scoped to the FRAME that exceeded the
-;; depth — other frames' app-dbs are untouched, and the depth-exceeded
-;; trace carries the right frame id".
+;; Per test-coverage-review-2026-05-12 P3-25: the companion
+;; `drain-depth-exceeded-keeps-durable-per-event-writes` only exercises
+;; :rf/default. The broader contract is "a depth-exceed is scoped to the
+;; FRAME that overflowed — other frames' app-dbs are untouched, and the
+;; depth-exceeded trace carries the right frame id". Per rf2-nj6p7
+;; (per-event epochs) the overflowing frame keeps its durable per-event
+;; writes (no whole-drain rollback); the isolation contract is unchanged.
 
 (deftest drain-depth-exceeded-isolated-to-the-overflowing-frame
   (testing "depth-exceed on frame :B rolls back :B's app-db only; :A's
@@ -438,14 +442,16 @@
                 :marker  :mid-cascade}
            :fx [[:dispatch [:loop/B]]]}))
 
-      ;; Dispatch the loop on :B. This trips the drain-depth limit; :B's
-      ;; app-db rolls back to the pre-drain snapshot.
+      ;; Dispatch the loop on :B. This trips :B's drain-depth limit. Per
+      ;; rf2-nj6p7 (per-event epochs) :B's completed events keep their
+      ;; durable writes — no whole-drain rollback — but the cascade stays
+      ;; isolated to :B; :A is untouched.
       (rf/dispatch-sync [:loop/B] {:frame :drain.iso/B})
 
-      ;; --- (a) :B's app-db is rolled back to its :on-create state.
-      (is (= {:where :B :counter 0 :marker :pristine}
+      ;; --- (a) :B's per-event writes are durable (4 events ran).
+      (is (= {:where :B :counter 4 :marker :mid-cascade}
              (rf/get-frame-db :drain.iso/B))
-          ":B's app-db is rolled back to the pre-drain snapshot")
+          ":B's durable per-event writes survive; no whole-drain rollback")
 
       ;; --- (b) :A's app-db is byte-identical to its pre-dispatch state.
       (is (= a-pre (rf/get-frame-db :drain.iso/A))
@@ -463,8 +469,8 @@
         (is (some? hit) "drain-depth-exceeded trace was emitted")
         (is (= :drain.iso/B (get-in hit [:tags :frame]))
             "the trace's :frame tag is :B (the overflowing frame), not :A")
-        (is (true? (get-in hit [:tags :rollback?]))
-            ":rollback? true tag flags the atomic rollback"))
+        (is (false? (get-in hit [:tags :rollback?]))
+            ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback"))
 
       (rf/unregister-listener! ::iso))))
 

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -2,8 +2,13 @@
   "Per-frame epoch history. Per Tool-Pair §Time-travel and Spec-Schemas
   §`:rf/epoch-record`.
 
-  Every event-cascade settle (drain reaching empty queue) marks an epoch
-  boundary. The runtime records, per frame, an `:rf/epoch-record` with:
+  Every DEQUEUED EVENT's run-to-completion marks an epoch boundary — one
+  `:rf/epoch-record` per event, NOT per drain (per Spec 002 §Drain versus
+  event, rf2-u6jsj/rf2-nj6p7). A drain that processes a parent event and
+  the `:fx [[:dispatch …]]` child it queued commits TWO records. A machine
+  macrostep (`:raise` / `:always` microsteps) runs inside one event and
+  stays ONE epoch. The runtime records, per frame, an `:rf/epoch-record`
+  with:
 
     :epoch-id       opaque, unique within a frame's history
     :frame          frame keyword
@@ -250,15 +255,85 @@
 ;; `find-trigger-event`) live in `re-frame.epoch.capture` (Phase-2
 ;; seam B, rf2-0wi86).
 
-;; ---- drain-settle hook ----------------------------------------------------
+;; ---- per-event settle hook ------------------------------------------------
+
+(defn- commit-record!
+  "Build, redact, ring-append, and fan out one `:rf/epoch-record`. Shared
+  by the per-event clean settle (`settle!`) and the per-event halt commit
+  (`commit-halt-record!`). `events` is the harvested cascade buffer (may
+  be empty for a halt whose event never ran); `trigger-event` is an
+  explicit `[event-id …]` vector to pin the record's trigger when the
+  buffer carries no `:event/run-start` (the depth-exceed halting event,
+  per rf2-nj6p7), or nil to let `build-record` derive the trigger from
+  the buffer (the normal `:ok` path)."
+  [frame-id db-before db-after events outcome halt-reason trigger-event]
+  ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook:
+  ;; `maybe-redact` runs ONCE per record between `build-record` and
+  ;; ring-append / listener fan-out so the ring and listeners see the
+  ;; SAME redacted shape. The `:rf.epoch/sensitive?` rollup inside
+  ;; `build-record` runs FIRST — the rollup reflects raw signals even
+  ;; when the redact-fn erases the leaves it keyed on.
+  (let [base   (assembly/build-record frame-id db-before db-after
+                                      events outcome halt-reason)
+        ;; Pin the explicit trigger when supplied AND the buffer didn't
+        ;; already resolve one (the halting event never ran, so no
+        ;; `:event/run-start` was buffered). Per Spec-Schemas
+        ;; §:rf/epoch-record the slots are :keyword / vector — never nil.
+        base   (cond-> base
+                 (and trigger-event (not (:event-id base)))
+                 (assoc :event-id      (first trigger-event)
+                        :trigger-event trigger-event))
+        record (assembly/maybe-redact base)]
+    (state/record! record)
+    ;; Per rf2-qs6dl: mark this as the frame's most-recently-settled
+    ;; epoch so post-settle async render emits (which fire at React
+    ;; commit time, after this event settled) are attributed back to
+    ;; THIS event rather than buffered into the next one. Set after
+    ;; `record!` so the record is in the ring before any render can
+    ;; back-fill into it.
+    (state/set-last-settled-epoch! frame-id (:epoch-id record))
+    ;; Per rf2-931pm — focused-event-only cascade-DAG capture. Sticky
+    ;; hook (rf2-f72pd) published by `re-frame.trace.cascade` at ns-load;
+    ;; when the trace.cascade ns has not been loaded (e.g. tooling-
+    ;; stripped JVM consumers) the lookup returns nil and the call
+    ;; short-circuits. The aggregator's own focus-predicate gate decides
+    ;; whether to emit `:rf.cascade/captured` — off-focus epochs pay just
+    ;; the predicate call (default predicate returns false).
+    (when-let [capture (late-bind/get-fn-cached
+                         :trace.cascade/capture-for-epoch!)]
+      (try
+        (capture frame-id (:epoch-id record) (:event-id record) events)
+        (catch #?(:clj Throwable :cljs :default) _ nil)))
+    (trace/emit! :rf.epoch :rf.epoch/snapshotted
+                 {:frame    frame-id
+                  :epoch-id (:epoch-id record)
+                  :event-id (:event-id record)
+                  :outcome  outcome})
+    (listeners/notify-listeners! record)
+    record))
 
 (defn settle!
-  "Hook called by the router on every drain boundary — clean settle AND
-  halts. Per Tool-Pair §Time-travel and rf2-v0jwt §Outcomes.
+  "Hook called by the router once per DEQUEUED EVENT — at each event's
+  run-to-completion boundary, NOT once per drain. Per Spec 002
+  §Drain versus event — the epoch unit (rf2-u6jsj/rf2-nj6p7) and
+  Tool-Pair §Time-travel and rf2-v0jwt §Outcomes.
+
+  Per rf2-nj6p7: the epoch boundary is the dequeued event, not the
+  drain-settle. A drain that processes a parent event and an
+  `:fx [[:dispatch …]]` child it queued therefore produces TWO records
+  (one per event), each with its OWN `:db-before` / `:db-after` snapshot
+  pair and its own harvested trace buffer. The router calls this after
+  each `process-event!` returns, so the capture buffer it harvests holds
+  exactly that one event's six-domino cascade (within a frame, execution
+  is single-threaded run-to-completion, so the buffer is cleanly the
+  in-flight event's). A machine macrostep — `:raise` sub-events and
+  `:always` microsteps — runs INSIDE a single `process-event!`, so its
+  emits ride the triggering event's buffer and settle as ONE epoch (per
+  Spec 005 §macrostep); they do not allocate a new epoch.
 
   Arities:
     (settle! frame-id db-before db-after)
-      Clean drain-settle. `:outcome` is `:ok`. Equivalent to passing
+      Clean per-event settle. `:outcome` is `:ok`. Equivalent to passing
       `:ok` as `outcome` explicitly. Skips recording when the captured
       buffer is empty (a truly empty cascade — likely a rejected
       dispatch — is degenerate and would emit a misleading record).
@@ -292,56 +367,52 @@
    (settle! frame-id db-before db-after :ok nil))
   ([frame-id db-before db-after outcome halt-reason]
    (when interop/debug-enabled?
-     (let [events (state/harvest-buffer! frame-id)]
+     ;; Per rf2-nj6p7: scoped harvest — take only the settling event's
+     ;; traces (its `:dispatch-id` + pre-cascade tagalongs), LEAVING any
+     ;; child's `:event/dispatched` marker (emitted during THIS event's
+     ;; do-fx, carrying the child's id) in the buffer for the child's own
+     ;; settle. Keeps each epoch's `:trace-events` to one `:dispatch-id`
+     ;; (Spec 009 §Dispatch correlation: one dispatch-id = one epoch).
+     (let [events (state/harvest-buffer-for-event! frame-id)]
        ;; Empty-buffer policy (consistent across outcomes): an empty
        ;; capture buffer means no cascade context was recorded for
-       ;; this frame — skip emission rather than commit a record with
-       ;; no :event-id / :trigger-event. For halt outcomes, the
-       ;; cooperating seam (e.g. on-frame-destroyed harvesting events
-       ;; in the mid-drain-destroy path) emits the partial record;
-       ;; this seam fires when a router-only halt path (e.g. depth-
-       ;; exceeded with an in-flight cascade) holds the events.
+       ;; this event — skip emission rather than commit a record with
+       ;; no :event-id / :trigger-event. A rejected/aborted dispatch
+       ;; (no `:event/run-start` ever fired) reaches this seam with an
+       ;; empty buffer and is correctly suppressed. Halt paths whose
+       ;; halting event never ran (the per-event depth-exceed boundary,
+       ;; per rf2-nj6p7) use `commit-halt-record!` instead, which
+       ;; synthesises the halting event's trigger explicitly.
        (when (seq events)
-         ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook:
-         ;; `maybe-redact` runs ONCE per record between
-         ;; `build-record` and ring-append / listener fan-out so the
-         ;; ring and listeners see the SAME redacted shape. The
-         ;; `:rf.epoch/sensitive?` rollup inside `build-record` runs
-         ;; FIRST — the rollup reflects raw signals even when the
-         ;; redact-fn erases the leaves it keyed on.
-         (let [record (assembly/maybe-redact
-                        (assembly/build-record frame-id db-before db-after
-                                               events outcome halt-reason))]
-           (state/record! record)
-           ;; Per rf2-qs6dl: mark this as the frame's most-recently-
-           ;; settled epoch so post-settle async render emits (which
-           ;; fire at React commit time, after this cascade settled) are
-           ;; attributed back to THIS cascade rather than buffered into
-           ;; the next one. Set after `record!` so the record is in the
-           ;; ring before any render can back-fill into it.
-           (state/set-last-settled-epoch! frame-id (:epoch-id record))
-           ;; Per rf2-931pm — focused-event-only cascade-DAG capture.
-           ;; Sticky hook (rf2-f72pd) published by `re-frame.trace.cascade`
-           ;; at ns-load; when the trace.cascade ns has not been loaded
-           ;; (e.g. tooling-stripped JVM consumers) the lookup returns
-           ;; nil and the call short-circuits. The aggregator's own
-           ;; focus-predicate gate decides whether to emit
-           ;; `:rf.cascade/captured` — off-focus epochs pay just the
-           ;; predicate call (default predicate returns false).
-           (when-let [capture (late-bind/get-fn-cached
-                                :trace.cascade/capture-for-epoch!)]
-             (try
-               (capture frame-id
-                        (:epoch-id record)
-                        (:event-id record)
-                        events)
-               (catch #?(:clj Throwable :cljs :default) _ nil)))
-           (trace/emit! :rf.epoch :rf.epoch/snapshotted
-                        {:frame    frame-id
-                         :epoch-id (:epoch-id record)
-                         :event-id (:event-id record)
-                         :outcome  outcome})
-           (listeners/notify-listeners! record)))))))
+         (commit-record! frame-id db-before db-after events outcome
+                         halt-reason nil))))))
+
+(defn commit-halt-record!
+  "Commit a `:halted-*` epoch record for a drain halt whose halting event
+  never ran to completion — the per-event depth-exceed boundary
+  (rf2-nj6p7). Unlike `settle!`, this does NOT skip on an empty capture
+  buffer: under per-event epochs the events that ALREADY ran each
+  harvested their own buffer and committed their own `:ok` epoch, so the
+  buffer is empty when the depth limit trips. The halting event (the next
+  one that would have been dequeued) never ran, so it has no cascade
+  trace; this seam synthesises its `:halted-depth` record from the
+  explicit `trigger-event` so devtools (Causa, re-frame2-pair) get a
+  clear 'drain halted here' marker following the runaway `:ok` epochs.
+
+  `db-before` / `db-after` are equal — the halting event made no db write
+  (it never ran). Per rf2-nj6p7 the already-settled sibling events are
+  DURABLE (their `:ok` epochs and db writes survive); there is no
+  whole-drain rollback under per-event epochs — see the router's
+  `handle-depth-exceeded!` and the report note on the rule-3 reconcile.
+
+  Harvests-and-clears any residual buffer first so a stray pre-halt emit
+  (there should be none under per-event settling) can't leak into the
+  next cascade for this frame."
+  [frame-id db-before db-after outcome halt-reason trigger-event]
+  (when interop/debug-enabled?
+    (let [events (state/harvest-buffer! frame-id)]
+      (commit-record! frame-id db-before db-after events outcome
+                      halt-reason trigger-event))))
 
 (defn- discard-buffer!
   "Drop the in-flight capture buffer for frame-id WITHOUT committing a
@@ -547,6 +618,10 @@
 ;; rather than throwing.
 
 (late-bind/set-fn! :epoch/settle!             settle!)
+;; rf2-nj6p7: per-event halt commit — the depth-exceed boundary whose
+;; halting event never ran (so the buffer is empty and `settle!` would
+;; skip). Synthesises the halting event's `:halted-depth` record.
+(late-bind/set-fn! :epoch/commit-halt-record! commit-halt-record!)
 (late-bind/set-fn! :epoch/discard-buffer!     discard-buffer!)
 (late-bind/set-fn! :epoch/capture-event       capture/capture-event!)
 ;; rf2-25zo2: in-flight cascade-cause lookup for :rf.view/rendered. Views

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -6,8 +6,10 @@
   Three responsibilities live here:
 
     1. `build-record`   — produces the record (one allocation per
-                          drain-settle). Delegates the cascade-buffer
-                          walks to `re-frame.epoch.capture`.
+                          DEQUEUED EVENT — per rf2-nj6p7 the epoch
+                          boundary is the event, not the drain).
+                          Delegates the cascade-buffer walks to
+                          `re-frame.epoch.capture`.
     2. `sensitive-rollup` — computes `:rf.epoch/sensitive?` from raw
                           signals (trace-event stamps + schema-declared
                           sensitive paths).
@@ -56,7 +58,7 @@
   — the whole epoch surface shares that gate; this helper carries no
   separate production gate.
 
-  HOT PATH: fires once per drain-settle. Hot-path cost when no fn is
+  HOT PATH: fires once per dequeued event (rf2-nj6p7). Hot-path cost when no fn is
   installed is a single keyword lookup on the config map and an
   identity return."
   [record]
@@ -149,7 +151,7 @@
   recorded db. Returns `false` otherwise (always a strict boolean —
   consumers branch on `(true? ...)` / `(false? ...)`).
 
-  HOT PATH: fires once per drain-settle. `sensitive-paths-for` derefs
+  HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
   the elision registry once; the leaf check short-circuits at the
   first non-nil hit; the trace-event check short-circuits at the first
   stamped event. For the common case (no schema-declared sensitive
@@ -228,7 +230,7 @@
   schema-declared sensitive paths whose value differs between
   `db-before` and `db-after` (per rf2-dl3gx).
 
-  HOT PATH: fires once per drain-settle. `sensitive-paths-for` derefs
+  HOT PATH: fires once per dequeued event (rf2-nj6p7). `sensitive-paths-for` derefs
   the elision registry once and the walk is O(P) where P is the
   declared-sensitive-path count for the frame — typically a small
   constant (apps declare a handful of `[:auth :password]`-shaped

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -576,6 +576,57 @@
     (swap! capture-buffers dissoc frame-id)
     b))
 
+(defn- settling-dispatch-id
+  "The `:dispatch-id` of the event being settled, read off the FIRST
+  `:event/run-start` emit in the buffer. nil when no run-start fired (a
+  rejected / aborted dispatch, or a halt path whose event never ran)."
+  [events]
+  (some (fn [ev]
+          (when (and (= :event (:op-type ev))
+                     (= :event (:operation ev))
+                     (= :run-start (-> ev :tags :phase)))
+            (-> ev :tags :dispatch-id)))
+        events))
+
+(defn harvest-buffer-for-event!
+  "Per rf2-nj6p7 — per-event harvest. Atomically read the frame's in-flight
+  buffer and split it by the settling event's `:dispatch-id`:
+
+    * RETURN the events that belong to the settling event — those whose
+      `:tags :dispatch-id` matches the buffer's first `:event/run-start`
+      id, PLUS any events carrying NO `:dispatch-id` (pre-cascade tagalongs
+      such as a `:frame/created` emit that fired outside any cascade; they
+      ride the first settling event of the drain).
+    * LEAVE in the buffer the events that belong to a DIFFERENT dequeued
+      event — a child's `:event/dispatched` marker fires during the
+      PARENT's do-fx (so it lands in the parent's window) but carries the
+      CHILD's `:dispatch-id`; under per-event epochs it must ride the
+      child's epoch, not the parent's (Spec 009 §Dispatch correlation:
+      one `:dispatch-id` = one epoch). It stays buffered for the child's
+      own `harvest-buffer-for-event!` at the child's settle.
+
+  Falls back to a full read-and-clear when the buffer carries no
+  `:event/run-start` (a rejected / aborted dispatch) — there is no
+  settling id to scope by, and `settle!`'s empty-buffer / no-trigger
+  policy handles the degenerate record."
+  [frame-id]
+  (let [b (get @capture-buffers frame-id [])]
+    (if-let [sid (settling-dispatch-id b)]
+      (let [{mine true theirs false}
+            (group-by (fn [ev]
+                        (let [did (-> ev :tags :dispatch-id)]
+                          (or (nil? did) (= did sid))))
+                      b)]
+        ;; Leave the other-event traces (non-nil, non-matching id) in the
+        ;; buffer for their own event's settle; take ours.
+        (if (seq theirs)
+          (swap! capture-buffers assoc frame-id (vec theirs))
+          (swap! capture-buffers dissoc frame-id))
+        (vec mine))
+      ;; No run-start — rejected/aborted dispatch. Clear and return all.
+      (do (swap! capture-buffers dissoc frame-id)
+          b))))
+
 (defn drop-frame-buffer!
   "Drop the frame's in-flight capture buffer."
   [frame-id]

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -3,8 +3,10 @@
 
   Bead rf2-shjf coverage:
 
-    1. Recording — drain-settle commits a record; multi-event cascades
-       commit one record (not one per event).
+    1. Recording — each DEQUEUED EVENT commits its own record; a
+       multi-event drain (an :fx-dispatched child) commits one record
+       PER EVENT, not one per drain (per rf2-nj6p7 / Spec 002 §Drain
+       versus event).
     2. Per-frame isolation — two frames, each gets its own ring.
     3. Ring depth cap — dispatch >depth events; oldest get evicted.
     4. Configurable depth — `(rf/configure :epoch-history {:depth N})`.
@@ -127,7 +129,10 @@
       (is (vector? (:effects r))))))
 
 (deftest record-multi-event-cascade
-  (testing "a multi-event cascade (run-to-completion) commits ONE record"
+  (testing "per rf2-nj6p7 (Spec 002 §Drain versus event): each dequeued
+            event in a multi-event drain commits its OWN epoch — an
+            :fx [[:dispatch …]] child is a separate dequeued event, so it
+            yields a separate record, NOT folded into the parent's epoch"
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:order []}))
     (rf/reg-event-fx :outer
@@ -139,19 +144,126 @@
     (rf/reg-event-db :inner-2 (fn [db _] (update db :order conj :inner-2)))
 
     (rf/dispatch-sync [:seed]  {:frame :test/main})
+    ;; ONE drain: :outer runs, then its two :fx-dispatched children
+    ;; (:inner-1, :inner-2) drain in the same turn — but each is its own
+    ;; dequeued event = its own epoch.
     (rf/dispatch-sync [:outer] {:frame :test/main})
 
-    (let [history (rf/epoch-history :test/main)
-          last-r  (last history)]
-      ;; Two cascades: :seed and :outer (which itself cascades inner-1 / inner-2).
+    (let [history (rf/epoch-history :test/main)]
+      ;; Four dequeued events: :seed (own drain), then :outer + :inner-1 +
+      ;; :inner-2 (one drain, three epochs).
+      (is (= 4 (count history))
+          "one epoch per dequeued event — the :fx-dispatched children are
+           NOT folded into :outer's epoch")
+      (is (= [:seed :outer :inner-1 :inner-2]
+             (mapv :event-id history))
+          "epochs land in dequeue order, oldest-first")
+      ;; Each event's db-before / db-after chains from the previous —
+      ;; per-event run-to-completion snapshots.
+      (is (= [{:order []}
+              {:order [:outer]}
+              {:order [:outer :inner-1]}]
+             (mapv :db-before (rest history)))
+          ":db-before of :outer / :inner-1 / :inner-2 chains per event")
+      (is (= [{:order [:outer]}
+              {:order [:outer :inner-1]}
+              {:order [:outer :inner-1 :inner-2]}]
+             (mapv :db-after (rest history)))
+          ":db-after of :outer / :inner-1 / :inner-2 chains per event")
+      ;; Distinct correlation: each epoch has its own :epoch-id, and the
+      ;; per-event :dispatch-id rides the trace stream distinctly. Per
+      ;; rf2-nj6p7 + Spec 009 §Dispatch correlation, each epoch's
+      ;; :trace-events carry EXACTLY ONE :dispatch-id (one dispatch-id =
+      ;; one epoch) — a child's :event/dispatched marker (fired during the
+      ;; parent's do-fx) rides the CHILD's epoch, not the parent's.
+      (is (apply distinct? (mapv :epoch-id history))
+          "every dequeued event gets a distinct :epoch-id")
+      (let [dispatch-ids-of
+            (fn [r] (->> (:trace-events r)
+                         (keep #(-> % :tags :dispatch-id))
+                         distinct))
+            outer-dids  (dispatch-ids-of (nth history 1))
+            inner1-dids (dispatch-ids-of (nth history 2))]
+        (is (= 1 (count outer-dids))
+            ":outer epoch's traces carry exactly ONE :dispatch-id — the
+             child's :event/dispatched marker does NOT leak in")
+        (is (= 1 (count inner1-dids))
+            ":inner-1 epoch's traces carry exactly ONE :dispatch-id")
+        (is (not= (first outer-dids) (first inner1-dids))
+            "parent and :fx-dispatched child have DISTINCT :dispatch-ids
+             — the child is a separate dequeued event / epoch")))))
+
+(deftest on-create-event-is-its-own-epoch
+  (testing "per rf2-nj6p7 (Spec 002 §Drain versus event): the frame-creation
+            :on-create event is itself a dequeued event, so it commits its
+            OWN epoch — distinct from any later user dispatch's epoch"
+    (rf/reg-event-db :app/init (fn [_ _] {:booted true :n 0}))
+    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    ;; reg-frame dispatch-syncs the :on-create event at registration.
+    (rf/reg-frame :test/main {:on-create [:app/init]})
+
+    (let [after-create (rf/epoch-history :test/main)]
+      (is (= 1 (count after-create))
+          "the :on-create cascade settled its own epoch at reg-frame time")
+      (let [r (first after-create)]
+        (is (= :app/init (:event-id r))
+            "the :on-create event is the trigger of its own epoch")
+        (is (= {} (:db-before r)))
+        (is (= {:booted true :n 0} (:db-after r))
+            ":on-create's epoch carries its own db-before / db-after pair")))
+
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
       (is (= 2 (count history))
-          "the entire :outer cascade is one epoch, not three")
-      (is (= :outer (:event-id last-r))
-          "the outer event is the trigger of the cascade")
-      (is (= {:order []}
-             (:db-before last-r)))
-      (is (= {:order [:outer :inner-1 :inner-2]}
-             (:db-after last-r))))))
+          ":on-create epoch (pos 0) + the user :inc epoch (pos 1)")
+      (is (= [:app/init :inc] (mapv :event-id history))
+          ":on-create and the user dispatch are SEPARATE epochs")
+      (is (apply distinct? (mapv :epoch-id history))
+          "each has its own :epoch-id"))))
+
+;; ---- machine macrostep stays ONE epoch (rf2-nj6p7) ------------------------
+
+(deftest machine-raise-macrostep-is-one-epoch
+  (testing "per rf2-nj6p7 + Spec 005 §macrostep: a machine's :raise sub-events
+            are in-memory microsteps inside a SINGLE macrostep — they ride
+            the TRIGGERING event's epoch and do NOT allocate new epochs.
+            Only separately-dequeued events get their own epoch."
+    (rf/reg-frame :test/main {})
+    ;; A 2-deep :raise chain: one [:e1] dispatch drives three transitions
+    ;; (s0 → s1 → s2 → s3) in one macrostep via two pre-commit :raises.
+    (rf/reg-machine :mac/chain
+      {:initial :s0
+       :actions {:a1 (fn [_] {:fx [[:raise [:e2]]]})
+                 :a2 (fn [_] {:fx [[:raise [:e3]]]})
+                 :a3 (fn [_] {})}
+       :states  {:s0 {:on {:e1 {:target :s1 :action :a1}}}
+                 :s1 {:on {:e2 {:target :s2 :action :a2}}}
+                 :s2 {:on {:e3 {:target :s3 :action :a3}}}
+                 :s3 {}}})
+
+    (rf/dispatch-sync [:mac/chain [:e1]] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
+      ;; ONE dequeued event ([:mac/chain [:e1]]) → ONE epoch, even though
+      ;; the macrostep ran three transitions via two :raises.
+      (is (= 1 (count history))
+          "the whole :raise chain rides ONE epoch — :raises are microsteps,
+           not separate dequeued events")
+      (let [r (first history)]
+        (is (= :mac/chain (:event-id r))
+            "the triggering machine event is the epoch's trigger")
+        (is (= :s3 (:state (get-in (:db-after r) [:rf/machines :mac/chain])))
+            "the macrostep reached the terminal state — all three
+             transitions committed inside this one epoch")
+        ;; Every trace in the epoch rides the SAME :dispatch-id — the
+        ;; :raises did NOT mint a new correlation id (Spec 009).
+        (let [dispatch-ids (->> (:trace-events r)
+                                (keep #(-> % :tags :dispatch-id))
+                                distinct)]
+          (is (= 1 (count dispatch-ids))
+              "the macrostep's emits (incl. raised transitions) all carry
+               the triggering event's single :dispatch-id"))))))
 
 ;; ---- per-frame isolation ---------------------------------------------------
 
@@ -817,11 +929,15 @@
     (rf/dispatch-sync [:seed]  {:frame :test/main})
     (rf/dispatch-sync [:outer] {:frame :test/main})
 
-    (let [r       (last (rf/epoch-history :test/main))
+    ;; Per rf2-nj6p7: per-event epochs — the two `:dispatch` fx fire
+    ;; during :outer's own do-fx, so they project onto :outer's record
+    ;; (NOT the last record, which is now the second :inc child epoch).
+    (let [history (rf/epoch-history :test/main)
+          r       (first (filter #(= :outer (:event-id %)) history))
           effects (:effects r)
           dispatches (filterv #(= :dispatch (:fx-id %)) effects)]
       (is (= 2 (count dispatches))
-          "two :dispatch fx → two :effects entries")
+          "two :dispatch fx → two :effects entries on the :outer epoch")
       (is (every? #(= :ok (:outcome %)) dispatches)))))
 
 (deftest effects-projection-one-entry-per-fx
@@ -854,39 +970,53 @@
 ;; ---- partial-drain semantics (rf2-v0jwt) ---------------------------------
 
 (deftest depth-exceeded-commits-halted-record
-  (testing "a depth-exceeded drain commits a :halted-depth epoch record so
-            devtools (Causa, re-frame2-pair) receive cascade context for
-            the failing cascade. :db-after equals :db-before (atomic
-            rollback per Spec 002 §Run-to-completion §Rules rule 3) and
-            :halt-reason carries the depth-exceeded descriptor."
+  (testing "per rf2-nj6p7 (per-event epochs): a depth-exceeded drain leaves
+            the events that already ran as DURABLE :ok epochs (no whole-
+            drain rollback — each settled event is independently atomic),
+            and commits a single trailing :halted-depth record marking the
+            halt boundary. The halting event (next in queue) never ran, so
+            its record's :db-before / :db-after both equal the durable
+            last-settled db. NOTE: this changes Spec 002 rule 3's pre-
+            rf2-u6jsj whole-drain-rollback semantics — see report."
     (rf/reg-frame :test/main {:drain-depth 5})
     (rf/reg-event-fx :loop
-      (fn [_ _] {:fx [[:dispatch [:loop]]]}))
+      (fn [{:keys [db]} _]
+        {:db (update (or db {}) :n (fnil inc 0))
+         :fx [[:dispatch [:loop]]]}))
 
     (rf/dispatch-sync [:loop] {:frame :test/main})
 
     (let [history (rf/epoch-history :test/main)]
-      (is (= 1 (count history))
-          "exactly one halted-cascade record committed")
-      (let [r (first history)]
+      ;; Five :loop events ran (the depth limit), each a durable :ok
+      ;; epoch, then a trailing :halted-depth marker.
+      (is (= 6 (count history))
+          "five durable :ok epochs + one trailing :halted-depth marker")
+      (is (= (repeat 5 :ok) (mapv :outcome (take 5 history)))
+          "the events that ran are durable :ok epochs — NOT rolled back")
+      (is (= {:n 5} (:db-after (nth history 4)))
+          "the durable db reflects the five completed events' writes")
+      (let [r (last history)]
         (is (= :halted-depth (:outcome r))
-            ":outcome :halted-depth pins the depth-exceed path")
-        (is (= (:db-before r) (:db-after r))
-            ":db-after equals :db-before — atomic rollback semantics")
+            "the trailing record pins the depth-exceed halt boundary")
+        (is (= {:n 5} (:db-before r) (:db-after r))
+            "the halting event never ran — :db-before = :db-after = the
+             durable last-settled db (no rollback)")
         (is (= :rf.error/drain-depth-exceeded
                (-> r :halt-reason :operation))
             ":halt-reason carries the structured halt descriptor")
         (is (= 5 (-> r :halt-reason :depth))
             ":halt-reason carries the depth at which the drain tripped")
         (is (= :loop (:event-id r))
-            "the cascade's trigger-event survives in the partial record")
-        (is (seq (:trace-events r))
-            "the partial record carries the cascade's trace events
-             so devtools can render the cascade-up-to-halt")))))
+            "the halting event's trigger pins the :halted-depth record")
+        (is (= [:loop] (:trigger-event r))
+            "the synthesised trigger-event is the halting event vector")))))
 
 (deftest halted-record-fires-listeners
   (testing "register-epoch-listener! listeners receive halted records too —
-            devtools route off :outcome to render failure shapes"
+            devtools route off :outcome to render failure shapes. Per
+            rf2-nj6p7 (per-event epochs) the listener observes each durable
+            :ok event epoch as it settles, then the trailing :halted-depth
+            marker."
     (rf/reg-frame :test/main {:drain-depth 5})
     (rf/reg-event-fx :loop
       (fn [_ _] {:fx [[:dispatch [:loop]]]}))
@@ -896,10 +1026,13 @@
                              (fn [record] (swap! received conj record)))
       (rf/dispatch-sync [:loop] {:frame :test/main})
 
-      (is (= 1 (count @received))
-          "exactly one record delivered to the listener")
-      (is (= :halted-depth (:outcome (first @received)))
-          "listener observed the :halted-depth outcome"))))
+      (is (= 6 (count @received))
+          "five durable :ok records + the trailing :halted-depth marker
+           delivered to the listener")
+      (is (= (repeat 5 :ok) (mapv :outcome (take 5 @received)))
+          "the events that ran surface as durable :ok records")
+      (is (= :halted-depth (:outcome (last @received)))
+          "listener observed the trailing :halted-depth outcome"))))
 
 (deftest restore-non-ok-record-refused
   (testing "restore-epoch refuses non-:ok records — halted records are
@@ -913,12 +1046,14 @@
     ;; Drive the halted cascade to land a non-:ok record in history.
     (rf/dispatch-sync [:loop] {:frame :test/main})
 
+    ;; Per rf2-nj6p7: per-event epochs — the :halted-depth marker is the
+    ;; trailing record (the durable :ok event epochs precede it).
     (let [history     (rf/epoch-history :test/main)
-          halted      (first history)
+          halted      (last history)
           recorded    (record-trace!)
           result      (rf/restore-epoch :test/main (:epoch-id halted))]
       (is (= :halted-depth (:outcome halted))
-          "sanity — the only record in history is the halted one")
+          "sanity — the trailing record in history is the halted one")
       (is (false? result)
           "restore-epoch returned false — refusal is observable to callers")
       (is (has-error-op? @recorded :rf.epoch/restore-non-ok-record)

--- a/spec/conformance/fixtures/drain-depth-limit.edn
+++ b/spec/conformance/fixtures/drain-depth-limit.edn
@@ -1,25 +1,33 @@
 ;; Conformance fixture: drain/depth-limit
 ;; Exercises the drain-depth-exceeded error. A handler that recursively
-;; dispatches itself triggers the configured drain depth limit. Per
-;; Spec 002 §Run-to-completion §Rules rule 3, the runtime restores
-;; app-db to its pre-drain snapshot when the limit trips — the partial
-;; writes from the cascade are NOT preserved.
+;; dispatches itself triggers the configured drain depth limit.
 ;;
-;; Per rf2-v0jwt (§Outcomes): the runtime ALSO commits a partial
-;; :rf/epoch-record with :outcome :halted-depth so devtools (Causa,
-;; re-frame2-pair) receive cascade context for the failing cascade.
-;; :db-after equals :db-before (atomic rollback) and :halt-reason
-;; carries the structured halt descriptor. The fixture's
-;; :epoch-records assertion pins the partial-record shape.
+;; Per rf2-u6jsj/rf2-nj6p7 (Spec 002 §Drain versus event — the epoch
+;; unit): the epoch boundary is the dequeued EVENT, not the drain, so the
+;; runaway events that already ran each settled their OWN durable :ok
+;; epoch (and their own db write) before the limit tripped. There is NO
+;; whole-drain rollback under per-event epochs — each settled event is
+;; independently atomic. The depth limit stops the NEXT (halting) event;
+;; the runtime commits a trailing :halted-depth :rf/epoch-record for it
+;; (rf2-v0jwt §Outcomes) so devtools (Causa, re-frame2-pair) get a clear
+;; "drain halted here" marker following the durable :ok epochs. The
+;; halting event never ran, so its record's :db-before / :db-after both
+;; equal the durable last-settled db.
+;;
+;; SUPERSEDES the pre-rf2-u6jsj per-drain rollback semantics (Spec 002
+;; rule 3's "restore app-db to its pre-drain snapshot" / "epoch history
+;; records nothing for the failed drain"), which was written for the
+;; per-drain epoch model. Rule 3 needs tightening to the per-event
+;; boundary — see rf2-nj6p7.
 
 {:fixture/id           :drain/depth-limit
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/error :core/trace}
- :fixture/doc          "A handler that always dispatches itself recursively. Drain hits the configured depth limit and emits :rf.error/drain-depth-exceeded. The runtime rolls app-db back to the pre-drain snapshot (atomic rollback per Spec 002 rule 3) AND commits a :halted-depth partial :rf/epoch-record (rf2-v0jwt §Outcomes) so devtools receive cascade context for the failing cascade."
+ :fixture/doc          "A handler that always dispatches itself recursively. Drain hits the configured depth limit and emits :rf.error/drain-depth-exceeded. Per rf2-u6jsj/rf2-nj6p7 (per-event epochs) the events that already ran are DURABLE :ok epochs (no whole-drain rollback); the runtime commits a trailing :halted-depth :rf/epoch-record for the halting event (which never ran) so devtools receive a halt marker."
 
  :fixture/registry
  {:event {:recursive {:doc "Always dispatches itself."}}
-  :sub   {:depth {:doc "How many times the handler ran (rolled back on overflow)."}}}
+  :sub   {:depth {:doc "How many times the handler ran (durable per-event writes)."}}}
 
  :fixture/handlers
  {:event {:recursive [[:update [:depth] [:fn :inc]]
@@ -33,11 +41,11 @@
  [[:recursive]]
 
  :fixture/expect
- {;; The handler ran 5 times (the depth limit) before the runtime aborted.
-  ;; Then app-db was rolled back to the pre-drain snapshot ({} since the
-  ;; frame had no :on-create event seeding state). Per Spec 002 rule 3 —
-  ;; partial writes from a failed cascade do not survive.
-  :final-app-db {}
+ {;; The handler ran 5 times (the depth limit) before the runtime stopped
+  ;; the 6th. Per rf2-nj6p7 each :recursive event settled its own durable
+  ;; epoch + db write — there is NO whole-drain rollback — so the final
+  ;; app-db reflects the five completed writes.
+  :final-app-db {:depth 5}
 
   :trace-emissions
   [{:operation :event :tags {:event-id :recursive}}
@@ -45,37 +53,47 @@
    {:operation :event :tags {:event-id :recursive}}
    {:operation :event :tags {:event-id :recursive}}
    {:operation :event :tags {:event-id :recursive}}
-   ;; Drain depth exceeded — the 6th attempt is rejected and the
-   ;; rolled-back app-db is published before the error trace fires.
-   ;; The :rollback? true tag flags the atomic rollback per Spec 002.
+   ;; Drain depth exceeded — the 6th (halting) event is not run. Per
+   ;; rf2-nj6p7 there is no whole-drain rollback, so :rollback? is false;
+   ;; the already-settled events are durable.
    {:operation :rf.error/drain-depth-exceeded
     :op-type   :error
     :tags      {:category   :rf.error/drain-depth-exceeded
                 :depth      5
                 :queue-size 1
                 :last-event [:recursive]
-                :rollback?  true}
+                :rollback?  false}
     :recovery  :no-recovery}
-   ;; Per rf2-v0jwt: the runtime commits a partial :halted-depth
-   ;; epoch record AFTER the error trace fires (the router's
-   ;; settle! call for the halt outcome). The :rf.epoch/snapshotted
-   ;; trace carries the :outcome :halted-depth tag so listeners
-   ;; can discriminate from clean-settle records without inspecting
-   ;; the epoch-history vector.
+   ;; The trailing :halted-depth marker (the router's commit-halt-record!
+   ;; call). The :rf.epoch/snapshotted trace carries :outcome :halted-depth
+   ;; so listeners discriminate it from the durable :ok records. (Each :ok
+   ;; event also emits a :rf.epoch/snapshotted; the matcher is a
+   ;; subsequence match, so this trailing one is found last.)
    {:operation :rf.epoch/snapshotted
     :tags      {:frame   :rf/default
                 :outcome :halted-depth}}]
 
-  ;; Per rf2-v0jwt §Outcomes: the recorded epoch carries the partial-
-  ;; record shape — :outcome :halted-depth, :db-after equals :db-before
-  ;; (the atomic-rollback contract), :halt-reason carries the structured
-  ;; halt descriptor.
+  ;; Per rf2-nj6p7 §Drain versus event: five durable :ok epochs (one per
+  ;; dequeued :recursive event, db chaining {:depth 1}…{:depth 5}) followed
+  ;; by the trailing :halted-depth marker. The marker's :db-before /
+  ;; :db-after both equal the durable last-settled db ({:depth 5}); the
+  ;; halting event never ran.
   :epoch-records
-  [{:frame :rf/default
+  [{:frame :rf/default :record {:outcome :ok :event-id :recursive
+                                :db-before {} :db-after {:depth 1}}}
+   {:frame :rf/default :record {:outcome :ok :event-id :recursive
+                                :db-before {:depth 1} :db-after {:depth 2}}}
+   {:frame :rf/default :record {:outcome :ok :event-id :recursive
+                                :db-before {:depth 2} :db-after {:depth 3}}}
+   {:frame :rf/default :record {:outcome :ok :event-id :recursive
+                                :db-before {:depth 3} :db-after {:depth 4}}}
+   {:frame :rf/default :record {:outcome :ok :event-id :recursive
+                                :db-before {:depth 4} :db-after {:depth 5}}}
+   {:frame :rf/default
     :record {:outcome   :halted-depth
              :event-id  :recursive
-             :db-before {}
-             :db-after  {}
+             :db-before {:depth 5}
+             :db-after  {:depth 5}
              :halt-reason
              {:operation  :rf.error/drain-depth-exceeded
               :depth      5


### PR DESCRIPTION
## Summary

Implements the merged spec (PR #1948, rf2-u6jsj): **one `:rf/epoch-record` per DEQUEUED event** — a UI `dispatch`, an `:fx [[:dispatch …]]` child, or the frame-creation `:on-create` event each gets its own epoch. Moves the epoch capture boundary from per-drain-settle to per-event run-to-completion. Fixes the root cause of rf2-48nsi (`:fx`-dispatched children folding into the parent's epoch).

## Runtime changes

- **`router/run-one-pass!`** now snapshots `db-before`/`db-after` per dequeued event and settles one epoch per `process-event!` (was one settle per whole drain). `dispatch-sync` and async `dispatch` both flow through this path.
- **`epoch/settle!`** is the per-event commit point. Harvest is now **`:dispatch-id`-scoped** (`harvest-buffer-for-event!`): each epoch's `:trace-events` carry exactly one `:dispatch-id`. A child's `:event/dispatched` marker (emitted during the parent's do-fx) rides the **child's** epoch, not the parent's — per Spec 009 (one dispatch-id = one epoch).
- **Macrostep preservation (Spec 005):** a machine's `:raise` sub-events and `:always` microsteps run inside one `process-event!` and stay **ONE** epoch — they do not allocate new epochs. Verified by a new test.
- New `:epoch/commit-halt-record!` hook commits a `:halted-*` record even on an empty buffer (the halting event never ran).

## Depth-exceed edge — NOTE for spec-tightening

Under per-event epochs there is **no whole-drain rollback** — each settled event is independently atomic and durable. `handle-depth-exceeded!` keeps the already-settled `:ok` epochs (and their db writes), discards the remaining queue, and commits a single trailing `:halted-depth` marker for the halting event. The depth-exceeded error trace now carries `:rollback? false`.

This **supersedes Spec 002 rule 3** ("restore app-db to its pre-drain snapshot" / "epoch history records nothing for the failed drain") and the `drain-depth-limit.edn` conformance fixture, both written for the pre-rf2-u6jsj per-drain model. The merged spec redefined the epoch as per-event but did NOT update rule 3 / the fixture (it said "impl follow-up rf2-nj6p7"). The conformance fixture is updated here (it's the encoding of the behavior being implemented); **Spec 002 rule 3 prose needs a follow-up spec bead** to reconcile its rollback language to the per-event boundary. The spec worker's "already-settled siblings durable; halted event gets a `:halted-*` record" guidance is what's implemented.

## Files changed

- `implementation/core/src/re_frame/router.cljc` — per-event settle in `run-one-pass!`; rewrote `handle-depth-exceeded!` (no rollback, per-event durable, halt marker for the peeked halting event).
- `implementation/core/src/re_frame/late_bind/directory.cljc` — register `:epoch/commit-halt-record!`; update `:epoch/settle!` description.
- `implementation/epoch/src/re_frame/epoch.cljc` — `settle!` per-event + scoped harvest; new `commit-halt-record!` + shared `commit-record!`.
- `implementation/epoch/src/re_frame/epoch/state.cljc` — `harvest-buffer-for-event!` (dispatch-id-scoped harvest).
- `implementation/epoch/src/re_frame/epoch/assembly.cljc` — docstring accuracy (per-event).
- `implementation/epoch/test/re_frame/epoch_test.clj` — new regression tests + updated multi-event/depth tests.
- `implementation/core/test/re_frame/drain_test.clj` — per-event durability (no whole-drain rollback).
- `spec/conformance/fixtures/drain-depth-limit.edn` — per-event durability + halt marker.

## Test plan

- [x] epoch JVM (`clojure -M:test` from `implementation/epoch/`): **198 tests, 739 assertions, 0 failures**
- [x] core JVM (`clojure -M:test` from `implementation/core/`, incl. conformance + late-bind drift): **719 tests, 3427 assertions, 0 failures**
- [x] `npm run test:cljs`: **4115 tests, 12507 assertions, 0 failures**
- [x] `npm run test:elision`: **production 36/36 absent**
- [x] machines JVM (sanity): **242 tests, 815 assertions, 0 failures**
- [x] New regression tests: parent + `:fx` child → two distinct epochs (distinct epoch-id/dispatch-id, one-dispatch-id-per-epoch purity); `:on-create` → own epoch; machine `:raise` macrostep → ONE epoch; depth-exceed → durable siblings + trailing `:halted-depth`.
- [ ] Recommend running the Causa feature gate (`npm run test:causa-feature-gate`) on merge — Causa is the primary beneficiary (rf2-48nsi); not in this bead's required gate set.