### PR TITLE
fix(machines-viz): grammar-coverage parser/projection bugs + clarity (rf2-ee38b.21)

### DIFF
--- a/tools/machines-viz/spec/README.md
+++ b/tools/machines-viz/spec/README.md
@@ -36,8 +36,12 @@ shipped surface is the Mermaid `stateDiagram-v2` exporter.
 - **Mermaid `stateDiagram-v2` exporter** — per
   [rf2-deo2i](../../../.beads/) and
   [`API.md`](API.md) §Mermaid `stateDiagram-v2`. Implemented at
-  `src/day8/re_frame2_machines_viz/mermaid.cljc` (~500 LoC). Covers
-  the read-only diagram surface enumerated in
+  `implementation/machines/src/re_frame/machines/mermaid.cljc`
+  (namespace `re-frame.machines.mermaid`) — rf2-ee38b.21 corrected the
+  prior `src/day8/re_frame2_machines_viz/mermaid.cljc` claim; the
+  emitter lives under `implementation/machines/` per
+  [`000-Vision.md`](000-Vision.md) §Static renderer, NOT under this
+  tool. Covers the read-only diagram surface enumerated in
   [`000-Vision.md`](000-Vision.md) §item 5 (single-state machines,
   composite states, parallel regions, transition labels, entry/exit
   actions, action/`do` labels, `invoke-all` row layout). JVM + CLJS

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -120,6 +120,11 @@
         to-path    (.-toPath d)
         clickable? (and (fn? on-click) (some? event-id))
         self-loop? (boolean (.-selfLoop d))
+        ;; rf2-ee38b.21 — an INTERNAL self-transition (Spec 005:
+        ;; omit :target) runs only :action; :exit / :entry do NOT fire.
+        ;; Render it WITHOUT the re-entry arrowhead + with a dashed loop
+        ;; so it reads as "no exit/entry re-trigger" (Stately parity).
+        internal?  (boolean (.-internal d))
         {:keys [edge-label-px edge-label-backplate-opacity]} vc
         ;; A self-transition (source == target) renders as a small loop
         ;; off the node's edge instead of xyflow's degenerate near-zero
@@ -147,9 +152,12 @@
       [:<>
        [:> BaseEdge {:id (.-id props)
                      :path path
-                     :markerEnd marker-end
+                     ;; Internal self-transitions suppress the arrowhead
+                     ;; (no exit/entry re-trigger to point back at).
+                     :markerEnd (when-not internal? marker-end)
                      :style #js {:stroke stroke
                                  :strokeWidth stroke-w
+                                 :strokeDasharray (when internal? "4 3")
                                  :animation (when focused?
                                               "mv-chart-transition-glow 720ms ease-out infinite")}}]
        (when (seq label)
@@ -159,6 +167,11 @@
                :data-active (str active?)
                :data-focused-edge (str focused?)
                :data-after-ms (when after-ms (str after-ms))
+               ;; rf2-ee38b.21 — surface internal / machine-level so the
+               ;; DOM suite + a host can distinguish self-transition kind
+               ;; + inherited fallbacks.
+               :data-internal (str internal?)
+               :data-machine-level (str (boolean (.-machineLevel d)))
                ;; rf2-u422r — clickable edges surface their fireable
                ;; event-id so a host (Causa on-chart sim) + tests can
                ;; address them; inert (auto / no-callback) edges omit it.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -110,29 +110,75 @@
     (pop path)
     []))
 
