### PR TITLE
impl(eventloop): machine-internal continuation events front-of-queue (rf2-j20a7)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -183,11 +183,21 @@
   `:dispatch` / `:dispatch-later` fx-handler running in the do-fx
   phase). Lineage is preserved via `:parent-dispatch-id`; the origin
   tag answers \"who emitted THIS dispatch?\" not \"what initiated the
-  cascade?\"."
+  cascade?\".
+
+  Per rf2-j20a7 / Spec 005 §Level 4: when the parent envelope is tagged
+  `:rf.machine/internal? true` (the router stamps it in
+  `run-handler-cascade!` whenever the emitting handler is a machine),
+  the child is a machine-internal continuation event and inherits the
+  flag. `re-frame.router/dispatch!` reads it to insert the child at the
+  FRONT of the queue so the machine settles its macrostep to quiescence
+  before the next external event. Unlike the trace-only inheritable
+  keys, this is a runtime ordering flag — carried unconditionally."
   [frame-id parent-envelope]
   (if parent-envelope
-    (-> (select-keys parent-envelope inheritable-envelope-keys)
-        (assoc :rf/dispatch-origin :fx-emit))
+    (cond-> (select-keys parent-envelope inheritable-envelope-keys)
+      true                                     (assoc :rf/dispatch-origin :fx-emit)
+      (:rf.machine/internal? parent-envelope)  (assoc :rf.machine/internal? true))
     {:frame frame-id :rf/dispatch-origin :fx-emit}))
 
 (def ^:private reserved-fx-handlers

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -131,7 +131,21 @@
         fallthrough?       (when interop/debug-enabled?
                              (and (not explicit-frame?)
                                   (nil? frame/*current-frame*)
-                                  (= :rf/default default-frame)))]
+                                  (= :rf/default default-frame)))
+        ;; Per rf2-j20a7 / Spec 005 §Level 4: a dispatch emitted from a
+        ;; machine's own processing (its `:action` / `:entry` / `:exit` /
+        ;; transition handling, via `:fx [[:dispatch …]]` or an inter-
+        ;; machine dispatch) is a machine-internal continuation. The
+        ;; `:dispatch` / `:dispatch-later` fx body stamps
+        ;; `:rf.machine/internal? true` on the child opts when the
+        ;; emitting handler is a machine (see `child-dispatch-opts` in
+        ;; re-frame.fx, which copies the flag off the machine-tagged
+        ;; parent envelope). `dispatch!` reads it to insert the envelope
+        ;; at the FRONT of the queue so the macrostep settles to
+        ;; quiescence before the next EXTERNAL event. This is a runtime
+        ;; ordering guarantee — NOT a trace concern — so the flag is
+        ;; carried unconditionally (never gated on interop/debug-enabled?).
+        machine-internal?  (true? (:rf.machine/internal? opts))]
     (cond-> {:event                  event
              :frame                  (or (:frame opts) default-frame)
              ;; Per rf2-5uwl: merge the lexical-scope `*fx-overrides*`
@@ -162,7 +176,10 @@
       call-site          (assoc :call-site         call-site)
       dispatch-id        (assoc :dispatch-id        dispatch-id)
       parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id)
-      fallthrough?       (assoc :fell-through-to-default? true))))
+      fallthrough?       (assoc :fell-through-to-default? true)
+      ;; Per rf2-j20a7: carry the machine-internal continuation flag onto
+      ;; the envelope so `dispatch!` can front-of-queue insert it.
+      machine-internal?  (assoc :rf.machine/internal? true))))
 
 (defn- resolve-handler [event-id]
   (registrar/lookup :event event-id))
@@ -848,6 +865,22 @@
   (let [{:keys [full-chain initial-ctx fx-overrides emit-event
                 schema-sensitive?]}
         (prepare-handler-ctx envelope frame frame-record handler-meta)
+        ;; Per rf2-j20a7 / Spec 005 §Level 4: tag the in-flight envelope
+        ;; as machine-originated when THIS handler is a machine (its
+        ;; registration meta carries `:rf/machine? true`, stamped by
+        ;; re-frame.machines `reg-machine*`). The tagged envelope is the
+        ;; `parent-envelope` threaded into `do-fx`; `child-dispatch-opts`
+        ;; (re-frame.fx) copies the flag onto every `:dispatch` /
+        ;; `:dispatch-later` child emitted during this handler's fx walk,
+        ;; so those continuation events front-of-queue insert (see
+        ;; `enqueue-envelope!`). The cut is the dispatch's ORIGIN — an
+        ;; event that merely TARGETS a machine but originates elsewhere
+        ;; carries no flag and stays FIFO. `:raise` is untouched: it
+        ;; never reaches the router queue (it drains in-memory inside the
+        ;; machine handler invocation, pre-commit).
+        envelope   (cond-> envelope
+                     (:rf/machine? handler-meta)
+                     (assoc :rf.machine/internal? true))
         ;; The schema-derived `:rf/sensitive?` key drives the scope's
         ;; `:sensitive?` trace-event stamp (read by `handler-scope-from-
         ;; meta`). Path-marked via app-schema slot meta; the handler-
@@ -1386,10 +1419,66 @@
                        (:parent-dispatch-id envelope)
                        (assoc :parent-dispatch-id (:parent-dispatch-id envelope))))))))
 
+(defn- front-insert-machine-internal
+  "Return `q` (a PersistentQueue of envelopes) with `envelope` spliced in
+  at the boundary between the machine-internal PREFIX and the external
+  TAIL — i.e. after any already-queued machine-internal envelopes but
+  ahead of the first external one.
+
+  Why a boundary splice, not a head `cons`: each sibling machine-internal
+  dispatch from one macrostep (`:fx [[:dispatch :a] [:dispatch :b]]`,
+  walked left-to-right by `do-fx`) is a SEPARATE `dispatch!` call, so this
+  fn is invoked once per sibling. A plain head-push would reverse them
+  (`:b` ends up ahead of `:a`). Inserting each new internal envelope at
+  the END of the existing internal prefix keeps siblings in source order
+  (`[:a :b …external]`) while still placing the whole internal run ahead
+  of every external event already on the queue.
+
+  PersistentQueue has no native splice, so the queue is rebuilt: take the
+  leading run of machine-internal envelopes, append `envelope`, then the
+  external remainder. `split-with` on `:rf.machine/internal?` is exact —
+  external envelopes never carry the flag."
+  [q envelope]
+  (let [[internal external] (split-with :rf.machine/internal? q)]
+    (into interop/empty-queue (concat internal [envelope] external))))
+
+(defn- enqueue-envelope!
+  "Insert `envelope` into the frame's router queue. Per Spec 002, ordinary
+  dispatches go to the BACK (plain FIFO via `conj` on the PersistentQueue).
+
+  Per rf2-j20a7 / Spec 005 §Level 4 — the one exception: a machine-
+  internal continuation envelope (`:rf.machine/internal? true`, stamped
+  by `build-envelope` from the machine-tagged child opts) leap-frogs
+  ahead of any already-queued EXTERNAL events, so the machine settles its
+  macrostep to quiescence before the next external event runs (SCXML
+  'internal before external'). It is spliced in by
+  `front-insert-machine-internal` AFTER any sibling machine-internal
+  envelopes already queued this macrostep, so source order is preserved
+  among siblings (first emitted is dequeued first).
+
+  Front-of-queue changes ORDER ONLY, not granularity: the leap-frogged
+  envelope is still a separately-dequeued event with its own epoch (per
+  Spec 002 §Drain versus event and Spec 005 §Level 4). `:raise` is a
+  different lever — it never reaches this queue (it drains in-memory,
+  intra-macrostep, inside the machine handler invocation)."
+  [router envelope]
+  (if (:rf.machine/internal? envelope)
+    (swap! router update :queue front-insert-machine-internal envelope)
+    (swap! router update :queue conj envelope)))
+
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:
-  FIFO at the runtime layer; no reordering, no priority lanes. The drain
-  loop picks it up in this same drain cycle (run-to-completion).
+  FIFO at the runtime layer. The drain loop picks it up in this same
+  drain cycle (run-to-completion).
+
+  Per rf2-j20a7 / Spec 005 §Level 4: the single exception to FIFO is a
+  machine-internal continuation event (a dispatch emitted from a
+  machine's own processing), which `enqueue-envelope!` inserts at the
+  FRONT of the queue so the machine settles its macrostep before the
+  next external event. The cut is the dispatch's ORIGIN (machine
+  processing), not its target — an event that merely targets a machine
+  but originates from user code / the UI / a non-machine effect stays
+  FIFO at the back.
 
   Per rf2-ts1a: the runtime-callable fn form (`re-frame.core/dispatch*`
   in public API terms). The macro form `re-frame.core/dispatch` stamps
@@ -1418,7 +1507,7 @@
        :else
        (let [router (:router frame-record)]
          (emit-dispatched-trace! envelope false)
-         (swap! router update :queue conj envelope)
+         (enqueue-envelope! router envelope)
          (ensure-drain-scheduled! (:frame envelope) router)))
      nil)))
 

--- a/implementation/core/test/re_frame/router_front_of_queue_test.cljc
+++ b/implementation/core/test/re_frame/router_front_of_queue_test.cljc
@@ -1,0 +1,149 @@
+(ns re-frame.router-front-of-queue-test
+  "Per rf2-j20a7 / Spec 005 §Level 4 — machine-internal continuation
+  events insert at the FRONT of the per-frame router queue, while
+  ordinary (external) dispatches stay plain-FIFO at the back.
+
+  This file pins the ROUTER-LEVEL mechanism in core, independent of the
+  machines artefact: the marking flag is `:rf.machine/internal?`, which
+  `re-frame.machines` stamps onto machine-originated child dispatches
+  (covered end-to-end in
+  `re-frame.machine-front-of-queue-test` in the machines artefact). Here
+  we drive `dispatch*` with the flag set explicitly so the queue-
+  insertion semantics are tested in isolation:
+
+    1. a flagged dispatch leap-frogs an already-queued external event;
+    2. an unflagged dispatch (even one targeting the same handler) stays
+       FIFO at the back;
+    3. sibling flagged dispatches preserve source order at the front;
+    4. each leap-frogged event is still its own dequeued event (its own
+       handler cascade / epoch) — front-of-queue changes ORDER, not
+       granularity.
+
+  Deterministic harness: everything runs inside ONE `dispatch-sync`
+  drain. The seed handler issues its child dispatches in its body; they
+  enqueue onto the in-progress sync drain (no async drain is scheduled
+  while `:in-sync-drain?` holds), then the sync drain pops them in queue
+  order. Run-order is recorded into an atom by each handler."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private run-log (atom []))
+
+(defn- log! [k] (swap! run-log conj k))
+
+(defn- reg-marker
+  "Register a no-op event handler that records its id into `run-log`."
+  [id]
+  (rf/reg-event-fx id (fn [_ _] (log! id) {})))
+
+;; ---- (1) flagged dispatch leap-frogs a pending external event -------------
+
+(deftest machine-internal-dispatch-leapfrogs-external
+  (testing "an :rf.machine/internal? dispatch jumps ahead of an external
+   event already queued before it"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :cont)
+    ;; Seed handler enqueues an EXTERNAL event first, THEN a machine-
+    ;; internal continuation. Arrival order is [:ext :cont]; FIFO would
+    ;; run :ext before :cont, but front-of-queue must run :cont first.
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        (rf/dispatch* [:ext] {})
+        (rf/dispatch* [:cont] {:rf.machine/internal? true})
+        {}))
+    (rf/dispatch-sync [:seed])
+    (is (= [:seed :cont :ext] @run-log)
+        ":cont (machine-internal) leap-frogged the earlier-queued :ext")))
+
+;; ---- (2) unflagged dispatch stays FIFO (origin, not target) ---------------
+
+(deftest external-dispatch-stays-fifo
+  (testing "an unflagged dispatch stays at the BACK even when queued after
+   an external event — plain FIFO; the cut is origin, not target"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :plain)
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        (rf/dispatch* [:ext] {})
+        (rf/dispatch* [:plain] {}) ;; NOT machine-internal
+        {}))
+    (rf/dispatch-sync [:seed])
+    (is (= [:seed :ext :plain] @run-log)
+        "both unflagged dispatches ran in arrival order (no leap-frog)")))
+
+;; ---- (3) sibling machine-internal dispatches preserve source order --------
+
+(deftest sibling-machine-internal-preserve-source-order
+  (testing "multiple machine-internal dispatches from one macrostep keep
+   their emit order at the front (first emitted is dequeued first), ahead
+   of the external event"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :a)
+    (reg-marker :b)
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        (rf/dispatch* [:ext] {})
+        ;; Two machine-internal continuations, emitted :a then :b. Each
+        ;; front-inserts onto the head of the EXISTING queue, so the net
+        ;; head order is [:a :b ...], not the reversed [:b :a ...].
+        (rf/dispatch* [:a] {:rf.machine/internal? true})
+        (rf/dispatch* [:b] {:rf.machine/internal? true})
+        {}))
+    (rf/dispatch-sync [:seed])
+    (is (= [:seed :a :b :ext] @run-log)
+        ":a before :b (source order) at the front, both ahead of :ext")))
+
+;; ---- (4) epoch-per-event preserved: each leap-frogged event runs its own
+;;          full handler cascade (its own :run-start), not collapsed --------
+
+(defn- run-starts-of
+  "Filter recorded trace events down to per-event :run-start markers,
+  returning their event-ids in order. The `trace/emit!` payload (the
+  `{:event-id … :phase :run-start}` map) rides under `:tags`; only
+  `:operation` is top-level."
+  [evs]
+  (->> evs
+       (filter #(and (= :event (:operation %))
+                     (= :run-start (:phase (:tags %)))))
+       (mapv #(:event-id (:tags %)))))
+
+(deftest each-leapfrogged-event-is-its-own-epoch
+  (testing "front-of-queue changes order only — each dequeued event
+   (machine-internal or not) still runs as its own event with its own
+   handler cascade / :run-start (Spec 002 §Drain versus event)"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :c1)
+    (reg-marker :c2)
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        (rf/dispatch* [:ext] {})
+        (rf/dispatch* [:c1] {:rf.machine/internal? true})
+        (rf/dispatch* [:c2] {:rf.machine/internal? true})
+        {}))
+    (let [seen (atom [])]
+      (rf/register-listener! ::epoch-rec (fn [ev] (swap! seen conj ev)))
+      (try
+        (rf/dispatch-sync [:seed])
+        (finally (rf/unregister-listener! ::epoch-rec)))
+      ;; Run order reflects the leap-frog.
+      (is (= [:seed :c1 :c2 :ext] @run-log))
+      ;; One :run-start per dequeued event — four distinct events, none
+      ;; collapsed by the front-insertion.
+      (let [starts (run-starts-of @seen)]
+        (is (= 4 (count starts))
+            "one :run-start per dequeued event — no collapse")
+        (is (= [:seed :c1 :c2 :ext] starts)
+            ":run-start order matches the dequeue (leap-frogged) order")))))

--- a/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_test.cljc
@@ -1,0 +1,136 @@
+(ns re-frame.machine-front-of-queue-test
+  "Per rf2-j20a7 / Spec 005 §Level 4 — end-to-end coverage that a REAL
+  machine's continuation dispatch (`:fx [[:dispatch …]]` emitted from an
+  action) leap-frogs to the FRONT of the router queue, while an event
+  that merely TARGETS a machine but originates externally stays FIFO.
+
+  The router-level queue-insertion mechanism is pinned in
+  `re-frame.router-front-of-queue-test` (core). Here we exercise the
+  marking SEAM: `re-frame.router/run-handler-cascade!` tags the in-flight
+  envelope `:rf.machine/internal? true` when the handler's registration
+  meta carries `:rf/machine? true` (stamped by `reg-machine*`); that flag
+  rides the parent envelope into `do-fx`, and `child-dispatch-opts`
+  copies it onto the `:fx [[:dispatch …]]` child — so the continuation
+  front-inserts. A plain handler's identical `:fx [[:dispatch …]]` does
+  NOT (the cut is the dispatch's ORIGIN).
+
+  Deterministic harness: one `dispatch-sync` drain. The seed handler
+  enqueues its events in its body; they ride the in-progress sync drain,
+  which pops them in queue order. Run-order is recorded into an atom."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.machines]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private run-log (atom []))
+
+(defn- log! [k] (swap! run-log conj k))
+
+(defn- reg-marker [id]
+  (rf/reg-event-fx id (fn [_ _] (log! id) {})))
+
+;; ---- (1) a machine action's :fx [[:dispatch …]] leap-frogs a pending
+;;          external event ----------------------------------------------------
+
+(deftest machine-action-dispatch-leapfrogs-external
+  (testing "a continuation event dispatched from a machine action runs
+   BEFORE an external event that was queued earlier (Spec 005 §Level 4)"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :cont)
+    (rf/reg-machine :rf2-j20a7/leapfrog
+      {:initial :idle
+       :data    {}
+       :actions {:emit-cont
+                 (fn [_]
+                   (log! :machine-action)
+                   ;; Machine-ORIGINATED continuation — must front-insert.
+                   {:fx [[:dispatch [:cont]]]})}
+       :states  {:idle {:on {:go {:target :done :action :emit-cont}}}
+                 :done {}}})
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        ;; Machine event queued FIRST, external event SECOND.
+        (rf/dispatch* [:rf2-j20a7/leapfrog [:go]] {})
+        (rf/dispatch* [:ext] {})
+        {}))
+    (rf/dispatch-sync [:seed])
+    (is (= [:seed :machine-action :cont :ext] @run-log)
+        ":cont (machine continuation) leap-frogged the earlier-queued :ext")))
+
+;; ---- (2) an event TARGETING a machine, but originating externally, stays
+;;          FIFO -------------------------------------------------------------
+
+(deftest external-dispatch-targeting-machine-stays-fifo
+  (testing "the cut is ORIGIN not target — an externally-dispatched event
+   that targets a machine goes to the BACK like any other external event"
+    (reset! run-log [])
+    (reg-marker :plain)
+    (rf/reg-machine :rf2-j20a7/fifo-target
+      {:initial :idle
+       :data    {}
+       :actions {:noop (fn [_] (log! :machine-ran) {})}
+       :states  {:idle {:on {:go {:target :done :action :noop}}}
+                 :done {}}})
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        ;; Both are EXTERNAL dispatches (origin = this plain handler's fx
+        ;; emit). The machine event is queued first; targeting a machine
+        ;; must NOT move it relative to the later plain event.
+        (rf/dispatch* [:rf2-j20a7/fifo-target [:go]] {})
+        (rf/dispatch* [:plain] {})
+        {}))
+    (rf/dispatch-sync [:seed])
+    (is (= [:seed :machine-ran :plain] @run-log)
+        "machine target ran in arrival order; no leap-frog for external origin")))
+
+;; ---- (3) macrostep quiesces (all machine continuations settle) before the
+;;          next external event ------------------------------------------------
+
+(deftest macrostep-quiesces-before-next-external
+  (testing "a chain of machine-originated continuations all settle ahead of
+   the pending external event — the machine drives to quiescence first"
+    (reset! run-log [])
+    (reg-marker :ext)
+    (reg-marker :cont-1)
+    ;; :cont-2 is dispatched FROM :cont-1, which is itself a plain
+    ;; (non-machine) handler — so :cont-2 is a BACK-of-queue dispatch.
+    ;; This verifies the boundary precisely: only the machine-ORIGINATED
+    ;; hop leap-frogs; once control leaves the machine, FIFO resumes.
+    (rf/reg-event-fx :cont-1
+      (fn [_ _]
+        (log! :cont-1)
+        (rf/dispatch* [:cont-2] {}) ;; plain origin → back of queue
+        {}))
+    (reg-marker :cont-2)
+    (rf/reg-machine :rf2-j20a7/quiesce
+      {:initial :idle
+       :data    {}
+       :actions {:fire (fn [_]
+                         (log! :machine-action)
+                         {:fx [[:dispatch [:cont-1]]]})}
+       :states  {:idle {:on {:go {:target :done :action :fire}}}
+                 :done {}}})
+    (rf/reg-event-fx :seed
+      (fn [_ _]
+        (log! :seed)
+        (rf/dispatch* [:rf2-j20a7/quiesce [:go]] {})
+        (rf/dispatch* [:ext] {})
+        {}))
+    (rf/dispatch-sync [:seed])
+    ;; Trace through the queue:
+    ;;   seed do-fx:        queue [[:M :go] [:ext]]
+    ;;   pop [:M :go]:      machine fronts :cont-1 → [[:cont-1] [:ext]]
+    ;;   pop [:cont-1]:     plain backs :cont-2   → [[:ext] [:cont-2]]
+    ;;   pop [:ext]:        (the external event)  → [[:cont-2]]
+    ;;   pop [:cont-2]
+    (is (= [:seed :machine-action :cont-1 :ext :cont-2] @run-log)
+        ":cont-1 (machine continuation) preceded :ext; :cont-2 (plain
+         origin, back-of-queue) followed :ext — FIFO resumes once control
+         leaves the machine")))


### PR DESCRIPTION
## Summary

Per **Spec 005 §Level 4** + **Spec 002 §event-loop**: machine-INTERNAL continuation events now insert ahead of any already-queued EXTERNAL events on the per-frame router queue, so a machine drains its macrostep to quiescence before the next external event runs (SCXML "internal before external"). External events (user / UI / non-machine) stay plain FIFO at the back.

The cut is the dispatch's **ORIGIN, not its target**: a dispatch emitted from a machine's own processing (its action / entry / exit / transition handling, via `:fx [[:dispatch ...]]`) is machine-internal and leap-frogs; an event that merely *targets* a machine but originates from user code / the UI / a non-machine effect stays FIFO.

## Marking-mechanism seam

- `run-handler-cascade!` (router) tags the in-flight envelope `:rf.machine/internal? true` when the handler's registration meta carries `:rf/machine? true` (stamped by `reg-machine*`).
- That flag rides the parent envelope into `do-fx`; `child-dispatch-opts` (fx) copies it onto the child dispatch (unconditionally — it's a runtime ordering flag, not a trace-only key).
- `build-envelope` stamps the child envelope; `dispatch!` routes it through `enqueue-envelope!`, which splices it via `front-insert-machine-internal` — **after** any sibling machine-internal envelopes (source order preserved) but **ahead** of the external tail.

## Invariants preserved

- `:raise` untouched — in-memory, intra-macrostep, never reaches the router queue.
- **Epoch-per-event preserved** — each leap-frogged event is still a separately dequeued event with its own handler cascade / `:run-start`. This is an order change only, not a granularity change (pinned by a dedicated test asserting one `:run-start` per dequeued event).
- Drain-to-fixed-point + microtask scheduling unchanged.

## Tests

New `re-frame.router-front-of-queue-test` (core) pins the router-level queue-insertion mechanism in isolation; new `re-frame.machine-front-of-queue-test` (machines) covers it end-to-end through a real machine action's `:fx [[:dispatch ...]]`:

1. machine action `:fx :dispatch` leap-frogs a pending external event
2. external event TARGETING a machine stays FIFO (origin not target)
3. macrostep quiesces before next external; FIFO resumes once control leaves the machine
4. sibling machine-internal dispatches preserve source order at the front
5. epoch-per-event preserved (one `:run-start` per dequeued event)

## Test plan

- [x] core JVM `clojure -M:test` — 723 tests / 3433 assertions, 0 failures
- [x] machines JVM `clojure -M:test` — 245 tests / 818 assertions, 0 failures
- [x] `npm run test:cljs` — 4119 tests / 12541 assertions, 0 failures
- [x] `npm run test:elision` — PASS (production 36/36 absent; control 36/36 present)