### PR TITLE
feat(causa): redesign chrome + events ribbons; frame-as-view-scope (rf2-4vp5j)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -191,37 +191,63 @@
   ;; semantically, but the mute set is a separate slot so it persists
   ;; independently of the pill set and the unmute manager has a clean
   ;; surface to enumerate.)
+  ;; rf2-4vp5j Workstream C — the frame scope reads the dedicated
+  ;; `:rf.causa/view-scope-frame` slot (a single defaulted VIEW SCOPE),
+  ;; NOT the spine's `[:focus :frame]` (which epoch auto-alignment + the
+  ;; focus-step walk also write — reading it here silently re-scoped the
+  ;; list to whatever epoch the user stepped onto). The frame is applied
+  ;; as a view scope FIRST, then the pill chain + mutes (the actual
+  ;; filters) compose on top.
+  ;;
+  ;; The frameless `:ungrouped` pseudo-cascade is frame-agnostic: it is
+  ;; preserved through the view scope ONLY when the `show-ungrouped?`
+  ;; opt-in is on (so it can be REVEALED under a scope); with the opt-in
+  ;; off the strict frame filter drops it, matching the default
+  ;; silent-by-default L2 list (no frameless bucket leaks into the data
+  ;; layer when nobody asked for it).
   (rf/reg-sub :rf.causa/filtered-cascades
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/active-filters]
-    :<- [:rf.causa/focus-slot]
+    :<- [:rf.causa/view-scope-frame]
     :<- [:rf.causa/muted-event-ids]
-    (fn [[cascades filters focus-slot muted] _query]
+    :<- [:rf.causa/show-ungrouped?]
+    (fn [[cascades filters view-scope-frame muted show-ungrouped?] _query]
       (-> cascades
-          (matcher/filter-cascades-by-frame (:frame focus-slot))
+          (cond->
+            show-ungrouped?       (matcher/filter-cascades-by-view-scope view-scope-frame)
+            (not show-ungrouped?) (matcher/filter-cascades-by-frame view-scope-frame))
           (typed/filter-cascades filters)
           (spine-filters/filter-cascades muted))))
 
