### PR TITLE
fix(ssr-ring): plug streaming-redirect frame leak; add error-view; trim dead code (rf2-ee38b.11)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -32,39 +32,22 @@
 
   ---- file split (rf2-pjsrc, rf2-zkca8.1) ----
 
-  Pre-split this namespace was 747 LoC carrying nine independent
-  concerns enumerated by its own `;; ----` banners. After the rf2-pjsrc
-  split it became a thin façade over eight flat sub-namespaces; the
-  rf2-zkca8.1 recombine pass merged the two single-consumer-trivia
-  leaves back here / into `pipeline`. Current sub-namespaces:
-
-    - `re-frame.ssr.ring.cookie`           — RFC 6265 Set-Cookie wire
-                                             serialisation.
-    - `re-frame.ssr.ring.headers`          — pair-vec → Ring header-map
-                                             collapse, multi-valued
-                                             headers, content-type
-                                             default.
-    - `re-frame.ssr.ring.shell`            — `default-html-shell`.
-    - `re-frame.ssr.ring.payload`          — `build-payload`,
-                                             `resolve-version`.
-    - `re-frame.ssr.ring.lifecycle`        — frame teardown, root-view /
-                                             head resolution, on-create
-                                             enrichment.
-    - `re-frame.ssr.ring.pipeline`         — `setup-request-frame!` +
-                                             `build-full-response` +
-                                             `ssr-response->ring-response`
-                                             (the 4-step request pipeline
-                                             and its accumulator →
-                                             Ring-map materialiser).
-
-  `default-on-error` + `handler-defaults` + `validate-handler-opts!`
-  live here (the pre-rf2-zkca8.1 `handler-defaults` sub-ns was 45 L
-  and had `ring` as its only consumer; folding them in keeps the
-  handler-constructor reading top-down as one concept).
+  This namespace is a thin façade over flat sub-namespaces, one concern
+  each (see the `:require` list): `cookie` (RFC 6265 Set-Cookie),
+  `headers` (pair-vec → Ring header-map collapse + content-type
+  default), `shell` (`default-html-shell` + shared envelope helpers),
+  `payload` (`build-payload` / `resolve-version`), `lifecycle` (frame
+  teardown, root-view / head resolution, required-opt validation,
+  `default-on-error`), `pipeline` (the 4-step request pipeline +
+  accumulator → Ring-map materialiser), `trust` (trusted-shell-hook
+  contract), `streaming` (chunked-HTTP counterpart). `handler-defaults`
+  + `validate-handler-opts!` live here so the handler constructor reads
+  top-down as one concept.
 
   This façade re-exposes the public surface (`ssr-handler`,
-  `ssr-middleware`, `cookie->set-cookie-header`, `default-html-shell`)
-  and wires the sub-namespaces into the request lifecycle.
+  `ssr-middleware`, `stream-handler`, `cookie->set-cookie-header`,
+  `default-html-shell`) and wires the sub-namespaces into the request
+  lifecycle.
 
   Public surface:
 
@@ -134,31 +117,11 @@
 ;;
 ;; Pre-rf2-zkca8.1 these lived in `re-frame.ssr.ring.handler-defaults`
 ;; (45 L, one consumer — this ns). Recombined here so the handler
-;; constructor reads top-down as one concept.
+;; constructor reads top-down as one concept. `default-on-error` is
+;; re-exported from `lifecycle` (shared with `stream-handler` so the
+;; rf2-kzvwq topology-leak contract lives in one place).
 
-(defn default-on-error
-  "Minimal 500 response used when the caller doesn't supply `:on-error`.
-  The SSR runtime's error projector handles trace-emitted errors
-  during drain; this hook covers exceptions the projector can't see
-  (Ring-layer throws, render-time CLJ exceptions).
-
-  rf2-kzvwq / security audit 2026-05-14 §P2.1 — the body MUST NOT leak
-  the throwable's message. `.getMessage` carries internal topology that
-  has no business reaching the wire: JDBC URLs (host, port, database
-  name), file paths under deploy roots, partial SQL fragments, server-
-  internal class names. Pre-fix, an attacker who could trigger any
-  unhandled JVM exception would see e.g.
-  `\"SSR error: Connection refused: jdbc:postgresql://internal-db.svc:5432/auth\"`
-  on the public wire — direct topology disclosure.
-
-  We now emit a fixed generic body matching the projector's
-  `fallback-public-error` shape. Apps that want dev-mode detail
-  override via `:on-error` (the recommended pattern is
-  `(if dev? log-and-detail log-only-quietly)`)."
-  [_request ^Throwable _t]
-  {:status  500
-   :headers {"Content-Type" "text/plain; charset=utf-8"}
-   :body    "Internal error"})
+(def default-on-error lifecycle/default-on-error)
 
 (def handler-defaults
   {:emit-hash?   true
@@ -197,20 +160,14 @@
   a structural error (map / vector / symbol) surfaces here as
   `:rf.error/ssr-trusted-shell-opt-invalid`. The framework names the
   trust boundary; the content trust itself remains the caller's per
-  Spec 011 §Trusted shell hook contract."
-  [{:keys [on-create root-view] :as opts}]
-  (when-not on-create
-    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
-                    {:rf.error/id :rf.error/ssr-ring-missing-on-create
-                     :where    'rf.ssr/ssr-handler
-                     :reason   "ssr-handler requires :on-create (an event vector)"
-                     :recovery :no-recovery})))
-  (when-not root-view
-    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
-                    {:rf.error/id :rf.error/ssr-ring-missing-root-view
-                     :where    'rf.ssr/ssr-handler
-                     :reason   "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"
-                     :recovery :no-recovery})))
+  Spec 011 §Trusted shell hook contract.
+
+  The required-opt presence checks (`:on-create` / `:root-view`) and
+  the policy / trusted-shell checks are shared with `stream-handler`
+  (`lifecycle/validate-required-opts!` + `payload-policy` + `trust`) so
+  both handlers fail closed at the same boundary."
+  [opts]
+  (lifecycle/validate-required-opts! opts)
   (payload-policy/validate-policy-opts! opts)
   (trust/validate-trusted-shell-opts! opts))
 
@@ -270,12 +227,27 @@
                       \"text/html; charset=utf-8\" (matches the SSR
                       runtime's default in the response accumulator).
     :on-error       — (request throwable) → ring-response. Called when
-                      the per-request frame setup OR render throws.
-                      Defaults to a minimal 500 response. The SSR
-                      runtime's error projector handles trace-emitted
-                      errors during drain; this hook covers the
-                      exceptions the projector can't see (Ring-layer
-                      throws, render-time CLJ exceptions).
+                      the per-request frame setup OR a Ring-layer /
+                      transport failure the projector can't see throws.
+                      Defaults to a minimal 500 response. NOTE: normal
+                      projected render/drain errors do NOT reach this
+                      hook — they flow through the error projector and
+                      render `:error-view` / the default error template
+                      (see below). `:on-error` is the last-resort
+                      transport-failure net.
+    :error-view     — (optional) the projected-error page body (Spec 011
+                      §Server error projection step 5). Either a
+                      registered-view keyword (resolved as
+                      `[error-view public-error]` — the view receives
+                      the public-error map as its single prop) OR a
+                      1-arity fn `(public-error) → hiccup`. Rendered
+                      through the standard SSR emitter so the public-
+                      error map flows through position-appropriate
+                      escaping and the app's own styling. When absent,
+                      the host emits a minimal default error template.
+                      A buggy `:error-view` falls back to the default
+                      template (the error boundary cannot be bypassed
+                      by a bug in the caller's error page).
 
   Trusted shell-hook opts (per Spec 011 §Trusted shell hook contract,
   rf2-o6ndb) — four optional strings the default shell injects RAW

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/headers.clj
@@ -25,23 +25,6 @@
       (string? existing)     (assoc m k [existing v])
       (vector? existing)     (assoc m k (conj existing v)))))
 
