### PR TITLE
fix(skills): re-frame2-pair correctness + clarity remediation

### DIFF
--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -60,7 +60,7 @@ This is a **router skill**. The trigger-time guard rails live below; the operati
 
 ## The three primitives
 
-Your agency runs through three coupled primitives, all part of re-frame2's own [Tool-Pair contract](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md):
+Your agency runs through three coupled primitives, all part of re-frame2's own [Tool-Pair contract](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md):
 
 1. **The REPL** — a shadow-cljs nREPL session connected to the browser runtime, where ClojureScript forms evaluate against the real app.
 2. **The trace stream** — `(re-frame.trace.tooling/register-listener! id cb)` for live trace events; `(re-frame.trace.tooling/trace-buffer opts)` for the retain-N ring of recent events. (`register-listener!` is re-exported on `rf/`, but `trace-buffer` is a **JVM-only** alias on `rf/` — CLJS callers, including this shim's `cljs-eval`, must reach for `re-frame.trace.tooling/trace-buffer` directly or the form silently returns nil.) This skill registers exactly *one* trace listener (under id `:re-frame2-pair`) so multiple tools can coexist.
@@ -89,7 +89,7 @@ Where the runtime lives:
 - **npm consumers**: the `@day8/re-frame2-pair` package ships the `preload/` directory; the source-path entry above points there.
 - **Local-dev / linked checkouts**: substitute the absolute path to `skills/re-frame2-pair/preload/` for the `node_modules/...` entry.
 
-Verification — run `discover-app` (the MCP tool `mcp__re-frame2-pair__discover-app`). The success result includes `:ok? true :session-id "..." :build-id :app`. If the preload is missing you get back:
+Verification — run `discover-app` (the MCP tool `mcp__re-frame2-pair__discover-app`). The success result is the runtime health map merged with `:ok? true` and `:build-id`, e.g. `:ok? true :debug-enabled? true :frames [:rf/default] :coord-annotation-enabled? true :build-id :app` (plus `:session-id`, `:selected-frame`, `:operating-frame` and the other health slots). If the preload is missing you get back:
 
 ```edn
 {:ok? false :reason :runtime-not-preloaded

--- a/skills/re-frame2-pair/STATUS.md
+++ b/skills/re-frame2-pair/STATUS.md
@@ -63,7 +63,7 @@ Does `scripts/eval-cljs.sh '(+ 1 2)'` return `{:ok? true :value 3}`? If not, `op
 
 ### 3. `data-rf2-source-coord` format — RESOLVED 2026-05-09
 
-Per [Spec 006 §Source-coord annotation](https://github.com/day8/re-frame2/blob/master/spec/006-ReactiveSubstrate.md) and [Tool-Pair §Source-mapping](https://github.com/day8/re-frame2/blob/master/spec/Tool-Pair.md) the emitted attribute value is:
+Per [Spec 006 §Source-coord annotation](https://github.com/day8/re-frame2/blob/main/spec/006-ReactiveSubstrate.md) and [Tool-Pair §Source-mapping](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md) the emitted attribute value is:
 
 ```
 data-rf2-source-coord="<ns>:<handler-id>:<line>:<col>"

--- a/skills/re-frame2-pair/docs/initial-spec.md
+++ b/skills/re-frame2-pair/docs/initial-spec.md
@@ -10,7 +10,7 @@
 
 `re-frame2-pair` is a Claude Code Skill (and Plugin) that lets Claude act as a pair programmer for a **live, running [re-frame2](https://github.com/day8/re-frame2) application**. It attaches to the application's runtime via shadow-cljs nREPL and exposes a small set of operations that map directly onto re-frame2's primitives: frames, `app-db`, events, subscriptions, effects, interceptors, machines.
 
-This is the re-frame2 sibling of v1 [`re-frame-pair`](https://github.com/day8/re-frame-pair). It consumes only re-frame2's own [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md) surfaces. **It has no re-frame-10x dependency.**
+This is the re-frame2 sibling of v1 [`re-frame-pair`](https://github.com/day8/re-frame-pair). It consumes only re-frame2's own [Tool-Pair Spec](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md) surfaces. **It has no re-frame-10x dependency.**
 
 ### Why this shape
 
@@ -50,7 +50,7 @@ re-frame2-pair itself contributes **zero** additional host-project configuration
 - **Reactive graph.** re-frame2's subscription signal graph, with value-equal recompute suppression.
 - **Per-frame state.** Each frame's `app-db` is reachable via `(rf/get-frame-db frame-id)` and `(rf/snapshot-of path opts)`.
 - **Writes.** `dispatch` (with `:origin :pair` opt), `reg-*` re-registration, `restore-epoch`, container reset (rare).
-- **Runtime introspection API.** Every Tool-Pair surface listed in [Tool-Pair §How AI tools attach](https://github.com/day8/re-frame2/blob/master/docs/specification/Tool-Pair.md#how-ai-tools-attach).
+- **Runtime introspection API.** Every Tool-Pair surface listed in [Tool-Pair §How AI tools attach](https://github.com/day8/re-frame2/blob/main/spec/Tool-Pair.md#how-ai-tools-attach).
 - **Connection mechanism.** nREPL -> shadow-cljs -> browser runtime.
 - **Packaging.** `SKILL.md` + bash shim scripts + babashka ops dispatcher.
 - **Cardinal rule.** Two modes — REPL (ephemeral) vs source edit (permanent via hot-reload). See §3.

--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -624,6 +624,17 @@
   (let [[ob oa c] (data/diff db-before db-after)]
     {:only-before ob :only-after oa :common c}))
 
+(defn frame-diff
+  "Cross-frame counterpart to `epoch-diff`: diff the current `app-db`
+   of two frames. Use to compare two Story variants (variant-id IS the
+   frame-id) or any two live frames. Returns the cross-frame vocabulary:
+       {:only-in-a <map> :only-in-b <map> :common <map>}
+   where A is `frame-id-a` and B is `frame-id-b`."
+  [frame-id-a frame-id-b]
+  (let [[a b c] (data/diff (rf/get-frame-db frame-id-a)
+                           (rf/get-frame-db frame-id-b))]
+    {:only-in-a a :only-in-b b :common c}))
+
 ;; ---------------------------------------------------------------------------
 ;; Trace stream listener (raw-trace, retain-N buffer is in framework)
 ;; ---------------------------------------------------------------------------

--- a/skills/re-frame2-pair/references/errors.md
+++ b/skills/re-frame2-pair/references/errors.md
@@ -17,7 +17,7 @@ Every script returns structured edn like `{:ok? false :reason ...}` rather than 
 
 Every `:rf.error/*` trace event carries `:rf.trace/trigger-handler` — `{:kind :event :id :user/save :source-coord {:ns ... :file ... :line ... :column ...}}` — naming the handler that was executing when the error fired (event, sub, fx, cofx, view, interceptor, or late-bind hook). Report the `:source-coord` as `<file>:<line>` so the user can jump to source; the field is present in production traces too. The field is **absent** for dispatch-time errors where no handler is in scope yet (e.g. `:rf.error/no-such-event`); for those, the `:rf.error/data` is the only handle.
 - `:timed-out? true` on a `dispatch-and-collect` → drain didn't settle in the wait window (a long-running async cascade, or a stuck `:dispatch-later`). Inspect the in-flight cascade via the trace buffer.
-- `:connection :lost` → reconnect by calling `mcp__re-frame2-pair__discover-app` (legacy: `scripts/discover-app.sh`) again.
+- `:connection :lost` → reconnect by calling `mcp__re-frame2-pair__discover-app` again.
 - Restore failures (`:rf.epoch/restore-*`) → see the time-travel failure table in [ops.md](ops.md#time-travel-epoch-restore).
 
 ## `:on-error` policy violations

--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -1,17 +1,13 @@
-# MCP transport — preferred path
+# MCP transport — the skill's only transport
 
-The re-frame2-pair ops are reachable two ways:
-
-1. **MCP server** (preferred) — a persistent stdio JSON-RPC server
-   that holds one nREPL socket open for the whole session. Per-op
-   latency ~5–50ms.
-2. **Bash shims** (legacy, deprecated) — `scripts/*.sh` under this
-   skill, each spawning bash → babashka → fresh nREPL connect per
-   call. Per-op latency ~700ms. Kept for back-compat.
-
-Pick the MCP server whenever it's available. If the agent host
-doesn't have it configured, fall back to the bash shims; the
-op semantics are identical.
+The re-frame2-pair ops run over the **MCP server** — a persistent
+stdio JSON-RPC server that holds one nREPL socket open for the whole
+session (per-op latency ~5–50ms). This is the only transport the
+skill exposes; the bash shims under `scripts/` are retired from the
+skill's tool surface (no shell tool is in `allowed-tools:`) and
+remain on disk only for the project's own e2e test harness. The
+shell-counterpart mapping lives in [`ops.md` §Bash-shim appendix](ops.md#bash-shim-appendix-not-reachable-from-this-skill)
+for that harness; do not reach for it as a fallback transport.
 
 ## Install / configure (one-time)
 
@@ -40,26 +36,26 @@ The server auto-discovers the nREPL port from (in order):
 3. `.shadow-cljs/nrepl.port`
 4. `.nrepl-port`
 
-## Bash-shim → MCP tool mapping
+## MCP tool reference (args)
 
-| Bash shim                         | MCP tool       | Same args? |
-|-----------------------------------|----------------|------------|
-| `scripts/discover-app.sh`         | `discover-app` | yes (optional `build`) |
-| `scripts/eval-cljs.sh '<form>'`   | `eval-cljs`    | pass form as `{form: "..."}` |
-| `scripts/dispatch.sh '<event>' --sync --frame :foo` | `dispatch` | `{event: "...", sync: true, frame: ":foo"}` |
-| `scripts/trace-window.sh 1000`    | `trace-window` | `{ms: 1000}` |
-| `scripts/watch-epochs.sh --event-id-prefix :cart` | `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
-| `scripts/tail-build.sh --probe '<form>'` | `tail-build` | `{probe: "..."}` |
-| _(none — MCP-only)_                | `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"], path: "[:cart :items]"}` — default `:app-db` mode is **`:summary`** (tree-summary marker, not the full value); pass `path` to slice. Root `path: "[]"` opts back into the full slice. See [`ops.md` §Read](ops.md#read). |
-| _(none — MCP-only)_                | `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive. Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. |
-| _(none — MCP-only, push-mode)_     | `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
-| _(none — MCP-only)_                | `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
-| _(none — MCP-only)_                | `list-subscriptions` | `{}` (or `{topic: "epoch"}` / `{sub-id: "<uuid>"}`) — list active streaming subscriptions with `:queue-depth`, `:dropped-events`, `:overflow-reason` without draining queues. Diagnostic for "is my probe still alive?". |
-| _(none — MCP-only)_                | `list-handlers` | `{kind: "event"}` — discovery: every id registered under one kind. `{:ok? true :kind :event :ids [...] :count n}`, ids sorted. Kinds: `event` / `sub` / `fx` / `cofx` / `view` / `frame` / `route` / `flow` / `head` / `error-projector` / `machine`. Prefer over a `registrar-list` eval. See [`ops.md` §Read](ops.md#read). |
-| _(none — MCP-only)_                | `handler-meta` | `{kind: "event", id: ":user/login"}` — drill: registration metadata for one id (source-coord + `:doc` + `:tags` + an `:rf.source/uri` clickable jump-to-editor link). `{:ok? false :reason :not-registered ...}` on a miss. Composite sub ids pass as the vector-string form. Prefer over a `registrar-describe` eval. See [`ops.md` §Read](ops.md#read). |
-| _(none — MCP-only)_                | `get-re-frame2-pair-instructions` | `{}` — inline agent-onboarding text (tool catalogue, EDN posture, tagged-mutation conventions, streaming semantics, wire pipeline). No nREPL round-trip. Optionally call at session start to orient before the first real op. |
+| MCP tool       | Args |
+|----------------|------|
+| `discover-app` | `{}` (optional `build`) |
+| `eval-cljs`    | `{form: "..."}` |
+| `dispatch`     | `{event: "...", sync: true, frame: ":foo"}` |
+| `trace-window` | `{ms: 1000}` |
+| `watch-epochs` | `{pred: {"event-id-prefix": ":cart"}}` (pull-mode — call repeatedly with `since-id`) |
+| `tail-build`   | `{probe: "..."}` |
+| `snapshot`     | `{frames: "all"\|[":rf/default"...], include: ["app-db","sub-cache","machines","epochs","traces"], path: "[:cart :items]"}` — default `:app-db` mode is **`:summary`** (tree-summary marker, not the full value); pass `path` to slice. Root `path: "[]"` opts back into the full slice. See [`ops.md` §Read](ops.md#read). |
+| `get-path`     | `{path: "[:cart :items 0 :sku]", frame: ":rf/default"}` — targeted-read primitive. Returns `{ok? true :exists? true :value <subtree>}` or `{ok? false :reason :path-not-found :deepest-valid-prefix [...]}`. `:exists?` distinguishes a path that legitimately points at `nil` from a missing path. |
+| `subscribe`    | `{topic: "trace"\|"epoch"\|"fx"\|"error", filter: {...}, max-events: 0, max-ms: 0}` — push-mode; emits `notifications/progress` ticks; resolves on cancel / `max-events` / `max-ms` / `unsubscribe`. See `references/streaming-subscriptions.md`. |
+| `unsubscribe`  | `{sub-id: "<uuid>"}` — idempotent close. |
+| `list-subscriptions` | `{}` (or `{topic: "epoch"}` / `{sub-id: "<uuid>"}`) — list active streaming subscriptions with `:queue-depth`, `:dropped-events`, `:overflow-reason` without draining queues. Diagnostic for "is my probe still alive?". |
+| `list-handlers` | `{kind: "event"}` — discovery: every id registered under one kind. `{:ok? true :kind :event :ids [...] :count n}`, ids sorted. Kinds: `event` / `sub` / `fx` / `cofx` / `view` / `frame` / `route` / `flow` / `head` / `error-projector` / `machine`. Prefer over a `registrar-list` eval. See [`ops.md` §Read](ops.md#read). |
+| `handler-meta` | `{kind: "event", id: ":user/login"}` — drill: registration metadata for one id (source-coord + `:doc` + `:tags` + an `:rf.source/uri` clickable jump-to-editor link). `{:ok? false :reason :not-registered ...}` on a miss. Composite sub ids pass as the vector-string form. Prefer over a `registrar-describe` eval. See [`ops.md` §Read](ops.md#read). |
+| `get-re-frame2-pair-instructions` | `{}` — inline agent-onboarding text (tool catalogue, EDN posture, tagged-mutation conventions, streaming semantics, wire pipeline). No nREPL round-trip. Optionally call at session start to orient before the first real op. |
 
-The `subscribe` / `unsubscribe` pair is the **push-mode** replacement for `watch-epochs`. Each batch of matching events arrives as a `notifications/progress` notification correlated by the call's `progressToken`; the tool's final result is a summary. Use `subscribe` whenever you want a live narration; fall back to `watch-epochs` (pull-mode) when the agent host doesn't surface progress notifications to the model.
+The `subscribe` / `unsubscribe` pair is the **push-mode** counterpart to `watch-epochs`. Each batch of matching events arrives as a `notifications/progress` notification correlated by the call's `progressToken`; the tool's final result is a summary. Use `subscribe` whenever you want a live narration; use `watch-epochs` (pull-mode, polled in a loop) when the agent host doesn't surface progress notifications to the model.
 
 (`inject-runtime` is gone — the runtime ships into the app via
 shadow-cljs `:devtools :preloads`. See `SKILL.md` §Setup.)
@@ -106,8 +102,7 @@ Use `get-path` (next section) when you already know the addressed subtree — it
 
 ## Preload probe (no inject step)
 
-Both transports handle preload verification the same way: every op
-that needs the in-browser runtime first probes
+Every op that needs the in-browser runtime first probes
 `js/globalThis.__re_frame2_pair_runtime` — the load-time marker the
 preload installs. If the marker is missing the op refuses with
 `{:ok? false :reason :runtime-not-preloaded :hint "..."}`. A full
@@ -126,10 +121,11 @@ answers `tools/list` but every `tools/call` returns
 Start shadow-cljs and retry — the server picks up the port on the
 next call.
 
-## Why two transports
+## The bash shims (out of scope for this skill)
 
-The MCP server is the structural shift. The bash shims stay for
-back-compat — older skill installations that haven't migrated, agent
-hosts without MCP support, ad-hoc shell scripting. Both consume the
-same `re-frame2-pair.runtime` namespace; the runtime contract is
-transport-agnostic.
+The shims under `scripts/` predate the MCP server and remain on disk
+only for the project's own e2e test harness and ad-hoc shell use
+outside the skill. They consume the same `re-frame2-pair.runtime`
+namespace — the runtime contract is transport-agnostic — but they are
+**not** reachable from this skill (no shell tool in `allowed-tools:`).
+Treat the MCP tools above as the complete operating surface.

--- a/skills/re-frame2-pair/references/on-error.md
+++ b/skills/re-frame2-pair/references/on-error.md
@@ -27,7 +27,7 @@ The runtime accepts exactly six values; anything else triggers `:rf.error/bad-on
 
 ## What `:retry-count` was — and isn't
 
-The framework does NOT implement retry semantics. `:retry-count` is **not part of the contract** and never was. If you find a policy in the user's code returning `{:recovery :retried :retry-count 3}` (an old idiom from drafts), the runtime now rejects it: `:rf.error/bad-on-error-return` is emitted and the category default applies. The `:retried` keyword exists in the recovery enum but is **reserved for `:rf.http/retry-attempt`** traces emitted by managed-HTTP — that surface owns its own backoff. An `:on-error` policy that wants to fire the event again MUST dispatch a fresh event from the policy body.
+The framework does NOT implement retry semantics. `:retry-count` is **not part of the contract** and never was. If you find a policy in the user's code returning `{:recovery :retried :retry-count 3}` (an old idiom from drafts), the runtime now rejects it: `:rf.error/bad-on-error-return` is emitted and the category default applies. `:retried` is **not** one of the six `:on-error` return values — it is the runtime's own `:recovery` disposition stamped on `:rf.http/retry-attempt` traces emitted by managed-HTTP (Spec 009 §Catalogue / Spec 014 §Retry and backoff), where that surface owns its own backoff. An `:on-error` policy that wants to fire the event again MUST dispatch a fresh event from the policy body.
 
 ## `:replacement` — only honoured under `:replaced-with-default`
 
@@ -71,7 +71,6 @@ mcp__re-frame2-pair__eval-cljs {
 }
 ```
 
-Legacy bash form (if the MCP server isn't wired): replace each `mcp__re-frame2-pair__eval-cljs {form: "..."}` with `scripts/eval-cljs.sh '<form>'`.
 
 ## Quick checklist for proposing a policy
 

--- a/skills/re-frame2-pair/references/ops.md
+++ b/skills/re-frame2-pair/references/ops.md
@@ -1,6 +1,6 @@
 # Operations catalogue
 
-The op vocabulary the skill operates through. Each op is reachable via the **MCP transport** (preferred — ~14× faster, single persistent nREPL connection) or the **bash-shim transport** (legacy fallback). The MCP form is shown in the Invocation column; the bash-shim equivalents are catalogued in the [Bash-shim back-compat appendix](#bash-shim-back-compat-appendix) at the end of this file.
+The op vocabulary the skill operates through. Every op runs over the **MCP transport** (the only transport this skill exposes) — see [`mcp-transport.md`](mcp-transport.md). The MCP form is shown in the Invocation column. The bash shims under `scripts/` are retired from the skill's tool surface; their shell counterparts are catalogued in the [Bash-shim appendix](#bash-shim-appendix-not-reachable-from-this-skill) for the project's own e2e harness only.
 
 Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `eval-cljs {form: "<runtime call>"}`. Dedicated MCP tools (`dispatch`, `snapshot`, `get-path`, `trace-window`, `watch-epochs`, `tail-build`, `subscribe`, `unsubscribe`) cover the broader concerns. Prefer the **structured ops** over `repl/eval` whenever a structured op fits. See [`mcp-transport.md`](mcp-transport.md) for transport details.
 
@@ -14,7 +14,7 @@ Most ops wrap a call into `re-frame2-pair.runtime`; for those, the MCP form is `
 - [Live watch (push-mode)](#live-watch-push-mode)
 - [Hot-reload coordination](#hot-reload-coordination)
 - [Time-travel (epoch restore)](#time-travel-epoch-restore)
-- [Bash-shim back-compat appendix](#bash-shim-back-compat-appendix)
+- [Bash-shim appendix (not reachable from this skill)](#bash-shim-appendix-not-reachable-from-this-skill)
 - [Dropped from v1 (re-frame-pair) — surfaces with no v2 equivalent](#dropped-from-v1-re-frame-pair--surfaces-with-no-v2-equivalent)
 
 ## Read
@@ -98,7 +98,7 @@ Read-only from the trace stream + epoch history.
 
 ## Live watch (push-mode)
 
-Two transports, same underlying assembled-epoch / trace stream.
+Two modes — `subscribe` (push) and `watch-epochs` (poll) — over the same underlying assembled-epoch / trace stream.
 
 **MCP streaming subscriptions (preferred for push-mode).** True server-pushed events delivered via `notifications/progress`, correlated by the call's `progressToken`. See [streaming-subscriptions.md](streaming-subscriptions.md) for topics, filters, termination, and the recipes that prefer this path.
 
@@ -107,29 +107,28 @@ Two transports, same underlying assembled-epoch / trace stream.
 | `trace/subscribe` | `mcp__re-frame2-pair__subscribe` | Open a streaming subscription on the `:trace`, `:epoch`, `:fx`, or `:error` bus. Returns a `sub-id`; each batch arrives as a `notifications/progress` tick until termination. |
 | `trace/unsubscribe` | `mcp__re-frame2-pair__unsubscribe` | Close a subscription by `sub-id`. Idempotent — unknown ids return `:existed? false`. |
 
-**Pull-mode poll (legacy / fallback).** The `watch-epochs` MCP tool is the pull-mode wrapper: call repeatedly with `since-id` to drain new matches. Use this when the agent host doesn't surface `notifications/progress` to the model, or when you want a finite window summary rather than a live stream.
+**Pull-mode poll (fallback).** The `watch-epochs` MCP tool is poll-only: each call returns the matching epochs that landed *after* `since-id`. To live-watch, call it repeatedly, passing the previous response's `:head-id` as the next `since-id`. Use this when the agent host doesn't surface `notifications/progress` to the model, or when you want a finite, controlled drain rather than a push stream.
+
+The tool's accepted args (`:additionalProperties false` — anything else is rejected): `since-id`, `pred`, `frame`, `limit`, `cursor`, `epochs-mode`, `dedup`, `include-sensitive`, `build`. There is **no** `window-ms`/`count`/`stream`/`stop` arg — those are bash-shim flags only (see the bash-shim appendix).
 
 | Op | Invocation | Behaviour |
 |---|---|---|
-| `watch/window` | `mcp__re-frame2-pair__watch-epochs {window-ms: 30000, pred: {"event-id-prefix": ":checkout/"}}` | Runs for N ms, reports every matching epoch, summarises at end |
-| `watch/count` | `mcp__re-frame2-pair__watch-epochs {count: 5}` | Runs until N epochs match |
-| `watch/stream` | `mcp__re-frame2-pair__watch-epochs {stream: true, pred: {"event-id-prefix": ":cart/"}}` | Streams until disconnect, idle-timeout, or `watch/stop` |
-| `watch/stop` | `mcp__re-frame2-pair__watch-epochs {stop: true}` | Terminates any active watch for this session |
+| `watch/first-poll` | `mcp__re-frame2-pair__watch-epochs {pred: {"event-id-prefix": ":checkout/"}}` | Drains matching epochs already in the ring; response carries `:matches`, `:count`, and `:head-id` |
+| `watch/resume` | `mcp__re-frame2-pair__watch-epochs {since-id: "<last-head-id>", pred: {...}}` | Returns only matches that landed after `since-id`; repeat to live-watch |
+| `watch/paginate` | `mcp__re-frame2-pair__watch-epochs {pred: {...}, limit: 20, cursor: "<next-cursor>"}` | When a poll's matches exceed `:limit` (default 50), `:next-cursor`/`:has-more?` let you page the rest |
 
-Predicate keys (any combination, inside `pred`): `event-id`, `event-id-prefix`, `effects`, `timing-ms` (e.g. `">100"`), `touches-path`, `sub-ran`, `render`, `origin` (`:pair|:app|:ui|:timer|:http`), `frame`.
+"Run for N matches" and "stream until disconnect" are *loops the agent runs*, not tool args: call `watch-epochs` repeatedly, advancing `since-id`, until you've seen enough matches or the user stops you.
 
-Mode rules:
+Predicate keys (any combination, inside `pred`): `event-id`, `event-id-prefix`, `effects`, `timing-ms` (e.g. `">100"`), `touches-path`, `sub-ran`, `render`, `origin` (`:app|:pair|:story|:test`), `frame`.
 
-- `window-ms` and `count` are independent. `window-ms` alone runs for N ms with no count limit; `count` alone runs until N matches with no window timeout. If both are set, the first condition to fire wins. With neither (and no `stream: true`), the default is a 30 s window.
-
-The watch transport polls the assembled-epoch stream by tracking the last seen `:epoch-id` in the operating frame's history and asking for everything since. See `docs/initial-spec.md` §4.4.
+Each call tracks the last seen `:epoch-id` in the operating frame's history via `since-id` and returns everything matching since. See `docs/initial-spec.md` §4.4.
 
 ## Hot-reload coordination
 
 Editing source is legitimate and often correct. The protocol is strict — after any source edit, before the next `dispatch` / `trace/*`:
 
 1. Make the edit with `Edit` / `Write`.
-2. Call `mcp__re-frame2-pair__tail-build` with a `probe` that verifies the browser has the new code (legacy fallback: `scripts/tail-build.sh --probe '...'`).
+2. Call `mcp__re-frame2-pair__tail-build` with a `probe` that verifies the browser has the new code.
 3. Only after the probe succeeds do you proceed to `dispatch`, `trace/*`, etc.
 4. If the probe times out, treat that as a compile error in the user's code — read the tail output, report it to the user, do *not* retry dispatching.
 
@@ -173,13 +172,13 @@ When `restore-epoch` returns `false`, read the matching trace event from `(re-fr
 
 **Caveat (always tell the user before restoring):** restore rewinds `app-db` only. Side effects that already fired (HTTP requests sent, navigation pushed, localStorage written, `:dispatch-later` already landed) are *not* undone.
 
-## Bash-shim back-compat appendix
+## Bash-shim appendix (not reachable from this skill)
 
-The bash shims under `scripts/` are the legacy transport — each spawns bash → babashka → a fresh nREPL connect per call (~700ms per op). The MCP server (above) is the canonical path; keep the shims for ad-hoc shell scripting, CI scripts, or when the MCP server isn't configured in the agent host. Op semantics are identical between transports.
+The bash shims under `scripts/` are **retired from this skill's tool surface** — the `allowed-tools:` frontmatter carries no shell tool, so you cannot run them. They remain on disk only for the project's own e2e test harness and ad-hoc shell use outside the skill. Every op above is an MCP tool. This appendix documents the legacy mapping for the harness only; do not reach for it as a "fallback transport".
 
-Map MCP tools to bash shims:
+For the harness, each MCP tool has a behavioural shell counterpart. Note the watch shim carries flags (`--window-ms`, `--count`, `--stream`, `--stop`) that have **no MCP equivalent** — the MCP `watch-epochs` tool is poll-only (`since-id`/`cursor`); those flags exist on the shim alone.
 
-| MCP tool | Bash-shim equivalent |
+| MCP tool | Shell counterpart (harness only) |
 |---|---|
 | `eval-cljs {form: "..."}` | `scripts/eval-cljs.sh '<form>'` |
 | `dispatch {event: "[:foo]"}` | `scripts/dispatch.sh '[:foo]'` |
@@ -188,15 +187,12 @@ Map MCP tools to bash shims:
 | `dispatch {event: "...", trace: true}` | `scripts/dispatch.sh '...' --trace` |
 | `dispatch {event: "...", fx-overrides: {...}}` | `scripts/dispatch.sh '...' --fx-override :http=:stub-http` |
 | `trace-window {ms: N}` | `scripts/trace-window.sh N` |
-| `watch-epochs {window-ms: ..., pred: {...}}` | `scripts/watch-epochs.sh --window-ms ... --event-id-prefix ...` |
-| `watch-epochs {count: N}` | `scripts/watch-epochs.sh --count N` |
-| `watch-epochs {stream: true, ...}` | `scripts/watch-epochs.sh --stream ...` |
-| `watch-epochs {stop: true}` | `scripts/watch-epochs.sh --stop` |
+| `watch-epochs {pred: {...}, since-id: "..."}` (poll loop) | `scripts/watch-epochs.sh --window-ms ... --event-id-prefix ...` (shim-only `--window-ms`/`--count`/`--stream`/`--stop` modes) |
 | `tail-build {wait-ms: ..., probe: "..."}` | `scripts/tail-build.sh --wait-ms ... --probe '...'` |
 | `discover-app {}` | `scripts/discover-app.sh` |
-| `snapshot {...}` | _MCP-only_ (no bash-shim equivalent; chain individual `eval-cljs` calls for `snapshot`-style mega-reads via the legacy transport) |
-| `get-path {path: "..."}` | _MCP-only_ (use `eval-cljs '(re-frame2-pair.runtime/app-db-at [...])'` for a coarse equivalent) |
-| `subscribe` / `unsubscribe` | _MCP-only_ (push-mode requires `notifications/progress`; under the bash shim use `scripts/watch-epochs.sh --stream` for the pull-mode approximation) |
+| `snapshot {...}` | _MCP-only_ (no shell counterpart; chain individual `eval-cljs.sh` calls for `snapshot`-style mega-reads) |
+| `get-path {path: "..."}` | _MCP-only_ (use `eval-cljs.sh '(re-frame2-pair.runtime/app-db-at [...])'` for a coarse equivalent) |
+| `subscribe` / `unsubscribe` | _MCP-only_ (push-mode requires `notifications/progress`; the shim approximates pull-mode with `scripts/watch-epochs.sh --stream`) |
 
 For full transport mechanics and the `:app-db` slice modes that only the MCP `snapshot` tool exposes, see [`mcp-transport.md`](mcp-transport.md).
 

--- a/skills/re-frame2-pair/references/recipes.md
+++ b/skills/re-frame2-pair/references/recipes.md
@@ -2,7 +2,7 @@
 
 Named procedures the user may ask for. When the user asks a matching question, run the procedure below rather than improvising.
 
-Each recipe leads with the **MCP-tool form** (preferred — ~14× faster, single persistent nREPL connection). When the agent host hasn't configured the MCP server, fall back to the bash-shim equivalents — these are catalogued in [`ops.md` §Bash-shim back-compat appendix](ops.md#bash-shim-back-compat-appendix). Op semantics are identical between transports.
+Each recipe is expressed in **MCP-tool form** — the only transport this skill exposes. (The bash shims under `scripts/` are retired from the skill's tool surface; see [`mcp-transport.md`](mcp-transport.md).)
 
 ## Contents
 
@@ -68,7 +68,6 @@ Procedure:
               (fn [e] (= :expired (get-in (:db-after e) [:auth-state]))))"
    }
    ```
-   Legacy bash form: `scripts/eval-cljs.sh '(re-frame2-pair.runtime/find-where (fn [e] (= :expired (get-in (:db-after e) [:auth-state]))))'`.
 4. Report that epoch as the culprit: its `:trigger-event`, the diff between `:db-before` and `:db-after`, and (crucially) the cascade tree. Often the root-cause dispatch is a child of another event — follow `:parent-dispatch-id` upstream via `trace/cascade <dispatch-id>`.
 5. If no single epoch is responsible — the state drifted over many events — use `find-all-where` to get the trajectory. Narrate the 3–5 most relevant transitions rather than all of them.
 6. Propose a fix. Usually one of: a handler that shouldn't have fired, a handler that did fire but was wrong, or a missing guard.
@@ -140,7 +139,7 @@ Canonical procedure:
    - *Handlers / subs / fx:* `(rf/reg-event-fx :foo ...)` / `(rf/reg-sub :bar ...)` / `(rf/reg-fx :baz ...)` via `repl/eval`. The registrar replaces; `:rf.registry/handler-replaced` fires.
    - *Machines:* `(rf/reg-machine :auth ...)` — bumps the machine's `:version` if one is supplied. Old snapshots may now `:rf.epoch/restore-version-mismatch` against this machine.
    - *Views / helpers (plain `defn`s):* redefine the var via `repl/eval`. Subsequent renders pick up the new fn.
-   - *Permanent change:* `Edit` the source file, then `mcp__re-frame2-pair__tail-build {probe: "..."}` to wait for the reload to land (legacy: `scripts/tail-build.sh --probe '...'`).
+   - *Permanent change:* `Edit` the source file, then `mcp__re-frame2-pair__tail-build {probe: "..."}` to wait for the reload to land.
 5. **Verify the patch took before re-dispatching.** `registrar/describe :event :foo` should now return different `:line` / `:column` (or a different `:handler-fn` hash) than what you captured at step 1. If the patch didn't land, re-dispatching will silently test the old code.
 6. `trace/dispatch-and-collect [:foo ...]` → observe the new behaviour.
 7. Compare the two epochs (`epoch-diff` between their `:db-after` values; cross-check `:sub-runs` and `:renders` projections). Repeat until satisfied.
@@ -157,8 +156,6 @@ mcp__re-frame2-pair__dispatch {
 }
 ```
 
-Legacy bash form: `scripts/dispatch.sh '[:cart/checkout]' --fx-override :http=:stub-http`.
-
 The stub must already be registered via `(rf/reg-fx :stub-http (fn [_ v] ...))`. The override applies for this dispatch only; subsequent dispatches use the canonical `:http` again.
 
 For `:rf.http/managed` failure-category experiments (Spec 014 §Failure categories), stub `:http` to fire one of the canonical failure traces directly.
@@ -167,7 +164,7 @@ For `:rf.http/managed` failure-category experiments (Spec 014 §Failure categori
 
 Prefer the push-mode MCP path: call `mcp__re-frame2-pair__subscribe` with `{topic: "epoch", max-events: N}`. Each batch arrives as a `notifications/progress` tick; report each epoch as a short paragraph (event id, `:trigger-event`, key entries from `:effects` and `:sub-runs`, `app-db` diff summary) as it fires. The tool resolves with a summary once `max-events` is reached.
 
-Fallback (host doesn't surface progress notifications): `mcp__re-frame2-pair__watch-epochs {count: N}` (pull-mode) with no filter, narrate on each pull.
+Fallback (host doesn't surface progress notifications): poll `mcp__re-frame2-pair__watch-epochs {}` (no filter) repeatedly, passing the previous response's `:head-id` back as `since-id`, narrating each pull's `:matches`; stop once you've narrated N events. (`watch-epochs` is poll-only — there is no `count` arg.)
 
 See [streaming-subscriptions.md](streaming-subscriptions.md) for topic / filter / termination detail.
 
@@ -175,23 +172,17 @@ See [streaming-subscriptions.md](streaming-subscriptions.md) for topic / filter 
 
 Prefer `mcp__re-frame2-pair__subscribe {topic: "epoch", filter: {":timing-ms": ">100"}}` — the `:timing-ms` predicate rides server-side so only slow cascades cross the wire. Accepts a number (sugar for `>= N`) or a comparison string (`">100"`, `"<=50"`, `">=100"`, `"<200"`, `"=42"`); see [streaming-subscriptions.md](streaming-subscriptions.md) §Filter shape. On each `notifications/progress` tick, narrate matches and pull per-interceptor timings from the raw trace if needed. Close with `unsubscribe` when the user moves on (or pass `max-ms` for a hard upper bound).
 
-Fallback (pull-mode, no host progress notifications): `mcp__re-frame2-pair__watch-epochs {pred: {"timing-ms": ">100"}}`.
+Fallback (pull-mode, no host progress notifications): poll `mcp__re-frame2-pair__watch-epochs {pred: {"timing-ms": ">100"}}` repeatedly, advancing `since-id` to the previous response's `:head-id` each time.
 
 ## "Watch for X while I interact"
 
 Prefer `mcp__re-frame2-pair__subscribe {topic: "epoch", filter: {":event-id-prefix": ":checkout/"}}` (or other predicate from the `epoch-matches?` vocab — see [streaming-subscriptions.md](streaming-subscriptions.md) §Filter shape). Narrate each match as it arrives via `notifications/progress`; summarise when the stream goes idle. Close with `unsubscribe` (or `max-events` / `max-ms`) when the user moves on.
 
-Fallback: `mcp__re-frame2-pair__watch-epochs {stream: true, pred: {"event-id-prefix": ":checkout/"}}`.
+Fallback: poll `mcp__re-frame2-pair__watch-epochs {pred: {"event-id-prefix": ":checkout/"}}` in a loop, passing the previous response's `:head-id` as `since-id` so each call only returns new matches. (There is no `stream` arg — looping the poll is the pull-mode equivalent.)
 
 ### Inspect what's currently subscribed
 
-The `list-subscriptions` MCP tool reports every open subscription's `{:id :topic :filter :queue-depth :queue-bytes :dropped-events :dropped-bytes :overflow-reason :created-at}` without draining the queues. To list active streams:
-
-```
-mcp__re-frame2-pair__list-subscriptions {}
-```
-
-Optional filters: pass `topic` (`trace` / `epoch` / `fx` / `error`) to narrow, or `sub-id` to look up a specific stream. Use this when a streaming probe seems to have gone quiet — confirm it's still registered (and that its queue-depth isn't piling up against a dead consumer) before assuming the bus is dry.
+When a streaming probe seems to have gone quiet, call `mcp__re-frame2-pair__list-subscriptions {}` to confirm it's still registered and check its `:queue-depth` before assuming the bus is dry. Full return shape and filters: see [streaming-subscriptions.md §Diagnostics](streaming-subscriptions.md#diagnostics--whats-currently-registered).
 
 ## "Drive a Story variant from a re-frame2-pair session"
 
@@ -207,7 +198,6 @@ Optional filters: pass `topic` (`trace` / `epoch` / `fx` / `error`) to narrow, o
      form: "(filter #(= \"story\" (namespace %)) (rf/frame-ids))"
    }
    ```
-   Legacy bash form: `scripts/eval-cljs.sh '(filter #(= "story" (namespace %)) (rf/frame-ids))'`.
    If the user has the story-mcp jar loaded, prefer `mcp__re-frame2-story-mcp__list-stories` — richer metadata (tags, modes, parent story).
 2. If the variant isn't mounted yet, mount it via story-mcp:
    ```
@@ -247,7 +237,6 @@ Optional filters: pass `topic` (`trace` / `epoch` / `fx` / `error`) to narrow, o
               (clojure.data/diff a b))"
    }
    ```
-   Legacy bash form: `scripts/eval-cljs.sh '(let [a (rf/get-frame-db :story.counter/empty) b (rf/get-frame-db :story.counter/loaded)] (clojure.data/diff a b))'`.
    The runtime helper `(re-frame2-pair.runtime/frame-diff :a-id :b-id)` returns `{:only-in-a :only-in-b :common}` — semantics match `epoch-diff` but across frames instead of across one epoch's before/after.
 3. Cross-check the cascade: `(rf/epoch-history :story.counter/empty)` and `(rf/epoch-history :story.counter/loaded)`. If the variants ran the same events but ended in different states, look at the loaders — they often seed divergent fixtures.
 4. Narrate the divergence in terms the user can act on: *"variant `:loaded` carries `[:items]` with 7 entries from its `:counter/initialise 7` event; variant `:empty` has no `:items` key because its events list is empty."*

--- a/skills/re-frame2-pair/references/streaming-subscriptions.md
+++ b/skills/re-frame2-pair/references/streaming-subscriptions.md
@@ -24,7 +24,7 @@ Two transports cover the same buses; pick by interaction shape.
 | Want | Reach for |
 |---|---|
 | Live narration while the user interacts; report events the moment they fire | `subscribe` (push-mode) |
-| Finite window summary at the end (e.g. "show me everything in the next 30s") | `watch-epochs` (pull-mode) with `since-id` polling. Legacy fallback: the `scripts/watch-epochs.sh --window-ms` shim. |
+| Finite window summary at the end (e.g. "show me everything in the next 30s") | `watch-epochs` (pull-mode): poll in a loop, advancing `since-id` to each response's `:head-id`, until your window elapses. |
 | Stream until a fixed number of matches, then summarise | `subscribe` with `max-events` |
 | Agent host doesn't surface `notifications/progress` to the model | `watch-epochs` (pull-mode) |
 
@@ -56,11 +56,11 @@ Mirrors `(re-frame.trace.tooling/trace-buffer)` per Spec 009. Recognised keys:
 - `:operation` — exact trace operation keyword (e.g. `:rf.event/dispatched`)
 - `:op-type` — broad category: `:rf.event` `:rf.sub` `:rf.fx` `:rf.view` `:rf.registry` `:rf.frame` `:rf.machine` `:error` `:warning` `:info`
 - `:frame` — frame id (e.g. `:rf/default`)
-- `:severity` — `:debug` `:info` `:warn` `:error`
+- `:severity` — alias for `:op-type`, restricted to `:error` `:warning` `:info` (no `:debug`; the spelling is `:warning`, not `:warn`)
 - `:event-id` — exact event id keyword
 - `:handler-id` — exact handler id keyword (e.g. for `:rf.sub/run` traces)
-- `:source` — `:tags.source` value
-- `:origin` — `:tags.origin` value (`:pair` `:app` `:ui` `:timer` `:http`)
+- `:source` — `:tags.source` value (trigger kind: `:ui` `:timer` `:http` `:repl` `:machine` `:ssr-hydration`)
+- `:origin` — `:tags.origin` value (actor: `:app` `:pair` `:story` `:test`)
 - `:dispatch-id` — exact dispatch-id; combine with `cascade-of` for tree drills
 - `:since-ms` / `:between` — time-window keys (see [ops.md](ops.md) `trace/buffer`)
 

--- a/skills/re-frame2-pair/references/variant-as-frame.md
+++ b/skills/re-frame2-pair/references/variant-as-frame.md
@@ -44,7 +44,6 @@ mcp__re-frame2-pair__eval-cljs {form: "(re-frame2-pair.runtime/snapshot {:frame 
 mcp__re-frame2-pair__get-path  {path: "[:count]", frame: ":story.counter/loaded"}
 ```
 
-Legacy bash forms (if the MCP server isn't wired): `scripts/dispatch.sh '[:counter/inc]' --frame :story.counter/loaded` and `scripts/eval-cljs.sh '(re-frame2-pair.runtime/snapshot {:frame :story.counter/loaded})'`.
 
 Use Idiom 1 for long sessions inside one variant; Idiom 2 for cross-variant work (recipe 2 below).
 
@@ -80,7 +79,6 @@ Story-registered variants appear as `:story.*` keywords. Filter:
 mcp__re-frame2-pair__eval-cljs {form: "(filter #(= \"story\" (namespace %)) (rf/frame-ids))"}
 ```
 
-Legacy bash form: `scripts/eval-cljs.sh '(filter #(= "story" (namespace %)) (rf/frame-ids))'`.
 
 For richer metadata (parent story, tags, modes, substrates), use Story's side-table via the MCP transport if available (`mcp__re-frame2-story-mcp__list-stories` / `get-variant`), or fall back to `(re-frame.story/variant->edn <id>)` over `repl/eval`. The variant-id grammar (`:story.<dotted.path>/<variant-name>`) is documented in `skills/re-frame2/references/tooling/stories.md`.
 
@@ -92,7 +90,7 @@ To discover the *active* variant in the user's canvas (the one currently visible
 - **`destroy-frame!` happens on variant-unmount.** If the user navigates away from the variant in the canvas, the frame is gone. Subsequent ops against `:story.foo/bar` return `:rf.error/no-such-handler` (kind `:frame`). The fix is to navigate back, or to call `(re-frame.story/run-variant :story.foo/bar)` to re-mount the variant programmatically.
 - **`reset-frame!` on re-registration.** Hot-reloading a variant (or `register-variant` over MCP with the same id) calls `reset-frame!` on its frame — `app-db` reverts to `{}`, then loaders + events re-run. Any REPL-only state you'd injected (`app-db/reset`, hot-swapped handlers' side effects on app-db) is gone. Permanent state lives in the variant body's `:loaders` / `:events` slots.
 - **Loaders run before re-frame2-pair can see them.** Phase 1 loaders dispatch-sync into the variant's frame at mount time — `:rf.event/dispatched` traces fire, but if you attach re-frame2-pair *after* the variant mounted, those traces are already in the retain-N ring (visible) but not in the recent dispatch window. Use `trace/buffer` (not `trace/recent`) to see loader events that fired before you attached.
-- **`:play-script` steps look like user interactions.** The play-runner uses `dispatch` / `dispatch-sync` per phase 4; epoch records carry the dispatched event in `:trigger-event`. There's no `:origin :play-script` distinguisher (the dispatch-origin tagging closed-enum — Spec 002 §Dispatch origin tagging — is `:user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal`; play-runner dispatches land under `:test-harness` or `:tool` depending on caller). If you need to tell agent-driven from play-driven dispatches inside a variant, filter on something else (e.g. timing, or assert from outside the variant).
+- **`:play-script` steps look like user interactions.** The play-runner uses `dispatch` / `dispatch-sync` per phase 4; epoch records carry the dispatched event in `:trigger-event`. Dispatch tagging has two independent axes (Spec 002 §Dispatch origin tagging): `:origin` — the *actor*, an **open vocabulary** defaulting to `:app` (pair tools stamp `:origin :pair`; common values are `:pair`, `:claude`, `:story`, `:test`) — and `:source` — the *trigger kind*, the closed enum `:ui / :timer / :http / :machine / :repl / :ssr-hydration / :test / :other`. The play-runner currently dispatches with only `:frame` set (`(dispatch-sync event {:frame frame-id})`), so its events fall under the default `:origin :app` — there is no `:origin :play-script` distinguisher. Your own re-frame2-pair dispatches *do* carry `:origin :pair`, so to tell pair-driven from play-driven dispatches inside a variant, filter `pred {:origin :pair}` for your own, or scope reads to the variant's frame (via `frames/select`) and lean on timing / phase rather than expecting a play-specific origin tag.
 - **Workspaces nest frame-providers.** A `reg-workspace` containing variants A, B, C renders each variant inside its own `frame-provider`. Workspace frames may or may not exist as registered frames themselves (per spec/007 §Relationship-with-frames: *"may be ordinary frames containing nested `frame-provider`s"*). When the user points at "the workspace", clarify whether they mean the layout-level frame (if any) or one of its variant frames.
 
 ## Cross-references


### PR DESCRIPTION
## Summary

Remediates `skills/re-frame2-pair` from the 3-lens review sweep (rf2-ee38b.27). Fixes stale/fabricated invocation details that would make an agent's first MCP calls **fail**, plus clarity cleanups. All changes verified against the current `tools/re-frame2-pair-mcp/` source/registry (14 tools; no `restore-epoch`/`reset-frame-db` MCP tool exists yet in this base — the parallel .18 work hasn't merged).

### Correctness (would break calls)
- **watch-epochs (P1):** dropped the bash-shim-only args (`window-ms`/`count`/`stream`/`stop`) the MCP schema (`:additionalProperties false`) hard-rejects; documented the real poll-only shape (`since-id`/`pred`/`limit`/`cursor`) and reframed "run for N" / "stream" as agent-run poll loops. Fixed the three `recipes.md` fallbacks.
- **frame-diff (P1):** added the cited helper to the preload runtime (mirrors `epoch-diff`, cross-frame) so `(re-frame2-pair.runtime/frame-diff a b)` resolves instead of erroring.
- **dispatch-origin enum:** replaced the invented enum in `variant-as-frame.md` with the real two-axis model (`:origin` open-vocab default `:app` vs `:source` enum); noted play-runner dispatches default to `:origin :app` (it sets only `:frame`).
- **Tool-Pair cross-ref:** `docs/specification/Tool-Pair.md@master` → `spec/Tool-Pair.md@main` in `SKILL.md`, `docs/initial-spec.md`, `STATUS.md`.
- **streaming-subscriptions.md `:severity`/`:origin`/`:source`:** `:severity` is an `:op-type` alias (`:error`/`:warning`/`:info`); dropped `:debug`, fixed `:warn`→`:warning`; corrected `:origin`/`:source` value lists.
- **on-error.md:** `:retried` is not one of the six `:on-error` return values — it's the runtime's `:recovery` disposition on `:rf.http/retry-attempt`.
- **discover-app shape:** `SKILL.md` aligned to the canonical health-map return (`:session-id` is real but the descriptor's documented slots now lead).

### Clarity
- Removed the "Legacy bash form" lines / fallback framing that contradicted the README's "retired" claim and described an unreachable capability (no shell tool in `allowed-tools`); reframed the `ops.md` appendix + `mcp-transport.md` as harness-only.
- Reduced the duplicated `list-subscriptions` block in `recipes.md` to a pointer.

### Left for the shared bead
Cross-skill dedup (shared Tool-Pair primitives list, privacy posture across 4 files, Story/variant 3-file overlap) — deferred to the final shared-skills bead.

## Test plan
- [x] `python scripts/check_doc_slugs.py` → exit 0 (no broken links/anchors)
- [x] No stale `window-ms`/`count`/`stream`/`stop` MCP-arg presentations remain
- [x] `frame-diff` defined in preload + referenced in recipe

Refs rf2-ee38b.27