### PR TITLE
feat(causa): interactive on-chart machine simulation (rf2-u422r)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -254,6 +254,15 @@
     :current-state      — live snapshot state for the active-state
                           highlight. Optional; nil renders no
                           highlight.
+    :sim?               — rf2-u422r. When true the active-state
+                          highlight uses the amber sim palette (so the
+                          on-chart hermetic simulator reads distinct
+                          from the live cyan highlight). Forwarded to
+                          `mv-chart/MachineChart`.
+    :on-edge-click      — rf2-u422r. `(fn [#js {:eventId :fromPath
+                          :toPath}] ...)` invoked when a transition
+                          edge's label is clicked. The Static Machines
+                          on-chart sim wires this to `sim-step`.
     :on-state-click     — `(fn [path] ...)` invoked on node click.
     :show-after-rings?  — when true (default) overlay the
                           `:after`-timer countdown rings. Dynamic
@@ -268,7 +277,8 @@
   internally — no host-side viewport machinery is needed
   post-migration."
   [{:keys [definition machine-id from-highlight to-highlight current-state
-           on-state-click show-after-rings? show-view-mode-toggle?
+           sim? on-state-click on-edge-click
+           show-after-rings? show-view-mode-toggle?
            show-controls? testid inner-testid]
     :or   {show-after-rings?       true
            show-view-mode-toggle?  true
@@ -299,7 +309,9 @@
       :from-highlight  from-highlight
       :to-highlight    to-highlight
       :current-state   current-state
+      :sim?            sim?
       :on-state-click  on-state-click
+      :on-edge-click   on-edge-click
       :show-minimap?   false
       :show-controls?  show-controls?
       :show-background? true

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs
@@ -39,15 +39,33 @@
     - **Exit** disposes the per-machine sim slot and flips the strip's
       sub-mode back to `:topology`.
 
+  ## On-chart simulation (rf2-u422r, epic rf2-nrrtb)
+
+  Stately's signature is simulating ON the chart. The Sim body is a
+  two-pane split: `SimChart` (the topology chart bound to this engine)
+  is the PRIMARY surface — the active state highlights amber, the taken
+  transition's edge animates, and clicking an outgoing transition edge
+  SENDS that event into the sim. The `SimRail` side column carries the
+  payload input + Reset / Exit + guard error toast + audit trail. The
+  on-chart path REUSES the existing engine end-to-end (no new
+  transition logic): an edge click coerces the edge's fireable
+  event-id and folds ONE `step-sim` through the same
+  `rf/machine-transition` call the step-button drives.
+
   ## What this ns owns
 
     - The `body` view — the per-machine Sim panel mounted as the
       `:sim` sub-mode body in the Static Machines panel.
+    - `SimChart` — the on-chart simulation surface (rf2-u422r).
+    - `SimRail` — the side controls/diagnostics column.
     - The `pill` affordance — the `Sim` pill in the 4-mode sub-strip.
     - The `:rf.causa.static.machines/sim-*` events:
-      `sim-start`, `sim-step`, `sim-reset`, `sim-stop`, plus
+      `sim-start`, `sim-step`, `sim-reset`, `sim-stop`,
+      `sim-chart-edge-clicked` (rf2-u422r on-chart step), plus
       `sim-set-pending-event` / `sim-set-pending-data`.
-    - The `:rf.causa.static.machines/sim-*` sub family.
+    - The `:rf.causa.static.machines/sim-*` sub family, incl.
+      `sim-current-state` / `sim-last-transition` (rf2-u422r chart
+      binding).
 
   ## Helper algebra
 
@@ -55,6 +73,7 @@
   target drives it (`clojure -M:test`). This ns is the thin CLJS
   wrapper that wires the helpers to the reactive substrate."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.static.machines.sim-helpers :as sim-h]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -126,7 +145,22 @@
     :<- [:rf.causa.static.machines/sim-state]
     (fn [sim _query]
       (when sim
-        (sim-h/event-id-suggestions (:definition sim))))))
+        (sim-h/event-id-suggestions (:definition sim)))))
+
+  ;; rf2-u422r — the sim's current snapshot state, for the on-chart
+  ;; active-state highlight (amber via the chart's `:sim?` palette).
+  (rf/reg-sub :rf.causa.static.machines/sim-current-state
+    :<- [:rf.causa.static.machines/sim-state]
+    (fn [sim _query]
+      (sim-h/current-sim-state sim)))
+
+  ;; rf2-u422r — the most-recent transition `{:from :to :event}`, feeding
+  ;; the chart's focused-event lens so the taken edge animates after each
+  ;; on-chart (or step-button) step. nil before the first step.
+  (rf/reg-sub :rf.causa.static.machines/sim-last-transition
+    :<- [:rf.causa.static.machines/sim-state]
+    (fn [sim _query]
+      (sim-h/last-transition sim))))
 
 ;; ---- events -------------------------------------------------------------
 
@@ -172,6 +206,26 @@
           (assoc-in db [:rf.causa.static.machines/sim-by-machine machine-id]
             next-sim))
         db)))
