### PR TITLE
fix(machines+routing): complete :rf.* trace migration + warning op-type + pin conformance op-type

### DIFF
--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -15,26 +15,30 @@
   consumers need above the raw stream for the common 'render this
   cascade as six dominoes' use case.
 
-  The cascade-wide `:dispatch-id` makes the projection robust against
-  events the framework emits *inside* a drain even though they aren't
-  `:event/dispatched` — fx invocations, sub-runs, renders, errors.
-  Every such event carries `:tags :dispatch-id` so the group-by below
-  assembles a complete cascade record.
+  The cascade-wide `:rf.trace/dispatch-id` makes the projection robust
+  against events the framework emits *inside* a drain even though they
+  aren't `:rf.event/dispatched` — fx invocations, sub-runs, renders,
+  errors. Every such event carries `:tags :rf.trace/dispatch-id` so the
+  group-by below assembles a complete cascade record.
 
   ## Bucketing (per Spec 009 §`:op-type` vocabulary)
 
   Six dominoes:
 
-    1. `:event`    — `:op-type :event` + `:operation :event/dispatched`
+    1. `:event`    — `:op-type :rf.event` + `:operation :rf.event/dispatched`
                      (cascade-root marker; bucket value is the event vector)
-    2. `:handler`  — `:op-type :event` + `:operation :event`
-                     (the handler ran; tags carry `:phase :run-start` / `:run-end`)
-    3. `:fx`       — `:op-type :event` + `:operation :event/do-fx`
+    2. `:handler`  — `:op-type :rf.event` + `:operation :rf.event`
+                     (the handler ran; tags carry
+                     `:rf.trace/phase :run-start` / `:run-end`)
+    3. `:fx`       — `:op-type :rf.fx` + `:operation :rf.fx/do-fx`
                      (effects map computed and about to be walked)
-    4. `:effect`   — `:op-type :fx` (any `:operation` — `:rf.fx/handled`,
-                     `:rf.fx/override-applied`, `:rf.fx/skipped-on-platform`)
-    5. `:sub`      — `:op-type :sub/run` or `:sub/create`
-    6. `:render`   — `:op-type :view` + `:operation :view/render`
+    4. `:effect`   — `:op-type :rf.fx` (any other `:operation` —
+                     `:rf.fx/handled`, `:rf.fx/override-applied`,
+                     `:rf.fx/skipped-on-platform`)
+    5. `:sub`      — `:op-type :rf.sub` (`:operation :rf.sub/run` recompute,
+                     `:rf.sub/skip` memo-hit, or `:rf.sub/create` first-time
+                     signal-graph build)
+    6. `:render`   — `:op-type :rf.view` + `:operation :rf.view/render`
 
   Events whose op-type/operation pair doesn't fit any bucket flow
   through `:other` so the cascade-record shape is fully accountable to
@@ -47,7 +51,7 @@
     panel and causality-graph node renderer; the `:ungrouped` slot covers
     free-floating traces (e.g. registry events emitted at app boot).
   - re-frame2-pair's `cascade-of` MCP op currently walks
-    `:event/dispatched` traces in a slimmer form; it migrates to this
+    `:rf.event/dispatched` traces in a slimmer form; it migrates to this
     projection so 'show me every fx in this cascade' becomes one slice
     of the returned record.")
 
@@ -106,7 +110,7 @@
 
   `:event` is the dispatched event VECTOR (the convenient
   slim form most consumers need). `:dispatched` is the full
