### PR TITLE
fix(causa): remediate 3-lens review findings (rf2-ee38b.2)

### DIFF
--- a/tools/causa/spec/012-Views.md
+++ b/tools/causa/spec/012-Views.md
@@ -1,6 +1,26 @@
 # 012-Views
 
-> **See also**: [`021-Dynamic-Panel-Designs.md` §3](021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8) for the canonical Views panel content design. The L3 tab display label is **`Views`** — the all-plural-domain-noun convention (Mike-direction 2026-05-21) keeps the tab vocabulary uniform across both tab sets (Views / Flows / Schemas / Routes / Machines are all plural). The tab key + spec doc continue to use `:views` / `012-Views.md` for stability. Per-panel content semantics moved to 021.
+> **SUPERSEDED by [`021-Dynamic-Panel-Designs.md` §3](021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8) (rf2-ee38b.2, 2026-05-23).**
+> The shipped Views panel implements 021 §3's lean **three-stacked-tables**
+> design (Level 1 subs / Level 2+ subs / Views — columns name · changed ·
+> inputs · read-by · code), per the rf2-8ve8z landing. The richer surface
+> this document describes below — three TEMPORAL groups (mounted /
+> re-rendered / unmounted), subs nested under views with inline return
+> values, ≥50 grid clustering, a component/sub group-by toggle, a
+> right-click component-filter chip, per-component inline drilldown
+> (props-diff + Fiber metadata), and the five-state sub-status glyph
+> taxonomy — is **NOT implemented** and is **not the destination**. The
+> file names it cites (`views_helpers.cljc`, `views_view.cljs`, a
+> `sub-status` classifier) do not exist; the live panel is
+> `panels/reactive_panel_view.cljs` + `panels/reactive_panel_subs.cljs`.
+> Read **021 §3** for the normative Views design. The material below is
+> retained as historical design exploration only — not normative spec.
+>
+> The L3 tab display label is **`Views`** — the all-plural-domain-noun
+> convention (Mike-direction 2026-05-21) keeps the tab vocabulary uniform
+> across both tab sets (Views / Flows / Schemas / Routes / Machines are all
+> plural). The tab key + spec doc continue to use `:views` / `012-Views.md`
+> for stability.
 
 ## Bug class
 

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -21,6 +21,16 @@ the registry's surface from this catalogue alone, without reading
 > separately; until then, treat any §Time-travel / §MCP server /
 > §Routes / §Schemas / §Hydration / §Effects / §Flows / §Performance
 > subsection as historical reference, not normative spec.