+(defn name-of
+  "Render a guard / action / entry / exit symbol-like value as a short
+  string WITHOUT throwing on fn values. Keywords use `ns/name` when
+  namespaced, plain `name` otherwise; non-keywords fall through to
+  `str`. Inlined fn guards / actions surface their `:name` meta (named
+  `(fn name [...] ...)` / `(defn ...)`) or `\"fn\"` when anonymous — so
+  the xstate label reads cleanly instead of `#object[Function]`.
+
+  Public + namespace-preserving — `chart.projection` reuses this (it
+  previously carried a near-duplicate `safe-name` that dropped the
+  namespace; rf2-ee38b.21 collapses the two)."
+  [v]
+  (cond
+    (nil? v)     nil
+    (keyword? v) (if-let [n (namespace v)]
+                   (str n "/" (name v))
+                   (name v))
+    (fn? v)      (or (some-> v meta :name str) "fn")
+    :else        (str v)))
+
 (defn- resolve-target-path
-  "Resolve a transition target relative to source-path."
+  "Resolve a transition target relative to source-path.
+
+  Per Spec 005 §Self-transitions (`spec/005-StateMachines.md:206,263,
+  289-294`):
+
+  - `:target :same-state` — the **external** self-transition sentinel.
+    Resolve to `source-path` so the edge is a true self-loop
+    (source == target) and renders via the existing `:selfLoop` path.
+  - a plain keyword target — resolve relative to the parent path.
+  - a vector-path target — take it verbatim.
+  - nil (no `:target`) — returns nil. The **internal** self-transition
+    case (a candidate map that omits `:target`) is NOT handled here:
+    `collect-state-edges` detects the missing key and self-anchors the
+    edge itself (flagging `:internal? true`), so this fn never sees it."
   [source-path target]
   (cond
-    (keyword? target)     (conj (parent-path source-path) target)
-    (target-path? target) (vec target)
-    :else                 nil))
+    (= :same-state target) (vec source-path)
+    (keyword? target)      (conj (parent-path source-path) target)
+    (target-path? target)  (vec target)
+    :else                  nil))
 
 (defn- collect-state-edges
   "Walk a state node and return edge-maps for every statically-
-  resolvable transition declared on it. Compound substates recurse."
+  resolvable transition declared on it. Compound substates recurse.
+
+  Self-transitions (Spec 005 §Self-transitions) chart as self-loops:
+  `:target :same-state` (external) resolves to the source path; a
+  candidate that omits `:target` entirely (internal — runs only its
+  `:action`) self-anchors and is flagged `:internal? true` so the
+  renderer can distinguish it (no exit/entry re-trigger)."
   [state-path state-node]
   (let [edges-from
         (concat
          (mapcat (fn [[event-id spec]]
                    (keep (fn [candidate]
-                           (when-let [tp (resolve-target-path state-path
-                                                              (:target candidate))]
-                             {:from   state-path
-                              :to     tp
-                              :event  event-id
-                              :guard  (:guard candidate)
-                              :action (:action candidate)}))
+                           (let [internal? (and (map? candidate)
+                                                (not (contains? candidate :target)))
+                                 tp        (if internal?
+                                             (vec state-path)
+                                             (resolve-target-path state-path
+                                                                  (:target candidate)))]
+                             (when tp
+                               (cond-> {:from   state-path
+                                        :to     tp
+                                        :event  event-id
+                                        :guard  (:guard candidate)
+                                        :action (:action candidate)}
+                                 internal? (assoc :internal? true)))))
                          (transition-candidates spec)))
                  (:on state-node))
          (mapcat (fn [[delay spec]]
@@ -174,13 +220,20 @@
   [parent-path state-map]
   (mapcat (fn [[state-id state-node]]
             (let [path (conj parent-path state-id)
-                  self {:path     path
-                        :label    (name state-id)
-                        :depth    (count parent-path)
-                        :initial? (boolean (:initial? state-node))
-                        :final?   (:final? state-node)
-                        :compound? (boolean (:states state-node))
-                        :tags     (set (:tags state-node))}
+                  self (cond-> {:path     path
+                                :label    (name state-id)
+                                :depth    (count parent-path)
+                                :initial? (boolean (:initial? state-node))
+                                :final?   (boolean (:final? state-node))
+                                :compound? (boolean (:states state-node))
+                                :tags     (set (:tags state-node))}
+                         ;; rf2-ee38b.21 — :entry / :exit state actions
+                         ;; (Spec 005 §State nodes L218-219) surface as
+                         ;; short name strings so the renderer can paint
+                         ;; `entry / <name>` / `exit / <name>` rows. nil
+                         ;; when absent (cond-> skips the assoc).
+                         (:entry state-node) (assoc :entry (name-of (:entry state-node)))
+                         (:exit state-node)  (assoc :exit  (name-of (:exit state-node))))
                   init-key     (:initial state-node)
                   raw-children (when (:states state-node)
                                  (collect-nodes path (:states state-node)))
@@ -196,53 +249,74 @@
 
 ;; ---- public ids ---------------------------------------------------------
 
+(defn- escape-id-segment
+  "Sanitise one path segment into an xyflow-id-safe string
+  INJECTIVELY — distinct inputs always yield distinct outputs.
+
+  The naive `str/replace #\"[^a-zA-Z0-9_]\" \"_\"` collapses `:a/b`,
+  `:a-b`, `:a_b` all to `\"a_b\"` (rf2-ee38b.21 P2): a React key
+  collision drops one node + makes every edge addressing either
+  ambiguous. Hyphens are pervasive in re-frame keywords
+  (`:logged-in`, `:rate-limited`), so the collision is reachable.
+
+  Scheme: every char outside `[a-zA-Z0-9]` becomes `_<hex>` (the
+  underscore itself included), so the mapping is reversible and no two
+  distinct chars share an encoding. The path separator `__` (double
+  underscore) can never appear inside a segment because a literal `_`
+  encodes to `_5f`."
+  [s]
+  (str/join
+    (map (fn [ch]
+           (if (re-matches #"[a-zA-Z0-9]" (str ch))
+             (str ch)
+             (str "_" #?(:clj  (format "%02x" (int ch))
+                         :cljs (let [h (.toString (.charCodeAt (str ch) 0) 16)]
+                                 (if (= 1 (count h)) (str "0" h) h))))))
+         s)))
+
 (defn node-id
   "Stable string id for a node, suitable for xyflow ids and SCXML
   / Mermaid emitter ids. Exported so every consumer addresses nodes
-  the same way."
+  the same way.
+
+  rf2-ee38b.21 — the id is INJECTIVE: distinct paths always mint
+  distinct ids (the old `[^a-zA-Z0-9_]`-collapse merged `:a/b` /
+  `:a-b` / `:a_b`). Segments are `_<hex>`-escaped (see
+  `escape-id-segment`) and joined with `__`."
   [path]
   (->> path
        (map (fn [p]
               (if (keyword? p)
                 (if-let [ns (namespace p)]
-                  (str ns "_" (name p))
-                  (name p))
-                (str p))))
-       (str/join "__")
-       (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
+                  (str (escape-id-segment ns) "_2f" (escape-id-segment (name p)))
+                  (escape-id-segment (name p)))
+                (escape-id-segment (str p)))))
+       (str/join "__")))
 
 (defn region-node-id
   "Stable string id for a parallel region's synthetic compound node.
   Prefixed `region__` so it never collides with a state `node-id`
-  (rf2-lkwev). `region-id` is the region's key in the `:regions` map."
+  (rf2-lkwev). `region-id` is the region's key in the `:regions` map.
+
+  rf2-ee38b.21 — segments are `escape-id-segment`-escaped (the same
+  injective scheme `node-id` uses) so a region named `:auth/main` and
+  a state `:auth-main` can never collapse to the same id."
   [region-id]
   (str "region__"
        (if (keyword? region-id)
          (if-let [ns (namespace region-id)]
-           (str ns "_" (name region-id))
-           (name region-id))
-         (str region-id))))
-
-(defn- name-of
-  "Render a guard/action symbol-like value as a short string. Keywords
-  use `ns/name` when namespaced, plain `name` otherwise. Non-keywords
-  fall through to `str`."
-  [v]
-  (cond
-    (nil? v)     nil
-    (keyword? v) (if-let [n (namespace v)]
-                   (str n "/" (name v))
-                   (name v))
-    ;; Inlined fn guards / actions surface their `:name` meta (named
-    ;; `(fn name [...] ...)` / `(defn ...)`) or `fn` when anonymous —
-    ;; so the xstate label reads cleanly instead of `#object[Function]`.
-    (fn? v)      (or (some-> v meta :name str) "fn")
-    :else        (str v)))
+           (str (escape-id-segment ns) "_2f" (escape-id-segment (name region-id)))
+           (escape-id-segment (name region-id)))
+         (escape-id-segment (str region-id)))))
 
 (defn event-segment
   "Render the leading event segment of an edge label per the
   xstate-stately convention.
 
+    - `:*` wildcard         → `\"* (any)\"` (Spec 005 §Wildcard — the
+                              `:on` key that matches any otherwise-
+                              unhandled event; NOT a real fireable
+                              event, so it reads as an 'otherwise' arm)
     - regular event keyword → `\"event-id\"` (with namespace when present)
     - `:after` transition   → `\"after(<delay>)\"`
     - `:always` transition  → `\"always\"`"
@@ -250,6 +324,7 @@
   (cond
     after            (str "after(" after ")")
     always?          "always"
+    (= :* event)     "* (any)"
     (keyword? event) (if-let [n (namespace event)]
                        (str n "/" (name event))
                        (name event))
@@ -283,14 +358,68 @@
 
 (defn- edge-id
   "Stable string id for an edge — composite of source-id, target-id,
-  and event segment so multiple parallel edges between the same pair
-  of states do not collide."
-  [from-path to-path edge]
+  event segment, AND the guard/action segment so multiple candidate
+  edges between the same pair of states do not collide. The vector-of-
+  candidates grammar (`spec/005-StateMachines.md:253-256`) routinely
+  produces same-event/same-target edges differing only by guard, so
+  folding the guard/action in keeps them distinct (xyflow drops a
+  duplicate-id edge). The `parse-flat` caller appends a per-key ordinal
+  as a final tiebreak for the rare byte-identical-candidate case."
+  [from-path to-path {:keys [guard action] :as edge}]
   (str (node-id from-path)
        "__"
        (node-id to-path)
        "__"
-       (event-segment edge)))
+       (event-segment edge)
+       (when guard  (str "__g_" (name-of guard)))
+       (when action (str "__a_" (name-of action)))))
+
+(defn- collect-machine-edges
+  "Emit edges for the machine-level (top-level) `:on` fallback
+  transitions (Spec 005 `spec/005-StateMachines.md:181,199` — `:on`
+  is valid `per-state AND top-level`; a top-level entry is a machine-
+  wide fallback every state inherits).
+
+  Renders one edge from every LEAF state to the transition's target,
+  flagged `:machine-level? true` so the projection / SCXML emitter can
+  distinguish an inherited fallback from a state-local transition. Leaf
+  states (no `:states`) are the real transition sources — a compound
+  parent's inherited fallback fires from whichever leaf is active.
+  Edges back into a leaf's own state are kept (they self-loop). The
+  `:*` wildcard fallback is supported too (rendered as a non-fireable
+  affordance downstream)."
+  [machine-on leaf-paths]
+  (when (seq machine-on)
+    (mapcat
+      (fn [[event-id spec]]
+        (mapcat
+          (fn [leaf-path]
+            (keep (fn [candidate]
+                    (let [target    (:target candidate)
+                          internal? (and (map? candidate)
+                                         (not (contains? candidate :target)))
+                          ;; A machine-level transition's target is
+                          ;; resolved at the TOP level (a top-level
+                          ;; state), NOT relative to the inheriting
+                          ;; leaf's parent — so `resolve-target-path`
+                          ;; is called with a root-level `[]` source.
+                          ;; `:same-state` / omitted-target self-loop on
+                          ;; the leaf itself.
+                          tp        (cond
+                                      internal?              (vec leaf-path)
+                                      (= :same-state target) (vec leaf-path)
+                                      :else (resolve-target-path [] target))]
+                      (when tp
+                        (cond-> {:from           leaf-path
+                                 :to             tp
+                                 :event          event-id
+                                 :guard          (:guard candidate)
+                                 :action         (:action candidate)
+                                 :machine-level? true}
+                          internal? (assoc :internal? true)))))
+                  (transition-candidates spec)))
+          leaf-paths))
+      machine-on)))
 
 ;; ---- public projection --------------------------------------------------
 
@@ -301,7 +430,7 @@
   machine (the per-region nodes/edges then get tagged with their
   region + parent-id)."
   [definition]
-  (let [{:keys [initial states]} definition
+  (let [{:keys [initial states on]} definition
         base-nodes (vec (collect-nodes [] states))
         initial-path (when initial [initial])
         nodes (mapv (fn [n]
@@ -318,18 +447,40 @@
                                    (assoc :parent-id (node-id (pop path))))]
                         (assoc n' :id (node-id path))))
                     base-nodes)
-        raw-edges (vec (mapcat (fn [[state-id state-node]]
-                                 (collect-state-edges [state-id] state-node))
-                               states))
-        edges (vec (map (fn [e]
-                          (assoc e
-                            :id          (edge-id (:from e) (:to e) e)
-                            :source      (node-id (:from e))
-                            :target      (node-id (:to e))
-                            :from-path   (:from e)
-                            :to-path     (:to e)
-                            :event-label (edge-label e)))
-                        raw-edges))]
+        leaf-paths (->> base-nodes
+                        (remove :compound?)
+                        (mapv :path))
+        raw-edges (vec (concat
+                         (mapcat (fn [[state-id state-node]]
+                                   (collect-state-edges [state-id] state-node))
+                                 states)
+                         ;; Machine-level (top-level) :on fallback
+                         ;; transitions every state inherits (Spec 005).
+                         (collect-machine-edges on leaf-paths)))
+        ;; rf2-ee38b.21 — disambiguate edges that share source/target/
+        ;; event but differ by guard/action/machine-level (the vector-of-
+        ;; candidates grammar routinely produces same-event/same-target
+        ;; forks that differ only by guard). `edge-id` folds guard/action
+        ;; in; a trailing per-key ordinal guarantees uniqueness even when
+        ;; two candidates are byte-identical.
+        edges (->> raw-edges
+                   (reduce
+                     (fn [{:keys [seen out]} e]
+                       (let [base (edge-id (:from e) (:to e) e)
+                             n    (get seen base 0)
+                             id   (if (zero? n) base (str base "__" n))]
+                         {:seen (assoc seen base (inc n))
+                          :out  (conj out
+                                      (assoc e
+                                        :id          id
+                                        :source      (node-id (:from e))
+                                        :target      (node-id (:to e))
+                                        :from-path   (:from e)
+                                        :to-path     (:to e)
+                                        :event-label (edge-label e)))}))
+                     {:seen {} :out []})
+                   :out
+                   vec)]
     {:nodes        nodes
      :edges        edges
      :initial-path initial-path}))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -22,9 +22,10 @@
       large body containing nested children (xyflow's `parentNode`
       mechanic handles the hierarchical layout; this node renders
       the outer container chrome).
-    - `initial-marker` + `final-marker` — small glyph nodes paired
-      with state nodes to mark the machine's initial / final
-      transitions.
+    - `initial-marker` — a small glyph node paired with the initial
+      state to mark the machine's entry transition. (Final states paint
+      a doubled ring + ✓ glyph inline on `state-node`; there is no
+      separate final-marker node — rf2-ee38b.21 removed the dead one.)
 
   ## Token integration
 
@@ -174,6 +175,8 @@
         sim?           (boolean (.-sim d))
         final?         (boolean (.-final d))
         tags           (js->clj (.-tags d))
+        entry          (.-entry d)
+        exit           (.-exit d)
         on-click       (.-onClick d)
         emphasised?    (or active? from-highlight? to-highlight?)
         active-affordance? (or active? to-highlight?)
@@ -250,6 +253,26 @@
                (for [t tags] (tag-pill t vc))))
        ;; Label
        [:div {:style {:line-height "1.2"}} label]