-  ;; rf2-jvghz defect #1 — the 'N events hidden by filters' indicator
-  ;; model. Composes the raw + filtered cascade lists and the active
-  ;; filter state into the pure `hidden/summary` record the L2 list's
-  ;; indicator renders against. Counts over the L2 visible-row set
-  ;; (`l2-visible?`) so N matches the rows the user sees. This is the
-  ;; affordance that makes persisted filters/frame-pin a VISIBLE cause
-  ;; rather than a silently-broken-looking list.
+  ;; rf2-jvghz defect #1 + rf2-4vp5j Workstream C — the 'N events hidden
+  ;; by filters' message model. Composes the raw + filtered cascade lists
+  ;; and the active filter state into the pure `hidden/summary` record
+  ;; the events ribbon renders against. Counts over the L2 visible-row
+  ;; set (`l2-visible?`) so N matches the rows the user sees.
+  ;;
+  ;; FRAME IS A VIEW SCOPE, NOT A FILTER (rf2-4vp5j Workstream C): the
+  ;; count BASELINE is computed WITHIN the selected frame — `raw` is
+  ;; first scoped to the view-scope frame, then pills/mutes are measured
+  ;; against that scope. This means switching frames NEVER inflates
+  ;; "hidden" (previously `raw` counted across all frames, so picking a
+  ;; frame made every other frame's events look "hidden by filters").
+  ;; The summary carries no `:frame` cause; only pill/mute suppression
+  ;; is the cause and the count.
   (rf/reg-sub :rf.causa/hidden-by-filters
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/filtered-cascades]
     :<- [:rf.causa/active-filters]
-    :<- [:rf.causa/focus-slot]
+    :<- [:rf.causa/view-scope-frame]
     :<- [:rf.causa/muted-event-ids]
     :<- [:rf.causa/show-ungrouped?]
-    (fn [[raw filtered filters focus-slot muted show-ungrouped?] _query]
-      (let [raw-n      (count (filterv #(l2-visible? % show-ungrouped?) raw))
-            filtered-n (count (filterv #(l2-visible? % show-ungrouped?) filtered))]
+    (fn [[raw filtered filters view-scope-frame muted show-ungrouped?] _query]
+      (let [;; Scope the raw baseline to the VIEW-SCOPE frame so frame
+            ;; selection is a view scope, not counted as suppression.
+            frame-scoped (matcher/filter-cascades-by-view-scope raw view-scope-frame)
+            raw-n        (count (filterv #(l2-visible? % show-ungrouped?) frame-scoped))
+            filtered-n   (count (filterv #(l2-visible? % show-ungrouped?) filtered))]
         (hidden/summary raw-n filtered-n
                         {:filters filters
-                         :frame   (:frame focus-slot)
                          :muted   muted}))))
 
   ;; Popup state — three slots so the open / trigger / draft tiers
@@ -352,29 +378,30 @@
              :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})
           {:db (close-popup db)}))))
 
-  ;; ---- clear-all (rf2-jvghz) ------------------------------------------
+  ;; ---- clear-all (rf2-jvghz + rf2-4vp5j) ------------------------------
   ;;
-  ;; One-click reset behind the L2 'N hidden by filters' indicator.
-  ;; Resets EVERY suppressing surface so the filtered list snaps back to
-  ;; the raw list:
+  ;; One-click reset behind the events ribbon's `Clear Filters` button.
+  ;; Resets every suppressing FILTER so the filtered list snaps back to
+  ;; the (frame-scoped) raw list:
   ;;
   ;;   1. IN/OUT pills        → `{:in [] :out []}` (+ persist)
-  ;;   2. frame pin           → `:rf.causa/select-frame nil` (the
-  ;;      canonical write surface — re-seeds the spine + clears the
-  ;;      frame-switcher localStorage so the unpin survives reload)
-  ;;   3. muted event-ids     → `:rf.causa/clear-muted-event-ids` (+ its
+  ;;   2. muted event-ids     → `:rf.causa/clear-muted-event-ids` (+ its
   ;;      own persist fx)
   ;;
+  ;; Per rf2-4vp5j Workstream C the FRAME is a view SCOPE, not a filter —
+  ;; Clear Filters must NOT change the frame. The previous
+  ;; `[:dispatch [:rf.causa/select-frame nil]]` was removed; the picker's
+  ;; selection survives a Clear Filters.
+  ;;
   ;; Pills are reset inline (this handler already owns the
-  ;; `:active-filters` slot + persist fx); the frame-pin and mute resets
-  ;; route through their owning events via `:dispatch` so each surface's
-  ;; persistence / instrumentation stays in one place.
+  ;; `:active-filters` slot + persist fx); the mute reset routes through
+  ;; its owning event via `:dispatch` so its persistence /
+  ;; instrumentation stays in one place.
   (rf/reg-event-fx :rf.causa/clear-all-filters
     (fn [{:keys [db]} _event]
       (let [cleared {:in [] :out []}]
         {:db (assoc db :active-filters cleared)
          :fx [[:rf.causa.filters/persist cleared]
-              [:dispatch [:rf.causa/select-frame nil]]
               [:dispatch [:rf.causa/clear-muted-event-ids]]]})))
 
   ;; ---- right-click row → OUT filter shortcut --------------------------

--- a/tools/causa/src/day8/re_frame2_causa/filters/hidden.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/hidden.cljc
@@ -1,21 +1,29 @@
 (ns day8.re-frame2-causa.filters.hidden
-  "Pure derivation for the L2 'N events hidden by filters' indicator
-  (rf2-jvghz, defect #1).
+  "Pure derivation for the events-ribbon 'N events hidden by filters'
+  message (rf2-jvghz, defect #1; frame-decoupled per rf2-4vp5j).
 
   ## Why
 
   After the epoch-per-event merges, Causa's L2 event list could look
   broken on reload: persisted filters (a `:machine` IN-pill under
-  `re-frame2.causa.filters.v1`, a frame pin under
-  `re-frame2.causa.frame-switcher.v1`) survived in localStorage and
-  silently suppressed cascade rows with NO visible indicator. The L2
-  list reads `:rf.causa/filtered-cascades` (filtered) while the raw
-  stream lives on `:rf.causa/cascades`; when filters suppressed rows
-  the list was indistinguishable from a broken tool.
+  `re-frame2.causa.filters.v1`) survived in localStorage and silently
+  suppressed cascade rows with NO visible indicator. The L2 list reads
+  `:rf.causa/filtered-cascades` (filtered) while the raw stream lives on
+  `:rf.causa/cascades`; when filters suppressed rows the list was
+  indistinguishable from a broken tool.
 
   This ns is the pure data primitive behind the affordance: given the
   raw + filtered visible-cascade counts and the active filter state,
   it answers 'is anything hidden, how many, and what is the cause?'.
+
+  ## Frame is a view SCOPE, not a filter (rf2-4vp5j Workstream C)
+
+  The picker-selected frame is a single, defaulted VIEW SCOPE — it is
+  NOT part of the filter chain conceptually. It is therefore NEVER
+  counted as 'hidden', never listed as a cause, and never reset by
+  Clear Filters. The caller computes the raw/filtered counts WITHIN the
+  selected frame so switching frames does not inflate the count; this
+  ns only models pill + mute suppression.
 
   ## The count contract
 
@@ -23,7 +31,7 @@
   list renders — i.e. both the raw and filtered vectors must already be
   passed through the list's `l2-cascade-visible?` predicate by the
   caller (the `:rf.causa/hidden-by-filters` sub does this). That keeps
-  the indicator's N consistent with the rows the user actually sees:
+  the message's N consistent with the rows the user actually sees:
   the `:ungrouped` bucket never inflates the count, and the
   filtered-to-empty / filtered-to-one cases both report the true
   suppressed total.
@@ -49,29 +57,25 @@
   [{:keys [in out]}]
   (boolean (or (seq in) (seq out))))
 
-(defn frame-pinned?
-  "True iff a frame pin is active — i.e. the picker has selected a
-  specific frame so `:rf.causa/filtered-cascades` restricts to it.
-  nil means no frame filter."
-  [frame-id]
-  (some? frame-id))
-
 (defn mutes-present?
   "True iff at least one event-id is muted. nil / `#{}` → false."
   [muted]
   (boolean (seq muted)))
 
 (defn any-filter-active?
-  "True iff ANY suppressing surface is active: IN/OUT pills, a frame
-  pin, or a non-empty mute set. This is the predicate behind 'is there
-  anything a Clear-filters click would reset?'. It is independent of
-  the hidden COUNT — a pill can be active yet hide nothing (it happens
-  to match every current cascade); the count is what gates the
-  indicator's render, this predicate is what 'Clear filters' acts on."
-  [{:keys [filters frame muted]}]
+  "True iff ANY suppressing FILTER is active: IN/OUT pills or a non-empty
+  mute set. This is the predicate behind 'is there anything a Clear
+  Filters click would reset?'. It is independent of the hidden COUNT — a
+  pill can be active yet hide nothing (it happens to match every current
+  cascade); the count is what gates the message's render, this predicate
+  is what 'Clear Filters' acts on.
+
+  Per rf2-4vp5j the frame is a view SCOPE, not a filter — it is NOT part
+  of this predicate, so a frame selection alone never shows the events-
+  ribbon action cluster and Clear Filters never resets the frame."
+  [{:keys [filters muted]}]
   (boolean
     (or (pills-present? filters)
-        (frame-pinned? frame)
         (mutes-present? muted))))
 
 (defn indicator-visible?
@@ -102,20 +106,22 @@
           (or out []))))
 
 (defn summary
-  "The full indicator model for the L2 list. Pure — takes the raw +
-  filtered visible counts and the active filter state, returns the map
-  the view renders against:
+  "The full message model for the events ribbon. Pure — takes the raw +
+  filtered visible counts (both already scoped to the selected frame by
+  the caller) and the active filter state, returns the map the view
+  renders against:
 
       {:hidden          <int>     ; suppressed visible-row count
        :raw-count       <int>
        :filtered-count  <int>
-       :visible?        <bool>    ; should the indicator render?
-       :any-active?     <bool>    ; would Clear-filters reset anything?
+       :visible?        <bool>    ; should the N-hidden message render?
+       :any-active?     <bool>    ; would Clear Filters reset anything?
        :pills           [{…} …]   ; IN/OUT pill summaries
-       :frame           <kw|nil>  ; pinned frame, nil = unpinned
        :muted-count     <int>}    ; muted event-ids
 
-  `state` is `{:filters {:in [] :out []} :frame <kw|nil> :muted #{}}`."
+  `state` is `{:filters {:in [] :out []} :muted #{}}`. Per rf2-4vp5j the
+  frame is a view scope, NOT a filter — it is excluded from this model
+  entirely (no `:frame` key, never a cause, never counted as hidden)."
   [raw-visible-count filtered-visible-count state]
   (let [hidden (hidden-count raw-visible-count filtered-visible-count)]
     {:hidden         hidden
@@ -124,5 +130,4 @@
      :visible?       (indicator-visible? hidden)
      :any-active?    (any-filter-active? state)
      :pills          (pill-summaries (:filters state))
-     :frame          (:frame state)
      :muted-count    (count (or (:muted state) #{}))}))

--- a/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
@@ -199,3 +199,31 @@
   (if (nil? picker-frame)
     cascades
     (filterv #(keep-cascade-for-frame? % picker-frame) cascades)))
+
+(defn keep-cascade-for-view-scope?
+  "True iff `cascade` is in the picker-selected VIEW SCOPE `scope-frame`
+  (rf2-4vp5j). Like `keep-cascade-for-frame?` but the FRAMELESS
+  `:ungrouped` pseudo-cascade (nil `:frame` — registry-time emits /
+  lifecycle outside a drain) is frame-AGNOSTIC and always survives the
+  scope: it has no frame to match, and whether it RENDERS is gated
+  separately by the `show-ungrouped?` opt-in (`l2-cascade-visible?`).
+
+  This is the view-scope analogue of `keep-cascade-for-frame?`: a view
+  scope narrows to one host frame's events without swallowing the
+  frame-agnostic bucket. Pure data; JVM-runnable."
+  [cascade scope-frame]
+  (or (nil? scope-frame)
+      (nil? (:frame cascade))
+      (= scope-frame (:frame cascade))))
+
+(defn filter-cascades-by-view-scope
+  "Restrict `cascades` to the picker-selected VIEW SCOPE `scope-frame`,
+  preserving frameless `:ungrouped` pseudo-cascades (rf2-4vp5j). nil
+  `scope-frame` returns `cascades` unchanged. Pure — no I/O, no atoms
+  read. The L2 list + hidden-count baseline read THIS (not the strict
+  `filter-cascades-by-frame`) so a defaulted view scope never drops the
+  frame-agnostic bucket."
+  [cascades scope-frame]
+  (if (nil? scope-frame)
+    cascades
+    (filterv #(keep-cascade-for-view-scope? % scope-frame) cascades)))

--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -124,6 +124,27 @@
       []
       cascades)))
 
+(defn head-frame
+  "Pure helper — the DEFAULT view-scope frame on load (rf2-4vp5j
+  Decision 1): the frame of the head (most recent) pickable cascade.
+
+  Walks `cascades` newest-first and returns the first frame that is
+  pickable (non-nil, not an `internal-frames` tool frame). nil only
+  when the stream carries no pickable frame at all (empty / tool-only).
+
+  This is the seam that makes the frame a SINGLE defaulted view scope:
+  on a fresh load the L2 list scopes to whichever frame produced the
+  most recent event, rather than merging every frame. The user can
+  override via the picker; the override lives on the dedicated
+  `:view-scope-frame` slot (NOT persisted — rf2-swclw)."
+  [cascades]
+  (some (fn [cascade]
+          (let [f (:frame cascade)]
+            (when (and (some? f)
+                       (not (contains? internal-frames f)))
+              f)))
+        (reverse cascades)))
+
 ;; ---- persistence ---------------------------------------------------------
 
 (def default-storage-key
@@ -381,10 +402,53 @@
   ;; already pulls in `:rf.causa/cascades`; the raw slot is the right
   ;; primitive.
 
+  ;; `:rf.causa/view-scope-frame` (rf2-4vp5j Workstream C) — the
+  ;; dedicated VIEW-SCOPE slot. The frame is a single defaulted view
+  ;; scope, NOT a filter and NOT the spine's `[:focus :frame]` slot
+  ;; (which is also written by epoch auto-alignment + the focus-step
+  ;; walk — reading it for the LIST scope was the conflation bug). The
+  ;; picker writes `:view-scope-frame` directly; the L2 list +
+  ;; hidden-count read it.
+  ;;
+  ;; Resolution order (first non-nil wins):
+  ;;   1. the explicit picker slot (`:view-scope-frame`);
+  ;;   2. the host-seeded `:target-frame` (rf2-ulpp8 — a host calling
+  ;;      `core/set-target-frame!` is saying 'observe this frame', which
+  ;;      IS the view scope on first mount);
+  ;;   3. the head epoch's frame (`head-frame`) — the rf2-4vp5j Decision-1
+  ;;      default so a fresh load with no host seed scopes to whichever
+  ;;      frame produced the most recent event.
+  ;; Composes off `:rf.causa/cascades` so the head default re-resolves
+  ;; as the stream grows; once the user explicitly picks, slot #1 wins.
+  (rf/reg-sub :rf.causa/view-scope-frame
+    :<- [:rf.causa/view-scope-frame-slot]
+    :<- [:rf.causa/target-frame-slot]
+    :<- [:rf.causa/cascades]
+    (fn [[slot target-slot cascades] _query]
+      (or slot target-slot (head-frame cascades))))
+
+  ;; Raw stored slots — separated so the composed sub above can default
+  ;; off the cascade list without a cycle.
+  (rf/reg-sub :rf.causa/view-scope-frame-slot
+    (fn [db _query]
+      (:view-scope-frame db)))
+
+  ;; Raw `:target-frame` slot WITHOUT the `:rf.causa/target-frame`
+  ;; sub's `default-target-frame` fallback — nil when no host seed has
+  ;; been applied, so it only contributes to the view-scope default when
+  ;; a host explicitly called `set-target-frame!`.
+  (rf/reg-sub :rf.causa/target-frame-slot
+    (fn [db _query]
+      (:target-frame db)))
+
+  ;; `:rf.causa/current-frame` — what the picker shows + writes against.
+  ;; Reads the resolved VIEW-SCOPE frame (rf2-4vp5j) so the dropdown
+  ;; reflects the single defaulted view scope, decoupled from the
+  ;; spine's auto-tracking `[:focus :frame]`.
   (rf/reg-sub :rf.causa/current-frame
-    :<- [:rf.causa/focus-slot]
-    (fn [focus _query]
-      (:frame focus)))
+    :<- [:rf.causa/view-scope-frame]
+    (fn [view-scope-frame _query]
+      view-scope-frame))
 
   ;; `:rf.causa/available-frames` is the canonical 'which frames is it
   ;; meaningful to pick right now' list. Composes off `:rf.causa/
@@ -408,9 +472,22 @@
   ;; so every persistence / instrumentation layer we add lives in one
   ;; place. See `palette/events.cljs`'s `:palette/select-frame` clause.
 
+  ;; Writes the dedicated `:view-scope-frame` slot (rf2-4vp5j) — the
+  ;; single source of truth for the L2 list's view scope — AND still
+  ;; dispatches the spine's `:rf.causa/set-frame` so the LEGITIMATE
+  ;; per-frame epoch alignment (App-DB Diff / Views / machine-inspector
+  ;; reading `:epoch-history`, rf2-ulpp8) follows the picker. The two
+  ;; concerns are now distinct slots: `:view-scope-frame` scopes the
+  ;; LIST; `[:focus :frame]` (via set-frame) aligns the per-frame
+  ;; epoch reads. nil clears the view scope back to its head-frame
+  ;; default. Persist fx is retained (the data layer); init does not
+  ;; restore it (rf2-swclw — frame is transient).
   (rf/reg-event-fx :rf.causa/select-frame
-    (fn [_ctx [_ frame-id]]
-      {:fx [[:dispatch [:rf.causa/set-frame frame-id]]
+    (fn [{:keys [db]} [_ frame-id]]
+      {:db (if (some? frame-id)
+             (assoc db :view-scope-frame frame-id)
+             (dissoc db :view-scope-frame))
+       :fx [[:dispatch [:rf.causa/set-frame frame-id]]
             [:rf.causa.frame-switcher/persist frame-id]]}))
 
   ;; NO hydrate from localStorage on install (rf2-swclw). The frame pin

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -667,59 +667,37 @@
       "✕"]]))
 
 (rf/reg-view ribbon
-  "L1 ribbon — per spec/018 §3 Top ribbon anatomy. Four clusters left
-  to right: nav · frame · filters · right icons. The REDACTED
-  indicator surfaces on-demand next to the right-icons cluster when
-  the suppressed-sensitive count is positive.
+  "L1 **chrome ribbon** — the top stratum per rf2-4vp5j's two-ribbon
+  redesign. Compact (`:top-strip-height`, lowered to 40px) because it
+  now carries only scope SELECTORS on the left and chrome ACTIONS on
+  the right:
 
-  Per Round-3 rf2-g9pee the explicit `● LIVE` / `◐ RETRO` mode pill
-  was dropped — the spine mode is already derivable from sticky-row
-  selection + the `[◀ ▶ ⏭]` nav cluster. Space / L / G keybindings
-  preserve the toggle access the pill used to surface.
+    - **LEFT** — the Frame dropdown (`frame-switcher/frame-switcher-
+      view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`).
+      Both share one compact control style so they read as a single
+      selector stratum.
+    - **RIGHT** — the mute (🔇 N) + REDACTED (● N) silent-by-default
+      indicators, then the `⚙` settings + `✕` close icon-buttons.
+
+  The nav cluster (`[◀ ▶ ⏭]`), the focus-chip, and the filter pills
+  moved DOWN to the events ribbon (`events-ribbon`) — they are
+  spine/filter chrome, not scope selectors. Moving them out is what
+  buys the compacted height.
+
+  The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
+  #2 — violet Dynamic / cyan Static) stays as the at-a-glance mode cue,
+  so the understated mode dropdown can recede without losing the signal.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
   [_props]
-  (let [focus           @(rf/subscribe [:rf.causa/focus])
-        cascades        @(rf/subscribe [:rf.causa/cascades])
-        focus-set       @(rf/subscribe [:rf.causa/focus-set])
-        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
-        ;; bucket. Default OFF preserves silent-by-default; ON
-        ;; includes the bucket in L2 + the ribbon's boundary walk
-        ;; so the nav cluster's `[◀ ▶ ⏭]` agrees with what the user
-        ;; sees in L2.
-        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
-        redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
-        ;; rf2-ikuwt — mute-count drives the L1 ribbon indicator next
-        ;; to the REDACTED indicator. Reading the count sub (not the
-        ;; raw set) means the ribbon re-renders only when the count
-        ;; changes; the indicator's click opens the unmute manager.
-        muted-count     @(rf/subscribe [:rf.causa/muted-event-ids-count])
-        filters         @(rf/subscribe [:rf.causa/active-filters])
-        focused-id      (:dispatch-id focus)
-        ;; Per rf2-fzbrw: the boundary predicates must align with the
-        ;; user-visible event list. The L2 list filters `:ungrouped`
-        ;; (registry-time emits / lifecycle / REPL evals) by default;
-        ;; when the rf2-r9lyy opt-in is on the bucket appears in L2
-        ;; and the ribbon's walk MUST include it too, otherwise the
-        ;; user could click a visible bucket row in L2 that the
-        ;; `[<]` boundary refuses to step past. The `l2-cascade-
-        ;; visible?` predicate is the single source of truth — both
-        ;; surfaces compose against it.
-        event-cascades  (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
-        ;; rf2-a1z3b — when a focus-set is active the nav buttons walk
-        ;; ONLY the in-focus subset. Boundary predicates honour that
-        ;; so `[◀]` greys at the first in-focus row and `[▶]` greys at
-        ;; the last. When no focus-set is active, fall through to the
-        ;; existing full-stream boundary semantics.
-        ids             (if focus-set
-                          (fh/in-focus-ids event-cascades focus-set)
-                          (mapv :dispatch-id event-cascades))
-        at-head?        (or (empty? ids)
-                            (= focused-id (last ids))
-                            (and (nil? focused-id) (not focus-set)))
-        at-tail?        (or (empty? ids)
-                            (= focused-id (first ids)))]
+  (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
+        ;; rf2-ikuwt — mute-count drives the chrome ribbon's silent-by-
+        ;; default indicator next to the REDACTED indicator. Reading the
+        ;; count sub (not the raw set) means the ribbon re-renders only
+        ;; when the count changes; the indicator's click opens the
+        ;; unmute manager.
+        muted-count    @(rf/subscribe [:rf.causa/muted-event-ids-count])]
     [:div {:data-testid "rf-causa-ribbon"
            :style {:display          "flex"
                    :align-items      "center"
@@ -742,27 +720,31 @@
                                           (static-shell/stripe-hex-for-mode :dynamic))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
-     ;; rf2-o5f5f.1 — mode pill at ribbon-left. Always rendered
-     ;; (the `:rf.causa/static-mode?` feature gate was removed per
-     ;; rf2-8l3uk — Static mode is unconditionally available).
-     [mode-pill/mode-pill]
-     [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail?}]
-     [ribbon-focus-chip {:focus-set focus-set}]
-     ;; L1 frame-switcher slot (rf2-iwwou) — single contractually-
-     ;; anchored surface. The view itself reads `:rf.causa/current-
-     ;; frame` + `:rf.causa/available-frames` and writes via
-     ;; `:rf.causa/select-frame` — no ad-hoc frame access from the
-     ;; ribbon. See `frame_switcher.cljs` for the contract.
-     [frame-switcher/frame-switcher-view]
-     [ribbon-filter-pills {:filters filters}]
+     ;; LEFT cluster — scope selectors (Frame + Dynamic/Static), one
+     ;; shared compact control style so they read as one stratum.
+     [:div {:data-testid "rf-causa-ribbon-selectors"
+            :style {:display "flex" :align-items "center" :gap "8px"}}
+      ;; L1 frame-switcher slot (rf2-iwwou) — single contractually-
+      ;; anchored surface. The view itself reads `:rf.causa/current-
+      ;; frame` + `:rf.causa/available-frames` and writes via
+      ;; `:rf.causa/select-frame` — no ad-hoc frame access from the
+      ;; ribbon. See `frame_switcher.cljs` for the contract. The frame
+      ;; is a view SCOPE, not a filter (rf2-4vp5j Workstream C).
+      [frame-switcher/frame-switcher-view]
+      ;; Dynamic/Static dropdown (rf2-4vp5j) — compact, understated;
+      ;; the accent stripe carries the mode signal so the control
+      ;; itself stays quiet. Always rendered (the `:rf.causa/static-
+      ;; mode?` feature gate was removed per rf2-8l3uk).
+      [mode-pill/mode-pill]]
+     ;; RIGHT cluster — silent-by-default indicators + chrome actions.
      [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
       ;; rf2-ikuwt — mute indicator (🔇 N) renders inline next to the
       ;; REDACTED indicator. Both are silent-by-default surfaces that
       ;; only paint when their count is positive. Click → unmute
       ;; manager modal.
       [spine-filters/ribbon-mute-indicator muted-count]
-      [ribbon-redacted-indicator redacted-count]]
-     [ribbon-right-icons]]))
+      [ribbon-redacted-indicator redacted-count]
+      [ribbon-right-icons]]]))
 
 ;; ---- L2 event list -------------------------------------------------------
 
@@ -1313,21 +1295,32 @@
      ;; the row's trailing edge.
      (relative-time-chip cascade now-ms)]))
 
-;; ---- 'N hidden by filters' indicator (rf2-jvghz, defect #1) -------------
+;; ---- events ribbon (rf2-4vp5j) -----------------------------------------
 ;;
-;; Persisted filters (a `:machine` IN-pill under
-;; `re-frame2.causa.filters.v1`, a frame pin under
-;; `re-frame2.causa.frame-switcher.v1`) survive reload via localStorage
-;; and silently suppress L2 rows. Without an indicator the list looks
-;; broken — it fooled the project author. This banner renders whenever
-;; the filtered visible-row set is strictly smaller than the raw set
-;; (`:rf.causa/hidden-by-filters` → `:visible?`), making the active
-;; pills / frame-pin / mutes the VISIBLE cause and offering a one-click
-;; reset (`:rf.causa/clear-all-filters`).
+;; The SECOND stratum below the chrome ribbon. LEFT → RIGHT:
+;;
+;;   Events:  [◀ ▶ ⏭]  [🎯 focus-chip]  [+pill ×pill +]   …   N hidden  [Clear Filters]
+;;
+;; Left = spine state + navigation; right = filter actions. The
+;; `N events hidden by filters` message + Clear Filters appear ONLY when
+;; filters are active (per rf2-4vp5j Decision 3):
+;;
+;;   - both absent when no pills + no mutes (clean default → empty right);
+;;   - Clear Filters shows when ANY filter is active;
+;;   - the message shows beside it ONLY when N > 0.
+;;
+;; The hidden COUNT reflects pill/mute suppression ONLY — the frame is a
+;; view SCOPE, not a filter (rf2-4vp5j Workstream C), so switching frames
+;; never inflates "hidden" and Clear Filters never touches the frame.
+;; The message keeps rf2-jvghz's prominent yellow accent (Mike values
+;; it). Persisted filters survive reload via localStorage and used to
+;; silently suppress L2 rows; this ribbon makes them a VISIBLE cause +
+;; one-click reset (`:rf.causa/clear-all-filters`).
 
 (defn- filter-cause-chip
-  "One small chip naming an active suppressing surface (a pill, the
-  frame pin, or the mute set) inside the indicator banner."
+  "One small chip naming an active suppressing surface (a pill or the
+  mute set) inside the hidden-count message. Frame is NOT a cause —
+  it is a view scope (rf2-4vp5j Workstream C)."
   [{:keys [testid tone label title]}]
   [:span {:data-testid testid
           :title       title
@@ -1343,34 +1336,27 @@
                   :white-space    "nowrap"}}
    label])
 
-(defn filters-hidden-indicator
-  "Pure hiccup. Given the `:rf.causa/hidden-by-filters` summary map,
-  render the 'N events hidden by filters' banner — the offending pills
-  / frame pin / mute count as visible cause chips + a one-click
-  'Clear filters' button. Returns nil when nothing is hidden so the
-  no-filter case stays chromeless.
-
-  Covers the filtered-to-empty and filtered-to-one cases: both report a
-  positive `:hidden` whenever the raw stream carried more visible rows,
-  so the banner renders even when the list below shows 'No events.'"
-  [{:keys [hidden visible? pills frame muted-count] :as _summary}]
+(defn filters-hidden-message
+  "Pure hiccup. The `N events hidden by filters` message + its pill /
+  mute cause chips — the RIGHT-side signal of the events ribbon. Renders
+  nil unless the hidden count is positive (`:visible?`). Keeps rf2-jvghz's
+  prominent yellow accent. Counts pill/mute suppression ONLY — the frame
+  is a view scope, never counted as hidden (rf2-4vp5j Workstream C)."
+  [{:keys [hidden visible? pills muted-count] :as _summary}]
   (when visible?
     [:div {:data-testid "rf-causa-filters-hidden-indicator"
            :role        "status"
-           :style {:display       "flex"
-                   :align-items   "center"
-                   :flex-wrap     "wrap"
-                   :gap           "8px"
-                   :padding       "6px 10px"
-                   :background    (:bg-3 tokens)
-                   :border-bottom (str "1px solid " (:yellow tokens))
-                   :font-family   sans-stack
-                   :font-size     (:caption type-scale)
-                   :color         (:text-primary tokens)}}
+           :style {:display     "inline-flex"
+                   :align-items "center"
+                   :flex-wrap   "wrap"
+                   :gap         "6px"
+                   :font-family sans-stack
+                   :font-size   (:caption type-scale)
+                   :color       (:text-primary tokens)}}
      [:span {:data-testid "rf-causa-filters-hidden-count"
              :style {:font-weight 600 :color (:yellow tokens) :white-space "nowrap"}}
       (str hidden " event" (when (not= 1 hidden) "s") " hidden by filters")]
-     ;; Cause chips — the active pills, the frame pin, the mute set.
+     ;; Cause chips — the active pills + the mute set (NOT the frame).
      (into [:span {:data-testid "rf-causa-filters-hidden-causes"
                    :style {:display "flex" :align-items "center"
                            :flex-wrap "wrap" :gap "4px"}}]
@@ -1383,36 +1369,119 @@
                  :title  (str (name mode) " filter pill")
                  :label  (str (if (= mode :out) "× " "+ ")
                               (when glyph (str glyph ":")) label)}])
-             (when frame
-               [^{:key "frame"}
-                [filter-cause-chip
-                 {:testid "rf-causa-filters-hidden-frame"
-                  :tone   (:accent-violet tokens)
-                  :title  "Frame pin — only this frame's events show"
-                  :label  (str "Frame: " frame)}]])
              (when (pos? muted-count)
                [^{:key "muted"}
                 [filter-cause-chip
                  {:testid "rf-causa-filters-hidden-muted"
                   :tone   (:text-secondary tokens)
                   :title  "Muted event-ids hidden from the spine"
-                  :label  (str "🔇 " muted-count)}]])))
-     [:button {:data-testid "rf-causa-filters-hidden-clear"
-               :on-click    #(rf/dispatch [:rf.causa/clear-all-filters]
-                                          {:frame :rf/causa})
-               :title       "Clear every filter pill, the frame pin, and all mutes"
-               :style {:margin-left   "auto"
-                       :background    "transparent"
-                       :border        (str "1px solid " (:yellow tokens))
-                       :color         (:yellow tokens)
-                       :cursor        "pointer"
-                       :font-family   sans-stack
-                       :font-size     (:caption type-scale)
-                       :font-weight   600
-                       :padding       "2px 10px"
-                       :border-radius "10px"
-                       :white-space   "nowrap"}}
-      "Clear filters"]]))
+                  :label  (str "🔇 " muted-count)}]])))]))
+
+(defn- clear-filters-button
+  "Restrained outline `Clear Filters` button — resets pills + mutes (NOT
+  the frame; rf2-4vp5j Workstream C). Rendered only when a filter is
+  active (`:any-active?`)."
+  []
+  [:button {:data-testid "rf-causa-filters-hidden-clear"
+            :on-click    #(rf/dispatch [:rf.causa/clear-all-filters]
+                                       {:frame :rf/causa})
+            :title       "Clear every filter pill and all mutes"
+            :style {:background    "transparent"
+                    :border        (str "1px solid " (:border-default tokens))
+                    :color         (:text-secondary tokens)
+                    :cursor        "pointer"
+                    :font-family   sans-stack
+                    :font-size     (:caption type-scale)
+                    :font-weight   500
+                    :padding       "2px 10px"
+                    :border-radius "4px"
+                    :white-space   "nowrap"}}
+   "Clear Filters"])
+
+(rf/reg-view events-ribbon
+  "L1.5 **events ribbon** (rf2-4vp5j) — the second stratum below the
+  chrome ribbon. LEFT → RIGHT: `Events:` label · the `[◀ ▶ ⏭]` nav
+  cluster · the focus-chip · the active filter pills + add-pill widget.
+  FAR RIGHT (only when a filter is active): the `N hidden` message +
+  the `Clear Filters` button.
+
+  The nav cluster, focus-chip, and filter pills moved here from the
+  chrome ribbon (they are spine/filter chrome, not scope selectors).
+  Boundary detection for the nav cluster is computed here against the
+  same `l2-cascade-visible?` visible-row set the L2 list renders.
+
+  Visibility of the right-side action cluster (rf2-4vp5j Decision 3):
+    - both absent in the clean/default state (no pills, no mutes);
+    - `Clear Filters` shows when ANY filter is active (`:any-active?`);
+    - the `N hidden` message shows beside it only when N > 0
+      (`:visible?`) — an active filter that hides nothing → button
+      present, message absent.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`. A distinct `bg-2` background + `border-subtle` hairline
+  separate it from the chrome ribbon's `bg-1` as a distinct layer."
+  []
+  (let [focus           @(rf/subscribe [:rf.causa/focus])
+        ;; rf2-4vp5j — boundary detection walks the FILTERED cascade
+        ;; list (frame view-scope + pills + mutes) so the `[◀ ▶]`
+        ;; disabled glyphs match exactly what the user sees in L2.
+        cascades        @(rf/subscribe [:rf.causa/filtered-cascades])
+        focus-set       @(rf/subscribe [:rf.causa/focus-set])
+        filters         @(rf/subscribe [:rf.causa/active-filters])
+        hidden-summary  @(rf/subscribe [:rf.causa/hidden-by-filters])
+        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
+        ;; bucket. The boundary walk MUST agree with what the user
+        ;; sees in L2, so it composes against the same
+        ;; `l2-cascade-visible?` predicate the L2 list uses.
+        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
+        focused-id      (:dispatch-id focus)
+        event-cascades  (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
+        ;; rf2-a1z3b — when a focus-set is active the nav buttons walk
+        ;; ONLY the in-focus subset; boundary predicates honour that.
+        ids             (if focus-set
+                          (fh/in-focus-ids event-cascades focus-set)
+                          (mapv :dispatch-id event-cascades))
+        at-head?        (or (empty? ids)
+                            (= focused-id (last ids))
+                            (and (nil? focused-id) (not focus-set)))
+        at-tail?        (or (empty? ids)
+                            (= focused-id (first ids)))
+        any-active?     (:any-active? hidden-summary)]
+    [:div {:data-testid "rf-causa-events-ribbon"
+           :role        "toolbar"
+           :aria-label  "Causa events"
+           :style {:display          "flex"
+                   :align-items      "center"
+                   :justify-content  "space-between"
+                   :gap              "12px"
+                   :min-height       (:events-ribbon-height layout)
+                   :flex-wrap        "wrap"
+                   :padding          "0 12px"
+                   :background       (:bg-2 tokens)
+                   :border-bottom    (str "1px solid " (:border-subtle tokens))
+                   :font-family      sans-stack
+                   :font-size        (:body type-scale)}}
+     ;; LEFT cluster — label · nav · focus-chip · filter pills.
+     [:div {:data-testid "rf-causa-events-ribbon-left"
+            :style {:display "flex" :align-items "center"
+                    :flex-wrap "wrap" :gap "8px"}}
+      [:span {:data-testid "rf-causa-events-ribbon-label"
+              :style {:color       (:text-secondary tokens)
+                      :font-size   (:body-tight type-scale)
+                      :white-space "nowrap"}}
+       "Events:"]
+      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail?}]
+      [ribbon-focus-chip {:focus-set focus-set}]
+      [ribbon-filter-pills {:filters filters}]]
+     ;; RIGHT cluster — hidden-count message + Clear Filters. Both
+     ;; absent in the clean state; rendered together only when a filter
+     ;; is active (Clear always when active; message only when N > 0).
+     (when any-active?
+       [:div {:data-testid "rf-causa-events-ribbon-actions"
+              :style {:display "flex" :align-items "center" :gap "8px"
+                      :margin-left "auto"}}
+        (filters-hidden-message hidden-summary)
+        [clear-filters-button]])]))
 
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
@@ -1459,10 +1528,11 @@
   ;; no-op everywhere it matters.
   (inject-scrollbar-style!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
-        ;; rf2-jvghz — the hidden-by-filters summary drives the banner
-        ;; above the scroll container so suppressed-by-persisted-filter
-        ;; rows are a VISIBLE cause, not a silently-broken-looking list.
-        hidden-summary @(rf/subscribe [:rf.causa/hidden-by-filters])
+        ;; rf2-4vp5j — the hidden-by-filters message moved UP to the
+        ;; events ribbon (`events-ribbon`); the L2 list no longer renders
+        ;; the banner itself. The events ribbon is the always-present
+        ;; second stratum so the count surfaces above the list rather
+        ;; than as an inline banner inside it.
         focus          @(rf/subscribe [:rf.causa/focus])
         focus-set      @(rf/subscribe [:rf.causa/focus-set])
         ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
@@ -1495,11 +1565,9 @@
         focus-pred     (fh/build-focus-predicate focus-set)]
     [:div {:data-testid "rf-causa-event-list-wrap"
            :style {:display "flex" :flex-direction "column"}}
-     ;; rf2-jvghz — the hidden-by-filters banner sits ABOVE the scroll
-     ;; container so it stays visible even when the filtered list is
-     ;; empty (the filtered-to-empty case) — that is precisely the case
-     ;; that looked broken before.
-     (filters-hidden-indicator hidden-summary)
+     ;; rf2-4vp5j — the hidden-by-filters message now lives in the
+     ;; events ribbon (above this list) rather than as an inline banner
+     ;; here; the list is just the scroll container.
      [:div {:data-testid "rf-causa-event-list"
             :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
                     :min-height    "48px"    ; 2 rows minimum
@@ -1735,9 +1803,13 @@
 ;; discipline as the rest of the shell.
 
 (rf/reg-view dynamic-chrome
-  "The Dynamic 4-layer chrome (L1 ribbon · L2 event list · L3 tab bar ·
-  L4 detail panel) wrapped as a single component. Extracted from the
-  inline composition in `shell-view` so the Static surface can swap in
+  "The Dynamic chrome wrapped as a single component. Per rf2-4vp5j the
+  top splits into two strata — the **chrome ribbon** (`ribbon`: Frame +
+  Dynamic/Static dropdowns, `⚙`/`✕`) and the **events ribbon**
+  (`events-ribbon`: `Events:` + nav + focus-chip + pills, and the
+  hidden-count + Clear Filters on the right) — above the L2 event list,
+  L3 tab bar, and L4 detail panel. Extracted from the inline
+  composition in `shell-view` so the Static surface can swap in
   alongside it via the mode composer (rf2-o5f5f.1).
 
   Per rf2-in6l2 `reg-view`-registered for parity with every other
@@ -1745,6 +1817,7 @@
   []
   [:<>
    [ribbon {}]
+   [events-ribbon]
    [event-list]
    [tab-bar]
    [detail-panel]])

--- a/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-causa.static.mode-pill
-  "Ribbon-left mode pill — two-segment radio toggling Dynamic ↔ Static
-  (rf2-o5f5f.1).
+  "Ribbon-left mode control — a compact single-select dropdown toggling
+  Dynamic ↔ Static (rf2-o5f5f.1, reshaped by rf2-4vp5j).
 
   ## Purpose
 
@@ -15,146 +15,102 @@
       design language as Dynamic; differentiation is temperature,
       not vocabulary.
 
-  The pill is the user-facing toggle that lives at ribbon-left in
-  BOTH modes. Cmd-Shift-M (the global chord — see `keybinding.cljs`)
-  fires the same `:rf.causa/toggle-mode` event so the chord and the
-  pill are wired to the same handler.
+  The control is the user-facing toggle that lives at chrome-ribbon-
+  left in BOTH modes. Cmd-Shift-M (the global chord — see
+  `keybinding.cljs`) fires the same `:rf.causa/toggle-mode` event so the
+  chord and the dropdown are wired to the same handler.
 
-  ## Geometry
+  ## Why a dropdown, not the old two-button pill (rf2-4vp5j)
 
-  Per the parent epic's mode-signal mechanism (4 stacked signals;
-  signal #1 is the pill):
+  Mode is an OCCASIONAL-use control — most sessions never flip it. The
+  earlier 160px two-segment radio pill was too dominant for that
+  cadence, anchoring the eye at chrome-left where the Frame picker now
+  belongs. The reshape collapses it to a compact `<select>` that shares
+  the frame picker's weight (`bg-2` fill, `border-default` hairline,
+  4px radius). The MODE SIGNAL is carried elsewhere — the chrome
+  ribbon's 2-px left-edge accent stripe (violet Dynamic / cyan Static,
+  `static/shell/stripe-hex-for-mode`) — so the control itself can
+  recede without losing the at-a-glance mode cue.
 
-    - 160px total width (28px tall, two 76px halves + a 2px divider —
-      the rounded corners + 1px borders fold into the half widths).
-    - Accent-violet fill + white glyph on the active segment.
-    - 200ms cross-fade on the active-state swap, threaded through the
-      `--rf-causa-motion-scale` seam so `prefers-reduced-motion: reduce`
-      collapses the fade to a single frame.
-
-  ## Why a single registered view, not two leaf fns
+  ## Why a single registered view
 
   `(rf/reg-view mode-pill …)` is the canonical Causa shape: subscribes
   inside the component body resolve to `:rf/causa` via React-context
   (rf2-in6l2 / Spec 004 §Plain Reagent fns do not pick up the
-  surrounding frame). The two segments are inline so the keyed
-  cross-fade has one DOM container to interpolate against.
+  surrounding frame). The `<select>` is native so keyboard + screen-
+  reader navigation work out of the box.
 
   ## Production posture
 
   Mounted only by `static/shell.cljs` (Static mode) AND by `shell.cljs`'s
-  L1 ribbon (Dynamic mode) — see the ribbon-left cluster wiring. Both
-  call sites pass the current mode in as a prop so the pill doesn't
-  re-subscribe per render."
+  chrome ribbon (Dynamic mode) — see the chrome-left cluster wiring.
+  The component subscribes to `:rf.causa/mode` directly so neither call
+  site threads the active mode as a prop."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale sans-stack]]))
 
-;; ---- segments + glyphs --------------------------------------------------
+;; ---- options ------------------------------------------------------------
 
-(def ^:private segments
-  "Pure inventory of the pill's two segments. Order is left → right and
-  ships the visible label, glyph, and the mode keyword each segment
-  selects when clicked. Exported (not private) so tests can assert
-  against the canonical inventory without hard-coding the strings.
+(def ^:private modes
+  "Pure inventory of the dropdown's two options. Order is the visible
+  option order and ships the label + the mode keyword each option
+  selects. Exported (not private) so tests can assert against the
+  canonical inventory without hard-coding the strings."
+  [{:mode :dynamic :label "Dynamic"}
+   {:mode :static  :label "Static"}])
 
-  Glyphs match Causa's existing `●` (active) / `○` (inactive) language
-  (cf. `shell.cljs/tab-button`). The selected segment is rendered with
-  `●`; the other with `○`."
-  [{:mode :dynamic :label "Dynamic" :title "Dynamic mode — event-coupled spine (Cmd-Shift-M)"}
-   {:mode :static  :label "Static"  :title "Static mode — registry browse (Cmd-Shift-M)"}])
-
-(defn segment-glyph
-  "Pure helper. `●` for the active segment, `○` for the inactive one.
-  Mirrors the chrome's `tab-button` convention."
-  [{:keys [mode]} active-mode]
-  (if (= mode active-mode) "●" "○"))
+(defn mode-label
+  "Pure helper. The display label for `mode` (`Dynamic` / `Static`).
+  Falls back to the Dynamic label for an unrecognised keyword so the
+  control always renders a stable option string."
+  [mode]
+  (or (some (fn [{m :mode l :label}] (when (= m mode) l)) modes)
+      "Dynamic"))
 
 ;; ---- view ---------------------------------------------------------------
 
-(defn- segment-style
-  "Inline style for one segment. Active segments paint accent-violet on
-  the canonical chrome surface (`bg-2`) so the pill sits cleanly on
-  the ribbon's `bg-1`. Inactive segments are flat — the pill reads as
-  a radio, not a dual-button toolbar.
-
-  Per parent-epic signal #1 the cross-fade rides
-  `--rf-causa-motion-scale` so `prefers-reduced-motion: reduce`
-  collapses the transition to a single frame (see `theme/global-
-  styles/motion-css`)."
-  [active?]
-  (let [duration (t/duration-css 200)]
-    (cond-> {:background      (if active? (:accent-violet tokens) "transparent")
-             :color           (if active? (:white tokens) (:text-secondary tokens))
-             :border          "none"
-             :border-radius   "12px"
-             :cursor          "pointer"
-             :display         "inline-flex"
-             :align-items     "center"
-             :gap             "4px"
-             :flex            "1 1 50%"
-             :height          "24px"
-             :justify-content "center"
-             :font-family     sans-stack
-             :font-size       (:caption type-scale)
-             :font-weight     (if active? 600 500)
-             :padding         "0"
-             :transition      (str "background-color " duration " ease-out, "
-                                   "color " duration " ease-out")}
-      active? (assoc :box-shadow "0 0 0 1px rgba(124, 92, 255, 0.35)"))))
-
-(defn- segment-button
-  "One pill segment. Click dispatches `:rf.causa/set-mode <mode>` against
-  the `:rf/causa` frame so the slot lands on Causa's app-db. The
-  segment is a `<button>` so screen-readers + keyboard navigation
-  work out of the box; `role='radio'` + `aria-checked` exposes the
-  proper ARIA radio-group pattern (a paired radio-pill, not two
-  independent toggles)."
-  [{:keys [mode label title] :as seg} active-mode]
-  (let [active? (= mode active-mode)]
-    [:button {:data-testid     (str "rf-causa-mode-pill-" (name mode))
-              :role            "radio"
-              :aria-checked    (if active? "true" "false")
-              :aria-label      (str "Switch to " label " mode")
-              :title           title
-              :on-click        (when-not active?
-                                 #(rf/dispatch [:rf.causa/set-mode mode]
-                                               {:frame :rf/causa}))
-              :style           (segment-style active?)}
-     [:span {:style {:font-size (:micro type-scale)}}
-      (segment-glyph seg active-mode)]
-     label]))
-
 (rf/reg-view mode-pill
-  "Ribbon-left mode pill (rf2-o5f5f.1) — two-segment radio toggling
-  Dynamic ↔ Static. The active segment paints accent-violet; the
-  inactive segment is flat. 200ms cross-fade via CSS transitions
-  (no JS animation), threaded through the `--rf-causa-motion-scale`
-  seam so reduced-motion users see an instant swap.
+  "Chrome-ribbon mode dropdown (rf2-o5f5f.1 / rf2-4vp5j) — a compact
+  single-select `<select>` toggling Dynamic ↔ Static. Shares the frame
+  picker's control style (`bg-2`, `border-default`, 4px radius) so the
+  two chrome-left selectors read as one stratum. The mode SIGNAL is the
+  ribbon's left-edge accent stripe, not this control — the dropdown is
+  deliberately understated for an occasional-use toggle.
 
-  Per spec/007-UX-IA.md §Static mode + parent-epic rf2-o5f5f mode-
-  signal mechanism (signal #1).
+  Selecting an option dispatches `:rf.causa/set-mode <mode>` against the
+  `:rf/causa` frame so the slot lands on Causa's app-db (the same
+  handler Cmd-Shift-M's `:rf.causa/toggle-mode` ends at).
 
-  The component itself subscribes to `:rf.causa/mode` — no prop
-  threading required at the call site. `reg-view`-registered so
-  the subscribe resolves to `:rf/causa` via React-context."
+  The component subscribes to `:rf.causa/mode` — no prop threading at
+  the call site. `reg-view`-registered so the subscribe resolves to
+  `:rf/causa` via React-context."
   []
   (let [active-mode @(rf/subscribe [:rf.causa/mode])]
-    [:div {:data-testid "rf-causa-mode-pill"
-           :role        "radiogroup"
-           :aria-label  "Causa mode"
-           :data-active-mode (name active-mode)
-           :style       {:display         "inline-flex"
-                         :align-items     "center"
-                         :gap             "2px"
-                         :width           "160px"
-                         :height          "28px"
-                         :padding         "2px"
-                         :background      (:bg-2 tokens)
-                         :border          (str "1px solid " (:border-default tokens))
-                         :border-radius   "14px"
-                         :flex-shrink     0}}
-     (for [seg segments]
-       ^{:key (:mode seg)}
-       [segment-button seg active-mode])]))
+    [:select {:data-testid (str "rf-causa-mode-pill")
+              :data-active-mode (name active-mode)
+              :aria-label  "Causa mode"
+              :title       "Switch Causa mode — Dynamic / Static (Cmd-Shift-M)"
+              :value       (name active-mode)
+              :on-change   (fn [^js e]
+                             (let [v    (.. e -target -value)
+                                   mode (keyword v)]
+                               (when (not= mode active-mode)
+                                 (rf/dispatch [:rf.causa/set-mode mode]
+                                              {:frame :rf/causa}))))
+              :style       {:background    (:bg-2 tokens)
+                            :color         (:text-primary tokens)
+                            :border        (str "1px solid " (:border-default tokens))
+                            :border-radius "4px"
+                            :padding       "2px 6px"
+                            :font-family   sans-stack
+                            :font-size     (:body-tight type-scale)
+                            :line-height   "1.4"
+                            :cursor        "pointer"
+                            :flex-shrink   0}}
+     (for [{:keys [mode label]} modes]
+       ^{:key mode}
+       [:option {:data-testid (str "rf-causa-mode-pill-" (name mode))
+                 :value       (name mode)}
+        label])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -261,15 +261,18 @@
                  :border-left      (str "2px solid " (stripe-hex-for-mode :static))
                  :font-family      sans-stack
                  :font-size        (:body type-scale)}}
-   [mode-pill/mode-pill]
-   ;; L1 frame-switcher slot (rf2-iwwou) — same contract as Dynamic's
-   ;; ribbon (`shell.cljs/ribbon`). The view reads `:rf.causa/current-
-   ;; frame` + `:rf.causa/available-frames` and writes via
-   ;; `:rf.causa/select-frame`. Mode-independent: the picker persists
-   ;; across mode toggles so the user can keep browsing the same
-   ;; frame's registrations as they flip between event-coupled
+   ;; LEFT cluster — scope selectors (Frame + Dynamic/Static), mirroring
+   ;; the Dynamic chrome ribbon's left cluster (rf2-4vp5j). The frame
+   ;; picker is mode-INDEPENDENT — same contract as Dynamic's ribbon
+   ;; (`shell.cljs/ribbon`): reads `:rf.causa/current-frame` +
+   ;; `:rf.causa/available-frames`, writes via `:rf.causa/select-frame`.
+   ;; The picker persists across mode toggles so the user keeps browsing
+   ;; the same frame's registrations as they flip between event-coupled
    ;; (Dynamic) and event-independent (Static) lenses.
-   [frame-switcher/frame-switcher-view]
+   [:div {:data-testid "rf-causa-static-ribbon-selectors"
+          :style {:display "flex" :align-items "center" :gap "8px"}}
+    [frame-switcher/frame-switcher-view]
+    [mode-pill/mode-pill]]
    [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
     [ribbon-right-icons]]])
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -412,8 +412,18 @@
   The 4-layer chrome is L1 ribbon (top-strip) + L2 event list + L3
   tab bar + L4 detail panel — no bottom rail, no sidebar (both dropped
   in earlier Causa redesigns and the now-unused `:sidebar-width` /
-  `:bottom-rail-height` tokens were retired in Round-3 rf2-g9pee)."
-  {:top-strip-height "56px"})
+  `:bottom-rail-height` tokens were retired in Round-3 rf2-g9pee).
+
+  Per rf2-4vp5j the top of the shell splits into TWO strata: the
+  **chrome ribbon** (`:top-strip-height`, made compact — it now carries
+  only the Frame + Dynamic/Static dropdowns on the left and `⚙`/`✕` on
+  the right; nav, focus-chip and filter pills moved down) and the
+  **events ribbon** (`:events-ribbon-height`, carrying `Events:` + nav +
+  focus-chip + pills on the left and the hidden-count + Clear Filters on
+  the right). The compacted chrome height reclaims vertical canvas for
+  the L2 event list."
+  {:top-strip-height     "40px"
+   :events-ribbon-height "36px"})
 
 ;; ---- motion (rf2-5kfxe.5) ----------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
@@ -124,17 +124,27 @@
     (is (= 1 (count (:pills s))))
     (is (= :out (:mode (first (:pills s)))))))
 
-(deftest hidden-by-filters-counts-frame-pin-suppression
-  (causa-setup!)
-  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
-  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-y))
-  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:c] :rf/frame-y))
-  ;; Pin to :rf/frame-y → only 2 of 3 survive, 1 hidden, frame named.
-  (frame-dispatch [:rf.causa/select-frame :rf/frame-y])
-  (let [s (frame-sub [:rf.causa/hidden-by-filters])]
-    (is (= 1 (:hidden s)))
-    (is (true? (:visible? s)))
-    (is (= :rf/frame-y (:frame s)))))
+(deftest frame-is-a-view-scope-not-a-filter
+  (testing "rf2-4vp5j Workstream C — selecting a frame is a view SCOPE,
+            not a filter: it is NEVER counted as hidden, NEVER an active
+            filter, and the summary carries no `:frame` cause. The count
+            baseline is computed WITHIN the selected frame so switching
+            frames does not inflate 'hidden'."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-y))
+    (trace-bus/collect-trace! (dispatch-trace-ev 3 [:c] :rf/frame-y))
+    ;; Scope to :rf/frame-y → the list shows frame-y's events; the
+    ;; other frame's events are out-of-SCOPE, not hidden-by-filter.
+    (frame-dispatch [:rf.causa/select-frame :rf/frame-y])
+    (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+      (is (= 0 (:hidden s)) "frame scope is NOT counted as hidden")
+      (is (false? (:visible? s)) "no hidden-count message for a scope change")
+      (is (false? (:any-active? s)) "a frame scope alone is not an active filter")
+      (is (not (contains? s :frame)) "no :frame cause in the model")
+      ;; the list is scoped to frame-y (2 events), decoupled from filters
+      (is (= :rf/frame-y (frame-sub [:rf.causa/view-scope-frame])))
+      (is (= 2 (count (frame-sub [:rf.causa/filtered-cascades])))))))
 
 (deftest hidden-by-filters-counts-mute-suppression
   (causa-setup!)
@@ -146,17 +156,21 @@
     (is (= 1 (:muted-count s)))
     (is (true? (:visible? s)))))
 
-(deftest hidden-by-filters-frame-pin-to-empty-still-visible
-  (testing "the looked-broken case — pin to a frame with no events leaves
-            zero filtered rows but the summary stays visible"
+(deftest frame-scope-to-empty-frame-is-not-hidden-by-filters
+  (testing "rf2-4vp5j — scoping to a frame with no events leaves zero
+            rows, but that is an empty SCOPE, not 'hidden by filters'.
+            The count baseline is within the selected frame (0 raw, 0
+            filtered) so nothing is counted as hidden and no message
+            renders."
     (causa-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
     (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-x))
     (frame-dispatch [:rf.causa/select-frame :rf/empty-frame])
     (let [s (frame-sub [:rf.causa/hidden-by-filters])]
-      (is (= 2 (:hidden s)))
+      (is (= 0 (:hidden s)) "frame scope is never counted as hidden")
       (is (= 0 (:filtered-count s)))
-      (is (true? (:visible? s))))))
+      (is (false? (:visible? s)) "no hidden-count message for an empty scope")
+      (is (false? (:any-active? s))))))
 
 ;; -------------------------------------------------------------------------
 ;; (2) view renders the banner
@@ -192,31 +206,34 @@
 ;; (3) clear-all-filters resets every surface
 ;; -------------------------------------------------------------------------
 
-(deftest clear-all-filters-resets-pills-frame-and-mutes
-  (when (and (exists? js/window) (.-localStorage js/window))
-    (causa-setup!)
-    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
-    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-x))
-    (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick] :rf/frame-x))
-    (frame-dispatch [:rf.causa/add-filter :in {:pattern :a}])
-    (frame-dispatch [:rf.causa/mute-event-id :noise/tick])
-    (frame-dispatch [:rf.causa/select-frame :rf/frame-x])
-    ;; Pre-clear — pills, frame pin, mute all active.
-    (is (true? (:any-active? (frame-sub [:rf.causa/hidden-by-filters]))))
-    (frame-dispatch [:rf.causa/clear-all-filters])
-    (let [s (frame-sub [:rf.causa/hidden-by-filters])]
-      (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters]))
-          "pills reset")
-      (is (nil? (frame-sub [:rf.causa/current-frame]))
-          "frame pin cleared")
-      (is (= #{} (frame-sub [:rf.causa/muted-event-ids]))
-          "mutes cleared")
-      (is (= 0 (:hidden s)) "nothing hidden after clear")
-      (is (false? (:visible? s)) "indicator vanishes")
-      (is (= 3 (:filtered-count s)) "filtered list snaps back to raw"))
-    ;; Persistence — the unpin + unmute survive a reload read.
-    (is (nil? (frame-switcher/load)) "frame-pin localStorage cleared")
-    (is (= #{} (spine-filters/load)) "mute localStorage cleared")))
+(deftest clear-all-filters-resets-pills-and-mutes-not-frame
+  (testing "rf2-4vp5j Workstream C — Clear Filters resets pills + mutes
+            but LEAVES the frame view scope untouched (frame is a scope,
+            not a filter)."
+    (when (and (exists? js/window) (.-localStorage js/window))
+      (causa-setup!)
+      (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a] :rf/frame-x))
+      (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b] :rf/frame-x))
+      (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick] :rf/frame-x))
+      (frame-dispatch [:rf.causa/add-filter :in {:pattern :a}])
+      (frame-dispatch [:rf.causa/mute-event-id :noise/tick])
+      (frame-dispatch [:rf.causa/select-frame :rf/frame-x])
+      ;; Pre-clear — pills + mute active (frame is a scope, not counted).
+      (is (true? (:any-active? (frame-sub [:rf.causa/hidden-by-filters]))))
+      (frame-dispatch [:rf.causa/clear-all-filters])
+      (let [s (frame-sub [:rf.causa/hidden-by-filters])]
+        (is (= {:in [] :out []} (frame-sub [:rf.causa/active-filters]))
+            "pills reset")
+        (is (= :rf/frame-x (frame-sub [:rf.causa/current-frame]))
+            "frame view scope is PRESERVED — Clear Filters never touches it")
+        (is (= #{} (frame-sub [:rf.causa/muted-event-ids]))
+            "mutes cleared")
+        (is (= 0 (:hidden s)) "nothing hidden after clear")
+        (is (false? (:visible? s)) "message vanishes")
+        ;; list snaps back to frame-x's full set (3 events)
+        (is (= 3 (:filtered-count s)) "filtered list snaps back to frame scope"))
+      ;; Persistence — the unmute survives a reload read.
+      (is (= #{} (spine-filters/load)) "mute localStorage cleared"))))
 
 (deftest clear-all-filters-removes-banner-from-view
   (causa-setup!)

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_test.cljc
@@ -1,10 +1,15 @@
 (ns day8.re-frame2-causa.filters.hidden-test
-  "Pure-data tests for the L2 'N hidden by filters' indicator
-  derivation (rf2-jvghz, defect #1).
+  "Pure-data tests for the events-ribbon 'N hidden by filters' message
+  derivation (rf2-jvghz, defect #1; frame-decoupled per rf2-4vp5j).
 
   CLJC so the JVM corpus exercises the hidden-count derivation +
   visibility predicate without a CLJS runtime — the helper is pure
-  data, no atoms, no I/O."
+  data, no atoms, no I/O.
+
+  Per rf2-4vp5j Workstream C the FRAME is a view SCOPE, not a filter —
+  it is never counted as hidden, never a cause, never reset by Clear
+  Filters. The summary model carries no `:frame` key and
+  `any-filter-active?` ignores frame state entirely."
   (:require [clojure.test :refer [deftest is testing]]
             [day8.re-frame2-causa.filters.hidden :as hidden]))
 
@@ -30,10 +35,6 @@
   (is (true?  (hidden/pills-present? {:in [{:pattern :a}] :out []})))
   (is (true?  (hidden/pills-present? {:in [] :out [{:pattern :b}]}))))
 
-(deftest frame-pinned?-is-some
-  (is (false? (hidden/frame-pinned? nil)))
-  (is (true?  (hidden/frame-pinned? :rf/cart-frame))))
-
 (deftest mutes-present?-detects-nonempty-set
   (is (false? (hidden/mutes-present? nil)))
   (is (false? (hidden/mutes-present? #{})))
@@ -41,27 +42,32 @@
 
 ;; ---- any-filter-active? -------------------------------------------------
 
-(deftest any-filter-active?-true-for-each-surface
+(deftest any-filter-active?-true-for-each-filter-surface
   (is (false? (hidden/any-filter-active?
-                {:filters {:in [] :out []} :frame nil :muted #{}})))
+                {:filters {:in [] :out []} :muted #{}})))
   (is (true?  (hidden/any-filter-active?
-                {:filters {:in [{:pattern :a}] :out []} :frame nil :muted #{}}))
+                {:filters {:in [{:pattern :a}] :out []} :muted #{}}))
       "an IN pill counts")
   (is (true?  (hidden/any-filter-active?
-                {:filters {:in [] :out []} :frame :rf/cart-frame :muted #{}}))
-      "a frame pin counts")
-  (is (true?  (hidden/any-filter-active?
-                {:filters {:in [] :out []} :frame nil :muted #{:noise}}))
+                {:filters {:in [] :out []} :muted #{:noise}}))
       "a mute counts"))
+
+(deftest any-filter-active?-ignores-frame-scope
+  (testing "rf2-4vp5j — the frame is a view SCOPE, not a filter; a frame
+            in the state map (even if a caller passes one) never makes
+            any-filter-active? true on its own"
+    (is (false? (hidden/any-filter-active?
+                  {:filters {:in [] :out []} :frame :rf/cart-frame :muted #{}}))
+        "a frame selection alone is NOT an active filter")))
 
 (deftest any-filter-active?-independent-of-hidden-count
   (testing "a filter can be active yet hide nothing (it matches every
             current cascade) — any-filter-active? is about whether a
-            Clear-filters click would reset anything, not about the
+            Clear Filters click would reset anything, not about the
             count"
     (is (true? (hidden/any-filter-active?
                  {:filters {:in [{:pattern :a}] :out []}
-                  :frame nil :muted #{}})))))
+                  :muted #{}})))))
 
 ;; ---- indicator-visible? -------------------------------------------------
 
@@ -105,7 +111,6 @@
                             {:filters {:in [{:kind :machine
                                              :params {:machine-id :checkout/fsm}}]
                                        :out []}
-                             :frame nil
                              :muted #{}})]
       (is (= 4 (:hidden s)))
       (is (true? (:visible? s)))
@@ -114,34 +119,41 @@
       (is (= 1 (:filtered-count s)))
       (is (= 1 (count (:pills s))))
       (is (= ":checkout/fsm" (:label (first (:pills s)))))
-      (is (nil? (:frame s)))
       (is (= 0 (:muted-count s))))))
 
+(deftest summary-carries-no-frame-key
+  (testing "rf2-4vp5j — the frame is a view scope, not a filter; the
+            summary model never carries a `:frame` key, even if a caller
+            leaks one into the state map"
+    (let [s (hidden/summary 6 4 {:filters {:in [] :out []}
+                                 :frame :rf/other-frame
+                                 :muted #{}})]
+      (is (not (contains? s :frame))
+          "no :frame in the message model — frame is a scope, not a cause"))))
+
 (deftest summary-filtered-to-empty-still-visible
-  (testing "the frame-pin-to-empty case — raw has rows, the pin leaves
-            zero; the banner MUST still render (this is the looked-broken
-            case)"
+  (testing "the filtered-to-empty case — raw has rows, the pill leaves
+            zero; the message MUST still render (this is the
+            looked-broken case)"
     (let [s (hidden/summary 6 0
-                            {:filters {:in [] :out []}
-                             :frame :rf/other-frame
+                            {:filters {:in [{:pattern :a}] :out []}
                              :muted #{}})]
       (is (= 6 (:hidden s)))
-      (is (true? (:visible? s)))
-      (is (= :rf/other-frame (:frame s))))))
+      (is (true? (:visible? s))))))
 
 (deftest summary-filtered-to-one-visible
   (testing "the filtered-to-one case — raw 4, filtered 1; reports 3
             hidden and renders"
     (let [s (hidden/summary 4 1
                             {:filters {:in [{:pattern :a}] :out []}
-                             :frame nil :muted #{}})]
+                             :muted #{}})]
       (is (= 3 (:hidden s)))
       (is (true? (:visible? s))))))
 
 (deftest summary-nothing-hidden-not-visible
-  (testing "no filter active, filtered == raw → no banner"
+  (testing "no filter active, filtered == raw → no message"
     (let [s (hidden/summary 7 7
-                            {:filters {:in [] :out []} :frame nil :muted #{}})]
+                            {:filters {:in [] :out []} :muted #{}})]
       (is (= 0 (:hidden s)))
       (is (false? (:visible? s)))
       (is (false? (:any-active? s))))))
@@ -149,7 +161,6 @@
 (deftest summary-counts-mutes
   (let [s (hidden/summary 5 3
                           {:filters {:in [] :out []}
-                           :frame nil
                            :muted #{:noise/tick :user/mouse-move}})]
     (is (= 2 (:hidden s)))
     (is (= 2 (:muted-count s)))

--- a/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
@@ -216,3 +216,36 @@
                     {:dispatch-id 2 :frame :cart-frame}]]
       (is (= [1 2] (mapv :dispatch-id
                          (matcher/filter-cascades-by-frame cascades :cart-frame)))))))
+
+;; ---- view-scope filter (rf2-4vp5j) --------------------------------------
+
+(deftest keep-cascade-for-view-scope-nil-keeps-everything
+  (testing "nil scope-frame means 'no view scope' — every cascade survives"
+    (is (matcher/keep-cascade-for-view-scope? {:frame :cart-frame} nil))
+    (is (matcher/keep-cascade-for-view-scope? {:frame nil} nil))))
+
+(deftest keep-cascade-for-view-scope-keeps-matching-and-frameless
+  (testing "rf2-4vp5j — a view scope keeps the matching frame AND the
+            frame-agnostic `:ungrouped` bucket (nil frame); only OTHER
+            real frames drop"
+    (is (matcher/keep-cascade-for-view-scope? {:frame :cart-frame} :cart-frame))
+    (is (matcher/keep-cascade-for-view-scope? {:frame nil} :cart-frame)
+        "frameless :ungrouped bucket survives the view scope")
+    (is (not (matcher/keep-cascade-for-view-scope? {:frame :other-frame} :cart-frame))
+        "a different real frame drops out of scope")))
+
+(deftest filter-cascades-by-view-scope-preserves-frameless-bucket
+  (testing "rf2-4vp5j — unlike the strict frame filter, the view-scope
+            filter keeps the frameless `:ungrouped` bucket so a defaulted
+            scope never swallows it (its render is gated by show-ungrouped?)"
+    (let [cascades [{:dispatch-id 1 :frame :cart-frame}
+                    {:dispatch-id :ungrouped :frame nil}
+                    {:dispatch-id 2 :frame :other-frame}
+                    {:dispatch-id 3 :frame :cart-frame}]]
+      (is (= [1 :ungrouped 3]
+             (mapv :dispatch-id
+                   (matcher/filter-cascades-by-view-scope cascades :cart-frame)))))))
+
+(deftest filter-cascades-by-view-scope-nil-is-identity
+  (let [cascades [{:dispatch-id 1 :frame :a} {:dispatch-id 2 :frame :b}]]
+    (is (= cascades (matcher/filter-cascades-by-view-scope cascades nil)))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -161,6 +161,12 @@
    ;; surfaces. See `frame_switcher.cljs` for the full contract.
    :rf.causa/current-frame
    :rf.causa/available-frames
+   ;; rf2-4vp5j — the dedicated VIEW-SCOPE frame slot (frame is a view
+   ;; scope, not a filter): the resolved scope + its raw stored slot +
+   ;; the raw target-frame slot it falls back to on a host seed.
+   :rf.causa/view-scope-frame
+   :rf.causa/view-scope-frame-slot
+   :rf.causa/target-frame-slot
    :rf.causa/focused-slice-path
    :rf.causa/issues-filters
    :rf.causa/issues-ribbon

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -195,30 +195,27 @@
 ;; (2) L1 ribbon clusters
 ;; -------------------------------------------------------------------------
 
-(deftest ribbon-mounts-all-four-clusters
-  (testing "spec/018 §3 + Round-3 rf2-g9pee — ribbon carries nav ·
-            frame · filter pills · right icons in fixed left-to-right
-            order. The explicit `● LIVE` / `◐ RETRO` SPINE-mode pill
-            was dropped in Round-3 — spine mode is derivable from
-            sticky-row selection + the `[◀ ▶ ⏭]` cluster, and Space /
-            L / G keybindings preserve toggle access.
-
-            Note: the Dynamic/Static MODE pill (rf2-o5f5f.1, testid
-            `rf-causa-mode-pill`) is a different widget — it mounts
-            at ribbon-left unconditionally per rf2-8l3uk and is
-            asserted by `static/shell_cljs_test.cljs`."
+(deftest ribbon-mounts-all-clusters-across-two-strata
+  (testing "rf2-4vp5j — the top of the shell is TWO strata. The chrome
+            ribbon carries the Frame + Dynamic/Static selectors (left)
+            and the right-icons cluster; the events ribbon carries the
+            nav cluster + filter pills (moved down from the old single
+            ribbon). All clusters still mount somewhere in the shell
+            tree."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)]
         (is (some? (find-by-testid tree "rf-causa-ribbon-nav"))
-            "nav cluster present")
+            "nav cluster present (now in the events ribbon)")
         (is (or (find-by-testid tree "rf-causa-ribbon-frame")
                 (find-by-testid tree "rf-causa-ribbon-frame-picker"))
-            "frame cluster present (label or dropdown)")
+            "frame selector present (label or dropdown) in the chrome ribbon")
+        (is (some? (find-by-testid tree "rf-causa-mode-pill"))
+            "Dynamic/Static mode dropdown present in the chrome ribbon")
         (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
-            "filter cluster present")
+            "filter cluster present (now in the events ribbon)")
         (is (some? (find-by-testid tree "rf-causa-ribbon-icons"))
-            "right-icons cluster present")))))
+            "right-icons cluster present in the chrome ribbon")))))
 
 (deftest ribbon-omits-popout-button
   (testing "rf2-u3qm1 — the right-icons cluster mounts only Settings +
@@ -240,6 +237,128 @@
             "pop-out ribbon button is absent (silent-by-default)")
         (is (not (re-find #"stubbed" (text-nodes icons)))
             "no `stubbed` copy in the right-icons cluster")))))
+
+;; -------------------------------------------------------------------------
+;; (2b) Two-ribbon redesign — chrome ribbon + events ribbon (rf2-4vp5j)
+;; -------------------------------------------------------------------------
+
+(deftest chrome-ribbon-carries-only-selectors-and-icons
+  (testing "rf2-4vp5j Workstream A — the chrome ribbon (rf-causa-ribbon)
+            carries the Frame + Dynamic/Static selectors on the left and
+            the right-icons cluster; the nav cluster + focus-chip +
+            filter pills moved OUT to the events ribbon."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [ribbon (shell/ribbon nil)]
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-selectors"))
+            "left selector cluster present")
+        (is (or (find-by-testid ribbon "rf-causa-ribbon-frame")
+                (find-by-testid ribbon "rf-causa-ribbon-frame-picker"))
+            "Frame selector in the chrome ribbon")
+        (is (some? (find-by-testid ribbon "rf-causa-mode-pill"))
+            "Dynamic/Static mode dropdown in the chrome ribbon")
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-icons"))
+            "right-icons cluster in the chrome ribbon")
+        ;; spine/filter chrome moved DOWN to the events ribbon
+        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-nav"))
+            "nav cluster is NOT in the chrome ribbon")
+        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-filters"))
+            "filter pills are NOT in the chrome ribbon")
+        (is (nil? (find-by-testid ribbon "rf-causa-focus-chip"))
+            "focus-chip is NOT in the chrome ribbon")))))
+
+(deftest events-ribbon-carries-label-nav-and-pills
+  (testing "rf2-4vp5j Workstream B — the events ribbon
+            (rf-causa-events-ribbon) carries the `Events:` label, the
+            nav cluster, and the filter pills on the left."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            ribbon (find-by-testid tree "rf-causa-events-ribbon")]
+        (is (some? ribbon) "events ribbon mounts as its own stratum")
+        (is (some? (find-by-testid tree "rf-causa-events-ribbon-label"))
+            "`Events:` label present")
+        (is (re-find #"Events:" (text-nodes ribbon))
+            "the label text reads `Events:`")
+        (is (some? (find-by-testid tree "rf-causa-ribbon-nav"))
+            "nav cluster present in the events ribbon")
+        (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
+            "filter pills present in the events ribbon")))))
+
+(deftest events-ribbon-actions-absent-when-no-filters
+  (testing "rf2-4vp5j Decision 3 — with no pills + no mutes, the events
+            ribbon's right-side action cluster (Clear Filters + N-hidden
+            message) is absent (clean default state)."
+    (causa-setup!)
+    (trace-bus/collect-trace! {:id 1 :op-type :event :operation :event/dispatched
+                               :tags {:event [:a] :frame :rf/default :dispatch-id 1}})
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (nil? (find-by-testid tree "rf-causa-events-ribbon-actions"))
+            "no action cluster when no filter is active")
+        (is (nil? (find-by-testid tree "rf-causa-filters-hidden-clear"))
+            "no Clear Filters button when no filter is active")
+        (is (nil? (find-by-testid tree "rf-causa-filters-hidden-indicator"))
+            "no N-hidden message when no filter is active")))))
+
+(deftest events-ribbon-shows-clear-filters-when-filter-active
+  (testing "rf2-4vp5j Decision 3 — when a filter is active, Clear Filters
+            appears; the N-hidden message appears beside it only when N>0."
+    (causa-setup!)
+    (trace-bus/collect-trace! {:id 1 :op-type :event :operation :event/dispatched
+                               :tags {:event [:a] :frame :rf/default :dispatch-id 1}})
+    (trace-bus/collect-trace! {:id 2 :op-type :event :operation :event/dispatched
+                               :tags {:event [:noise/tick] :frame :rf/default :dispatch-id 2}})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/add-filter :out {:pattern :noise/tick}]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (some? (find-by-testid tree "rf-causa-events-ribbon-actions"))
+            "action cluster present when a filter is active")
+        (is (some? (find-by-testid tree "rf-causa-filters-hidden-clear"))
+            "Clear Filters button present")
+        (is (some? (find-by-testid tree "rf-causa-filters-hidden-indicator"))
+            "N-hidden message present (the OUT pill hides 1 row → N>0)")
+        ;; the message says 'Clear Filters' (capitalised label per redesign)
+        (is (re-find #"Clear Filters"
+                     (text-nodes (find-by-testid tree "rf-causa-events-ribbon-actions"))))))))
+
+(deftest close-icon-dispatches-close-shell
+  (testing "rf2-4vp5j Workstream A — the chrome ribbon `✕` dispatches the
+            existing `:rf.causa/close-shell` event (landed by rf2-fq491);
+            it does NOT reimplement the hide logic."
+    (causa-setup!)
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree    (shell/shell-view)
+                close   (find-by-testid tree "rf-causa-icon-close")
+                handler (:on-click (second close))]
+            (is (some? close) "close icon present in the chrome ribbon")
+            (when handler (handler nil)))))
+      (is (some #(= :rf.causa/close-shell (first %)) @dispatches)
+          "`✕` click dispatches :rf.causa/close-shell"))))
+
+(deftest mode-dropdown-change-dispatches-set-mode
+  (testing "rf2-4vp5j Workstream A — selecting Static in the mode
+            dropdown dispatches `:rf.causa/set-mode :static`."
+    (causa-setup!)
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [ribbon  (shell/ribbon nil)
+                select  (find-by-testid ribbon "rf-causa-mode-pill")
+                on-chg  (:on-change (second select))]
+            (is (some? on-chg) "mode dropdown carries an on-change handler")
+            (when on-chg
+              (on-chg #js {:target #js {:value "static"}})))))
+      (is (some #(and (= :rf.causa/set-mode (first %))
+                      (= :static (second %))) @dispatches)
+          "selecting Static dispatches :rf.causa/set-mode :static"))))
 
 (deftest ribbon-nav-buttons-dispatch-spine-events
   (testing "spec/018 §3 — ribbon `◀ ▶ ⏭` dispatch focus-cascade-prev /

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -393,43 +393,48 @@
     (is (= :accent-violet (static-shell/stripe-token-for-mode nil)))))
 
 ;; -------------------------------------------------------------------------
-;; (7) Mode pill — radio pattern + active segment
+;; (7) Mode dropdown — compact single-select (rf2-4vp5j reshape)
 ;; -------------------------------------------------------------------------
+;;
+;; rf2-4vp5j replaced the two-button radio pill with a compact `<select>`
+;; dropdown (mode is an occasional-use control; the accent stripe carries
+;; the mode signal). Both `<option>` testids + the `data-active-mode`
+;; attribute remain so the inventory + active-mode are assertable.
 
-(deftest mode-pill-renders-two-segments
-  (testing "mode pill is a 2-segment radio group with Dynamic + Static"
+(deftest mode-dropdown-renders-both-options
+  (testing "mode control is a single-select dropdown with Dynamic +
+            Static options"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (mode-pill/mode-pill)]
-        (is (some? (find-by-testid tree "rf-causa-mode-pill")))
-        (is (some? (find-by-testid tree "rf-causa-mode-pill-dynamic")))
-        (is (some? (find-by-testid tree "rf-causa-mode-pill-static")))))))
+        (is (some? (find-by-testid tree "rf-causa-mode-pill"))
+            "the select control is present")
+        (is (= :select (first tree)) "the control is a native <select>")
+        (is (some? (find-by-testid tree "rf-causa-mode-pill-dynamic"))
+            "Dynamic option present")
+        (is (some? (find-by-testid tree "rf-causa-mode-pill-static"))
+            "Static option present")))))
 
-(deftest mode-pill-active-segment-aria-checked
-  (testing "the active segment carries aria-checked='true'"
+(deftest mode-dropdown-reflects-active-mode
+  (testing "the dropdown's :value + data-active-mode track the live mode"
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (let [tree     (mode-pill/mode-pill)
-            dynamic  (find-by-testid tree "rf-causa-mode-pill-dynamic")
-            static-b (find-by-testid tree "rf-causa-mode-pill-static")]
-        (is (= "true"  (:aria-checked (second dynamic))))
-        (is (= "false" (:aria-checked (second static-b))))))
+      (let [attrs (second (mode-pill/mode-pill))]
+        (is (= "dynamic" (:value attrs)))
+        (is (= "dynamic" (:data-active-mode attrs)))))
     ;; flip to Static and re-render
     (frame-dispatch [:rf.causa/set-mode :static])
     (rf/with-frame :rf/causa
-      (let [tree     (mode-pill/mode-pill)
-            dynamic  (find-by-testid tree "rf-causa-mode-pill-dynamic")
-            static-b (find-by-testid tree "rf-causa-mode-pill-static")]
-        (is (= "false" (:aria-checked (second dynamic))))
-        (is (= "true"  (:aria-checked (second static-b))))))))
+      (let [attrs (second (mode-pill/mode-pill))]
+        (is (= "static" (:value attrs)))
+        (is (= "static" (:data-active-mode attrs)))))))
 
-(deftest mode-pill-segment-glyphs
-  (testing "active segment renders ● and inactive renders ○
-            (mirrors Causa's existing tab-button glyph language)"
-    (is (= "●" (mode-pill/segment-glyph {:mode :dynamic} :dynamic)))
-    (is (= "○" (mode-pill/segment-glyph {:mode :static}  :dynamic)))
-    (is (= "○" (mode-pill/segment-glyph {:mode :dynamic} :static)))
-    (is (= "●" (mode-pill/segment-glyph {:mode :static}  :static)))))
+(deftest mode-dropdown-label-helper
+  (testing "the pure mode-label helper maps each mode to its display text"
+    (is (= "Dynamic" (mode-pill/mode-label :dynamic)))
+    (is (= "Static"  (mode-pill/mode-label :static)))
+    (is (= "Dynamic" (mode-pill/mode-label :nonsense))
+        "unknown modes fall back to the Dynamic label")))
 
 ;; -------------------------------------------------------------------------
 ;; (8) Surface composer — shell.cljs dispatches Dynamic vs Static

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -1950,14 +1950,15 @@ async function runConfigurePartialUpdate(page, state) {
 // feature-matrix carried zero browser coverage for the highest-user-
 // visible Causa surface to land in the recent cluster. This scenario:
 //
-//   1. Asserts the Dynamic baseline — mode pill present with `dynamic`
-//      segment selected (aria-checked=true), L2 spine event-list
-//      visible (4-layer chrome).
+//   1. Asserts the Dynamic baseline — mode dropdown present with
+//      `dynamic` selected (rf2-4vp5j reshaped the two-button pill into a
+//      compact `<select>`; `data-active-mode`/`value` carry the state),
+//      L2 spine event-list visible (4-layer chrome).
 //   2. Fires Ctrl+Shift+M (the cross-platform chord per
 //      `keybinding.cljs/mode-toggle-key?` — Cmd-Shift-M on macOS,
 //      Ctrl-Shift-M elsewhere; Playwright drives Ctrl as the headless
 //      Chromium maps to Ctrl reliably). Asserts the mode flips: the
-//      `static` segment becomes selected, the Static surface mounts
+//      dropdown reads `static`, the Static surface mounts
 //      (`rf-causa-static-surface` with `data-rf-causa-mode="static"`),
 //      the L2 spine disappears (3-layer silhouette — chrome-silhouette
 //      mode-signal #4), the Machines sub-tab is selected by default
@@ -1965,8 +1966,8 @@ async function runConfigurePartialUpdate(page, state) {
 //      / Views / Flows) mounts its real panel root testid while
 //      `:events` (rf2-o5f5f.6 — last remaining placeholder) still
 //      renders a placeholder card naming the sibling bead.
-//   3. Clicks `rf-causa-mode-pill-dynamic`; mode flips back; L2 spine
-//      returns (proves the pill is the canonical toggle path too —
+//   3. Selects `Dynamic` in the dropdown; mode flips back; L2 spine
+//      returns (proves the dropdown is the canonical toggle path too —
 //      not just the chord).
 //   4. Reloads the page; asserts localStorage `causa.mode` round-
 //      trips the last-set mode (Dynamic here, per the flip-back step).
@@ -1986,22 +1987,17 @@ async function runStaticModeChromeAndChord(page, state) {
   await openCausa(page);
 
   // ---- (1) Dynamic baseline -----------------------------------------
-  // Per rf2-8l3uk the mode pill is always rendered (the Static-mode
-  // feature gate was removed). The Dynamic segment must be selected
-  // by default.
+  // Per rf2-8l3uk the mode control is always rendered (the Static-mode
+  // feature gate was removed). Per rf2-4vp5j it is a compact `<select>`
+  // dropdown; `data-active-mode` + `value` carry the active mode.
+  // Dynamic must be selected by default.
   await expectVisible(
     page.locator('[data-testid="rf-causa-mode-pill"]'),
     5000,
   );
   const dynamicBaseline = await waitForValue(
     () => page.evaluate(() => {
-      const dynamicPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-dynamic"]',
-      );
-      const staticPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-static"]',
-      );
-      const pillGroup = document.querySelector(
+      const modeSelect = document.querySelector(
         '[data-testid="rf-causa-mode-pill"]',
       );
       const eventList = document.querySelector(
@@ -2011,16 +2007,14 @@ async function runStaticModeChromeAndChord(page, state) {
         '[data-testid="rf-causa-static-surface"]',
       );
       return {
-        dynamicPillChecked: dynamicPill ? dynamicPill.getAttribute('aria-checked') : null,
-        staticPillChecked: staticPill ? staticPill.getAttribute('aria-checked') : null,
-        pillGroupActiveMode: pillGroup ? pillGroup.getAttribute('data-active-mode') : null,
+        modeSelectValue: modeSelect ? modeSelect.value : null,
+        pillGroupActiveMode: modeSelect ? modeSelect.getAttribute('data-active-mode') : null,
         eventListPresent: Boolean(eventList),
         staticSurfacePresent: Boolean(staticSurface),
       };
     }),
     (snap) =>
-      snap.dynamicPillChecked === 'true' &&
-      snap.staticPillChecked === 'false' &&
+      snap.modeSelectValue === 'dynamic' &&
       snap.pillGroupActiveMode === 'dynamic' &&
       snap.eventListPresent &&
       !snap.staticSurfacePresent,
@@ -2031,13 +2025,7 @@ async function runStaticModeChromeAndChord(page, state) {
   await page.keyboard.press('Control+Shift+M');
   const afterChord = await waitForValue(
     () => page.evaluate(() => {
-      const dynamicPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-dynamic"]',
-      );
-      const staticPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-static"]',
-      );
-      const pillGroup = document.querySelector(
+      const modeSelect = document.querySelector(
         '[data-testid="rf-causa-mode-pill"]',
       );
       const surface = document.querySelector(
@@ -2063,9 +2051,8 @@ async function runStaticModeChromeAndChord(page, state) {
         '[data-testid="rf-causa-static-detail-panel-machines"]',
       );
       return {
-        dynamicPillChecked: dynamicPill ? dynamicPill.getAttribute('aria-checked') : null,
-        staticPillChecked: staticPill ? staticPill.getAttribute('aria-checked') : null,
-        pillGroupActiveMode: pillGroup ? pillGroup.getAttribute('data-active-mode') : null,
+        modeSelectValue: modeSelect ? modeSelect.value : null,
+        pillGroupActiveMode: modeSelect ? modeSelect.getAttribute('data-active-mode') : null,
         staticSurfacePresent: Boolean(surface),
         staticSurfaceModeAttr: surface ? surface.getAttribute('data-rf-causa-mode') : null,
         ribbonPresent: Boolean(ribbon),
@@ -2076,8 +2063,7 @@ async function runStaticModeChromeAndChord(page, state) {
       };
     }),
     (snap) =>
-      snap.staticPillChecked === 'true' &&
-      snap.dynamicPillChecked === 'false' &&
+      snap.modeSelectValue === 'static' &&
       snap.pillGroupActiveMode === 'static' &&
       snap.staticSurfacePresent &&
       snap.staticSurfaceModeAttr === 'static' &&
@@ -2152,18 +2138,14 @@ async function runStaticModeChromeAndChord(page, state) {
     5000,
   );
 
-  // ---- (3) Click Dynamic pill — Static → Dynamic --------------------
-  await page.locator('[data-testid="rf-causa-mode-pill-dynamic"]').click();
+  // ---- (3) Select Dynamic in the dropdown — Static → Dynamic --------
+  // rf2-4vp5j — the mode control is a `<select>`; flipping back is a
+  // selectOption (the canonical toggle path, not just the chord).
+  await page.locator('[data-testid="rf-causa-mode-pill"]').selectOption('dynamic');
   const afterClickBack = await waitForValue(
     () => page.evaluate(() => {
-      const pillGroup = document.querySelector(
+      const modeSelect = document.querySelector(
         '[data-testid="rf-causa-mode-pill"]',
-      );
-      const dynamicPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-dynamic"]',
-      );
-      const staticPill = document.querySelector(
-        '[data-testid="rf-causa-mode-pill-static"]',
       );
       const eventList = document.querySelector(
         '[data-testid="rf-causa-event-list"]',
@@ -2172,20 +2154,18 @@ async function runStaticModeChromeAndChord(page, state) {
         '[data-testid="rf-causa-static-surface"]',
       );
       return {
-        pillGroupActiveMode: pillGroup ? pillGroup.getAttribute('data-active-mode') : null,
-        dynamicPillChecked: dynamicPill ? dynamicPill.getAttribute('aria-checked') : null,
-        staticPillChecked: staticPill ? staticPill.getAttribute('aria-checked') : null,
+        pillGroupActiveMode: modeSelect ? modeSelect.getAttribute('data-active-mode') : null,
+        modeSelectValue: modeSelect ? modeSelect.value : null,
         eventListPresent: Boolean(eventList),
         staticSurfacePresent: Boolean(surface),
       };
     }),
     (snap) =>
       snap.pillGroupActiveMode === 'dynamic' &&
-      snap.dynamicPillChecked === 'true' &&
-      snap.staticPillChecked === 'false' &&
+      snap.modeSelectValue === 'dynamic' &&
       snap.eventListPresent &&
       !snap.staticSurfacePresent,
-    { timeoutMs: 5000, description: 'Dynamic restored after clicking pill segment' },
+    { timeoutMs: 5000, description: 'Dynamic restored after selecting Dynamic in the dropdown' },
   );
 
   // Per rf2-8l3uk Static mode is unconditionally available — no feature


### PR DESCRIPTION
## Summary

Reshapes the top of the Causa **Dynamic** shell into two clean strata and makes the frame a view **scope** rather than a filter (rf2-4vp5j).

### Workstream A — chrome ribbon (compact)
- Lowered `:top-strip-height` 56px → 40px (nav/pills moved out reclaim the vertical space for the L2 list).
- **LEFT:** Frame dropdown + a new compact **Dynamic / Static `<select>`** — `static/mode_pill.cljs` was reshaped from the two-button radio pill into an understated dropdown sharing the frame picker's control style. The mode signal is carried by the existing left-edge accent stripe (violet/cyan), so the control can recede.
- **RIGHT:** mute (🔇) + REDACTED (●) silent-by-default indicators, then `⚙` settings + `✕` close.
- The `✕` simply dispatches the existing **`:rf.causa/close-shell`** (landed by rf2-fq491) — no hide logic reimplemented.

### Workstream B — events ribbon (new second stratum, `bg-2`)
- **LEFT:** `Events:` label · `[◀ ▶ ⏭]` nav · focus-chip · filter pills + add-pill (all moved down from the old single ribbon).
- **RIGHT (only when a filter is active):** the `N events hidden by filters` message (kept rf2-jvghz's prominent **yellow** accent) + a restrained outline **Clear Filters** button. Both absent in the clean default; Clear Filters shows when any filter is active; the message shows beside it only when N>0.

### Workstream C — frame is a view SCOPE, not a filter
- New dedicated `:view-scope-frame` slot drives the L2 list + hidden-count baseline, **decoupled** from the spine's `[:focus :frame]` (which epoch auto-alignment + the focus-step walk also write — the conflation bug). Default resolution: explicit picker pick → host-seeded `:target-frame` (rf2-ulpp8) → **head epoch's frame** → nil.
- Frame is **never counted as hidden**, never a cause chip, and **Clear Filters no longer resets it**.
- New `filter-cascades-by-view-scope` preserves the frame-agnostic `:ungrouped` bucket through scoping (gated by the `show-ungrouped?` opt-in in `filtered-cascades`); the strict `filter-cascades-by-frame` is retained.
- `set-frame` epoch-alignment (App-DB Diff / Views / machine-inspector, rf2-ulpp8) is preserved — `:rf.causa/select-frame` writes both slots.

`spine.cljs` untouched (rf2-rly4a). Trace op-type/tag `:rf.*` migration left to **rf2-y4qpy.3**.

## What I tested
- `npm run test:cljs` — **0 failures** (4114 tests; +6 new shell structural tests: two-ribbon split, chrome-vs-events placement, events-ribbon action visibility, `✕` → close-shell, mode dropdown → set-mode).
- `npm run test:causa-feature-gate` — **13/13** (updated the `static mode chrome and chord` Playwright scenario for the dropdown).
- `cd tools/causa && clojure -M:test` — **0 failures** (840 tests; updated `hidden_test.cljc` for frame-decouple + new `matcher_test` view-scope cases; updated `hidden_indicator` integration tests for frame-as-scope + Clear-Filters-preserves-frame).

## Notes for review (visual)
- I can't see a browser — the structure + token usage is CLJS-tested, but the final pixel polish of the two strata (heights, gaps, the mode dropdown's understated weight, the Clear Filters/N-hidden right cluster) wants your eye.
- The superseded `ai/prompt/causa-events-filter-ribbon.md` is local-only (gitignored, not in the worktree) — please delete it from your mayor checkout if it still exists.