### PR TITLE
fix(causa): Trace panel — epoch-scoped rows, no header, no filtering (rf2-o6yqq + rf2-td380 + rf2-gkczt)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -369,22 +369,27 @@ panel-owned events — reuses `:rf.causa/select-dispatch-id` and
 
 ## Trace panel
 
-Consumer of the canonical 9-axis filter vocabulary documented in
-[`spec/009-Instrumentation.md` §Filter vocabulary](../../../spec/009-Instrumentation.md#filter-vocabulary).
+Epoch-scoped raw-event ribbon (rf2-td380): reads the focused epoch
+record's `:trace-events` (the complete domino trail for one event —
+both the synchronous event-side rows AND the async nil-dispatch-id
+reactive rows) via `:rf.causa/focus` + `:rf.causa/epoch-history`,
+resolved through `panels.shared.focus-resolver`. No chip-filtering
+(rf2-gkczt) and no top header row (rf2-o6yqq) — the focused epoch IS
+the scope, and the per-row payload-expand affordance is the drill-down.
 
 ### Subscriptions
 
 | Sub | Returns |
 |---|---|
-| `:rf.causa/trace-filters` | The current 9-axis filter map. |
-| `:rf.causa/trace-feed` | Composite — `{:rows :total :rendered :distinct :counts :filters :any-filter? :empty-kind}`. |
+| `:rf.causa/trace-feed` | Composite over the focused epoch's `:trace-events` — `{:rows :total :rendered :epoch-id :empty-kind}`. `:empty-kind` ∈ `#{:no-focus :epoch-evicted :no-events nil}`. |
+| `:rf.causa/trace-expanded-row-ids` | The set of trace-row ids whose inline payload is expanded (spec/021 §5.4). |
 
 ### Events
 
 | Event | Vector shape | Behaviour |
 |---|---|---|
-| `:rf.causa/set-trace-filter` | `[_ axis value]` | Sets / clears one axis. `nil` value clears that axis. v1 is single-value per axis; multi-value rides a follow-on. |
-| `:rf.causa/clear-trace-filters` | `[_]` | Clears every axis. |
+| `:rf.causa/toggle-trace-row-expand` | `[_ row-id]` | Toggle a row's inline payload expansion membership. |
+| `:rf.causa/clear-trace-expand` | `[_]` | Drop every expanded trace-row id. |
 
 ## Routes panel
 

--- a/tools/causa/src/day8/re_frame2_causa/panels.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels.cljs
@@ -71,7 +71,7 @@
   | **event-detail** | `:rf.causa/focus` · `:rf.causa/cascades` · `:rf.causa/target-frame-db` | `:rf.causa/focus-cascade` |
   | **app-db (current-state inspector)** | `:rf.causa/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area — rf2-okvit) | `:rf.causa/open-segment-inspector` |
   | **reactive-panel** | `:rf.causa/reactive-data` (composite over focused cascade's `:trace-events`) | `:rf.causa/reactive-toggle-unchanged` |
-  | **trace** | `:rf.causa/trace-feed` (incremental projection over the buffer) | `:rf.causa/select-dispatch-id` · `:rf.causa/open-in-editor` |
+  | **trace** | `:rf.causa/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events`, rf2-td380) | `:rf.causa/toggle-trace-row-expand` · `:rf.causa/open-in-editor` |
   | **machine-inspector** | `:rf.causa/machine-chart-data` · `:rf.causa/active-timers-for-focused-machine` · `:rf.causa/machine-scrubber-position` | scrubber events · `:rf.causa/focus-cascade` |
   | **routing** | `:rf.causa/registered-routes` · `:rf.causa/current-route-slice` · `:rf.causa/routing-tab-data` | route-simulation events |
   | **issues-ribbon** | `:rf.causa/issues-ribbon` (composite over focused epoch's `:trace-events` + filter chips per spec/021 §8) | `:rf.causa.issues/toggle-severity` · `:rf.causa.issues/toggle-prefix` · `:rf.causa.issues/clear-filters` |

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -1,75 +1,65 @@
 (ns day8.re-frame2-causa.panels.trace
-  "Trace panel — Phase 5 (rf2-argrj, parent rf2-5aw5v).
+  "Trace panel — Phase 5 (rf2-argrj, parent rf2-5aw5v);
+  epoch-scoped rework (rf2-o6yqq + rf2-td380 + rf2-gkczt).
 
   Per `tools/causa/spec/000-Vision.md` L89 (panel-inventory row) the
   Trace panel is the raw-event ribbon — every trace event in the
-  buffer renders as one timestamped row, filterable along the 13-axis
-  vocabulary documented in `spec/009-Instrumentation.md` §Filter
-  vocabulary. Where the Issues ribbon collapses the stream to
-  issues only, this panel surfaces every op-type so a programmer
-  can grep across the full vocabulary.
+  FOCUSED EPOCH renders as one timestamped row.
 
   ## What this panel shows
 
-  A scrollable, timestamped ribbon. Each row carries:
+  A scrollable, timestamped ribbon scoped to the spine's focused
+  epoch. Each row carries:
 
       timestamp · op-type-dot · operation · description · source-coord
 
-  Clicking a row → the parent dispatch-id is selected
-  (`:rf.causa/select-dispatch-id`) and the user pivots to the
-  event-detail panel for the cascade. Empty `:dispatch-id` events
-  (registry-time / lifecycle) stay non-clickable.
+  Clicking a row toggles its inline payload expansion (no nav).
 
-  Per-row chip-filter affordance: clicking any axis value in the
-  row narrows the filter on that axis to the clicked value (the
-  bead's 'per-row chip-filter UI' contract). The header's clear-all
-  affordance drops every filter at once.
-
-  ## Filter axes (Spec 009 §Filter vocabulary)
-
-  The 8 named axes the vocabulary enumerates that the chip-row UI
-  surfaces:
-
-      :op-type      :severity     :source      :origin
-      :operation    :event-id     :handler-id  :dispatch-id
-
-  `:frame` is in the Spec-009 vocabulary but intentionally omitted
-  from the chip-row UI — post-rf2-ycoct the Trace tab is cascade-
-  scoped, so every visible row already shares the focused event's
-  frame; a frame chip would offer to filter on the only value
-  present. The filter algebra still accepts `:frame` if a dispatcher
-  sets it programmatically.
-
-  Each axis is set via `:rf.causa/set-trace-filter` (axis, value);
-  `nil` clears the axis. The numeric `:since` / `:since-ms` /
-  `:between` and `:pred` axes are accepted by the filter algebra but
-  ride a follow-on bead for the UI (drag-zoom on the time-axis,
-  expression input).
-
-  ## Cascade-scope (rf2-ycoct)
+  ## Epoch-scoped feed (rf2-td380)
 
   Per spec/018 §6 every L4 panel is a lens on the spine's focused
-  event, not a global ribbon. The trace tab pre-filters its ribbon
-  to events in the focused cascade's window via the
-  `:rf.causa/focus` sub (composed by the spine in `spine.cljs`). User
-  chip filters AND with the cascade scope; the chip rows continue to
-  reflect user state only — the cascade-scope is a system-level
-  invariant, not a user narrowing. Clicking a different cascade in
-  the L2 event list re-binds the spine and the ribbon re-renders
-  with the new cascade's events.
+  event, not a global ribbon. The Trace tab reads the FOCUSED EPOCH's
+  `:trace-events` — the per-frame settling epoch record's raw trace
+  slice — which folds the COMPLETE domino trail for one event: both
+  the synchronous event-side rows (dispatch-id N) AND the async
+  reactive rows (`:sub/run` / `:view/render`, nil dispatch-id) that
+  fire post-cascade for that settling.
+
+  The prior shape scoped the global trace bus by `:dispatch-id`,
+  which DROPPED those async reactive rows (their dispatch-id is nil),
+  so the rendered trail was incomplete (e.g. 4 rows shown vs the
+  epoch's real 12). Reading the epoch record's `:trace-events` —
+  resolved via the shared `panels.shared.focus-resolver` against
+  `:rf.causa/focus` + `:rf.causa/epoch-history`, exactly as the
+  Issues / App-DB Diff panels do — renders the whole trail: event →
+  db-changed → subs ran → views rendered.
+
+  Per-event epochs (merged) mean the focused epoch's `:trace-events`
+  is the right scope: one epoch per event, each carrying its own
+  reactive settling.
+
+  ## No filtering (rf2-gkczt)
+
+  The Trace panel surfaces the epoch-scoped rows with NO filtering
+  UI — the focused epoch IS the scope, and the per-row payload-expand
+  affordance is the drill-down. The 13-axis chip-filter rows, the
+  per-row chip affordances, and the clear-filters control are gone.
+
+  ## No header row (rf2-o6yqq)
+
+  The duplicate film-strip nav (Prev/Next), the `X / Y in view`
+  counts, and the `epoch #N · X ops` indicator are removed from this
+  panel — the L2 events list already owns spine focus navigation
+  (`:rf.causa/focus-cascade-prev` / `-next`), and the L4 tab strip is
+  the panel-name source-of-truth.
 
   ## Empty states
 
-  Per the bead's contract:
-
-    :no-events   → 'No events.' Once the trace bus starts flowing
-                   this clears immediately.
-    :no-focus    → defensive: buffer is non-empty but the spine has
-                   no `:dispatch-id`. Per rf2-639lc default-focus
-                   should always land on a real cascade, so this
-                   should never render in practice.
-    :no-matches  → events exist but the active filters hide them
-                   all. 'No events match current filters' + Clear.
+    :no-events     → 'No events.' (the focused epoch carries no
+                     trace events).
+    :no-focus      → defensive: no focused epoch AND no history.
+    :epoch-evicted → the focused epoch aged out of the
+                     `:epoch-history` ring buffer.
 
   ## Pure hiccup (rf2-tijr)
 
@@ -79,264 +69,20 @@
 
   ## Helpers
 
