### PR TITLE
fix(causa): Machines panel shows on machine events only + topology fills panel height (rf2-zdfbm)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -49,7 +49,6 @@
             [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]
-            [day8.re-frame2-causa.panels.machines.topology-view :as topology-view]
             [day8.re-frame2-causa.share :as share]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -176,10 +175,18 @@
       :data-to-state (str to-state)
       :data-on-event (str on-event)
       :data-microstep (str (boolean microstep?))
+      ;; rf2-zdfbm — the topology is the panel's centrepiece, so the
+      ;; section grows to fill the focused-event host's available
+      ;; height. A flex column lets the canvas chart (`flex 1` below)
+      ;; expand into the panel instead of sitting in a fixed 320px box.
       :style {:margin "12px"
               :border (str "1px solid " (:border-default tokens))
               :border-radius "4px"
-              :background (:bg-2 tokens)}}
+              :background (:bg-2 tokens)
+              :flex "1 1 0"
+              :min-height 0
+              :display "flex"
+              :flex-direction "column"}}
      ;; Right-click on the per-machine section header fires
      ;; `:rf.causa/filter-by-machine` with this section's machine-id
      ;; (rf2-piye4) — drops a typed `:machine` IN pill into the ribbon
@@ -260,9 +267,20 @@
                   :data-from-highlight-id (or from-id "")
                   :data-to-highlight-id (or to-id "")
                   :data-view-mode "canvas"
+                  ;; rf2-zdfbm — fill the section's available height so the
+                  ;; topology chart (`machine-canvas/Chart` is `height
+                  ;; 100%`) expands into the panel rather than collapsing
+                  ;; to its 260px min. `flex 1` + `min-height 0` lets the
+                  ;; chart grow inside the flex-column section; the
+                  ;; min-height floor keeps xyflow's non-zero-parent-
+                  ;; height requirement satisfied when the panel is short.
                   :style {:padding "12px"
                           :background (:bg-1 tokens)
                           :overflow "hidden"
+                          :flex "1 1 0"
+                          :min-height "320px"
+                          :display "flex"
+                          :flex-direction "column"
                           ;; position-relative so the after-rings overlay
                           ;; can absolute-position itself over the chart SVG.
                           :position "relative"}}
@@ -348,8 +366,13 @@
     (when (seq records)
       (into [:div {:data-testid "rf-causa-machine-focused-event"
                    :data-section-count (count records)
+                   ;; rf2-zdfbm — fill the focused-event host so each
+                   ;; per-machine section (`flex 1`) can grow its topology
+                   ;; chart into the panel's available height.
                    :style {:display "flex"
-                           :flex-direction "column"}}]
+                           :flex-direction "column"
+                           :flex 1
+                           :min-height 0}}]
             (for [rec records]
               (with-meta (focused-event-section rec)
                 {:key (str (:machine-id rec) "-"
@@ -357,85 +380,35 @@
                            (:from-state rec) "-"
                            (:to-state rec))}))))))
 
-(defn- blank-state-section
-  "One per-machine section rendered in the blank state (Case B per
-  spec/021 §6.2 + §17.4.1). The Topology view receives the full
-  `:epoch-history` so it can walk back to the most-recent transition
-  for this machine, and the live `:snapshot-state` keyword so it can
-  fall back to the snapshot's `:state` when the buffer has no
-  transition for this machine at all. Both args flow into
-  `topology-view`'s 4-source precedence chain (rf2-dbi87)."
-  [{:keys [machine-id definition snapshot-state epoch-history]}]
-  [:section {:data-testid (str "rf-causa-machine-inspector-blank-section-"
-                               (when machine-id (subs (str machine-id) 1)))
-             :data-machine-id (str machine-id)
-             :style {:margin "12px"
-                     :border (str "1px solid " (:border-default tokens))
-                     :border-radius "4px"
-                     :background (:bg-2 tokens)}}
-   [:header {:style {:padding "10px 12px"
-                     :display "flex"
-                     :align-items "center"
-                     :gap "10px"
-                     :border-bottom (str "1px solid " (:border-subtle tokens))
-                     :background (:bg-3 tokens)
-                     :font-family mono-stack
-                     :font-size "12px"
-                     :color (:text-primary tokens)}}
-    [:strong {:style {:color (:accent-violet tokens)}}
-     (h/format-machine-id machine-id)]
-    [:span {:style {:color (:text-tertiary tokens)
-                    :font-family sans-stack
-                    :font-size "11px"
-                    :margin-left "auto"}}
-     "no activity this epoch · current ●"]]
-   [:div {:style {:padding "12px"
-                  :background (:bg-1 tokens)}}
-    [topology-view/Topology
-     {:machine-id     machine-id
-      :definition     definition
-      :epoch-history  epoch-history
-      :snapshot-state snapshot-state
-      :height         "260px"
-      :testid         (str "rf-causa-machine-inspector-blank-topology-"
-                           (when machine-id (subs (str machine-id) 1)))}]]])
-
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
-  cascade — Case B per spec/021 §6.2 + §17.4.1 (rf2-dbi87). The
-  panel renders one section per registered machine, each carrying
-  the full topology with the most-recent-known state annotated as
-  `:current`. Resolution of the current-state ● flows through
-  `topology-view`'s 4-source precedence chain (explicit > focused-
-  epoch traces > epoch-history walk-back > live snapshot state).
+  cascade. The Dynamic Machines panel is **event-driven only** (Mike's
+  2026-05-19 redesign, panel docstring §4-15): it is silent-by-default
+  (rf2-g3ghh) when the focused event triggered no machine transition.
 