-(defn headers->ring-map
-  "Collapse an ordered vec-of-[name value] pairs into Ring's
-  `{name string-or-vec}` shape, preserving the multi-valued case.
-
-  Ordering note (audit rf2-asmj1 R9 / cluster rf2-sljs1) — the
-  PER-NAME ordering of multi-valued headers (e.g. multiple `Set-Cookie`
-  entries) is preserved by `merge-pair-into-header-map`'s `conj` onto
-  the existing vector. The ACROSS-NAME ordering (the iteration order
-  Ring's downstream wire-writer sees when it walks the map's keys) is
-  the JDK's HAMT iteration order — stable per Clojure's persistent-map
-  contract but not first-seen-pair order. Ring servers don't promise
-  cross-name header order on the wire either; debug logs that compare
-  serialised output across requests should sort the keys before
-  diffing."
-  [pairs]
-  (reduce merge-pair-into-header-map {} pairs))
-
 (defn append-set-cookies
   "For every cookie map in the response's :cookies vector, append one
   Set-Cookie header to the headers map. Returns the updated headers
@@ -54,41 +37,26 @@
     headers-map
     cookies))
 
-(defn ensure-content-type
-  "If the response's header pairs already declare Content-Type
-  (case-insensitive), return them unchanged; otherwise append a
-  pair carrying `content-type`. Pure helper.
-
-  rf2-depii — the prior check looked up `\"content-type\"` /
-  `\"Content-Type\"` only, missing every other case variant
-  (`\"CONTENT-TYPE\"`, `\"CoNtEnT-TyPe\"`, …) the caller might supply.
-  An existing mixed-case header would slip past and the helper would
-  duplicate the Content-Type, breaking Ring's multi-valued-header
-  collapse downstream. We now lower-case every pair's name once and
-  scan the lower-cased set — true case-insensitive match per RFC 7230
-  §3.2 (header names are tokens; tokens are case-insensitive)."
-  [pairs content-type]
-  (let [has-ct? (some (fn [[k _v]]
-                        (= "content-type"
-                           (str/lower-case (str k))))
-                      pairs)]
-    (if has-ct?
-      pairs
-      (conj (vec pairs) ["Content-Type" content-type]))))
-
 (defn headers->ring-map+default-content-type
-  "Single-pass equivalent of `(-> pairs (ensure-content-type ct)
-  headers->ring-map)` (rf2-uj9z8). Pre-fix the two helpers each
-  walked the pairs vector — `ensure-content-type` lower-cased every
-  name to scan for an existing `Content-Type`, then `headers->ring-map`
-  re-walked the same pairs to fold them into the Ring header map. The
-  combined form walks once: it folds each pair into the accumulator
-  AND lower-cases each name once to flag whether `Content-Type` was
-  seen, appending the default at the end iff not.
+  "Collapse an ordered vec-of-[name value] pairs into Ring's
+  `{name string-or-vec}` shape, defaulting `Content-Type` to
+  `content-type` (case-insensitive) in the SAME single pass when the
+  pairs don't already declare one (rf2-uj9z8). Folds each pair into the
+  accumulator AND lower-cases each name once to flag whether
+  `Content-Type` was seen, appending the default at the end iff not and
+  iff `content-type` is non-nil.
 
-  Behaviour is identical to the two-step composition; the no-default
-  path (caller didn't supply `content-type`) is a straight
-  `headers->ring-map`."
+  Case-insensitive Content-Type detection (rf2-depii) covers every
+  casing variant (`CONTENT-TYPE`, `CoNtEnT-TyPe`, …) per RFC 7230 §3.2
+  (header names are tokens; tokens are case-insensitive) — a mixed-case
+  caller header must NOT get a duplicate default appended.
+
+  Ordering note (audit rf2-asmj1 R9 / cluster rf2-sljs1) — the PER-NAME
+  ordering of multi-valued headers (multiple `Set-Cookie` entries) is
+  preserved by `merge-pair-into-header-map`'s `conj`. The ACROSS-NAME
+  ordering is the JDK's HAMT iteration order — stable but not first-seen
+  order; Ring servers don't promise cross-name header order on the wire
+  either."
   [pairs content-type]
   (let [step (fn [[m saw-ct?] [k v :as pair]]
                [(merge-pair-into-header-map m pair)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -25,6 +25,27 @@
 
 (set! *warn-on-reflection* true)
 
+(defn default-on-error
+  "Minimal 500 response used when a handler caller doesn't supply
+  `:on-error`. Shared by `ssr-handler` AND `stream-handler` so the
+  topology-leak contract below lives in exactly one place.
+
+  The SSR runtime's error projector handles trace-emitted errors during
+  drain; this hook covers exceptions the projector can't see (Ring-layer
+  throws, render-time CLJ exceptions, writer-thread-pre-spawn throws).
+
+  rf2-kzvwq / security audit 2026-05-14 §P2.1 — the body MUST NOT leak
+  the throwable's message. `.getMessage` carries internal topology that
+  has no business reaching the wire: JDBC URLs (host, port, database
+  name), file paths under deploy roots, partial SQL fragments, server-
+  internal class names. We emit a fixed generic body matching the
+  projector's `fallback-public-error` shape. Apps that want dev-mode
+  detail override via `:on-error`."
+  [_request _t]
+  {:status  500
+   :headers {"Content-Type" "text/plain; charset=utf-8"}
+   :body    "Internal error"})
+
 (defn destroy-frame-quietly!
   "Best-effort frame teardown. Exceptions during destroy must not mask
   a real handler error; swallow + emit a `:warning` trace is preferred
@@ -107,9 +128,9 @@
 
 (defn validate-on-create!
   "Validate the caller's :on-create event vector and return it verbatim.
-  `:on-create` is required (per `handler-defaults/validate-handler-opts!`),
-  so a non-vector here is a programmer error — surface it as an
-  ex-info rather than letting `reg-frame` produce an obscure failure
+  `:on-create` is required (per `validate-required-opts!`), so a
+  non-vector here is a programmer error — surface it as an ex-info
+  rather than letting `reg-frame` produce an obscure failure
   downstream. Audit rf2-cegm7 A3 / rf2-j54ee."
   [on-create]
   (if (vector? on-create)
@@ -120,3 +141,37 @@
                      :reason   ":on-create must be a vector (event)"
                      :received on-create
                      :recovery :no-recovery}))))
+
+(defn validate-required-opts!
+  "Throw a structured `:rf.error/ssr-ring-missing-*` ex-info when a
+  caller omits a required handler opt (`:on-create` / `:root-view`).
+
+  Shared by `re-frame.ssr.ring/ssr-handler` AND
+  `re-frame.ssr.ring.streaming/stream-handler` so both fail closed at
+  handler-construction time (boot) rather than at first request — the
+  canonical fail-closed pattern (rf2-gtgf9, extended here to the two
+  required opts). A streaming handler built without `:on-create` would
+  otherwise fail per-request inside `setup-request-frame!`; one built
+  without `:root-view` would fail inside the writer thread, truncating
+  the chunked response. Both must refuse to construct, exactly as the
+  non-streaming handler does. Returns `opts` unchanged on success.
+
+  Sibling-validator placement (not in the `ring` façade): `streaming`
+  already requires `lifecycle` and the `ring` façade does too, so
+  hosting the check here avoids the circular-require between the
+  streaming sub-namespace and the façade — same rationale as
+  `trust`/`payload-policy`."
+  [{:keys [on-create root-view] :as opts}]
+  (when-not on-create
+    (throw (ex-info ":rf.error/ssr-ring-missing-on-create"
+                    {:rf.error/id :rf.error/ssr-ring-missing-on-create
+                     :where    'rf.ssr/ssr-handler
+                     :reason   "ssr-handler requires :on-create (an event vector)"
+                     :recovery :no-recovery})))
+  (when-not root-view
+    (throw (ex-info ":rf.error/ssr-ring-missing-root-view"
+                    {:rf.error/id :rf.error/ssr-ring-missing-root-view
+                     :where    'rf.ssr/ssr-handler
+                     :reason   "ssr-handler requires :root-view (a hiccup vector or 0-arity fn)"
+                     :recovery :no-recovery})))
+  opts)

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -41,14 +41,10 @@
        check-version fx still no-ops cleanly on the client when neither
        side has the hook registered (matched value → no mismatch).
 
-  Audit rf2-asmj1 S8 / cluster rf2-l8fi6: prior to this the adapter
-  hard-coded `(or version 1)` inline, which silently disagreed with
-  whatever the client-side `:rf2/runtime-version` hook returned and
-  defeated the version-mismatch check on every host that hadn't passed
-  `:version` explicitly. Threading both sides through the same hook
-  eliminates the silent-divergence trap; the terminal `1` is the v1
-  pattern-protocol stamp, named instead of inlined so the convention
-  travels back to Spec-Schemas via search."
+  Both sides of the wire read `:version` through the same hook so a host
+  that doesn't pass `:version` explicitly still pins a value the client
+  agrees with (the inline `(or version 1)` it replaced silently defeated
+  the version-mismatch check; rf2-asmj1 S8 / rf2-l8fi6)."
   [explicit-version]
   (or explicit-version
       (when-let [f (late-bind/get-fn :rf2/runtime-version)]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -40,7 +40,8 @@
             [re-frame.ssr.html-helpers :as html-helpers]
             [re-frame.ssr.ring.headers :as headers]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
-            [re-frame.ssr.ring.payload :as payload]))
+            [re-frame.ssr.ring.payload :as payload]
+            [re-frame.trace :as trace]))
 
 (set! *warn-on-reflection* true)
 
@@ -54,15 +55,30 @@
   The optional 3-arg form (rf2-uj9z8) accepts a `default-content-type`
   that's stamped onto the Ring header map if (and only if) the response
   pairs don't already carry a Content-Type (case-insensitive). The
-  defaulting happens INSIDE the single header-fold pass — pre-fix the
-  pipeline called `ensure-content-type` over the pairs vector, then
-  `headers->ring-map` re-walked the same pairs to fold them. Single
-  pass now."
+  defaulting happens INSIDE the single header-fold pass
+  (`headers->ring-map+default-content-type`)."
   ([resp body] (ssr-response->ring-response resp body nil))
   ([{:keys [status headers cookies redirect]} body default-content-type]
    (if redirect
      (let [{:keys [location url to] redirect-status :status} redirect
            target (or location url to)]
+       ;; A redirect with no target is a malformed wire response — a
+       ;; 3xx with no `Location` leaves the browser nowhere to go. The
+       ;; runtime accepts a target-less `:rf.server/redirect` (the
+       ;; location is caller-trusted and optional at the fx boundary),
+       ;; so the adapter is the last line: emit a warning trace so the
+       ;; defect is observable rather than silently shipping a broken
+       ;; redirect. We still emit the status (we have no target to
+       ;; invent) — the trace is the signal.
+       (when-not target
+         (trace/emit! :warning :rf.ssr/ssr-redirect-no-target
+                      {:where    :ssr-ring/ssr-response->ring-response
+                       :status   (or redirect-status status 302)
+                       :reason   (str ":rf.server/redirect set :redirect with no "
+                                      ":location/:url/:to — the response carries a "
+                                      "3xx status with no Location header (malformed "
+                                      "redirect; the browser has no target)")
+                       :recovery :warned-and-emitted-statusonly}))
        {:status  (or redirect-status status 302)
         :headers (-> (headers/headers->ring-map+default-content-type
                        headers default-content-type)
@@ -128,20 +144,19 @@
         {:short-circuit (on-error request t)}))))
 
 (defn ^:private render-error-body
-  "Build a minimal HTML body from a public-error map. Used by the
-  render-time projector path (rf2-zwgsv) when `render-to-string`
-  throws and the host can no longer rely on the user's root-view to
-  produce wire bytes. The body is fully escaped through
-  `escape-html` — the public-error's `:message` is caller-controlled
-  (custom projectors may produce arbitrary strings) so we treat it
-  as untrusted-for-HTML.
+  "Build a minimal HTML body from a public-error map — the host's
+  DEFAULT error template (Spec 011 §Server error projection step 5,
+  the \"or the host's default error template\" branch). Used when no
+  caller `:error-view` is registered and `render-to-string` has
+  thrown, so the host can no longer rely on the user's root-view to
+  produce wire bytes. The body is fully escaped through `escape-html`
+  / `escape-attr` — the public-error's `:message`/`:code` are caller-
+  controlled (custom projectors may produce arbitrary strings) so we
+  treat them as untrusted-for-HTML.
 
-  Carries no internal trace detail — Spec 011 §Server error
-  projection §Where sanitisation happens locks the wire surface to
-  the four public-error keys. The internal Throwable already rode
-  the trace bus via `project-render-exception!`'s
-  `trace/emit-error!` call; monitoring listeners see it, the wire
-  does not."
+  Carries no internal trace detail — the wire surface is locked to the
+  public-error keys; the internal Throwable already rode the trace bus
+  via `project-render-exception!`."
   [{:keys [status code message]}]
   (let [status* (or status 500)
         code*   (when code (name code))
@@ -157,6 +172,55 @@
                 " (status " status* ")"
                 "</p>"))
          "</body></html>")))
+
+(defn ^:private resolve-error-body
+  "Resolve the projected-error HTML body (Spec 011 §Server error
+  projection step 5 — \"a registered view (or the host's default error
+  template) … receiving the public-error map as its prop\").
+
+  When the caller supplied an `:error-view` opt, render it through the
+  standard SSR emitter so the public-error map flows through position-
+  appropriate escaping and the app's own styling/shell, instead of the
+  hardcoded minimal `render-error-body`:
+
+    - a keyword → resolved as a registered view: `[error-view public]`
+      (the view receives the public-error map as its single prop),
+    - a 1-arity fn → called with the public-error map, returning hiccup.
+
+  Both paths render via `render-to-string` (no doctype, no hash — the
+  error body is the inner shell body). If the error-view itself throws
+  (a buggy error page must not take down the error response), we fall
+  back to the host default `render-error-body` — the boundary cannot be
+  bypassed by a bug in the caller's error view, mirroring the runtime's
+  projector-throws-→-locked-500 fallback (Spec 011 §Where sanitisation
+  happens). When no `:error-view` is supplied, the default template is
+  used directly."
+  [frame-id error-view public]
+  (if (nil? error-view)
+    (render-error-body public)
+    (try
+      (let [hiccup (cond
+                     (keyword? error-view) [error-view public]
+                     (fn? error-view)      (error-view public)
+                     :else
+                     (throw (ex-info ":rf.error/ssr-ring-invalid-error-view"
+                                     {:rf.error/id :rf.error/ssr-ring-invalid-error-view
+                                      :where    'rf.ssr/ssr-handler
+                                      :reason   ":error-view must be a registered-view keyword or a 1-arity fn"
+                                      :received error-view
+                                      :recovery :no-recovery})))]
+        (rf/with-frame frame-id
+          (ssr/render-to-string hiccup {:doctype? false :emit-hash? false})))
+      (catch Throwable t
+        ;; A buggy error-view must not bypass the error boundary —
+        ;; surface the throw on the trace bus and fall back to the
+        ;; locked host default template.
+        (trace/emit-error! :rf.error/ssr-ring-error-view-failed
+                           {:frame     frame-id
+                            :exception (.getMessage t)
+                            :ex-class  (.getName (class t))
+                            :recovery  :fell-back-to-default-error-template})
+        (render-error-body public)))))
 
 (defn ^:private build-full-response*
   "The non-error path of `build-full-response`. Split into its own fn
@@ -210,14 +274,12 @@
                            :html-attrs  html-attrs
                            :body-attrs  body-attrs)
         html        (html-shell body-html payload-edn shell-opts)]
-    ;; Content-Type defaulting (rf2-uj9z8): pre-fix the pipeline called
-    ;; ensure-content-type over the pairs vector, then
-    ;; ssr-response->ring-response re-walked the same pairs to fold them
-    ;; into the Ring header map — two passes. The 3-arg form folds and
-    ;; defaults in one walk. The SSR runtime defaults [:rf/response
-    ;; :headers] to include content-type so the default is usually a
-    ;; no-op, but we still pass `content-type` through so an opts
-    ;; override and absence-of-default both work.
+    ;; Content-Type defaulting (rf2-uj9z8): the 3-arg form folds the
+    ;; header pairs into the Ring map AND defaults Content-Type in one
+    ;; walk. The SSR runtime defaults [:rf/response :headers] to include
+    ;; content-type so the default is usually a no-op, but we still pass
+    ;; `content-type` through so an opts override and absence-of-default
+    ;; both work.
     (ssr-response->ring-response resp html content-type)))
 
 (defn build-full-response
@@ -286,6 +348,9 @@
                               {:status 500 :code :internal-error
                                :message "Something went wrong"
                                :retryable? false})
-            body-html     (render-error-body public*)
+            ;; Spec 011 §Server error projection step 5: render a
+            ;; caller-registered `:error-view` (receiving the public-
+            ;; error map) when present, else the host default template.
+            body-html     (resolve-error-body frame-id (:error-view opts) public*)
             content-type  (:content-type opts)]
         (ssr-response->ring-response resp* body-html content-type)))))

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/shell.clj
@@ -91,6 +91,48 @@
                                  "security audit 2026-05-14 §P3.4 / rf2-2n5gg")})))
           (recur))))))
 
+;; ---- shared <html> attribute bag (lang fallback) --------------------------
+
+(defn html-attr-bag
+  "Resolve the `<html>` attribute bag from the `:html-attrs` opt with a
+  `:lang` fallback. `:html-attrs` wins; when absent OR omitting `:lang`,
+  the `lang` argument is the fallback (an explicit `:lang` inside
+  `:html-attrs` takes precedence — the bag is used verbatim). Shared by
+  `default-html-shell` and the streaming prefix so the two envelopes
+  can't silently diverge on the lang-fallback rule."
+  [html-attrs lang]
+  (if (seq html-attrs)
+    (cond-> html-attrs
+      (not (contains? html-attrs :lang)) (assoc :lang lang))
+    {:lang lang}))
+
+;; ---- shared hydration-payload <script> envelope (rf2-7ksyr) ---------------
+;;
+;; The id-pinned, `</script>`-escaped payload `<script>` is emitted in
+;; two places — the non-streaming `default-html-shell` and the streaming
+;; final chunk (`re-frame.ssr.ring.streaming`). The escape is security-
+;; load-bearing (rf2-7ksyr); a fix or id change to one path MUST track
+;; the other, so both call this single helper.
+
+(defn payload-script-tag
+  "Build the id-pinned `<script type=\"application/edn\">` carrying the
+  already-`pr-str`'d hydration payload EDN. `payload-edn` is escaped
+  through `html/escape-script-body-string` so a payload containing
+  `</script>` (sourced from any user-controlled string round-tripped
+  through app-db) can't close the envelope — the XSS gate from
+  security audit 2026-05-14 §P1 (rf2-7ksyr). The EDN reader accepts the
+  `\\u003c` escape for `<`, so the payload round-trips through
+  `clojure.edn/read-string` on the client unchanged.
+
+  The id is pinned in `re-frame.ssr.constants/payload-script-id`
+  (`\"__rf_payload\"`) — the contract between this server-side emit and
+  the client bootstrap's `document.getElementById(...)` read (Spec 011
+  §Hydration payload script id, rf2-cegm7 CQ-3 / rf2-j54ee)."
+  [payload-edn]
+  (str "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
+       (html/escape-script-body-string payload-edn)
+       "</script>"))
+
 (defn default-html-shell
   "The default HTML envelope. Returns a string wrapping the rendered
   body in a minimal-but-runnable document. Override via `:html-shell`
@@ -165,35 +207,18 @@
            script-src      "/main.js"
            lang            "en"}}]
   (check-body-end-csp-hosts! body-end csp-script-src-allowlist)
