### PR TITLE
fix(core): orphan trace events stay uncorrelated, not folded into next epoch (rf2-avvwm)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -196,6 +196,33 @@
             (record-sub-run! frame-id event)
             (state/buffer-event! frame-id event))
 
+          ;; Out-of-cascade orphan — drop from the capture buffer (rf2-avvwm).
+          ;; An emit with NO cascade context (no in-flight cascade for the
+          ;; frame AND no `:dispatch-id` on its tags) belongs to no cascade:
+          ;; a frame-lifecycle emit (`:frame/created` / `:frame/re-registered`)
+          ;; fired between the last settled event and the next dequeue, or a
+          ;; registry-time emit. Per Spec 009 §Dispatch correlation it stays
+          ;; UNCORRELATED — neither a new epoch nor folded into another
+          ;; epoch's `:trace-events`. It still rides the raw trace ring +
+          ;; listener fan-out (those run independently of this capture seam);
+          ;; only the epoch-record capture buffer skips it.
+          ;;
+          ;; Pre-rf2-avvwm such an orphan was buffered, then the NEXT
+          ;; dequeued event's harvest vacuumed it in as the first
+          ;; `:trace-events` entry (the per-event-epoch boundary from
+          ;; rf2-nj6p7 left it stranded; the post-settle render/sub-run
+          ;; branches above already gate on the same `in-flight-cascade?`
+          ;; signal — this is the third out-of-cascade emit class).
+          ;;
+          ;; A `:dispatch-id`-bearing emit is ALWAYS buffered even when no
+          ;; cascade is in flight for THIS frame at the instant of the emit:
+          ;; a child's `:event/dispatched` marker fires during the PARENT's
+          ;; do-fx carrying the child's id, and rides the child's later
+          ;; `harvest-buffer-for-event!` settle.
+          (and (not (in-flight-cascade? frame-id))
+               (nil? (:dispatch-id tags)))
+          nil
+
           :else
           (state/buffer-event! frame-id event))))))
 

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -594,9 +594,13 @@
 
     * RETURN the events that belong to the settling event — those whose
       `:tags :dispatch-id` matches the buffer's first `:event/run-start`
-      id, PLUS any events carrying NO `:dispatch-id` (pre-cascade tagalongs
-      such as a `:frame/created` emit that fired outside any cascade; they
-      ride the first settling event of the drain).
+      id. Per rf2-avvwm an out-of-cascade ORPHAN (no `:dispatch-id` — e.g.
+      a `:frame/created` emit fired between the last settled event and the
+      next dequeue) is NOT folded in: Spec 009 §Dispatch correlation keeps
+      an emit outside any cascade uncorrelated (neither a new epoch nor part
+      of another epoch's record). Orphans are dropped upstream at the capture
+      seam (`re-frame.epoch.capture/capture-event!`) so they never reach this
+      buffer; the `did = sid` predicate below is the matching guard.
     * LEAVE in the buffer the events that belong to a DIFFERENT dequeued
       event — a child's `:event/dispatched` marker fires during the
       PARENT's do-fx (so it lands in the parent's window) but carries the
