### PR TITLE
fix(mcp-base): byte-identical int parse + shared cursor/envelope API + spec drift (rf2-ee38b.19)

### DIFF
--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -21,29 +21,41 @@
 ;;   - `vocab.cljc`     — cross-MCP wire-vocabulary constants (the
 ;;                        `:rf.mcp/*` and `:rf.size/*` namespaced
 ;;                        keywords, JSON-RPC error codes).
-;;   - `sensitive.cljc` — spec/009 §Privacy default-suppress filter.
+;;   - `sensitive.cljc` — spec/009 §Privacy fail-closed default-suppress
+;;                        filter.
 ;;   - `elision.cljc`   — wire-boundary elision-marker walker
 ;;                        (`count-elided-markers`, rf2-9fz64).
 ;;   - `args.cljc`      — argument-coercion helpers (booleans, limits,
 ;;                        keyword reading) used by every MCP tool.
 ;;   - `diff_encode.cljc` — path-keyed structural diff for epoch
-;;                          records (rf2-1wdzp, used at the wire
-;;                          boundary inside re-frame2-pair-mcp; the encoding
-;;                          contract is a cross-MCP convention).
+;;                          records (rf2-1wdzp), projected into
+;;                          path-headed cluster sections (rf2-qeous).
 ;;                          Pinned via Malli `patch-schema` /
-;;                          `patches-schema` at the encoder boundary
-;;                          (rf2-rgg7d) so a future tuple-grammar
-;;                          drift trips the dev-build gate.
+;;                          `patches-schema` / `section-schema` at both
+;;                          the encoder and decoder boundary (rf2-rgg7d)
+;;                          so a future grammar drift trips the gate.
+;;   - `section_grouping.cljc` — patch-list → path-headed cluster
+;;                          sections (rf2-qeous); consumed by
+;;                          diff-encode.
 ;;   - `overflow.cljc`  — overflow-marker payload builder (rf2-rvyzy).
+;;   - `cap.cljc`       — two-stage wire-boundary token-budget cap
+;;                        pipeline + `ResultIO` protocol (rf2-eyelu /
+;;                        rf2-ih7g4).
+;;   - `cursor.cljc`    — shared cursor-pagination machinery: base64
+;;                        codec, opaque encode/decode with `::malformed`
+;;                        recovery, `:limit` clamp, `cursor-stale-result`
+;;                        envelope (rf2-ee38b.19). Parameterised by the
+;;                        consumer's payload-shape predicate so each
+;;                        server keeps its own cursor SHAPE.
+;;   - `envelope.cljc`  — indicator-field `with-indicators` splice
+;;                        (`:dropped-sensitive` / `:elided-large`
+;;                        omit-when-zero MUST) + wire-bounded
+;;                        `:rf.mcp/*` marker detection (rf2-ee38b.19).
 ;;
 ;; What deliberately does NOT live here:
 ;;   - Wire-transport code (cheshire JSON for story-mcp's JVM-side;
 ;;     applied-science.js-interop / npm MCP SDK for re-frame2-pair-mcp's
 ;;     CLJS-side). Each consumer terminates its own transport.
-;;   - Cursor base64 encoding — `js/Buffer` (re-frame2-pair-mcp) vs `Base64`
-;;     (story-mcp would use java.util.Base64 if it had cursors). The
-;;     EDN-cursor SHAPE is conventional; the base64 codec is
-;;     consumer-side.
 ;;   - Tool registry — each MCP server's tools are domain-specific.
 ;;
 ;; ## Bundle isolation

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -37,18 +37,21 @@ that ride on those framework surfaces.
 
 ## Index
 
-Seven namespaces under `re-frame.mcp-base.*`. Each ships its own
+Ten namespaces under `re-frame.mcp-base.*`. Each ships its own
 per-namespace contract doc; the table below indexes them:
 
-| ns | Lines (src) | Surface | Per-namespace spec |
-|---|---|---|---|
-| `vocab` | 228 | `:rf.mcp/*` + `:rf.size/*` marker keys + envelope slots + JSON-RPC error codes. | [`vocab.md`](vocab.md) |
-| `sensitive` | 212 | spec/009 §Privacy default-suppress filter (`sensitive-event?`, `strip-sensitive`, `scrub-snapshot`) + fail-closed suppressed-event counter. | [`sensitive.md`](sensitive.md) |
-| `elision` | 60 | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). | [`elision.md`](elision.md) |
-| `args` | 253 | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
-| `diff-encode` | 318 | Path-keyed structural diff for epoch `:db-after` slots (rf2-1wdzp) + decoder gate. | [`diff-encode.md`](diff-encode.md) |
-| `overflow` | 60 | Overflow-marker payload SHAPE builder + per-tool hint table (rf2-rvyzy). | [`overflow.md`](overflow.md) |
-| `cap` | 242 | Wire-boundary token-budget cap pipeline + `ResultIO` protocol (rf2-eyelu) + resource controls + token splitter. | [`cap.md`](cap.md) |
+| ns | Surface | Per-namespace spec |
+|---|---|---|
+| `vocab` | `:rf.mcp/*` + `:rf.size/*` marker keys + envelope slots + JSON-RPC error codes. | [`vocab.md`](vocab.md) |
+| `sensitive` | spec/009 §Privacy fail-closed default-suppress filter (`sensitive-event?`, `strip-sensitive`, per-frame `scrub-snapshot`) + malformed-stamp counter. | [`sensitive.md`](sensitive.md) |
+| `elision` | Wire-boundary `:rf.size/large-elided` walker (`count-elided-markers`, rf2-9fz64). | [`elision.md`](elision.md) |
+| `args` | Argument coercion helpers (`parse-boolean`, `parse-positive-int`, `fresh-keyword`, `safe-keyword`, `parse-mode`, …). | [`args.md`](args.md) |
+| `diff-encode` | Path-keyed structural diff for epoch `:db-after` slots projected into path-headed cluster sections (rf2-1wdzp / rf2-qeous) + encoder/decoder Malli gate. | [`diff-encode.md`](diff-encode.md) |
+| `section-grouping` | Patch-list → path-headed cluster sections (`group-patches-into-sections` / `sections->patches`, rf2-qeous); consumed by `diff-encode`. | [`section-grouping.md`](section-grouping.md) |
+| `overflow` | Overflow-marker payload SHAPE builder (`overflow-payload`) + `token-estimate` + fallback hint (rf2-rvyzy). | [`overflow.md`](overflow.md) |
+| `cap` | Wire-boundary two-stage token-budget cap pipeline + `max-tokens` resolver + `ResultIO` protocol (rf2-eyelu / rf2-ih7g4). | [`cap.md`](cap.md) |
+| `cursor` | Shared cursor-pagination machinery — base64 codec, opaque encode/decode with `::malformed` recovery, `:limit` clamp, `cursor-stale-result` envelope (rf2-ee38b.19). | _(see ns docstring)_ |
+| `envelope` | Indicator-field `with-indicators` splice (`:dropped-sensitive` / `:elided-large`, omit-when-zero MUST) + wire-bounded `:rf.mcp/*` marker detection (rf2-ee38b.19). | _(see ns docstring)_ |
 
 All `.cljc`, so consumers compile them under their own platform —
 re-frame2-pair-mcp's shadow-cljs node build, story-mcp's JVM
@@ -69,23 +72,29 @@ third server instance and lands as a separate bead.
 
 The bead's scope holds the line at primitives that are truly
 identical across the pair's wire / privacy / size surfaces.
-Three categories stay consumer-side:
+Two categories stay consumer-side:
 
 1. **Wire transport.** story-mcp uses Cheshire for JSON-RPC over
    stdin/stdout; re-frame2-pair-mcp uses the npm `@modelcontextprotocol/sdk`'s
    stdio transport. The framing is different by language; there's
    nothing useful to share here.
 
-2. **Cursor base64 codec.** The cursor *shape* (`{:v 1 :after-id ...
-   :ms ... :until-ms ... :frame ...}`) is conventional — but
-   re-frame2-pair-mcp uses `js/Buffer.from … "base64"` and a JVM consumer
-   would use `java.util.Base64`. Factoring the codec means a
-   protocol-shaped helper per platform; with only one Node-side
-   consumer today, a single codec helper here is not yet warranted.
-
-3. **Tool registries.** Each MCP server's tool catalogue is domain-
+2. **Tool registries.** Each MCP server's tool catalogue is domain-
    specific. The base provides building blocks; it does NOT
    prescribe how the registry is shaped.
+
+> **Note (rf2-ee38b.19):** the cursor base64 codec USED to be listed
+> here as consumer-side, on the premise that `js/Buffer` vs
+> `java.util.Base64` forced a per-platform helper. story-mcp's own
+> `.cljc` cursor codec refuted that — the codec lifts cleanly as a
+> reader-conditional — so the shared machinery (base64 codec, opaque
+> encode/decode + `::malformed` recovery, `:limit` clamp,
+> `cursor-stale-result` envelope) now lives in `cursor.cljc`,
+> parameterised by each consumer's cursor-payload SHAPE. The cursor
+> *resource controls* (concurrent-stream cap, token-bucket rate-limit,
+> abuse window) remain consumer-side — they live only in pair-mcp's
+> `resource_controls.cljs` and are not yet a candidate to lift (single
+> streaming consumer today).
 
 ## Cross-MCP vocabulary as a versioned contract
 

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/cap.md
+++ b/tools/mcp-base/spec/cap.md
@@ -3,13 +3,14 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the ALGORITHM that drives the overflow marker into a result. Until rf2-eyelu this pipeline was duplicated near-identically in re-frame2-pair-mcp (CLJS, `#js {:content #js [...]}`-shaped results) and story-mcp (CLJ, `{:content [...] :structuredContent ...}`-shaped results). The only structural difference between the two implementations was the SHAPE of the result map and the platform-appropriate accessor used to read its `:text` slots — algorithm identical.
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md).
 
 ## Scope
 
 `cap` owns:
 
-- The three-step cap algorithm (sum tokens → compare → pass-through or replace).
+- The two-stage cap algorithm (sum tokens + chars in one pass → primary token gate OR secondary char gate → pass-through or replace).
+- The `max-tokens` per-call cap resolver (`0` resolves to `nil` = disabled; absent / non-number → `default-max-tokens`).
 - The `ResultIO` protocol — the per-consumer specialisation hook.
 - The recursion-safety invariant (the overflow marker itself must fit under the cap).
 
@@ -21,27 +22,40 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 
 ## Algorithm
 