-  Snapshot resolution honours the test override (`:rf.causa/machine-
-  snapshots-override`) ahead of the live snapshot sub — same shape as
-  the `:rf.causa/machine-inspector-data` composite — so view tests
-  can seed snapshot state without writing to the target frame's
-  `:rf/machines` slot."
+  This is a TRULY BLANK affordance — not a topology render. The earlier
+  rf2-t5wp9 (#1757) variant rendered one per-machine topology section
+  here, which contradicted the event-driven-only contract and produced
+  the inverted visibility bug (rf2-zdfbm): content surfaced on
+  non-machine events, drowning the panel's lens job. The most-recent-
+  known-state topology view belongs to the future Static Machines
+  surface (rf2-r4nao), not the Dynamic lens."
   []
-  (let [machines           @(rf/subscribe [:rf.causa/registered-machines])
-        definitions        @(rf/subscribe [:rf.causa/machine-definitions])
-        live-snapshots     @(rf/subscribe [:rf.causa/machine-snapshots])
-        snapshots-override @(rf/subscribe [:rf.causa/machine-snapshots-override])
-        snapshots          (or snapshots-override live-snapshots {})
-        epoch-history      @(rf/subscribe [:rf.causa/epoch-history])
-        rows               (->> (or machines [])
-                                (map (fn [id]
-                                       {:machine-id     id
-                                        :definition     (get definitions id)
-                                        :snapshot-state (get-in snapshots [id :state])
-                                        :epoch-history  epoch-history}))
-                                (sort-by (comp str :machine-id))
-                                vec)]
-    (into [:div {:data-testid "rf-causa-machine-inspector-blank"
-                 :data-section-count (str (count rows))
-                 :style {:display "flex"
-                         :flex-direction "column"}}]
-          (for [{:keys [machine-id] :as row} rows]
-            ^{:key (str machine-id)}
-            (blank-state-section row)))))
+  [:div {:data-testid "rf-causa-machine-inspector-blank"
+         :style {:padding "16px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "13px"
+                 :flex 1
+                 :display "flex"
+                 :flex-direction "column"
+                 :align-items "center"
+                 :justify-content "center"
+                 :text-align "center"}}
+   [:p {:style {:margin "0 0 6px 0" :font-size "14px"}}
+    "No machine activity in the focused event."]
+   [:p {:style {:margin 0 :font-size "12px" :color (:text-tertiary tokens)}}
+    "Select an event that triggered a transition to inspect machines."]])
 
 ;; ---- empty state (no machines registered at all) -----------------------
 
@@ -526,8 +499,13 @@
        (empty-state)
 
        (seq records)
+       ;; rf2-zdfbm — flex column so the focused-event view fills the
+       ;; host and the topology chart grows into the panel height.
        [:div {:data-testid "rf-causa-machine-inspector-focused-event-host"
-              :style {:flex 1 :overflow "auto"}}
+              :style {:flex 1
+                      :overflow "auto"
+                      :display "flex"
+                      :flex-direction "column"}}
         (focused-event-view)]
 
        :else

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology_view.cljs
@@ -107,8 +107,12 @@
                            current-state ● annotation when neither the
                            focused epoch nor the history buffer carries
                            a transition for this machine.
-    :height              — outer wrapper height (default `'320px'`).
-                           xyflow requires a non-zero parent height.
+    :height              — outer wrapper height (default `'100%'` so the
+                           chart fills its container — the topology is the
+                           centrepiece and should not sit in a fixed box).
+                           A `min-height` floor keeps xyflow's non-zero-
+                           parent-height requirement satisfied when the
+                           container itself is auto-height.
     :show-controls?      — pass-through to wrapper (default true).
     :testid              — pass-through wrapper testid (default
                            `'rf-causa-machines-topology'`).
