### PR TITLE
fix(story): reconcile residual :play references to :play-script (rf2-v89ay)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -155,7 +155,8 @@
      {:doc                   \"...\"
       :extends               <variant-id>
       :events                [[:event-id args...]]
-      :play                  [[:event-id args...]]
+      :play-script           {:script [[:dispatch [:event-id args...]] ...]}
+      :plays                 [{:name \"...\" :script [...]} ...]
       :args                  {<arg-key> <value>}
       :argtypes              {...}
       :tags                  #{...}
@@ -872,9 +873,9 @@
   on a variant's `:decorators` slot:
 
       (story/reg-variant :story.auth/login-pending
-        {:decorators [[story/force-fx-stub-id :http {:status :pending}]]
-         :play       [[:auth/login]
-                      [:rf.assert/effect-emitted :http]]})"
+        {:decorators  [[story/force-fx-stub-id :http {:status :pending}]]
+         :play-script {:script [[:dispatch [:auth/login]]
+                                [:dispatch [:rf.assert/effect-emitted :http]]]}})"
   fx-stubs/force-fx-stub-id)
 
 ;; ---- public SOTA-feature surface ----------------------------------------
@@ -1024,7 +1025,7 @@
 ;; ---- rf2-5fc15 — Test Codegen recorder public surface --------------------
 ;;
 ;; Per bead rf2-5fc15 the recorder captures canvas-dispatched events as
-;; a `:play` body. Exposing the entry points here lets tests, MCP
+;; a `:play-script` body. Exposing the entry points here lets tests, MCP
 ;; tooling, and headless integrations drive recording programmatically
 ;; without going through the toolbar UI.
 
@@ -1063,9 +1064,11 @@
   (recorder/clear!))
 
 (defn gen-play-snippet
-  "Render an EDN snippet `(reg-variant <id> {... :play [...]})` for
+  "Render an EDN snippet `(reg-variant <id> {... :play-script {...}})` for
   `events`. Pure data → string; round-trips through `read-string` and
-  re-frame's registrar machinery.
+  re-frame's registrar machinery. Per rf2-0wrud `:play-script` is the
+  canonical AND ONLY phase-4 slot — each captured event vector is wrapped
+  as a `[:dispatch-sync <event-vec>]` step under `:play-script :script`.
 
   `opts` accepts:
     :variant-id  required — keyword id for the new variant.
@@ -1073,7 +1076,7 @@
     :extends     optional — keyword id of a variant to `:extends`.
     :alias       optional — short ns alias for the form (default `story`).
 
-  Empty `events` still produces a valid form (with `:play []`) so the
-  user sees the shape to fill in."
+  Empty `events` still produces a valid form (with an empty `:script []`)
+  so the user sees the shape to fill in."
   [events opts]
   (recorder/gen-play-snippet events opts))

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -173,7 +173,7 @@
   "Per IMPL-SPEC §3.5 + Phase-2 §5.1 #9: true iff every entry in
   `assertions` has `:passed? true`. An assertions vector with zero
   entries is vacuously passing — this is the spec/007 §Story-as-test
-  duality contract: a variant with no `:play` (and therefore no
+  duality contract: a variant with no `:play-script` (and therefore no
   assertions) still 'passes', and shows up as green in test reports.
 
   Accepts either an assertions vector or a `run-variant` result map."

--- a/tools/story/src/re_frame/story/fx_stubs.cljc
+++ b/tools/story/src/re_frame/story/fx_stubs.cljc
@@ -6,10 +6,10 @@
   ## Authoring shape
 
       (story/reg-variant :story.auth/login-pending
-        {:decorators [[:rf.story/force-fx-stub :http {:status :pending}]]
-         :play       [[:auth/login]
-                      [:rf.assert/effect-emitted :http]
-                      [:rf.assert/path-equals [:auth :status] :pending]]})
+        {:decorators  [[:rf.story/force-fx-stub :http {:status :pending}]]
+         :play-script {:script [[:dispatch [:auth/login]]
+                                [:dispatch [:rf.assert/effect-emitted :http]]
+                                [:dispatch [:rf.assert/path-equals [:auth :status] :pending]]]}})
 
   ## Authoring shape — value-form
 

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -319,7 +319,7 @@
     AND
   - the resolved decorator stack carries no `:frame-setup` decorators.
 
-  The variant body's `:events` and `:play` slots are ignored — events
+  The variant body's `:events` and `:play-script` slots are ignored — events
   dispatch synchronously after mount and play runs strictly after
   `:ready`, so neither holds the lifecycle in a loading phase.
   `:hiccup` and `:fx-override` decorators don't drive the lifecycle

--- a/tools/story/src/re_frame/story/predicates.cljc
+++ b/tools/story/src/re_frame/story/predicates.cljc
@@ -54,15 +54,15 @@
   Used by `recorder/gen-play-snippet`, `save-variant/gen-variant-
   snippet`, and `review-dialog`'s snippet renderer to join multi-line
   EDN bodies. The argument is the literal first-line text preceding
-  the items (e.g. `\"   :play [\"` or `\"   :args {\"`) — passing the
+  the items (e.g. `\"   :script [\"` or `\"   :args {\"`) — passing the
   rendered prefix verbatim keeps the geometry obvious and
   breakage-resistant.
 
   Example:
 
