### PR TITLE
fix(causa): panel_gallery Trace fixtures seed epoch records, not the bus (rf2-ofoqu)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/panel_gallery_trace_fixtures_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panel_gallery_trace_fixtures_cljs_test.cljs
@@ -1,0 +1,102 @@
+(ns day8.re-frame2-causa.panel-gallery-trace-fixtures-cljs-test
+  "Fixture-shape coverage for the panel_gallery Trace tab (rf2-ofoqu).
+
+  After PR #1958 (rf2-td380) the Trace panel reads the FOCUSED EPOCH's
+  `:trace-events` — resolved via the shared `focus-resolver` over
+  `:rf.causa/focus` + `:rf.causa/epoch-history` — instead of the trace
+  bus. The gallery's Trace variants were rewired (rf2-ofoqu) to seed
+  `:epoch-history` (a vector of `:rf/epoch-record` maps) via
+  `:rf.causa/sync-epoch-history` rather than the bus via
+  `:rf.causa/sync-trace-buffer`.
+
+  This test pins that the rewired fixture builders produce the shape
+  the panel actually reads:
+
+    1. Each history is a vector of `:rf/epoch-record` maps, each
+       carrying an `:epoch-id` and a `:trace-events` slice.
+    2. Running the SAME resolver + projection the panel's
+       `:rf.causa/trace-feed` sub runs (no focus pinned → head-fallback)
+       yields the panel's data map — non-empty rows for the populated
+       variants, the `:no-events` empty-kind for the empty variant.
+
+  Pure data → data; no React, no live runtime. The testbed namespace
+  is on shadow's `:source-paths` so the `:node-test` build's
+  `cljs-test$` regex discovers this file."
+  (:require [cljs.test :refer-macros [deftest is testing are]]
+            [panel-gallery.fixtures-trace :as fx]
+            [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]
+            [day8.re-frame2-causa.panels.trace-helpers :as h]))
+
+(defn- feed-from-history
+  "Mirror `:rf.causa/trace-feed` (trace.cljs install!) with no focus
+  pinned: resolve the head epoch via the focus-resolver's head-fallback
+  and project its `:trace-events`."
+  [history]
+  (let [focus-epoch-id nil
+        status (focus/resolve-focus-status focus-epoch-id history)
+        record (focus/find-epoch-record focus-epoch-id history)]
+    (h/project-feed-from-epoch record status)))
+
+(defn- epoch-record? [r]
+  (and (map? r)
+       (some? (:epoch-id r))
+       (vector? (:trace-events r))))
+
+(deftest histories-are-epoch-record-vectors
+  (testing "every history builder yields a non-empty vector of :rf/epoch-record maps"
+    (are [history] (and (vector? history)
+                        (seq history)
+                        (every? epoch-record? history))
+      (fx/empty-trace-history)
+      (fx/short-trace-history)
+      (fx/medium-trace-history)
+      (fx/long-trace-history)
+      (fx/errors-trace-history)
+      (fx/flows-trace-history)
+      (fx/mixed-op-types-history)
+      (fx/redacted-trace-history)
+      (fx/cross-frame-history)
+      (fx/source-coord-history))))
+
+(deftest populated-variants-render-non-empty-rows
+  (testing "head-fallback resolves the variant epoch and the panel feed is non-empty"
+    (are [history expected-rows]
+        (let [{:keys [rows empty-kind]} (feed-from-history history)]
+          (and (nil? empty-kind)
+               (= expected-rows (count rows))))
+      (fx/short-trace-history)      10
+      (fx/medium-trace-history)     100
+      (fx/errors-trace-history)     5
+      (fx/mixed-op-types-history)   10
+      (fx/redacted-trace-history)   3
+      (fx/cross-frame-history)      12
+      (fx/source-coord-history)     6)))
+
+(deftest long-trace-feed-is-capped
+  (testing "the 1000-row trail projects 1000 rows; cap handled by the view's overflow/capped-list"
+    (let [{:keys [rows total empty-kind]} (feed-from-history (fx/long-trace-history))]
+      (is (nil? empty-kind))
+      (is (= 1000 (count rows)))
+      (is (= 1000 total)))))
+
+(deftest empty-variant-renders-no-events
+  (testing "a focused epoch with an empty :trace-events slice → :no-events empty-state"
+    (let [{:keys [rows empty-kind]} (feed-from-history (fx/empty-trace-history))]
+      (is (= :no-events empty-kind))
+      (is (empty? rows)))))
+
+(deftest flows-variant-head-is-the-flow-epoch
+  (testing "multi-op history: head-fallback renders the flow cascade, not the leading counter epoch"
+    (let [{:keys [rows empty-kind]} (feed-from-history (fx/flows-trace-history))
+          op-types (set (map :op-type rows))]
+      (is (nil? empty-kind))
+      (is (= 7 (count rows)) "the flow epoch's trail is 7 rows")
+      (is (contains? op-types :rf.flow/computed)
+          "the focused epoch surfaces the flow op-type"))))
+
+(deftest source-coord-variant-rows-carry-source-coord
+  (testing "the source-coord variant's projected rows carry a :source-coord string"
+    (let [{:keys [rows]} (feed-from-history (fx/source-coord-history))]
+      (is (seq rows))
+      (is (every? :source-coord rows)
+          "every projected row carries a file:line source-coord"))))