+       ;; rf2-ee38b.21 — :entry / :exit action rows (Stately parity:
+       ;; `entry / <name>` / `exit / <name>` below the label, mono, dim).
+       (when (or entry exit)
+         [:div {:data-testid "rf-mv-chart-state-actions"
+                :style {:display        "flex"
+                        :flex-direction "column"
+                        :align-items    "center"
+                        :margin-top     "3px"
+                        :font-family    mono-stack
+                        :font-size      (str (max 8 (- state-label-px 3)) "px")
+                        :color          (:text-tertiary tokens/tokens)
+                        :line-height    "1.3"}}
+          (when entry
+            [:div {:data-testid "rf-mv-chart-state-entry"
+                   :data-entry  entry}
+             (str "entry / " entry)])
+          (when exit
+            [:div {:data-testid "rf-mv-chart-state-exit"
+                   :data-exit   exit}
+             (str "exit / " exit)])])
        ;; Final-state check glyph
        (when final?
          [:div {:style {:position    "absolute"
@@ -310,7 +333,7 @@
                      :color       (:accent-violet tokens/tokens)}}
         label]])))
 
-;; ---- initial / final marker nodes --------------------------------------
+;; ---- initial marker node ------------------------------------------------
 
 (defn initial-marker
   "Reagent component for the machine's initial-state marker — a
@@ -326,29 +349,12 @@
      [:> Handle {:type "source" :position pos-right
                  :style {:opacity 0}}]]))
 
-(defn final-marker
-  "Reagent component for a final-state marker — concentric circle
-  glyph. Reserved for the `[*]` end-state-as-node pattern when a
-  future bead surfaces it; v1 paints the doubled ring inline on
-  `state-node`."
-  [^js _props]
-  (r/as-element
-    [:div {:data-testid "rf-mv-chart-final-marker"
-           :style {:width            "14px"
-                   :height           "14px"
-                   :border-radius    "50%"
-                   :border           (str "2px solid " (:green tokens/tokens))
-                   :background       "transparent"
-                   :position         "relative"}}
-     [:div {:style {:position         "absolute"
-                   :top              "3px"
-                   :left             "3px"
-                   :width            "4px"
-                   :height           "4px"
-                   :border-radius    "50%"
-                   :background       (:green tokens/tokens)}}]
-     [:> Handle {:type "target" :position pos-left
-                 :style {:opacity 0}}]]))
+;; rf2-ee38b.21 — the dead `final-marker` component + its node-type
+;; registration were removed. The projector only ever emits
+;; `initial-marker` nodes; final states paint the doubled ring + ✓
+;; glyph inline on `state-node`. The end-state-as-node `[*]` pattern,
+;; if it ever lands, files its own bead (same posture the codebase
+;; took when it removed the dead `spawn-edge` registration).
 
 ;; ---- node-types map -----------------------------------------------------
 
