### PR TITLE
feat(causa): machine topology edge/state semantics (rf2-54s5a)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
@@ -94,51 +94,97 @@
        (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
 
 (defn- walk-states
-  "Walk a `{state-id state-node}` map under `parent-path`; emit
-  `[{:path :final? :label} ...]`. Compound + parallel states are NOT
-  recursively flattened in v1 (parent is emitted as a single node;
-  children stay invisible). Same posture as the existing
-  chart-layout's `:depth 0` slice."
-  [parent-path state-map]
-  (when (map? state-map)
-    (mapv (fn [[state-id state-node]]
-            (let [path (conj (vec parent-path) state-id)]
-              {:path     path
-               :label    (name state-id)
-               :final?   (boolean (:final? state-node))
-               :initial? (boolean (:initial? state-node))}))
-          state-map)))
-
-(defn- collect-edges
-  "Walk a `{state-id state-node}` map; emit edges. Each edge is
-  `{:from :to :label :id}`. v1 reads `:on` map (event-id → target-
-  spec) on the immediate children of `:states`. Targets are coerced
-  to `[target-state-id]` paths (single-level). Self-transitions
-  (target = source) are emitted; the renderer can decide to render
-  or suppress."
+  "Walk a `{state-id state-node}` map under `parent-path`; emit a flat
+  `[{:path :label :final? :initial? :compound?} ...]` seq. Compound
+  substates ARE recursively flattened (the parent emits as one node;
+  every nested child emits too). A compound parent's `:initial` child is
+  flagged `:initial? true` so the marker surfaces at every level."
   [parent-path state-map]
   (when (map? state-map)
     (vec
       (mapcat
         (fn [[state-id state-node]]
-          (let [from-path (conj (vec parent-path) state-id)]
-            (when-let [on (:on state-node)]
-              (for [[event-id target-spec] on
-                    :let [target-id (cond
-                                      (keyword? target-spec) target-spec
-                                      (map? target-spec)     (:target target-spec)
-                                      :else                  nil)
-                          to-path   (when target-id [target-id])]
-                    :when to-path]
-                {:id    (str (node-id-for-path from-path)
-                             "__"
-                             (node-id-for-path to-path)
-                             "__"
-                             (name event-id))
-                 :from  from-path
-                 :to    to-path
-                 :label (name event-id)
-                 :event event-id}))))
+          (let [path (conj (vec parent-path) state-id)
+                self {:path     path
+                      :label    (name state-id)
+                      :final?   (boolean (:final? state-node))
+                      :initial? (boolean (:initial? state-node))
+                      :compound? (boolean (:states state-node))}
+                init-key     (:initial state-node)
+                raw-children (when (:states state-node)
+                               (walk-states path (:states state-node)))
+                children     (if init-key
+                               (mapv (fn [c]
+                                       (if (= (:path c) (conj path init-key))
+                                         (assoc c :initial? true)
+                                         c))
+                                     raw-children)
+                               raw-children)]
+            (cons self children)))
+        state-map))))
+
+(defn- seg-name
+  "Render a guard / action / event label segment to a string WITHOUT
+  throwing on fn values. `cljs.core/name` blows up on fns
+  (`Doesn't support name: function …` — rf2-ujra6), and re-frame2
+  machines may inline a fn guard / action (`:guard (fn …)`), so coerce
+  defensively: namespaced keywords keep their namespace, fns surface
+  their `:name` meta (or `fn` when anonymous)."
+  [v]
+  (cond
+    (nil? v)     nil
+    (keyword? v) (if-let [n (namespace v)] (str n "/" (name v)) (name v))
+    (symbol? v)  (str v)
+    (string? v)  v
+    (fn? v)      (or (some-> v meta :name str) "fn")
+    :else        (str v)))
+
+(defn- edge-label-str
+  "Compose an xstate-stately edge label: `event [guard] / action`.
+  Brackets / slash appear ONLY when the segment is present, matching
+  `machines-viz`'s `chart.layout/edge-label` convention. Fn-safe via
+  `seg-name`."
+  [event-id guard action]
+  (str (seg-name event-id)
+       (when guard  (str " [" (seg-name guard) "]"))
+       (when action (str " / " (seg-name action)))))
+
+(defn- collect-edges
+  "Walk a `{state-id state-node}` map; emit edges. Each edge is
+  `{:from :to :label :id :event :guard :action}`. Reads the `:on` map
+  (event-id → target-spec) on every state INCLUDING compound substates
+  (recurses). Map target-specs surface their `:guard` / `:action` into
+  the xstate-style label. Targets resolve relative to the source's
+  parent path; self-transitions (target == source) are emitted."
+  [parent-path state-map]
+  (when (map? state-map)
+    (vec
+      (mapcat
+        (fn [[state-id state-node]]
+          (let [from-path (conj (vec parent-path) state-id)
+                own (when-let [on (:on state-node)]
+                      (for [[event-id target-spec] on
+                            :let [target-id (cond
+                                              (keyword? target-spec) target-spec
+                                              (map? target-spec)     (:target target-spec)
+                                              :else                  nil)
+                                  guard     (when (map? target-spec) (:guard target-spec))
+                                  action    (when (map? target-spec) (:action target-spec))
+                                  to-path   (when target-id
+                                              (conj (vec parent-path) target-id))]
+                            :when to-path]
+                        {:id    (str (node-id-for-path from-path) "__"
+                                     (node-id-for-path to-path) "__"
+                                     (name event-id))
+                         :from  from-path
+                         :to    to-path
+                         :label (edge-label-str event-id guard action)
+                         :event event-id
+                         :guard guard
+                         :action action}))
+                nested (when (:states state-node)
+                         (collect-edges from-path (:states state-node)))]
+            (concat own nested)))
         state-map))))
 
 ;; ---- definition → graph -------------------------------------------------