-  All pure-data logic — filter application, row projection, axis
-  enumeration, empty-state classification — lives in
-  `trace_helpers.cljc` so the algebra runs under the JVM unit-test
-  target."
+  All pure-data logic — row projection, epoch-scoped feed projection,
+  empty-state classification — lives in `trace_helpers.cljc` so the
+  algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
-            [day8.re-frame2-causa.panels.shared.film-strip.header
-             :as film-strip]
+            [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
-             :as t
-             :refer [tokens mono-stack sans-stack display-stack]]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]
+             :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
-
-;; ---- axis labelling -----------------------------------------------------
-
-(def ^:private axis-labels
-  "Human-readable label for each filter axis. The view uses these
-  for the chip-row headers and for the 'active filter' badges in the
-  header strip.
-
-  `:frame` is intentionally absent — post-rf2-ycoct the Trace tab is
-  cascade-scoped, so a frame-filter chip on top of the cascade scope
-  is redundant (the focused event has exactly one frame). See
-  `trace-helpers/filter-axes` for the full rationale."
-  {:op-type     "op-type"
-   :severity    "severity"
-   :source      "source"
-   :origin      "origin"
-   :operation   "operation"
-   :event-id    "event-id"
-   :handler-id  "handler-id"
-   :dispatch-id "dispatch-id"})
-
-(defn- format-axis-value
-  "Render an axis value for display. Keywords render with their
-  namespace; numbers / strings render as-is; nils as '(none)'."
-  [v]
-  (cond
-    (nil? v)     "(none)"
-    (keyword? v) (str v)
-    :else        (pr-str v)))
-
-;; ---- chip helpers -------------------------------------------------------
-
-(defn- chip
-  "One filter chip. `active?` drives the highlighted styling.
-  `on-click` fires the relevant axis toggle. `orphan?` (rf2-vu0mp)
-  marks chips whose value is no longer represented in the current
-  buffer — the chip still renders so the user always sees what's
-  narrowing the ribbon, but is styled dashed-border + italic to
-  signal 'no buffered matches'."
-  [{:keys [label active? on-click test-id colour orphan? title]}]
-  [:button {:data-testid test-id
-            :on-click    on-click
-            :title       title
-            :style       {:background    (if active?
-                                           (:bg-active tokens)
-                                           "transparent")
-                          :color         (if active?
-                                           (:text-primary tokens)
-                                           (or colour (:text-secondary tokens)))
-                          :border        (str "1px "
-                                              (if orphan? "dashed" "solid")
-                                              " "
-                                              (if active?
-                                                (or colour (:border-default tokens))
-                                                (:border-subtle tokens)))
-                          :border-radius "999px"
-                          :padding       "2px 10px"
-                          :cursor        "pointer"
-                          :font-family   sans-stack
-                          :font-size     "11px"
-                          :font-weight   (if active? 600 400)
-                          :font-style    (if orphan? "italic" "normal")
-                          :letter-spacing "0.2px"
-                          :margin-right  "6px"
-                          :margin-bottom "4px"}}
-   label])
-
-(defn- axis-chip-row
-  "Render a chip-row for one filter axis. Each chip toggles the axis
-  to its value; the currently-active value (if any) renders highlit.
-  Renders when at least two distinct values are present OR when an
-  active filter selection is present (so the user can always see /
-  toggle off their narrowing — even when the selected value has
-  aged out of the buffer per rf2-vu0mp).
-
-  Per rf2-vu0mp the helper's `effective-distinct` ALREADY unions the
-  active value into the per-axis distinct vector, so an orphaned
-  active value renders as one of the chips. We mark it visually with
-  the orphan-styling discipline on the chip (dashed border + italic +
-  count `0`) so the user can tell `:source = :timer` is selected but
-  the buffer no longer carries any `:timer`-sourced events."
-  [{:keys [axis active-value distinct counts axis-colour]}]
-  (when (and (sequential? distinct)
-             (or (>= (count distinct) 2)
-                 (some? active-value)))
-    (into [:div {:data-testid (str "rf-causa-trace-axis-row-" (name axis))
-                 :style       {:display    "flex"
-                               :flex-wrap  "wrap"
-                               :align-items "baseline"
-                               :margin-top "4px"}}
-           [:span {:style {:font-family   sans-stack
-                           :font-size     "10px"
-                           :color         (:text-tertiary tokens)
-                           :text-transform "uppercase"
-                           :letter-spacing "0.5px"
-                           :margin-right  "8px"
-                           :min-width     "70px"}}
-            (get axis-labels axis (name axis))]]
-          (for [value distinct
-                :let [active? (= active-value value)
-                      n       (get counts value 0)
-                      orphan? (and active? (zero? n))
-                      colour  (cond
-                                (and (= axis :op-type) (some? value))
-                                (h/op-type-colour value)
-                                (= axis :severity)
-                                (h/op-type-colour value)
-                                :else axis-colour)]]
-            (chip {:label    (str (format-axis-value value) " · " n)
-                   :active?  active?
-                   :colour   colour
-                   :orphan?  orphan?
-                   :title    (when orphan?
-                               (str "no buffered events match — "
-                                    (name axis) " = "
-                                    (format-axis-value value)
-                                    " (aged out of the ring buffer)"))
-                   :test-id  (str "rf-causa-trace-axis-chip-"
-                                  (name axis) "-"
-                                  (if (keyword? value)
-                                    (str (some-> value namespace (str "_"))
-                                         (name value))
-                                    (str value)))
-                   :on-click #(rf/dispatch
-                                [:rf.causa/set-trace-filter
-                                 axis
-                                 (when-not active? value)] {:frame :rf/causa})})))))
-
-;; ---- header strip -------------------------------------------------------
-
-(defn- epoch-indicator
-  "Per spec/021 §5.2 — the film-strip header's middle slot reads
-  `epoch #N · X ops`. `epoch-id` is the focused cascade's settling
-  epoch (the canonical per-frame epoch primary key per spec/018 §6);
-  `rendered` is the post-filter row count (= 'X ops' visible right
-  now)."
-  [{:keys [epoch-id rendered]}]
-  (let [epoch-label (if (some? epoch-id)
-                      (str "epoch #" epoch-id)
-                      "no epoch focused")
-        ops-label   (str rendered " "
-                         (if (= 1 rendered) "op" "ops"))]
-    [:span {:data-testid "rf-causa-trace-epoch-indicator"
-            :style       {:color       (:text-tertiary tokens)
-                          :font-family mono-stack
-                          :font-size   "11px"}}
-     (str epoch-label " · " ops-label)]))
-
-(defn- header
-  "Panel header — film-strip + title + counts + chip rows + clear-all.
-
-  Per spec/021 §5.2 the Trace panel header carries:
-
-    - title `TRACE · epoch #N` (left)
-    - film-strip `[◀ Prev] [Next ▶]` (right)
-
-  The film-strip prev/next semantics per spec/021 §5.5 are
-  *chronological*: walk the L2 cascade list one epoch at a time
-  regardless of dispatch-origin. We delegate to the spine's
-  `:rf.causa/focus-cascade-prev` / `:rf.causa/focus-cascade-next`
-  handlers — the same surface the L1 ribbon nav uses — so prev/next
-  semantics live in ONE place and panels stay declarative."
-  [{:keys [total rendered distinct counts filters any-filter?
-           focus at-head? at-tail?]}]
-  (let [epoch-id (:epoch-id focus)]
-    [:header {:style {:padding       "12px 16px 6px 16px"
-                      :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     [:div {:style {:display     "flex"
-                    :align-items "baseline"
-                    :gap         "12px"}}
-      ;; rf2-6xezz — Mike-direction 2026-05-21: the large h1 "Trace"
-      ;; heading is scrubbed; the L4 tab strip is the panel-name
-      ;; source-of-truth. The counts / clear-filters / film-strip
-      ;; affordances stay in this row.
-      [:span {:data-testid "rf-causa-trace-counts"
-              :style {:font-size   "11px"
-                      :color       (:text-tertiary tokens)
-                      :font-family mono-stack}}
-       (str rendered " / " total " in view")]
-      (when any-filter?
-        [:button {:data-testid "rf-causa-trace-clear-filters"
-                  :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
-                  :style       {:background  "transparent"
-                                :color       (:cyan tokens)
-                                :border      (str "1px solid " (:border-default tokens))
-                                :padding     "2px 8px"
-                                :border-radius "3px"
-                                :cursor      "pointer"
-                                :font-family sans-stack
-                                :font-size   "11px"}}
-         "Clear filters"])
-      ;; rf2-7dyi8 — film-strip header per spec/021 §5.2 + §5.5.
-      ;; Sits on the right edge of the title row; dispatches the
-      ;; canonical spine prev/next events so this panel's nav and the
-      ;; L1 ribbon's nav walk the same cascade vector with identical
-      ;; boundary semantics.
-      [:div {:style {:margin-left "auto"}}
-       (film-strip/header
-         {:panel-id  "trace"
-          :prev-fn   #(rf/dispatch [:rf.causa/focus-cascade-prev] {:frame :rf/causa})
-          :next-fn   #(rf/dispatch [:rf.causa/focus-cascade-next] {:frame :rf/causa})
-          :has-prev? (not at-tail?)
-          :has-next? (not at-head?)
-          :indicator (epoch-indicator {:epoch-id epoch-id
-                                       :rendered rendered})})]]
-     [:div {:style {:margin-top "8px"}}
-      (for [axis h/filter-axes]
-        ^{:key axis}
-        [axis-chip-row {:axis         axis
-                        :active-value (get filters axis)
-                        :distinct     (get distinct axis)
-                        :counts       (get counts axis)
-                        :axis-colour  (:accent-violet tokens)}])]]))
-
-;; ---- per-row -------------------------------------------------------------
-
-(defn- row-chip
-  "A minimal in-row chip — clicking it sets the panel's filter on
-  the named axis to the clicked value, per the bead's per-row chip-
-  filter UI contract."
-  [{:keys [axis value test-id]}]
-  (when (some? value)
-    [:button {:data-testid test-id
-              :on-click    (fn [e]
-                             (.stopPropagation e)
-                             (rf/dispatch [:rf.causa/set-trace-filter
-                                           axis value] {:frame :rf/causa}))
-              :title       (str "filter " (name axis) " = "
-                                (format-axis-value value))
-              :style       {:background    "transparent"
-                            :color         (:text-tertiary tokens)
-                            :border        (str "1px solid "
-                                                (:border-subtle tokens))
-                            :border-radius "3px"
-                            :padding       "1px 6px"
-                            :cursor        "pointer"
-                            :font-family   mono-stack
-                            :font-size     "10px"
-                            :margin-right  "4px"}}
-     (format-axis-value value)]))
 
 ;; ---- payload renderer ---------------------------------------------------
 ;;
@@ -379,7 +125,7 @@
   membership in `:rf.causa/trace-expanded-row-ids`; expanded rows
   render the shared data-display renderer below the row inside the
   same `<li>` so the React-key + scroll-anchoring discipline holds."
-  [{:keys [id time op-type operation source origin frame description
+  [{:keys [id time op-type operation description
            source-coord dispatch-id]
     :as row}
    {:keys [expanded?]}]
@@ -424,7 +170,7 @@
      [:div {:data-testid (str row-test-id "-summary")
             :style       {:display       "grid"
                           :grid-template-columns
-                          "84px 14px minmax(140px, 1fr) 2fr auto auto auto"
+                          "84px 14px minmax(140px, 1fr) 2fr auto auto"
                           :gap           "10px"
                           :align-items   "center"
                           :padding       "6px 16px"}}
@@ -457,22 +203,6 @@
                            :white-space   "nowrap"}
              :title       description}
       description]
-     ;; Per-row chip-filters — the bead's contract. We surface the
-     ;; commonly-grepped axes that ride on the row directly (source,
-     ;; origin). The op-type / severity chips ride the dot; clicking
-     ;; the dot itself is a future affordance — for v1 the chip-row in
-     ;; the header is the op-type entry point. `:frame` is omitted —
-     ;; post-rf2-ycoct the Trace tab is cascade-scoped, so every visible
-     ;; row already shares the focused event's frame; a frame chip on
-     ;; the row would offer to filter on the only value present.
-     [:span {:data-testid (str row-test-id "-row-chips")
-             :style       {:display "flex"
-                           :align-items "center"
-                           :white-space "nowrap"}}
-      (row-chip {:axis :source :value source
-                 :test-id (str row-test-id "-source-chip")})
-      (row-chip {:axis :origin :value origin
-                 :test-id (str row-test-id "-origin-chip")})]
      ;; Source-coord (when present)
      (if source-coord
        [:button {:data-testid (str row-test-id "-source-coord")
@@ -525,11 +255,13 @@
 
 ;; ---- empty states -------------------------------------------------------
 
-(defn- empty-state-no-events
-  "Per the bead's contract — the buffer is empty (no traces observed
-  yet)."
-  []
-  [:div {:data-testid "rf-causa-trace-empty-no-events"
+(defn- empty-state-message
+  "Shared terse empty-state block. `kind` drives the data-testid +
+  copy. Per rf2-td380 the Trace panel is epoch-scoped, so the empty
+  states discriminate the focus-resolver's three statuses plus the
+  'focused epoch carries no trace events' case."
+  [kind copy]
+  [:div {:data-testid (str "rf-causa-trace-empty-" (name kind))
          :style       {:padding     "24px"
                        :font-family sans-stack
                        :font-size   "13px"
@@ -537,114 +269,29 @@
                        :color       (:text-secondary tokens)}}
    [:p {:style {:margin 0
                 :color  (:text-tertiary tokens)}}
-    "No events."]])
+    copy]])
+
+(defn- empty-state-no-events
+  "The focused epoch carries no trace events."
+  []
+  (empty-state-message :no-events "No events."))
 
 (defn- empty-state-no-focus
-  "Defensive empty-state — the buffer has events but the spine focus
-  has no `:dispatch-id`. Per rf2-639lc the default-focus rule should
-  always land on a real cascade, so this branch should never render
-  in practice; the terse copy + testid here let us spot a regression
-  when it does."
+  "Defensive empty-state — no focused epoch AND no epoch history. Per
+  rf2-639lc the default-focus rule should always land on a real
+  cascade, so this branch should never render in practice; the terse
+  copy + testid here let us spot a regression when it does."
   []
-  [:div {:data-testid "rf-causa-trace-empty-no-focus"
-         :style       {:padding     "24px"
-                       :font-family sans-stack
-                       :font-size   "13px"
-                       :line-height 1.5
-                       :color       (:text-secondary tokens)}}
-   [:p {:style {:margin 0
-                :color  (:text-tertiary tokens)}}
-    "No focused event."]])
+  (empty-state-message :no-focus "No focused event."))
 
-(defn- active-filter-pill
-  "Per rf2-vu0mp — one pill in the no-matches empty state's 'narrowing
-  on' strip. Clicking removes the axis from the filter map. Orphan
-  pills (value aged out of the buffer) carry an additional '(orphaned)'
-  marker so the user knows the active value will not match anything
-  in the current buffer until either the filter is cleared OR a new
-  event with that value arrives."
-  [{:keys [axis value present?]}]
-  (let [axis-name (name axis)
-        value-str (cond
-                    (nil? value)     "(none)"
-                    (keyword? value) (str value)
-                    :else            (pr-str value))
-        test-id   (str "rf-causa-trace-empty-active-" axis-name)
-        label     (if present?
-                    (str axis-name " = " value-str)
-                    (str axis-name " = " value-str " (orphaned)"))]
-    [:button {:data-testid test-id
-              :on-click    #(rf/dispatch [:rf.causa/set-trace-filter
-                                          axis nil] {:frame :rf/causa})
-              :title       (if present?
-                             (str "Drop " axis-name " filter")
-                             (str axis-name " = " value-str
-                                  " — value aged out of the buffer"))
-              :style       {:background    (if present?
-                                             (:bg-active tokens)
-                                             "transparent")
-                            :color         (if present?
-                                             (:text-primary tokens)
-                                             (:text-secondary tokens))
-                            :border        (str "1px "
-                                                (if present? "solid" "dashed")
-                                                " "
-                                                (:border-default tokens))
-                            :border-radius "999px"
-                            :padding       "3px 10px"
-                            :cursor        "pointer"
-                            :font-family   sans-stack
-                            :font-size     "11px"
-                            :font-style    (if present? "normal" "italic")
-                            :margin-right  "6px"
-                            :margin-bottom "4px"}}
-     label]))
-
-(defn- empty-state-no-matches
-  "Per the bead's contract — events exist but the active filters
-  hide them all. Carries a Clear filters affordance.
-
-  Per rf2-vu0mp: surfaces an 'narrowing on:' strip listing every
-  active axis=value pair with an orphan marker. Without this strip
-  the user has no in-panel cue WHICH filter is responsible when the
-  selected value has aged out of the buffer (the chip in the header
-  may not be obvious; with multiple axes active the user has to
-  scan)."
-  [{:keys [active-filters]}]
-  [:div {:data-testid "rf-causa-trace-empty-no-matches"
-         :style       {:padding     "24px"
-                       :font-family sans-stack
-                       :font-size   "13px"
-                       :line-height 1.5
-                       :color       (:text-secondary tokens)}}
-   [:p {:style {:margin "0 0 12px 0"
-                :color (:text-primary tokens)
-                :font-weight 600}}
-    "No events match current filters."]
-   (when (seq active-filters)
-     [:div {:data-testid "rf-causa-trace-empty-active-filters"
-            :style       {:margin "0 0 12px 0"}}
-      [:span {:style {:font-size      "10px"
-                      :color          (:text-tertiary tokens)
-                      :text-transform "uppercase"
-                      :letter-spacing "0.5px"
-                      :margin-right   "8px"}}
-       "narrowing on:"]
-      (into [:span {:style {:display "inline-flex" :flex-wrap "wrap"
-                            :align-items "baseline"}}]
-            (for [{:keys [axis] :as pill} active-filters]
-              ^{:key axis} [active-filter-pill pill]))])
-   [:button {:data-testid "rf-causa-trace-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
-             :style       {:background "transparent"
-                           :color      (:cyan tokens)
-                           :border     (str "1px solid " (:border-default tokens))
-                           :padding    "4px 10px"
-                           :border-radius "3px"
-                           :cursor     "pointer"
-                           :font-family sans-stack
-                           :font-size  "12px"}}
-    "Clear filters"]])
+(defn- empty-state-epoch-evicted
+  "The focused epoch's record has aged out of the `:epoch-history`
+  ring buffer. Mirrors the Issues / App-DB Diff placeholder per
+  spec/021 §10.7."
+  []
+  (empty-state-message
+    :epoch-evicted
+    "This epoch has been evicted from the history buffer."))
 
 ;; ---- cascade status timeline bar (rf2-b76v4) ---------------------------
 
@@ -684,20 +331,17 @@
 
 (rf/reg-view Panel
   "The Trace panel's root view. Subscribes to `:rf.causa/trace-feed`
-  and renders either the chip-filterable ribbon or the empty-state.
+  (the epoch-scoped feed, rf2-td380) and renders the focused epoch's
+  domino-trail ribbon or an empty-state. No header row (rf2-o6yqq),
+  no filtering UI (rf2-gkczt).
 
   ## rf2-b76v4 — cascade-status timeline bar
 
   A 3px bar above the ribbon fills with the focused cascade's
-  lifecycle-status colour. The bar is the Trace tab's representation
-  of the bead's 'timeline bar fill' surface — ONE bar driven by
-  `event-status-colour`, the same fn the L2 row + Event header
-  consume. The Trace tab is cascade-scoped (rf2-ycoct), so the bar's
-  status reflects every visible row's parent cascade."
+  lifecycle-status colour — ONE bar driven by `event-status-colour`,
+  the same fn the L2 row + Event header consume."
   []
-  (let [{:keys [rows total rendered distinct counts filters
-                any-filter? empty-kind active-filters]
-         :as _data}
+  (let [{:keys [rows empty-kind] :as _data}
         @(rf/subscribe [:rf.causa/trace-feed])
         ;; rf2-b76v4 — pull the focused cascade + focus map so the
         ;; cascade-status timeline bar can render with the canonical
@@ -709,17 +353,6 @@
         focused-cascade (when focused-id
                           (some #(when (= focused-id (:dispatch-id %)) %)
                                 cascades))
-        ;; rf2-7dyi8 — film-strip nav boundaries. We walk the same
-        ;; cascade list the L1 ribbon walks (`cascades` already passes
-        ;; through `trace-bus/causa-internal-cascade?` in the registry
-        ;; sub) so prev/next semantics match exactly. Empty cascade
-        ;; list → both buttons disabled.
-        cascade-ids    (mapv :dispatch-id cascades)
-        at-head?       (or (empty? cascade-ids)
-                           (= focused-id (last cascade-ids))
-                           (nil? focused-id))
-        at-tail?       (or (empty? cascade-ids)
-                           (= focused-id (first cascade-ids)))
         ;; rf2-7dyi8 — per-row inline payload expansion set. The
         ;; trace-row hiccup reads `expanded?` from the closure built
         ;; here so the row-fn keeps the single-arg shape `overflow/
@@ -738,149 +371,75 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     (header {:total       total
-              :rendered    rendered
-              :distinct    distinct
-              :counts      counts
-              :filters     filters
-              :any-filter? any-filter?
-              :focus       focus
-              :at-head?    at-head?
-              :at-tail?    at-tail?})
-     ;; rf2-b76v4 — cascade-status timeline bar. Renders only when a
-     ;; cascade is in focus and the ribbon has rows; the empty-state
-     ;; branches don't carry a 'focused cascade' surface to colour.
-     (when (and focused-cascade (nil? empty-kind))
+     ;; rf2-b76v4 — cascade-status timeline bar. Renders whenever a
+     ;; cascade is in focus — the bar reflects the focused CASCADE's
+     ;; lifecycle (sourced from `:rf.causa/cascades` + focus), which is
+     ;; orthogonal to the epoch feed's empty-kind (rf2-td380: the feed
+     ;; scopes by the focused epoch's `:trace-events`).
+     (when focused-cascade
        (cascade-status-bar {:cascade focused-cascade
                             :focus   focus}))
      [:div {:style {:flex 1 :overflow "auto"}}
       (case empty-kind
-        :no-events  (empty-state-no-events)
-        :no-focus   (empty-state-no-focus)
-        :no-matches (empty-state-no-matches {:active-filters active-filters})
-        nil         (overflow/capped-list
-                      rows
-                      {:panel-id "trace"
-                       :ul-attrs {:data-testid "rf-causa-trace-feed"
-                                  :style       {:list-style "none"
-                                                :margin     0
-                                                :padding    0}}
-                       :row-fn   row-with-state}))]]))
+        :no-events     (empty-state-no-events)
+        :no-focus      (empty-state-no-focus)
+        :epoch-evicted (empty-state-epoch-evicted)
+        nil            (overflow/capped-list
+                         rows
+                         {:panel-id "trace"
+                          :ul-attrs {:data-testid "rf-causa-trace-feed"
+                                     :style       {:list-style "none"
+                                                   :margin     0
+                                                   :padding    0}}
+                          :row-fn   row-with-state}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
   "Idempotent install for the Trace panel's Causa-side registrations
-  (Phase 5, rf2-argrj)."
+  (Phase 5, rf2-argrj; epoch-scoped rework rf2-td380 + rf2-gkczt)."
   []
-  ;; ---- Phase 5 (rf2-argrj) — Trace panel ------------------------------
+  ;; ---- Trace panel — epoch-scoped feed (rf2-td380) --------------------
   ;;
-  ;; The Trace panel is the UI consumer of the canonical 13-axis filter
-  ;; vocabulary documented in spec/009-Instrumentation.md §Filter
-  ;; vocabulary. Where the Issues ribbon collapses the stream to issues
-  ;; only, this panel surfaces the raw stream so a programmer can grep
-  ;; across every op-type / operation / source / origin / frame / etc.
+  ;; Per spec/018 §6 every L4 panel is a lens on the spine's focused
+  ;; event, not a global ribbon. The Trace tab reads the FOCUSED
+  ;; EPOCH's `:trace-events` — the per-frame settling epoch record's
+  ;; raw trace slice, which folds the COMPLETE domino trail for one
+  ;; event (the synchronous event-side dispatch-id-N rows AND the
+  ;; async nil-dispatch-id reactive rows — `:sub/run` / `:view/render`
+  ;; — that fire post-cascade for that settling). The prior shape
+  ;; scoped the global trace bus by `:dispatch-id`, which dropped the
+  ;; async reactive rows; reading the epoch record renders the whole
+  ;; trail.
+  ;;
+  ;; The focused epoch record is resolved exactly as the Issues /
+  ;; App-DB Diff panels resolve theirs: join `:rf.causa/focus`
+  ;; (carrying `:epoch-id`) + `:rf.causa/epoch-history` (the
+  ;; framework's per-frame ring of `:rf/epoch-record` maps), then run
+  ;; the shared `panels.shared.focus-resolver` — which classifies the
+  ;; focus status (`:no-focus` / `:focused` / `:epoch-evicted`, with
+  ;; the rf2-h0120 head-fallback) and looks up the record.
+  ;;
+  ;; No filtering (rf2-gkczt): the focused epoch IS the scope, so the
+  ;; feed is the epoch's domino trail with no chip narrowing.
   ;;
   ;; Shape of `:rf.causa/trace-feed`:
   ;;
-  ;;     {:rows         [<row> ...]      ;; post-filter, newest first
-  ;;      :total        <int>            ;; pre-filter count
-  ;;      :rendered     <int>            ;; post-filter count
-  ;;      :distinct     {<axis> [...]}   ;; per-axis chip values
-  ;;      :counts       {<axis> {<value> <int>}}
-  ;;      :filters      <pass-through normalised>
-  ;;      :any-filter?  <bool>
-  ;;      :empty-kind   <:no-events / :no-matches / nil>}
-
-  ;; The current 13-axis filter map. Each axis is independent; the
-  ;; helper's `normalise-filters` drops nil / empty values before
-  ;; applying — the view sets axis = nil to clear an axis.
-  (rf/reg-sub :rf.causa/trace-filters
-    (fn [db _query]
-      (get db :trace-filters {})))
-
-  ;; Per rf2-44vzy: the trace-feed projection now reads a pre-
-  ;; computed snapshot maintained incrementally by the
-  ;; `:rf.causa/note-trace-event` handler in `registry.cljs`. The
-  ;; snapshot carries the projected rows plus per-axis distinct /
-  ;; counts / seen state and is updated in O(axes) on every push
-  ;; (and O(axes) on every cap eviction). Pre-rf2-44vzy the sub re-
-  ;; walked the entire buffer on every push — at 60Hz × 1000-event
-  ;; buffer that was ~60k row-touches/sec on the main thread before
-  ;; any render work happened.
-  ;;
-  ;; Fallback path: when `:trace-feed-state` is absent (a consumer
-  ;; that bypasses the mirror — e.g. a headless test driving
-  ;; `collect-trace!` without the `mount.cljs/open!` seed) the sub
-  ;; rebuilds the snapshot from the raw buffer on read. The rebuild
-  ;; is the same cost shape as the pre-rf2-44vzy sub, so the worst
-  ;; case under the fallback path is no slower than the prior shape.
-  ;;
-  ;; The fallback chain mirrors `:rf.causa/trace-buffer`'s contract
-  ;; (registry.cljs L100-102): app-db slot → trace-bus atom. The
-  ;; atom path keeps headless tests (`collect-trace!` without
-  ;; `mount.cljs/open!`) functional — the prior `project-feed` sub
-  ;; consumed `:rf.causa/trace-buffer` which already chained through
-  ;; this fallback, so preserving the chain keeps headless behaviour
-  ;; identical.
-  (rf/reg-sub :rf.causa/trace-feed-state
-    (fn [db _query]
-      (or (get db :trace-feed-state)
-          (h/rebuild-feed-state
-            (or (get db :trace-buffer)
-                (trace-bus/buffer))))))
-
-  ;; Composite — produces every slot the view consumes. Reactive
-  ;; surface: trace-feed-state (incrementally maintained) + filter
-  ;; state + spine focus. The helper's `project-feed-from-state` does
-  ;; the read-side work: a single reverse-then-filter walk over
-  ;; already-projected rows. Filter-only changes still O(rows) but
-  ;; with no per-event `project-row` cost.
-  ;;
-  ;; ## Cascade-scope by default (rf2-ycoct)
-  ;;
-  ;; Per spec/018 §6 every L4 panel is a lens on the spine's focused
-  ;; event, not a global ribbon. The trace tab pre-filters to events
-  ;; in the focused cascade's window using the focus sub's
-  ;; `:dispatch-id` (which the spine composer auto-resolves to the
-  ;; head cascade in LIVE mode per rf2-s0s5x, or pins to the retro
-  ;; selection in RETRO mode). User chip filters still apply AND-wise
-  ;; on top of the cascade scope.
-  ;;
-  ;; The cascade-scope is a SYSTEM-level invariant (not a user
-  ;; narrowing), so the `:rf.causa/trace-filters` map and the chip
-  ;; rows continue to reflect user state only. A user click on a
-  ;; `:dispatch-id` chip becomes redundant when it matches the
-  ;; focused id (both filters yield the same set) and acts as an
-  ;; AND-wise narrower when it doesn't — but the typical workflow is
-  ;; to focus via L2 and let the panel auto-scope.
+  ;;     {:rows       [<row> ...]   ;; the epoch's domino trail, newest first
+  ;;      :total      <int>         ;; the epoch's trace-event count
+  ;;      :rendered   <int>         ;; same as :total (no filtering)
+  ;;      :epoch-id   <int-or-nil>  ;; the focused epoch's id
+  ;;      :empty-kind <:no-events / :no-focus / :epoch-evicted / nil>}
   (rf/reg-sub :rf.causa/trace-feed
-    :<- [:rf.causa/trace-feed-state]
-    :<- [:rf.causa/trace-filters]
     :<- [:rf.causa/focus]
-    (fn [[state filters focus] _query]
-      (h/project-feed-from-state
-        state
-        filters
-        {:cascade-dispatch-id (:dispatch-id focus)})))
-
-  ;; Set or clear one axis. Passing nil-value clears that axis;
-  ;; setting a value replaces any existing value on that axis (the
-  ;; chip-filter UI is single-value per axis for v1; multi-value
-  ;; rides a follow-on bead).
-  (rf/reg-event-db :rf.causa/set-trace-filter
-    (fn [db [_ axis value]]
-      (let [current (get db :trace-filters {})]
-        (assoc db :trace-filters
-               (if (nil? value)
-                 (dissoc current axis)
-                 (assoc current axis value))))))
-
-  ;; Clear every filter axis in one shot. Wired from the header's
-  ;; 'Clear filters' button + the no-matches empty state.
-  (rf/reg-event-db :rf.causa/clear-trace-filters
-    (fn [db _event]
-      (dissoc db :trace-filters)))
+    :<- [:rf.causa/epoch-history]
+    (fn [[focus epoch-history] _query]
+      (let [focus-epoch-id (:epoch-id focus)
+            focus-status   (focus/resolve-focus-status focus-epoch-id
+                                                       epoch-history)
+            record         (focus/find-epoch-record focus-epoch-id
+                                                    epoch-history)]
+        (h/project-feed-from-epoch record focus-status))))
 
   ;; ---- rf2-7dyi8 — per-row inline payload expansion ------------------
   ;;

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -1,75 +1,44 @@
 (ns day8.re-frame2-causa.panels.trace-helpers
-  "Pure-data helpers for Causa's Trace panel (Phase 5, rf2-argrj).
+  "Pure-data helpers for Causa's Trace panel (Phase 5, rf2-argrj;
+  epoch-scoped rework rf2-td380 + rf2-gkczt).
 
   ## Why a separate `.cljc` ns
 
   The panel view in `trace.cljs` paints a scrollable, timestamped
-  ribbon of raw trace events and dispatches into the Causa frame.
-  The *logic* — applying the 13-axis filter vocabulary from Spec 009
-  §Filter vocabulary, projecting raw events into row shape,
-  enumerating per-axis distinct values for the chip rows, and
+  ribbon of the focused epoch's trace events and dispatches into the
+  Causa frame. The *logic* — projecting raw events into row shape and
   classifying the empty state — is pure data → data. Splitting the
   algebra into `.cljc` so it runs under the JVM unit-test target
   (`clojure -M:test`) is required by the standing rule
   `feedback_jvm_interop_must_work.md`.
 
-  ## Substrate (per `spec/009-Instrumentation.md` §Filter vocabulary)
+  ## Epoch-scoped feed (rf2-td380)
 
-  The Trace panel is the UI consumer of the canonical 13-axis filter
-  vocabulary documented in Spec 009 §Filter vocabulary (the algebra
-  itself is implemented in `re-frame.trace/trace-buffer` and exposed
-  pure-data via `day8.re-frame2-causa.trace-bus/filter-events`).
-  Where the Issues ribbon collapses the stream to issues
-  only, the Trace panel surfaces the *raw* stream — every op-type,
-  every operation — so a programmer can grep across the full
-  vocabulary.
+  Per spec/018 §6 every L4 panel is a lens on the spine's focused
+  event, not a global ribbon. The Trace tab reads the FOCUSED EPOCH's
+  `:trace-events` (the per-frame settling epoch record's raw trace
+  slice — `re-frame.epoch/epoch-history` keeps oldest-first records,
+  each carrying the complete domino trail for one event: the
+  synchronous event-side dispatch-id-N events AND the async
+  nil-dispatch-id reactive events — `:sub/run` / `:view/render` —
+  that fire post-cascade for that settling). The prior shape scoped
+  the global trace bus by `:dispatch-id`, which DROPPED those async
+  reactive rows (they carry a nil dispatch-id), so the rendered trail
+  was incomplete (e.g. 4 rows shown vs the epoch's real 12). Reading
+  the epoch record's `:trace-events` folds both sides, so rendered
+  rows = the complete domino trail (event → db-changed → subs ran →
+  views rendered).
 
-  ## Filter axes (per the bead's minimum-viable contract)
+  ## No chip filtering (rf2-gkczt)
 
-  All 13 axes Spec 009 §Filter vocabulary enumerates are accepted:
-
-      :operation     keyword           single value
-      :op-type       keyword           single value
-      :since         number            cursor on :id
-      :frame         keyword           :tags :frame match
-      :severity      kw                :error / :warning / :info
-      :event-id      keyword           :tags :event-id
-      :handler-id    keyword           :tags :handler-id
-      :source        keyword           :ui / :timer / :http / ...
-      :origin        keyword           :app / :pair / :story / ...
-      :dispatch-id   number            cascade-wide
-      :since-ms      number            wall-clock cutoff
-      :between       [t0 t1]           wall-clock window
-      :pred          (fn [ev] truthy)  escape hatch
-
-  Empty / nil values disable an axis. Composition is AND-wise — the
-  canonical `trace-bus/filter-events` does the work; this ns adds
-  the panel's projection + per-axis chip enumeration on top."
+  Per Mike-direction 2026-05-22 the Trace panel surfaces the
+  epoch-scoped rows with NO filtering UI — the focused epoch IS the
+  scope, and the per-row payload-expand affordance is the drill-down.
+  The 13-axis filter vocabulary, per-axis chip enumeration, and the
+  buffer-snapshot incremental projection are gone."
   (:require [clojure.string :as str]
             [day8.re-frame2-causa.panels.common-helpers :as common]
-            [day8.re-frame2-causa.theme.tokens :as tokens]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]))
-
-;; ---- the canonical 13-axis vocabulary -----------------------------------
-
-(def filter-axes
-  "The canonical filter-vocabulary axes Spec 009 §Filter vocabulary
-  enumerates. Render order for the chip rows in the panel — most-
-  commonly-used axes first. Source/Origin/Severity ride the
-  enumerable-as-chips path; everything else (:dispatch-id, :event-id,
-  :handler-id, :operation, :op-type) is per-row click-to-filter; the
-  numeric axes (:since, :since-ms, :between) and :pred ride a
-  follow-on bead.
-
-  Note: `:frame` is NOT a chip-row axis. Post-rf2-ycoct the Trace tab
-  is cascade-scoped to the spine's focused event — and the focused
-  event has exactly ONE frame — so a frame-filter chip on top of the
-  cascade scope is doubly redundant (the user has already selected a
-  frame by selecting an event). The underlying filter algebra in
-  `trace-bus/build-filter-predicate` still accepts `:frame` as a
-  vocabulary primitive; we just don't surface a UI for it."
-  [:op-type :severity :source :origin
-   :operation :event-id :handler-id :dispatch-id])
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- short-description ---------------------------------------------------
 
@@ -184,610 +153,68 @@
   [events]
   (mapv project-row events))
 
-;; ---- filter application -------------------------------------------------
+;; ---- epoch-scoped feed projection (the panel reads this) ----------------
 
-(defn normalise-filters
-  "Drop axis entries whose value is nil / empty so the downstream
-  `trace-bus/filter-events` receives only meaningful axes. Pure data;
-  JVM-testable. The view sets axis = nil to clear an axis; this fn
-  is the single 'is this axis active?' arbiter."
-  [filters]
-  (into {}
-        (filter (fn [[_ v]]
-                  (cond
-                    (nil? v)                              false
-                    (and (string? v) (str/blank? v))      false
-                    (and (coll? v) (empty? v))            false
-                    :else                                 true)))
-        (or filters {})))
-
-(defn any-filter-active?
-  "True iff at least one filter axis is active. Drives the
-  'Clear filters' affordance in the header."
-  [filters]
-  (boolean (seq (normalise-filters filters))))
-
-(defn apply-filters
-  "Apply the 13-axis filter vocabulary to `events`. Pure data →
-  vector; JVM-testable. Delegates to `trace-bus/filter-events` so
-  the algebra stays in lockstep with the framework's canonical
-  filter. Returns a vector in chronological order (oldest first)."
-  [events filters]
-  (let [normalised (normalise-filters filters)]
-    (if (empty? normalised)
-      (vec events)
-      (trace-bus/filter-events events normalised))))
-
-;; ---- enumeration --------------------------------------------------------
-
-(defn distinct-values
-  "Return the distinct values of `axis` present in `rows`, in first-
-  seen order, dropping nils. The view uses this to populate the chip-
-  filter rows with only the axis values that have at least one row —
-  empty chips would be noise. Pure data → vector; JVM-testable."
-  [rows axis]
-  (into []
-        (comp (map axis)
-              (remove nil?)
-              (distinct))
-        rows))
-
-(defn axis-counts
-  "Histogram per-axis value → count. Drives chip badge counts. Pure
-  data → map; JVM-testable."
-  [rows axis]
-  (reduce
-    (fn [acc row]
-      (let [v (get row axis)]
-        (if (nil? v) acc (update acc v (fnil inc 0)))))
-    {}
-    rows))
-
-;; ---- orphan-filter surfacing (rf2-vu0mp) --------------------------------
-;;
-;; The chip-row enumeration is built from the events currently in the
-;; buffer. When the buffer rotates past the cap, the oldest event(s)
-;; age out and any axis value carried ONLY by those events drops out
-;; of `:distinct` / `:counts` / `:seen`. If the user has narrowed the
-;; ribbon on that value, the filter remains active (it lives in
-;; `:trace-filters`, separate from the buffer) but the chip that
-;; represents it has nothing to highlight, the empty-state paints
-;; `:no-matches`, and there is no in-panel surface telling the user
-;; what value is responsible. The user is left guessing.
-;;
-;; The fix has two faces, both surfaced through this ns so the algebra
-;; stays JVM-testable:
-;;
-;;   1. `effective-distinct` unions every active filter value into the
-;;      per-axis distinct list (preserving first-seen order and
-;;      avoiding duplication) so the chip ALWAYS renders for the
-;;      currently-active value — orphan or not. The chip-row in the
-;;      header keeps its existing "active value renders highlit"
-;;      discipline; absent values render at the tail of the row.
-;;
-;;   2. `active-filters-summary` produces an ordered list of
-;;      `{:axis :value :present?}` entries the no-matches empty state
-;;      renders as 'narrowing on: axis=value (orphaned)' affordances.
-;;      `:present?` is false iff the value is no longer represented
-;;      in `seen` for that axis, i.e. has aged out of the buffer.
-;;
-;; Both helpers are total over their inputs (nil-tolerant). Per Spec
-;; 009 §Filter vocabulary the active filter map is the canonical
-;; source of truth — the buffer is the renderable substrate.
-
-(defn- distinct-append
-  "Append `value` to `distinct-vec` iff not already present. Stable —
-  preserves first-seen order. Pure data → vector."
-  [distinct-vec value]
-  (if (some #(= value %) distinct-vec)
-    distinct-vec
-    (conj distinct-vec value)))
-
-(defn effective-distinct
-  "Union the currently-active filter values into the per-axis
-  `distinct` map so the chip rows ALWAYS render the active selection
-  — even when the value has aged out of the buffer (rf2-vu0mp).
-
-  `distinct-map` is the per-axis `{axis [value ...]}` first-seen
-  vectors produced by the projection walk; `seen-map` is the parallel
-  `{axis #{value ...}}` membership sets the walk maintains; `filters`
-  is the normalised filter map. For each active axis whose filter
-  value is NOT in `(seen-map axis)`, append the value to the axis
-  distinct vector. Other axes pass through unchanged.
-
-  Pure data → map; JVM-testable."
-  [distinct-map seen-map filters]
-  (reduce-kv
-    (fn [acc axis value]
-      (cond
-        (nil? value)                         acc
-        (and (some? (get seen-map axis))
-             (contains? (get seen-map axis) value)) acc
-        :else
-        (update acc axis (fnil distinct-append []) value)))
-    distinct-map
-    (or filters {})))
-
-(defn active-filters-summary
-  "Ordered list of `{:axis :value :present?}` entries for every
-  active filter axis (rf2-vu0mp). `:present?` is true when the
-  value is still represented in the buffer (via `seen-map`),
-  false when the value has aged out (orphaned). The view renders
-  this in the `:no-matches` empty state so the user always sees
-  what is narrowing the ribbon, even when no buffered event
-  carries the value any more.
-
-  Iteration follows `filter-axes` order so the empty state's chip
-  list matches the header's chip-row ordering.
-
-  Pure data → vector; JVM-testable."
-  [filters seen-map]
-  (let [norm (normalise-filters filters)]
-    (into []
-          (keep (fn [axis]
-                  (let [v (get norm axis)]
-                    (when (some? v)
-                      {:axis     axis
-                       :value    v
-                       :present? (boolean
-                                   (and (some? (get seen-map axis))
-                                        (contains? (get seen-map axis) v)))}))))
-          filter-axes)))
-
-;; ---- composite projection (the panel reads this) ------------------------
-
-(defn project-feed
-  "Top-level projection — produces every slot the view needs. Pure
+(defn project-feed-from-epoch
+  "Top-level projection — produces every slot the Trace view needs,
+  scoped to the FOCUSED EPOCH's `:trace-events` (rf2-td380). Pure
   data → data; JVM-testable.
 
-  Single-pass over the trace buffer (rf2-7mwc8 / audit 2a): the
-  earlier shape ran 28 row-touching passes per recompute (project-
-  rows ×2 + apply-filters + 13× distinct-values + 13× axis-counts).
-  This shape collapses to:
+  `epoch-record` is the `:rf/epoch-record` looked up from
+  `:rf.causa/epoch-history` whose `:epoch-id` matches the focused
+  `:epoch-id` from `:rf.causa/focus` (resolved via the shared
+  `panels.shared.focus-resolver`). Its `:trace-events` slot carries
+  the complete domino trail for one settling — both the synchronous
+  event-side rows (dispatch-id N) and the async reactive rows
+  (`:sub/run` / `:view/render`, nil dispatch-id) — oldest-first.
 
-    1. one walk to project + filter (also accumulates pre-filter
-       per-axis distinct + count maps in the same reduce);
-    2. one reverse over the filtered rows for newest-first display.
+  `focus-status` is the discriminator from
+  `focus-resolver/resolve-focus-status`:
 
-  Total: ~2× over the buffer instead of 28×. The filter test runs
-  inside the same walk via `trace-bus/event-passes-filters?`. Per
-  Spec 009 §Filter vocabulary the algebra delegates to the framework
-  filter so the contract stays in lockstep.
-
-  ## Incremental update path (rf2-44vzy)
-
-  This function performs a **full re-walk** of `events` on every
-  call. Under burst traffic (60Hz × 1000-event buffer) that costs
-  ~60k row-touches/sec on the main thread before any actual render.
-  The reactive path in `panels/trace.cljs` now consults
-  `:rf.causa/trace-feed-state` — an incrementally-maintained snapshot
-  of the projection (`init-feed-state` / `feed-state+ev` /
-  `feed-state-evict`) that updates in O(axes) on each
-  `:rf.causa/note-trace-event` rather than re-walking the buffer.
-  This `project-feed` retains the from-scratch shape as the JVM-
-  testable reference + the fallback when no state is precomputed
-  (mount-time seed, headless tests, code paths that hold a raw event
-  vector without a prior state).
+    :no-focus       — no focused epoch AND no history (cold start
+                      before any cascade has settled)
+    :epoch-evicted  — focus has an :epoch-id but the matching record
+                      is gone from history (capped per :epoch-history)
+    :focused        — focus resolved to a real epoch record (either
+                      explicit pin or head-fallback per rf2-h0120)
 
   Returns:
 
-      {:rows              [<row> ...]    ;; post-filter, newest first
-       :total             <int>          ;; pre-filter count
-       :rendered          <int>          ;; post-filter count
-       :distinct          {<axis> [...]} ;; per-axis chip values
-       :counts            {<axis> {<value> <int>}}
-       :filters           <pass-through normalised>
-       :any-filter?       <bool>
-       :empty-kind        <:no-events / :no-matches / nil>
-       :active-filters    [{:axis <kw> :value <v> :present? <bool>} ...]}
+      {:rows        [<row> ...]   ;; the epoch's domino trail, newest first
+       :total       <int>         ;; the epoch's trace-event count
+       :rendered    <int>         ;; same as :total (no filtering, rf2-gkczt)
+       :epoch-id    <int-or-nil>  ;; the focused epoch's id
+       :empty-kind  <:no-events / :no-focus / :epoch-evicted / nil>}
 
-  `events` is the raw trace-buffer. `filters` is the 13-axis filter
-  map (per Spec 009 §Filter vocabulary).
+  `:empty-kind` discriminates the empty-state branches:
 
-  `:empty-kind` discriminates the two empty-state branches:
+      :no-focus       — spine carries no focused epoch AND history is
+                        empty (cold start, no cascades have settled).
+      :epoch-evicted  — focused epoch's record has aged out of the
+                        history ring buffer.
+      :no-events      — focused epoch carries no trace events.
+      nil             — at least one row; render the ribbon.
 
-      :no-events  — the buffer is empty (no traces observed yet).
-      :no-matches — events exist but the active filters hide them
-                    all. The view paints 'No events match current
-                    filters' with a clear-filters affordance.
-      nil         — at least one event passes; render the ribbon.
-
-  `:active-filters` (rf2-vu0mp) lists each active axis/value pair
-  with a `:present?` flag — true when the value is still represented
-  in the current distinct values for that axis, false when the value
-  has aged out of the buffer (orphaned). The view surfaces this in
-  the no-matches empty state so the user always knows what is
-  narrowing the ribbon."
-  [events filters]
-  (let [normalised   (normalise-filters filters)
-        passes?      (trace-bus/build-filter-predicate normalised)
-        ;; Single-pass accumulator state:
-        ;;   :rev-filtered — filtered rows in REVERSE order (newest
-        ;;                   first, as the view wants); we conj rather
-        ;;                   than build oldest-first then reverse.
-        ;;   :total        — pre-filter row count.
-        ;;   :rendered     — post-filter row count.
-        ;;   :distinct     — {axis [first-seen-value ...]}; built
-        ;;                   alongside :seen so the order is stable.
-        ;;   :seen         — {axis #{value ...}} membership set used
-        ;;                   to dedupe :distinct.
-        ;;   :counts       — {axis {value n}} histogram.
-        init-state   {:rev-filtered ()
-                      :total        0
-                      :rendered     0
-                      :distinct     (into {} (map (fn [a] [a []])) filter-axes)
-                      :seen         (into {} (map (fn [a] [a #{}])) filter-axes)
-                      :counts       (into {} (map (fn [a] [a {}])) filter-axes)}
-        accumulate
-        (fn [state ev]
-          (let [row    (project-row ev)
-                ;; Distinct + counts walk every axis once per row,
-                ;; folding into the per-axis maps.
-                state' (reduce
-                         (fn [s axis]
-                           (let [v (get row axis)]
-                             (cond
-                               (nil? v)
-                               s
-
-                               (contains? (get-in s [:seen axis]) v)
-                               (update-in s [:counts axis v]
-                                          (fnil inc 0))
-
-                               :else
-                               (-> s
-                                   (update-in [:distinct axis] conj v)
-                                   (update-in [:seen axis] conj v)
-                                   (update-in [:counts axis v]
-                                              (fnil inc 0))))))
-                         state
-                         filter-axes)
-                state'' (update state' :total inc)]
-            (if (passes? ev)
-              (-> state''
-                  (update :rev-filtered conj row)
-                  (update :rendered inc))
-              state'')))
-        result         (reduce accumulate init-state events)
-        ;; Per rf2-z4fza: rows are returned as a plain newest-first
-        ;; vector. The earlier shape stamped a positional `:row-index`
-        ;; on every row so the view could mix it into the React key;
-        ;; that meant every trace push shifted every visible row's
-        ;; index and React unmounted+remounted the entire viewport on
-        ;; every push (audit `ai/findings/causa-story-ui-stress-audit-
-        ;; 2026-05-17.md` F1). The view now keys on the row's stable
-        ;; trace `:id` (via `row-key` below) so `:row-index` carries
-        ;; no information for any consumer and is gone — its mere
-        ;; presence on the row was a footgun inviting positional keys.
-        sorted-display (vec (:rev-filtered result))
-        empty-kind  (cond
-                      (zero? (:total result))    :no-events
-                      (zero? (:rendered result)) :no-matches
-                      :else                      nil)
-        active-filters (active-filters-summary normalised (:seen result))]
-    {:rows           sorted-display
-     :total          (:total result)
-     :rendered       (:rendered result)
-     :distinct       (effective-distinct (:distinct result)
-                                         (:seen result)
-                                         normalised)
-     :counts         (:counts result)
-     :filters        normalised
-     :any-filter?    (boolean (seq normalised))
-     :empty-kind     empty-kind
-     :active-filters active-filters}))
-
-;; ---- incremental projection state (rf2-44vzy) ---------------------------
-;;
-;; `project-feed` is single-pass over the buffer (rf2-7mwc8), but the
-;; reactive sub re-runs the whole walk on every `:rf.causa/note-trace-
-;; event` dispatch — at 60Hz × 1000-event buffer that's ~60k
-;; row-touches/sec on the main thread before any render work happens.
-;;
-;; The fix folds the work into the buffer-write path: a small
-;; `:rf.causa/trace-feed-state` snapshot is maintained in app-db
-;; alongside `:trace-buffer`, updated in O(axes) per push and O(axes)
-;; per evict — so the cost is bounded by the axis count (13), not the
-;; buffer size. The sub reads the snapshot, applies filters, and
-;; returns the same shape `project-feed` always returned.
-;;
-;; The state shape mirrors `project-feed`'s pre-filter accumulator
-;; (post-renaming):
-;;
-;;     {:projected-rows [<projected-row> ...]  ;; one-to-one with buffer
-;;      :distinct       {<axis> [<value> ...]} ;; first-seen order
-;;      :seen           {<axis> #{<value>}}    ;; dedup set
-;;      :counts         {<axis> {<value> <n>}} ;; per-value count
-;;      :total          <int>}                 ;; same as count rows
-;;
-;; Add path: `feed-state+ev` runs `project-row` once + walks 13 axes,
-;; incrementing counts and appending to distinct on first-seen.
-;;
-;; Evict path: `feed-state-evict` walks 13 axes on the head row,
-;; decrementing counts. When a count drops to zero, drop the value
-;; from `:seen` and `:distinct` (the chip row must stop offering a
-;; value the buffer no longer carries). Compaction is O(distinct-
-;; size) per evicted axis in the worst case — bounded in practice by
-;; the panel's chip-row vocabulary (op-types, sources, frames, etc.
-;; are small enumerations).
-;;
-;; ## Privacy invariant (rf2-lqmje / Spec 009 §Privacy)
-;;
-;; The privacy gate sits in `trace-bus/collect-trace!` BEFORE any
-;; buffer push; sensitive events are dropped at ingest and never reach
-;; either the `:trace-buffer` slot or the `:trace-feed-state`
-;; accumulator. The `set-show-sensitive!` toggle-off path clears the
-;; buffer via `clear-buffer!`, which mirrors `:rf.causa/clear-trace-
-;; buffer` into Causa's app-db. The matching event handler in
-;; `registry.cljs` dissocs `:trace-feed-state` in lockstep so the
-;; projection never carries pre-toggle distinct values, counts, or
-;; rows. The incremental shape therefore inherits the same retroactive-
-;; scrub guarantee `clear-buffer!` provides — no new surface where
-;; privacy-sensitive data could survive a toggle.
-
-(defn init-feed-state
-  "Fresh per-axis accumulator state with empty distinct / seen /
-  counts maps for every axis in `filter-axes`, an empty
-  `:projected-rows` vector, and a zero `:total`. Pure data; JVM-
-  testable."
-  []
-  {:projected-rows []
-   :distinct       (into {} (map (fn [a] [a []])) filter-axes)
-   :seen           (into {} (map (fn [a] [a #{}])) filter-axes)
-   :counts         (into {} (map (fn [a] [a {}])) filter-axes)
-   :total          0})
-
-(defn- inc-axis
-  "Bump the count of `row`'s value on `axis` in `state`. Appends to
-  `:distinct` on first-seen. Pure data; JVM-testable."
-  [state axis row]
-  (let [v (get row axis)]
-    (cond
-      (nil? v)
-      state
-
-      (contains? (get-in state [:seen axis]) v)
-      (update-in state [:counts axis v] (fnil inc 0))
-
-      :else
-      (-> state
-          (update-in [:distinct axis] conj v)
-          (update-in [:seen axis] conj v)
-          (update-in [:counts axis v] (fnil inc 0))))))
-
-(defn- dec-axis
-  "Drop one occurrence of `row`'s value on `axis` in `state`. When
-  the count hits zero, drop the value from `:seen` and `:distinct`
-  too so the chip row stops offering an axis value the buffer no
-  longer carries. Pure data; JVM-testable."
-  [state axis row]
-  (let [v   (get row axis)
-        cur (get-in state [:counts axis v] 0)]
-    (cond
-      (nil? v)
-      state
-
-      (<= cur 1)
-      (-> state
-          (update-in [:counts axis] dissoc v)
-          (update-in [:seen axis] disj v)
-          (update-in [:distinct axis] (fn [vs] (filterv #(not= % v) vs))))
-
-      :else
-      (update-in state [:counts axis v] dec))))
-
-(defn feed-state+ev
-  "Fold `event` into the incremental projection state — append the
-  projected row, bump axis counts, and grow distinct values
-  on first-seen. O(axes) per call regardless of buffer size. Pure
-  data → state; JVM-testable."
-  [state event]
-  (let [row (project-row event)]
-    (-> (reduce (fn [s axis] (inc-axis s axis row)) state filter-axes)
-        (update :projected-rows conj row)
-        (update :total inc))))
-
-(defn feed-state-evict
-  "Evict the head (oldest) projected row from `state`, decrementing
-  per-axis counts and compacting distinct entries that hit zero.
-  Returns `state` unchanged when `:projected-rows` is empty. Pure
-  data → state; JVM-testable."
-  [state]
-  (let [rows (:projected-rows state)]
-    (if (empty? rows)
-      state
-      (let [head (nth rows 0)
-            state' (reduce (fn [s axis] (dec-axis s axis head))
-                           state filter-axes)]
-        (-> state'
-            (update :projected-rows subvec 1)
-            (update :total dec))))))
-
-(defn feed-state-push
-  "Append `event` to `state`, evicting the oldest projected row when
-  the post-push total would exceed `depth`. Mirrors `trace-bus/push`'s
-  capped-vector eviction algebra — the projection state stays in
-  lockstep with the buffer slot. O(axes) per call. Pure data; JVM-
-  testable."
-  [state depth event]
-  (let [state' (feed-state+ev state event)]
-    (if (> (:total state') depth)
-      (feed-state-evict state')
-      state')))
-
-(defn rebuild-feed-state
-  "Build `:trace-feed-state` from scratch over `events`. Used at
-  mount-time seed (the trace-bus atom may already hold pre-mount
-  emits) and as the fallback when the slot has not been initialised.
-  Pure data → state; JVM-testable."
-  [events]
-  (reduce feed-state+ev (init-feed-state) events))
-
-(defn project-feed-from-state
-  "Like `project-feed` but reads the pre-computed `:trace-feed-state`
-  snapshot rather than re-walking the buffer. The state is kept in
-  lockstep with `:trace-buffer` by the `:rf.causa/note-trace-event`
-  handler in `registry.cljs` (push) and the `:rf.causa/clear-trace-
-  buffer` / `:rf.causa/sync-trace-buffer` handlers (reset/seed). Pure
-  data → data; JVM-testable.
-
-  The filter pass still walks the projected-row vector (a single
-  reverse-then-filter over rows that are ALREADY projected — no
-  per-event `project-row` cost) and stops at `cap` matches so the
-  view never sees more than its render-cap rows. `:total` reflects
-  the in-scope, pre-user-filter denominator (see Scoped denominator
-  below); `:buffer-total` carries the whole buffer's size for callers
-  that need it.
-
-  ## Cascade-scope (rf2-ycoct)
-
-  The optional 3-arity takes `opts` with `:cascade-dispatch-id`. When
-  the spine has a focus, the projection pre-filters rows to those
-  belonging to the focused cascade — honouring spec/018 §6 (every L4
-  panel is a lens on the spine's focused event, not a global ribbon).
-  User chip filters still apply AND-wise on top of the cascade scope.
-
-  ## Scoped denominator (rf2-r6d6u)
-
-  The Trace tab is a per-cascade lens, so its 'X / Y in view' header
-  must report a denominator that lives INSIDE the cascade scope. `Y`
-  (`:total`) is the count of in-scope rows BEFORE user chip filters;
-  `X` (`:rendered`) is the count AFTER user filters. When unscoped
-  (the 2-arity global-ribbon bridge / headless test rigs that pass no
-  `opts`) `:total` is the whole buffer — the global ribbon's
-  denominator IS the buffer. The previous shape always returned the
-  whole-buffer `:total`, so a `:below`-focused cascade with 8 in-scope
-  ops reported '8 / 113 in view' where 113 spanned every recent
-  cascade AND every frame — leaking the unscoped, cross-frame total
-  and violating frame isolation. `:buffer-total` preserves the
-  whole-buffer count for any caller that needs the raw ring size.
-
-  Scope semantics:
-
-    - `nil`         — no spine focus (cold start with an empty buffer
-                      or a broken default-focus rule). Empty buffer is
-                      classified `:no-events`; non-empty buffer with
-                      nil focus is the defensive `:no-focus` branch
-                      (rf2-639lc says default-focus should land on
-                      head, so this should never occur in practice).
-    - `:ungrouped`  — the projection's catch-all bucket for events
-                      without a dispatch-id (registry-time emits,
-                      frame lifecycle outside a drain). The scope
-                      matches rows whose `:dispatch-id` is nil — the
-                      same rows the `:ungrouped` cascade groups.
-    - `<id>`        — match rows whose `:dispatch-id` equals `<id>`.
-
-  Cascade-scope is independent of the user filter map (it is enforced
-  regardless of whether `:dispatch-id` is in the user's chip filter)
-  so `:any-filter?` / `:filters` continue to reflect the USER state
-  only — the cascade-scope is a system-level invariant, not a user
-  narrowing.
-
-  Returned shape adds / changes:
-
-    :total               — the in-scope, pre-user-filter row count
-                           (the 'Y' of 'X / Y in view'). Equals
-                           `:buffer-total` when unscoped.
-    :buffer-total        — the whole buffer's row count, regardless of
-                           scope (was the prior meaning of `:total`).
-    :cascade-dispatch-id — the resolved scope value (nil when
-                           unscoped) — the view uses it to label the
-                           cascade-scope chip in the header.
-    :empty-kind          — adds the `:no-focus` branch on top of the
-                           existing `:no-events` / `:no-matches` /
-                           nil cases."
-  ([state filters]
-   (project-feed-from-state state filters nil))
-  ([state filters opts]
-   (let [{:keys [cascade-dispatch-id]} opts
-         ;; Spine wiring presence — the caller passing an `opts` map
-         ;; signals that the panel is now spine-aware. When `opts` is
-         ;; absent (the 2-arity bridge, callers that pre-date the
-         ;; rf2-ycoct cascade-scope wiring, headless test rigs that
-         ;; build state directly) we behave as a global ribbon — no
-         ;; cascade-scope, no `:no-focus` defensive branch.
-         spine-aware? (some? opts)
-         normalised (normalise-filters filters)
-         passes?    (trace-bus/build-filter-predicate normalised)
-         ;; `buffer-total` is the whole ring's size; `total` (returned)
-         ;; is the in-scope, pre-user-filter denominator computed below.
-         buffer-total (:total state)
-         no-focus?  (and spine-aware?
-                         (nil? cascade-dispatch-id)
-                         (pos? buffer-total))
-         in-scope?  (cond
-                      no-focus?
-                      (constantly false)
-
-                      (= :ungrouped cascade-dispatch-id)
-                      (fn [row] (nil? (:dispatch-id row)))
-
-                      (some? cascade-dispatch-id)
-                      (fn [row] (= cascade-dispatch-id (:dispatch-id row)))
-
-                      :else
-                      (constantly true))
-         scoped?    (or no-focus? (some? cascade-dispatch-id))
-         no-user-filters? (empty? normalised)
-         rows       (:projected-rows state)
-         rev-rows   (rseq rows)
-         ;; Single walk produces three numbers + the display vector:
-         ;;   scoped-total — in-scope rows, BEFORE user chip filters
-         ;;                  (the 'Y' of 'X / Y in view').
-         ;;   rendered     — in-scope rows that ALSO pass user filters
-         ;;                  (the 'X').
-         ;;   display-rows — the rendered rows, newest-first.
-         scoped+rendered+rows
-         (cond
-           ;; Defensive no-focus path: short-circuit to empty rows
-           ;; without walking the buffer.
-           no-focus?
-           [0 0 []]
-
-           ;; Fast path: no user filters AND no cascade-scope → every
-           ;; row is in scope and passes; scoped-total = rendered =
-           ;; the full buffer.
-           (and no-user-filters? (not scoped?))
-           [buffer-total buffer-total (vec rev-rows)]
-
-           :else
-           (loop [remain rev-rows
-                  scoped-total 0
-                  rendered 0
-                  acc      (transient [])]
-             (if (nil? (seq remain))
-               [scoped-total rendered (persistent! acc)]
-               (let [row (first remain)
-                     ev  (:raw row)]
-                 (if (in-scope? row)
-                   (if (or no-user-filters? (passes? ev))
-                     (recur (next remain) (inc scoped-total) (inc rendered)
-                            (conj! acc row))
-                     (recur (next remain) (inc scoped-total) rendered acc))
-                   (recur (next remain) scoped-total rendered acc))))))
-         [scoped-total rendered display-rows] scoped+rendered+rows
-         ;; The denominator the view shows: in-scope when scoped, the
-         ;; whole buffer when unscoped (global ribbon).
-         total      (if scoped? scoped-total buffer-total)
-         empty-kind (cond
-                      (zero? buffer-total) :no-events
-                      no-focus?            :no-focus
-                      (zero? rendered)     :no-matches
-                      :else                nil)
-         active-filters (active-filters-summary normalised (:seen state))]
-     {:rows                display-rows
-      :total               total
-      :buffer-total        buffer-total
-      :rendered            rendered
-      :distinct            (effective-distinct (:distinct state)
-                                               (:seen state)
-                                               normalised)
-      :counts              (:counts state)
-      :filters             normalised
-      :any-filter?         (boolean (seq normalised))
-      :empty-kind          empty-kind
-      :active-filters      active-filters
-      :cascade-dispatch-id cascade-dispatch-id})))
+  No `:no-matches` branch — there is no user filter to hide rows
+  (rf2-gkczt)."
+  [epoch-record focus-status]
+  (let [record-present? (= :focused focus-status)
+        trace-events    (when record-present?
+                          (:trace-events epoch-record))
+        rows            (project-rows (or trace-events []))
+        ;; Newest first for display parity with the issues ribbon.
+        display-rows    (vec (reverse rows))
+        n               (count rows)
+        empty-kind      (cond
+                          (= focus-status :no-focus)      :no-focus
+                          (= focus-status :epoch-evicted) :epoch-evicted
+                          (zero? n)                       :no-events
+                          :else                           nil)]
+    {:rows       display-rows
+     :total      n
+     :rendered   n
+     :epoch-id   (:epoch-id epoch-record)
+     :empty-kind empty-kind}))
 
 ;; ---- React keys ---------------------------------------------------------
 
@@ -846,11 +273,10 @@
    :frame              :text-secondary})
 
 (defn op-type-colour
-  "Colour swatch for an op-type. Drives the per-row dot + the
-  op-type chip styling. Resolves the semantic token keyword
-  through `theme/tokens` (rf2-5kfxe.4) so the palette has exactly
-  one source of truth. Falls back to `:text-secondary` for unknown
-  op-types."
+  "Colour swatch for an op-type. Drives the per-row dot styling.
+  Resolves the semantic token keyword through `theme/tokens`
+  (rf2-5kfxe.4) so the palette has exactly one source of truth. Falls
+  back to `:text-secondary` for unknown op-types."
   [op-type]
   (get tokens/tokens
        (get op-type->token op-type :text-secondary)))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -68,8 +68,7 @@
             [day8.re-frame2-causa.panels.managed-fx-subs :as managed-fx-subs]
             [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.reactive-panel :as reactive-panel]
-            [day8.re-frame2-causa.panels.trace :as trace]
-            [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
+            [day8.re-frame2-causa.panels.trace :as trace]))
 
 ;; ---- defaults (re-exported for back-compat callers) ---------------------
 ;;
@@ -487,6 +486,13 @@
     ;; is still callable by tests that exercise the legacy per-event
     ;; shape — there it preserves the rf2-z4fza contract those tests
     ;; assert.
+    ;;
+    ;; rf2-td380: the `:trace-feed-state` incremental snapshot
+    ;; (rf2-44vzy) was the read-side substrate for the OLD Trace feed,
+    ;; which scoped the global buffer by `:dispatch-id`. The Trace
+    ;; panel now reads the focused epoch record's `:trace-events`
+    ;; directly (epoch-scoped), so the snapshot has no consumer — it
+    ;; is gone, and these handlers single-write `:trace-buffer` again.
     (rf/reg-event-db :rf.causa/note-trace-event
       {:rf.trace/no-emit? true}
       (fn [db [_ event]]
@@ -495,40 +501,17 @@
               ev-id (:id event)]
           (if (and ev-id (some #(= ev-id (:id %)) buf))
             db
-            ;; Dual-write: keep the raw `:trace-buffer` slot in
-            ;; lockstep with the incrementally-maintained
-            ;; `:trace-feed-state` snapshot (rf2-44vzy). The trace
-            ;; panel's `:rf.causa/trace-feed` sub reads
-            ;; `:trace-feed-state`; every other consumer that holds
-            ;; a raw event vector keeps reading `:trace-buffer`.
-            ;; `feed-state-push` mirrors `trace-bus/push`'s capped
-            ;; eviction so the snapshot stays bounded by the same
-            ;; depth contract.
-            (let [feed-state (or (get db :trace-feed-state)
-                                 (trace-helpers/init-feed-state))]
-              (-> db
-                  (assoc :trace-buffer
-                         (trace-bus/push buf depth event))
-                  (assoc :trace-feed-state
-                         (trace-helpers/feed-state-push
-                           feed-state depth event))))))))
+            (assoc db :trace-buffer
+                   (trace-bus/push buf depth event))))))
 
     ;; Clear the mirrored slot in lockstep with the trace-bus atom
     ;; (dispatched from `trace-bus/clear-buffer!` in CLJS). Per
     ;; rf2-qsjda the `:rf.trace/no-emit?` flag applies for the same
     ;; loop-avoidance reason as `:rf.causa/note-trace-event`.
-    ;;
-    ;; Per rf2-44vzy: drop `:trace-feed-state` alongside the raw
-    ;; buffer so the precomputed projection inherits the same
-    ;; retroactive-scrub guarantee `trace-bus/clear-buffer!`
-    ;; provides — no projection residue surviving a privacy toggle
-    ;; (rf2-lqmje §Privacy / retroactive-scrub).
     (rf/reg-event-db :rf.causa/clear-trace-buffer
       {:rf.trace/no-emit? true}
       (fn [db _event]
-        (-> db
-            (dissoc :trace-buffer)
-            (dissoc :trace-feed-state))))
+        (dissoc db :trace-buffer)))
 
     ;; Wholesale overwrite of the mirrored slot. Dispatched from
     ;; `mount.cljs/open!` on first Ctrl+Shift+C to seed `:rf/causa`'s
@@ -537,20 +520,10 @@
     ;; when the depth shrinks so the mirror reflects the post-shrink
     ;; contents. Per rf2-qsjda `:rf.trace/no-emit? true` for the same
     ;; loop-avoidance reason.
-    ;;
-    ;; Per rf2-44vzy: rebuild `:trace-feed-state` from the seeded
-    ;; buffer so the incremental projection starts in lockstep with
-    ;; the slot. The rebuild is O(buffer × axes); paid once on seed
-    ;; (mount-time or post-shrink) — every subsequent note-trace-
-    ;; event runs in O(axes).
     (rf/reg-event-db :rf.causa/sync-trace-buffer
       {:rf.trace/no-emit? true}
       (fn [db [_ buffer]]
-        (let [buf (vec buffer)]
-          (-> db
-              (assoc :trace-buffer buf)
-              (assoc :trace-feed-state
-                     (trace-helpers/rebuild-feed-state buf))))))
+        (assoc db :trace-buffer (vec buffer))))
 
     ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
     ;; Dispatched from `trace-bus/collect-trace!` (CLJS) under

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/trace_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/trace_reactivity_cljs_test.cljs
@@ -1,12 +1,13 @@
 (ns day8.re-frame2-causa.panels.reactivity.trace-reactivity-cljs-test
   "Sub-reactivity guard for the Trace panel's primary composite
-  (rf2-dhoc9).
+  (rf2-dhoc9; epoch-scoped rework rf2-td380).
 
-  Per the rf2-70tkv affected-panels matrix Trace tracked LIVE
-  correctly pre-fix — it pivots on the spine's `:dispatch-id` axis
-  through `:rf.causa/trace-feed`'s third input. This test pins that
-  cascade-scope rebind so a regression in the trace-feed → focus
-  reactive chain would surface in millis."
+  Per the rf2-70tkv affected-panels matrix Trace pivots on the spine's
+  focus. Post-rf2-td380 the feed is EPOCH-scoped: `:rf.causa/trace-feed`
+  reads the focused epoch record's `:trace-events` (joined from
+  `:rf.causa/focus` + `:rf.causa/epoch-history`). This test pins that
+  rebind so a regression in the trace-feed → focus reactive chain would
+  surface in millis."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
@@ -16,42 +17,53 @@
   [(h/cascade :c1 :rf/default)
    (h/cascade :c2 :rf/default)])
 
+(defn- seed-epochs!
+  "Seed two epoch records, each carrying its own distinct
+  `:trace-events` slice, paired to cascades :c1 / :c2."
+  []
+  (h/seed-epoch-history!
+    [(h/mock-epoch 1 :c1 {} {:counter 1}
+                   {:trace-events
+                    [{:id 1 :op-type :event :operation :event/dispatched
+                      :tags {:dispatch-id :c1 :frame :rf/default}}
+                     {:id 2 :op-type :sub/run :operation :sub/run :tags {}}]})
+     (h/mock-epoch 2 :c2 {:counter 1} {:counter 2}
+                   {:trace-events
+                    [{:id 3 :op-type :event :operation :event/dispatched
+                      :tags {:dispatch-id :c2 :frame :rf/default}}
+                     {:id 4 :op-type :view/render :operation :view/render :tags {}}
+                     {:id 5 :op-type :fx :operation :rf.fx/handled :tags {}}]})]))
+
 (deftest trace-feed-tracks-focus-flip
-  (testing "rf2-dhoc9 — the trace-feed projection is cascade-scoped
-            (rf2-ycoct): only trace rows whose `:dispatch-id` matches
-            the spine's focus pass through. Flipping focus between
-            cascades must change the projected feed."
+  (testing "rf2-td380 — the trace-feed projection is epoch-scoped: it
+            reads the focused epoch record's `:trace-events`. Flipping
+            focus between epochs must change the projected feed."
     (h/setup-causa-frame!)
     (h/seed-cascades! cascades)
+    (seed-epochs!)
     (h/focus-cascade! :c1)
     (let [feed-1 (h/read-sub :rf.causa/trace-feed)]
-      ;; Sanity — feed is shaped; the cascade-scope filter is applied.
       (is (map? feed-1) "trace-feed returns the projected shape")
       (h/focus-cascade! :c2)
       (let [feed-2 (h/read-sub :rf.causa/trace-feed)]
         (is (not= feed-1 feed-2)
-            "trace-feed re-fired on focus flip — the cascade-scope
-             dispatch-id axis changed, so the projected rows
-             window changed")))))
+            "trace-feed re-fired on focus flip — the focused epoch's
+             :epoch-id changed, so the projected rows changed")))))
 
-(deftest trace-feed-cascade-scope-is-the-focused-dispatch-id
-  (testing "rf2-dhoc9 — the projection's `:cascade-dispatch-id` option
-            is the focused cascade's id. Verify by inspecting the
-            projected rows themselves: each cascade's seed event
-            carries a distinct `:dispatch-id` tag, so the feed's row
-            set differs between focuses."
+(deftest trace-feed-scope-is-the-focused-epochs-trace-events
+  (testing "rf2-td380 — the feed's rows are exactly the focused epoch's
+            :trace-events (including the async nil-dispatch-id reactive
+            rows). Verify by inspecting the projected row id sets."
     (h/setup-causa-frame!)
-    ;; Cascade :c1 has its own seed event; cascade :c2 has its own.
     (h/seed-cascades! cascades)
+    (seed-epochs!)
     (h/focus-cascade! :c1)
-    (let [feed-c1 (h/read-sub :rf.causa/trace-feed)
-          rows-c1 (:rows feed-c1)]
+    (let [feed-c1 (h/read-sub :rf.causa/trace-feed)]
+      (is (= #{1 2} (set (map :id (:rows feed-c1))))
+          "epoch 1's whole trail — event + the nil-dispatch-id :sub/run")
       (h/focus-cascade! :c2)
-      (let [feed-c2 (h/read-sub :rf.causa/trace-feed)
-            rows-c2 (:rows feed-c2)]
-        ;; The feed rows for each cascade should reference the
-        ;; cascade's own seed event. The two projections cover
-        ;; different events, so the row shapes differ.
-        (is (not= rows-c1 rows-c2)
-            "projected rows differ across focuses — cascade-scope
-             dispatch-id changed with the focus flip")))))
+      (let [feed-c2 (h/read-sub :rf.causa/trace-feed)]
+        (is (= #{3 4 5} (set (map :id (:rows feed-c2))))
+            "epoch 2's whole trail — event + view/render + fx")
+        (is (not= (:rows feed-c1) (:rows feed-c2))
+            "projected rows differ across focuses — epoch-scope changed")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.panels.trace-helpers-cljs-test
-  "Pure-data tests for Causa's Trace panel helpers (Phase 5, rf2-argrj).
+  "Pure-data tests for Causa's Trace panel helpers (Phase 5, rf2-argrj;
+  epoch-scoped rework rf2-td380 + rf2-gkczt).
 
   ## Why the `.cljc` + `_cljs_test` naming
 
@@ -14,16 +15,10 @@
 
     1. **Per-row projection** — `project-row` populates every axis
        slot from raw trace events (Spec 009 §Filter vocabulary).
-    2. **Each of the 9 filter axes** filters correctly in isolation:
-       `:operation` / `:op-type` / `:since` / `:frame` / `:severity`
-       / `:event-id` / `:handler-id` / `:source` / `:origin` /
-       `:dispatch-id` / `:since-ms` / `:between` / `:pred`.
-    3. **Composition** — axes combine AND-wise.
-    4. **`:between` and `:since-ms`** time-range axes work.
-    5. **`:pred`** arbitrary predicate axis works.
-    6. **`normalise-filters`** drops nil / empty values.
-    7. **`distinct-values` + `axis-counts`** populate the chip rows.
-    8. **`project-feed`** composite + empty-kind classification."
+    2. **Epoch-scoped feed** — `project-feed-from-epoch` projects the
+       focused epoch record's `:trace-events` into the view shape and
+       classifies the empty state across the focus-resolver statuses
+       (rf2-td380)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-causa.panels.trace-helpers :as h]
@@ -32,9 +27,9 @@
 ;; ---- fixture builders ---------------------------------------------------
 
 (defn- ev
-  "Build a Spec 009-shaped trace event for the tests. The 9 filter
-  axes pull from both top-level slots and `:tags` — the fixture
-  surfaces every slot the vocabulary documents."
+  "Build a Spec 009-shaped trace event for the tests. The axis slots
+  pull from both top-level slots and `:tags` — the fixture surfaces
+  every slot the projection documents."
   [{:keys [id op-type operation time source origin frame event-id
            handler-id dispatch-id tags coord]
     :or {time 1000 tags {}}}]
@@ -90,217 +85,136 @@
                            (ev {:id 1 :op-type :event
                                 :operation :event/dispatched})))))))
 
-;; ---- (2) the 9 filter axes — each in isolation -------------------------
+(deftest project-rows-preserves-chronological-order
+  (let [evs  [(ev {:id 1 :op-type :event :operation :event/dispatched :time 100})
+              (ev {:id 2 :op-type :fx    :operation :rf.fx/handled    :time 200})
+              (ev {:id 3 :op-type :sub/run :operation :sub/run        :time 300})]
+        rows (h/project-rows evs)]
+    (is (= [1 2 3] (mapv :id rows))
+        "project-rows keeps the events' oldest-first order")))
 
-(defn- events-fixture
-  "A small mixed-vocabulary fixture used across the axis tests. Every
-  axis the panel filters on has at least two distinct values so a
-  filter actually does work."
+;; ---- (2) epoch-scoped feed projection — rf2-td380 ----------------------
+;;
+;; Per spec/018 §6 the Trace tab is a lens on the spine's focused event:
+;; it reads the FOCUSED EPOCH's `:trace-events` (the per-frame settling
+;; epoch record's raw trace slice — both the synchronous event-side rows
+;; AND the async nil-dispatch-id reactive rows of the complete domino
+;; trail). `project-feed-from-epoch` takes the looked-up epoch record +
+;; the focus-resolver status and produces the view shape.
+
+(defn- domino-trail-epoch
+  "A fixture `:rf/epoch-record` whose `:trace-events` carry the COMPLETE
+  domino trail for one event — folding both the synchronous event-side
+  rows (dispatch-id N) AND the async reactive rows (`:sub/run` /
+  `:view/render`, nil dispatch-id) that fire post-cascade. This is the
+  exact shape the OLD dispatch-id-scoped feed dropped (it filtered to
+  the dispatch-id, losing the nil-dispatch-id reactive tail)."
   []
-  [(ev {:id 1 :op-type :event   :operation :event/dispatched
-        :time 100 :source :ui :origin :app
-        :frame :rf/default :event-id :user/login
-        :dispatch-id 10 :tags {:event [:user/login]}})
-   (ev {:id 2 :op-type :error   :operation :rf.error/handler-exception
-        :time 200 :source :ui :origin :app
-        :frame :rf/default :handler-id :user/login-handler
-        :dispatch-id 10
-        :tags {:exception-message "boom"}})
-   (ev {:id 3 :op-type :warning :operation :rf.warning/missing-doc
-        :time 300 :source :timer :origin :pair
-        :frame :rf/causa :dispatch-id 11})
-   (ev {:id 4 :op-type :sub/run :operation :sub/run
-        :time 400 :source :ui :origin :app
-        :frame :rf/default :dispatch-id 10
-        :tags {:sub-id :app/counter}})
-   (ev {:id 5 :op-type :info    :operation :rf.http/retry-attempt
-        :time 500 :source :http :origin :app
-        :frame :rf/default :dispatch-id 12})])
+  {:epoch-id 17
+   :trace-events
+   [;; ---- synchronous event side (dispatch-id 42) ----
+    (ev {:id 1 :op-type :event :operation :event/dispatched
+         :time 100 :dispatch-id 42 :event-id :counter/inc
+         :tags {:event [:counter/inc]}})
+    (ev {:id 2 :op-type :event :operation :event/run-end
+         :time 101 :dispatch-id 42})
+    (ev {:id 3 :op-type :event/db-changed :operation :event/db-changed
+         :time 102 :dispatch-id 42})
+    (ev {:id 4 :op-type :fx :operation :rf.fx/handled
+         :time 103 :dispatch-id 42})
+    ;; ---- async reactive tail (nil dispatch-id) ----
+    (ev {:id 5 :op-type :sub/run :operation :sub/run
+         :time 110 :tags {:sub-id :app/counter}})
+    (ev {:id 6 :op-type :sub/run :operation :sub/run
+         :time 111 :tags {:sub-id :app/derived}})
+    (ev {:id 7 :op-type :view/render :operation :view/render
+         :time 120})]})
 
-(deftest filter-by-operation
-  (is (= [2]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:operation :rf.error/handler-exception})))))
-
-(deftest filter-by-op-type
-  (is (= [2]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:op-type :error}))))
-  (is (= [4]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:op-type :sub/run})))))
-
-(deftest filter-by-since-cursor
-  (testing ":since is a cursor on :id — strictly greater than"
-    (is (= [3 4 5]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:since 2}))))))
-
-(deftest filter-by-frame
-  (is (= [3]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:frame :rf/causa}))))
-  (is (= [1 2 4 5]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:frame :rf/default})))))
-
-(deftest filter-by-severity
-  (testing ":severity is the synonym axis on :op-type restricted to
-            the three tiers"
-    (is (= [2]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:severity :error}))))
-    (is (= [3]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:severity :warning}))))
-    (is (= [5]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:severity :info}))))))
-
-(deftest filter-by-event-id
-  (is (= [1]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:event-id :user/login})))))
-
-(deftest filter-by-handler-id
-  (is (= [2]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:handler-id :user/login-handler})))))
-
-(deftest filter-by-source
-  (is (= [3]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:source :timer}))))
-  (is (= [5]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:source :http})))))
-
-(deftest filter-by-origin
-  (is (= [3]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:origin :pair})))))
-
-(deftest filter-by-dispatch-id
-  (is (= [1 2 4]
-         (mapv :id (h/apply-filters (events-fixture)
-                                    {:dispatch-id 10})))))
-
-(deftest filter-by-since-ms
-  (testing ":since-ms restricts events whose :time is strictly greater"
-    (is (= [4 5]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:since-ms 300}))))))
-
-(deftest filter-by-between
-  (testing ":between is a [t0 t1] inclusive window"
-    (is (= [2 3 4]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:between [200 400]}))))))
-
-(deftest filter-by-pred
-  (testing ":pred is an arbitrary fn against the raw event map"
-    (is (= [3]
-           (mapv :id (h/apply-filters
-                       (events-fixture)
-                       {:pred (fn [e]
-                                (= "rf.warning" (some-> e :operation
-                                                        namespace)))}))))))
-
-;; ---- (3) axes compose AND-wise -----------------------------------------
-
-(deftest filters-compose-and-wise
-  (testing "two axes intersect"
-    (is (= [3]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:op-type :warning
-                                       :frame   :rf/causa})))))
-  (testing "three axes intersect"
-    (is (= [4]
-           (mapv :id (h/apply-filters (events-fixture)
-                                      {:dispatch-id 10
-                                       :source      :ui
-                                       :op-type     :sub/run}))))))
-
-;; ---- (4) normalise-filters / any-filter? -------------------------------
-
-(deftest normalise-drops-nil-and-empty
-  (is (= {} (h/normalise-filters nil)))
-  (is (= {} (h/normalise-filters {})))
-  (is (= {} (h/normalise-filters {:op-type nil})))
-  (is (= {} (h/normalise-filters {:operation nil :source nil})))
-  (is (= {:op-type :event}
-         (h/normalise-filters {:op-type :event :source nil}))))
-
-(deftest any-filter-active-mirrors-normalise
-  (is (false? (h/any-filter-active? nil)))
-  (is (false? (h/any-filter-active? {:op-type nil})))
-  (is (true?  (h/any-filter-active? {:op-type :event}))))
-
-;; ---- (5) distinct-values + axis-counts ---------------------------------
-
-(deftest distinct-values-first-seen-order
-  (let [rows (h/project-rows (events-fixture))]
-    (is (= [:event :error :warning :sub/run :info]
-           (h/distinct-values rows :op-type)))
-    (is (= [:ui :timer :http]
-           (h/distinct-values rows :source)))
-    (is (= [:app :pair]
-           (h/distinct-values rows :origin)))
-    (is (= [:rf/default :rf/causa]
-           (h/distinct-values rows :frame)))))
-
-(deftest axis-counts-correct-histogram
-  (let [rows (h/project-rows (events-fixture))]
-    (is (= {:ui 3 :timer 1 :http 1}
-           (h/axis-counts rows :source)))
-    (is (= {:app 4 :pair 1}
-           (h/axis-counts rows :origin)))))
-
-;; ---- (6) project-feed (composite) --------------------------------------
-
-(deftest project-feed-empty-buffer
-  (let [feed (h/project-feed [] {})]
-    (is (= 0 (:total feed)))
-    (is (= 0 (:rendered feed)))
-    (is (= :no-events (:empty-kind feed)))
-    (is (false? (:any-filter? feed)))))
-
-(deftest project-feed-no-matches
-  (let [feed (h/project-feed (events-fixture)
-                             {:op-type :error :frame :rf/causa})]
-    (is (= 5 (:total feed)))
-    (is (= 0 (:rendered feed)))
-    (is (= :no-matches (:empty-kind feed)))
-    (is (true?  (:any-filter? feed)))))
-
-(deftest project-feed-rows-newest-first
-  (let [feed (h/project-feed (events-fixture) {})]
-    (testing ":rows is newest first for display"
-      (is (= [5 4 3 2 1] (mapv :id (:rows feed)))))
-    (testing ":empty-kind is nil when there are matches"
+(deftest project-feed-from-epoch-folds-the-complete-domino-trail
+  (testing "rf2-td380 headline: scoping by the focused epoch's
+            `:trace-events` renders BOTH the synchronous event-side
+            rows (dispatch-id 42) AND the async nil-dispatch-id reactive
+            tail (subs ran + view rendered) — the complete domino trail.
+            The OLD dispatch-id-scoped feed dropped the nil-dispatch-id
+            tail (3 reactive rows here), rendering 4 rows instead of 7."
+    (let [epoch (domino-trail-epoch)
+          feed  (h/project-feed-from-epoch epoch :focused)]
+      (is (= 7 (:total feed))
+          ":total = every trace event in the focused epoch")
+      (is (= 7 (:rendered feed))
+          ":rendered = :total (no filtering, rf2-gkczt)")
+      (is (= #{1 2 3 4 5 6 7} (set (map :id (:rows feed))))
+          "rows are the WHOLE trail — including the nil-dispatch-id
+           reactive rows the dispatch-id scope would have dropped")
+      (is (some #(and (nil? (:dispatch-id %)) (= :sub/run (:op-type %)))
+                (:rows feed))
+          "the async :sub/run rows (nil dispatch-id) are present")
+      (is (some #(= :view/render (:op-type %)) (:rows feed))
+          "the async :view/render row is present")
+      (is (= 17 (:epoch-id feed)))
       (is (nil? (:empty-kind feed))))))
 
-(deftest project-feed-distinct-and-counts-per-axis
-  (let [feed (h/project-feed (events-fixture) {})]
-    (is (= [:ui :timer :http]
-           (get-in feed [:distinct :source])))
-    (is (= {:ui 3 :timer 1 :http 1}
-           (get-in feed [:counts :source])))
-    (is (contains? (:distinct feed) :op-type))
-    (is (contains? (:distinct feed) :severity))
-    (is (contains? (:distinct feed) :origin))
-    (is (not (contains? (:distinct feed) :frame))
-        ":frame is not enumerated as a chip-row axis post-rf2-ycoct
-         (the Trace tab is cascade-scoped so every visible row
-         already shares the focused event's frame)")))
+(deftest project-feed-from-epoch-rows-newest-first
+  (testing "rows render newest-first for display parity with the issues
+            ribbon (the epoch's :trace-events are oldest-first)"
+    (let [epoch (domino-trail-epoch)
+          feed  (h/project-feed-from-epoch epoch :focused)]
+      (is (= [7 6 5 4 3 2 1] (mapv :id (:rows feed)))))))
 
-(deftest project-feed-filters-pass-through-normalised
-  (let [feed (h/project-feed (events-fixture)
-                             {:op-type :error :source nil})]
-    (testing "normalised filters drop the nil axis"
-      (is (= {:op-type :error} (:filters feed))))))
+(deftest project-feed-from-epoch-no-events
+  (testing "a focused epoch with empty :trace-events → :no-events"
+    (let [feed (h/project-feed-from-epoch {:epoch-id 3 :trace-events []}
+                                          :focused)]
+      (is (= 0 (:total feed)))
+      (is (= 0 (:rendered feed)))
+      (is (= [] (:rows feed)))
+      (is (= 3 (:epoch-id feed)))
+      (is (= :no-events (:empty-kind feed))))))
 
-;; ---- (7) format-time ---------------------------------------------------
+(deftest project-feed-from-epoch-no-focus
+  (testing "focus-status :no-focus → :no-focus empty-kind, no rows
+            (the record is irrelevant — there is no focused epoch)"
+    (let [feed (h/project-feed-from-epoch nil :no-focus)]
+      (is (= :no-focus (:empty-kind feed)))
+      (is (= 0 (:total feed)))
+      (is (= 0 (:rendered feed)))
+      (is (= [] (:rows feed)))
+      (is (nil? (:epoch-id feed))))))
+
+(deftest project-feed-from-epoch-epoch-evicted
+  (testing "focus-status :epoch-evicted → :epoch-evicted empty-kind,
+            no rows (the focused epoch aged out of the ring buffer)"
+    (let [feed (h/project-feed-from-epoch nil :epoch-evicted)]
+      (is (= :epoch-evicted (:empty-kind feed)))
+      (is (= 0 (:total feed)))
+      (is (= 0 (:rendered feed)))
+      (is (= [] (:rows feed))))))
+
+(deftest project-feed-from-epoch-ignores-record-unless-focused
+  (testing "rf2-td380: only :focused status reads the record's
+            :trace-events — a non-:focused status renders empty even
+            when a stray record is passed (defensive: the sub never
+            does this, but the contract is total)"
+    (let [epoch (domino-trail-epoch)]
+      (is (= 0 (:total (h/project-feed-from-epoch epoch :no-focus))))
+      (is (= 0 (:total (h/project-feed-from-epoch epoch :epoch-evicted)))))))
+
+(deftest project-feed-from-epoch-shape-keys
+  (testing "rf2-gkczt: the feed shape carries NO filtering keys —
+            :filters / :any-filter? / :distinct / :counts /
+            :active-filters / :cascade-dispatch-id are all gone"
+    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
+      (is (contains? feed :rows))
+      (is (contains? feed :total))
+      (is (contains? feed :rendered))
+      (is (contains? feed :epoch-id))
+      (is (contains? feed :empty-kind))
+      (doseq [k [:filters :any-filter? :distinct :counts
+                 :active-filters :cascade-dispatch-id]]
+        (is (not (contains? feed k))
+            (str "removed filtering key " k " must not be in the feed shape"))))))
+
+;; ---- (3) format-time ---------------------------------------------------
 
 (deftest format-time-renders-hms-with-millis
   (testing "format-time returns nil on non-numeric input"
@@ -311,14 +225,14 @@
       (is (string? s))
       (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
 
-;; ---- (8) find-row ------------------------------------------------------
+;; ---- (4) find-row ------------------------------------------------------
 
 (deftest find-row-by-id
   (let [rows [{:id 1} {:id 2} {:id 3}]]
     (is (= {:id 2} (h/find-row rows 2)))
     (is (nil? (h/find-row rows 99)))))
 
-;; ---- (9) op-type-colour ------------------------------------------------
+;; ---- (5) op-type-colour ------------------------------------------------
 
 (deftest op-type-colour-mapping
   ;; Post rf2-on4cm `op-type-colour` returns CSS-variable strings —
@@ -335,7 +249,7 @@
   ;; Defensive fallback.
   (is (= (:text-secondary tokens/tokens) (h/op-type-colour :totally-unknown))))
 
-;; ---- (10) source-coord -------------------------------------------------
+;; ---- (6) source-coord -------------------------------------------------
 
 (deftest source-coord-projection
   (testing "source-coord pulls file:line from :rf.trace/trigger-handler"
@@ -352,7 +266,7 @@
              {:id 1 :op-type :event
               :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"}}})))))
 
-;; ---- (11) short-description --------------------------------------------
+;; ---- (7) short-description --------------------------------------------
 
 (deftest short-description-priority-order
   (testing "event vector is preferred"
@@ -381,32 +295,7 @@
              (ev {:id 1 :op-type :event :operation :event/dispatched
                   :tags {}}))))))
 
-;; ---- (12) filter-axes coverage matches the bead's contract -------------
-
-(deftest filter-axes-cover-the-bead-contract
-  (testing "the panel surfaces every named axis from Spec 009
-            §Filter vocabulary that has a chip-row presentation.
-
-            Note: `:frame` is intentionally NOT in `filter-axes` —
-            post-rf2-ycoct the Trace tab is cascade-scoped, so the
-            focused event has exactly one frame and a frame chip on
-            top of the scope is redundant. The underlying algebra in
-            `trace-bus/build-filter-predicate` still accepts `:frame`
-            as a vocabulary primitive (covered by `filter-by-frame`
-            below); we just don't enumerate it as a chip-row axis."
-    (let [axes (set h/filter-axes)]
-      (is (contains? axes :op-type))
-      (is (contains? axes :severity))
-      (is (contains? axes :source))
-      (is (contains? axes :origin))
-      (is (contains? axes :operation))
-      (is (contains? axes :event-id))
-      (is (contains? axes :handler-id))
-      (is (contains? axes :dispatch-id))
-      (is (not (contains? axes :frame))
-          ":frame is not a chip-row axis post-rf2-ycoct cascade-scope"))))
-
-;; ---- (13) row-key — rf2-z4fza (sibling of rf2-kgn0c) -------------------
+;; ---- (8) row-key — rf2-z4fza (sibling of rf2-kgn0c) -------------------
 ;;
 ;; Per rf2-z4fza: the trace ribbon's React `:key` must be a stable
 ;; per-trace-event identity (the framework's monotonic `:id`). The
@@ -415,15 +304,6 @@
 ;; React remounted the entire viewport — the dominant frame cost
 ;; under burst event rate. Same discipline class as rf2-kgn0c's
 ;; `v:<variant-id>` keys in the story workspace.
-
-(deftest project-feed-rows-carry-no-row-index-slot
-  (testing "rf2-z4fza acceptance: rows MUST NOT carry a :row-index
-            slot — its mere presence on the row was a footgun
-            inviting positional React keys"
-    (let [feed (h/project-feed (events-fixture) {})]
-      (doseq [row (:rows feed)]
-        (is (not (contains? row :row-index))
-            (str "row " (:id row) " must not carry :row-index"))))))
 
 (deftest row-key-uses-stable-trace-id
   (testing "row-key reads only :id — the framework's monotonic trace
@@ -449,474 +329,11 @@
       (is (= (h/row-key row-a) (h/row-key row-c))
           "row-key with :row-index 99 equals row-key without :row-index"))))
 
-(deftest row-keys-are-stable-across-trace-pushes
-  (testing "rf2-z4fza headline guarantee: appending a new trace event
-            does NOT change the React key of any previously-existing
-            row — same input row → same key. This is the property
-            React's reconciler needs to reuse DOM nodes across pushes
-            instead of unmounting+remounting the viewport on every push."
-    (let [events-1 (events-fixture)
-          ;; Simulate a burst — append three new events to the buffer.
-          new-evs  [(ev {:id 6 :op-type :event :operation :event/dispatched
-                         :time 600 :source :ui :origin :app
-                         :frame :rf/default})
-                    (ev {:id 7 :op-type :fx :operation :rf.fx/handled
-                         :time 700 :source :ui :origin :app
-                         :frame :rf/default})
-                    (ev {:id 8 :op-type :error :operation :rf.error/handler-threw
-                         :time 800 :source :ui :origin :app
-                         :frame :rf/default})]
-          events-2 (vec (concat events-1 new-evs))
-          feed-1   (h/project-feed events-1 {})
-          feed-2   (h/project-feed events-2 {})
-          keys-1   (into {} (map (juxt :id h/row-key) (:rows feed-1)))
-          keys-2   (into {} (map (juxt :id h/row-key) (:rows feed-2)))]
-      (doseq [[id k1] keys-1]
-        (is (= k1 (get keys-2 id))
-            (str "row id " id ": key must be stable across pushes "
-                 "(pre-push=" (pr-str k1) ", post-push=" (pr-str (get keys-2 id))
-                 "). rf2-z4fza: positional :row-index in the key would shift "
-                 "this on every append and re-mount the entire viewport.")))
-      (testing "all post-push keys are unique"
-        (let [all-keys (vals keys-2)]
-          (is (= (count all-keys) (count (distinct all-keys))))))
-      (testing "new events get fresh keys, not collisions"
-        (doseq [id [6 7 8]]
-          (is (some? (get keys-2 id)))
-          (is (not (contains? keys-1 id))))))))
-
-;; ---- (14) orphan-filter surfacing — rf2-vu0mp --------------------------
-;;
-;; The chip-row enumeration is built from the events currently in the
-;; buffer. When the buffer rotates past the cap and the selected
-;; filter value's last instance ages out, `:trace-filters` still
-;; carries the selection but the chip row no longer shows that value
-;; — user sees `:no-matches` with no visible cue what's narrowing the
-;; view. Per rf2-vu0mp the fix surfaces the active value in BOTH the
-;; chip row (orphan still rendered, marked) AND the empty state
-;; (`:active-filters` strip).
-
-(deftest effective-distinct-passes-through-when-active-is-present
-  (testing "no orphan: active filter value is in seen → distinct map
-            passes through unchanged"
-    (let [distinct-map {:op-type [:event :error]
-                        :source  [:ui :timer]}
-          seen-map     {:op-type #{:event :error}
-                        :source  #{:ui :timer}}]
-      (is (= distinct-map
-             (h/effective-distinct distinct-map seen-map
-                                   {:op-type :error :source :ui}))))))
-
-(deftest effective-distinct-appends-orphan-active-value
-  (testing "active filter value NOT in seen → appended to distinct
-            so the chip ALWAYS renders for the user's selection"
-    (let [distinct-map {:source [:ui]}
-          seen-map     {:source #{:ui}}
-          result       (h/effective-distinct distinct-map seen-map
-                                             {:source :timer})]
-      (is (= [:ui :timer] (get result :source))
-          "the orphan :timer value lands at the tail of :source"))))
-
-(deftest effective-distinct-handles-axis-absent-from-seen
-  (testing "axis missing entirely from seen → still appends orphan"
-    (let [distinct-map {}
-          seen-map     {}
-          result       (h/effective-distinct distinct-map seen-map
-                                             {:frame :rf/test})]
-      (is (= [:rf/test] (get result :frame))))))
-
-(deftest effective-distinct-skips-no-duplicate-active-value
-  (testing "if active value is already in distinct it is not duplicated"
-    (let [distinct-map {:source [:timer :ui]}
-          seen-map     {:source #{:ui}}  ;; :timer dropped from seen
-          result       (h/effective-distinct distinct-map seen-map
-                                             {:source :timer})]
-      (is (= [:timer :ui] (get result :source))
-          "no duplicate — first-seen order preserved"))))
-
-(deftest effective-distinct-tolerates-nil-filters
-  (testing "nil / empty filters → pass-through"
-    (let [distinct-map {:source [:ui]}
-          seen-map     {:source #{:ui}}]
-      (is (= distinct-map (h/effective-distinct distinct-map seen-map nil)))
-      (is (= distinct-map (h/effective-distinct distinct-map seen-map {}))))))
-
-(deftest active-filters-summary-marks-present-and-orphaned
-  (let [seen-map {:op-type #{:event :error}
-                  :source  #{:ui}
-                  :origin  #{:app}}
-        summary  (h/active-filters-summary
-                   {:op-type :error
-                    :source  :timer    ;; orphan
-                    :origin  :app}
-                   seen-map)]
-    (testing "every active axis has an entry"
-      (is (= 3 (count summary))))
-    (testing "iteration follows filter-axes order (op-type, severity,
-              source, origin, ...)"
-      (is (= [:op-type :source :origin] (mapv :axis summary))))
-    (testing "present? is true when value is in seen"
-      (is (true?  (:present? (some #(when (= :op-type (:axis %)) %) summary))))
-      (is (false? (:present? (some #(when (= :source  (:axis %)) %) summary))))
-      (is (true?  (:present? (some #(when (= :origin  (:axis %)) %) summary)))))
-    (testing "value is preserved verbatim for the empty-state render"
-      (is (= :timer (:value (some #(when (= :source (:axis %)) %) summary)))))))
-
-(deftest active-filters-summary-handles-empty-or-nil
-  (is (= [] (h/active-filters-summary nil nil)))
-  (is (= [] (h/active-filters-summary {} {})))
-  (is (= [] (h/active-filters-summary {:source nil} {}))
-      "nil-valued filters are dropped by normalise-filters first"))
-
-(deftest project-feed-orphan-filter-distinct-is-effective
-  (testing "rf2-vu0mp: filtering on a value not present in the buffer
-            still produces a distinct entry for that value so the chip
-            row keeps rendering the user's selection"
-    (let [events (events-fixture)
-          ;; No :source = :timer in the all-:ui-/-:http events besides id=3.
-          ;; Filter on an axis where the value DOES NOT exist in buffer:
-          feed   (h/project-feed events
-                                 {:source :sse})]
-      (testing "the orphan value lands in distinct so the chip is rendered"
-        (is (some #(= :sse %) (get-in feed [:distinct :source]))
-            "orphan :sse appended to :source distinct"))
-      (testing ":counts is unchanged — the value has 0 buffered events"
-        (is (not (contains? (get-in feed [:counts :source]) :sse))
-            "no synthetic count entry — the renderer reads 0 via get-default"))
-      (testing ":active-filters surfaces the orphan with :present? false"
-        (let [src-pill (some #(when (= :source (:axis %)) %)
-                             (:active-filters feed))]
-          (is (= :sse (:value src-pill)))
-          (is (false? (:present? src-pill)))))
-      (testing "empty-kind is :no-matches"
-        (is (= :no-matches (:empty-kind feed)))))))
-
-(deftest project-feed-active-filters-empty-when-no-filters
-  (let [feed (h/project-feed (events-fixture) {})]
-    (is (= [] (:active-filters feed))
-        "no active filter → empty pill list")))
-
-;; ---- (15) incremental projection state — rf2-44vzy ---------------------
-;;
-;; The trace-feed projection now reads a pre-computed snapshot
-;; maintained incrementally by `:rf.causa/note-trace-event` rather
-;; than re-walking the full buffer on every push. The snapshot is
-;; updated in O(axes) per add and O(axes) per evict — bounded by the
-;; axis count (13), not the buffer size.
-;;
-;; These tests pin the incremental algebra against the from-scratch
-;; `project-feed` reference: for any sequence of events, building
-;; the state event-by-event must produce the same distinct/counts/
-;; rows shape as walking the events end-to-end in one shot.
-
-(deftest init-feed-state-has-empty-axis-maps
-  (let [state (h/init-feed-state)]
-    (is (= 0 (:total state)))
-    (is (= [] (:projected-rows state)))
-    (doseq [axis h/filter-axes]
-      (is (= [] (get-in state [:distinct axis]))
-          (str "axis " axis " starts with empty distinct"))
-      (is (= #{} (get-in state [:seen axis]))
-          (str "axis " axis " starts with empty seen"))
-      (is (= {} (get-in state [:counts axis]))
-          (str "axis " axis " starts with empty counts")))))
-
-(deftest feed-state+ev-bumps-axis-counts
-  (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
-                   :time 100 :source :ui :origin :app
-                   :frame :rf/default})
-        e2    (ev {:id 2 :op-type :event :operation :event/dispatched
-                   :time 200 :source :ui :origin :app
-                   :frame :rf/default})
-        state (-> (h/init-feed-state)
-                  (h/feed-state+ev e1)
-                  (h/feed-state+ev e2))]
-    (is (= 2 (:total state)))
-    (is (= 2 (count (:projected-rows state))))
-    (is (= [:event]      (get-in state [:distinct :op-type])))
-    (is (= [:ui]         (get-in state [:distinct :source])))
-    (is (= {:event 2}    (get-in state [:counts :op-type])))
-    (is (= {:ui 2}       (get-in state [:counts :source])))))
-
-(deftest feed-state-evict-decrements-and-compacts
-  (testing "evicting the head row decrements per-axis counts; when a
-            count hits zero the value is dropped from seen + distinct
-            so the chip row stops offering an aged-out value"
-    (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
-                     :time 100 :source :timer :origin :app
-                     :frame :rf/default})
-          e2    (ev {:id 2 :op-type :error :operation :rf.error/x
-                     :time 200 :source :ui :origin :app
-                     :frame :rf/default})
-          state (-> (h/init-feed-state)
-                    (h/feed-state+ev e1)
-                    (h/feed-state+ev e2)
-                    h/feed-state-evict)]
-      (is (= 1 (:total state)))
-      (is (= 1 (count (:projected-rows state))))
-      (testing ":source :timer was unique to the evicted row → dropped"
-        (is (= [:ui] (get-in state [:distinct :source])))
-        (is (not (contains? (get-in state [:seen :source]) :timer)))
-        (is (not (contains? (get-in state [:counts :source]) :timer))))
-      (testing ":source :ui still present (carried by e2)"
-        (is (contains? (get-in state [:seen :source]) :ui))
-        (is (= 1 (get-in state [:counts :source :ui])))))))
-
-(deftest feed-state-evict-decrements-shared-value-without-compaction
-  (testing "if two rows share a value, evicting one only decrements
-            the count — the value stays in distinct / seen"
-    (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
-                     :source :ui :frame :rf/default})
-          e2    (ev {:id 2 :op-type :event :operation :event/dispatched
-                     :source :ui :frame :rf/default})
-          state (-> (h/init-feed-state)
-                    (h/feed-state+ev e1)
-                    (h/feed-state+ev e2)
-                    h/feed-state-evict)]
-      (is (= [:ui] (get-in state [:distinct :source])))
-      (is (= 1 (get-in state [:counts :source :ui]))))))
-
-(deftest feed-state-evict-noop-on-empty
-  (testing "evicting from empty state returns the same shape"
-    (let [empty-state (h/init-feed-state)]
-      (is (= empty-state (h/feed-state-evict empty-state))))))
-
-(deftest feed-state-push-respects-depth-cap
-  (testing "feed-state-push mirrors trace-bus/push's eviction algebra
-            — total never exceeds depth, oldest is evicted"
-    (let [depth 3
-          evs   (mapv #(ev {:id %1 :op-type :event :operation :event/dispatched
-                            :source (case (mod %1 3)
-                                      0 :ui 1 :timer 2 :http)
-                            :frame :rf/default})
-                      (range 1 11))
-          state (reduce (fn [s e] (h/feed-state-push s depth e))
-                        (h/init-feed-state)
-                        evs)]
-      (is (= depth (:total state)))
-      (is (= depth (count (:projected-rows state))))
-      (testing "the head row is the (depth)-most-recent"
-        (let [retained-ids (mapv :id (:projected-rows state))]
-          (is (= [8 9 10] retained-ids)))))))
-
-(deftest rebuild-feed-state-equals-incremental
-  (testing "building state from scratch via rebuild-feed-state
-            equals folding events one at a time via feed-state+ev"
-    (let [evs        (events-fixture)
-          rebuilt    (h/rebuild-feed-state evs)
-          folded     (reduce h/feed-state+ev (h/init-feed-state) evs)]
-      (is (= rebuilt folded)))))
-
-(deftest project-feed-from-state-matches-project-feed-no-filter
-  (testing "project-feed-from-state produces the same shape as
-            project-feed when no filter is active"
-    (let [evs        (events-fixture)
-          state      (h/rebuild-feed-state evs)
-          from-state (h/project-feed-from-state state {})
-          from-raw   (h/project-feed evs {})]
-      (is (= (:total from-state)    (:total from-raw)))
-      (is (= (:rendered from-state) (:rendered from-raw)))
-      (is (= (mapv :id (:rows from-state))
-             (mapv :id (:rows from-raw))))
-      (is (= (:distinct from-state) (:distinct from-raw)))
-      (is (= (:counts from-state)   (:counts from-raw)))
-      (is (= (:empty-kind from-state) (:empty-kind from-raw))))))
-
-(deftest project-feed-from-state-matches-project-feed-with-filter
-  (testing "project-feed-from-state produces equivalent shape under
-            active filters — early-stop filter walk preserves rendered
-            count and row order"
-    (let [evs        (events-fixture)
-          filters    {:dispatch-id 10}
-          state      (h/rebuild-feed-state evs)
-          from-state (h/project-feed-from-state state filters)
-          from-raw   (h/project-feed evs filters)]
-      (is (= (:total from-state)    (:total from-raw)))
-      (is (= (:rendered from-state) (:rendered from-raw)))
-      (is (= (mapv :id (:rows from-state))
-             (mapv :id (:rows from-raw))))
-      (is (= (:filters from-state)  (:filters from-raw)))
-      (is (= (:empty-kind from-state) (:empty-kind from-raw))))))
-
-(deftest project-feed-from-state-orphan-filter-surfaces
-  (testing "rf2-vu0mp via incremental path: orphan filter value still
-            renders in distinct + active-filters carries :present? false"
-    (let [evs   (events-fixture)
-          state (h/rebuild-feed-state evs)
-          feed  (h/project-feed-from-state state {:source :sse})]
-      (is (some #(= :sse %) (get-in feed [:distinct :source])))
-      (is (= :no-matches (:empty-kind feed)))
-      (let [pill (some #(when (= :source (:axis %)) %)
-                       (:active-filters feed))]
-        (is (= :sse (:value pill)))
-        (is (false? (:present? pill)))))))
-
-(deftest project-feed-from-state-empty-buffer
-  (let [feed (h/project-feed-from-state (h/init-feed-state) {})]
-    (is (= 0 (:total feed)))
-    (is (= 0 (:rendered feed)))
-    (is (= :no-events (:empty-kind feed)))))
-
-(deftest incremental-and-from-scratch-equivalence-under-cap-rotation
-  (testing "after pushing 5× the cap, the incremental state matches a
-            from-scratch rebuild over the same retained window — the
-            evict path correctly compacts dropped values"
-    (let [depth 5
-          all   (mapv #(ev {:id %1 :op-type (case (mod %1 3)
-                                              0 :event 1 :error 2 :warning)
-                             :operation (case (mod %1 2)
-                                          0 :event/dispatched
-                                          :rf.error/handler-exception)
-                             :time %1
-                             :source (case (mod %1 4)
-                                       0 :ui 1 :timer 2 :http 3 :sse)
-                             :origin :app
-                             :frame  :rf/default
-                             :dispatch-id (quot %1 2)})
-                      (range 1 26))
-          state (reduce (fn [s e] (h/feed-state-push s depth e))
-                        (h/init-feed-state)
-                        all)
-          ;; What the buffer should look like post-rotation:
-          retained (vec (drop (- (count all) depth) all))
-          rebuilt  (h/rebuild-feed-state retained)]
-      (is (= (:total state)    (:total rebuilt)))
-      (is (= (:projected-rows state) (:projected-rows rebuilt)))
-      (is (= (:counts state)   (:counts rebuilt)))
-      (is (= (:seen state)     (:seen rebuilt)))
-      (testing "distinct may differ in order (incremental preserves
-                first-seen-since-eviction order, not all-time order)
-                — assert content equality via set, not vector"
-        (doseq [axis h/filter-axes]
-          (is (= (set (get-in state [:distinct axis]))
-                 (set (get-in rebuilt [:distinct axis])))))))))
-
-(deftest project-feed-from-state-active-filters-empty-when-no-filters
-  (let [state (h/rebuild-feed-state (events-fixture))
-        feed  (h/project-feed-from-state state {})]
-    (is (= [] (:active-filters feed)))))
-
-;; ---- (7) cascade-scope (rf2-ycoct) -------------------------------------
-;;
-;; Mike's call on rf2-ycoct: the Trace tab is cascade-scoped by default
-;; (audit findings 2026-05-18). project-feed-from-state's 3-arity takes
-;; `{:cascade-dispatch-id <id-or-:ungrouped-or-nil>}` and pre-filters
-;; rows to the focused cascade. User chip filters AND on top.
-
-(deftest project-feed-from-state-cascade-scope-narrows-to-cascade
-  (testing "rf2-ycoct: cascade-scope filters rows to those whose
-            :dispatch-id matches the focused cascade's id"
-    (let [evs   (events-fixture)
-          state (h/rebuild-feed-state evs)
-          ;; Fixture has dispatch-ids 10, 11, 12. Scope to 10 → rows 1, 2, 4.
-          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 10})]
-      ;; rf2-r6d6u: the denominator the view shows ('Y' of 'X / Y in
-      ;; view') is the in-scope, pre-user-filter count — NOT the whole
-      ;; buffer. Three rows belong to cascade 10, so :total is 3.
-      (is (= 3 (:total feed))
-          ":total reflects the in-scope subset (cascade 10), not the buffer")
-      (is (= 5 (:buffer-total feed))
-          ":buffer-total still carries the whole ring's size")
-      (is (= 3 (:rendered feed))
-          "three rows belong to cascade 10")
-      (is (= #{1 2 4} (set (mapv :id (:rows feed))))
-          "exactly cascade 10's events surface")
-      (is (= 10 (:cascade-dispatch-id feed))
-          ":cascade-dispatch-id rides on the result"))))
-
-(deftest project-feed-from-state-cascade-scope-ands-with-user-filter
-  (testing "rf2-ycoct: user chip filter AND-wise with cascade-scope"
-    (let [evs    (events-fixture)
-          state  (h/rebuild-feed-state evs)
-          ;; Cascade 10 has 3 rows (ids 1, 2, 4). Of those, op-type :error
-          ;; is only row 2. AND-wise: cascade 10 ∩ op-type :error = {2}.
-          feed   (h/project-feed-from-state state
-                                            {:op-type :error}
-                                            {:cascade-dispatch-id 10})]
-      (is (= 1 (:rendered feed)))
-      (is (= [2] (mapv :id (:rows feed))))
-      ;; rf2-r6d6u: the denominator stays the in-scope, PRE-user-filter
-      ;; count — cascade 10 has 3 rows, so 'X / Y in view' is '1 / 3',
-      ;; NOT '1 / 1'. The user filter narrows X, never Y.
-      (is (= 3 (:total feed))
-          ":total is the in-scope count before the user chip filter")
-      (is (= 5 (:buffer-total feed))))))
-
-(deftest project-feed-from-state-cascade-scope-no-overlap-empty
-  (testing "rf2-ycoct: scope on a cascade not in the buffer renders
-            zero rows and reports :no-matches"
-    (let [evs   (events-fixture)
-          state (h/rebuild-feed-state evs)
-          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 99999})]
-      (is (= 0 (:rendered feed)))
-      ;; rf2-r6d6u: no row is in scope → the scoped denominator is 0.
-      (is (= 0 (:total feed))
-          ":total is 0 when no buffered row matches the scope")
-      (is (= 5 (:buffer-total feed)))
-      (is (= :no-matches (:empty-kind feed)))
-      (is (= 99999 (:cascade-dispatch-id feed))))))
-
-(deftest project-feed-from-state-cascade-scope-ungrouped-matches-nil-dispatch-id
-  (testing "rf2-ycoct: scope :ungrouped matches rows whose :dispatch-id
-            is nil (the projection's catch-all bucket)"
-    (let [evs   [(ev {:id 1 :op-type :event :operation :event/dispatched
-                      :time 100 :source :ui})           ; no dispatch-id
-                 (ev {:id 2 :op-type :event :operation :event/dispatched
-                      :time 200 :source :ui :dispatch-id 10})
-                 (ev {:id 3 :op-type :info  :operation :rf/lifecycle
-                      :time 300 :source :ui})]          ; no dispatch-id
-          state (h/rebuild-feed-state evs)
-          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id :ungrouped})]
-      (is (= 2 (:rendered feed))
-          "rows 1 and 3 have no :dispatch-id → they belong to :ungrouped")
-      (is (= #{1 3} (set (mapv :id (:rows feed)))))
-      ;; rf2-r6d6u: the :ungrouped bucket has 2 in-scope rows → :total 2.
-      (is (= 2 (:total feed))
-          ":total counts the in-scope (:ungrouped) rows")
-      (is (= 3 (:buffer-total feed))))))
-
-(deftest project-feed-from-state-no-focus-defensive-empty-state
-  (testing "rf2-ycoct defensive: opts passed with nil :cascade-dispatch-id
-            and a non-empty buffer triggers :no-focus (the default-focus
-            rule from rf2-639lc should prevent this in production)"
-    (let [evs   (events-fixture)
-          state (h/rebuild-feed-state evs)
-          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id nil})]
-      (is (= :no-focus (:empty-kind feed)))
-      (is (= 0 (:rendered feed)))
-      (is (= [] (:rows feed)))
-      ;; rf2-r6d6u: no focused cascade → nothing is in scope → the
-      ;; scoped denominator is 0. The raw ring is still surfaced via
-      ;; :buffer-total (the state is broken, not the data).
-      (is (= 0 (:total feed))
-          ":total is 0 — no focused cascade means nothing is in view")
-      (is (= 5 (:buffer-total feed))
-          ":buffer-total reflects the buffer (the state is broken, not the data)"))))
-
-(deftest project-feed-from-state-2-arity-preserves-global-ribbon-shape
-  (testing "rf2-ycoct: the 2-arity (no opts) keeps the pre-rf2-ycoct
-            global-ribbon behaviour — no cascade-scope, no :no-focus
-            defensive branch. Headless test rigs / callers that pre-
-            date the spine wiring continue to work."
-    (let [evs   (events-fixture)
-          state (h/rebuild-feed-state evs)
-          feed  (h/project-feed-from-state state {})]
-      (is (= 5 (:rendered feed))
-          "every buffered row renders — no cascade-scope applied")
-      ;; rf2-r6d6u: unscoped → the global ribbon's denominator IS the
-      ;; whole buffer, so :total = :buffer-total = 5.
-      (is (= 5 (:total feed))
-          "unscoped :total is the whole buffer")
-      (is (= 5 (:buffer-total feed)))
-      (is (nil? (:empty-kind feed)))
-      (is (nil? (:cascade-dispatch-id feed))
-          "the scope key is nil (no scope was passed)"))))
-
-(deftest project-feed-from-state-cascade-scope-empty-buffer
-  (testing "rf2-ycoct: with an empty buffer, :no-events wins regardless
-            of the cascade-scope value (the buffer is empty FIRST,
-            scoping is a no-op)"
-    (let [state (h/init-feed-state)
-          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 100})]
-      (is (= :no-events (:empty-kind feed))
-          ":no-events takes precedence over :no-focus when total = 0"))))
+(deftest project-feed-from-epoch-rows-carry-no-row-index-slot
+  (testing "rf2-z4fza acceptance: rows MUST NOT carry a :row-index slot
+            — its mere presence on the row was a footgun inviting
+            positional React keys"
+    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
+      (doseq [row (:rows feed)]
+        (is (not (contains? row :row-index))
+            (str "row " (:id row) " must not carry :row-index"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -1,45 +1,46 @@
 (ns day8.re-frame2-causa.panels.trace-view-cljs-test
   "CLJS-side wiring + view tests for Causa's Trace panel
-  (Phase 5, rf2-argrj; view-test coverage filed under rf2-zvrbw).
+  (Phase 5, rf2-argrj; epoch-scoped rework rf2-o6yqq + rf2-td380 +
+  rf2-gkczt).
 
   ## What's under test (in addition to the pure-data tests in
   `trace_helpers_cljs_test.cljc`)
 
     1. **Registry wires the composite sub** under
-       `:rf.causa/trace-feed`, plus the per-axis filter events
-       (`:rf.causa/set-trace-filter`, `:rf.causa/clear-trace-filters`).
+       `:rf.causa/trace-feed` (the epoch-scoped feed).
 
-    2. **Render contract** — the section + header + counts +
-       data-testid wiring matches the production view tree.
+    2. **Render contract** — the section + feed + data-testid wiring
+       matches the production view tree. The top header row (counts /
+       epoch-indicator / film-strip) is GONE (rf2-o6yqq); the
+       chip-filter rows + clear-filters control are GONE (rf2-gkczt).
 
-    3. **Empty states** — `:no-events` and `:no-matches` branches each
-       render their distinct container; the `:no-matches` branch
-       carries a clear-filters affordance.
+    3. **Focused-epoch scope** (spec/018 §6 + rf2-td380) — the panel
+       surfaces the focused epoch record's `:trace-events` (the
+       complete domino trail, including the async nil-dispatch-id
+       reactive rows); refocusing changes the rendered feed.
 
-    4. **Sub-driven rendering** — when the trace buffer is populated
-       the feed renders one `<li>` per row.
+    4. **Empty states** — `:no-events`, `:no-focus`, `:epoch-evicted`
+       each render their distinct container.
 
-    5. **9-axis filter** — each canonical axis narrows the rendered
-       row set (source / origin / frame / op-type / severity / event-id /
-       handler-id / dispatch-id / operation) and axis combinations
-       compose AND-wise.
+    5. **Row interactions** — clicking a row toggles inline payload
+       expansion; clicking the source-coord chip fires :open-in-editor
+       and does NOT also toggle.
 
-    6. **Chip rows** — only axes with >=2 distinct values render their
-       chip row (so a single-value axis isn't noise). The clear-all
-       affordance surfaces whenever any filter axis is active.
-
-    7. **Row interactions** — clicking a row with a dispatch-id pivots
-       to event-detail; clicking a row chip narrows the corresponding
-       axis; clicking the source-coord chip fires :open-in-editor and
-       does NOT also pivot.
-
-    8. **Frame isolation** — the panel's filter state lives on
-       `:rf/causa`, never on `:rf/default`.
+    6. **React-key stability** (rf2-z4fza) — rows keyed on the stable
+       trace id.
 
   ## Pure hiccup
 
-  Same approach as `subscriptions_view_cljs_test.cljs` — walk the view's
-  hiccup tree by `data-testid` rather than mounting to the DOM."
+  Same approach as `issues_ribbon_view_cljs_test.cljs` — walk the
+  view's hiccup tree by `data-testid` rather than mounting to the DOM.
+
+  ## Seeding
+
+  The Trace panel is epoch-scoped: it reads the focused epoch record's
+  `:trace-events`, NOT the global trace bus. So trace events are seeded
+  by attaching them to a `:rf/epoch-record`'s `:trace-events` slot and
+  syncing the per-frame ring via `:rf.causa/sync-epoch-history`, then
+  focusing via `:rf.causa/focus-cascade`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -47,23 +48,16 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.test-support :as causa-test-support]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]
-            [day8.re-frame2-causa.panels.trace :as trace]
-            [day8.re-frame2-causa.panels.trace-helpers :as h]))
+            [day8.re-frame2-causa.panels.trace :as trace]))
 
 ;; ---- fixtures -----------------------------------------------------------
-
-(defn- causa-init! []
-  (causa-test-support/reset-all!)
-  (trace-bus/clear-buffer!))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter plain-atom/adapter
-     :init-fn causa-init!}))
+     :init-fn causa-test-support/reset-all!}))
 
 ;; ---- hiccup walkers ----------------------------------------------------
 ;; Thin aliases over re-frame.test-helpers so the local call sites read
@@ -73,8 +67,8 @@
 (def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
 
 (defn- hiccup-seq
-  "Local kept for the orphan-pill text-label helper. Expands fn
-  components via the framework walker, then yields depth-first nodes."
+  "Expands fn components via the framework walker, then yields
+  depth-first nodes."
   [tree]
   (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
@@ -82,22 +76,11 @@
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {}))
 
-(defn- push-trace! [ev]
-  ;; Per rf2-e9s81: `:rf.causa/trace-buffer` thunks the trace-bus
-  ;; atom; pushing via `seed-buffer-for-test!` (the test-side bypass
-  ;; of the public collector) lands the event in the atom and the
-  ;; next subscribe sees it. We bypass `collect-trace!` because
-  ;; rf2-xs8vu's self-noise filter drops `:frame :rf/causa` events
-  ;; before the buffer push — the trace Panel filter axes need to
-  ;; assert against synthetic events with arbitrary `:frame` slots
-  ;; (including `:rf/causa`) to lock the filter algebra, separately
-  ;; from the ingest guard.
-  (trace-bus/seed-buffer-for-test! ev))
-
-;; Construct a synthetic trace event with the canonical 9-axis tags.
+;; Construct a synthetic trace event living INSIDE an epoch record's
+;; `:trace-events` slot.
 (defn- mk-trace
   [{:keys [id time op-type operation source origin frame
-           severity event-id handler-id dispatch-id reason]
+           event-id handler-id dispatch-id reason]
     :or   {time 1000}}]
   {:id        id
    :time      time
@@ -111,261 +94,251 @@
                 handler-id  (assoc :handler-id handler-id)
                 dispatch-id (assoc :dispatch-id dispatch-id)
                 source      (assoc :source source)
-                severity    (assoc :severity severity)
                 reason      (assoc :reason reason))})
+
+(defn- mk-epoch
+  "Build a minimal `:rf/epoch-record` carrying the supplied
+  `trace-events`. `dispatch-id` defaults to (10 + epoch-id) so the
+  spine resolver pairs the record with `:rf.causa/focus-cascade
+  <dispatch-id>` deterministically."
+  ([epoch-id trace-events]
+   (mk-epoch epoch-id (+ 10 epoch-id) trace-events))
+  ([epoch-id dispatch-id trace-events]
+   {:epoch-id      epoch-id
+    :dispatch-id   dispatch-id
+    :event-id      :test/event
+    :trigger-event [:test/event]
+    :db-before     {}
+    :db-after      {}
+    :renders       []
+    :sub-runs      []
+    :committed-at  (* 1000 epoch-id)
+    :trace-events  (vec trace-events)}))
+
+(defn- seed-history!
+  "Dispatch `:rf.causa/sync-epoch-history` to seed the per-frame ring
+  buffer. Must be called inside `(rf/with-frame :rf/causa ...)`."
+  [records]
+  (rf/dispatch-sync [:rf.causa/sync-epoch-history (vec records)]))
+
+(defn- focus!
+  "Pin focus to the cascade with the given `dispatch-id`. Per
+  `spine/focus-cascade-reducer` the spine resolves the matching
+  `:epoch-id` from `:epoch-history`."
+  [dispatch-id]
+  (rf/dispatch-sync [:rf.causa/focus-cascade dispatch-id nil]))
 
 ;; ---- (1) registry wiring ------------------------------------------------
 
 (deftest registry-installs-trace-handlers
-  (testing "register-causa-handlers! installs the Phase 5 (rf2-argrj)
-            composite sub + every supporting event"
+  (testing "register-causa-handlers! installs the epoch-scoped
+            composite sub + the row-expand events"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/trace-feed))
         ":rf.causa/trace-feed sub registered")
-    (is (some? (registrar/handler :sub :rf.causa/trace-filters))
-        ":rf.causa/trace-filters sub registered")
-    (is (some? (registrar/handler :event :rf.causa/set-trace-filter))
-        ":rf.causa/set-trace-filter event registered")
-    (is (some? (registrar/handler :event :rf.causa/clear-trace-filters))
-        ":rf.causa/clear-trace-filters event registered")))
+    (is (some? (registrar/handler :sub :rf.causa/trace-expanded-row-ids))
+        ":rf.causa/trace-expanded-row-ids sub registered")
+    (is (some? (registrar/handler :event :rf.causa/toggle-trace-row-expand))
+        ":rf.causa/toggle-trace-row-expand event registered")))
 
-(deftest trace-feed-defaults-empty
-  (testing "with no events in the buffer the composite returns an empty
-            feed with empty-kind :no-events"
+(deftest filter-handlers-are-gone
+  (testing "rf2-gkczt: the chip-filter subs + events MUST NOT register"
+    (registry/register-causa-handlers!)
+    (is (nil? (registrar/handler :sub :rf.causa/trace-filters))
+        ":rf.causa/trace-filters sub is gone")
+    (is (nil? (registrar/handler :sub :rf.causa/trace-feed-state))
+        ":rf.causa/trace-feed-state buffer-snapshot sub is gone (rf2-td380)")
+    (is (nil? (registrar/handler :event :rf.causa/set-trace-filter))
+        ":rf.causa/set-trace-filter event is gone")
+    (is (nil? (registrar/handler :event :rf.causa/clear-trace-filters))
+        ":rf.causa/clear-trace-filters event is gone")))
+
+(deftest trace-feed-defaults-no-focus
+  (testing "rf2-td380: with no focus + no epoch history the composite
+            returns an empty feed with :no-focus (cold start — the
+            focus-resolver classifies nil-focus + empty-history as
+            :no-focus)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= [] (:rows feed)))
         (is (= 0 (:total feed)))
         (is (= 0 (:rendered feed)))
-        (is (false? (:any-filter? feed)))
-        (is (= :no-events (:empty-kind feed)))))))
+        (is (= :no-focus (:empty-kind feed)))))))
 
-(deftest trace-feed-projects-events-into-rows
-  (testing "with events in the buffer the composite returns one row per
-            event with the canonical 9-axis projection"
+(deftest trace-feed-projects-focused-epoch-events-into-rows
+  (testing "rf2-td380: with a focused epoch the composite returns one
+            row per trace event in that epoch's :trace-events"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui :origin :app :frame :rf/default
-                              :event-id :cart/add :dispatch-id 42}))
-      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
-                              :source :ui :origin :app :frame :rf/default
-                              :event-id :cart/add :handler-id :cart/add-handler
-                              :dispatch-id 42 :reason "boom"}))
+      (seed-history!
+        [(mk-epoch 1 42
+                   [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                               :dispatch-id 42 :event-id :cart/add})
+                    (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
+                               :dispatch-id 42 :reason "boom"})])])
+      (focus! 42)
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 2 (:total feed)))
         (is (= 2 (:rendered feed)))
         (is (nil? (:empty-kind feed)))
