### PR TITLE
feat(causa): shared-subscription edges in the Views panel (rf2-y23uw)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
@@ -68,12 +68,20 @@
          :subs-ran        [{:sub-id _ :value-changed? _ ...} ...]
          :subs-skipped    [{:sub-id _ ...} ...]
          :views-rendered  [{:view-id _ ...} ...]      ; legacy count slot
-         :level-1-subs    [{:sub-id _ :changed? _ :coord _} ...]
-         :level-2-subs    [{:sub-id _ :changed? _ :inputs [...] :coord _} ...]
+         :level-1-subs    [{:sub-id _ :changed? _ :coord _ :readers [...]} ...]
+         :level-2-subs    [{:sub-id _ :changed? _ :inputs [...] :coord _
+                            :readers [...]} ...]
+         :sub-readers     {<sub-id> [<view-id> ...] ...}
          :view-rows       [{:view-id _ :action _ :reason {...} :coord _} ...]
          :counts          {:subs-ran N :subs-skipped N
                            :views-rendered N
                            :flows-recomputed N}}
+
+  `:sub-readers` (rf2-y23uw) is the shared-subscription edge map — for
+  each sub-id, the views that deref'd it this cascade ('which views read
+  sub X'), derived from the per-view `:rf.view/deref-subs` read-sets. The
+  same list rides each sub row's `:readers` slot so the Views panel can
+  show, per sub, the views that share it.
 
   The `:reason` slot on a `:view-row` is `{:kind :reactive :subs [...]}`
   | `{:kind :structural}` | `{:kind :none}` (unmount). The view layer
@@ -213,6 +221,53 @@
                     :else nil))))
         (or trace-events [])))
 