-  (let [;; :html-attrs wins; otherwise fall back to {:lang lang}. An
-        ;; explicit :lang inside :html-attrs takes precedence over the
-        ;; :lang opt without us having to do anything special — the
-        ;; bag is used verbatim.
-        html-attr-bag (if (seq html-attrs)
-                        (cond-> html-attrs
-                          (not (contains? html-attrs :lang)) (assoc :lang lang))
-                        {:lang lang})]
+  (let [attr-bag (html-attr-bag html-attrs lang)]
     (str "<!DOCTYPE html>"
-         "<html" (html/attr-string html-attr-bag) ">"
+         "<html" (html/attr-string attr-bag) ">"
          "<head>"
          "<meta charset=\"utf-8\">"
          (or head "")
          "</head>"
          "<body" (html/attr-string body-attrs) ">"
          "<div id=\"" app-element-id "\">" body-html "</div>"
-         ;; The id is pinned in `re-frame.ssr.constants/payload-script-id`
-         ;; — the contract between this server-side emit and the client-
-         ;; side bootstrap's `document.getElementById(...)` read. Per
-         ;; Spec 011 §Hydration payload script id (rf2-cegm7 CQ-3).
-         "<script id=\"" constants/payload-script-id "\" type=\"application/edn\">"
-         ;; rf2-7ksyr — escape `<` chars in the EDN string so a payload
-         ;; containing `</script>` (sourced from any user-controlled
-         ;; string round-tripped through app-db) can't close the
-         ;; envelope. The EDN reader accepts `<` as the literal
-         ;; escape for `<`, so this round-trips through
-         ;; `clojure.edn/read-string` on the client unchanged.
-         (html/escape-script-body-string payload-edn)
-         "</script>"
+         ;; Shared id-pinned, `</script>`-escaped payload <script>
+         ;; (rf2-7ksyr) — same helper the streaming final chunk uses.
+         (payload-script-tag payload-edn)
          (when script-src
            (str "<script src=\"" script-src "\"></script>"))
          (or body-end "")

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -43,11 +43,11 @@
   forthcoming as host-opt-in)."
   (:require [re-frame.core :as rf]
             [re-frame.ssr :as ssr]
-            [re-frame.ssr.constants :as constants]
             [re-frame.ssr.html-helpers :as html]
             [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.ring.lifecycle :as lifecycle]
             [re-frame.ssr.ring.pipeline :as pipeline]
+            [re-frame.ssr.ring.shell :as shell]
             [re-frame.ssr.ring.trust :as trust]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.trace :as trace])
@@ -71,15 +71,14 @@
 
 (defn default-streaming-prefix
   "The shell prefix flushed as the first chunk. Mirrors the non-streaming
-  `default-html-shell`'s open + head + body-open + app-div-open."
+  `default-html-shell`'s open + head + body-open + app-div-open. Shares
+  the `:html-attrs`/`:lang` fallback with the non-streaming shell via
+  `shell/html-attr-bag` so the two envelopes can't diverge."
   [head-html {:keys [html-attrs body-attrs lang app-element-id]
               :or   {lang "en" app-element-id "app"}}]
-  (let [html-attr-bag (if (seq html-attrs)
-                        (cond-> html-attrs
-                          (not (contains? html-attrs :lang)) (assoc :lang lang))
-                        {:lang lang})]
+  (let [attr-bag (shell/html-attr-bag html-attrs lang)]
     (str "<!DOCTYPE html>"
-         "<html" (html/attr-string html-attr-bag) ">"
+         "<html" (html/attr-string attr-bag) ">"
          "<head>"
          "<meta charset=\"utf-8\">"
          (or head-html "")
@@ -168,12 +167,9 @@
                                :schema-digest  schema-digest
                                :payload-keys   payload-keys
                                :payload-policy payload-policy}))]
-        (write-chunk! out
-                      (str "<script id=\"" constants/payload-script-id
-                           "\" type=\"application/edn\">"
-                           (html/escape-script-body-string
-                             (pr-str final-payload))
-                           "</script>")))
+        ;; Shared id-pinned, `</script>`-escaped payload <script>
+        ;; (rf2-7ksyr) — same helper the non-streaming shell uses.
+        (write-chunk! out (shell/payload-script-tag (pr-str final-payload))))
       ;; Chunk N+3 — shell suffix close.
       (write-chunk! out (default-streaming-suffix opts)))
     (catch Throwable t
@@ -202,11 +198,13 @@
       synchronous :on-create drain),
     - reads the response accumulator; if :redirect is set, short-
       circuits to a non-streamed Location response (Spec 011 §Redirect
-      precedence),
-    - otherwise spawns a streaming writer (same calling thread) that
-      flushes shell → continuations → final payload → close,
-    - destroys the frame in finally so the per-frame side-channels
-      clear (Spec 011 §Per-request frame teardown contract).
+      precedence) AND destroys the per-request frame inline (the writer
+      thread is never spawned on this branch),
+    - otherwise spawns a streaming writer on a daemon thread that
+      flushes shell → continuations → final payload → close, and
+      destroys the frame in that thread's finally so the per-frame
+      side-channels clear (Spec 011 §Per-request frame teardown
+      contract) without blocking the response close.
 
   The response body is a `PipedInputStream` Ring accepts directly; the
   pipe's writer side runs on a daemon thread so Jetty/http-kit/Aleph