-        (is (= #{1 2} (set (map :id (:rows feed)))))))))
+        (is (= #{1 2} (set (map :id (:rows feed)))))
+        (is (= 1 (:epoch-id feed)))))))
 
 ;; ---- (2) render contract ------------------------------------------------
 
 (deftest panel-container-renders
-  (testing "the panel renders its root container regardless of buffer state"
+  (testing "the panel renders its root container regardless of focus state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace"))
-            "panel container present")
-        (is (some? (find-by-testid tree "rf-causa-trace-counts"))
-            "counts span present")
-        ;; rf2-6xezz · Mike-direction 2026-05-21 — the panel-icon
-        ;; lived inside the deleted h1 heading.
-        (is (nil? (find-by-testid tree "rf-causa-trace-panel-icon"))
-            "panel header icon is gone (lived in the scrubbed h1)")))))
+            "panel container present")))))
 
-(deftest feed-list-renders-when-events-present
-  (testing "with events in the buffer the panel renders the <ul> feed
-            with one <li> per row"
+(deftest top-header-row-is-gone
+  (testing "rf2-o6yqq: the top header row — counts, epoch-indicator,
+            film-strip nav — is removed from the Trace panel"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 2 :op-type :fx :operation :rf.fx/handled
-                              :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
-                              :dispatch-id 1}))
+      (seed-history!
+        [(mk-epoch 1 42
+                   [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                               :dispatch-id 42})])])
+      (focus! 42)
+      (let [tree (trace/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-trace-counts"))
+            "counts span is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-epoch-indicator"))
+            "epoch indicator is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-film-strip"))
+            "film-strip wrapper is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-film-strip-prev"))
+            "film-strip prev button is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-film-strip-next"))
+            "film-strip next button is gone")))))
+
+(deftest chip-filter-ui-is-gone
+  (testing "rf2-gkczt: the chip-filter rows, per-row chip affordances,
+            and clear-filters control are removed"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 42
+                   [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                               :dispatch-id 42 :source :ui})
+                    (mk-trace {:id 2 :op-type :error :operation :rf.error/x
+                               :dispatch-id 42 :source :timer})])])
+      (focus! 42)
+      (let [tree (trace/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-trace-axis-row-op-type"))
+            "op-type chip row is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-axis-row-source"))
+            "source chip row is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-clear-filters"))
+            "clear-filters control is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-1-source-chip"))
+            "per-row source chip is gone")
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-1-row-chips"))
+            "per-row chip cell is gone")))))
+
+(deftest feed-list-renders-when-focused-epoch-has-events
+  (testing "rf2-td380: with a focused epoch the panel renders the <ul>
+            feed with one <li> per row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                               :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :fx :operation :rf.fx/handled
+                               :dispatch-id 1})
+                    (mk-trace {:id 3 :op-type :sub/run :operation :sub/run})])])  ; nil dispatch-id
+      (focus! 1)
       (let [tree (trace/Panel)
             rows (find-all-by-testid-prefix tree "rf-causa-trace-row-")]
         (is (some? (find-by-testid tree "rf-causa-trace-feed"))
             "feed <ul> present")
-        ;; Each row has many sub-testids prefixed with rf-causa-trace-row-<id>-…
-        ;; so filter to just the row containers (no trailing -dash).
+        (is (some? (find-by-testid tree "rf-causa-trace-row-3"))
+            "the async nil-dispatch-id reactive row is present (rf2-td380)")
         (is (>= (count rows) 3)
             "at least one rendered node per row")))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 