@@ -116,7 +120,7 @@
   Returns hiccup."
   [{:keys [machine-id definition current-state-path trace-events
            epoch-history snapshot-state height show-controls? testid]
-    :or   {height          "320px"
+    :or   {height          "100%"
            show-controls?  true
            testid          "rf-causa-machines-topology"}}]
   (let [cur-path  (resolve-current-state-path machine-id
@@ -172,6 +176,12 @@
              :style {:position "relative"
                      :width  "100%"
                      :height height
+                     ;; rf2-zdfbm — non-zero-parent-height floor so xyflow
+                     ;; still mounts when `:height` resolves against an
+                     ;; auto-height container (the default is now `100%`,
+                     ;; letting the topology fill its panel instead of
+                     ;; sitting in a fixed 320px box).
+                     :min-height "320px"
                      :background (:bg-1 tokens)
                      :border (str "1px solid " (:border-default tokens))
                      :border-radius "6px"

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -53,10 +53,6 @@
   (rf/dispatch-sync
     [:rf.causa/set-registered-machines-override-for-test machines]))
 
-(defn- override-snapshots! [snapshots]
-  (rf/dispatch-sync
-    [:rf.causa/set-machine-snapshots-override-for-test snapshots]))
-
 (defn- override-definitions! [definitions]
   (rf/dispatch-sync
     [:rf.causa/set-machine-definitions-override-for-test definitions]))
@@ -136,16 +132,27 @@
             "panel header icon is gone (lived in the scrubbed h1)")))))
 
 ;; ---- (3) blank state (event has no machine activity) ------------------
+;;
+;; rf2-zdfbm — visibility-gate polarity. The Dynamic Machines panel is
+;; **event-driven only** (panel docstring §4-15, Mike's 2026-05-19
+;; redesign): TRULY BLANK when the focused event triggered no machine
+;; transition; the per-machine topology surface ONLY mounts when a
+;; transition fired. The earlier rf2-t5wp9 variant rendered an all-
+;; machines topology in the blank state, which inverted the panel's
+;; visibility (content on non-machine events, drowning the lens job).
+;; These tests pin the correct (non-inverted) polarity.
 
