### PR TITLE
fix(causa): L2 list surfaces an "N hidden by filters" indicator + clear (rf2-jvghz)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -27,10 +27,28 @@
             [re-frame.frame :as frame]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.filters.edit-popup :as edit-popup]
+            [day8.re-frame2-causa.filters.hidden :as hidden]
             [day8.re-frame2-causa.filters.matcher :as matcher]
             [day8.re-frame2-causa.filters.persistence :as persistence]
             [day8.re-frame2-causa.filters.typed-predicates :as typed]
             [day8.re-frame2-causa.spine-filters :as spine-filters]))
+
+;; ---- L2 visible-row predicate (rf2-jvghz) -------------------------------
+;;
+;; Mirrors `shell/l2-cascade-visible?` — kept local so the
+;; `:rf.causa/hidden-by-filters` sub below can count over the SAME
+;; visible-row set the L2 list renders without a shell ↔ filters require
+;; cycle (the shell already requires this ns transitively). The
+;; `:ungrouped` bucket carries `:dispatch-id :ungrouped`; it only renders
+;; in L2 when the rf2-r9lyy power-user opt-in is on, so it is excluded
+;; from the hidden-count's visible set by default — keeping N consistent
+;; with the rows the user sees.
+
+(defn- l2-visible?
+  [cascade show-ungrouped?]
+  (if (= :ungrouped (:dispatch-id cascade))
+    (boolean show-ungrouped?)
+    true))
 
 ;; ---- Modal --------------------------------------------------------------
 
@@ -184,6 +202,28 @@
           (typed/filter-cascades filters)
           (spine-filters/filter-cascades muted))))
 