-(deftest empty-state-no-events-renders
-  (testing "with no events the panel renders the :no-events empty-state"
+(deftest empty-state-no-events-renders-for-empty-epoch
+  (testing "with a focused epoch carrying no trace events the panel
+            renders the :no-events empty-state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
+      (seed-history! [(mk-epoch 1 11 [])])
+      (focus! 11)
       (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-empty-no-events"))
             ":no-events empty-state container present")
         (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
-            "no feed list when buffer is empty")))))
+            "no feed list when focused epoch carries no events")))))
 
-(deftest empty-state-no-matches-renders-when-filters-hide-all
-  (testing "with events present but a filter that matches nothing the
-            panel renders the :no-matches empty-state with clear button.
-            The event carries `:dispatch-id 1` so the spine has a
-            focusable cascade (rf2-fzbrw strips :ungrouped from the
-            focusable list; without a focusable cascade the panel
-            would render :no-focus, not :no-matches)."
+(deftest empty-state-no-focus-renders
+  (testing "rf2-td380: with no focus + no history the panel renders the
+            :no-focus empty-state (cold start — the focus-resolver
+            classifies nil-focus + empty-history as :no-focus)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :no-such-source])
       (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
-            ":no-matches empty-state container present")
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-clear-filters"))
-            "clear-filters button surfaces in :no-matches state")
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-focus"))
+            "cold-start :no-focus empty-state present")
         (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
-            "no feed list when no rows survive filtering")))))
+            "no feed list at cold start")))))
 