@@ -155,18 +201,26 @@
     {:nodes [] :edges [] :initial-path nil}
 
     (= :parallel (:type definition))
-    ;; v1: project the first region only — matches chart-layout's
-    ;; existing posture. A follow-on bead surfaces full parallel
-    ;; rendering using xyflow's group/parent-node mechanic.
-    (let [[_region-id region] (first (:regions definition))]
-      (parse-definition region))
+    ;; Project EVERY region's states + edges (concatenated, flat). Each
+    ;; region's own `:initial` flags survive; the parallel root has no
+    ;; single initial path.
+    (let [per (map (fn [[_region-id region]] (parse-definition region))
+                   (:regions definition))]
+      {:nodes        (vec (mapcat :nodes per))
+       :edges        (vec (mapcat :edges per))
+       :initial-path nil})
 
     :else
     (let [{:keys [initial states]} definition
-          nodes        (walk-states [] states)
+          base-nodes   (walk-states [] states)
           initial-path (when initial [initial])
+          nodes        (mapv (fn [n]
+                               (if (= (:path n) initial-path)
+                                 (assoc n :initial? true)
+                                 n))
+                             base-nodes)
           edges        (collect-edges [] states)]
-      {:nodes        (vec nodes)
+      {:nodes        nodes
        :edges        edges
        :initial-path initial-path})))
 
@@ -293,9 +347,10 @@
                {:id       id
                 :type     "default"
                 :position pos
-                :data     {:label (:label n)
-                           :kind  kind
-                           :path  (:path n)}
+                :data     {:label   (:label n)
+                           :kind    kind
+                           :initial (boolean (:initial? n))
+                           :path    (:path n)}
                 :style    (node-style-fn kind)
                 :draggable false
                 :selectable false}))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
@@ -63,14 +63,41 @@
       (is (= [:a] (-> g :edges first :from)))
       (is (= [:b] (-> g :edges first :to))))))
 