+  ;; rf2-jvghz defect #1 — the 'N events hidden by filters' indicator
+  ;; model. Composes the raw + filtered cascade lists and the active
+  ;; filter state into the pure `hidden/summary` record the L2 list's
+  ;; indicator renders against. Counts over the L2 visible-row set
+  ;; (`l2-visible?`) so N matches the rows the user sees. This is the
+  ;; affordance that makes persisted filters/frame-pin a VISIBLE cause
+  ;; rather than a silently-broken-looking list.
+  (rf/reg-sub :rf.causa/hidden-by-filters
+    :<- [:rf.causa/cascades]
+    :<- [:rf.causa/filtered-cascades]
+    :<- [:rf.causa/active-filters]
+    :<- [:rf.causa/focus-slot]
+    :<- [:rf.causa/muted-event-ids]
+    :<- [:rf.causa/show-ungrouped?]
+    (fn [[raw filtered filters focus-slot muted show-ungrouped?] _query]
+      (let [raw-n      (count (filterv #(l2-visible? % show-ungrouped?) raw))
+            filtered-n (count (filterv #(l2-visible? % show-ungrouped?) filtered))]
+        (hidden/summary raw-n filtered-n
+                        {:filters filters
+                         :frame   (:frame focus-slot)
+                         :muted   muted}))))
+
   ;; Popup state — three slots so the open / trigger / draft tiers
   ;; are individually subscribable.
   (rf/reg-sub :rf.causa/edit-popup-open?
@@ -311,6 +351,31 @@
             {:db next-db
              :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})
           {:db (close-popup db)}))))
+
+  ;; ---- clear-all (rf2-jvghz) ------------------------------------------
+  ;;
+  ;; One-click reset behind the L2 'N hidden by filters' indicator.
+  ;; Resets EVERY suppressing surface so the filtered list snaps back to
+  ;; the raw list:
+  ;;
+  ;;   1. IN/OUT pills        → `{:in [] :out []}` (+ persist)
+  ;;   2. frame pin           → `:rf.causa/select-frame nil` (the
+  ;;      canonical write surface — re-seeds the spine + clears the
+  ;;      frame-switcher localStorage so the unpin survives reload)
+  ;;   3. muted event-ids     → `:rf.causa/clear-muted-event-ids` (+ its
+  ;;      own persist fx)
+  ;;
+  ;; Pills are reset inline (this handler already owns the
+  ;; `:active-filters` slot + persist fx); the frame-pin and mute resets
+  ;; route through their owning events via `:dispatch` so each surface's
+  ;; persistence / instrumentation stays in one place.
+  (rf/reg-event-fx :rf.causa/clear-all-filters
+    (fn [{:keys [db]} _event]
+      (let [cleared {:in [] :out []}]
+        {:db (assoc db :active-filters cleared)
+         :fx [[:rf.causa.filters/persist cleared]
+              [:dispatch [:rf.causa/select-frame nil]]
+              [:dispatch [:rf.causa/clear-muted-event-ids]]]})))
 
   ;; ---- right-click row → OUT filter shortcut --------------------------
   ;;

--- a/tools/causa/src/day8/re_frame2_causa/filters/hidden.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/hidden.cljc
@@ -1,0 +1,128 @@
+(ns day8.re-frame2-causa.filters.hidden
+  "Pure derivation for the L2 'N events hidden by filters' indicator
+  (rf2-jvghz, defect #1).
+
+  ## Why
+
+  After the epoch-per-event merges, Causa's L2 event list could look
+  broken on reload: persisted filters (a `:machine` IN-pill under
+  `re-frame2.causa.filters.v1`, a frame pin under
+  `re-frame2.causa.frame-switcher.v1`) survived in localStorage and
+  silently suppressed cascade rows with NO visible indicator. The L2
+  list reads `:rf.causa/filtered-cascades` (filtered) while the raw
+  stream lives on `:rf.causa/cascades`; when filters suppressed rows
+  the list was indistinguishable from a broken tool.
+
+  This ns is the pure data primitive behind the affordance: given the
+  raw + filtered visible-cascade counts and the active filter state,
+  it answers 'is anything hidden, how many, and what is the cause?'.
+
+  ## The count contract
+
+  The hidden count is computed against the SAME visible-row set the L2
+  list renders — i.e. both the raw and filtered vectors must already be
+  passed through the list's `l2-cascade-visible?` predicate by the
+  caller (the `:rf.causa/hidden-by-filters` sub does this). That keeps
+  the indicator's N consistent with the rows the user actually sees:
+  the `:ungrouped` bucket never inflates the count, and the
+  filtered-to-empty / filtered-to-one cases both report the true
+  suppressed total.
+
+  Pure data; JVM-runnable. Tests in
+  `tools/causa/test/.../filters/hidden_test.cljc`."
+  (:require [day8.re-frame2-causa.filters.typed-predicates :as typed]))
+
+(defn hidden-count
+  "How many visible cascades the active filters / frame-pin / mutes are
+  suppressing: `(max 0 (- raw-visible-count filtered-visible-count))`.
+
+  Both counts MUST be taken over the list's visible-row set (post
+  `l2-cascade-visible?`) so N matches the rows the user sees. Clamped
+  at zero so a transient count skew (filtered briefly larger than raw
+  mid-recompute) never renders a negative."
+  [raw-visible-count filtered-visible-count]
+  (max 0 (- raw-visible-count filtered-visible-count)))
+
+(defn pills-present?
+  "True iff the `:active-filters` map carries at least one IN or OUT
+  pill. nil / `{:in [] :out []}` → false."
+  [{:keys [in out]}]
+  (boolean (or (seq in) (seq out))))
+
+(defn frame-pinned?
+  "True iff a frame pin is active — i.e. the picker has selected a
+  specific frame so `:rf.causa/filtered-cascades` restricts to it.
+  nil means no frame filter."
+  [frame-id]
+  (some? frame-id))
+
+(defn mutes-present?
+  "True iff at least one event-id is muted. nil / `#{}` → false."
+  [muted]
+  (boolean (seq muted)))
+
+(defn any-filter-active?
+  "True iff ANY suppressing surface is active: IN/OUT pills, a frame
+  pin, or a non-empty mute set. This is the predicate behind 'is there
+  anything a Clear-filters click would reset?'. It is independent of
+  the hidden COUNT — a pill can be active yet hide nothing (it happens
+  to match every current cascade); the count is what gates the
+  indicator's render, this predicate is what 'Clear filters' acts on."
+  [{:keys [filters frame muted]}]
+  (boolean
+    (or (pills-present? filters)
+        (frame-pinned? frame)
+        (mutes-present? muted))))
+
+(defn indicator-visible?
+  "Should the 'N hidden by filters' indicator render? True iff the
+  hidden count is positive — i.e. the filtered visible set is strictly
+  smaller than the raw visible set. Covers the filtered-to-empty and
+  filtered-to-one cases (both have a positive hidden count whenever raw
+  had more rows). A hidden count of zero hides the indicator even when
+  a filter is technically active but currently suppressing nothing."
+  [hidden]
+  (pos? hidden))
+
+(defn pill-summaries
+  "Flatten the active IN/OUT pills into a render-ready vector of
+  `{:mode :in|:out :label <str> :glyph <str-or-nil>}` so the indicator
+  can list the offending pills as the visible cause. Order: IN pills
+  then OUT pills, preserving bucket order. Pure data — the view wraps
+  each entry in chrome."
+  [{:keys [in out]}]
+  (into
+    (mapv (fn [p] {:mode  :in
+                   :label (typed/pill-label p)
+                   :glyph (typed/pill-glyph p)})
+          (or in []))
+    (mapv (fn [p] {:mode  :out
+                   :label (typed/pill-label p)
+                   :glyph (typed/pill-glyph p)})
+          (or out []))))
+
+(defn summary
+  "The full indicator model for the L2 list. Pure — takes the raw +
+  filtered visible counts and the active filter state, returns the map
+  the view renders against:
+
+      {:hidden          <int>     ; suppressed visible-row count
+       :raw-count       <int>
+       :filtered-count  <int>
+       :visible?        <bool>    ; should the indicator render?
+       :any-active?     <bool>    ; would Clear-filters reset anything?
+       :pills           [{…} …]   ; IN/OUT pill summaries
+       :frame           <kw|nil>  ; pinned frame, nil = unpinned
+       :muted-count     <int>}    ; muted event-ids
+
+  `state` is `{:filters {:in [] :out []} :frame <kw|nil> :muted #{}}`."
+  [raw-visible-count filtered-visible-count state]
+  (let [hidden (hidden-count raw-visible-count filtered-visible-count)]
+    {:hidden         hidden
+     :raw-count      raw-visible-count
+     :filtered-count filtered-visible-count
+     :visible?       (indicator-visible? hidden)
+     :any-active?    (any-filter-active? state)
+     :pills          (pill-summaries (:filters state))
+     :frame          (:frame state)
+     :muted-count    (count (or (:muted state) #{}))}))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -1313,6 +1313,107 @@
      ;; the row's trailing edge.
      (relative-time-chip cascade now-ms)]))
 
+;; ---- 'N hidden by filters' indicator (rf2-jvghz, defect #1) -------------
+;;
+;; Persisted filters (a `:machine` IN-pill under
+;; `re-frame2.causa.filters.v1`, a frame pin under
+;; `re-frame2.causa.frame-switcher.v1`) survive reload via localStorage
+;; and silently suppress L2 rows. Without an indicator the list looks
+;; broken — it fooled the project author. This banner renders whenever
+;; the filtered visible-row set is strictly smaller than the raw set
+;; (`:rf.causa/hidden-by-filters` → `:visible?`), making the active
+;; pills / frame-pin / mutes the VISIBLE cause and offering a one-click
+;; reset (`:rf.causa/clear-all-filters`).
+
+(defn- filter-cause-chip
+  "One small chip naming an active suppressing surface (a pill, the
+  frame pin, or the mute set) inside the indicator banner."
+  [{:keys [testid tone label title]}]
+  [:span {:data-testid testid
+          :title       title
+          :style {:display        "inline-flex"
+                  :align-items    "center"
+                  :gap            "3px"
+                  :border         (str "1px solid " tone)
+                  :color          tone
+                  :padding        "0 5px"
+                  :border-radius  "8px"
+                  :font-family    mono-stack
+                  :font-size      (:caption type-scale)
+                  :white-space    "nowrap"}}
+   label])
+
+(defn filters-hidden-indicator
+  "Pure hiccup. Given the `:rf.causa/hidden-by-filters` summary map,
+  render the 'N events hidden by filters' banner — the offending pills
+  / frame pin / mute count as visible cause chips + a one-click
+  'Clear filters' button. Returns nil when nothing is hidden so the
+  no-filter case stays chromeless.
+
+  Covers the filtered-to-empty and filtered-to-one cases: both report a
+  positive `:hidden` whenever the raw stream carried more visible rows,
+  so the banner renders even when the list below shows 'No events.'"
+  [{:keys [hidden visible? pills frame muted-count] :as _summary}]
+  (when visible?
+    [:div {:data-testid "rf-causa-filters-hidden-indicator"
+           :role        "status"
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :flex-wrap     "wrap"
+                   :gap           "8px"
+                   :padding       "6px 10px"
+                   :background    (:bg-3 tokens)
+                   :border-bottom (str "1px solid " (:yellow tokens))
+                   :font-family   sans-stack
+                   :font-size     (:caption type-scale)
+                   :color         (:text-primary tokens)}}
+     [:span {:data-testid "rf-causa-filters-hidden-count"
+             :style {:font-weight 600 :color (:yellow tokens) :white-space "nowrap"}}
+      (str hidden " event" (when (not= 1 hidden) "s") " hidden by filters")]
+     ;; Cause chips — the active pills, the frame pin, the mute set.
+     (into [:span {:data-testid "rf-causa-filters-hidden-causes"
+                   :style {:display "flex" :align-items "center"
+                           :flex-wrap "wrap" :gap "4px"}}]
+           (concat
+             (for [[idx {:keys [mode label glyph]}] (map-indexed vector pills)]
+               ^{:key (str "pill-" idx)}
+               [filter-cause-chip
+                {:testid (str "rf-causa-filters-hidden-pill-" idx)
+                 :tone   (if (= mode :out) (:magenta tokens) (:green tokens))
+                 :title  (str (name mode) " filter pill")
+                 :label  (str (if (= mode :out) "× " "+ ")
+                              (when glyph (str glyph ":")) label)}])
+             (when frame
+               [^{:key "frame"}
+                [filter-cause-chip
+                 {:testid "rf-causa-filters-hidden-frame"
+                  :tone   (:accent-violet tokens)
+                  :title  "Frame pin — only this frame's events show"
+                  :label  (str "Frame: " frame)}]])
+             (when (pos? muted-count)
+               [^{:key "muted"}
+                [filter-cause-chip
+                 {:testid "rf-causa-filters-hidden-muted"
+                  :tone   (:text-secondary tokens)
+                  :title  "Muted event-ids hidden from the spine"
+                  :label  (str "🔇 " muted-count)}]])))
+     [:button {:data-testid "rf-causa-filters-hidden-clear"
+               :on-click    #(rf/dispatch [:rf.causa/clear-all-filters]
+                                          {:frame :rf/causa})
+               :title       "Clear every filter pill, the frame pin, and all mutes"
+               :style {:margin-left   "auto"
+                       :background    "transparent"
+                       :border        (str "1px solid " (:yellow tokens))
+                       :color         (:yellow tokens)
+                       :cursor        "pointer"
+                       :font-family   sans-stack
+                       :font-size     (:caption type-scale)
+                       :font-weight   600
+                       :padding       "2px 10px"
+                       :border-radius "10px"
+                       :white-space   "nowrap"}}
+      "Clear filters"]]))
+
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
   latest-on-bottom, ~8 visible at the tightened 22px row height
@@ -1358,6 +1459,10 @@
   ;; no-op everywhere it matters.
   (inject-scrollbar-style!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
+        ;; rf2-jvghz — the hidden-by-filters summary drives the banner
+        ;; above the scroll container so suppressed-by-persisted-filter
+        ;; rows are a VISIBLE cause, not a silently-broken-looking list.
+        hidden-summary @(rf/subscribe [:rf.causa/hidden-by-filters])
         focus          @(rf/subscribe [:rf.causa/focus])
         focus-set      @(rf/subscribe [:rf.causa/focus-set])
         ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
@@ -1388,44 +1493,51 @@
         ;; so the per-row work is a single fn call rather than a
         ;; predicate rebuild per row.
         focus-pred     (fh/build-focus-predicate focus-set)]
-    [:div {:data-testid "rf-causa-event-list"
-           :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
-                   :min-height    "48px"    ; 2 rows minimum
-                   :overflow-y    "auto"
-                   :overflow-x    "hidden"
-                   :background    (:bg-2 tokens)
-                   :border-bottom (str "1px solid " (:border-subtle tokens))
-                   :resize        "vertical"   ; native vertical resize for the L2/L3 drag handle
-                   :padding       "4px"
-                   ;; rf2-ieg6d Bug 2 — Firefox standardised props for the
-                   ;; slim scrollbar. WebKit/Blink pseudo-element rules ship
-                   ;; via the `inject-scrollbar-style!` <style> tag above —
-                   ;; pseudo-elements can't be set via React inline-style.
-                   :scrollbar-width "thin"
-                   :scrollbar-color "rgba(107, 112, 128, 0.4) transparent"}}
-     (if (empty? event-cascades)
-       [:div {:data-testid "rf-causa-event-list-empty"
-              :style {:padding   "16px"
-                      :color     (:text-secondary tokens)
-                      :font-family sans-stack
-                      :font-size (:body type-scale)}}
-        "No events."]
-       (into [:ul {:style {:list-style "none" :margin 0 :padding 0
-                           :display "flex" :flex-direction "column"
-                           :gap "2px"}}]
-             (for [cascade event-cascades]
-               ^{:key (str (:dispatch-id cascade))}
-               [event-row {:cascade     cascade
-                           :focused-id  focused-id
-                           :auto-track? auto-track?
-                           :focus-set   focus-set
-                           :in-focus?   (focus-pred cascade)
-                           ;; rf2-b76v4 — pass the spine focus through
-                           ;; so the row's lifecycle-status classifier
-                           ;; can read `:mode` (RETRO → :stale) and
-                           ;; `:paused?` (paused-by-tool → :cyan).
-                           :focus       focus
-                           :now-ms      now-ms}])))]))
+    [:div {:data-testid "rf-causa-event-list-wrap"
+           :style {:display "flex" :flex-direction "column"}}
+     ;; rf2-jvghz — the hidden-by-filters banner sits ABOVE the scroll
+     ;; container so it stays visible even when the filtered list is
+     ;; empty (the filtered-to-empty case) — that is precisely the case
+     ;; that looked broken before.
+     (filters-hidden-indicator hidden-summary)
+     [:div {:data-testid "rf-causa-event-list"
+            :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
+                    :min-height    "48px"    ; 2 rows minimum
+                    :overflow-y    "auto"
+                    :overflow-x    "hidden"
+                    :background    (:bg-2 tokens)
+                    :border-bottom (str "1px solid " (:border-subtle tokens))
+                    :resize        "vertical"   ; native vertical resize for the L2/L3 drag handle
+                    :padding       "4px"
+                    ;; rf2-ieg6d Bug 2 — Firefox standardised props for the
+                    ;; slim scrollbar. WebKit/Blink pseudo-element rules ship
+                    ;; via the `inject-scrollbar-style!` <style> tag above —
+                    ;; pseudo-elements can't be set via React inline-style.
+                    :scrollbar-width "thin"
+                    :scrollbar-color "rgba(107, 112, 128, 0.4) transparent"}}
+      (if (empty? event-cascades)
+        [:div {:data-testid "rf-causa-event-list-empty"
+               :style {:padding   "16px"
+                       :color     (:text-secondary tokens)
+                       :font-family sans-stack
+                       :font-size (:body type-scale)}}
+         "No events."]
+        (into [:ul {:style {:list-style "none" :margin 0 :padding 0
+                            :display "flex" :flex-direction "column"
+                            :gap "2px"}}]
+              (for [cascade event-cascades]
+                ^{:key (str (:dispatch-id cascade))}
+                [event-row {:cascade     cascade
+                            :focused-id  focused-id
+                            :auto-track? auto-track?
+                            :focus-set   focus-set
+                            :in-focus?   (focus-pred cascade)
+                            ;; rf2-b76v4 — pass the spine focus through
+                            ;; so the row's lifecycle-status classifier
+                            ;; can read `:mode` (RETRO → :stale) and
+                            ;; `:paused?` (paused-by-tool → :cyan).
+                            :focus       focus
+                            :now-ms      now-ms}])))]]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
@@ -1,0 +1,233 @@
+(ns day8.re-frame2-causa.filters.hidden-indicator-cljs-test
+  "Integration tests for the L2 'N hidden by filters' indicator
+  (rf2-jvghz, defect #1). Covers:
+
+    1. `:rf.causa/hidden-by-filters` sub composition — raw vs filtered
+       visible counts under an IN pill, a frame pin, and a mute.
+    2. The indicator view renders the count + cause chips + Clear
+       button whenever filtered-count < raw-count (incl. filtered-to-
+       empty).
+    3. `:rf.causa/clear-all-filters` resets pills + frame pin + mutes so
+       the filtered list snaps back to raw and the indicator vanishes.
+
+  Mirrors the spine_filters integration test's registry / frame /
+  trace-bus setup so the sub-graph resolves through the `:rf/causa`
+  frame."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.spine-filters :as spine-filters]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (spine-filters/clear-raw!)
+  (frame-switcher/clear!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (spine-filters/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync ev)))
+
+(defn- dispatch-trace-ev
+  ([id event-vec] (dispatch-trace-ev id event-vec :rf/default))
+  ([id event-vec frame-id]
+   {:id           id
+    :op-type      :event
+    :operation    :event/dispatched
+    :tags         {:event       event-vec
+                   :frame       frame-id
+                   :dispatch-id id}}))
+
+;; ---- hiccup helpers (mirrors spine_filters_cljs_test) -------------------
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- text-of
+  "Concatenate the string leaves under a node — good enough to assert
+  the count message reads as expected."
+  [node]
+  (apply str (filter string? (hiccup-seq node))))
+
+;; -------------------------------------------------------------------------
+;; (1) sub composition
+;; -------------------------------------------------------------------------
+
+(deftest hidden-by-filters-zero-when-no-filters
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b]))
+  (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+    (is (= 0 (:hidden s)))
+    (is (false? (:visible? s)))
+    (is (false? (:any-active? s)))
+    (is (= 2 (:raw-count s)))
+    (is (= 2 (:filtered-count s)))))
+
+(deftest hidden-by-filters-counts-out-pill-suppression
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:auth/login]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:user/mouse-move]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:order/submit]))
+  ;; OUT pill hides :user/mouse-move → 1 hidden.
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :user/mouse-move}])
+  (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+    (is (= 1 (:hidden s)))
+    (is (true? (:visible? s)))
+    (is (true? (:any-active? s)))
+    (is (= 3 (:raw-count s)))
+    (is (= 2 (:filtered-count s)))
+    (is (= 1 (count (:pills s))))
+    (is (= :out (:mode (first (:pills s)))))))
+
+(deftest hidden-by-filters-counts-frame-pin-suppression
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-y))
+  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:c] :rf/frame-y))
+  ;; Pin to :rf/frame-y → only 2 of 3 survive, 1 hidden, frame named.
+  (frame-dispatch [:rf.causa/select-frame :rf/frame-y])
+  (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+    (is (= 1 (:hidden s)))
+    (is (true? (:visible? s)))
+    (is (= :rf/frame-y (:frame s)))))
+
+(deftest hidden-by-filters-counts-mute-suppression
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:noise/tick]))
+  (frame-dispatch [:rf.causa/mute-event-id :noise/tick])
+  (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+    (is (= 1 (:hidden s)))
+    (is (= 1 (:muted-count s)))
+    (is (true? (:visible? s)))))
+
+(deftest hidden-by-filters-frame-pin-to-empty-still-visible
+  (testing "the looked-broken case — pin to a frame with no events leaves
+            zero filtered rows but the summary stays visible"
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-x))
+    (frame-dispatch [:rf.causa/select-frame :rf/empty-frame])
+    (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+      (is (= 2 (:hidden s)))
+      (is (= 0 (:filtered-count s)))
+      (is (true? (:visible? s))))))
+
+;; -------------------------------------------------------------------------
+;; (2) view renders the banner
+;; -------------------------------------------------------------------------
+
+(deftest indicator-renders-count-and-clear-when-hidden
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick]))
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :noise/tick}])
+  (rf/with-frame :rf/causa
+    (let [tree (shell/shell-view)
+          indicator (find-by-testid tree "rf-causa-filters-hidden-indicator")
+          count-node (find-by-testid tree "rf-causa-filters-hidden-count")]
+      (is (some? indicator) "banner renders when rows are hidden")
+      (is (some? (find-by-testid tree "rf-causa-filters-hidden-clear"))
+          "Clear filters button present")
+      (is (some? (find-by-testid tree "rf-causa-filters-hidden-pill-0"))
+          "the OUT pill is named as the cause")
+      (is (re-find #"1 event hidden by filters" (text-of count-node))))))
+
+(deftest indicator-absent-when-nothing-hidden
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b]))
+  (rf/with-frame :rf/causa
+    (let [tree (shell/shell-view)]
+      (is (nil? (find-by-testid tree "rf-causa-filters-hidden-indicator"))
+          "no banner when filtered == raw"))))
+
+;; -------------------------------------------------------------------------
+;; (3) clear-all-filters resets every surface
+;; -------------------------------------------------------------------------
+
+(deftest clear-all-filters-resets-pills-frame-and-mutes
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-x))
+    (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick] :rf/frame-x))
+    (frame-dispatch [:rf.causa/add-filter :in {:pattern :a}])
+    (frame-dispatch [:rf.causa/mute-event-id :noise/tick])
+    (frame-dispatch [:rf.causa/select-frame :rf/frame-x])
+    ;; Pre-clear — pills, frame pin, mute all active.
+    (is (true? (:any-active? (frame-sub [:rf.causa/hidden-by-filters]))))
+    (frame-dispatch [:rf.causa/clear-all-filters])
+    (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+      (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters]))
+          "pills reset")
+      (is (nil? (frame-sub [:rf.causa/current-frame]))
+          "frame pin cleared")
+      (is (= #{} (frame-sub [:rf.causa/muted-event-ids]))
+          "mutes cleared")
+      (is (= 0 (:hidden s)) "nothing hidden after clear")
+      (is (false? (:visible? s)) "indicator vanishes")
+      (is (= 3 (:filtered-count s)) "filtered list snaps back to raw"))
+    ;; Persistence — the unpin + unmute survive a reload read.
+    (is (nil? (frame-switcher/load)) "frame-pin localStorage cleared")
+    (is (= #{} (spine-filters/load)) "mute localStorage cleared")))
+
+(deftest clear-all-filters-removes-banner-from-view
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick]))
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :noise/tick}])
+  (rf/with-frame :rf/causa
+    (is (some? (find-by-testid (shell/shell-view)
+                               "rf-causa-filters-hidden-indicator")))
+    (rf/dispatch-sync [:rf.causa/clear-all-filters])
+    (is (nil? (find-by-testid (shell/shell-view)
+                              "rf-causa-filters-hidden-indicator"))
+        "banner gone after Clear filters")))

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_test.cljc
@@ -1,0 +1,156 @@
+(ns day8.re-frame2-causa.filters.hidden-test
+  "Pure-data tests for the L2 'N hidden by filters' indicator
+  derivation (rf2-jvghz, defect #1).
+
+  CLJC so the JVM corpus exercises the hidden-count derivation +
+  visibility predicate without a CLJS runtime — the helper is pure
+  data, no atoms, no I/O."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.filters.hidden :as hidden]))
+
+;; ---- hidden-count -------------------------------------------------------
+
+(deftest hidden-count-is-raw-minus-filtered
+  (is (= 3 (hidden/hidden-count 5 2)))
+  (is (= 0 (hidden/hidden-count 4 4))
+      "nothing hidden when filtered == raw")
+  (is (= 4 (hidden/hidden-count 4 0))
+      "filtered-to-empty hides the whole raw set"))
+
+(deftest hidden-count-clamps-at-zero
+  (testing "a transient skew where filtered briefly exceeds raw never
+            yields a negative count"
+    (is (= 0 (hidden/hidden-count 2 5)))))
+
+;; ---- present? predicates ------------------------------------------------
+
+(deftest pills-present?-detects-any-bucket
+  (is (false? (hidden/pills-present? nil)))
+  (is (false? (hidden/pills-present? {:in [] :out []})))
+  (is (true?  (hidden/pills-present? {:in [{:pattern :a}] :out []})))
+  (is (true?  (hidden/pills-present? {:in [] :out [{:pattern :b}]}))))
+
+(deftest frame-pinned?-is-some
+  (is (false? (hidden/frame-pinned? nil)))
+  (is (true?  (hidden/frame-pinned? :rf/cart-frame))))
+
+(deftest mutes-present?-detects-nonempty-set
+  (is (false? (hidden/mutes-present? nil)))
+  (is (false? (hidden/mutes-present? #{})))
+  (is (true?  (hidden/mutes-present? #{:a}))))
+
+;; ---- any-filter-active? -------------------------------------------------
+
+(deftest any-filter-active?-true-for-each-surface
+  (is (false? (hidden/any-filter-active?
+                {:filters {:in [] :out []} :frame nil :muted #{}})))
+  (is (true?  (hidden/any-filter-active?
+                {:filters {:in [{:pattern :a}] :out []} :frame nil :muted #{}}))
+      "an IN pill counts")
+  (is (true?  (hidden/any-filter-active?
+                {:filters {:in [] :out []} :frame :rf/cart-frame :muted #{}}))
+      "a frame pin counts")
+  (is (true?  (hidden/any-filter-active?
+                {:filters {:in [] :out []} :frame nil :muted #{:noise}}))
+      "a mute counts"))
+
+(deftest any-filter-active?-independent-of-hidden-count
+  (testing "a filter can be active yet hide nothing (it matches every
+            current cascade) — any-filter-active? is about whether a
+            Clear-filters click would reset anything, not about the
+            count"
+    (is (true? (hidden/any-filter-active?
+                 {:filters {:in [{:pattern :a}] :out []}
+                  :frame nil :muted #{}})))))
+
+;; ---- indicator-visible? -------------------------------------------------
+
+(deftest indicator-visible?-only-when-something-hidden
+  (is (false? (hidden/indicator-visible? 0)))
+  (is (true?  (hidden/indicator-visible? 1)))
+  (is (true?  (hidden/indicator-visible? 9))))
+
+;; ---- pill-summaries -----------------------------------------------------
+
+(deftest pill-summaries-flatten-in-then-out
+  (let [summaries (hidden/pill-summaries
+                    {:in  [{:pattern :auth/login}]
+                     :out [{:pattern :noise/tick}]})]
+    (is (= 2 (count summaries)))
+    (is (= :in  (:mode (first summaries))))
+    (is (= :out (:mode (second summaries))))
+    (is (= ":auth/login" (:label (first summaries))))
+    (is (= ":noise/tick" (:label (second summaries))))))
+
+(deftest pill-summaries-carry-typed-glyph
+  (testing "a :machine typed pill surfaces its 'M' glyph + machine-id
+            label so the indicator names it as the cause"
+    (let [[s] (hidden/pill-summaries
+                {:in [{:kind :machine :params {:machine-id :checkout/fsm}}]
+                 :out []})]
+      (is (= "M" (:glyph s)))
+      (is (= ":checkout/fsm" (:label s))))))
+
+(deftest pill-summaries-empty-for-no-pills
+  (is (= [] (hidden/pill-summaries {:in [] :out []})))
+  (is (= [] (hidden/pill-summaries nil))))
+
+;; ---- summary (the full model) -------------------------------------------
+
+(deftest summary-machine-pill-suppressing-rows
+  (testing "the persisted :machine IN-pill case from the bug — raw has 5
+            visible rows, the pill leaves 1; the summary reports 4 hidden,
+            visible, with the pill named as cause"
+    (let [s (hidden/summary 5 1
+                            {:filters {:in [{:kind :machine
+                                             :params {:machine-id :checkout/fsm}}]
+                                       :out []}
+                             :frame nil
+                             :muted #{}})]
+      (is (= 4 (:hidden s)))
+      (is (true? (:visible? s)))
+      (is (true? (:any-active? s)))
+      (is (= 5 (:raw-count s)))
+      (is (= 1 (:filtered-count s)))
+      (is (= 1 (count (:pills s))))
+      (is (= ":checkout/fsm" (:label (first (:pills s)))))
+      (is (nil? (:frame s)))
+      (is (= 0 (:muted-count s))))))
+
+(deftest summary-filtered-to-empty-still-visible
+  (testing "the frame-pin-to-empty case — raw has rows, the pin leaves
+            zero; the banner MUST still render (this is the looked-broken
+            case)"
+    (let [s (hidden/summary 6 0
+                            {:filters {:in [] :out []}
+                             :frame :rf/other-frame
+                             :muted #{}})]
+      (is (= 6 (:hidden s)))
+      (is (true? (:visible? s)))
+      (is (= :rf/other-frame (:frame s))))))
+
+(deftest summary-filtered-to-one-visible
+  (testing "the filtered-to-one case — raw 4, filtered 1; reports 3
+            hidden and renders"
+    (let [s (hidden/summary 4 1
+                            {:filters {:in [{:pattern :a}] :out []}
+                             :frame nil :muted #{}})]
+      (is (= 3 (:hidden s)))
+      (is (true? (:visible? s))))))
+
+(deftest summary-nothing-hidden-not-visible
+  (testing "no filter active, filtered == raw → no banner"
+    (let [s (hidden/summary 7 7
+                            {:filters {:in [] :out []} :frame nil :muted #{}})]
+      (is (= 0 (:hidden s)))
+      (is (false? (:visible? s)))
+      (is (false? (:any-active? s))))))
+
+(deftest summary-counts-mutes
+  (let [s (hidden/summary 5 3
+                          {:filters {:in [] :out []}
+                           :frame nil
+                           :muted #{:noise/tick :user/mouse-move}})]
+    (is (= 2 (:hidden s)))
+    (is (= 2 (:muted-count s)))
+    (is (true? (:visible? s)))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -143,6 +143,9 @@
    :rf.causa/epoch-history
    :rf.causa/event-detail
    :rf.causa/filtered-cascades
+   ;; rf2-jvghz — model behind the L2 'N hidden by filters' indicator
+   ;; (raw vs filtered visible counts + the active filter cause).
+   :rf.causa/hidden-by-filters
    :rf.causa/focus
    ;; rf2-70tkv — App-DB diff subs pivot off the spine's focus
    ;; `:epoch-id` (which auto-tracks head in LIVE mode) instead of
@@ -361,6 +364,9 @@
    :rf.causa/cancellation-cascade-open
    :rf.causa/cancellation-cascade-set-expanded
    :rf.causa/cancellation-cascade-toggle-expand
+   ;; rf2-jvghz — one-click reset behind the L2 'N hidden by filters'
+   ;; indicator (resets IN/OUT pills + frame pin + mutes).
+   :rf.causa/clear-all-filters
    :rf.causa/clear-machine-selection
    ;; rf2-a1z3b — focus-navigation primitive (gutter click on L2 row sets a
    ;; focus-set; `[◀][▶]` step within the in-focus subset).


### PR DESCRIPTION
## Summary

Defect #1 of rf2-jvghz only.

**Root cause.** After the epoch-per-event merges, Causa's L2 event list could look broken on reload: persisted filters left in localStorage silently suppressed cascade rows with NO visible indicator. Specifically the `re-frame2.causa.filters.v1` `:machine` IN-pill, the `re-frame2.causa.frame-switcher.v1` frame pin, and the `causa.spine.muted-event-ids` set survive reload. The L2 list reads `:rf.causa/filtered-cascades` while the raw stream lives on `:rf.causa/cascades`, so a filter-suppressed list was indistinguishable from a broken tool (it fooled the project author).

**The fix.** A prominent "events hidden by filters" affordance in the L2 list:

- `filters/hidden.cljc` — pure (JVM-runnable) derivation: hidden count `(raw-visible - filtered-visible, clamped)`, the indicator-visibility predicate, and the active-filter cause summary.
- `:rf.causa/hidden-by-filters` sub — composes raw + filtered cascades and the active filter state, counting over the same `l2-cascade-visible?` set the list renders so N matches the rows the user sees. Renders whenever `filtered-count < raw-count` — covers the filtered-to-empty and filtered-to-one cases.
- The L2 list renders a banner above the scroll container: "N events hidden by filters", the offending IN/OUT pills + frame pin + mute count as visible cause chips, and a one-click **Clear filters** button.
- `:rf.causa/clear-all-filters` event — resets IN/OUT pills + frame pin + mutes (each via its owning persistence path) so the filtered list snaps back to raw.

**Scope / deferred (this PR does NOT change these):**
- Persistence behaviour (persist-vs-reset of filter pills / frame-pin across reload) is left exactly as-is — a Mike design decision, filed as **rf2-swclw**.
- Machine-pill causal-parent matching under epoch-per-event (defect #2) is unchanged — filed as **rf2-a1eld**.

rf2-jvghz stays `in_progress` (defect #2 lives there); defect #1 (the indicator) lands here.

## Test plan

- [x] `npm run test:cljs` — 4087 tests / 12413 assertions, 0 failures (incl. new `filters/hidden_test.cljc` + `filters/hidden_indicator_cljs_test.cljs`; registry drift snapshot updated for the new event + sub)
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- [ ] Manual: load Causa with a persisted filter, confirm the banner names the cause and Clear filters restores the full list