-;; ---- (4) 9-axis filter --------------------------------------------------
-
-(deftest set-trace-filter-writes-to-causa-frame
-  (testing ":rf.causa/set-trace-filter mutates the per-axis filter map"
+(deftest empty-state-epoch-evicted-renders
+  (testing "rf2-td380: when focus pins an :epoch-id no longer in
+            :epoch-history the panel paints the evicted-epoch
+            placeholder (mirrors the Issues panel, spec/021 §10.7)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (is (= {:source :ui} @(rf/subscribe [:rf.causa/trace-filters])))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
-      (is (= {:source :ui :origin :app}
-             @(rf/subscribe [:rf.causa/trace-filters]))
-          "second axis adds; existing axis is preserved")
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source nil])
-      (is (= {:origin :app} @(rf/subscribe [:rf.causa/trace-filters]))
-          "passing nil clears that axis"))))
+      (seed-history! [(mk-epoch 1 11 [])])
+      (rf/dispatch-sync
+        [:day8.re-frame2-causa.panels.trace-view-cljs-test/seed-evicted-focus])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])
+            tree (trace/Panel)]
+        (is (= :epoch-evicted (:empty-kind feed))
+            "composite signals :epoch-evicted when no record matches focus")
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-epoch-evicted"))
+            "canonical placeholder container rendered")
+        (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
+            "no feed list when the focused epoch has been evicted")))))
 
