### PR TITLE
fix(http): timeout-0 opt-out + JVM redirect + 3-lens remediation (rf2-ee38b.7)

### DIFF
--- a/implementation/http/src/re_frame/http_decode.cljc
+++ b/implementation/http/src/re_frame/http_decode.cljc
@@ -130,10 +130,40 @@
             :cljs (try (resolve 'malli.core/validate)
                        (catch :default _ nil)))))
 
+(defonce ^:private malli-absent-warned?
+  ;; rf2-ee38b.7 — one-shot latch so the "schema supplied but Malli
+  ;; absent" warning fires once per runtime, not once per response. The
+  ;; degraded path is steady-state for a Malli-less app, so a per-request
+  ;; trace would be noise; the single warning makes the silent no-op
+  ;; visible without flooding the trace surface.
+  (atom false))
+
+(defn- warn-malli-absent! [schema]
+  ;; Visible-degradation trace per Spec 014 §JSON decoder hardening
+  ;; ("no silent fallback"). When a real schema rides `:decode` but
+  ;; Malli is not on the classpath, the decode/validate delays resolve
+  ;; to nil and validation is skipped — unchecked data flows to
+  ;; `:accept`. Emit a `:rf.warning/http-malli-absent` so the dropped
+  ;; validation is observable rather than silent.
+  (when (and interop/debug-enabled?
+             (compare-and-set! malli-absent-warned? false true))
+    (trace/emit! :warning :rf.warning/http-malli-absent
+                 {:reason (str "a `:decode` schema was supplied but malli.core is "
+                               "not on the classpath; schema validation is SKIPPED "
+                               "and the parsed value flows to `:accept` unchecked. "
+                               "Add the Malli dependency to enable schema-driven decode.")
+                  :schema schema})))
+
 (defn- malli-decode
   "Run a Malli schema's `decode` over `value`, falling back to plain
   validate-or-throw if the transformer pipeline is unavailable. Throws
-  on failure so the caller can classify as `:rf.http/decode-failure`."
+  on failure so the caller can classify as `:rf.http/decode-failure`.
+
+  Per rf2-ee38b.7: when Malli is absent entirely (decode AND validate
+  both nil), the parsed value is returned UNVALIDATED — but a one-shot
+  `:rf.warning/http-malli-absent` trace fires so the degraded path is
+  visible (it was previously a silent no-op, the anti-pattern §JSON
+  decoder hardening calls out)."
   [schema value]
   (let [decode      @malli-decode-fn
         transformer @malli-transformer-fn
@@ -142,6 +172,10 @@
                       (and decode transformer) (decode schema value (transformer))
                       decode                   (decode schema value nil)
                       :else                    value)]
+    ;; Malli wholly absent (no decode, no validate) → schema validation
+    ;; was skipped. Surface the degradation once.
+    (when (and (nil? decode) (nil? validate))
+      (warn-malli-absent! schema))
     (when validate
       (when-not (validate schema decoded)
         (throw (ex-info ":rf.error/http-schema-validation-failed"

--- a/implementation/http/src/re_frame/http_handlers.cljc
+++ b/implementation/http/src/re_frame/http_handlers.cljc
@@ -92,9 +92,11 @@
 
   The `:or {timeout-ms 30000}` clause below substitutes only when the
   key is ABSENT (Clojure destructuring semantics — `:or` does not
-  fire on an explicit `nil` value). The downstream JVM/CLJS transport
-  treats nil/0 as opt-out, so the three-way contract is preserved
-  end-to-end without any reshaping here."
+  fire on an explicit `nil` value). Both `nil` and `0` thread through
+  unchanged; the downstream JVM/CLJS transport collapses them to the
+  no-timeout opt-out via a `(pos? timeout-ms)` guard (NOT a bare
+  truthiness check — `0` is truthy in Clojure). The three-way contract
+  is thus preserved end-to-end without any reshaping here."
   [{:keys [request decode accept retry timeout-ms
            on-success on-failure request-id abort-signal]
     :or   {timeout-ms 30000}

--- a/implementation/http/src/re_frame/http_privacy.cljc
+++ b/implementation/http/src/re_frame/http_privacy.cljc
@@ -17,8 +17,9 @@
 
   - `re-frame.http-privacy-headers` — header denylist + `redact-headers`.
   - `re-frame.http-url` — query-param denylist + `redact-url` /
-    `redact-url-query-string` (and future home of `url-encode` /
-    `params->query` / `merge-params` per rf2-5ijhk).
+    `redact-url-query-string`. (URL *building* — `url-encode` /
+    `params->query` / `merge-params` — lives in `re-frame.http-encoding`,
+    not here.)
 
   Three cooperating mechanisms, mirroring Spec 009's schema-first
   privacy split:
@@ -68,8 +69,13 @@
   "The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
   in the `:rf/` reserved-keyword namespace so apps cannot legitimately
   produce it as a payload value. Consumers wanting \"was this redacted?\"
-  check `(= :rf/redacted v)`."
-  :rf/redacted)
+  check `(= :rf/redacted v)`.
+
+  rf2-ee38b.7 — re-exported from the canonical `re-frame.http-url`
+  definition so the keyword + its string form (`redacted-url-token`)
+  cannot drift across the privacy cluster. This var preserves the
+  public `re-frame.http-privacy/redacted-sentinel` surface."
+  url/redacted-sentinel)
 
 ;; ---- trace-event redaction helpers ----------------------------------------
 
@@ -116,7 +122,11 @@
   query-param denylist (rf2-2p8wr) are always redacted regardless of
   `sensitive?` — denylisted param names are themselves the signal.
 
-  Idempotent and total: missing slots are left alone."
+  Idempotent and total: missing slots are left alone.
+
+  rf2-ee38b.7 — public for direct test assertion only; production reaches
+  redaction via the `prepare-emit-*` composers (which use the `*-with-flag`
+  forms). No production caller invokes this non-flag wrapper."
   [tags sensitive?]
   (first (redact-request-tags-with-flag tags sensitive?)))
 
@@ -164,7 +174,11 @@
   a `:rf.http/*` trace event, redact response-side payload slots when
   `sensitive?` is true. Always redacts headers via the denylist; always
   redacts URL query-string values whose param name is in the query-
-  param denylist (rf2-2p8wr) — denylisted param names are the signal."
+  param denylist (rf2-2p8wr) — denylisted param names are the signal.
+
+  rf2-ee38b.7 — public for direct test assertion only; production reaches
+  redaction via `prepare-emit-failure` (which uses the `*-with-flag`
+  form). No production caller invokes this non-flag wrapper."
   [failure sensitive?]
   (when failure
     (first (redact-failure-with-flag failure sensitive?))))
@@ -181,7 +195,10 @@
   per the spec contract.
 
   When `sensitive?` is false the slot is OMITTED (not stamped to false)
-  per Spec 009 line 1176: \"Consumers treat absent as false.\""
+  per Spec 009 line 1176: \"Consumers treat absent as false.\"
+
+  rf2-ee38b.7 — public for direct test assertion + composer reuse;
+  production reaches it through the `prepare-emit-*` composers."
   [tags sensitive?]
   (cond-> tags
     sensitive? (assoc :sensitive? true)))

--- a/implementation/http/src/re_frame/http_privacy_headers.cljc
+++ b/implementation/http/src/re_frame/http_privacy_headers.cljc
@@ -22,14 +22,17 @@
   itself ships in production (it's app-readable state —
   `declare-sensitive-header!` writes through)."
   (:require [clojure.set :as set]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [re-frame.http-url :as url]))
 
