### PR TITLE
fix(causa): Issues panel renders feed/empty-state under cascade scope (rf2-djuf3)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -348,6 +348,105 @@
       (is (= [1] (mapv :id (:issues feed))))
       (is (= 6 (:epoch-id feed)) "feed epoch-id reflects the head"))))
 
+;; ---- (6b) feed-under-cascade-scope: SSR hydration-mismatch (rf2-djuf3) --
+;;
+;; Pins the regression the `hydration mismatch debugger` feature-gate
+;; scenario surfaces: the Issues panel is the focused-epoch (cascade)
+;; lens, so a `:rf.ssr/hydration-mismatch` error that LANDS in a cascade's
+;; `:trace-events` MUST project into the feed under that cascade's scope.
+;;
+;; (When `verify-hydration!` emits the mismatch OUTSIDE any dispatch the
+;; framework's epoch capture drops the orphan — rf2-avvwm — so it never
+;; reaches an epoch record. That out-of-cascade case is exercised by the
+;; orphan-drop epoch-capture tests, not here; this test pins the in-
+;; cascade projection that the panel's contract guarantees.)
+
+(defn- hydration-mismatch-ev
+  "A Spec 011-shaped `:rf.ssr/hydration-mismatch` error trace event as
+  it lands in a cascade's `:trace-events` (op-type :error, recovery
+  hoisted, payload in :tags)."
+  [id]
+  (error-ev id :rf.ssr/hydration-mismatch
+            {:time     500
+             :recovery :warned-and-replaced
+             :tags     {:server-hash "deadbeef"
+                        :client-hash "91de1ba6"
+                        :failing-id  :rf/hydrate
+                        :reason      "Hydration mismatch: server hash 'deadbeef' != client hash '91de1ba6'."}}))
+
+(deftest project-feed-hydration-mismatch-surfaces-under-cascade-scope
+  (testing "an in-cascade :rf.ssr/hydration-mismatch error projects into
+            the focused epoch's feed under cascade scope"
+    (let [record (epoch-record 2 [(non-issue-ev 1)
+                                  (hydration-mismatch-ev 9)
+                                  (non-issue-ev 2)])
+          feed   (h/project-feed record {} :focused)]
+      (is (nil? (:empty-kind feed)) "feed renders, not an empty state")
+      (is (= 1 (:total feed)))
+      (is (= 1 (:rendered feed)))
+      (is (= [9] (mapv :id (:issues feed))))
+      (let [row (first (:issues feed))]
+        (is (= :error               (:severity row)))
+        (is (= "rf.ssr"             (:category-prefix row)))
+        (is (= :rf.ssr/hydration-mismatch (:operation row)))
+        (is (re-find #"Hydration mismatch" (:description row))))
+      (is (= 2 (:epoch-id feed)) "feed epoch-id reflects the focused cascade")
+      (is (= {:error 1} (:severity-counts feed)))
+      (is (= ["rf.ssr"] (:distinct-prefixes feed))))))
+
+(deftest project-feed-hydration-mismatch-head-fallback-sub-call-site
+  (testing "rf2-djuf3 — the panel's sub call-site shape: nil focus +
+            non-empty history head-falls-back (rf2-h0120) onto the
+            cascade carrying the hydration-mismatch, and the feed
+            renders that issue under cascade scope"
+    (let [hist           [(epoch-record 1 [])
+                          (epoch-record 2 [(hydration-mismatch-ev 9)])]
+          focus-epoch-id nil
+          focus-status   (h/resolve-focus-status focus-epoch-id hist)
+          record         (h/find-epoch-record   focus-epoch-id hist)
+          feed           (h/project-feed record {} focus-status)]
+      (is (= :focused focus-status))
+      (is (= 2 (:epoch-id record)))
+      (is (nil? (:empty-kind feed)))
+      (is (= [9] (mapv :id (:issues feed)))))))
+
+(deftest project-feed-always-renders-feed-or-empty-state
+  (testing "rf2-djuf3 invariant — under EVERY focus-status the panel sub
+            yields a renderable shape: either the feed (empty-kind nil)
+            or exactly one of the four empty-state discriminators. The
+            feature-gate scenario waits on this union; an unhandled
+            empty-kind would silently render nothing."
+    (let [renderable? #{nil :no-focus :epoch-evicted :no-issues :no-matches}]
+      (testing ":no-focus → :no-focus empty-state"
+        (is (= :no-focus (:empty-kind (h/project-feed nil {} :no-focus)))))
+      (testing ":epoch-evicted → :epoch-evicted empty-state"
+        (is (= :epoch-evicted
+               (:empty-kind (h/project-feed nil {} :epoch-evicted)))))
+      (testing ":focused + no issues → :no-issues empty-state"
+        (is (= :no-issues
+               (:empty-kind (h/project-feed (epoch-record 1 []) {} :focused)))))
+      (testing ":focused + issues hidden by filters → :no-matches empty-state"
+        (is (= :no-matches
+               (:empty-kind (h/project-feed
+                              (epoch-record 1 [(hydration-mismatch-ev 9)])
+                              {:severities #{:advisory}}
+                              :focused)))))
+      (testing ":focused + visible issue → feed (empty-kind nil)"
+        (is (nil? (:empty-kind (h/project-feed
+                                 (epoch-record 1 [(hydration-mismatch-ev 9)])
+                                 {}
+                                 :focused)))))
+      (testing "every branch's empty-kind is in the view's renderable set"
+        (doseq [[record filters status]
+                [[nil {} :no-focus]
+                 [nil {} :epoch-evicted]
+                 [(epoch-record 1 []) {} :focused]
+                 [(epoch-record 1 [(hydration-mismatch-ev 9)])
+                  {:severities #{:advisory}} :focused]
+                 [(epoch-record 1 [(hydration-mismatch-ev 9)]) {} :focused]]]
+          (is (contains? renderable?
+                         (:empty-kind (h/project-feed record filters status)))))))))
+
 (deftest project-feed-newest-first
   (testing "the feed reverses the trace-events stream — newest first"
     (let [record (epoch-record 1 [(error-ev   1 :rf.error/a {:time 100})

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -1619,39 +1619,26 @@ async function runHydration(page) {
   //
   // Post rf2-xy4yb: the dedicated Hydration debugger panel was
   // dropped. Per spec/018 §5 hydration mismatches surface as
-  // `:rf.ssr/*` rows (category-prefix "rf.ssr").
-  //
-  // Per rf2-u6dhp + rf2-g1pt8 + rf2-fzbrw the Causa-side surfacing
-  // chain has THREE invariants the user-facing panels uphold:
-  //
-  //   1. The Issues feed is cascade-scoped: only issues whose
-  //      `:dispatch-id` matches the focused cascade pass through
-  //      (rf2-u6dhp).
-  //   2. Causa-internal `:rf.causa/*` cascades are stripped from
-  //      `:rf.causa/cascades` (rf2-g1pt8) so the user never sees
-  //      Causa instrumenting itself.
-  //   3. The `:ungrouped` bucket is structurally unfocusable — the
-  //      spine's `compose-focus` snaps any `:ungrouped` slot to
-  //      head per rf2-fzbrw's no-aggregate-state invariant.
+  // `:rf.ssr/*` rows (category-prefix "rf.ssr") in the Issues tab.
   //
   // `:rf.ssr/hydration-mismatch` is emitted by `verify-hydration!`
-  // OUTSIDE any event-handler context (see testbed `core.cljs:188`),
-  // so the projector buckets it as `:dispatch-id :ungrouped`. With
-  // invariant (3) above, the user cannot pin the `:ungrouped`
-  // bucket, so this particular issue class CANNOT surface in the
-  // cascade-scoped feed — the Causa-side surfacing is a known gap
-  // for `verify-hydration!`-style traces (separate bead territory).
+  // OUTSIDE any event-handler context (see testbed `core.cljs:188`).
+  // The framework's epoch capture (`re-frame.epoch.capture/capture-
+  // event!`) drops out-of-cascade orphan emits — an error with no
+  // in-flight cascade AND no `:dispatch-id` (rf2-avvwm) — so the
+  // mismatch trace never lands in any `:rf/epoch-record`'s
+  // `:trace-events`. Surfacing orphaned out-of-cascade errors in the
+  // focused-epoch Issues lens is a deliberately separate concern
+  // (the L2 timeline's per-row badges, not this per-epoch panel).
   //
-  // What this scenario CAN verify end-to-end:
+  // What this scenario verifies end-to-end:
   //
   //   - the trace fired (testbed banner renders the projected
   //     payload — proves `verify-hydration!` reached `emit-error!`)
-  //   - the Issues panel mounts cleanly when the focused cascade
-  //     carries no `:rf.ssr/*` issues (silent-by-default empty-state
-  //     branch — proves cascade-scoping doesn't crash the panel)
-  //
-  // Asserting the feed `<ul>` testid here would require pinning the
-  // `:ungrouped` bucket, which invariant (3) forbids.
+  //   - the Issues panel mounts cleanly under cascade (focused-epoch)
+  //     scope and renders either the feed or a proper empty-state —
+  //     proving the focused-epoch projection doesn't crash and the
+  //     head-fallback (rf2-h0120) resolves to a real epoch record.
   const mismatchBanner = page.locator('[data-testid="mismatch-banner"]');
   await expectVisible(mismatchBanner, 10000);
   await expectVisible(page.locator('[data-testid="mismatch-server-hash"]'), 5000);
@@ -1659,19 +1646,26 @@ async function runHydration(page) {
   // ---- (2) Causa Issues panel mounts cleanly under cascade scope ----
   await openCausa(page);
   await clickTab(page, 'issues', 'rf-causa-issues-ribbon');
-  // Issues panel ribbon is up; the focused cascade (the L4 default-
-  // focuses head per rf2-639lc) carries no `:rf.ssr/*` issues so the
-  // panel renders the silent-by-default empty-state per rf2-g3ghh.
-  // Either the empty-state testid OR the feed `<ul>` is acceptable —
-  // both prove cascade-scoping is honoured without crashing.
-  const emptyForEvent = page.locator(
-    '[data-testid="rf-causa-issues-empty-no-issues-for-event"]',
+  // The Issues panel is the focused-epoch lens (rf2-jio48): with no
+  // explicit focus it head-falls-back to the most-recent epoch
+  // (rf2-h0120). That epoch carries no projected `:error`/`:warning`/
+  // `:advisory` issue (the mismatch trace is out-of-cascade — see
+  // above), so the panel paints the positive `:no-issues` empty-state.
+  // Either the feed `<ul>` OR any of the panel's empty-state branches
+  // is acceptable — all prove the focused-epoch projection is honoured
+  // without crashing. (The legacy cascade-scoped `-for-event` empty
+  // state was collapsed into `:no-issues` by the rf2-jio48 rebuild.)
+  const feedOrEmptyState = page.locator(
+    [
+      '[data-testid="rf-causa-issues-feed"]',
+      '[data-testid="rf-causa-issues-empty-no-issues"]',
+      '[data-testid="rf-causa-issues-empty-no-matches"]',
+      '[data-testid="rf-causa-issues-empty-no-focus"]',
+      '[data-testid="rf-causa-issues-empty-epoch-evicted"]',
+    ].join(', '),
   );
-  const feed = page.locator('[data-testid="rf-causa-issues-feed"]');
   await waitForValue(
-    async () => (
-      (await emptyForEvent.count()) + (await feed.count()) > 0
-    ),
+    async () => (await feedOrEmptyState.count()) > 0,
     (n) => n === true,
     {
       timeoutMs: 5000,


### PR DESCRIPTION
## Cause

The `hydration mismatch debugger` feature-gate scenario (1 of 13) failed perpetually:
`waitForValue expected 'Issues panel renders feed-or-empty-state under cascade scope' within 5000ms (last=false)`.

The scenario waited on the testid `rf-causa-issues-empty-no-issues-for-event`. The `rf2-jio48` focused-epoch rebuild collapsed the old cascade-scoped panel into a focused-epoch lens and **dropped** that `-for-event` empty-state, renaming it to `rf-causa-issues-empty-no-issues`. The panel rendered correctly (screenshot shows `epoch #2 · 0/0 in view` + "No issues in this epoch."), but the scenario could never observe the renamed testid, nor the feed (the focused epoch carries no in-cascade issue).

Why no issue in the feed: `verify-hydration!` emits `:rf.ssr/hydration-mismatch` **outside** any dispatch, so the framework's epoch capture drops it as an out-of-cascade orphan (rf2-avvwm). It never lands in any `:rf/epoch-record`'s `:trace-events` — so the focused-epoch panel correctly shows the positive empty-state. The scenario's old comment block described the pre-rebuild `:ungrouped`-bucket design and was stale.

## Fix

- Update the scenario to assert against the union of the focused-epoch panel's **actual** surfaces: the feed `<ul>` OR any of its four empty-state discriminators (`no-issues` / `no-matches` / `no-focus` / `epoch-evicted`).
- Rewrite the stale `:ungrouped`-bucket comment to describe the current orphan-drop (rf2-avvwm) + head-fallback (rf2-h0120) behaviour.

No panel/framework code changed — the panel was already correct; the gate's assertion had drifted from the rebuilt contract.

## New unit tests (`issues_ribbon_helpers_cljs_test.cljc`)

Pin the issues-feed-under-cascade-scope derivation at the cheap layer:
- `project-feed-hydration-mismatch-surfaces-under-cascade-scope` — an in-cascade `:rf.ssr/hydration-mismatch` projects into the focused epoch's feed (severity / prefix / description).
- `project-feed-hydration-mismatch-head-fallback-sub-call-site` — nil focus + non-empty history head-falls-back onto the cascade carrying the mismatch and renders it.
- `project-feed-always-renders-feed-or-empty-state` — every focus-status path yields a renderable feed-or-empty-state (the invariant the gate waits on).

## Gates

- `npm run test:causa-feature-gate` — **13/13**, 0 failures.
- `npm run test:cljs` — 4096 tests / 12465 assertions, 0 failures.