+
+  ;; rf2-u422r — on-chart edge click → step. The chart's clickable edge
+  ;; hands us the raw fireable event-id; coerce it to a step event vector
+  ;; and fold it through the SAME engine path as the step-button (no new
+  ;; transition logic — `step-sim` + `run-machine-transition` are reused).
+  ;; A nil/non-keyword event-id (an inert auto edge) is a no-op so the
+  ;; click never produces a malformed dispatch.
+  (rf/reg-event-db :rf.causa.static.machines/sim-chart-edge-clicked
+    (fn [db [_ {:keys [machine-id event-id]}]]
+      (let [sim     (get-in db [:rf.causa.static.machines/sim-by-machine
+                                machine-id])
+            event-v (sim-h/edge-click->event event-id)]
+        (if (and sim event-v)
+          (let [runtime-fn (fn [ev]
+                             (run-machine-transition
+                               (:definition sim) (:snapshot sim) ev))
+                next-sim   (sim-h/step-sim sim event-v runtime-fn)]
+            (assoc-in db [:rf.causa.static.machines/sim-by-machine machine-id]
+              next-sim))
+          db))))
 
   ;; Update the pending event-input text (controlled-input).
   (rf/reg-event-db :rf.causa.static.machines/sim-set-pending-event
@@ -593,6 +647,73 @@
        (available-transitions-list machine-id (:pending-event sim) transitions)
        (audit-trail (:audit-trail sim))])))
 