-;; The framework-reserved redaction sentinel per Spec 009 §Privacy. Sits
-;; in the `:rf/` reserved-keyword namespace so apps cannot legitimately
-;; produce it as a payload value. Held here (not just in
-;; `re-frame.http-privacy`) so this leaf namespace doesn't depend on its
-;; orchestrating parent.
-(def ^:private redacted-sentinel :rf/redacted)
+;; rf2-ee38b.7 — the framework-reserved redaction sentinel per Spec 009
+;; §Privacy now has a single canonical home in the sibling leaf
+;; `re-frame.http-url` (which carries no privacy deps, so there is no
+;; leaf→parent cycle). Previously this namespace held its own private
+;; copy AND `http-url` held the string form AND `http-privacy` held the
+;; keyword — three coordinated edits to change one value. Refer to the
+;; canonical def instead.
+(def ^:private redacted-sentinel url/redacted-sentinel)
 
 (def default-header-denylist
   "Canonical always-sensitive HTTP header names, lower-cased. These are

--- a/implementation/http/src/re_frame/http_registry.cljc
+++ b/implementation/http/src/re_frame/http_registry.cljc
@@ -59,20 +59,23 @@
 
   Returns the (possibly-stamped) handle so the natural-completion
   sites can hold a reference for the 2-arg `clear-in-flight!` cleanup
-  path. `request-id` and `actor-id` are both optional. When both are
-  nil the handle is unindexed and only reachable via natural
-  completion."
-  ([request-id handle]
-   (record-in-flight! request-id nil handle))
-  ([request-id actor-id handle]
-   (let [stamped (cond-> handle
-                   request-id (assoc :request-id request-id)
-                   actor-id   (assoc :actor-id actor-id))]
-     (when request-id
-       (swap! in-flight assoc request-id stamped))
-     (when actor-id
-       (swap! actor-in-flight update actor-id (fnil conj []) stamped))
-     stamped)))
+  path. `request-id` and `actor-id` are both optional (pass nil). When
+  both are nil the handle is unindexed and only reachable via natural
+  completion.
+
+  rf2-ee38b.7 — the convenience 2-arity `[request-id handle]` was
+  dropped; it had no production caller (the single call site in
+  `http-transport/run-attempt!` always passes the 3-arity with an
+  actor-id, possibly nil) and no test depended on it."
+  [request-id actor-id handle]
+  (let [stamped (cond-> handle
+                  request-id (assoc :request-id request-id)
+                  actor-id   (assoc :actor-id actor-id))]
+    (when request-id
+      (swap! in-flight assoc request-id stamped))
+    (when actor-id
+      (swap! actor-in-flight update actor-id (fnil conj []) stamped))
+    stamped))
 
 (defn- remove-from-actor-index! [actor-id handle]
   (when actor-id

--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -31,7 +31,8 @@
             [re-frame.interop       :as interop]
             [re-frame.trace         :as trace])
   #?(:clj (:import [java.net URI]
-                   [java.net.http HttpClient HttpRequest
+                   [java.net.http HttpClient HttpClient$Redirect
+                                  HttpRequest
                                   HttpRequest$BodyPublishers
                                   HttpResponse HttpResponse$BodyHandlers]
                    [java.time Duration]
@@ -111,7 +112,19 @@
            (-> (js/Promise.race
                  #js [(js/fetch url init)
                       (js/Promise. (fn [_ reject]
-                                     (when (and timeout-ms internal-controller)
+                                     ;; Per Spec 014 §`:timeout-ms` security
+                                     ;; defaults: BOTH `nil` and `0` are
+                                     ;; explicit opt-outs (no per-attempt
+                                     ;; timeout). `0` is truthy in CLJS, so
+                                     ;; `(when timeout-ms …)` would arm a
+                                     ;; `setTimeout(…, 0)` that aborts the
+                                     ;; request on the next macrotask — the
+                                     ;; opposite of "unbounded". The
+                                     ;; `(pos? …)` guard collapses
+                                     ;; `nil`/`0`/negative to "no timeout".
+                                     (when (and timeout-ms
+                                                (pos? timeout-ms)
+                                                internal-controller)
                                        (reset! timeout-handle
                                                (js/setTimeout
                                                  (fn []
@@ -261,13 +274,72 @@
 ;; ---- platform transport: JVM java.net.http.HttpClient ---------------------
 
 #?(:clj
-   (defonce ^:private jvm-http-client
-     ;; 10s connect timeout — distinct from `:timeout-ms` (which bounds
-     ;; the whole request). Caps the TCP/TLS handshake so a black-holed
-     ;; host fails fast instead of leaning on the per-request timeout.
-     (delay (-> (HttpClient/newBuilder)
-                (.connectTimeout (Duration/ofSeconds 10))
-                (.build)))))
+   (defn- redirect->policy
+     "Map the request envelope's `:redirect` (Spec 014 §Request envelope:
+     `:follow` / `:error` / `:manual`, default `:follow`) onto a JDK
+     `HttpClient.Redirect` policy.
+
+     The JDK client only models `ALWAYS` / `NORMAL` / `NEVER` — there is
+     no `:manual` (caller-handles-the-3xx) analogue. So:
+
+     - `:follow` (the spec default) → `NORMAL` (follow same-or-more-
+       secure redirects; the JDK declines HTTPS→HTTP downgrades, which
+       is the safe reading of \"follow\").
+     - `:error` / `:manual`         → `NEVER` (do not auto-follow; the
+       3xx surfaces to the caller).
+     - anything else / nil          → `NORMAL` (honour the spec default).
+
+     The `:error`-vs-`:manual` distinction (error = treat 3xx as a
+     failure; manual = hand the raw 3xx back) is not separable on the
+     JDK; both collapse to NEVER, which surfaces the 3xx through the
+     `:else` arm of `handle-response!`. This is documented as a JVM
+     limitation rather than silently dropping the whole key."
+     [redirect]
+     (case redirect
+       :follow HttpClient$Redirect/NORMAL
+       :error  HttpClient$Redirect/NEVER
+       :manual HttpClient$Redirect/NEVER
+       HttpClient$Redirect/NORMAL)))
+
+#?(:clj
+   (defn- build-jvm-http-client
+     "Build a JDK `HttpClient` for the given redirect policy.
+
+     10s connect timeout — distinct from `:timeout-ms` (which bounds the
+     whole request). Caps the TCP/TLS handshake so a black-holed host
+     fails fast instead of leaning on the per-request timeout. The
+     redirect policy is a per-CLIENT setting on the JDK (not per-request),
+     so we memoise one client per distinct policy (`jvm-http-clients`)
+     to preserve connection pooling per rf2-ee38b.7."
+     [^HttpClient$Redirect policy]
+     (-> (HttpClient/newBuilder)
+         (.connectTimeout (Duration/ofSeconds 10))
+         (.followRedirects policy)
+         (.build))))
+
+#?(:clj
+   (defonce ^:private jvm-http-clients
+     ;; redirect-policy → memoised HttpClient. The JDK applies its
+     ;; redirect policy at the client level, not per request, so honouring
+     ;; the spec's `:redirect` envelope key (default `:follow`) requires a
+     ;; client per policy. Two policies are live in practice (NORMAL for
+     ;; `:follow`, NEVER for `:error`/`:manual`), so this caches at most a
+     ;; handful of clients while preserving each one's connection pool.
+     (atom {})))
+
+#?(:clj
+   (defn- jvm-http-client-for
+     "Return the memoised JDK `HttpClient` honouring `redirect` (Spec 014
+     §Request envelope default `:follow`)."
+     [redirect]
+     (let [policy (redirect->policy redirect)]
+       (or (get @jvm-http-clients policy)
+           (get (swap! jvm-http-clients
+                       (fn [m]
+                         (if (contains? m policy)
+                           m
+                           (assoc m policy (build-jvm-http-client policy)))))
+                policy)))))
 
 #?(:clj
    (defn- jvm-build-request
@@ -279,7 +351,14 @@
                        (bytes? body) (HttpRequest$BodyPublishers/ofByteArray ^bytes body)
                        :else (HttpRequest$BodyPublishers/ofString ^String (str body)))]
        (.method b (str/upper-case (name method)) publisher)
-       (when timeout-ms
+       ;; Per Spec 014 §`:timeout-ms` security defaults: BOTH `nil` and
+       ;; `0` are explicit opt-outs (no per-attempt timeout). `0` is
+       ;; truthy in Clojure, so `(when timeout-ms …)` is NOT enough — and
+       ;; `(Duration/ofMillis 0)` throws `IllegalArgumentException` on the
+       ;; JDK, surfacing the opt-out as a spurious `:rf.http/transport`
+       ;; failure. The `(pos? …)` guard collapses `nil`/`0`/negative to
+       ;; "no timeout" so the JDK request carries no per-request deadline.
+       (when (and timeout-ms (pos? timeout-ms))
          (.timeout b (Duration/ofMillis (long timeout-ms))))
        (doseq [[k v] headers]
          ;; rf2-9lun0 — surface JDK HttpClient header-validation throws
@@ -352,9 +431,12 @@
      :headers :body-text}` or completes-exceptionally with an ex-info.
 
      `opts` carries `:sensitive?` so `jvm-build-request` can route any
-     header-validation warning through the privacy composer (rf2-1jcpm)."
+     header-validation warning through the privacy composer (rf2-1jcpm).
+     `opts` carries `:redirect` (Spec 014 §Request envelope, default
+     `:follow`) so the client honouring the right redirect policy is
+     selected per rf2-ee38b.7."
      [opts]
-     (let [client ^HttpClient @jvm-http-client
+     (let [client ^HttpClient (jvm-http-client-for (:redirect opts))
            req    (jvm-build-request opts)
            future-resp (.sendAsync client req
                                    (HttpResponse$BodyHandlers/ofString))]
@@ -381,20 +463,29 @@
      happened to contain those words) as `:rf.http/timeout` /
      `:rf.http/aborted`, polluting the failure taxonomy. Anything not
      matching an instance check stays at `:rf.http/transport` — the
-     correct catch-all for unknown JDK failures."
-     [^Throwable t]
-     (let [cause (or (.getCause t) t)
-           msg   (.getMessage cause)
-           cls   (.getName (class cause))]
-       (cond
-         (instance? java.net.http.HttpTimeoutException cause)
-         {:kind :rf.http/timeout :elapsed-ms nil :limit-ms nil :message msg}
+     correct catch-all for unknown JDK failures.
 
-         (instance? java.util.concurrent.CancellationException cause)
-         {:kind :rf.http/aborted :reason :user :message msg}
+     Per rf2-ee38b.7 the optional `timeout-ms` (the configured per-attempt
+     limit, in scope at the `run-attempt!` call sites) fills the
+     `:limit-ms` tag on a timeout failure so the JVM shape matches the
+     CLJS path (Spec 014 §Failure categories types `:rf.http/timeout` as
+     `:elapsed-ms` / `:limit-ms`). `:elapsed-ms` stays nil on the JVM —
+     the JDK's `HttpTimeoutException` does not surface the elapsed wall
+     clock, and there is no faithful value to synthesise."
+     ([^Throwable t] (classify-jvm-error t nil))
+     ([^Throwable t timeout-ms]
+      (let [cause (or (.getCause t) t)
+            msg   (.getMessage cause)
+            cls   (.getName (class cause))]
+        (cond
+          (instance? java.net.http.HttpTimeoutException cause)
+          {:kind :rf.http/timeout :elapsed-ms nil :limit-ms timeout-ms :message msg}
 
-         :else
-         {:kind :rf.http/transport :message msg :cause cls}))))
+          (instance? java.util.concurrent.CancellationException cause)
+          {:kind :rf.http/aborted :reason :user :message msg}
+
+          :else
+          {:kind :rf.http/transport :message msg :cause cls})))))
 
 ;; ---- per-row CLJS-only-key tracing on JVM ---------------------------------
 
@@ -413,7 +504,16 @@
 #?(:clj
    (defn check-cljs-only-keys! [{:keys [request abort-signal]} sensitive?]
      (let [url (:url request)]
-       (doseq [k [:mode :cache :referrer :integrity]]
+       ;; rf2-ee38b.7 — `:credentials` joins the JVM-degraded set. Unlike
+       ;; `:redirect` (now honoured on JVM via the redirect-policy client),
+       ;; the browser same-origin/include cookie model has no faithful
+       ;; `HttpClient` analogue — the shared client configures no
+       ;; CookieHandler, so cookies are neither sent nor stored regardless
+       ;; of the value. Rather than silently no-op, emit the standard
+       ;; `:rf.http/cljs-only-key-ignored-on-jvm` trace so the dropped key
+       ;; is visible to off-box monitors. (Spec 014 §JVM degradation table
+       ;; needs the `:credentials` row added — left for the mayor.)
+       (doseq [k [:mode :cache :referrer :integrity :credentials]]
          (when (contains? request k)
            (emit-cljs-only-skipped! k url sensitive?)))
        (when abort-signal
@@ -443,6 +543,29 @@
        :reply-payload reply-payload
        :kind          kind}
       frame)))
+
+;; rf2-ee38b.7 — the failure-reply and success-reply dispatch shapes were
+;; spelled out inline at four / two sites across finalise-success!,
+;; finalise-failure! and the abort path's dispatch-aborted!. These two
+;; helpers collapse each to one line and make the abort/natural symmetry
+;; the surrounding comments describe visible in code. The load-bearing
+;; concurrency comments stay at the call sites.
+
+(defn- dispatch-failure!
+  "Dispatch a `:failure` reply carrying `failure` as its `:failure` slot."
+  [ctx failure]
+  (dispatch-reply! (assoc ctx
+                          :kind          :failure
+                          :reply-payload {:kind    :failure
+                                          :failure failure})))
+
+(defn- dispatch-success!
+  "Dispatch a `:success` reply carrying `value` as its `:value` slot."
+  [ctx value]
+  (dispatch-reply! (assoc ctx
+                          :kind          :success
+                          :reply-payload {:kind  :success
+                                          :value value})))
 
 (defn- already-replied?
   "rf2-on7sj — the once-only reply guard. The handle carries a
@@ -517,25 +640,16 @@
                                sensitive?)]
               (trace/emit-error! :rf.http/aborted redacted)))
           (when-not (= :request-id-superseded (:reason failure))
-            (dispatch-reply! (assoc ctx
-                                    :kind          :failure
-                                    :reply-payload {:kind    :failure
-                                                    :failure failure}))))
+            (dispatch-failure! ctx failure)))
         (cond
           (contains? accepted :ok)
-          (dispatch-reply! (assoc ctx
-                                  :kind :success
-                                  :reply-payload {:kind  :success
-                                                  :value (:ok accepted)}))
+          (dispatch-success! ctx (:ok accepted))
 
           (contains? accepted :failure)
-          (dispatch-reply! (assoc ctx
-                                  :kind :failure
-                                  :reply-payload {:kind    :failure
-                                                  :failure {:kind       :rf.http/accept-failure
-                                                            :detail     (:failure accepted)
-                                                            :decoded    (:decoded ctx)
-                                                            :request-id (:request-id ctx)}})))))))
+          (dispatch-failure! ctx {:kind       :rf.http/accept-failure
+                                  :detail     (:failure accepted)
+                                  :decoded    (:decoded ctx)
+                                  :request-id (:request-id ctx)}))))))
 
 (defn- finalise-failure!
   "Final-failure dispatch (after retries exhausted or non-retriable).
@@ -597,10 +711,7 @@
       (let [superseded? (and (= :rf.http/aborted (:kind effective))
                              (= :request-id-superseded (:reason effective)))]
         (when-not superseded?
-          (dispatch-reply! (assoc ctx
-                                  :kind          :failure
-                                  :reply-payload {:kind    :failure
-                                                  :failure effective})))))))
+          (dispatch-failure! ctx effective))))))
 
 (defn- maybe-retry!
   "Decide between retry, immediate-final-failure, and successful-completion.
@@ -736,8 +847,15 @@
       :else
       ;; Non-2xx that didn't fall in 4xx/5xx (e.g., 1xx/3xx that the
       ;; runtime didn't follow) — surface as 4xx-shaped failure with
-      ;; the raw body-text.
-      (finalise-failure!
+      ;; the raw body-text. Per rf2-ee38b.7 this routes through
+      ;; `maybe-retry!` (was `finalise-failure!` directly) so the retry
+      ;; semantics match the `:rf.http/http-4xx` category label: a caller
+      ;; with `:retry {:on #{:rf.http/http-4xx} …}` retries a real 4xx,
+      ;; and this synthetic-4xx (1xx/3xx) now retries consistently rather
+      ;; than silently never retrying. The branch is rare in practice (the
+      ;; JVM `NORMAL` / Fetch stacks follow 3xx by default), but the
+      ;; inconsistency is removed.
+      (maybe-retry!
         ctx
         {:kind        :rf.http/http-4xx
          :status      status
@@ -826,11 +944,7 @@
                               ;; (`:user`, `:actor-destroyed`, `:timeout`)
                               ;; all dispatch the failure reply normally.
                               (when-not (= :request-id-superseded reason)
-                                (dispatch-reply!
-                                  (assoc ctx-no-handle
-                                         :kind          :failure
-                                         :reply-payload {:kind    :failure
-                                                         :failure failure})))))
+                                (dispatch-failure! ctx-no-handle failure))))
         ;; Register the abort handle. The handle ref is stamped into ctx
         ;; so finalise-* can clear it from both indexes without needing
         ;; the request-id (handles anonymous-from-actor requests too —
@@ -950,6 +1064,10 @@
                            :headers    headers
                            :body       enc-body
                            :timeout-ms timeout-ms
+                           ;; rf2-ee38b.7 — honour the spec's `:redirect`
+                           ;; envelope key on the JVM (default `:follow`).
+                           ;; Selects the redirect-policy-specific client.
+                           :redirect   (:redirect request)
                            :sensitive? (true? (:sensitive? ctx))})]
            ;; rf2-on7sj — publish cf to the abort-fn closure's holder
            ;; BEFORE wiring whenComplete. A racing abort that arrives
@@ -969,7 +1087,7 @@
                           (reify java.util.function.BiConsumer
                             (accept [_ result throwable]
                               (if throwable
-                                (maybe-retry! ctx' (classify-jvm-error throwable))
+                                (maybe-retry! ctx' (classify-jvm-error throwable timeout-ms))
                                 (handle-response! ctx' result))))))
          (catch Throwable t
-           (maybe-retry! ctx' (classify-jvm-error t)))))))
+           (maybe-retry! ctx' (classify-jvm-error t timeout-ms)))))))

--- a/implementation/http/src/re_frame/http_url.cljc
+++ b/implementation/http/src/re_frame/http_url.cljc
@@ -2,11 +2,11 @@
   "URL handling for the http artefact — query-string redaction surface
   (Spec 014 §Privacy, rf2-2p8wr) plus the query-param denylist.
 
-  This namespace owns URLs end-to-end for the http artefact. Today it
-  hosts the redaction half (split, walk, redact, denylist). When the
-  http-encoding split lands (rf2-5ijhk), `url-encode`, `params->query`,
-  and `merge-params` move here too — making `http-url` the single
-  authority for URL parsing, building, and scrubbing across the artefact.
+  This namespace owns URL *redaction / scrubbing* for the http artefact
+  (split, walk, redact, denylist). URL *building* — `url-encode`,
+  `params->query`, `merge-params` — lives in `re-frame.http-encoding`
+  (the rf2-5ijhk encoding split). The two halves stay separate: redaction
+  is a privacy-leaf surface, building is an encoding concern.
 
   ## Query-param denylist (rf2-2p8wr)
 
@@ -34,6 +34,22 @@
   through), but no walker runs without the trace surface."
   (:require [clojure.set :as set]
             [clojure.string :as str]))
+
+;; ---- canonical redaction sentinel -----------------------------------------
+;;
+;; rf2-ee38b.7 — single source of truth for the framework-reserved
+;; redaction sentinel per Spec 009 §Privacy. Sits in the `:rf/` reserved-
+;; keyword namespace so apps cannot legitimately produce it as a payload
+;; value. `http-url` is the natural owner: it is the privacy leaf with no
+;; intra-privacy dependencies, so `http-privacy` and `http-privacy-headers`
+;; can both refer to it without creating a leaf→parent cycle. Consumers
+;; wanting "was this redacted?" check `(= :rf/redacted v)`.
+
+(def redacted-sentinel
+  "The framework-reserved redaction sentinel keyword per Spec 009 §Privacy.
+  Canonical home (rf2-ee38b.7) — `http-privacy` re-exports it and
+  `http-privacy-headers` refers to it."
+  :rf/redacted)
 
 ;; ---- query-param denylist (rf2-2p8wr) -------------------------------------
 
@@ -116,8 +132,11 @@
   token they can detect (`:rf%2Fredacted` once URL-encoded into the wire
   string we serialise). The unencoded form is `:rf/redacted` — identical
   text to the keyword's `pr-str` — chosen so a human inspecting a trace
-  event reads the same sentinel they see in any other redacted slot."
-  ":rf/redacted")
+  event reads the same sentinel they see in any other redacted slot.
+
+  rf2-ee38b.7 — derived from the canonical `redacted-sentinel` keyword so
+  the two forms can never drift."
+  (str redacted-sentinel))
 
 (defn- split-url-on-query
   "Split `url-str` into `[base query-string]`. `query-string` is nil
@@ -205,6 +224,11 @@
 (defn redact-url
   "Convenience wrapper around `redact-url-query-string` that returns only
   the redacted URL string. Use when the caller does not need the
-  any-redacted? flag (e.g. inside a generic tag-walker)."
+  any-redacted? flag (e.g. inside a generic tag-walker).
+
+  rf2-ee38b.7 — public for direct test assertion only; production reaches
+  URL redaction via `re-frame.http-privacy`'s `prepare-emit-*` composers
+  (which use `redact-url-query-string` directly for the flag). No
+  production caller invokes this single-value wrapper."
   [url-str sensitive?]
   (first (redact-url-query-string url-str sensitive?)))

--- a/implementation/http/test/re_frame/http_cljs_test.cljs
+++ b/implementation/http/test/re_frame/http_cljs_test.cljs
@@ -247,3 +247,85 @@
                      (is (false? (:ok? result)))
                      (done)))
             (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
+;; ---- rf2-ee38b.7 — `:timeout-ms 0` is the opt-out, not a near-instant abort ----
+
+(defn- with-deferred-fetch
+  "Like `with-stub-fetch` but `js/fetch` resolves `resp` on the NEXT
+  macrotask (`setTimeout 0`) rather than synchronously. This is the
+  trap that exposes the pre-fix timeout-0 bug: pre-fix `:timeout-ms 0`
+  armed its own `setTimeout(…, 0)` that would race this resolution and
+  abort+reject the request. Post-fix the `(pos? timeout-ms)` guard arms
+  no timeout, so the deferred fetch resolution always wins."
+  [resp f]
+  (let [orig (.-fetch js/globalThis)]
+    (set! (.-fetch js/globalThis)
+          (fn [_url _init]
+            (js/Promise. (fn [resolve _reject]
+                           (js/setTimeout (fn [] (resolve resp)) 0)))))
+    (-> (f)
+        (.finally (fn [] (set! (.-fetch js/globalThis) orig))))))
+
+;; ---- rf2-ee38b.7 — CLJS Fetch threads `:redirect` into the init ----------
+
+(defn- with-init-capturing-fetch
+  "Run `f` with `js/fetch` stubbed to resolve `resp` while recording the
+  `init` arg into `captured-init`. Restores the original afterwards."
+  [resp captured-init f]
+  (let [orig (.-fetch js/globalThis)]
+    (set! (.-fetch js/globalThis)
+          (fn [_url init]
+            (reset! captured-init init)
+            (js/Promise.resolve resp)))
+    (-> (f)
+        (.finally (fn [] (set! (.-fetch js/globalThis) orig))))))
+
+(deftest cljs-fetch-passes-redirect-into-init
+  (testing "rf2-ee38b.7 — the CLJS transport threads `:redirect` into the
+  Fetch `init` (cross-host parity with the JVM redirect-policy fix).
+  Explicit `:error` rides through name-stringified."
+    (async done
+      (let [captured-init (atom nil)
+            resp (fake-response {:status 200 :content-type "application/json"
+                                 :text-val "{}"})]
+        (-> (with-init-capturing-fetch resp captured-init
+              #(cljs-fetch {:method   :get
+                            :url      "/x"
+                            :headers  {}
+                            :decode   :json
+                            :redirect :error
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [_]
+                     (is (= "error" (aget @captured-init "redirect"))
+                         ":redirect is name-stringified into the Fetch init")
+                     (done)))
+            (.catch (fn [e] (is false (str "unexpected reject: " e)) (done))))))))
+
+(deftest zero-timeout-ms-does-not-arm-near-instant-abort
+  (testing "rf2-ee38b.7 — `:timeout-ms 0` is an explicit opt-out (no
+  per-attempt timeout) per Spec 014 §`:timeout-ms` security defaults,
+  semantically identical to `:timeout-ms nil`. Pre-fix `0` was truthy,
+  so `(when (and timeout-ms internal-controller) …)` armed a
+  `setTimeout(…, 0)` that aborted the request on the next macrotask and
+  rejected with the timeout ex-info. This test defers the fetch
+  resolution by one macrotask: pre-fix the timeout abort would win and
+  reject; post-fix the request resolves successfully."
+    (async done
+      (let [resp (fake-response {:status 200 :content-type "application/json"
+                                 :text-val "{\"ok\":true}"})]
+        (-> (with-deferred-fetch resp
+              #(cljs-fetch {:method     :get
+                            :url        "/slow"
+                            :headers    {}
+                            :decode     :json
+                            :timeout-ms 0
+                            :internal-controller (js/AbortController.)}))
+            (.then (fn [result]
+                     (is (= "{\"ok\":true}" (:body-text result))
+                         ":timeout-ms 0 must NOT abort — the deferred fetch resolves normally")
+                     (is (true? (:ok? result)))
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "rf2-ee38b.7 regression — :timeout-ms 0 "
+                                     "armed a near-instant abort and rejected: " e))
+                      (done))))))))