@@ -218,28 +216,33 @@
 
     (fn handler [ring-request] ring-response)"
   [raw-opts]
-  ;; Per rf2-gtgf9 — validate the hydration-payload policy at handler-
-  ;; construction time so misconfigured deployments fail at boot rather
-  ;; than at first request. Mirrors `ssr-handler`'s validate-handler-
-  ;; opts! call site in `re-frame.ssr.ring`. Throws
-  ;; `:rf.error/ssr-missing-payload-policy` on absence of both
-  ;; `:payload-keys` and `:payload-policy`.
+  ;; Construction-time validation — identical fail-closed-at-boot
+  ;; contract as `ssr-handler`'s `validate-handler-opts!`. A
+  ;; misconfigured streaming handler MUST refuse to construct, not fail
+  ;; per-request (missing :on-create → per-request 500; missing
+  ;; :root-view → silently-truncated chunked response from the writer
+  ;; thread). The three checks are the same ones the non-streaming
+  ;; handler runs:
+  ;;   - required-opt presence (:on-create / :root-view) per rf2-gtgf9,
+  ;;     shared via `lifecycle/validate-required-opts!`,
+  ;;   - hydration-payload policy (:payload-keys / :payload-policy) per
+  ;;     rf2-gtgf9 — throws `:rf.error/ssr-missing-payload-policy`,
+  ;;   - the four trusted-shell-hook opts are strings (or nil) per
+  ;;     rf2-o6ndb — the streaming prefix/suffix injects these RAW into
+  ;;     the HTML envelope, same trust contract as the non-streaming
+  ;;     `default-html-shell`. Throws
+  ;;     `:rf.error/ssr-trusted-shell-opt-invalid` on a structural
+  ;;     mistake (map / vector / symbol / number).
+  (lifecycle/validate-required-opts! raw-opts)
   (payload-policy/validate-policy-opts! raw-opts)
