### PR TITLE
docs(spec): reconcile remaining :halted-depth rollback wording (rf2-f0n92)

### DIFF
--- a/spec/Design-TransducerRouter.md
+++ b/spec/Design-TransducerRouter.md
@@ -197,15 +197,20 @@ specific to the v1 queue-pump shape. Under Stage B they collapse into a single `
 `microtask-driver` definition.
 
 **What stays.** Spec 002's normative behaviour is unchanged: run-to-completion, FIFO ordering
-within a frame, depth-exceeded rollback, `:dispatch-sync` reentrancy guard, frame-destroy
-mid-drain semantics. Each is a property of the *reducing function* under Stage B, not of
-ad-hoc drain code.
+within a frame, depth-exceeded halt (per-event, **not** whole-drain rollback),
+`:dispatch-sync` reentrancy guard, frame-destroy mid-drain semantics. Each is a property of the
+*reducing function* under Stage B, not of ad-hoc drain code.
 
-**Atomic rollback.** v1's depth-exceeded path (`handle-depth-exceeded!`) restores the
-pre-cascade `:db` and emits a `:halted-depth` epoch. Under Stage B this becomes the
-**transducer's `completing` arity**: when the reducing function detects depth exhaustion it
-short-circuits via `reduced` carrying the rollback marker, and the completing arity emits the
-epoch record. Pure, testable, no flag.
+**Depth-exceeded halt (no rollback).** Per [Spec 002 §Run-to-completion rule 3](002-Frames.md#run-to-completion-dispatch-drain-semantics)
+the atomicity unit is the **event**, not the drain: every already-settled event kept its own
+durable `:ok` epoch + `:db` write — there is **no** whole-drain rollback and no pre-cascade
+restore. v1's depth-exceeded path (`handle-depth-exceeded!`) discards the remaining queued
+events (the halting event never runs) and emits a single trailing `:halted-depth` epoch whose
+`:db-before` and `:db-after` both equal the durable last-settled `app-db`. Under Stage B this
+becomes the **transducer's `completing` arity**: when the reducing function detects depth
+exhaustion it short-circuits via `reduced` carrying the halt marker (`:rollback? false`), and
+the completing arity emits the trailing `:halted-depth` record over the durable state. Pure,
+testable, no flag.
 
 ---
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2345,7 +2345,7 @@ Per-frame epoch snapshot, recorded **per dequeued event** in dev builds — one 
    [:db-before     :any]                                                    ;; app-db before the cascade
    [:db-after      :any]                                                    ;; app-db the runtime settled to (see :outcome)
    [:outcome       [:enum :ok                                               ;; (rf2-v0jwt) the event's own cascade settled cleanly
-                          :halted-depth                                     ;; drain-depth limit tripped; atomic rollback
+                          :halted-depth                                     ;; drain-depth limit tripped; halting event never ran (no whole-drain rollback) — :db-before = :db-after = durable last-settled db
                           :halted-destroy                                   ;; frame destroyed mid-drain
                           :halted-handler-exception]]                       ;; reserved — current impl does not halt the drain on handler-exception, see §Outcomes below
    [:halt-reason   {:optional true} :any]                                   ;; structured descriptor of the halt (operation + key tags), absent on :ok
@@ -2405,7 +2405,7 @@ The runtime commits one epoch record per dequeued event (per [002 §Drain versus
 | `:outcome` | When the runtime commits | `:db-before` | `:db-after` |
 |---|---|---|---|
 | `:ok` | The dequeued event's own six-domino cascade settled cleanly. The traditional record — one per dequeued event. | Pre-cascade snapshot. | Post-cascade snapshot. |
-| `:halted-depth` | Drain hit the configured depth limit; the runtime performed an atomic rollback per [Spec 002 §Run-to-completion dispatch](002-Frames.md#run-to-completion-dispatch-drain-semantics). | Pre-cascade snapshot. | Equal to `:db-before` (the rolled-back state). |
+| `:halted-depth` | Drain hit the configured depth limit. Per [Spec 002 §Run-to-completion dispatch rule 3](002-Frames.md#run-to-completion-dispatch-drain-semantics) the atomicity unit is the **event**, not the drain: every already-settled event kept its own durable `:ok` epoch + db write (**no whole-drain rollback**), the remaining queued events are discarded, and this single trailing record marks the **halting event** — which never ran. | The durable last-settled `app-db` (the value after the final `:ok` event). | Equal to `:db-before` — the halting event made no write. |
 | `:halted-destroy` | A handler called `destroy-frame!` on its own frame mid-cascade; the drain interrupts and drops remaining queued events per [Spec 002 §Edge cases worth pinning §Frame disposal mid-drain](002-Frames.md). | Pre-cascade snapshot. | The state at destroy-time — the partial cascade's writes survive in the recorded value, but the frame is gone so the live container can no longer be read. |
 | `:halted-handler-exception` | **Reserved.** Spec 010 §Per-step recovery line 140 describes "cascade halts" on handler exception, but the reference runtime currently routes through the interceptor chain's error-capture seam: the failing handler's `:db` / `:fx` / flows do **not** apply (the chain caught the exception before `:effects` were populated), but the drain itself continues with the next queued event. No record carries this outcome under today's CLJS reference. Held for a future runtime path that aborts the drain on handler exception. | — | — |
 


### PR DESCRIPTION
## Summary

Spec 002 rule 3 (PR #1954, merged) corrected `:halted-depth` to the **per-event halt model**. Two other docs still carried the OLD per-drain "atomic rollback" wording. This PR reconciles both to match 002 §Run-to-completion rule 3 and `spec/conformance/fixtures/drain-depth-limit.edn`.

### The corrected model (per-event halt)
- NO whole-drain rollback. Already-settled `:ok` epochs (+ their db writes) are KEPT (durable).
- Remaining queued events are discarded; the halting event never runs.
- The halting event gets a single trailing `:halted-depth` `:rf/epoch-record` with `:db-before = :db-after =` the durable last-settled `app-db`.
- Error trace carries `:rollback? false`.

### Changes
**`spec/Spec-Schemas.md`**
- `EpochRecord` EDN comment (`:halted-depth` enum line): `atomic rollback` → `halting event never ran (no whole-drain rollback) — :db-before = :db-after = durable last-settled db`.
- §Outcomes table `:halted-depth` row: replaced "performed an atomic rollback" / "rolled-back state" with the per-event halt semantics; `:db-before` now = durable last-settled `app-db`, `:db-after` = `:db-before` (halting event made no write).

**`spec/Design-TransducerRouter.md`**
- "What stays" bullet: `depth-exceeded rollback` → `depth-exceeded halt (per-event, not whole-drain rollback)`.
- "Atomic rollback" subsection retitled "Depth-exceeded halt (no rollback)"; removed pre-cascade restore / rollback-marker wording; now states durable `:ok` epochs are kept, queue discarded, trailing `:halted-depth` over durable state, `:rollback? false`.

### Consistency
Both docs now match `spec/002-Frames.md` §Run-to-completion rule 3, the §Drain-versus-event epoch unit, 005 macrostep semantics, and `drain-depth-limit.edn`. Every stale spot grepped (`atomic rollback`, `pre-drain`, `rollback? true`, `restore app-db`, `whole drain`, `rolled-back`) reconciled. The remaining `:rollback?` mention (Spec-Schemas L714) is the per-handler `:where :app-db` schema-failure field — correctly per-event, not whole-drain — left unchanged.

## Test plan
- [ ] `mkdocs build --strict` (not installed locally; CI validates)

Closes rf2-f0n92.