--- a/implementation/http/test/re_frame/http_transport_security_test.clj
+++ b/implementation/http/test/re_frame/http_transport_security_test.clj
@@ -11,7 +11,7 @@
             [re-frame.http-handlers]
             [re-frame.http-transport]
             [re-frame.trace :as trace])
-  (:import [java.net.http HttpRequest]
+  (:import [java.net.http HttpClient HttpClient$Redirect HttpRequest]
            [java.time Duration]
            [java.util Optional]))
 
@@ -122,6 +122,22 @@
       (is (nil? (request-timeout-ms req))
           "nil timeout-ms produces an HttpRequest with no per-request timeout"))))
 
+(deftest jvm-build-request-zero-timeout-ms-omits-jdk-timeout
+  (testing "rf2-ee38b.7 — `:timeout-ms 0` is the SECOND opt-out per Spec
+  014 §`:timeout-ms` security defaults (semantically identical to nil:
+  no per-attempt timeout). Pre-fix this was broken: `0` is truthy in
+  Clojure, so `(when timeout-ms …)` armed `(Duration/ofMillis 0)`, which
+  throws `IllegalArgumentException` on the JDK and surfaced the opt-out
+  as a spurious `:rf.http/transport` failure. The `(pos? timeout-ms)`
+  guard now collapses `0` to no-timeout. This builds the request to
+  prove it neither throws nor stamps a per-request deadline."
+    (let [req (jvm-build-request
+                {:method     :get
+                 :url        "https://example.invalid/"
+                 :timeout-ms 0})]
+      (is (nil? (request-timeout-ms req))
+          "zero timeout-ms produces an HttpRequest with no per-request timeout (and does not throw)"))))
+
 ;; ---- rf2-it1cd — normalise-args applies the 30000 default ---------------
 
 (def ^:private normalise-args @#'re-frame.http-handlers/normalise-args)
@@ -156,8 +172,12 @@
           "nil opt-out threads through unchanged"))))
 
 (deftest normalise-args-passes-explicit-zero-timeout-ms-through
-  (testing "rf2-it1cd — `:timeout-ms 0` is also an explicit opt-out
-  (the JVM transport's `(when timeout-ms ...)` skips on falsy)"
+  (testing "rf2-it1cd — `:timeout-ms 0` is also an explicit opt-out and
+  threads through normalisation unchanged. The transport then collapses
+  it to no-timeout via a `(pos? timeout-ms)` guard — NOT a bare
+  truthiness check, since `0` is truthy in Clojure. (The transport-level
+  opt-out is pinned by `jvm-build-request-zero-timeout-ms-omits-jdk-timeout`
+  below.)"
     (let [ctx (normalise-args {:request    {:url "/x"}
                                :timeout-ms 0}
                               {:event [:some/event]})]
@@ -253,6 +273,63 @@
             (is (= "https://example.invalid/v1?q=:rf/redacted&page=:rf/redacted"
                    (:url tags)))
             (is (true? (:sensitive? w)))))))))
