### PR TITLE
fix(causa): strip add-filter dialog to event-id only — remove match-scope scaffolding (rf2-o8pjv)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -1001,17 +1001,6 @@ Pill `✎` icon (pencil) = "click to edit." Whole pill is the clickable target.
 │   :auth/*                          │
 │   (keyword · glob · namespace)     │
 │                                    │
-│ Match scope                        │
-│   ☑ event-id                       │
-│   ☐ event-args                     │
-│   ☐ source-coord                   │
-│   ☐ tags                           │
-│                                    │
-│ Quick presets                      │
-│   ⚡ errors-only (IN)               │
-│   ⚡ http-only  (IN)                │
-│   ⚡ machine-only (IN)              │
-│                                    │
 │ ──────────────────────────────────  │
 │ [Delete]      [Cancel]    [Apply]  │
 └────────────────────────────────────┘
@@ -1019,8 +1008,7 @@ Pill `✎` icon (pencil) = "click to edit." Whole pill is the clickable target.
 
 - **Mode toggle** flips IN ↔ OUT without delete/recreate.
 - **Pattern field** accepts: exact keyword (`:auth/login`), glob (`:auth/*`, `:order.cart/*`), namespace (`:order/*` matches namespace `order`), substring (`/login`).
-- **Match scope** defaults to event-id; advanced users widen.
-- **Quick presets** = single-click pre-filled patterns.
+- **Event-id is the only scope.** The dialog produces exactly the `{:pattern <kw-or-str>}` shape keyed off the cascade's event-id (rf2-o8pjv). There is no match-scope selector — the matcher honours event-id exclusively.
 - **Trailing `+`** opens the same popup with empty pattern + default mode = IN.
 
 ### Right-click event-row → context menu
@@ -1078,13 +1066,13 @@ Per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md), th
 
 This section's earlier wording — that the right-click context menu's "Always hide this event-type" item silently appends to the OUT bucket — is **superseded by v1's actually-landed behaviour** (rf2-ak4ms).
 
-**v1 ships:** the right-click → "Always hide this event-type" item **opens the edit popup pre-populated** with the event-id as the pattern + mode = OUT, source = `:context`. The user sees what's about to land in the OUT bucket and can fine-tune the pattern, widen the match scope, or cancel before commit. No `[Delete]` button (the pill doesn't exist yet); `[Apply]` confirms.
+**v1 ships:** the right-click → "Always hide this event-type" item **opens the edit popup pre-populated** with the event-id as the pattern + mode = OUT, source = `:context`. The user sees what's about to land in the OUT bucket and can fine-tune the pattern or cancel before commit. No `[Delete]` button (the pill doesn't exist yet); `[Apply]` confirms.
 
 Rationale: pre-alpha posture (per the masterpiece principle). Silent mutation of the filter set on a right-click is the kind of surprise the visible-confirm flow trades a click to avoid. The popup's three trigger sources — `:pill` (edit existing), `:add` (trailing `+`), `:context` (right-click) — share the same modal so the edit-popup is the single mutation site for the IN/OUT slot.
 
-### Pre-alpha matcher scope
+### Matcher scope: event-id only (rf2-o8pjv)
 
-The popup's "Match scope" checkboxes — `event-id` / `event-args` / `source-coord` / `tags` — surface the visual contract for spec/018 §7 'Click-pill → edit popup'. **v1's matcher (`filters/matcher.cljc`) operates on `event-id` only**; the wider scopes are stored as data in the pill record and consumed when the matcher widens in a follow-on bead. The `event-id` scope is the default and always-on; widening it is the future rev.
+The dialog filters on **`event-id` only** — it is the implicit, only scope. The matcher (`filters/matcher.cljc`) consults the pill's `:pattern` against the cascade's event-id. Earlier drafts shipped a "Match scope" section (`event-id` / `event-args` / `source-coord` / `tags` checkboxes) as speculative scaffolding for a future widening pass; the three wider scopes were never matched, only stored. Per the pre-alpha masterpiece posture (no non-functional UI, no shims) that section and all its plumbing were removed: the pill shape reduces to `{:pattern <kw-or-str>}`. Surface-aware predicates (machine / http-correlation / fx) arrive as distinct typed-predicate **kinds** via right-click affordances on other panels (`filters/typed_predicates.cljc`), not as a scope-widening of this dialog.
 
 ### Filter persistence — write-through, reset-on-load (rf2-swclw)
 
@@ -1165,9 +1153,9 @@ Filter applied at DATA layer (`:rf.causa/filtered-cascades` sub), not render. Se
 ```clojure
 :rf.causa/active-filters
 ;; ->
-{:in  [{:pattern <kw-or-glob-or-ns> :scope #{:event-id :event-args :source-coord :tags}}
+{:in  [{:pattern <kw-or-glob-or-ns>}  ; event-id only (rf2-o8pjv)
        …]
- :out [{:pattern <…> :scope #{…}}
+ :out [{:pattern <…>}
        …]}
 ```
 

--- a/tools/causa/spec/020-Filter-Predicates.md
+++ b/tools/causa/spec/020-Filter-Predicates.md
@@ -13,9 +13,9 @@ Owner: tools/causa.
 Every IN / OUT pill is one of:
 
 ```clojure
-;; Legacy keyword-pattern (rf2-ak4ms — back-compat persisted shape):
-{:pattern <kw-or-str>
- :scope   #{:event-id}}
+;; Keyword-pattern (rf2-ak4ms — the Add-filter dialog's only output):
+;; event-id is the implicit, only scope (rf2-o8pjv).
+{:pattern <kw-or-str>}
 
 ;; Typed predicate (rf2-piye4):
 {:kind   <keyword>
@@ -23,9 +23,11 @@ Every IN / OUT pill is one of:
 ```
 
 The matcher (`filters/typed-predicates`) `canonicalise-pill`s on the way
-through, so legacy shape hydrates as `:event-id-pattern` without a
-migration step. New pills written by right-click affordances persist
-under the typed shape; the round-trip is symmetric.
+through, so the keyword-pattern shape hydrates as `:event-id-pattern`
+without a migration step. New pills written by right-click affordances
+persist under the typed shape; the round-trip is symmetric. A stale
+`:scope` key on a pre-rf2-o8pjv persisted pill is dropped on hydration —
+the matcher honours event-id only.
 
 ## §2 v1 kinds
 

--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -138,7 +138,6 @@
     - Events: `:rf.causa/open-edit-popup`, `:rf.causa/close-edit-popup`,
               `:rf.causa/edit-popup-set-mode`,
               `:rf.causa/edit-popup-set-pattern`,
-              `:rf.causa/edit-popup-toggle-scope`,
               `:rf.causa/save-edit-popup`,
               `:rf.causa/delete-edit-popup`,
               `:rf.causa/hide-event-type`,
@@ -300,15 +299,6 @@
     (fn [db [_ pattern]]
       (assoc-in db [:edit-popup-draft :pattern] (or pattern ""))))
 
-  (rf/reg-event-db :rf.causa/edit-popup-toggle-scope
-    {:rf.trace/no-emit? true}
-    (fn [db [_ scope-key]]
-      (let [current (or (get-in db [:edit-popup-draft :scope]) #{:event-id})
-            next    (if (contains? current scope-key)
-                      (disj current scope-key)
-                      (conj current scope-key))]
-        (assoc-in db [:edit-popup-draft :scope] next))))
-
   ;; ---- events: save / delete -------------------------------------------
   ;;
   ;; Save and Delete both mutate the live `:active-filters` slot and
@@ -416,8 +406,7 @@
 
   (rf/reg-event-db :rf.causa/hide-event-type
     (fn [db [_ event-id]]
-      (let [pill {:pattern (when event-id (str event-id))
-                  :scope   #{:event-id}}]
+      (let [pill {:pattern (when event-id (str event-id))}]
         (-> db
             (assoc :edit-popup-open? true)
             (assoc :edit-popup-trigger

--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -11,24 +11,18 @@
       │   :auth/*                          │
       │   (keyword · glob · namespace)     │
       │                                    │
-      │ Match scope                        │
-      │   ☑ event-id                       │
-      │   ☐ event-args                     │
-      │   ☐ source-coord                   │
-      │   ☐ tags                           │
-      │                                    │
       │ ──────────────────────────────────  │
       │ [Delete]      [Cancel]    [Apply]  │
       └────────────────────────────────────┘
 
-  ## Pre-alpha scope
+  ## Scope
 
-  Pre-alpha the matcher (`filters/matcher.cljc`) operates on event-id
-  only — event-args / source-coord / tags scopes are surfaced in the
-  popup so the visual contract ships, but the checkboxes are stored
-  as data and consumed later when the matcher widens. The 'event-id'
-  scope is the default and always-on; widening the scope is a future
-  rev.
+  The matcher (`filters/matcher.cljc`) operates on event-id only —
+  event-id is the implicit, only scope. The dialog creates exactly
+  one pill shape: `{:pattern <kw-or-str>}` keyed off the cascade's
+  event-id. (Typed-predicate kinds — machine / http-correlation / fx
+  — arrive via right-click affordances on other panels, not this
+  dialog; see `filters/typed_predicates.cljc`.)
 
   ## Trigger sources (spec/018 §7)
 
@@ -155,18 +149,16 @@
 
 (defn draft->pill
   "Project the user-edited `draft` into the canonical pill record the
-  registry slot expects. Pre-alpha the canonical shape is `{:pattern
-  <str-or-kw>}` — the matcher only consults `:pattern`. A non-default
-  `:scope` is attached when present so the future widening pass has
-  the data; the default `#{:event-id}` scope (always-on per spec/018
-  §7) is NOT serialised because every pill carries it implicitly.
+  registry slot expects. The canonical shape is `{:pattern <str-or-kw>}`
+  — the matcher consults `:pattern` only; event-id is the implicit,
+  only scope.
 
   String patterns starting with `:` are normalised to keywords so the
   stored shape matches what spec/018 §7 catalogues (`:auth/*`,
   `:order/cart/*`). Whitespace-only / blank patterns survive as nil —
   the registry's save handler drops the pill rather than persisting
   an unmatchable one."
-  [{:keys [pattern scope]}]
+  [{:keys [pattern]}]
   (let [trimmed (when (string? pattern)
                   (clojure.string/trim pattern))
         p       (cond
@@ -177,26 +169,17 @@
                       (keyword (subs trimmed 1))
                       (catch :default _ trimmed))
                     trimmed)
-                  :else                      nil)
-        ;; Only attach :scope when the user widened past the default
-        ;; #{:event-id} — pre-alpha there is no widening surface but
-        ;; the data plumbing carries any non-default set through.
-        non-default-scope?
-        (and (set? scope)
-             (not= scope #{:event-id})
-             (seq scope))]
-    (cond-> {:pattern p}
-      non-default-scope? (assoc :scope scope))))
+                  :else                      nil)]
+    {:pattern p}))
 
 (defn pill->draft
   "Hydrate a stored pill into the user-editable draft shape. nil pill
   → empty draft."
-  [{:keys [pattern scope] :as _pill}]
+  [{:keys [pattern] :as _pill}]
   {:pattern (cond
               (nil? pattern)         ""
               (keyword? pattern)     (str pattern)
-              :else                  (str pattern))
-   :scope   (or scope #{:event-id})})
+              :else                  (str pattern))})
 
 ;; ---- view ----------------------------------------------------------------
 
@@ -221,39 +204,6 @@
                             {:frame :rf/causa})}]
      (case mode :in "IN (show only)" :out "OUT (hide)")]))
 
-(defn- scope-checkbox
-  [{:keys [scope-key label current-scope]}]
-  (let [checked? (boolean (and current-scope (contains? current-scope scope-key)))
-        ;; Pre-alpha the matcher only honours :event-id; the other
-        ;; scopes ship as data-only so the popup's visual contract is
-        ;; complete. event-id stays disabled — it's always on so a
-        ;; pattern always has somewhere to match.
-        always-on? (= scope-key :event-id)]
-    [:label {:data-testid (str "rf-causa-edit-popup-scope-" (name scope-key))
-             :style {:display     "flex"
-                     :align-items "center"
-                     :gap         "8px"
-                     :padding     "2px 0"
-                     :cursor      (if always-on? "default" "pointer")
-                     :color       (if always-on?
-                                    (:text-primary tokens)
-                                    (:text-secondary tokens))
-                     :font-family sans-stack
-                     :font-size   (:body type-scale)}}
-     [:input {:type      "checkbox"
-              :checked   (or always-on? checked?)
-              :disabled  always-on?
-              :on-change #(when-not always-on?
-                            (rf/dispatch
-                              [:rf.causa/edit-popup-toggle-scope scope-key]
-                              {:frame :rf/causa}))}]
-     label
-     (when (not always-on?)
-       [:span {:style {:margin-left "6px"
-                       :color (:text-tertiary tokens)
-                       :font-size (:caption type-scale)}}
-        "(pre-alpha: stored, not yet matched)"])]))
-
 (defn popup-view
   "The popup body. Caller (`filters/Modal`) gates the mount on
   `:rf.causa/edit-popup-open?`."
@@ -262,7 +212,6 @@
         draft       @(rf/subscribe [:rf.causa/edit-popup-draft])
         positioning @(rf/subscribe [:rf.causa/modal-positioning])
         mode        (or (:mode draft) :in)
-        scope       (or (:scope draft) #{:event-id})
         editing?    (= :pill (:source trigger))
         title       (case (:source trigger)
                       :pill    "Edit filter"
@@ -340,21 +289,6 @@
                       :font-family sans-stack
                       :font-size (:caption type-scale)}}
         "keyword · glob (:foo/*) · namespace (:foo) · substring"]]
-
-      [:div {:style (section-style)}
-       [:label {:style (label-style)} "Match scope"]
-       [scope-checkbox {:scope-key :event-id
-                        :label "event-id"
-                        :current-scope scope}]
-       [scope-checkbox {:scope-key :event-args
-                        :label "event-args"
-                        :current-scope scope}]
-       [scope-checkbox {:scope-key :source-coord
-                        :label "source-coord"
-                        :current-scope scope}]
-       [scope-checkbox {:scope-key :tags
-                        :label "tags"
-                        :current-scope scope}]]
 
       [:div {:style (footer-style)}
        (if editing?

--- a/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
@@ -121,9 +121,7 @@
 
 (defn match-pill?
   "True iff the pill matches `event-id`. Pills are
-  `{:pattern <kw-or-str>}`; an optional `:scope` set may be threaded
-  in future (event-args / source-coord / tags scopes per spec/018 §7)
-  — pre-alpha we match on event-id only.
+  `{:pattern <kw-or-str>}` — event-id is the only scope.
 
   Returns false when the pill is malformed (missing pattern)."
   [{:keys [pattern]} event-id]

--- a/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
@@ -91,11 +91,10 @@
         (update :params #(or % {})))
 
     (contains? pill :pattern)
-    ;; Legacy shape: surface the pattern under params so the matcher
-    ;; reads from one slot.
+    ;; Event-id-pattern shape: surface the pattern under params so the
+    ;; matcher reads from one slot. Event-id is the only scope.
     {:kind   :event-id-pattern
-     :params {:pattern (:pattern pill)
-              :scope   (or (:scope pill) #{:event-id})}}
+     :params {:pattern (:pattern pill)}}
 
     :else
     {:kind :never :params {}}))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -239,8 +239,9 @@
     ;; ---- 4-layer chrome — active filter pills (rf2-xy4yb / spec/018 §7) ----
     ;;
     ;; The ribbon's filter cluster reads `:rf.causa/active-filters` —
-    ;; shape `{:in [{:pattern <str> :scope #{:event-id ...}}]
-    ;;         :out [{:pattern <str> :scope #{...}}]}`. The
+    ;; shape `{:in [{:pattern <str>}] :out [{:pattern <str>}]}` (pills
+    ;; are keyed off event-id only; typed-predicate kinds add a
+    ;; `{:kind … :params …}` shape via right-click affordances). The
     ;; `:rf.causa/filtered-cascades` sub (rf2-ak4ms, installed via
     ;; `filters/install!` further down) composes against this slot to
     ;; produce the filtered cascade list every consumer reads.

--- a/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
@@ -3,12 +3,13 @@
 
   Covers:
    - open-edit-popup hydrates the draft from the trigger payload
-   - set-mode / set-pattern / toggle-scope mutate the draft
+   - set-mode / set-pattern mutate the draft
    - save-edit-popup mutates :active-filters and closes the popup
    - delete-edit-popup drops the pill and closes
    - close-edit-popup discards the draft
    - hide-event-type (right-click row path) pre-populates OUT mode"
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -60,27 +61,22 @@
   (is (= {:pattern nil}
          (edit-popup/draft->pill {:pattern "   "}))))
 
-(deftest draft-to-pill-attaches-non-default-scope
-  (testing "the default scope (#{:event-id}) is implicit and not
-            serialised; widened scopes are preserved verbatim"
+(deftest draft-to-pill-is-event-id-only
+  (testing "the pill shape carries the pattern only — event-id is the
+            implicit, only scope; no :scope key is ever serialised"
     (is (= {:pattern :auth/login}
-           (edit-popup/draft->pill {:pattern ":auth/login"
-                                    :scope   #{:event-id}}))
-        "default scope omitted")
-    (is (= {:pattern :auth/login
-            :scope   #{:event-id :event-args}}
-           (edit-popup/draft->pill {:pattern ":auth/login"
-                                    :scope   #{:event-id :event-args}}))
-        "widened scope preserved")))
+           (edit-popup/draft->pill {:pattern ":auth/login"}))
+        "pattern-only shape")
+    (is (= [:pattern]
+           (keys (edit-popup/draft->pill {:pattern ":auth/login"})))
+        "no :scope (or any other) key in the projected pill")))
 
 (deftest pill-to-draft-stringifies-keyword
-  (is (= {:pattern ":auth/*"
-          :scope   #{:event-id}}
+  (is (= {:pattern ":auth/*"}
          (edit-popup/pill->draft {:pattern :auth/*}))))
 
 (deftest pill-to-draft-empty-pill
-  (is (= {:pattern ""
-          :scope   #{:event-id}}
+  (is (= {:pattern ""}
          (edit-popup/pill->draft nil))))
 
 ;; -------------------------------------------------------------------------
@@ -126,17 +122,6 @@
   (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
   (frame-dispatch [:rf.causa/edit-popup-set-pattern ":auth/*"])
   (is (= ":auth/*" (:pattern (frame-sub [:rf.causa/edit-popup-draft])))))
-
-(deftest toggle-scope-flips-membership
-  (causa-setup!)
-  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
-  (is (= #{:event-id} (:scope (frame-sub [:rf.causa/edit-popup-draft]))))
-  (frame-dispatch [:rf.causa/edit-popup-toggle-scope :event-args])
-  (is (= #{:event-id :event-args}
-         (:scope (frame-sub [:rf.causa/edit-popup-draft]))))
-  (frame-dispatch [:rf.causa/edit-popup-toggle-scope :event-args])
-  (is (= #{:event-id}
-         (:scope (frame-sub [:rf.causa/edit-popup-draft])))))
 
 ;; -------------------------------------------------------------------------
 ;; (4) Save round-trip
@@ -299,6 +284,14 @@
             node))
         (tree-seq (some-fn vector? seq?) seq (expand-tree tree))))
 
+(defn- testids-with-prefix [tree prefix]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (:data-testid (second node)))))
+       (filter #(and (string? %) (str/starts-with? % prefix)))
+       (into #{})))
+
 (deftest backdrop-defaults-to-fixed-positioning
   (testing "with no :rf.causa/modal-positioning slot set, the edit
             popup backdrop renders position: fixed at the production
@@ -332,3 +325,60 @@
             "z-index drops to a sane in-cell value")
         (is (= "absolute"
                (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+;; -------------------------------------------------------------------------
+;; (9) Dialog is event-id-only (rf2-o8pjv)
+;; -------------------------------------------------------------------------
+;;
+;; The Add-filter dialog reduces to exactly Mode (Only include /
+;; Filter out) + Pattern + footer. The Match-scope section
+;; (event-id / event-args / source-coord / tags checkboxes) and its
+;; `:rf.causa/edit-popup-toggle-scope` plumbing are excised — event-id
+;; is the implicit, only scope.
+
+(deftest dialog-renders-mode-and-pattern-only
+  (testing "the rendered dialog has Mode radios + the Pattern input +
+            footer, and NO match-scope checkboxes"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (rf/with-frame :rf/causa
+      (let [rendered (filters/Modal)]
+        ;; Kept surfaces.
+        (is (some? (find-by-testid rendered "rf-causa-edit-popup-mode-in"))
+            "Mode IN radio present")
+        (is (some? (find-by-testid rendered "rf-causa-edit-popup-mode-out"))
+            "Mode OUT radio present")
+        (is (some? (find-by-testid rendered "rf-causa-edit-popup-pattern"))
+            "Pattern input present")
+        (is (some? (find-by-testid rendered "rf-causa-edit-popup-cancel"))
+            "Cancel button present")
+        (is (some? (find-by-testid rendered "rf-causa-edit-popup-save"))
+            "Add/Apply button present")
+        ;; Excised surface — no scope checkboxes of any key.
+        (is (= #{} (testids-with-prefix rendered "rf-causa-edit-popup-scope-"))
+            "no match-scope checkboxes render")))))
+
+(deftest toggle-scope-event-is-unregistered
+  (testing "the `:rf.causa/edit-popup-toggle-scope` event is fully
+            removed — dispatching it is a no-op (no scope slot appears)"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    ;; The handler is gone; an unhandled dispatch must not introduce a
+    ;; :scope slot into the draft.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/edit-popup-toggle-scope :event-args]))
+    (is (nil? (:scope (frame-sub [:rf.causa/edit-popup-draft])))
+        "draft carries no :scope slot")))
+
+(deftest saved-pill-is-event-id-only
+  (testing "a saved pill carries :pattern only — no :scope (or any
+            other) key. The matcher honours event-id exclusively."
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (frame-dispatch [:rf.causa/edit-popup-set-pattern ":auth/*"])
+    (frame-dispatch [:rf.causa/save-edit-popup])
+    (let [pill (-> (frame-sub [:rf.causa/active-filters]) :in first)]
+      (is (= {:pattern :auth/*} pill)
+          "stored pill is the event-id pattern shape only")
+      (is (= [:pattern] (keys pill))
+          "no :scope key persisted"))))

--- a/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
@@ -48,20 +48,24 @@
     (is (= {:kind :machine :params {}}
            (typed/canonicalise-pill {:kind :machine})))))
 
-(deftest canonicalise-legacy-pattern-pill-becomes-event-id-pattern
-  (testing "rf2-ak4ms legacy shape `{:pattern <kw-or-str>}` hydrates as
-            `:event-id-pattern` so persisted pills round-trip cleanly"
+(deftest canonicalise-pattern-pill-becomes-event-id-pattern
+  (testing "`{:pattern <kw-or-str>}` (the dialog's only output shape)
+            hydrates as `:event-id-pattern` so persisted pills
+            round-trip cleanly. Event-id is the only scope — no :scope
+            slot is ever produced (rf2-o8pjv)."
     (is (= {:kind   :event-id-pattern
-            :params {:pattern :auth/login
-                     :scope   #{:event-id}}}
+            :params {:pattern :auth/login}}
            (typed/canonicalise-pill {:pattern :auth/login})))))
 
-(deftest canonicalise-legacy-pill-preserves-scope
-  (is (= {:kind   :event-id-pattern
-          :params {:pattern :auth/*
-                   :scope   #{:event-id :event-args}}}
-         (typed/canonicalise-pill {:pattern :auth/*
-                                   :scope   #{:event-id :event-args}}))))
+(deftest canonicalise-drops-stale-scope-key
+  (testing "a pill carrying a stale `:scope` key (persisted before
+            rf2-o8pjv) hydrates to the event-id-pattern shape WITHOUT
+            the :scope — the matcher honours event-id only, so the
+            stale slot is excised on the way through"
+    (is (= {:kind   :event-id-pattern
+            :params {:pattern :auth/*}}
+           (typed/canonicalise-pill {:pattern :auth/*
+                                     :scope   #{:event-id :event-args}})))))
 
 (deftest canonicalise-malformed-pill-is-never
   (is (= {:kind :never :params {}}

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_filter_pill_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_filter_pill_reactivity_cljs_test.cljs
@@ -35,7 +35,7 @@
           "default state — both buckets empty")
       (h/dispatch-causa!
         [:rf.causa/add-filter :out
-         {:pattern :evt/inc :scope #{:event-id}}])
+         {:pattern :evt/inc}])
       (let [filters-1 (h/read-sub :rf.causa/active-filters)]
         (is (= 1 (count (:out filters-1)))
             "one pill added to :out bucket")
@@ -55,7 +55,7 @@
           "both cascades present before filter")
       (h/dispatch-causa!
         [:rf.causa/add-filter :out
-         {:pattern :evt/inc :scope #{:event-id}}])
+         {:pattern :evt/inc}])
       (let [cascades-after (h/read-sub :rf.causa/filtered-cascades)]
         (is (= 1 (count cascades-after))
             "filtered cascade dropped from list")
@@ -71,7 +71,7 @@
     (h/seed-cascades! cascades)
     (h/dispatch-causa!
       [:rf.causa/add-filter :out
-       {:pattern :evt/inc :scope #{:event-id}}])
+       {:pattern :evt/inc}])
     (is (= 1 (count (h/read-sub :rf.causa/filtered-cascades)))
         "filter is active")
     (h/dispatch-causa! [:rf.causa/remove-filter :out 0])

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -398,7 +398,6 @@
    :rf.causa/delete-edit-popup
    :rf.causa/edit-popup-set-mode
    :rf.causa/edit-popup-set-pattern
-   :rf.causa/edit-popup-toggle-scope
    :rf.causa/epoch-recorded
    ;; rf2-piye4 — typed-predicate filter events. Each appends a
    ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click


### PR DESCRIPTION
## Summary

Causa's "Add filter" dialog over-shipped a **Match scope** section — four checkboxes (`event-id` always-on, `event-args`, `source-coord`, `tags`) where the matcher only ever honoured `:event-id`. The latter three were speculative, "(pre-alpha: stored, not yet matched)" scaffolding. Per the pre-alpha masterpiece posture (no non-functional UI, no shims) this strips the dialog to exactly **Mode** (IN / OUT) + **Pattern** (event-id) + footer, and excises all the match-scope plumbing.

The pill shape reduces to `{:pattern <kw-or-str>}` — event-id is the implicit, only scope.

### Removed (UI + plumbing)
- **`edit_popup.cljs`** — the `scope-checkbox` fn + `rf-causa-edit-popup-scope-*` testids, the Match-scope section in `popup-view`, the `:scope` handling in `draft->pill` / `pill->draft`, and the ns docstring + ASCII-diagram box.
- **`filters.cljs`** — the `:rf.causa/edit-popup-toggle-scope` event handler + its `install!` docstring entry; dropped `:scope #{:event-id}` from the `hide-event-type` pill.
- **`matcher.cljc`** — cleaned the `match-pill?` docstring (event-id is the only scope).
- **`typed_predicates.cljc`** — `canonicalise-pill` no longer manufactures a `:scope` slot; a stale persisted `:scope` is dropped on hydration.
- **`registry.cljs`** — `:rf.causa/active-filters` shape comment now `{:pattern}`-only.
- **spec 018 / 020** — diagram, pill-record, and matcher-scope sections updated to the event-id-only contract.

Surface-aware typed predicates (machine / http-correlation / fx) are distinct **kinds** added via right-click affordances on other panels — untouched by this change.

### Tests
- Removed scope / `toggle-scope` assertions; updated `typed_predicates_test` and the pill-reactivity tests to the `{:pattern}`-only shape.
- Added regression tests: the dialog renders **no** match-scope checkboxes, the `toggle-scope` event is unregistered (dispatch is a no-op), and a saved pill is `:pattern`-only.

## Test plan
- [x] `npm run test:cljs` — 4119 tests / 12571 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 13 scenarios, 0 failures, 13/13 matrix rows