@@ -361,5 +367,4 @@
   #js {"state"           state-node
        "compound"        compound-node
        "parallel-region" parallel-region-node/parallel-region-node
-       "initial-marker"  initial-marker
-       "final-marker"    final-marker})
+       "initial-marker"  initial-marker})

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings.cljs
@@ -85,7 +85,7 @@
   DOM seam (rf2-ed099)."
   [^js root node-id]
   (when (and root node-id)
-    (anchor/query-node-rect-by-testid root (geo/state->node-testid node-id))))
+    (anchor/query-node-rect-by-testid root (anchor/node->testid node-id))))
 
 (defn- measure-rings
   "Walk the DOM under `root` for every ring-spec's bearing node and

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry.cljc
@@ -30,8 +30,7 @@
   Radius is half the node's longer dimension plus a breathing gap so
   the ring sits clearly OUTSIDE the node's border, then scaled by the
   rendered zoom (the node rect is already zoom-scaled by xyflow, so a
-  proportional gap keeps the ring crisp at any zoom level)."
-  (:require [clojure.string :as str]))
+  proportional gap keeps the ring crisp at any zoom level).")
 
 (def ring-gap-px
   "Breathing gap (px, at 1x zoom) between the node's bounding box and
@@ -89,20 +88,10 @@
         :cy (- ncy cy-origin)
         :r  (ring-radius node-rect zoom)}))))
 
-(defn state->node-testid
-  "The xyflow node `data-testid` the overlay queries for a given
-  resolved node-id. Mirrors `chart.nodes/state-node`'s
-  `(str \"rf-mv-chart-node-\" id)` contract — the overlay walks the
-  DOM with `[data-testid=\"<this>\"]` to find the bearing node.
-
-  `node-id` is the string `chart.layout/node-id` mints from a state
-  path; the overlay's `:id-fn` resolves a timer's `:state` to it.
-
-  Returns nil for a nil / blank node-id so the overlay skips the
-  ring rather than querying for a garbage selector."
-  [node-id]
-  (when (and node-id (not (str/blank? (str node-id))))
-    (str "rf-mv-chart-node-" node-id)))
+;; rf2-ee38b.21 — the byte-identical `state->node-testid` helper that
+;; lived here was removed; the canonical node-id → testid helper is
+;; `overlay-anchor/node->testid` (the shared overlay seam). `after_rings`
+;; calls it directly.
 
 (defn overlay-rings
   "Pure projection: for each `{:node-id ...}`-bearing ring spec, merge

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -52,7 +52,7 @@
   (when (and root node-id)
     (let [container (anchor/rect->map (.getBoundingClientRect root))
           node      (anchor/query-node-rect-by-testid
-                      root (anchor/node->card-testid node-id))]
+                      root (anchor/node->testid node-id))]
       (anchor/anchor-below node container))))
 
 ;; ---- cascade-step glyph -------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor.cljc
@@ -29,11 +29,15 @@
   overlay card so the card sits clear of the node + its affordance."
   12)
 
-(defn node->card-testid
+(defn node->testid
   "The xyflow node `data-testid` an overlay queries for a bearing
   node-id. Mirrors `chart.nodes/state-node`'s `(str \"rf-mv-chart-node-
   <id>\")` contract. Returns nil for a nil / blank node-id so the
-  overlay skips rather than querying a garbage selector."
+  overlay skips rather than querying a garbage selector.
+
+  rf2-ee38b.21 — this is the SINGLE canonical helper for the
+  node-id → testid string. `after_rings_geometry` previously carried a
+  byte-identical `state->node-testid`; it now points here."
   [node-id]
   (when (and node-id (not (str/blank? (str node-id))))
     (str "rf-mv-chart-node-" node-id)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -51,7 +51,7 @@
   (when (and root node-id)
     (let [container (anchor/rect->map (.getBoundingClientRect root))
           node      (anchor/query-node-rect-by-testid
-                      root (anchor/node->card-testid node-id))]
+                      root (anchor/node->testid node-id))]
       (anchor/anchor-right-of node container))))
 
 ;; ---- child-row glyph ----------------------------------------------------

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -31,7 +31,8 @@
       `chart.cljs`; they touch JS objects and are not portable to the
       JVM.
     - **Topology parsing** — lives in `chart.layout`."
-  (:require [day8.re-frame2-machines-viz.theme.tokens :as tokens]
+  (:require [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.theme.tokens :as tokens]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- node-size floor constants -----------------------------------------
@@ -119,21 +120,7 @@
   children surface through the `chart.overlays.spawn-all-join`
   inspector, not as an edge in this chart."
   [edge]
-  (cond
-    (:after edge) "after"
-    :else         "transition"))
-
-(defn- safe-name
-  "Coerce a guard / action ref to a string WITHOUT throwing on fn
-  values. `cljs.core/name` blows up on fns (`Doesn't support name:
-  function …`), and re-frame2 machines may inline a fn guard / action,
-  so fns surface their `:name` meta (or `fn` when anonymous)."
-  [v]
-  (cond
-    (nil? v)     nil
-    (keyword? v) (name v)
-    (fn? v)      (or (some-> v meta :name str) "fn")
-    :else        (str v)))
+  (if (:after edge) "after" "transition"))
 
 (defn xyflow-graph
   "Project the parsed graph + a `{node-id position}` map into the
@@ -209,6 +196,14 @@
                                           :final          (boolean (:final? n))
                                           :compound       (boolean (:compound? n))
                                           :tags           (vec (:tags n))
+                                          ;; rf2-ee38b.21 — :entry / :exit
+                                          ;; state actions (Spec 005
+                                          ;; §State nodes) ride the payload
+                                          ;; so state-node paints
+                                          ;; `entry / <name>` rows. nil when
+                                          ;; the state declares none.
+                                          :entry          (:entry n)
+                                          :exit           (:exit n)
                                           :chart          chart
                                           :onClick        on-state-click}
                                    region? (assoc :regionId    (:region n)
@@ -238,9 +233,16 @@
                       marker-color (if (or focused? from-active?)
                                      (:cyan tokens/tokens)
                                      (:border-default tokens/tokens))
+                      ;; A `:*` wildcard `:on` arm is a real transition
+                      ;; but NOT a fireable event (Spec 005 §Wildcard —
+                      ;; it matches "any otherwise-unhandled event").
+                      ;; Excluding it keeps `:eventId` nil so the on-chart
+                      ;; sim can't dispatch a literal `[:* ...]` (same
+                      ;; inert posture as `:after` / `:always`).
                       fireable?    (and (nil? (:after e))
                                         (not (:always? e))
-                                        (keyword? (:event e)))
+                                        (keyword? (:event e))
+                                        (not= :* (:event e)))
                       event-id     (when fireable? (:event e))]
                   {:id     (:id e)
                    :source (:source e)
@@ -254,9 +256,17 @@
                             :active     from-active?
                             :focused    focused?
                             :afterMs    (:after e)
-                            :guard      (safe-name (:guard e))
-                            :action     (safe-name (:action e))
+                            :guard      (layout/name-of (:guard e))
+                            :action     (layout/name-of (:action e))
                             :selfLoop   self-loop?
+                            ;; rf2-ee38b.21 — an internal self-transition
+                            ;; (omit :target) runs only :action; the
+                            ;; renderer draws it as a self-loop with no
+                            ;; exit/entry re-trigger affordance.
+                            :internal     (boolean (:internal? e))
+                            ;; A machine-level (top-level :on) fallback
+                            ;; transition every state inherits.
+                            :machineLevel (boolean (:machine-level? e))
                             :eventId    event-id
                             :fromPath   (:from-path e)
                             :toPath     (:to-path e)
@@ -303,6 +313,7 @@
                  :data        {:eventLabel "" :entry true
                                :active false :focused false :afterMs nil
                                :guard nil :action nil :selfLoop false
+                               :internal false :machineLevel false
                                :eventId nil :fromPath nil :toPath nil
                                :onClick on-edge-click :chart chart}})
               initial-nodes)]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/scxml.cljc