-  ;; Per rf2-o6ndb — validate the four trusted-shell-hook opts are
-  ;; strings (or nil) at construction time. The streaming prefix/suffix
-  ;; injects these RAW into the rendered HTML envelope, same trust
-  ;; contract as the non-streaming `default-html-shell`. Throws
-  ;; `:rf.error/ssr-trusted-shell-opt-invalid` on a structural-shape
-  ;; mistake (map / vector / symbol / number).
   (trust/validate-trusted-shell-opts! raw-opts)
-  ;; Mirror ssr-handler's defaults + validation so streaming and non-
-  ;; streaming handlers feel symmetric to callers.
+  ;; Mirror ssr-handler's defaults so streaming and non-streaming
+  ;; handlers feel symmetric to callers. `:on-error` reuses the shared
+  ;; `lifecycle/default-on-error` so the rf2-kzvwq topology-leak
+  ;; contract is not silently re-implemented.
   (let [opts        (merge {:emit-hash?   true
                             :content-type "text/html; charset=utf-8"
-                            :on-error     (fn [_req _t]
-                                            {:status  500
-                                             :headers {"Content-Type" "text/plain; charset=utf-8"}
-                                             :body    "Internal error"})}
+                            :on-error     lifecycle/default-on-error}
                            raw-opts)
         {:keys [on-error content-type]} opts]
     (fn ring-handler [request]
@@ -250,8 +253,22 @@
           (try
             (let [resp (ssr/get-response frame-id)]
               (if (some? (:redirect resp))
-                ;; Redirect short-circuits the stream — no chunked body.
-                (pipeline/ssr-response->ring-response resp nil content-type)
+                ;; Redirect short-circuits the stream — no chunked body,
+                ;; so the writer thread (whose `finally` normally tears
+                ;; the frame down) is never spawned. Destroy the per-
+                ;; request frame inline BEFORE returning, or every
+                ;; redirected streaming request leaks the frame + its
+                ;; three side-channel slots (request / response /
+                ;; pending-error-trace) — a per-request leak on auth-
+                ;; gated SSR routes where redirects are common (Spec 011
+                ;; §Per-request frame teardown contract). The 2-arg form
+                ;; (no `content-type`) matches the non-streaming redirect
+                ;; path — a bodiless redirect has no meaningful Content-
+                ;; Type to default.
+                (try
+                  (pipeline/ssr-response->ring-response resp nil)
+                  (finally
+                    (lifecycle/destroy-frame-quietly! frame-id)))
                 ;; Streaming path: build a pipe + spawn the writer thread.
                 ;; 16 KiB pipe buffer — large enough to absorb the shell
                 ;; chunk in one write so the writer thread rarely blocks

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -8,9 +8,12 @@
     3. streaming writer flushes shell → continuations → final payload → close
     4. response body is a PipedInputStream; we drain it into a string
     5. asserts on chunk shapes + final-payload."
-  (:require [clojure.string :as str]
+  (:require [clojure.set]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ssr :as ssr]
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.test-fixture :as tf])
   (:import [java.io InputStream]))
@@ -155,3 +158,92 @@
       (is (str/includes? body "__rf_payload") "final payload emitted")
       (is (not (str/includes? body "data-rf2-suspense-id")) "no boundary markers")
       (is (str/includes? body "</body></html>") "body closes cleanly"))))