+;; ---- shared-subscription edges (rf2-y23uw) --------------------------------
+
+(defn sub-readers
+  "Build the sub→readers map for this cascade — `{sub-id [view-id ...]}` —
+  the 'which views read sub X' shared-subscription edge set.
+
+  Walks the cascade's `:rf.view/rendered` ops and, for each, unions its
+  view-id into the reader list of every sub-id it derefs (its
+  `:rf.view/deref-subs` read-set). The result lets the Views panel show,
+  per sub row, the set of views that read it — the shared-sub detection
+  the per-render `:rf.view/cause-subs`/`:rf.sub/reader-render-key` pair
+  can't supply (cause-subs is cascade-wide and over-reports; the
+  reader-render-key names only the TRIGGERING reader of a recompute, not
+  every reader, and not unchanged subs a view also reads).
+
+  Reader lists preserve first-seen view order across the trace and
+  de-duplicate (a view that re-derefs the same sub, or two instances of
+  the same view-id, contribute the view-id once). nil-safe; non-view ops
+  and ops without a `:view-id` / `:deref-subs` are skipped."
+  [trace-events]
+  (-> (reduce
+        (fn [acc ev]
+          (if (= :rf.view/rendered (op-kw ev))
+            (let [tags    (:tags ev)
+                  view-id (or (:rf.view/id tags) (:rf.view/id ev))]
+              (if (nil? view-id)
+                acc
+                (reduce
+                  (fn [m qv]
+                    (if-let [sid (query-id qv)]
+                      ;; Ordered-distinct union: a sorted set would lose
+                      ;; first-seen order, so track an explicit vector +
+                      ;; membership in one entry, flattened below.
+                      (update m sid
+                              (fn [{:keys [seen order] :or {seen #{} order []}}]
+                                (if (contains? seen view-id)
+                                  {:seen seen :order order}
+                                  {:seen (conj seen view-id)
+                                   :order (conj order view-id)})))
+                      m))
+                  acc
+                  (or (:rf.view/deref-subs tags) []))))
+            acc))
+        {}
+        (or trace-events []))
+      (->> (reduce-kv (fn [m sid entry] (assoc m sid (:order entry))) {}))))
+
 ;; ---- sub-level partition (rf2-8ve8z, sub-topology contract) ---------------
 
 (defn topology-coord
@@ -240,35 +295,46 @@
   `subs-ran` is the `:sub-runs` projection slice (each entry carries
   `:sub-id` + `:value-changed?`). `topology` is the
   `re-frame.subs.tooling/sub-topology` map (`{sub-id {:inputs [...]
-  :ns :line :file}}`).
+  :ns :line :file}}`). `readers` (optional, rf2-y23uw) is the sub→readers
+  map from `sub-readers` (`{sub-id [view-id ...]}`).
 
   Returns `{:level-1 [row ...] :level-2 [row ...]}` where each row:
 
-    Level 1: {:sub-id _ :changed? bool :coord {...}?}
+    Level 1: {:sub-id _ :changed? bool :coord {...}? :readers [view-id ...]}
     Level 2: {:sub-id _ :changed? bool :inputs [<input-sub-id> ...]
-              :coord {...}?}
+              :coord {...}? :readers [view-id ...]}
+
+  `:readers` is the views that deref this sub THIS cascade — the
+  shared-subscription edge (rf2-y23uw); absent when no rendered view read
+  it (e.g. a handler-side or upstream-input sub no view directly derefs).
 
   Order preserved from `subs-ran` within each level. nil-safe: a sub
   absent from the topology degrades to Level 1 with no inputs / no
-  coord. Both args may be nil."
-  [subs-ran topology]
-  (let [topo (or topology {})]
-    (reduce
-      (fn [acc sub-run]
-        (let [sub-id     (:sub-id sub-run)
-              topo-entry (get topo sub-id)
-              changed?   (boolean (:value-changed? sub-run))
-              coord      (topology-coord topo-entry)]
-          (if (level-1? topo-entry)
-            (update acc :level-1 conj
-                    (cond-> {:sub-id sub-id :changed? changed?}
-                      coord (assoc :coord coord)))
-            (update acc :level-2 conj
-                    (cond-> {:sub-id sub-id :changed? changed?
-                             :inputs (vec (:inputs topo-entry))}
-                      coord (assoc :coord coord))))))
-      {:level-1 [] :level-2 []}
-      (or subs-ran []))))
+  coord; absent / nil `readers` simply omits the slot. All args may be
+  nil."
+  ([subs-ran topology] (partition-subs-by-level subs-ran topology nil))
+  ([subs-ran topology readers]
+   (let [topo (or topology {})
+         rdrs (or readers {})]
+     (reduce
+       (fn [acc sub-run]
+         (let [sub-id     (:sub-id sub-run)
+               topo-entry (get topo sub-id)
+               changed?   (boolean (:value-changed? sub-run))
+               coord      (topology-coord topo-entry)
+               sub-rdrs   (get rdrs sub-id)]
+           (if (level-1? topo-entry)
+             (update acc :level-1 conj
+                     (cond-> {:sub-id sub-id :changed? changed?}
+                       coord         (assoc :coord coord)
+                       (seq sub-rdrs) (assoc :readers (vec sub-rdrs))))
+             (update acc :level-2 conj
+                     (cond-> {:sub-id sub-id :changed? changed?
+                              :inputs (vec (:inputs topo-entry))}
+                       coord         (assoc :coord coord)
+                       (seq sub-rdrs) (assoc :readers (vec sub-rdrs)))))))
+       {:level-1 [] :level-2 []}
+       (or subs-ran [])))))
 
 ;; ---- record projection ----------------------------------------------------
 
@@ -305,13 +371,15 @@
          flows-comp    (count (get grouped :rf.flow/computed []))
          flows-skipped (count (get grouped :rf.flow/skip []))
          changed-set   (changed-sub-id-set ran)
-         {:keys [level-1 level-2]} (partition-subs-by-level ran topology)
+         readers       (sub-readers trace-events)
+         {:keys [level-1 level-2]} (partition-subs-by-level ran topology readers)
          v-rows        (view-rows trace-events changed-set)]
      {:subs-ran        ran
       :subs-skipped    skipped
       :views-rendered  renders
       :level-1-subs    level-1
       :level-2-subs    level-2
+      :sub-readers     readers
       :view-rows       v-rows
       :counts          {:subs-ran         (count ran)
                         :subs-skipped     (count skipped)

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -10,18 +10,22 @@
 
       Level 1 Subscriptions   one row per Level 1 sub that ran this
                               cascade. Columns:
-                                name | changed | code
+                                name | changed | read by | code
                               `changed` is the accent flag from the
-                              `:value-changed?` projection; `code` is a
+                              `:value-changed?` projection; `read by`
+                              (rf2-y23uw) lists the views that deref this
+                              sub this cascade — the shared-subscription
+                              edge from `:sub-readers`; `code` is a
                               jump-to-source [code] chip from the static
                               topology coord.
 
       Level 2+ Subscriptions  one row per composed sub that ran.
                               Columns:
-                                name | changed | inputs | code
+                                name | changed | inputs | read by | code
                               `inputs` lists the input-sub names ONE PER
                               LINE (the static `:<-` chain from
-                              `sub-topology`).
+                              `sub-topology`); `read by` is the shared-sub
+                              edge as in Level 1.
 
       Views                   one row per view render / unmount this
                               cascade. Columns:
@@ -370,20 +374,41 @@
   (when (> total shown)
     [:div {:style overflow-style} (str "+" (- total shown) " more")]))
 
+(defn- readers-cell
+  "The `read by` column (rf2-y23uw) — the views that deref THIS sub this
+  cascade (the shared-subscription edge), one per line, honestly
+  truncated with `+N more`. A muted em-dash when no rendered view read
+  the sub (e.g. an upstream-input sub a composed sub reads but no view
+  derefs directly)."
+  [readers]
+  (let [n     (count readers)
+        shown (take max-inline-list readers)]
+    [:td {:style td-style}
+     (if (seq readers)
+       (into [:div {:style {:display "flex" :flex-direction "column"
+                            :gap "1px"}}]
+             (concat
+               (for [[i v] (map-indexed vector shown)]
+                 ^{:key i} [:span {:style {:color (:text-secondary tokens)}}
+                            (format-id v)])
+               [(overflow-line max-inline-list n)]))
+       [:span {:style changed-no-style} "—"])]))
+
 ;; ---- table 1: Level 1 subs --------------------------------------------
 
 (defn- level-1-row
-  "One Level 1 sub row: name | changed | code.
+  "One Level 1 sub row: name | changed | read by | code.
 
   testids:
     row       `rf-causa-reactive-l1-row-<slug>`
     code chip `rf-causa-reactive-l1-code-<slug>`"
-  [{:keys [sub-id changed? coord]}]
+  [{:keys [sub-id changed? coord readers]}]
   (let [slug (id-slug sub-id)]
     [:tr {:data-testid (str "rf-causa-reactive-l1-row-" slug)
           :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
      [:td {:style name-cell-style} (format-id sub-id)]
      (changed-cell changed?)
+     (readers-cell readers)
      (code-cell coord (str "rf-causa-reactive-l1-code-" slug))]))
 
 (defn- level-1-section
@@ -399,6 +424,7 @@
          [:tr
           [:th {:style th-style} "name"]
           [:th {:style th-style} "changed"]
+          [:th {:style th-style} "read by"]
           [:th {:style th-style} "code"]]]
         (into [:tbody]
               (concat
@@ -406,7 +432,7 @@
                   (with-meta (level-1-row r) {:key i}))
                 (when (> n max-table-rows)
                   [[:tr {:data-testid "rf-causa-reactive-l1-overflow"}
-                    [:td {:colSpan 3 :style (assoc td-style :padding-left "0")}
+                    [:td {:colSpan 4 :style (assoc td-style :padding-left "0")}
                      (overflow-line max-table-rows n)]]])))]
        (empty-row "rf-causa-reactive-l1-empty" "(no Level 1 subs ran)"))]))
 
@@ -431,18 +457,19 @@
        [:span {:style changed-no-style} "—"])]))
 
 (defn- level-2-row
-  "One Level 2+ sub row: name | changed | inputs | code.
+  "One Level 2+ sub row: name | changed | inputs | read by | code.
 
   testids:
     row       `rf-causa-reactive-l2-row-<slug>`
     code chip `rf-causa-reactive-l2-code-<slug>`"
-  [{:keys [sub-id changed? inputs coord]}]
+  [{:keys [sub-id changed? inputs coord readers]}]
   (let [slug (id-slug sub-id)]
     [:tr {:data-testid (str "rf-causa-reactive-l2-row-" slug)
           :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
      [:td {:style name-cell-style} (format-id sub-id)]
      (changed-cell changed?)
      (inputs-cell inputs)
+     (readers-cell readers)
      (code-cell coord (str "rf-causa-reactive-l2-code-" slug))]))
 
 (defn- level-2-section
@@ -459,6 +486,7 @@
           [:th {:style th-style} "name"]
           [:th {:style th-style} "changed"]
           [:th {:style th-style} "inputs"]
+          [:th {:style th-style} "read by"]
           [:th {:style th-style} "code"]]]
         (into [:tbody]
               (concat
@@ -466,7 +494,7 @@
                   (with-meta (level-2-row r) {:key i}))
                 (when (> n max-table-rows)
                   [[:tr {:data-testid "rf-causa-reactive-l2-overflow"}
-                    [:td {:colSpan 4 :style (assoc td-style :padding-left "0")}
+                    [:td {:colSpan 5 :style (assoc td-style :padding-left "0")}
                      (overflow-line max-table-rows n)]]])))]
        (empty-row "rf-causa-reactive-l2-empty" "(no Level 2+ subs ran)"))]))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
@@ -277,6 +277,63 @@
       (is (nil? (-> level-1 first :coord))
           "no coord when topology absent"))))
 
+;; ---- shared-subscription edges (rf2-y23uw) ----------------------------
+
+(deftest sub-readers-maps-each-sub-to-views-that-read-it
+  (testing "rf2-y23uw — sub-readers builds {sub-id [view-id ...]}: every
+            view that derefs a sub this cascade lands in that sub's reader
+            list (the shared-sub edge)."
+    (let [events [(rendered-ev :v/a false [[:s/x] [:s/y]])
+                  (rendered-ev :v/b false [[:s/x]])
+                  (rendered-ev :v/c false [[:s/z]])]
+          readers (subs/sub-readers events)]
+      (is (= [:v/a :v/b] (:s/x readers))
+          ":s/x is read by both v/a and v/b (shared sub)")
+      (is (= [:v/a] (:s/y readers)))
+      (is (= [:v/c] (:s/z readers))))))
+
+(deftest sub-readers-preserves-first-seen-view-order-and-dedupes
+  (testing "rf2-y23uw — a view that re-derefs the same sub, or two ops for
+            the same view-id, contribute the view-id once; reader order is
+            first-seen across the trace."
+    (let [events [(rendered-ev :v/b false [[:s/x] [:s/x]]) ; re-deref same sub
+                  (rendered-ev :v/a false [[:s/x]])
+                  (rendered-ev :v/b false [[:s/x]])]        ; same view again
+          readers (subs/sub-readers events)]
+      (is (= [:v/b :v/a] (:s/x readers))
+          "first-seen order, de-duplicated"))))
+
+(deftest sub-readers-nil-safe-and-skips-non-view-ops
+  (testing "rf2-y23uw — nil-safe; non-view ops, ops without :view-id, and
+            structural renders (no :deref-subs) contribute no edges."
+    (is (= {} (subs/sub-readers nil)))
+    (is (= {} (subs/sub-readers [])))
+    (let [events [{:operation :rf.sub/run :tags {:rf.sub/id :s/x}}
+                  (rendered-ev :v/structural false nil)
+                  (rendered-ev :v/ok false [[:s/x]])]
+          readers (subs/sub-readers events)]
+      (is (= {:s/x [:v/ok]} readers)
+          "only the rendered view that derefs a sub contributes an edge"))))
+
+(deftest partition-attaches-readers-to-sub-rows
+  (testing "rf2-y23uw — partition-subs-by-level attaches each sub's
+            :readers (which views read it) onto the L1 / L2 row; absent
+            when no view read the sub."
+    (let [readers {:cart/state [:cart/Header :cart/Summary]
+                   :cart/total [:cart/Summary]}
+          {:keys [level-1 level-2]}
+          (subs/partition-subs-by-level
+            [(sub-run+ :cart/state true true)
+             (sub-run+ :cart/items true false) ; no reader → :readers absent
+             (sub-run+ :cart/total true true)]
+            topology readers)]
+      (is (= [:cart/Header :cart/Summary] (-> level-1 first :readers))
+          ":cart/state's readers ride its L1 row")
+      (is (not (contains? (second level-1) :readers))
+          ":cart/items has no reader → :readers slot omitted")
+      (is (= [:cart/Summary] (-> level-2 first :readers))
+          ":cart/total's reader rides its L2 row"))))
+
 ;; ---- project-record composes the phase-B slots ------------------------
 
 (deftest project-record-emits-level-and-view-slots
@@ -295,7 +352,12 @@
           ":cart/Summary derefs :cart/total which changed → reactive")
       (is (= [:cart/total] (-> p :view-rows first :reason :subs)))
       (is (= :unmount (-> p :view-rows second :action)))
-      (is (= 2 (-> p :counts :view-rows))))))
+      (is (= 2 (-> p :counts :view-rows)))
+      ;; rf2-y23uw — shared-sub edges thread through project-record.
+      (is (= {:cart/total [:cart/Summary]} (:sub-readers p))
+          ":sub-readers maps :cart/total → the views that read it")
+      (is (= [:cart/Summary] (-> p :level-2-subs first :readers))
+          ":cart/total's L2 row carries its :readers"))))
 
 (deftest project-record-degrades-without-topology
   (testing "rf2-8ve8z — nil topology: every sub falls to Level 1; the

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -168,6 +168,29 @@
         (is (re-find #":cart/state" row-text) "input :cart/state listed")
         (is (re-find #":cart/items" row-text) "input :cart/items listed")))))
 
+(deftest sub-row-renders-readers-shared-sub-edge
+  (testing "rf2-y23uw — a sub row's `read by` column lists the views that
+            deref it this cascade (the shared-subscription edge); a sub no
+            view read shows a muted placeholder, not the views."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :view-rows []
+       :level-1-subs [{:sub-id :cart/state :changed? true
+                       :readers [:cart/Header :cart/Summary]}]
+       :level-2-subs [{:sub-id :cart/total :changed? false
+                       :inputs [:cart/state]}]}) ; no readers → placeholder
+    (let [tree (view/reactive-panel)
+          l1-text (text-of tree "rf-causa-reactive-l1-row-_cart_state")
+          l2-text (text-of tree "rf-causa-reactive-l2-row-_cart_total")]
+      (is (re-find #":cart/Header" l1-text)
+          "shared-sub reader :cart/Header listed in the L1 `read by` column")
+      (is (re-find #":cart/Summary" l1-text)
+          "shared-sub reader :cart/Summary listed")
+      (is (not (re-find #":cart/Header|:cart/Summary" l2-text))
+          ":cart/total has no readers → no view names in its `read by` column"))))
+
 ;; ---- view action + reason (rf2-8ve8z) ---------------------------------
 
 (deftest view-row-reactive-reason-lists-changed-subs


### PR DESCRIPTION
## Spec-vs-live gap & STEP-1 findings

Bead rf2-y23uw claimed `:rf.view/rendered` is missing its spec'd `:deref-subs` in the live build. **Verification shows the premise is stale, not a real substrate gap.**

- **Never-implemented vs migration-dropped:** Neither. `:rf.view/deref-subs` was **fully implemented** in PR #1941 (rf2-9hoos) and **carried intact** through the `:rf.*` migration (#1973). It is emitted today.
- **Does a deref-capture mechanism exist?** Yes — fully. `re-frame.views/*view-deref-sink*` (a per-render volatile bound by `build-frame-aware-view`), pushed by `re-frame.subs/subscribe` via the `:views/record-view-deref!` late-bind hook (every deref, hit and miss), read back after the render and stamped onto `:rf.view/rendered` as `:rf.view/deref-subs`. The whole surface is `interop/debug-enabled?`-gated (elision-probe pinned).
- **Spec 009** already documents `:rf.view/deref-subs` (`[[query-id args] …]`, first-seen order, absent on a pure structural render) and the `:rf.view/rendered-cap-reached` marker (100/cascade). Impl matches spec — **no 009 edit needed.**
- **Why the sample looked empty:** the bead's sample was a **mount** of a view that derefs no subs → `:deref-subs` correctly absent by spec (`(seq deref-subs)` guard). The substrate-agnostic `views.cljs` wrapper emits it for all three substrates (the React-hook spine's `make-wrap-view` only adds source-coord + unmount sentinel on top).
- **Causa feature (1)** — per-view reactive-vs-parent reason — already exists (`reactive_panel_subs/compute-view-reason` intersects `:rf.view/deref-subs` with the cascade's `:value-changed?` subs). Done + tested.

## What this PR adds — Causa feature (2): shared-subscription detection

The one genuine outstanding feature ("which views read sub X") did not exist. Added as a **pure consumer** over the already-emitted per-view read-sets:

- `sub-readers` builds `{sub-id [view-id ...]}` from each cascade `:rf.view/rendered` op's `:rf.view/deref-subs` (first-seen order, de-duplicated, nil-safe).
- `partition-subs-by-level` attaches each sub's `:readers`; `project-record` exposes `:sub-readers` and threads readers onto every L1/L2 sub row.
- The Views panel renders a **"read by" column** on the Level 1 / Level 2+ sub tables (one view per line, `+N more` overflow; muted `—` when no rendered view read the sub).

No new instrumentation — the substrate side was already complete.

## Gates

- `npx shadow-cljs compile node-test` (clean recompile) → 988 files, 0 warnings; `node out/node-test.js` → **4127 tests / 12604 assertions, 0 failures** (5 new tests / 15 assertions).
- `npm run test:causa-feature-gate` → **13 scenarios, 0 failures, 13 matrix rows.**

Cross-ref: rf2-y23uw.