### PR TITLE
fix(core): tool frames (:rf/causa) emit no trace — stop inspector saturating the shared ring (rf2-2qaqh)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -295,6 +295,15 @@
   [id metadata]
   (let [config (source-coords/merge-coords (expand-preset metadata))]
     (registrar/register! :frame id config)
+    ;; Frame-level trace-emission gate (rf2-2qaqh): a frame registered
+    ;; with `:rf.trace/frame-no-emit? true` is a tool / inspector frame
+    ;; (e.g. Causa's `:rf/causa`) whose own reactive substrate must NOT
+    ;; flood the shared trace ring it inspects. The flag is the frame-
+    ;; scoped sibling of the handler-scoped `:rf.trace/no-emit?`
+    ;; (Spec 009 §Trace-emission opt-out). Honoured on BOTH first
+    ;; registration and re-registration so a hot-reload can flip it
+    ;; either way; `trace.cljc` owns the canonical set + predicate.
+    (trace/set-frame-no-emit! id (true? (:rf.trace/frame-no-emit? config)))
     (let [existing (get @frames id)]
       (cond
         ;; First registration: create everything.

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -164,6 +164,75 @@
                                     (->HandlerScope nil cs# did# false false))]
           ~@body))))
 
+;; ---- trace-disabled (tool / inspector) frames ----------------------------
+;;
+;; Per rf2-2qaqh: an inspector tool (Causa, Story, re-frame2-pair) renders
+;; its OWN UI inside a dedicated frame (`:rf/causa`). That UI's reactive
+;; substrate emits `:sub/run` + `:view/render` trace events on every panel
+;; render — and because the shared ring buffer is process-global, the
+;; tool's self-instrumentation evicts every APPLICATION event from the
+;; ring (observed: 200/200 events were `:rf/causa`; zero app events). The
+;; inspector must not flood the buffer it inspects.
+;;
+;; The fix is a frame-level emission gate, the frame-scoped sibling of the
+;; handler-scoped `:rf.trace/no-emit?` (Spec 009 §Trace-emission opt-out):
+;; a frame registered with `:rf.trace/frame-no-emit? true` is recorded
+;; here, and `emit!` / `emit-error!` short-circuit (no envelope alloc, no
+;; delivery) for any event tagged with that frame. Causa marks `:rf/causa`
+;; trace-disabled at frame registration (`mount/ensure-causa-frame!`), so
+;; tool frames produce no trace at all while application frames are
+;; unaffected.
+;;
+;; Mechanism (not a hardcoded `:rf/causa` literal): `frame.cljc`'s
+;; `reg-frame` reads the config flag and calls `set-frame-no-emit!` —
+;; trace.cljc owns the canonical set + predicate so the gate is single-
+;; sourced. The set is held under a defonce atom so a hot `:after-load`
+;; cycle never wipes prior registrations; the empty-set common case (no
+;; tool frame mounted) short-circuits on `(seq …)` before any membership
+;; test, so the hot emit path pays a single nil-check when no tool frame
+;; is registered.
+
+(defonce ^:private trace-disabled-frames
+  ;; Set of frame-ids whose trace emission is suppressed. Populated by
+  ;; `frame.cljc`'s `reg-frame` from the `:rf.trace/frame-no-emit?`
+  ;; config flag (and cleared on re-registration when the flag drops).
+  (atom #{}))
+
+(defn set-frame-no-emit!
+  "Mark / unmark `frame-id` as trace-disabled. When `no-emit?` is truthy
+  the frame is added to the trace-disabled set; otherwise it is removed.
+  `emit!` / `emit-error!` short-circuit for any event whose `:frame` tag
+  is in the set. Idempotent. Per Spec 009 §Trace-emission opt-out
+  (frame-level) and rf2-2qaqh."
+  [frame-id no-emit?]
+  (swap! trace-disabled-frames (if no-emit? conj disj) frame-id)
+  nil)
+
+(defn frame-trace-disabled?
+  "Canonical predicate: true iff `frame-id` is currently registered
+  trace-disabled (a tool / inspector frame). Single-sourced here so no
+  call site hardcodes `:rf/causa`."
+  [frame-id]
+  (contains? @trace-disabled-frames frame-id))
+
+(defn clear-frame-no-emit!
+  "Reset the trace-disabled-frames set to empty. Test / teardown helper —
+  the per-frame flag is otherwise process-sticky (it tracks frame
+  registrations, which `reset! frame/frames {}` does not unwind)."
+  []
+  (reset! trace-disabled-frames #{})
+  nil)
+
+(defn- tagged-frame-trace-disabled?
+  "True when `tags` carries a `:frame` that is registered trace-disabled.
+  The empty-set common case (no tool frame mounted) short-circuits
+  before the membership test so the hot emit path is unaffected when no
+  inspector is running."
+  [tags]
+  (let [disabled @trace-disabled-frames]
+    (and (seq disabled)
+         (contains? disabled (:frame tags)))))
+
 ;; ---- emission -------------------------------------------------------------
 
 (defn- deliver-to-epoch-capture!
@@ -319,8 +388,13 @@
     ;; `:no-emit?` short-circuit sits *inside* the outer
     ;; `interop/debug-enabled?` gate per Spec 009 §Production builds
     ;; (the outer gate must stand alone for Closure DCE — see
-    ;; §Production-elision verification).
-    (when-not (true? (some-> *handler-scope* :no-emit?))
+    ;; §Production-elision verification). The frame-level gate
+    ;; (rf2-2qaqh) is its sibling: an event tagged with a trace-
+    ;; disabled (tool / inspector) frame is suppressed before any
+    ;; envelope is built — the inspector's own reactivity must not
+    ;; flood the buffer it inspects.
+    (when-not (or (true? (some-> *handler-scope* :no-emit?))
+                  (tagged-frame-trace-disabled? tags))
       (deliver! (maybe-project-marks (build-event op operation tags))))))
 
 (defn emit-error!
@@ -341,7 +415,11 @@
   (when interop/debug-enabled?
     ;; `:no-emit?` short-circuit sits *inside* the outer
     ;; `interop/debug-enabled?` gate per Spec 009 §Production builds.
-    (when-not (true? (some-> *handler-scope* :no-emit?))
+    ;; The frame-level gate (rf2-2qaqh) suppresses errors emitted from
+    ;; a trace-disabled (tool / inspector) frame too — symmetric with
+    ;; `emit!`.
+    (when-not (or (true? (some-> *handler-scope* :no-emit?))
+                  (tagged-frame-trace-disabled? tags))
       (deliver! (maybe-project-marks (build-event :error error-operation tags))))))
 
 ;; ---- late-bind hook registration ------------------------------------------

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -34,6 +34,10 @@
   (reset! schemas/schemas-by-frame {})
   (trace/clear-listeners!)
   (rf/clear-trace-buffer!)
+  ;; rf2-2qaqh — the frame-level trace-emission gate (the trace-disabled
+  ;; frame set) is process-sticky and is NOT unwound by `reset! frames`,
+  ;; so clear it between tests to avoid a tool-frame flag bleeding forward.
+  (trace/clear-frame-no-emit!)
   ;; Restore default depth between tests so a depth-tweaking test does
   ;; not bleed configuration into the next.
   (rf/configure :trace-buffer {:depth 200})
@@ -494,3 +498,86 @@
     (let [router-evs (rf/trace-buffer {:rf/dispatch-origin :router})]
       (is (seq router-evs))
       (is (every? #(= :router (get-in % [:tags :rf/dispatch-origin])) router-evs)))))
+
+;; ---- 5. Frame-level trace-emission gate (rf2-2qaqh) ------------------------
+;;
+;; A tool / inspector frame registered with `:rf.trace/frame-no-emit? true`
+;; (e.g. Causa's `:rf/causa`) produces NO trace — its own reactivity must
+;; not flood the shared ring buffer it inspects. The frame-scoped sibling
+;; of the handler-scoped `:rf.trace/no-emit?` (Spec 009 §Trace-emission
+;; opt-out). The gate keys on the event's `:frame` tag, single-sourced via
+;; `trace/frame-trace-disabled?`.
+
+(deftest tool-frame-emits-no-trace
+  (testing "a frame registered :rf.trace/frame-no-emit? true grows the ring by 0"
+    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
+    (rf/reg-event-db :tool/work (fn [db _] (assoc db :ran? true)))
+    (rf/clear-trace-buffer!)
+    (is (= [] (rf/trace-buffer))
+        "buffer empty after clear (the :frame/created emit was suppressed too)")
+    ;; Drive a full cascade ON the tool frame: dispatch, db-change, the
+    ;; whole drain. None of it should reach the ring.
+    (rf/dispatch-sync [:tool/work] {:frame :tool/inspector})
+    (is (= [] (rf/trace-buffer))
+        "no trace event from a trace-disabled frame's cascade reaches the ring")))
+
+(deftest app-frame-emits-trace-while-tool-frame-silent
+  (testing "an app frame's cascade DOES grow the ring; the tool frame's does NOT"
+    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
+    (rf/reg-frame :app/main {:doc "ordinary application frame"})
+    (rf/reg-event-db :work (fn [db _] (assoc db :ran? true)))
+    (rf/clear-trace-buffer!)
+    ;; Interleave: tool-frame noise must never displace app-frame signal.
+    (dotimes [_ 20] (rf/dispatch-sync [:work] {:frame :tool/inspector}))
+    (rf/dispatch-sync [:work] {:frame :app/main})
+    (let [buf (rf/trace-buffer)]
+      (is (seq buf) "app-frame cascade produced trace")
+      (is (every? #(not= :tool/inspector
+                         (or (:frame %) (get-in % [:tags :frame])))
+                  buf)
+          "NO event in the ring is tagged with the trace-disabled frame")
+      (is (some #(= :app/main (or (:frame %) (get-in % [:tags :frame]))) buf)
+          "the app-frame events survived (not evicted by tool noise)"))))
+
+(deftest tool-frame-self-instrumentation-does-not-saturate-ring
+  (testing "the rf2-2qaqh scenario: heavy tool-frame churn cannot evict app events"
+    (rf/configure :trace-buffer {:depth 50})
+    (rf/reg-frame :tool/inspector {:rf.trace/frame-no-emit? true})
+    (rf/reg-frame :app/main {:doc "app"})
+    (rf/reg-event-db :work (fn [db _] db))
+    (rf/dispatch-sync [:work] {:frame :app/main})
+    (rf/clear-trace-buffer!)
+    ;; Seed one app cascade, then bury it under far more tool-frame churn
+    ;; than the ring depth — pre-fix this evicted the app event entirely.
+    (rf/dispatch-sync [:work] {:frame :app/main})
+    (dotimes [_ 500] (rf/dispatch-sync [:work] {:frame :tool/inspector}))
+    (let [buf (rf/trace-buffer)]
+      (is (some #(= :app/main (or (:frame %) (get-in % [:tags :frame]))) buf)
+          "the app-frame event is STILL in the ring after 500 tool dispatches")
+      (is (empty? (rf/trace-buffer {:frame :tool/inspector}))
+          "zero tool-frame events in the ring"))))
+
+(deftest frame-no-emit-flag-clears-on-re-registration
+  (testing "re-registering a frame WITHOUT the flag re-enables its trace"
+    (rf/reg-frame :flip/frame {:rf.trace/frame-no-emit? true})
+    (rf/reg-event-db :work (fn [db _] db))
+    (is (trace/frame-trace-disabled? :flip/frame)
+        "predicate reports the flag is set")
+    (rf/clear-trace-buffer!)
+    (rf/dispatch-sync [:work] {:frame :flip/frame})
+    (is (= [] (rf/trace-buffer)) "trace suppressed while flag set")
+    ;; Surgical re-registration drops the flag → trace re-enabled.
+    (rf/reg-frame :flip/frame {:doc "now a normal frame"})
+    (is (not (trace/frame-trace-disabled? :flip/frame))
+        "predicate reports the flag cleared on re-registration")
+    (rf/clear-trace-buffer!)
+    (rf/dispatch-sync [:work] {:frame :flip/frame})
+    (is (seq (rf/trace-buffer)) "trace flows again once the flag is cleared")))
+
+(deftest frame-trace-disabled-predicate-is-single-sourced
+  (testing "set-frame-no-emit! / frame-trace-disabled? toggle the canonical set"
+    (is (not (trace/frame-trace-disabled? :probe/frame)))
+    (trace/set-frame-no-emit! :probe/frame true)
+    (is (trace/frame-trace-disabled? :probe/frame))
+    (trace/set-frame-no-emit! :probe/frame false)
+    (is (not (trace/frame-trace-disabled? :probe/frame)))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -460,6 +460,24 @@ Semantics:
 
 Per rf2-nk01x / rf2-qsjda and the framework `re-frame.trace/*handler-scope*` Var's `:no-emit?` slot (per [§Handler-scope](#handler-scope-the-in-scope-reading-at-emit-time)).
 
+### Frame-level trace-emission opt-out: `:rf.trace/frame-no-emit?` frame-config
+
+A frame registered with `:rf.trace/frame-no-emit? true` produces **no trace events**: `emit!` / `emit-error!` short-circuit (no envelope allocation, no delivery) for any event whose `:frame` tag matches a frame so marked. This is the frame-scoped sibling of the handler-scoped `:rf.trace/no-emit?` above — the same suppression boundary, keyed on the frame rather than the in-scope handler.
+
+```clojure
+(rf/reg-frame :rf/causa {:rf.trace/frame-no-emit? true})   ;; <- tool / inspector frame
+```
+
+The flag is the framework-level escape hatch for **inspector tools** (Causa, Story, re-frame2-pair) that render their own UI inside a dedicated frame. That UI's reactive substrate emits `:sub/run` + `:view/render` on every panel render; because the retain-N ring is process-global, an inspector's self-instrumentation would otherwise evict every *application* event from the buffer it inspects (observed under rf2-2qaqh: the ring held 200/200 `:rf/causa` events and zero app events, so any other raw-buffer consumer saw only inspector noise). Marking the tool frame trace-disabled means tool frames produce no trace at all, while application frames are unaffected.
+
+Semantics:
+
+- **What's suppressed.** Every trace + error emit tagged with the marked frame — `:event/dispatched`, `:run-start` / `:run-end`, `:event/db-changed`, `:sub/run`, `:view/render`, `:frame/created` for the frame itself, and every `:rf.error/*` whose `:frame` is the marked frame. The framework's emit sites already thread `:frame` onto these tags, so the gate keys on `(:frame tags)`.
+- **Mechanism (one canonical predicate).** `re-frame.trace/frame-trace-disabled?` is the single source of truth; `reg-frame` reads the config flag and calls `re-frame.trace/set-frame-no-emit!`. No call site hardcodes a frame id (e.g. `:rf/causa`). Honoured on first registration *and* surgical re-registration so a hot-reload can flip it either way.
+- **Production elision.** The gate sits inside the same `interop/debug-enabled?` `when` as the rest of the emit substrate, so it DCEs out of `:advanced` production builds (which emit no trace at all).
+
+Per rf2-2qaqh.
+
 ### Where trace emission lives
 
 The framework emits trace events from these call sites:

--- a/spec/API.md
+++ b/spec/API.md
@@ -461,6 +461,7 @@ Event-handler registration accepts a `:rf.trace/no-emit? true` metadata flag (rf
 | Metadata key | Where | Value | Default | Effect |
 |---|---|---|---|---|
 | `:rf.trace/no-emit?` | `reg-event-db` / `reg-event-fx` / `reg-event-ctx` metadata map | boolean | `false` | When `true`, suppresses all trace + event-emit emissions inside the handler's scope. Per [009 §Trace-emission opt-out](009-Instrumentation.md#trace-emission-opt-out-rftraceno-emit-event-meta). |
+| `:rf.trace/frame-no-emit?` | `reg-frame` config map | boolean | `false` | When `true`, marks the frame a tool / inspector frame: the runtime suppresses every trace emission tagged with that frame, so the inspector's own reactivity does not flood the shared ring it inspects. The frame-scoped sibling of `:rf.trace/no-emit?`. Per [009 §Frame-level trace-emission opt-out](009-Instrumentation.md#frame-level-trace-emission-opt-out-rftraceframe-no-emit-frame-config) (rf2-2qaqh). |
 
 ### Epoch history (per Tool-Pair)
 

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -395,7 +395,17 @@
     in lockstep — symmetric with the picker path and the public
     `core/set-target-frame!` API."
   []
-  (rf/reg-frame :rf/causa {})
+  ;; `:rf.trace/frame-no-emit? true` marks `:rf/causa` a tool / inspector
+  ;; frame: the framework suppresses all trace emission tagged with this
+  ;; frame so Causa's own UI reactivity (`:sub/run` + `:view/render` on
+  ;; every panel render) does NOT flood the shared trace ring it inspects
+  ;; (rf2-2qaqh). Without this, Causa's self-instrumentation evicted every
+  ;; application event from the process-global ring buffer — any other
+  ;; consumer reading the raw buffer (re-frame2-pair, Story) saw only
+  ;; Causa noise. The flag is the frame-scoped sibling of the handler-
+  ;; scoped `:rf.trace/no-emit?`; the framework's `reg-frame` honours it
+  ;; on every (re-)registration so the gate survives hot-reload.
+  (rf/reg-frame :rf/causa {:rf.trace/frame-no-emit? true})
   (doseq [{:keys [handler]} @first-mount-hooks]
     (handler)))
 


### PR DESCRIPTION
## Summary

Fixes **rf2-2qaqh** (P2): Causa's self-instrumentation saturated the shared raw trace ring — the process-global retain-N buffer held 200/200 `:rf/causa` events and zero application events, so any other consumer reading the raw buffer (re-frame2-pair, Story) saw only inspector noise.

### The mechanism (option (a), preferred per the bead)

A frame registered with `:rf.trace/frame-no-emit? true` now produces **no trace at all**: `emit!` / `emit-error!` short-circuit (no envelope allocation, no delivery) for any event whose `:frame` tag matches a trace-disabled frame. This is the **frame-scoped sibling** of the existing handler-scoped `:rf.trace/no-emit?`.

- **One canonical predicate** — `re-frame.trace/frame-trace-disabled?` is the single source of truth; `reg-frame` reads the config flag and calls `set-frame-no-emit!`. No call site hardcodes `:rf/causa`.
- Honoured on **both** first registration and surgical re-registration (hot-reload can flip it either way).
- The framework already threads `:frame` onto every emit (`:event/dispatched`, `:run-start`/`:run-end`, `:event/db-changed`, `:sub/run`, `:view/render`, `:rf.error/*`), so the gate covers the whole `:rf/causa` cascade, not just renders.
- Gate sits inside the existing `interop/debug-enabled?` `when` → DCEs out of `:advanced` production builds.

Causa marks `:rf/causa` trace-disabled in `mount/ensure-causa-frame!`.

### Cap-discrepancy finding (the bead's "ALSO CHECK")

The observed buffer length 200 vs Causa's reported `:trace-buffer/keep 1000` is **not a framework bug**: the framework ring default is `200` (`re-frame.trace.tooling/default-buffer-depth`) and only changes via `configure-trace-buffer!`. Causa's `:buffer-depths` / `:trace-buffer/keep` are documented as *"accepted today but ignored at runtime"* (`tools/causa/.../core.cljs`) and are never pushed into the framework ring. Cosmetic mismatch; made moot by this fix.

## Test plan

- [x] New CLJS/JVM unit tests in `trace_buffer_test.clj`: tool-frame cascade grows the ring by 0; app-frame cascade DOES; 500 tool dispatches cannot evict a buried app event (the rf2-2qaqh scenario); flag clears on re-registration; predicate is single-sourced.
- [x] `npm run test:cljs` — 4084 tests, 0 failures
- [x] JVM `clojure -M:test` (core) — 728 tests, 0 failures
- [x] `npm run test:causa-feature-gate` — 12/13 pass; the one failure (`hydration mismatch debugger`) is **pre-existing on origin/main**, tracked as rf2-djuf3 (all its events are `:rf/default`, untouched by this gate)
- [x] `npm run test:elision` — production 36/36 trace markers absent
- [x] `npm run test:bundle-isolation` — no tooling leak; DCE intact
- [x] `scripts/test-fast-pr.sh` — PASS

Docs: added the `:rf.trace/frame-no-emit?` contract to Spec 009 §Frame-level trace-emission opt-out and the API.md metadata-key table.