-(deftest clear-trace-filters-drops-every-axis
-  (testing ":rf.causa/clear-trace-filters drops every axis in one shot"
+;; ---- (4) focused-epoch scope (refocus) ----------------------------------
+
+(deftest trace-feed-rescopes-on-refocus
+  (testing "rf2-td380: focusing a different epoch re-renders with that
+            epoch's :trace-events"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
-      (rf/dispatch-sync [:rf.causa/clear-trace-filters])
-      (is (= {} @(rf/subscribe [:rf.causa/trace-filters]))
-          "every filter axis cleared"))))
-
-(deftest filter-by-source-narrows-rendered-rows
-  (testing "setting :source narrows the feed to events with that source.
-            All events share `:dispatch-id 1` so the rf2-ycoct cascade-
-            scope is a no-op for this axis-in-isolation assertion (the
-            spine's head cascade is 1, every row is in scope)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                              :source :timer :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (seed-history!
+        [(mk-epoch 1 100
+                   [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                               :dispatch-id 100})
+                    (mk-trace {:id 2 :op-type :fx :operation :rf.fx/handled})])  ; nil dispatch-id reactive
+         (mk-epoch 2 200
+                   [(mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                               :dispatch-id 200})
+                    (mk-trace {:id 4 :op-type :sub/run :operation :sub/run})
+                    (mk-trace {:id 5 :op-type :view/render :operation :view/render})])])
+      ;; Focus epoch 1 (cascade 100).
+      (focus! 100)
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 2 (:total feed)))
-        (is (= 1 (:rendered feed)))
-        (is (= [1] (mapv :id (:rows feed))))))))
-
-(deftest filter-by-op-type-narrows-rendered-rows
-  (testing "setting :op-type narrows the feed to events with that op-type.
-            All events share `:dispatch-id 1` so the rf2-ycoct cascade-
-            scope is a no-op (rf2-fzbrw strips :ungrouped from focusable
-            cascades — events without :dispatch-id would otherwise leave
-            the spine with no focusable cascade and trigger :no-focus)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
-                              :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 3 :op-type :fx    :operation :rf.fx/handled
-                              :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :op-type :error])
+        (is (= #{1 2} (set (map :id (:rows feed))))
+            "epoch 1's rows — including the nil-dispatch-id reactive row 2")
+        (is (= 1 (:epoch-id feed))))
+      ;; Refocus to epoch 2 (cascade 200).
+      (focus! 200)
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 1 (:rendered feed)))
-        (is (= [2] (mapv :id (:rows feed))))))))
+        (is (= #{3 4 5} (set (map :id (:rows feed))))
+            "epoch 2's rows — the whole domino trail (event + sub + view)")
+        (is (= 2 (:epoch-id feed)))))))
 
-(deftest filter-axes-compose-and-wise
-  (testing "two filter axes compose AND-wise — only rows matching both
-            survive. All events share `:dispatch-id 1` so the rf2-ycoct
-            cascade-scope is a no-op for this composition assertion."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui    :origin :app  :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                              :source :ui    :origin :pair :dispatch-id 1}))
-      (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                              :source :timer :origin :app  :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 1 (:rendered feed))
-            "only the row matching both axes survives")
-        (is (= [1] (mapv :id (:rows feed))))))))
-
-(deftest filter-by-dispatch-id-collapses-cascade
-  (testing "setting :dispatch-id slices the feed to one cascade's events.
-            Per rf2-ycoct the panel is cascade-scoped to the focused
-            cascade by default; here we explicitly focus 42, then the
-            user's `:dispatch-id` chip-filter narrows to the same id
-            (redundant in this case — both filters land on the same
-            set, which is the expected workflow when the user clicks
-            the dispatch-id chip on a row of the already-focused
-            cascade)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :dispatch-id 42}))
-      (push-trace! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                              :dispatch-id 42}))
-      (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                              :dispatch-id 99}))
-      ;; Focus cascade 42 (the spine's LIVE auto-snap would land on 99 —
-      ;; the head — so we pin to 42 explicitly to assert the axis
-      ;; filter algebra in isolation from the auto-scope).
-      (rf/dispatch-sync [:rf.causa/focus-cascade 42])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :dispatch-id 42])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 2 (:rendered feed)))
-        (is (= #{1 2} (set (map :id (:rows feed)))))))))
-
-;; ---- (5) chip rows ------------------------------------------------------
-
-(deftest chip-row-renders-only-when-axis-has-two-plus-values
-  (testing "an axis with one distinct value has nothing to filter on,
-            so its chip row is suppressed; an axis with >=2 renders"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Two events with the same :source but different :op-type.
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui}))
-      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
-                              :source :ui}))
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-trace-axis-row-op-type"))
-            ":op-type has two distinct values → chip row renders")
-        (is (nil? (find-by-testid tree "rf-causa-trace-axis-row-source"))
-            ":source has one distinct value → chip row suppressed")))))
-
-(deftest clear-filters-button-renders-only-when-axis-active
-  (testing "the header's Clear filters affordance appears iff at least
-            one filter axis is active"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui}))
-      (is (nil? (find-by-testid (trace/Panel) "rf-causa-trace-clear-filters"))
-          "no Clear filters button when no axis is active")
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (is (some? (find-by-testid (trace/Panel) "rf-causa-trace-clear-filters"))
-          "Clear filters button surfaces once an axis is active"))))
-
-;; ---- (6) row interactions -----------------------------------------------
+;; ---- (5) row interactions -----------------------------------------------
 
 (deftest row-click-toggles-inline-payload-expansion
   (testing "rf2-7dyi8 — clicking a row dispatches
@@ -374,8 +347,11 @@
             panel surfaces row payloads inline; no nav."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 7 :op-type :event :operation :event/dispatched
-                              :dispatch-id 42 :frame :rf/default}))
+      (seed-history!
+        [(mk-epoch 1 42
+                   [(mk-trace {:id 7 :op-type :event :operation :event/dispatched
+                               :dispatch-id 42 :frame :rf/default})])])
+      (focus! 42)
       (let [dispatches (atom [])]
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
@@ -391,11 +367,7 @@
         (is (not-any? #(and (vector? %)
                             (= :rf.causa/select-dispatch-id (first %)))
                       @dispatches)
-            "the legacy pivot is gone — no select-dispatch-id fired")
-        (is (not-any? #(and (vector? %)
-                            (= :rf.causa/select-tab (first %)))
-                      @dispatches)
-            "no select-tab fired (no nav per spec/021 §5.4)")))))
+            "the legacy pivot is gone — no select-dispatch-id fired")))))
 
 (deftest toggle-trace-row-expand-event-mutates-set
   (testing "rf2-7dyi8 — :rf.causa/toggle-trace-row-expand toggles row
@@ -421,8 +393,11 @@
             below the row (Trace payloads are current-state)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 13 :op-type :event :operation :event/dispatched
-                              :dispatch-id 1 :source :ui :origin :app}))
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 13 :op-type :event :operation :event/dispatched
+                               :dispatch-id 1 :source :ui :origin :app})])])
+      (focus! 1)
       ;; Pre-expansion — no payload.
       (let [tree (trace/Panel)]
         (is (nil? (find-by-testid tree "rf-causa-trace-row-13-payload"))
@@ -432,10 +407,6 @@
       (let [tree    (trace/Panel)
             payload (find-by-testid tree "rf-causa-trace-row-13-payload")]
         (is (some? payload) "payload block renders when row is expanded")
-        ;; Per rf2-dmso5 browse is current-state cljs-devtools — the
-        ;; widget stamps `rf-causa-edn-widget-browse-trace-<render-id>`;
-        ;; pin that the panel's per-row render-id wiring lands in the
-        ;; canonical per-row slot.
         (is (some? (find-by-testid tree
                                    "rf-causa-edn-widget-browse-trace-trace-row-13"))
             "cljs-devtools browse mounted with per-row render-id")))))