--- a/tools/causa/testbeds/panel_gallery/fixtures_trace.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_trace.cljs
@@ -1,19 +1,55 @@
 (ns panel-gallery.fixtures-trace
   "Pure fixture builders for the Causa Trace tab gallery (rf2-sszlr —
-  rebuild for new 6-tab Causa shape).
+  rebuild for new 6-tab Causa shape; epoch-scoped rewire rf2-ofoqu).
 
-  The trace panel reads its rows from `:rf.causa/trace-feed`, a
-  composite over:
+  ## Epoch-scoped feed (rf2-td380 / rf2-ofoqu)
 
-    - `:rf.causa/trace-buffer`   — the raw trace ring buffer
-    - `:rf.causa/trace-filters`  — the active 9-axis filter map
+  After PR #1958 (rf2-td380 / rf2-o6yqq / rf2-gkczt) the Trace panel
+  is a lens on the spine's FOCUSED EPOCH, not the global trace bus.
+  Its sub `:rf.causa/trace-feed` joins:
 
-  Each variant seeds via `:rf.causa/sync-trace-buffer` — the canonical
-  seed event used by `mount.cljs/open!` to publish the trace-bus
-  contents into Causa's frame app-db. The handler `assoc`s the buffer
-  vector into Causa's frame app-db; Story's `:rf.story/*` runtime slots
-  survive untouched per `tools/story/spec/002-Runtime.md` §Coexistence
-  with hosting application state.
+    - `:rf.causa/focus`          — carries `:epoch-id`
+    - `:rf.causa/epoch-history`  — the per-frame ring of `:rf/epoch-record`
+                                   maps (the framework's settling records)
+
+  and renders the focused epoch's `:trace-events` slice (the complete
+  domino trail for one settling). It NO LONGER reads the trace bus /
+  `:trace-buffer`, so seeding the bus produces an empty panel.
+
+  Each variant therefore seeds via `:rf.causa/sync-epoch-history` — the
+  canonical seed event (`epoch.cljs`) that `assoc`s the history vector
+  into Causa's frame app-db under `:epoch-history`. The handler is
+  tagged `{:rf.trace/no-emit? true}`; Story's `:rf.story/*` runtime
+  slots survive untouched per `tools/story/spec/002-Runtime.md`
+  §Coexistence with hosting application state.
+
+  ## Focus resolution (head-fallback)
+
+  No variant pins `:rf.causa/focus`. With no trace bus seeded there are
+  no cascades, so `compose-focus` leaves the focus `:epoch-id` nil; the
+  shared `panels.shared.focus-resolver` then applies its head-fallback
+  (rf2-h0120): nil focus + non-empty history → `:focused`, resolving to
+  the HEAD record `(peek epoch-history)`. `:rf.causa/epoch-history` is
+  oldest-first, so the variant's representative epoch is placed LAST in
+  the history vector and is what the panel renders. Multi-op variants
+  put older epochs ahead of the focused one to exercise a realistic
+  ring without changing which epoch renders.
+
+  ## Epoch-record shape (per spec/004-AppDbDiff + re-frame.epoch)
+
+  Each `:rf/epoch-record` the resolver looks up carries:
+
+      {:epoch-id      <int>             ; stable id, ring-buffer key
+       :frame         :rf/default
+       :committed-at  <ms>
+       :event-id      <kw>              ; first elem of :trigger-event
+       :trigger-event <event-vec>
+       :trace-events  [<trace-event> ...]}  ; the domino trail (what the
+                                            ; Trace panel projects)
+
+  The Trace panel reads ONLY `:epoch-id` (for the head/feed key) and
+  `:trace-events` (the rows), so these records populate just enough for
+  a faithful render.
 
   ## Trace-event shape (per Spec 009 §Trace bus + trace_helpers/project-row)
 
