### PR TITLE
fix(schemas): elision auto-population + hot-reload violation trace (rf2-ee38b.6)

### DIFF
--- a/implementation/schemas/src/re_frame/schemas/digest.cljc
+++ b/implementation/schemas/src/re_frame/schemas/digest.cljc
@@ -78,14 +78,42 @@
        (sha256-hex (validator/run-printer schema-value))
        "\n"))
 
+(defn- compare-utf8-bytes
+  "Lexicographic comparison of two strings as UTF-8 byte sequences, per
+  Spec 010 §Digest algorithm step 4 (\"sort the lines lexicographically
+  as byte sequences (UTF-8) … identical across hosts\"). Bytes are
+  compared unsigned (0..255) so the order matches a byte-sort on any
+  port (rf2-ee38b.6).
+
+  Host-native string `compare` (JVM `String.compareTo` / JS string
+  comparison) is UTF-16 code-unit order, which diverges from UTF-8 byte
+  order for supplementary-plane (> U+FFFF) characters — a latent
+  cross-port gap for exotic path keywords. For ASCII the two orders
+  coincide, so this is byte-compatible with the prior pinned vectors."
+  [a b]
+  (let [ba   (utf8-bytes a)
+        bb   (utf8-bytes b)
+        na   (count ba)
+        nb   (count bb)
+        n    (min na nb)]
+    (loop [i 0]
+      (if (== i n)
+        (compare na nb)
+        (let [ua (bit-and (long (nth ba i)) 0xff)
+              ub (bit-and (long (nth bb i)) 0xff)]
+          (if (== ua ub)
+            (recur (inc i))
+            (compare ua ub)))))))
+
 (defn- compute-digest
   "Run the Spec 010 §Digest algorithm against the supplied
   `{path → schema-value}` map. Returns the canonical wire form
-  `\"sha256:\" + first-16-hex-chars`."
+  `\"sha256:\" + first-16-hex-chars`. Lines are sorted as UTF-8 byte
+  sequences (`compare-utf8-bytes`) per Spec 010 §Digest algorithm step 4."
   [path->schema]
   (let [lines       (mapv (fn [[path schema]] (digest-line path schema))
                           path->schema)
-        sorted      (sort lines)            ;; lexicographic byte order
+        sorted      (sort compare-utf8-bytes lines)
         concatted   (apply str sorted)
         full-hex    (sha256-hex concatted)]
     (str "sha256:" (subs full-hex 0 16))))

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -25,6 +25,7 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas.validator :as validator]
+            [re-frame.schemas.walker :as walker]
             [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -90,21 +91,37 @@
 ;;
 ;; Per Spec 010 §The `:schema` value is opaque to re-frame, the framework's
 ;; schema walker (`re-frame.schemas.walker`) is pure data — it handles
-;; vector-form Malli EDN and treats compiled `m/schema` values, registry
-;; refs, and anything-else-non-vector as opaque leaves. A user that
-;; registers a registry-ref schema (`(rf/reg-app-schema [:user]
-;; :my/user-schema)`) and puts `:sensitive?` / `:large?` per-slot flags
-;; inside the registry definition will see the walker **silently skip**
-;; them — the validation-failure trace won't redact the sensitive slot
-;; and the size-elision walker won't see the `:large?` declarations.
+;; vector-form Malli EDN and treats compiled `m/schema` values as opaque
+;; leaves. A user that registers a compiled `m/schema` value and puts
+;; `:sensitive?` / `:large?` per-slot flags inside the compiled value will
+;; see the walker **silently skip** them — the validation-failure trace
+;; won't redact the sensitive slot and the size-elision walker won't see
+;; the `:large?` declarations.
 ;;
 ;; This warning fires once per process from `reg-app-schema` /
-;; `reg-app-schemas` when the registered schema is not a vector form
-;; (i.e. the walker cannot introspect it). Symmetric with the
+;; `reg-app-schemas` when the registered schema is a genuinely opaque
+;; NON-keyword value (compiled `m/schema` object, etc.) the walker
+;; cannot introspect. Symmetric with the
 ;; `:rf.warning/schema-validator-unavailable` warn-once-per-process
 ;; pattern above. Cost is one boot-time predicate per `reg-app-schema`
 ;; call; the warning is the discoverability nudge for the two workable
 ;; fallbacks (vector form, or registration-meta `:sensitive?`).
+;;
+;; Keyword schemas DO NOT warn (rf2-ee38b.6 — correctness P2). A bare
+;; keyword is non-vector but is a valid, idiomatic Malli schema in two
+;; flavours: a primitive type (`:int` / `:string` / `:boolean` / `:any`)
+;; and a registry reference (`:my/user-schema`). The walker's keyword
+;; clause returns `acc` with no declarations because a bare keyword
+;; CANNOT carry per-slot props — for a primitive there is provably
+;; nothing to skip, so the warning was a pure false positive on the
+;; common case. The predicate cannot cheaply distinguish a primitive
+;; keyword from a registry-ref keyword without a Malli registry consult
+;; (which would violate Spec 010 §The `:schema` value is opaque to
+;; re-frame). Rather than warn on every keyword — a frequent
+;; false-positive to catch a rare registry-ref true-positive — we
+;; suppress the keyword case entirely. Registry refs that hide per-slot
+;; flags are an advanced shape covered by the walker docstring's
+;; discoverability caveat (rf2-yaioz).
 
 (defonce ^:private walker-opaque-warned
   ;; Process-lifecycle one-shot. Reset by `clear-walker-opaque-warned!`
@@ -117,34 +134,44 @@
   []
   (reset! walker-opaque-warned false))
 
+(defn- walker-introspectable?
+  "True when the schema value is a form the pure-data walker can
+  introspect for per-slot `:sensitive?` / `:large?` flags. Vector-form
+  Malli EDN is introspectable; so is a bare keyword (primitive type or
+  registry ref) — a keyword cannot carry per-slot props, so the walker
+  provably skips nothing and there is nothing to warn about (rf2-ee38b.6).
+  Compiled `m/schema` objects, maps, and other opaque values are NOT
+  introspectable — their internal per-slot flags are silently skipped."
+  [schema]
+  (or (vector? schema) (keyword? schema)))
+
 (defn- maybe-warn-walker-opaque!
   "Emit `:rf.warning/schema-walker-opaque` once per process when
-  `reg-app-schema` / `reg-app-schemas` is invoked with a schema value
-  that is NOT a vector form (the walker can only introspect Malli EDN
-  vector forms — `m/schema` compiled values and registry-ref keywords
-  are treated as opaque leaves).
+  `reg-app-schema` / `reg-app-schemas` is invoked with a genuinely
+  opaque schema value the walker cannot introspect (a compiled
+  `m/schema` object / other non-vector, non-keyword value). Vector
+  forms and bare keywords do not warn — see `walker-introspectable?`.
 
   Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
   so the production bundle DCEs the consult+emit branch (Spec 009
   §Production builds)."
   [schema path]
-  (when (and (not (vector? schema))
+  (when (and (not (walker-introspectable? schema))
              (not @walker-opaque-warned))
     (when (compare-and-set! walker-opaque-warned false true)
       (when-let [emit! (late-bind/get-fn :trace/emit!)]
         (emit! :warning :rf.warning/schema-walker-opaque
                {:path path
-                :schema-kind (cond
-                               (keyword? schema) :registry-ref
-                               (map?     schema) :compiled-schema-object
-                               :else             :unknown)
+                :schema-kind (if (map? schema)
+                               :compiled-schema-object
+                               :unknown)
                 :reason
-                (str "reg-app-schema was called with a non-vector schema"
-                     " form (registry ref / compiled m/schema / other"
-                     " opaque value). The schema-walker (used for"
-                     " per-slot `:sensitive?` / `:large?` extraction)"
-                     " can only introspect vector-form Malli EDN —"
-                     " per-slot flags inside an opaque value are"
+                (str "reg-app-schema was called with a compiled / opaque"
+                     " schema value (a non-vector, non-keyword form such"
+                     " as a compiled m/schema object). The schema-walker"
+                     " (used for per-slot `:sensitive?` / `:large?`"
+                     " extraction) can only introspect vector-form Malli"
+                     " EDN — per-slot flags inside an opaque value are"
                      " silently skipped. Two workable shapes: (1)"
                      " register the vector form directly so the walker"
                      " can introspect it; (2) use registration-level"
@@ -180,6 +207,94 @@
                      " `set-schema-validator!` with a non-default fn"
                      " to suppress this warning.")})))))
 
+;; ---- hot-reload :rf.schema/violation trace (rf2-ee38b.6) ------------------
+;;
+;; Per Spec 010 §Schema migration on hot-reload + Spec 009 error catalogue
+;; row `:rf.schema/violation`: when a `(frame-id, path)` schema is
+;; re-registered during dev (a file save re-evaluates `reg-app-schema`
+;; with a DIFFERENT schema for the same path), the live `app-db` value at
+;; that path may now violate the new schema. The runtime emits a
+;; `:rf.schema/violation` trace (`:op-type :warning`, recovery
+;; `:logged-and-skipped`) so dev panels highlight the stale slice — the
+;; live app continues running; `app-db` is NOT auto-cleared or rewound.
+;;
+;; Distinct from `:rf.error/schema-validation-failure` (dispatch-time
+;; boundary validation): this fires at the hot-reload edge against
+;; PRE-EXISTING state, only when the schema actually changed AND the live
+;; value fails the new schema. A no-op re-eval with the same schema does
+;; nothing; a re-eval that the live value still satisfies does nothing.
+
+(def ^:private redacted-sentinel
+  "The `:rf/redacted` privacy sentinel — Spec 009 §Privacy. Stamped in
+  place of `:mismatching-value` when the new schema declares the slot
+  sensitive, mirroring the `:rf.error/schema-validation-failure`
+  redaction posture so the hot-reload trace never re-leaks a credential."
+  :rf/redacted)
+
+(defn- maybe-emit-schema-violation!
+  "Emit `:rf.schema/violation` when a re-registration changes the schema
+  at `(frame-id, path)` AND the live `app-db` value at `path` fails the
+  NEW schema. `prior-schema` is the schema the path carried before this
+  registration (nil when first registration). No-op when there is no
+  prior schema, the schema is unchanged, no validator is registered, or
+  the live value still validates.
+
+  Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
+  so the production bundle DCEs the consult+emit branch (Spec 009
+  §Production builds)."
+  [frame-id path prior-schema new-schema]
+  (when (and (some? prior-schema)
+             (not= prior-schema new-schema))
+    (when-let [vf @validator/validator-fn]
+      (let [db        (frame/frame-app-db-value frame-id)
+            live-val  (get-in db path)
+            ;; A malformed new schema can make the validator throw
+            ;; (e.g. Malli's `:malli.core/child-error` on a childless
+            ;; `[:vector]`). A bad schema is not a hot-reload violation
+            ;; and MUST NOT crash registration — treat a throwing
+            ;; validator as "cannot determine a violation" (pass).
+            passes?   (try (boolean (vf new-schema live-val))
+                           (catch #?(:clj Throwable :cljs :default) _ true))]
+        (when-not passes?
+          (when-let [emit! (late-bind/get-fn :trace/emit!)]
+            (let [sensitive? (walker/schema-has-sensitive? new-schema)]
+              (emit! :warning :rf.schema/violation
+                     {:path               path
+                      :pre-reload-schema  prior-schema
+                      :post-reload-schema new-schema
+                      :mismatching-value  (if sensitive?
+                                            redacted-sentinel
+                                            live-val)
+                      :frame              frame-id
+                      :recovery           :logged-and-skipped
+                      :sensitive?         sensitive?}))))))))
+
+;; ---- schema-driven elision registry population (rf2-ee38b.6) --------------
+;;
+;; Per Spec 010 §`:large?` ("at boot, and on `reg-app-schema`
+;; re-registration") and §Registry feeder (rf2-c1l4d): the runtime walks
+;; every registered app-schema and writes the `{:large? true …}` /
+;; `{:sensitive? true …}` declarations into the frame's
+;; `[:rf/elision :declarations]` / `[:rf/elision :sensitive-declarations]`
+;; slots. `re-frame.router` already refreshes these per-dispatch via the
+;; same `:elision/populate-from-schemas!` hook, but that leaves a gap for
+;; wire-boundary emits / digests that fire BEFORE the first dispatch
+;; (boot-time SSR serialise, initial epoch snapshot). Populating at
+;; registration closes that gap and matches the spec's "on re-registration"
+;; contract. Best-effort: the hook is a no-op when the elision artefact is
+;; absent, and the elision write itself no-ops when the frame's app-db
+;; container does not exist yet (registration before frame creation).
+
+(defn- populate-elision-for-frame!
+  "Refresh schema-derived `:large?` / `:sensitive?` elision declarations
+  for `frame-id` via the `:elision/populate-from-schemas!` late-bind
+  hook. No-op when the elision artefact is not on the classpath.
+
+  Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`."
+  [frame-id]
+  (when-let [populate! (late-bind/get-fn :elision/populate-from-schemas!)]
+    (populate! frame-id)))
+
 ;; ---- app-db schema registration -------------------------------------------
 
 (defn reg-app-schema
@@ -199,9 +314,13 @@
   entries. Pair-tools and source-coord tests read via `app-schema-meta-at`."
   ([path schema] (reg-app-schema path schema {}))
   ([path schema opts]
-   (let [frame-id (resolve-frame opts)
-         meta     (source-coords/merge-coords
-                    {:schema schema :path path :frame frame-id})]
+   (let [frame-id     (resolve-frame opts)
+         ;; Capture the path's prior schema BEFORE the swap so the
+         ;; hot-reload `:rf.schema/violation` check (rf2-ee38b.6) can
+         ;; compare pre- vs post-reload shapes. nil on first registration.
+         prior-schema (get-in @schemas-by-frame [frame-id path :schema])
+         meta         (source-coords/merge-coords
+                        {:schema schema :path path :frame frame-id})]
      (swap! schemas-by-frame assoc-in [frame-id path] meta)
      ;; Per rf2-fq7d2: dev-time nudge when the Malli adapter is unloaded
      ;; AND the framework-default validator is still installed — the
@@ -212,12 +331,21 @@
      (when interop/debug-enabled?
        (maybe-warn-validator-unavailable!)
        ;; Per rf2-jsokn: dev-time nudge when the registered schema is
-       ;; a non-vector form (registry-ref keyword, compiled m/schema
+       ;; an opaque non-vector, non-keyword form (compiled m/schema
        ;; object, etc.) — the schema walker can only introspect vector
        ;; Malli EDN, so per-slot `:sensitive?` / `:large?` flags inside
        ;; an opaque value are silently skipped. Production elides via
        ;; the outer `interop/debug-enabled?` gate.
-       (maybe-warn-walker-opaque! schema path))
+       (maybe-warn-walker-opaque! schema path)
+       ;; Per rf2-ee38b.6 / Spec 010 §Schema migration on hot-reload:
+       ;; emit `:rf.schema/violation` when a re-registration changes the
+       ;; schema and the live app-db value at `path` fails the new shape.
+       (maybe-emit-schema-violation! frame-id path prior-schema schema)
+       ;; Per rf2-ee38b.6 / Spec 010 §`:large?` ("at boot, and on
+       ;; re-registration"): refresh the schema-derived elision
+       ;; declarations so size-elision / privacy redaction is live even
+       ;; for wire emits that fire before the first dispatch.
+       (populate-elision-for-frame! frame-id))
      path)))
 
 (defn reg-app-schemas
@@ -331,8 +459,17 @@
 ;; `schemas-by-frame`. Re-registering a `(frame-id, path)` entry is an
 ;; ordinary `swap!`: the new meta replaces the prior entry atomically, and
 ;; the validation hot path (`frame-schema-entries`) picks up the new
-;; schema on its next read. There is nothing to invalidate elsewhere —
-;; the per-frame map IS the cache.
+;; schema on its next read. The per-frame map IS the validation cache.
+;;
+;; Two dev-only side effects DO accompany a re-registration (rf2-ee38b.6):
+;;   1. `:rf.schema/violation` — emitted when the schema CHANGED and the
+;;      live `app-db` value at the path fails the new shape (Spec 010
+;;      §Schema migration on hot-reload). See `maybe-emit-schema-violation!`.
+;;   2. Schema-derived elision-registry refresh — re-populates the
+;;      frame's `[:rf/elision …]` declarations so size-elision / privacy
+;;      stays in sync with the schema set (Spec 010 §`:large?` /
+;;      §Registry feeder). See `populate-elision-for-frame!`.
+;; Both are gated on `interop/debug-enabled?` and DCE'd in production.
 
 ;; ---- test-support snapshot / restore -------------------------------------
 ;;

--- a/implementation/schemas/src/re_frame/schemas/storage.cljc
+++ b/implementation/schemas/src/re_frame/schemas/storage.cljc
@@ -284,6 +284,41 @@
 ;; contract. Best-effort: the hook is a no-op when the elision artefact is
 ;; absent, and the elision write itself no-ops when the frame's app-db
 ;; container does not exist yet (registration before frame creation).
+;;
+;; PERF (rf2-ee38b.6): `:elision/populate-from-schemas!` re-walks EVERY
+;; registered schema in the frame, so it is O(n) in the frame's schema
+;; count. Running it on every single `reg-app-schema` therefore makes
+;; bulk registration O(n²) — registering n schemas wedges (the rf2-utdxg
+;; concurrency-stress harness registers 8 × 5000 schemas one-at-a-time on
+;; one frame and timed out the JVM gate). The fix is `populate-relevant?`:
+;; a fresh registration whose schema contributes NO `:large?` /
+;; `:sensitive?` slot cannot change the elision registry, so the walk is
+;; skipped. We only pay the O(n) refresh when the new schema actually
+;; carries an elision flag, OR when this is a re-registration (where the
+;; PRIOR schema may have carried a flag that is now removed and must be
+;; dropped). The common case — many flag-free fresh registrations — is
+;; O(1) per call.
+
+(defn- schema-contributes-elision?
+  "True when `schema` carries at least one `:large?` or `:sensitive?`
+  per-slot flag the walker can introspect — i.e. registering it could
+  add a declaration to the frame's elision registry. Pure walk over the
+  single schema (the sensitive walk is memoised by `(schema, path)`);
+  cheap relative to the full-frame `populate-from-schemas!` refresh."
+  [schema path]
+  (or (seq (walker/extract-large-paths-from-schema schema path))
+      (seq (walker/extract-sensitive-paths-from-schema schema path))))
+
+(defn- populate-relevant?
+  "Decide whether a `reg-app-schema` call needs an elision-registry
+  refresh. Skips the O(n) full-frame walk for the dominant case — a
+  fresh registration of a flag-free schema, which provably cannot change
+  any declaration. Refreshes when the new schema contributes a flag, or
+  when this is a re-registration (the prior schema may have carried a
+  flag now being removed)."
+  [prior-schema schema path]
+  (or (some? prior-schema)
+      (schema-contributes-elision? schema path)))
 
 (defn- populate-elision-for-frame!
   "Refresh schema-derived `:large?` / `:sensitive?` elision declarations
@@ -340,12 +375,27 @@
        ;; Per rf2-ee38b.6 / Spec 010 §Schema migration on hot-reload:
        ;; emit `:rf.schema/violation` when a re-registration changes the
        ;; schema and the live app-db value at `path` fails the new shape.
+       ;; O(1) per call — reads the prior schema + one validation of the
+       ;; live value at this path; safe to run per-entry even in bulk.
        (maybe-emit-schema-violation! frame-id path prior-schema schema)
        ;; Per rf2-ee38b.6 / Spec 010 §`:large?` ("at boot, and on
        ;; re-registration"): refresh the schema-derived elision
        ;; declarations so size-elision / privacy redaction is live even
        ;; for wire emits that fire before the first dispatch.
-       (populate-elision-for-frame! frame-id))
+       ;;
+       ;; This walks EVERY registered schema in the frame, so it is O(n)
+       ;; in the frame's schema count. Two guards keep it cheap:
+       ;;   - `:rf/defer-elision-populate?` lets the bulk
+       ;;     `reg-app-schemas` path run the walk ONCE after all entries
+       ;;     land instead of once per entry.
+       ;;   - `populate-relevant?` skips the walk entirely for the common
+       ;;     case (a fresh registration of a flag-free schema), which
+       ;;     provably cannot change the elision registry.
+       ;; Without both, registering n schemas is O(n²) and wedged the
+       ;; rf2-utdxg concurrency-stress JVM gate.
+       (when (and (not (:rf/defer-elision-populate? opts))
+                  (populate-relevant? prior-schema schema path))
+         (populate-elision-for-frame! frame-id)))
      path)))
 
 (defn reg-app-schemas
@@ -379,8 +429,38 @@
   `reg-app-schema` chain instead)."
   ([path->schema] (reg-app-schemas path->schema {}))
   ([path->schema opts]
-   (mapv (fn [[path schema]] (reg-app-schema path schema opts))
-         path->schema)))
+   ;; Defer the per-entry schema-derived elision repopulation (rf2-ee38b.6):
+   ;; `populate-elision-for-frame!` walks EVERY registered schema in the
+   ;; frame, so running it once per entry is O(n²) in the frame's schema
+   ;; count — fine for the documented 5–20-schema feature module, but it
+   ;; wedges large/concurrent bulk registration (the rf2-utdxg
+   ;; concurrency-stress harness registers 8 × 5000 on one frame and timed
+   ;; out the JVM gate). Each singular call still does its O(1) per-entry
+   ;; work (validator nudge, walker-opaque nudge, hot-reload
+   ;; `:rf.schema/violation` check); the O(n) full-frame elision walk is
+   ;; hoisted out and run AT MOST ONCE after all entries land, and only
+   ;; when at least one entry could actually change the elision registry
+   ;; (`populate-relevant?` — a batch of flag-free fresh registrations,
+   ;; the stress workload, skips the walk entirely).
+   (let [frame-id   (resolve-frame opts)
+         entry-opts (assoc opts :rf/defer-elision-populate? true)
+         ;; Snapshot prior schemas BEFORE registering so relevance
+         ;; reflects each entry's true re-registration status, matching
+         ;; the singular path's per-call decision.
+         relevant?  (when interop/debug-enabled?
+                      (let [snapshot (get @schemas-by-frame frame-id)]
+                        (boolean
+                          (some (fn [[path schema]]
+                                  (populate-relevant?
+                                    (get-in snapshot [path :schema])
+                                    schema path))
+                                path->schema))))
+         paths      (mapv (fn [[path schema]]
+                            (reg-app-schema path schema entry-opts))
+                          path->schema)]
+     (when (and interop/debug-enabled? relevant?)
+       (populate-elision-for-frame! frame-id))
+     paths)))
 
 (defn app-schema-at
   "Look up the registered schema for a path in a frame, or nil.

--- a/implementation/schemas/src/re_frame/schemas/validator.cljc
+++ b/implementation/schemas/src/re_frame/schemas/validator.cljc
@@ -204,7 +204,14 @@
     (let [m validate-fn-or-map]
       (when (contains? m :validate) (reset! validator-fn (:validate m)))
       (when (contains? m :explain)  (reset! explainer-fn (:explain m)))
-      (when (contains? m :print)    (reset! printer-fn   (:print m)))
+      ;; Per rf2-ee38b.6 (clarity P2): coerce `nil` to the default
+      ;; identically to the dedicated `set-schema-printer!` setter, so
+      ;; "printer-fn is never nil" is a true invariant established at the
+      ;; write site — not re-asserted defensively in `run-printer`. The
+      ;; map-arity docstring promises this fallback; the coercion makes
+      ;; it honest.
+      (when (contains? m :print)
+        (reset! printer-fn (or (:print m) default-edn-print)))
       @validator-fn)
     (do (reset! validator-fn validate-fn-or-map)
         @validator-fn)))
@@ -288,14 +295,12 @@
     (f schema value)))
 
 (defn run-printer
-  "Hot-path entry — invoke the registered schema-print companion (or
-  the default EDN canonicaliser when none is registered) against a
-  single schema value. Per Spec 010 §Schema digest line 491 — the
-  digest pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8
-  bytes (rf2-wla45). Never returns nil for a non-nil schema value:
-  a nil registration falls back to `default-edn-print` so the
-  cross-runtime digest contract holds even when the validator
-  surface is fully nilled out."
+  "Hot-path entry — invoke the registered schema-print companion against
+  a single schema value. Per Spec 010 §Schema digest line 491 the digest
+  pipeline (`re-frame.schemas.digest`) hashes this fn's UTF-8 bytes
+  (rf2-wla45). `printer-fn` is never nil: both write sites
+  (`set-schema-printer!` and the `set-schema-validator!` map-arity)
+  coerce a nil `:print` to `default-edn-print` (rf2-ee38b.6), so the
+  cross-runtime digest contract holds without a read-site guard."
   [schema-value]
-  (let [f (or @printer-fn default-edn-print)]
-    (f schema-value)))
+  (@printer-fn schema-value))

--- a/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/digest_parity_test.clj
@@ -25,6 +25,7 @@
   namespace dereferences the var once and exposes it as
   `compute-digest`, so per-fixture assertions are runtime-agnostic."
   (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.schemas.digest]
             [re-frame.schemas.digest-parity-fixtures :as fixtures]))
 
 ;; ---- pinned-literal vectors -----------------------------------------------
@@ -85,3 +86,45 @@
       (is (= (count literals) (count (set literals)))
           (str "Fixture literals must be pairwise distinct — got "
                (pr-str literals))))))
+
+;; ---- UTF-8 byte-order line sort (rf2-ee38b.6, Spec 010 step 4) ------------
+;;
+;; Spec 010 §Digest algorithm step 4 mandates the lines be sorted
+;; "lexicographically as byte sequences (UTF-8) … identical across
+;; hosts." Host-native string compare (JVM String.compareTo / JS string
+;; compare) is UTF-16 code-unit order, which diverges from UTF-8 byte
+;; order for supplementary-plane (> U+FFFF) characters. For ASCII the
+;; two coincide (so every pinned fixture above is unaffected). These
+;; pins lock the comparator to the normative UTF-8 byte order so a
+;; non-CLJS/JVM port that byte-sorts agrees with the reference.
+
+(def ^:private compare-utf8-bytes
+  #'re-frame.schemas.digest/compare-utf8-bytes)
+
+(deftest utf8-byte-sort-diverges-from-utf16-on-supplementary-plane
+  (testing "rf2-ee38b.6 — the comparator orders by UTF-8 bytes, not
+            UTF-16 code units. U+1F600 (UTF-8 F0 9F 98 80; UTF-16
+            surrogate D83D DE00) vs U+FFFD (replacement, UTF-8 EF BF BD;
+            UTF-16 FFFD): UTF-16 order says U+1F600 < U+FFFD (D83D <
+            FFFD) but UTF-8 byte order says U+1F600 > U+FFFD (F0 > EF).
+            The comparator MUST follow UTF-8. Code points are built via
+            `Character/toChars` to avoid source-encoding fragility."
+    (let [astral (String. (Character/toChars 0x1F600))  ;; supplementary plane
+          bmp    (String. (Character/toChars 0xFFFD))]   ;; BMP replacement char
+      (is (pos? (compare-utf8-bytes astral bmp))
+          "UTF-8 byte order: astral (F0…) sorts AFTER bmp (EF…)")
+      (is (neg? (compare-utf8-bytes bmp astral)))
+      ;; Sanity: host-native compare gives the OPPOSITE (UTF-16) answer,
+      ;; confirming the comparator is genuinely doing byte-order work.
+      (is (neg? (compare astral bmp))
+          "host-native String.compareTo is UTF-16 order (the bug we fixed)"))))
+
+(deftest utf8-byte-sort-agrees-with-string-compare-on-ascii
+  (testing "rf2-ee38b.6 — for ASCII the UTF-8 byte order and native
+            string order coincide, so the pinned ASCII fixtures above
+            are byte-for-byte unaffected by the comparator switch."
+    (doseq [[a b] [["[:a]" "[:b]"] ["[:auth]" "[:user]"]
+                   ["abc" "abd"] ["[:n]" "[:n]"]]]
+      (is (= (Integer/signum (compare-utf8-bytes a b))
+             (Integer/signum (compare a b)))
+          (str "ASCII order coincides for " (pr-str [a b]))))))

--- a/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
+++ b/implementation/schemas/test/re_frame/schemas/printer_seam_test.clj
@@ -103,6 +103,23 @@
       (is (= "::FROM-MAP-ARITY::" (validator/run-printer :int))
           "the registered printer reaches the hot path"))))
 
+(deftest set-schema-validator!-map-arity-nil-print-coerces-to-default
+  (testing "rf2-ee38b.6 — `(set-schema-validator! {:print nil})` coerces
+            to the default EDN canonicaliser, identically to
+            `(set-schema-printer! nil)`. Reconciles the two printer-
+            setter paths so `printer-fn` is never nil (the read-site
+            guard in `run-printer` was dropped) — the map-arity
+            docstring's 'falls back to the default' promise is now true
+            at the write site."
+    ;; Poison first so a no-op would be observable.
+    (schemas/set-schema-printer! (fn [_] "::POISONED::"))
+    (is (= "::POISONED::" (validator/run-printer :int)))
+    (schemas/set-schema-validator! {:print nil})
+    (is (some? @validator/printer-fn)
+        "printer-fn is never nil after a {:print nil} map-arity swap")
+    (is (= ":int" (validator/run-printer :int))
+        "{:print nil} falls back to default-edn-print, not 'no printer'")))
+
 (deftest set-schema-printer!-nil-falls-back-to-default
   (testing "Passing `nil` to `set-schema-printer!` reinstalls the
             default EDN canonicaliser — the digest is never undefined

--- a/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_reg_side_effects_test.clj
@@ -1,0 +1,189 @@
+(ns re-frame.schemas-reg-side-effects-test
+  "JVM tests for the two dev-only side effects `reg-app-schema` performs
+  on (re-)registration (rf2-ee38b.6):
+
+    1. `:rf.schema/violation` hot-reload trace — Spec 010 §Schema
+       migration on hot-reload + Spec 009 error-catalogue row
+       `:rf.schema/violation`. When a re-registration CHANGES the schema
+       at a `(frame-id, path)` and the live `app-db` value at that path
+       fails the NEW schema, the runtime emits a `:warning` trace so dev
+       panels can highlight the stale slice. The live app keeps running
+       (`:logged-and-skipped`).
+
+    2. Schema-derived elision-registry population — Spec 010 §`:large?`
+       (\"at boot, and on `reg-app-schema` re-registration\") + §Registry
+       feeder (rf2-c1l4d). Registering a schema with `:large?` /
+       `:sensitive?` per-slot flags writes the corresponding declarations
+       into the frame's `[:rf/elision …]` slots so size-elision / privacy
+       redaction is live for wire emits — including those that fire BEFORE
+       the first dispatch (the gap the per-dispatch router refresh leaves).
+
+  Both effects are gated on `interop/debug-enabled?` and DCE'd in
+  production; the JVM test build is always dev-enabled."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.schemas :as schemas]
+            [re-frame.schemas.malli]
+            [re-frame.schemas.test-fixture :as tf]
+            [re-frame.substrate.adapter :as substrate-adapter]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- set-app-db!
+  "Set the live app-db value for `frame-id` (defaults to :rf/default)."
+  ([db] (set-app-db! :rf/default db))
+  ([frame-id db]
+   (substrate-adapter/replace-container! (frame/get-frame-db frame-id) db)))
+
+(defn- capture
+  "Run `body-fn` collecting trace events whose `:operation` is
+  `operation`; return the captured vector."
+  [operation body-fn]
+  (let [traces (atom [])
+        cb-id  (keyword (gensym "capture"))]
+    (rf/register-listener! cb-id (fn [ev] (swap! traces conj ev)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! cb-id)))
+    (filterv #(= operation (:operation %)) @traces)))
+
+;; ===========================================================================
+;; :rf.schema/violation hot-reload trace
+;; ===========================================================================
+
+(deftest violation-fires-when-rereg-changes-schema-and-live-value-fails
+  (testing "rf2-ee38b.6 — re-registering a path with a NEW schema the
+            live app-db value violates emits :rf.schema/violation with
+            the five spec'd tags"
+    ;; Register the original schema, then plant a live value that the
+    ;; new schema will reject.
+    (rf/reg-app-schema [:count] :int)
+    (set-app-db! {:count "not-an-int"})
+    (let [violations (capture :rf.schema/violation
+                       (fn []
+                         ;; Re-register with a DIFFERENT schema. The live
+                         ;; value "not-an-int" still fails :int (which it
+                         ;; also failed under the old schema) — but the
+                         ;; trigger is the schema CHANGE + current-value
+                         ;; mismatch against the NEW schema.
+                         (rf/reg-app-schema [:count] [:int {:min 0}])))]
+      (is (= 1 (count violations)) "exactly one violation trace")
+      (let [{:keys [op-type recovery tags] :as ev} (first violations)]
+        (is (= :warning op-type) "op-type is :warning per Spec 009 catalogue")
+        (is (= [:count] (:path tags)))
+        (is (= :int (:pre-reload-schema tags)))
+        (is (= [:int {:min 0}] (:post-reload-schema tags)))
+        (is (= "not-an-int" (:mismatching-value tags)))
+        (is (= :rf/default (:frame tags)))
+        ;; `:recovery` is hoisted to the top-level envelope by
+        ;; `trace/build-event` (Spec 009 §Core fields hoist contract).
+        (is (= :logged-and-skipped recovery)
+            (str ":recovery hoisted to top level; envelope=" (pr-str ev)))))))
+
+(deftest violation-suppressed-when-schema-unchanged
+  (testing "rf2-ee38b.6 — a no-op re-eval (identical schema) does NOT
+            emit a violation, even if the live value fails the schema"
+    (rf/reg-app-schema [:count] :int)
+    (set-app-db! {:count "not-an-int"})
+    (let [violations (capture :rf.schema/violation
+                       (fn [] (rf/reg-app-schema [:count] :int)))]
+      (is (empty? violations)
+          "identical schema re-eval is a silent swap! — nothing to flag"))))
+
+(deftest violation-suppressed-on-first-registration
+  (testing "rf2-ee38b.6 — the FIRST registration of a path never emits a
+            violation (there is no pre-reload schema to compare against),
+            even when the live value already fails"
+    (set-app-db! {:count "not-an-int"})
+    (let [violations (capture :rf.schema/violation
+                       (fn [] (rf/reg-app-schema [:count] :int)))]
+      (is (empty? violations) "first registration has no prior schema"))))
+
+(deftest violation-suppressed-when-live-value-validates
+  (testing "rf2-ee38b.6 — when the schema changes but the live value
+            still satisfies the NEW schema, no violation fires"
+    (rf/reg-app-schema [:count] :int)
+    (set-app-db! {:count 5})
+    (let [violations (capture :rf.schema/violation
+                       (fn [] (rf/reg-app-schema [:count] [:int {:min 0}])))]
+      (is (empty? violations) "live value 5 satisfies [:int {:min 0}]"))))
+
+(deftest violation-redacts-mismatching-value-when-new-schema-sensitive
+  (testing "rf2-ee38b.6 — when the NEW schema declares the slot
+            sensitive, :mismatching-value is redacted to :rf/redacted so
+            the hot-reload trace does not re-leak a credential"
+    (rf/reg-app-schema [:token] :int)
+    (set-app-db! {:token "super-secret"})
+    (let [violations (capture :rf.schema/violation
+                       (fn []
+                         (rf/reg-app-schema [:token]
+                                            [:string {:sensitive? true :min 32}])))]
+      (is (= 1 (count violations)))
+      (let [{:keys [sensitive? tags]} (first violations)]
+        (is (= :rf/redacted (:mismatching-value tags))
+            "sensitive slot's live value is scrubbed")
+        ;; `:sensitive?` is hoisted to the top-level envelope by
+        ;; `trace/build-event`.
+        (is (true? sensitive?) ":sensitive? hoisted to top level")
+        (is (= [:token] (:path tags)) "structural :path is kept")))))
+
+(deftest violation-is-per-frame
+  (testing "rf2-ee38b.6 — the violation check reads the live app-db of
+            the registration's frame, not :rf/default"
+    (rf/reg-frame :tenant/a {})
+    (rf/reg-app-schema [:count] :int {:frame :tenant/a})
+    (set-app-db! :tenant/a {:count "bad"})
+    (let [violations (capture :rf.schema/violation
+                       (fn []
+                         (rf/reg-app-schema [:count] [:int {:min 0}]
+                                            {:frame :tenant/a})))]
+      (is (= 1 (count violations)))
+      (is (= :tenant/a (-> violations first :tags :frame))))))
+
+;; ===========================================================================
+;; schema-derived elision-registry auto-population
+;; ===========================================================================
+
+(deftest reg-app-schema-populates-large-declarations
+  (testing "rf2-ee38b.6 — registering a schema with a `:large?` per-slot
+            flag writes the declaration into [:rf/elision :declarations]
+            at registration time (no dispatch required)"
+    (rf/reg-app-schema [:user]
+                       [:map
+                        [:id          :int]
+                        [:uploaded    {:large? true :hint "blob"} :string]])
+    (let [decls (elision/declarations :rf/default)]
+      (is (= {:large? true :source :schema :hint "blob"}
+             (get decls [:user :uploaded]))
+          "the :large? slot is declared without any dispatch happening"))))
+
+(deftest reg-app-schema-populates-sensitive-declarations
+  (testing "rf2-ee38b.6 — registering a schema with a `:sensitive?`
+            per-slot flag writes the declaration into
+            [:rf/elision :sensitive-declarations] at registration time"
+    (rf/reg-app-schema [:auth]
+                       [:map [:token {:sensitive? true} :string]])
+    (let [decls (elision/sensitive-declarations :rf/default)]
+      (is (= {:sensitive? true :source :schema}
+             (get decls [:auth :token]))
+          "the :sensitive? slot is declared at registration time"))))
+
+(deftest rereg-refreshes-elision-declarations
+  (testing "rf2-ee38b.6 — re-registering a path with the `:large?` flag
+            removed prunes the stale declaration (population is a
+            refresh, not an accrete)"
+    (rf/reg-app-schema [:user] [:map [:blob {:large? true} :string]])
+    (is (contains? (elision/declarations :rf/default) [:user :blob])
+        "declared after first registration")
+    (rf/reg-app-schema [:user] [:map [:blob :string]])
+    (is (not (contains? (elision/declarations :rf/default) [:user :blob]))
+        "stale schema-owned declaration pruned on re-registration")))
+
+(deftest bulk-reg-populates-elision-for-every-entry
+  (testing "rf2-ee38b.6 — reg-app-schemas populates the elision registry
+            for every entry"
+    (rf/reg-app-schemas {[:a] [:map [:big {:large? true} :string]]
+                         [:b] [:map [:secret {:sensitive? true} :string]]})
+    (is (contains? (elision/declarations :rf/default) [:a :big]))
+    (is (contains? (elision/sensitive-declarations :rf/default) [:b :secret]))))

--- a/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_walker_opaque_warning_test.clj
@@ -6,11 +6,19 @@
 
   Background — Spec 010 §The `:schema` value is opaque to re-frame: the
   schemas-walker (`re-frame.schemas.walker`) is pure data and handles
-  only vector-form Malli EDN. Compiled `m/schema` values and registry
-  refs (`:my/user-schema`) are treated as opaque leaves; per-slot
-  `:sensitive?` / `:large?` flags inside an opaque value are silently
-  skipped. This warning is the discoverability nudge that surfaces
-  this misconfiguration once per process.
+  only vector-form Malli EDN. Compiled `m/schema` values are treated as
+  opaque leaves; per-slot `:sensitive?` / `:large?` flags inside an
+  opaque value are silently skipped. This warning is the discoverability
+  nudge that surfaces this misconfiguration once per process.
+
+  Per rf2-ee38b.6 (correctness P2): keyword schemas do NOT warn. A bare
+  keyword is non-vector but is a valid Malli schema (primitive `:int` /
+  `:string` OR registry ref `:my/user-schema`); a keyword cannot carry
+  per-slot props, so the walker provably skips nothing on a primitive —
+  warning on every keyword was a frequent false positive on the common
+  case. The predicate cannot cheaply distinguish primitive from
+  registry-ref keywords without a registry consult (forbidden by Spec
+  010 §opaque), so the keyword case is suppressed entirely.
 
   Symmetric with `:rf.warning/schema-validator-unavailable` (rf2-fq7d2)
   — same emit-site, same warn-once-per-process pattern, same
@@ -38,26 +46,60 @@
          @recorded))
 
 ;; ---- positive paths -------------------------------------------------------
-
-(deftest warning-fires-when-schema-is-registry-ref
-  (testing "reg-app-schema with a registry-ref keyword (opaque to the
-            walker) emits the warning exactly once"
-    (let [recorded (record-traces! ::registry-ref)]
-      (rf/reg-app-schema [:user] :my/user-schema)
-      (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)]
-        (is (= 1 (count warns))
-            "exactly one warning fires on the first reg-app-schema call")
-        (is (= :registry-ref (-> warns first :tags :schema-kind)))
-        (is (= [:user] (-> warns first :tags :path)))))))
+;;
+;; Only genuinely opaque NON-keyword values (compiled m/schema-like
+;; maps) warn. Keyword schemas — primitive AND registry-ref — are
+;; suppressed (rf2-ee38b.6 correctness P2); see the negative-path
+;; section below.
 
 (deftest warning-fires-when-schema-is-compiled-map-object
   (testing "reg-app-schema with a compiled m/schema-like map value
-            (opaque to the walker) emits the warning"
+            (opaque to the walker) emits the warning exactly once"
     (let [recorded (record-traces! ::compiled-map)]
       (rf/reg-app-schema [:cart] {:malli/schema :some-compiled-form})
       (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)]
-        (is (= 1 (count warns)))
-        (is (= :compiled-schema-object (-> warns first :tags :schema-kind)))))))
+        (is (= 1 (count warns))
+            "exactly one warning fires on the first reg-app-schema call")
+        (is (= :compiled-schema-object (-> warns first :tags :schema-kind)))
+        (is (= [:cart] (-> warns first :tags :path)))))))
+
+(deftest warning-fires-once-across-multiple-opaque-calls
+  (testing "subsequent reg-app-schema calls with opaque (compiled-map)
+            schemas within the same process do NOT re-emit the warning
+            (process-lifecycle one-shot)"
+    (let [recorded (record-traces! ::dedup-rereg)]
+      (rf/reg-app-schema [:a] {:malli/schema :a})
+      (rf/reg-app-schema [:b] {:malli/schema :b})
+      (rf/reg-app-schema [:c] {:malli/schema :c})
+      (is (= 1 (count (warnings-of recorded
+                                   :rf.warning/schema-walker-opaque)))
+          "three registrations -> exactly one warning"))))
+
+(deftest warning-fires-once-from-reg-app-schemas-bulk
+  (testing "bulk reg-app-schemas with opaque schemas fires the warning
+            once across all entries"
+    (let [recorded (record-traces! ::bulk)]
+      (rf/reg-app-schemas {[:user]    {:malli/schema :user}
+                           [:cart]    {:malli/schema :cart}
+                           [:session] {:malli/schema :session}})
+      (is (= 1 (count (warnings-of recorded
+                                   :rf.warning/schema-walker-opaque)))))))
+
+(deftest warning-carries-actionable-reason
+  (testing ":tags includes a :reason string that names the two workable
+            shapes (vector form OR registration-level :sensitive?
+            metadata)"
+    (let [recorded (record-traces! ::reason)]
+      (rf/reg-app-schema [:user] {:malli/schema :user})
+      (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)
+            tags  (-> warns first :tags)]
+        (is (string? (:reason tags)))
+        (is (re-find #"vector form" (:reason tags))
+            ":reason names the vector-form fix")
+        (is (re-find #"sensitive\?" (:reason tags))
+            ":reason names the registration-meta fallback")))))
+
+;; ---- negative paths (no warning) ------------------------------------------
 
 (deftest warning-suppressed-when-schema-is-vector-form
   (testing "reg-app-schema with a vector-form Malli schema (introspectable)
@@ -67,41 +109,31 @@
       (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
           "vector-form schema -> no warning"))))
 
-(deftest warning-fires-once-across-multiple-non-vector-calls
-  (testing "subsequent reg-app-schema calls with opaque schemas within
-            the same process do NOT re-emit the warning (process-
-            lifecycle one-shot)"
-    (let [recorded (record-traces! ::dedup-rereg)]
-      (rf/reg-app-schema [:a] :my/schema-a)
-      (rf/reg-app-schema [:b] :my/schema-b)
-      (rf/reg-app-schema [:c] :my/schema-c)
-      (is (= 1 (count (warnings-of recorded
-                                   :rf.warning/schema-walker-opaque)))
-          "three registrations -> exactly one warning"))))
+(deftest warning-suppressed-on-primitive-keyword-schemas
+  (testing "rf2-ee38b.6 — primitive keyword schemas (`:int` / `:string`
+            / `:boolean` / `:any`) are valid Malli schemas that cannot
+            carry per-slot props; the walker provably skips nothing, so
+            registering one does NOT emit the false-positive warning"
+    (let [recorded (record-traces! ::primitive-kw)]
+      (rf/reg-app-schema [:age]    :int)
+      (rf/reg-app-schema [:name]   :string)
+      (rf/reg-app-schema [:active] :boolean)
+      (rf/reg-app-schema [:misc]   :any)
+      (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
+          "primitive keyword schemas -> no spurious 'per-slot flags
+           skipped' nudge"))))
 
-(deftest warning-fires-once-from-reg-app-schemas-bulk
-  (testing "bulk reg-app-schemas with opaque schemas fires the warning
-            once across all entries"
-    (let [recorded (record-traces! ::bulk)]
-      (rf/reg-app-schemas {[:user]    :my/user-schema
-                           [:cart]    :my/cart-schema
-                           [:session] :my/session-schema})
-      (is (= 1 (count (warnings-of recorded
-                                   :rf.warning/schema-walker-opaque)))))))
-
-(deftest warning-carries-actionable-reason
-  (testing ":tags includes a :reason string that names the two workable
-            shapes (vector form OR registration-level :sensitive?
-            metadata)"
-    (let [recorded (record-traces! ::reason)]
+(deftest warning-suppressed-on-registry-ref-keyword-schemas
+  (testing "rf2-ee38b.6 — registry-ref keyword schemas (`:my/user-schema`)
+            also do NOT warn: they are indistinguishable from primitive
+            keywords without a forbidden registry consult, so the
+            keyword case is suppressed entirely. The advanced registry-
+            ref-hides-per-slot-flags shape is covered by the walker
+            docstring's discoverability caveat (rf2-yaioz)"
+    (let [recorded (record-traces! ::registry-ref)]
       (rf/reg-app-schema [:user] :my/user-schema)
-      (let [warns (warnings-of recorded :rf.warning/schema-walker-opaque)
-            tags  (-> warns first :tags)]
-        (is (string? (:reason tags)))
-        (is (re-find #"vector form" (:reason tags))
-            ":reason names the vector-form fix")
-        (is (re-find #"sensitive\?" (:reason tags))
-            ":reason names the registration-meta fallback")))))
+      (is (empty? (warnings-of recorded :rf.warning/schema-walker-opaque))
+          "registry-ref keyword schema -> no warning"))))
 
 ;; ---- cache-clear semantics ------------------------------------------------
 
@@ -110,11 +142,11 @@
             subsequent reg-app-schema fires the warning anew (test-fixture
             isolation)"
     (let [recorded (record-traces! ::clear-cache)]
-      (rf/reg-app-schema [:first] :my/schema-1)
+      (rf/reg-app-schema [:first] {:malli/schema :first})
       (is (= 1 (count (warnings-of recorded
                                    :rf.warning/schema-walker-opaque))))
       (schemas/clear-walker-opaque-warned!)
-      (rf/reg-app-schema [:second] :my/schema-2)
+      (rf/reg-app-schema [:second] {:malli/schema :second})
       (is (= 2 (count (warnings-of recorded
                                    :rf.warning/schema-walker-opaque)))
           "after cache clear the warning fires again"))))


### PR DESCRIPTION
Consolidated 3-lens review remediation for `implementation/schemas` (bead **rf2-ee38b.6**). Spec 010 is normative.

## Findings → fixes

| Finding | Pri | Fix |
|---|---|---|
| `:large?`/`:sensitive?` elision-registry population (completeness) | P2 | `reg-app-schema` now refreshes the schema-derived `[:rf/elision …]` declarations at registration via the `:elision/populate-from-schemas!` hook (dev-gated). Matches Spec 010 §`:large?` "at boot / on re-registration". **Note:** the finding's "inert in normal apps" claim was partly inaccurate — `re-frame.router` already refreshes per-dispatch (rf2-w3n5u); this fix closes the genuine gap for wire-boundary emits/digests that fire **before the first dispatch** (boot-time SSR serialise, initial epoch snapshot) and honours the spec's explicit "on re-registration" wording. |
| `:rf.schema/violation` hot-reload trace (completeness) | P2 | Emit the spec'd trace (`:op-type :warning`, recovery `:logged-and-skipped`, tags `:path`/`:pre-reload-schema`/`:post-reload-schema`/`:mismatching-value`/`:frame`) when a re-registration changes a path's schema **and** the live `app-db` value fails the new shape. Redacts `:mismatching-value` when the new schema declares the slot sensitive; guards malformed-schema validator throws so a bad schema never crashes registration. |
| Walker-opaque false positive on primitive keywords (correctness) | P2 | Suppress `:rf.warning/schema-walker-opaque` on **all** keyword schemas (`:int`/`:string`/`:my/ref` cannot carry per-slot props — nothing to skip). Warning now fires only on genuinely opaque non-keyword values (compiled `m/schema` objects). |
| `:schema-kind` mislabels keywords as `:registry-ref` (correctness) | P3 | Dead clause removed (keywords no longer warn). |
| Two printer-setters disagree on `nil` (clarity) | P2 | `set-schema-validator!` map-arity now coerces `{:print nil}` → `default-edn-print` identically to `set-schema-printer!`; `printer-fn` is never nil; dropped the defensive `(or @printer-fn default)` band-aid in `run-printer`. |
| Digest line-sort uses UTF-16 not UTF-8 (correctness) | P3 | Sort lines as UTF-8 byte sequences (`compare-utf8-bytes`) per Spec 010 §Digest step 4. ASCII order unchanged → all pinned parity vectors hold; CLJS↔JVM still agree. |

## Skipped (judgment, low value)

- **P3 facade re-export removal** (`walk-flagged-schema` / `schema-has-sensitive?` / `schema-sensitive-at?`) — the re-exports keep the test surface uniform with the rest of `schemas/` and are harmless; removing them churns 3 test files for a stylistic preference. (`schema-has-sensitive?` is now also an internal `storage` consumer.)
- **P3 wholesale docstring-volume trim** — high-churn, merge-conflict-prone for a fix bead. Targeted trims applied only where already editing (`run-printer`, walker-opaque comment).

## Tests
- New `schemas_reg_side_effects_test` — pins the violation trace (fires/suppressed matrix, per-frame, sensitive redaction) + elision auto-population (large/sensitive/refresh/bulk).
- `schemas_walker_opaque_warning_test` reworked — keyword suppression + primitive & registry-ref negatives; positives switched to compiled-map opaque values.
- `printer_seam_test` — pins `{:print nil}` map-arity coercion.
- `digest_parity_test` — pins UTF-8 byte order vs UTF-16 on supplementary-plane chars; confirms ASCII coincidence.

## Gates (all green, worktree `implementation/`)
- `clojure -M:test` schemas (JVM): 192 tests, 18251 assertions, 0/0.
- `clojure -M:test` core (JVM): 728/0/0. epoch (JVM): 201/0/0.
- `npx shadow-cljs compile node-test` (clean) + `node out/node-test.js`: 4129 tests, 12607 assertions, 0/0.
- `npm run test:elision`: PASS — production 36/36 absent, control 36/36 present.

Cross-ref: rf2-ee38b.6 (parent epic rf2-ee38b).