@@ -614,8 +618,19 @@
     (if-let [sid (settling-dispatch-id b)]
       (let [{mine true theirs false}
             (group-by (fn [ev]
-                        (let [did (-> ev :tags :dispatch-id)]
-                          (or (nil? did) (= did sid))))
+                        ;; Per rf2-avvwm: ONLY the settling event's own
+                        ;; traces (matching :dispatch-id) ride this epoch.
+                        ;; A nil-:dispatch-id orphan (out-of-cascade emit
+                        ;; such as :frame/created) is no longer folded in —
+                        ;; orphans are dropped at the capture seam
+                        ;; (capture/capture-event! out-of-cascade branch) so
+                        ;; they never reach this buffer; this predicate is
+                        ;; the matching guard (any nil-did event that did
+                        ;; slip through is LEFT in the buffer, not vacuumed
+                        ;; into the settling epoch). Pre-fix `(or (nil? did)
+                        ;; (= did sid))` swept an orphan in as the cascade's
+                        ;; first :trace-events entry — the regression closed.
+                        (= (-> ev :tags :dispatch-id) sid))
                       b)]
         ;; Leave the other-event traces (non-nil, non-matching id) in the
         ;; buffer for their own event's settle; take ours.

--- a/implementation/epoch/test/re_frame/epoch_attribution_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_attribution_test.clj
@@ -59,6 +59,14 @@
            (rf2-wi900 / rf2-l1jz8).
     inv-5  a view re-render whose own subs did NOT change is NOT spuriously
            attributed (the rf2-vh1k3 value-change-per-view discriminator).
+    inv-6  an out-of-cascade ORPHAN emit (`:frame/created` and the general
+           class) stays UNCORRELATED — never a new epoch, never folded into
+           the NEXT dequeued event's `:trace-events` (rf2-avvwm, a P1
+           regression from #1952's per-event epoch boundary). The fourth
+           out-of-cascade-emit-attribution member:
+           unlike the post-settle render / sub-run / mount cases (back-filled
+           to their CAUSING cascade), an orphan belongs to NO cascade and is
+           dropped at the capture seam.
 
   Supporting cases pin the boundary behaviour each fix also relies on:
   in-flight emits ride their own cascade (not back-filled); the back-fill
@@ -641,3 +649,105 @@
             "the value-UNCHANGED view (sidebar, :open → :open) is NOT
              spuriously attributed to epoch 3 — its render anchors elsewhere
              (its mount epoch), not this cascade")))))
+
+;; ===========================================================================
+;; INVARIANT 6 — an out-of-cascade ORPHAN emit (:frame/created and the
+;;                general class) stays UNCORRELATED: not a new epoch, and not
+;;                folded into the next dequeued event's :trace-events
+;;                (rf2-avvwm — P1 regression from #1952 epoch-per-event)
+;; ===========================================================================
+;;
+;; The fourth member of this suite's "which epoch does an out-of-cascade emit
+;; belong to?" family. The first three (renders / sub-runs / mount renders)
+;; fire AFTER a cascade settled and are back-filled to their CAUSING cascade.
+;; This one is different: a `:frame/created` (or registry-time) emit belongs
+;; to NO cascade at all — `reg-frame` runs `:on-create` via dispatch-sync
+;; FIRST (which settles its own epoch), THEN emits `:frame/created` with no
+;; in-flight cascade and no `:dispatch-id`. Per Spec 009 §Dispatch correlation
+;; it must stay uncorrelated. Pre-rf2-avvwm it lingered in the capture buffer
+;; and the NEXT dequeued event's harvest vacuumed it in as that epoch's FIRST
+;; :trace-events entry (the per-event-epoch boundary stranded it).
+
+(defn- trace-ops
+  "The [op-type operation] pairs in an epoch record's :trace-events, in
+  order. nil-safe — a record whose :trace-events was elided returns []."
+  [record]
+  (mapv (juxt :op-type :operation) (:trace-events record)))
+
+(deftest inv-6-frame-created-not-folded-into-next-epoch
+  (testing "rf2-avvwm — :frame/created, emitted by reg-frame AFTER :on-create's
+            epoch already settled, must NOT appear in the NEXT dequeued event's
+            :trace-events. Mirrors the parallel-frames :below repro: boot the
+            frame with an :on-create, then dispatch a user event; that event's
+            :trace-events must begin with its OWN ops, not [:frame
+            :frame/created]."
+    (rf/reg-event-db :app/init (fn [_ _] {:booted true :n 0}))
+    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    ;; reg-frame dispatch-syncs :on-create (settles epoch 1), THEN emits the
+    ;; orphan :frame/created.
+    (rf/reg-frame :test/main {:on-create [:app/init]})
+    ;; The next dequeued user event.
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
+      (is (= [:app/init :inc] (mapv :event-id history))
+          "exactly two epochs — :on-create and the user :inc; :frame/created
+           is NOT a third epoch")
+      (doseq [r history]
+        (is (not-any? #(= [:frame :frame/created] %) (trace-ops r))
+            (str "no epoch's :trace-events carries the orphan :frame/created — "
+                 "epoch " (:event-id r))))
+      (let [inc-epoch (last history)
+            ops       (trace-ops inc-epoch)]
+        (is (seq ops) ":inc epoch retained its raw :trace-events")
+        (is (= :event (first (first ops)))
+            ":inc epoch's :trace-events BEGIN with its OWN event op
+             (:event/dispatched), not the stranded [:frame :frame/created]")
+        (is (every? (fn [ev] (= [:inc] (-> ev :tags :event)))
+                    (filter #(= :event (:op-type %)) (:trace-events inc-epoch)))
+            "every :event-op trace in the :inc epoch belongs to [:inc]")))))
+
+(deftest inv-6-orphan-not-correlated-on-the-record
+  (testing "rf2-avvwm — the orphan carries no :dispatch-id, so no epoch's
+            :trace-events should reference it. Belt-and-braces on the
+            correlation contract: walk every retained epoch's :trace-events
+            and assert none is a :frame op."
+    (rf/reg-event-db :app/init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :inc      (fn [db _] (update db :n inc)))
+    (rf/reg-frame :test/main {:on-create [:app/init]})
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+    (rf/dispatch-sync [:inc] {:frame :test/main})
+
+    (doseq [r (rf/epoch-history :test/main)]
+      (is (not-any? #(= :frame (:op-type %)) (:trace-events r))
+          (str "no :frame-op orphan in epoch " (:event-id r)
+               "'s :trace-events")))))
+
+(deftest inv-6-harvest-leaves-orphan-uncorrelated
+  (testing "rf2-avvwm — direct unit test on the harvest seam. An orphan event
+            (no :dispatch-id) that reaches the capture buffer is NOT folded
+            into the settling event's harvest; only the settling event's own
+            :dispatch-id traces are returned."
+    (let [frame :test/harvest
+          ;; Hand-craft a buffer: an orphan with no :dispatch-id, then a
+          ;; run-start + a body trace for dispatch-id 42.
+          orphan    {:op-type :frame :operation :frame/created :tags {}}
+          run-start {:op-type :event :operation :event
+                     :tags {:phase :run-start :dispatch-id 42 :event-id :inc}}
+          body      {:op-type :event :operation :event/db-changed
+                     :tags {:dispatch-id 42}}]
+      (state/buffer-event! frame orphan)
+      (state/buffer-event! frame run-start)
+      (state/buffer-event! frame body)
+      (let [harvested (state/harvest-buffer-for-event! frame)]
+        (is (= [run-start body] harvested)
+            "harvest returns ONLY the settling event's (:dispatch-id 42)
+             traces — the orphan is left uncorrelated, not vacuumed in")
+        (is (not-any? #(= :frame/created (:operation %)) harvested)
+            "the orphan :frame/created is not in the settling epoch's harvest")
+        ;; The orphan stays behind in the buffer (left, not swept forward).
+        (is (= [orphan] (state/buffer-for frame))
+            "the orphan remains in the buffer, uncorrelated — not folded into
+             any epoch's :trace-events")
+        ;; Clean up the hand-seeded buffer so it doesn't leak to siblings.
+        (state/drop-frame-buffer! frame)))))


### PR DESCRIPTION
## The bug (rf2-avvwm — P1 regression from #1952 epoch-per-event)

Under the per-event epoch model (#1952 / rf2-nj6p7), a trace event emitted **outside any dequeued-event cascade** — `:frame/created` is the visible instance — was mis-attributed into the **next** dequeued event's `:rf/epoch-record :trace-events`.

### The orphan mechanism

`reg-frame` runs `:on-create` via `dispatch-sync` **first** (which settles its own epoch(s)), then emits `:frame/created` **after** — by which point there is no frame-creation settle to harvest it. Because the emit fires outside any cascade it carries **no `:dispatch-id`**. It lingered orphaned in the per-frame capture buffer until the **next** dequeued event settled — and that event's harvest vacuumed it in as the **first** `:trace-events` entry.

Observed (parallel-frames, `:below`): clicking `+` created an epoch whose `:trace-events` wrongly **began** with `[:frame :frame/created]` before the real counter-inc ops.

### The contract (Spec 009 §Dispatch correlation)

A trace event emitted outside any in-flight cascade carries no `:dispatch-id` and must stay **uncorrelated** — neither a new epoch nor folded into another epoch's `:trace-events`. (`cascade_dispatch_id_test/dispatch-id-unbound-outside-any-cascade` already pins this on the raw stream.)

## The fix (capture-site — the architecturally-aligned seam)

The post-settle render (rf2-qs6dl) and sub-run (rf2-wi900) branches in `capture-event!` already gate on an `in-flight-cascade?` signal. An orphan is the third out-of-cascade emit class, so it belongs at the same seam:

- **`epoch/capture.cljc` `capture-event!`** — add an out-of-cascade branch: an emit with **no in-flight cascade for the frame AND no `:dispatch-id`** is dropped from the epoch capture buffer. It still rides the raw trace ring + listener fan-out (those run independently of the capture seam); only the epoch-record source skips it. This fixes the **general class** (frame-lifecycle + registry-time emits), not just `:frame/created`. A `:dispatch-id`-bearing emit is always buffered (a child's `:event/dispatched` marker fires during the parent's do-fx carrying the child's id, and must ride the child's later settle).
- **`epoch/state.cljc` `harvest-buffer-for-event!`** — tighten the grouping predicate to `did = sid` (was `(or (nil? did) (= did sid))`). Any nil-`:dispatch-id` event that somehow reaches the buffer is now **left** uncorrelated rather than swept into the settling epoch. Matching guard to the capture-site drop.

Chose capture-site over a pure harvest-filter because leaving orphans in the buffer (harvest-filter only) would let them accumulate indefinitely; dropping at capture is the clean single-gate design with no shim.

## Tests (`epoch_attribution_test.clj` — the standing out-of-cascade-emit suite, now inv-6)

- `inv-6-frame-created-not-folded-into-next-epoch` — real frame-boot repro mirroring parallel-frames `:below`: exactly two epochs (`:on-create`, `:inc`); **no** epoch's `:trace-events` carries `[:frame :frame/created]`; the `:inc` epoch's `:trace-events` begin with its **own** ops.
- `inv-6-orphan-not-correlated-on-the-record` — no `:frame`-op orphan in any retained epoch across two user dispatches.
- `inv-6-harvest-leaves-orphan-uncorrelated` — direct unit test on the harvest seam: the orphan stays in the buffer, only the settling dispatch-id's traces are returned.

## Gates

- JVM epoch: `clojure -M:test` — 201 tests / 751 assertions, 0 failures.
- JVM core/router: `clojure -M:test` — 723 tests / 3433 assertions, 0 failures.
- CLJS: `npm run test:cljs` — 4078 tests / 12382 assertions, 0 failures.
- Fast PR spine: `scripts/test-fast-pr.sh` — PASS.