@@ -447,11 +418,13 @@
             now, the source-coord button bubbles must not toggle it)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      ;; Push a trace whose :rf.trace/trigger-handler carries a source-coord.
-      (push-trace! (-> (mk-trace {:id 9 :op-type :event :operation :event/dispatched
-                                  :dispatch-id 1})
-                       (assoc :rf.trace/trigger-handler
-                              {:source-coord {:file "core.cljs" :line 42}})))
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(-> (mk-trace {:id 9 :op-type :event
+                                   :operation :event/dispatched :dispatch-id 1})
+                        (assoc :rf.trace/trigger-handler
+                               {:source-coord {:file "core.cljs" :line 42}}))])])
+      (focus! 1)
       (let [dispatches (atom [])
             stop-evt   (atom nil)]
         (with-redefs [rf/dispatch* (fn
@@ -472,30 +445,26 @@
         (is @stop-evt "stopPropagation was called so the row's pivot
                        handler doesn't also fire")))))
 
-;; ---- (7) frame isolation ------------------------------------------------
+;; ---- (6) frame isolation ------------------------------------------------
 
-(deftest trace-filter-state-does-not-leak-into-default-frame
-  (testing "the panel's filter state lives on :rf/causa, never :rf/default"
+(deftest trace-expand-state-does-not-leak-into-default-frame
+  (testing "the panel's expand state lives on :rf/causa, never :rf/default"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui]))
+      (rf/dispatch-sync [:rf.causa/toggle-trace-row-expand 5]))
     (let [causa-db   (frame/frame-app-db-value :rf/causa)
           default-db (frame/frame-app-db-value :rf/default)]
-      (is (= {:source :ui} (:trace-filters causa-db))
-          "filter map lands on Causa")
-      (is (nil? (:trace-filters default-db))
-          "filter map did NOT leak into :rf/default"))))
+      (is (= #{5} (:trace-expanded-row-ids causa-db))
+          "expand set lands on Causa")
+      (is (nil? (:trace-expanded-row-ids default-db))
+          "expand set did NOT leak into :rf/default"))))
 
-;; ---- (8) React-key stability across trace pushes — rf2-z4fza -----------
+;; ---- (7) React-key stability across the feed — rf2-z4fza ---------------
 ;;
-;; Sibling of rf2-kgn0c (same React-key discipline class). The earlier
-;; trace row shape keyed `<li>` on a tuple that included the row's
-;; positional index inside the visible viewport. Every trace push
-;; shifted every visible row's index → every key changed → React
-;; unmounted + remounted the entire viewport on EVERY push — the
-;; dominant frame cost under burst event rate (animation frames,
-;; polling). This test pins the fix: the rendered `<li>` for any row
-;; that survives a push has the SAME `:key` before and after.
+;; Sibling of rf2-kgn0c (same React-key discipline class). The rendered
+;; `<li>` for any row keys on the stable trace `:id` (`t:<id>`), not a
+;; positional index — so React's reconciler reuses DOM nodes instead of
+;; remounting the viewport.
 
 (defn- row-li-by-id
   "Walk the rendered tree and return the `<li>` whose data-testid is
@@ -510,598 +479,43 @@
               node))
           (hiccup-seq tree))))
 