+;; ---- on-chart simulation surface (rf2-u422r) ---------------------------
+
+(defn SimChart
+  "The on-chart simulation surface — the topology chart bound to the
+  hermetic sim engine (rf2-u422r, epic rf2-nrrtb). Stately's signature
+  is simulating ON the chart; this is the binding seam that delivers it.
+
+  Reuses the EXISTING engine end-to-end — no new transition logic:
+
+    - **Active state** — the sim snapshot's `:state`
+      (`:sim-current-state`) drives `machine-canvas/Chart`'s
+      `:current-state` with `:sim? true`, so the live node highlights
+      AMBER (distinct from the live cyan highlight on the Dynamic
+      surface).
+    - **Taken transition** — the last audit-trail row's `:from` / `:to`
+      (`:sim-last-transition`) drive the chart's focused-event lens
+      (`:from-highlight` / `:to-highlight`), animating the edge just
+      taken.
+    - **Click to send** — a click on an outgoing transition edge
+      dispatches `:sim-chart-edge-clicked`, which coerces the edge's
+      fireable event-id and folds ONE `step-sim` through the same
+      `rf/machine-transition` path the step-button uses. Guard
+      pass/fail surfaces exactly as it does for the button — a failed
+      guard leaves the snapshot put + stamps `:last-error` (rendered in
+      the side rail's error toast).
+
+  Returns nil when sim is inactive (the auto-start gap) so the host's
+  `when sim` guard keeps the render safe.
+
+  Pure hiccup (Causa rf2-tijr convention) — subscribes/dispatches
+  resolve against `:rf/causa` via the shell's frame-provider."
+  [{:keys [machine-id definition]}]
+  (let [current     @(rf/subscribe
+                       [:rf.causa.static.machines/sim-current-state])
+        last-trans  @(rf/subscribe
+                       [:rf.causa.static.machines/sim-last-transition])]
+    [:div {:data-testid "rf-causa-static-machines-sim-chart"
+           :data-machine-id (str machine-id)
+           :data-current-state (sim-h/format-state-display current)
+           :style {:position   "relative"
+                   :flex       "1 1 auto"
+                   :min-height "260px"
+                   :background (:bg-1 tokens)
+                   :border-top (str "1px solid " (:yellow tokens))
+                   :overflow   "hidden"}}
+     [machine-canvas/Chart
+      {:definition             definition
+       :machine-id             machine-id
+       :current-state          current
+       :from-highlight         (:from last-trans)
+       :to-highlight           (:to last-trans)
+       :sim?                   true
+       :show-after-rings?      false
+       :show-view-mode-toggle? false
+       :inner-testid           "rf-causa-static-machines-sim-chart-svg"
+       :on-edge-click
+       (fn [payload]
+         ;; The chart hands a JS payload `#js {:eventId :fromPath
+         ;; :toPath}`; read the fireable event-id off it and dispatch
+         ;; the on-chart step. nil/inert edges produce a no-op event.
+         (let [event-id (some-> payload (aget "eventId"))]
+           (rf/dispatch
+             [:rf.causa.static.machines/sim-chart-edge-clicked
+              {:machine-id machine-id
+               :event-id   event-id}]
+             {:frame :rf/causa})))}]]))
+
 ;; ---- body (mounted from definition_detail.cljs) ------------------------
 
 (defn body
@@ -606,7 +727,18 @@
 
   The auto-start is fire-and-forget via `rf/dispatch` (not
   `dispatch-sync`) so the render itself stays pure; the subsequent
-  reactive cycle re-mounts with sim-state populated."
+  reactive cycle re-mounts with sim-state populated.
+
+  ## On-chart layout (rf2-u422r)
+
+  The sim body is a two-pane split: the interactive `SimChart` is the
+  PRIMARY surface (left/main) — the user clicks transition edges on the
+  chart to drive the sim, watches the active state highlight amber, and
+  sees the taken edge animate. The `SimRail` side column (right) carries
+  the controls + diagnostics that don't belong on the canvas: the
+  payload input, Reset / Exit, guard pass/fail error toast, and the
+  audit trail. The chart and rail read the SAME sim-state, so clicking
+  an edge and clicking a Step button are interchangeable."
   [{:keys [machine-id definition]}]
   (let [sim @(rf/subscribe [:rf.causa.static.machines/sim-state])]
     (when (and (some? machine-id)
@@ -642,15 +774,31 @@
        " — Sim cannot clone what isn't there."]
 
       ;; Sim-state has landed (or the auto-start dispatch just queued).
-      ;; Render the rail; the `when sim` guard inside SimRail keeps
-      ;; the gap render safe.
+      ;; rf2-u422r — two-pane split: the on-chart sim surface is primary,
+      ;; the rail is the side detail/controls column. Both guard the
+      ;; auto-start gap (`SimChart` returns its wrapper unconditionally
+      ;; but the chart degrades on a nil definition; `SimRail`'s `when
+      ;; sim` keeps the gap render safe).
       :else
       [:section {:data-testid "rf-causa-static-machines-sim-body"
                  :data-machine-id (str machine-id)
                  :style {:display "flex"
-                         :flex-direction "column"
-                         :height "100%"}}
-       [SimRail]])))
+                         :flex-direction "row"
+                         :height "100%"
+                         :min-height "0"}}
+       [:div {:data-testid "rf-causa-static-machines-sim-chart-pane"
+              :style {:display "flex"
+                      :flex-direction "column"
+                      :flex "1 1 auto"
+                      :min-width "0"
+                      :min-height "0"}}
+        [SimChart {:machine-id machine-id :definition definition}]]
+       [:div {:data-testid "rf-causa-static-machines-sim-rail-pane"
+              :style {:flex "0 0 320px"
+                      :max-width "360px"
+                      :overflow "auto"
+                      :border-left (str "1px solid " (:border-subtle tokens))}}
+        [SimRail]]])))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/sim_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/sim_helpers.cljc
@@ -67,7 +67,11 @@
     7. `result-ok?` / `result-snap` / `result-info` — thin shims so
        the CLJS panel can read Result values without importing the
        machines artefact ns directly (Causa has no compile-time dep
-       on `re-frame.machines.result`)."
+       on `re-frame.machines.result`).
+    8. `last-transition` / `current-sim-state` / `edge-click->event`
+       — rf2-u422r on-chart binding algebra: the focused-edge lens
+       inputs + active-state highlight + edge-click → step-event
+       coercion that bind the topology chart to the sim engine."
   (:require [clojure.string :as str]
             #?(:clj  [clojure.edn :as edn]
                :cljs [cljs.reader :as edn])))
@@ -359,6 +363,53 @@
 
       :else
       (record-error sim-state event nil "engine returned a non-Result value"))))
+
+;; ---- on-chart binding helpers (rf2-u422r) -------------------------------
+;;
+;; The on-chart simulator (rf2-u422r, epic rf2-nrrtb) renders the sim ON
+;; the topology chart: the active state highlights amber, the taken
+;; transition's edge animates, and clicking an outgoing event edge sends
+;; that event into the SAME hermetic engine the step-button drives. These
+;; pure helpers are the chart↔sim binding algebra — JVM-runnable so the
+;; binding is unit-tested without a CLJS/xyflow runtime.
+
+(defn last-transition
+  "Project the sim's MOST RECENT step into the chart's focused-event lens
+  inputs `{:from :to :event}` (or nil when no step has been taken yet).
+  The chart renders `:from` with the dashed origin highlight + `:to`
+  with the landing highlight, animating the taken edge.
+
+  Reads the tail of the `:audit-trail` (newest-last per `append-audit-row`)
+  — the audit row already carries `{:from :to :event}`, so this is a thin
+  projection that keeps the chart binding from re-deriving it. Returns nil
+  for a nil sim-state or an empty trail (no transition to animate)."
+  [sim-state]
+  (when-let [row (last (:audit-trail sim-state))]
+    {:from  (:from row)
+     :to    (:to row)
+     :event (:event row)}))
+
+(defn current-sim-state
+  "The sim snapshot's current `:state` value (keyword or path vector),
+  for the chart's active-state highlight. nil-safe — nil sim-state or
+  missing snapshot returns nil (no highlight)."
+  [sim-state]
+  (get-in sim-state [:snapshot :state]))
+
+(defn edge-click->event
+  "Coerce an on-chart edge click into a re-frame event vector for
+  `sim-step`. `event-id` is the raw fireable event keyword the chart's
+  edge payload carried (the chart only makes plain `:on` transition
+  edges clickable; `:after` / `:always` auto edges arrive with a nil
+  event-id). Returns `[event-id]` for a usable keyword, nil otherwise —
+  the caller suppresses the step on nil so an inert-edge click is a
+  no-op rather than a malformed dispatch.
+
+  Pure data — JVM-runnable; the CLJS click handler reads `:eventId` off
+  the JS payload and hands the keyword here."
+  [event-id]
+  (when (keyword? event-id)
+    [event-id]))
 
 ;; ---- display helpers ----------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -296,6 +296,11 @@
    :rf.causa.static.machines/sim-by-machine
    :rf.causa.static.machines/sim-event-suggestions
    :rf.causa.static.machines/sim-state
+   ;; rf2-u422r (epic rf2-nrrtb) — on-chart sim binding subs: the
+   ;; current snapshot state (active-state highlight) + the last
+   ;; transition (focused-edge animation).
+   :rf.causa.static.machines/sim-current-state
+   :rf.causa.static.machines/sim-last-transition
    ;; rf2-nqw0v Phase 5 — Share affordance subs.
    :rf.causa/share-copy-status
    :rf.causa/share-modal-open?
@@ -556,6 +561,10 @@
    :rf.causa.static.machines/sim-start
    :rf.causa.static.machines/sim-step
    :rf.causa.static.machines/sim-stop
+   ;; rf2-u422r (epic rf2-nrrtb) — on-chart edge click → step. Coerces
+   ;; the clicked transition edge's fireable event-id and folds one
+   ;; step through the same engine path the step-button drives.
+   :rf.causa.static.machines/sim-chart-edge-clicked
    :rf.causa/sync-epoch-history
    :rf.causa/sync-trace-buffer
    ;; rf2-7hwwe — `:after` countdown rings event family. timer-tick

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/sim_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/sim_cljs_test.cljs
@@ -39,6 +39,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.static.machines.sim :as sim]
             [day8.re-frame2-causa.test-support :as causa-test-support]
@@ -93,6 +94,14 @@
                  (some-> (:data-testid (second node))
                          (.startsWith prefix))))
           (hiccup-seq tree)))
+
+;; rf2-u422r — a RAW walker that does NOT invoke fn components, so a
+;; `[machine-canvas/Chart {...}]` child survives as data and its props
+;; are assertable (the expanding `hiccup-seq` would replace it with the
+;; component's render output).
+
+(defn- raw-hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
 
 ;; ---- fixture data --------------------------------------------------------
 
@@ -251,6 +260,96 @@
         (is (= :idle (get-in sim [:snapshot :state])))
         (is (some? (:last-error sim)))))))
 
+;; ---- (4b) on-chart edge click → step (rf2-u422r) ------------------------
+
+(deftest registry-installs-on-chart-sim-handlers
+  (testing "rf2-u422r — register-causa-handlers! installs the on-chart
+            sub family + the edge-click step event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa.static.machines/sim-current-state)))
+    (is (some? (registrar/handler :sub :rf.causa.static.machines/sim-last-transition)))
+    (is (some? (registrar/handler :event :rf.causa.static.machines/sim-chart-edge-clicked)))))
+
+(deftest sim-chart-edge-clicked-steps-via-engine
+  (testing "rf2-u422r — an on-chart edge click folds ONE step through the
+            SAME engine path as the step-button: snapshot advances +
+            audit-trail grows. No new transition logic."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+        (rf/dispatch-sync [:rf.causa.static.machines/sim-chart-edge-clicked
+                           {:machine-id :auth/login
+                            :event-id   :start}]))
+      (let [sim @(rf/subscribe [:rf.causa.static.machines/sim-state])]
+        (is (= :authing (get-in sim [:snapshot :state]))
+            "snapshot advanced via the on-chart click")
+        (is (= 1 (count (:audit-trail sim))))
+        (is (= [:start] (-> sim :audit-trail last :event))
+            "the clicked edge's event-id was coerced to the step vector")))))
+
+(deftest sim-chart-edge-clicked-nil-event-is-noop
+  (testing "rf2-u422r — clicking an inert (auto / non-fireable) edge with
+            a nil event-id is a no-op: no step, no trail growth"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-chart-edge-clicked
+                         {:machine-id :auth/login
+                          :event-id   nil}])
+      (let [sim @(rf/subscribe [:rf.causa.static.machines/sim-state])]
+        (is (= :idle (get-in sim [:snapshot :state]))
+            "snapshot unchanged on an inert-edge click")
+        (is (= 0 (count (:audit-trail sim))))))))
+
+(deftest sim-chart-edge-clicked-fail-surfaces-guard-error
+  (testing "rf2-u422r — a failed-guard transition fired ON the chart
+            surfaces the error exactly as the button does: snapshot stays
+            put + :last-error stamped (rendered in the rail's error toast)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (with-redefs [rf/machine-transition (fn [_d _s _e] fail-result)]
+        (rf/dispatch-sync [:rf.causa.static.machines/sim-chart-edge-clicked
+                           {:machine-id :auth/login
+                            :event-id   :start}]))
+      (let [sim @(rf/subscribe [:rf.causa.static.machines/sim-state])]
+        (is (= :idle (get-in sim [:snapshot :state]))
+            "snapshot stays put on a failed on-chart step")
+        (is (= [:start] (-> sim :last-error :event))
+            "guard pass/fail surfaces via :last-error")))))
+
+(deftest sim-current-state-and-last-transition-subs
+  (testing "rf2-u422r — the chart-binding subs derive the active state +
+            the taken transition off sim-state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      ;; Before any step: current = initial, last-transition = nil.
+      (is (= :idle @(rf/subscribe [:rf.causa.static.machines/sim-current-state])))
+      (is (nil? @(rf/subscribe [:rf.causa.static.machines/sim-last-transition])))
+      ;; After a step the chart subs reflect the advance.
+      (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+        (rf/dispatch-sync [:rf.causa.static.machines/sim-chart-edge-clicked
+                           {:machine-id :auth/login :event-id :start}]))
+      (is (= :authing @(rf/subscribe [:rf.causa.static.machines/sim-current-state])))
+      (let [lt @(rf/subscribe [:rf.causa.static.machines/sim-last-transition])]
+        (is (= :idle (:from lt)))
+        (is (= :authing (:to lt)))
+        (is (= [:start] (:event lt)))))))
+
 ;; ---- (5) sim-reset ------------------------------------------------------
 
 (deftest sim-reset-rewinds-snapshot
@@ -408,6 +507,87 @@
       (let [sim @(rf/subscribe [:rf.causa.static.machines/sim-state])]
         (is (some? sim) "sim-state landed via the body's auto-start")
         (is (= :idle (get-in sim [:snapshot :state])))))))
+
+;; ---- (8b) on-chart sim surface (rf2-u422r) ------------------------------
+
+(deftest sim-chart-returns-canvas-bound-to-sim
+  (testing "rf2-u422r — SimChart returns the topology chart wrapper bound
+            to the sim engine (the on-chart simulation surface)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (let [tree (sim/SimChart {:machine-id :auth/login
+                                :definition fixture-definition})]
+        (is (= "rf-causa-static-machines-sim-chart"
+               (:data-testid (second tree)))
+            "the on-chart sim wrapper mounts")
+        ;; The wrapper carries the machine-canvas Chart hiccup as data.
+        (is (some (fn [node]
+                    (and (vector? node)
+                         (= machine-canvas/Chart (first node))))
+                  (raw-hiccup-seq tree))
+            "the wrapper embeds machine-canvas/Chart")))))
+
+(deftest sim-chart-passes-sim-bindings-to-canvas
+  (testing "rf2-u422r — SimChart hands the canvas the amber sim palette,
+            the current snapshot state, the focused-edge lens off the last
+            transition, and an on-edge-click callback"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+        (rf/dispatch-sync [:rf.causa.static.machines/sim-chart-edge-clicked
+                           {:machine-id :auth/login :event-id :start}]))
+      (let [tree        (sim/SimChart {:machine-id :auth/login
+                                       :definition fixture-definition})
+            chart-node  (some (fn [node]
+                                (when (and (vector? node)
+                                           (= machine-canvas/Chart (first node)))
+                                  node))
+                              (raw-hiccup-seq tree))
+            chart-props (second chart-node)]
+        (is (true? (:sim? chart-props)) "amber sim palette is on")
+        (is (= :authing (:current-state chart-props))
+            "active-state highlight = the advanced snapshot state")
+        (is (= :idle (:from-highlight chart-props))
+            "focused-edge origin = last transition :from")
+        (is (= :authing (:to-highlight chart-props))
+            "focused-edge landing = last transition :to")
+        (is (fn? (:on-edge-click chart-props))
+            "the chart gets an on-edge-click callback")))))
+
+(deftest sim-body-renders-chart-and-rail-panes
+  (testing "rf2-u422r — the sim body is a two-pane split: the on-chart sim
+            surface (primary) + the rail side column"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (select-static-machine! :auth/login)
+      (rf/dispatch-sync [:rf.causa.static.machines/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (let [tree (sim/body {:machine-id :auth/login
+                            :definition fixture-definition})]
+        (is (some? (find-by-testid tree "rf-causa-static-machines-sim-body")))
+        (is (some? (find-by-testid tree "rf-causa-static-machines-sim-chart-pane"))
+            "chart pane present")
+        (is (some? (find-by-testid tree "rf-causa-static-machines-sim-rail-pane"))
+            "rail pane present")
+        (is (some? (find-by-testid tree "rf-causa-static-machines-sim-chart"))
+            "on-chart sim surface present")
+        (is (some? (find-by-testid tree "rf-causa-static-machines-sim-rail"))
+            "side rail still present")))))
 
 (deftest body-renders-no-definition-hint-when-missing
   (setup-causa-frame!)

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/sim_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/sim_helpers_cljs_test.cljc
@@ -271,7 +271,83 @@
     (is (= [:start] (-> trail first :event)))
     (is (= [:ok]    (-> trail last :event)))))
 
-;; ---- (8) format helpers --------------------------------------------------
+;; ---- (8) on-chart binding helpers (rf2-u422r) ---------------------------
+;;
+;; The on-chart simulator binds the topology chart to this same engine:
+;; `current-sim-state` drives the active-state highlight, `last-transition`
+;; drives the focused-edge animation, and `edge-click->event` coerces an
+;; on-chart edge click into a step-event. Pure data → data, so pinned here
+;; at the cheap JVM layer.
+
+(deftest current-sim-state-reads-snapshot-state
+  (testing "current-sim-state returns the snapshot's :state for the chart
+            active-state highlight"
+    (let [s0 (sim-h/make-sim-state :auth/login flat-definition)]
+      (is (= :idle (sim-h/current-sim-state s0))))))
+
+(deftest current-sim-state-is-nil-safe
+  (testing "nil sim-state / missing snapshot → nil (no highlight)"
+    (is (nil? (sim-h/current-sim-state nil)))
+    (is (nil? (sim-h/current-sim-state {})))))
+
+(deftest current-sim-state-tracks-vector-paths
+  (testing "a hierarchical :state path surfaces unchanged for the chart"
+    (let [s0 (sim-h/make-sim-state :auth/login hierarchical-definition)]
+      ;; hierarchical-definition's :initial is :auth (a compound) — the
+      ;; seed snapshot keeps it as the declared :initial value.
+      (is (= :auth (sim-h/current-sim-state s0))))))
+
+(deftest last-transition-nil-before-any-step
+  (testing "no step taken yet → nil (no edge to animate)"
+    (let [s0 (sim-h/make-sim-state :auth/login flat-definition)]
+      (is (nil? (sim-h/last-transition s0)))
+      (is (nil? (sim-h/last-transition nil))))))
+
+(deftest last-transition-projects-most-recent-audit-row
+  (testing "last-transition projects the newest audit row into the chart's
+            focused-event lens {:from :to :event}"
+    (let [ok1 {:re-frame.machines.result/tag :ok
+               :re-frame.machines.result/snap {:state :authing :data {}}
+               :re-frame.machines.result/fx []}
+          ok2 {:re-frame.machines.result/tag :ok
+               :re-frame.machines.result/snap {:state :done :data {}}
+               :re-frame.machines.result/fx []}
+          s0  (sim-h/make-sim-state :auth/login flat-definition)
+          s1  (sim-h/step-sim s0 [:start] (constantly ok1))
+          s2  (sim-h/step-sim s1 [:ok]    (constantly ok2))
+          lt  (sim-h/last-transition s2)]
+      (is (= :authing (:from lt)) "from = the second step's prior state")
+      (is (= :done    (:to lt))   "to = the second step's landing state")
+      (is (= [:ok]    (:event lt))))))
+
+(deftest last-transition-unchanged-by-failed-step
+  (testing "a failed step does not append a row, so last-transition still
+            reflects the last SUCCESSFUL transition (the chart keeps the
+            prior edge lit while the guard error toasts)"
+    (let [ok  {:re-frame.machines.result/tag :ok
+               :re-frame.machines.result/snap {:state :authing :data {}}
+               :re-frame.machines.result/fx []}
+          s0  (sim-h/make-sim-state :auth/login flat-definition)
+          s1  (sim-h/step-sim s0 [:start] (constantly ok))
+          s2  (sim-h/step-sim s1 [:bad]   (constantly fail-result))
+          lt  (sim-h/last-transition s2)]
+      (is (= :idle    (:from lt)))
+      (is (= :authing (:to lt)))
+      (is (= [:start] (:event lt))))))
+
+(deftest edge-click->event-coerces-keyword-to-vector
+  (testing "a fireable event-id keyword → a `[event-id]` step vector"
+    (is (= [:start] (sim-h/edge-click->event :start)))
+    (is (= [:auth/login] (sim-h/edge-click->event :auth/login)))))
+
+(deftest edge-click->event-nil-for-non-fireable
+  (testing "a nil event-id (an inert :after / :always auto edge, or a
+            non-keyword) → nil so the click is a no-op step"
+    (is (nil? (sim-h/edge-click->event nil)))
+    (is (nil? (sim-h/edge-click->event "start")))
+    (is (nil? (sim-h/edge-click->event 42)))))
+
+;; ---- (9) format helpers --------------------------------------------------
 
 (deftest format-state-display-handles-shapes
   (is (= "(none)" (sim-h/format-state-display nil)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -232,6 +232,14 @@
     :sim?              — flips the highlight palette to amber for
                          the simulator path.
     :on-state-click    — `(fn [path] ...)` invoked on node click.
+    :on-edge-click     — rf2-u422r. `(fn [#js {:eventId :fromPath
+                         :toPath}] ...)` invoked when a transition edge's
+                         label is clicked. Only edges with a fireable
+                         event (plain `:on` transitions) are clickable;
+                         `:after` / `:always` auto edges stay inert. The
+                         on-chart machine simulator wires this to send
+                         the clicked event into the hermetic sim engine
+                         (\"simulate ON the chart\"). nil = no wiring.
     :read-only?        — when true all `:on-*` callbacks are no-op'd.
                          The viewer page sets this.
     :direction         — `:tb` (top-to-bottom, default) or `:lr`.
@@ -307,7 +315,7 @@
   (let [positions     (r/atom {})
         layout-key    (r/atom nil)]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
-                 sim? on-state-click read-only?
+                 sim? on-state-click on-edge-click read-only?
                  direction layout-options density
                  height show-minimap? show-controls? show-background?
                  after-ring-specs after-ring-tick
@@ -384,6 +392,7 @@
                 from-highlight-id (layout/highlight-id from-highlight)
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
+                edge-callback     (when-not read-only? on-edge-click)
                 {:keys [nodes edges]}
                 (projection/xyflow-graph parsed
                               @positions
@@ -392,6 +401,7 @@
                                :to-highlight-id   to-highlight-id
                                :sim?              sim?
                                :on-state-click    callback
+                               :on-edge-click     edge-callback
                                :chart             chart-vc})
                 aria-label (str "State machine"
                                 (when machine-id

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -109,6 +109,16 @@
         active?    (boolean (.-active d))
         focused?   (boolean (.-focused d))
         after-ms   (.-afterMs d)
+        ;; rf2-u422r — on-chart click wiring. `:onClick` is the host
+        ;; callback (e.g. Causa's on-chart sim → sim-step); `:eventId`
+        ;; is the raw fireable event keyword (nil for `:after` / `:always`
+        ;; auto edges). A label is clickable only when BOTH a callback +
+        ;; a fireable event-id are present, so auto edges stay inert.
+        on-click   (.-onClick d)
+        event-id   (.-eventId d)
+        from-path  (.-fromPath d)
+        to-path    (.-toPath d)
+        clickable? (and (fn? on-click) (some? event-id))
         {:keys [edge-label-px edge-label-backplate-opacity]} vc
         ;; xyflow's getBezierPath returns [path-string label-x label-y
         ;; offset-x offset-y]. Use a JS-side destructure via aget.
@@ -139,18 +149,40 @@
                :data-active (str active?)
                :data-focused-edge (str focused?)
                :data-after-ms (when after-ms (str after-ms))
+               ;; rf2-u422r — clickable edges surface their fireable
+               ;; event-id so a host (Causa on-chart sim) + tests can
+               ;; address them; inert (auto / no-callback) edges omit it.
+               :data-clickable (str clickable?)
+               :data-event-id (when (and clickable? event-id)
+                                (str event-id))
+               :role (when clickable? "button")
+               :title (when clickable?
+                        (str "Send " event-id))
+               :on-click (when clickable?
+                           (fn [ev]
+                             ;; Stop the click bubbling to the xyflow
+                             ;; pane (which would pan / clear selection).
+                             (.stopPropagation ev)
+                             (on-click
+                               #js {:eventId  event-id
+                                    :fromPath from-path
+                                    :toPath   to-path})))
                :style {:position       "absolute"
                        :transform      (str "translate(-50%, -50%) translate("
                                             label-x "px," label-y "px)")
                        :pointer-events "auto"
+                       :cursor         (if clickable? "pointer" "default")
                        :font-family    mono-stack
                        :font-size      (str edge-label-px "px")
-                       :font-weight    400
+                       :font-weight    (if (and clickable? focused?) 600 400)
                        :color          (:bg-0 tokens/tokens)
                        :background     (tokens/with-alpha :white edge-label-backplate-opacity)
                        :padding        "1px 5px"
                        :border-radius  "3px"
-                       :border         (str "1px solid " (tokens/with-alpha :border-subtle 0.4))
+                       :border         (str "1px solid "
+                                            (if clickable?
+                                              (tokens/with-alpha :yellow 0.55)
+                                              (tokens/with-alpha :border-subtle 0.4)))
                        :white-space    "nowrap"
                        :user-select    "none"}}
          label]]])))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -139,6 +139,19 @@
     :sim?                — flips the highlight palette to amber.
     :on-state-click      — `(fn [path] ...)` invoked when a state
                            node is clicked.
+    :on-edge-click       — rf2-u422r. `(fn [{:keys [event-id from-path
+                           to-path]}] ...)` invoked when a transition
+                           edge's label is clicked. Threaded onto every
+                           edge `:data` as `:onClick` (+ the raw
+                           `:eventId` / `:fromPath` / `:toPath` so the
+                           edge component can hand the host the
+                           originating transition). The on-chart machine
+                           simulator (Causa) wires this to send the
+                           clicked event into the hermetic sim engine.
+                           Edges with no fireable event (`:after` /
+                           `:always`) carry the callback too but a nil
+                           `:eventId`; the host filters those out. nil
+                           omits the wiring entirely (no-op edge labels).
     :chart               — rf2-k647w. The resolved visual-constants
                            map for the active `:density`
                            (`visual-constants/chart-for-density`).
@@ -154,7 +167,8 @@
                            pixel-identical to pre-rf2-k647w."
   [{:keys [nodes edges]}
    positions
-   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click chart]
+   {:keys [highlight-id from-highlight-id to-highlight-id sim?
+           on-state-click on-edge-click chart]
     :or   {chart vc/chart-regular}}]
   {:nodes
    ;; rf2-lkwev — region container nodes MUST precede their children in
@@ -227,7 +241,16 @@
                  ;; url to its `<BaseEdge>`.
                  marker-color (if (or focused? from-active?)
                                 (:cyan tokens/tokens)
-                                (:border-default tokens/tokens))]
+                                (:border-default tokens/tokens))
+                 ;; rf2-u422r — only plain `:on` transitions carry a
+                 ;; user-fireable event-id. `:after`-timer + `:always`
+                 ;; eventless edges fire automatically inside the engine,
+                 ;; so their click carries a nil `:eventId` (the host —
+                 ;; e.g. Causa's on-chart sim — filters those out).
+                 fireable?    (and (nil? (:after e))
+                                    (not (:always? e))
+                                    (keyword? (:event e)))
+                 event-id     (when fireable? (:event e))]
              {:id     (:id e)
               :source (:source e)
               :target (:target e)
@@ -242,6 +265,15 @@
                        :afterMs    (:after e)
                        :guard      (some-> (:guard e) name)
                        :action     (some-> (:action e) name)
+                       ;; rf2-u422r — on-chart click wiring. `:eventId`
+                       ;; is the raw fireable event keyword (nil for
+                       ;; auto edges); `:fromPath` / `:toPath` give the
+                       ;; host the originating transition. `:onClick` is
+                       ;; the host callback (omitted when no wiring).
+                       :eventId    event-id
+                       :fromPath   (:from-path e)
+                       :toPath     (:to-path e)
+                       :onClick    on-edge-click
                        ;; rf2-k647w — resolved density constants for the
                        ;; edge-label typography (same rationale as the
                        ;; node payload above).

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -399,6 +399,70 @@
       ;; corner-radius is the locked invariant — identical across both
       (is (= (:corner-radius regular) (:corner-radius compact) 6)))))
 
+;; ---- on-chart edge-click wiring (rf2-u422r) ----------------------------
+;;
+;; The on-chart machine simulator clicks a transition edge to send its
+;; event into the hermetic sim engine. The projector threads the host's
+;; `:on-edge-click` callback onto every edge `:data {:onClick}` + carries
+;; the raw fireable `:eventId` / `:fromPath` / `:toPath` so the edge
+;; component can hand the host the originating transition. These JVM pins
+;; guard that wiring; the edge component's click behaviour is pinned at
+;; the DOM layer (chart_dom).
+
+(deftest xyflow-graph-edge-carries-fireable-event-id
+  (testing "rf2-u422r — a plain `:on` transition edge carries its raw
+            fireable `:eventId` (the keyword the sim sends) + the
+            from/to paths on its `:data`"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          start  (first (filter #(= (:source %) (layout/node-id [:idle]))
+                                (:edges graph)))]
+      (is (some? start) "fixture has the idle→loading :start edge")
+      (is (= :start (:eventId (:data start)))
+          "the raw fireable event keyword rides on the edge data")
+      (is (= [:idle] (:fromPath (:data start))))
+      (is (= [:loading] (:toPath (:data start)))))))
+
+(deftest xyflow-graph-after-and-always-edges-are-not-fireable
+  (testing "rf2-u422r — `:after`-timer + `:always` eventless edges fire
+            automatically inside the engine, so they carry a nil
+            `:eventId` (the host filters them out — they are not
+            user-clickable on the chart)"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          after  (first (filter #(:afterMs (:data %)) (:edges graph)))
+          ;; the `:always` edge's label segment starts with "always"
+          ;; (the guarded fixture renders "always [loaded?]").
+          always (first (filter #(re-find #"^always"
+                                          (or (:eventLabel (:data %)) ""))
+                                (:edges graph)))]
+      (is (some? after) "fixture has an :after edge")
+      (is (nil? (:eventId (:data after)))
+          "the :after edge is not user-fireable")
+      (is (some? always) "fixture has an :always edge")
+      (is (nil? (:eventId (:data always)))
+          "the :always edge is not user-fireable"))))
+
+(deftest xyflow-graph-threads-on-edge-click-onto-every-edge
+  (testing "rf2-u422r — the host's `:on-edge-click` callback threads onto
+            EVERY edge's `:data {:onClick}` (the edge component decides
+            clickability from the presence of BOTH the callback + a
+            fireable event-id)"
+    (let [parsed   (layout/parse-definition idle-loading)
+          captured (atom nil)
+          cb       (fn [m] (reset! captured m))
+          graph    (projection/xyflow-graph parsed {} {:on-edge-click cb})]
+      (is (seq (:edges graph)))
+      (is (every? #(= cb (:onClick (:data %))) (:edges graph))
+          "every edge carries the same on-edge-click callback"))))
+
+(deftest xyflow-graph-omits-on-click-when-no-callback
+  (testing "rf2-u422r — omitting `:on-edge-click` leaves `:onClick` nil
+            so the edge label stays inert (no wiring)"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (is (every? #(nil? (:onClick (:data %))) (:edges graph))))))
+
 ;; ---- ->elk-children (G3) -----------------------------------------------
 
 (deftest elk-children-flat-is-one-per-node


### PR DESCRIPTION
## Summary

Integrate the existing hermetic Static Machines sim engine with the xyflow topology chart so the user simulates **ON the chart** (Stately's signature) instead of driving a separate step-button UI. This is a UI/integration layer that binds the chart's nodes/edges to the engine — **no new transition logic**: `sim-start/step/reset/stop`, guard evaluation, the pure `rf/machine-transition` call, and the hermetic clone in app-db are all reused unchanged.

Child of epic **rf2-nrrtb**.

## The chart↔sim binding seam

- **machines-viz (generic capability):** `MachineChart` gains `:on-edge-click`. The projection (`chart/projection.cljc`) threads the host callback onto every edge `:data {:onClick}` and carries the raw fireable `:eventId` / `:fromPath` / `:toPath`. Only plain `:on` transitions are clickable; `:after` / `:always` auto edges arrive with a nil event-id (the host filters them out). The `transition-edge` label wires the click, surfaces `data-clickable` / `data-event-id`, and stops propagation so the click doesn't pan the pane. `machine-canvas/Chart` forwards `:sim?` + `:on-edge-click` through.

- **Causa (the sim binding):** the Sim sub-mode body is now a **two-pane split** — `SimChart` (the topology chart bound to the engine) is the primary surface, `SimRail` is the side controls/diagnostics column.

## How current-state / transition render on-chart

- **Active state** — the sim snapshot's `:state` (`:sim-current-state` sub) drives the chart's `:current-state` with `:sim? true`, so the live node highlights **amber** (distinct from the live cyan highlight on the Dynamic surface).
- **Taken transition** — the last audit row's `:from` / `:to` (`:sim-last-transition` sub) drive the chart's focused-event lens (`:from-highlight` / `:to-highlight`), animating the edge just taken.
- **Click to send** — clicking an outgoing event edge dispatches `:sim-chart-edge-clicked`, which coerces the edge's fireable event-id (`edge-click->event`) and folds **one** `step-sim` through the same `rf/machine-transition` path the step-button uses. **Guard pass/fail** surfaces identically — a failed guard leaves the snapshot put + stamps `:last-error` (rendered in the rail's error toast).

## Dynamic-chart sim affordance

**Left as-is.** The sim is hermetic and Static-only by design (per the engine's own docstring: "Sim now lives ONLY on the Static surface"). The Dynamic panel uses a separate projector/wrapper (`panels/machines/topology.cljs` + `xyflow_wrapper.cljs`) that does not consume `machine-canvas/Chart`; wiring a sim there would mean duplicating sim-state machinery onto a different chart adapter — out of scope and not clean.

## Files changed

- `tools/machines-viz/src/.../chart.cljs` — `:on-edge-click` prop + read-only gate.
- `tools/machines-viz/src/.../chart/projection.cljc` — thread `:onClick` + `:eventId`/`:fromPath`/`:toPath` onto edge data.
- `tools/machines-viz/src/.../chart/edges.cljs` — wire the click on the edge label.
- `tools/causa/src/.../panels/machine_canvas.cljs` — forward `:sim?` + `:on-edge-click`.
- `tools/causa/src/.../static/machines/sim.cljs` — `SimChart`, `sim-chart-edge-clicked` event, `sim-current-state` / `sim-last-transition` subs, two-pane body.
- `tools/causa/src/.../static/machines/sim_helpers.cljc` — pure binding helpers `last-transition` / `current-sim-state` / `edge-click->event`.
- Tests: machines-viz projection pins (edge-click threading), Causa sim helper + wiring + component pins, registry-snapshot updates.

## Test plan

- [x] `npm run test:cljs` — 4139 tests / 12602 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures (exit 0)
- [x] `npx shadow-cljs compile node-test` — 0 warnings
- [ ] Browser visual confirm of the on-chart highlight/animation (edge-label DOM mounts post-async-layout; pinned at the data layer rather than racing the elk Promise, per the existing chart_dom posture)