@@ -305,3 +341,120 @@
        (ev {:id 7 :time 1006 :op-type :view :operation :view/render
             :source :ui :origin :app :frame :rf/default :dispatch-id 100
             :render-key [:cart/badge nil]})])))
+
+;; ---- epoch-record + history builders (rf2-ofoqu) -------------------------
+;;
+;; The Trace panel reads the FOCUSED EPOCH's `:trace-events`, resolved
+;; via the shared focus-resolver over `:rf.causa/epoch-history`. These
+;; builders wrap the per-event buffer builders above into `:rf/epoch-
+;; record` maps so each variant seeds an epoch the panel can project.
+
+(defn epoch-record
+  "Build a minimal `:rf/epoch-record` carrying a `:trace-events` slice.
+  The Trace panel reads only `:epoch-id` (head/feed key) and
+  `:trace-events` (the domino-trail rows); the remaining slots mirror
+  the framework's settling-record shape for fidelity."
+  [{:keys [epoch-id event trace-events]}]
+  {:epoch-id      epoch-id
+   :frame         :rf/default
+   :committed-at  (* 1000 (or epoch-id 0))
+   :event-id      (first event)
+   :trigger-event event
+   :trace-events  (vec trace-events)})
+
+(defn single-epoch-history
+  "Wrap one trace-event vector into a one-record history. The single
+  record is the head (oldest-first vector of one) so the focus-
+  resolver's head-fallback renders it. `event` is the epoch's trigger
+  event (cosmetic — surfaces in the record's `:event-id`)."
+  [{:keys [epoch-id event trace-events]}]
+  [(epoch-record {:epoch-id     epoch-id
+                  :event        event
+                  :trace-events trace-events})])
+
+(defn empty-trace-history
+  "One epoch whose `:trace-events` slice is empty — drives the panel's
+  `:no-events` empty-state ('No events.'). Distinct from no history at
+  all (`:no-focus`): the focus resolves to a real record that simply
+  carries no trace rows."
+  []
+  (single-epoch-history
+    {:epoch-id 1 :event [:counter/init] :trace-events (empty-buffer)}))
+
+(defn short-trace-history
+  "One epoch whose domino trail is the ten-event cascade — a normal,
+  representative settling spanning every canonical op-type."
+  []
+  (single-epoch-history
+    {:epoch-id 2 :event [:cart/add :apple]
+     :trace-events (ten-events-buffer)}))
+
+(defn medium-trace-history
+  "One epoch carrying a 100-row domino trail. The cap (200) is not hit;
+  the overflow indicator stays quiet."
+  []
+  (single-epoch-history
+    {:epoch-id 3 :event [:dashboard/recompute-all]
+     :trace-events (hundred-events-buffer)}))
+
+(defn long-trace-history
+  "One epoch carrying a 1000-row trail — exercises the 200-row cap and
+  the overflow indicator at the head of the feed."
+  []
+  (single-epoch-history
+    {:epoch-id 4 :event [:storm/replay]
+     :trace-events (thousand-events-buffer)}))
+
+(defn errors-trace-history
+  "One epoch whose trail is all issues (errors / warnings / info) —
+  every row carries a severity tier."
+  []
+  (single-epoch-history
+    {:epoch-id 5 :event [:report/upload]
+     :trace-events (error-buffer)}))
+
+(defn flows-trace-history
+  "A multi-op history: a prior counter epoch precedes the focused
+  flow-cascade epoch. The focused (head) epoch carries the
+  `:cart/add` cascade with three `:rf.flow/computed` recompute rows
+  and a downstream render — the panel renders the flow op-type
+  alongside the dominoes. The leading epoch exercises a realistic
+  ring while head-fallback keeps the flow epoch in view."
+  []
+  [(epoch-record {:epoch-id 6 :event [:counter/inc]
+                  :trace-events (ten-events-buffer)})
+   (epoch-record {:epoch-id 7 :event [:cart/add :apple]
+                  :trace-events (flows-buffer)})])
+
+(defn mixed-op-types-history
+  "One epoch whose trail mixes event + fx op-types (no chip-filtering
+  post-rf2-gkczt — the feed renders every row)."
+  []
+  (single-epoch-history
+    {:epoch-id 8 :event [:cart/add :apple]
+     :trace-events (filtered-active-buffer)}))
+
+(defn redacted-trace-history
+  "One epoch whose dispatched-event payload carries `:rf/redacted`
+  markers on `:password` + `:totp` — the panel surfaces the marker
+  verbatim per Spec 009 §Privacy."
+  []
+  (single-epoch-history
+    {:epoch-id 9 :event [:auth/sign-in]
+     :trace-events (redacted-buffer)}))
+
+(defn cross-frame-history
+  "One epoch whose trail spans three frames evenly — exercises the
+  panel's per-row frame projection across the full ladder."
+  []
+  (single-epoch-history
+    {:epoch-id 10 :event [:tenant/poke]
+     :trace-events (cross-frame-buffer)}))
+
+(defn source-coord-history
+  "One epoch whose every row carries a `:source-coord` slot — exercises
+  the panel's clickable source-coord chip (jump-to-editor affordance)."
+  []
+  (single-epoch-history
+    {:epoch-id 11 :event [:counter/inc]
+     :trace-events (source-coord-buffer)}))