-(defn- sync-push!
-  "Push a trace event AND synchronously flush the `:rf.causa/note-
-  trace-event` mirror into `:rf/causa`'s app-db. The production
-  `collect-trace!` mirror dispatches async (`rf/dispatch`); the
-  layer-1 `:rf.causa/trace-buffer` sub falls back to the atom when
-  the db slot is nil, which lets the first read succeed in tests.
-  But once the sub has materialised, subsequent atom-only pushes
-  are invisible to the cached sub. `dispatch-sync` of the note
-  event forces the db update so the sub re-fires."
-  [ev]
-  (push-trace! ev)
-  (rf/dispatch-sync [:rf.causa/note-trace-event ev]))
-
-(deftest trace-row-react-keys-are-stable-across-pushes
-  (testing "rf2-z4fza — appending a new trace event must NOT change the
-            :key of any previously-rendered <li>. Same input row → same
-            React key → React's reconciler reuses the DOM node instead
-            of unmounting + remounting it. Mirrors rf2-kgn0c's
-            v:<variant-id> discipline in the story workspace.
-
-            All six events share `:dispatch-id 1` so the rf2-ycoct
-            cascade-scope is a no-op for this key-stability assertion
-            (the spine's head cascade stays 1, every row is in scope)."
+(deftest trace-row-react-keys-are-stable-trace-ids
+  (testing "rf2-z4fza — the rendered <li> :key is the stable trace id
+            (`t:<id>`), distinct per row and free of any positional
+            component"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      ;; Seed three rows.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                             :time 200 :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
-                             :time 300 :dispatch-id 1}))
-      (let [tree-1   (trace/Panel)
-            keys-1   {1 (:key (second (row-li-by-id tree-1 1)))
-                      2 (:key (second (row-li-by-id tree-1 2)))
-                      3 (:key (second (row-li-by-id tree-1 3)))}]
-        (is (every? some? (vals keys-1))
-            "every initial row carries a React :key")
-        (is (= 3 (count (distinct (vals keys-1))))
-            "initial row keys are distinct")
-        ;; Push three more events in the SAME cascade — under the
-        ;; broken positional-key shape, this would shift every
-        ;; existing key.
-        (sync-push! (mk-trace {:id 4 :op-type :event :operation :event/dispatched
-                               :time 400 :dispatch-id 1}))
-        (sync-push! (mk-trace {:id 5 :op-type :fx    :operation :rf.fx/handled
-                               :time 500 :dispatch-id 1}))
-        (sync-push! (mk-trace {:id 6 :op-type :error :operation :rf.error/handler-threw
-                               :time 600 :dispatch-id 1}))
-        (let [tree-2 (trace/Panel)
-              keys-2 {1 (:key (second (row-li-by-id tree-2 1)))
-                      2 (:key (second (row-li-by-id tree-2 2)))
-                      3 (:key (second (row-li-by-id tree-2 3)))
-                      4 (:key (second (row-li-by-id tree-2 4)))
-                      5 (:key (second (row-li-by-id tree-2 5)))
-                      6 (:key (second (row-li-by-id tree-2 6)))}]
-          (doseq [id [1 2 3]]
-            (is (= (get keys-1 id) (get keys-2 id))
-                (str "row id " id ": React :key must be identical before "
-                     "and after the burst push (pre=" (pr-str (get keys-1 id))
-                     " post=" (pr-str (get keys-2 id)) "). "
-                     "If this fails, the trace ribbon is re-mounting the "
-                     "viewport on every push — the rf2-z4fza regression.")))
-          (is (every? some? (vals keys-2))
-              "every row in the post-push tree carries a React :key")
-          (is (= 6 (count (distinct (vals keys-2))))
-              "all six row keys remain distinct after the burst push"))))))
-
-(deftest trace-row-react-keys-have-no-positional-component
-  (testing "rf2-z4fza acceptance: the rendered <li> :key contains only
-            the stable trace id, NOT a positional row-index. Pins the
-            key shape so a future regression that re-introduces a
-            positional component would fail loudly here."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 11 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 22 :op-type :fx    :operation :rf.fx/handled
-                             :time 200 :dispatch-id 1}))
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 11 :op-type :event :operation :event/dispatched
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 22 :op-type :fx :operation :rf.fx/handled
+                               :time 200 :dispatch-id 1})
+                    (mk-trace {:id 33 :op-type :sub/run :operation :sub/run
+                               :time 300})])])
+      (focus! 1)
       (let [tree (trace/Panel)
             k11  (:key (second (row-li-by-id tree 11)))
-            k22  (:key (second (row-li-by-id tree 22)))]
+            k22  (:key (second (row-li-by-id tree 22)))
+            k33  (:key (second (row-li-by-id tree 33)))]
         (is (= "t:11" k11)
             "row 11 keyed on stable trace id alone (no positional prefix)")
-        (is (= "t:22" k22)
-            "row 22 keyed on stable trace id alone (no positional prefix)")
-        (is (string? k11)
-            "key is a string (not the positional-tuple from the
-             pre-rf2-z4fza shape)")))))
+        (is (= "t:22" k22))
+        (is (= "t:33" k33))
+        (is (= 3 (count (distinct [k11 k22 k33])))
+            "all row keys distinct")))))
 
-;; ---- (9) orphan-filter surfacing — rf2-vu0mp ---------------------------
-;;
-;; When the buffer rotates past the cap and the selected filter value's
-;; last instance ages out, :trace-filters still carries the selection
-;; but the chip-row no longer shows that value (audit F6). Per rf2-vu0mp
-;; the fix:
-;;
-;;   1. The header's chip-row keeps rendering the active value (the
-;;      helper's effective-distinct unions it back into distinct);
-;;      orphan chips are marked visually (count = 0, dashed border,
-;;      italic).
-;;   2. The :no-matches empty state surfaces an 'narrowing on:' strip
-;;      listing every active axis=value pair so the user always has
-;;      an in-panel cue what is filtering the ribbon — orphan or not.
+;; ---- evicted-focus helper ----------------------------------------------
 
-(deftest orphan-chip-renders-in-header-when-filter-value-aged-out
-  (testing "rf2-vu0mp: filtering on a value not present in the buffer
-            still renders an axis chip for that value so the user can
-            see / toggle off their selection. The chip carries count 0."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Push a single :ui-sourced event then narrow on :timer — the
-      ;; :timer value is NOT in the buffer (orphan).
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-trace-axis-row-source"))
-            "the :source chip-row renders even though only one buffered
-             distinct value exists (the active orphan brings the chip
-             count to 2 — distinct :ui + orphan :timer)")
-        (is (some? (find-by-testid tree "rf-causa-trace-axis-chip-source-timer"))
-            "an orphan chip for the active :timer selection renders")))))
-
-(deftest orphan-empty-state-surfaces-active-filter-strip
-  (testing "rf2-vu0mp: the :no-matches empty state surfaces an
-            'narrowing on:' strip listing each active axis=value pair
-            so the user always sees what is filtering the ribbon.
-            Events carry `:dispatch-id 1` so the spine has a focusable
-            cascade (rf2-fzbrw)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Push two events that won't match the filter.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app :frame :rf/default
-                             :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app :frame :rf/default
-                             :dispatch-id 1}))
-      ;; Narrow on a value the buffer doesn't carry — orphan.
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
-            ":no-matches empty state renders")
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-active-filters"))
-            "rf2-vu0mp: active-filters strip renders inside no-matches")
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-active-source"))
-            "a pill for the :source axis surfaces")))))
-
-(deftest active-filter-pill-click-drops-the-axis
-  (testing "rf2-vu0mp: clicking an active-filter pill drops that axis
-            from the filter map (lets the user clear an orphan without
-            hunting through the header). Event carries `:dispatch-id 1`
-            so the spine has a focusable cascade (rf2-fzbrw)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app
-                             :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :rf/missing-origin])
-      (let [dispatches (atom [])]
-        (with-redefs [rf/dispatch* (fn
-                                     ([ev]      (swap! dispatches conj ev) nil)
-                                     ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
-                pill    (find-by-testid tree "rf-causa-trace-empty-active-source")
-                handler (:on-click (second pill))]
-            (is (some? pill) ":source pill rendered")
-            (when handler (handler))))
-        (is (some #(= [:rf.causa/set-trace-filter :source nil] %) @dispatches)
-            "clicking the pill fires set-trace-filter with nil-value
-             (the canonical 'drop this axis' shape)")))))
-
-(deftest empty-state-active-filter-pill-marks-present-vs-orphan
-  (testing "rf2-vu0mp: a present axis pill (the value still exists in
-            the buffer) is styled differently from an orphan pill — the
-            data-driven marker on the chip label.
-
-            Post-rf2-ycoct `:frame` is no longer a chip-row axis (the
-            Trace tab is cascade-scoped so the focused event already
-            pins one frame). We exercise the orphan path with `:origin`
-            instead — same algebra; different axis. Event carries
-            `:dispatch-id 1` so the spine has a focusable cascade
-            (rf2-fzbrw)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Push :ui-sourced events; then add TWO filters: source = :ui
-      ;; (present, but combined with the second filter renders zero
-      ;; rows) AND origin = :rf/missing-origin (orphan).
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app
-                             :dispatch-id 1}))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :rf/missing-origin])
-      (let [tree         (trace/Panel)
-            source-pill  (find-by-testid tree "rf-causa-trace-empty-active-source")
-            origin-pill  (find-by-testid tree "rf-causa-trace-empty-active-origin")]
-        (is (some? source-pill) "present axis pill renders")
-        (is (some? origin-pill)  "orphan axis pill renders")
-        (testing "present pill has no orphan marker"
-          (is (not (re-find #"orphaned" (th/text-content source-pill)))))
-        (testing "orphan pill carries the orphan marker"
-          (is (re-find #"orphaned" (th/text-content origin-pill))))))))
-
-;; ---- (10) incremental projection wiring — rf2-44vzy --------------------
-;;
-;; The trace-feed sub now reads :trace-feed-state — an incrementally-
-;; maintained snapshot of the projection updated O(axes) per push by
-;; the :rf.causa/note-trace-event handler. These tests pin the wiring
-;; contract: registry installs the new state-keeping handlers; the
-;; sub returns the same shape as before; clear/sync drop the
-;; snapshot in lockstep with the buffer (privacy invariant from
-;; rf2-lqmje §Privacy retroactive-scrub).
-
-(deftest trace-feed-state-sub-registered
-  (testing "registry registers the :rf.causa/trace-feed-state sub
-            (the per-rf2-44vzy reactive surface)"
-    (registry/register-causa-handlers!)
-    (is (some? (registrar/handler :sub :rf.causa/trace-feed-state))
-        ":rf.causa/trace-feed-state sub registered")))
-
-(deftest note-trace-event-updates-feed-state-snapshot
-  (testing "rf2-44vzy: the note-trace-event handler dual-writes —
-            populates both :trace-buffer and :trace-feed-state. The
-            snapshot's :total, :counts, and :seen mirror what a from-
-            scratch project-feed would produce."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default}))
-      (sync-push! (mk-trace {:id 2 :op-type :error :operation :rf.error/x
-                             :source :timer :frame :rf/causa}))
-      (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
-        (is (= 2 (:total state)))
-        (is (= 2 (count (:projected-rows state))))
-        (is (contains? (get-in state [:seen :source]) :ui))
-        (is (contains? (get-in state [:seen :source]) :timer))
-        (is (= 1 (get-in state [:counts :source :ui])))
-        (is (= 1 (get-in state [:counts :source :timer])))))))
-
-(deftest clear-trace-buffer-drops-feed-state
-  (testing "rf2-44vzy + rf2-lqmje §Privacy retroactive-scrub: the
-            `:rf.causa/clear-trace-buffer` handler dissocs BOTH
-            `:trace-buffer` and `:trace-feed-state` in lockstep so
-            the incremental snapshot never carries pre-clear residue.
-
-            We assert the handler shape directly (sync dispatch) — the
-            production path is `trace-bus/clear-buffer!`, which also
-            clears the atom + queues this dispatch."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Populate both the app-db slot AND the atom by going through
-      ;; sync-push! (dispatches :rf.causa/note-trace-event sync).
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui}))
-      (is (pos? (:total @(rf/subscribe [:rf.causa/trace-feed-state])))
-          "snapshot populated before clear")
-      ;; Clear the atom + the slot atomically: drop the atom first so
-      ;; the sub's fallback path produces an empty state, then sync-
-      ;; dispatch the clear handler so the slot is dissoced too.
-      (trace-bus/clear-buffer!)
-      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
-      (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
-        (testing "post-clear: snapshot rebuilt from now-empty buffer →
-                 empty / fresh state"
-          (is (= 0 (:total state)))
-          (is (= [] (:projected-rows state))))))))
-
-(deftest sync-trace-buffer-rebuilds-feed-state
-  (testing "rf2-44vzy: :rf.causa/sync-trace-buffer rebuilds the
-            snapshot from the seeded buffer — every distinct value
-            present in the seed must land in :seen"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (let [seed [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default})
-                  (mk-trace {:id 2 :op-type :error :operation :rf.error/x
-                             :source :timer :frame :rf/causa})]]
-        (rf/dispatch-sync [:rf.causa/sync-trace-buffer seed])
-        (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
-          (is (= 2 (:total state)))
-          (is (contains? (get-in state [:seen :source]) :ui))
-          (is (contains? (get-in state [:seen :source]) :timer)))))))
-
-(deftest trace-feed-shape-stable-across-incremental-path
-  (testing "rf2-44vzy: the public :rf.causa/trace-feed shape is
-            unchanged — :rows / :total / :rendered / :distinct /
-            :counts / :filters / :any-filter? / :empty-kind all
-            present. Adds rf2-vu0mp's :active-filters key."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default}))
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (contains? feed :rows))
-        (is (contains? feed :total))
-        (is (contains? feed :rendered))
-        (is (contains? feed :distinct))
-        (is (contains? feed :counts))
-        (is (contains? feed :filters))
-        (is (contains? feed :any-filter?))
-        (is (contains? feed :empty-kind))
-        (is (contains? feed :active-filters)
-            "rf2-vu0mp adds :active-filters for the empty-state strip")
-        (is (contains? feed :cascade-dispatch-id)
-            "rf2-ycoct adds :cascade-dispatch-id for the spine-scoped
-             view")))))
-
-;; ---- (11) cascade-scope (focused-event invariant) — rf2-ycoct ----------
-;;
-;; Per spec/018 §6 every L4 panel is a lens on the spine's focused event,
-;; not a global ribbon. Mike's call (audit findings 2026-05-18) on
-;; rf2-ycoct: the Trace tab is cascade-scoped by default. The composite
-;; reads :rf.causa/focus and pre-filters rows to the focused cascade's
-;; events; user chip filters AND on top of the scope.
-
-(deftest trace-feed-cascade-scoped-to-focused-event
-  (testing "rf2-ycoct: with two cascades in the buffer, focusing one
-            scopes the feed to that cascade's events. Switching focus
-            to the other re-renders with the other cascade's events."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Cascade A: dispatch-id 100, events 1+2.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 100 :frame :rf/default}))
-      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                             :time 110 :dispatch-id 100 :frame :rf/default}))
-      ;; Cascade B: dispatch-id 200, events 3+4+5.
-      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                             :time 200 :dispatch-id 200 :frame :rf/default}))
-      (sync-push! (mk-trace {:id 4 :op-type :fx    :operation :rf.fx/handled
-                             :time 210 :dispatch-id 200 :frame :rf/default}))
-      (sync-push! (mk-trace {:id 5 :op-type :error :operation :rf.error/x
-                             :time 220 :dispatch-id 200 :frame :rf/default}))
-      ;; Focus cascade A.
-      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        ;; rf2-r6d6u: the 'X / Y in view' denominator is cascade-scoped
-        ;; — :total is cascade A's 2 in-scope events, NOT the 5-event
-        ;; buffer. The raw ring is surfaced via :buffer-total.
-        (is (= 2 (:total feed))
-            ":total is the in-scope (cascade A) count — the per-cascade
-             lens denominator, not the whole buffer")
-        (is (= 5 (:buffer-total feed))
-            ":buffer-total carries the whole ring's size")
-        (is (= 2 (:rendered feed))
-            "only the two events in cascade A are rendered")
-        (is (= #{1 2} (set (mapv :id (:rows feed))))
-            "rows are exactly cascade A's events")
-        (is (= 100 (:cascade-dispatch-id feed))
-            "the scope value rides on the feed shape"))
-      ;; Pivot focus to cascade B.
-      (rf/dispatch-sync [:rf.causa/focus-cascade 200])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 3 (:rendered feed))
-            "rendered count flips to cascade B's three events")
-        (is (= 3 (:total feed))
-            ":total flips to cascade B's 3 in-scope events")
-        (is (= 5 (:buffer-total feed)))
-        (is (= #{3 4 5} (set (mapv :id (:rows feed))))
-            "rows are exactly cascade B's events")
-        (is (= 200 (:cascade-dispatch-id feed)))))))
-
-(deftest trace-feed-user-chip-filter-ands-with-cascade-scope
-  (testing "rf2-ycoct: user chip filters AND on top of the cascade
-            scope — the panel is a lens AND a filterable ribbon."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Cascade A: two events, mixed sources.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 100 :source :ui}))
-      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                             :time 110 :dispatch-id 100 :source :timer}))
-      ;; Cascade B: one :ui-sourced event (would survive a global
-      ;; :source :ui filter if scope were not applied).
-      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                             :time 200 :dispatch-id 200 :source :ui}))
-      ;; Focus cascade A, then narrow on :source :ui — the AND-wise
-      ;; result must be cascade-A AND :source :ui = event 1 only.
-      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 1 (:rendered feed))
-            "AND-wise: cascade-A ∩ :source :ui = event 1 only")
-        (is (= [1] (mapv :id (:rows feed))))
-        (is (true? (:any-filter? feed))
-            ":any-filter? reflects USER filter state (cascade-scope is
-             a system invariant, not a user narrowing)")))))
-
-(deftest trace-feed-live-mode-auto-tracks-head-cascade
-  (testing "rf2-ycoct + rf2-s0s5x: in LIVE mode the spine auto-tracks
-            the head cascade, so a new cascade landing rebinds the
-            scope automatically. No explicit focus event needed — the
-            panel ALWAYS shows the latest cascade by default."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Cascade A — head while it's alone.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 100}))
-      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                             :time 110 :dispatch-id 100}))
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 2 (:rendered feed))
-            "with one cascade, LIVE auto-scope shows that cascade")
-        (is (= 100 (:cascade-dispatch-id feed))))
-      ;; Cascade B lands — head pivots, LIVE auto-tracks.
-      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                             :time 200 :dispatch-id 200}))
-      (sync-push! (mk-trace {:id 4 :op-type :fx    :operation :rf.fx/handled
-                             :time 210 :dispatch-id 200}))
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (= 2 (:rendered feed))
-            "scope auto-pivoted to cascade B (the new head)")
-        (is (= #{3 4} (set (mapv :id (:rows feed)))))
-        (is (= 200 (:cascade-dispatch-id feed)))))))
-
-(deftest trace-feed-cascade-scope-no-match-renders-no-matches
-  (testing "rf2-ycoct: when the focused cascade is in the buffer but
-            user filters reduce it to zero rendered rows, the
-            :no-matches empty-state renders (not :no-events)."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :time 100 :dispatch-id 100 :source :ui}))
-      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
-                             :time 110 :dispatch-id 100 :source :ui}))
-      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
-      ;; Narrow on a source that doesn't exist in cascade A.
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])
-            tree (trace/Panel)]
-        (is (= :no-matches (:empty-kind feed)))
-        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches")))))))
-
-(deftest trace-feed-defensive-no-focus-empty-state
-  (testing "rf2-ycoct defensive branch: when the buffer is non-empty
-            but the spine's focus has no :dispatch-id (default-focus
-            rule from rf2-639lc broken / not yet applied), the panel
-            renders the terse :no-focus empty state.
-
-            We construct this state directly via the helper to pin the
-            contract — the spine's LIVE auto-snap normally prevents
-            this state from arising in the running app."
-    (let [state  (h/rebuild-feed-state
-                   [(mk-trace {:id 1 :op-type :event
-                               :operation :event/dispatched
-                               :dispatch-id 100})])
-          feed   (h/project-feed-from-state
-                   state {} {:cascade-dispatch-id nil})]
-      (is (= :no-focus (:empty-kind feed)))
-      (is (= 0 (:rendered feed))
-          "no rows render in the no-focus defensive branch")
-      ;; rf2-r6d6u: no focused cascade → nothing is in scope → :total 0.
-      ;; The raw ring is still surfaced via :buffer-total.
-      (is (= 0 (:total feed))
-          ":total is 0 — no focused cascade means nothing is in view")
-      (is (= 1 (:buffer-total feed))
-          ":buffer-total still reflects the buffer (the state is broken,
-           not the data)"))))
-
-(deftest panel-spine-auto-snap-guards-against-no-focus-in-production
-  (testing "rf2-ycoct + rf2-s0s5x guard: in LIVE mode with cascades
-            present, the spine ALWAYS snaps focus to head — the
-            defensive :no-focus state should never arise in production.
-            This pins the contract: a regression in the spine's auto-
-            snap behaviour that left :dispatch-id nil with a non-empty
-            buffer would fail this assertion."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 100}))
-      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
-        (is (not= :no-focus (:empty-kind feed))
-            "LIVE auto-snap → focus has :dispatch-id 100 → no :no-focus")
-        (is (= 100 (:cascade-dispatch-id feed))
-            "scope landed on the head cascade automatically")))))
-
-;; ---- (10) film-strip header — rf2-7dyi8 --------------------------------
-;;
-;; Per spec/021 §5.2 the Trace panel header carries a `[◀ Prev] [Next ▶]`
-;; film-strip on the right. Per §5.5 prev/next semantics are chronological
-;; — the shared component delegates to the spine's
-;; `:rf.causa/focus-cascade-prev` / `:rf.causa/focus-cascade-next` events.
-
-(deftest film-strip-header-renders-in-trace-panel
-  (testing "the film-strip header sits in the Trace panel header with
-            the canonical panel-id testid prefix"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 1}))
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-trace-film-strip"))
-            "film-strip wrapper present")
-        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-prev"))
-            "prev button present")
-        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-next"))
-            "next button present")
-        (is (some? (find-by-testid tree "rf-causa-trace-film-strip-indicator"))
-            "indicator slot present")
-        (is (some? (find-by-testid tree "rf-causa-trace-epoch-indicator"))
-            "indicator carries the 'epoch #N · X ops' content")))))
-
-(deftest film-strip-prev-dispatches-focus-cascade-prev
-  (testing "rf2-7dyi8 — clicking the film-strip prev button dispatches
-            :rf.causa/focus-cascade-prev (the canonical spine prev
-            event the L1 ribbon also uses). Requires at least two
-            cascades so the boundary doesn't disable the button."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Two cascades + focus on the head — prev should be enabled.
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :dispatch-id 2}))
-      (let [dispatches (atom [])]
-        (with-redefs [rf/dispatch* (fn
-                                     ([ev]      (swap! dispatches conj ev) nil)
-                                     ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
-                btn     (find-by-testid tree "rf-causa-trace-film-strip-prev")
-                handler (:on-click (second btn))]
-            (is (some? btn) "prev button found")
-            (is (some? handler)
-                "prev button is enabled (two cascades, focused on head)")
-            (when handler (handler))))
-        (is (some #(= [:rf.causa/focus-cascade-prev] %) @dispatches)
-            ":rf.causa/focus-cascade-prev fired on prev click")))))
-
-(deftest film-strip-next-dispatches-focus-cascade-next
-  (testing "rf2-7dyi8 — clicking the film-strip next button dispatches
-            :rf.causa/focus-cascade-next. Pin focus to the tail so
-            next is enabled."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :dispatch-id 2}))
-      ;; Step focus to the tail (cascade 1) so next is enabled.
-      (rf/dispatch-sync [:rf.causa/focus-cascade 1])
-      (let [dispatches (atom [])]
-        (with-redefs [rf/dispatch* (fn
-                                     ([ev]      (swap! dispatches conj ev) nil)
-                                     ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/Panel)
-                btn     (find-by-testid tree "rf-causa-trace-film-strip-next")
-                handler (:on-click (second btn))]
-            (is (some? btn) "next button found")
-            (is (some? handler)
-                "next button is enabled (focused on tail with newer cascade)")
-            (when handler (handler))))
-        (is (some #(= [:rf.causa/focus-cascade-next] %) @dispatches)
-            ":rf.causa/focus-cascade-next fired on next click")))))
-
-(deftest film-strip-prev-disabled-at-tail
-  (testing "rf2-7dyi8 — when focused on the tail cascade (oldest), the
-            prev button renders in the disabled visual state with no
-            on-click handler attached."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :dispatch-id 2}))
-      (rf/dispatch-sync [:rf.causa/focus-cascade 1])  ;; tail
-      (let [tree    (trace/Panel)
-            btn     (find-by-testid tree "rf-causa-trace-film-strip-prev")
-            handler (:on-click (second btn))]
-        (is (some? btn) "prev button still rendered (in disabled state)")
-        (is (nil? handler)
-            "prev button has no on-click when at the tail boundary")
-        (is (true? (:disabled (second btn)))
-            "prev button carries the HTML disabled attribute")))))
-
-(deftest film-strip-next-disabled-at-head
-  (testing "rf2-7dyi8 — when focused on the head cascade (newest), the
-            next button renders in the disabled visual state with no
-            on-click handler attached."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :dispatch-id 1}))
-      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :dispatch-id 2}))
-      ;; LIVE auto-snap puts focus on the head (dispatch-id 2).
-      (let [tree    (trace/Panel)
-            btn     (find-by-testid tree "rf-causa-trace-film-strip-next")
-            handler (:on-click (second btn))]
-        (is (some? btn) "next button still rendered (in disabled state)")
-        (is (nil? handler)
-            "next button has no on-click when at the head boundary")
-        (is (true? (:disabled (second btn)))
-            "next button carries the HTML disabled attribute")))))
+;; A test-only event that pins :focus to an :epoch-id that's not in
+;; history — exercises the :epoch-evicted classifier path. Production
+;; only reaches this state when the framework's `:epoch-history`
+;; setting caps the buffer and older epochs roll off; in tests we
+;; synthesise the same in-memory shape directly.
+(rf/reg-event-db
+  :day8.re-frame2-causa.panels.trace-view-cljs-test/seed-evicted-focus
+  (fn [db _event]
+    (assoc db :focus {:dispatch-id 999
+                      :epoch-id    999
+                      :mode        :retro
+                      :frame       nil})))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -315,11 +315,11 @@
    :rf.causa/trace-buffer
    ;; rf2-7dyi8 — per-row inline payload expansion state (spec/021 §5.4).
    :rf.causa/trace-expanded-row-ids
+   ;; rf2-td380 — epoch-scoped feed (reads the focused epoch record's
+   ;; `:trace-events` directly). The `:rf.causa/trace-feed-state`
+   ;; buffer snapshot + `:rf.causa/trace-filters` chip-filter slot were
+   ;; removed with rf2-td380 + rf2-gkczt.
    :rf.causa/trace-feed
-   ;; rf2-39n8h discovered — trace-feed UI-state slot (selection /
-   ;; expansion state shared by the Trace panel).
-   :rf.causa/trace-feed-state
-   :rf.causa/trace-filters
    ;; Reactive panel (rf2-wyvf2 · spec/021 §3 · renamed from Views per
    ;; §11.5; tab key stays `:views`, display label rebases). Reads the
    ;; focused cascade's `:trace-events` for the substrate ops landed in
@@ -367,7 +367,6 @@
    :rf.causa/close-segment-inspector
    ;; rf2-7dyi8 — drop every expanded trace-row id in one shot.
    :rf.causa/clear-trace-expand
-   :rf.causa/clear-trace-filters
    :rf.causa/close-edit-popup
    :rf.causa/close-shell
    :rf.causa/copy-path-to-clipboard
@@ -526,7 +525,6 @@
    :rf.causa/machine-focus-prev
    :rf.causa/machine-focus-next
    :rf.causa/set-target-frame
-   :rf.causa/set-trace-filter
    ;; rf2-9poxq — Settings popup events.
    ;; rf2-ttnst — Settings popup Buffer-tab clear-buffer family
    ;; (confirm / cancel / clear).
@@ -1072,12 +1070,6 @@
         (is (= #{} (:prefixes filters)))
         (is (nil? (:since-ms filters)))))))
 
-(deftest sub-trace-filters-default-empty-map
-  (testing ":rf.causa/trace-filters defaults to {}"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (is (= {} @(rf/subscribe [:rf.causa/trace-filters]))))))
-
 (deftest sub-reactive-show-unchanged-defaults-false
   (testing ":rf.causa/reactive-show-unchanged? defaults to false
             (rf2-wyvf2 — Reactive panel disclosure slot per spec/021
@@ -1129,13 +1121,15 @@
         (is (= :no-focus (:empty-kind data)))))))
 
 (deftest sub-trace-feed-shape-on-empty-buffer
-  (testing ":rf.causa/trace-feed returns :no-events empty-kind initially"
+  (testing ":rf.causa/trace-feed returns :no-focus empty-kind initially
+            (rf2-td380 — epoch-scoped: no focused epoch + empty history
+            → :no-focus / 0 rows)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (let [data @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 0 (:total data)))
         (is (= 0 (:rendered data)))
-        (is (false? (:any-filter? data)))))))
+        (is (= :no-focus (:empty-kind data)))))))
 
 (deftest sub-machine-inspector-data-shape-empty
   (testing ":rf.causa/machine-inspector-data returns :no-machines kind when
@@ -1213,21 +1207,6 @@
       (let [f @(rf/subscribe [:rf.causa/issues-filters])]
         (is (= #{} (:severities f)))
         (is (= #{} (:prefixes f)))))))
-
-(deftest event-set-trace-filter-axis-and-clear
-  (testing ":rf.causa/set-trace-filter sets/clears a single axis"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :op-type :event])
-      (is (= {:op-type :event} @(rf/subscribe [:rf.causa/trace-filters])))
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :test])
-      (is (= {:op-type :event :source :test}
-             @(rf/subscribe [:rf.causa/trace-filters])))
-      ;; nil value clears that axis only
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :op-type nil])
-      (is (= {:source :test} @(rf/subscribe [:rf.causa/trace-filters])))
-      (rf/dispatch-sync [:rf.causa/clear-trace-filters])
-      (is (= {} @(rf/subscribe [:rf.causa/trace-filters]))))))
 
 (deftest event-reactive-toggle-unchanged-flips-slot
   (testing ":rf.causa/reactive-toggle-unchanged toggles the panel's

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -581,49 +581,6 @@ async function setCausaTargetFrame(page, frame) {
   }
 }
 
-async function setCausaTraceFilter(page, axis, value) {
-  const result = await page.evaluate(({ axisName, valueName }) => {
-    const cljs = window.cljs && window.cljs.core;
-    const rf = window.re_frame && window.re_frame.core;
-    const dispatch = rf && (rf.dispatch_STAR_ ||
-      (window.re_frame.router && window.re_frame.router.dispatch_BANG_));
-    if (!cljs || typeof dispatch !== 'function') {
-      return {
-        ok: false,
-        reason: 'cljs.core or re_frame.core.dispatch_STAR_ unavailable',
-        reFrameCoreKeys: rf ? Object.keys(rf).sort().slice(0, 40) : [],
-      };
-    }
-    function keyword(s) {
-      const trimmed = String(s).replace(/^:/, '');
-      const parts = trimmed.split('/');
-      if (parts.length === 2) {
-        return cljs.keyword.call
-          ? cljs.keyword.call(null, parts[0], parts[1])
-          : cljs.keyword(parts[0], parts[1]);
-      }
-      return cljs.keyword.call
-        ? cljs.keyword.call(null, trimmed)
-        : cljs.keyword(trimmed);
-    }
-    const event = cljs.PersistentVector.fromArray([
-      keyword(':rf.causa/set-trace-filter'),
-      keyword(axisName),
-      keyword(valueName),
-    ], true);
-    const opts = cljs.hash_map(keyword(':frame'), keyword(':rf/causa'));
-    if (dispatch.cljs$core$IFn$_invoke$arity$2) {
-      dispatch.cljs$core$IFn$_invoke$arity$2(event, opts);
-    } else {
-      dispatch(event, opts);
-    }
-    return { ok: true, axis: axisName, value: valueName };
-  }, { axisName: axis, valueName: value });
-  if (!result.ok) {
-    failWithDetails('Could not set Causa trace filter', { axis, value, observed: result });
-  }
-}
-
 /**
  * Find the `:dispatch-id` of the bus trace event matching the given
  * (`frame`, `eventId`) pair (an `:event/dispatched` record) and
@@ -738,30 +695,6 @@ async function focusCascadeByFrameEvent(page, { frame, eventId }) {
     });
   }
   return result;
-}
-
-async function readTraceCounts(page) {
-  const text = ((await page.locator('[data-testid="rf-causa-trace-counts"]').textContent()) || '').trim();
-  const match = /(\d+)\s*\/\s*(\d+)\s+in view/.exec(text);
-  if (!match) {
-    throw new Error(`Could not parse trace counts: ${JSON.stringify(text)}`);
-  }
-  return { rendered: Number(match[1]), total: Number(match[2]), text };
-}
-
-async function readTraceDomBudget(page) {
-  return page.evaluate(() => {
-    const root = document.getElementById('rf-causa-root');
-    const feed = root && root.querySelector('[data-testid="rf-causa-trace-feed"]');
-    const overflow = root && root.querySelector('[data-testid="rf-causa-trace-overflow-indicator"]');
-    return {
-      rootPresent: Boolean(root),
-      feedPresent: Boolean(feed),
-      rowCount: root ? root.querySelectorAll('li[data-testid^="rf-causa-trace-row-"]').length : 0,
-      overflowPresent: Boolean(overflow),
-      overflowText: overflow ? (overflow.textContent || '').trim() : null,
-    };
-  });
 }
 
 // rf2-r6d6u: the trace header's 'X / Y in view' denominator is now
@@ -916,7 +849,6 @@ async function readLaunchModeProjection(page) {
         // rendered, 0 when the empty container or orphaned branch is.
         cascadeRows: count(root, '[data-testid="rf-causa-event-detail-cascade"]'),
         traceRows: count(root, '[data-testid^="rf-causa-trace-row-"]'),
-        traceCountsText: text(root, '[data-testid="rf-causa-trace-counts"]'),
       };
     }
     const trace = traceEvents();
@@ -1016,10 +948,15 @@ async function runShellFeatureSweep(page) {
   );
 
   await clickTab(page, 'trace', 'rf-causa-trace');
-  const traceCounts = await readTraceCounts(page);
-  if (traceCounts.total < 1) {
-    throw new Error(`Expected non-empty trace feed, got ${traceCounts.text}.`);
-  }
+  // rf2-td380: the Trace panel is epoch-scoped — after the host
+  // dispatches above, LIVE auto-snap focuses the head epoch whose
+  // `:trace-events` populate the ribbon. Assert non-empty via the
+  // rendered rows (the 'X / Y in view' counts header is gone, rf2-o6yqq).
+  await waitForValue(
+    () => page.locator('li[data-testid^="rf-causa-trace-row-"]').count(),
+    (count) => count > 0,
+    { timeoutMs: 5000, description: 'epoch-scoped trace feed renders rows' },
+  );
 }
 
 async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
@@ -1028,7 +965,10 @@ async function runSourceCoordinatesAndLaunchModes(page, state, ctx) {
   await clearTrace(page);
   await clickHostButtonByLabel(page, '+');
   await waitForTraceMatch(page, /counter\/core\.cljs/, 'counter source-coordinate trace');
-  await setCausaTraceFilter(page, ':source', ':ui');
+  // rf2-td380 + rf2-gkczt: the Trace panel is epoch-scoped with no chip
+  // filter. After the host dispatch the spine auto-snaps focus to the
+  // head epoch (LIVE), whose `:trace-events` carry the source-coord
+  // rows — no filter step needed; every row's source-coord chip renders.
   await waitForValue(
     () => page.locator('[data-testid^="rf-causa-trace-row-"] button[data-testid$="-source-coord"]').count(),
     (count) => count > 0,
@@ -1740,44 +1680,6 @@ async function runHydration(page) {
   );
 }
 
-async function runTwentyEventLoad(page, state) {
-  await expectHostCounterEquals(page, 5, 10000);
-  await openCausa(page);
-  await clickTab(page, 'trace', 'rf-causa-trace');
-  await clearTrace(page);
-  const before = await readTraceCounts(page).catch(() => ({ rendered: 0, total: 0, text: 'empty' }));
-  const start = Date.now();
-  for (let i = 0; i < 20; i += 1) {
-    await clickHostButtonByLabel(page, i % 2 === 0 ? '+' : '-');
-  }
-  const after = await waitForValue(
-    () => readTraceCounts(page),
-    (counts) => counts.total > before.total,
-    { timeoutMs: 10000, description: 'trace count growth after 20 dispatches' },
-  );
-  const elapsedMs = Date.now() - start;
-  await clickTab(page, 'event', 'rf-causa-event-detail');
-  // Per rf2-639lc the L4 panel default-focuses the head cascade on
-  // mount — assert the cascade-detail surface rendered (proves the
-  // spine pipeline emitted routable cascades visible to L4).
-  await waitForValue(
-    () => page.locator('[data-testid="rf-causa-event-detail-cascade"]').count(),
-    (count) => count > 0,
-    { timeoutMs: 5000, description: 'event-detail cascade default-focus after load' },
-  );
-  // Post rf2-xy4yb + rf2-y0z5b: the Causality Graph panel was
-  // dropped entirely. The 20-event load-recheck still asserts trace
-  // + event-tab cascade growth, which exercises the spine +
-  // projection pipeline end-to-end.
-  state.loadStats = {
-    eventCountBefore: before.total,
-    eventCountAfter: after.total,
-    visibleRows: after.rendered,
-    traceBufferDepth: after.total,
-    elapsedMs,
-  };
-}
-
 async function runTraceBudgetSaturation(page, state) {
   await expectHostCounterEquals(page, 5, 10000);
   await openCausa(page);
@@ -1785,57 +1687,42 @@ async function runTraceBudgetSaturation(page, state) {
   await clearTrace(page);
   const start = Date.now();
   const pushed = await pushSyntheticTraceEvents(page, 1000);
-  // rf2-r6d6u: assert ring saturation against the BUS depth, not the
-  // header denominator (the latter is now cascade-scoped, not the ring).
+  // rf2-r6d6u + rf2-td380: the saturation invariant is a RING property,
+  // read straight from the trace bus. Post-rf2-td380 the Trace PANEL is
+  // epoch-scoped — it renders the focused epoch record's `:trace-events`,
+  // NOT the global bus — so the synthetic bus events do not reach the
+  // panel DOM and the old 'panel DOM caps at 200 bus rows' assertion no
+  // longer describes the panel. We assert the bus ring caps at 1000 and
+  // stays capped under continued host traffic.
   const saturatedDepth = await waitForValue(
     () => readTraceBufferDepth(page),
     (depth) => depth === 1000,
     { timeoutMs: 10000, description: 'trace buffer saturation at 1000 rows' },
   );
-  const saturated = await readTraceCounts(page);
-  const saturatedDom = await waitForValue(
-    () => readTraceDomBudget(page),
-    (budget) => budget.rowCount === 200 && budget.overflowPresent,
-    { timeoutMs: 10000, description: 'trace DOM row budget at 200 with overflow indicator' },
-  );
-  if (saturatedDom.rowCount > 200) {
-    failWithDetails('Trace panel exceeded its 200-row DOM budget under saturation', {
-      pushed,
-      counts: saturated,
-      dom: saturatedDom,
-    });
-  }
 
   for (let i = 0; i < 20; i += 1) {
     await clickHostButtonByLabel(page, i % 2 === 0 ? '+' : '-');
   }
-  // rf2-r6d6u: 'still capped' is a RING invariant — assert the bus depth
-  // stays at 1000 (host dispatches evict synthetic rows but never grow
-  // the ring) and the DOM budget stays ≤ 200. The header denominator is
-  // now cascade-scoped, so it no longer equals the ring depth.
+  // 'still capped' is a RING invariant — the bus depth stays at 1000
+  // (host dispatches evict synthetic rows but never grow the ring) and
+  // the host's own events keep flowing through the bus.
   const after = await waitForValue(
     async () => ({
       depth: await readTraceBufferDepth(page),
-      counts: await readTraceCounts(page),
-      dom: await readTraceDomBudget(page),
       events: await readTrace(page),
     }),
     (snapshot) =>
       snapshot.depth === 1000 &&
-      snapshot.dom.rowCount <= 200 &&
       snapshot.events.some((event) => event.includes(':counter/inc')) &&
       snapshot.events.some((event) => event.includes(':counter/dec')),
-    { timeoutMs: 10000, description: 'trace budget still capped after 20 host dispatches' },
+    { timeoutMs: 10000, description: 'trace ring still capped after 20 host dispatches' },
   );
   state.loadStats = {
     eventCountBefore: saturatedDepth,
     eventCountAfter: after.depth,
     traceBufferDepth: after.depth,
-    scopedDenominator: after.counts.total,
-    visibleRowCount: after.dom.rowCount,
     renderDurationMs: Date.now() - start,
     bufferEvictionCount: Math.max(0, saturatedDepth + 20 - after.depth),
-    overflowText: after.dom.overflowText,
     syntheticEventsPushed: pushed.pushed,
   };
 }

--- a/tools/causa/testbeds/panel_gallery/gallery_trace.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_trace.cljs
@@ -93,14 +93,15 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 7. filter active --------------------------------------------
-  (story/reg-variant :story.causa.trace/filter-active
-    {:doc        "Ten events with an active :op-type :event filter.
-                 Header surfaces 'Clear filters'; the chip row
-                 surfaces the active chip highlit. Feed renders only
-                 the matching rows."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/filtered-active-buffer)]
-                  [:rf.causa/set-trace-filter :op-type :event]]
+  ;; ----- 7. mixed op-types -------------------------------------------
+  ;; rf2-gkczt: chip-filtering was removed from the Trace panel — the
+  ;; focused epoch IS the scope. This variant now just exercises a
+  ;; mixed-op-type buffer (the former 'filter-active' fixture) with no
+  ;; filter event.
+  (story/reg-variant :story.causa.trace/mixed-op-types
+    {:doc        "Ten events spanning mixed op-types. The feed renders
+                 every row (no chip-filtering post-rf2-gkczt)."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/filtered-active-buffer)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 


### PR DESCRIPTION
## Summary

Comprehensive Trace-panel rework — three related beads, one PR (all on `panels/trace.cljs` + `trace_helpers.cljc`).

- **rf2-o6yqq — remove the top header row.** Drops the `X / Y in view` count, the `epoch #N · X ops` indicator, and the duplicate Prev/Next film-strip. Spine focus navigation lives in the L2 events list; the panel no longer duplicates it. **The spine focus events (`:rf.causa/focus-cascade-prev` / `-next`) are kept** — only the panel's duplicate film-strip UI is gone; the L2 list (shell.cljs), keybindings, and spine still use them.

- **rf2-td380 — scope rows by the focused epoch's `:trace-events`.** The old feed scoped the global trace bus by `:cascade-dispatch-id`, which **dropped the cascade's async reactive rows** (`:sub/run` / `:view/render` fire post-cascade with nil dispatch-id) → incomplete domino trail (live evidence: 4 rows shown vs the epoch's real 12). The feed now reads the focused **epoch record's** `:trace-events` (resolved via the shared `panels.shared.focus-resolver`, exactly as Issues / App-DB Diff do), which folds BOTH the synchronous event-side rows AND the async reactive tail. Rendered rows = the complete trail (event → db-changed → subs ran → views rendered).

- **rf2-gkczt — remove ALL chip filtering.** Drops the per-axis chip rows, the per-row click-to-filter affordance, and the clear-filters control. The focused epoch IS the scope; the per-row payload-expand is the drill-down.

### One-line scope change
Trace rows: `(trace-bus/buffer) + :cascade-dispatch-id` → focused **epoch record's `:trace-events`** (complete per-event domino trail, incl. nil-dispatch async reactive rows).

### Dead surfaces removed cleanly (grep-verified single-consumer)
- `trace_helpers.cljc`: the entire filter algebra (`filter-axes`, `normalise/apply-filters`, `distinct-values`, `axis-counts`, `effective-distinct`, `active-filters-summary`) + the incremental feed-state machinery (`init-feed-state`, `feed-state+ev/evict/push`, `rebuild-feed-state`, `project-feed`, `project-feed-from-state`). Replaced by a single `project-feed-from-epoch`.
- `trace.cljs` subs/events: `:rf.causa/trace-filters`, `:rf.causa/trace-feed-state`, `:rf.causa/set-trace-filter`, `:rf.causa/clear-trace-filters`.
- `registry.cljs`: the `:trace-feed-state` buffer-snapshot dual-write (rf2-44vzy) — its only reader was the old buffer-scoped feed; the note/clear/sync handlers single-write `:trace-buffer` again, and the now-unused `trace-helpers` require is dropped.

### Tests / docs
- `trace_view_cljs_test` + `trace_helpers_cljs_test` + `trace_reactivity_cljs_test`: reworked to seed epoch records; drop header/count/epoch-indicator/film-strip/chip-filter assertions; ADD helper tests pinning the epoch-scoped row semantics (incl. one asserting the nil-dispatch async reactive rows render — the headline rf2-td380 fix).
- `registry_cljs_test`: catalogue + assertions updated for the removed subs/events.
- `feature_matrix/scenarios.cjs` + `spec/014` + `panels.cljs` doc + `panel_gallery/gallery_trace.cljs`: updated for the removed header/filter surfaces.

## Test plan
- [x] `npm run test:cljs` — 0 failures, 0 errors (4047 tests / 12288 assertions)
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures, 13 matrix rows covered
- [x] Spine focus events (`:rf.causa/focus-cascade-prev`/`-next`) + L2 nav confirmed intact (shell.cljs / spine.cljs / keybinding.cljs untouched)