+
+;; ---- rf2-ee38b.7 — JVM honours the spec's `:redirect` envelope key -------
+
+(def ^:private redirect->policy
+  @#'re-frame.http-transport/redirect->policy)
+
+(def ^:private jvm-http-client-for
+  @#'re-frame.http-transport/jvm-http-client-for)
+
+(deftest jvm-redirect-policy-maps-spec-values
+  (testing "rf2-ee38b.7 — `:redirect` maps onto the JDK redirect policy.
+  Spec 014 §Request envelope defaults `:redirect` to `:follow`; the JVM
+  transport previously dropped the key entirely (JDK default NEVER), so a
+  request relying on the spec default did NOT follow redirects on JVM/SSR.
+  `:follow` → NORMAL, `:error`/`:manual` → NEVER, and the default (nil /
+  unknown) → NORMAL to honour the spec default."
+    (is (= HttpClient$Redirect/NORMAL (redirect->policy :follow))
+        ":follow → NORMAL")
+    (is (= HttpClient$Redirect/NEVER  (redirect->policy :error))
+        ":error → NEVER")
+    (is (= HttpClient$Redirect/NEVER  (redirect->policy :manual))
+        ":manual → NEVER (no JDK manual analogue)")
+    (is (= HttpClient$Redirect/NORMAL (redirect->policy nil))
+        "absent :redirect → NORMAL (the spec default :follow)")
+    (is (= HttpClient$Redirect/NORMAL (redirect->policy :unknown))
+        "unknown value → NORMAL (the spec default :follow)")))
+
+(deftest jvm-http-client-honours-follow-by-default
+  (testing "rf2-ee38b.7 — the per-policy memoised client carries the right
+  `followRedirects` setting. The spec default (`:follow`/nil) yields a
+  client set to NORMAL (NOT the JDK's bare-builder default NEVER)."
+    (let [^HttpClient default-client (jvm-http-client-for nil)
+          ^HttpClient follow-client  (jvm-http-client-for :follow)
+          ^HttpClient never-client   (jvm-http-client-for :error)]
+      (is (= HttpClient$Redirect/NORMAL (.followRedirects default-client))
+          "default (nil :redirect) client follows redirects per the spec default")
+      (is (= HttpClient$Redirect/NORMAL (.followRedirects follow-client))
+          ":follow client follows redirects")
+      (is (= HttpClient$Redirect/NEVER (.followRedirects never-client))
+          ":error/:manual client does not auto-follow")
+      (is (identical? follow-client (jvm-http-client-for :follow))
+          "clients are memoised per policy — connection pool is preserved"))))
+
+;; ---- rf2-ee38b.7 — JVM timeout failure carries :limit-ms -----------------
+
+(deftest jvm-timeout-failure-carries-limit-ms
+  (testing "rf2-ee38b.7 — a JVM `:rf.http/timeout` failure now carries the
+  configured `:limit-ms` (Spec 014 §Failure categories types
+  `:rf.http/timeout` with `:elapsed-ms` / `:limit-ms`). The CLJS path
+  always populated both; the JVM path emitted nil for both. `:elapsed-ms`
+  legitimately stays nil on JVM (the JDK exposes no elapsed value)."
+    (let [classify @#'re-frame.http-transport/classify-jvm-error
+          t   (java.net.http.HttpTimeoutException. "request timed out")
+          out (classify t 5000)]
+      (is (= :rf.http/timeout (:kind out)))
+      (is (= 5000 (:limit-ms out)) ":limit-ms is threaded from the configured timeout-ms")
+      (is (nil? (:elapsed-ms out)) ":elapsed-ms stays nil on JVM"))))
 
 ;; ---- rf2-q3ts4 — classify-jvm-error no longer string-matches "abort"/"timed out" ----
 


### PR DESCRIPTION
Consolidated remediation for `implementation/http` (Spec 014 managed-HTTP) from the 3-lens review sweep. Cross-refs **rf2-ee38b.7**.

## Findings → fixes

### Correctness
- **`:timeout-ms 0` opt-out broken on both hosts (P1)** — `0` is truthy in Clojure/CLJS, so `(when timeout-ms …)` armed `Duration.ofMillis(0)` on JVM (throws `IllegalArgumentException` → spurious `:rf.http/transport`) and `setTimeout(…,0)` on CLJS (near-instant abort). **Fix:** both transport guards now `(pos? timeout-ms)`, collapsing `nil`/`0`/negative to no-timeout per Spec 014. Corrected the false "treats nil/0 as opt-out via falsy" handler docstring and the test comment that pinned "skips on falsy".
- **non-2xx-else (1xx/3xx) bypasses `maybe-retry!` (P3)** — routed through `maybe-retry!` so the `:rf.http/http-4xx` label matches retry semantics.
- **JVM `:rf.http/timeout` nil `:limit-ms` (P3)** — threaded the configured `timeout-ms` into `classify-jvm-error` (new 2-arity); JVM timeout shape now matches CLJS. `:elapsed-ms` stays nil (JDK exposes none).
- **Malli-absent `:decode <schema>` silently skips validation (P3)** — one-shot `:rf.warning/http-malli-absent` trace; the degraded path is now visible.

### Completeness
- **JVM drops `:redirect` (P1)** — JDK default is `NEVER` vs spec default `:follow`, silently. **Fix:** per-redirect-policy memoised `HttpClient` (`:follow`→`NORMAL`, `:error`/`:manual`→`NEVER`), preserving connection pooling. `redirect->policy` documents the JVM `:error`/`:manual` collapse.
- **JVM drops `:credentials` (P2)** — the browser same-origin/include cookie model has no faithful `HttpClient` analogue. **Fix:** added `:credentials` to the JVM-degraded set so it emits `:rf.http/cljs-only-key-ignored-on-jvm` instead of a silent no-op. (Spec 014 §JVM-degradation table needs a `:credentials` row — see below.)

### Clarity / minimalism
- Hoisted `redacted-sentinel` to a single canonical home (`http-url`); `http-privacy` re-exports it, `http-privacy-headers` refers to it (was defined 3×).
- Deleted stale "future home" docstrings (the rf2-5ijhk encoding split already landed).
- Noted the test-only public redaction wrappers (`redact-request-tags`/`redact-failure`/`redact-url`/`stamp-sensitive`).
- Extracted `dispatch-failure!`/`dispatch-success!` helpers (collapsed 4/2 inline reply shapes).
- Dropped the unused `record-in-flight!` 2-arity (no production or test caller).

## Skipped (left for mayor)
- **`:request-id`/`:abort-signal` mutual exclusivity (P3)** — the implementation deliberately composes both signals (rf2-1jcpm forwards the caller signal into the internal controller); enforcing a throw would break that. Enforce-vs-soften-the-spec is a genuine decision.
- **JVM `:status-text ""` (P3)** — the JDK exposes no HTTP reason phrase; documentation-only.
- **Spec 014** needs a `:credentials` row added to the §JVM-degradation table to match the new trace.

## Test plan
- [x] http JVM `clojure -M:test` — 263 tests / 1388 assertions, 0 failures (3 new: redirect-policy mapping, client `followRedirects`, JVM timeout `:limit-ms`).
- [x] CLJS clean recompile (`npx shadow-cljs compile node-test`) — 0 warnings.
- [x] CLJS `node out/node-test.js` — 4129 tests / 12607 assertions, 0 failures (new: `:timeout-ms 0` no-near-instant-abort, `:redirect` threads into Fetch init).