+
+;; ===========================================================================
+;; rf2-ee38b.11 — streaming redirect short-circuit MUST destroy the
+;; per-request frame.
+;;
+;; The redirect branch returns BEFORE the writer thread (whose `finally`
+;; tears the frame down on the streaming path) is ever spawned, so the
+;; teardown must happen inline. Pre-fix the redirect branch returned
+;; directly from inside the `try` with no enclosing `finally`, leaking
+;; the per-request frame + its three side-channel slots (request /
+;; response / pending-error-trace) on every redirected streaming request
+;; — a per-request leak on auth-gated SSR routes (login redirects) where
+;; redirects are common. Spec 011 §Per-request frame teardown contract.
+;; ===========================================================================
+
+(deftest stream-handler-redirect-destroys-frame
+  (testing "rf2-ee38b.11: a :rf.server/redirect on the streaming path
+            short-circuits to a Location response AND destroys the per-
+            request frame inline — no frame / side-channel-slot leak.
+            The redirect branch never spawns the writer thread, so the
+            teardown CANNOT defer to the writer's finally."
+    (rf/reg-event-fx :rf.test.stream/redirect
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
+    (rf/reg-view ^{:rf/id :test/should-not-stream} should-not-stream []
+      [:div "should not render under redirect"])
+    (let [handler       (ssr-ring/stream-handler
+                          {:on-create [:rf.test.stream/redirect]
+                           :root-view [:test/should-not-stream]
+                           :payload-policy :rf.ssr.payload/whole-app-db})
+          baseline-fids (disj (frame/frame-ids) :rf/default)
+          response      (handler {:uri "/secret" :request-method :get})]
+      ;; Redirect response shape — status + Location, empty body, no
+      ;; chunked InputStream (a redirect has no streamed body).
+      (is (= 302 (:status response)) "redirect status on the wire")
+      (let [headers (:headers response)
+            loc     (or (get headers "Location") (get headers "location"))]
+        (is (= "/login" loc) "Location header carries the redirect target"))
+      (is (= "" (:body response))
+          "redirect short-circuits the stream — empty body, no InputStream")
+      (is (not (instance? InputStream (:body response)))
+          "redirect body is NOT a streamed pipe — it short-circuits")
+      ;; Teardown — the per-request frame + its request slot MUST be
+      ;; gone immediately after the call (no writer thread to wait on).
+      (let [end-fids (disj (frame/frame-ids) :rf/default)
+            leaked   (clojure.set/difference end-fids baseline-fids)]
+        (is (empty? leaked)
+            (str "the per-request frame MUST be destroyed on the streaming
+                 redirect path — found leaked frame-ids: " (vec leaked))))
+      (doseq [fid (disj (frame/frame-ids) :rf/default)]
+        (is (nil? (ssr/get-request fid))
+            (str "no request slot leaks for frame " fid))))))
+
+(deftest stream-handler-redirect-no-content-type-stamped
+  (testing "rf2-ee38b.11: the streaming redirect path does NOT stamp a
+            default Content-Type on the bodiless 302 — it agrees with the
+            non-streaming redirect path (which passes no default-content-
+            type). A redirect has no body, so a defaulted Content-Type is
+            meaningless; the two handlers must not diverge."
+    (rf/reg-event-fx :rf.test.stream/redirect-ct
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302 :location "/login"}]]}))
+    (rf/reg-view ^{:rf/id :test/redirect-ct-root} redirect-ct-root []
+      [:div "noop"])
+    (let [handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.stream/redirect-ct]
+                      :root-view [:test/redirect-ct-root]
+                      :payload-policy :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/secret" :request-method :get})
+          headers  (:headers response)
+          ct       (or (get headers "Content-Type") (get headers "content-type"))]
+      (is (= 302 (:status response)))
+      ;; The SSR runtime may set a Content-Type in the response
+      ;; accumulator's default headers; the contract under test is that
+      ;; the streaming redirect does not ADD the handler's
+      ;; `:content-type` default on top — it passes the 2-arg form. Pin
+      ;; the agreement: whatever Content-Type rides is the accumulator's,
+      ;; identical to the non-streaming redirect of the same response.
+      (let [ns-handler (ssr-ring/ssr-handler
+                         {:on-create [:rf.test.stream/redirect-ct]
+                          :root-view [:test/redirect-ct-root]
+                          :payload-policy :rf.ssr.payload/whole-app-db})
+            ns-resp    (ns-handler {:uri "/secret" :request-method :get})
+            ns-ct      (or (get (:headers ns-resp) "Content-Type")
+                           (get (:headers ns-resp) "content-type"))]
+        (is (= ct ns-ct)
+            "streaming + non-streaming redirect paths agree on Content-Type")))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -287,6 +287,37 @@
           "redirect short-circuits — no body, no payload script")
       (is (not (str/includes? (:body response) "should not render"))))))
 
+(deftest handler-redirect-no-target-warns
+  (testing "rf2-ee38b.11: a :rf.server/redirect with no :location/:url/:to
+            produces a 3xx with no Location header (malformed redirect —
+            the runtime accepts a target-less redirect since location is
+            caller-trusted/optional at the fx boundary). The adapter is
+            the last line: it emits :rf.ssr/ssr-redirect-no-target so the
+            defect is observable rather than silently shipping a broken
+            redirect."
+    (rf/reg-event-fx :init/redirect-no-target
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/redirect {:status 302}]]}))
+    (rf/reg-view* :pages/noop-rt (fn [] [:div]))
+    (let [traces (atom [])]
+      (rf/register-listener! ::redirect-no-target-watch
+        (fn [ev] (when (= :rf.ssr/ssr-redirect-no-target (:operation ev))
+                   (swap! traces conj ev))))
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create [:init/redirect-no-target]
+                        :root-view [:pages/noop-rt]
+                        :payload-policy :rf.ssr.payload/whole-app-db})
+            response (handler {:uri "/secret" :request-method :get})
+            headers  (:headers response)]
+        (rf/unregister-listener! ::redirect-no-target-watch)
+        (is (= 302 (:status response)) "still emits the redirect status")
+        (is (nil? (or (get headers "Location") (get headers "location")))
+            "no Location header — there is no target to write")
+        (is (seq @traces)
+            ":rf.ssr/ssr-redirect-no-target warning fired so the malformed
+             redirect is observable")))))
+
 ;; ===========================================================================
 ;; ssr-handler — cookies serialise to Set-Cookie headers
 ;; ===========================================================================
@@ -419,6 +450,97 @@
            (HTML-escaped — `escape-html` over the message text)")
       (is (str/includes? (:body response) "teapot")
           "the custom projector's :code rides the wire body."))))
