### PR TITLE
fix(causa): focus.epoch-id correlation re-populates Views + Trace after refresh (rf2-rly4a)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -287,7 +287,7 @@
    ;; trigger-less buffer is `on-frame-destroyed!`'s `:halted-destroy`
    ;; commit; the conditional `cond->` slots make that record valid
    ;; against the schema.
-   (let [{:keys [event-id event]}     (capture/find-trigger-event events)
+   (let [{:keys [event-id event dispatch-id]} (capture/find-trigger-event events)
          ;; Per rf2-ecu37: one fused walk producing all three
          ;; projections, replacing three independent transducer
          ;; passes over the same buffer. Mirrors `find-trigger-event`'s
@@ -327,4 +327,17 @@
               :effects            effects}
        event-id    (assoc :event-id event-id)
        event       (assoc :trigger-event event)
+       ;; Per rf2-rly4a — pin the settling cascade's `:dispatch-id` as a
+       ;; first-class record slot. It is the stable cross-counter-space
+       ;; link between the epoch ring (epoch-id space) and the raw trace
+       ;; stream's cascade list (dispatch-id space) that Causa's
+       ;; `:rf.causa/focus` correlation pivots on. Pinned here — not
+       ;; re-derived from `:trace-events` at read time — so the link
+       ;; survives `:trace-events-keep` elision on older records and the
+       ;; post-settle reactive back-fill (which pads `:trace-events` with
+       ;; nil-`:dispatch-id` sub-run / render events). Optional per
+       ;; Spec-Schemas §`:rf/epoch-record`: a cascade whose trace carried
+       ;; no `:dispatch-id` (a rejected dispatch, a halt before run-start)
+       ;; omits the slot, matching `:event-id` / `:trigger-event`.
+       dispatch-id (assoc :dispatch-id dispatch-id)
        halt-reason (assoc :halt-reason halt-reason)))))

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -8,8 +8,9 @@
     project-all        -- one fused reducer pass producing the
                           `:sub-runs`, `:renders`, `:effects` slots.
     find-trigger-event -- one walk extracting `:event-id` + `:event`
-                          from the cascade's first `:event/run-start`,
-                          with a `:event-id`-only fallback.
+                          + `:dispatch-id` from the cascade's first
+                          `:event/run-start`, with a `:event-id`-only
+                          fallback.
 
   Per rf2-0wi86 Phase-2 seam B: this namespace owns the cascade-buffer
   *behaviour*; the buffer atom itself and the low-level
@@ -444,7 +445,8 @@
 
 (defn find-trigger-event
   "Walk the buffered events to find the first :event/run-start trace.
-  That carries the `:event` and `:event-id` for the cascade.
+  That carries the `:event`, `:event-id` AND `:dispatch-id` for the
+  cascade.
 
   When the cascade had no successful event handler (e.g. an unknown
   event id or a frame-destroyed dispatch), no :run-start fires; fall
@@ -454,6 +456,17 @@
   that originally carried payload as payload-less. `build-record`'s
   conditional `cond->` (rf2-kl5p1) omits the `:trigger-event` slot
   when `:event` is nil, which the schema's open map admits.
+
+  Per rf2-rly4a: the run-start's `:dispatch-id` is surfaced here so
+  `build-record` can pin it as a first-class `:dispatch-id` slot on the
+  epoch record. The settling cascade's id is the record's stable
+  cross-counter-space link to the raw trace stream's cascade list — and
+  must NOT depend on `:trace-events` (which `:trace-events-keep` elides
+  on older records and the post-settle reactive back-fill pads with
+  nil-`:dispatch-id` events). Causa's `:rf.causa/focus` epoch-id
+  correlation walks this slot; pre-rf2-rly4a it walked `:trace-events`
+  tags, which returned nil whenever the focused cascade's epoch had its
+  raw stream elided — starving the epoch-scoped Views + Trace panels.
 
   Per rf2-txrq9: single-walk reduction over `events` — the original
   two-pass `or`-of-`some` reordered both walks across the buffer
@@ -471,18 +484,23 @@
                        (= :event (:operation ev))
                        (= :run-start (:phase tags)))
                 ;; run-start beats the fallback; short-circuit.
-                (reduced {:run-start {:event-id (:event-id tags)
-                                      :event    (:event tags)}})
+                (reduced {:run-start {:event-id    (:event-id tags)
+                                      :event       (:event tags)
+                                      :dispatch-id (:dispatch-id tags)}})
                 ;; Capture the first :event-id we see as the fallback.
                 ;; Per rf2-7kxxx: do NOT fabricate `:event` — when the
                 ;; tag is absent we leave the field nil, and downstream
                 ;; `build-record` (rf2-kl5p1) omits the
                 ;; `:trigger-event` slot entirely rather than emit a