-1. **Sum tokens.** Sum the cumulative `overflow/token-estimate` across every `:text` slot in the result's `:content` vector.
-2. **Compare against cap.** Compare against the per-call cap (`:max-tokens` MCP arg, default `overflow/default-max-tokens`, `0` disables).
-3. **Pass-through or replace.** Under-budget responses pass through unchanged; over-budget responses are replaced with a fresh result carrying the `:rf.mcp/overflow` marker.
+The pipeline is a **two-stage** gate (rf2-ih7g4) that folds both sums in a **single pass** (rf2-hyp0z) over the content `:text` slots:
+
+1. **Resolve the cap.** `max-tokens` turns the raw `:max-tokens` MCP arg into the per-call cap: `nil` (caller passed `0` → disabled), `default-max-tokens` (5000; absent or non-number), or a positive integer (custom cap). When the resolved cap is `nil`, `apply-cap` short-circuits and returns the result untouched — **the disable mechanism is `max-tokens` resolving to `nil`, not the arg being `0` at the gate**.
+2. **Single-pass token + char sum.** One `transduce` over the `:text`-slot strings folds both `Σ token-estimate` and `Σ (count s)` in one walk (so a story-mcp `:structuredContent` is materialised once, not twice).
+3. **Two-stage over-budget decision** (`over-cap?`): trip when EITHER the token sum `> cap` (primary gate) OR the char sum `> cap * byte-cap-multiplier` (secondary byte gate — defence-in-depth against payloads where `(count s)/4` undercounts: CJK, emoji, base64, dense code). `reported-count` selects which count rides the marker's `:token-count` slot (the char count when the secondary gate is the one that tripped, else the token sum).
+4. **Pass-through or replace.** Under-budget responses pass through unchanged; over-budget responses are replaced with a fresh result carrying the `:rf.mcp/overflow` marker (built via `overflow/overflow-payload`).
 
 ```clojure
-(defn enforce-cap [io result max-tokens]
-  (if (zero? max-tokens)
-    result                                                    ; 0 disables
-    (let [texts       (content-texts io result)
-          token-count (reduce + (map overflow/token-estimate texts))]
-      (if (<= token-count max-tokens)
-        result                                                ; under-budget
-        (let [marker (overflow/overflow-marker
+(defn enforce-cap [io result cap]                  ; cap = (max-tokens raw-arg)
+  (if (nil? cap)
+    result                                          ; nil cap ⇒ disabled
+    (let [{:keys [tokens chars]}                    ; single-pass fold
+          (transduce (filter string?)
+                     (completing
+                       (fn [acc s]
+                         {:tokens (+ (:tokens acc) (overflow/token-estimate s))
+                          :chars  (+ (:chars acc)  (count s))}))
+                     {:tokens 0 :chars 0}
+                     (content-texts io result))]
+      (if-not (over-cap? tokens chars cap)          ; token gate OR char gate
+        result                                      ; under-budget
+        (let [marker (overflow/overflow-payload
                        {:tool        (extract-tool-id result)
-                        :token-count token-count
-                        :cap-tokens  max-tokens
+                        :token-count (reported-count tokens chars cap)
+                        :cap         cap
                         :hint        (resolve-hint io result)})]
-          (build-overflow-result io marker result))))))       ; over-budget
+          (build-overflow-result io marker result)))))) ; over-budget
 ```
 
 The algorithm runs synchronously at the wire boundary, after the response body has been assembled but before the consumer-side transport ships it. The cost is one walk over the `:content` vector — O(content size).
+
+### Why the secondary char gate is structurally dominated today
+
+Under the live `token-estimate = (quot count 4)` rule, the two sums are not independent: if `chars > cap*8` then `tokens = (quot chars 4) > 2*cap > cap`, so the token gate has already tripped whenever the char gate would. The char disjunct is therefore intentional **defence-in-depth** against a FUTURE `token-estimate` refinement that decouples chars from tokens (one that recognises base64 / CJK with a lower per-char cost) — not dead code. `over-cap?` / `reported-count` are extracted as pure fns over already-summed counts so the dominated branch is unit-trippable in isolation (`cap_test.clj`).
 
 ## Per-server specialisation hook — the `ResultIO` protocol
 
@@ -99,7 +113,7 @@ The structural guarantee comes from the marker shape — `:limit`, `:token-count
 
 ## Disabling the cap
 
-`:max-tokens 0` disables the cap entirely. Documented use cases:
+`:max-tokens 0` disables the cap entirely — `max-tokens` resolves the `0` arg to `nil`, and `apply-cap` short-circuits on a `nil` cap. Documented use cases:
 
 1. **Conformance fixtures** — fixtures that assert the un-capped response shape need `:max-tokens 0` so the cap doesn't truncate the expected payload.
 2. **Local-host streaming consumers** — agents that stream tool responses (rather than load them into context) may opt out of the cap to receive the full payload.

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -1,18 +1,21 @@
 # `diff-encode` — path-keyed structural diff (rf2-1wdzp)
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost.
+> Each `:rf/epoch-record` carries `:db-before` and `:db-after` — near-identical full app-db snapshots. `pr-str` doesn't preserve structural sharing, so on the wire the pair is roughly 2× app-db per epoch; a 50-epoch default `:epochs` slice ⇒ up to 100× app-db. This ns replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before` so the wire payload approaches the structural-sharing cost rather than the deep-copy cost. The patch list is grouped into path-breadcrumb sections via [`section-grouping.md`](section-grouping.md).
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 
 ## Scope
 
 `diff-encode` owns:
 
-- The diff transform from `:db-before` / `:db-after` pair → `:db-before` + patch-encoded `:db-after`.
-- The patch grammar (`[<path> :assoc <new-value>]` / `[<path> :dissoc]`).
-- The decoder that reconstructs `:db-after` from `:db-before` + patches.
+- The diff transform from `:db-before` / `:db-after` pair → `:db-before` + section-encoded `:db-after`.
+- The patch grammar (`[<path> :assoc <new-value>]` / `[<path> :dissoc]`), pinned as a Malli `patch-schema` / `patches-schema`.
+- The decoder that reconstructs `:db-after` from `:db-before` + the per-section patch lists (flattened in section order).
+- The encoder/decoder validation symmetry (both boundaries Malli-gate; soft-pass when Malli absent; `goog-define`-elidable on CLJS prod).
 - The intra-record self-containedness invariant (each epoch's diff encodes against its OWN `:db-before`, not a sibling's).
+
+The path-headed **cluster grouping** (the `:sections` projection) is owned by [`section-grouping.md`](section-grouping.md); `diff-encode` consumes it.
 
 `diff-encode` does NOT own:
 
@@ -22,16 +25,21 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 
 ## What the transform does
 
-Replaces `:db-after` with a path-keyed structural diff against `:db-before`:
+Replaces `:db-after` with a **path-headed cluster projection** (rf2-qeous) of a path-keyed structural diff against `:db-before`:
 
 ```clojure
 {:db-before <full>
  :db-after  {:rf.mcp/diff-from :db-before
-             :patches [[<path> :assoc <new-value>]
-                       [<path> :dissoc]]}}
+             :sections [{:section-path [:cart :items]
+                         :section-kind :modified
+                         :patches      [[<path> :assoc <new-value>]
+                                        [<path> :dissoc]]}
+                        {:section-path [:checkout :state]
+                         :section-kind :modified
+                         :patches      [...]}]}}
 ```
 
-A patch is a 2- or 3-element vector — `[path :assoc v]` for new or changed leaves, `[path :dissoc]` for keys that disappeared. The decoder applies each patch in order via `assoc-in` / `update-in` / `dissoc-in` to reconstruct `:db-after`.
+The flat patch list is grouped into **sections** — each headed by a `:section-path` breadcrumb + a `:section-kind` summary (`:added` / `:removed` / `:modified`) so an agent asking "what did this cascade do?" reads N scoped cluster summaries instead of a flat triple list (see [`section-grouping.md`](section-grouping.md)). Inside a section, a patch is a 2- or 3-element vector — `[path :assoc v]` for new or changed leaves, `[path :dissoc]` for keys that disappeared. The decoder flattens sections back to a patch list (`section-grouping/sections->patches`) and applies each patch in order via `assoc-in` / `update-in` / `dissoc` to reconstruct `:db-after`.
 
 ## Patch grammar
 