@@ -194,13 +194,34 @@
               [(str (indent-str depth) "</" tag ">")])
       [(str (indent-str depth) "<" tag " " attrs "/>")])))
 
+(defn- emit-machine-level-on
+  "Emit the machine-level (top-level) `:on` fallback transitions
+  (Spec 005 `005-StateMachines.md:181,199`) directly under `<scxml>`.
+
+  rf2-ee38b.21 — these were previously dropped entirely (mirroring the
+  parser bug). W3C SCXML has no clean root-fallback-transition slot
+  (`<scxml>` does not host `<transition>` children per the schema, and
+  the import side drops root-level transitions), so a perfect
+  round-trip is impossible. Rather than silently lose the topology we
+  emit them as `<transition>` elements wrapped in a documenting comment
+  so the information survives the export and a human/tool reading the
+  SCXML sees the machine-wide fallback."
+  [on depth]
+  (when (seq on)
+    (concat
+      [(str (indent-str depth)
+            "<!-- machine-level (top-level) :on fallback transitions"
+            " — inherited by every state (Spec 005 §top-level :on) -->")]
+      (emit-transitions-for-on on depth))))
+
 (defn- emit-flat-or-compound
-  [{:keys [initial states]} depth]
+  [{:keys [initial states on]} depth]
   (concat
     [(str (indent-str depth)
           "<scxml xmlns=\"http://www.w3.org/2005/07/scxml\""
           " version=\"1.0\""
           " initial=\"" (escape-xml-attr (path->id-string initial)) "\">")]
+    (emit-machine-level-on on (inc depth))
     (mapcat (fn [[child-id child-node]]
               (emit-state child-id child-node (inc depth)))
             states)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -84,9 +84,6 @@
                                 (rf2-gg7ws — collision-avoidance v1)
     :final-glyph-px           — final-state ✓ glyph font-size
     :compound-title-px        — compound container title font-size
-    :caption-strip-px         — chart-level caption strip height
-                                (rf2-3zdzw)
-    :caption-text-px          — caption strip text font-size
     :compound-radius          — compound container corner radius
                                 (rf2-k647w — distinct from the
                                 state-node `:corner-radius` lock; the
@@ -121,8 +118,6 @@
    :edge-label-backplate-opacity 0.85
    :final-glyph-px         13
    :compound-title-px      13
-   :caption-strip-px       28
-   :caption-text-px        11
 
    ;; ── state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to
    ;;    the SHIPPED renderer numbers — height 16 / pad-x 6 / px 9 /
@@ -173,8 +168,6 @@
    :edge-label-backplate-opacity 0.85
    :final-glyph-px         11
    :compound-title-px      11
-   :caption-strip-px       22
-   :caption-text-px        9
 
    ;; ── state-tag pills (tighter than the regular 16/6/9/8) ──────
    :tag-pill-height        13
@@ -220,8 +213,6 @@
    :edge-label-backplate-opacity 0.85
    :final-glyph-px         15
    :compound-title-px      15
-   :caption-strip-px       34
-   :caption-text-px        13
 
    ;; ── state-tag pills (looser than the regular 16/6/9/8) ───────
    :tag-pill-height        19

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -175,9 +175,10 @@
 
 (deftest region-node-id-is-prefixed-and-distinct
   (testing "rf2-lkwev — region node-ids are region__-prefixed so they
-            never collide with a state node-id"
+            never collide with a state node-id. rf2-ee38b.21 — segments
+            are injectively escaped (the `/` ns separator → `_2f`)."
     (is (= "region__r1" (layout/region-node-id :r1)))
-    (is (= "region__auth_main" (layout/region-node-id :auth/main)))
+    (is (= "region__auth_2fmain" (layout/region-node-id :auth/main)))
     (is (not= (layout/region-node-id :r1) (layout/node-id [:r1]))
         "a region container id differs from the same-named state id")))
 
@@ -273,3 +274,166 @@
           labels (set (map :event-label edges))]
       (is (contains? labels "submit [authed?] / log-it"))
       (is (contains? labels "submit [anon?]")))))