+
+;; ===========================================================================
+;; rf2-ee38b.11 — :error-view caller hook (Spec 011 §Server error
+;; projection step 5 — "a registered view (or the host's default error
+;; template) … receiving the public-error map as its prop")
+;; ===========================================================================
+
+(deftest handler-render-error-renders-registered-error-view
+  (testing "rf2-ee38b.11: a caller-registered :error-view (keyword) is
+            rendered through the SSR emitter, receiving the public-error
+            map as its single prop — replacing the hardcoded default
+            error template. The public-error's :message rides the wire
+            HTML-escaped (the emitter escapes text-node children)."
+    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/broken-ev
+      (fn [] (throw (ex-info "boom-internal" {}))))
+    (rf/reg-view* :myapp/error-page
+      (fn [{:keys [status code message]}]
+        [:div.error-page
+         [:h1 "Custom error page"]
+         [:p.code (name code)]
+         [:p.status (str status)]
+         [:p.msg message]]))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create  [:init/ok]
+                      :root-view  [:pages/broken-ev]
+                      :error-view :myapp/error-page
+                      :payload-policy :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/broken" :request-method :get})
+          body     (:body response)]
+      (is (= 500 (:status response)) "projector status rides the response")
+      (is (str/includes? body "Custom error page")
+          "the caller's :error-view rendered, not the default template")
+      (is (str/includes? body "class=\"error-page\"")
+          "the error view's own markup / styling reaches the wire")
+      (is (str/includes? body "internal-error")
+          "the public-error :code flows to the error view")
+      (is (str/includes? body "Something went wrong")
+          "the public-error :message flows to the error view")
+      (is (not (str/includes? body "boom-internal"))
+          "rf2-kzvwq: the throwable message text MUST NOT reach the wire"))))
+
+(deftest handler-render-error-view-as-fn
+  (testing "rf2-ee38b.11: :error-view accepts a 1-arity fn receiving the
+            public-error map and returning hiccup"
+    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/broken-evf
+      (fn [] (throw (ex-info "boom" {}))))
+    (let [handler  (ssr-ring/ssr-handler
+                     {:on-create  [:init/ok]
+                      :root-view  [:pages/broken-evf]
+                      :error-view (fn [public]
+                                    [:section.fn-error
+                                     [:h2 "fn error view"]
+                                     [:span (:message public)]])
+                      :payload-policy :rf.ssr.payload/whole-app-db})
+          response (handler {:uri "/broken" :request-method :get})
+          body     (:body response)]
+      (is (= 500 (:status response)))
+      (is (str/includes? body "fn error view") "fn-form error view rendered")
+      (is (str/includes? body "class=\"fn-error\"") "fn view markup on the wire"))))
+
+(deftest handler-error-view-throw-falls-back-to-default-template
+  (testing "rf2-ee38b.11: a buggy :error-view (itself throwing) MUST NOT
+            bypass the error boundary — the host falls back to the
+            default error template and emits
+            :rf.error/ssr-ring-error-view-failed on the trace bus."
+    (rf/reg-event-fx :init/ok {:platforms #{:server}} (fn [_ _] {}))
+    (rf/reg-view* :pages/broken-evt
+      (fn [] (throw (ex-info "boom" {}))))
+    (let [traces (atom [])]
+      (rf/register-listener! ::error-view-throw-watch
+        (fn [ev] (when (= :rf.error/ssr-ring-error-view-failed (:operation ev))
+                   (swap! traces conj ev))))
+      (let [handler  (ssr-ring/ssr-handler
+                       {:on-create  [:init/ok]
+                        :root-view  [:pages/broken-evt]
+                        :error-view (fn [_public]
+                                      (throw (ex-info "error-view itself broke" {})))
+                        :payload-policy :rf.ssr.payload/whole-app-db})
+            response (handler {:uri "/broken" :request-method :get})
+            body     (:body response)]
+        (rf/unregister-listener! ::error-view-throw-watch)
+        (is (= 500 (:status response)) "still a 500 — boundary holds")
+        (is (str/includes? body "Something went wrong")
+            "fell back to the default error template's public :message")
+        (is (not (str/includes? body "error-view itself broke"))
+            "the error-view's own throwable message MUST NOT reach the wire")
+        (is (seq @traces)
+            ":rf.error/ssr-ring-error-view-failed trace fired for the
+             buggy error view")))))
 
 ;; ===========================================================================
 ;; ssr-handler — fn-form :root-view invoked exactly once per request (rf2-6t36h)
@@ -717,6 +839,50 @@
              :root-view [:pages/no-policy-stream]}))
         "stream-handler MUST throw at construction time when the
          policy is unset — same fail-closed contract as ssr-handler")))
+
+;; rf2-ee38b.11 — stream-handler MUST run the SAME required-opt
+;; (:on-create / :root-view) construction-time validation ssr-handler
+;; does. Pre-fix it only checked the policy + trusted-shell opts, so a
+;; misconfigured streaming handler shipped and failed per-request
+;; (missing :on-create → 500; missing :root-view → silently-truncated
+;; chunked response from the writer thread) instead of refusing to
+;; construct. Now both share `lifecycle/validate-required-opts!`.
+
+(deftest ssr-handler-construction-fails-closed-when-missing-on-create
+  (testing "rf2-ee38b.11: ssr-handler with no :on-create throws
+            :rf.error/ssr-ring-missing-on-create at construction"
+    (rf/reg-view* :pages/no-oncreate (fn [] [:div]))
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-ring-missing-on-create"
+          (ssr-ring/ssr-handler
+            {:root-view [:pages/no-oncreate]
+             :payload-policy :rf.ssr.payload/whole-app-db})))))
+
+(deftest stream-handler-construction-fails-closed-when-missing-on-create
+  (testing "rf2-ee38b.11: stream-handler with no :on-create throws
+            :rf.error/ssr-ring-missing-on-create at construction — same
+            fail-closed contract as ssr-handler (was missing pre-fix)"
+    (rf/reg-view* :pages/no-oncreate-stream (fn [] [:div]))
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-ring-missing-on-create"
+          (ssr-ring/stream-handler
+            {:root-view [:pages/no-oncreate-stream]
+             :payload-policy :rf.ssr.payload/whole-app-db})))))
+
+(deftest stream-handler-construction-fails-closed-when-missing-root-view
+  (testing "rf2-ee38b.11: stream-handler with no :root-view throws
+            :rf.error/ssr-ring-missing-root-view at construction — pre-fix
+            this surfaced only inside the writer thread, truncating the
+            chunked response instead of failing at boot"
+    (rf/reg-event-fx :init/no-rootview-stream {:platforms #{:server}} (fn [_ _] {}))
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #":rf\.error/ssr-ring-missing-root-view"
+          (ssr-ring/stream-handler
+            {:on-create [:init/no-rootview-stream]
+             :payload-policy :rf.ssr.payload/whole-app-db})))))
 
 (deftest fail-closed-proof-unpermitted-slot-not-on-wire
   (testing "rf2-gtgf9 FAIL-CLOSED PROOF: a server-only app-db key NOT in
@@ -1311,34 +1477,41 @@
             "X-Audit append-header reached the wire (multi-valued)")))))
 
 ;; ===========================================================================
