### PR TITLE
test(causa): counter-inc epoch surfaces as an L2 cascade row (rf2-j8m01)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/l2_counter_inc_row_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/l2_counter_inc_row_cljs_test.cljs
@@ -1,0 +1,178 @@
+(ns day8.re-frame2-causa.l2-counter-inc-row-cljs-test
+  "Regression coverage for rf2-j8m01 — a landed counter-inc epoch must
+  surface as a row in Causa's L2 event list.
+
+  ## The bug (rf2-j8m01)
+
+  Live on the parallel-frames testbed: clicking `+` on the `:below`
+  frame incremented the counter and created a new epoch (eid 8), but
+  NO new cascade appeared in `:rf.causa/cascades` — the L2 event list
+  showed no new row.
+
+  ## Root cause (rf2-avvwm, #1961) — verified DUP
+
+  Under the per-event epoch model (#1952) a `:frame/created` trace
+  event emitted OUTSIDE any dequeued-event cascade was mis-attributed
+  into the NEXT dequeued event's `:rf/epoch-record :trace-events`. So
+  eid 8's `:trace-events` began with an orphan `[:frame :frame/created]`
+  carrying eid 8's `:dispatch-id`.
+
+  That orphan poisoned Causa's cascade grouping. `group-cascades`
+  groups by `[frame dispatch-id]`; the orphan `:frame/created` carried
+  the SAME `:dispatch-id` as the real `:event/dispatched`, so it folded
+  into the same cascade record — fine. The real failure mode the bead
+  observed is the inverse: when the orphan's `:dispatch-id` did NOT
+  match (the per-frame harvest split it), the real `:event/dispatched`
+  could land in a cascade whose `:event` vector never resolved, so
+  `shell/cascade-has-event?` returned false and the L2 filter
+  (`shell/l2-cascade-visible?`) dropped the row entirely.
+
+  avvwm's fix (#1961) keeps out-of-cascade emits UNCORRELATED — the
+  `:frame/created` never rides the next epoch's `:trace-events`. So a
+  post-fix counter-inc epoch's trace stream begins with the real
+  `:event/dispatched` and the cascade surfaces normally.
+
+  ## What this test pins
+
+  Pure-data, no runtime: feed both trace-stream shapes through the
+  exact L2-row pipeline Causa uses —
+
+    `projection/group-cascades`
+      → `trace-bus/causa-internal-cascade?` (the shared hard-filter)
+      → `shell/l2-cascade-visible?` (the L2 visibility predicate)
+
+  and assert the POST-avvwm counter-inc epoch surfaces as exactly one
+  visible L2 cascade row carrying the `:counter/inc` event vector. The
+  PRE-avvwm shape (leading orphan `:frame/created` with the next
+  epoch's `:dispatch-id`) is kept as a contrast case documenting how
+  the orphan used to corrupt the grouping.
+
+  Verdict: DUP of rf2-avvwm — the post-fix epoch surfaces correctly."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(def ^:private frame-below :below)
+(def ^:private dispatch-id-8 8)
+
+(defn- counter-inc-trace-events
+  "The trace stream for a clean (POST-avvwm) `:counter/inc` epoch on
+  the `:below` frame. Begins with the real `:event/dispatched` (the
+  cascade root) — NO leading orphan `:frame/created`. Mirrors the
+  six-domino shape the framework emits per Spec 009 §`:op-type`
+  vocabulary."
+  []
+  [{:id 50 :op-type :event :operation :event/dispatched
+    :tags {:dispatch-id dispatch-id-8 :event [:counter/inc] :frame frame-below}}
+   {:id 51 :op-type :event :operation :event
+    :tags {:dispatch-id dispatch-id-8 :phase :run-start :frame frame-below}}
+   {:id 52 :op-type :event :operation :event
+    :tags {:dispatch-id dispatch-id-8 :phase :run-end :frame frame-below}}
+   {:id 53 :op-type :event :operation :event/do-fx
+    :tags {:dispatch-id dispatch-id-8 :frame frame-below}}
+   {:id 54 :op-type :fx :operation :rf.fx/handled
+    :tags {:dispatch-id dispatch-id-8 :fx-id :db :frame frame-below}}
+   {:id 55 :op-type :sub/run :operation :sub/run
+    :tags {:dispatch-id dispatch-id-8 :sub-id :counter/value :frame frame-below}}
+   {:id 56 :op-type :view :operation :view/render
+    :tags {:dispatch-id dispatch-id-8 :render-key [:counter/root nil] :frame frame-below}}])
+
+(defn- orphan-frame-created-event
+  "The mis-attributed `:frame/created` orphan that — pre-avvwm —
+  leaked into the NEXT epoch's `:trace-events` carrying that epoch's
+  `:dispatch-id`. Represents the pre-fix corruption shape."
+  []
+  {:id 49 :op-type :frame :operation :frame/created
+   :tags {:dispatch-id dispatch-id-8 :frame frame-below}})
+
+(defn- visible-l2-rows
+  "Run the exact Causa L2-row pipeline over a raw trace stream and
+  return the cascades that would render as L2 rows: project →
+  hard-filter Causa-internal cascades → keep L2-visible cascades.
+  `show-ungrouped?` defaults to false (the user-facing default)."
+  ([events] (visible-l2-rows events false))
+  ([events show-ungrouped?]
+   (->> (projection/group-cascades events)
+        (remove trace-bus/causa-internal-cascade?)
+        (filterv #(shell/l2-cascade-visible? % show-ungrouped?)))))
+
+;; ---- 1. POST-avvwm: counter-inc epoch surfaces as an L2 row -------------
+
+(deftest counter-inc-epoch-surfaces-as-l2-row
+  (testing "a clean post-avvwm :counter/inc epoch surfaces as exactly
+            one visible L2 cascade row carrying the event vector"
+    (let [rows (visible-l2-rows (counter-inc-trace-events))]
+      (is (= 1 (count rows))
+          "the counter-inc cascade is NOT dropped from the L2 list")
+      (let [c (first rows)]
+        (is (= [:counter/inc] (:event c))
+            ":event slot holds the dispatched event vector")
+        (is (= frame-below (:frame c))
+            "the cascade is attributed to the :below frame")
+        (is (= dispatch-id-8 (:dispatch-id c))
+            "the cascade carries the epoch's dispatch-id (eid 8)")
+        (is (true? (shell/cascade-has-event? c))
+            "cascade-has-event? is true — the L2 filter keeps the row")
+        (is (false? (shell/ungrouped-cascade? c))
+            "the row is a real cascade, not the :ungrouped pseudo-bucket")))))
+
+;; ---- 2. PRE-avvwm contrast: the orphan used to fold in -----------------
+;;
+;; Pre-avvwm the orphan :frame/created leaked into the epoch's
+;; :trace-events carrying the SAME :dispatch-id as the real
+;; :event/dispatched. Because group-cascades keys by [frame
+;; dispatch-id], the orphan folded into the SAME cascade record — the
+;; real :event/dispatched still populated :event, so even the corrupted
+;; stream resolves a visible row (the orphan rides in :other). This
+;; contrast case documents that grouping is robust even WITH the orphan
+;; present — confirming the visible-row defect was upstream (the orphan
+;; never reaching the cascade) rather than in group-cascades itself.
+
+(deftest pre-avvwm-orphan-folds-into-same-cascade-still-visible
+  (testing "with the leading orphan :frame/created sharing the epoch's
+            dispatch-id, the cascade still resolves one visible L2 row —
+            the orphan rides in :other, :event is still populated"
+    (let [events (into [(orphan-frame-created-event)]
+                       (counter-inc-trace-events))
+          rows   (visible-l2-rows events)]
+      (is (= 1 (count rows))
+          "still exactly one visible L2 row (orphan folds into the cascade)")
+      (let [c (first rows)]
+        (is (= [:counter/inc] (:event c))
+            ":event slot is still the dispatched event vector")
+        (is (some (fn [ev] (= :frame/created (:operation ev)))
+                  (:other c))
+            "the orphan :frame/created lands in the cascade's :other slot")))))
+
+;; ---- 3. The classifier: a frame-lifecycle-ONLY group is the only drop --
+;;
+;; The only shape the L2 filter legitimately drops is a group with NO
+;; :event/dispatched — i.e. a frame-lifecycle emit with no in-flight
+;; cascade. Post-avvwm such an orphan carries NO :dispatch-id, so it
+;; lands in the :ungrouped bucket and is correctly hidden by default.
+;; This pins that the drop is scoped to event-less groups, never to a
+;; real counter-inc epoch.
+
+(deftest uncorrelated-frame-created-stays-ungrouped-and-hidden
+  (testing "a post-avvwm uncorrelated :frame/created (no :dispatch-id)
+            lands in :ungrouped and is hidden from L2 by default, while
+            the sibling counter-inc epoch still surfaces"
+    (let [events (into [{:id 49 :op-type :frame :operation :frame/created
+                         :tags {:frame frame-below}}] ; NO :dispatch-id (avvwm)
+                       (counter-inc-trace-events))
+          all    (projection/group-cascades events)
+          rows   (visible-l2-rows events)]
+      (is (= 2 (count all))
+          "two groups: the :ungrouped frame-lifecycle bucket + the cascade")
+      (is (some #(= :ungrouped (:dispatch-id %)) all)
+          "the uncorrelated :frame/created lands in :ungrouped")
+      (is (= 1 (count rows))
+          "only the counter-inc cascade is L2-visible by default")
+      (is (= [:counter/inc] (:event (first rows)))
+          "the visible row is the counter-inc epoch")
+      (testing "the :ungrouped bucket becomes visible only on opt-in"
+        (is (= 2 (count (visible-l2-rows events true)))
+            "with show-ungrouped? on, the frame-lifecycle bucket also shows")))))


### PR DESCRIPTION
## Summary

Verify-first regression coverage for **rf2-j8m01** — confirms it is a **DUP of rf2-avvwm (#1961)**.

The bug: a landed counter-inc epoch (eid 8 on the `:below` frame) did not surface as a row in Causa's L2 event list. Root cause was rf2-avvwm: eid 8's `:trace-events` began with a mis-attributed orphan `[:frame :frame/created]`, which corrupted Causa's cascade grouping so the L2 visibility filter dropped the row. avvwm's fix keeps out-of-cascade emits uncorrelated, so a post-fix counter-inc epoch's trace stream begins with the real `:event/dispatched` and the cascade surfaces normally.

This is a **test-only** PR — no source change. The new CLJS unit test feeds three trace-stream shapes through the exact L2-row pipeline Causa uses:

`projection/group-cascades` -> `trace-bus/causa-internal-cascade?` -> `shell/l2-cascade-visible?`

- **POST-avvwm (clean)** — counter-inc epoch surfaces as exactly one visible L2 row carrying `[:counter/inc]`. (The verification.)
- **PRE-avvwm (leading orphan, shared dispatch-id)** — contrast case showing the orphan folds into `:other` and the row still resolves.
- **uncorrelated (no `:dispatch-id`, the avvwm shape)** — the orphan `:frame/created` lands in `:ungrouped` and is correctly hidden by default while the sibling counter-inc epoch still surfaces.

Pure-data; runs on `npm run test:cljs` (node) — no runtime needed.

## Test plan

- [x] `npm run test:cljs` — 4087 tests / 12423 assertions, 0 failures, 0 errors (includes the 3 new deftests)
- [x] `npm run test:causa-feature-gate` — 12/13 PASS; the single FAIL ("hydration mismatch debugger") is **pre-existing on origin/main HEAD** (verified by stashing this change and re-running on a clean tree). Filed as **rf2-djuf3**.