+>
+> **rf2-ee38b.2 follow-up (2026-05-23).** The dead `:rf.causa/selected-
+> dispatch-id` / `:rf.causa/selected-dispatch-frame` shim subs were
+> deleted (zero production consumers; the Event panel reads focus off the
+> spine `:rf.causa/focus`). Their rows are removed from §Event detail
+> below. A full regeneration of this catalogue from `registry_cljs_test`'s
+> `all-sub-names` / `all-event-names` / `all-fx-names` enumerations (the
+> authoritative live shape) remains the proper fix and is left for the
+> mayor — a 581-line blind regen inside a remediation PR carries its own
+> drift risk.
 
 The thesis: per [`spec/Conventions.md` §Library-owned prefixes](../../../spec/Conventions.md#library-owned-prefixes)
 and [`008-Embedding-Contract.md` §Registry-key isolation via `:rf.causa/*` prefix](./008-Embedding-Contract.md#registry-key-isolation-via-rfcausa-prefix),
@@ -110,9 +120,7 @@ Spec: [`007-UX-IA.md`](./007-UX-IA.md) §The default landing view, §10 Lock 7.
 
 | Sub | Inputs | Returns | When recomputes |
 |---|---|---|---|
-| `:rf.causa/selected-dispatch-id` | `db` | Dispatch-id keyword or `nil` (empty-state). | On selection-change events. |
-| `:rf.causa/selected-dispatch-frame` | `db` | Frame-id keyword the selected dispatch ran in, or `nil`. Resolved from the selected-dispatch ref (either `:selected-dispatch` map or `:selected-dispatch-id` keyword). | On selection-change events. |
-| `:rf.causa/event-detail` | `:rf.causa/trace-buffer`, `:rf.causa/selected-dispatch-id` | `{:cascades [...] :selected-dispatch-id ... :selected-cascade ...}` — composite. `:selected-cascade` is `nil` when no selection OR when the id is no longer in the buffer. | Buffer or selection change. |
+| `:rf.causa/event-detail` | `:rf.causa/cascades`, `:rf.causa/focus` | `{:cascades [...] :selected-dispatch-id ... :selected-dispatch-frame ... :selected-cascade ...}` — composite. Derives the focused cascade off the spine `:rf.causa/focus` (rf2-ee38b.2 removed the standalone `:rf.causa/selected-dispatch-id` / `-frame` shim subs — focus is the single source of truth; the `:selected-dispatch-id`/`-frame` KEYS in this composite's return map remain live). `:selected-cascade` is `nil` when no selection OR when the id is no longer in the buffer. | Cascades or focus change. |
 
 ### Events
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -572,9 +572,13 @@ as the developer scans.
 
 `<event-id>   ✓/✗/⚠ <outcome> · <duration-ms> · cascade #<id> [· SSR✓]`
 
-- Glyph + colour: `✓ green` for success, `✗ red` for handler exception
-  / unhandled `:rf.error/*`, `⚠ amber` for partial outcomes
-  (`:rf.warning/depth-exceeded`, `:rf.warning/schema-violation-skipped`).
+- Glyph + colour: classified off the universal `:op-type` severity axis
+  (Spec 009), not an enumerated op list. `✗ red` when the cascade's
+  `:other` bucket carries any `:op-type :error` / `:rf.error/*` trace
+  (handler exception, drain-depth overflow, flow-eval failure, fx/cofx
+  error, …); `⚠ amber` when it carries any `:op-type :warning` /
+  `:rf.warning/*` trace; `✓ green` otherwise. Error severity wins over a
+  co-resident warning.
 - `SSR✓` orientation badge when the focused event is
   `:rf.ssr/hydrated` / `:rf.ssr/hydration-complete`; omitted for
   purely-client-side cascades.

--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -1026,7 +1026,7 @@ Dense case:
 │                                                                       │
 │ 2 issues                                                              │
 │                                                                       │
-│ ⚠ ERROR    :rf.error/handler-threw                                    │
+│ ⚠ ERROR    :rf.error/handler-exception                               │
 │   Handler  :checkout/submit                                           │
 │   Message  AssertionError: cart-id must be string, got nil            │
 │   At       impl/events.cljs:88                                        │

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -171,7 +171,10 @@ implementation reality — ~40 symbols across 6 namespaces).
 (causa/set-target-frame! :app/main)
 
 (causa/load-theme css-string)
-;; Programmatically swap the theme (useful for editor-driven palette sync).
+;; Programmatically swap the palette: injects `css-string` as a dedicated
+;; <style> override appended last to <head> (so it wins on authoring order).
+;; Idempotent — successive calls replace the override; nil/blank clears it.
+;; Useful for editor-driven palette sync. No-op outside a DOM.
 ```
 
 The facade also re-exports the four highest-traffic config setters

--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -431,6 +431,26 @@ empty-state removal), PR #1439 (7-pattern text-audit cluster).
 - [`000-Vision.md`](./000-Vision.md) — Causa's claim; the cascade you
   can see, not the cascade you can read narration about.
 
+## Docstrings state the present contract, not the change history
+
+(rf2-ee38b.2) Source docstrings and section comments describe what the
+code does **now** — the present-state contract. Superseded-design
+rationale and bead lineage belong in commit messages and bead notes, not
+in the source the next reader must scan to learn the current behaviour.
+
+- **Good:** "Reads focus off the spine `:rf.causa/focus` — the single
+  source of truth."
+- **Avoid:** "This used to read `:selected-dispatch-id` (rf2-aaa), then
+  Mike changed it to the spine on 2026-05-19 (rf2-bbb) because the old
+  design double-wrote two slots…"
+
+A single bead reference is fine when it points a reader at the
+authoritative context (`per rf2-xxx`); a multi-paragraph archaeology of
+how the code reached its current shape is not. When editing a file,
+collapse any "this replaced X because…" passage you touch to a one-line
+present-tense statement. This is a judgement pass per file, never a bulk
+find-replace over the ~1.3K `rf2-*` references tree-wide.
+
 ## See also
 
 - `tools/causa/spec/017-Test-Coverage-Matrix.md` — feature-level coverage

--- a/tools/causa/spec/README.md
+++ b/tools/causa/spec/README.md
@@ -62,10 +62,10 @@ main read**.
   via the `:rf/causa` frame-provider.
 - **[011-Launch-Modes.md](011-Launch-Modes.md)** — In-app true-inline
   host and standalone-via-MCP remote-attach.
-- **[012-Views.md](012-Views.md)** — Views tab: three-group layout
-  (mounted / re-rendered / unmounted); subs nested under each view row;
-  cluster-large-grids; per-component inline drilldown. Replaces the
-  legacy Subscriptions panel.
+- **[012-Views.md](012-Views.md)** — _Superseded by [021 §3](021-Dynamic-Panel-Designs.md#3-the-view-panel-reactive-perspective--steps-7-8)
+  (rf2-ee38b.2)._ The shipped Views panel is 021 §3's lean three-stacked-tables
+  design; 012's richer three-temporal-group surface is unimplemented historical
+  design exploration. Read **021 §3** for the normative Views design.
 - **[013-Trace-Bus.md](013-Trace-Bus.md)** — The trace-bus + collector
   contract: the ring-buffer data plane every panel reads from, the
   consumer-side filter algebra, the `:sensitive?` privacy gate. Future:

--- a/tools/causa/src/day8/re_frame2_causa/core.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/core.cljs
@@ -54,12 +54,12 @@
   seam) live in their own namespaces by design — see the per-namespace
   documentation for the rationale on each."
   (:require [re-frame.core :as rf]
-            [re-frame.trace :as trace]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.keybinding :as keybinding]
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.preload :as preload]
-            [day8.re-frame2-causa.registry :as registry]))
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.theme.global-styles :as global-styles]))
 
 ;; ---- mount entry points (re-exports from mount.cljs) --------------------
 ;;
@@ -177,26 +177,20 @@
     (rf/dispatch [:rf.causa/set-target-frame frame-id]))
   nil)
 
-;; ---- TBD-impl stubs -----------------------------------------------------
-;;
-;; `load-theme` is promised by `spec/API.md` §Public CLJS API but the
-;; runtime CSS-swap plumbing has not landed. Calling it emits a
-;; `:rf.warning/*` trace event so the gap is visible in the trace stream
-;; (and surfaces in Causa's own Issues ribbon).
+;; ---- runtime theme override ---------------------------------------------
 
 (defn load-theme
-  "Programmatically swap the Causa shell's CSS theme. **TBD-impl.**
-  The theme module exists (`day8.re-frame2-causa.theme/*`) but the
-  runtime CSS-swap surface is not yet wired. This stub emits
-  `:rf.warning/causa-load-theme-not-yet-implemented` and returns nil.
+  "Programmatically swap the Causa shell's palette by handing in a CSS
+  string (typically a block re-declaring the `--rf-causa-*` custom
+  properties the shell reads). Useful for editor-driven palette sync.
 
-  Forward-compatible — host code may call with a CSS string today and
-  expect the impl to land under a follow-on bead."
-  [_css-string]
-  (trace/emit! :rf.warning
-               :rf.warning/causa-load-theme-not-yet-implemented
-               {:origin :causa
-                :where  'day8.re-frame2-causa.core/load-theme})
+  The CSS rides in a single dedicated `<style>` block appended LAST to
+  `<head>` so its rules win on authoring order against the built-in
+  per-theme block. Idempotent: successive calls REPLACE the override in
+  place; a nil / blank string clears it and restores the built-in
+  palette. No-op outside a DOM (server render / JVM). Returns nil."
+  [css-string]
+  (global-styles/set-host-theme-css! css-string)
   nil)
 
 ;; ---- config knob re-exports --------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
@@ -1,12 +1,22 @@
 (ns day8.re-frame2-causa.data-display.render
-  "Shared data-display renderer for Causa L4 panels (rf2-jgip1).
+  "Causa's lazy collapsible EDN tree-walker (rf2-jgip1).
 
-  The renderer is **ONE canonical component used everywhere data appears**
-  — App-db's huge nested map, the Event panel's coeffects + effects, the
-  Reactive panel's sub values, Trace ops' expanded payloads, Issues
-  `ex-data`. Operator learns one interaction pattern; applies it
-  everywhere. Per spec/021-Dynamic-Panel-Designs.md §10 (canonical ·
-  merged in #1720).
+  This is the tree ENGINE — the collapsible, diff-aware, path-clickable
+  walker that renders a CLJS value as a hierarchical expand/collapse
+  tree. It is one of the two engines behind the canonical
+  `views/edn-widget/widget` facade (the other is `cljs-devtools-render`,
+  which owns CLJS-aware leaf formatting). Panels reach for the
+  `edn-widget` facade (`browse` / `diff` / `mini`), not this ns
+  directly; the facade routes collection-tree + diff + sticky-expansion
+  concerns here. The structural difftastic-style renderer
+  (`diff/render`) is a separate surface for the section-grouped diff
+  engine — not part of this tree.
+
+  Where this tree shows up (via the facade): App-db's nested map, the
+  Event panel's coeffects + effects, the Reactive panel's sub values,
+  Trace ops' expanded payloads, Issues `ex-data`. Operator learns one
+  expand/collapse + path-click interaction. Per
+  spec/021-Dynamic-Panel-Designs.md §10 (merged in #1720).
 
   ## Capabilities (LOCKED per super-prompt B.9)
 

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -368,9 +368,9 @@
   - `:trace-buffer` — seeded from the trace-bus atom (rf2-in6l2). The
     atom collects pre-mount traces; the seed lifts them into the
     reactive slot at first Ctrl+Shift+C. Subsequent
-    `trace-bus/collect-trace!` calls dispatch
-    `:rf.causa/note-trace-event` into `:rf/causa` so the sub fires
-    IMMEDIATELY on every push.
+    `trace-bus/collect-trace!` calls request a coalesced
+    `:rf.causa/sync-trace-buffer` (rf2-wq6gx) so the sub fires on every
+    push without one dispatch per trace event.
 
   - `:epoch-history` + `:target-frame` (rf2-1barg + rf2-boyc2) —
     seeded together via `:rf.causa/set-target-frame` so the slot is

--- a/tools/causa/src/day8/re_frame2_causa/panel_registry.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panel_registry.cljc
@@ -81,27 +81,16 @@
 ;; ---- registry atom ------------------------------------------------------
 
 (defonce ^{:doc "The L4 tab registry. Map of `[mode tab-id] → tab-entry`
-                 — composite key because the same `:id` may legitimately
-                 register against multiple modes (e.g. `:routes` exists
-                 as both the Dynamic Routing tab — `panels/routing.cljs`
-                 (focused-event lens) — and the Static Routes catalogue
-                 tab — `static/routes/panel.cljs` (browse-all); same id,
-                 different content). Atom (not a defonce on a literal
-                 map) so per-panel `install!` mutations are visible to
-                 readers without re-loading this ns. Re-loading this ns
-                 under shadow-cljs
-                 `:after-load` preserves the atom's contents — `defonce`
-                 semantics.
-
-                 Tabs registered against multiple modes (a single tab
-                 entry with `:modes #{:dynamic :static}`) materialise
-                 as ONE entry per `[mode id]` key — the registration
-                 mutation expands the `:modes` set across keys so
-                 lookup-by-mode is a constant-time `get`. Today every
-                 panel registers a single-mode entry so the expansion
-                 is the identity; the multi-mode pathway is structural
-                 insurance for the future routing/schemas-style verbs
-                 that might span modes."}
+                 — the key is composite because the same `:id` legitimately
+                 registers against both modes via SEPARATE single-mode
+                 entries: `:routes` is the Dynamic Routing tab
+                 (`panels/routing.cljs`, focused-event lens) AND the Static
+                 Routes catalogue tab (`static/routes/panel.cljs`,
+                 browse-all) — same id, different panel, keyed apart by
+                 mode. Atom (not a defonce on a literal map) so per-panel
+                 `install!` mutations are visible to readers without
+                 re-loading this ns; `defonce` preserves contents across
+                 shadow-cljs `:after-load`."}
   registry
   (atom {}))
 
@@ -150,34 +139,29 @@
 ;; ---- mutation -----------------------------------------------------------
 
 (defn reg-l4-tab!
-  "Register an L4 tab entry. Idempotent — re-registering the same
-  `[mode id]` replaces the prior entry (same posture as re-frame's
-  registrar). Returns the registered entry.
+  "Register an L4 tab entry under `[mode id]`. Idempotent —
+  re-registering the same `[mode id]` replaces the prior entry (same
+  posture as re-frame's registrar). Returns the registered entry.
 
   Each panel's `(defn install! [] ...)` calls this alongside its
   `reg-sub` / `reg-event-*` / `reg-fx` registrations so the tab
-  inventory is declarative-per-panel rather than hard-coded in
-  the shell.
+  inventory is declarative-per-panel rather than hard-coded in the
+  shell.
 
-  Tabs registered against multiple modes (`:modes #{:dynamic :static}`)
-  materialise as one entry per `[mode id]` key — every mode in the
-  set gets its own entry pointing at the same metadata. Today every
-  panel registers a single-mode entry; the multi-mode pathway is
-  insurance for cross-mode verbs that might land later."
+  `:modes` is a single-element set (`#{:dynamic}` or `#{:static}`) —
+  a panel belongs to exactly one mode's tab bar. The same `:id` in
+  both modes is two separate registrations of two separate panels
+  (e.g. Dynamic Routing vs Static Routes), keyed apart by mode."
   [{:keys [id label mnem modes panel order placeholder-bead] :as tab}]
   {:pre [(keyword? id)
          (string? label)
          (or (nil? mnem) (string? mnem))
          (set? modes)
-         (seq modes)
+         (= 1 (count modes))
          (every? #{:dynamic :static} modes)
          (or (nil? order) (number? order))
          (or (nil? placeholder-bead) (string? placeholder-bead))]}
-  (swap! registry
-         (fn [reg]
-           (reduce (fn [acc mode] (assoc acc [mode id] tab))
-                   reg
-                   modes)))
+  (swap! registry assoc [(first modes) id] tab)
   tab)
 
 (defn unreg-l4-tab!

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_helpers.cljc
@@ -52,8 +52,8 @@
 
   The cascade pivots on a single anchor: a `:rf.machine.lifecycle/
   destroyed` or `:rf.machine/destroyed` trace event whose `:reason`
-  is one of the cancellation reasons (`:explicit`,
-  `:parent-unmount-cascade`, `:parent-frame-destroyed`). The anchor's
+  is one of the cancellation reasons the substrate emits (`:explicit`,
+  `:parent-frame-destroyed`, `:actor-destroyed`). The anchor's
   `:dispatch-id` (when present) is the cascade boundary; aborts that
   share the same `:dispatch-id` (or land within a small wall-clock
   window of the anchor for the actor-destroy case where the abort
@@ -114,13 +114,13 @@
     :rf.machine.spawn/cancelled-on-join-resolution})
 
 (def ^:private cancellation-reasons
-  "Reasons that classify a destroy as part of a cancellation cascade
-  (per Spec 009 §Trace events L110-L119). `:rf.machine/finished` is
-  excluded — it represents a natural termination, not a cancellation."
+  "Destroy `:reason` values that classify a destroy as part of a
+  cancellation cascade — the reasons the substrate actually stamps on
+  `:rf.machine/destroyed` traces (per `machines/lifecycle_fx/destroy`,
+  `frame_destroy`, and the destroy-trace-shape tests). `:rf.machine/finished`
+  is excluded — it is a natural termination, not a cancellation."
   #{:explicit
-    :parent-unmount-cascade
     :parent-frame-destroyed
-    :rf.machine/cancelled
     :actor-destroyed})
 
 (def ^:const default-actor-destroy-window-ms

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -79,15 +79,6 @@
 
 ;; ---- selection plumbing (survives from v1) -----------------------------
 
-(defn- selected-ref
-  "Normalise the selection slot. Newer callers pass
-  `{:dispatch-id <id> :frame <frame-id>}`; older callers continue to
-  resolve by raw id."
-  [selection]
-  (if (map? selection)
-    selection
-    {:dispatch-id selection}))
-
 (defn- cascade-has-event?
   "True iff `cascade` carries a real `:event` vector. The `:ungrouped`
   bucket produced by `re-frame.trace.projection/group-cascades` for
@@ -104,11 +95,13 @@
   (last (filterv cascade-has-event? cascades)))
 
 (defn- cascade-matches-selection?
-  [{:keys [dispatch-id frame]} selection]
-  (let [{selected-id :dispatch-id selected-frame :frame} (selected-ref selection)]
-    (and (= selected-id dispatch-id)
-         (or (nil? selected-frame)
-             (= selected-frame frame)))))
+  "True iff `cascade` is the one named by the `selection`
+  `{:dispatch-id <id> :frame <frame-id>}` map. A nil selection frame
+  matches any frame (frame-agnostic selection)."
+  [{:keys [dispatch-id frame]} {selected-id :dispatch-id selected-frame :frame}]
+  (and (= selected-id dispatch-id)
+       (or (nil? selected-frame)
+           (= selected-frame frame))))
 
 ;; ---- pure projection helpers --------------------------------------------
 
@@ -143,29 +136,53 @@
   handler)
 
 (defn- has-handler-exception?
-  "True iff the cascade's `:other` bucket carries a handler exception
-  trace. Used to swap the cascade-outcome glyph from ✓ to ✗ and to
-  suppress §5/§6 (the handler never returned)."
+  "True iff the cascade's `:other` bucket carries the specific
+  `:rf.error/handler-exception` trace — the handler threw and never
+  returned. This is the narrow signal used to SUPPRESS §5/§6 (effects
+  returned / fx handlers ran): when the handler itself blew up there
+  were no effects to walk. The broader `has-error?` predicate (any
+  `:op-type :error` / `:rf.error/*` op) drives the outcome glyph; this
+  one is reserved for the section-suppression behaviour where only a
+  thrown handler is meaningful. Pure predicate over `:other`."
   [{:keys [other]}]
   (boolean
-    (some (fn [ev]
-            (let [op (:operation ev)]
-              (or (= :rf.error/handler-exception op)
-                  (= :rf.error/handler-threw op))))
+    (some (fn [ev] (= :rf.error/handler-exception (:operation ev)))
           (or other []))))
 
-(defn- has-warning?
-  "True iff the cascade carries a non-fatal warning that should pivot
-  the outcome glyph to ⚠ (amber). Per §5.1 the warning set is:
-  depth-exceeded, schema-violation-then-skipped. Pure predicate over
-  the cascade's `:other` bucket."
+(defn- error-trace?
+  "True iff `ev` is an error trace — classified by the universal
+  severity axis (`:op-type :error`, per Spec 009) with a namespace
+  fallback for any `:rf.error/*` operation. Mirrors the namespace-based
+  idiom in `shell/row-badges` and `issues-ribbon-helpers/op-type->severity`
+  rather than enumerating individual ops the substrate may add over time."
+  [{:keys [op-type operation] :as _ev}]
+  (or (= :error op-type)
+      (and (keyword? operation) (= "rf.error" (namespace operation)))))
+
+(defn- warning-trace?
+  "True iff `ev` is a warning trace — `:op-type :warning` (per Spec 009)
+  with an `:rf.warning/*` namespace fallback. Severity-driven, not
+  op-enumerated."
+  [{:keys [op-type operation] :as _ev}]
+  (or (= :warning op-type)
+      (and (keyword? operation) (= "rf.warning" (namespace operation)))))
+
+(defn- has-error?
+  "True iff the cascade carries ANY error trace (severity `:error` /
+  `:rf.error/*`) in its `:other` bucket — handler exceptions, drain-depth
+  overflow, flow-eval failures, fx/cofx errors, machine action throws,
+  etc. Drives the outcome glyph to ✗. Pure predicate over `:other`."
   [{:keys [other]}]
-  (boolean
-    (some (fn [ev]
-            (let [op (:operation ev)]
-              (or (= :rf.warning/depth-exceeded op)
-                  (= :rf.warning/schema-violation-skipped op))))
-          (or other []))))
+  (boolean (some error-trace? (or other []))))
+
+(defn- has-warning?
+  "True iff the cascade carries any non-fatal warning that should pivot
+  the outcome glyph to ⚠ (amber). Classified by the universal severity
+  axis (`:op-type :warning` / `:rf.warning/*`), so every warning the
+  substrate emits flips the glyph — not a hand-maintained op enumeration.
+  Pure predicate over the cascade's `:other` bucket."
+  [{:keys [other]}]
+  (boolean (some warning-trace? (or other []))))
 
 (defn cascade-outcome
   "Project a cascade record into a outcome-summary map for the top-of-
@@ -185,9 +202,9 @@
         ssr?        (or (= :rf.ssr/hydrated event-id)
                         (= :rf.ssr/hydration-complete event-id))
         [outcome glyph] (cond
-                          (has-handler-exception? cascade) [:error   "✗"]
-                          (has-warning? cascade)           [:warning "⚠"]
-                          :else                            [:ok      "✓"])]
+                          (has-error? cascade)   [:error   "✗"]
+                          (has-warning? cascade) [:warning "⚠"]
+                          :else                  [:ok      "✓"])]
     {:event-id    event-id
      :glyph       glyph
      :outcome     outcome
@@ -1510,27 +1527,16 @@
 
 (defn install!
   "Idempotent install for the Event Detail panel's Causa-side
-  registrations. Owns the selection slot the panel + its cross-panel
-  `:rf.causa/cascades` consumers read off:
+  registrations:
 
-    - `:rf.causa/selected-dispatch-id` sub (cascade selection)
-    - `:rf.causa/event-detail` composite sub
-    - `:rf.causa/select-dispatch-id` event
-    - `:rf.causa/clear-selected-dispatch-id` event
+    - `:rf.causa/event-detail` composite sub (the panel's single read —
+      derives the focused cascade off the spine `:rf.causa/focus`)
+    - `:rf.causa/select-dispatch-id` event (writes focus through the spine)
+    - `:rf.causa/clear-selected-dispatch-id` event (resets focus to LIVE)
 
   The cross-panel `:rf.causa/cascades` projection itself lives in
-  `registry.cljs` — it is shared with the Performance panel."
+  `registry.cljs`."
   []
-  (rf/reg-sub :rf.causa/selected-dispatch-id
-    (fn [db _query]
-      (:dispatch-id (selected-ref (or (get db :selected-dispatch)
-                                      (get db :selected-dispatch-id))))))
-
-  (rf/reg-sub :rf.causa/selected-dispatch-frame
-    (fn [db _query]
-      (:frame (selected-ref (or (get db :selected-dispatch)
-                                (get db :selected-dispatch-id))))))
-
   ;; Event-detail composite — produces everything the panel needs in
   ;; one read so the view stays a thin renderer. Reads the EFFECTIVE
   ;; focused dispatch-id off the spine sub (`:rf.causa/focus`); spine
@@ -1587,7 +1593,7 @@
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
       (-> db
-          (dissoc :selected-dispatch :selected-dispatch-id :selected-epoch-id)
+          (dissoc :selected-epoch-id)
           (update :focus (fnil assoc {})
                   :dispatch-id nil
                   :epoch-id    nil

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
@@ -389,13 +389,11 @@
                         :flows-skipped    flows-skipped}})))
 
 (defn- triggered-by
-  "Reconstruct the triggering event from the epoch record. Reuses the
-  `:event` slot the spine seeds on every record (per spec/018)."
+  "The triggering event vector for the epoch. Reads the `:event` slot
+  the spine seeds on every epoch record (per spec/018) — the single
+  reliable source. Returns nil for records without a seeded event."
   [record]
-  (or (:event record)
-      (some (fn [e] (when (= :rf/event-dispatched (op-kw e))
-                      (or (:payload e) (:args e))))
-            (:trace-events record))))
+  (:event record))
 
 (defn- seed-paths
   "Derive seed paths from the cascade `:db-before` → `:db-after` diff.

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -437,85 +437,34 @@
     ;; registrar replaces in place (rf2-fq491).
     (mount/install-fx!)
 
-    ;; ---- trace-buffer mirror events (rf2-in6l2 / rf2-wq6gx) -------
+    ;; ---- trace-buffer mirror events -------------------------------
     ;;
     ;; The reactive surface for the layer-1 `:rf.causa/trace-buffer`
     ;; sub is Causa's `:rf/causa` app-db `:trace-buffer` slot. Three
-    ;; events drive that slot:
+    ;; events drive that slot, all flagged `:rf.trace/no-emit? true`
+    ;; (rf2-qsjda) so the mirror dispatch does not re-enter the trace
+    ;; fan-out and loop:
     ;;
     ;;   `:rf.causa/sync-trace-buffer` — wholesale overwrite with a
-    ;;     full buffer vector. The PRODUCTION write path under
-    ;;     rf2-wq6gx: `trace-bus/request-mirror-sync!` coalesces every
-    ;;     same-tick mirror request (collect-trace! / clear-buffer! /
-    ;;     set-buffer-depth!) into ONE dispatch of this event carrying
-    ;;     `@trace-bus/buffer-state` — capping the cascade at depth 1
-    ;;     regardless of host trace-event volume. Also used by
-    ;;     `mount.cljs/ensure-causa-frame!` for the first-mount seed.
+    ;;     full buffer vector. The PRODUCTION write path:
+    ;;     `trace-bus/request-mirror-sync!` coalesces every same-tick
+    ;;     mirror request into ONE dispatch carrying the atom snapshot,
+    ;;     capping the cascade at depth 1 regardless of trace volume.
+    ;;     Also seeds the slot at first mount.
     ;;
     ;;   `:rf.causa/note-trace-event` — single-event append with
-    ;;     capped-vector eviction. The legacy per-event mirror under
-    ;;     rf2-in6l2; the production trace-bus collector no longer
-    ;;     dispatches this (replaced by the coalesced sync above to
-    ;;     fix the drain-depth saturation regression — rf2-wq6gx).
-    ;;     Retained as a registered handler for direct callers
-    ;;     (consumer-test surface in
-    ;;     `tools/causa/test/.../registry_cljs_test.cljs` and
-    ;;     `panels/trace_view_cljs_test.cljs`).
+    ;;     capped-vector eviction. No production caller (the coalesced
+    ;;     sync above owns the live path); retained as a directly-callable
+    ;;     append helper for the test surface.
     ;;
     ;;   `:rf.causa/clear-trace-buffer` — drop the slot entirely.
-    ;;     The production clear path under rf2-wq6gx routes through
-    ;;     the coalesced sync (an empty atom snapshot clears the
-    ;;     slot), but this event is retained for direct callers and
-    ;;     for the test surface that asserts the documented contract.
-    ;;
-    ;; Per rf2-qsjda + the matching `:rf.causa/note-sensitive-
-    ;; suppressed` pattern: `:rf.trace/no-emit? true` opts every
-    ;; handler in this group out of framework trace emission. Without
-    ;; it the dispatch would emit `:rf.event/dispatched` etc. back
-    ;; through the trace-cb fan-out, the collector would see its own
-    ;; self-emit, and the cascade would loop until `drain-depth-
-    ;; default` terminated it.
-    ;;
-    ;; ## Why snapshot semantics obviate the rf2-z4fza dedup walk
-    ;;
-    ;; The original rf2-in6l2 per-event mirror dispatched
-    ;; `:rf.causa/note-trace-event` for every trace event AND seeded
-    ;; via `:rf.causa/sync-trace-buffer` at mount time. The seed and
-    ;; the per-event mirror raced inside `ensure-causa-frame!`: the
-    ;; `(rf/reg-frame :rf/causa {})` call synchronously emitted a
-    ;; `:frame/created` trace event whose note-trace-event dispatch
-    ;; queued before the seed's dispatch-sync ran; once the queued
-    ;; dispatch drained, it re-pushed the same `:id` already inside
-    ;; the seeded slot, producing duplicate React keys (per rf2-z4fza
-    ;; the Trace panel keys `<li>`s on `t:<id>`). The fix was an
-    ;; O(slot) dedup walk inside `:rf.causa/note-trace-event`.
-    ;;
-    ;; Under the rf2-wq6gx coalesced-snapshot design the production
-    ;; path NEVER appends per-event into the slot — every mirror is a
-    ;; wholesale overwrite. Seeds and post-seed syncs idempotently
-    ;; write the atom's current contents; a duplicate `:id` is
-    ;; structurally impossible in production. The dedup walk inside
-    ;; `:rf.causa/note-trace-event` is retained because the handler
-    ;; is still callable by tests that exercise the legacy per-event
-    ;; shape — there it preserves the rf2-z4fza contract those tests
-    ;; assert.
-    ;;
-    ;; rf2-td380: the `:trace-feed-state` incremental snapshot
-    ;; (rf2-44vzy) was the read-side substrate for the OLD Trace feed,
-    ;; which scoped the global buffer by `:dispatch-id`. The Trace
-    ;; panel now reads the focused epoch record's `:trace-events`
-    ;; directly (epoch-scoped), so the snapshot has no consumer — it
-    ;; is gone, and these handlers single-write `:trace-buffer` again.
     (rf/reg-event-db :rf.causa/note-trace-event
       {:rf.trace/no-emit? true}
       (fn [db [_ event]]
-        (let [buf   (get db :trace-buffer [])
-              depth (trace-bus/current-depth)
-              ev-id (:id event)]
-          (if (and ev-id (some #(= ev-id (:id %)) buf))
-            db
-            (assoc db :trace-buffer
-                   (trace-bus/push buf depth event))))))
+        (assoc db :trace-buffer
+               (trace-bus/push (get db :trace-buffer [])
+                               (trace-bus/current-depth)
+                               event))))
 
     ;; Clear the mirrored slot in lockstep with the trace-bus atom
     ;; (dispatched from `trace-bus/clear-buffer!` in CLJS). Per

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -69,12 +69,15 @@
 
   ## Detail panel (L4)
 
-  Renders the active tab's projection of the focused event. Tabs
-  reuse the existing per-panel views where possible (Event tab →
-  `event-detail/Panel`, App-db → `app-db-diff/Panel`, Trace →
-  `trace/Panel`, Machines → `machine-inspector/Panel`, Routing →
-  `routing/Panel`, Issues → `issues-ribbon/Panel`). The Views tab
-  is a stub pending the §5.3 per-view content design.
+  Renders the active tab's projection of the focused event. The L4
+  panel is registry-driven (rf2-2moh1): each tab registers its
+  `:panel` via `panel-registry/reg-l4-tab!` and the shell mounts the
+  active tab through `panel-registry/tab-by-id`. The seven Dynamic
+  tabs all mount real panels — Event → `event-detail/Panel`, App-db →
+  `app-db-diff/Panel`, Views → `reactive-panel/Panel` (the 021 §3
+  three-stacked-tables design, rf2-8ve8z), Trace → `trace/Panel`,
+  Machines → `machine-inspector/Panel`, Routing → `routing/Panel`,
+  Issues → `issues-ribbon/Panel`.
 
   ## Frame isolation (rf2-tijr Option C + rf2-in6l2)
 
@@ -1783,9 +1786,12 @@
    "Unknown tab: " [:code (pr-str selected)]])
 
 (rf/reg-view detail-panel
-  "L4 detail panel — case-switch on `:rf.causa/selected-tab`. Reuses
-  existing Panel views for Event / App-db / Trace / Machines /
-  Routing / Issues; Views is a stub pending follow-on impl.
+  "L4 detail panel — mounts the active `:rf.causa/selected-tab`'s panel
+  via the registry-driven `panel-registry/tab-by-id :dynamic` lookup
+  (rf2-2moh1). All seven Dynamic tabs mount real panels (Event /
+  App-db / Views / Trace / Machines / Routing / Issues); the former
+  literal case-switch is gone. An unrecognised tab falls back to
+  `unknown-tab-stub`.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`. The wrapping `<div>` paints `bg-2` as a contrast
@@ -1795,8 +1801,8 @@
   ## rf2-5kfxe.3 — 180ms cross-fade on tab switch
 
   Spec/007 §Motion + animation calls for a 180ms cross-fade when the
-  user switches L4 tabs. The case-switch above is otherwise an instant
-  DOM swap. The trick: wrap the chosen panel in an inner `<div>`
+  user switches L4 tabs. The registry mount below is otherwise an
+  instant DOM swap. The trick: wrap the chosen panel in an inner `<div>`
   *keyed on `selected`*. When the key changes Reagent unmounts the
   previous wrapper + mounts a new one, which auto-plays the
   `rf-causa-fade-in` CSS animation declared in

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -39,23 +39,16 @@
   `:dispatch-id` are always derived from the current cascade vector —
   never stale.
 
-  ## Shim to legacy selection slots
+  ## `:selected-epoch-id` shim slot
 
-  Pre-rf2-adve5, two panels owned their own selection: event-detail
-  owned `:selected-dispatch-id` / `:selected-dispatch` and time-travel
-  owned `:selected-epoch-id`. Spec 018 §6 collapses those into the
-  spine, but legacy event handlers + their sibling subs continue to
-  exist (each panel reads its own slot directly today). The spine's
-  `:rf.causa/focus-cascade` event writes BOTH the new `:focus` slot
-  AND the legacy `:selected-dispatch-id` slot so existing panels keep
-  rendering with no per-panel change.
-
-  The legacy `:rf.causa/select-dispatch-id` and `:rf.causa/select-
-  epoch` events also write through the spine (in their existing
-  install! fns under event_detail.cljs / time_travel_events.cljs) so
-  the other direction shims too — a click in the existing Time Travel
-  panel updates the spine, and a click in a future spine-aware list
-  updates the legacy slots."
+  Spec 018 §6 collapses per-panel selection into the spine. The one
+  surviving mirror is `:selected-epoch-id`: the spine reducers stamp it
+  alongside `:focus`'s `:epoch-id` so the App-DB-diff / Views panels can
+  follow the focused epoch through `epoch.cljs`'s `:selected-epoch-id`
+  sub → `app_db_diff_subs`. The Event panel reads focus directly off the
+  `:rf.causa/event-detail` composite (derived from the spine), so the
+  former `:selected-dispatch-id` / `:selected-dispatch` mirror slots are
+  gone — there is no longer a dual-write for them."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.config :as config]
@@ -408,10 +401,9 @@
   "Pure reducer for the `:rf.causa/focus-cascade <id>` event. Writes
   `:dispatch-id` into the `:focus` slot, picks the spine `:mode`,
   stamps `:epoch-id` (the cascade's settling epoch primary key per
-  spec/018 §6 Spine events), and shims the legacy
-  `:selected-dispatch-id` / `:selected-dispatch` / `:selected-epoch-
-  id` slots so the existing event-detail / machine-inspector / app-db
-  / time-travel panels keep rendering without per-panel change.
+  spec/018 §6 Spine events), and mirrors `:epoch-id` into the
+  `:selected-epoch-id` shim slot the App-DB-diff / Views panels follow
+  (epoch.cljs sub → app_db_diff_subs).
 
   ## Mode selection (rf2-xzzih)
 
@@ -444,18 +436,20 @@
                           :mode        mode
                           :previewing? false)
        frame-id   (assoc-in [:focus :frame] frame-id)
-       ;; Legacy shim — panels reading these slots stay live.
-       true       (assoc :selected-dispatch-id dispatch-id
-                         :selected-epoch-id    epoch-id
-                         :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
-                                                 frame-id (assoc :frame frame-id)))))))
+       ;; `:selected-epoch-id` is the live App-DB-diff shim slot
+       ;; (epoch.cljs sub → app_db_diff_subs) — App-DB / Views follow the
+       ;; spine's focused epoch through it. The dispatch-id slots are gone:
+       ;; the Event panel reads focus off the `:rf.causa/event-detail`
+       ;; composite (which derives off the spine), not a mirrored db slot.
+       true       (assoc :selected-epoch-id epoch-id)))))
 
 (defn focus-step-reducer
   "Pure reducer for `:rf.causa/focus-cascade-prev` / `-next`. Steps
   the `:dispatch-id` through the cascade vector by `delta` (-1 or
   +1), resolves the cascade's settling `:epoch-id` from
-  `epoch-history` (per spec/018 §6 Spine events), updates the legacy
-  shim slots, and flips mode based on the step's outcome — stepping
+  `epoch-history` (per spec/018 §6 Spine events), mirrors it into the
+  `:selected-epoch-id` shim slot, and flips mode based on the step's
+  outcome — stepping
   back from head → :retro; stepping forward back to head → :live (the
   user has scrubbed home).
 
@@ -530,18 +524,16 @@
                             :previewing? false
                             :paused? false)
            frame-id (assoc-in [:focus :frame] frame-id)
-           true     (assoc :selected-dispatch-id new-id
-                           :selected-epoch-id    epoch-id
-                           :selected-dispatch    (cond-> {:dispatch-id new-id}
-                                                   frame-id (assoc :frame frame-id)))))))))
+           ;; `:selected-epoch-id` is the live App-DB-diff shim (see
+           ;; focus-cascade-reducer); the dispatch-id slots are gone.
+           true     (assoc :selected-epoch-id epoch-id)))))))
 
 (defn follow-head-reducer
   "Pure reducer for `:rf.causa/follow-head`. Snaps the spine to LIVE,
   clears the pinned id (`:dispatch-id nil` means 'track head'), and
   clears `:paused?` so the LIVE buffer flow resumes. Also clears the
-  legacy `:selected-dispatch-id` / `:selected-epoch-id` slots in
-  lockstep so the event-detail / app-db / time-travel panels return
-  to their LIVE-tracking landing views."
+  `:selected-epoch-id` shim slot so the App-DB / Views panels return to
+  their LIVE-tracking landing views."
   [db]
   (-> db
       (update :focus (fnil assoc {})
@@ -550,7 +542,7 @@
               :mode :live
               :paused? false
               :previewing? false)
-      (dissoc :selected-dispatch :selected-dispatch-id :selected-epoch-id)))
+      (dissoc :selected-epoch-id)))
 
 (defn toggle-live-pause-reducer
   "Pure reducer for `:rf.causa/toggle-live-pause`. Toggles `:paused?`

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -1505,3 +1505,45 @@
     (inject-grain-style!)
     (reset! installed? true))
   nil)
+
+;; ---- host-supplied theme override (rf2-ee38b.2) -------------------------
+;;
+;; The public `core/load-theme` entry point lets an embedding host swap the
+;; Causa shell's palette by handing in a CSS string (e.g. editor-driven
+;; palette sync). The override rides in a single dedicated `<style>` block
+;; appended LAST to `<head>`, so its rules win on authoring order against
+;; the built-in `inject-themes-style!` block. Re-injecting REPLACES the
+;; node's text (not append), so successive calls swap cleanly and an empty
+;; / nil string clears the override.
+
+(def ^:private host-theme-style-id
+  "rf-causa-host-theme")
+
+(defn set-host-theme-css!
+  "Install (or replace) the host-supplied theme override `<style>` block.
+  `css` is an arbitrary CSS string — typically a block re-declaring the
+  `--rf-causa-*` custom properties the shell reads. Idempotent on id:
+  successive calls overwrite the same node so the theme swaps in place.
+  A nil / blank string clears the override. No-op outside a DOM."
+  [css]
+  (when (and (exists? js/document)
+             (.-head js/document)
+             (.-createElement js/document)
+             (.-getElementById js/document))
+    (let [existing (.getElementById js/document host-theme-style-id)]
+      (cond
+        ;; Clear: blank / nil drops the override node entirely.
+        (or (nil? css) (= "" (.trim (str css))))
+        (when existing (.remove existing))
+
+        ;; Replace the text of the existing node.
+        existing
+        (set! (.-textContent existing) (str css))
+
+        ;; First install — append last so it outranks the built-in block.
+        :else
+        (let [node (.createElement js/document "style")]
+          (set! (.-id node) host-theme-style-id)
+          (.appendChild node (.createTextNode js/document (str css)))
+          (.appendChild (.-head js/document) node)))))
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -416,6 +416,16 @@
 
 ;; ---- consumer-side filter ------------------------------------------------
 ;;
+;; FORWARD-COMPAT SURFACE — NO CURRENT PRODUCTION CALLER (rf2-ee38b.2).
+;; The Trace panel dropped its filtering UI (rf2-gkczt, Mike-direction
+;; 2026-05-22); `build-filter-predicate` / `filter-events` are retained
+;; deliberately as the framework-parity consumer primitive (the algebra
+;; a future buffer-slicing panel will reuse rather than re-implement) and
+;; are exercised only by `filter_vocab_consumer_cljs_test`. That suite is
+;; a contract guard, NOT live-path coverage — do not read its green as
+;; proof a panel consumes this. Mayor call deferred: remove both fns +
+;; the consumer test if no buffer-slicing panel is on the roadmap.
+;;
 ;; Causa's panels slice the buffer by the same filter vocabulary the
 ;; framework exposes on `(rf/trace-buffer opts)` per Spec 009 §Retain-N
 ;; trace ring buffer + §Filter vocabulary — the 13-axis vocabulary

--- a/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/core_cljs_test.cljs
@@ -18,9 +18,11 @@
      rf2-qy0nu; the 4-layer shell switches via `:rf.causa/selected-
      tab` and the API is gone.)
 
-  3. **TBD stubs do not crash.** `load-theme` emits a
-     `:rf.warning/*` trace event and returns nil — host code that
-     wires the call ahead of the impl must not throw."
+  3. **`load-theme` is a safe no-op without a DOM.** It injects a
+     host-supplied CSS override into `<head>` when a DOM is present
+     (rf2-ee38b.2 wired it through `global-styles/set-host-theme-css!`);
+     under node-test there is no `js/document`, so it must return nil
+     without throwing for any input (CSS string / empty / nil)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -111,21 +113,26 @@
       (is (= [[:rf.causa/set-target-frame :app/main]] @seen)
           "facade dispatches the right event with the right arg"))))
 
-;; ---- (3) TBD stubs — emit warning trace, return nil --------------------
+;; ---- (3) load-theme — DOM-bearing impl, no-op without a DOM -------------
 
-(deftest load-theme-emits-warning-trace
-  (testing "load-theme emits :rf.warning/causa-load-theme-not-yet-implemented and returns nil"
+(deftest load-theme-is-safe-without-document
+  (testing "rf2-ee38b.2 — load-theme is wired through
+            global-styles/set-host-theme-css!. Under node-test there is
+            no js/document, so it returns nil without throwing for any
+            input and emits NO warning trace (the old not-yet-implemented
+            stub is gone). DOM-bearing CSS injection is exercised by the
+            browser target."
     (preload/register-trace-collector!)
     (let [result (core/load-theme ".foo { color: red; }")
           events (trace-bus/buffer)
-          theme-event (first (filter #(= :rf.warning/causa-load-theme-not-yet-implemented
-                                         (:operation %))
-                                     events))]
-      (is (nil? result) "stub returns nil")
-      (is (some? theme-event)
-          "trace bus carries the warning emit")
-      (is (= :causa (get-in theme-event [:tags :origin]))
-          "warning is tagged :origin :causa"))))
+          stale  (filter #(= :rf.warning/causa-load-theme-not-yet-implemented
+                             (:operation %))
+                         events)]
+      (is (nil? result) "load-theme returns nil")
+      (is (empty? stale)
+          "no not-yet-implemented warning — the stub is gone")
+      (is (nil? (core/load-theme ""))  "empty string is a safe no-op")
+      (is (nil? (core/load-theme nil)) "nil is a safe no-op"))))
 
 ;; ---- init! contract ----------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_helpers_cljs_test.cljc
@@ -134,7 +134,10 @@
   (is (false? (h/abort-event? (destroy-ev {:machine-id :x})))))
 
 (deftest cancellation-anchor?-true-for-cancel-reasons
-  (doseq [r [:explicit :parent-unmount-cascade :parent-frame-destroyed]]
+  ;; rf2-ee38b.2 — pinned to the destroy reasons the substrate actually
+  ;; stamps (:explicit / :parent-frame-destroyed / :actor-destroyed);
+  ;; the phantom :parent-unmount-cascade was never emitted.
+  (doseq [r [:explicit :parent-frame-destroyed :actor-destroyed]]
     (is (true? (h/cancellation-anchor?
                  (destroy-ev {:machine-id :x :reason r}))))))
 
@@ -241,10 +244,10 @@
                             :reason :explicit})
                (destroy-ev {:machine-id :child-a :dispatch-id 1
                             :time 1011 :id 3
-                            :reason :parent-unmount-cascade})
+                            :reason :parent-frame-destroyed})
                (destroy-ev {:machine-id :child-b :dispatch-id 1
                             :time 1012 :id 4
-                            :reason :parent-unmount-cascade})
+                            :reason :parent-frame-destroyed})
                (http-abort-ev {:request-id :r1 :actor-id :child-a
                                :dispatch-id 1 :time 1020 :id 5})
                (http-abort-ev {:request-id :r2 :actor-id :child-b

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
@@ -98,13 +98,15 @@
    :tags      {:rf.trace/dispatch-id dispatch-id :rf.trace/event-id :foo}})
 
 (defn- warning-ev
-  "An :rf.warning/depth-exceeded trace pinned to `dispatch-id`. The
-  cascade projection routes the trace into the cascade's `:other`
-  bucket; `cascade-outcome` resolves to :warning / yellow."
+  "A real `:rf.warning/large-value-unschema` trace (an op the substrate
+  actually emits — see implementation/core/src/re_frame/elision.cljc)
+  pinned to `dispatch-id`. The cascade projection routes the trace into
+  the cascade's `:other` bucket; `cascade-outcome` resolves to
+  :warning / yellow via the universal :op-type severity axis."
   [id dispatch-id]
   {:id        id
    :op-type   :warning
-   :operation :rf.warning/depth-exceeded
+   :operation :rf.warning/large-value-unschema
    :tags      {:rf.trace/dispatch-id dispatch-id}})
 
 ;; ---- (1) L2 event-list row pickups -------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -335,16 +335,38 @@
         (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-error")))
         (is (nil?  (find-by-testid tree "rf-causa-event-detail-outcome-glyph-ok")))))))
 
-(deftest cascade-outcome-warning-glyph-when-depth-exceeded
-  (testing "a depth-exceeded warning flips the outcome to ⚠ warning"
+(deftest cascade-outcome-error-glyph-for-non-handler-exception-error
+  (testing "rf2-ee38b.2 — an error trace that is NOT a handler exception
+            (e.g. :rf.error/drain-depth-exceeded, a real substrate op)
+            still flips the outcome to ✗. The glyph is driven by the
+            universal severity axis (:op-type :error), not by an
+            enumerated handler-exception set."
     (seed-buffer!
       (conj (cascade-evs 100 [:foo] 0)
-            {:id 99 :op-type :warning :operation :rf.warning/depth-exceeded
+            {:id 99 :op-type :error :operation :rf.error/drain-depth-exceeded
              :tags {:rf.trace/dispatch-id 100}}))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-warning")))))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-error")))
+        (is (nil?  (find-by-testid tree "rf-causa-event-detail-outcome-glyph-ok")))))))
+
+(deftest cascade-outcome-warning-glyph-for-real-substrate-warning
+  (testing "rf2-ee38b.2 — a REAL warning op the substrate actually emits
+            (:rf.warning/large-value-unschema) flips the outcome to ⚠.
+            Previously the test fabricated :rf.warning/depth-exceeded —
+            an op the runtime never produces — and the production code
+            matched the same phantom keyword, so the ⚠ branch was
+            structurally dead. Now classified by :op-type :warning."
+    (seed-buffer!
+      (conj (cascade-evs 100 [:foo] 0)
+            {:id 99 :op-type :warning :operation :rf.warning/large-value-unschema
+             :tags {:rf.trace/dispatch-id 100}}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-warning")))
+        (is (nil?  (find-by-testid tree "rf-causa-event-detail-outcome-glyph-ok")))))))
 
 (deftest cascade-outcome-ssr-badge-when-hydrated
   (testing ":rf.ssr/hydrated event surfaces the SSR✓ badge on the
@@ -972,6 +994,54 @@
                  :dispatch-id 1 :other []})]
       (is (= #{:event-id :glyph :outcome :duration-ms :dispatch-id :ssr?}
              (set (keys out)))))))
+
+(deftest cascade-outcome-classifies-by-severity-axis
+  (testing "rf2-ee38b.2 — cascade-outcome resolves the glyph off the
+            universal :op-type severity axis, so EVERY warning/error op
+            the substrate emits is covered (not a hand-maintained set)."
+    ;; Happy path.
+    (is (= [:ok "✓"]
+           ((juxt :outcome :glyph)
+            (event-detail/cascade-outcome
+              {:event [:foo] :dispatch-id 1 :other []}))))
+    ;; Any :op-type :warning trace → ⚠, regardless of the specific op.
+    (doseq [op [:rf.warning/large-value-unschema
+                :rf.warning/schema-walker-opaque
+                :rf.warning/epoch-redact-fn-exception
+                :rf.warning/some-future-op-not-yet-invented]]
+      (is (= [:warning "⚠"]
+             ((juxt :outcome :glyph)
+              (event-detail/cascade-outcome
+                {:event [:foo] :dispatch-id 1
+                 :other [{:id 9 :op-type :warning :operation op}]})))
+          (str "warning op " op " flips the glyph to ⚠")))
+    ;; Any :op-type :error trace → ✗ (handler-exception OR not).
+    (doseq [op [:rf.error/handler-exception
+                :rf.error/drain-depth-exceeded
+                :rf.error/flow-eval-exception
+                :rf.error/no-such-handler]]
+      (is (= [:error "✗"]
+             ((juxt :outcome :glyph)
+              (event-detail/cascade-outcome
+                {:event [:foo] :dispatch-id 1
+                 :other [{:id 9 :op-type :error :operation op}]})))
+          (str "error op " op " flips the glyph to ✗")))
+    ;; Error wins over a co-resident warning.
+    (is (= [:error "✗"]
+           ((juxt :outcome :glyph)
+            (event-detail/cascade-outcome
+              {:event [:foo] :dispatch-id 1
+               :other [{:id 9 :op-type :warning :operation :rf.warning/large-value-unschema}
+                       {:id 10 :op-type :error :operation :rf.error/drain-depth-exceeded}]})))
+        "error severity trumps a co-resident warning")
+    ;; Namespace fallback: an :rf.error/* op missing an :op-type still
+    ;; classifies as an error (defensive against partial trace shapes).
+    (is (= :error
+           (:outcome
+            (event-detail/cascade-outcome
+              {:event [:foo] :dispatch-id 1
+               :other [{:id 9 :operation :rf.error/flow-eval-exception}]})))
+        ":rf.error/* namespace flips the glyph even without :op-type")))
 
 (deftest effects-handlers-ran-projects-rows-from-effects-bucket
   (testing "effects-handlers-ran reads cascade :effects directly"

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -124,7 +124,7 @@
 
 (deftest issue-event?-classification
   (testing "every issue op-type is an issue"
-    (is (true? (h/issue-event? (error-ev    1 :rf.error/handler-threw))))
+    (is (true? (h/issue-event? (error-ev    1 :rf.error/handler-exception))))
     (is (true? (h/issue-event? (warning-ev  2 :rf.warning/recoverable))))
     (is (true? (h/issue-event? (advisory-ev 3 :rf.info/note)))))
   (testing "non-issue op-types are NOT issues"
@@ -137,7 +137,7 @@
 
 (deftest category-prefix-projects-keyword-namespace
   (testing "category-prefix is the operation's keyword namespace"
-    (is (= "rf.error"   (h/category-prefix (error-ev 1 :rf.error/handler-threw))))
+    (is (= "rf.error"   (h/category-prefix (error-ev 1 :rf.error/handler-exception))))
     (is (= "rf.warning" (h/category-prefix (warning-ev 2 :rf.warning/recoverable))))
     (is (= "rf.ssr"     (h/category-prefix (warning-ev 3 :rf.ssr/hydration-mismatch))))
     (is (= "rf.info"    (h/category-prefix (advisory-ev 4 :rf.info/note))))
@@ -154,14 +154,14 @@
 
 (deftest project-issue-builds-row-shape
   (testing "a projected issue carries every cell the row needs"
-    (let [row (h/project-issue (error-ev 7 :rf.error/handler-threw
+    (let [row (h/project-issue (error-ev 7 :rf.error/handler-exception
                                          {:time 9999
                                           :tags {:reason "kaboom"}}))]
       (is (= 7                          (:id row)))
       (is (= 9999                       (:time row)))
       (is (= :error                     (:severity row)))
       (is (= :error                     (:op-type row)))
-      (is (= :rf.error/handler-threw    (:operation row)))
+      (is (= :rf.error/handler-exception    (:operation row)))
       (is (= "rf.error"                 (:category-prefix row)))
       (is (re-find #"kaboom"            (:description row)))
       (is (some?                        (:raw row))))))
@@ -252,7 +252,7 @@
     (is (= :epoch-evicted (h/resolve-focus-status 1 nil)))))
 
 (deftest find-epoch-record-returns-match
-  (let [hist [(epoch-record 5 [(error-ev 100 :rf.error/handler-threw)])
+  (let [hist [(epoch-record 5 [(error-ev 100 :rf.error/handler-exception)])
               (epoch-record 6 [(warning-ev 101 :rf.warning/recoverable)])]]
     (is (= 5 (:epoch-id (h/find-epoch-record 5 hist))))
     (is (= 6 (:epoch-id (h/find-epoch-record 6 hist))))
@@ -263,12 +263,12 @@
             (most-recent) record. epoch-history is oldest-first per
             re-frame.epoch/epoch-history, so the head is the last
             element."
-    (let [hist [(epoch-record 5 [(error-ev 100 :rf.error/handler-threw)])
+    (let [hist [(epoch-record 5 [(error-ev 100 :rf.error/handler-exception)])
                 (epoch-record 6 [(warning-ev 101 :rf.warning/recoverable)])
                 (epoch-record 7 [])]]
       (is (= 7 (:epoch-id (h/find-epoch-record nil hist))))))
   (testing "single-record history's head is that single record"
-    (let [hist [(epoch-record 42 [(error-ev 1 :rf.error/handler-threw)])]]
+    (let [hist [(epoch-record 42 [(error-ev 1 :rf.error/handler-exception)])]]
       (is (= 42 (:epoch-id (h/find-epoch-record nil hist))))))
   (testing "focus nil AND history empty/nil returns nil"
     (is (nil? (h/find-epoch-record nil [])))
@@ -312,7 +312,7 @@
   (testing "the focused epoch's :trace-events feed the projection;
             non-issue traces are silently dropped"
     (let [record (epoch-record 42
-                   [(error-ev   1 :rf.error/handler-threw)
+                   [(error-ev   1 :rf.error/handler-exception)
                     (non-issue-ev 2)
                     (warning-ev 3 :rf.warning/recoverable)
                     (non-issue-ev 4)
@@ -458,7 +458,7 @@
 (deftest project-feed-empty-kind-no-matches-when-filters-hide-all
   (testing "issues exist in the focused epoch but the chip filters hide
             them all → :no-matches"
-    (let [record (epoch-record 1 [(error-ev 1 :rf.error/handler-threw)])
+    (let [record (epoch-record 1 [(error-ev 1 :rf.error/handler-exception)])
           feed   (h/project-feed record {:severities #{:advisory}} :focused)]
       (is (= 1 (:total feed)))
       (is (= 0 (:rendered feed)))
@@ -467,7 +467,7 @@
 (deftest project-feed-histograms-are-epoch-scoped
   (testing "severity-counts and distinct-prefixes reflect the focused
             epoch's :trace-events — NOT a global stream"
-    (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-threw)
+    (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-exception)
                                   (warning-ev 2 :rf.warning/recoverable)
                                   (error-ev   3 :rf.ssr/hydration-mismatch)])
           feed   (h/project-feed record {} :focused)]
@@ -477,7 +477,7 @@
 
 (deftest project-feed-chip-filter-anding
   (testing "chip filters AND on top of the focused-epoch projection"
-    (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-threw)
+    (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-exception)
                                   (warning-ev 2 :rf.warning/missing-doc)
                                   (error-ev   3 :rf.ssr/hydration-mismatch)])
           feed   (h/project-feed record
@@ -504,7 +504,7 @@
                (epoch-record 1 [(non-issue-ev 1)
                                 (warning-ev 2 :rf.warning/recoverable)]))))
   (is (true? (h/epoch-has-issues?
-               (epoch-record 1 [(error-ev 1 :rf.error/handler-threw)])))))
+               (epoch-record 1 [(error-ev 1 :rf.error/handler-exception)])))))
 
 ;; ---- (10) format-time ---------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -250,7 +250,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 11)
       ;; Toggle in a severity the issue doesn't carry — filter excludes it.
       (rf/dispatch-sync [:rf.causa.issues/toggle-severity :advisory])
@@ -272,7 +272,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :warning
                                :operation :rf.warning/missing})])])
       (focus! 11)
@@ -292,7 +292,7 @@
       (seed-history!
         [(mk-epoch 42 142
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 142)
       (let [tree (issues-ribbon/Panel)
             chip (find-by-testid tree "rf-causa-issues-epoch-chip")]
@@ -310,7 +310,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 3 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 11)
       (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-time"))
@@ -352,7 +352,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 11)
       (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-prefix-chips"))
@@ -385,7 +385,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :warning
                                :operation :rf.warning/recoverable})
                     (mk-issue {:id 3 :op-type :info
@@ -418,7 +418,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :error
                                :operation :rf.ssr/hydration-mismatch})])])
       (focus! 11)
@@ -434,7 +434,7 @@
     (rf/with-frame :rf/causa
       (seed-history!
         [(mk-epoch 1 11 [(mk-issue {:id 1 :op-type :error
-                                    :operation :rf.error/handler-threw})])])
+                                    :operation :rf.error/handler-exception})])])
       (focus! 11)
       (is (nil? (find-by-testid (issues-ribbon/Panel)
                                 "rf-causa-issues-clear-filters"))
@@ -455,12 +455,12 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :warning
                                :operation :rf.warning/recoverable})])
          (mk-epoch 2 12
                    [(mk-issue {:id 3 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 4 :op-type :warning
                                :operation :rf.warning/recoverable})])])
       ;; Pin the spine focus to epoch 1 (defaults to head = 2 in LIVE).
@@ -479,10 +479,10 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})])
+                               :operation :rf.error/handler-exception})])
          (mk-epoch 2 12
                    [(mk-issue {:id 2 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       ;; Initially focus epoch 1.
       (focus! 11)
       (let [data-a @(rf/subscribe [:rf.causa/issues-ribbon])]
@@ -500,12 +500,12 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :warning
                                :operation :rf.warning/recoverable})])
          (mk-epoch 2 12
                    [(mk-issue {:id 3 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 11)
       (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
       (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
@@ -523,7 +523,7 @@
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 4 :op-type :error
-                               :operation :rf.error/handler-threw})])])
+                               :operation :rf.error/handler-exception})])])
       (focus! 11)
       (let [dispatches (atom [])]
         (with-redefs [rf/dispatch* (fn
@@ -545,7 +545,7 @@
     (rf/with-frame :rf/causa
       ;; Issue whose :rf.trace/trigger-handler carries source-coord.
       (let [iss (-> (mk-issue {:id 8 :op-type :error
-                               :operation :rf.error/handler-threw})
+                               :operation :rf.error/handler-exception})
                     (assoc :rf.trace/trigger-handler
                            {:source-coord {:file "events.cljs" :line 17}}))]
         (seed-history! [(mk-epoch 1 11 [iss])]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
@@ -19,7 +19,7 @@
   [(h/mock-epoch :e1 :c1 {} {:counter 1}
                  {:trace-events
                   [{:id 1 :op-type :error
-                    :operation :rf.error/handler-threw
+                    :operation :rf.error/handler-exception
                     :tags {:rf.trace/dispatch-id :c1}}]})
    (h/mock-epoch :e2 :c2 {:counter 1} {:counter 2}
                  {:trace-events

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -175,7 +175,7 @@
         [(mk-epoch 1 42
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 42 :event-id :cart/add})
-                    (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
+                    (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-exception
                                :dispatch-id 42 :reason "boom"})])])
       (focus! 42)
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -245,8 +245,6 @@
    :rf.causa.static.interceptors/registry
    :rf.causa.static.interceptors/registry-override
    :rf.causa.static.interceptors/tab-data
-   :rf.causa/selected-dispatch-frame
-   :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
    :rf.causa/selected-epoch-diff
    ;; rf2-39n8h discovered — selected-epoch composites: per-flow writes
@@ -812,15 +810,15 @@
           "empty atom → sub returns []"))))
 
 (deftest sub-trace-buffer-immediate-reactive-update-via-mirror
-  (testing "Per rf2-in6l2 — once the `:rf/causa` frame is registered,
-            `collect-trace!` mirrors each push into Causa's app-db slot
-            `:trace-buffer` via `:rf.causa/note-trace-event` so the
-            layer-1 sub fires on the standard app-db-write reactive
-            path. Drive the mirror event synchronously via dispatch-
-            sync (the production path uses dispatch — async drain —
-            but the same handler runs); assert that the sub reads
-            from app-db rather than the atom fall-through once the
-            slot is populated."
+  (testing "Per rf2-in6l2 — mirroring trace pushes into Causa's app-db
+            slot `:trace-buffer` makes the layer-1 sub fire on the
+            standard app-db-write reactive path. This drives the
+            directly-callable `:rf.causa/note-trace-event` append helper
+            (the production live path is the coalesced
+            `:rf.causa/sync-trace-buffer` per rf2-wq6gx; the append
+            handler is the per-event surface tests exercise); assert the
+            sub reads from app-db rather than the atom fall-through once
+            the slot is populated."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Seed the app-db slot via the production event handler. With
@@ -878,56 +876,6 @@
         (rf/dispatch-sync [:rf.causa/sync-trace-buffer [{:id 200 :tags {}}]])
         (is (= [{:id 200 :tags {}}] @(rf/subscribe [:rf.causa/trace-buffer]))
             "second sync wholly replaces the slot (no merge)")))))
-
-(deftest sub-trace-buffer-note-event-dedupes-on-id
-  (testing "rf2-z4fza follow-up: `:rf.causa/note-trace-event` skips the
-            push when the incoming event's `:id` already exists in the
-            slot. The mount seed-race window — where the `:frame/created`
-            trace for `:rf/causa` lands in both the atom snapshot the
-            seed reads AND a queued mirror dispatch — would otherwise
-            land the same event id twice, producing a duplicate React
-            `t:<id>` key in the Trace panel and one extra `<li>` past
-            the 200-row budget that survives reconciliation."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      ;; Simulate the seed-race directly: seed lands the event id 42 in
-      ;; the slot wholesale, then a `:rf.causa/note-trace-event` for the
-      ;; same id arrives from a queued mirror dispatch.
-      (rf/dispatch-sync [:rf.causa/sync-trace-buffer
-                         [{:id 42 :op-type :rf.frame :operation :rf.frame/created
-                           :tags {:frame :rf/causa}}]])
-      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
-      (rf/dispatch-sync [:rf.causa/note-trace-event
-                         {:id 42 :op-type :rf.frame :operation :rf.frame/created
-                          :tags {:frame :rf/causa}}])
-      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer])))
-          "duplicate-id push is a no-op — slot length unchanged")
-      (is (= [42] (mapv :id @(rf/subscribe [:rf.causa/trace-buffer])))
-          "only the seeded entry remains; the duplicate mirror push was
-           skipped")
-      ;; Distinct ids still push normally — dedup is per-id, not blanket
-      ;; deduplication-by-anything.
-      (rf/dispatch-sync [:rf.causa/note-trace-event
-                         {:id 43 :op-type :rf.event :operation :rf.test/y
-                          :tags {}}])
-      (is (= [42 43] (mapv :id @(rf/subscribe [:rf.causa/trace-buffer])))
-          "fresh ids still append — dedup is :id-keyed, not push-blocking"))))
-
-(deftest sub-trace-buffer-note-event-allows-events-without-id
-  (testing "rf2-z4fza follow-up: the dedup gate predicates on `:id`
-            being present (the framework's `next-event-id` stamp). An
-            event without `:id` is still pushed — defensive against
-            synthetic/test events that omit the slot."
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/note-trace-event
-                         {:op-type :rf.event :operation :rf.test/no-id
-                          :tags {}}])
-      (rf/dispatch-sync [:rf.causa/note-trace-event
-                         {:op-type :rf.event :operation :rf.test/also-no-id
-                          :tags {}}])
-      (is (= 2 (count @(rf/subscribe [:rf.causa/trace-buffer])))
-          "events without :id are not deduped — both push lands"))))
 
 (deftest sub-trace-buffer-evicts-on-overflow
   (testing "trace-bus enforces the eviction-on-overflow algebra against
@@ -1186,13 +1134,16 @@
 ;; ---- (4) high-value event contracts -------------------------------------
 
 (deftest event-select-dispatch-id-and-clear
-  (testing ":rf.causa/select-dispatch-id + clear round-trip"
+  (testing ":rf.causa/select-dispatch-id + clear round-trip — rf2-ee38b.2
+            reads focus off the canonical spine `:rf.causa/focus` sub
+            (the dead standalone :rf.causa/selected-dispatch-id sub is
+            gone; focus is the single source of truth)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 42])
-      (is (= 42 @(rf/subscribe [:rf.causa/selected-dispatch-id])))
+      (is (= 42 (:dispatch-id @(rf/subscribe [:rf.causa/focus]))))
       (rf/dispatch-sync [:rf.causa/clear-selected-dispatch-id])
-      (is (nil? @(rf/subscribe [:rf.causa/selected-dispatch-id]))))))
+      (is (nil? (:dispatch-id @(rf/subscribe [:rf.causa/focus])))))))
 
 (deftest event-select-epoch-passive-scrub
   (testing ":rf.causa/select-epoch sets selected-epoch-id (passive scrub)"
@@ -1407,10 +1358,13 @@
     (let [causa-db   (frame/frame-app-db-value :rf/causa)
           default-db (frame/frame-app-db-value :rf/default)]
       (is (= :event (:selected-tab causa-db)))
-      (is (= 1 (:selected-dispatch-id causa-db)))
+      ;; rf2-ee38b.2 — :rf.causa/select-dispatch-id writes focus to the
+      ;; spine `:focus` slot (the dead :selected-dispatch-id mirror is
+      ;; gone); :select-epoch writes the surviving :selected-epoch-id shim.
+      (is (= 1 (get-in causa-db [:focus :dispatch-id])))
       (is (= :e (:selected-epoch-id causa-db)))
       (is (nil? (:selected-tab default-db)))
-      (is (nil? (:selected-dispatch-id default-db)))
+      (is (nil? (get-in default-db [:focus :dispatch-id])))
       (is (nil? (:selected-epoch-id default-db))))))
 
 ;; ---- (9) edge cases over a dormant frame --------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -12,10 +12,10 @@
      re-frame machinery needed.
   2. `compose-focus` derives `:head?` + the effective `:dispatch-id`
      correctly across LIVE / RETRO / paused / evicted-cascade states.
-  3. The legacy shim — `:rf.causa/select-dispatch-id` writes through
-     to `:focus`, and `:rf.causa/focus-cascade` writes through to the
-     legacy `:selected-dispatch-id` slot. Existing panels continue to
-     read the legacy slot; new spine consumers read `:rf.causa/focus`.
+  3. The `:selected-epoch-id` shim — `:rf.causa/select-dispatch-id` and
+     `:rf.causa/focus-cascade` write `:focus` AND mirror the epoch into
+     `:selected-epoch-id` (the slot App-DB-diff / Views follow). Spine
+     consumers read `:rf.causa/focus`.
   4. The registered sub composes the slot + cascades via the standard
      re-frame reactive path."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
@@ -268,36 +268,38 @@
     (is (= :retro (get-in r [:focus :mode])))
     (is (= :rf/default (get-in r [:focus :frame])))))
 
-(deftest focus-cascade-reducer-writes-legacy-shim
-  (testing "the legacy :selected-dispatch-id + :selected-dispatch slots
-            update in lockstep so existing event-detail / machine-
-            inspector panels keep rendering"
-    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default)]
-      (is (= :c2 (:selected-dispatch-id r)))
-      (is (= {:dispatch-id :c2 :frame :rf/default}
-             (:selected-dispatch r))))))
+(deftest focus-cascade-reducer-writes-epoch-shim
+  (testing "rf2-ee38b.2 — the only surviving shim slot is
+            :selected-epoch-id (App-DB-diff / Views follow it). The dead
+            :selected-dispatch-id / :selected-dispatch mirror slots are
+            gone — the Event panel reads focus off the spine composite."
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default 77)]
+      (is (= 77 (:selected-epoch-id r)) ":selected-epoch-id mirrors :focus epoch")
+      (is (not (contains? r :selected-dispatch-id))
+          "dead :selected-dispatch-id slot is no longer written")
+      (is (not (contains? r :selected-dispatch))
+          "dead :selected-dispatch slot is no longer written"))))
 
 (deftest focus-cascade-reducer-without-frame-omits-frame
   (let [r (spine/focus-cascade-reducer {} :c2 nil)]
     (is (= :c2 (get-in r [:focus :dispatch-id])))
-    (is (= :c2 (:selected-dispatch-id r)))
-    (is (= {:dispatch-id :c2} (:selected-dispatch r))
-        "no :frame key when frame-id was nil")))
+    (is (nil? (get-in r [:focus :frame]))
+        "no :frame key in the focus slot when frame-id was nil")))
 
 ;; -------------------------------------------------------------------------
 ;; (4) focus-step-reducer — prev/next stepping
 ;; -------------------------------------------------------------------------
 
 (deftest focus-step-reducer-prev-flips-to-retro
-  (let [db {:focus {:dispatch-id :c3 :mode :live} :selected-dispatch-id :c3}
+  (let [db {:focus {:dispatch-id :c3 :mode :live}}
         r  (spine/focus-step-reducer db fixture-cascades -1)]
     (is (= :c2 (get-in r [:focus :dispatch-id])))
     (is (= :retro (get-in r [:focus :mode])))
-    (is (= :c2 (:selected-dispatch-id r))
-        "legacy shim updated alongside")))
+    (is (not (contains? r :selected-dispatch-id))
+        "dead :selected-dispatch-id mirror slot is no longer written")))
 
 (deftest focus-step-reducer-next-returns-to-head-as-live
-  (let [db {:focus {:dispatch-id :c2 :mode :retro} :selected-dispatch-id :c2}
+  (let [db {:focus {:dispatch-id :c2 :mode :retro}}
         r  (spine/focus-step-reducer db fixture-cascades +1)]
     (is (= :c3 (get-in r [:focus :dispatch-id])))
     (is (= :live (get-in r [:focus :mode]))
@@ -305,12 +307,11 @@
 
 (deftest focus-step-reducer-from-empty-slot-snaps-to-head-then-steps
   (testing "rf2-s0s5x Phase A — with an empty `:focus` slot the
-            current-id is derived through `compose-focus` (which
-            snaps to head in :live), not lifted off the legacy
-            `:selected-dispatch-id` slot. The legacy slot is a
-            shim-write-target now, not a read source — keeping
-            spine as the canonical source of truth."
-    (let [db {:selected-dispatch-id :c2}
+            current-id is derived through `compose-focus` (which snaps
+            to head in :live). The spine `:focus` slot is the sole
+            source of truth — there is no legacy selection slot to lift
+            a stale id from."
+    (let [db {}
           r  (spine/focus-step-reducer db fixture-cascades -1)]
       (is (= :c2 (get-in r [:focus :dispatch-id]))
           "step prev: empty :focus → composer derives head (c3) → prev
@@ -322,16 +323,14 @@
 
 (deftest follow-head-reducer-snaps-to-live
   (let [db {:focus {:dispatch-id :c1 :mode :retro :paused? true}
-            :selected-dispatch-id :c1
-            :selected-dispatch    {:dispatch-id :c1}}
+            :selected-epoch-id 5}
         r  (spine/follow-head-reducer db)]
     (is (nil? (get-in r [:focus :dispatch-id]))
         "follow-head clears :dispatch-id so compose-focus snaps to head")
     (is (= :live (get-in r [:focus :mode])))
     (is (false? (get-in r [:focus :paused?])))
-    (is (nil? (:selected-dispatch-id r))
-        "legacy slots cleared in lockstep")
-    (is (nil? (:selected-dispatch r)))))
+    (is (nil? (:selected-epoch-id r))
+        ":selected-epoch-id shim cleared in lockstep")))
 
 ;; -------------------------------------------------------------------------
 ;; (6) toggle-live-pause-reducer
@@ -348,7 +347,7 @@
 (deftest toggle-live-pause-reducer-noop-in-retro
   (testing "in :retro, toggle-live-pause is a no-op — Space has no
             meaning when the user has pinned an older row"
-    (let [db {:focus {:mode :retro :paused? false} :selected-dispatch-id :c1}
+    (let [db {:focus {:mode :retro :paused? false}}
           r  (spine/toggle-live-pause-reducer db)]
       (is (= db r) "db unchanged"))))
 
@@ -493,20 +492,6 @@
       (is (= :c2 (:dispatch-id r))
           "spine focus tracks the legacy selection event")
       (is (= :retro (:mode r))))))
-
-(deftest legacy-selected-dispatch-id-shimmed-by-focus-cascade
-  (testing "dispatching the new :rf.causa/focus-cascade writes
-            through to the legacy slot — existing event-detail panel
-            keeps reading :selected-dispatch-id unchanged"
-    (setup-causa-frame!)
-    (seed-cascades! fixture-cascades)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/focus-cascade :c2 :rf/default]))
-    (let [legacy (rf/with-frame :rf/causa
-                   @(rf/subscribe [:rf.causa/selected-dispatch-id]))]
-      (is (= :c2 legacy)
-          "legacy sub rebinds because the focus-cascade event also
-           wrote the legacy slot"))))
 
 (deftest focus-sub-step-events-walk-cascades
   (setup-causa-frame!)
@@ -867,14 +852,13 @@
 
 (deftest focus-cascade-reducer-4-arg-writes-epoch-id
   (testing "the 4-arg reducer writes :epoch-id into the :focus slot AND
-            the legacy :selected-epoch-id shim slot — App-db pivots
+            the :selected-epoch-id shim slot — App-db pivots
             from L2-list clicks once this lands (rf2-ak3ty)"
     (let [r (spine/focus-cascade-reducer {} :c2 :rf/default :e2)]
       (is (= :e2 (get-in r [:focus :epoch-id])))
       (is (= :e2 (:selected-epoch-id r))
-          "legacy slot the App-db panel reads pivots in lockstep")
-      (is (= :c2 (get-in r [:focus :dispatch-id])))
-      (is (= :c2 (:selected-dispatch-id r))))))
+          "the slot the App-db panel reads pivots in lockstep")
+      (is (= :c2 (get-in r [:focus :dispatch-id]))))))
 
 (deftest focus-cascade-reducer-3-arg-leaves-epoch-id-nil
   (testing "the back-compat 3-arg reducer leaves :epoch-id nil — the
@@ -921,8 +905,7 @@
 
 (deftest focus-step-reducer-4-arg-writes-epoch-id
   (testing "step events resolve :epoch-id for the new dispatch-id"
-    (let [db       {:focus {:dispatch-id :c3 :mode :live}
-                    :selected-dispatch-id :c3}
+    (let [db       {:focus {:dispatch-id :c3 :mode :live}}
           history  [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
           r        (spine/focus-step-reducer db fixture-cascades history -1)]
       (is (= :c2 (get-in r [:focus :dispatch-id])))
@@ -933,10 +916,9 @@
   (testing "follow-head clears the App-db legacy slot in lockstep with
             the dispatch-id slot — the panel returns to its landing
             view"
-    (let [db {:focus                {:dispatch-id :c1 :epoch-id :e1
-                                     :mode :retro}
-              :selected-dispatch-id :c1
-              :selected-epoch-id    :e1}
+    (let [db {:focus             {:dispatch-id :c1 :epoch-id :e1
+                                  :mode :retro}
+              :selected-epoch-id :e1}
           r  (spine/follow-head-reducer db)]
       (is (nil? (get-in r [:focus :epoch-id])))
       (is (nil? (:selected-epoch-id r))))))
@@ -1043,8 +1025,7 @@
   (testing "rf2-r9lyy — when `show-ungrouped?` is on, stepping forward
             from the last real cascade lands on :ungrouped (the bucket
             sorts at the head per the first-id sentinel)"
-    (let [db {:focus {:dispatch-id :c2 :mode :retro}
-              :selected-dispatch-id :c2}
+    (let [db {:focus {:dispatch-id :c2 :mode :retro}}
           r  (spine/focus-step-reducer db
                                        fixture-cascades-with-ungrouped
                                        []
@@ -1056,8 +1037,7 @@
 (deftest focus-step-reducer-skips-ungrouped-when-opt-in-off
   (testing "rf2-r9lyy — when `show-ungrouped?` is off (default), the
             step walk never lands on :ungrouped (rf2-fzbrw default)"
-    (let [db {:focus {:dispatch-id :c2 :mode :retro}
-              :selected-dispatch-id :c2}
+    (let [db {:focus {:dispatch-id :c2 :mode :retro}}
           r  (spine/focus-step-reducer db
                                        fixture-cascades-with-ungrouped
                                        []
@@ -1071,8 +1051,7 @@
             unchanged. The boundary is a true no-op so focus cannot
             shuffle into the :ungrouped bucket or any other aggregate
             state."
-    (let [db {:focus {:dispatch-id :c1 :mode :retro}
-              :selected-dispatch-id :c1}
+    (let [db {:focus {:dispatch-id :c1 :mode :retro}}
           r  (spine/focus-step-reducer db
                                        fixture-cascades-with-ungrouped
                                        -1)]
@@ -1081,8 +1060,7 @@
 (deftest focus-step-reducer-next-on-head-is-no-op
   (testing "rf2-fzbrw — [>] on the head (newest real event) returns db
             unchanged. Symmetric counterpart of the [<] boundary."
-    (let [db {:focus {:dispatch-id :c2 :mode :live}
-              :selected-dispatch-id :c2}
+    (let [db {:focus {:dispatch-id :c2 :mode :live}}
           r  (spine/focus-step-reducer db
                                        fixture-cascades-with-ungrouped
                                        +1)]
@@ -1094,8 +1072,7 @@
             the bucket, [<] at the only real event is a no-op."
     (let [cascades [(cascade :ungrouped nil)
                     (cascade :only-real :rf/default)]
-          db       {:focus {:dispatch-id :only-real :mode :live}
-                    :selected-dispatch-id :only-real}
+          db       {:focus {:dispatch-id :only-real :mode :live}}
           r        (spine/focus-step-reducer db cascades -1)]
       (is (= db r)
           "single real event → [<] is a no-op, not a slide into :ungrouped"))))
@@ -1178,7 +1155,6 @@
       (is (= :c3 (get-in r [:focus :dispatch-id])))
       (is (= :live (get-in r [:focus :mode]))
           "head click → :live (auto-follow continues)")
-      (is (= :c3 (:selected-dispatch-id r)))
       (is (= :e3 (get-in r [:focus :epoch-id]))))))
 
 (deftest focus-cascade-reducer-5-arg-non-head-pins-retro

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -607,3 +607,16 @@
     (is (nil? (gs/install!)))
     (is (nil? (gs/install!))
         "second call is also a no-op")))
+
+;; ---- host theme override (rf2-ee38b.2) ---------------------------------
+
+(deftest set-host-theme-css-is-safe-without-document
+  (testing "rf2-ee38b.2 — under node-test `js/document` is absent;
+            `set-host-theme-css!` (the impl behind the public
+            `core/load-theme`) must no-op rather than throw, for any
+            input — a CSS string, an empty string, or nil. DOM-bearing
+            behaviour (replace-in-place, clear-on-blank) is exercised by
+            the browser target; here we pin the no-DOM safety contract."
+    (is (nil? (gs/set-host-theme-css! ":root { --rf-causa-bg-1: #000 }")))
+    (is (nil? (gs/set-host-theme-css! "")))
+    (is (nil? (gs/set-host-theme-css! nil)))))

--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -273,7 +273,7 @@
 ;; ---- specialised cascade builders --------------------------------------
 
 (defn exception-cascade-buffer
-  "Cascade whose handler threw — surfaces `:rf.error/handler-threw`
+  "Cascade whose handler threw — surfaces `:rf.error/handler-exception`
   alongside the regular domino emits. The panel's `other-row` branch
   renders the error row with severity dot + exception-message."
   []
@@ -286,7 +286,7 @@
       :tags (assoc tag :rf.trace/phase :run-start)}
      {:id (+ id-base 3) :op-type :rf.event :operation :rf.event/run-end
       :tags (assoc tag :rf.trace/phase :run-end :duration-ms 5)}
-     {:id (+ id-base 4) :op-type :error :operation :rf.error/handler-threw
+     {:id (+ id-base 4) :op-type :error :operation :rf.error/handler-exception
       :tags (assoc tag :rf.event/v [:checkout/submit {:order-id 42}]
                        :handler-id :checkout/submit-h
                        :severity :error

--- a/tools/causa/testbeds/panel_gallery/fixtures_issues.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_issues.cljs
@@ -85,7 +85,7 @@
   "Single error event — panel surfaces one feed row."
   []
   [(issue {:id 1 :time 1000 :severity :error
-           :operation :rf.error/handler-threw
+           :operation :rf.error/handler-exception
            :event [:cart/add :apple] :dispatch-id 100
            :reason "handler threw NPE on :cart/add"
            :exception-message "NullPointerException at cart/add-h"})])
@@ -97,13 +97,15 @@
   (vec
     (for [i (range 24)]
       (let [sev (nth [:error :warning :advisory] (mod i 3))
-            ops [:rf.error/handler-threw
-                 :rf.error/fx-failed
-                 :rf.warning/large-value-unschema'd
-                 :rf.warning/handler-replaced
+            ;; Real substrate ops (per implementation/**) so the gallery
+            ;; mirrors the shapes the Issues panel actually classifies.
+            ops [:rf.error/handler-exception
+                 :rf.error/drain-depth-exceeded
+                 :rf.warning/large-value-unschema
+                 :rf.warning/registration-collision
                  :rf.info/snapshot-restored
                  :rf.ssr/hydration-mismatch
-                 :rf.fx/dispatch-loop-suspected
+                 :rf.fx/no-such-fx
                  :rf.epoch/ring-evict
                  :rf.http/request-timeout]
             op  (nth ops (mod i (count ops)))]
@@ -117,7 +119,7 @@
   the chip ladder is readable at a glance."
   []
   [(issue {:id 1 :time 1000 :severity :error
-           :operation :rf.error/handler-threw :dispatch-id 100
+           :operation :rf.error/handler-exception :dispatch-id 100
            :reason "handler threw NPE"})
    (issue {:id 2 :time 1001 :severity :error
            :operation :rf.error/fx-failed :dispatch-id 101
@@ -141,7 +143,7 @@
   §Privacy."
   []
   [(issue {:id 1 :time 1000 :severity :error
-           :operation :rf.error/handler-threw
+           :operation :rf.error/handler-exception
            :event [:auth/sign-in {:email "ada@example.com"
                                   :password :rf/redacted
                                   :totp :rf/redacted}]
@@ -165,7 +167,7 @@
            :path [:cart :items 0 :id] :dispatch-id 101
            :reason "expected keyword, got integer"})
    (issue {:id 3 :time 1002 :severity :error
-           :operation :rf.error/handler-threw
+           :operation :rf.error/handler-exception
            :event [:user/save :profile] :dispatch-id 100
            :reason "handler threw"})])
 
@@ -197,7 +199,7 @@
   (vec
     (for [i (range 4)]
       (issue {:id (+ i 1) :time (+ 1000 (* 10 i)) :severity :error
-              :operation :rf.error/handler-threw
+              :operation :rf.error/handler-exception
               :event [(nth [:cart/add :auth/sign-in :report/upload :dashboard/refresh] i)]
               :dispatch-id (+ 100 i)
               :exception-message (nth ["NullPointerException at cart/add-h:42"
@@ -211,7 +213,7 @@
   many warnings + errors). Mixes exceptions + schema + SSR + HTTP."
   []
   [(issue {:id 1 :time 1000 :severity :error
-           :operation :rf.error/handler-threw :dispatch-id 100
+           :operation :rf.error/handler-exception :dispatch-id 100
            :event [:cart/add :apple]
            :reason "handler threw"
            :exception-message "NullPointerException at cart/add-h:42"})
@@ -245,7 +247,7 @@
   surfaces the spread."
   []
   [(issue {:id 1 :time 1000 :severity :error
-           :operation :rf.error/handler-threw :dispatch-id 100
+           :operation :rf.error/handler-exception :dispatch-id 100
            :reason "handler threw" :recovery :rollback})
    (issue {:id 2 :time 1001 :severity :error
            :operation :rf.error/fx-failed :dispatch-id 101

--- a/tools/causa/testbeds/panel_gallery/fixtures_trace.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_trace.cljs
@@ -154,7 +154,7 @@
             :source :http :origin :app :frame :rf/default :dispatch-id 100
             :sub-id :user/profile :severity :warning
             :reason "payload truncated at 1MB"})
-       (ev {:id 10 :time 1201 :op-type :error :operation :rf.error/handler-threw
+       (ev {:id 10 :time 1201 :op-type :error :operation :rf.error/handler-exception
             :source :http :origin :app :frame :rf/default
             :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100
             :severity :error :reason "handler threw NPE"})])))
@@ -248,7 +248,7 @@
   "A buffer where every row is an issue (error / warning / info) —
   exercises the severity chip row with all three levels populated."
   []
-  [(ev {:id 1 :time 1000 :op-type :error :operation :rf.error/handler-threw
+  [(ev {:id 1 :time 1000 :op-type :error :operation :rf.error/handler-exception
         :source :ui :origin :app :frame :rf/default
         :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100
         :severity :error :reason "handler threw NPE on :cart/add"})

--- a/tools/causa/testbeds/panel_gallery/gallery_event.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_event.cljs
@@ -119,7 +119,7 @@
   ;; ----- 6. cascade with handler exception ----------------------------
   (story/reg-variant :story.causa.event/exception
     {:doc        "Selected cascade carries a handler exception
-                 (`:rf.error/handler-threw`) alongside the domino emits.
+                 (`:rf.error/handler-exception`) alongside the domino emits.
                  The panel's `other-row` branch surfaces the error row
                  with severity dot + exception-message."
      :events     [[:rf.causa/sync-trace-buffer (fixtures/exception-cascade-buffer)]


### PR DESCRIPTION
Consolidated remediation for `tools/causa` from the 3-lens review sweep (rf2-ee38b.2). All findings actioned to the masterpiece bar; each listed below with fix or skip+reason.

## Correctness
- **[P1] Event-lens warning/error outcome classification** — `cascade-outcome` keyed off two phantom warning ops (`:rf.warning/depth-exceeded`, `:rf.warning/schema-violation-skipped`) the substrate never emits, so `⚠` was structurally dead and real warning/non-handler-exception-error cascades rendered `✓`. Now classifies off the universal `:op-type` severity axis (any `:op-type :warning` / `:rf.warning/*` → `⚠`; any `:op-type :error` / `:rf.error/*` → `✗`), mirroring `issues-ribbon-helpers/op-type->severity`. `has-handler-exception?` retained narrowly for §5/§6 suppression.
- **[P1] False-green outcome tests re-pinned** — the warning test fabricated a non-existent op; now seeds a real `:rf.warning/large-value-unschema` and adds a non-handler-exception error case (`:rf.error/drain-depth-exceeded`) plus a pure-fn severity sweep over real ops.
- **[P3] Stale `:rf/event-dispatched` fallback** in `reactive_panel_subs/triggered-by` — deleted (phantom op + phantom fields; `:event` slot is reliable per spec/018).
- **[P3] `cancellation-reasons`** — dropped phantom `:parent-unmount-cascade` / `:rf.machine/cancelled` (substrate emits `:explicit` / `:parent-frame-destroyed` / `:actor-destroyed`); tests re-pinned.
- **[P3] Dead `filter-events` consumer surface** — kept (option a): added a NO-CURRENT-CALLER forward-compat banner so the green consumer test isn't mistaken for live coverage. Full deletion flagged as a mayor call per the finding.
- Also renamed phantom `:rf.error/handler-threw` → real `:rf.error/handler-exception` across Causa test fixtures + panel-gallery, and swapped other phantom gallery ops (`:rf.error/fx-failed`, `:rf.warning/large-value-unschema'd` typo, etc.) for real substrate ops.

## Completeness
- **[P1] Views 012-vs-021 divergence** — marked `spec/012-Views.md` SUPERSEDED by `021 §3` with an explicit banner + demoted in the spec README (impl is the lean three-stacked-tables design; 012's richer surface is unimplemented historical exploration).
- **[P2] `load-theme` stub** — IMPLEMENTED (was a TBD warn-stub). Wired through new `global-styles/set-host-theme-css!` which injects a host CSS string into a dedicated, replace-in-place `<style>` block; API.md + tests updated.
- **[P2] 014 Registry Catalogue** — removed the deleted shim-sub rows; updated the `:rf.causa/event-detail` row; extended the drift notice. Full 581-line regen from the live test enumerations left for the mayor (blind regen in a fix PR is its own drift risk).
- **[P3] Stale shell docstrings** — refreshed (`detail-panel` is registry-driven via `panel-registry/tab-by-id`; Views is a real registered panel, not a stub).
- **[P2] Test-matrix I1-I4 isolation gates** — SKIPPED here: landing browser feature-gates as default CI is test-infra work cross-cutting beyond a code-fix PR. Left for the mayor.

## Clarity / minimalism
- **[P1] Dead `:selected-dispatch-id` / `-frame` shim subs** — deleted, along with the spine reducers' dual-writes (`focus-cascade-reducer`, `focus-step-reducer`, `follow-head-reducer`). Kept the live `:selected-epoch-id` shim (App-DB-diff / Views follow it). Tests + docstrings updated; the composite `:rf.causa/event-detail`'s own `:selected-dispatch-id` key stays (derived off the spine).
- **[P2] `:rf.causa/note-trace-event`** — reduced to a plain append (removed the O(slot) dedup walk the snapshot design made impossible); collapsed the ~50-line history comment to a present-state contract; removed the two dedup-only tests; fixed the stale mount docstring.
- **[P3] panel_registry multi-mode expansion** — dropped the speculative reduce-over-modes (every entry is single-mode); `:pre` now asserts exactly one mode; kept the load-bearing `[mode id]` composite key.
- **[P3] data_display/render "ONE canonical" claim** — softened to its actual remit (the tree-walker engine behind the `edn-widget` facade).
- **[P2] Change-history comments** — added a Conventions.md "docstrings state the present contract" entry (the finding's suggested anchor); did targeted history→present collapses in every file touched. A tree-wide 1.3K-ref pass is explicitly a per-file judgement pass, not in scope here.

## Gates (all green from the worktree's `implementation/`)
- `node-test`: 4127 tests, 12609 assertions, 0 failures, 0 errors
- causa JVM (`clojure -M:test`): 840 tests, 2725 assertions, 0 failures, 0 errors
- `npm run test:causa-feature-gate`: 13 scenarios, 0 failures, 13 matrix rows

## Left for the mayor
- Full `spec/014` catalogue regeneration from the live `all-sub-names` / `all-event-names` / `all-fx-names` enumerations.
- Landing the merge-blocking I1-I4 frame-isolation + Static-composer-isolation browser feature gates as default CI (017 matrix `partial` rows).
- Decision on deleting the forward-compat `trace-bus/filter-events` + its 449-line consumer test.

Closes rf2-ee38b.2.