### PR TITLE
docs(story): README teaches :play-script (not retired :play) (rf2-m3umc)

### DIFF
--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -26,11 +26,11 @@ playground:
   panel — time-travel via `restore-epoch` is a UI affordance, not a
   reimplementation.
 - The `:test` mode pane ships a **play step-debugger** — step / pause /
-  rewind / step-back / breakpoint controls over a variant's `:play`
+  rewind / step-back / breakpoint controls over a variant's `:play-script`
   sequence (see [`spec/009-Test-Mode.md` §Play step-debugger](spec/009-Test-Mode.md#play-step-debugger-rf2-ulw5m)).
   Storybook's Interactions panel ships these for `play()` functions;
   Story's parity surface drives the same controls over the
-  `:rf.assert/*`-bearing play vector, with the canvas re-rendering against
+  `:rf.assert/*`-bearing `:play-script`, with the canvas re-rendering against
   each step's app-db.
 
 The agent-facing MCP surface ships as a separate artefact at
@@ -63,8 +63,8 @@ core jar does not transitively pull stdio / JSON-RPC machinery.
    :events [[:auth/initialise]
             [:auth/email-changed "not-an-email"]
             [:auth/login-pressed]]
-   :play   [[:rf.assert/path-equals [:auth :status] :rejected]
-            [:rf.assert/no-warnings]]
+   :play-script [[:dispatch-sync [:rf.assert/path-equals [:auth :status] :rejected]]
+                 [:dispatch-sync [:rf.assert/no-warnings]]]
    :tags   #{:dev :docs :test}})
 ```
 


### PR DESCRIPTION
## Summary
- The top-level Story README (`tools/story/README.md`) still taught the retired `:play` slot — the `:play`→`:play-script` reconcile (#1971/rf2-v89ay) missed this file.
- Step-debugger prose now references a variant's `:play-script` sequence (and the `:rf.assert/*`-bearing `:play-script` instead of "play vector").
- Authoring-example EDN now uses `:play-script` with each `:rf.assert/*` event wrapped in `[:dispatch-sync …]` per the post-#1726 shape.

Genuine history notes elsewhere in the Story spec docs (e.g. "`:play` was removed in rf2-0wrud") were left intact — only the parts that *teach* `:play` as current were fixed.

## Gates
- `python scripts/check_doc_slugs.py` — clean (exit 0).
- `mkdocs build --strict` — N/A: `tools/story/README.md` is not in the mkdocs nav (lives under `tools/`, outside `docs/`).

Closes rf2-m3umc.