### PR TITLE
feat(causa): reset transient filters on load; persist only durable view prefs (rf2-swclw)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -442,11 +442,13 @@
       (assoc db :active-filters
                 (or filters {:in [] :out []}))))
 
-  ;; Hydrate on install. The actual logic lives in `hydrate!` below
-  ;; so `ensure-causa-frame!` (in mount.cljs) can call it again on
-  ;; first open — the production order is preload-time install
-  ;; (`:rf/causa` frame not yet registered) then keypress-time
-  ;; `ensure-causa-frame!` (frame registered). Either call path
-  ;; converges on the same slot.
-  (hydrate!)
+  ;; NO hydrate on install (rf2-swclw). The IN/OUT pills are a TRANSIENT
+  ;; exploration filter — they reset to unfiltered on every page load so
+  ;; a fresh session never silently carries a stale filter. The slot
+  ;; starts at its registry default `{:in [] :out []}` and
+  ;; `mount.cljs`'s `::reset-transient-filters` first-mount hook clears
+  ;; the stale localStorage slot so storage matches. `hydrate!` / `load`
+  ;; remain as the data layer (exercised by the persistence round-trip
+  ;; tests + reachable by hosts that opt back in), but init does not
+  ;; restore.
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -344,8 +344,12 @@
               records the choice.
     - Effects: `:rf.causa.frame-switcher/persist` — localStorage
               write fx.
-    - Side-effect: hydrate `[:focus :frame]` from localStorage at
-              first install via `hydrate!`.
+
+  Does NOT hydrate `[:focus :frame]` from localStorage (rf2-swclw): the
+  frame pin is a transient exploration filter, reset to unpinned on
+  every page load. `mount.cljs`'s `::reset-transient-filters` first-
+  mount hook clears the stale slot. `hydrate!` / `load` remain as the
+  data layer for tests and opt-in hosts, but init does not restore.
 
   Called from `registry/register-causa-handlers!` after `spine/install!`
   so the canonical event-fx's `[:dispatch [:rf.causa/set-frame ...]]`
@@ -409,9 +413,14 @@
       {:fx [[:dispatch [:rf.causa/set-frame frame-id]]
             [:rf.causa.frame-switcher/persist frame-id]]}))
 
-  ;; Hydrate from localStorage. The actual logic lives in `hydrate!`
-  ;; above so first-mount (`mount/ensure-causa-frame!`) can call the
-  ;; same fn to converge.
-  (hydrate!)
+  ;; NO hydrate from localStorage on install (rf2-swclw). The frame pin
+  ;; is a TRANSIENT exploration filter — it resets to unpinned on every
+  ;; page load so a fresh session never silently scopes the inspector to
+  ;; a frame chosen in a past session. The `[:focus :frame]` slot starts
+  ;; at its registry default (unpinned) and `mount.cljs`'s
+  ;; `::reset-transient-filters` first-mount hook clears the stale
+  ;; localStorage slot so storage matches. `hydrate!` / `load` remain as
+  ;; the data layer (exercised by the round-trip tests), but init does
+  ;; not restore.
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -49,7 +49,8 @@
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.defaults :as defaults]
-            [day8.re-frame2-causa.filters :as filters]
+            [day8.re-frame2-causa.filters.persistence :as filters-persistence]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
             [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.shell :as shell]
             [day8.re-frame2-causa.spine :as spine]