-                ;; misleading synthesised vector.
+                ;; misleading synthesised vector. The fallback also
+                ;; carries its `:dispatch-id` (rf2-rly4a) so a no-run-
+                ;; start cascade still pins the slot when its trace
+                ;; carried an id.
                 (if (or (:fallback acc) (nil? (:event-id tags)))
                   acc
-                  (assoc acc :fallback {:event-id (:event-id tags)
-                                        :event    (:event tags)})))))
+                  (assoc acc :fallback {:event-id    (:event-id tags)
+                                        :event       (:event tags)
+                                        :dispatch-id (:dispatch-id tags)})))))
           {}
           events)]
     (or (:run-start result) (:fallback result))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -126,7 +126,16 @@
       (is (vector? (:trace-events r)))
       (is (vector? (:sub-runs r)))
       (is (vector? (:renders r)))
-      (is (vector? (:effects r))))))
+      (is (vector? (:effects r)))
+      ;; rf2-rly4a — the settling cascade's :dispatch-id is pinned as a
+      ;; first-class slot (the stable epoch-id ↔ cascade link Causa's
+      ;; focus correlation reads). It must equal the :dispatch-id tag the
+      ;; cascade's own trace events carry.
+      (is (some? (:dispatch-id r))
+          "record carries the pinned :dispatch-id slot")
+      (is (= (:dispatch-id r)
+             (some #(get-in % [:tags :dispatch-id]) (:trace-events r)))
+          ":dispatch-id slot equals the cascade's trace :dispatch-id tag"))))
 
 (deftest record-multi-event-cascade
   (testing "per rf2-nj6p7 (Spec 002 §Drain versus event): each dequeued

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -2342,6 +2342,7 @@ Per-frame epoch snapshot, recorded **per dequeued event** in dev builds — one 
    [:committed-at  :any]                                                    ;; timestamp
    [:event-id      :keyword]                                                ;; the event that triggered the cascade
    [:trigger-event [:vector :any]]                                          ;; the full event vector
+   [:dispatch-id   {:optional true} :any]                                   ;; (rf2-rly4a) the settling cascade's opaque router dispatch-id, pinned from the `:event/run-start` tag — the stable cross-counter-space link from this epoch (epoch-id space) to the raw trace stream's cascade list (dispatch-id space); survives `:trace-events` elision + reactive back-fill; absent when the cascade carried no dispatch-id (rejected dispatch / pre-run-start halt / synthetic reset epoch)
    [:db-before     :any]                                                    ;; app-db before the cascade
    [:db-after      :any]                                                    ;; app-db the runtime settled to (see :outcome)
    [:outcome       [:enum :ok                                               ;; (rf2-v0jwt) the event's own cascade settled cleanly

--- a/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/common_helpers.cljc
@@ -122,15 +122,31 @@
 ;; ---- epoch → dispatch-id resolution -------------------------------------
 
 (defn dispatch-id-of-epoch
-  "Walk an `:rf/epoch-record`'s `:trace-events` for the first
-  cascade-root `:dispatch-id` tag and return it; nil when no
-  dispatch-id-bearing event is present (synthetic epochs from
-  `reset-frame-db!` record `:trace-events []`).
+  "Return an `:rf/epoch-record`'s settling cascade `:dispatch-id`, or nil
+  when none is known (synthetic epochs from `reset-frame-db!`, a rejected
+  dispatch that never reached run-start).
 
-  Pure data → cascade-id-or-nil. Used by the time-travel panel
-  (when building a fresh pin or deciding chip presentation)."
+  Per rf2-rly4a the record carries `:dispatch-id` as a first-class slot
+  (pinned in `re-frame.epoch.assembly/build-record` from the settling
+  event's `:event/run-start` tags) — read it directly. This is the stable
+  link between the epoch ring (epoch-id space) and the raw trace stream's
+  cascade list (dispatch-id space) that Causa's `:rf.causa/focus`
+  correlation pivots on, and it survives both `:trace-events-keep`
+  elision on older records and the post-settle reactive back-fill (which
+  pads `:trace-events` with nil-`:dispatch-id` sub-run / render events).
+
+  Falls back to a `:trace-events` walk for records produced before the
+  slot existed (or restored fixtures that omit it) — the first cascade-
+  root `:dispatch-id` / `:parent-dispatch-id` tag. The fallback is nil-
+  safe: a record with neither the slot nor a dispatch-id-bearing trace
+  yields nil.
+
+  Pure data → cascade-id-or-nil. Used by Causa's `:rf.causa/focus`
+  epoch-id correlation and the time-travel panel (when building a fresh
+  pin or deciding chip presentation)."
   [epoch-record]
-  (some (fn [ev]
-          (or (get-in ev [:tags :dispatch-id])
-              (get-in ev [:tags :parent-dispatch-id])))
-        (:trace-events epoch-record)))
+  (or (:dispatch-id epoch-record)
+      (some (fn [ev]
+              (or (get-in ev [:tags :dispatch-id])
+                  (get-in ev [:tags :parent-dispatch-id])))
+            (:trace-events epoch-record))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/focus_epoch_id_correlation_e2e_cljs_test.cljs
@@ -1,0 +1,184 @@
+(ns day8.re-frame2-causa.panels-e2e.focus-epoch-id-correlation-e2e-cljs-test
+  "Multi-frame end-to-end coverage for rf2-rly4a — the `:rf.causa/focus`
+  epoch-id correlation.
+
+  ## The bug (rf2-rly4a, P1 regression)
+
+  After a page refresh the parallel-frames testbed rendered Causa's
+  Views + Trace panels EMPTY because `:rf.causa/focus` returned
+  `:epoch-id nil`. Those panels are epoch-scoped — `:rf.causa/reactive-
+  data` (Views) and `:rf.causa/trace-feed` (Trace) read the focused
+  epoch RECORD via `focus.epoch-id` — so a nil epoch-id starves them.
+
+  ## Root cause
+
+  `compose-focus` derives `:epoch-id` by correlating the focused
+  cascade `:dispatch-id` (from the raw trace stream's cascade list,
+  depth 1000) against `:rf.causa/epoch-history` via
+  `epoch-id-for-cascade` → `dispatch-id-of-epoch`. Pre-fix that helper
+  walked the record's `:trace-events` for a `:dispatch-id` tag — but
+  `:trace-events-keep` (default 5) ELIDES `:trace-events` from all but
+  the 5 most-recent records, and the post-settle reactive back-fill
+  (rf2-qs6dl / rf2-wi900) pads `:trace-events` with nil-`:dispatch-id`
+  sub-run / render events. So any focused cascade whose epoch was
+  outside the keep-window correlated to nil → empty panels.
+
+  ## Fix
+
+  `build-record` now pins the settling cascade `:dispatch-id` as a
+  first-class record slot (from the `:event/run-start` tag, surfaced by
+  `find-trigger-event`); `dispatch-id-of-epoch` reads the slot directly,
+  falling back to the legacy `:trace-events` walk. The slot survives
+  elision + back-fill, so the correlation is stable for every retained
+  epoch.
+
+  These tests drive the REAL pipeline (host dispatches → trace bus →
+  epoch ring → Causa's subs) — no synthetic-cascade seam — exactly as
+  `parallel_frames_e2e_cljs_test` does."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private frame-below :below)
+
+(defn- install-causa! []
+  (trace-bus/clear-buffer!)
+  (causa-test-support/reset-all!)
+  (registry/register-causa-handlers!)
+  (preload/register-trace-collector!)
+  (preload/register-epoch-collector!)
+  nil)
+
+(defn- install-counter! []
+  (rf/reg-event-db :counter/inc (fn [db _] (update db :counter (fnil inc 0))))
+  (rf/reg-sub :counter/value (fn [db _] (:counter db))))
+
+(defn- mount-causa-with-target! [target]
+  (frame/reg-frame :rf/causa {})
+  (let [buffer (trace-bus/buffer)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer])
+      (rf/dispatch-sync [:rf.causa/set-target-frame target])))
+  nil)
+
+(defn- sub-causa [query]
+  (rf/with-frame :rf/causa @(rf/subscribe query)))
+
+(defn- dispatch-host-frame [event frame-id]
+  (rf/dispatch-sync event {:frame frame-id})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])
+    (rf/dispatch-sync [:rf.causa/set-target-frame frame-id])))
+
+(defn- focus-cascade! [dispatch-id frame-id]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade dispatch-id frame-id])))
+
+(defn- below-host-cascades []
+  (filterv #(= frame-below (:frame %)) (sub-causa [:rf.causa/cascades])))
+
+;; ---------------------------------------------------------------------------
+
+(deftest head-focus-resolves-epoch-id-and-feeds-panels
+  (testing "LIVE head focus — `:rf.causa/focus :epoch-id` is non-nil and
+  the head epoch's `:dispatch-id` slot matches the head cascade. Views +
+  Trace see the focused record (rf2-rly4a)."
+    (install-causa!)
+    (frame/reg-frame frame-below {})
+    (install-counter!)
+    (mount-causa-with-target! frame-below)
+    (dispatch-host-frame [:counter/inc] frame-below)
+    (let [focus    (sub-causa [:rf.causa/focus])
+          history  (sub-causa [:rf.causa/epoch-history])
+          head     (last (below-host-cascades))
+          reactive (sub-causa [:rf.causa/reactive-data])
+          trace    (sub-causa [:rf.causa/trace-feed])]
+      (is (:head? focus) "test setup: focus is on the LIVE head")
+      (is (some? (:epoch-id focus))
+          (str "head focus epoch-id is nil — Views + Trace would render "
+               "empty (rf2-rly4a). focus: " (pr-str focus)))
+      ;; The head epoch's pinned :dispatch-id slot links it to the head cascade.
+      (let [head-record (some #(when (= (:epoch-id focus) (:epoch-id %)) %)
+                              history)]
+        (is (= (:dispatch-id head) (:dispatch-id head-record))
+            "head epoch's :dispatch-id slot must equal the head cascade id"))
+      (is (:has-cascade? reactive)
+          (str "Views (:rf.causa/reactive-data) saw no focused epoch record — "
+               "rf2-rly4a. reactive-data: " (pr-str (select-keys reactive
+                                                                 [:has-cascade?
+                                                                  :epoch-id]))))
+      (is (= (:epoch-id focus) (:epoch-id trace))
+          "Trace (:rf.causa/trace-feed) epoch-id must equal the focused epoch-id")
+      (is (pos? (:total trace))
+          (str "Trace feed has no rows for the focused epoch — rf2-rly4a. "
+               "trace: " (pr-str (select-keys trace [:total :epoch-id :empty-kind])))))))
+
+(deftest retro-focus-on-trace-elided-epoch-resolves-epoch-id
+  (testing "RETRO focus on an OLD cascade whose epoch had `:trace-events`
+  elided by the `:trace-events-keep` window (default 5). Pre-rf2-rly4a
+  the `dispatch-id-of-epoch` `:trace-events` walk returned nil for these
+  records, so `focus.epoch-id` was nil and Views + Trace went empty. The
+  first-class `:dispatch-id` slot survives elision — the correlation
+  must resolve."
+    (install-causa!)
+    (frame/reg-frame frame-below {})
+    (install-counter!)
+    (mount-causa-with-target! frame-below)
+    ;; Drive 10 cascades so the earliest ones fall well outside the
+    ;; keep-5 window (their `:trace-events` get dissoc'd).
+    (dotimes [_ 10] (dispatch-host-frame [:counter/inc] frame-below))
+    (let [history    (sub-causa [:rf.causa/epoch-history])
+          ;; Pick the OLDEST host cascade — its epoch is trace-elided.
+          old-id     (-> (below-host-cascades) first :dispatch-id)
+          ;; Its epoch record (matched by the pinned slot).
+          old-record (some #(when (= old-id (:dispatch-id %)) %) history)]
+      (is (some? old-id) "test setup: there is an old host cascade")
+      (is (some? old-record)
+          "test setup: the old cascade correlates to a retained epoch record")
+      (is (not (contains? old-record :trace-events))
+          (str "test setup: the old epoch must have had :trace-events elided "
+               "(it must be outside the keep-window for this test to bite). "
+               "epoch-id: " (pr-str (:epoch-id old-record))))
+      ;; Focus the old cascade — flips spine to RETRO.
+      (focus-cascade! old-id frame-below)
+      (let [focus    (sub-causa [:rf.causa/focus])
+            reactive (sub-causa [:rf.causa/reactive-data])
+            trace    (sub-causa [:rf.causa/trace-feed])]
+        (is (= :retro (:mode focus)) "test setup: focusing a non-head cascade pins RETRO")
+        (is (= (:epoch-id old-record) (:epoch-id focus))
+            (str "RETRO focus on a trace-elided epoch resolved the WRONG (or nil) "
+                 "epoch-id — rf2-rly4a. focus: " (pr-str focus)
+                 " expected epoch-id: " (pr-str (:epoch-id old-record))))
+        (is (:has-cascade? reactive)
+            "Views saw no record for the trace-elided focused epoch — rf2-rly4a")
+        (is (= (:epoch-id old-record) (:epoch-id trace))
+            "Trace feed did not scope to the trace-elided focused epoch — rf2-rly4a")))))
+
+(deftest dispatch-id-slot-pinned-on-every-retained-epoch
+  (testing "Every retained epoch record carries the first-class
+  `:dispatch-id` slot independent of `:trace-events` retention — the
+  structural property the correlation now leans on (rf2-rly4a)."
+    (install-causa!)
+    (frame/reg-frame frame-below {})
+    (install-counter!)
+    (mount-causa-with-target! frame-below)
+    (dotimes [_ 8] (dispatch-host-frame [:counter/inc] frame-below))
+    (let [history (sub-causa [:rf.causa/epoch-history])
+          elided  (filterv #(not (contains? % :trace-events)) history)]
+      (is (seq elided)
+          "test setup: at least one record should have :trace-events elided")
+      (is (every? #(some? (:dispatch-id %)) history)
+          (str "some retained epoch lacks the pinned :dispatch-id slot — "
+               "rf2-rly4a. epochs missing the slot: "
+               (pr-str (mapv :epoch-id (remove #(some? (:dispatch-id %)) history)))))
+      (is (every? #(some? (:dispatch-id %)) elided)
+          "a trace-elided record must STILL carry the pinned :dispatch-id slot"))))


### PR DESCRIPTION
## Summary

P1 regression fix: after a page refresh Causa's Views + Trace panels rendered EMPTY in the parallel-frames testbed because `:rf.causa/focus` returned `:epoch-id nil`.

## Root cause

Views (`:rf.causa/reactive-data`) and Trace (`:rf.causa/trace-feed`) are epoch-scoped — they read the focused epoch RECORD via `focus.epoch-id`. `compose-focus` derives that epoch-id by correlating the focused cascade `:dispatch-id` (raw trace stream, depth 1000) against `:rf.causa/epoch-history` via `epoch-id-for-cascade` → `dispatch-id-of-epoch`.

Pre-fix, `dispatch-id-of-epoch` **walked the record's `:trace-events`** for a `:dispatch-id` tag. But:
- `:trace-events-keep` (default **5**) ELIDES `:trace-events` from all but the 5 most-recent records (`elide-just-crossed-trace-events`).
- The post-settle reactive back-fill (rf2-qs6dl / rf2-wi900) pads `:trace-events` with nil-`:dispatch-id` sub-run / render events.

So any focused cascade whose epoch fell outside the keep-window correlated to **nil** → empty panels. The regression surfaced this session because the deep parallel-frames boot (two frames, on-create flows, machine snapshots, async replies) pushes the focused epoch out of the keep-5 window. Verified live with a node-test probe: focusing an old cascade whose epoch had `:trace-events` elided returned `:epoch-id nil` pre-fix.

## Fix

`build-record` now pins the settling cascade `:dispatch-id` as a **first-class `:rf/epoch-record` slot** (from the `:event/run-start` tag, surfaced by `find-trigger-event`). `dispatch-id-of-epoch` reads the slot directly, falling back to the legacy `:trace-events` walk for pre-slot / fixture records. The slot survives elision + back-fill, so the epoch-id ↔ cascade link is stable for every retained epoch.

- `implementation/epoch/capture.cljc` — `find-trigger-event` surfaces `:dispatch-id`
- `implementation/epoch/assembly.cljc` — `build-record` pins the `:dispatch-id` slot (optional `cond->`, matching `:event-id` / `:trigger-event`)
- `spec/Spec-Schemas.md` — declare optional `:dispatch-id` on `:rf/epoch-record`
- `tools/causa/.../common_helpers.cljc` — `dispatch-id-of-epoch` reads the slot first

## Tests

- New real-pipeline e2e (`focus_epoch_id_correlation_e2e_cljs_test.cljs`): LIVE head focus resolves epoch-id + feeds Views/Trace; **RETRO focus on a trace-elided epoch** resolves the correct epoch-id (the exact bug); every retained epoch (incl. elided) carries the pinned slot.
- `epoch_test.clj record-shape-canonical` — asserts the new `:dispatch-id` slot equals the cascade's trace `:dispatch-id`.

## Test plan

- [x] `npm run test:cljs` — 4109 tests, 0 failures
- [x] `npm run test:causa-feature-gate` — 13/13, 0 failures
- [x] `implementation/epoch` JVM tests — 201 tests, 0 failures