@@ -40,7 +48,9 @@ A patch is a 2- or 3-element vector — `[path :assoc v]` for new or changed lea
 | `[<path> :assoc <new-value>]` | Set the value at `path` to `new-value` (creates the slot if it didn't exist). | `[[:user :name] :assoc "alice"]` |
 | `[<path> :dissoc]` | Remove the key at `path` (no-op if it doesn't exist). | `[[:user :temp-flag] :dissoc]` |
 
-Patches are applied **in order**; later patches see the state after earlier patches. The order is preserved on the wire; reorderings break decode.
+Patches are applied **in order** within the flattened list; later patches see the state after earlier patches. The section grouping is deterministic (sorted by `:section-path`), so concatenating every section's `:patches` reproduces a stable, replayable patch list.
+
+The patch tuple grammar is pinned as a Malli schema (`patch-schema` / `patches-schema`) and validated at BOTH the encoder boundary (`diff-encode-db-after`) and the decoder boundary (`apply-patches`); the section grammar is pinned as `section-schema` / `sections-schema`. Validation soft-passes when Malli is not on the runtime classpath (mcp-base stays Malli-free at its own dep boundary; consumers bring Malli), and is `goog-define`-elidable on CLJS production builds via `validate-patches?`.
 
 ## Why patches, not `clojure.data/diff`
 
@@ -60,26 +70,32 @@ The `:rf.mcp/diff-from` marker key lives in [`vocab.md`](vocab.md); the same sha
 
 ## Decoder algorithm
 
+The `:db-after` marker carries `:sections`, so the decoder first flattens the per-section patch lists (in section order) via `section-grouping/sections->patches`, then replays the flattened list:
+
 ```clojure
 (defn decode-diff [record]
   (let [{:keys [db-before db-after]} record]
     (if (and (map? db-after) (contains? db-after :rf.mcp/diff-from))
-      (let [base    (get record (:rf.mcp/diff-from db-after))
-            patches (:patches db-after)]
+      (let [base     (get record (:rf.mcp/diff-from db-after))
+            patches  (sections->patches (:sections db-after))]  ; flatten sections
         (reduce
           (fn [acc patch]
             (let [[path op v] patch]
               (case op
-                :assoc  (assoc-in acc path v)
-                :dissoc (let [parent (drop-last path)
+                :assoc  (if (empty? path) v (assoc-in acc path v))
+                :dissoc (let [parent (vec (butlast path))
                               k      (last path)]
-                          (update-in acc parent dissoc k)))))
+                          (if (empty? parent)
+                            (dissoc acc k)
+                            (update-in acc parent dissoc k))))))
           base
           patches))
       db-after)))   ; not diff-encoded; passthrough
 ```
 
-Both story-mcp and re-frame2-pair-mcp implement this shape; the consumer-side decoder is ~20 lines.
+The shipped decoder (`decode-db-after`) Malli-validates `:sections` at the decode boundary (`validate-sections!`, symmetric with the encoder's gate) then replays via the non-validating `apply-patches*` to avoid a redundant second Malli walk on the JVM decode hot path. Both story-mcp and re-frame2-pair-mcp consume this shape; the agent-host decoder is small.
+
+> **Note** root-path patches: an `[[] :assoc <full>]` patch replaces `base` outright (whole-DB replacement, e.g. `reset-frame-db!`); an `[[] :dissoc]` is a no-op by convention.
 
 ## Cross-platform
 
@@ -92,6 +108,8 @@ The conformance harness at `tools/mcp-conformance/` drives epoch-shaped tool res
 ## See also
 
 - [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`section-grouping.md`](section-grouping.md) — the path-headed cluster grouping (`:sections` projection) this ns consumes.
 - [`../../../spec/Tool-Pair.md`](../../../spec/Tool-Pair.md) — the pair-tool runtime contract this ns is downstream of (the time-travel slice that produces `:rf/epoch-record`s).
 - [`vocab.md`](vocab.md) — the `:rf.mcp/diff-from` marker key.
 - rf2-1wdzp — the bead that landed this encoding.
+- rf2-qeous — the path-headed cluster projection (`:sections`) that replaced the flat `:patches` shape.

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Per [`../../../spec/009-Instrumentation.md` §Size elision in traces](../../../spec/009-Instrumentation.md), the framework's `rf/elide-wire-value` walker substitutes over-threshold leaves with a `{:rf.size/large-elided {…}}` marker before the payload leaves the runtime. Every MCP tool that returns a tree-typed payload surfaces a scalar count of those substitutions on its response envelope (the `:elided-large` slot — see [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)). This namespace owns the **counter**, not the walker.
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 
 ## Scope
 

--- a/tools/mcp-base/spec/overflow.md
+++ b/tools/mcp-base/spec/overflow.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > Owns the SHAPE of the overflow marker (the `{:rf.mcp/overflow {:limit :reached :token-count … :cap-tokens … :tool … :hint …}}` map). The cap-enforcement glue (counting tokens, replacing the payload) lives in [`cap.md`](cap.md).
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`cap.md`](cap.md).
 
 ## Scope
 
@@ -12,7 +12,7 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 - `default-max-tokens` const (**5000**).
 - The `token-estimate` cheap character→token approximation.
 - `overflow-hint-fallback` (generic fallback hint).
-- `overflow-marker` — the builder fn that returns the canonical marker map shape.
+- `overflow-payload` — the builder fn that returns the canonical marker map shape.
 
 `overflow` does NOT own:
 
@@ -40,26 +40,29 @@ The estimate is intentionally simple — running a tokeniser per response would 
 
 Generic hint used when a tool isn't listed in the per-tool hint table:
 
-> "Response exceeded token cap; consider narrowing your query or paginating via the tool's slice args."
+> "Response over budget. Re-call with narrower args, or raise `max-tokens` (0 disables the cap)."
 
 The per-tool hint table lives consumer-side and is keyed by tool id. The builder fn delegates to the consumer's hint resolver via a small adapter.
 
-### `overflow-marker` — builder fn
+### `overflow-payload` — builder fn
 
-Builds the canonical marker map shape:
+Builds the canonical marker map shape. Note the input/output key
+asymmetry: the destructured INPUT key is `:cap` (the cap in tokens),
+which the builder emits into the OUTPUT under the wire slot
+`:cap-tokens`:
 
 ```clojure
-(defn overflow-marker
-  [{:keys [tool token-count cap-tokens hint]}]
+(defn overflow-payload
+  [{:keys [tool token-count cap hint]}]
   {:rf.mcp/overflow
    {:limit       :reached
     :token-count token-count
-    :cap-tokens  cap-tokens
+    :cap-tokens  cap
     :tool        tool
     :hint        (or hint overflow-hint-fallback)}})
 ```
 
-The shape is the wire-protocol contract; the slot names are pinned by the conformance gate. Consumer-side overrides only the `:hint` text via the consumer's per-tool table.
+The output shape is the wire-protocol contract; the slot names are pinned by the conformance gate. Consumer-side overrides only the `:hint` text via the consumer's per-tool table. `cap.cljc`'s `apply-cap` calls `overflow-payload` with `:cap` (the resolved per-call cap) and `:token-count` (the count that tripped the gate).
 
 ## Hint table
 

--- a/tools/mcp-base/spec/section-grouping.md
+++ b/tools/mcp-base/spec/section-grouping.md
@@ -1,0 +1,83 @@
+# `section-grouping` — patch-list → path-headed cluster sections (rf2-qeous)
+
+> **Type:** Reference (`tools/mcp-base/spec/`)
+> Projects a flat diff patch-list into path-headed cluster **sections** — the same sections-per-cluster decomposition Causa's panel renderer ships (rf2-gfxmk Phase 1 of rf2-abts7), but computed from the patch list rather than the annotated tree. [`diff-encode.md`](diff-encode.md) consumes this to shape the `:db-after` marker's `:sections` slot.
+
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+
+## Scope
+
+`section-grouping` owns:
+
+- `group-patches-into-sections` — the flat-patch-list → sections projection.
+- `sections->patches` — the lossless inverse (flatten sections back to a replayable patch list).
+- `default-opts` (`{:max-coalesce-depth 3}`) — the tunable cluster-coalescence knob, mirroring Causa's defaults.
+
+`section-grouping` does NOT own:
+
+- The patch grammar itself — that's [`diff-encode.md`](diff-encode.md) (`patch-schema`).
+- The `:section-path` / `:section-kind` / `:patches` section grammar's Malli schema — that's `diff-encode`'s `section-schema` (pinned at the encode/decode boundary).
+- The annotated-tree engine + Causa's panel `sections-per-cluster` pass — those live in `tools/causa/.../diff/`; mcp-base cannot pull Causa in (the dep arrow is tool → mcp-base, never the reverse), so it projects from patches instead.
+
+## Why operate on patches, not the annotated tree
+
+The patches already carry path + op + value — every signal needed to head a cluster. Operating on patches keeps mcp-base dep-free (no Causa pull-in), round-trips losslessly (each section's `:patches` is a subset of the flat list; concatenating them reconstructs the path-ordered list that `apply-patches` replays unchanged), and loses no fidelity vs the annotated-tree projection for the agent-query use case — both produce the same N path-headed clusters; only the per-cluster body shape differs (patches here vs annotated subtree there).
+
+## Shape
+
+**Input:** a flat patch vector (the output of `diff-encode/collect-patches`). A patch is `[path :assoc v]` (3-tuple) or `[path :dissoc]` (2-tuple).
+
+**Output:** a sorted vector of sections —
+
+```clojure
+[{:section-path [:cart :items]
+  :section-kind :modified
+  :patches      [[[:cart :items 0 :qty] :assoc 2]
+                 [[:cart :items 0 :discount] :assoc 0.1]]}
+ {:section-path [:checkout :state]
+  :section-kind :modified
+  :patches      [[[:checkout :state] :assoc :paying]]}]
+```
+
+- `:section-path` — the cluster's breadcrumb: the shared ancestor for multi-patch clusters; the patch's parent for promoted singletons; the patch's own path for top-level singletons; `[]` for whole-DB replacement.
+- `:section-kind` — one of `:added` / `:removed` / `:modified`.
+- `:patches` — a sub-sequence of the input list.
+
+## Algorithm
+
+Mirrors the Causa pass (`section_grouping.cljc` §3.1.1), recast over patches:
+
+1. **Trivial cases first.** Empty patches → `[]`. A single root-path `:assoc` (`[[] :assoc <full-db>]`, the `reset-frame-db!` signature) → one `[]`-headed `:modified` section.
+
+2. **Sort by path-as-`pr-str`.** Makes the cluster algorithm deterministic and reorder-tolerant. (`collect-patches` already emits in walk order; the sort pins it.)
+
+3. **Coalesce siblings.** Walk the sorted patches; for each, take the longest common prefix with the running cluster. Fold the patch in when that prefix is non-empty AND both paths sit within `max-coalesce-depth` (default 3) levels of it (narrowing the cluster prefix to the common ancestor). Otherwise start a new cluster. Root coalescence (empty common prefix) is reserved for the whole-DB case — two unrelated root-key changes each get their own cluster rather than collapsing to a `[]`-headed section that would defeat the breadcrumb premise.
+
+4. **Promote singletons to parent.** A cluster with exactly one patch at a path deeper than 1 segment heads at the patch's *parent* (a change to `[:user :prefs :theme]` heads as `[:user :prefs]`). Top-level singletons (path length 1) keep their full path.
+
+5. **Classify each section** (`:section-kind`):
+   - all `:dissoc` → `:removed`.
+   - all `:assoc` AND every patch is exactly one segment deeper than `:section-path` (a newly-introduced container) → `:added`.
+   - otherwise → `:modified` (the conservative default; a mix of inserts / changes / deletes). A more precise `:added` vs `:modified` split would need `:db-before` to detect "was this path previously absent?" — patches alone can't tell, so the rule errs toward `:modified`.
+
+## Ordering
+
+Sections sort by `:section-path` (lexicographic, `pr-str`-keyed) — stable across re-renders, so the same cascade always produces the same section order.
+
+## Cost
+
+- Sort: O(N log N) where N = patch count.
+- Coalesce / promote / classify: O(N).
+
+All passes are linear in patch count — negligible vs the walk that produced the patches. Pure data → data; `.cljc`.
+
+## Round-trip invariant
+
+`sections->patches` is the lossless inverse of `group-patches-into-sections` — `(apply-patches db-before (sections->patches (group-patches-into-sections patches)))` reproduces the value `(apply-patches db-before patches)` produces (modulo within-section order, which is stable per the sort). `diff-encode`'s decoder relies on this: it flattens `:sections` → patch list, then replays.
+
+## See also
+
+- [`README.md`](README.md) — the per-namespace index this doc is part of.
+- [`diff-encode.md`](diff-encode.md) — the diff transform that produces the patch list this ns groups, and the `section-schema` Malli gate that pins the section shape at the wire boundary.
+- rf2-qeous — the bead that landed the path-headed cluster projection.
+- rf2-gfxmk / rf2-abts7 — Causa's panel `sections-per-cluster` decomposition this projection mirrors.

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -3,16 +3,16 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The cross-MCP privacy filter. Framework-published forwarders — Sentry / Honeybadger, re-frame2-pair server, Story-MCP, Causa-MCP — MUST default-drop trace events whose registration declared `:sensitive? true`. The runtime stamps the flag at the top level of every emitted trace event inside such a registration's handler scope; the forwarder's job is to gate egress on it before any data crosses the trust boundary.
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 
 ## Scope
 
 `sensitive` owns:
 
-- The cross-MCP `sensitive-event?` predicate over a trace-event map.
+- The cross-MCP fail-closed `sensitive-event?` predicate over a trace-event map.
 - The `strip-sensitive` walker (returns `[kept dropped-count]`).
-- The `scrub-snapshot` walker that recurses through a snapshot payload and removes `:sensitive?`-stamped subtrees.
-- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped silently every time a non-boolean truthy `:sensitive?` stamp arrives and is dropped + logged.
+- The `scrub-snapshot` walker that strips `:traces` / `:epochs` slices from each per-frame snapshot map.
+- The fail-closed malformed-stamp counter (`malformed-count` / `reset-malformed-count!`) — operator-surface observability for the rf2-ih7g4 fail-closed posture; bumped every time a non-boolean truthy `:sensitive?` stamp arrives and is dropped + logged.
 - The fixed cross-server arg-vocabulary name (`:include-sensitive?`) every MCP tool surfacing trace-like data MUST accept.
 
 `sensitive` does NOT own:
@@ -25,16 +25,24 @@ This doc is one of seven per-namespace contracts indexed from [`README.md`](READ
 
 ### `sensitive-event?` — predicate
 
-Predicate over a trace-event map. **Conservative** — only the literal `true` value drops. Mirrors the Spec-Schemas contract: `:sensitive?` is typed boolean.
+Predicate over a trace-event map. **Fail-closed** (rf2-ih7g4): the literal `true` value drops (the documented spec/009 path), AND any other *truthy non-boolean* stamp also drops — with a stderr / `console.warn` contract-drift warning and a bump of the malformed counter. Only an explicit `false` / `nil` / absent stamp passes. The `:rf/trace-event` schema types `:sensitive?` as a boolean (Spec 009 + Spec-Schemas); a non-boolean stamp is a serialisation-bug *contract violation* that we surface (warn + drop) rather than silently treat as non-sensitive.
 
 Definition (effectively):
 
 ```clojure
 (defn sensitive-event? [ev]
-  (and (map? ev) (true? (:sensitive? ev))))
+  (and (map? ev)
+       (let [stamp (:sensitive? ev)]
+         (cond
+           (true? stamp)  true              ; documented spec/009 drop
+           (false? stamp) false             ; non-sensitive
+           (nil? stamp)   false             ; absent ⇒ non-sensitive
+           :else          (do (bump-malformed!)   ; truthy non-boolean:
+                              (log-malformed! stamp)
+                              true)))))            ; fail-closed drop + warn
 ```
 
-The same shape applies whether the trace event is a top-level emission or a nested fragment inside a snapshot — the predicate is conservative everywhere.
+The earlier `true?`-only predicate was fail-**open** on contract drift: an upstream serialisation bug coercing the boolean into a string (`"true"`) would silently leak every sensitive event past the filter. The fail-closed posture closes that leak. The same predicate applies whether the trace event is a top-level emission or a nested fragment inside a snapshot.
 
 ### `strip-sensitive` — coll → `[kept dropped-count]`
 
@@ -42,11 +50,16 @@ Walks a collection of trace events; returns a `[kept dropped-count]` 2-vector wh
 
 The count feeds the indicator-field slot the agent reads to know the payload was filtered without re-inferring from absence.
 
-### `scrub-snapshot` — snapshot tree walker
+### `scrub-snapshot` — per-frame snapshot scrubber
 
-Recurses through a snapshot payload (snapshot mode `:full` / `:summary`) and removes any `:sensitive?`-stamped sub-tree.
+Walks a snapshot map keyed by frame and, for each per-frame map, applies the strip-fn to the `:traces` and `:epochs` slices only. Returns `[scrubbed-snapshot total-dropped]`. Non-map slices and non-snapshot inputs pass through unchanged.
 
-Snapshot scrubbing is **stricter** than trace-event filtering — the snapshot payload may contain nested registration handles whose sub-trees carry sensitive declarations; the walker descends into those sub-trees and removes them rather than relying on the top-level flag.
+The walk is **shallow by design** (per rf2-zq0n1 / rf2-3cted): it strips sensitive trace events from `:traces` / `:epochs` but **leaves `:app-db`, `:sub-cache`, and `:machines` untouched**. App-db payload redaction is `redact-interceptor`'s job at *write-time*, not the forwarder's job at *read-time* — `scrub-snapshot` does NOT descend into arbitrary sub-trees and does NOT redact app-db values. (A reviewer should not assume app-db redaction happens here; it does not.)
+
+Two arities:
+
+- `[snapshot include?]` — uses the base `strip-sensitive` predicate (the spec/009 §Privacy stamp check).
+- `[snapshot include? strip-fn]` — accepts a custom strip-fn matching the `[items include?] => [kept dropped]` contract (re-frame2-pair-mcp passes a union predicate that also catches the epoch-level `:sensitive?` rollup).
 
 ## Cross-server arg-vocabulary convention
 
@@ -62,7 +75,7 @@ The default-OFF posture aligns with the framework's privacy-by-default stance (p
 
 ## Zero-dep rationale
 
-re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp is JVM-side and DOES have the framework primitive available. The predicate here (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and identical to `re-frame.privacy/sensitive?`.
+re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp is JVM-side and DOES have the framework primitive available. The predicate here matches the spirit of `re-frame.privacy/sensitive?` but adds the fail-closed posture (rf2-ih7g4): the runtime always stamps the literal boolean, but if a transport bug delivers any other truthy value, the filter drops the event AND logs so the contract drift surfaces in operator output rather than leaking the event.
 
 Consumers that want to bind to the framework primitive (story-mcp does, for code-review locality) alias the surface in their own ns and delegate through here.
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -3,7 +3,7 @@
 > **Type:** Reference (`tools/mcp-base/spec/`)
 > The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 pair — `re-frame2-pair-mcp` and `story-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
 
-This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
+This doc is one of eight per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`section-grouping.md`](section-grouping.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 
 ## Scope
 

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -36,12 +36,23 @@
                          :else default))
     :else            default))
 
+(def ^:private int-string-re
+  "Strict integer-string grammar: optional sign + one-or-more digits,
+  nothing else. Trailing garbage (`\"12abc\"`) is rejected so the
+  string arm parses byte-identically across hosts (rf2-ee38b.19) —
+  `Long/parseLong` (JVM) already rejects trailing garbage; raw
+  `js/parseInt` (CLJS) parses a numeric PREFIX (`\"12abc\"` ⇒ 12),
+  which would diverge from the JVM default-fallback. Guarding both
+  arms with this regex closes the divergence."
+  #"[-+]?\d+")
+
 (defn- parse-int*
   "Shared helper for `parse-positive-int` / `parse-non-negative-int`.
-  `floor` is the lower clamp (1 for positive, 0 for non-negative); the
-  two input arms (number / string + try/catch) cover every shape the
-  agent surface produces. `integer?` is a subset of `number?`, so the
-  single `number?` arm catches both."
+  `floor` is the lower clamp (1 for positive, 0 for non-negative).
+  Two input arms: a numeric `raw` is floored directly; a string `raw`
+  is strict-parsed (must match `int-string-re` end-to-end — trailing
+  garbage falls back to `default`, identically on JVM and CLJS).
+  Every other shape falls back to `default`."
   [raw default floor]
   (cond
     (nil? raw)
@@ -51,13 +62,23 @@
     (max floor (long raw))
 
     (string? raw)
-    #?(:clj (try
-              (max floor (Long/parseLong (str/trim raw)))
-              (catch NumberFormatException _ default))
-       :cljs (let [n (js/parseInt raw 10)]
-               (if (and (number? n) (not (js/isNaN n)))
-                 (max floor (long n))
-                 default)))
+    (let [s (str/trim raw)]
+      (if-not (re-matches int-string-re s)
+        default
+        #?(:clj  (try
+                   (max floor (Long/parseLong s))
+                   (catch NumberFormatException _ default))
+           ;; Match the JVM `Long/parseLong` posture: a digit string
+           ;; outside the safely-representable integer range is a parse
+           ;; failure → `default` (JVM throws NumberFormatException on
+           ;; long overflow; JS would silently coerce to a lossy float).
+           ;; `js/Number.isSafeInteger` is the CLJS analogue of "fits a
+           ;; long" for the small ints the agent surface produces.
+           :cljs (let [n (js/parseInt s 10)]
+                   (if (and (not (js/isNaN n))
+                            (js/Number.isSafeInteger n))
+                     (max floor (long n))
+                     default)))))
 
     :else
     default))

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -202,28 +202,19 @@
 (defn over-cap?
   "Two-stage over-budget predicate (rf2-ih7g4). True when EITHER the
   token sum exceeds `cap` OR the char sum exceeds `cap *
-  byte-cap-multiplier` (the secondary byte gate).
-
-  Pure over already-summed `tokens` / `chars` so the secondary char
-  gate is trippable in isolation — under the live `token-estimate`
-  rule the char disjunct is structurally dominated (see the ns-level
-  comment above), but the gate guards against a future token-rule
-  refinement that decouples chars from tokens."
+  byte-cap-multiplier`. Pure over already-summed counts so the
+  dominated char gate is unit-trippable in isolation (see the comment
+  block above for the structural-domination argument)."
   [tokens chars cap]
   (or (> tokens cap)
       (> chars (* cap byte-cap-multiplier))))
 
 (defn reported-count
-  "The `:token-count` reported in the overflow marker. When the
-  secondary char gate is the one that tripped (`chars > cap *
-  byte-cap-multiplier`), report the char count so the agent's overflow
-  handler sees an actionable number reflecting the payload that
-  escaped the token heuristic; otherwise report the token sum.
-
-  Pure over already-summed `tokens` / `chars` (companion to
-  `over-cap?`) — exercised directly in `cap_test.clj` so the char-gate
-  reporting arm is covered even though the live `apply-cap` path cannot
-  reach it under the current `token-estimate` rule."
+  "The `:token-count` reported in the overflow marker: the char count
+  when the secondary char gate tripped (so the agent sees an actionable
+  number for the payload that escaped the token heuristic), else the
+  token sum. Pure companion to `over-cap?` — unit-tested directly since
+  the live `apply-cap` path can't reach the char-gated arm."
   [tokens chars cap]
   (if (> chars (* cap byte-cap-multiplier))
     chars
@@ -254,31 +245,11 @@
     (nil? cap)    result
     (nil? result) result
     :else
-    ;; Two-stage check (rf2-ih7g4):
-    ;;
-    ;; 1. Primary token cap — `(quot count 4)` per Anthropic's English
-    ;;    rule-of-thumb. The published contract pinned by every
-    ;;    consumer and documented in spec.
-    ;;
-    ;; 2. Secondary char-byte cap — `cap * byte-cap-multiplier`.
-    ;;    Defence-in-depth against payloads where the (count s)/4
-    ;;    heuristic undercounts: CJK, emoji, base64, dense code. Trips
-    ;;    independently of the token sum; reports the char count as
-    ;;    the `:token-count` so the agent's overflow handler sees an
-    ;;    actionable number (not zero, not nil).
-    ;;
-    ;; Either gate trips the same truncate-with-marker fallback.
-    ;;
-    ;; ## Single-pass token+char sum (rf2-hyp0z / F9-F10)
-    ;;
-    ;; The previous implementation called `sum-text-tokens` and
-    ;; `sum-text-chars` separately, each invoking `content-texts` on
-    ;; `io` once. For story-mcp's reify that materialised the result
-    ;; twice (including a `(pr-str (:structuredContent result))` on
-    ;; each call — the dominant cost for structured-content responses
-    ;; up to 30K chars). The single-pass transduce below folds both
-    ;; sums in one walk of the content-texts seq, materialising the
-    ;; expensive accessor exactly once per response.
+    ;; Two-stage gate (`over-cap?`) + single-pass token/char sum — see
+    ;; the `over-cap?` comment block above (rf2-ih7g4) for why the char
+    ;; disjunct is structurally dominated today, and rf2-hyp0z for why
+    ;; both sums fold in ONE walk (avoids materialising story-mcp's
+    ;; `:structuredContent` twice).
     (let [{:keys [tokens chars]}
           (transduce (filter string?)
                      (completing

--- a/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cursor.cljc
@@ -1,0 +1,220 @@
+(ns re-frame.mcp-base.cursor
+  "Shared cursor-pagination machinery for the MCP pair (rf2-ee38b.19).
+
+  Per `spec/Principles.md` §Pagination and `spec/Tool-Pair.md`
+  §Cursor pagination, every read tool whose return size is a function
+  of registry / ring size MUST accept a `:limit` arg and return an
+  opaque `:cursor` for continuation. Cursors are OPAQUE on the wire —
+  the agent passes them back verbatim and has no business decoding the
+  format.
+
+  ## Why this ns
+
+  Both servers previously hand-rolled the SAME machinery:
+
+    - `tools/story-mcp/.../cursor.cljc`     (offset/total/sig over
+                                             append-mostly registries)
+    - `tools/re-frame2-pair-mcp/.../cursor.cljs` (after-id/ms over the
+                                             bounded epoch ring)
+
+  The cursor PAYLOAD differs by domain — story carries
+  `{:offset :total :sig}`, pair carries `{:after-id :ms :until-ms
+  :frame}` — but the base64 codec, the EDN read with tagged-literal
+  rejection + size guard, the `::malformed` recovery contract, the
+  `:limit` clamp, and the `cursor-stale-result` envelope are identical.
+  Earlier the README argued the codec was consumer-side because
+  `js/Buffer` vs `java.util.Base64` differ — but story-mcp's
+  `cursor.cljc` already proved the codec lifts cleanly as a `.cljc`
+  reader-conditional, so it lives here now.
+
+  ## What is parameterised vs fixed
+
+  - The base64 codec, the tagged-literal-rejecting EDN reader, the
+    1 KB size cap, and the `::malformed` sentinel are FIXED here.
+  - The cursor SHAPE is the consumer's — `decode-cursor` takes a
+    `valid?` predicate so each server validates its own payload map
+    while sharing the codec + recovery flow.
+  - `parse-limit-arg` takes the consumer's `default` + `max`.
+  - `cursor-stale-result` takes the consumer's `error-result` fn so
+    the envelope is shaped per the consumer's wire convention while the
+    `:reason` stays the cross-MCP `vocab/cursor-stale-reason`.
+
+  ## Cross-platform
+
+  Pure CLJC. The base64 codec resolves to `java.util.Base64` on the
+  JVM (story-mcp) and `js/Buffer` on CLJS (re-frame2-pair-mcp). The EDN
+  read uses `clojure.edn/read-string` (JVM) / `cljs.reader/read-string`
+  (CLJS) — both gated by a `:default` tagged-literal handler that
+  throws so a hostile / corrupt cursor cannot smuggle a tagged literal
+  past the reader."
+  (:require [clojure.string :as str]
+            #?(:clj [clojure.edn :as edn])
+            [re-frame.mcp-base.args :as args]
+            [re-frame.mcp-base.vocab :as vocab])
+  #?(:cljs (:require [cljs.reader]))
+  #?(:clj (:import (java.util Base64))))
+
+(def ^:const max-cursor-bytes
+  "Hard ceiling on a cursor token's character length. Cursors are short
+  opaque tokens (a base64'd EDN map of a handful of scalar slots);
+  anything longer is rejected before parsing as a cheap DoS / malformed
+  guard. 1 KB is far past any legitimate cursor."
+  1024)
+
+;; ---------------------------------------------------------------------------
+;; Base64 codec — the `.cljc` reader-conditional both servers share.
+;; ---------------------------------------------------------------------------
+
+(defn b64-encode
+  "Base64-encode a UTF-8 string. `java.util.Base64` on the JVM,
+  `js/Buffer` on CLJS."
+  [^String s]
+  #?(:clj  (-> (Base64/getEncoder)
+               (.encodeToString (.getBytes s "UTF-8")))
+     :cljs (-> (js/Buffer.from s "utf8")
+               (.toString "base64"))))
+
+(defn b64-decode
+  "Decode a base64 string back to UTF-8. Inverse of `b64-encode`."
+  [^String s]
+  #?(:clj  (String. (.decode (Base64/getDecoder) s) "UTF-8")
+     :cljs (-> (js/Buffer.from s "base64")
+               (.toString "utf8"))))
+
+;; ---------------------------------------------------------------------------
+;; Limit clamp.
+;; ---------------------------------------------------------------------------
+
+(defn parse-limit-arg
+  "Normalise the `:limit` MCP arg into an integer in `[1, max]`,
+  defaulting to `default`. Caller-supplied values above `max` clamp
+  DOWN (a legitimate large request still works, just capped). Delegates
+  to `re-frame.mcp-base.args/parse-positive-int` for the shared
+  string/number coercion + default posture, then applies the ceiling.
+
+  Each server bakes its own `default` (story 25, pair 50) and `max`
+  (story's 200; pair's wire-cap is the implicit ceiling) — the
+  convention is the CLAMP behaviour, not the numbers."
+  [raw default max]
+  (min max (args/parse-positive-int raw default)))
+
+;; ---------------------------------------------------------------------------
+;; Opaque cursor codec — pr-str + base64 of an EDN payload map.
+;; ---------------------------------------------------------------------------
+
+(defn encode-cursor
+  "Encode a cursor payload map as an opaque base64 string.
+
+  This is the unconditional encoder — it always produces a token for a
+  payload map. The caller decides WHEN to emit a cursor (i.e. when
+  there are more entries / records); the absence-of-cursor IS the
+  end-of-pagination signal, so the caller passes `nil` rather than
+  calling this when pagination is over. Returns `nil` for a nil /
+  non-map payload as a safety net."
+  [payload]
+  (when (map? payload)
+    (b64-encode (pr-str payload))))
+
+(defn- read-edn-no-tags
+  "Read an EDN string with EVERY tagged literal rejected. The
+  `:default` data-reader throws `:rf.error/mcp-cursor-bad-edn-tag` so a
+  hostile / corrupt cursor cannot smuggle a `#js`, `#inst`, or custom
+  tagged literal past the reader. Caught by the surrounding try in
+  `decode-cursor` → `::malformed`."
+  [s]
+  (let [opts {:default (fn [_tag _val]
+                         (throw (ex-info ":rf.error/mcp-cursor-bad-edn-tag"
+                                         {:rf.error/id :rf.error/mcp-cursor-bad-edn-tag
+                                          :where       'mcp-base/decode-cursor
+                                          :recovery    :no-recovery
+                                          :reason      "EDN cursor carried a tagged literal — none are permitted"})))}]
+    #?(:clj  (edn/read-string opts s)
+       :cljs (cljs.reader/read-string opts s))))
+
+(defn decode-cursor
+  "Decode an opaque base64 cursor back to its EDN payload map.
+
+  Returns:
+    - `nil`         — the cursor arg is absent (nil / undefined) or
+                      blank. The caller treats this as 'start from the
+                      beginning' (offset 0 / head).
+    - `::malformed` — the cursor exists but is not a well-formed,
+                      `valid?`-passing payload map: it failed to
+                      base64/EDN-decode, carried a tagged literal,
+                      exceeded `max-cursor-bytes`, or its payload map
+                      failed the consumer's `valid?` predicate. Callers
+                      treat `::malformed` exactly like a STALE cursor —
+                      drop it and restart.
+
+  `valid?` is the consumer's payload-shape predicate (e.g.
+  `#(and (map? %) (integer? (:offset %)) (string? (:sig %)))` for
+  story; `#(and (map? %) (string? (:after-id %)))` for pair). The
+  codec, the size cap, and the tagged-literal rejection are shared; the
+  shape check is the consumer's.
+
+  Hardened: non-string input ⇒ `::malformed`; oversize input ⇒
+  `::malformed` BEFORE parsing; the input is decoded exactly once."
+  [s valid?]
+  (cond
+    (or (nil? s)
+        #?(:cljs (undefined? s) :clj false)
+        (and (string? s) (str/blank? s)))
+    nil
+
+    (not (string? s))
+    ::malformed
+
+    (> (count s) max-cursor-bytes)
+    ::malformed
+
+    :else
+    (try
+      (let [v (read-edn-no-tags (b64-decode s))]
+        (if (and (map? v) (valid? v))
+          v
+          ::malformed))
+      (catch #?(:clj Throwable :cljs :default) _ ::malformed))))
+
+(defn malformed?
+  "True when `decoded` is the `::malformed` sentinel returned by
+  `decode-cursor`. Convenience for consumers that prefer a predicate
+  over the qualified-keyword literal at the call site."
+  [decoded]
+  (= ::malformed decoded))
+
+;; ---------------------------------------------------------------------------
+;; Cursor-stale envelope.
+;; ---------------------------------------------------------------------------
+
+(defn cursor-stale-result
+  "Build a structured cursor-stale error result via the consumer's
+  `error-result` fn.
+
+  The `:reason` slot is the cross-MCP `vocab/cursor-stale-reason`
+  (`:rf.mcp/cursor-stale`) so an agent that learned the recovery path
+  on one server reuses it on the other — whether staleness means
+  ring-rotation (pair) or registry-change-between-pages (story).
+
+  `error-result` is the consumer's error-envelope builder. It is
+  called as `(error-result message data-map)` where `message` is a
+  human-readable string and `data-map` carries the structured slots
+  (`:ok? false`, `:reason`, `:tool`, `:hint`, plus any caller `extra`).
+  Each server's `error-result` shapes the wire envelope its own way
+  (story-mcp's `h/error-result`, pair-mcp's `wire/err-text`); this
+  builder owns only the cross-MCP slot vocabulary.
+
+  `opts`:
+    :message — override the default human-readable message.
+    :hint    — override the default recovery hint.
+    :extra   — a map of additional structured slots to merge in
+               (e.g. pair's `:requested-id` / `:head-id`)."
+  [error-result tool {:keys [message hint extra]}]
+  (error-result
+    (or message
+        (str "Cursor stale: it no longer addresses a valid position. "
+             "Drop the cursor and restart `" tool "`."))
+    (merge {:ok?    false
+            :reason vocab/cursor-stale-reason
+            :tool   tool
+            :hint   (or hint "Drop :cursor and re-request from the start.")}
+           extra)))

--- a/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/envelope.cljc
@@ -1,0 +1,130 @@
+(ns re-frame.mcp-base.envelope
+  "Cross-MCP response-envelope helpers (rf2-ee38b.19).
+
+  The MCP servers decorate their tool-response envelopes with two
+  cross-cutting concerns that are pure data and identical across the
+  pair:
+
+    1. The indicator-field counters (`:dropped-sensitive` /
+       `:elided-large`) — the MUST-level 'omit when zero' parity rule
+       per Conventions §Cross-MCP indicator-field vocabulary and
+       Spec 009 §Indicator field on tool responses.
+    2. Wire-bounded marker detection — recognising the `:rf.mcp/*`
+       replacement envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`)
+       that the cache + cap boundary steps emit themselves, so later
+       boundary steps don't re-walk a sub-cap-by-construction marker.
+
+  Both indicator KEYS already live in `vocab.cljc`; the producers of
+  the counts (`elision/count-elided-markers`,
+  `sensitive/strip-sensitive`) already live in the base. This ns adds
+  the helper that SPLICES them onto the envelope — previously
+  pair-mcp-only despite being pure data — so the single emit-path the
+  spec mandates lives in one place the conformance gate can test
+  directly.
+
+  ## Cross-platform
+
+  Pure CLJC, no transport / no host shape. `with-indicators` operates
+  on a Clojure envelope map. `marker-text?` operates on the RENDERED
+  text string — the consumer reads its own platform's content slot
+  (`:text` from a Clojure map / `j/get :text` from a JS object) and
+  passes the string here, so the shape-specific accessor stays
+  consumer-side while the prefix-detection logic is shared."
+  (:require [clojure.string :as str]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Indicator-field splice — the MUST-level 'omit when zero' rule.
+;; ---------------------------------------------------------------------------
+
+(defn with-indicators
+  "Splice the cross-MCP indicator-field slots onto a tool's envelope
+  map, enforcing the MUST-level 'omit when zero' rule from
+  Conventions §Cross-MCP indicator-field vocabulary and Spec 009
+  §Indicator field on tool responses.
+
+  Every tool that walks a tree-typed payload (`snapshot`, `get-path`,
+  `trace-window`, `watch-epochs`, `subscribe`, …) routes its
+  envelope-tail through here so the rule lives in one place — drift
+  across emit sites can no longer silently violate the MUST.
+
+  `counts`:
+    :dropped — count of `:sensitive? true` leaves dropped at the wire
+               boundary (from `sensitive/strip-sensitive`). Emitted
+               under `vocab/dropped-sensitive-key` when positive.
+    :elided  — count of leaves replaced with the
+               `:rf.size/large-elided` marker (from
+               `elision/count-elided-markers`). Emitted under
+               `vocab/elided-large-key` when positive.
+
+  A zero / nil / absent count omits its slot entirely (the 'omit when
+  zero' MUST). Returns `envelope` unchanged when both counts are
+  zero — identity-preserving on the common path."
+  [envelope {:keys [dropped elided]}]
+  (cond-> envelope
+    (pos? (or dropped 0)) (assoc vocab/dropped-sensitive-key dropped)
+    (pos? (or elided  0)) (assoc vocab/elided-large-key      elided)))
+
+;; ---------------------------------------------------------------------------
+;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi).
+;;
+;; The `:rf.mcp/cache-hit` and `:rf.mcp/overflow` envelopes are
+;; replacement results the cache + cap boundary steps emit themselves.
+;; By construction they are sub-cap size — re-walking either is wasted
+;; work and a cache check on a hit-marker would hash the marker, not
+;; the original payload.
+;;
+;; Substring-match on the rendered text is the cheap detector — the
+;; marker map's namespaced key is the first key of the outer map, so a
+;; `starts-with?` on the trimmed text is fast and tight. We match BOTH
+;; print forms the single-key namespaced marker map can take: the flat
+;; form `{:rf.mcp/overflow ...` (the form CLJS `pr-str` emits and the
+;; form JVM emits with `*print-namespace-maps*` false) and the
+;; namespaced-map shorthand `#:rf.mcp{:overflow ...` (the form JVM
+;; `pr-str` emits by default for a single-namespace map). Matching both
+;; keeps the detector host- and print-setting-agnostic. A false
+;; positive would require an agent-supplied payload that ALSO renders
+;; with `:rf.mcp/cache-hit` / `:rf.mcp/overflow` as its leading top-
+;; level key — not a realistic shape for any tool's result.
+;; ---------------------------------------------------------------------------
+
+(defn- marker-key-prefixes
+  "Both print-form prefixes for a single-key namespaced marker map
+  whose sole key is `marker-key` (e.g. `:rf.mcp/overflow`):
+
+    - flat form           `{:rf.mcp/overflow`
+    - namespaced-map form `#:rf.mcp{:overflow`"
+  [marker-key]
+  (let [flat (str "{" marker-key)
+        ns'  (namespace marker-key)
+        nm   (name marker-key)]
+    [flat
+     (if ns'
+       (str "#:" ns' "{:" nm)
+       flat)]))
+
+(def marker-prefixes
+  "Rendered-text prefixes of the wire-bounded `:rf.mcp/*` replacement
+  envelopes (`:rf.mcp/cache-hit`, `:rf.mcp/overflow`). Includes BOTH
+  the flat and the namespaced-map print forms (see the comment block
+  above) so the detector works regardless of host or
+  `*print-namespace-maps*`. A response whose text starts with one of
+  these is a boundary-step marker that later boundary steps must NOT
+  re-walk."
+  (into [] (mapcat marker-key-prefixes) [vocab/cache-hit-key vocab/overflow-key]))
+
+(defn marker-text?
+  "Is `text` (the rendered EDN text of a response's first content slot)
+  a wire-bounded `:rf.mcp/*` marker envelope?
+
+  Returns true for `:rf.mcp/cache-hit` / `:rf.mcp/overflow` markers —
+  the two envelopes the cache + cap steps emit themselves. The
+  consumer reads its own platform's content text (`:text` from a
+  Clojure map, `j/get :text` from a JS object) and passes the string
+  here; this fn owns only the prefix-match logic, shared across hosts.
+
+  Nil-safe: a nil / non-string `text` is not a marker."
+  [text]
+  (boolean
+    (and (string? text)
+         (some #(str/starts-with? text %) marker-prefixes))))

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -29,11 +29,10 @@
                  the wire.
 
   Unqualified envelope slots — `:dropped-sensitive` /
-  `:elided-large` — ride alongside the tool's unqualified envelope
-  slots; they are scalar counters summarising the walker's
-  suppression count on a per-call basis. Per Conventions §Cross-MCP
-  indicator-field vocabulary and Spec 009 §Size elision in traces
-  (Indicator field on tool responses, MUST-level).
+  `:elided-large` — are scalar suppression counters that ride the
+  envelope (MUST-level per Conventions §Cross-MCP indicator-field
+  vocabulary). The rationale for keeping them unqualified lives at
+  their defs below.
 
   ## JSON-RPC error codes
 
@@ -66,9 +65,12 @@
 (def diff-from-key
   "Marker on an epoch's `:db-after` slot indicating it is a structural
   diff against a sibling slot. The value names the source slot
-  (`:db-before`). Shape:
-    `{:db-after {:rf.mcp/diff-from :db-before :patches [...]}}`.
-  Per rf2-1wdzp."
+  (`:db-before`). Shape (path-headed cluster projection, rf2-qeous):
+    `{:db-after {:rf.mcp/diff-from :db-before
+                 :sections [{:section-path [...] :section-kind <kw>
+                             :patches [...]} ...]}}`.
+  Per rf2-1wdzp / rf2-qeous. See `re-frame.mcp-base.diff-encode` and
+  `re-frame.mcp-base.section-grouping`."
   :rf.mcp/diff-from)
 
 (def cursor-stale-reason

--- a/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/args_test.clj
@@ -72,6 +72,43 @@
   (is (zero? (args/parse-non-negative-int -5 5000))))
 
 ;; ---------------------------------------------------------------------------
+;; Cross-host strict-parse contract (rf2-ee38b.19).
+;;
+;; Pin the trailing-garbage case that previously diverged: JVM
+;; `Long/parseLong` threw on a non-numeric tail and fell back to the
+;; default, while raw CLJS `js/parseInt` parsed a numeric PREFIX
+;; (`"12abc"` ⇒ 12). The strict `int-string-re` guard makes both hosts
+;; fall back to `default`. The mirror CLJS assertions live in
+;; `re-frame.mcp-base.cljs-branches-cljs-test` so the same expectations
+;; are pinned on both platforms.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-positive-int-rejects-trailing-garbage
+  (is (= 50 (args/parse-positive-int "12abc" 50))
+      "trailing garbage falls back to default (was 12 on CLJS before the fix)")
+  (is (= 50 (args/parse-positive-int "5xyz" 50)))
+  (is (= 50 (args/parse-positive-int "12 34" 50)) "internal whitespace rejected")
+  (is (= 50 (args/parse-positive-int "0x10" 50)) "hex-prefixed string rejected")
+  (is (= 50 (args/parse-positive-int "1.5" 50)) "decimal string rejected")
+  (is (= 50 (args/parse-positive-int "1e3" 50)) "scientific notation rejected"))
+
+(deftest parse-positive-int-accepts-clean-and-signed
+  (is (= 12 (args/parse-positive-int "12" 50)))
+  (is (= 12 (args/parse-positive-int "  12  " 50)) "surrounding whitespace trimmed")
+  (is (= 12 (args/parse-positive-int "+12" 50)) "leading plus accepted")
+  (is (= 1 (args/parse-positive-int "-5" 50)) "negative parses then clamps to floor"))
+
+(deftest parse-non-negative-int-rejects-trailing-garbage
+  (is (= 5000 (args/parse-non-negative-int "12abc" 5000)))
+  (is (= 5000 (args/parse-non-negative-int "100x" 5000))))
+
+(deftest parse-positive-int-rejects-out-of-long-range
+  ;; A digit string that overflows a JVM long is a parse failure →
+  ;; default. The CLJS arm mirrors this via Number.isSafeInteger so the
+  ;; two hosts agree on the rejection (not a lossy truncation).
+  (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50))))
+
+;; ---------------------------------------------------------------------------
 ;; fresh-keyword — positive-named intern for operator-gated write paths
 ;; (rf2-xxtrz, the successor to the retired `parse-keyword`).
 ;; ---------------------------------------------------------------------------

--- a/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
+++ b/tools/mcp-base/test/re_frame/mcp_base/cljs_branches_cljs_test.cljs
@@ -25,8 +25,11 @@
   into the private helpers — we pin the behaviour the consumers depend
   on."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.mcp-base.args :as args]
             [re-frame.mcp-base.cap :as cap]
+            [re-frame.mcp-base.cursor :as cursor]
             [re-frame.mcp-base.diff-encode :as de]
+            [re-frame.mcp-base.envelope :as envelope]
             [re-frame.mcp-base.overflow :as overflow]
             [re-frame.mcp-base.vocab :as vocab]))
 
@@ -133,3 +136,71 @@
     (let [r   {:content [{:type "text" :text (pr-str {:small :payload})}]}
           out (cap/apply-cap map-io r {:tool "snapshot" :cap overflow/default-max-tokens})]
       (is (identical? r out)))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Cross-host strict integer-parse contract (rf2-ee38b.19). The string
+;;    arm of `parse-int*` previously diverged: raw `js/parseInt` parses a
+;;    numeric PREFIX (`"12abc"` ⇒ 12) while JVM `Long/parseLong` rejects
+;;    trailing garbage and falls back to default. This pins the CLJS half
+;;    of the contract; the JVM half lives in args_test.clj. Both MUST
+;;    agree (byte-identical default-fallback posture).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-int-strict-cross-host-cljs
+  (testing "trailing garbage falls back to default on CLJS too"
+    (is (= 50 (args/parse-positive-int "12abc" 50)) "was 12 on CLJS before the fix")
+    (is (= 50 (args/parse-positive-int "5xyz" 50)))
+    (is (= 50 (args/parse-positive-int "1.5" 50)))
+    (is (= 50 (args/parse-positive-int "1e3" 50)))
+    (is (= 5000 (args/parse-non-negative-int "100x" 5000))))
+  (testing "clean and signed strings still parse"
+    (is (= 12 (args/parse-positive-int "12" 50)))
+    (is (= 12 (args/parse-positive-int "+12" 50)))
+    (is (= 1 (args/parse-positive-int "-5" 50)) "clamps to floor"))
+  (testing "out-of-safe-range digit string rejected (mirrors JVM long overflow)"
+    (is (= 50 (args/parse-positive-int "99999999999999999999999999" 50)))))
+
+;; ---------------------------------------------------------------------------
+;; 6. Shared cursor codec round-trips under CLJS (rf2-ee38b.19). The base64
+;;    codec is reader-conditional (`js/Buffer` on CLJS); pin the encode →
+;;    decode round-trip and the malformed/oversize sentinels on the
+;;    Node runtime the pair-mcp server actually runs on.
+;; ---------------------------------------------------------------------------
+
+(deftest cursor-codec-round-trips-under-cljs
+  (testing "encode then decode reproduces the payload"
+    (let [payload {:v 1 :after-id "ev-42" :ms 1000}
+          token   (cursor/encode-cursor payload)
+          back    (cursor/decode-cursor token (fn [m] (and (map? m) (string? (:after-id m)))))]
+      (is (string? token))
+      (is (= payload back))))
+  (testing "absent cursor decodes to nil"
+    (is (nil? (cursor/decode-cursor nil any?)))
+    (is (nil? (cursor/decode-cursor "" any?))))
+  (testing "garbage / oversize / failing-payload predicate => ::malformed"
+    (is (= :re-frame.mcp-base.cursor/malformed
+           (cursor/decode-cursor "!!!not-base64-edn!!!" any?)))
+    (is (= :re-frame.mcp-base.cursor/malformed
+           (cursor/decode-cursor (apply str (repeat 2000 "a")) any?)))
+    (let [token (cursor/encode-cursor {:v 1 :after-id "x"})]
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor token (fn [_] false))))))
+  (testing "tagged literals in the cursor are rejected"
+    (let [evil (cursor/b64-encode "#js {:a 1}")]
+      (is (= :re-frame.mcp-base.cursor/malformed
+             (cursor/decode-cursor evil any?))))))
+
+;; ---------------------------------------------------------------------------
+;; 7. Shared with-indicators envelope helper under CLJS (rf2-ee38b.19).
+;;    The MUST-level "omit when zero" parity rule runs identically on
+;;    both hosts; pin the CLJS half.
+;; ---------------------------------------------------------------------------
+
+(deftest with-indicators-omit-when-zero-cljs
+  (is (= {:trace [1]} (envelope/with-indicators {:trace [1]} {:dropped 0 :elided 0})))
+  (is (= {:trace [1] :dropped-sensitive 3}
+         (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 0})))
+  (is (= {:trace [1] :elided-large 2}
+         (envelope/with-indicators {:trace [1]} {:dropped 0 :elided 2})))
+  (is (= {:trace [1] :dropped-sensitive 3 :elided-large 2}
+         (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 2}))))