@@ -447,23 +448,32 @@
         (rf/dispatch-sync [:rf.causa/set-target-frame seed-frame])))))
 
 (register-first-mount-hook!
-  ::hydrate-filters
-  ;; Hydrate the auto-filter pills (rf2-ak4ms). The preload-time
-  ;; `filters/install!` call ran BEFORE the `:rf/causa` frame was
-  ;; registered, so its hydrate attempt no-op'd; re-running here under
-  ;; the now-registered frame lifts the localStorage / seed value into
-  ;; the slot. Idempotent — re-running with an unchanged source
-  ;; produces the same slot.
-  filters/hydrate!)
-
-(register-first-mount-hook!
-  ::hydrate-spine-filters
-  ;; Hydrate the muted-event-ids set (rf2-ikuwt). Same rationale as
-  ;; `filters/hydrate!` above — the preload-time `spine-filters/
-  ;; install!` ran before `:rf/causa` was registered, so re-running
-  ;; here under the now-registered frame lifts the localStorage value
-  ;; into the slot.
-  spine-filters/hydrate!)
+  ::reset-transient-filters
+  ;; Reset the TRANSIENT exploration filters to unfiltered on every page
+  ;; load (rf2-swclw). Three suppressing surfaces — the IN/OUT pills
+  ;; (rf2-ak4ms), the muted-event-ids set (rf2-ikuwt), and the frame pin
+  ;; (rf2-iwwou) — are session-scoped: a fresh load must NOT silently
+  ;; carry a stale filter from a past session (the trap that hid events
+  ;; and made the inspector look broken — rf2-jvghz). An inspector's
+  ;; prime directive is to show the truth, so the first paint starts
+  ;; fully unfiltered.
+  ;;
+  ;; Mechanism: we do NOT hydrate these slots, so app-db starts at its
+  ;; registry default (empty pills / empty mute set / unpinned frame).
+  ;; We additionally CLEAR each slot's stale localStorage value so the
+  ;; storage matches what the user sees and a phantom value can never
+  ;; resurface — if we only ignored-on-read, the next mute / pin write
+  ;; would overwrite a slot that still held last session's ghost until
+  ;; then. Clearing keeps storage honest from the first frame.
+  ;;
+  ;; DURABLE view prefs (Dynamic/Static mode, density, panel layout)
+  ;; still hydrate via their own hooks below — only transient filters
+  ;; reset. The #1962 'N events hidden by filters' indicator stays as
+  ;; the in-session safety net once the user reaches for a filter.
+  (fn []
+    (filters-persistence/clear!)
+    (spine-filters/clear-raw!)
+    (frame-switcher/clear!)))
 
 (register-first-mount-hook!
   ::hydrate-static-mode

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -615,11 +615,13 @@
     ;; Frame-switcher slot (rf2-iwwou) — hardened L1 frame-switcher
     ;; contract. MUST install AFTER `spine/install!` so the canonical
     ;; `:rf.causa/select-frame` event-fx's `[:dispatch [:rf.causa/set-
-    ;; frame ...]]` resolves at hydration time. Registers the
+    ;; frame ...]]` resolves at install time. Registers the
     ;; `:rf.causa/current-frame` + `:rf.causa/available-frames` subs,
-    ;; the `:rf.causa/select-frame` event-fx, the `:rf.causa.frame-
-    ;; switcher/persist` localStorage write fx, and hydrates the
-    ;; `[:focus :frame]` slot from localStorage at first install.
+    ;; the `:rf.causa/select-frame` event-fx, and the `:rf.causa.frame-
+    ;; switcher/persist` localStorage write fx. Does NOT restore the pin
+    ;; on init (rf2-swclw) — the frame pin is a transient filter, reset
+    ;; to unpinned on every page load by mount.cljs's
+    ;; `::reset-transient-filters` hook.
     (frame-switcher/install!)
     (app-db-diff/install!)
     ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any