+
+;; ---- self-transitions (rf2-ee38b.21) -----------------------------------
+;;
+;; Spec 005 §Self-transitions: `:target :same-state` is the EXTERNAL
+;; self-transition (exit+entry fire); omitting `:target` is the INTERNAL
+;; one (only :action runs). Both must chart as a self-loop (source ==
+;; target). Pre-fix, `:same-state` resolved to a phantom node-id and
+;; the internal form emitted nothing.
+
+(deftest parse-definition-external-self-transition-same-state
+  (testing "rf2-ee38b.21 — `:target :same-state` resolves to the source
+            path itself (a true self-loop), NOT a phantom :same-state
+            node"
+    (let [m {:initial :a :states {:a {:on {:ping {:target :same-state}}} }}
+          {:keys [nodes edges]} (layout/parse-definition m)
+          node-ids (set (map :id nodes))
+          self     (first (filter #(= :ping (:event %)) edges))]
+      (is (some? self) "the :ping self-transition is charted")
+      (is (= [:a] (:from self)))
+      (is (= [:a] (:to self)) "target resolves to the source path")
+      (is (= (:source self) (:target self)) "source == target → self-loop")
+      (is (contains? node-ids (:target self))
+          "the self-loop target is a REAL node (no phantom :same-state)")
+      (is (not (contains? node-ids "same_state"))
+          "no dangling :same-state node is minted"))))
+
+(deftest parse-definition-internal-self-transition-omit-target
+  (testing "rf2-ee38b.21 — a transition that omits :target (internal —
+            runs only :action) charts as a self-anchored edge flagged
+            :internal? rather than silently dropping"
+    (let [m {:initial :a :states {:a {:on {:tick {:action :inc}}}}}
+          {:keys [edges]} (layout/parse-definition m)
+          tick (first (filter #(= :tick (:event %)) edges))]
+      (is (some? tick) "the internal :tick transition is charted")
+      (is (= [:a] (:from tick)))
+      (is (= [:a] (:to tick)) "internal transition self-anchors")
+      (is (true? (:internal? tick)) "flagged internal")
+      (is (= :inc (:action tick))))))
+
+;; ---- wildcard `:*` (rf2-ee38b.21) --------------------------------------
+
+(deftest parse-definition-wildcard-event-label
+  (testing "rf2-ee38b.21 — the `:*` wildcard `:on` arm (Spec 005
+            §Wildcard) renders as `* (any)`, not a bare `*` that reads
+            like a real event"
+    (let [m {:initial :a :states {:a {:on {:* :b}} :b {}}}
+          {:keys [edges]} (layout/parse-definition m)
+          wild (first (filter #(= :* (:event %)) edges))]
+      (is (some? wild) "the wildcard transition is charted")
+      (is (= "* (any)" (:event-label wild))))))
+
+;; ---- machine-level (top-level) :on fallback (rf2-ee38b.21) -------------
+
+(deftest parse-definition-machine-level-on-fallback
+  (testing "rf2-ee38b.21 — a top-level (machine-level) :on fallback
+            (Spec 005 — `:on` valid per-state AND top-level) charts one
+            edge from every leaf state, flagged :machine-level?, rather
+            than being dropped entirely"
+    (let [m {:initial :a :on {:logout :a} :states {:a {} :b {}}}
+          {:keys [edges]} (layout/parse-definition m)
+          logout (filter #(= :logout (:event %)) edges)]
+      (is (= 2 (count logout)) "one inherited edge per leaf state")
+      (is (every? :machine-level? logout) "flagged machine-level")
+      (is (= #{[:a] [:b]} (set (map :from logout))) "from every leaf")
+      (is (every? #(= [:a] (:to %)) logout) "all land on the target"))))
+
+(deftest parse-definition-machine-level-on-targets-top-level-state
+  (testing "rf2-ee38b.21 — a machine-level :on target is a TOP-LEVEL
+            state, resolved at the root — NOT relative to the inheriting
+            leaf's parent (a compound leaf must still reach :unauth)"
+    (let [m {:initial :authenticated
+             :on      {:logout :unauth}
+             :states  {:unauth        {}
+                       :authenticated {:initial :browsing
+                                       :states  {:browsing {}
+                                                 :paying   {}}}}}
+          {:keys [edges]} (layout/parse-definition m)
+          logout (filter #(= :logout (:event %)) edges)]
+      (is (every? #(= [:unauth] (:to %)) logout)
+          "every inherited :logout lands on the top-level :unauth")
+      (is (contains? (set (map :from logout)) [:authenticated :browsing])
+          "compound leaves inherit it too"))))
+
+;; ---- node-id injectivity (rf2-ee38b.21) --------------------------------
+
+(deftest node-id-is-injective-over-hyphen-ns-underscore
+  (testing "rf2-ee38b.21 — distinct paths mint DISTINCT ids. The old
+            `[^a-zA-Z0-9_]`-collapse merged `:a/b`, `:a-b`, `:a_b` all
+            to `\"a_b\"` (React key collision dropped a node)"
+    (let [ids (map (comp layout/node-id vector) [:a/b :a-b :a_b :logged-in :logged_in])]
+      (is (= (count ids) (count (set ids)))
+          "all five distinct keywords yield distinct ids")
+      (is (not= (layout/node-id [:a/b]) (layout/node-id [:a-b])))
+      (is (not= (layout/node-id [:a-b]) (layout/node-id [:a_b])))
+      (is (not= (layout/node-id [:logged-in]) (layout/node-id [:logged_in]))))))
+
+(deftest node-id-distinct-from-region-container-id
+  (testing "rf2-ee38b.21 — a state literally named :region__foo cannot
+            collide with a region container's id"
+    (is (not= (layout/node-id [:region__foo])
+              (layout/region-node-id :foo)))))
+
+;; ---- edge-id collision (rf2-ee38b.21) ----------------------------------
+
+(deftest parse-definition-edge-ids-distinct-for-guarded-fork
+  (testing "rf2-ee38b.21 — a same-event/same-target fork that differs
+            only by guard mints DISTINCT edge ids so xyflow keeps both
+            branches (pre-fix the ids collided → one branch dropped)"
+    (let [m {:initial :a
+             :states  {:a {:on {:go [{:target :b :guard :g1}
+                                     {:target :b :guard :g2}]}}
+                       :b {}}}
+          {:keys [edges]} (layout/parse-definition m)
+          go-edges (filter #(= :go (:event %)) edges)
+          ids      (map :id go-edges)]
+      (is (= 2 (count go-edges)) "both candidate edges survive")
+      (is (= 2 (count (set ids))) "their xyflow ids are distinct"))))
+
+(deftest parse-definition-edge-ids-distinct-for-identical-candidates
+  (testing "rf2-ee38b.21 — even byte-identical candidates (same target,
+            no guard/action) get distinct ids via the per-key ordinal"
+    (let [m {:initial :a
+             :states  {:a {:on {:go [{:target :b} {:target :b}]}}
+                       :b {}}}
+          {:keys [edges]} (layout/parse-definition m)
+          ids (map :id (filter #(= :go (:event %)) edges))]
+      (is (= 2 (count ids)))
+      (is (= 2 (count (set ids))) "ordinal disambiguates identical candidates"))))
+
+;; ---- entry / exit state actions (rf2-ee38b.21) -------------------------
+
+(deftest parse-definition-threads-entry-exit-onto-nodes
+  (testing "rf2-ee38b.21 — :entry / :exit state actions (Spec 005
+            §State nodes) surface as name strings on the parsed node"
+    (let [m {:initial :a
+             :states  {:a {:entry :on-enter :exit :on-leave}
+                       :b {:entry (with-meta (fn [_]) {:name 'do-thing})}}}
+          {:keys [nodes]} (layout/parse-definition m)
+          a (first (filter #(= [:a] (:path %)) nodes))
+          b (first (filter #(= [:b] (:path %)) nodes))]
+      (is (= "on-enter" (:entry a)))
+      (is (= "on-leave" (:exit a)))
+      (is (= "do-thing" (:entry b)) "fn entry surfaces its :name meta")
+      (is (not (contains? b :exit)) "absent exit is omitted"))))
+
+(deftest parse-definition-no-entry-exit-when-absent
+  (testing "rf2-ee38b.21 — a state with no :entry / :exit carries
+            neither key (cond-> skips the assoc)"
+    (let [{:keys [nodes]} (layout/parse-definition idle-loading-success)
+          idle (first (filter #(= [:idle] (:path %)) nodes))]
+      (is (not (contains? idle :entry)))
+      (is (not (contains? idle :exit))))))
+
+;; ---- :final? is always boolean (rf2-ee38b.21) --------------------------
+
+(deftest parse-definition-final-flag-is-boolean
+  (testing "rf2-ee38b.21 — :final? is boolean-wrapped (false, not nil)
+            for non-final states, matching its sibling flags"
+    (let [{:keys [nodes]} (layout/parse-definition idle-loading-success)
+          idle    (first (filter #(= [:idle] (:path %)) nodes))
+          success (first (filter #(= [:success] (:path %)) nodes))]
+      (is (false? (:final? idle)) ":final? is false, not nil")
+      (is (true?  (:final? success))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/after_rings_geometry_cljs_test.cljc
@@ -63,17 +63,10 @@
                             {:left 0 :top 0 :width 10 :height 10}))
       "zero-width node (not laid out yet) → no ring"))
 
-;; ---- state->node-testid -------------------------------------------------
-
-(deftest state->node-testid-matches-state-node-contract
-  (is (= "rf-mv-chart-node-idle" (geo/state->node-testid "idle")))
-  (is (= "rf-mv-chart-node-auth_login__idle"
-         (geo/state->node-testid "auth_login__idle"))))
-
-(deftest state->node-testid-nil-on-blank
-  (is (nil? (geo/state->node-testid nil)))
-  (is (nil? (geo/state->node-testid "")))
-  (is (nil? (geo/state->node-testid "   "))))
+;; rf2-ee38b.21 — the byte-identical `state->node-testid` helper was
+;; removed from `after_rings_geometry`; the canonical node-id → testid
+;; helper now lives once on `overlay-anchor/node->testid` (pinned by
+;; `overlay_anchor_cljs_test`).
 
 ;; ---- overlay-rings (the seam the CLJS overlay drives) ------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/overlays/overlay_anchor_cljs_test.cljc
@@ -15,17 +15,17 @@
             [day8.re-frame2-machines-viz.chart.overlays.overlay-anchor
              :as anchor]))
 
-;; ---- node->card-testid --------------------------------------------------
+;; ---- node->testid (rf2-ee38b.21 — the single canonical helper) -----------
 
-(deftest node-card-testid-matches-state-node-contract
-  (is (= "rf-mv-chart-node-idle" (anchor/node->card-testid "idle")))
+(deftest node-testid-matches-state-node-contract
+  (is (= "rf-mv-chart-node-idle" (anchor/node->testid "idle")))
   (is (= "rf-mv-chart-node-auth_login__hydrating"
-         (anchor/node->card-testid "auth_login__hydrating"))))
+         (anchor/node->testid "auth_login__hydrating"))))
 
-(deftest node-card-testid-nil-on-blank
-  (is (nil? (anchor/node->card-testid nil)))
-  (is (nil? (anchor/node->card-testid "")))
-  (is (nil? (anchor/node->card-testid "   "))))
+(deftest node-testid-nil-on-blank
+  (is (nil? (anchor/node->testid nil)))
+  (is (nil? (anchor/node->testid "")))
+  (is (nil? (anchor/node->testid "   "))))
 
 ;; ---- anchor-right-of (join inspector) -----------------------------------
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -61,6 +61,35 @@
    :states  {:idle {:on {:ping :idle :go :busy}}
              :busy {:on {:done :idle}}}})
 
+(def same-state-machine
+  "rf2-ee38b.21 — external self-transition via the `:target :same-state`
+  sentinel (Spec 005). Must project a self-loop, not a phantom node."
+  {:initial :a
+   :states  {:a {:on {:ping {:target :same-state}}}}})
+
+(def internal-self-machine
+  "rf2-ee38b.21 — internal self-transition (omit :target). Self-anchors
+  and projects `:internal true`."
+  {:initial :a
+   :states  {:a {:on {:tick {:action :inc}}}}})
+
+(def wildcard-machine
+  "rf2-ee38b.21 — a `:*` wildcard `:on` arm (Spec 005 §Wildcard)."
+  {:initial :a
+   :states  {:a {:on {:start :b :* :err}}
+             :b {}
+             :err {}}})
+
+(def machine-level-on-machine
+  "rf2-ee38b.21 — a machine-level (top-level) :on fallback."
+  {:initial :a :on {:logout :a} :states {:a {} :b {}}})
+
+(def entry-exit-machine
+  "rf2-ee38b.21 — :entry / :exit state actions."
+  {:initial :a
+   :states  {:a {:entry :on-enter :exit :on-leave}
+             :b {}}})
+
 (defn- edge-by-id
   "Pluck an edge from a projected graph by xyflow id."
   [graph id]
@@ -591,3 +620,81 @@
       (is (some? authed) "compound parent is a top-level elk child")
       (is (= 2 (count (:children authed)))
           "browsing + paying nest inside"))))
+
+;; ---- self-transitions / wildcard / machine-level :on (rf2-ee38b.21) ----
+
+(deftest xyflow-graph-same-state-projects-self-loop
+  (testing "rf2-ee38b.21 — `:target :same-state` projects a true
+            self-loop (source == target, :selfLoop true) into a REAL
+            node — not a dangling edge to a phantom :same-state node"
+    (let [parsed   (layout/parse-definition same-state-machine)
+          graph    (projection/xyflow-graph parsed {} {})
+          node-ids (set (map :id (:nodes graph)))
+          ;; the only non-entry edge is the :ping self-transition
+          ping     (first (remove #(:entry (:data %)) (:edges graph)))]
+      (is (some? ping))
+      (is (= (:source ping) (:target ping)) "source == target")
+      (is (true? (:selfLoop (:data ping))))
+      (is (contains? node-ids (:target ping))
+          "target is a real node, not a phantom :same-state"))))
+
+(deftest xyflow-graph-internal-self-transition-flagged
+  (testing "rf2-ee38b.21 — an internal self-transition (omit :target)
+            projects a self-loop flagged `:internal true`"
+    (let [parsed (layout/parse-definition internal-self-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          tick   (first (remove #(:entry (:data %)) (:edges graph)))]
+      (is (some? tick))
+      (is (= (:source tick) (:target tick)))
+      (is (true? (:selfLoop (:data tick))))
+      (is (true? (:internal (:data tick)))))))
+
+(deftest xyflow-graph-wildcard-not-fireable
+  (testing "rf2-ee38b.21 — the `:*` wildcard edge carries a NIL :eventId
+            so the on-chart sim can't dispatch a literal `[:* ...]`
+            (same inert posture as :after / :always); the real `:start`
+            event stays fireable"
+    (let [parsed (layout/parse-definition wildcard-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          wild   (first (filter #(re-find #"\(any\)"
+                                          (or (:eventLabel (:data %)) ""))
+                                (:edges graph)))
+          start  (first (filter #(= :start (:eventId (:data %)))
+                                (:edges graph)))]
+      (is (some? wild) "the wildcard edge is present")
+      (is (nil? (:eventId (:data wild))) "wildcard is NOT fireable")
+      (is (some? start) "the real :start edge stays fireable")
+      (is (= :start (:eventId (:data start)))))))
+
+(deftest xyflow-graph-machine-level-on-flagged
+  (testing "rf2-ee38b.21 — machine-level (top-level) :on fallback edges
+            project with `:machineLevel true` from every leaf"
+    (let [parsed (layout/parse-definition machine-level-on-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          logout (filter #(= :logout (:eventId (:data %))) (:edges graph))]
+      (is (= 2 (count logout)) "one inherited edge per leaf")
+      (is (every? #(true? (:machineLevel (:data %))) logout)))))
+
+(deftest xyflow-graph-state-only-transitions-not-machine-level
+  (testing "rf2-ee38b.21 — a normal state-local transition carries
+            `:machineLevel false`"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})
+          start  (first (filter #(= :start (:eventId (:data %))) (:edges graph)))]
+      (is (some? start))
+      (is (false? (:machineLevel (:data start))))
+      (is (false? (:internal (:data start)))))))
+
+;; ---- entry / exit state actions (rf2-ee38b.21) -------------------------
+
+(deftest xyflow-graph-threads-entry-exit-onto-node-data
+  (testing "rf2-ee38b.21 — :entry / :exit action name strings ride the
+            node :data so state-node can paint `entry / <name>` rows"
+    (let [parsed (layout/parse-definition entry-exit-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          a      (node-by-id graph (layout/node-id [:a]))
+          b      (node-by-id graph (layout/node-id [:b]))]
+      (is (= "on-enter" (:entry (:data a))))
+      (is (= "on-leave" (:exit (:data a))))
+      (is (nil? (:entry (:data b))) "a state with no entry carries nil")
+      (is (nil? (:exit (:data b)))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/scxml_cljs_test.cljc
@@ -71,6 +71,14 @@
              :ready    {}
              :blocked  {}}})
 
+(def machine-level-on-machine
+  "rf2-ee38b.21 — a flat machine with a top-level (machine-level) :on
+  fallback transition every state inherits (Spec 005 §top-level :on)."
+  {:initial :a
+   :on      {:logout :a}
+   :states  {:a {:on {:go :b}}
+             :b {}}})
+
 (def parallel-machine
   "A `:type :parallel` machine with two regions."
   {:type    :parallel
@@ -139,6 +147,20 @@
     (let [out (scxml/spec->scxml after-machine)]
       (is (str/includes? out "event=\"after.5000\""))
       (is (str/includes? out "target=\"timeout\"")))))
+
+(deftest emit-machine-level-on-not-dropped
+  (testing "rf2-ee38b.21 — a top-level (machine-level) :on fallback is
+            emitted (as a documented <transition> under <scxml>) rather
+            than silently dropped (the parser-side P2 mirror). W3C SCXML
+            has no clean root-fallback slot so this can't round-trip,
+            but the topology survives the export."
+    (let [out (scxml/spec->scxml machine-level-on-machine)]
+      (is (str/includes? out "machine-level")
+          "a comment documents the inherited fallback")
+      (is (str/includes? out "event=\"logout\"")
+          "the machine-level :logout transition is emitted")
+      ;; the per-state :go transition still emits normally
+      (is (str/includes? out "event=\"go\"")))))
 
 (deftest emit-always-transitions-omit-event-attribute
   (testing ":always candidates render as eventless <transition>s
@@ -243,3 +265,16 @@
                          ["parallel-machine"            parallel-machine]]]
       (testing name
         (is (= spec (-> spec scxml/spec->scxml scxml/scxml->spec)))))))
+
+(deftest round-trip-machine-level-on-is-lossy
+  (testing "rf2-ee38b.21 — a machine-level (top-level) :on fallback is
+            EXPORTED (no longer silently dropped) but does NOT round-trip:
+            W3C SCXML has no root-fallback-transition slot, and the
+            import side drops root-level transitions. Naming the loss
+            explicitly per this section's contract."
+    (let [spec machine-level-on-machine
+          back (-> spec scxml/spec->scxml scxml/scxml->spec)]
+      (is (not= spec back) "the top-level :on does not survive the import")
+      (is (nil? (:on back)) "the inherited fallback is lost on import")
+      (is (= (:states spec) (:states back))
+          "the per-state topology DOES round-trip"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -63,8 +63,9 @@
     :edge-label-backplate-opacity
     :final-glyph-px
     :compound-title-px
-    :caption-strip-px
-    :caption-text-px
+    ;; rf2-ee38b.21 — :caption-strip-px / :caption-text-px removed:
+    ;; no renderer ever read them (there is no caption strip in the
+    ;; chart). They were carried only to satisfy this parity test.
     ;; state-tag pills (rf2-m1b88; rf2-k647w drift reconciled to shipped)
     :tag-pill-height
     :tag-pill-pad-x


### PR DESCRIPTION
## Summary

Remediates the 3-lens review findings (correctness / completeness / clarity) for `tools/machines-viz`. Closes **rf2-ee38b.21**.

### Correctness (finding → fix)
- **`:target :same-state` dangling edge (P1)** → `resolve-target-path` special-cases the sentinel to the source path; the edge is now a true self-loop (`source == target`, `:selfLoop true`) into a real node — no phantom `same_state` node.
- **`:*` wildcard fireable (P1)** → `xyflow-graph`'s `fireable?` excludes `:*`, so the edge carries `nil :eventId` (inert, like `:after`/`:always`); `event-segment` renders it `"* (any)"`. The on-chart sim can no longer dispatch `[:* ...]`.
- **top-level (machine-level) `:on` dropped (P2)** → new `collect-machine-edges` emits one edge per leaf state (flagged `:machine-level?`); machine-level targets resolve at the **root** (so a compound leaf still reaches the top-level target). Mirrored in the SCXML emitter (`emit-machine-level-on`).
- **node-id regex collapse (P2)** → new injective `escape-id-segment` (`_<hex>` per non-alnum char); `:a/b`, `:a-b`, `:a_b`, `:logged-in`, `:logged_in` now mint distinct ids. `region-node-id` uses the same scheme.
- **edge-id collision (P2)** → `edge-id` folds guard/action; `parse-flat` appends a per-key ordinal so byte-identical candidate forks stay distinct.
- **internal self-transition dropped (P3)** → omit-`:target` candidates self-anchor (flagged `:internal?`); rendered as a dashed, arrowhead-less self-loop (Stately parity).
- **`:final?` leaks nil (P3)** → `boolean`-wrapped to match sibling flags.

### Completeness
- **`:entry`/`:exit` unrendered (P2)** → threaded onto node `:data`; `state-node` paints `entry / <name>` / `exit / <name>` rows.
- **Mermaid location contradiction (P3)** → README corrected to `re-frame.machines.mermaid` (`implementation/machines/`).
- **Share-URL / export / viewer-page absent (P1)** → larger v1.0 feature gap, deferred to follow-up bead **rf2-8d7w1** (also tracks the README↔Vision status contradiction).

### Clarity / minimalism
- Collapsed the two `node-id → testid` helpers into one `overlay-anchor/node->testid` (P1).
- Promoted `layout/name-of` public + deleted the near-duplicate `projection/safe-name` (resolves the ns-rendering divergence) (P2).
- Removed the dead `final-marker` node + its `node-types` registration (P2).
- Removed the dead `:caption-strip-px` / `:caption-text-px` density constants from all three maps + the parity test (P2).
- `choose-edge-type` `cond` → `if` (P3).

### Skipped (wrong-on-inspection)
- The form-3 overlay-shell extraction (clarity P1) and the overlay-fill-style hoist (P3) were **not** done — they are a sizeable refactor of three working `.cljs` components with no behavioural defect; bundling them risked the gate and exceeded the correctness-focused scope. Noted for a future clarity pass if desired.

### Tests
New projection-suite pins: external + internal self-transitions, wildcard non-fireability, root-`:on` (incl. compound top-level-target resolution), node-id injectivity, edge-id collision, entry/exit threading, `:final?` boolean, and SCXML machine-level emission + explicit lossy-roundtrip.

## Test plan
- [x] `npx shadow-cljs compile node-test` — clean recompile, 0 warnings
- [x] `node out/node-test.js` — 4145 tests / 12660 assertions / 0 failures / 0 errors

Cross-ref: rf2-ee38b.21 (parent epic rf2-ee38b). Follow-up: rf2-8d7w1.