### PR TITLE
fix(causa): ✕ close button actually hides the shell (rf2-fq491)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -558,6 +558,29 @@
   []
   (if (visible?) (close!) (open!)))
 
+;; ---- close-shell effect (rf2-fq491) -------------------------------------
+;;
+;; The shell `✕` button (and any other in-app close affordance) dispatches
+;; `:rf.causa/close-shell`, an app-db event. That event sets the reactive
+;; `:close-requested?` flag, but the actual DOM hide lives here in `close!`
+;; (the same path the Ctrl+Shift+C keybinding drives via `toggle!`). This
+;; fx is the bridge: the event returns `[:rf.causa.fx/hide-shell]` and the
+;; effect calls `close!`, so the flag and the visible hide stay in lock-
+;; step. Co-locating the effect with the DOM action (mirrors
+;; `static-persistence/install-fx!`) keeps `registry.cljs` free of any
+;; direct DOM-toggle call.
+(defn install-fx!
+  "Idempotently register `:rf.causa.fx/hide-shell` — the effect that
+  performs the DOM-side shell hide. re-frame's registrar replaces in
+  place, so repeat calls (shadow-cljs `:after-load`) are harmless.
+
+  Handler signature `(fn [ctx args])` per the v2 reg-fx contract."
+  []
+  (rf/reg-fx :rf.causa.fx/hide-shell
+    (fn [_ctx _args]
+      (close!)))
+  nil)
+
 (defn- teardown-popout-state!
   "Internal: tear down the popout singleton if present. Invokes the
   substrate unmount, clears the opener-gone watchdog, attempts to

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -44,6 +44,7 @@
             [day8.re-frame2-causa.epoch :as epoch]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.frame-switcher :as frame-switcher]
+            [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.settings.effects :as settings-effects]
@@ -417,12 +418,23 @@
         ;; Settings popup lands behind rf2-pending-settings-modal.
         (assoc db :settings-open? true)))
 
-    (rf/reg-event-db :rf.causa/close-shell
-      (fn [db _event]
-        ;; Close intent — mount.cljs reads the slot in production to
-        ;; drive the CSS-only hide. The reactive flag is set here so
-        ;; tests can assert the round-trip.
-        (assoc db :close-requested? true)))
+    (rf/reg-event-fx :rf.causa/close-shell
+      (fn [{:keys [db]} _event]
+        ;; Close intent (rf2-fq491). Two outcomes, kept in lock-step:
+        ;;   :db  — set the reactive `:close-requested?` flag so the
+        ;;          round-trip is observable/testable.
+        ;;   :fx  — `:rf.causa.fx/hide-shell` performs the actual DOM
+        ;;          hide via `mount/close!` (the same CSS-only toggle the
+        ;;          Ctrl+Shift+C keybinding drives through `mount/toggle!`).
+        ;; Previously this only set the flag and nothing consumed it, so
+        ;; the `✕` button was a no-op.
+        {:db (assoc db :close-requested? true)
+         :fx [[:rf.causa.fx/hide-shell]]}))
+
+    ;; Install the DOM-side `:rf.causa.fx/hide-shell` effect that the
+    ;; `:rf.causa/close-shell` event above fires. Idempotent — re-frame's
+    ;; registrar replaces in place (rf2-fq491).
+    (mount/install-fx!)
 
     ;; ---- trace-buffer mirror events (rf2-in6l2 / rf2-wq6gx) -------
     ;;

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -540,6 +540,62 @@
                  toggle-after-mount transitions")))))))
 
 ;; -------------------------------------------------------------------------