--- a/tools/causa/testbeds/panel_gallery/gallery_trace.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_trace.cljs
@@ -1,11 +1,24 @@
 (ns panel-gallery.gallery-trace
   "Story coverage for the **Trace tab** of the new 6-tab Causa chrome
-  (rf2-sszlr — gallery rebuild for spec/018-Event-Spine).
+  (rf2-sszlr — gallery rebuild for spec/018-Event-Spine; epoch-scoped
+  rewire rf2-ofoqu).
 
   The Trace tab body is the `trace/Panel` view: the raw-event ribbon
-  over the 9-axis filter vocabulary. Each variant seeds its frame's
-  `:trace-buffer` (and optionally `:trace-filters`) via REAL Causa
-  init events fired into the variant frame."
+  scoped to the spine's FOCUSED EPOCH (rf2-td380). The panel reads the
+  focused epoch's `:trace-events` slice — resolved via the shared
+  `focus-resolver` over `:rf.causa/focus` + `:rf.causa/epoch-history` —
+  NOT the trace bus.
+
+  ## Why seed via `:rf.causa/sync-epoch-history` (rf2-ofoqu)
+
+  Pre-rewire each variant seeded the trace BUS via
+  `:rf.causa/sync-trace-buffer`, which the epoch-scoped panel no longer
+  reads — so the variants rendered empty. Each variant now seeds its
+  frame's `:epoch-history` via `:rf.causa/sync-epoch-history` (a vector
+  of `:rf/epoch-record` maps, each carrying a populated `:trace-events`
+  slice). No variant pins focus: with no bus seeded there are no
+  cascades, so the focus-resolver's head-fallback renders the HEAD
+  epoch record (`(peek epoch-history)`)."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures-trace :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
@@ -23,115 +36,118 @@
 
   (story/reg-tag :feature/causa-trace
     {:axis :feature
-     :doc  "Causa Trace tab — raw-event ribbon over the 9-axis
-            filter vocabulary (per spec/018-Event-Spine §5.4)."})
+     :doc  "Causa Trace tab — the focused-epoch domino-trail ribbon
+            (per spec/018-Event-Spine §5.4 + rf2-td380)."})
 
   (story/reg-story :story.causa.trace
     {:doc        "Visual gallery of the Causa Trace tab under varying
-                 buffer depth + filter state. Each variant seeds its
-                 frame's :trace-buffer via :rf.causa/sync-trace-buffer;
-                 the rendered panel reads from the variant frame in
-                 isolation."
+                 epoch trace-event depth + shape. Each variant seeds
+                 its frame's :epoch-history via
+                 :rf.causa/sync-epoch-history; the panel reads the
+                 focused epoch's :trace-events from the variant frame
+                 in isolation."
      :component  :panel-gallery.trace/Panel
      :tags       #{:dev :feature/causa-trace}
      :substrates #{:reagent}})
 
-  ;; ----- 1. short trace (empty) --------------------------------------
+  ;; ----- 1. empty trace (focused epoch carries no events) ------------
   (story/reg-variant :story.causa.trace/empty-trace
-    {:doc        "No events in the buffer. Panel renders the
-                 :no-events empty-state copy."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
+    {:doc        "Focused epoch carries an empty :trace-events slice.
+                 Panel renders the :no-events empty-state ('No
+                 events.')."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/empty-trace-history)]]
      :tags       #{:dev :state/empty}
      :substrates #{:reagent}})
 
-  ;; ----- 2. short trace (ten events) ---------------------------------
+  ;; ----- 2. short trace (normal ten-row cascade) ---------------------
   (story/reg-variant :story.causa.trace/short-trace
-    {:doc        "Ten events spanning every canonical op-type. Chip
-                 rows surface op-type / source / origin / frame with
-                 ≥2 values each; the feed renders one row per event."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/ten-events-buffer)]]
+    {:doc        "A normal cascade — the focused epoch's domino trail
+                 is ten events spanning every canonical op-type. One
+                 row per event, newest first."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/short-trace-history)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})
 
-  ;; ----- 3. medium trace (100 events) --------------------------------
+  ;; ----- 3. medium trace (100 rows) ----------------------------------
   (story/reg-variant :story.causa.trace/medium-trace
-    {:doc        "One hundred events spanning all four op-types,
-                 three frames, three origins, four sources. The cap
-                 (200) is not hit; cap-eviction indicator stays
-                 quiet."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/hundred-events-buffer)]]
+    {:doc        "Focused epoch with a 100-row domino trail spanning
+                 all four op-types. The 200-row cap is not hit; the
+                 overflow indicator stays quiet."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/medium-trace-history)]]
      :tags       #{:dev :state/medium}
      :substrates #{:reagent}})
 
-  ;; ----- 4. long trace (1000 events; cap-eviction) -------------------
+  ;; ----- 4. long trace (1000 rows; cap-eviction) ---------------------
   (story/reg-variant :story.causa.trace/long-trace
-    {:doc        "One thousand events — exercises the 200-row cap and
-                 surfaces the overflow indicator at the head of the
-                 feed. Per `overflow_indicator.cljc` §capped-list the
-                 panel renders 200 rows + one '... N rows hidden'
-                 indicator row."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/thousand-events-buffer)]]
+    {:doc        "Focused epoch with a 1000-row trail — exercises the
+                 200-row cap and surfaces the overflow indicator at the
+                 head of the feed."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/long-trace-history)]]
      :tags       #{:dev :state/large}
      :substrates #{:reagent}})
 
   ;; ----- 5. trace with errors ----------------------------------------
   (story/reg-variant :story.causa.trace/trace-with-errors
-    {:doc        "Every row is an issue: two errors, two warnings,
-                 one info. Severity chip row surfaces all three
-                 tiers populated; per-row dot colours match."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/error-buffer)]]
+    {:doc        "Focused epoch whose every row is an issue: two
+                 errors, two warnings, one info. Per-row dot colours
+                 match the severity tiers."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/errors-trace-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 6. trace with flows -----------------------------------------
+  ;; ----- 6. multi-op epoch with flows --------------------------------
+  ;; A multi-op history: a leading counter epoch precedes the focused
+  ;; flow-cascade epoch (head), exercising a realistic ring while
+  ;; head-fallback keeps the flow epoch in view.
   (story/reg-variant :story.causa.trace/trace-with-flows
-    {:doc        "Cascade rooted on `:cart/add` that triggers three
-                 `:rf.flow/computed` recompute events followed by a
-                 downstream view render. Pins the panel's rendering
-                 of the flow op-type alongside the dominoes."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/flows-buffer)]]
+    {:doc        "Multi-op history. The focused (head) epoch is a
+                 `:cart/add` cascade that triggers three
+                 `:rf.flow/computed` recompute rows then a downstream
+                 view render — the panel renders the flow op-type
+                 alongside the dominoes. A prior counter epoch sits
+                 behind it in the ring."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/flows-trace-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- 7. mixed op-types -------------------------------------------
   ;; rf2-gkczt: chip-filtering was removed from the Trace panel — the
-  ;; focused epoch IS the scope. This variant now just exercises a
-  ;; mixed-op-type buffer (the former 'filter-active' fixture) with no
-  ;; filter event.
+  ;; focused epoch IS the scope. This variant exercises a mixed-op-type
+  ;; trail with no filter event.
   (story/reg-variant :story.causa.trace/mixed-op-types
-    {:doc        "Ten events spanning mixed op-types. The feed renders
-                 every row (no chip-filtering post-rf2-gkczt)."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/filtered-active-buffer)]]
+    {:doc        "Focused epoch whose trail mixes event + fx op-types.
+                 The feed renders every row (no chip-filtering
+                 post-rf2-gkczt)."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/mixed-op-types-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- 8. redacted slot --------------------------------------------
   (story/reg-variant :story.causa.trace/redacted
-    {:doc        "Dispatched event payload carries `:rf/redacted`
-                 markers on `:password` + `:totp` slots. The panel's
-                 description column renders the marker verbatim per
-                 Spec 009 §Privacy."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/redacted-buffer)]]
+    {:doc        "Focused epoch whose dispatched event payload carries
+                 `:rf/redacted` markers on `:password` + `:totp`. The
+                 panel's description column renders the marker verbatim
+                 per Spec 009 §Privacy."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/redacted-trace-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- 9. cross-frame ----------------------------------------------
   (story/reg-variant :story.causa.trace/cross-frame
-    {:doc        "Twelve events spanning three frames evenly. The
-                 :frame chip row populates the full ladder; the per-
-                 row chip surfaces the frame on every event.
-                 Panel-specific axis."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/cross-frame-buffer)]]
+    {:doc        "Focused epoch whose trail spans three frames evenly.
+                 The per-row frame projection surfaces the frame on
+                 every event. Panel-specific axis."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/cross-frame-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
   ;; ----- 10. source-coord --------------------------------------------
   (story/reg-variant :story.causa.trace/source-coord
-    {:doc        "Six events each carrying a `:source-coord` slot
-                 (file + line). The per-row source-coord chip
-                 renders with the cyan accent and is clickable.
-                 Panel-specific axis: source-coord jump-to-editor."
-     :events     [[:rf.causa/sync-trace-buffer (fixtures/source-coord-buffer)]]
+    {:doc        "Focused epoch whose every row carries a
+                 `:source-coord` slot (file + line). The per-row
+                 source-coord chip renders with the cyan accent and is
+                 clickable. Panel-specific axis: jump-to-editor."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/source-coord-history)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
@@ -139,7 +155,7 @@
   (story/reg-workspace :Workspace.causa.trace/all
     {:doc      "All ten Trace tab variants in one auto-grid. Scroll
                 to see the panel's response across empty / short /
-                medium / long / errors / flows / filter-active /
+                medium / long / errors / flows / mixed-op-types /
                 redacted / cross-frame / source-coord."
      :layout   :variants-grid
      :story    :story.causa.trace


### PR DESCRIPTION
## Summary
- PR #1958 (rf2-td380/o6yqq/gkczt) rescoped the Causa Trace panel to read the **focused epoch's** `:trace-events` (resolved via `:rf.causa/focus` + `:rf.causa/epoch-history` through the shared `focus-resolver`) instead of the trace bus. The `panel_gallery` Trace variants still seeded the bus via `:rf.causa/sync-trace-buffer`, so they rendered **empty**.
- Rewired `gallery_trace.cljs` + `fixtures_trace.cljs` to seed `:epoch-history` (vectors of `:rf/epoch-record` maps, each carrying a populated `:trace-events` slice) via `:rf.causa/sync-epoch-history`, mirroring the App-db gallery. No variant pins focus; the focus-resolver's head-fallback renders the head epoch.
- Kept the variants representative: empty (`:no-events`), normal ten-row cascade, 100-row, capped 1000-row, all-issues, a **multi-op** flow epoch (a counter epoch behind the focused `:cart/add` flow cascade), mixed op-types, redacted, cross-frame, source-coord. The rich per-event builders are reused as the `:trace-events` source.
- Added a CLJS unit test (`panel_gallery_trace_fixtures_cljs_test.cljs`) asserting each fixture builds `:rf/epoch-record` data and that the panel's resolver + `trace-helpers/project-feed-from-epoch` yield the expected non-empty rows (empty variant → `:no-events`).

The chrome gallery's `:panel-gallery.chrome/seed!` (core.cljs) legitimately still seeds both bus + epoch-history for its event-list/cascade derivations — out of scope, untouched.

## Test plan
- [x] `npx shadow-cljs compile :testbeds/panel-gallery` — clean (549 files, 0 warnings)
- [x] `npx shadow-cljs compile node-test` — clean (0 warnings)
- [x] `node out/node-test.js` — 4084 tests / 12409 assertions, 0 failures, 0 errors (incl. the new fixture-shape test)
- [ ] (optional) visual check at http://localhost:8765 — Trace variants now render non-empty