-(deftest blank-state-renders-when-focused-event-has-no-machine-activity
+(deftest blank-state-is-truly-blank-when-focused-event-has-no-machine-activity
   (testing "when machines are registered but the focused event triggered
-            no transitions, the panel renders the BLANK state — Case B
-            per spec/021 §6.2 + §17.4.1 (rf2-dbi87 / rf2-t5wp9). The
-            blank container is present; the focused-event surface is
-            suppressed."
+            no transitions, the panel renders the TRULY BLANK affordance:
+            the blank container is present, NO per-machine topology
+            section/chart is rendered, and the focused-event surface is
+            suppressed (rf2-zdfbm visibility gate)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (override-machines! [:auth/login])
+      (override-machines!    [:auth/login :checkout/flow])
+      (override-definitions! {:auth/login    fixture-definition
+                              :checkout/flow fixture-definition})
       (let [tree (machine-inspector/Panel)
             root (find-by-testid tree "rf-causa-machine-inspector")]
         (is (= "focused-event" (:data-view-mode (second root))))
@@ -153,68 +160,33 @@
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-blank"))
             "blank-state container present")
         (is (nil? (find-by-testid tree "rf-causa-machine-focused-event"))
-            "no focused-event surface when cascade has no transitions")))))
+            "no focused-event surface when cascade has no transitions")
+        ;; The inversion guard — NO topology renders on a non-machine
+        ;; event. Pre-fix (rf2-t5wp9) this surfaced one section + chart
+        ;; per registered machine, producing the "content on non-machine
+        ;; events" half of the inverted-visibility bug.
+        (is (empty? (find-all-by-testid-prefix
+                      tree "rf-causa-machine-inspector-blank-section-"))
+            "no per-machine topology sections render in the blank state")
+        (is (empty? (find-all-by-testid-prefix
+                      tree "rf-causa-machine-inspector-blank-topology-"))
+            "no topology chart renders in the blank state")
+        (is (empty? (find-all-by-testid-prefix
+                      tree "rf-causa-machines-topology"))
+            "no Topology view mounts when the focused event is not
+             machine-related")))))
 
-(deftest blank-state-renders-one-section-per-registered-machine
-  (testing "Case B (rf2-t5wp9): blank state renders one per-machine
-            section so the topology stays visible even when the focused
-            epoch fired no transitions"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (override-machines!    [:auth/login :checkout/flow])
-      (override-definitions! {:auth/login    fixture-definition
-                              :checkout/flow fixture-definition})
-      (let [tree     (machine-inspector/Panel)
-            blank    (find-by-testid tree "rf-causa-machine-inspector-blank")
-            sections (find-all-by-testid-prefix
-                       tree "rf-causa-machine-inspector-blank-section-")]
-        (is (some? blank) "blank container present")
-        (is (= "2" (:data-section-count (second blank)))
-            "data-section-count tracks the rendered row count")
-        (is (= 2 (count sections))
-            "one section per registered machine")
-        (is (= [":auth/login" ":checkout/flow"]
-               (mapv #(:data-machine-id (second %)) sections))
-            "sections appear in deterministic alphabetical order")))))
-
-(deftest blank-state-passes-snapshot-state-into-topology-view
-  (testing "Case B (rf2-t5wp9): the live machine snapshot's :state is
-            piped through to the Topology view so its 4-source
-            precedence resolves the current ● annotation from the
-            snapshot when neither traces nor epoch-history carry a
-            transition"
+(deftest blank-state-stays-blank-on-an-event-less-focused-epoch
+  (testing "an explicitly-focused epoch whose :trace-events carry no
+            machine transitions keeps the panel blank — the gate does
+            not leak a topology even when epoch-history holds prior
+            transitions for the machine (rf2-zdfbm)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!    [:auth/login])
       (override-definitions! {:auth/login fixture-definition})
-      (override-snapshots!   {:auth/login {:state :authing :data {}}})
-      (let [tree     (machine-inspector/Panel)
-            topology (find-by-testid
-                       tree "rf-causa-machine-inspector-blank-topology-auth/login")]
-        (is (some? topology)
-            "the per-machine topology mount lands inside the blank state")
-        (is (= "snapshot" (:data-current-state-source (second topology)))
-            "current-state-source falls back to the live snapshot when
-             no traces / no epoch-history carry a transition for this
-             machine")
-        (is (= "[:authing]" (:data-current-state (second topology)))
-            "the snapshot's :state keyword resolves to a [:authing] path
-             via Topology's :snapshot-state arg")
-        (is (= "true" (:data-no-transition-this-epoch (second topology)))
-            "Case B flag — no transition this epoch")))))
-
-(deftest blank-state-passes-epoch-history-into-topology-view
-  (testing "Case B (rf2-t5wp9): the panel's :rf.causa/epoch-history is
-            piped through to Topology so the 4-source precedence walks
-            back to the prior epoch that touched this machine when the
-            focused epoch has no transition for it"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (override-machines!    [:auth/login])
-      (override-definitions! {:auth/login fixture-definition})
-      ;; epoch 1 carries an :auth/login transition. epoch 2 is the
-      ;; focused epoch — no machine activity. The blank state should
-      ;; walk epoch-history back to epoch 1 and surface :authing.
+      ;; epoch 1 carries an :auth/login transition; epoch 2 (the
+      ;; focused epoch) is event-less. The panel must stay blank.
       (override-epoch-history!
         [{:epoch-id 1
           :trace-events
@@ -225,33 +197,14 @@
                    :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}
          {:epoch-id 2 :trace-events []}])
       (focus-epoch! 2)
-      (let [tree     (machine-inspector/Panel)
-            topology (find-by-testid
-                       tree "rf-causa-machine-inspector-blank-topology-auth/login")]
-        (is (some? topology)
-            "the per-machine topology mounts in the blank state when the
-             focused epoch carries no machine activity")
-        (is (= "epoch-history" (:data-current-state-source (second topology)))
-            "current-state-source resolves from the epoch-history walk-
-             back when the focused epoch is event-less")
-        (is (= "[:authing]" (:data-current-state (second topology)))
-            "Topology projected :authing as the most-recent-known state
-             for :auth/login from the epoch-history walk-back")))))
-
-(deftest blank-state-degrades-when-definition-is-not-introspectable
-  (testing "Case B (rf2-t5wp9): blank state renders even when the
-            registered machine has no introspectable definition —
-            Topology falls back to its no-definition surface"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (override-machines! [:auth/login])
-      ;; No definition override → :rf.causa/machine-definitions yields
-      ;; nil for this id. Topology emits its `*-no-definition` testid.
       (let [tree (machine-inspector/Panel)]
-        (is (some? (find-by-testid
-                     tree "rf-causa-machine-inspector-blank-topology-auth/login-no-definition"))
-            "Topology's no-definition fallback surface renders inside the
-             blank section when the machine spec is not introspectable")))))
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-blank"))
+            "blank-state container present on the event-less focused epoch")
+        (is (nil? (find-by-testid tree "rf-causa-machine-focused-event"))
+            "focused-event surface suppressed — no transition this epoch")
+        (is (empty? (find-all-by-testid-prefix
+                      tree "rf-causa-machines-topology"))
+            "no topology renders for a focused epoch with no transition")))))
 
 ;; ---- (4) focused-event lens (one section per transition) --------------
 
@@ -284,6 +237,52 @@
             "the section renders the topology chart")
         (is (nil? (find-by-testid tree "rf-causa-machine-inspector-blank"))
             "the blank-state is suppressed when records exist")))))
+
+(deftest gate-reads-the-migrated-rf-machine-transition-op-only
+  (testing "the machine-relatedness gate keys on the `:rf.*` migrated op
+            `:rf.machine/transition` (post-#1973). A focused epoch whose
+            trace carries ONLY the pre-migration `:machine/transition`
+            op does NOT trip the gate — the panel stays blank — while
+            the migrated op shows the focused-event surface. Pins that
+            the op name is load-bearing for detection (rf2-zdfbm): a
+            stale `:machine/transition` read would misfire the gate and
+            invert the panel's visibility."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      ;; epoch 1 — only the LEGACY (pre-#1973) op. Must NOT trip the gate.
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree (machine-inspector/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-machine-focused-event"))
+            "legacy `:machine/transition` op does NOT show the focused-
+             event surface")
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-blank"))
+            "panel stays blank when only the legacy op is present"))
+      ;; epoch 2 — the MIGRATED op. Must trip the gate.
+      (override-epoch-history!
+        [{:epoch-id 2
+          :trace-events
+          [{:id 2 :time 20 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before {:state :idle :data {}}
+                   :after  {:state :authing :data {}}
+                   :event [:auth/submit] :rf.trace/dispatch-id "d-2"}}]}])
+      (focus-epoch! 2)
+      (let [tree (machine-inspector/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-machine-focused-event"))
+            "migrated `:rf.machine/transition` op shows the focused-event
+             surface")
+        (is (nil? (find-by-testid tree "rf-causa-machine-inspector-blank"))
+            "blank suppressed when the migrated op fired")))))
 
 (deftest focused-event-section-emits-from-and-to-highlight-ids
   (testing "the per-section chart carries data-from/to-highlight-id so


### PR DESCRIPTION
## Summary

Two defects in the Dynamic Machines panel (`machine_inspector.cljs`).

### Defect 1 — inverted visibility (P1): LOCAL gate bug, not rly4a-residual

The panel is **event-driven only** (panel docstring §4-15, Mike's 2026-05-19 redesign): truly BLANK when the focused event triggers no machine transition; the machine topology (+ FROM/TO highlight, guards/actions, cascade, after-rings) only when one fired.

**Root cause:** rf2-t5wp9 (#1757) replaced the truly-blank affordance with an *all-machines topology* render inside `blank-state`, so the panel surfaced content on every non-machine event — exactly the "shows on non-machine events" half of the observed inversion. The machine-relatedness detection already keyed on the migrated `:rf.machine/transition` op, so the "blank on machine events" half was the rly4a focus.epoch-id correlation regression (now fixed on base) and no longer reproduces.

**Gate fix:** restore `blank-state` to the truly-blank "No machine activity in the focused event" affordance (matches the original rf2-y9xmf collapse). Drop the per-machine blank-state topology section + the now-unused `topology-view` require. (The most-recent-known-state topology belongs to the future Static Machines surface, rf2-r4nao — not the Dynamic lens.)

### Defect 2 — topology too small (P2)

The focused-event chart is the centrepiece. Section + chart container now flex to fill the panel height (`flex 1` / `min-height 0`) instead of collapsing to the chart's 260px min. `topology_view`'s default `:height` flips `320px` → `100%` with a `320px` `min-height` floor so it fills its container while satisfying xyflow's non-zero-parent-height requirement.

## Tests

- Replaced the rf2-t5wp9 blank-state-renders-topology tests with correct-polarity gate tests: blank (no section, no chart, no `topology` mount) when no transition this epoch; stays blank on an event-less focused epoch even when epoch-history holds prior transitions.
- New `gate-reads-the-migrated-rf-machine-transition-op-only` — pins that detection keys on the `:rf.*` migrated `:rf.machine/transition` op; the legacy `:machine/transition` op does NOT trip the gate (a stale read would invert visibility).

## Gate results

- `npm run test:cljs` — 4119 tests / 12581 assertions, 0 failures, 0 errors.
- `npm run test:causa-feature-gate` — 13/13 scenarios, 0 failures.