-      (str \"   :play [item1\" (indent-after \"   :play [\") \"item2]\")
-      ;; => \"   :play [item1\\n          item2]\"
-      ;;                  ^---------- item2 aligns under item1
+      (str \"   :script [item1\" (indent-after \"   :script [\") \"item2]\")
+      ;; => \"   :script [item1\\n             item2]\"
+      ;;                    ^---------- item2 aligns under item1
 
   Lives in the predicates leaf (rf2-ar0t9) so producers
   (recorder / save-variant) don't have to `:require` the consumer

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -1,12 +1,13 @@
 (ns re-frame.story.recorder
-  "Test Codegen — record canvas-dispatched events as a `:play` body.
+  "Test Codegen — record canvas-dispatched events as a `:play-script` body.
 
   Per bead rf2-5fc15: Storybook 9's killer feature is the record-and-save
   workflow — the user interacts with the canvas, the tool watches the
   event bus, and on 'stop' it emits a code snippet the user appends to
-  a new variant. Story's `:play` body is a vector of event vectors, so
-  the captured trace is the codegen output verbatim — no Testing
-  Library / page-object translation layer is needed.
+  a new variant. Story's `:play-script` body wraps each captured event
+  vector as a `[:dispatch-sync <event-vec>]` step (rf2-0wrud), so the
+  captured trace is the codegen output verbatim — no Testing Library /
+  page-object translation layer is needed.
 
   ## What this namespace does
 
@@ -37,7 +38,7 @@
   ## `:sensitive?` events — record-but-redact (rf2-hdadz)
 
   Per rf2-hdadz (pragmatic stance, 2026-05-14): events flagged
-  `:sensitive? true` are STILL captured into the `:play` body, but the
+  `:sensitive? true` are STILL captured into the `:play-script` body, but the
   event payload is replaced with the framework's `:rf/redacted`
   sentinel so the credential / PII / auth-token doesn't ride into the
   snippet text. Mirrors rf2-vnjfg's enforcement on the always-on
@@ -48,8 +49,8 @@
      temporal ordering of dispatches; a recording that goes `:click`
      → `<dropped>` → `:click` is harder to read than `:click` →
      `[:rf/redacted]` → `:click`.
-  2. **Re-play stays well-formed.** A `:play` body of `[<vec> ... <vec>]`
-     stays a vector-of-vectors; round-trip through `read-string` and
+  2. **Re-play stays well-formed.** The captured events vector of
+     `[<vec> ... <vec>]` stays a vector-of-vectors; round-trip through `read-string` and
      re-dispatch find a `[:rf/redacted]` event vector rather than a bare
      sentinel keyword (no handler registered for `:rf/redacted`, so the
      re-play raises a clean dispatch error rather than a malformed
@@ -77,7 +78,7 @@
   Recording captures user dispatches. Assertions are the dual — the
   user wants to say 'after I click this button, the counter shows 3'.
   The canonical seven `:rf.assert/*` ids (per spec/004) compose with
-  the captured `:play` body exactly the way they compose with a hand-
+  the captured `:play-script` body exactly the way they compose with a hand-
   authored one — `dispatch-sync` them in line. The `recordable-event?`
   filter drops them off the trace bus (assertions are authored, not
   observed), so we expose an explicit insertion path:
@@ -120,13 +121,13 @@
 ;;
 ;; The recorder skips assertion events (`:rf.assert/*`) and Story's
 ;; own internal helpers (`:rf.story/*` / `:re-frame.story.*`) so the
-;; emitted `:play` body is exactly the user-facing dispatches that
+;; emitted `:play-script` body is exactly the user-facing dispatches that
 ;; reproduce the canvas state.
 ;; ---------------------------------------------------------------------------
 
 (defn- internal-namespace?
   "True iff `ns-str` is a Story-internal namespace whose events should
-  not appear in a recorded `:play` body."
+  not appear in a recorded `:play-script` body."
   [ns-str]
   (and (string? ns-str)
        (or (= pred/reserved-assertion-ns ns-str)   ; "rf.assert"
@@ -136,7 +137,7 @@
 
 (defn recordable-event?
   "True iff `event` (a re-frame event vector) is one the recorder should
-  capture into a `:play` body. Filters out assertion events and
+  capture into a `:play-script` body. Filters out assertion events and
   Story's own internal helper events. Pure data → boolean; JVM-
   testable."
   [event]
@@ -150,9 +151,9 @@
   "The placeholder event vector the recorder appends in place of a
   `:sensitive? true` event when the show-sensitive? flag is false
   (default). Per rf2-hdadz: record-but-redact preserves the row's
-  temporal position in the captured `:play` body without leaking the
+  temporal position in the captured `:play-script` body without leaking the
   credential / PII / auth-token. The single-element vector keeps the
-  `:play` shape (vector-of-event-vectors) intact so the snippet
+  captured-events shape (vector-of-event-vectors) intact so the snippet
   round-trips through `read-string` cleanly; re-play sees a well-
   formed event vector whose id (`:rf/redacted`, the framework sentinel
   from `re-frame.privacy`) has no registered handler — the resulting
@@ -238,7 +239,7 @@
 ;; ids are reserved. The recorder's mid-recording insertion picker
 ;; enumerates these to drive a single-click 'add assertion' affordance —
 ;; pick the id, supply the payload, the assertion event lands inline
-;; in the captured `:play` body alongside the dispatched events.
+;; in the captured `:play-script` body alongside the dispatched events.
 ;;
 ;; The vocabulary is data, not behaviour — the actual handlers live in
 ;; `re-frame.story.assertions`. This list is for the picker UI and for
@@ -419,8 +420,8 @@
 (def initial-state
   "The recorder's idle state shape. `:recording?` flips true while a
   capture is in flight; `:events` accumulates the captured event
-  vectors in declared order (oldest first, ready to drop straight
-  into `:play`); `:entries` (rf2-d5u89) accumulates the richer
+  vectors in declared order (oldest first, ready for `gen-play-snippet`
+  to wrap as `:play-script` `:dispatch-sync` steps); `:entries` (rf2-d5u89) accumulates the richer
   per-entry maps (`:event/dispatch` + `:dom/click` / `:dom/type` /
   `:dom/submit`) with per-event timestamps — consumed by the
   `:play-script` translator; `:variant-id` records which frame the
@@ -454,8 +455,9 @@
   (:variant-id @state))
 
 (defn recorded-events
-  "Return the vector of captured event vectors (oldest first). Back-
-  compat surface — feeds the legacy `:play` snippet codegen."
+  "Return the vector of captured event vectors (oldest first). Feeds the
+  simple `gen-play-snippet` codegen, which wraps each as a
+  `:play-script` `:dispatch-sync` step."
   []
   (:events @state))
 
@@ -483,11 +485,11 @@
 ;; ---------------------------------------------------------------------------
 ;; rf2-d5u89 — per-event timestamps + DOM-event entries
 ;;
-;; The legacy recorder model carried `:events` (a vector of event
-;; vectors) — sufficient for the v1 `:play` slot which dispatches
-;; them on mount, but blind to TIMING and DOM INTERACTION which the
-;; rich `:play-script` DSL needs to emit `:click` / `:type` / `:wait`
-;; steps.
+;; The original recorder model carried `:events` (a vector of event
+;; vectors) — sufficient for the simple `gen-play-snippet` codegen which
+;; wraps each as a `:dispatch-sync` step, but blind to TIMING and DOM
+;; INTERACTION which the rich `:play-script` DSL needs to emit `:click`
+;; / `:type` / `:wait` steps.
 ;;
 ;; The model now carries a parallel `:entries` vector keyed on the
 ;; same index as `:events`. Each entry is one of:
@@ -497,9 +499,9 @@
 ;;   {:kind :dom/type       :selector <str> :text <str> :t <ms>}
 ;;   {:kind :dom/submit     :selector <str> :t <ms>}
 ;;
-;; `:events` stays canonical for the legacy `:play` snippet codegen
-;; (gen-play-snippet) — back-compat is non-negotiable. `:entries` is
-;; the new richer surface the `:play-script` translator consumes.
+;; `:events` stays canonical for the simple `gen-play-snippet` codegen
+;; (which emits `:dispatch-sync` `:play-script` steps). `:entries` is
+;; the richer surface the rich `:play-script` translator consumes.
 ;;
 ;; `:t` is ms since `:started-ms`; pure helpers accept a `now-ms`
 ;; argument for deterministic testing. (Helper fns `now-ms*`,
@@ -515,8 +517,8 @@
   Per rf2-d5u89 the call ALSO appends a parallel `:entries` entry
   `{:kind :event/dispatch :event <vec> :t <ms>}` so the
   `:play-script` translator sees the timing alongside the event.
-  `:events` (bare event vectors) stays as-is for back-compat with
-  the legacy `:play` snippet codegen.
+  `:events` (bare event vectors) stays as-is for the simple
+  `gen-play-snippet` codegen.
 
   Two-arg form (`(append state event now-ms)`) lets callers pin
   the timestamp for deterministic tests."
@@ -789,7 +791,7 @@
   Sensitive events (`:sensitive? true`) are RECORDED-BUT-REDACTED per
   rf2-hdadz: the placeholder `redacted-event` vector replaces the
   event payload so the credential / PII / auth-token doesn't ride into
-  the captured `:play` body, while the row's temporal position is
+  the captured `:play-script` body, while the row's temporal position is
   preserved for correlation. The suppressed-events counter is still
   bumped (Spec 009 §Privacy + rf2-bclgj — Story is a framework-
   published trace consumer that default-suppresses sensitive events)

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -5,9 +5,9 @@
 
   The recorder (`re-frame.story.recorder`) captures dispatched events
   during a canvas session and surfaces them in a save-as-variant
-  dialog as a `(reg-variant ... :play [...])` EDN snippet — the
-  legacy `:play` slot, a bare vector of event vectors that re-fires
-  on mount.
+  dialog as a `(reg-variant ... :play-script {...})` EDN snippet — the
+  simple `gen-play-snippet` codegen, which wraps each captured event
+  vector as a `[:dispatch-sync <event-vec>]` step (rf2-0wrud).
 
   The rich `:play-script` DSL landed in rf2-8i2a9 — tagged steps
   (`[:dispatch ...]`, `[:wait ms]`, `[:assert-db ...]`,

--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -4,7 +4,7 @@
 
   Two save-as flows ship today:
 
-  - record-as-`:play` — `re-frame.story.recorder` captures a trace of
+  - record-as-`:play-script` — `re-frame.story.recorder` captures a trace of
     dispatched events and surfaces the generated `(reg-variant ...)`
     EDN form in a modal for the user to copy + paste into source.
   - snapshot-args-as-`:args` — `re-frame.story.save-variant` captures
@@ -210,8 +210,8 @@
 ;; bracket/brace of their body key — e.g.
 ;;
 ;;     (story/reg-variant :id
-;;       {:play [[:counter/inc]
-;;               [:counter/dec]]})
+;;       {:play-script {:script [[:dispatch-sync [:counter/inc]]
+;;                               [:dispatch-sync [:counter/dec]]]}})
 ;;
 ;; Per rf2-ar0t9: `indent-after` lives in `re-frame.story.predicates`
 ;; so producers (recorder, save-variant) don't have to `:require`

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -2,7 +2,7 @@
   "Save-current-canvas-state-as-new-variant — the SB9 'Save' affordance
   (rf2-one3t; SB9 story-from-UI parity per rf2-v05qb §2.2).
 
-  Story-from-UI in two affordances: (a) record-as-`:play` (Test Codegen,
+  Story-from-UI in two affordances: (a) record-as-`:play-script` (Test Codegen,
   rf2-5fc15 — `re-frame.story.recorder`); (b) snapshot-args-as-`:args`
   (this namespace). Both surface the captured state through the same
   review-then-commit modal pattern — Story emits an EDN snippet the user
@@ -132,7 +132,7 @@
   round-trips through re-frame's registrar machinery.
 
   Unlike `re-frame.story.recorder/gen-play-snippet` (which produces a
-  `:play` body for record-as-test), this generator captures the canvas
+  `:play-script` body for record-as-test), this generator captures the canvas
   STATE — the args snapshot — so the new variant renders with the same
   controls as the source the user was tweaking when they clicked Save."
   [{:keys [variant-id extends args doc alias]
@@ -323,7 +323,7 @@
 ;; The event id is `:rf.story/save-current-as-variant`; the namespace
 ;; prefix `:rf.story/*` is filtered by the Test Codegen recorder's
 ;; `recordable-event?` predicate, so a save dispatched during an active
-;; recording never appears in the recorded `:play` body.
+;; recording never appears in the recorded `:play-script` body.
 ;; ---------------------------------------------------------------------------
 
 (def ^:const id-save-current-as-variant

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -399,7 +399,7 @@
                       (str "Recording " (count (:events rec))
                            " events — click to stop and save as variant")
                       :else
-                      "Record canvas dispatches as a :play body (Test Codegen)")
+                      "Record canvas dispatches as a :play-script body (Test Codegen)")
       :on-click     on-click}
      (when rec? [:span {:style (:dot styles)}])
      "REC"
@@ -418,7 +418,7 @@
 ;;      buttons. Click selects one + advances to phase 2.
 ;;   2. Field entry — one EDN input per payload field declared in the
 ;;      vocabulary entry. A live preview shows the event vector that
-;;      will land in the captured `:play` body. 'Insert' calls
+;;      will land in the captured `:play-script` body. 'Insert' calls
 ;;      `recorder/insert-assertion!`; 'cancel' returns to phase 1.
 ;;
 ;; The picker is overlay-style modal so it stays visible while the
@@ -721,7 +721,7 @@
        [:button
         {:style     (:assert-btn styles)
          :data-test "story-recorder-add-assertion"
-         :title     "Insert a :rf.assert/* assertion into the captured :play body"
+         :title     "Insert a :rf.assert/* assertion into the captured :play-script body"
          :on-click  (fn [_] (open-picker!))}
         "+ assert"]
        [:button
@@ -743,7 +743,7 @@
 
 (defn save-dialog
   "Modal dialog rendered after the user stops a non-empty recording.
-  Shows the EDN snippet — `(reg-variant <id> {... :play [...]})` —
+  Shows the EDN snippet — `(reg-variant <id> {... :play-script {...}})` —
   and a 'copy to clipboard' affordance.
 
   The user edits the variant id inline; the snippet re-generates on
@@ -777,7 +777,7 @@
            :on-discard        (fn [] (recorder/clear!) (close-dialog!))
            ;; rf2-x9zsr — open the :play-script export dialog with the
            ;; captured snapshot. We DON'T close the parent dialog
-           ;; (user may want to copy the :play form too); the export
+           ;; (user may want to copy the simple :play-script form too); the export
            ;; dialog stacks on top via a higher z-index.
            :on-export         (fn []
                                 (export-dialog/open-from-recorder-dialog!

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -2,9 +2,10 @@
   "Recorder → :play-script export dialog UI (rf2-x9zsr).
 
   The recorder's existing save-as-variant dialog
-  (`re-frame.story.ui.recorder/save-dialog`) emits the legacy `:play`
-  body — a bare vector of event vectors that re-fires on mount. The
-  rich `:play-script` DSL landed in rf2-8i2a9; this dialog is its
+  (`re-frame.story.ui.recorder/save-dialog`) emits the simple
+  `:play-script` body — each captured event vector wrapped as a
+  `[:dispatch-sync <event-vec>]` step (rf2-0wrud). The rich
+  `:play-script` DSL landed in rf2-8i2a9; this dialog is its
   twin — same recording, different output shape:
 
       (story/reg-variant :story.your/recorded

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -83,7 +83,7 @@
 ;; ---------------------------------------------------------------------------
 ;; Button styling — the controls-panel-local affordance. The modal
 ;; itself reuses `re-frame.story.review-dialog`'s shared styles so the
-;; two save-as flows (record-as-:play + snapshot-as-:args) share
+;; two save-as flows (record-as-:play-script + snapshot-as-:args) share
 ;; visual language.
 ;; ---------------------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -187,7 +187,7 @@
 (defn- compute-testable-content-hashes
   "Walk the registered testable variants and return a `{variant-id →
   hex-hash}` map of snapshot-identity content hashes. The hash captures
-  the variant's `:play` / `:events` / `:loaders` / `:decorators` /
+  the variant's `:play-script` / `:events` / `:loaders` / `:decorators` /
   `:tags` slots plus the parent story's slice, the view's registered
   schema-digest, AND the variant's resolved effective args (which fold
   in the user's live `:cell-overrides`). See `re-frame.story.identity`
@@ -680,7 +680,7 @@
   composed of header / prose / args / decorators / parameters / tags
   sections. Per rf2-qmjo the `:test` pane renders `test-mode-view/test-view`
   — the in-canvas aggregated pass/fail summary of the variant's
-  `:play` sequence + assertions. `:dev` preserves the existing canvas
+  `:play-script` sequence + assertions. `:dev` preserves the existing canvas
   / workspace behaviour."
   []
   (let [shell      @state/shell-state-atom

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -199,7 +199,7 @@
 
 (defn status-dot
   "Render the per-variant status glyph. Variants not in `[:tests :runs]`
-  (no recorded run AND not tagged `:test`/empty `:play`) skip the dot
+  (no recorded run AND not tagged `:test`/empty `:play-script`) skip the dot
   entirely — the row layout shifts left a few pixels but stays
   readable. Variants whose status is `:pending` show an empty-ring dot
   so the user can see the slot is reserved.
@@ -471,8 +471,8 @@
 
 (defn test-widget
   "Chrome-level test widget. Aggregates `run-variant` outcomes across
-  every testable variant. `:test`-tagged + `:play`-bearing variants
-  contribute; variants without `:play` are excluded by `testable-
+  every testable variant. `:test`-tagged + `:play-script`-bearing variants
+  contribute; variants without `:play-script` are excluded by `testable-
   variant-ids` so the headline counts don't mislead.
 
   Renders nothing when no variants are testable — the widget is the

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -164,7 +164,8 @@
 
 ;; ---- pure: play-step scrubber data (rf2-lc36w) --------------------------
 ;;
-;; Each entry in the variant body's `:play` vector is dispatched as a
+;; Each play event derived from the variant body's `:play-script` is
+;; dispatched as a
 ;; single event — each dispatch produces exactly one epoch in the variant
 ;; frame's `epoch-history`. So the play sequence maps 1-to-1 onto a slice
 ;; of epochs. The scrubber row renders one tick per play event; clicking
@@ -182,7 +183,7 @@
 ;;   - per-step `:label` — `(pr-str (first event))` for a compact tick
 ;;     title; tooltip text the CLJS renderer wires onto each tick.
 ;;
-;;   - the trailing epoch-id slice — the last `count(:play)` epoch-ids
+;;   - the trailing epoch-id slice — the last `count(play-events)` epoch-ids
 ;;     pulled from the variant frame's history. The CLJS side captures
 ;;     this on `run-variant` resolve so a later epoch (e.g. a Re-run on
 ;;     a different tab) can't drift the scrubber's mapping.
@@ -202,7 +203,8 @@
     :else                     (pr-str (first event))))
 
 (defn play-step-statuses
-  "Pure: given a `:play` events vector and an `:assertions` records vector,
+  "Pure: given a play-events vector (derived from `:play-script`) and an
+  `:assertions` records vector,
   return a vector of step-status maps — one per play event.
 
   Each entry:
@@ -257,7 +259,7 @@
 
 (defn epoch-id-slice
   "Pure: given the variant frame's full `history` vector (oldest-first)
-  + the count `n` of `:play` events, return the trailing `n` `:epoch-id`s
+  + the count `n` of play events, return the trailing `n` `:epoch-id`s
   (in play-step order, oldest-first). Returns `[]` when the history
   has fewer than `n` records (production / ring-buffer-trimmed contexts
   — the scrubber gracefully degrades to no ticks rather than mis-mapping

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
@@ -4,7 +4,7 @@
 
   The step-debugger gives the `:test` mode pane Storybook's
   Interactions-panel feel: step / pause / rewind / step-back / breakpoint
-  controls over the variant's `:play` sequence. Everything below is pure
+  controls over the variant's `:play-script` sequence. Everything below is pure
   data → data so the JVM test corpus pins the contract without booting
   Reagent or the runtime.
 

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_view.cljs
@@ -261,7 +261,7 @@
        (step-list variant-id slot)
        [:div {:style     (:inactive styles)
               :data-test "story-stepper-inactive"}
-        "Click Start to step through the :play sequence one event at a time."])]))
+        "Click Start to step through the :play-script sequence one event at a time."])]))
 
 (defn stepper-section
   "Top-level component. Renders the step-debugger section for `variant-id`.

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -3,7 +3,7 @@
   Per rf2-qmjo + spec/009.
 
   Replaces the `mode-tabs/tests-placeholder` stub that landed with the
-  mode-tabs primitive (rf2-9hc8). The pane runs the variant's `:play`
+  mode-tabs primitive (rf2-9hc8). The pane runs the variant's `:play-script`
   sequence via `run-variant`, reads the `:assertions` vector off the
   result, and renders an aggregated pass/fail summary inside the
   canvas:
@@ -21,7 +21,7 @@
       │           the source-coord stamping                   │
       └──────────────────────────────────────────────────────┘
 
-  When the variant body's `:play` slot is empty / absent the pane
+  When the variant body's `:play-script` slot is empty / absent the pane
   short-circuits and renders an empty-state placeholder pointing at
   the canonical testing-recipes leaf (Story doesn't auto-allocate a
   frame in this branch).
@@ -90,7 +90,7 @@
                                (when running? (:rerun-running styles)))
         :data-test      "story-test-rerun"
         :disabled       running?
-        :aria-label     "Re-run the variant's :play sequence"
+        :aria-label     "Re-run the variant's :play-script sequence"
         :on-click       (fn [_] (when-not running? (state/run-variant-pane! variant-id)))}
        (if running? "Running…" "Re-run")]
       [:div {:style (:last-run styles)}
@@ -158,13 +158,13 @@
     "·"))
 
 (defn- scrubber-section
-  "Step-through scrubber (rf2-lc36w). One tick per `:play` event with
+  "Step-through scrubber (rf2-lc36w). One tick per play event with
   pass/fail/event/skip status colouring. Click a tick (or drag the
   slider below) to restore the variant's app-db to that step's
   epoch — the canvas re-renders against it.
 
   Renders nothing until a run has captured an epoch slice. When
-  `:play` ran but no epochs were captured (production elision, or
+  the `:play-script` ran but no epochs were captured (production elision, or
   the ring buffer was disabled), the section short-circuits to a
   muted hint rather than a broken scrubber."
   [variant-id]
@@ -320,7 +320,7 @@
              ;; rf2-tistm — :expanded is keyed by the row's stable
              ;; identity (:row-key from assertion-row, the rendered
              ;; label string) rather than positional index. A re-run
-             ;; that reorders or inserts assertions (e.g. a new :play
+             ;; that reorders or inserts assertions (e.g. a new :play-script
              ;; step lands between two existing ones) would otherwise
              ;; open the wrong row.
              (for [[i row] (map-indexed vector rows)]
@@ -354,7 +354,7 @@
                      "")]]))]]])))))
 
 (defn- empty-state
-  "Placeholder when the variant has no `:play` slot."
+  "Placeholder when the variant has no `:play-script` slot."
   [variant-id]
   [:div {:style     (:empty styles)
          :data-test "story-test-empty"}
@@ -363,7 +363,7 @@
     "No tests registered for this variant"]
    [:div
     "Add a "
-    [:code ":play"]
+    [:code ":play-script"]
     " slot to "
     [:code (str variant-id)]
     " to register assertions."]

--- a/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
@@ -111,7 +111,7 @@
             once the substrate ships:
               1. A variant whose :events seed a sensitive payload at
                  [:auth :token].
-              2. A :play asserting [:rf.assert/path-equals [:auth :token] ...].
+              2. A :play-script asserting [:rf.assert/path-equals [:auth :token] ...].
               3. The recorded :actual slot's contract.
 
             Today: the assertion-evaluator (assertions/evaluate-path-

--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
@@ -71,7 +71,7 @@
 
 (defn- register-variants!
   "Two stories with one non-testable variant each, plus one workspace.
-  No `:test` tag / `:play` slot → both variants take the non-testable
+  No `:test` tag / `:play-script` slot → both variants take the non-testable
   branch in `variant-row` (the branch that emits `[glyphs/variant-glyph
   10]`)."
   []
@@ -183,7 +183,7 @@
             `[glyphs/variant-glyph]` sentinel as the iconographic
             prefix in the variant-glyph branch of `variant-row`. Both
             registered variants are non-testable (no `:test` tag, no
-            `:play`), so both rows take this branch."
+            `:play-script`), so both rows take this branch."
     (e2e/with-story-and-causa-frames
       {:register-stories register-variants!}
       (fn []

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -12,7 +12,7 @@
     `record-test-run` / `clear-test-run` state transitions;
     `variant-test-status` lookup; `test-summary` aggregation across a
     fixture of variants in mixed states; `testable-variant-ids`
-    filter (must be both `:test`-tagged AND `:play`-bearing); the
+    filter (must be both `:test`-tagged AND `:play-script`-bearing); the
     `status->dot-style-key` projection and `dot-aria-label`.
   - **CLJS-only**: the rendered hiccup for the chrome widget carries
     the expected counts + headline; the sidebar's variant-row hiccup
@@ -133,7 +133,7 @@
 ;; ---- pure: testable-variant-ids -----------------------------------------
 
 (deftest testable-variant-ids-filters-by-tag-and-play
-  (testing "only :test-tagged variants with non-empty :play count"
+  (testing "only :test-tagged variants with non-empty :play-script count"
     (story/reg-variant :story.x/a {:tags #{:test} :events []
                                    :play-script [[:dispatch-sync [:rf.assert/path-equals [:c] 0]]]})
     (story/reg-variant :story.x/b {:tags #{:test} :events [] :play-script []})

--- a/tools/story/test/re_frame/story_assertions_test.clj
+++ b/tools/story/test/re_frame/story_assertions_test.clj
@@ -159,7 +159,7 @@
 ;; ===========================================================================
 
 (deftest dispatched-pass
-  (testing ":rf.assert/dispatched? passes when an earlier event in :play fired"
+  (testing ":rf.assert/dispatched? passes when an earlier event in :play-script fired"
     (rf/reg-event-db :test/click
       (fn [db _] (assoc db :clicked? true)))
     (story/reg-variant :story.dispatched/v
@@ -267,7 +267,7 @@
     (story/reg-variant :story.empty/v {:events [] :play-script []})
     (let [r (async/deref-blocking (story/run-variant :story.empty/v) 5000)]
       (is (true? (story/assertions-passing? r))
-          "a variant with no :play still 'passes' for cljs.test integration")
+          "a variant with no :play-script still 'passes' for cljs.test integration")
       (is (empty? (:assertions r))))
     (story/destroy-variant! :story.empty/v)))
 

--- a/tools/story/test/re_frame/story_decorator_chain_test.clj
+++ b/tools/story/test/re_frame/story_decorator_chain_test.clj
@@ -20,7 +20,7 @@
   - Two variants registered with the same event ids each get an
     independent frame: dispatching into A leaves B's app-db, emitted
     fx, assertions, and trace history untouched.
-  - The pair runs the SAME `:play` body against DIFFERENT seed args —
+  - The pair runs the SAME `:play-script` body against DIFFERENT seed args —
     so the only thing distinguishing the two frames' final app-db is
     the seed.
 
@@ -130,7 +130,7 @@
                     [:seed-user]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :events     [[:record/observed]]
-       ;; :emit/track dispatches in :play so the assertion accumulator
+       ;; :emit/track dispatches in :play-script so the assertion accumulator
        ;; (reset at play-start by reset-trace-accumulators!) sees it.
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:seen-user :name] "alice"]]
                     [:dispatch-sync [:emit/track]]
@@ -142,7 +142,7 @@
       (is (= 1 (count (:fx-override pack))) ":fx-override slot populated")
       (is (empty? (:errors pack))           "no decorator errors"))
     ;; Run end-to-end: :frame-setup fires first, then :events observe
-    ;; the seeded slot, then :play asserts.
+    ;; the seeded slot, then :play-script asserts.
     (let [r (async/deref-blocking
               (story/run-variant :story.multi-kind/v) 5000)]
       (is (= :ready (:lifecycle r))
@@ -233,7 +233,7 @@
       {:decorators [[:seed-A]
                     [:rf.story/force-fx-stub :analytics {:ack? true}]]
        :events     [[:inc-and-track] [:inc-and-track]]
-       ;; :play emits one more inc-and-track so :rf.assert/effect-emitted
+       ;; :play-script emits one more inc-and-track so :rf.assert/effect-emitted
        ;; sees a fresh emission (the events-phase emissions are wiped by
        ;; reset-trace-accumulators! at play start by design).
        :play-script [[:dispatch-sync [:rf.assert/path-equals [:counter] 102]]
@@ -261,7 +261,7 @@
       ;; app-db isolation: each frame walks its own counter. Two
       ;; events-phase incs + one play-phase inc = 3 increments.
       (is (= 103 (:counter (:app-db rA)))
-          "A starts at 100 + two :events :inc-and-track + one :play
+          "A starts at 100 + two :events :inc-and-track + one :play-script
            :inc-and-track = 103")
       (is (= 203 (:counter (:app-db rB)))
           "B starts at 200 + same three increments = 203 — A's
@@ -273,13 +273,13 @@
           "all B's assertions pass against B's app-db")
       ;; emitted-fx isolation: the stub-call log keys by frame-id; each
       ;; frame's log carries only its own emissions. Three per frame:
-      ;; two during :events phase + one during :play phase. Note the
+      ;; two during :events phase + one during :play-script phase. Note the
       ;; stub-call log accumulates across phases (unlike the assertion
       ;; emitted-fx accumulator which the play-runner resets at play
       ;; start).
       (is (= 3 (count logA))
           "frame A's stub log carries exactly three entries — two from
-           :events + one from :play")
+           :events + one from :play-script")
       (is (= 3 (count logB))
           "frame B's stub log carries exactly three entries — and ZERO
            of A's entries leaked across")

--- a/tools/story/test/re_frame/story_mcp_surface_test.clj
+++ b/tools/story/test/re_frame/story_mcp_surface_test.clj
@@ -159,14 +159,14 @@
           ":decorators slot present — the resolved decorator pack"))))
 
 (deftest run-variant-empty-play-still-returns-shape
-  (testing "even a variant with no :play surfaces the full return shape
+  (testing "even a variant with no :play-script surfaces the full return shape
             — agents must not have to special-case the no-play branch"
     (story/reg-variant :story.mcp.run/no-play {:events []})
     (let [result (story-async/deref-blocking
                    (story/run-variant :story.mcp.run/no-play) 5000)]
       (is (= :story.mcp.run/no-play (:frame result)))
       (is (= [] (:assertions result))
-          "empty :play → empty :assertions vector (not nil)")
+          "empty :play-script → empty :assertions vector (not nil)")
       (is (map? (:app-db result))))))
 
 ;; ===========================================================================

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -52,7 +52,7 @@
 ;; ===========================================================================
 
 (deftest execute-play-empty
-  (testing "execute-play! against an empty :play resolves to []"
+  (testing "execute-play! against an empty :play-script resolves to []"
     (story/reg-variant :story.play/empty {:events []})
     (async/deref-blocking (story/run-variant :story.play/empty) 5000)
     (let [p (play/execute-play! :story.play/empty [])]

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -18,7 +18,7 @@
     atom alongside the predicate filter.
   - `gen-play-snippet` — the codegen output is `read-string`-able
     EDN; the assertion is shape-level (round-trips back to the same
-    `:play` vector) so future cosmetic changes to formatting don't
+    `:play-script` body) so future cosmetic changes to formatting don't
     churn the test."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
@@ -175,11 +175,11 @@
 ;; ---- gen-play-snippet ----------------------------------------------------
 
 (deftest gen-play-snippet-empty
-  (testing "gen-play-snippet with no events renders an empty :play vector"
+  (testing "gen-play-snippet with no events renders an empty :play-script :script vector"
     (let [snip (recorder/gen-play-snippet [] {:variant-id :story.x/y})]
       (is (string? snip))
       (is (str/includes? snip ":story.x/y"))
-      (is (str/includes? snip ":play"))
+      (is (str/includes? snip ":play-script"))
       (is (str/includes? snip "[]")))))
 
 (deftest gen-play-snippet-renders-reg-variant
@@ -562,7 +562,7 @@
     (recorder/remove-trace-listener!)))
 
 (deftest trace-listener-skips-assertion-events
-  (testing "with a recording active, :rf.assert/* dispatches don't leak into the captured :play body"
+  (testing "with a recording active, :rf.assert/* dispatches don't leak into the captured :play-script body"
     (reset-rf-state!)
     (rf/reg-event-db :counter/inc
       (fn [db _] (update db :n (fnil inc 0))))
@@ -619,7 +619,7 @@
     (recorder/remove-trace-listener!)))
 
 (deftest end-to-end-recording-to-snippet
-  (testing "the full record→stop→gen-play-snippet cycle produces a valid :play body"
+  (testing "the full record→stop→gen-play-snippet cycle produces a valid :play-script body"
     (reset-rf-state!)
     (rf/reg-event-db :counter/inc
       (fn [db _] (update db :n (fnil inc 0))))

--- a/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_review_dialog_cljs_test.cljs
@@ -194,9 +194,9 @@
 (deftest indent-after-matches-prefix-width
   (testing "indent-after returns \\n + N spaces equal to the prefix length"
     (is (= "\n" (pred/indent-after "")))
-    (is (= "\n          " (pred/indent-after "   :play [")))
+    (is (= "\n          " (pred/indent-after "   :name {")))
     (is (= "\n          " (pred/indent-after "   :args {")))
-    (is (= (pred/indent-after "   :play [")
+    (is (= (pred/indent-after "   :name {")
            (pred/indent-after "   :args {"))
         "both flows' prefixes collapse to the same indent")))
 

--- a/tools/story/test/re_frame/story_review_dialog_test.clj
+++ b/tools/story/test/re_frame/story_review_dialog_test.clj
@@ -194,22 +194,22 @@
     (is (= "\n     " (pred/indent-after "12345")))))
 
 (deftest indent-after-aligns-recorder-play-body
-  (testing "the indent lines events up under the first item of `:play [` on the previous line"
-    (let [prefix      "   :play ["
-          first-line  (str prefix "[:counter/inc]")
+  (testing "the indent lines steps up under the first item of `:script [` on the previous line"
+    (let [prefix      "   :script ["
+          first-line  (str prefix "[:dispatch-sync [:counter/inc]]")
           cont-indent (pred/indent-after prefix)
-          full        (str first-line cont-indent "[:counter/dec]")
+          full        (str first-line cont-indent "[:dispatch-sync [:counter/dec]]")
           lines       (clojure.string/split full #"\n")
-          ;; column of the first event char on line 1 = (count prefix)
-          ;; (the `[` of `:play [` is the last char of prefix; the next
-          ;; char — the first event's leading `[` — sits at index N.)
+          ;; column of the first step char on line 1 = (count prefix)
+          ;; (the `[` of `:script [` is the last char of prefix; the next
+          ;; char — the first step's leading `[` — sits at index N.)
           line1-event-col (count prefix)
-          ;; column of the first event char on line 2 = the indent's
+          ;; column of the first step char on line 2 = the indent's
           ;; space-count, which equals (count cont-indent) - 1 for `\n`.
           line2-event-col (dec (count cont-indent))]
       (is (= 2 (count lines)))
       (is (= line1-event-col line2-event-col)
-          "second event's leading char aligns under first event's leading char"))))
+          "second step's leading char aligns under first step's leading char"))))
 
 (deftest indent-after-aligns-save-variant-args-map
   (testing "the indent lines kv pairs up under the first kv of `:args {` on the previous line"
@@ -226,9 +226,9 @@
 
 (deftest indent-after-pure-and-deterministic
   (testing "the helper is pure — same input → same output"
-    (is (= (pred/indent-after "   :play [")
-           (pred/indent-after "   :play [")))
-    ;; And the recorder + save-variant prefixes collapse to the same width
+    (is (= (pred/indent-after "   :name {")
+           (pred/indent-after "   :name {")))
+    ;; And two equal-width body prefixes collapse to the same indent width
     ;; (both keys are 4 chars; both bodies indent 3 + key + space + bracket = 10)
-    (is (= (pred/indent-after "   :play [")
+    (is (= (pred/indent-after "   :name {")
            (pred/indent-after "   :args {")))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -636,7 +636,7 @@
     (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
         "presence of :frame-setup decorators → not events-only")
     (is (true?  (loaders/events-only-variant? {:play-script [[:dispatch-sync [:assert]]]} {}))
-        ":play does not gate the lifecycle (runs strictly after :ready)")
+        ":play-script does not gate the lifecycle (runs strictly after :ready)")
     (is (true?  (loaders/events-only-variant? {} {:hiccup    [{:body {}}]
                                                   :fx-override [{:body {}}]}))
         ":hiccup + :fx-override decorators don't drive the lifecycle machine")))

--- a/tools/story/test/re_frame/story_source_coords_test.clj
+++ b/tools/story/test/re_frame/story_source_coords_test.clj
@@ -1,6 +1,6 @@
 (ns re-frame.story-source-coords-test
   "Regression test for rf2-ulxi — `:rf.assert/*` events surfaced from
-  `:play` sequences were emitting source-coords with `:file
+  `:play-script` sequences were emitting source-coords with `:file
   \"NO_SOURCE_PATH\"`. Root cause: `coords-form` read `*file*` at
   macro-expansion time, but the CLJS analyzer never binds Clojure's
   `*file*` during macro expansion (it binds `cljs.analyzer/*cljs-file*`
@@ -97,7 +97,7 @@
   (testing "rf2-ulxi end-to-end: the gen-reg-call expansion (which
             reg-variant feeds) carries the form-meta :file through to
             the *pending-coords* binding form — covers the actual macro
-            path Story uses for variants whose :play sequences emit
+            path Story uses for variants whose :play-script sequences emit
             :rf.assert/* events"
     (let [form-meta {:line 42 :column 3 :file "stories.cljs"}
           expansion (macros/gen-reg-call

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -1190,7 +1190,7 @@
 
 (deftest test-view-empty-state-without-play
   (testing "test-view renders the empty-state placeholder when the
-            variant body has no :play slot — the variant is registered
+            variant body has no :play-script slot — the variant is registered
             but declares zero assertions, so no run is fired."
     (story/reg-variant :story.tv/no-play {:events []})
     (let [result (test-mode-view/test-view :story.tv/no-play)]

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -764,12 +764,12 @@
     (is (nil? (test-mode/parent-story-id nil)))))
 
 (deftest test-mode-variant-has-tests?-checks-play-slot
-  (testing "variant-has-tests? is false when :play is absent or empty"
+  (testing "variant-has-tests? is false when :play-script is absent or empty"
     (story/reg-variant :story.tm/empty {:events []})
     (story/reg-variant :story.tm/empty-play {:events [] :play-script []})
     (is (not (test-mode/variant-has-tests? :story.tm/empty)))
     (is (not (test-mode/variant-has-tests? :story.tm/empty-play))))
-  (testing "variant-has-tests? is true when :play carries any event"
+  (testing "variant-has-tests? is true when :play-script carries any step"
     (story/reg-variant :story.tm/has
       {:events [] :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]})
     (is (test-mode/variant-has-tests? :story.tm/has)))
@@ -940,7 +940,7 @@
           assertions [{:assertion :rf.assert/path-equals :passed? true}
                       {:assertion :rf.assert/path-equals :passed? false}]
           out        (test-mode/play-step-statuses play assertions)]
-      (is (= 4 (count out)) "one row per :play event")
+      (is (= 4 (count out)) "one row per play event")
       (is (= [:event :event :pass :fail] (mapv :status out)))
       (is (= [0 1 2 3] (mapv :index out)))
       (is (= ":auth/email-changed" (-> out (nth 0) :label)))

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -537,7 +537,7 @@ module.exports = {
        *     for an fx-id the variant did NOT stub renders as a passing
        *     row IFF the fx genuinely emitted, otherwise as a failing
        *     row whose reason text identifies the missed fx-id. The
-       *     `:story.counter/loaded` variant's `:play` carries no
+       *     `:story.counter/loaded` variant's `:play-script` carries no
        *     effect-emitted assertion; we navigate to it and confirm
        *     three passing rows + zero stub leak (no rogue fx-id
        *     emitted from a previous variant survives into a new
@@ -593,7 +593,7 @@ module.exports = {
       }
 
       // (b) Cross-variant isolation: navigate to a variant whose
-      // :play declares NO effect-emitted assertion. The emitted-fx
+      // :play-script declares NO effect-emitted assertion. The emitted-fx
       // accumulator is per-frame, so the newly-allocated frame must
       // start empty — no rogue carry-over from :save-stubbed.
       await clickVariant(page, '/loaded');
@@ -623,7 +623,7 @@ module.exports = {
       // it to do); the force-fx-stub :fx-override redirects it to a
       // local stub fx that only writes the per-frame stub-call-log.
       // Walking back to :save-stubbed and re-running the assertion
-      // suite via the test pane re-fires the :play sequence — which
+      // suite via the test pane re-fires the :play-script sequence — which
       // dispatches :counter/save and emits :counter/sync-to-server
       // again. If the stub leaks, a real cross-origin request lands
       // in the page's request log.
@@ -1725,7 +1725,7 @@ module.exports = {
        *         row in test mode surfaces a source-coord chip when
        *         the assertion's source map is available. /loaded's
        *         three passing assertions all carry source metadata
-       *         from the variant's :play vector registration; the
+       *         from the variant's :play-script registration; the
        *         test pane's row detail should expose at least one
        *         data-test="story-open-in-editor-chip"-tagged chip
        *         (or, when the failing-row detail expands, the


### PR DESCRIPTION
## Summary

#1726 (rf2-0wrud) made `:play-script` the only play slot (`:play` removed); the spec was reconciled by #1969, which flagged the Story **implementation** still carrying residual `:play` references. This is a surgical text/vocabulary reconciliation — no behaviour change.

## Residual `:play` found + reconciled

**Live-looking authoring examples migrated to `:play-script`** (docstrings, not code paths):
- `story.cljc` — `reg-variant` body-shape docstring (`:play` slot line → `:play-script` + `:plays`); `force-fx-stub-id` example; `gen-play-snippet` docstring (it already emits `:play-script`).
- `fx_stubs.cljc` — `force-fx-stub` authoring-shape example.
- `review_dialog.cljc` — indent-illustration example.

**Stale descriptions of the recorder output corrected.** `recorder/gen-play-snippet` has emitted a `:play-script` body (each event wrapped as `[:dispatch-sync ...]`) since rf2-0wrud, but many comments/docstrings still called it "the legacy `:play` body" and invoked "back-compat is non-negotiable" (contradicting pre-alpha stance). Reconciled across `recorder.cljc`, `recorder/play_export.cljc`, `save_variant.cljc`, `review_dialog.cljc`, and the recorder/test-mode UI (`ui/recorder.cljs`, `ui/recorder_export_dialog.cljs`, `ui/save_variant.cljs`).

**User-facing strings** (tooltips, aria-labels, empty-state copy) in `ui/recorder.cljs`, `ui/shell.cljs`, `ui/test_mode/view.cljs`, `ui/test_mode/stepper_view.cljs` — including the empty-state "Add a `:play` slot" instruction → `:play-script`.

**Slot-name docstrings** in `loaders.cljc`, `assertions.cljc`, `ui/sidebar.cljs`, `ui/test_mode/pure.cljc`, `ui/test_mode/stepper_pure.cljc`.

**Test descriptions/comments** referencing the removed slot updated to `:play-script` across 15 test files (bodies already used `:play-script`); tightened `gen-play-snippet-empty`'s assertion to `:play-script`; swapped the `indent-after` geometry fixtures off the now-defunct `:play [` prefix.

## Left intact (with reason)

- `identity.cljc` rf2-bgwnf bug note ("tracked `:play`, which silently no longer existed") — deliberate historical record.
- `play.cljc` / `runtime.cljc` / `recorder.cljc` rf2-0wrud removal notes explaining *why* `:dispatch-sync` is the wrapping — correct history.
- `runner-events/run-play!`, `::play-trace-test` listener id — not the slot.
- Scope exclusion respected: no Story trace `:rf.*` migration (rf2-y4qpy.4).

## Test plan

- [x] `npm run test:cljs` — 4108 tests, 12516 assertions, 0 failures, 0 errors.
- [x] Story JVM tests (`clojure -M:test`) — 848 tests, 2507 assertions, 0 failures, 0 errors.