--- a/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
@@ -652,9 +652,12 @@
     (fn [db [_ muted]]
       (assoc db :muted-event-ids (set (or muted #{})))))
 
-  ;; Hydrate on install. Mirrors `filters/hydrate!`'s pre-mount /
-  ;; post-mount split — the dispatch is gated on the `:rf/causa` frame
-  ;; existing, so the preload-time call short-circuits and the post-
-  ;; mount `ensure-causa-frame!` call lands the slot.
-  (hydrate!)
+  ;; NO hydrate on install (rf2-swclw). The muted-event-ids set is a
+  ;; TRANSIENT exploration filter — it resets to empty on every page
+  ;; load so a fresh session never silently hides events muted in a
+  ;; past session. The slot starts at its registry default `#{}` and
+  ;; `mount.cljs`'s `::reset-transient-filters` first-mount hook clears
+  ;; the stale localStorage slot so storage matches. `hydrate!` / `load`
+  ;; remain as the data layer (exercised by the round-trip tests), but
+  ;; init does not restore.
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/init_filter_reset_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/init_filter_reset_cljs_test.cljs
@@ -1,0 +1,235 @@
+(ns day8.re-frame2-causa.init-filter-reset-cljs-test
+  "Init policy: reset TRANSIENT filters to unfiltered on every page load;
+  persist only DURABLE view prefs (rf2-swclw).
+
+  Causa's L2 filters used to persist across reload via localStorage,
+  which silently hid events and made the inspector look broken (rf2-jvghz
+  — it fooled even the project author). The decision (Mike, 2026-05-22):
+  an inspector's prime directive is to show the truth, so a fresh load
+  must never silently carry a stale filter from a past session. The
+  three transient exploration filters —
+
+    1. the IN/OUT filter pills  (localStorage `re-frame2.causa.filters.v1`)
+    2. the muted-event-ids set  (localStorage `causa.spine.muted-event-ids`)
+    3. the frame pin            (localStorage `re-frame2.causa.frame-switcher.v1`)
+
+  — do NOT restore on init regardless of what localStorage holds, and
+  their stale slots are CLEARED so storage stays honest. DURABLE view
+  prefs (the Dynamic ↔ Static mode under `causa.mode`) still restore.
+
+  These tests drive the REAL production init path
+  (`mount/ensure-causa-frame!` — the first-mount hook walker) so the
+  policy is pinned against the actual boot sequence. `ensure-causa-frame!`
+  registers the `:rf/causa` frame then walks the hook table; no DOM mount
+  point is required (that happens later in `open!`).
+
+  Node-test has no jsdom, so this ns installs a minimal in-memory
+  `js/window.localStorage` stub for the fixture's duration (the same
+  pattern as `routing_history_cljs_test`'s window stub). The stub lets us
+  SEED stale values pre-boot and assert they neither survive into app-db
+  nor linger in storage after the reset hook runs."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.filters.persistence :as filters-persistence]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
+            [day8.re-frame2-causa.mount :as mount]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.spine-filters :as spine-filters]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+;; -------------------------------------------------------------------------
+;; in-memory localStorage stub (node-test has no jsdom)
+;; -------------------------------------------------------------------------
+
+(defn- make-local-storage []
+  (let [store (atom {})]
+    #js {:getItem    (fn [k] (get @store k nil))
+         :setItem    (fn [k v] (swap! store assoc k (str v)) js/undefined)
+         :removeItem (fn [k] (swap! store dissoc k) js/undefined)
+         :clear      (fn [] (reset! store {}) js/undefined)}))
+
+(defn- install-local-storage! []
+  (when-not (exists? js/globalThis.window)
+    (set! (.-window js/globalThis) #js {}))
+  (set! (.-localStorage js/globalThis.window) (make-local-storage)))
+
+(defn- uninstall-local-storage! []
+  ;; Drop the whole window stub we installed so we don't leak a
+  ;; localStorage into sibling test namespaces.
+  (js-delete js/globalThis "window"))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  ;; Start every scenario from a clean localStorage so the seeding below
+  ;; is the only signal the init path can read.
+  (filters-persistence/clear!)
+  (spine-filters/clear-raw!)
+  (frame-switcher/clear!)
+  (static-persistence/clear!))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- with-local-storage-stub
+  "Install an in-memory `js/window.localStorage` for the test's duration,
+  then run the runtime fixture (whose :init-fn clears the stub to a clean
+  slate), then tear the whole window stub down so sibling namespaces see
+  the absent window they expect."
+  [test-fn]
+  (install-local-storage!)
+  (try
+    (runtime-fixture test-fn)
+    (finally
+      (uninstall-local-storage!))))
+
+(use-fixtures :each with-local-storage-stub)
+
+(defn- boot!
+  "Drive the production init path: register the Causa handlers, then run
+  `ensure-causa-frame!` (which registers `:rf/causa` and walks the
+  first-mount hook table — the SAME walk a real page load performs)."
+  []
+  (registry/register-causa-handlers!)
+  (mount/ensure-causa-frame!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(def ^:private stale-pills
+  "A non-empty IN/OUT pill set, as a past session would have persisted."
+  {:in  [{:pattern ":auth/*"}]
+   :out [{:pattern ":mouse-move"}]})
+
+(def ^:private stale-mutes
+  "A non-empty mute set, as a past session would have persisted."
+  #{:user/mouse-move :ui/tick})
+
+(def ^:private stale-frame
+  "A pinned frame, as a past session would have persisted."
+  :cart-frame)
+
+;; -------------------------------------------------------------------------
+;; (0) sanity: the localStorage stub round-trips (preconditions are real)
+;; -------------------------------------------------------------------------
+
+(deftest local-storage-stub-round-trips
+  (testing "the in-memory stub backs save!/load so the seeding below is real"
+    (filters-persistence/save! stale-pills)
+    (is (= stale-pills (filters-persistence/load)))
+    (spine-filters/save! stale-mutes)
+    (is (= stale-mutes (spine-filters/load)))
+    (frame-switcher/save! stale-frame)
+    (is (= stale-frame (frame-switcher/load)))
+    (static-persistence/save! :static)
+    (is (= :static (static-persistence/load)))))
+
+;; -------------------------------------------------------------------------
+;; (1) IN/OUT filter pills reset to unfiltered on load
+;; -------------------------------------------------------------------------
+
+(deftest init-resets-stale-filter-pills
+  (testing "stale persisted IN/OUT pills do NOT restore on init"
+    (filters-persistence/save! stale-pills)
+    (is (= stale-pills (filters-persistence/load))
+        "precondition: localStorage holds the stale pills")
+    (boot!)
+    (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters]))
+        "init yields unfiltered pills despite the stale localStorage value")
+    (is (= {:in [] :out []} (filters-persistence/load))
+        "the stale pill slot is cleared so storage stays honest")))
+
+;; -------------------------------------------------------------------------
+;; (2) muted-event-ids reset to empty on load
+;; -------------------------------------------------------------------------
+
+(deftest init-resets-stale-mutes
+  (testing "stale persisted mutes do NOT restore on init"
+    (spine-filters/save! stale-mutes)
+    (is (= stale-mutes (spine-filters/load))
+        "precondition: localStorage holds the stale mute set")
+    (boot!)
+    (is (= #{} (frame-sub [:rf.causa/muted-event-ids]))
+        "init yields an empty mute set despite the stale localStorage value")
+    (is (= #{} (spine-filters/load))
+        "the stale mute slot is cleared so storage stays honest")))
+
+;; -------------------------------------------------------------------------
+;; (3) frame pin resets to unpinned on load
+;; -------------------------------------------------------------------------
+;;
+;; The frame pin lives in localStorage; on init the slot is cleared so a
+;; stale pin can never resurface. The `:rf.causa/current-frame` sub does
+;; NOT read back as nil after boot — the unrelated `::seed-trace-and-
+;; target-frame` first-mount hook seeds the focus frame to the head
+;; focusable cascade (here `:rf/default`, since the trace buffer is
+;; empty). That seed is the panel-observed frame, not a user pin; the
+;; reset signal is the cleared localStorage slot.
+
+(deftest init-resets-stale-frame-pin
+  (testing "a stale persisted frame pin does NOT restore on init"
+    (frame-switcher/save! stale-frame)
+    (is (= stale-frame (frame-switcher/load))
+        "precondition: localStorage holds the stale frame pin")
+    (boot!)
+    (is (nil? (frame-switcher/load))
+        "the stale frame-pin slot is cleared so the pin can't resurface")
+    (is (not= stale-frame (frame-sub [:rf.causa/current-frame]))
+        "the observed frame is NOT the stale pin")))
+
+;; -------------------------------------------------------------------------
+;; (4) all three transient filters reset together (the real-load shape)
+;; -------------------------------------------------------------------------
+
+(deftest init-resets-all-transient-filters-together
+  (testing "a fresh load with ALL transient slots stale comes up fully unfiltered"
+    (filters-persistence/save! stale-pills)
+    (spine-filters/save! stale-mutes)
+    (frame-switcher/save! stale-frame)
+    (boot!)
+    (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters])))
+    (is (= #{} (frame-sub [:rf.causa/muted-event-ids])))
+    (testing "and every transient localStorage slot is cleared"
+      (is (= {:in [] :out []} (filters-persistence/load)))
+      (is (= #{} (spine-filters/load)))
+      (is (nil? (frame-switcher/load))))))
+
+;; -------------------------------------------------------------------------
+;; (5) durable view prefs STILL restore (the policy's other half)
+;; -------------------------------------------------------------------------
+
+(deftest init-restores-durable-mode-pref
+  (testing "the Dynamic ↔ Static mode is a DURABLE pref — it restores on init"
+    (static-persistence/save! :static)
+    (is (= :static (static-persistence/load))
+        "precondition: localStorage holds the durable :static mode")
+    (boot!)
+    (is (= :static (frame-sub [:rf.causa/mode]))
+        "the durable mode pref restores even as transient filters reset")
+    (is (= :static (static-persistence/load))
+        "the durable mode slot is NOT cleared")))
+
+(deftest init-restores-durable-mode-alongside-transient-reset
+  (testing "durable mode restores WHILE the transient filters reset — both halves of the policy hold in one boot"
+    (static-persistence/save! :static)
+    (filters-persistence/save! stale-pills)
+    (spine-filters/save! stale-mutes)
+    (frame-switcher/save! stale-frame)
+    (boot!)
+    (is (= :static (frame-sub [:rf.causa/mode]))
+        "durable mode restored")
+    (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters]))
+        "transient pills reset")
+    (is (= #{} (frame-sub [:rf.causa/muted-event-ids]))
+        "transient mutes reset")
+    (is (= {:in [] :out []} (filters-persistence/load))
+        "transient pill slot cleared")
+    (is (= #{} (spine-filters/load))
+        "transient mute slot cleared")
+    (is (nil? (frame-switcher/load))
+        "transient frame-pin slot cleared")))


### PR DESCRIPTION
## Decision (operator-approved 2026-05-22)

**RESET transient filters to unfiltered on EVERY page load; PERSIST only durable view preferences.**

Causa's L2 filters used to persist across reload via localStorage, which silently hid events and made the inspector look broken (rf2-jvghz — it fooled even the project author). PR #1962 added a prominent "N events hidden by filters" indicator + one-click Clear so the suppression became *visible*, but did not change *whether* filters persist. This is the follow-on policy decision.

## Rationale

An inspector's prime directive is to show the truth; a fresh load must never silently carry a stale filter from a past session. Filters are session-scoped exploration — reached for *within* a session, not state that ambushes you on reload. The #1962 hidden-count indicator stays as the in-session safety net once the user reaches for a filter.

## What resets on every load (transient exploration filters)

- IN/OUT filter pills — `re-frame2.causa.filters.v1`
- muted-event-ids set — `causa.spine.muted-event-ids`
- frame pin — `re-frame2.causa.frame-switcher.v1`

## What still restores (durable view prefs)

- Dynamic ↔ Static mode — `causa.mode` (untouched; still hydrates)

## Mechanism

Stop hydrating the three transient slots on init — app-db starts at its registry defaults (empty pills / empty mute set / unpinned frame) — and **clear** their stale localStorage slots via a single `::reset-transient-filters` first-mount hook (replacing the old `::hydrate-filters` + `::hydrate-spine-filters` hooks and the inline `frame-switcher/hydrate!`). Clearing (vs ignore-on-read) keeps storage honest from the first frame: otherwise the next mute/pin write would overwrite a slot that still held last session's ghost until then. The per-subsystem inline `(hydrate!)` calls in each `install!` are removed; `hydrate!` / `load` remain as the data layer (still exercised by the persistence round-trip tests + reachable by opt-in hosts).

One clear init policy, concentrated in `mount.cljs` — not scattered conditionals.

## Tests (CLJS unit, not Playwright)

New `tools/causa/test/.../init_filter_reset_cljs_test.cljs` drives the real production init path (`mount/ensure-causa-frame!` — the first-mount hook walker) with an in-memory `localStorage` stub seeded with stale values, and pins:

- stale IN/OUT pills do NOT restore → unfiltered, slot cleared
- stale mutes do NOT restore → empty set, slot cleared
- stale frame pin does NOT restore → slot cleared (pin can't resurface)
- all three transient slots stale → fully unfiltered + every slot cleared
- durable Static mode STILL restores (not cleared) — both halves of the policy in one boot

## Gates

- `npm run test:cljs` — 4106 tests, 0 failures, 0 errors
- `npm run test:causa-feature-gate` — 13/13 (rebased onto latest main to pick up #1965's pre-existing gate fix; the earlier hydration-mismatch fail was rf2-djuf3, not this diff)