-(deftest parse-definition-handles-parallel-by-first-region
-  (testing "parallel definitions project the first region only (v1)"
+(deftest parse-definition-projects-all-regions
+  (testing "parallel definitions project EVERY region (rf2-54s5a)"
     (let [par {:type    :parallel
                :regions {:r1 {:initial :a :states {:a {} :b {}}}
                          :r2 {:initial :c :states {:c {}}}}}
           g   (topology/parse-definition par)]
-      (is (= 2 (count (:nodes g)))
-          "first region's 2 states; second region not flattened"))))
+      (is (= 3 (count (:nodes g)))
+          "both regions' states flatten (a + b + c)"))))
+
+(deftest parse-definition-recurses-compound-substates
+  (testing "compound substates are flattened, not left invisible (rf2-54s5a)"
+    (let [def {:initial :unauth
+               :states  {:unauth {:on {:login :authed}}
+                         :authed {:initial :browsing
+                                  :states  {:browsing {:on {:checkout :paying}}
+                                            :paying   {:on {:done :browsing}}}}}}
+          g     (topology/parse-definition def)
+          paths (set (map :path (:nodes g)))]
+      (is (contains? paths [:authed :browsing]))
+      (is (contains? paths [:authed :paying]))
+      (is (= 4 (count (:nodes g)))
+          "unauth + authed + browsing + paying")
+      (is (true? (-> (filter #(= [:authed :browsing] (:path %)) (:nodes g))
+                     first :initial?))
+          "the compound's :initial substate is flagged"))))
+
+(deftest parse-definition-edge-label-includes-guard
+  (testing "map target-spec :guard surfaces into the xstate label (rf2-54s5a)"
+    (let [def {:initial :a
+               :states  {:a {:on {:go {:target :b :guard :ready?}}}
+                         :b {}}}
+          g   (topology/parse-definition def)
+          e   (first (:edges g))]
+      (is (= "go [ready?]" (:label e)))
+      (is (= :ready? (:guard e))))))
 
 ;; ---- node-kind ----------------------------------------------------------
 
@@ -138,6 +165,14 @@
         (is (string? (-> e :markerEnd :color))
             "marker colour resolves (falls back to currentColor when the
              style fn omits a stroke)")))))
+
+(deftest project-surfaces-initial-flag
+  (testing ":data :initial is true for the initial-state node (rf2-54s5a)"
+    (let [out      (topology/project {:definition (toy-definition)})
+          by-label (into {} (map (juxt #(-> % :data :label) identity)
+                                 (:nodes out)))]
+      (is (true?  (-> by-label (get "empty") :data :initial)))
+      (is (false? (-> by-label (get "populated") :data :initial))))))
 
 (deftest project-applies-current-state-overlay
   (testing "current-state-path marks the matching node as :current"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -106,9 +106,12 @@
         opts    (-> default-elk-options
                     (merge (or layout-options {}))
                     (assoc "elk.direction" dir-str)
-                    ;; Hierarchical layout must descend into region
-                    ;; children for the parallel case (rf2-lkwev).
-                    (cond-> (:parallel? parsed)
+                    ;; Hierarchical layout must descend into nested
+                    ;; children — parallel-region states (rf2-lkwev) AND
+                    ;; compound substates (rf2-54s5a). Enable whenever any
+                    ;; node nests (has :parent-id) or the graph is parallel.
+                    (cond-> (or (:parallel? parsed)
+                                (some :parent-id (:nodes parsed)))
                       (assoc "elk.hierarchyHandling" "INCLUDE_CHILDREN")))]
     #js {:id "root"
          :layoutOptions (clj->js opts)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -119,19 +119,28 @@
         from-path  (.-fromPath d)
         to-path    (.-toPath d)
         clickable? (and (fn? on-click) (some? event-id))
+        self-loop? (boolean (.-selfLoop d))
         {:keys [edge-label-px edge-label-backplate-opacity]} vc
-        ;; xyflow's getBezierPath returns [path-string label-x label-y
-        ;; offset-x offset-y]. Use a JS-side destructure via aget.
-        bz (get-bezier-path
-             #js {:sourceX        src-x
-                  :sourceY        src-y
-                  :sourcePosition src-pos
-                  :targetX        tgt-x
-                  :targetY        tgt-y
-                  :targetPosition tgt-pos})
-        path  (aget bz 0)
-        label-x (aget bz 1)
-        label-y (aget bz 2)
+        ;; A self-transition (source == target) renders as a small loop
+        ;; off the node's edge instead of xyflow's degenerate near-zero
+        ;; bezier. Everything else uses `getBezierPath`, which returns
+        ;; [path-string label-x label-y offset-x offset-y] (aget'd).
+        [path label-x label-y]
+        (if self-loop?
+          (let [r 30]
+            [(str "M " src-x "," src-y
+                  " C " (+ src-x r) "," (- src-y r)
+                  " "  (+ src-x r) "," (+ src-y r)
+                  " "  src-x       "," src-y)
+             (+ src-x r 4) src-y])
+          (let [bz (get-bezier-path
+                     #js {:sourceX        src-x
+                          :sourceY        src-y
+                          :sourcePosition src-pos
+                          :targetX        tgt-x
+                          :targetY        tgt-y
+                          :targetPosition tgt-pos})]
+            [(aget bz 0) (aget bz 1) (aget bz 2)]))
         stroke  (edge-stroke {:active? active? :focused? focused?})
         stroke-w (edge-stroke-width {:active? active? :focused? focused? :chart vc})]
     (r/as-element
@@ -143,6 +152,7 @@
                                  :strokeWidth stroke-w
                                  :animation (when focused?
                                               "mv-chart-transition-glow 720ms ease-out infinite")}}]
+       (when (seq label)
        [:> EdgeLabelRenderer
         [:div {:data-testid (str "rf-mv-chart-edge-" (.-id props))
                :data-event (when label label)
@@ -185,7 +195,7 @@
                                               (tokens/with-alpha :border-subtle 0.4)))
                        :white-space    "nowrap"
                        :user-select    "none"}}
-         label]]])))
+         label]])])))
 
 ;; ---- after-edge ---------------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -165,19 +165,32 @@
 
 (defn- collect-nodes
   "Walk a state-map and return a flat seq of node-maps. Each map
-  carries the full path so compound nesting is preserved as data."
+  carries the full path so compound nesting is preserved as data.
+
+  A compound parent's `:initial` child is flagged `:initial? true` so
+  the initial-state marker surfaces at EVERY compound level (not just
+  the machine root) — xstate/SCXML semantics. The flag also feeds the
+  SCXML / Mermaid emitters' `<initial>` rendering."
   [parent-path state-map]
   (mapcat (fn [[state-id state-node]]
             (let [path (conj parent-path state-id)
                   self {:path     path
                         :label    (name state-id)
                         :depth    (count parent-path)
-                        :initial? (:initial? state-node)
+                        :initial? (boolean (:initial? state-node))
                         :final?   (:final? state-node)
                         :compound? (boolean (:states state-node))
                         :tags     (set (:tags state-node))}
-                  children (when (:states state-node)
-                             (collect-nodes path (:states state-node)))]
+                  init-key     (:initial state-node)
+                  raw-children (when (:states state-node)
+                                 (collect-nodes path (:states state-node)))
+                  children     (if init-key
+                                 (map (fn [c]
+                                        (if (= (:path c) (conj path init-key))
+                                          (assoc c :initial? true)
+                                          c))
+                                      raw-children)
+                                 raw-children)]
               (cons self children)))
           state-map))
 