-  `:event/dispatched` trace EVENT — preserved so consumers (Causa's
+  `:rf.event/dispatched` trace EVENT — preserved so consumers (Causa's
   Event lens) can read top-level hoisted slots like
   `:rf.trace/call-site` (per rf2-twt7m Change 1) without reaching
   back into the raw trace buffer."
@@ -131,13 +135,14 @@
 
 (defn- cascade-id
   "Extract the cascade identifier from an event. Per Spec 009 §Dispatch
-  correlation, `:dispatch-id` is cascade-wide. For `:event/dispatched`
-  events, `:parent-dispatch-id` documents inter-cascade lineage; for
-  pair-shaped tools assembling 'the cascade caused by THAT dispatch',
-  the event's own `:dispatch-id` is the right key (the
-  `:event/dispatched` event rides under its own cascade's id). Events
-  outside any drain (registry-time, frame-creation) carry no
-  `:dispatch-id` — they land in the `:ungrouped` bucket."
+  correlation, `:rf.trace/dispatch-id` is cascade-wide. For
+  `:rf.event/dispatched` events, `:rf.trace/parent-dispatch-id` documents
+  inter-cascade lineage; for pair-shaped tools assembling 'the cascade
+  caused by THAT dispatch', the event's own `:rf.trace/dispatch-id` is
+  the right key (the `:rf.event/dispatched` event rides under its own
+  cascade's id). Events outside any drain (registry-time, frame-creation)
+  carry no `:rf.trace/dispatch-id` — they land in the `:ungrouped`
+  bucket."
   [ev]
   (or (dispatch-id ev) :ungrouped))
 
@@ -218,32 +223,34 @@
 
 (defn group-cascades
   "Project a sequence of raw trace events into one cascade record per
-  `:dispatch-id`. Pure data — JVM and CLJS.
+  `:rf.trace/dispatch-id`. Pure data — JVM and CLJS.
 
   Returns a vector of maps shaped:
 
       {:dispatch-id <cascade-id-or-:ungrouped>
        :frame       <frame-id-or-nil>
-       :event       <event-vector or nil>     ;; from :event/dispatched :tags
-       :dispatched  <trace-event or nil>      ;; the full :event/dispatched
+       :event       <event-vector or nil>     ;; from :rf.event/dispatched :tags
+       :dispatched  <trace-event or nil>      ;; the full :rf.event/dispatched
                                               ;;   trace event (top-level
                                               ;;   :rf.trace/call-site,
                                               ;;   :source, :origin per
                                               ;;   rf2-twt7m Change 1)
        :handler     <trace-event or nil>      ;; the :run-end emit (last wins)
-       :fx          <trace-event or nil>      ;; :event/do-fx
-       :effects     [<trace-event> ...]       ;; :op-type :fx
-       :subs        [<trace-event> ...]       ;; :sub/run + :sub/create
-       :renders     [<trace-event> ...]       ;; :view/render
+       :fx          <trace-event or nil>      ;; :rf.fx/do-fx
+       :effects     [<trace-event> ...]       ;; :op-type :rf.fx
+       :subs        [<trace-event> ...]       ;; :rf.sub/run + :rf.sub/skip
+                                              ;;   + :rf.sub/create
+       :renders     [<trace-event> ...]       ;; :rf.view/render
        :other       [<trace-event> ...]}      ;; everything else
                                               ;;   (errors, warnings,
                                               ;;   machine, frame,
                                               ;;   flow, etc.)
 
-  Events without a `:dispatch-id` (registry-time emits, frame
-  lifecycle outside a drain, REPL evals) collect under
-  `:dispatch-id :ungrouped`. The returned vector is sorted by the
-  lowest `:id` in each cascade, so cascades render in emission order.
+  Events without a `:rf.trace/dispatch-id` tag (registry-time emits,
+  frame lifecycle outside a drain, REPL evals) collect under the
+  projection's `:dispatch-id :ungrouped` slot. The returned vector is
+  sorted by the lowest `:id` in each cascade, so cascades render in
+  emission order.
 
   Stable / additive: future framework op-types that don't fit a
   domino slot will surface under `:other` automatically. Tools that

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -48,7 +48,7 @@
   (testing "events outside the six-domino vocabulary land in :other"
     (is (= :other (p/domino-bucket {:op-type :error :operation :rf.error/no-such-handler})))
     (is (= :other (p/domino-bucket {:op-type :warning :operation :rf.warning/interceptors-in-metadata-map})))
-    (is (= :other (p/domino-bucket {:op-type :machine :operation :rf.machine/transition})))
+    (is (= :other (p/domino-bucket {:op-type :rf.machine :operation :rf.machine/transition})))
     (is (= :other (p/domino-bucket {:op-type :rf.frame :operation :rf.frame/created})))
     (is (= :other (p/domino-bucket {:op-type :flow :operation :rf.flow/computed})))
     (is (= :other (p/domino-bucket {:op-type :rf.registry :operation :rf.registry/handler-registered})))))

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -383,45 +383,50 @@
               (is (some?    (:id t)))
               (is (true?    (:different-fn? t))))))
 
