### PR TITLE
fix(causa): shell row-badges detects migrated :rf.machine/* family

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -300,23 +300,59 @@
     (:whole-redacted? cascade)            "▥"
     :else                                 "●"))
 
+(defn- op-namespace
+  "The `:operation` keyword's namespace as a string, or nil when the
+  operation is missing / not a keyword. Mirrors the family-detection
+  idiom in `panels.l2-timeline` so badge classification matches the
+  rest of the post-`:rf.*`-migration Causa code."
+  [op]
+  (when (keyword? op) (namespace op)))
+
+(defn- ns-in-family?
+  "True when the operation keyword belongs to `family` — either an
+  exact namespace match (`:rf.http/settled` → `\"rf.http\"`) or a
+  dotted sub-family (`:rf.machine.lifecycle/destroyed` →
+  `\"rf.machine.lifecycle\"` is in the `rf.machine` family). Lets a
+  single family check fold in lifecycle / microstep sub-streams without
+  a fragile substring regex."
+  [op family]
+  (when-let [ns (op-namespace op)]
+    (or (= ns family)
+        (str/starts-with? ns (str family ".")))))
+
 (defn row-badges
   "Per spec/018 §4 Row badges. Returns a vector of present badges in
-  the fixed `[:warn :http :machine]` order. Stub heuristic until the
-  per-row classifier lands — looks at the cascade's `:other` bucket
-  for op-types we recognise."
+  the fixed `[:warn :http :machine]` order. Walks the cascade's
+  `:other` bucket and classifies each event by its Spec 009 `:op-type`
+  family (`:rf.machine`, `:rf.http`, severity discriminators) — the
+  same family-detection idiom `panels.l2-timeline` uses, NOT a
+  substring regex.
+
+  Post-`:rf.*`-migration the machine op-type is `:rf.machine` and
+  operations are `:rf.machine/transition` etc.; the old `#\":machine\"`
+  regex matched the pre-migration `:machine/*` shape but NOT
+  `:rf.machine/*` (whose substring is `.machine`, not `:machine`), so
+  the badge silently stopped rendering. Detection now matches the
+  `:op-type` / `:operation` namespace precisely and folds in the
+  `:rf.machine.lifecycle/*` and `:rf.machine.microstep/*` sub-streams.
+  The legacy bare `:machine` / `:http` shapes are still recognised so
+  any pre-migration trace replayed through Causa keeps lighting up."
   [cascade]
   (let [others (:other cascade)
         warn?  (some (fn [e] (or (= :error (:op-type e))
                                  (= :warning (:op-type e))))
                      others)
-        http?  (some (fn [e] (when-let [op (:operation e)]
-                               (let [n (str op)]
-                                 (or (re-find #":http/" n)
-                                     (re-find #":rf\.http" n)))))
+        http?  (some (fn [e]
+                       (or (contains? #{:rf.http :http} (:op-type e))
+                           (let [op (:operation e)]
+                             (or (ns-in-family? op "rf.http")
+                                 (ns-in-family? op "http")))))
                      others)
-        machine? (some (fn [e] (when-let [op (:operation e)]
-                                 (re-find #":machine" (str op))))
+        machine? (some (fn [e]
+                         (or (contains? #{:rf.machine :machine} (:op-type e))
+                             (let [op (:operation e)]
+                               (or (ns-in-family? op "rf.machine")
+                                   (ns-in-family? op "machine")))))
                        others)]
     (cond-> []
       warn?    (conj "⚠")
@@ -939,9 +975,12 @@
   - **`⚠`** — exception/error glyph (from `:other` carrying
     `:op-type :error` / `:warning`, or `:errors` slot populated).
   - **`🌐`** — managed-HTTP marker (from `:other` carrying an
-    `:operation` matching `:http/*` or `:rf.http/*`).
+    `:op-type :rf.http` or an `:operation` in the `:rf.http/*` /
+    legacy `:http/*` family).
   - **`🤖`** — state-machine marker (from `:other` carrying an
-    `:operation` matching `:machine`).
+    `:op-type :rf.machine` or an `:operation` in the `:rf.machine/*`
+    family, including the `:rf.machine.lifecycle/*` and
+    `:rf.machine.microstep/*` sub-streams).
 
   Dropped from the default view (moved to hover tooltip + Event
   detail tab): the full event vector with args, the sequence

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -1613,11 +1613,49 @@
       "no recognised op-types → no badges"))
 
 (deftest row-badges-detects-errors-and-http-and-machine
+  ;; Canonical post-`:rf.*`-migration trace shape (Spec 009): the
+  ;; machine op-type is `:rf.machine` / operation `:rf.machine/*` and
+  ;; HTTP is `:rf.http` / `:rf.http/*`. Feeding this shape would FAIL
+  ;; against the pre-fix `#":machine"` substring regex — `(str
+  ;; :rf.machine/transition)` is ":rf.machine/transition", which does
+  ;; NOT contain ":machine" (the substring is ".machine"). Pinning the
+  ;; migrated shape here closes the false-green blind spot where the
+  ;; old test fed `:machine/transition` and passed while the live badge
+  ;; never rendered.
   (let [cascade {:other [{:op-type :error}
-                         {:operation :http/get}
-                         {:operation :machine/transition}]}]
+                         {:op-type :rf.http :operation :rf.http/settled}
+                         {:op-type :rf.machine :operation :rf.machine/transition}]}]
     (is (= ["⚠" "🌐" "🤖"] (shell/row-badges cascade))
-        "badges in fixed left-to-right order")))
+        "migrated :rf.machine/* + :rf.http/* shapes light all three badges")))
+
+(deftest row-badges-machine-detection-covers-op-type-and-sub-families
+  (testing "machine badge fires on the bare :op-type :rf.machine"
+    (is (= ["🤖"] (shell/row-badges {:other [{:op-type :rf.machine}]}))))
+  (testing "machine badge fires on a :rf.machine/* operation alone"
+    (is (= ["🤖"] (shell/row-badges
+                   {:other [{:operation :rf.machine/snapshot-updated}]}))))
+  (testing "machine badge folds in the :rf.machine.lifecycle/* sub-stream"
+    (is (= ["🤖"] (shell/row-badges
+                   {:other [{:operation :rf.machine.lifecycle/destroyed}]}))))
+  (testing "machine badge folds in the :rf.machine.microstep/* sub-stream"
+    (is (= ["🤖"] (shell/row-badges
+                   {:other [{:operation :rf.machine.microstep/transition}]}))))
+  (testing "a non-machine :rf.* family does NOT trip the machine badge"
+    (is (= [] (shell/row-badges {:other [{:operation :rf.event/dispatched}]})))))
+
+(deftest row-badges-http-detection-covers-op-type-and-canonical-family
+  (testing "http badge fires on the canonical :rf.http/* operation"
+    (is (= ["🌐"] (shell/row-badges
+                   {:other [{:op-type :rf.http :operation :rf.http/settled}]}))))
+  (testing "http badge still recognises the legacy :http/* alias"
+    (is (= ["🌐"] (shell/row-badges {:other [{:operation :http/get}]})))))
+
+(deftest row-badges-still-recognises-legacy-pre-migration-shape
+  ;; A pre-migration trace replayed through Causa keeps lighting up.
+  (let [cascade {:other [{:operation :machine/transition}
+                         {:operation :http/get}]}]
+    (is (= ["🌐" "🤖"] (shell/row-badges cascade))
+        "legacy :machine/* + :http/* still detected")))
 
 (deftest event-id-of-cascade-plucks-first-element
   (is (= :foo/bar (shell/event-id-of-cascade {:event [:foo/bar {:x 1}]})))


### PR DESCRIPTION
## What & why

The `:rf.*` single-root trace migration renamed the machine op-type from `:machine` to `:rf.machine` (operations are `:rf.machine/transition`, `:rf.machine/snapshot-updated`, ...). But Causa's L2 row-badge logic in `tools/causa/src/day8/re_frame2_causa/shell.cljs` (`row-badges`) detected machine rows with a substring regex `#":machine"`.

That pattern does **not** match `:rf.machine/*` — `(str :rf.machine/transition)` is `":rf.machine/transition"`, whose relevant substring is `.machine`, not `:machine`. **Result: the machine badge silently stopped rendering for any real, post-migration trace.**

The existing test fed the OLD shape (`:operation :machine/transition`), which the stale regex *did* match, so it passed green while the live code was broken — a false-green blind spot of the same class #1979 just fixed for conformance fixtures.

## The fix

- **Detection** — replaced the substring regexes with the `:op-type` / `:operation`-namespace family idiom already established in `panels.l2-timeline` (`op-namespace` + family check), instead of inventing a new regex.
  - Machine: matches `:op-type :rf.machine` **or** an `:operation` in the `rf.machine` family. Old regex `#":machine"` → new: `:op-type` ∈ `{:rf.machine :machine}` or `:operation` namespace = `"rf.machine"` / a `"rf.machine.*"` sub-family. This also folds in the `:rf.machine.lifecycle/*` and `:rf.machine.microstep/*` sub-streams the old regex would have missed (well, would have matched `.lifecycle` only by accident, never under `:rf.`).
  - **Other badges shared the defect class**: the `http?` check used the same fragile substring approach (`#":http/"` / `#":rf\.http"`). Hardened it to the same idiom (`:op-type :rf.http` / `:http`, or namespace `"rf.http"` / legacy `"http"`). The `warn?` check was already exact `:op-type` matching — left as-is.
  - Legacy bare `:machine` / `:http` shapes are still recognised so any pre-migration trace replayed through Causa keeps lighting up.

- **Test** — `row-badges-detects-errors-and-http-and-machine` now feeds the **canonical migrated** `:rf.machine/*` + `:rf.http/*` shape, so it exercises the post-migration path and **fails against the old regex**. Added sub-family + op-type + legacy-tolerance coverage. Verified: against the pre-fix `#":machine"` regex the suite shows **5 failures** (e.g. `(not (= ["🤖"] []))`); with the fix it is green.

Note: the live `event-row` cluster (`data-testid rf-causa-row-badges`) is already sourced from the migration-correct `l2-timeline/activity-badges`; `row-badges` is the legacy stub fn that only the test exercised — this fix brings it onto the same correct idiom and closes the test blind spot.

## Gates

- `npx shadow-cljs compile node-test` + `node out/node-test.js` (= `npm run test:cljs`): **4122 tests / 12589 assertions, 0 failures, 0 errors**.
- `npm run test:causa-feature-gate`: **13 scenarios, 0 failures, 13 matrix rows**.
- Sanity: tests **FAIL (5)** against the old regex, **PASS** with the fix.

Closes rf2-s7rt4.