+;; (5b) close-shell event — the `✕` button round-trip (rf2-fq491)
+;; -------------------------------------------------------------------------
+;;
+;; The shell `✕` button dispatches `:rf.causa/close-shell` rather than
+;; calling `mount/close!` directly. Before rf2-fq491 the event only set
+;; the reactive `:close-requested?` flag and nothing consumed it, so the
+;; button was a no-op. The event is now a `reg-event-fx` that sets the
+;; flag AND fires `:rf.causa.fx/hide-shell` (registered by
+;; `mount/install-fx!`, called from the registry orchestrator) which
+;; performs the actual DOM hide via `close!`. These tests prove the
+;; flag + the visible hide land together.
+
+(deftest close-shell-event-hides-the-shell
+  (testing "rf2-fq491 — dispatching :rf.causa/close-shell on a visible
+            shell flips it hidden: visible? false, container display=none,
+            and the reactive :close-requested? flag set — all in one
+            round-trip, the same hide path the keybinding drives"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn unmount-calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (is (true? (mount/visible?)) "precondition: shell visible")
+            (rf/with-frame :rf/causa
+              (rf/dispatch-sync [:rf.causa/close-shell]))
+            (is (false? (mount/visible?))
+                "close-shell event drove the DOM hide — not just a flag")
+            (is (= "none"
+                   (.-display (.-style (:node @@#'mount/mount-state))))
+                "container.style.display = none after the event")
+            (is (true? (mount/mounted?))
+                "mount-state retained — close-shell hides, never tears down")
+            (is (= 0 @unmount-calls)
+                "close-shell must NOT invoke the substrate unmount fn")
+            (is (true? (:close-requested? (frame/frame-app-db-value :rf/causa)))
+                "reactive :close-requested? flag set in lock-step")))))))
+
+(deftest close-shell-then-open!-reopens-the-shell
+  (testing "rf2-fq491 — a shell hidden via the close-shell event re-opens
+            on the existing open mechanism (CSS-only show, no re-render),
+            so the `✕` close is reversible"
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn calls]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (rf/with-frame :rf/causa
+              (rf/dispatch-sync [:rf.causa/close-shell]))
+            (is (false? (mount/visible?)))
+            (mount/open!)
+            (is (true? (mount/visible?))
+                "open! re-shows the shell hidden by close-shell")
+            (is (= 1 (count @calls))
+                "re-show is CSS-only — no second substrate render")))))))
+
+;; -------------------------------------------------------------------------
 ;; (6) Teardown — full destroy
 ;; -------------------------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -596,6 +596,10 @@
    :rf.causa.fx/open-in-new-tab
    ;; rf2-0us27 — Per-cascade structured export: text-file download fx.
    :rf.causa.fx/download-text-file
+   ;; rf2-fq491 — `✕` close button: the DOM-side shell-hide effect fired
+   ;; by `:rf.causa/close-shell`. Registered via `mount/install-fx!` from
+   ;; the orchestrator; calls `mount/close!`.
+   :rf.causa.fx/hide-shell
    ;; rf2-ak4ms — auto-filter persistence side-effect. Lives under the
    ;; filter-specific prefix because the localStorage write is bound
    ;; to the filter-mutating events (add-filter / remove-filter /


### PR DESCRIPTION
## Cause
The Causa shell `✕` button dispatches `:rf.causa/close-shell`, but the handler was a `reg-event-db` that only did `(assoc db :close-requested? true)` — a reactive flag whose comment claimed `mount.cljs` reads it to drive the hide, yet **nothing consumed it**. So clicking `✕` set a flag and nothing hid the shell. (The `Ctrl+Shift+C` keybinding path was unaffected — it calls `mount/toggle!` directly.)

## Fix
- `mount.cljs`: add `install-fx!`, which registers `:rf.causa.fx/hide-shell` — an effect that performs the real DOM hide via the existing `mount/close!` (CSS-only `display:none`, render tree retained).
- `registry.cljs`: change `:rf.causa/close-shell` to a `reg-event-fx` that sets the `:close-requested?` flag **and** returns `[[:rf.causa.fx/hide-shell]]`, and call `(mount/install-fx!)` from the orchestrator. Flag + visible hide now land in lock-step; re-open works on the existing `open!` mechanism.

Minimal + surgical (no `shell.cljs` change). The chrome-ribbon redesign (rf2-4vp5j) builds on this.

## Test
`mount_cljs_test.cljs` — two new CLJS unit tests:
- `close-shell-event-hides-the-shell`: dispatching `:rf.causa/close-shell` flips `visible?` false, sets `display:none`, sets `:close-requested?`, retains mount-state (no substrate unmount).
- `close-shell-then-open!-reopens-the-shell`: a shell hidden via the event re-opens on `open!` (CSS-only, no re-render).
- `registry_cljs_test.cljs`: added `:rf.causa.fx/hide-shell` to the fx-snapshot set.

## Gates
- `npm run test:cljs` — 0 failures (4108 tests / 12516 assertions)
- `npm run test:causa-feature-gate` — 13/13 scenarios, 0 failures