-;; rf2-depii — ensure-content-type case-insensitive normalisation
+;; rf2-depii — Content-Type default is case-insensitive (no duplicate)
 ;;
-;; The helper documents itself as case-insensitive but the prior check
-;; only matched "content-type" / "Content-Type", so any other casing
-;; (CONTENT-TYPE, CoNtEnT-TyPe) would duplicate the header. RFC 7230 §3.2
-;; — header names are tokens; tokens are case-insensitive.
+;; `headers->ring-map+default-content-type` defaults Content-Type only
+;; when the pairs don't already declare one — and the detection is
+;; case-insensitive, so any casing (CONTENT-TYPE, CoNtEnT-TyPe) of a
+;; caller-supplied header suppresses the default. RFC 7230 §3.2 —
+;; header names are tokens; tokens are case-insensitive.
+;;
+;; rf2-ee38b.11 — re-pointed at the live single-pass fn (the prior
+;; `ensure-content-type` / `headers->ring-map` helpers were orphaned by
+;; the rf2-uj9z8 single-pass refactor and have been deleted). The live
+;; fn is the production path, so the test now gives real confidence.
 ;; ===========================================================================
 
-(deftest ensure-content-type-no-duplicate-on-mixed-case
+(deftest content-type-default-no-duplicate-on-mixed-case
   (testing "rf2-depii: a preexisting Content-Type pair in ANY casing
-            short-circuits ensure-content-type — no duplicate appended"
-    (let [headers-ns (requiring-resolve 're-frame.ssr.ring.headers/ensure-content-type)]
+            suppresses the default — exactly one content-type key in the
+            folded Ring header map, carrying the CALLER's value"
+    (let [fold (requiring-resolve
+                 're-frame.ssr.ring.headers/headers->ring-map+default-content-type)]
       (doseq [casing ["content-type"
                       "Content-Type"
                       "CONTENT-TYPE"
                       "CoNtEnT-TyPe"
                       "content-Type"]]
-        (let [pairs   [[casing "application/json"]]
-              result  (headers-ns pairs "text/html; charset=utf-8")]
-          (is (= pairs result)
+        (let [pairs  [[casing "application/json"]]
+              result (fold pairs "text/html; charset=utf-8")
+              ct-keys (filter (fn [k] (= "content-type" (str/lower-case (str k))))
+                              (keys result))]
+          (is (= 1 (count ct-keys))
               (str "casing " (pr-str casing)
-                   " short-circuits — pairs returned unchanged, no duplicate"))
-          (is (= 1 (count (filter
-                            (fn [[k _v]]
-                              (= "content-type" (str/lower-case (str k))))
-                            result)))
+                   " — exactly one content-type key after the fold, no duplicate"))
+          (is (= "application/json" (get result (first ct-keys)))
               (str "casing " (pr-str casing)
-                   " — exactly one content-type pair after ensure-content-type")))))))
+                   " — the caller's Content-Type value wins, not the default")))))))
 
 ;; ===========================================================================
 ;; rf2-7ksyr — hydration payload </script> injection (security audit §P1)


### PR DESCRIPTION
Consolidated remediation for `implementation/ssr-ring` from the 3-lens review sweep. Cross-ref **rf2-ee38b.11**. Findings in `ai/findings/review/{correctness,completeness,clarity}--implementation-ssr-ring.md`.

## Finding → fix

### P1 — streaming redirect leaks the per-request frame (correctness + completeness)
`stream-handler`'s redirect short-circuit returned directly from inside the `try` with no enclosing `finally`. The writer thread (whose `finally` tears the frame down on the streaming path) is never spawned on the redirect branch, so `destroy-frame-quietly!` never ran — leaking the frame + its request/response/pending-error-trace side-channel slots on **every** redirected streaming request (auth-gated login redirects are exactly where this compounds). **Fix:** wrap the redirect branch in `try`/`finally` to destroy the frame inline. **Test:** `stream-handler-redirect-destroys-frame` asserts redirect shape + frame/request-slot gone (mirrors the writer-throw teardown observation).

### P1 — `ensure-content-type` + `headers->ring-map` dead code (clarity)
Orphaned by the rf2-uj9z8 single-pass refactor; kept alive only by their own test. **Fix:** deleted both; re-pointed the orphan test at the live `headers->ring-map+default-content-type` (`content-type-default-no-duplicate-on-mixed-case`).

### P2 — `stream-handler` skipped `:on-create`/`:root-view` construction validation
Failed per-request (500 / silently-truncated chunk) instead of at boot, contradicting the in-code comment. **Fix:** extracted `lifecycle/validate-required-opts!`, shared by both handlers. **Tests:** `stream-handler-construction-fails-closed-when-missing-{on-create,root-view}` + an ssr-handler mirror.

### P3 — redirect with no target (correctness)
Was a silent 302 with no `Location`. **Fix:** adapter emits `:rf.ssr/ssr-redirect-no-target` warning trace (runtime keeps location caller-trusted/optional; adapter is the last observable line). Test `handler-redirect-no-target-warns`.

### P3 — streaming vs non-streaming Content-Type disagreement (correctness)
Streaming redirect passed `content-type`; non-streaming did not. **Fix:** dropped the arg on the streaming redirect (2-arg form). Test `stream-handler-redirect-no-content-type-stamped` pins agreement.

### P3 — error-page-view hook gap (completeness)
Spec 011 §error projection step 5 describes a registered error view; only the hardcoded default template existed. **Fix:** new optional `:error-view` opt (registered-view keyword or 1-arity fn receiving the public-error map), rendered through the SSR emitter; a buggy error view falls back to the default template and traces `:rf.error/ssr-ring-error-view-failed`. Tests: keyword view, fn view, throw-fallback.

### Clarity dups
- `default-on-error` hoisted to `lifecycle`, shared by both handlers (rf2-kzvwq contract lives once).
- `payload-script-tag` + `html-attr-bag` extracted to `shell`, used by both the non-streaming shell and the streaming chunks (security-load-bearing `</script>` escape no longer duplicated).
- Fixed the `stream-handler` docstring self-contradiction ("same calling thread" vs daemon thread).
- Trimmed audit-archaeology docstrings (ns file-split block, `resolve-version`, header/pipeline narratives).

## Skipped / judgment
- **Redirect no-target runtime gate**: kept the fix adapter-side rather than touching `re-frame.ssr/redirect-fx` (a different artefact) — the runtime intentionally treats `:location` as caller-trusted/optional, and the malformed-wire concern lives at the adapter boundary.
- **`:as` bindings (clarity P3)**: non-finding after inspection per the clarity doc — all live. No change.
- **Cross-artefact `resolve-version`/`build-final-payload` dup**: flagged by the clarity doc as out-of-scope (the `ssr` core artefact) — left for a possible cross-artefact dedup bead.

## Test plan
- [x] `clojure -M:test` for ssr-ring (JVM) — 72 tests, 354 assertions, 0 failures/errors
- [x] No reflection warnings on namespace load
- [x] All changes confined to `implementation/ssr-ring`