@@ -220,6 +233,10 @@
     (keyword? v) (if-let [n (namespace v)]
                    (str n "/" (name v))
                    (name v))
+    ;; Inlined fn guards / actions surface their `:name` meta (named
+    ;; `(fn name [...] ...)` / `(defn ...)`) or `fn` when anonymous —
+    ;; so the xstate label reads cleanly instead of `#object[Function]`.
+    (fn? v)      (or (some-> v meta :name str) "fn")
     :else        (str v)))
 
 (defn event-segment
@@ -288,10 +305,18 @@
         base-nodes (vec (collect-nodes [] states))
         initial-path (when initial [initial])
         nodes (mapv (fn [n]
-                      (let [n' (if (= (:path n) initial-path)
-                                 (assoc n :initial? true)
-                                 n)]
-                        (assoc n' :id (node-id (:path n')))))
+                      (let [path (:path n)
+                            n'   (cond-> n
+                                   (= path initial-path) (assoc :initial? true)
+                                   ;; A node nested inside a compound parent
+                                   ;; carries `:parent-id` (the parent's
+                                   ;; node-id) so the projector wires xyflow's
+                                   ;; parentNode sub-flow — the SAME mechanic
+                                   ;; that nests parallel-region states. Top-
+                                   ;; level states (path length 1) carry none.
+                                   (> (count path) 1)
+                                   (assoc :parent-id (node-id (pop path))))]
+                        (assoc n' :id (node-id path))))
                     base-nodes)
         raw-edges (vec (mapcat (fn [[state-id state-node]]
                                  (collect-state-edges [state-id] state-node))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -76,30 +76,28 @@
 (defn ->elk-children
   "Project parsed nodes into elk.js's `children` shape.
 
-  Flat (non-parallel) machines emit one flat child per node. Parallel
-  machines (rf2-lkwev) nest each region's states UNDER their region
-  container node so elkjs lays the states out INSIDE the region's
-  bounding box (xyflow's parentNode sub-flow then renders them inside
-  the dashed region boundary). Region containers carry their own
-  `elk.algorithm`/`elk.padding` so each orthogonal zone gets a clean
-  internal layout, and the regions themselves are laid side-by-side at
+  Nesting is keyed on `:parent-id`: parallel-region states (rf2-lkwev)
+  AND compound substates carry it, so BOTH nest UNDER their container
+  and elkjs lays them out inside the container's bounding box (xyflow's
+  parentNode sub-flow then renders them inside the dashed boundary).
+  Nesting recurses — a compound inside a region, or a compound inside a
+  compound, lays out correctly. Each container (region OR compound) gets
+  its own `elk.algorithm`/`elk.padding` so the header strip has room and
+  the zone gets a clean internal layout; top-level nodes are laid out at
   the root."
-  [{:keys [nodes parallel?]}]
-  (if-not parallel?
-    (mapv elk-child nodes)
-    (let [region-nodes (filterv :region? nodes)
-          ;; Group the non-region (state) nodes by their parent region.
-          by-parent    (group-by :parent-id (remove :region? nodes))]
-      (mapv (fn [rn]
-              (let [children (get by-parent (:id rn) [])]
-                {:id    (:id rn)
-                 :labels [{:text (:label rn)}]
-                 ;; Each region lays out its own states internally;
-                 ;; padding leaves room for the region header strip.
-                 :layoutOptions {"elk.algorithm" "layered"
-                                 "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}
-                 :children (mapv elk-child children)}))
-            region-nodes))))
+  [{:keys [nodes]}]
+  (let [by-parent (group-by :parent-id nodes)
+        build (fn build [n]
+                (let [kids (get by-parent (:id n))]
+                  (cond-> (elk-child n)
+                    (seq kids)
+                    (assoc :children (mapv build kids)
+                           ;; Container lays out its own children;
+                           ;; padding leaves top room for the header strip
+                           ;; (region label / compound title).
+                           :layoutOptions {"elk.algorithm" "layered"
+                                           "elk.padding"   "[top=34,left=14,bottom=14,right=14]"}))))]
+    (mapv build (get by-parent nil))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 
@@ -124,6 +122,18 @@
   (cond
     (:after edge) "after"
     :else         "transition"))
+
+(defn- safe-name
+  "Coerce a guard / action ref to a string WITHOUT throwing on fn
+  values. `cljs.core/name` blows up on fns (`Doesn't support name:
+  function …`), and re-frame2 machines may inline a fn guard / action,
+  so fns surface their `:name` meta (or `fn` when anonymous)."
+  [v]
+  (cond
+    (nil? v)     nil
+    (keyword? v) (name v)
+    (fn? v)      (or (some-> v meta :name str) "fn")
+    :else        (str v)))
 
 (defn xyflow-graph
   "Project the parsed graph + a `{node-id position}` map into the
@@ -170,112 +180,131 @@
    {:keys [highlight-id from-highlight-id to-highlight-id sim?
            on-state-click on-edge-click chart]
     :or   {chart vc/chart-regular}}]
-  {:nodes
-   ;; rf2-lkwev — region container nodes MUST precede their children in
-   ;; the xyflow nodes array (xyflow requires a parentNode to appear
-   ;; before any node that references it). Regions are already emitted
-   ;; before their states by `parse-parallel`, but sort defensively so
-   ;; the parent-before-child invariant holds regardless of upstream
-   ;; ordering.
-   (mapv (fn [n]
-           (let [pos     (get positions (:id n) {:x 0 :y 0})
-                 region? (boolean (:region? n))
-                 active? (= (:id n) highlight-id)
-                 from-hi? (= (:id n) from-highlight-id)
-                 to-hi?   (= (:id n) to-highlight-id)
-                 base
-                 {:id       (:id n)
-                  :type     (cond
-                              region?         "parallel-region"
-                              (:compound? n)  "compound"
-                              :else           "state")
-                  :position {:x (:x pos) :y (:y pos)}
-                  :data     (cond-> {:label          (:label n)
-                                     :path           (:path n)
-                                     :active         active?
-                                     :fromHighlight  from-hi?
-                                     :toHighlight    to-hi?
-                                     :sim            (boolean (and active? sim?))
-                                     :final          (boolean (:final? n))
-                                     :compound       (boolean (:compound? n))
-                                     :tags           (vec (:tags n))
-                                     ;; rf2-k647w — the resolved density's
-                                     ;; visual constants ride on every node
-                                     ;; payload so the xyflow node component
-                                     ;; reads geometry/typography off `:data`
-                                     ;; (it is invoked outside the render's
-                                     ;; binding scope, so a dynamic var would
-                                     ;; not be in effect).
-                                     :chart          chart
-                                     :onClick        on-state-click}
-                              region? (assoc :regionId    (:region n)
-                                             :regionIndex (:region-index n)))
-                  :draggable false
-                  :selectable false}]
-             (cond-> base
-               ;; Region containers carry an explicit measured size so
-               ;; xyflow draws the zone box at the elk-computed extent.
-               region? (assoc :style {:width  (:width pos)
-                                      :height (:height pos)})
-               ;; A state inside a region attaches to its parent region
-               ;; via xyflow's parentNode sub-flow; `:extent "parent"`
-               ;; clamps it inside the dashed boundary.
-               (and (not region?) (:parent-id n))
-               (assoc :parentNode (:parent-id n)
-                      :extent     "parent"))))
-         (sort-by #(if (:region? %) 0 1) nodes))
-   :edges
-   (mapv (fn [e]
-           (let [from-active? (or (= (:source e) highlight-id)
-                                  (= (:target e) highlight-id))
-                 focused?     (and (some? from-highlight-id)
-                                   (some? to-highlight-id)
-                                   (= (:source e) from-highlight-id)
-                                   (= (:target e) to-highlight-id))
-                 ;; rf2-5qsxo — arrowhead colour tracks the edge stroke
-                 ;; (focused/active edges glow cyan; the rest the default
-                 ;; border colour) so the marker reads as part of the same
-                 ;; line. xyflow renders a `<marker>` def per edge when
-                 ;; `:markerEnd` is present; the custom edge component
-                 ;; (`chart.edges/transition-edge`) forwards the resolved
-                 ;; url to its `<BaseEdge>`.
-                 marker-color (if (or focused? from-active?)
-                                (:cyan tokens/tokens)
-                                (:border-default tokens/tokens))
-                 ;; rf2-u422r — only plain `:on` transitions carry a
-                 ;; user-fireable event-id. `:after`-timer + `:always`
-                 ;; eventless edges fire automatically inside the engine,
-                 ;; so their click carries a nil `:eventId` (the host —
-                 ;; e.g. Causa's on-chart sim — filters those out).
-                 fireable?    (and (nil? (:after e))
-                                    (not (:always? e))
-                                    (keyword? (:event e)))
-                 event-id     (when fireable? (:event e))]
-             {:id     (:id e)
-              :source (:source e)
-              :target (:target e)
-              :type   (choose-edge-type e)
-              :markerEnd {:type "arrowclosed"
-                          :color marker-color
-                          :width 18
-                          :height 18}
-              :data   {:eventLabel (:event-label e)
-                       :active     from-active?
-                       :focused    focused?
-                       :afterMs    (:after e)
-                       :guard      (some-> (:guard e) name)
-                       :action     (some-> (:action e) name)
-                       ;; rf2-u422r — on-chart click wiring. `:eventId`
-                       ;; is the raw fireable event keyword (nil for
-                       ;; auto edges); `:fromPath` / `:toPath` give the
-                       ;; host the originating transition. `:onClick` is
-                       ;; the host callback (omitted when no wiring).
-                       :eventId    event-id
-                       :fromPath   (:from-path e)
-                       :toPath     (:to-path e)
-                       :onClick    on-edge-click
-                       ;; rf2-k647w — resolved density constants for the
-                       ;; edge-label typography (same rationale as the
-                       ;; node payload above).
-                       :chart      chart}}))
-         edges)})
+  (let [;; rf2-lkwev — container nodes (parallel regions AND compound
+        ;; parents) MUST precede their children in the xyflow nodes
+        ;; array (xyflow requires a parentNode to appear before any node
+        ;; that references it). The parse already emits parents first;
+        ;; sort defensively so the parent-before-child invariant holds.
+        proj-nodes
+        (mapv (fn [n]
+                (let [pos      (get positions (:id n) {:x 0 :y 0})
+                      region?  (boolean (:region? n))
+                      active?  (= (:id n) highlight-id)
+                      from-hi? (= (:id n) from-highlight-id)
+                      to-hi?   (= (:id n) to-highlight-id)
+                      base
+                      {:id       (:id n)
+                       :type     (cond
+                                   region?        "parallel-region"
+                                   (:compound? n) "compound"
+                                   :else          "state")
+                       :position {:x (:x pos) :y (:y pos)}
+                       :data     (cond-> {:label          (:label n)
+                                          :path           (:path n)
+                                          :active         active?
+                                          :fromHighlight  from-hi?
+                                          :toHighlight    to-hi?
+                                          :sim            (boolean (and active? sim?))
+                                          :initial        (boolean (:initial? n))
+                                          :final          (boolean (:final? n))
+                                          :compound       (boolean (:compound? n))
+                                          :tags           (vec (:tags n))
+                                          :chart          chart
+                                          :onClick        on-state-click}
+                                   region? (assoc :regionId    (:region n)
+                                                  :regionIndex (:region-index n)))
+                       :draggable false
+                       :selectable false}]
+                  (cond-> base
+                    region? (assoc :style {:width  (:width pos)
+                                           :height (:height pos)})
+                    (and (not region?) (:parent-id n))
+                    (assoc :parentNode (:parent-id n)
+                           :extent     "parent"))))
+              (sort-by #(if (or (:region? %) (:compound? %)) 0 1) nodes))
+
+        proj-edges
+        (mapv (fn [e]
+                (let [from-active? (or (= (:source e) highlight-id)
+                                       (= (:target e) highlight-id))
+                      focused?     (and (some? from-highlight-id)
+                                        (some? to-highlight-id)
+                                        (= (:source e) from-highlight-id)
+                                        (= (:target e) to-highlight-id))
+                      ;; A self-transition (source == target) renders as a
+                      ;; loop, not a degenerate near-zero bezier; the edge
+                      ;; component reads the `:selfLoop` flag.
+                      self-loop?   (= (:source e) (:target e))
+                      marker-color (if (or focused? from-active?)
+                                     (:cyan tokens/tokens)
+                                     (:border-default tokens/tokens))
+                      fireable?    (and (nil? (:after e))
+                                        (not (:always? e))
+                                        (keyword? (:event e)))
+                      event-id     (when fireable? (:event e))]
+                  {:id     (:id e)
+                   :source (:source e)
+                   :target (:target e)
+                   :type   (choose-edge-type e)
+                   :markerEnd {:type "arrowclosed"
+                               :color marker-color
+                               :width 18
+                               :height 18}
+                   :data   {:eventLabel (:event-label e)
+                            :active     from-active?
+                            :focused    focused?
+                            :afterMs    (:after e)
+                            :guard      (safe-name (:guard e))
+                            :action     (safe-name (:action e))
+                            :selfLoop   self-loop?
+                            :eventId    event-id
+                            :fromPath   (:from-path e)
+                            :toPath     (:to-path e)
+                            :onClick    on-edge-click
+                            :chart      chart}}))
+              edges)
+
+        ;; Initial-state markers — a small filled dot wired into each
+        ;; `:initial?` state via an unlabelled entry edge. xstate/SCXML
+        ;; semantics: every compound level shows its own initial marker.
+        ;; The marker shares the state's xyflow coordinate frame (same
+        ;; parentNode for region/compound children) so it sits just left
+        ;; of the state inside its container.
+        initial-nodes (filter :initial? nodes)
+        marker-nodes
+        (mapv (fn [n]
+                (let [sid (:id n)
+                      pos (get positions sid {:x 0 :y 0})]
+                  (cond-> {:id        (str "initial__" sid)
+                           :type      "initial-marker"
+                           :position  {:x (- (:x pos) 48)
+                                       :y (+ (:y pos) 14)}
+                           :data      {:targetPath (:path n) :chart chart}
+                           :draggable false
+                           :selectable false}
+                    (:parent-id n)
+                    (assoc :parentNode (:parent-id n)
+                           :extent     "parent"))))
+              initial-nodes)
+        entry-edges
+        (mapv (fn [n]
+                {:id          (str "initial__" (:id n) "__entry")
+                 :source      (str "initial__" (:id n))
+                 :target      (:id n)
+                 :targetHandle "left"
+                 :type        "transition"
+                 :markerEnd   {:type "arrowclosed"
+                               :color (:border-default tokens/tokens)
+                               :width 14
+                               :height 14}
+                 ;; Entry edges are non-interactive, but carry the full
+                 ;; edge `:data` shape (flags + threaded callback/chart)
+                 ;; so the "every edge has X" projection invariants hold.
+                 :data        {:eventLabel "" :entry true
+                               :active false :focused false :afterMs nil
+                               :guard nil :action nil :selfLoop false
+                               :eventId nil :fromPath nil :toPath nil
+                               :onClick on-edge-click :chart chart}})
+              initial-nodes)]
+    {:nodes (into proj-nodes marker-nodes)
+     :edges (into proj-edges entry-edges)}))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -45,6 +45,23 @@
     (is (= 2 (count (filter :final? nodes)))
         "final states are flagged")))
 
+(deftest parse-definition-flags-compound-initial
+  (testing "rf2-54s5a — a compound parent's :initial child is flagged
+            :initial? (xstate per-level initial semantics)"
+    (let [{:keys [nodes]} (layout/parse-definition compound-machine)
+          browsing (first (filter #(= [:authenticated :browsing] (:path %)) nodes))]
+      (is (true? (:initial? browsing))))))
+
+(deftest parse-definition-wires-compound-parent-id
+  (testing "rf2-54s5a — compound substates carry :parent-id (the
+            parent's node-id) for xyflow parentNode nesting; top-level
+            states carry none"
+    (let [{:keys [nodes]} (layout/parse-definition compound-machine)
+          browsing (first (filter #(= [:authenticated :browsing] (:path %)) nodes))
+          unauth   (first (filter #(= [:unauth] (:path %)) nodes))]
+      (is (= (layout/node-id [:authenticated]) (:parent-id browsing)))
+      (is (nil? (:parent-id unauth))))))
+
 (deftest parse-definition-extracts-edges
   (let [{:keys [edges]} (layout/parse-definition idle-loading-success)
         edge-pairs (set (map (juxt :from :to :event) edges))]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -54,6 +54,13 @@
                      :states  {:hidden  {:on {:show :shown}}
                                :shown   {:on {:hide :hidden}}}}}})
 
+(def self-loop-machine
+  "A machine with a self-transition (:idle --ping--> :idle) so the
+  `:selfLoop` flag has a positive case."
+  {:initial :idle
+   :states  {:idle {:on {:ping :idle :go :busy}}
+             :busy {:on {:done :idle}}}})
+
 (defn- edge-by-id
   "Pluck an edge from a projected graph by xyflow id."
   [graph id]
@@ -513,3 +520,74 @@
                   children))
       (is (every? #(re-find #"top=" (get-in % [:layoutOptions "elk.padding"]))
                   children)))))
+
+;; ---- initial-state markers + self-loops (rf2-54s5a) --------------------
+
+(deftest xyflow-graph-emits-initial-marker-node-and-entry-edge
+  (testing "rf2-54s5a — the machine's initial state gets a synthetic
+            initial-marker node + an unlabelled entry edge into it"
+    (let [parsed   (layout/parse-definition idle-loading)
+          graph    (projection/xyflow-graph parsed {} {})
+          idle-id   (layout/node-id [:idle])
+          marker-id (str "initial__" idle-id)
+          marker   (node-by-id graph marker-id)
+          entry    (edge-by-id graph (str marker-id "__entry"))]
+      (is (some? marker) "initial-marker node emitted")
+      (is (= "initial-marker" (:type marker)))
+      (is (some? entry) "entry edge emitted")
+      (is (= marker-id (:source entry)))
+      (is (= idle-id (:target entry)))
+      (is (= "left" (:targetHandle entry)))
+      (is (= "" (:eventLabel (:data entry)))
+          "entry edge has no event label"))))
+
+(deftest xyflow-graph-threads-initial-flag-onto-node-data
+  (testing "rf2-54s5a — node :data carries :initial (true for the
+            machine's initial state, false otherwise)"
+    (let [parsed  (layout/parse-definition idle-loading)
+          graph   (projection/xyflow-graph parsed {} {})
+          idle    (node-by-id graph (layout/node-id [:idle]))
+          loading (node-by-id graph (layout/node-id [:loading]))]
+      (is (true?  (:initial (:data idle))))
+      (is (false? (:initial (:data loading)))))))
+
+(deftest xyflow-graph-emits-compound-substate-initial-marker
+  (testing "rf2-54s5a — a compound parent's :initial substate also
+            gets a marker (xstate per-level initial semantics) sharing
+            the compound's coordinate frame"
+    (let [parsed      (layout/parse-definition compound-machine)
+          graph       (projection/xyflow-graph parsed {} {})
+          browsing-id (layout/node-id [:authenticated :browsing])
+          marker      (node-by-id graph (str "initial__" browsing-id))]
+      (is (some? marker) "the compound's initial substate gets a marker")
+      (is (= (layout/node-id [:authenticated]) (:parentNode marker))))))
+
+(deftest xyflow-graph-flags-self-transition
+  (testing "rf2-54s5a — a source==target edge carries :data {:selfLoop true}"
+    (let [parsed   (layout/parse-definition self-loop-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          self     (first (filter #(= (:source %) (:target %)) (:edges graph)))
+          non-self (first (filter #(not= (:source %) (:target %)) (:edges graph)))]
+      (is (some? self) "fixture has a self-transition")
+      (is (true?  (:selfLoop (:data self))))
+      (is (false? (:selfLoop (:data non-self)))))))
+
+(deftest xyflow-graph-compound-children-wire-parent-node
+  (testing "rf2-54s5a — compound substates nest via xyflow parentNode
+            (same mechanic as parallel-region children)"
+    (let [parsed   (layout/parse-definition compound-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          browsing (node-by-id graph (layout/node-id [:authenticated :browsing]))]
+      (is (= (layout/node-id [:authenticated]) (:parentNode browsing)))
+      (is (= "parent" (:extent browsing))))))
+
+(deftest elk-children-nests-compound-substates
+  (testing "rf2-54s5a — a compound parent nests its substates as elk
+            :children (so they lay out inside the container)"
+    (let [parsed   (layout/parse-definition compound-machine)
+          children (projection/->elk-children parsed)
+          by-id    (into {} (map (juxt :id identity) children))
+          authed   (get by-id (layout/node-id [:authenticated]))]
+      (is (some? authed) "compound parent is a top-level elk child")
+      (is (= 2 (count (:children authed)))
+          "browsing + paying nest inside"))))


### PR DESCRIPTION
Closes the final child of the Causa Machines epic (rf2-nrrtb): both
chart implementations reach xstate/Stately-level topology richness.

## Discovery

The Dynamic chart (Causa `panels.machines.topology`) already renders
through the Static `mv-chart/MachineChart` (since rf2-5qsxo), so
"reuse vs extend" was already settled in favour of reuse. The Static
parse layer already had all-regions parallel, compound recursion, and
`event [guard] / action` labels. What was *actually* missing across
both:

- **initial-state markers** were never emitted (the `initial-marker`
  component existed + was registered but was dead — the projector never
  produced a marker node, and `:initial` wasn't even threaded into node
  `:data`).
- **compound children weren't nested** inside their container (only
  parallel-region children were wired via `parentNode`).
- **self-transitions** rendered as a degenerate near-zero bezier.
- the **Dynamic projector** undercounted compound/parallel machines
  (first-region-only + compound children invisible) → the view's
  `data-node-count`/`data-edge-count` were wrong — and lacked guards in
  its edge labels.
- a **latent crash**: `(name fn)` on inlined fn guards/actions
  (`Doesn't support name: function …`).

## Changes

**Static (`tools/machines-viz`)**
- `chart.projection/xyflow-graph`: emit an `initial-marker` node + an
  unlabelled entry edge for every `:initial?` state; thread `:initial`
  onto node `:data`; flag `source==target` edges `:selfLoop`; sort
  containers (region **and** compound) before children; fn-safe
  `:guard`/`:action`.
- `chart.layout`: flag each compound parent's `:initial` substate;
  wire `:parent-id` onto compound substates (xyflow nesting); fn-safe
  `name-of`.
- `chart.edges/transition-edge`: render a loop path for `:selfLoop`
  edges; suppress the empty label box on entry edges.
- `chart.cljs/->elk-input`: enable `hierarchyHandling` for compound
  nesting (not just parallel).

**Dynamic (`tools/causa`)**
- `panels.machines.topology`: `parse-definition` projects ALL parallel
  regions + recurses compound substates (fixes the view's counts);
  `collect-edges` composes `event [guard] / action` labels (fn-safe via
  `seg-name`); `project` surfaces `:initial`.

## Tests

- machines-viz projection: initial-marker emission, `:initial` flag,
  self-loop flag, compound `parentNode` nesting, elk compound nesting.
- machines-viz layout: compound-initial flag + compound `parent-id`.
- Causa topology: all-regions parallel, compound recursion, guard
  labels, `:initial` in `project`.
- CLJS suite **4078/0/0**; Causa feature gate **13/0**.

## Browser-unverified

The visual rendering of (a) the initial-marker glyph + entry arrow,
(b) the self-loop arc, and (c) elk compound hierarchical layout follows
the proven parallel-region pattern but was not browser-tested here
(node-test doesn't run elk/xyflow render). The pure-data projection is
fully unit-tested.