--- a/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/cursor_test.clj
@@ -1,0 +1,133 @@
+(ns re-frame.mcp-base.cursor-test
+  "Tests for the shared cursor-pagination machinery (rf2-ee38b.19).
+  The base64 codec, the EDN-read-with-tagged-literal-rejection, the
+  `::malformed` recovery contract, the `:limit` clamp, and the
+  `cursor-stale-result` envelope are the cross-MCP pieces both servers
+  consume; the JVM suite pins the `:clj` codec arm, the CLJS
+  branches test (`cljs_branches_cljs_test`) pins the `js/Buffer` arm."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.cursor :as cursor]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; A payload-shape predicate for the tests — mirrors story's cursor
+;; shape closely enough to exercise the `valid?` parameterisation.
+(defn- offset-cursor? [m]
+  (and (map? m)
+       (= 1 (:v m))
+       (integer? (:offset m))
+       (integer? (:total m))
+       (string? (:sig m))))
+
+;; ---------------------------------------------------------------------------
+;; base64 codec round-trip
+;; ---------------------------------------------------------------------------
+
+(deftest b64-round-trips
+  (is (= "hello" (cursor/b64-decode (cursor/b64-encode "hello"))))
+  (is (= "" (cursor/b64-decode (cursor/b64-encode ""))))
+  (testing "non-ASCII survives the UTF-8 round-trip"
+    (is (= "café — 日本" (cursor/b64-decode (cursor/b64-encode "café — 日本"))))))
+
+;; ---------------------------------------------------------------------------
+;; encode-cursor / decode-cursor round-trip
+;; ---------------------------------------------------------------------------
+
+(deftest encode-decode-round-trips
+  (let [payload {:v 1 :offset 25 :total 137 :sig "abc123"}
+        token   (cursor/encode-cursor payload)]
+    (is (string? token))
+    (is (= payload (cursor/decode-cursor token offset-cursor?))))
+  (testing "a different shape (pair-style) round-trips under its own valid?"
+    (let [payload {:v 1 :after-id "ev-9" :ms 500 :until-ms 1000 :frame :app}
+          token   (cursor/encode-cursor payload)]
+      (is (= payload (cursor/decode-cursor token #(and (map? %) (string? (:after-id %)))))))))
+
+(deftest encode-cursor-rejects-non-map
+  (is (nil? (cursor/encode-cursor nil)))
+  (is (nil? (cursor/encode-cursor 42)))
+  (is (nil? (cursor/encode-cursor "x"))))
+
+;; ---------------------------------------------------------------------------
+;; decode-cursor recovery contract
+;; ---------------------------------------------------------------------------
+
+(deftest decode-cursor-absent-is-nil
+  (is (nil? (cursor/decode-cursor nil offset-cursor?)))
+  (is (nil? (cursor/decode-cursor "" offset-cursor?)))
+  (is (nil? (cursor/decode-cursor "   " offset-cursor?))))
+
+(deftest decode-cursor-non-string-is-malformed
+  (is (= ::cursor/malformed (cursor/decode-cursor 42 offset-cursor?)))
+  (is (= ::cursor/malformed (cursor/decode-cursor {:offset 0} offset-cursor?))))
+
+(deftest decode-cursor-garbage-is-malformed
+  (is (= ::cursor/malformed (cursor/decode-cursor "!!!not-base64-edn!!!" offset-cursor?))))
+
+(deftest decode-cursor-oversize-is-malformed-before-parse
+  (let [oversize (apply str (repeat (inc cursor/max-cursor-bytes) "a"))]
+    (is (= ::cursor/malformed (cursor/decode-cursor oversize offset-cursor?)))))
+
+(deftest decode-cursor-failing-payload-predicate-is-malformed
+  ;; Valid base64+EDN map, but the consumer's shape predicate rejects it.
+  (let [token (cursor/encode-cursor {:v 1 :offset 0 :total 5 :sig "s"})]
+    (is (= ::cursor/malformed (cursor/decode-cursor token (constantly false))))
+    (is (= ::cursor/malformed
+           (cursor/decode-cursor (cursor/encode-cursor {:wrong :shape}) offset-cursor?)))))
+
+(deftest decode-cursor-rejects-tagged-literals
+  ;; The hardening contract: a cursor smuggling a tagged literal must
+  ;; be rejected by the reader's :default handler → ::malformed, never
+  ;; evaluated.
+  (let [evil-inst (cursor/b64-encode "#inst \"2024-01-01\"")
+        evil-map  (cursor/b64-encode "{:v 1 :offset #foo/bar 0 :total 5 :sig \"s\"}")]
+    (is (= ::cursor/malformed (cursor/decode-cursor evil-inst offset-cursor?)))
+    (is (= ::cursor/malformed (cursor/decode-cursor evil-map offset-cursor?)))))
+
+(deftest malformed?-predicate
+  (is (true? (cursor/malformed? ::cursor/malformed)))
+  (is (false? (cursor/malformed? nil)))
+  (is (false? (cursor/malformed? {:offset 0}))))
+
+;; ---------------------------------------------------------------------------
+;; parse-limit-arg
+;; ---------------------------------------------------------------------------
+
+(deftest parse-limit-arg-defaults-and-clamps
+  (testing "absent ⇒ default"
+    (is (= 25 (cursor/parse-limit-arg nil 25 200))))
+  (testing "in-range ⇒ passthrough"
+    (is (= 50 (cursor/parse-limit-arg 50 25 200)))
+    (is (= 50 (cursor/parse-limit-arg "50" 25 200))))
+  (testing "above max ⇒ clamp down"
+    (is (= 200 (cursor/parse-limit-arg 5000 25 200))))
+  (testing "non-positive ⇒ clamp up to 1 (positive-int floor)"
+    (is (= 1 (cursor/parse-limit-arg 0 25 200))))
+  (testing "trailing-garbage string ⇒ default (shared strict-parse)"
+    (is (= 25 (cursor/parse-limit-arg "50abc" 25 200)))))
+
+;; ---------------------------------------------------------------------------
+;; cursor-stale-result
+;; ---------------------------------------------------------------------------
+
+(deftest cursor-stale-result-shape
+  ;; A trivial error-result builder that captures [message data] so we
+  ;; can assert the cross-MCP slot vocabulary the helper owns.
+  (let [captured (atom nil)
+        builder  (fn [message data] (reset! captured {:message message :data data}) data)]
+    (testing "default message + hint, cross-MCP reason slot"
+      (let [r (cursor/cursor-stale-result builder "list-stories" {})]
+        (is (false? (:ok? r)))
+        (is (= vocab/cursor-stale-reason (:reason r)))
+        (is (= "list-stories" (:tool r)))
+        (is (string? (:hint r)))
+        (is (string? (:message @captured)))))
+    (testing "override message + hint + extra slots merge"
+      (let [r (cursor/cursor-stale-result builder "watch-epochs"
+                                          {:message "custom"
+                                           :hint    "rewind"
+                                           :extra   {:requested-id "ev-1" :head-id "ev-9"}})]
+        (is (= "custom" (:message @captured)))
+        (is (= "rewind" (:hint r)))
+        (is (= "ev-1" (:requested-id r)))
+        (is (= "ev-9" (:head-id r)))
+        (is (= vocab/cursor-stale-reason (:reason r)))))))

--- a/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/envelope_test.clj
@@ -1,0 +1,74 @@
+(ns re-frame.mcp-base.envelope-test
+  "Tests for the shared response-envelope helpers (rf2-ee38b.19) —
+  the indicator-field 'omit when zero' splice and the wire-bounded
+  marker detection."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.mcp-base.envelope :as envelope]
+            [re-frame.mcp-base.vocab :as vocab]))
+
+;; ---------------------------------------------------------------------------
+;; with-indicators — the MUST-level 'omit when zero' rule.
+;; ---------------------------------------------------------------------------
+
+(deftest with-indicators-omits-zero-counts
+  (testing "both zero ⇒ envelope unchanged (identity-preserving)"
+    (let [env {:trace [1 2 3]}]
+      (is (identical? env (envelope/with-indicators env {:dropped 0 :elided 0})))
+      (is (identical? env (envelope/with-indicators env {})))
+      (is (identical? env (envelope/with-indicators env {:dropped nil :elided nil})))))
+  (testing "only dropped positive ⇒ only :dropped-sensitive slot"
+    (is (= {:trace [1] :dropped-sensitive 3}
+           (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 0}))))
+  (testing "only elided positive ⇒ only :elided-large slot"
+    (is (= {:db {} :elided-large 2}
+           (envelope/with-indicators {:db {}} {:dropped 0 :elided 2}))))
+  (testing "both positive ⇒ both slots"
+    (is (= {:trace [1] :dropped-sensitive 3 :elided-large 2}
+           (envelope/with-indicators {:trace [1]} {:dropped 3 :elided 2})))))
+
+(deftest with-indicators-uses-vocab-keys
+  ;; The slots MUST be the canonical vocab keys, not literal keywords —
+  ;; pin the dependency so a vocab rename propagates here.
+  (let [r (envelope/with-indicators {} {:dropped 1 :elided 1})]
+    (is (contains? r vocab/dropped-sensitive-key))
+    (is (contains? r vocab/elided-large-key))))
+
+;; ---------------------------------------------------------------------------
+;; marker-text? — wire-bounded :rf.mcp/* marker detection.
+;; ---------------------------------------------------------------------------
+
+(defn- overflow-fixture []
+  {vocab/overflow-key {:limit :reached :token-count 9000 :cap-tokens 5000
+                       :tool "snapshot" :hint "narrow"}})
+
+(deftest marker-text?-recognises-boundary-markers
+  (testing "overflow marker text"
+    (is (true? (envelope/marker-text? (pr-str (overflow-fixture))))))
+  (testing "cache-hit marker text"
+    (is (true? (envelope/marker-text? (pr-str {vocab/cache-hit-key {:tool "x"}})))))
+  (testing "an ordinary tool payload is not a marker"
+    (is (false? (envelope/marker-text? (pr-str {:trace [1 2 3]}))))
+    (is (false? (envelope/marker-text? (pr-str {:db {:a 1}})))))
+  (testing "nil-safe / non-string"
+    (is (false? (envelope/marker-text? nil)))
+    (is (false? (envelope/marker-text? 42)))))
+
+(deftest marker-prefixes-are-derived-from-vocab
+  ;; The prefixes MUST track the vocab keys so a key rename can't
+  ;; silently desync the detector from the emitter. Both the flat and
+  ;; the namespaced-map print forms are present.
+  (is (some #(= % (str "{" vocab/overflow-key)) envelope/marker-prefixes))
+  (is (some #(= % (str "{" vocab/cache-hit-key)) envelope/marker-prefixes))
+  (is (some #(= % "#:rf.mcp{:overflow") envelope/marker-prefixes))
+  (is (some #(= % "#:rf.mcp{:cache-hit") envelope/marker-prefixes)))
+
+(deftest marker-text?-handles-both-print-forms
+  ;; JVM `pr-str` emits the namespaced-map shorthand for a single-ns
+  ;; map; CLJS emits the flat form. Both MUST be detected so the cap /
+  ;; cache boundary steps recognise a marker regardless of host.
+  (testing "namespaced-map form (JVM default)"
+    (is (true? (envelope/marker-text? "#:rf.mcp{:overflow {:limit :reached}}")))
+    (is (true? (envelope/marker-text? "#:rf.mcp{:cache-hit {:tool \"x\"}}"))))
+  (testing "flat form (CLJS / *print-namespace-maps* false)"
+    (is (true? (envelope/marker-text? "{:rf.mcp/overflow {:limit :reached}}")))
+    (is (true? (envelope/marker-text? "{:rf.mcp/cache-hit {:tool \"x\"}}")))))


### PR DESCRIPTION
Remediation of the 3-lens review sweep for `tools/mcp-base` (the foundation of the MCP cluster). Closes **rf2-ee38b.19**. This PR provides shared machinery the consumer wave (story-mcp .17, pair-mcp .18, mcp-conformance .20) will absorb; **no server dirs touched** (those are sequenced after).

## Correctness

- **[P2] parse-int* JVM/CLJS divergence** — finding: `"12abc"` → default on JVM (`Long/parseLong` rejects) but `12` on CLJS (`js/parseInt` parses a prefix), violating the byte-identical contract. **Fix:** a `^[-+]?\d+$` regex guard rejects trailing garbage on both hosts; the CLJS arm additionally rejects out-of-safe-range digit strings (mirrors JVM long overflow) via `Number.isSafeInteger`. Pinned by cross-host tests (`args_test.clj` + `cljs_branches_cljs_test.cljs`).
- **[P2] overflow.md** names a non-existent `overflow-marker` + wrong `:cap-tokens` input → fixed to `overflow-payload` with `:cap` input (emits `:cap-tokens`); corrected the fallback-hint text.
- **[P3] cap.md / diff-encode.md / sensitive.md** drift → fixed (see below).

## Completeness — shared machinery for the consumer wave

New `re-frame.mcp-base.cursor` (the duplicated codec, lifted):

```clojure
(b64-encode ^String s) ; -> base64 string   (java.util.Base64 / js/Buffer)
(b64-decode ^String s) ; -> utf-8 string
(parse-limit-arg raw default max) ; -> int in [1,max]
(encode-cursor payload-map) ; -> opaque base64 string (nil for non-map)
(decode-cursor s valid?)   ; -> payload-map | nil | ::malformed
(malformed? decoded)       ; -> boolean
(cursor-stale-result error-result tool {:keys [message hint extra]})
```

`decode-cursor` is parameterised by the consumer's `valid?` payload-shape predicate (so story keeps `:offset/:total/:sig`, pair keeps `:after-id/:ms/...`) while sharing the codec, the tagged-literal-rejecting EDN reader, the 1 KB size cap, and the `::malformed` recovery contract. `cursor-stale-result` is parameterised by the consumer's error-envelope builder; the `:reason` stays the cross-MCP `vocab/cursor-stale-reason`.

New `re-frame.mcp-base.envelope` (the pair-mcp-only helper, lifted):

```clojure
(with-indicators envelope {:keys [dropped elided]}) ; omit-when-zero MUST, keyed off vocab
(marker-text? text)   ; -> boolean (host-agnostic: flat AND #:ns{} print forms)
marker-prefixes       ; both print forms of cache-hit / overflow markers
```

`with-indicators` keys off the existing `vocab/dropped-sensitive-key` / `vocab/elided-large-key`. `marker-text?` operates on the rendered text (consumer reads its own platform's content slot) and matches both the flat `{:rf.mcp/...` and the JVM `#:rf.mcp{...` print forms, so the consumer wave's conformance gate can test the real fn instead of a byte-faithful source-grep simulation.

- **[P3] README** index now lists ten ns; added `section-grouping.md` (was undocumented public ns); dropped the phantom "resource controls + token splitter" from the `cap` row; refuted the stale "cursor codec is consumer-side" note; dropped the drifting line-count column; footer counts bumped to eight.

## Spec/doc drift

- **cap.md** — two-stage gate (token + char), single-pass sum, `max-tokens`→`nil` disable semantics.
- **diff-encode.md** — `:sections` shape (not flat `:patches`); decoder flattens via `sections->patches`; cross-links section-grouping; encoder/decoder Malli symmetry.
- **sensitive.md** — fail-closed predicate (drops truthy non-boolean + bumps counter); per-frame shallow `scrub-snapshot` (`:traces`/`:epochs` only; `:app-db`/`:sub-cache`/`:machines` left alone).
- **vocab.cljc** `diff-from-key` docstring → `:sections` shape.

## Clarity / minimalism

- Thinned the over-cap rationale from 4 restatements to one comment-block + pointers (`apply-cap` inline comment, `over-cap?`/`reported-count` docstrings).
- Trimmed the vocab unqualified-envelope prose from 3 sites to one authoritative site (the defs).
- Removed the `parse-int*` docstring's defence of an `integer?` branch the code lacks.

## Gates (all green)

- `clojure -M:test` (mcp-base JVM): **157 tests / 419 assertions**, 0 fail.
- `shadow-cljs compile cljs-test && node out/cljs-test.js`: **8 tests / 39 assertions**, 0 fail.
- `mcp-conformance/wire-vocab` `clojure -M:test`: **41 tests / 475 assertions**, 0 fail (cross-host corpus unaffected).

Cross-ref: rf2-ee38b.19 (parent rf2-ee38b).