### PR TITLE
fix(story): bridge rich-DSL asserts to slot, re-base step-debugger + remediation (rf2-ee38b.3)

### DIFF
--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -418,10 +418,12 @@ This replaces the legacy `ensure-causa-mounted!` whose name
 implied a mount but in practice fired the same three bridges PLUS
 called `mount/open!` on Causa's whole-shell mount path. Under the
 per-panel embed the panel-host owns the mount; `wire-cross-host!`
-fires the bridges only. `ensure-causa-mounted!` survives in the
-ns as a deprecated alias for callers that explicitly want the
-whole-shell shape (vanishingly rare; the popout escape hatch is
-the supported route).
+fires the bridges only. The deprecated `ensure-causa-mounted!`
+shim was REMOVED (rf2-ee38b.3 — no production caller, per the
+project's no-back-compat posture). A caller that genuinely needs
+the legacy whole-shell open composes
+`(do (wire-cross-host!) (apply-open!))` directly; the supported
+route is the popout escape hatch.
 
 ### Adding a third-party panel
 

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -27,13 +27,19 @@ into `:assertions` (see below) rather than throwing.
 Each handler returns a map of the form:
 
 ```clojure
-{:assertion :rf.assert/path-equals
- :payload   [[:auth :status] :authenticated]
- :passed?   true
- :actual    :authenticated
- :expected  :authenticated
- :source    {:file "..." :line ...}}             ; from source-coord stamping
+{:assertion    :rf.assert/path-equals
+ :payload      [[:auth :status] :authenticated]
+ :passed?      true
+ :actual       :authenticated
+ :expected     :authenticated
+ :source-coord {:file "..." :line ...}}          ; from source-coord stamping
 ```
+
+> **Record slot name (rf2-ee38b.3).** The per-record source slot is
+> `:source-coord` (the impl's `assertion-record` builder writes this
+> key; the variant *body*'s coord slot is `:source`, per spec/001). The
+> test-mode reader accepts either for robustness, but `:source-coord` is
+> canonical for assertion records.
 
 The play-runner collects these into `:assertions`. The list survives
 the `run-variant` return.
@@ -179,17 +185,23 @@ path-level data-classification contract
 ([spec/015-Data-Classification.md](../../../spec/015-Data-Classification.md)).
 The rules:
 
-1. **`:actual` / `:expected` / `:payload` pass through
-   `re-frame.elision/elide-wire-value` before landing in
-   `:assertions`.** If a variant declared per-frame marks via
+1. **`:actual` passes through `re-frame.elision/elide-wire-value`
+   before landing in `:assertions`** (wired by rf2-ee38b.3). If a
+   variant declared per-frame marks via
    `(re-frame.core/add-marks <variant-id> {path mark, ...})` or
    `(re-frame.core/set-marks <variant-id> {path mark, ...})` (per
    [spec/015 §2. App-db marks (per frame)](../../../spec/015-Data-Classification.md#2-app-db-marks-per-frame--add-marks--set-marks)),
-   then a `:rf.assert/path-equals [:auth :token] :rf/redacted` lookup
-   against a path-marked-sensitive slot records `:actual :rf/redacted`,
-   NOT the raw value. Same posture for `:rf.assert/sub-equals` against
-   a sub whose output is sensitive (per
-   [spec/015 §2. App-db → subs](../../../spec/015-Data-Classification.md#2-app-db--subs)).
+   then a `:rf.assert/path-equals [:auth :token] ...` lookup against a
+   path-marked-sensitive slot records `:actual :rf/redacted`, NOT the
+   raw value. The `assertions/evaluate-path-equals` /
+   `evaluate-path-matches` evaluators project `:actual` keyed on the
+   asserted path; `evaluate-sub-equals` projects keyed on the sub-vec's
+   args path (`(rest sub-vec)`), so a parameterised sub
+   `[:sub/id :user :ssn]` reading a marked `[:user :ssn]` redacts. A
+   bare sub-id whose args carry no app-db path relies on sub-engine
+   marker propagation (spec/015 §App-db → subs) — tracked separately.
+   `:expected` is author-supplied (typically the sentinel itself) and is
+   not projected.
 2. **The sentinel literal is a legal `:expected` value.** Authors
    write the `:rf/redacted` sentinel directly into the assertion to
    pin the redaction contract: a passing
@@ -214,30 +226,39 @@ See also:
   — the symmetric posture for `:rf.error/exception` assertion records.
 - The `Assertion-with-redaction` row in
   [`015-Test-Coverage.md`](015-Test-Coverage.md) §Assertion vocabulary
-  scenarios — substrate state and the deferred bd:rf2-shy6n integration.
+  scenarios — exercised live by
+  `assertion_redaction_cljs_test.cljs` (rf2-ee38b.3 wired the
+  evaluator → `elide-wire-value` projection; bd:rf2-shy6n).
 
 ## Test-runner integration
 
-Stage 5 ships a `cljs.test` adapter:
+Stage 5 ships the `story/assertions-passing?` predicate as the canonical
+`cljs.test` / `clojure.test` surface:
 
 ```clojure
 (deftest my-component-test
-  (run-variant-as-test :story.auth.login-form/happy-path))
+  (let [result @(story/run-variant :story.auth.login-form/happy-path {})]
+    (is (story/assertions-passing? result))))
 ```
 
-The adapter:
+`assertions-passing?` accepts either the `run-variant` result map or its
+`:assertions` vector and returns true iff every record has `:passed?
+true` (an empty vector is vacuously passing — the
+[spec/007 §Story-as-test duality](../../../implementation/...) contract:
+a variant with no `:play-script` still "passes"). The result map's
+`:assertions` slot now carries EVERY assertion outcome — both the
+`:rf.assert/*` dispatch-step records AND the rich-DSL `:assert-db` /
+`:assert-dom` step records (rf2-ee38b.3 closed the false-green gap where
+rich-DSL assert failures landed only in the runner's `run-state` atom).
 
-1. Runs the variant via `run-variant` (see
-   [`002-Runtime.md`](002-Runtime.md) §Programmatic API).
-2. Iterates the returned `:assertions` list.
-3. Calls `cljs.test/is` for each — passing assertion → `is` pass;
-   failing assertion → `is` fail with the assertion's `:expected` /
-   `:actual` shape.
-4. The `:source` slot on each assertion drives `is`-style
-   file/line reporting.
-
-A generic adapter shape covers kaocha and other test frameworks via
-their reporter protocols.
+> **Per-assertion `is` granularity (deferred — rf2-ee38b.3).** A
+> higher-fidelity `run-variant-as-test` adapter that iterates the
+> `:assertions` list and calls `cljs.test/is` per record (one failing
+> assertion → one `is` failure, with `:source-coord`-driven file/line
+> reporting + a generic kaocha-reporter shape) is a planned enhancement.
+> It is NOT yet shipped — `assertions-passing?` is the canonical surface
+> today. The adapter needs async-cljs.test plumbing (`run-variant`
+> returns a Promise) and is tracked separately.
 
 ## Cross-references
 

--- a/tools/story/spec/009-Test-Mode.md
+++ b/tools/story/spec/009-Test-Mode.md
@@ -382,6 +382,19 @@ will land); watch mode has nothing to detect in that build.
 > `begin-stepper!` / `step-once!` / `end-stepper!` per
 > [spec/004 §Play sequence execution](004-Assertions.md#play-sequence-execution).
 > What this section locks is the chrome that surfaces it.
+>
+> **rf2-ee38b.3 — full-script stepping.** The substrate walks the FULL
+> coerced `:play-script` — EVERY step type (`:dispatch` /
+> `:dispatch-sync` / `:wait` / `:click` / `:type` / `:assert-db` /
+> `:assert-dom`) — driving each through the SAME rich-DSL executor
+> (`runner-events/run-step!`) the canvas auto-run path uses. Each
+> `step-once!` returns the executed STEP (a coerced step vector) and
+> records the step-result into `play/stepper-state`'s `:results`. The
+> debugger and the auto-run path are therefore equivalent: the cursor /
+> total count every step, and `:assert-db` / `:assert-dom` outcomes
+> surface live during a stepped run. (Before rf2-ee38b.3 the stepper
+> drove only the dispatch steps from the legacy `variant-play-events`
+> projection and silently dropped the rest.)
 
 The step-debugger renders as a new section in the `:test` pane,
 positioned between the **Summary badge** (§2 above) and the
@@ -416,9 +429,14 @@ clicking **Start** brings up the full controls + step list.
 (breakpoint-hit? cursor breakpoints)
   ; bool — auto-play tick should pause before dispatching
 
+;; full-script step list (rf2-ee38b.3, JVM-testable):
+(step-statuses steps results)
+  ; → one row {:index :step :label :status} per coerced step; outcome
+  ;   read from the per-step result record (or :event for not-yet-run)
+
 ;; CLJS local state — re-frame.story.ui.test-mode.stepper-state:
 (begin!              variant-id)       ; re-allocate the frame + prime the substrate
-(step!               variant-id)       ; dispatch the next play event
+(step!               variant-id)       ; run the next play STEP (any step type)
 (step-back!          variant-id)       ; restore the prior epoch + decrement cursor
 (rewind!             variant-id)       ; restore the pre-play epoch + reset cursor
 (pause!              variant-id)       ; stop auto-play
@@ -435,7 +453,7 @@ The strip renders (left-to-right) when the stepper is active:
 |--------------|----------------------------------------------------------|----------------------------------------------|
 | Stop         | Tear down the stepper (return to inactive state).        | never (always available when active)         |
 | ← Back       | Restore the prior epoch; cursor decrements by one.       | `cursor = 0`                                 |
-| Step →       | Dispatch the next play event; cursor increments.         | `cursor = total` (parked at end)             |
+| Step →       | Run the next play step (any step type); cursor increments. | `cursor = total` (parked at end)             |
 | Pause / Play | Toggle auto-play (default 600ms between steps).          | Pause: not auto-playing. Play: auto-playing OR at end. |
 | ↺ Rewind     | Restore the pre-play epoch + reset cursor to 0.          | `cursor = 0`                                 |
 
@@ -497,14 +515,17 @@ The section renders (top-to-bottom):
 |---|---------------------|---------------------------------------------------------------|
 | 1 | Header strip        | "Step-debugger · {progress-label} · playing?" + keyboard hint |
 | 2 | Controls strip      | Start (inactive) OR Stop / Back / Step / Pause/Play / Rewind  |
-| 3 | Step list           | One row per `:play-script` step with glyph / index / label / BP chip; active state only |
+| 3 | Step list           | One row per coerced `:play-script` step (EVERY step type — rf2-ee38b.3) with glyph / index / label / BP chip; active state only |
 | 3'| Inactive hint       | One-line "Click Start to step…" placeholder; inactive only    |
 
 Each step row carries:
 - A position glyph (`▶` current, `○` pending, or the outcome glyph
-  `✓` / `✗` / `⊘` / `•` for done rows).
+  `✓` / `✗` / `⊘` / `•` for done rows). The outcome comes from the
+  step's recorded result (`:pass` / `:fail` / `:skip` / neutral
+  `:event`) per `stepper-pure/step-statuses`.
 - The step index (1-based for display) + the step label
-  (`(first event)` per `stepper-pure/play-step-label`).
+  (`runner/step-summary` — a human-readable summary of the step,
+  e.g. `assert-db [:n] = 5` / `wait 100ms` / `click "button.x"`).
 - A BP chip on the right; clicking the chip OR the row body toggles
   the breakpoint at that index.
 

--- a/tools/story/src/re_frame/story/args.cljc
+++ b/tools/story/src/re_frame/story/args.cljc
@@ -64,10 +64,14 @@
 
 ;; ---- parent-story lookup --------------------------------------------------
 ;;
-;; Re-export from `re-frame.story.predicates` so existing call sites keep
-;; their `args/parent-story-id` shape. The canonical definition lives in
-;; the leaf namespace; this is a transitional alias for the rest of the
-;; tree that hasn't yet migrated.
+;; Re-export from `re-frame.story.predicates` (the canonical leaf home).
+;; rf2-ee38b.3 dropped the docs / state / test-mode pure re-exports (which
+;; had ≤1 caller each); this `args/parent-story-id` alias survives because
+;; ~9 sibling namespaces (decorators, identity, runtime, canvas, controls,
+;; multi-substrate, panels, schema-validation, workspace) `:require` args
+;; already and call it through this alias. Folding those onto
+;; `pred/parent-story-id` directly is a mechanical follow-up; the alias is
+;; a thin pass-through, not new behaviour.
 
 (def parent-story-id
   "Derive the parent story id from a variant id. Per spec/007

--- a/tools/story/src/re_frame/story/assertions.cljc
+++ b/tools/story/src/re_frame/story/assertions.cljc
@@ -56,6 +56,7 @@
     consumer tests via the public `assertions-passing?`).
   - `canonical-assertion-ids` — the set of registered event ids."
   (:require [re-frame.core             :as rf]
+            [re-frame.elision          :as elision]
             [re-frame.interop          :as interop]
             [re-frame.subs             :as subs]
             [re-frame.story.config     :as config]
@@ -261,6 +262,32 @@
     :else                    false))
 
 ;; ---------------------------------------------------------------------------
+;; Redaction projection (spec/004 §Privacy, rf2-shy6n / rf2-ee38b.3)
+;;
+;; A value captured from a path / sub the frame marked sensitive (via
+;; `re-frame.core/add-marks` / `set-marks`, or a schema entry with
+;; `{:sensitive? true}`) MUST NOT land raw on the assertion record's
+;; `:actual` slot — the record serialises into observation surfaces (the
+;; test-mode pane, MCP `read-assertions`, JSON-log egress) per spec/015
+;; §Data-Classification. We project the captured value through
+;; `re-frame.elision/elide-wire-value` (the frame-aware wire-egress
+;; projection) so a sensitive path records `:rf/redacted`, not the secret.
+;; A path with no sensitive declaration passes through unchanged.
+;; ---------------------------------------------------------------------------
+
+(defn- redact-at
+  "Project `v` through `elision/elide-wire-value` as if it lives at
+  `path` in `frame-id`'s app-db, so sensitive sub-paths (or a sensitive
+  root path) substitute `:rf/redacted`. Tolerant — any elision error or
+  a nil frame-id returns `v` unchanged (record-don't-throw: redaction
+  failure must never break the assertion)."
+  [frame-id path v]
+  (try
+    (elision/elide-wire-value v (cond-> {:path (vec path)}
+                                  frame-id (assoc :frame frame-id)))
+    (catch #?(:clj Throwable :cljs :default) _ v)))
+
+;; ---------------------------------------------------------------------------
 ;; The canonical seven — defined as plain helper fns that produce the
 ;; assertion record. The `install-canonical-assertions!` boot fn wraps
 ;; each in a `reg-event-fx` shell that consults the cofx for the frame
@@ -268,9 +295,10 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- evaluate-path-equals
-  [db [path expected]]
-  (let [actual (get-in db path)
-        passed? (= expected actual)]
+  [frame-id db [path expected]]
+  (let [raw     (get-in db path)
+        passed? (= expected raw)
+        actual  (redact-at frame-id path raw)]
     {:passed?  passed?
      :expected expected
      :actual   actual
@@ -299,9 +327,10 @@
                      :cljs (str e)))])))
 
 (defn- evaluate-path-matches
-  [db [path schema]]
-  (let [actual              (get-in db path)
-        [passed? explanation] (malli-validate schema actual)]
+  [frame-id db [path schema]]
+  (let [raw                 (get-in db path)
+        [passed? explanation] (malli-validate schema raw)
+        actual              (redact-at frame-id path raw)]
     (cond-> {:passed?  passed?
              :path     path
              :expected schema
@@ -313,24 +342,33 @@
       explanation (assoc :explanation explanation))))
 
 (defn- evaluate-sub-equals
-  [_frame-id db [sub-vec expected]]
+  [frame-id db [sub-vec expected]]
   ;; Use compute-sub against the snapshot — bypasses the reactive cache
   ;; per Spec 008. Subscriptions registered against the variant's frame
   ;; resolve the same way they would in the running app.
-  (let [actual  (try
+  ;;
+  ;; Redaction: a sub reading a sensitive path propagates the sensitive
+  ;; marker into its output value (spec/015 §reg-sub). We project the
+  ;; sub's value through `elide-wire-value` keyed on the SUB's root path
+  ;; (`(rest sub-vec)` is the args; the first element is the sub-id, not
+  ;; an app-db path). Where the sub-vec carries an app-db path (the
+  ;; common `[:sub/id & path]` shape) the projection redacts; otherwise
+  ;; the value passes through unchanged.
+  (let [raw     (try
                   (subs/compute-sub sub-vec db)
                   (catch #?(:clj Throwable :cljs :default) _
                     ::compute-error))
-        passed? (and (not= actual ::compute-error)
-                     (= actual expected))]
+        passed? (and (not= raw ::compute-error)
+                     (= raw expected))
+        actual  (cond
+                  (= raw ::compute-error) :rf.assert/sub-threw
+                  :else                   (redact-at frame-id (vec (rest sub-vec)) raw))]
     {:passed?  passed?
      :expected expected
-     :actual   (if (= actual ::compute-error)
-                 :rf.assert/sub-threw
-                 actual)
+     :actual   actual
      :sub-vec  sub-vec
      :reason   (cond
-                 (= actual ::compute-error) "subscription threw during evaluation"
+                 (= raw ::compute-error) "subscription threw during evaluation"
                  passed? "subscription returned expected value"
                  :else (str "expected " (pr-str expected)
                             " from " (pr-str sub-vec)
@@ -443,8 +481,8 @@
           frame-id     (frame-id-from-cofx cofx)
           dispatch-id  (dispatch-id-from-cofx cofx)
           extras       (case evaluator-kind
-                         :path-equals     (evaluate-path-equals     db payload)
-                         :path-matches    (evaluate-path-matches    db payload)
+                         :path-equals     (evaluate-path-equals     frame-id db payload)
+                         :path-matches    (evaluate-path-matches    frame-id db payload)
                          :sub-equals      (evaluate-sub-equals      frame-id db payload)
                          :dispatched?     (evaluate-dispatched?     frame-id payload)
                          :state-is        (evaluate-state-is        db payload)

--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -199,7 +199,7 @@
 ;; Fires from two seams:
 ;;   1. `story/configure!` after `set-project-root!` lands — the common
 ;;      case (Causa's preload runs before the testbed `run` fn).
-;;   2. `ensure-causa-mounted!` — defense-in-depth for the (rare) case
+;;   2. `wire-cross-host!` — defense-in-depth for the (rare) case
 ;;      where Causa's config ns loads AFTER `story/configure!` has
 ;;      already fired (e.g. lazy loader / hot-reload edge).
 ;;
@@ -257,15 +257,15 @@
 ;; Per rf2-4eyik (the sibling bead that shipped the config slot) +
 ;; rf2-xea9u (the :rf.causa/* configure! rename): "Hosts MUST set
 ;; this BEFORE the Causa preload runs". Setting it from
-;; `ensure-causa-mounted!` means the slot lands at variant-selection
-;; time, after the preload's `keybinding/attach!` has already fired
-;; with the default `true`. The Causa-side bead is the slot owner;
-;; preload-time sequencing (e.g. a Story preload that sets the slot
-;; before Causa's preload runs) is the follow-on shape for live
-;; runtime collision removal. This wire-up is the in-source
-;; declaration of intent — every embed surface that drives Causa
-;; through `ensure-causa-mounted!` sets the slot, so downstream
-;; load-order fixes have a single canonical site to honour.
+;; `wire-cross-host!` means the slot lands at variant-selection time,
+;; after the preload's `keybinding/attach!` has already fired with the
+;; default `true`. The Causa-side bead is the slot owner; preload-time
+;; sequencing (e.g. a Story preload that sets the slot before Causa's
+;; preload runs) is the follow-on shape for live runtime collision
+;; removal. This wire-up is the in-source declaration of intent —
+;; every embed surface that drives Causa through `wire-cross-host!`
+;; sets the slot, so downstream load-order fixes have a single
+;; canonical site to honour.
 
 #?(:cljs
    (defn disable-keybinding!
@@ -274,17 +274,17 @@
      the call landed, or `nil` when Causa's `configure!` is not on the
      classpath (preload absent).
 
-     Called by `ensure-causa-mounted!` so Story-driven Causa-as-RHS
-     mounts never have Causa swallow the host's global keybindings
-     (typically `Cmd/Ctrl+K` for Story's command palette). Per
-     rf2-q7who.1 (rf2-4eyik sibling on the Causa side) + rf2-xea9u
-     (:rf.causa/* configure! rename). Idempotent — writing `false`
-     over an existing `false` is a plain reset!.
+     Called by `wire-cross-host!` so Story-driven Causa-as-RHS mounts
+     never have Causa swallow the host's global keybindings (typically
+     `Cmd/Ctrl+K` for Story's command palette). Per rf2-q7who.1
+     (rf2-4eyik sibling on the Causa side) + rf2-xea9u (:rf.causa/*
+     configure! rename). Idempotent — writing `false` over an existing
+     `false` is a plain reset!.
 
      Sequencing: `disable-keybinding!` flips the slot (intent
      declaration); rf2-ycrt2's `detach-keybinding!` removes the
      listener Causa's preload already installed under the default-true
-     posture (runtime mechanism). Both fire from `ensure-causa-mounted!`
+     posture (runtime mechanism). Both fire from `wire-cross-host!`
      in that order."
      []
      (when (and config/enabled? (causa-config-available?))
@@ -322,8 +322,8 @@
      call landed, or `nil` when Causa's `keybinding` ns is not on the
      classpath (preload absent).
 
-     Called by `ensure-causa-mounted!` AFTER `disable-keybinding!`
-     flipped the slot — the slot declares intent, `detach!` removes the
+     Called by `wire-cross-host!` AFTER `disable-keybinding!` flipped
+     the slot — the slot declares intent, `detach!` removes the
      listener Causa's preload installed under the default-true posture.
      The runtime gap rf2-q7who.1 declared but did not close — rf2-ycrt2
      closes it.
@@ -358,24 +358,15 @@
        (disable-keybinding!)
        (detach-keybinding!))))
 
-#?(:cljs
-   (defn ensure-causa-mounted!
-     "DEPRECATED — pre-rf2-v1ach the Story shell drove the full Causa
-     4-layer shell into a `[data-rf-causa-host]` 320px column. The
-     per-panel embed (`re-frame.story.ui.causa-embed`) replaced this
-     mount path; the new shape mounts one panel at a time via the
-     `panels/mount-<panel>!` contract.
-
-     Kept for back-compat callers that drove the whole-shell shape
-     explicitly. New code should let the embed own its mount and use
-     `wire-cross-host!` above for the project-root / keybinding
-     bridges."
-     []
-     (when (and config/enabled? (causa-available?))
-       (propagate-project-root!)
-       (disable-keybinding!)
-       (detach-keybinding!)
-       (apply-open!))))
+;; rf2-ee38b.3: the DEPRECATED `ensure-causa-mounted!` whole-shell-open
+;; shim was REMOVED (no production caller; the per-panel embed
+;; `re-frame.story.ui.causa-embed` owns its mount via the
+;; `panels/mount-<panel>!` contract). Cross-host configuration bridges
+;; (project-root + keybinding disable + listener detach) are driven by
+;; `wire-cross-host!` above; a caller that genuinely needs the legacy
+;; whole-shell open composes `(do (wire-cross-host!) (apply-open!))`
+;; directly — there is no shim. Matches the project's no-back-compat
+;; posture (the spec carve-out in 003-Render-Shell.md was removed too).
 
 #?(:cljs
    (defn- apply-tab!

--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -172,11 +172,15 @@
          nil))))
 
 #?(:cljs
-   (defn- apply-open!
+   (defn apply-open!
      "Drive the Causa shell open via `causa-mount/open!`. The symbol
      resolves at compile time via the direct `:require` at the top of
      this ns (rf2-ibpwr — replaces the pre-fix `find-ns-obj` walk that
-     false-negatived under node-test)."
+     false-negatived under node-test).
+
+     Public composition seam: callers that need the legacy whole-shell
+     open compose `(do (wire-cross-host!) (apply-open!))` directly (see
+     the no-shim note below)."
      []
      (when causa-mount/open!
        (safe-call! "open!" causa-mount/open!))))

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -94,19 +94,11 @@
 ;; The actual DCE happens because the macro expansion threads through
 ;; `(when re-frame.story.config/enabled? ...)`: in CLJS-advanced mode
 ;; with `enabled?` defined as `false`, Closure sees the boolean
-;; constant and removes the branch. The macro's job is to lay down that
-;; `(when enabled? ...)` form; the closure compiler does the rest.
-
-#?(:clj
-   (defn elide-form
-     "Wrap `expansion` in `(when re-frame.story.config/enabled? ...)` so
-     the closure compiler can prune the registration call under
-     `:advanced` builds where `enabled?` is defined as `false`.
-
-     Returns the wrapped form."
-     [expansion]
-     `(when re-frame.story.config/enabled?
-        ~expansion)))
+;; constant and removes the branch. The macro layer (`re-frame.story.
+;; macros`) lays down that `(when enabled? ...)` form inline; the
+;; closure compiler does the rest. (rf2-ee38b.3 removed a dead
+;; `elide-form` helper here — the macros open-code the wrapper and never
+;; called it.)
 
 ;; ---- *global-args* (Stage 3, rf2-von3) ----------------------------------
 ;;

--- a/tools/story/src/re_frame/story/extends.cljc
+++ b/tools/story/src/re_frame/story/extends.cljc
@@ -92,6 +92,25 @@
                                           "unregistered variant " parent-id)
                            :parent   parent-id})))))))
 
+(defn- drop-shadowed-siblings
+  "For each mutual-exclusion group in `exclusive-groups` (a coll of
+  key-sets), if `child` declares ANY key in the group then strip EVERY
+  key in that group from `inherited` before the merge. This lets a child
+  override a parent's alternative encoding wholesale — e.g. a parent's
+  `:play-script` and a child's `:plays` are sibling encodings of the
+  same play surface (rf2-tl7zk); without this the straight merge would
+  carry BOTH keys and the schema's mutual-exclusion `:fn` would reject a
+  body the author never wrote with both keys (rf2-ee38b.3)."
+  [inherited child exclusive-groups]
+  (reduce
+    (fn [acc group]
+      (let [group-set (set group)]
+        (if (some #(contains? child %) group-set)
+          (apply dissoc acc group-set)
+          acc)))
+    inherited
+    exclusive-groups))
+
 (defn resolve-extends
   "Resolve `:extends` on `body` against `lookup` (a fn from parent-id to
   parent-body). Returns the merged body with `:extends` stripped.
@@ -104,13 +123,28 @@
   recurse — the final body is the result of merging every ancestor in
   root-first order.
 
+  `exclusive-groups` (optional) is a coll of key-sets that are mutually-
+  exclusive ENCODINGS of one slot — when the child declares any key in a
+  group, the whole group is stripped from every inherited layer before
+  the merge so the child's encoding wins wholesale (per rf2-ee38b.3 the
+  Story play surface `#{:play-script :plays}` is one such group). Layers
+  closer to the child still shadow farther ones key-by-key as usual.
+
   Per IMPL-SPEC §4.6: 'Resolution at registration time. Cycles raise
   `:rf.error/extends-cycle`.'"
-  [body lookup]
-  (if-let [_parent-id (:extends body)]
-    (let [chain    (chain-of body lookup)
-          ;; Reduce parent-first: every parent's keys are overridden by
-          ;; the next (more specific) layer, ending with the child.
-          merged   (reduce merge {} (conj (vec chain) body))]
-      (dissoc merged :extends))
-    body))
+  ([body lookup] (resolve-extends body lookup nil))
+  ([body lookup exclusive-groups]
+   (if-let [_parent-id (:extends body)]
+     (let [chain  (chain-of body lookup)
+           ;; Reduce parent-first: every parent's keys are overridden by
+           ;; the next (more specific) layer, ending with the child. For
+           ;; each layer, strip any inherited mutual-exclusion group the
+           ;; more-specific layer overrides with its sibling encoding.
+           merged (reduce
+                    (fn [acc layer]
+                      (merge (drop-shadowed-siblings acc layer exclusive-groups)
+                             layer))
+                    {}
+                    (conj (vec chain) body))]
+       (dissoc merged :extends))
+     body)))

--- a/tools/story/src/re_frame/story/identity.cljc
+++ b/tools/story/src/re_frame/story/identity.cljc
@@ -67,6 +67,28 @@
   through `pr-str` deterministically across hosts."
   (-canon [x]))
 
+;; Shared canon bodies (rf2-ee38b.3) — the typed map/set cases AND the
+;; Object/default fallback must canonicalise maps + sets identically.
+;; Lifting the bodies into one private fn each keeps the two paths in
+;; lockstep instead of carrying verbatim copies.
+
+(defn- canon-map-entries
+  "Map canon: sort by the canonicalised key (via `pr-str` of the
+  canon-key) then flatten into a `[k v k v ...]` vector. Symmetric
+  across JVM + CLJS because `pr-str` over canonical scalars is
+  host-identical."
+  [m]
+  (let [entries (->> m
+                     (map (fn [[k v]] [(-canon k) (-canon v)]))
+                     (sort-by (fn [[k _]] (pr-str k))))]
+    (into [] (mapcat identity) entries)))
+
+(defn- canon-set
+  "Set canon: sort canonicalised elements by their `pr-str` into a
+  stable vector."
+  [s]
+  (vec (sort-by pr-str (map -canon s))))
+
 (extend-protocol Canonicalise
   nil
   (-canon [_] nil)
@@ -87,15 +109,7 @@
   (-canon [x] x)
 
   #?(:clj  clojure.lang.IPersistentMap  :cljs IMap)
-  (-canon [x]
-    ;; Map canon: sort by the canonicalised key (via pr-str of the
-    ;; canon-key). The serialisation is symmetric — both JVM and CLJS
-    ;; sort the same way because `pr-str` over canonical scalars is
-    ;; identical across hosts.
-    (let [entries (->> x
-                       (map (fn [[k v]] [(-canon k) (-canon v)]))
-                       (sort-by (fn [[k _]] (pr-str k))))]
-      (into [] (mapcat identity) entries)))
+  (-canon [x] (canon-map-entries x))
 
   #?(:clj  clojure.lang.IPersistentVector :cljs PersistentVector)
   (-canon [x] (mapv -canon x))
@@ -104,9 +118,7 @@
   (-canon [x] (mapv -canon x))
 
   #?(:clj  clojure.lang.IPersistentSet  :cljs PersistentHashSet)
-  (-canon [x]
-    ;; Stable set order: sort canonicalised elements by their pr-str.
-    (vec (sort-by pr-str (map -canon x))))
+  (-canon [x] (canon-set x))
 
   #?(:clj  Object             :cljs default)
   (-canon [x]
@@ -114,11 +126,8 @@
     ;; canonical recursion. `pr-str` over the result is deterministic.
     (cond
       (sequential? x) (mapv -canon x)
-      (set? x)        (vec (sort-by pr-str (map -canon x)))
-      (map? x)        (let [entries (->> x
-                                         (map (fn [[k v]] [(-canon k) (-canon v)]))
-                                         (sort-by (fn [[k _]] (pr-str k))))]
-                        (into [] (mapcat identity) entries))
+      (set? x)        (canon-set x)
+      (map? x)        (canon-map-entries x)
       :else           x)))
 
 (defn canonical-form

--- a/tools/story/src/re_frame/story/macros.clj
+++ b/tools/story/src/re_frame/story/macros.clj
@@ -108,17 +108,25 @@
   (let [story-str (subs (str story-id) 1)]    ; strip leading colon
     (keyword story-str (name variant-name))))
 
-(defn gen-reg-call
-  "Emit a single `(when enabled? (binding [*pending-coords* coords]
-  (registrar/<reg-fn>* id body)))` form. `reg-fn-sym` is a fully-qualified
-  symbol like `re-frame.story.registrar/reg-story*`. `form-meta` is the
-  caller's `(meta &form)`; `file` is the caller's `*file*`; `ns-sym` is
-  the consumer's `(ns-name *ns*)`."
-  [form-meta file ns-sym reg-fn-sym id body]
+(defn emit-reg
+  "Emit the canonical `(when enabled? (binding [*pending-coords* coords]
+  (<reg-fn> id body)))` wrapper. `coords` is a pre-computed coords FORM
+  (per `coords-form`); `reg-fn-sym` is a fully-qualified registrar helper
+  like `re-frame.story.registrar/reg-story*`. The single place the
+  elision-gate + source-coord binding shape is laid down (rf2-ee38b.3 —
+  was open-coded in three sites)."
+  [coords reg-fn-sym id body]
   `(when re-frame.story.config/enabled?
-     (binding [re-frame.story.registrar/*pending-coords*
-               ~(coords-form form-meta file ns-sym)]
+     (binding [re-frame.story.registrar/*pending-coords* ~coords]
        (~reg-fn-sym ~id ~body))))
+
+(defn gen-reg-call
+  "Emit a single registration form for `reg-fn-sym`. `reg-fn-sym` is a
+  fully-qualified symbol like `re-frame.story.registrar/reg-story*`.
+  `form-meta` is the caller's `(meta &form)`; `file` is the caller's
+  `*file*`; `ns-sym` is the consumer's `(ns-name *ns*)`."
+  [form-meta file ns-sym reg-fn-sym id body]
+  (emit-reg (coords-form form-meta file ns-sym) reg-fn-sym id body))
 
 ;; ---- reg-story Form-B desugaring -----------------------------------------
 
@@ -139,17 +147,15 @@
         body-form   (if variants
                       (dissoc literal-map :variants)
                       metadata)
-        story-call  `(when re-frame.story.config/enabled?
-                       (binding [re-frame.story.registrar/*pending-coords*
-                                 ~coords]
-                         (re-frame.story.registrar/reg-story* ~id ~body-form)))]
+        story-call  (emit-reg coords
+                              're-frame.story.registrar/reg-story*
+                              id body-form)]
     (if variants
       `(do
          ~story-call
          ~@(for [[v-name v-body] variants]
              (let [v-id (variant-id-for id v-name)]
-               `(when re-frame.story.config/enabled?
-                  (binding [re-frame.story.registrar/*pending-coords*
-                            ~coords]
-                    (re-frame.story.registrar/reg-variant* ~v-id ~v-body))))))
+               (emit-reg coords
+                         're-frame.story.registrar/reg-variant*
+                         v-id v-body))))
       story-call)))

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -70,6 +70,7 @@
             [re-frame.story.async      :as async]
             [re-frame.story.config     :as config]
             [re-frame.story.frames     :as frames]
+            [re-frame.story.late-bind  :as late-bind]
             [re-frame.story.play.runner :as runner]
             [re-frame.story.registrar  :as registrar]))
 
@@ -89,6 +90,21 @@
   ;; Per Spec 009 §Per-frame routing: the canonical tag key is :frame
   ;; (rf2-shaa1 dropped the :frame-id alias from impl emit sites).
   (get-in ev [:tags :frame]))
+
+;; rf2-ee38b.3: `:db` (and `:fx`) are framework fx-ids that nearly every
+;; handler emits — including the assertion handlers themselves. Recording
+;; them into the per-frame `:emitted-fx` accumulator made
+;; `[:rf.assert/effect-emitted :db]` vacuously always-true. We exclude
+;; the framework fx-ids so `:rf.assert/effect-emitted` reflects USER fx
+;; only. (`:fx`, the effect-vector aggregator, is similarly ubiquitous +
+;; not a meaningful assertion target.)
+(def ^:private framework-fx-ids
+  "Framework fx-ids excluded from the `:emitted-fx` accumulator."
+  #{:db :fx})
+
+(defn- framework-fx-id?
+  [fx-id]
+  (contains? framework-fx-ids fx-id))
 
 ;; Per-frame pending-exception accumulator. The listener captures
 ;; `:rf.error/handler-exception` synchronously (from inside the running
@@ -142,10 +158,11 @@
           :rf.fx        (case (:operation ev)
                           :rf.fx/do-fx (let [fx-map (get-in ev [:tags :rf.event/fx])]
                                          (when (map? fx-map)
-                                           (doseq [fx-id (keys fx-map)]
+                                           (doseq [fx-id (keys fx-map)
+                                                   :when (not (framework-fx-id? fx-id))]
                                              (assertions/record-emitted-fx! frame-id fx-id))))
                           (let [fx-id (get-in ev [:tags :rf.fx/id])]
-                            (when fx-id
+                            (when (and fx-id (not (framework-fx-id? fx-id)))
                               (assertions/record-emitted-fx! frame-id fx-id))))
           nil)))))
 
@@ -329,15 +346,42 @@
 
 ;; ---------------------------------------------------------------------------
 ;; UI play-stepper hook (Stage 4 placeholder, finalised here)
+;;
+;; rf2-ee38b.3 re-base: the stepper now walks the FULL coerced
+;; `:play-script` (every step type — `:dispatch` / `:dispatch-sync` /
+;; `:wait` / `:click` / `:type` / `:assert-db` / `:assert-dom`), driving
+;; each step through the SAME rich-DSL executor the canvas auto-run path
+;; uses (`runner-events/run-step!`, fetched via the `:run-play-step`
+;; late-bind hook to avoid the play ↔ runner-events cycle). Previously it
+;; dispatched only the `:dispatch`/`:dispatch-sync` events from
+;; `variant-play-events` and silently dropped the rest — so the cursor /
+;; total were wrong and assert outcomes never surfaced during a stepped
+;; run. The slot now holds STEPS, not bare event vectors.
 ;; ---------------------------------------------------------------------------
 
 (defonce
   ^{:doc "Per-frame play-stepper state. `{frame-id → {:remaining vec,
-         :ran vec}}`. The UI shell consumes this to render the
-         stepper widget. Used only when the play sequence is being
-         driven step-by-step rather than via `execute-play!`."}
+         :ran vec, :results vec}}` where `:remaining` / `:ran` carry
+         coerced `:play-script` STEPS (rf2-ee38b.3 — was bare event
+         vectors) and `:results` carries the per-step result records the
+         rich-DSL executor returned. The UI shell consumes this to
+         render the stepper widget. Used only when the play sequence is
+         being driven step-by-step rather than via `execute-play!`."}
   stepper-state
   (atom {}))
+
+(defn variant-play-steps
+  "Resolve the FULL coerced `:play-script` step vector for `variant-id`'s
+  default play (rf2-ee38b.3). Unlike `variant-play-events` (which drops
+  every non-dispatch step) this returns EVERY step the rich-DSL runner
+  recognises, in order, so the step-debugger walks the same sequence the
+  auto-run path executes.
+
+  Pure data → data; works on JVM + CLJS."
+  [variant-id]
+  (let [body (registrar/handler-meta :variant variant-id)
+        spec (runner/parse-spec (:play-script body))]
+    (vec (:script spec))))
 
 (defn play-stepper-active?
   [frame-id]
@@ -345,30 +389,89 @@
 
 (defn begin-stepper!
   "Initialise a step-by-step play run for `frame-id`. The UI's
-  play-stepper widget calls `step-once!` to advance one event."
+  play-stepper widget calls `step-once!` to advance one step.
+
+  rf2-ee38b.3: seeds the FULL coerced script (all step types), not just
+  the dispatch-bearing events."
   [frame-id]
   (when config/enabled?
     (assertions/reset-trace-accumulators! frame-id)
     (install-trace-listener! frame-id)
     (swap! stepper-state assoc frame-id
-           {:remaining (vec (variant-play-events frame-id))
-            :ran       []})
+           {:remaining (variant-play-steps frame-id)
+            :ran       []
+            :results   []})
     nil))
 
 (defn step-once!
-  "Advance the play stepper for `frame-id` by one event. Returns the
-  event that was dispatched, or nil when no events remain."
+  "Advance the play stepper for `frame-id` by one step. Executes the
+  step through the rich-DSL executor (`runner-events/run-step!` via the
+  `:run-play-step` late-bind hook) so EVERY step type runs in the
+  debugger exactly as it does on the live canvas. Returns the step that
+  ran, or nil when no steps remain.
+
+  rf2-ee38b.3: previously this dispatched only `:dispatch`/`:dispatch-
+  sync` events and dropped the rest. If the executor hook is absent (a
+  Stage-3-only build where `runner-events` never loaded) it falls back
+  to the legacy `dispatch-one!` for dispatch steps and a no-op record
+  for the rest, so the cursor stays honest."
   [frame-id]
   (when config/enabled?
     (let [{:keys [remaining]} (get @stepper-state frame-id)
-          ev (first remaining)]
-      (when ev
-        (dispatch-one! frame-id ev)
-        (swap! stepper-state update frame-id
-               (fn [s] (-> s
-                           (update :remaining subvec 1)
-                           (update :ran conj ev)))))
-      ev)))
+          step (first remaining)]
+      (when step
+        (let [idx     (count (:ran (get @stepper-state frame-id)))
+              run-fn  (late-bind/get-fn :run-play-step)
+              result  (cond
+                        run-fn (run-fn frame-id idx step)
+
+                        ;; Fallback: executor unavailable. Drive dispatch
+                        ;; steps the legacy way; record nothing for the
+                        ;; other step types but still advance the cursor.
+                        (#{:dispatch :dispatch-sync} (runner/step-type step))
+                        (do (dispatch-one! frame-id (runner/step-event step))
+                            (runner/step-skip idx step))
+
+                        :else (runner/step-skip idx step))]
+          (swap! stepper-state update frame-id
+                 (fn [s] (-> s
+                             (update :remaining subvec 1)
+                             (update :ran conj step)
+                             (update :results (fnil conj []) result))))))
+      step)))
+
+(defn stepper-step-back!
+  "Pop the most-recently-run step back into `:remaining` and drop its
+  recorded result, so a subsequent `step-once!` re-runs it cleanly. The
+  UI's step-back also restores the prior epoch (db state); this keeps the
+  substrate's remaining/ran/results cursor consistent with that restore.
+  No-op when no step has run. rf2-ee38b.3."
+  [frame-id]
+  (when config/enabled?
+    (swap! stepper-state update frame-id
+           (fn [s]
+             (if (seq (:ran s))
+               (let [last-step (peek (:ran s))]
+                 (-> s
+                     (update :ran pop)
+                     (update :results (fn [r] (if (seq r) (pop r) r)))
+                     (update :remaining (fn [rem] (into [last-step] rem)))))
+               s))))
+  nil)
+
+(defn stepper-rewind!
+  "Reset the substrate's run cursor to the start: every step back into
+  `:remaining`, `:ran` + `:results` emptied. The UI's rewind also
+  restores the pre-play epoch + clears the assertion accumulator.
+  rf2-ee38b.3."
+  [frame-id]
+  (when config/enabled?
+    (swap! stepper-state update frame-id
+           (fn [s]
+             (when s
+               (let [full (into (vec (:ran s)) (:remaining s))]
+                 (assoc s :remaining full :ran [] :results []))))))
+  nil)
 
 (defn end-stepper!
   "Tear down the play stepper for `frame-id`. The UI calls this when

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -37,7 +37,9 @@
   (:require [clojure.string             :as str]
             [re-frame.core              :as rf]
             #?(:cljs [reagent.core      :as r])
+            [re-frame.story.assertions  :as assertions]
             [re-frame.story.config      :as config]
+            [re-frame.story.late-bind   :as late-bind]
             [re-frame.story.play        :as play]
             [re-frame.story.play.dom    :as dom]
             [re-frame.story.play.runner :as runner]
@@ -248,6 +250,7 @@
 ;; ---- step executors ------------------------------------------------------
 
 (declare read-frame-db)
+(declare record-assertion-slot!)
 
 (defn- assertion-count
   "Count of records currently in the frame's `:rf.story/assertions`. Tolerant."
@@ -488,6 +491,40 @@
     :wait           (runner/step-skip idx step)   ; driver handles the actual sleep
     (runner/unknown-step idx step)))
 
+;; ---- single-step driver (rf2-ee38b.3 — step-debugger re-base) ------------
+;;
+;; The play step-debugger (`re-frame.story.ui.test-mode.stepper-state`)
+;; used to drive ONLY `:dispatch` / `:dispatch-sync` steps via the
+;; legacy `play/variant-play-events` projection — `:wait` / `:click` /
+;; `:type` / `:assert-db` / `:assert-dom` steps were silently dropped, so
+;; the stepper walked a TRUNCATED sequence with a wrong cursor/total and
+;; no assert outcomes. `run-step!` re-bases the stepper on the SAME rich-
+;; DSL executor the canvas auto-run path uses, so every step type runs in
+;; the debugger exactly as it does live.
+
+(defn run-step!
+  "Execute ONE coerced rich-DSL `step` (at index `idx`) against
+  `frame-id`, mirror assertion-class outcomes into the
+  `:rf.story/assertions` slot, emit the per-step trace event, and return
+  the step-result record. Synchronous on both runtimes (`:wait` records
+  a step-skip rather than blocking — the interactive stepper does not
+  sleep).
+
+  Public so the step-debugger substrate (`play/step-once!`) can drive a
+  full rich-DSL step without re-implementing the executor. Reached from
+  `play.cljc` via the `:run-play-step` late-bind hook to avoid the
+  play ↔ runner-events require cycle."
+  [frame-id idx step]
+  (let [result (try
+                 (exec-step! frame-id idx step)
+                 (catch #?(:clj Throwable :cljs :default) e
+                   (runner/step-exception idx step
+                                          #?(:clj  (.getMessage ^Throwable e)
+                                             :cljs (str e)))))]
+    (record-assertion-slot! frame-id step result)
+    (emit-trace! frame-id nil idx step result)
+    result))
+
 ;; ---- async scheduler -----------------------------------------------------
 
 (defn- schedule!
@@ -500,11 +537,81 @@
                (f)
                nil)))
 
+;; ---- assertion-slot bridge (rf2-ee38b.3 / rf2-uhq5j extension) ----------
+;;
+;; Rich-DSL `:assert-db` / `:assert-dom` step outcomes used to land ONLY
+;; in the runner's `run-state` atom. The `:rf.story/assertions` app-db
+;; slot — read by `run-variant`'s result map, `assertions-passing?`, the
+;; test-mode pane, the inline assertion strip, and the Causa assertions
+;; panel — never saw them, so a failing rich-DSL assertion read as a
+;; false GREEN through every slot consumer (only the toolbar chip + the
+;; CI/Playwright runner, which read `run-state` directly, observed it).
+;;
+;; The `:rf.assert/*` events (which ride `:dispatch-sync` steps) DO write
+;; the slot via their reg-event-fx handlers, so the contract was silently
+;; style-dependent. We close the gap by mirroring every assertion-class
+;; step result into `:rf.story/assertions` — the same record shape the
+;; `:rf.assert/*` handlers + the runtime's exception projection use.
+
+(def ^:const assert-db-id
+  "Synthetic assertion id stamped on `:rf.story/assertions` records for
+  rich-DSL `:assert-db` steps. In the `:rf.assert/*` reserved namespace
+  so `predicates/assertion-id?` and the pane's status logic treat it
+  uniformly with the canonical seven."
+  :rf.assert/db)
+
+(def ^:const assert-dom-id
+  "Synthetic assertion id for rich-DSL `:assert-dom` steps."
+  :rf.assert/dom)
+
+(defn- assertion-step-record
+  "Project an assertion-class step-result (`:assert-db` / `:assert-dom`)
+  into the `:rf.story/assertions` record shape. Returns nil for non-
+  assertion-class steps (`:dispatch` / `:wait` / `:click` / ...), whose
+  pass/fail is already represented by the `:rf.assert/*` records their
+  dispatched events recorded.
+
+  A `:skipped?` DOM step (no-DOM JVM context) is NOT recorded as a
+  failure — the step couldn't run, so it contributes no assertion
+  outcome to the slot (matching the run-state's `:passed? false` +
+  `:skipped? true` shape, which `finish` already tolerates)."
+  [frame-id step result]
+  (let [stype (runner/step-type step)]
+    (when (contains? runner/assertion-step-types stype)
+      (let [aid (case stype
+                  :assert-db  assert-db-id
+                  :assert-dom assert-dom-id)]
+        (cond->
+          {:assertion    aid
+           :passed?      (boolean (:passed? result))
+           :payload      (vec (rest step))
+           :source-coord (:source (registrar/handler-meta :variant frame-id))}
+          (contains? result :expected) (assoc :expected (:expected result))
+          (contains? result :actual)   (assoc :actual   (:actual result))
+          (:message result)            (assoc :reason   (:message result))
+          (:skipped? result)           (assoc :skipped? true))))))
+
+(defn- record-assertion-slot!
+  "Mirror an assertion-class step result into the frame's
+  `:rf.story/assertions` slot so every slot consumer agrees with the
+  run-state. No-op for non-assertion steps and for skipped DOM steps
+  (which record no outcome)."
+  [frame-id step result]
+  (when-let [rec (assertion-step-record frame-id step result)]
+    ;; A skipped DOM step ran but produced no pass/fail — keep it out of
+    ;; the slot so it doesn't read as a vacuous pass (slot consumers treat
+    ;; `:passed? true` as a pass).
+    (when-not (:skipped? rec)
+      (assertions/record! frame-id rec)))
+  nil)
+
 (defn- record-result!
-  "Append `result` to the run-state for `frame-id` and emit the trace
-  event."
+  "Append `result` to the run-state for `frame-id`, mirror assertion-
+  class outcomes into the `:rf.story/assertions` app-db slot, and emit
+  the trace event."
   [frame-id play-key name idx step result]
   (update-state! frame-id play-key runner/record-step-result result)
+  (record-assertion-slot! frame-id step result)
   (emit-trace! frame-id name idx step result)
   nil)
 
@@ -742,3 +849,12 @@
    (let [plays (variant-plays variant-id)]
      (when (seq plays)
        (run-plays-sequentially! variant-id (vec plays) done-cb)))))
+
+;; ---- step-debugger seam (rf2-ee38b.3) ------------------------------------
+;;
+;; `play.cljc` owns the step-debugger substrate but cannot `:require`
+;; this ns (the cycle: runner-events → play). It fetches `run-step!` via
+;; the `:run-play-step` late-bind hook. Registered at ns load so it is
+;; available as soon as the play module drives a stepped run.
+
+(late-bind/set-fn! :run-play-step run-step!)

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -64,8 +64,7 @@
   - Snapshot identity computation"
   (:require [re-frame.story.late-bind :as late-bind]
             [re-frame.story.schemas   :as schemas]
-            #?(:clj [re-frame.story.extends :as extends]
-               :cljs [re-frame.story.extends :as extends])))
+            [re-frame.story.extends   :as extends]))
 
 ;; ---- source-coord plumbing ------------------------------------------------
 ;;
@@ -331,8 +330,15 @@
   [id body]
   (maybe-auto-install!)
   (assert-id! :variant id)
-  (let [resolved (extends/resolve-extends body
-                                          (fn [pid] (handler-meta :variant pid)))
+  (let [resolved (extends/resolve-extends
+                   body
+                   (fn [pid] (handler-meta :variant pid))
+                   ;; rf2-ee38b.3: :play-script and :plays are sibling
+                   ;; encodings of the play surface. When the child
+                   ;; overrides one, drop the inherited other so the
+                   ;; merged body doesn't carry both (which the schema's
+                   ;; mutual-exclusion :fn would reject).
+                   [#{:play-script :plays}])
         body     (-> resolved
                      merge-coords
                      (->> (validate-shape! :variant id)))

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -170,11 +170,8 @@
         ts       (or (:tags vb) (:tags sb) #{})]
     (vec (sort ts))))
 
-(def parent-story-id
-  "Cheap parent-story derivation. Canonical definition lives in
-  `re-frame.story.predicates`; aliased here so the docs header chips
-  keep their `docs/parent-story-id` call shape."
-  pred/parent-story-id)
+;; rf2-ee38b.3: the `docs/parent-story-id` re-export was dropped; the
+;; header chips now call `pred/parent-story-id` directly.
 
 ;; ---- CLJS-side rendering -------------------------------------------------
 
@@ -286,7 +283,7 @@
            tag-filter (or (:tag-filter shell) #{})
            tags       (variant-tags variant-id)
            vb         (registrar/handler-meta :variant variant-id)
-           story-id   (parent-story-id variant-id)
+           story-id   (pred/parent-story-id variant-id)
            sb         (when story-id (registrar/handler-meta :story story-id))
            vdoc       (:doc vb)
            sdoc       (:doc sb)]

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -527,7 +527,8 @@
   panel), and Event-tab cascade view (replaces actions panel). Causa
   mounts into the `[data-rf-causa-host]` slot below via its standard
   `mount/open!` flow — driven from the selection-watcher whenever a
-  variant becomes focused (see `ensure-causa-mounted!`).
+  variant becomes focused (config bridges via
+  `causa-preset/wire-cross-host!`).
 
   Stage 6 (rf2-zhwd) adds `panels/render-panels-at-placement` so any
   `reg-story-panel` registration with `:placement :right` appears here.

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -35,7 +35,6 @@
   the shell entry point short-circuits before any subscription / mount
   call. Per IMPL-SPEC §6.3."
   (:require [re-frame.story.config                :as config]
-            [re-frame.story.predicates            :as pred]
             [re-frame.story.ui.state.filters      :as state.filters]
             [re-frame.story.ui.state.snapshot     :as state.snapshot]
             [re-frame.story.ui.state.tests        :as state.tests]
@@ -208,11 +207,10 @@
 (def filter-variants              state.filters/filter-variants)
 (def group-variants-by-story      state.filters/group-variants-by-story)
 
-(def parent-story-id
-  "Cheap parent-story derivation. Canonical definition lives in
-  `re-frame.story.predicates`; aliased here so existing sidebar call
-  sites keep their `state/parent-story-id` shape."
-  pred/parent-story-id)
+;; rf2-ee38b.3: the `state/parent-story-id` re-export was dropped — it
+;; had no internal src caller (sidebar / filters call
+;; `pred/parent-story-id` directly). The canonical helper lives in
+;; `re-frame.story.predicates`.
 
 ;; ---- registry snapshot (extracted to state.snapshot, rf2-gcpon) ---------
 

--- a/tools/story/src/re_frame/story/ui/state/tests.cljc
+++ b/tools/story/src/re_frame/story/ui/state/tests.cljc
@@ -170,34 +170,40 @@
                       (zero? running)
                       (zero? pending))}))
 
-(defn- play-script-has-steps?
-  "True iff `body` declares a non-empty `:play-script`. Handles both the
-  map form `{:auto-run? ... :script [...]}` and the bare-vector form
-  `:play-script [<step> ...]` (per rf2-0wrud — `:play-script` is the
-  canonical AND ONLY phase-4 slot; the runner normalises both forms)."
+(defn- play-surface-has-steps?
+  "True iff `body` declares a non-empty play surface — EITHER a
+  `:play-script` (map `:script` or bare-vector form, per rf2-0wrud) OR a
+  non-empty `:plays` vector (rf2-tl7zk multi-play). rf2-ee38b.3: the
+  `:plays` arm was added so a `:plays`-only variant counts as testable
+  in the chrome widget + sidebar dots, matching `ci-runner/has-any-play?`
+  and `test-mode.pure/variant-has-tests?`."
   [body]
-  (let [script (:play-script body)]
+  (let [script (:play-script body)
+        plays  (:plays body)]
     (boolean
-      (cond
-        (map? script)    (seq (:script script))
-        (vector? script) (seq script)
-        :else            false))))
+      (or
+        (cond
+          (map? script)    (seq (:script script))
+          (vector? script) (seq script)
+          :else            false)
+        (and (vector? plays) (seq plays))))))
 
 (defn testable-variant-ids
   "Return the seq of variant-ids tagged `:test`, in stable (alphabetical)
   order. The chrome widget + sidebar dots key off this seq.
 
   Variants are testable iff (a) their `:tags` contains `:test`, AND
-  (b) they declare a non-empty `:play-script` body. The second filter
-  prunes variants tagged `:test` but without any assertions to run —
-  those contribute neither to the headline counts nor to the 'Run all'
-  iteration. Pure data → data; JVM-testable. `id->body` is the
-  `{variant-id → body}` map from `(registrar/registrations :variant)`."
+  (b) they declare a non-empty play surface (`:play-script` OR `:plays`
+  — rf2-ee38b.3). The second filter prunes variants tagged `:test` but
+  without any assertions to run — those contribute neither to the
+  headline counts nor to the 'Run all' iteration. Pure data → data;
+  JVM-testable. `id->body` is the `{variant-id → body}` map from
+  `(registrar/registrations :variant)`."
   [id->body]
   (->> id->body
        (filter (fn [[_ body]]
                  (and (contains? (or (:tags body) #{}) :test)
-                      (play-script-has-steps? body))))
+                      (play-surface-has-steps? body))))
        (map first)
        sort
        vec))

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -18,29 +18,22 @@
 
 ;; ---- aliases on the leaf predicates ns ----------------------------------
 ;;
-;; `assertion-event?` + `parent-story-id` both live canonically in
-;; `re-frame.story.predicates` (a pure leaf ns the rest of Story consumes
-;; without cycle risk). Aliased here so internal call sites stay textually
-;; identical and external test fixtures keep their qualified shape.
+;; `assertion-event?` lives canonically in `re-frame.story.predicates`
+;; (a pure leaf ns the rest of Story consumes without cycle risk).
+;; Aliased here so internal call sites stay textually identical.
+;;
+;; rf2-ee38b.3: the `parent-story-id` re-export was DROPPED — its sole
+;; caller (`test-mode.view`) now calls `pred/parent-story-id` directly.
 
 (def ^:private assertion-event? pred/assertion-event?)
-(def parent-story-id            pred/parent-story-id)
 
 ;; ---- pure: variant-has-tests? -------------------------------------------
 
-(defn variant-has-tests?
-  "True iff `variant-id`'s registered body declares a non-empty
-  `:play-script` body. Used by the pane to gate between the
-  run-and-render path and the empty-state placeholder.
-
-  Per rf2-0wrud (2026-05-20) `:play-script` is the canonical AND ONLY
-  phase-4 slot. The body is a map `{:auto-run? ... :script [...]}`; we
-  consider the variant 'has tests' iff `:script` is non-empty.
-
-  Pure data → data; JVM-testable."
-  [variant-id]
-  (let [vb     (registrar/handler-meta :variant variant-id)
-        script (:play-script vb)]
+(defn- has-play-script?
+  "True iff `vb` carries a non-empty `:play-script` (map `:script` or
+  bare vector)."
+  [vb]
+  (let [script (:play-script vb)]
     (boolean
       (cond
         ;; Map form — {:auto-run? ... :script [...]}
@@ -49,6 +42,30 @@
         ;; the script vector directly; the runner normalises both.
         (vector? script) (seq script)
         :else            false))))
+
+(defn- has-plays?
+  "True iff `vb` carries a non-empty `:plays` vector (rf2-tl7zk multi-play)."
+  [vb]
+  (let [plays (:plays vb)]
+    (boolean (and (vector? plays) (seq plays)))))
+
+(defn variant-has-tests?
+  "True iff `variant-id`'s registered body declares a non-empty
+  `:play-script` OR a non-empty `:plays` vector. Used by the pane to
+  gate between the run-and-render path and the empty-state placeholder.
+
+  Per rf2-0wrud (2026-05-20) `:play-script` is the canonical phase-4
+  slot; rf2-tl7zk added the multi-play `:plays` slot. rf2-ee38b.3: this
+  predicate now recognises BOTH (it previously checked only
+  `:play-script`, so a `:plays`-only variant rendered the
+  'no tests registered' empty-state even though the runner + CI runner
+  see its runnable plays — matching `ci-runner/has-any-play?`).
+
+  Pure data → data; JVM-testable."
+  [variant-id]
+  (let [vb (registrar/handler-meta :variant variant-id)]
+    (or (has-play-script? vb)
+        (has-plays? vb))))
 
 ;; ---- pure: aggregate-summary --------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_pure.cljc
@@ -16,7 +16,56 @@
   - `re-frame.story.ui.test-mode.stepper-styles` — pure style map.
   - `re-frame.story.ui.test-mode.stepper-view`   — CLJS Reagent component."
   (:require [re-frame.story.predicates :as pred]
+            [re-frame.story.play.runner :as runner]
             [re-frame.story.ui.test-mode.pure :as test-mode-pure]))
+
+;; ---- step-outcome (rf2-ee38b.3 — full-script step list) ------------------
+;;
+;; The step-debugger now walks the FULL coerced :play-script (every step
+;; type), driving each through the rich-DSL executor. Each step that has
+;; run carries a result record (`runner/step-pass` / `step-fail` /
+;; `step-skip` / `step-exception`); steps not yet reached carry no result.
+;; This fold maps the full step vector + the per-step result records onto
+;; one row per step, so the cursor / total are honest and EVERY step type
+;; (incl. `:wait` / `:click` / `:type` / `:assert-db` / `:assert-dom`)
+;; renders a row. Pure data → data; JVM-testable.
+
+(defn- step-outcome
+  "Outcome glyph class for a step given its result record (or nil when
+  the step has not yet run). `:pass` / `:fail` / `:skip` for assertion-
+  class + DOM-skipped steps; `:event` (neutral) for dispatch / wait
+  steps and for not-yet-run steps."
+  [result]
+  (cond
+    (nil? result)               :event
+    (:skipped? result)          :skip
+    (true? (:passed? result))   :pass
+    (false? (:passed? result))  :fail
+    :else                       :event))
+
+(defn step-statuses
+  "Pure: given the FULL coerced step vector + the per-step result records
+  (in run order — `:results` from `play/stepper-state`), return a vector
+  of step-status maps, one per step:
+
+      {:index   <0-based step index>
+       :step    <the coerced step vector>
+       :label   <runner/step-summary string>
+       :status  :pass | :fail | :skip | :event}
+
+  A step at `index < (count results)` has run and takes its outcome from
+  `(nth results index)`; a step at or beyond the results length has not
+  run yet and renders neutral (`:event`). rf2-ee38b.3."
+  [steps results]
+  (let [recs (vec (or results []))]
+    (vec
+      (map-indexed
+        (fn [idx step]
+          {:index  idx
+           :step   step
+           :label  (runner/step-summary step)
+           :status (step-outcome (nth recs idx nil))})
+        (or steps [])))))
 
 ;; ---- step status -------------------------------------------------------
 ;;

--- a/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/stepper_state.cljs
@@ -14,11 +14,12 @@
 
       {:active?        <bool>         ; the stepper is in flight
        :auto-playing?  <bool>         ; the interval is ticking
-       :cursor         <int>          ; number of events dispatched so far
-       :total          <int>          ; count of play-script events in this run
-       :play-events    <vector>       ; immutable snapshot of the events
-                                      ;   (derived from :play-script via
-                                      ;    re-frame.story.play/variant-play-events)
+       :cursor         <int>          ; number of steps run so far
+       :total          <int>          ; count of play-script STEPS in this run
+       :play-steps     <vector>       ; immutable snapshot of the FULL coerced
+                                      ;   :play-script step vector (every step
+                                      ;   type — rf2-ee38b.3; derived via
+                                      ;   re-frame.story.play/variant-play-steps)
        :statuses       <vector>       ; `stepper-pure/enrich-statuses` rows
        :breakpoints    #{<int>}       ; step indices that pause auto-play
        :epoch-stack    <vector>       ; per-step :epoch-id pre-images, for
@@ -53,7 +54,6 @@
             [re-frame.story.play                          :as play]
             [re-frame.story.runtime                       :as runtime]
             [re-frame.story.assertions                    :as assertions]
-            [re-frame.story.ui.test-mode.pure             :as test-mode-pure]
             [re-frame.story.ui.test-mode.stepper-pure     :as stepper-pure]))
 
 ;; ---- ratom ---------------------------------------------------------------
@@ -73,17 +73,20 @@
 
 (defn- recompute-statuses
   "Pure: re-derive the enriched step list from a slot. Called after every
-  mutator that moves the cursor / changes breakpoints / records a step."
+  mutator that moves the cursor / changes breakpoints / records a step.
+
+  rf2-ee38b.3: the rows now cover the FULL coerced step vector (every
+  step type), and each row's outcome comes from the per-step result the
+  rich-DSL executor recorded into `play/stepper-state` — not from the
+  dispatch-only `:rf.story/assertions` projection (which never saw
+  rich-DSL `:assert-db` / `:assert-dom` / `:wait` / `:click` / `:type`
+  steps)."
   [slot]
-  (let [{:keys [play-events cursor breakpoints]} slot
-        ;; Read the assertion accumulator off the variant frame so the
-        ;; outcome glyphs land as the run progresses. The variant frame
-        ;; lives in `play/stepper-state` so we read the assertions via
-        ;; the assertions module.
-        records (assertions/read-assertions (:variant-id slot))]
+  (let [{:keys [play-steps cursor breakpoints variant-id]} slot
+        results (:results (get @play/stepper-state variant-id))]
     (assoc slot :statuses
            (stepper-pure/enrich-statuses
-             (test-mode-pure/play-step-statuses play-events records)
+             (stepper-pure/step-statuses play-steps results)
              cursor
              breakpoints))))
 
@@ -116,12 +119,13 @@
   ;; documented initial state.
   (-> (runtime/reset-variant variant-id)
       (.then  (fn [_]
-                ;; Per rf2-0wrud `:play-script` is the canonical AND ONLY
-                ;; phase-4 slot. `play/variant-play-events` derives the
-                ;; flat event-vec list from the variant's :play-script
-                ;; body — the same shape the legacy `:play` slot carried.
-                (let [play-events (play/variant-play-events variant-id)
-                      total       (count play-events)]
+                ;; rf2-ee38b.3: the stepper walks the FULL coerced
+                ;; :play-script (every step type), not just the dispatch-
+                ;; bearing events. `play/variant-play-steps` returns the
+                ;; complete step vector and `play/begin-stepper!` seeds the
+                ;; substrate from the same source.
+                (let [play-steps (play/variant-play-steps variant-id)
+                      total      (count play-steps)]
                   (play/begin-stepper! variant-id)
                   (swap! results-atom assoc variant-id
                          {:variant-id     variant-id
@@ -129,7 +133,7 @@
                           :auto-playing?  false
                           :cursor         0
                           :total          total
-                          :play-events    (vec play-events)
+                          :play-steps     (vec play-steps)
                           :statuses       []
                           :breakpoints    #{}
                           :epoch-stack    [(current-epoch-id variant-id)]
@@ -177,6 +181,9 @@
             target-id (peek new-stack)]
         (when target-id
           (epoch/restore-epoch variant-id target-id))
+        ;; Pop the substrate's last-run step + result so the row outcomes
+        ;; track the cursor and a re-step re-runs the popped step cleanly.
+        (play/stepper-step-back! variant-id)
         (swap! results-atom update variant-id
                (fn [s]
                  (-> s
@@ -200,6 +207,9 @@
         ;; Also reset the assertion accumulator so a fresh forward run
         ;; doesn't pile new records on top of the old ones.
         (assertions/reset-trace-accumulators! variant-id)
+        ;; Reset the substrate's run cursor (every step back to pending)
+        ;; so the rewound stepper re-runs the whole script cleanly.
+        (play/stepper-rewind! variant-id)
         (swap! results-atom update variant-id
                (fn [s]
                  (-> s

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -53,6 +53,7 @@
   `(when config/enabled? ...)`-gated mount call, so production builds
   never invoke it — closure DCEs the lot."
   (:require [reagent.core                              :as r]
+            [re-frame.story.predicates                 :as pred]
             [re-frame.story.ui.open-in-editor          :as open-in-editor]
             [re-frame.story.ui.state                   :as shell-state]
             [re-frame.story.ui.test-mode.pure          :as pure]
@@ -76,7 +77,7 @@
         ran-at-ms  (:ran-at-ms slot)
         result     (:result slot)
         elapsed    (:elapsed-ms result)
-        story-id   (pure/parent-story-id variant-id)]
+        story-id   (pred/parent-story-id variant-id)]
     [:div
      [:h1 {:style (:h1 styles)} (str variant-id)]
      [:div {:style     (:sub styles)

--- a/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/assertion_redaction_cljs_test.cljs
@@ -1,5 +1,6 @@
 (ns re-frame.story.assertion-redaction-cljs-test
-  "Assertion-with-redaction scenario (rf2-shy6n).
+  "Assertion-with-redaction scenario (rf2-shy6n; substrate wired by
+  rf2-ee38b.3).
 
   Per `tools/story/spec/015-Test-Coverage.md` §Assertion vocabulary
   scenarios, row 'Assertion-with-redaction (sensitive payload)':
@@ -10,44 +11,18 @@
   pipelines) and the contract is 'never leak the raw value to
   observation surfaces' per spec/015-Data-Classification.
 
-  ## Status: SUBSTRATE NOT YET WIRED — test marked as a documented skip
+  ## Status: WIRED (rf2-ee38b.3)
   ##
-  ## Investigation (cluster 2, 2026-05-18):
-  ##
-  ## The data-classification spec (`spec/015-Data-Classification.md`,
-  ## shipped via PR #1386 / rf2-t2rpu) defines `:rf/redacted` + the
-  ## seven first-class marking sites, of which `add-marks` / `set-marks`
-  ## per-frame is the API the assertion path would consume. The
-  ## implementation ships **most of the substrate**:
-  ##
-  ##   - `implementation/core/src/re_frame/elision.cljc` carries
-  ##     `populate-sensitive-from-schemas!` + `elide-wire-value` —
-  ##     the wire-egress projection that substitutes `:rf/redacted`
-  ##     at schema-declared sensitive paths.
-  ##
-  ##   - `re-frame.core/add-marks` and `re-frame.core/set-marks` (the
-  ##     dedicated per-frame marking API named in spec/015 §App-db
-  ##     marks) ship — split from the original `reg-marks` per
-  ##     rf2-5g3zq (add merges, set replaces).
-  ##
-  ## What is MISSING for assertion-redaction to work end-to-end:
-  ##
-  ##   - The assertion evaluators (`evaluate-path-equals` etc in
-  ##     `tools/story/src/re_frame/story/assertions.cljc`) call
-  ##     `(get-in db path)` and stamp the result raw onto `:actual`.
-  ##     No projection through `elision/elide-wire-value` happens.
-  ##
-  ## Per Mike's directive ('5 + 1 documented skip if substrate isn't
-  ## ready'), this file ships the contract-on-paper as a CLJS test
-  ## that aspires-to-pass once the assertion-evaluator integration
-  ## lands. The test BODY documents what the projection MUST look
-  ## like; the assertion is guarded by an `is (true? true)`
-  ## placeholder so the file compiles and the test suite stays green.
-  ##
-  ## When the assertion-evaluator is wired through `elide-wire-value`
-  ## (or a `marks`-aware projection), drop the `(is true)`
-  ## placeholder and uncomment the actual assertion. Existing
-  ## scaffolding (the schema seed + the fixture variant) is correct."
+  ## The assertion evaluators (`evaluate-path-equals` /
+  ## `evaluate-path-matches` / `evaluate-sub-equals` in
+  ## `tools/story/src/re_frame/story/assertions.cljc`) now project the
+  ## captured value through `re-frame.elision/elide-wire-value` (keyed
+  ## on the asserted path + the variant frame) BEFORE stamping `:actual`.
+  ## A path the frame marked sensitive (via `re-frame.core/add-marks` /
+  ## `set-marks`, or a schema entry with `{:sensitive? true}`) records
+  ## `:rf/redacted` instead of the raw value; a non-sensitive path passes
+  ## through unchanged. The tests below mark the path sensitive then
+  ## assert the recorded `:actual` is `:rf/redacted`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core             :as rf]
             [re-frame.frame            :as frame]
@@ -81,116 +56,111 @@
 (use-fixtures :each {:before reset-all!})
 
 ;; ===========================================================================
-;; rf2-shy6n — assertion-with-redaction
+;; rf2-ee38b.3 — assertion-with-redaction (substrate WIRED)
 ;;
-;; ASPIRATIONAL CONTRACT (substrate not yet wired):
+;;   Given a variant whose frame marks `[:auth :token]` sensitive (via
+;;   `re-frame.core/add-marks`), an assertion against that path records
+;;   `:rf/redacted` in `:actual`, NOT the raw token string. Same for
+;;   `:rf.assert/path-matches` and `:rf.assert/sub-equals`.
 ;;
-;;   Given a variant whose play emits
-;;     [:rf.assert/path-equals [:auth :token] :rf/redacted]
-;;   against a frame whose `:auth :token` slot is marked sensitive
-;;   (via `add-marks` / `set-marks` per-frame OR a schema entry with
-;;   `{:sensitive? true}`), the recorded assertion's `:actual` slot
-;;   MUST be `:rf/redacted`, NOT the raw token string.
-;;
-;;   Symmetrically for `:rf.assert/sub-equals`: a subscription returning
-;;   a sensitive value MUST surface its value as `:rf/redacted` in the
-;;   recorded `:actual`.
-;;
-;;   Symmetrically for `:rf.assert/path-matches` (Malli): the failure
-;;   case's `:actual` slot MUST be `:rf/redacted` when the path is
-;;   marked sensitive.
+;;   The marks live on the variant FRAME, so we run-variant once to
+;;   allocate the frame, mark the path sensitive, then re-run the play
+;;   (via execute-play!) and read the freshly-recorded assertion.
 ;; ===========================================================================
 
-(deftest assertion-with-redaction-substrate-not-yet-wired
-  (testing "rf2-shy6n: assertion-redaction substrate is NOT yet wired —
-            documented skip per spec/015-Data-Classification §
-            Implementation notes (rf2-t2rpu spec landed; assertion-
-            evaluator integration is a follow-on).
-
-            The fixture below builds the SHAPE the test will exercise
-            once the substrate ships:
-              1. A variant whose :events seed a sensitive payload at
-                 [:auth :token].
-              2. A :play-script asserting [:rf.assert/path-equals [:auth :token] ...].
-              3. The recorded :actual slot's contract.
-
-            Today: the assertion-evaluator (assertions/evaluate-path-
-            equals) reads (get-in db path) raw — no projection through
-            re-frame.elision/elide-wire-value. So the recorded :actual
-            carries the raw secret. The placeholder assertion below
-            (is true) documents the test is intentionally inert until
-            the substrate ships."
+(deftest assertion-path-equals-redacts-sensitive-actual
+  (testing "rf2-ee38b.3: :rf.assert/path-equals records :rf/redacted in
+            :actual for a sensitive path (not the raw bearer token)"
     (rf/reg-event-db :auth/login
       (fn [db _] (assoc-in db [:auth :token] "BEARER-secret-12345")))
     (story/reg-variant :story.redaction.path-equals/probe
       {:events [[:auth/login]]
        :play-script [[:dispatch-sync [:rf.assert/path-equals
                  [:auth :token]
-                 :rf/redacted]]]})
+                 "BEARER-secret-12345"]]]})
     (async done
       (-> (story/run-variant :story.redaction.path-equals/probe)
           (async-lib/then
+            (fn [_first-run]
+              ;; Mark the path sensitive on the variant frame, then re-run
+              ;; the assertion against the now-marked frame.
+              (rf/add-marks :story.redaction.path-equals/probe
+                            {[:auth :token] :sensitive})
+              (-> (story/execute-play! :story.redaction.path-equals/probe)
+                  (async-lib/then
+                    (fn [_]
+                      (let [recs (story/read-assertions
+                                   :story.redaction.path-equals/probe)
+                            pe   (last (filter #(= :rf.assert/path-equals
+                                                   (:assertion %))
+                                               recs))]
+                        (is (= :rf/redacted (:actual pe))
+                            "assertion :actual is :rf/redacted, NOT the raw token")
+                        ;; The assertion still PASSES — equality is checked
+                        ;; against the raw value before projection.
+                        (is (true? (:passed? pe))
+                            "redaction does not change the pass/fail outcome")
+                        (story/destroy-variant!
+                          :story.redaction.path-equals/probe)
+                        (done)))))))))))
+
+(deftest assertion-path-equals-non-sensitive-passes-value-through
+  (testing "rf2-ee38b.3: a NON-sensitive path records the raw value
+            unchanged (redaction only fires on marked paths)"
+    (rf/reg-event-db :ui/set-label (fn [db _] (assoc db :label "hello")))
+    (story/reg-variant :story.redaction.plain/probe
+      {:events [[:ui/set-label]]
+       :play-script [[:dispatch-sync [:rf.assert/path-equals [:label] "hello"]]]})
+    (async done
+      (-> (story/run-variant :story.redaction.plain/probe)
+          (async-lib/then
             (fn [result]
-              ;; Documented expected contract (commented out — uncomment
-              ;; when the substrate is wired):
-              ;;
-              ;;   (let [assertion-row (first (:assertions result))]
-              ;;     (is (= :rf/redacted (:actual assertion-row))
-              ;;         "assertion :actual MUST be :rf/redacted, NOT
-              ;;          the raw bearer-token string"))
-              ;;
-              ;; Today's reality — pin the lifecycle still executes so
-              ;; this file is not dead code:
-              (is (= :story.redaction.path-equals/probe (:frame result))
-                  "lifecycle still runs — the fixture is sound")
-              (is (vector? (:assertions result))
-                  ":assertions vector populated — record-don't-throw
-                   contract holds (regardless of redaction)")
-              ;; Placeholder — the actual contract goes here when the
-              ;; substrate is wired. Today: pass intentionally so the
-              ;; suite stays green while the substrate ships.
-              (is true
-                  "PLACEHOLDER: assertion-redaction substrate not yet
-                   wired. See rf2-shy6n + the namespace docstring.
-                   Replace with the (is (= :rf/redacted (:actual ...)))
-                   assertion when the assertion evaluator routes
-                   through elide-wire-value (the add-marks / set-marks
-                   per-frame API has shipped).")
-              (story/destroy-variant! :story.redaction.path-equals/probe)
+              (let [pe (first (filter #(= :rf.assert/path-equals (:assertion %))
+                                      (:assertions result)))]
+                (is (= "hello" (:actual pe))
+                    "non-sensitive value passes through unredacted"))
+              (story/destroy-variant! :story.redaction.plain/probe)
               (done)))))))
 
-(deftest assertion-with-redaction-sub-equals-also-deferred
-  (testing "rf2-shy6n: same status for :rf.assert/sub-equals — a
-            subscription whose value contains sensitive data should
-            surface :rf/redacted in the recorded :actual slot. Same
-            deferred-substrate caveat applies. The fixture is wired
-            so a future contributor can drop in the assertion and
-            the rest of the test runs.
+(deftest assertion-sub-equals-redacts-on-path-bearing-sub-vec
+  (testing "rf2-ee38b.3: :rf.assert/sub-equals redacts :actual when the
+            sub-vec carries the app-db path as its args (the projection
+            keys on (rest sub-vec)). A parameterised sub
+            [:sub/id :user :ssn] → args path [:user :ssn]; marking that
+            path sensitive redacts the recorded :actual.
 
-            Per spec/015-Data-Classification §reg-sub: a sub reading
-            a sensitive path auto-propagates the sensitive marker into
-            its output value (the §Implementation notes V1 path-walk
-            approach). Until that propagation engages on the assertion
-            path, this test is intentionally inert"
+            Note: a bare sub-id whose args carry NO app-db path (e.g.
+            [:user/ssn]) cannot be auto-redacted at the assertion layer —
+            full sub-marker propagation (spec/015 §reg-sub) is a sub-
+            engine feature tracked separately. The assertion layer
+            redacts what its path-key reaches."
     (rf/reg-event-db :session/save-pii
-      (fn [db _] (assoc db :user/ssn "123-45-6789")))
-    (rf/reg-sub :user/ssn (fn [db _] (:user/ssn db)))
+      (fn [db _] (assoc-in db [:user :ssn] "123-45-6789")))
+    ;; Parameterised sub: reads the path passed as args.
+    (rf/reg-sub :pii/at (fn [db [_ & path]] (get-in db (vec path))))
     (story/reg-variant :story.redaction.sub-equals/probe
       {:events [[:session/save-pii]]
        :play-script [[:dispatch-sync [:rf.assert/sub-equals
-                 [:user/ssn]
-                 :rf/redacted]]]})
+                 [:pii/at :user :ssn]
+                 "123-45-6789"]]]})
     (async done
       (-> (story/run-variant :story.redaction.sub-equals/probe)
           (async-lib/then
-            (fn [result]
-              (is (vector? (:assertions result)))
-              ;; Same placeholder as above — replace with
-              ;;   (is (= :rf/redacted
-              ;;          (:actual (first (:assertions result)))))
-              ;; when the substrate lands.
-              (is true
-                  "PLACEHOLDER: sub-side redaction propagation also
-                   pending. See namespace docstring.")
-              (story/destroy-variant! :story.redaction.sub-equals/probe)
-              (done)))))))
+            (fn [_first-run]
+              (rf/add-marks :story.redaction.sub-equals/probe
+                            {[:user :ssn] :sensitive})
+              (-> (story/execute-play! :story.redaction.sub-equals/probe)
+                  (async-lib/then
+                    (fn [_]
+                      (let [recs (story/read-assertions
+                                   :story.redaction.sub-equals/probe)
+                            se   (last (filter #(= :rf.assert/sub-equals
+                                                   (:assertion %))
+                                               recs))]
+                        (is (= :rf/redacted (:actual se))
+                            "sub-equals :actual redacts the sensitive value")
+                        (is (true? (:passed? se))
+                            "redaction does not change the pass/fail outcome")
+                        (story/destroy-variant!
+                          :story.redaction.sub-equals/probe)
+                        (done)))))))))))

--- a/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
@@ -24,11 +24,14 @@
     `keybinding/detach!` so the listener Causa's preload installed
     under the default-true posture is removed at runtime (the slot
     alone is read only at attach time).
-  - `ensure-causa-mounted!` (rf2-q7who.1 + rf2-ycrt2): calls
+  - `wire-cross-host!` (rf2-q7who.1 + rf2-ycrt2): calls
     `disable-keybinding!` then `detach-keybinding!` as part of the
-    mount edge so Story's RHS-mounted Causa never swallows the host's
-    Cmd/Ctrl+K command palette — both the intent declaration (slot
-    flip) and the runtime mechanism (detach!) fire together."
+    cross-host bridge so Story's RHS-mounted Causa never swallows the
+    host's Cmd/Ctrl+K command palette — both the intent declaration
+    (slot flip) and the runtime mechanism (detach!) fire together.
+    (rf2-ee38b.3 removed the DEPRECATED `ensure-causa-mounted!` shim;
+    the legacy whole-shell-open composes
+    `(do (wire-cross-host!) (apply-open!))` directly.)"
   (:require [clojure.test :refer [deftest is testing]]
             [day8.re-frame2-causa.config :as causa-config]
             [day8.re-frame2-causa.keybinding :as causa-keybinding]
@@ -103,22 +106,21 @@
       (is (nil? (causa-preset/detach-keybinding!))
           "no Causa → no work → nil"))))
 
-;; ---- ensure-causa-mounted! drives the bridges ----------------------------
+;; ---- wire-cross-host! drives the bridges (rf2-ee38b.3) -------------------
+;;
+;; The shim `ensure-causa-mounted!` was removed; the legacy whole-shell
+;; open is `(do (wire-cross-host!) (apply-open!))`. These tests pin the
+;; same bridge ordering against that composition.
 
-(deftest ensure-causa-mounted-disables-keybinding
-  (testing "ensure-causa-mounted! drives disable-keybinding! on the mount edge"
-    ;; The shell calls ensure-causa-mounted! on every variant-selection
-    ;; edge. Verify the keybinding-disable bridge is invoked as part of
-    ;; that flow. We shim the Causa-availability gate AND
-    ;; `disable-keybinding!` itself so we can assert the wiring without
-    ;; depending on the underlying configure! plumbing (covered by the
-    ;; shimmed-configure test above). We also stub `detach-keybinding!`
-    ;; and `apply-open!` directly so we don't actually try to mount a
-    ;; shell. (rf2-ibpwr: the pre-fix tests stubbed `resolve-fn` to
-    ;; intercept the `mount/open!` lookup; after rf2-ibpwr `apply-open!`
-    ;; references `causa-mount/open!` directly via compile-time symbol
-    ;; resolution — there is no `resolve-fn` call to intercept, so the
-    ;; cleaner seam is the `apply-open!` var itself.)
+(deftest wire-cross-host-disables-keybinding
+  (testing "wire-cross-host! drives disable-keybinding! + detach-keybinding!;
+            the composed (wire-cross-host! + apply-open!) still opens"
+    ;; The embed wires cross-host config on every variant-selection edge.
+    ;; Verify the keybinding bridges fire. We shim the Causa-availability
+    ;; gate AND the bridges so we can assert the wiring without depending
+    ;; on the underlying configure! plumbing (covered by the shimmed-
+    ;; configure test above), and shim `apply-open!` so we don't actually
+    ;; mount a shell.
     (let [disable-called? (atom false)
           detach-called?  (atom false)
           open-called?    (atom false)]
@@ -130,21 +132,21 @@
                     (fn [] (reset! detach-called? true) true)
                     causa-preset/apply-open!
                     (fn [] (reset! open-called? true) nil)]
-        (causa-preset/ensure-causa-mounted!)
+        (causa-preset/wire-cross-host!)
+        (causa-preset/apply-open!)
         (is (true? @disable-called?)
-            "disable-keybinding! is part of the mount edge")
+            "disable-keybinding! is part of the cross-host bridge")
         (is (true? @detach-called?)
-            "detach-keybinding! is part of the mount edge")
+            "detach-keybinding! is part of the cross-host bridge")
         (is (true? @open-called?)
-            "apply-open! still fires (keybinding wire-up does not break mount)")))))
+            "the composed open still fires (keybinding wire-up does not break mount)")))))
 
-(deftest ensure-causa-mounted-sequences-slot-then-detach
-  (testing "rf2-ycrt2 — ensure-causa-mounted! flips the slot BEFORE
-            removing the listener; sequencing matters because a host
-            (or test runner) inspecting the slot mid-flow must always
-            see the declared intent. We capture the order via a shared
-            log and assert disable-keybinding! ran before
-            detach-keybinding!."
+(deftest wire-cross-host-sequences-slot-then-detach
+  (testing "rf2-ycrt2 — wire-cross-host! flips the slot BEFORE removing
+            the listener; sequencing matters because a host (or test
+            runner) inspecting the slot mid-flow must always see the
+            declared intent. We capture the order via a shared log and
+            assert disable-keybinding! ran before detach-keybinding!."
     (let [calls (atom [])]
       (with-redefs [causa-preset/causa-available?
                     (fn [] true)
@@ -152,29 +154,28 @@
                     (fn [] (swap! calls conj :disable) true)
                     causa-preset/detach-keybinding!
                     (fn [] (swap! calls conj :detach) true)
-                    ;; rf2-ibpwr: shim apply-open! directly — see the
-                    ;; rationale on the disables-keybinding test above.
                     causa-preset/apply-open!
                     (fn [] (swap! calls conj :open) nil)]
-        (causa-preset/ensure-causa-mounted!)
+        (causa-preset/wire-cross-host!)
+        (causa-preset/apply-open!)
         (is (= [:disable :detach :open] @calls)
             "slot flip (intent) lands before detach! (runtime removal)
-             which lands before apply-open!")))))
+             which lands before the composed apply-open!")))))
 
 ;; ---- runtime integration: slot + detach! together (rf2-ycrt2) ------------
 
-(deftest ensure-causa-mounted-clears-attached-listener
+(deftest wire-cross-host-clears-attached-listener
   (testing "rf2-ycrt2 — simulate Causa's preload-time attach! under the
-            default-true posture, then drive ensure-causa-mounted!;
-            after the mount edge the keybinding sentinel must be false
-            (the listener was removed). This is the runtime contract
-            rf2-q7who.1 declared but did not close — the slot flip
-            alone wouldn't detach the listener; rf2-ycrt2 closes the
-            gap via detach-keybinding!."
+            default-true posture, then drive wire-cross-host!; after the
+            bridge the keybinding sentinel must be false (the listener
+            was removed). This is the runtime contract rf2-q7who.1
+            declared but did not close — the slot flip alone wouldn't
+            detach the listener; rf2-ycrt2 closes the gap via
+            detach-keybinding!."
     ;; Restore baseline so attach! sees the default-true slot. Then
     ;; simulate the preload: attach!. Without rf2-ycrt2 the listener
-    ;; would survive past ensure-causa-mounted!; with the fix the
-    ;; sentinel flips back to false.
+    ;; would survive past wire-cross-host!; with the fix the sentinel
+    ;; flips back to false.
     (causa-config/set-keybinding-enabled! true)
     (try
       ;; Skip the inner attach when js/document is unstubbable (real
@@ -184,24 +185,18 @@
         (causa-keybinding/attach!)
         (is (true? (causa-keybinding/attached?))
             "precondition: preload-style attach! installed the listener"))
-      ;; Drive the mount edge. We shim Causa-availability + apply-open!
-      ;; so we don't try to mount a shell. `disable-keybinding!` and
-      ;; `detach-keybinding!` run for real (with-redefs unchanged) and
-      ;; their inner `resolve-fn` lookups resolve against Causa's live
-      ;; config/keybinding namespaces (both on the test classpath).
-      ;; rf2-ibpwr: after the fix, `apply-open!` references
-      ;; `causa-mount/open!` directly via compile-time symbol
-      ;; resolution — no `resolve-fn` call to intercept. Shim
-      ;; `apply-open!` itself as the no-op seam so the test's intent
-      ;; (don't actually mount a shell, but DO run the real
-      ;; keybinding bridges) is preserved.
-      (with-redefs [causa-preset/causa-available? (fn [] true)
-                    causa-preset/apply-open!      (fn [] nil)]
-        (causa-preset/ensure-causa-mounted!))
+      ;; Drive the cross-host bridge. We shim Causa-availability so the
+      ;; gate passes; `disable-keybinding!` and `detach-keybinding!` run
+      ;; for real (their inner `resolve-fn` lookups resolve against
+      ;; Causa's live config/keybinding namespaces, both on the test
+      ;; classpath). No shell mount happens — `wire-cross-host!` never
+      ;; calls `apply-open!`.
+      (with-redefs [causa-preset/causa-available? (fn [] true)]
+        (causa-preset/wire-cross-host!))
       (is (false? (causa-config/keybinding-attach-enabled?))
-          "ensure-causa-mounted! flipped the slot to false")
+          "wire-cross-host! flipped the slot to false")
       (is (false? (causa-keybinding/attached?))
-          "ensure-causa-mounted! removed the listener (rf2-ycrt2 runtime gap closed)")
+          "wire-cross-host! removed the listener (rf2-ycrt2 runtime gap closed)")
       (finally
         ;; Restore defaults so neighbouring tests see the baseline.
         (causa-config/set-keybinding-enabled! true)

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -235,6 +235,94 @@
            (is (= :wrong  (:expected (nth assert-results 1))))
            (is (= :loaded (:actual   (nth assert-results 1)))))))))
 
+;; ---- rf2-ee38b.3: rich-DSL assert outcomes reach :rf.story/assertions ----
+;;
+;; Before this fix a failing `:assert-db` / `:assert-dom` step landed
+;; ONLY in run-state; the `:rf.story/assertions` app-db slot stayed empty
+;; so `run-variant`'s :assertions slot, `assertions-passing?`, the test
+;; pane, the inline strip, and the Causa panel all read FALSE-GREEN. The
+;; bridge in `record-result!` mirrors assertion-class outcomes into the
+;; slot. These tests must FAIL without the bridge.
+
+#?(:clj
+   (deftest assert-db-failure-lands-in-assertions-slot
+     (testing "a failing rich-DSL :assert-db step records a :passed? false
+              entry into :rf.story/assertions (not just run-state) so the
+              slot consumers + assertions-passing? observe the failure"
+       (rf/reg-event-db :rt/set-status
+         (fn [db [_ v]] (assoc db :status v)))
+       (story/reg-variant :story.bridge/db-fail
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/set-status :idle]]
+                                    [:assert-db [:status] :loaded]]}})
+       (async/deref-blocking (story/run-variant :story.bridge/db-fail) 5000)
+       (run-blocking :story.bridge/db-fail)
+       (let [slot (story/read-assertions :story.bridge/db-fail)
+             db-recs (filterv #(= :rf.assert/db (:assertion %)) slot)]
+         (is (= 1 (count db-recs))
+             "the failing rich-DSL :assert-db landed exactly one slot record")
+         (is (false? (:passed? (first db-recs)))
+             "the slot record carries :passed? false")
+         (is (= :loaded (:expected (first db-recs))))
+         (is (= :idle   (:actual   (first db-recs))))
+         (is (false? (story/assertions-passing? slot))
+             "assertions-passing? now sees the rich-DSL failure (was
+              false-green before rf2-ee38b.3)")))))
+
+#?(:clj
+   (deftest assert-db-pass-lands-in-assertions-slot
+     (testing "a passing rich-DSL :assert-db step records a :passed? true
+              entry so the slot is non-empty + still passes"
+       (rf/reg-event-db :rt/set-status
+         (fn [db [_ v]] (assoc db :status v)))
+       (story/reg-variant :story.bridge/db-pass
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/set-status :loaded]]
+                                    [:assert-db [:status] :loaded]]}})
+       (async/deref-blocking (story/run-variant :story.bridge/db-pass) 5000)
+       (run-blocking :story.bridge/db-pass)
+       (let [slot    (story/read-assertions :story.bridge/db-pass)
+             db-recs (filterv #(= :rf.assert/db (:assertion %)) slot)]
+         (is (= 1 (count db-recs)))
+         (is (true? (:passed? (first db-recs))))
+         (is (true? (story/assertions-passing? slot)))))))
+
+#?(:clj
+   (deftest run-variant-result-reflects-rich-dsl-assert-failure
+     (testing "the run-variant result map's :assertions slot carries the
+              rich-DSL failure — the cljs.test adapter path (assertions-
+              passing? on the result) is no longer false-green"
+       (rf/reg-event-db :rt/set-status
+         (fn [db [_ v]] (assoc db :status v)))
+       (story/reg-variant :story.bridge/result
+         {:events      []
+          :play-script {:script [[:dispatch-sync [:rt/set-status :idle]]
+                                 [:assert-db [:status] :loaded]]}})
+       (let [result (async/deref-blocking
+                      (story/run-variant :story.bridge/result) 5000)]
+         (is (some (fn [r] (and (= :rf.assert/db (:assertion r))
+                                (false? (:passed? r))))
+                   (:assertions result))
+             "the result map's :assertions slot includes the failed assert-db")
+         (is (false? (story/assertions-passing? result))
+             "assertions-passing? on the result map flips to false")))))
+
+#?(:clj
+   (deftest assert-db-skipped-dom-not-recorded-as-slot-pass
+     (testing "a no-DOM :assert-dom step (JVM) records NO slot entry —
+              it must not read as a vacuous slot pass (false-green)"
+       (story/reg-variant :story.bridge/dom-skip
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:assert-dom "div.foo" :visible]]}})
+       (async/deref-blocking (story/run-variant :story.bridge/dom-skip) 5000)
+       (run-blocking :story.bridge/dom-skip)
+       (let [slot (story/read-assertions :story.bridge/dom-skip)]
+         (is (empty? (filterv #(= :rf.assert/dom (:assertion %)) slot))
+             "a skipped (no-DOM) :assert-dom contributes no slot record")))))
+
 #?(:clj
    (deftest assert-db-pred-form
      (testing ":assert-db :pred resolves a symbol and applies it"

--- a/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/docs_mode_pane_cljs_test.cljs
@@ -35,6 +35,7 @@
             [re-frame.story            :as story]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.loaders    :as loaders]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.ui.docs    :as docs]
             [re-frame.story.ui.state   :as state]
             [re-frame.story.ui.state.transitions :as transitions]))
@@ -115,7 +116,7 @@
     (register-rich-variant!)
     ;; Parent story id is derived from the variant id namespace.
     (is (= :story.docs-rich
-           (docs/parent-story-id :story.docs-rich/v))
+           (pred/parent-story-id :story.docs-rich/v))
         "parent-story chip reads :story.docs-rich")
     ;; The header chip vector is the variant's :tags set sorted.
     (let [tags (docs/variant-tags :story.docs-rich/v)]

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_pure_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_pure_cljs_test.cljc
@@ -132,6 +132,53 @@
   (is (false? (pure/breakpoint-hit? 2 [2]))
       "non-set inputs are rejected — only a set returns hit"))
 
+;; ---- step-statuses (rf2-ee38b.3 — full-script step list) ----------------
+
+(deftest step-statuses-one-row-per-step
+  (testing "step-statuses produces one row per coerced step, covering EVERY
+            step type — not just the dispatch steps the legacy projection
+            surfaced"
+    (let [steps   [[:dispatch-sync [:e/a]]
+                   [:wait 50]
+                   [:assert-db [:n] 5]
+                   [:assert-dom "div.x" :visible]
+                   [:click "button.y"]]
+          rows    (pure/step-statuses steps [])]
+      (is (= 5 (count rows)) "all five step types render a row")
+      (is (= [0 1 2 3 4] (mapv :index rows)))
+      (is (= steps (mapv :step rows)))
+      ;; Labels come from runner/step-summary (every step type, not just
+      ;; the dispatch event id).
+      (is (= "dispatch-sync [:e/a]" (:label (nth rows 0))))
+      (is (= "wait 50ms"            (:label (nth rows 1))))
+      (is (= "assert-db [:n] = 5"   (:label (nth rows 2))))
+      ;; No results yet — every row is neutral.
+      (is (every? #(= :event (:status %)) rows)))))
+
+(deftest step-statuses-outcome-from-results
+  (testing "each run step takes its outcome from the matching result record"
+    (let [steps   [[:assert-db [:n] 5]      ; pass
+                   [:assert-db [:n] 9]      ; fail
+                   [:assert-dom "x" :visible] ; skip
+                   [:dispatch [:e/a]]]      ; neutral (dispatch)
+          results [{:type :assert-db  :passed? true}
+                   {:type :assert-db  :passed? false}
+                   {:type :assert-dom :passed? false :skipped? true}
+                   {:type :dispatch   :passed? nil}]
+          rows    (pure/step-statuses steps results)]
+      (is (= :pass  (:status (nth rows 0))))
+      (is (= :fail  (:status (nth rows 1))))
+      (is (= :skip  (:status (nth rows 2))))
+      (is (= :event (:status (nth rows 3)))))))
+
+(deftest step-statuses-not-yet-run-is-neutral
+  (testing "steps beyond the results length render neutral (not yet run)"
+    (let [steps   [[:assert-db [:n] 5] [:assert-db [:n] 6]]
+          results [{:type :assert-db :passed? false}]
+          rows    (pure/step-statuses steps results)]
+      (is (= :fail  (:status (nth rows 0))) "first step ran → its outcome")
+      (is (= :event (:status (nth rows 1))) "second step not yet run → neutral"))))
+
 ;; ---- play-step-label re-export ------------------------------------------
 
 (deftest play-step-label-roundtrips

--- a/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode/stepper_state_cljs_test.cljs
@@ -27,15 +27,15 @@
 ;; reset-variant promise.
 
 (defn- seed-slot!
-  [variant-id play-events]
-  (let [total (count play-events)]
+  [variant-id play-steps]
+  (let [total (count play-steps)]
     (swap! st/results-atom assoc variant-id
            {:variant-id    variant-id
             :active?       true
             :auto-playing? false
             :cursor        0
             :total         total
-            :play-events   (vec play-events)
+            :play-steps    (vec play-steps)
             :statuses      []
             :breakpoints   #{}
             :epoch-stack   [:epoch/seed]

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -220,6 +220,58 @@
         (is (= :story.x/no-such-parent (:parent (ex-data e))))))))
 
 ;; ===========================================================================
+;; EXTENDS — PLAY-SURFACE OVERRIDE (rf2-ee38b.3)
+;; ===========================================================================
+;;
+;; :play-script and :plays are mutually-exclusive sibling encodings of
+;; the play surface. A child overriding a parent's :play-script with
+;; :plays (or vice versa) used to FAIL: the straight merge carried BOTH
+;; keys and the schema's mutual-exclusion :fn rejected a body the author
+;; never wrote with both. resolve-extends now drops the inherited sibling
+;; when the child declares the other encoding.
+
+(deftest reg-variant-extends-child-plays-overrides-parent-play-script
+  (testing "a child declaring :plays while inheriting :play-script from
+            its parent resolves to ONLY :plays (no mutual-exclusion error)"
+    (story/reg-variant :story.extplay/parent
+      {:events      []
+       :play-script {:script [[:dispatch [:p/legacy]]]}})
+    ;; This used to throw :rf.error/variant-shape (both keys present).
+    (story/reg-variant :story.extplay/child
+      {:extends :story.extplay/parent
+       :plays   [{:name "happy" :script [[:dispatch [:c/happy]]]}]})
+    (let [body (story/handler-meta :variant :story.extplay/child)]
+      (is (contains? body :plays)      "child's :plays survived")
+      (is (not (contains? body :play-script))
+          "the inherited :play-script was dropped — no double-encoding"))))
+
+(deftest reg-variant-extends-child-play-script-overrides-parent-plays
+  (testing "the symmetric case — child :play-script overrides parent :plays"
+    (story/reg-variant :story.extplay/parent2
+      {:events []
+       :plays  [{:name "p" :script [[:dispatch [:p/plays]]]}]})
+    (story/reg-variant :story.extplay/child2
+      {:extends     :story.extplay/parent2
+       :play-script {:script [[:dispatch [:c/legacy]]]}})
+    (let [body (story/handler-meta :variant :story.extplay/child2)]
+      (is (contains? body :play-script) "child's :play-script survived")
+      (is (not (contains? body :plays))
+          "the inherited :plays was dropped"))))
+
+(deftest reg-variant-extends-inherits-play-surface-when-child-silent
+  (testing "a child that declares NEITHER play encoding inherits the
+            parent's :play-script unchanged"
+    (story/reg-variant :story.extplay/parent3
+      {:events      []
+       :play-script {:script [[:dispatch [:p/keep]]]}})
+    (story/reg-variant :story.extplay/child3
+      {:extends :story.extplay/parent3
+       :doc     "no play override"})
+    (let [body (story/handler-meta :variant :story.extplay/child3)]
+      (is (contains? body :play-script) "inherited :play-script kept")
+      (is (= [[:dispatch [:p/keep]]] (:script (:play-script body)))))))
+
+;; ===========================================================================
 ;; CANONICAL-ID-GRAMMAR ERROR
 ;; ===========================================================================
 

--- a/tools/story/test/re_frame/story_play_test.clj
+++ b/tools/story/test/re_frame/story_play_test.clj
@@ -139,6 +139,30 @@
     (story/destroy-variant! :story.reset/v)))
 
 ;; ===========================================================================
+;; rf2-ee38b.3 — framework :db / :fx fx-ids are excluded from :emitted-fx
+;; ===========================================================================
+
+(deftest effect-emitted-db-is-not-vacuously-true
+  (testing "the ubiquitous framework :db effect is NOT recorded into the
+            :emitted-fx accumulator, so :rf.assert/effect-emitted :db
+            FAILS rather than vacuously passing on every variant"
+    ;; A plain event that returns {:db ...} — emits the framework :db fx
+    ;; but no user fx-id.
+    (rf/reg-event-db :ee/touch (fn [db _] (assoc db :touched? true)))
+    (story/reg-variant :story.ee/db
+      {:events []
+       :play-script [[:dispatch-sync [:ee/touch]]
+                     [:dispatch-sync [:rf.assert/effect-emitted :db]]]})
+    (let [result (async/deref-blocking (story/run-variant :story.ee/db) 5000)
+          ee-rec (first (filter #(= :rf.assert/effect-emitted (:assertion %))
+                                (:assertions result)))]
+      (is (some? ee-rec) "the effect-emitted assertion recorded")
+      (is (false? (:passed? ee-rec))
+          ":db is excluded from :emitted-fx, so the assertion fails (was
+           vacuously true before rf2-ee38b.3)"))
+    (story/destroy-variant! :story.ee/db)))
+
+;; ===========================================================================
 ;; Frame teardown clears accumulator entries
 ;; ===========================================================================
 
@@ -156,7 +180,9 @@
 ;; ===========================================================================
 
 (deftest play-stepper-step-by-step
-  (testing "begin-stepper! + step-once! drives the play one event at a time"
+  (testing "begin-stepper! + step-once! drives the play one STEP at a time
+            (rf2-ee38b.3: step-once! returns the executed STEP, not the
+            bare event vector)"
     (rf/reg-event-db :step/one (fn [db _] (assoc db :one? true)))
     (rf/reg-event-db :step/two (fn [db _] (assoc db :two? true)))
     (story/reg-variant :story.stepper/v
@@ -170,17 +196,59 @@
       (loaders/finish-loaders! :story.stepper/v)
       (play/begin-stepper! :story.stepper/v)
       (is (play/play-stepper-active? :story.stepper/v))
-      (let [ev1 (play/step-once! :story.stepper/v)]
-        (is (= [:step/one] ev1))
+      (let [s1 (play/step-once! :story.stepper/v)]
+        (is (= [:dispatch-sync [:step/one]] s1))
         (is (true? (-> (rf/get-frame-db :story.stepper/v) :one?))))
-      (let [ev2 (play/step-once! :story.stepper/v)]
-        (is (= [:step/two] ev2))
+      (let [s2 (play/step-once! :story.stepper/v)]
+        (is (= [:dispatch-sync [:step/two]] s2))
         (is (true? (-> (rf/get-frame-db :story.stepper/v) :two?))))
       ;; Stepper exhausted.
       (is (nil? (play/step-once! :story.stepper/v)))
       (play/end-stepper! :story.stepper/v)
       (is (not (play/play-stepper-active? :story.stepper/v)))
       (story/destroy-variant! :story.stepper/v))))
+
+(deftest play-stepper-walks-every-step-type
+  (testing "rf2-ee38b.3: the step-debugger walks ALL step types — :wait,
+            :assert-db, :assert-dom, :click, :type — not just the dispatch
+            steps the legacy variant-play-events projection surfaced. The
+            cursor/total count every step and assert outcomes surface."
+    (rf/reg-event-db :st/set-n (fn [db [_ v]] (assoc db :n v)))
+    (story/reg-variant :story.stepper/full
+      {:events []
+       :play-script {:auto-run? false
+                     :script    [[:dispatch-sync [:st/set-n 5]]
+                                 [:wait 0]
+                                 [:assert-db [:n] 5]              ; pass
+                                 [:assert-db [:n] 99]             ; fail
+                                 [:assert-dom "div.x" :visible]   ; skip (no DOM)
+                                 [:click "button.y"]]}})          ; fail (no DOM)
+    (let [decorator-stack (story/resolve-decorators :story.stepper/full)]
+      (re-frame.story.frames/allocate! :story.stepper/full decorator-stack)
+      (loaders/start-loaders! :story.stepper/full)
+      (loaders/finish-loaders! :story.stepper/full)
+      (play/begin-stepper! :story.stepper/full)
+      ;; The substrate seeds the FULL six-step script.
+      (is (= 6 (count (:remaining (get @play/stepper-state :story.stepper/full))))
+          "all six steps (incl. :wait / :assert-* / :click) are queued")
+      ;; Walk every step.
+      (dotimes [_ 6] (play/step-once! :story.stepper/full))
+      (is (nil? (play/step-once! :story.stepper/full)) "exhausted after six steps")
+      (let [results (:results (get @play/stepper-state :story.stepper/full))]
+        (is (= 6 (count results)) "one result recorded per step")
+        (is (= :dispatch-sync (:type (nth results 0))))
+        (is (= :wait          (:type (nth results 1))))
+        (is (true?  (:passed? (nth results 2))) ":assert-db [:n] 5 passes")
+        (is (false? (:passed? (nth results 3))) ":assert-db [:n] 99 fails")
+        (is (:skipped? (nth results 4)) ":assert-dom records :skipped? (no DOM)"))
+      ;; The failing :assert-db landed in the :rf.story/assertions slot.
+      (let [slot (story/read-assertions :story.stepper/full)]
+        (is (some (fn [r] (and (= :rf.assert/db (:assertion r))
+                               (false? (:passed? r))))
+                  slot)
+            "the stepped rich-DSL :assert-db failure reached the slot too"))
+      (play/end-stepper! :story.stepper/full)
+      (story/destroy-variant! :story.stepper/full))))
 
 ;; ===========================================================================
 ;; :loaders-complete-when non-default forms — Stage 5 (rf2-h8et)

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -21,6 +21,7 @@
             [re-frame.story           :as story]
             [re-frame.story.config    :as config]
             [re-frame.story.loaders   :as loaders]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.command-palette :as command-palette]
             [re-frame.story.ui.docs   :as docs]
@@ -398,9 +399,9 @@
       (is (= 2 (count (get entries :story.g)))))))
 
 (deftest parent-story-id-derivation
-  (testing "parent-story-id mirrors args/parent-story-id"
-    (is (= :story.foo (state/parent-story-id :story.foo/bar)))
-    (is (nil? (state/parent-story-id :unqualified)))))
+  (testing "parent-story-id (canonical leaf in re-frame.story.predicates)"
+    (is (= :story.foo (pred/parent-story-id :story.foo/bar)))
+    (is (nil? (pred/parent-story-id :unqualified)))))
 
 ;; ---- faceted filter (rf2-7ncf9 — SB9 facet taxonomy) -------------------
 
@@ -628,11 +629,9 @@
 
 ;; ---- docs mode (rf2-rodx) -----------------------------------------------
 
-(deftest docs-parent-story-id
-  (testing "parent-story-id mirrors args/parent-story-id"
-    (is (= :story.foo (docs/parent-story-id :story.foo/bar)))
-    (is (nil? (docs/parent-story-id :no-namespace)))
-    (is (nil? (docs/parent-story-id nil)))))
+;; rf2-ee38b.3: the `docs/parent-story-id` re-export was dropped; the
+;; canonical helper lives in `re-frame.story.predicates` (covered there).
+;; The docs header chip calls `pred/parent-story-id` directly.
 
 (deftest docs-variant-tags-falls-back-to-story
   (testing "variant-tags reads variant :tags first"
@@ -757,11 +756,10 @@
 
 ;; ---- test mode (rf2-qmjo) -----------------------------------------------
 
-(deftest test-mode-parent-story-id
-  (testing "parent-story-id mirrors the docs helper"
-    (is (= :story.foo (test-mode/parent-story-id :story.foo/bar)))
-    (is (nil? (test-mode/parent-story-id :no-namespace)))
-    (is (nil? (test-mode/parent-story-id nil)))))
+;; rf2-ee38b.3: the `test-mode/parent-story-id` re-export was dropped;
+;; the canonical `parent-story-id` lives in `re-frame.story.predicates`
+;; (covered by its own tests). The view calls `pred/parent-story-id`
+;; directly.
 
 (deftest test-mode-variant-has-tests?-checks-play-slot
   (testing "variant-has-tests? is false when :play-script is absent or empty"
@@ -773,6 +771,12 @@
     (story/reg-variant :story.tm/has
       {:events [] :play-script [[:dispatch-sync [:rf.assert/path-equals [:count] 0]]]})
     (is (test-mode/variant-has-tests? :story.tm/has)))
+  (testing "rf2-ee38b.3: variant-has-tests? recognises the :plays slot too"
+    (story/reg-variant :story.tm/plays
+      {:events [] :plays [{:name "happy"
+                           :script [[:dispatch-sync [:rf.assert/path-equals [:n] 1]]]}]})
+    (is (test-mode/variant-has-tests? :story.tm/plays)
+        "a :plays-only variant is testable (was false before the fix)"))
   (testing "variant-has-tests? returns false for an unknown variant-id"
     (is (not (test-mode/variant-has-tests? :story.tm/unknown)))))
 


### PR DESCRIPTION
## Summary

Consolidated remediation for `tools/story` from the 3-lens review sweep (rf2-ee38b.3). Headline: closes two P1 false-green / dropped-step bugs, wires assertion redaction, resolves the `:extends` play-surface bug, and clears the shim/dead-code/migration debt the clarity lens flagged.

### Correctness
- **[P1] Rich-DSL assert → slot bridge.** `:assert-db` / `:assert-dom` step outcomes used to land ONLY in the runner's `run-state` atom; `:rf.story/assertions` (read by `run-variant`'s result, `assertions-passing?`, the test pane, the inline strip, the Causa panel) never saw them — a failing rich-DSL assertion read **false-green**. `record-result!` + the new `run-step!` now mirror assertion-class outcomes into the slot (records `:rf.assert/db` / `:rf.assert/dom`). Pinned by tests that fail without the bridge.
- **[P2] `:extends` play-surface override.** `resolve-extends` gains an `exclusive-groups` arg; `reg-variant*` passes `#{:play-script :plays}` so a child overriding a parent's `:play-script` with `:plays` (or vice versa) drops the inherited sibling instead of tripping the schema mutual-exclusion check.
- **[P3] `:rf.assert/effect-emitted :db`** no longer vacuously true — `:db` / `:fx` framework fx-ids are excluded from the `:emitted-fx` accumulator.

### Completeness
- **[P1] Step-debugger re-base.** The stepper now walks the FULL coerced `:play-script` (every step type) via `runner-events/run-step!` (fetched through the `:run-play-step` late-bind hook to dodge the play ↔ runner-events cycle), not the dispatch-only `variant-play-events` projection. Cursor/total are honest; `:wait` / `:click` / `:type` / `:assert-db` / `:assert-dom` steps render rows + surface outcomes. `step-once!` returns the executed STEP; new `stepper-pure/step-statuses` builds rows from the full step vector + per-step results.
- **[P2] Assertion redaction wired.** `evaluate-path-equals` / `-path-matches` / `-sub-equals` project `:actual` through `re-frame.elision/elide-wire-value` (frame-mark-aware) so a path marked sensitive records `:rf/redacted`. The placeholder redaction tests are flipped live.
- **[P2] `:plays` slot recognised** by `variant-has-tests?` (test pane gate) and the chrome `testable-variant-ids`, matching `ci-runner/has-any-play?`.
- **[P2/P3] spec/004 aligned** — `assertions-passing?` documented as the canonical Stage-5 surface; `:source-coord` is the canonical record slot. `run-variant-as-test` (per-assertion `is` adapter) documented as a deferred enhancement (needs async-cljs.test plumbing).

### Clarity / minimalism
- Deleted dead `config/elide-form`.
- Removed the DEPRECATED `ensure-causa-mounted!` shim (no production caller; per the no-back-compat posture). Spec carve-out updated; the 3 bridge-ordering tests retargeted at `wire-cross-host!` + `apply-open!`.
- Collapsed the open-coded reg-form wrapper into `macros/emit-reg` (3 sites).
- Extracted `identity/canon-map-entries` + `canon-set` (was duplicated map/set canon).
- Dropped the no-op `:clj`/`:cljs` reader conditional on the `extends` require.
- Dropped the `docs` / `state` / `test-mode.pure` `parent-story-id` re-exports (callers use `pred/parent-story-id` directly).

### Skipped / deferred (noted for the mayor)
- `run-variant-as-test` cljs.test adapter — documented as deferred (async-cljs.test); `assertions-passing?` is canonical.
- `args/parent-story-id` alias kept (≈9 sibling namespaces import it; folding them onto `pred/` directly is a wide mechanical follow-up with zero behavioural gain).
- Bare sub-id (no app-db path in args) redaction relies on sub-engine marker propagation (spec/015 §reg-sub) — a sub-engine feature, outside Story.
- Causa-side prose references to `ensure-causa-mounted!` (`tools/causa/spec/015`, `008`, a keybinding test docstring) left for the Causa surface.

## Test plan
- [x] `npx shadow-cljs compile node-test` clean (988 files, 0 warnings)
- [x] `node out/node-test.js` — 4131 tests / 12617 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` in tools/story — 858 tests / 2543 assertions, 0 failures, 0 errors

Cross-ref rf2-ee38b.3.