-        ;; ---- :machine op-type ----------------------------------------------
-        (testing ":machine :rf.machine/transition fires on a machine event"
-          (is (has-op? events :machine :rf.machine/transition)
-              "expected :machine :rf.machine/transition")
-          (let [t (:tags (find-op events :machine :rf.machine/transition))]
+        ;; ---- :rf.machine op-type -------------------------------------------
+        ;; Per Spec 009 §:op-type vocabulary the machine trace family rides
+        ;; op-type :rf.machine (the :rf.* single-root scheme; #1973 +
+        ;; rf2-aa5qi). The operation carries the slashed identity.
+        (testing ":rf.machine :rf.machine/transition fires on a machine event"
+          (is (has-op? events :rf.machine :rf.machine/transition)
+              "expected :rf.machine :rf.machine/transition")
+          (let [t (:tags (find-op events :rf.machine :rf.machine/transition))]
             (is (keyword? (:machine-id t)))
             (is (vector?  (:event t)))
             (is (map?     (:before t)))
             (is (map?     (:after t)))))
 
-        (testing ":machine :rf.machine.timer/scheduled fires when a state with :after is entered"
-          (is (has-op? events :machine :rf.machine.timer/scheduled)
-              "expected :machine :rf.machine.timer/scheduled")
-          (let [t (:tags (find-op events :machine :rf.machine.timer/scheduled))]
+        (testing ":rf.machine :rf.machine.timer/scheduled fires when a state with :after is entered"
+          (is (has-op? events :rf.machine :rf.machine.timer/scheduled)
+              "expected :rf.machine :rf.machine.timer/scheduled")
+          (let [t (:tags (find-op events :rf.machine :rf.machine.timer/scheduled))]
             (is (keyword? (:state t)))
             (is (number?  (:delay t)))))
 
-        ;; ---- routing :event ops --------------------------------------------
-        (testing ":event :rf.route.nav-token/allocated fires on :rf.route/transitioned full nav"
-          (is (has-op? events :event :rf.route.nav-token/allocated)
-              "expected :event :rf.route.nav-token/allocated")
-          (let [t (:tags (find-op events :event :rf.route.nav-token/allocated))]
+        ;; ---- routing :rf.event ops -----------------------------------------
+        ;; Route lifecycle traces ride the :rf.event family (op-type
+        ;; :rf.event; rf2-a20e9 completed the #1973 migration in routing).
+        (testing ":rf.event :rf.route.nav-token/allocated fires on :rf.route/transitioned full nav"
+          (is (has-op? events :rf.event :rf.route.nav-token/allocated)
+              "expected :rf.event :rf.route.nav-token/allocated")
+          (let [t (:tags (find-op events :rf.event :rf.route.nav-token/allocated))]
             (is (keyword? (:route-id t)))
             (is (some?    (:nav-token t)))))
 
-        (testing ":event :rf.route/fragment-changed fires on fragment-only navigation"
+        (testing ":rf.event :rf.route/fragment-changed fires on fragment-only navigation"
           ;; Per Spec 009 §:op-type vocabulary and Spec 012 §Fragments:
           ;; :rf.route/fragment-changed is the canonical op-name for fragment-only
           ;; navigation. Consumers discriminate full vs fragment-only by :tags.
-          (is (has-op? events :event :rf.route/fragment-changed)
-              "expected :event :rf.route/fragment-changed")
-          (let [t (:tags (find-op events :event :rf.route/fragment-changed))]
+          (is (has-op? events :rf.event :rf.route/fragment-changed)
+              "expected :rf.event :rf.route/fragment-changed")
+          (let [t (:tags (find-op events :rf.event :rf.route/fragment-changed))]
             (is (keyword? (:route-id t)))
             (is (string?  (:next-fragment t)))))
 
-        (testing ":event :rf.route/navigation-blocked fires when :can-leave returns false"
-          (is (has-op? events :event :rf.route/navigation-blocked)
-              "expected :event :rf.route/navigation-blocked")
-          (let [t (:tags (find-op events :event :rf.route/navigation-blocked))]
+        (testing ":rf.event :rf.route/navigation-blocked fires when :can-leave returns false"
+          (is (has-op? events :rf.event :rf.route/navigation-blocked)
+              "expected :rf.event :rf.route/navigation-blocked")
+          (let [t (:tags (find-op events :rf.event :rf.route/navigation-blocked))]
             (is (string?  (:requested-url t)))
             (is (keyword? (:rejecting-route t)))))
 
@@ -511,8 +516,12 @@
             (gap-check :rf.sub                        :rf.sub/create)
             (gap-check :rf.machine.lifecycle/created  :rf.machine.lifecycle/created)
             (gap-check :rf.machine.lifecycle/destroyed :rf.machine.lifecycle/destroyed)
-            (gap-check :rf.machine/event-received     :rf.machine/event-received)
-            (gap-check :rf.machine/snapshot-updated   :rf.machine/snapshot-updated)
+            ;; op-type is the machine FAMILY :rf.machine; the slashed
+            ;; identity lives in :operation (rf2-aa5qi fixed these two
+            ;; emit-sites which previously rode the malformed slashed
+            ;; op-type :rf.machine/event-received / :rf.machine/snapshot-updated).
+            (gap-check :rf.machine :rf.machine/event-received)
+            (gap-check :rf.machine :rf.machine/snapshot-updated)
             (gap-check :rf.registry :rf.registry/handler-registered)
             (gap-check :rf.registry :rf.registry/handler-cleared)))
 

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -184,7 +184,7 @@
         parent-path [:rf/machines parent-id]
         ;; (2) Emit `:rf.machine/done` trace BEFORE the destroy cascade
         ;; (D6 ordering).
-        _ (trace/emit! :machine :rf.machine/done
+        _ (trace/emit! :rf.machine :rf.machine/done
                        {:machine-id machine-id
                         :output     result
                         :parent-id  parent-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -160,7 +160,7 @@
   [frame-id parent-id invoke-id spec join-state'' child-id child-extra
    {:keys [fail-fired? success-fired?]}]
   (when fail-fired?
-    (trace/emit! :machine :rf.machine.spawn-all/any-failed
+    (trace/emit! :rf.machine :rf.machine.spawn-all/any-failed
                  {:machine-id parent-id
                   :spawn-id  invoke-id
                   :failed-id  child-id
@@ -170,12 +170,12 @@
                   :frame      frame-id}))
   (when success-fired?
     (if (= :all (:join spec :all))
-      (trace/emit! :machine :rf.machine.spawn-all/all-completed
+      (trace/emit! :rf.machine :rf.machine.spawn-all/all-completed
                    {:machine-id parent-id
                     :spawn-id  invoke-id
                     :done       (:done join-state'')
                     :frame      frame-id})
-      (trace/emit! :machine :rf.machine.spawn-all/some-completed
+      (trace/emit! :rf.machine :rf.machine.spawn-all/some-completed
                    {:machine-id parent-id
                     :spawn-id  invoke-id
                     :done       (:done join-state'')
@@ -209,7 +209,7 @@
                                    (remove (fn [[cid _]]
                                              (contains? completed-ids cid))))]
             (doseq [[cid spawned-id] survivors]
-              (trace/emit! :machine :rf.machine.spawn/cancelled-on-join-resolution
+              (trace/emit! :rf.machine :rf.machine.spawn/cancelled-on-join-resolution
                            {:machine-id parent-id
                             :spawn-id  invoke-id
                             :child-id   cid
@@ -273,7 +273,7 @@
           ;; Already resolved: ignore late-completion. Trace once for
           ;; observability so tools can correlate.
           (:resolved? join-state)
-          (do (trace/emit! :machine :rf.machine.spawn-all/late-completion
+          (do (trace/emit! :rf.machine :rf.machine.spawn-all/late-completion
                            {:machine-id parent-id
                             :spawn-id  invoke-id
                             :child-id   child-id

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -334,14 +334,14 @@
       ;; tag the headline machine-transition trace never reaches the
       ;; cascade's `:trace-events` slot, leaving the Causa Machine
       ;; Inspector chart blank for cascades that DID drive a transition.
-      (trace/emit! :machine :rf.machine/transition
+      (trace/emit! :rf.machine :rf.machine/transition
                    {:frame      frame-id
                     :machine-id machine-id
                     :event      inner-event
                     :before     snapshot
                     :after      next-snapshot})
       (when (not= snapshot next-snapshot)
-        (trace/emit! :rf.machine/snapshot-updated :rf.machine/snapshot-updated
+        (trace/emit! :rf.machine :rf.machine/snapshot-updated
                      {:machine-id machine-id
                       :path       path
                       :before     snapshot
@@ -396,7 +396,7 @@
       ;; Per Spec 009 §:op-type vocabulary: `:rf.machine/event-received`
       ;; fires at the top of the handler so consumers see the inbound
       ;; event before any state derivation.
-      (trace/emit! :rf.machine/event-received :rf.machine/event-received
+      (trace/emit! :rf.machine :rf.machine/event-received
                    {:machine-id (first event)
                     :event      event
                     :frame      (or frame :rf/default)})

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/spawn.cljc
@@ -134,7 +134,7 @@
                               system-id (assoc-in [:rf/system-ids system-id] spawned-id)
                               track?    (assoc-in [:rf/spawned parent-id invoke-id] spawned-id))))
     (when system-id
-      (trace/emit! :machine :rf.machine/system-id-bound
+      (trace/emit! :rf.machine :rf.machine/system-id-bound
                    {:frame      frame-id
                     :system-id  system-id
                     :machine-id spawned-id}))))
@@ -206,7 +206,7 @@
                         (allocate-actor-id-in-db old-db machine-id-for-alloc)
           :else         [old-db nil])
         spec''     (stamp-framework-data spec' spawned-id parent-id invoke-id)]
-    (trace/emit! :machine :rf.machine/spawned
+    (trace/emit! :rf.machine :rf.machine/spawned
                  {:frame      frame-id
                   :machine-id (:machine-id args)
                   :spawned-id spawned-id
@@ -275,7 +275,7 @@
         children   (:children join-state)]
     (frame/swap-frame-db! frame-id assoc-in
                           [:rf/spawned parent-id invoke-id] join-state)
-    (trace/emit! :machine :rf.machine.spawn-all/started
+    (trace/emit! :rf.machine :rf.machine.spawn-all/started
                  {:machine-id parent-id
                   :spawn-id  invoke-id
                   :child-ids  (set (keys children))

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/traces.cljc
@@ -37,7 +37,7 @@
     invoke-id :spawn-id
     :or {reason :explicit}
     :as args}]
-  (trace/emit! :machine :rf.machine/destroyed
+  (trace/emit! :rf.machine :rf.machine/destroyed
                (cond-> {:frame    frame
                         :actor-id actor-id
                         :reason   reason}
@@ -52,7 +52,7 @@
   was released as part of teardown. No-op when `sid` is nil."
   [frame-id sid actor-id]
   (when sid
-    (trace/emit! :machine :rf.machine/system-id-released
+    (trace/emit! :rf.machine :rf.machine/system-id-released
                  {:frame      frame-id
                   :system-id  sid
                   :machine-id actor-id})))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -200,7 +200,7 @@
     (let [k (after-timer-key parent-id invoke-id delay-key)
           prior-entry (get-in @after-timers [frame-id k])
           prior-ms    (:resolved-ms prior-entry)]
-      (trace/emit! :machine :rf.machine.timer/cancelled-on-resolution
+      (trace/emit! :rf.machine :rf.machine.timer/cancelled-on-resolution
                    {:machine-id parent-id
                     :state      state
                     :delay      prior-ms
@@ -279,7 +279,7 @@
             (when (and reaction (vector? delay-key))
               (try (subs/unsubscribe frame-id delay-key)
                    (catch #?(:clj Throwable :cljs :default) _ nil)))
-            (trace/emit! :machine :rf.warning/no-clock-configured
+            (trace/emit! :warning :rf.warning/no-clock-configured
                          {:machine-id   parent-id
                           :state        state
                           :delay-key    delay-key
@@ -289,7 +289,7 @@
 
           :else
           (let [_ (when emit-scheduled-trace?
-                    (trace/emit! :machine :rf.machine.timer/scheduled
+                    (trace/emit! :rf.machine :rf.machine.timer/scheduled
                                  (cond-> {:machine-id   parent-id
                                           :state        state
                                           :delay        resolved-ms

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -138,7 +138,7 @@
     true
     (let [g       (resolve-guard machine guard-ref)
           outcome (boolean (call-guard g snapshot event))]
-      (trace/emit! :machine :rf.machine/guard-evaluated
+      (trace/emit! :rf.machine :rf.machine/guard-evaluated
                    {:machine-id (or (:rf/parent-id machine) (:id machine))
                     :guard-id   guard-ref
                     :input      {:data  (:data snapshot)
@@ -555,7 +555,7 @@
           frame-id  (:rf/frame machine)]
       (try
         (let [r (call-action f snap event)]
-          (trace/emit! :machine :rf.machine/action-ran
+          (trace/emit! :rf.machine :rf.machine/action-ran
                        {:machine-id parent-id
                         :action-id  action-ref
                         :input      {:data  (:data snap)
@@ -564,7 +564,7 @@
                         :frame      frame-id})
           (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
-          (trace/emit! :machine :rf.machine/action-ran
+          (trace/emit! :rf.machine :rf.machine/action-ran
                        {:machine-id parent-id
                         :action-id  action-ref
                         :input      {:data  (:data snap)
@@ -669,7 +669,7 @@
                           ;; actual resolved-ms once it has frame access).
                           ms-tag       delay-key]
                       (if server?
-                        (trace/emit! :machine :rf.machine.timer/skipped-on-server
+                        (trace/emit! :rf.machine :rf.machine.timer/skipped-on-server
                                      (cond-> {:machine-id   parent-id
                                               :state        leaf-state
                                               :delay        ms-tag
@@ -680,7 +680,7 @@
                                               :recovery     :skipped}
                                        (= :sub delay-source)
                                        (assoc :sub-id (first delay-key))))
-                        (trace/emit! :machine :rf.machine.timer/scheduled
+                        (trace/emit! :rf.machine :rf.machine.timer/scheduled
                                      (cond-> {:machine-id   parent-id
                                               :state        leaf-state
                                               :delay        ms-tag
@@ -1354,7 +1354,7 @@
   [frame-id match]
   (when match
     (when (:stale? match)
-      (trace/emit! :machine :rf.machine.timer/stale-after
+      (trace/emit! :rf.machine :rf.machine.timer/stale-after
                    {:state           (:state match)
                     :delay           (:delay match)
                     :scheduled-epoch (:scheduled-epoch match)
@@ -1362,7 +1362,7 @@
                     :frame           frame-id
                     :recovery        :replaced-with-default}))
     (when (:guard-suppressed? match)
-      (trace/emit! :machine :rf.machine.timer/fired
+      (trace/emit! :rf.machine :rf.machine.timer/fired
                    {:state  (:state match)
                     :delay  (:delay match)
                     :epoch  (:epoch match)
@@ -1371,7 +1371,7 @@
     (when (and (not (:stale? match))
                (not (:guard-suppressed? match))
                (:delay match))
-      (trace/emit! :machine :rf.machine.timer/fired
+      (trace/emit! :rf.machine :rf.machine.timer/fired
                    {:state  (last (:decl-path match))
                     :delay  (:delay match)
                     :epoch  (:epoch match)

--- a/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
+++ b/implementation/machines/test/re_frame/lifecycle_composed_corners_test.clj
@@ -227,10 +227,10 @@
               "late child dispatch traced :rf.error/frame-destroyed")
           ;; The resolution event (:hydrate/done / :hydrate/failed) did
           ;; NOT fire — the join state is gone with the frame.
-          (is (not-any? #(and (= :event (:op-type %))
-                              (= :event/dispatched (:operation %))
-                              (or (= :hydrate/done   (first (:event (:tags %))))
-                                  (= :hydrate/failed (first (:event (:tags %))))))
+          (is (not-any? #(and (= :rf.event (:op-type %))
+                              (= :rf.event/dispatched (:operation %))
+                              (or (= :hydrate/done   (first (:rf.event/v (:tags %))))
+                                  (= :hydrate/failed (first (:rf.event/v (:tags %))))))
                         @recorded)
               "no :hydrate/done / :hydrate/failed dispatch was scheduled")
           (finally (unreg)))))))

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -177,7 +177,7 @@
       ;; §Hot-reload trace surface); not re-emitted here. Mirrors the
       ;; `:rf.flow/registered` symmetry (rf2-ehxez).
       (when (nil? previous)
-        (trace/emit! :event :rf.route/registered
+        (trace/emit! :rf.event :rf.route/registered
                      {:route-id id
                       :path     pattern})))
     id))
@@ -191,7 +191,7 @@
   (let [previous (registrar/lookup :route id)]
     (when previous
       (registrar/unregister! :route id)
-      (trace/emit! :event :rf.route/cleared
+      (trace/emit! :rf.event :rf.route/cleared
                    {:route-id id
                     :path     (:path previous)})))
   nil)
@@ -903,10 +903,10 @@
   `:rf.route/transitioned` event."
   [prev-id next-id]
   (when (and prev-id (not= prev-id next-id))
-    (trace/emit! :event :rf.route/deactivated
+    (trace/emit! :rf.event :rf.route/deactivated
                  {:route-id prev-id}))
   (when (and next-id (not= prev-id next-id))
-    (trace/emit! :event :rf.route/activated
+    (trace/emit! :rf.event :rf.route/activated
                  {:route-id next-id})))
 
 ;; Per Spec 012 §Per-route data loading §2. FIFO drain queues
@@ -1179,7 +1179,7 @@
                                                (:bypass-leave-guard? opts))]
         blocked
         (do
-          (trace/emit! :event :rf.route.nav-token/allocated
+          (trace/emit! :rf.event :rf.route.nav-token/allocated
                        {:route-id  route-id
                         :nav-token token})
           ;; Per rf2-dn26r: route lifecycle pair. Fires after the
@@ -1293,7 +1293,7 @@
     (when-not ok?
       (let [[db' pn-id] (alloc-pending-nav-id db)
             guard-id    (can-leave-guard-id current-meta)]
-        (trace/emit! :event :rf.route/navigation-blocked
+        (trace/emit! :rf.event :rf.route/navigation-blocked
                      {:requested-url   requested-url
                       :rejecting-route (:id current-route)
                       :rejecting-guard guard-id})
@@ -1380,7 +1380,7 @@
       (cond
         external?
         (do
-          (trace/emit! :event :rf.route/external-url-requested
+          (trace/emit! :rf.event :rf.route/external-url-requested
                        {:url url})
           {})
 
@@ -1469,7 +1469,7 @@
   `:prev-fragment` / `:next-fragment` in `:tags`. Scroll-capture (for the
   position the user is leaving) still rides along."
   [db prev next-fragment]
-  (trace/emit! :event :rf.route/fragment-changed
+  (trace/emit! :rf.event :rf.route/fragment-changed
                {:route-id      (:id prev)
                 :prev-fragment (:fragment prev)
                 :next-fragment next-fragment})
@@ -1590,7 +1590,7 @@
                                       :recovery :replaced-with-default}
                                frame      (assoc :frame frame)
                                malformed? (assoc :reason :malformed-url))))
-        (trace/emit! :event :rf.route.nav-token/allocated
+        (trace/emit! :rf.event :rf.route.nav-token/allocated
                      {:route-id  route-id
                       :nav-token token})
         ;; Per rf2-dn26r: route lifecycle pair. Fires after the nav-token
@@ -1704,13 +1704,13 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   (fn [{:keys [frame]} url]
     (if (url-bound-frame? frame)
       #?(:cljs (.pushState js/window.history nil "" url)
-         :clj  (trace/emit! :fx :rf.fx/skipped-on-platform
+         :clj  (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                             {:fx-id :rf.nav/push-url :url url}))
       ;; Non-URL-bound frame: skip the history mutation. Frame's
       ;; `:rf/route` slice still updates — only the browser-URL sync is
       ;; suppressed. Per Spec 012 §Multi-frame routing this is the right
       ;; default for story-variant / devcard / per-test fixtures.
-      (trace/emit! :fx :rf.fx/skipped-on-platform
+      (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                    {:fx-id :rf.nav/push-url
                     :url   url
                     :frame frame
@@ -1725,9 +1725,9 @@ no-op the fx so they don't race with the URL-owning frame (per Spec 012
   (fn [{:keys [frame]} url]
     (if (url-bound-frame? frame)
       #?(:cljs (.replaceState js/window.history nil "" url)
-         :clj  (trace/emit! :fx :rf.fx/skipped-on-platform
+         :clj  (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                             {:fx-id :rf.nav/replace-url :url url}))
-      (trace/emit! :fx :rf.fx/skipped-on-platform
+      (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                    {:fx-id :rf.nav/replace-url
                     :url   url
                     :frame frame
@@ -1748,7 +1748,7 @@ per-frame [:rf.route/scroll-positions <url>] map before leaving a route."}
                                  url
                                  pos)))
        :clj
-       (trace/emit! :fx :rf.fx/skipped-on-platform
+       (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                     {:fx-id :rf.nav/capture-scroll :url url}))))
 
 ;; ---- :url-bound? exclusivity check ----------------------------------------
@@ -1896,7 +1896,7 @@ unknown strategies as :preserve (no-op)."}
          ;; runtime doesn't blow up on a strategy it doesn't recognise.
          nil)
        :clj
-       (trace/emit! :fx :rf.fx/skipped-on-platform
+       (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                     {:fx-id :rf.nav/scroll :strategy strategy}))))
 
 ;; ---- framework-shipped subs over the slice -------------------------------

--- a/spec/conformance/fixtures/cross-spec-machine-microstep-subscribe.edn
+++ b/spec/conformance/fixtures/cross-spec-machine-microstep-subscribe.edn
@@ -98,15 +98,34 @@
   ;; trace), with :microsteps 1 (the :always microstep). Subs do NOT
   ;; recompute mid-cascade — the runtime's :sub/run only fires when
   ;; queried.
+  ;; `:op-type` is pinned on every entry below (rf2-a20e9): the prior
+  ;; fixture asserted `:operation` only, which is exactly the blind spot
+  ;; that let the machines `:op-type :machine → :rf.machine` drift pass
+  ;; CI. The op-type is the SEVERITY/FAMILY discriminator Causa's issue
+  ;; + reactive surfaces filter on; pinning it here catches any future
+  ;; envelope-level regression.
   :trace-emissions
-  [{:operation :rf.event :tags {:rf.trace/event-id :boot/init}}
-   {:operation :rf.event :tags {:rf.trace/event-id :quiz}}
-   ;; Outer macrostep trace — ONE per dispatch. Tags carry :before /
-   ;; :after snapshots (per machines.lifecycle-fx.registration/
-   ;; commit-or-finalize). The :after snapshot's :state is :winner
-   ;; (the committed end-state), not an intermediate microstep value;
-   ;; the partial-match matcher confirms :machine-id, and :sub-values
-   ;; above confirms the post-commit snapshot is what subs observe.
-   {:operation :rf.machine/transition
+  [{:op-type :rf.event :operation :rf.event :tags {:rf.trace/event-id :boot/init}}
+   {:op-type :rf.event :operation :rf.event :tags {:rf.trace/event-id :quiz}}
+   ;; Outer macrostep trace — ONE per dispatch. The op-type is the
+   ;; machine FAMILY discriminator `:rf.machine` (NOT the slashed
+   ;; operation `:rf.machine/transition`); pinning op-type here is the
+   ;; load-bearing addition. Tags carry :before / :after snapshots (per
+   ;; machines.lifecycle-fx.registration/commit-or-finalize). The :after
+   ;; snapshot's :state is :winner (the committed end-state), not an
+   ;; intermediate microstep value; the partial-match matcher confirms
+   ;; :machine-id, and :sub-values above confirms the post-commit
+   ;; snapshot is what subs observe.
+   {:op-type   :rf.machine
+    :operation :rf.machine/transition
     :tags      {:machine-id :quiz
-                :event      [:answer-correct]}}]}}
+                :event      [:answer-correct]}}
+   ;; Snapshot-updated rides op-type `:rf.machine` too (operation
+   ;; `:rf.machine/snapshot-updated`). This emit-site previously carried
+   ;; the MALFORMED slashed op-type `:rf.machine/snapshot-updated`
+   ;; (rf2-aa5qi); pinning op-type `:rf.machine` here is the regression
+   ;; guard for that specific defect. Fires because the macrostep moved
+   ;; the snapshot (:asking → :winner).
+   {:op-type   :rf.machine
+    :operation :rf.machine/snapshot-updated
+    :tags      {:machine-id :quiz}}]}}

--- a/tools/causa/test/day8/re_frame2_causa/l2_counter_inc_row_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/l2_counter_inc_row_cljs_test.cljs
@@ -81,11 +81,11 @@
     :tags {:rf.trace/dispatch-id dispatch-id-8 :rf.view/render-key [:counter/root nil] :frame frame-below}}])
 
 (defn- orphan-frame-created-event
-  "The mis-attributed `:frame/created` orphan that — pre-avvwm —
+  "The mis-attributed `:rf.frame/created` orphan that — pre-avvwm —
   leaked into the NEXT epoch's `:trace-events` carrying that epoch's
   `:dispatch-id`. Represents the pre-fix corruption shape."
   []
-  {:id 49 :op-type :rf.frame :operation :frame/created
+  {:id 49 :op-type :rf.frame :operation :rf.frame/created
    :tags {:rf.trace/dispatch-id dispatch-id-8 :frame frame-below}})
 
 (defn- visible-l2-rows
@@ -143,9 +143,9 @@
       (let [c (first rows)]
         (is (= [:counter/inc] (:event c))
             ":event slot is still the dispatched event vector")
-        (is (some (fn [ev] (= :frame/created (:operation ev)))
+        (is (some (fn [ev] (= :rf.frame/created (:operation ev)))
                   (:other c))
-            "the orphan :frame/created lands in the cascade's :other slot")))))
+            "the orphan :rf.frame/created lands in the cascade's :other slot")))))
 
 ;; ---- 3. The classifier: a frame-lifecycle-ONLY group is the only drop --
 ;;
@@ -160,7 +160,7 @@
   (testing "a post-avvwm uncorrelated :frame/created (no :dispatch-id)
             lands in :ungrouped and is hidden from L2 by default, while
             the sibling counter-inc epoch still surfaces"
-    (let [events (into [{:id 49 :op-type :rf.frame :operation :frame/created
+    (let [events (into [{:id 49 :op-type :rf.frame :operation :rf.frame/created
                          :tags {:frame frame-below}}] ; NO :dispatch-id (avvwm)
                        (counter-inc-trace-events))
           all    (projection/group-cascades events)

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -894,11 +894,11 @@
       ;; the slot wholesale, then a `:rf.causa/note-trace-event` for the
       ;; same id arrives from a queued mirror dispatch.
       (rf/dispatch-sync [:rf.causa/sync-trace-buffer
-                         [{:id 42 :op-type :rf.frame :operation :frame/created
+                         [{:id 42 :op-type :rf.frame :operation :rf.frame/created
                            :tags {:frame :rf/causa}}]])
       (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
       (rf/dispatch-sync [:rf.causa/note-trace-event
-                         {:id 42 :op-type :rf.frame :operation :frame/created
+                         {:id 42 :op-type :rf.frame :operation :rf.frame/created
                           :tags {:frame :rf/causa}}])
       (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer])))
           "duplicate-id push is a no-op — slot length unchanged")


### PR DESCRIPTION
Completes the atomic `:rf.*` single-root trace migration (#1973) in the **machines** and **routing** artefacts it missed, and closes the conformance op-type blind spot that let the drift pass CI. Audit: rf2-wj2h9. One PR, four beads.

## rf2-aa5qi (HIGH, completeness) — machines
- Migrated all machine trace emit-sites from bare op-type `:machine` -> `:rf.machine` across `transition.cljc`, `timer.cljc`, `registration.cljc`, `spawn.cljc`, `join.cljc`, `finalize.cljc`, `traces.cljc` (~18 sites). Operations/tags already carried the slashed `:rf.machine/*` identity.
- Fixed the **malformed slashed op-types** at `registration.cljc`: `snapshot-updated` (line 344) AND `event-received` (line 399) were riding their slashed *operation* keyword as the *op-type*. Op-type is now the family `:rf.machine`; operation keeps the slashed identity.
- `:rf.machine.lifecycle/*` emit-sites correctly **retain** the slashed form as op-type per Spec 009:185 (registrar-lifecycle channel) — left unchanged.
- Updated stale fixtures: `projection_test.cljc` machine op-type; Causa `l2_counter_inc_row` + `registry` synthetic `:frame/created` -> `:rf.frame/created`.

## rf2-sja8o (HIGH, correctness) — machine timer warning
- `timer.cljc:282` emitted `:rf.warning/no-clock-configured` under op-type `:machine`, making a real user-misconfiguration warning **invisible to every Causa issue/severity surface** (they filter op-type in `{:error :warning}`). Fixed to op-type `:warning` (operation unchanged). Verified the sole machine emit-site with this defect.

## rf2-a20e9 (MED) — routing migration + conformance op-type pin
- Migrated routing emit-sites: bare `:event` -> `:rf.event` (`:rf.route/*` ops) and bare `:fx` -> `:rf.fx` (`:rf.fx/skipped-on-platform`).
- **Pinned `:op-type`** in the `cross-spec-machine-microstep-subscribe` conformance fixture (transition + snapshot-updated) — fixtures previously asserted `:operation` only, the exact blind spot. Future op-type drift now fails the corpus.
- Updated the core `trace-stream-completeness` test to the migrated op-types (including the two gap-checks that were encoding the malformed slashed op-type).

## rf2-qtqdk (MED) — projection docstrings
- Rewrote `projection.cljc` ns + `group-cascades` docstrings/return-shape comments from the pre-migration vocabulary (`:event`/`:sub`/`:view`/`:event/do-fx`, `:dispatch-id`) to the live `:rf.*` vocabulary the code already dispatches on. Consumed by Causa/Story/pair `cascade-of`.

## Follow-up filed
- **rf2-s7rt4** (P2): Causa `shell.cljs` `row-badges` machine detection uses `#":machine"`, which does NOT match `:rf.machine/*` (it is `.machine`) — the machine badge never renders for real cascades post-migration. Same blind-spot class; adjacent to the rf2-zdfbm Machines-panel work, sequenced to avoid `shell.cljs` conflicts.

## Gates (all green)
- Core JVM (incl. conformance corpus with op-type now pinned): 728 tests, 0 failures
- JVM machines: 245 tests, 0 failures
- JVM routing: 113 tests, 0 failures
- `npm run test:cljs` (clean recompile): 4121 tests, 0 failures