### PR TITLE
fix(skills): re-frame2-implementor — correct EP-006 contract + conformance surface

### DIFF
--- a/skills/re-frame2-implementor/README.md
+++ b/skills/re-frame2-implementor/README.md
@@ -1,6 +1,6 @@
 # re-frame2-implementor
 
-> ↑ [`skills/`](../) — index of all seven re-frame2 skills.
+> ↑ [`skills/`](../) — index of all eight re-frame2 skills.
 
 A `Skill` that helps `Claude Code` (or any Anthropic-skill-compatible agent) guide an engineer **building a new re-frame2 implementation** — a port to a different host language or substrate, not an application built on the existing CLJS reference.
 
@@ -44,7 +44,7 @@ Pre-alpha. The skill is authored; it has not yet been exercised end-to-end again
 
 ```
 skills/re-frame2-implementor/
-├── SKILL.md                       # Router (~250 lines)
+├── SKILL.md                       # Router
 ├── README.md                      # This file
 ├── LICENSE                        # MIT
 ├── package.json                   # npm metadata for distribution

--- a/skills/re-frame2-implementor/SKILL.md
+++ b/skills/re-frame2-implementor/SKILL.md
@@ -16,7 +16,6 @@ description: >
   `re-frame2-pair`).
 allowed-tools:
   - Bash(gh issue *)
-  - Bash(gh pr *)
   - Read
   - Edit
   - Write
@@ -39,7 +38,7 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 
 ## Cardinal rules (one-liners; full text in [`references/cardinal-rules.md`](references/cardinal-rules.md))
 
-1. **Spec is the contract.** When `implementation/` and [`spec/`](../../spec/) disagree, the spec wins.
+1. **Spec is the contract — pinned before reading.** When `implementation/` and [`spec/`](../../spec/) disagree, the spec wins. The kickoff prompt names a `day8/re-frame2` commit/tag; verify the checkout's HEAD and origin before reading the spec and record the pin in `DECISIONS.md` (preamble before D1). An unverified checkout is not the contract.
 2. **Phase 1 before Phase 2.** Lock decisions in writing before writing code.
 3. **Dependency order.** EP 001 → 002 → 006 → 004 → 009 are the foundation; optional EPs sit downstream.
 4. **Substrate-agnostic phrasing.** Write to "the identity primitive", "the render-tree", "the reactive container" — not to hiccup / Reagent / keywords.
@@ -48,8 +47,7 @@ Full skill-disambiguation matrix lives at [`skills/README.md` §Skill routing �
 7. **Conformance corpus is the acceptance test.** Score is `passed / claimed-applicable`; a fixture you can't make pass without outside sources is a *spec gap*.
 8. **Spec gap → draft a GitHub issue against `day8/re-frame2` and ask before filing.** Don't paper, don't invent, don't extrapolate from the reference — but don't auto-file either. Show the engineer the drafted title + body, restrict the body to public spec-quoted evidence (no private port source), and wait for explicit OK before running `gh issue create`. The skill runs in the engineer's port repo; spec gaps reach the framework maintainers via the upstream repo's GitHub issues — never via `bd` (re-frame2's internal tracker, never invoked from a published skill).
 9. **Per-issue approval gate for any cross-repo side effect.** Before running `gh issue create` against a repo other than the one the engineer is working in, show the full draft (title, target repo, label set, body) and wait for explicit "yes" / "go" / "file it". Invoking the skill is consent to the workflow, not to each cross-repo write. See [`references/cardinal-rules.md` §9](references/cardinal-rules.md).
-10. **Pin the spec corpus.** The kickoff prompt names a specific `day8/re-frame2` commit/tag; verify the checkout's HEAD and origin before reading the spec, and record the pinned hash in `DECISIONS.md` (preamble before D1). An unverified checkout is not the contract.
-11. **Honour the reserved `:rf/*` scheme.** Framework-owned ids live under the single root namespace `:rf/*` (and its sub-namespaces); user code MUST NOT register under `:rf/*`. Reserved fx-ids and reserved app-db keys (`:rf/machines`, `:rf/route`, …) are part of the contract. A port that ignores the scheme fails conformance fixtures that assert `:rf.*` operation ids. Per [`spec/Conventions.md`](../../spec/Conventions.md); the "where does each surface live" map is [`spec/Ownership.md`](../../spec/Ownership.md).
+10. **Honour the reserved `:rf/*` scheme.** Framework-owned ids live under the single root namespace `:rf/*` (and its sub-namespaces); user code MUST NOT register under `:rf/*`. Reserved fx-ids and reserved app-db keys (`:rf/machines`, `:rf/route`, …) are part of the contract. A port that ignores the scheme fails conformance fixtures that assert `:rf.*` operation ids. Per [`spec/Conventions.md`](../../spec/Conventions.md); the "where does each surface live" map is [`spec/Ownership.md`](../../spec/Ownership.md).
 
 ## Phase 1 — lock the decisions
 
@@ -93,7 +91,7 @@ The corpus at [`spec/conformance/`](../../spec/conformance/) is host-agnostic da
 
 ## Reference files (all one level deep)
 
-- [`references/cardinal-rules.md`](references/cardinal-rules.md) — the eleven rules in prose + anti-pattern corollaries.
+- [`references/cardinal-rules.md`](references/cardinal-rules.md) — the ten rules in prose + anti-pattern corollaries.
 - [`references/phase-1-decisions.md`](references/phase-1-decisions.md) — Phase 1 walkthrough, seven decision blocks.
 - [`references/decision-record.md`](references/decision-record.md) — fill-in template for the locked-decision record.
 - [`references/phase-2-impl-order.md`](references/phase-2-impl-order.md) — EP-by-EP implementation order.

--- a/skills/re-frame2-implementor/references/cardinal-rules.md
+++ b/skills/re-frame2-implementor/references/cardinal-rules.md
@@ -8,7 +8,7 @@ These hold across every phase of building a new re-frame2 implementation. Each r
 
 [`spec/`](../../../spec/) is the source of truth. The CLJS implementation under `implementation/` is one worked example of how to realise the contract — not the contract itself. When the reference impl and the spec disagree, the spec wins; draft a GitHub issue against `day8/re-frame2` (against the spec or the reference impl as appropriate) and ask the engineer to OK it before filing — see rule 9.
 
-**Pin the spec before reading it.** Phase 1 names a specific re-frame2 commit/tag in `DECISIONS.md` (see [`decision-record.md`](decision-record.md) D1 preamble). Verify `git -C <path-to-re-frame2> rev-parse HEAD` matches the pin and that the origin is `https://github.com/day8/re-frame2` before reading the spec corpus. An unpinned or unverified checkout is not a contract — it's whatever happens to be on the filesystem.
+**Pin the spec before reading it.** The kickoff prompt names a specific `day8/re-frame2` commit/tag; Phase 1 records that pin in `DECISIONS.md` (the preamble before D1 — see [`decision-record.md`](decision-record.md)). Before reading the spec corpus, verify `git -C <path-to-re-frame2> rev-parse HEAD` matches the pin **and** that the origin is `https://github.com/day8/re-frame2`. The engineer actually runs this check in the Phase 1 preamble ([`phase-1-decisions.md`](phase-1-decisions.md)). An unpinned or unverified checkout is not a contract — it's whatever happens to be on the filesystem.
 
 ## 2. Phase 1 before Phase 2
 
@@ -71,11 +71,7 @@ Filing a GitHub issue against `day8/re-frame2` from inside the engineer's port r
 
 Invoking the skill is consent to the *workflow*, not consent to each *cross-repo write*. Treat the two as separate gates.
 
-## 10. Pin the spec corpus before reading it
-
-The kickoff prompt names a specific `day8/re-frame2` commit/tag. Verify the checkout's HEAD and origin before reading the spec, and record the pinned hash in `DECISIONS.md` (the preamble before D1). Confirm `git -C <path-to-re-frame2> rev-parse HEAD` matches the pin and that the origin is `https://github.com/day8/re-frame2`. An unpinned or unverified checkout is not the contract — it is whatever happens to be on the filesystem. (This restates, as a standalone rule, the pinning discipline also threaded through rule 1.)
-
-## 11. Honour the reserved `:rf/*` namespace scheme
+## 10. Honour the reserved `:rf/*` namespace scheme
 
 re-frame2 reserves **one root keyword namespace** for framework-owned ids: `:rf/*` (and its sub-namespaces — `:rf.fx/*`, `:rf.machine/*`, `:rf.error/*`, `:rf.registry/*`, …). Every framework runtime id — events, fx, cofx, app-db keys (`:rf/machines`, `:rf/route`), trace operations, error categories, warnings, registrar mutations, the default frame id (`:rf/default`) — lives under that root. **User code MUST NOT register handlers, fx, subs, or frames under `:rf/*`.** Your port must (a) emit framework ids under the reserved scheme and (b) leave the scheme free for the framework, never user code.
 
@@ -89,9 +85,4 @@ This is a conformance surface, not a style preference. Fixtures assert `:rf.*` o
 - **Don't skip Phase 1.** Decisions made under Phase 1 (especially F2 persistent data structures and F5 concurrency model) propagate through every line of Phase 2 code. Engineers who skip Phase 1 to "just start coding" end up rewriting the foundation halfway through.
 - **Don't declare Q1 (state machines) `yes` unless the FSM substrate is genuinely required.** EP 005 is substantial work and gates a large block of code. Smaller ports ship `Q1=no` and add the FSM substrate later — the events/subs/fx/views triad is self-sufficient for many use cases.
 - **Don't ship without conformance.** The corpus is the only objective measure of "is this re-frame2?" Without the corpus passing, the port is "inspired by re-frame2" but not a re-frame2 implementation. Run the harness early; the corpus is also useful as your test suite during development.
-- **Don't invent surfaces the spec is silent on.** If the spec says nothing about hierarchical FSM exit-order semantics in a specific edge case, *draft a GitHub issue against `day8/re-frame2`* (and ask the engineer to OK before filing — rule 9) — don't extrapolate from the CLJS reference. The reference's choice is one realisation; the spec's silence is a gap.
-- **Don't file cross-repo issues without explicit OK.** Every `gh issue create` against `day8/re-frame2` shows the engineer the full drafted title + body + labels and waits for "yes" / "go" / "file it" before running. The engineer always confirms each issue, not just the workflow. See rule 9.
-- **Don't paste private port content into a cross-repo issue body.** Issue bodies cite `spec/` and the fixture / EP. They do not include the engineer's source, commits, transcript, or repo-local paths. See rule 8.
-- **Don't interpolate transcript-derived text into a `gh issue create` command.** Use the here-doc + `--body "$(cat /tmp/file)"` pattern under rule 8.
-- **Don't read the spec corpus without verifying the pin.** Phase 1 records a `day8/re-frame2` commit/tag in `DECISIONS.md`. Confirm `git -C <path-to-re-frame2> rev-parse HEAD` matches and the origin is `day8/re-frame2` before reading. An unverified or unpinned checkout is not the contract.
 - **Don't promise the engineer "this skill will write the port for you".** The skill walks the workflow and surfaces the decisions; the engineer (or their Claude session) writes the code. Phase 2 is multi-week work in any host; the skill is the map, not the vehicle.

--- a/skills/re-frame2-implementor/references/conformance.md
+++ b/skills/re-frame2-implementor/references/conformance.md
@@ -9,7 +9,7 @@ The corpus lives at [`spec/conformance/`](https://github.com/day8/re-frame2/tree
 A directory of EDN files, one per fixture, each describing one canonical interaction. Two complementary fixture modes (per [`spec/conformance/README.md` §Fixture format](https://day8.github.io/re-frame2/spec/conformance/#fixture-format)):
 
 - **Mode A — dispatch-driven.** A frame configuration plus initial `app-db`, a sequence of dispatches, and the expected emissions after drain: final `app-db`, sub values, routed effects, trace events. Most fixtures use Mode A.
-- **Mode B — pure / direct-call.** No frame, no dispatch loop. Direct invocations of pure primitives (`machine-transition`, `match-url`, `route-url`, `render-to-string`) with call-local expectations.
+- **Mode B — pure / direct-call.** No frame, no dispatch loop. Direct invocations of pure primitives via `:fixture/calls`, each record naming the primitive in `:call` and carrying its own call-local expectation. The reserved `:call` operators the corpus uses are `:machine-transition`, `:reg-machine`, `:match-url`, `:route-url`, `:round-trip`, `:assert-rank-greater`, and `:render-to-string` (the set is additive — new pure primitives may register a new op in a later fixture spec version; existing ops are never redefined). The `:reg-machine` op pins the machine **registration-error taxonomy** (`:rf.error/machine-*` via the [009 `:rf.error/id` ex-data contract](https://day8.github.io/re-frame2/spec/009-Instrumentation/#the-thrown-error-shape--the-rferrorid-ex-data-contract)): each `:reg-machine` call carries a candidate `:definition` and either an `:expect-error` (the `:rf.error/<category>` the registration-time validator must throw) or none (a well-formed control that must validate silently). Fixtures using it declare the `:fsm/registration-validation` capability; a port that validates lazily declares that capability in `known-skipped-capabilities` (see [§Capability tagging](#capability-tagging)).
 
 Each fixture carries a `:fixture/capabilities` set — the capability tags it exercises. The harness runs every fixture whose capabilities are a subset of the port's claimed list (D7 of the decision record).
 
@@ -17,8 +17,8 @@ Each fixture carries a `:fixture/capabilities` set — the capability tags it ex
 
 The contract from [`spec/conformance/README.md` §How an implementation runs the corpus](https://day8.github.io/re-frame2/spec/conformance/#how-an-implementation-runs-the-corpus):
 
-1. **Read** all `.edn` files in `fixtures/`. If your host has no EDN reader, ship a small one (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap.
-2. **For each fixture**, check whether `:fixture/capabilities ⊆ claimed-capabilities`. If yes, run it; if no, report "not exercised."
+1. **Read** all `.edn` files in `fixtures/`. If your host has no EDN reader, ship a small one (~200 lines for any host with hash-maps and vectors) or translate the corpus locally as part of harness bootstrap. Each fixture also declares a `:fixture/spec-version`; the harness should surface (and per the corpus README's §Versioning, reject) implementations that haven't moved with a spec-shape bump — don't silently run mismatched-version fixtures.
+2. **For each fixture**, classify its `:fixture/capabilities`. If `⊆ claimed-capabilities`, run it. Otherwise the harness MUST distinguish two out-of-claim flavours — see [§The two out-of-claim flavours](#the-two-out-of-claim-flavours) — and report "skipped (out-of-claim)" only for capabilities on the explicit `known-skipped-capabilities` allowlist; an unknown capability (in neither set) MUST FAIL the suite with a diagnostic naming it.
 3. **Bootstrap the runtime** per the fixture's `:fixture/registry` (the kinds + ids the fixture expects to be registered).
 4. **Realise the handler bodies** from `:fixture/handlers` via the EDN-handler-body DSL (below).
 5. **Create a frame** per `:fixture/frame-config`.
@@ -56,7 +56,7 @@ Common ops (per the corpus's existing fixtures):
 
 The interpreter is ~50 lines per host. The CLJS reference's interpreter lives in `implementation/core/src/re_frame/test_support.cljc`; copy the dispatch-style and adapt the literal-op handlers.
 
-**Spec-gap signal.** When a fixture uses an op that isn't documented anywhere — that's a spec gap. Draft a GitHub issue against `day8/re-frame2` asking for the DSL to be documented in [`spec/conformance/README.md`](../../../spec/conformance/README.md), show the engineer the draft, wait for explicit OK before filing. Body via stdin or a here-doc file, never inline interpolation — see [`cardinal-rules.md` §8](cardinal-rules.md) and §9 (approval gate).
+**Spec-gap signal.** When a fixture uses an op that isn't documented anywhere — that's a spec gap (ask for the DSL to be documented in `spec/conformance/README.md`). File it as a GitHub issue per [`cardinal-rules.md` §§8–9](cardinal-rules.md).
 
 ## Capability tagging
 
@@ -64,16 +64,29 @@ From [`spec/conformance/README.md` §Capability tagging](https://day8.github.io/
 
 ```
 :core/*           pattern-required basics — always run
-:fsm/*            FSM-richness axis — flat / hierarchical / always / after / tags / parallel-regions
-:actor/*          actor-model axis — own-state / spawn-destroy / cross-actor-fx / invoke / spawn-and-join / system-id
+:fsm/*            FSM-richness axis — flat / hierarchical / eventless-always / delayed-after /
+                  tags / parallel-regions / final-states / registration-validation
+:actor/*          actor-model axis — own-state / spawn-destroy / cross-actor-fx / invoke /
+                  spawn-and-join / system-id
+:flow/*           Flows axis (EP 013) — :flow/basic, :flow/trace
+:rf.http/managed  managed-HTTP (EP 014)
 :routing/*        Q2 yes
 :ssr/*            Q3 yes
 :schemas/*        Q4 yes (regardless of mechanism)
 ```
 
-The decision record's D7 captures the claimed tag set. The harness uses the claim as the filter; only matching fixtures run.
+The decision record's D7 captures the claimed tag set. The harness uses the claim as the filter; only matching fixtures run. **Match the corpus, not the Implementor-Checklist:** the checklist's family list lags the corpus (it omits `:flow/*`, `:rf.http/managed`, `:fsm/final-states`, `:fsm/registration-validation`); the corpus is the acceptance test, so it wins. If you ship the optional EP 013 (Flows) or EP 014 (HTTP) surfaces, declare `:flow/*` / `:rf.http/managed` in D7 or their fixtures will trip the unknown-capability diagnostic below.
 
-A port that claims `:core/* + :fsm/flat + :actor/own-state` runs every `:core/*` fixture, every `:fsm/flat` fixture, and every `:actor/own-state` fixture — and skips the hierarchical FSM fixtures, the `:spawn` fixtures, the routing fixtures, etc. The skipped fixtures report as "not exercised," not as failures.
+A port that claims `:core/* + :fsm/flat + :actor/own-state` runs every `:core/*` fixture, every `:fsm/flat` fixture, and every `:actor/own-state` fixture — and skips the hierarchical FSM fixtures, the `:spawn` fixtures, the routing fixtures, etc.
+
+### The two out-of-claim flavours
+
+Per [`spec/conformance/README.md` §Capability tagging](https://day8.github.io/re-frame2/spec/conformance/), a fixture whose capabilities aren't a subset of the claim is **not** simply "skipped." The harness MUST distinguish:
+
+- **Intentional out-of-claim** — the capability is on the harness's explicit `known-skipped-capabilities` allowlist (e.g. a flat-FSM-only port listing `:fsm/hierarchical`, or a lazy-validating port listing `:fsm/registration-validation`). Reported as "skipped (out-of-claim)" — does **not** fail the suite.
+- **Typo / claim-set drift** — the capability is in neither the claimed set nor the allowlist. The suite **MUST FAIL** with a diagnostic naming the unknown capability. The remedy is either to add it to `claimed-capabilities` (with runtime backing to match) or to `known-skipped-capabilities` (an explicit decision not to claim it).
+
+The reference harness keeps `known-skipped-capabilities` empty today (every corpus capability is claimed); the allowlist exists so future divergence is an explicit decision, never silent rot. A harness that silently skips unknown capabilities is the shape the spec now forbids — build the fail-on-unknown one.
 
 ## Diagnosis — spec gap vs implementation bug
 
@@ -93,7 +106,7 @@ When a fixture fails, the question is: who's at fault?
 - The fixture's expectation seems to reflect a choice the CLJS reference made that isn't normative.
 - An AI armed only with `spec/` + the corpus + this skill couldn't reproduce the expectation without consulting `implementation/`.
 
-**Action:** draft a GitHub issue against `day8/re-frame2` and ask the engineer for explicit OK before filing (rule 9). Don't patch the port to match. The spec needs to grow to cover the case; once it does, the port (and every other port) can target the explicit contract. Use the here-doc + `--body "$(cat /tmp/file)"` pattern from [`cardinal-rules.md` §8](cardinal-rules.md), restrict the body to public spec-quoted evidence (no private port source), and never run `gh issue create` until the engineer has approved the specific draft.
+**Action:** don't patch the port to match — file the gap as a GitHub issue per [`cardinal-rules.md` §§8–9](cardinal-rules.md). The spec needs to grow to cover the case; once it does, the port (and every other port) can target the explicit contract.
 
 The framing from [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/) is normative here: *"A fixture an AI cannot reproduce without consulting outside sources is a **spec gap**, not an implementation gap."*
 
@@ -104,8 +117,8 @@ The mechanics depend on the host. Typical shape:
 ```
 $ <port-toolchain> conformance run --claimed=":core/* :fsm/flat :actor/own-state"
 
-Loading corpus from ../re-frame2/spec/conformance/fixtures ... 142 fixtures.
-Filtering by claimed capabilities ... 78 applicable, 64 not exercised.
+Loading corpus from ../re-frame2/spec/conformance/fixtures ... 136 fixtures.
+Filtering by claimed capabilities ... 78 applicable, 58 not exercised.
 
 PASS  counter-inc-once                 :core/event-handler :core/sub :core/trace
 PASS  closed-effect-map                :core/event-handler
@@ -123,7 +136,7 @@ Wire the harness into the port's CI; every commit should report the score. Confo
 
 ## When the corpus itself is incomplete
 
-The corpus is a living artefact — it grows as the spec grows. If your port implements a surface the corpus has no fixture for (e.g. a specific error category from EP 009, or a `:fsm/tags` interaction), that's not a port-side problem — that's a corpus gap. Draft a GitHub issue against `day8/re-frame2` requesting the missing fixture; show the engineer the draft (ideally including a draft fixture in the body) and wait for explicit OK before filing — see [`cardinal-rules.md` §9](cardinal-rules.md).
+The corpus is a living artefact — it grows as the spec grows. If your port implements a surface the corpus has no fixture for (e.g. a specific error category from EP 009, or a `:fsm/tags` interaction), that's not a port-side problem — that's a corpus gap. File it as a GitHub issue per [`cardinal-rules.md` §§8–9](cardinal-rules.md), ideally including a draft fixture in the body.
 
 ## Reporting conformance
 

--- a/skills/re-frame2-implementor/references/decision-record.md
+++ b/skills/re-frame2-implementor/references/decision-record.md
@@ -179,18 +179,24 @@ The set of capability tags this port claims:
 :fsm/delayed-after <yes / no>
 :fsm/tags         <yes / no>
 :fsm/parallel-regions <yes / no>
+:fsm/final-states <yes / no>
+:fsm/registration-validation <yes / no — yes if you validate machine specs at registration time>
 :actor/own-state  <yes / no>
 :actor/spawn-destroy <yes / no>
 :actor/cross-actor-fx <yes / no>
 :actor/invoke     <yes / no>
 :actor/spawn-and-join <yes / no>
 :actor/system-id  <yes / no>
+:flow/*           <yes / no — yes if D3 claims Flows (EP 013)>
+:rf.http/managed  <yes / no — yes if D3 claims HTTP (EP 014)>
 :routing/*        <yes / no>
 :ssr/*            <yes / no>
 :schemas/*        <yes / no — pick yes if D5 ≠ no, regardless of mechanism>
 ```
 
-Score reporting: this port's score is `passed / claimed-applicable` against the above set.
+The capability families above track the **conformance corpus** (`spec/conformance/README.md` §Capability tagging), which is the acceptance test. The Implementor-Checklist's family list lags the corpus (it omits `:flow/*`, `:rf.http/managed`, `:fsm/final-states`, `:fsm/registration-validation`); when they diverge, the corpus wins.
+
+Score reporting: this port's score is `passed / claimed-applicable` against the above set. A capability the port deliberately doesn't claim goes on the harness's `known-skipped-capabilities` allowlist (see [`conformance.md` §The two out-of-claim flavours](conformance.md#the-two-out-of-claim-flavours)); a fixture carrying a capability in neither the claim nor the allowlist must FAIL the suite, not skip silently.
 
 ---
 

--- a/skills/re-frame2-implementor/references/output-format.md
+++ b/skills/re-frame2-implementor/references/output-format.md
@@ -95,8 +95,8 @@ Produced after acceptance gate 2 passes. This is the final report for the port's
 - **Conformance score:** <claimed-applicable> / <claimed-applicable> on corpus commit <corpus-commit-hash>.
 - **Decision record:** `<port-repo>/DECISIONS.md` at <decisions-commit-hash>.
 - **Spec gaps filed (closed and open):**
-  - bd <id> — <one line; closed/open status>.
-  - bd <id> — <one line; closed/open status>.
+  - day8/re-frame2#<n> — <one line; open/closed status>.
+  - day8/re-frame2#<n> — <one line; open/closed status>.
 - **Per-EP commit chain:** <link to a tag, branch, or commit range covering all of Phase 2>.
 
 ## What v1 includes

--- a/skills/re-frame2-implementor/references/phase-1-decisions.md
+++ b/skills/re-frame2-implementor/references/phase-1-decisions.md
@@ -360,13 +360,17 @@ From [Implementor-Checklist §Errors](https://day8.github.io/re-frame2/spec/Impl
 **The capability tag families** ([`spec/conformance/README.md` §Capability tagging](https://day8.github.io/re-frame2/spec/conformance/)):
 
 - `:core/*` — pattern-required basics. Every conformant port claims these.
-- `:fsm/*` — FSM-richness axis (claim if D3 Q1 = yes; pick which sub-capabilities — `:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`).
+- `:fsm/*` — FSM-richness axis (claim if D3 Q1 = yes; pick which sub-capabilities — `:fsm/flat`, `:fsm/hierarchical`, `:fsm/eventless-always`, `:fsm/delayed-after`, `:fsm/tags`, `:fsm/parallel-regions`, `:fsm/final-states`, `:fsm/registration-validation`).
 - `:actor/*` — actor-model axis (claim if D3 Q1 = yes; pick which — `:actor/own-state`, `:actor/spawn-destroy`, `:actor/cross-actor-fx`, `:actor/invoke`, `:actor/spawn-and-join`, `:actor/system-id`).
+- `:flow/*` — Flows axis (`:flow/basic`, `:flow/trace`); claim if D3 ships EP 013.
+- `:rf.http/managed` — managed-HTTP; claim if D3 ships EP 014.
 - `:routing/*` — claim if D3 Q2 = yes.
 - `:ssr/*` — claim if D3 Q3 = yes.
 - `:schemas/*` — claim if D3 Q4 ≠ no (regardless of mechanism).
 
-The harness runs every fixture whose `:fixture/capabilities` is a subset of the claimed set and skips the rest. The score is `passed / claimed-applicable`.
+These families track the **corpus**, which is the acceptance test; the Implementor-Checklist's list lags it (omitting `:flow/*`, `:rf.http/managed`, `:fsm/final-states`, `:fsm/registration-validation`) — when they diverge, the corpus wins.
+
+The harness runs every fixture whose `:fixture/capabilities` is a subset of the claimed set. A deliberately-unclaimed capability goes on the harness's `known-skipped-capabilities` allowlist; a fixture whose capability is in neither the claim nor the allowlist must FAIL the suite, never skip silently (see [`conformance.md` §The two out-of-claim flavours](conformance.md#the-two-out-of-claim-flavours)). The score is `passed / claimed-applicable`.
 
 **Where the spec speaks.** [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/) — full capability tagging table and the harness contract.
 

--- a/skills/re-frame2-implementor/references/phase-2-impl-order.md
+++ b/skills/re-frame2-implementor/references/phase-2-impl-order.md
@@ -46,6 +46,7 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 - **Source-coord capture.** Hosts without macros (TS at runtime, OCaml-family) capture source coords from stack frames at `reg-*` call time, or via build-time codegen, or omit. The CLJS reference uses macros — that's a choice, not a requirement. Per [`spec/000-Vision.md` §What the pattern does NOT over-commit to](https://day8.github.io/re-frame2/spec/000-Vision/#what-the-pattern-does-not-over-commit-to).
 - **Metadata propagation.** The metadata on a `reg-event-*` registration must be reachable from the trace events fired during the event's drain. The CLJS reference threads `:doc` and source coords through the dispatch envelope; check that your design surfaces the same.
+- **`:machine-action` in the conformance fixtures is NOT a runtime registry kind.** The Mode-B FSM fixtures (`:machine-transition` / `:reg-machine`) use `:machine-action` as a top-level key under `:fixture/registry` / `:fixture/handlers` — a *harness-local* binding for attaching pure transition-action bodies in a frameless fixture (see [`spec/conformance/README.md`](https://day8.github.io/re-frame2/spec/conformance/)). The runtime closed kind set above is unchanged; do not wire `:machine-action` into your registrar or reject the fixture when you encounter it.
 
 ---
 
@@ -81,12 +82,20 @@ Each EP is multi-day work. Plan one focused session per EP; don't try to land tw
 
 **Read first.** [`spec/006-ReactiveSubstrate.md`](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/). All ~990 lines — this EP is the load-bearing contract between the runtime and the view layer.
 
-**The contract.**
+**The contract.** Nine entries total — verbatim from [`spec/006-ReactiveSubstrate.md` §The adapter API contract](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#the-adapter-api-contract). The function set is **closed for v1**.
 
-- **Six required functions** the adapter must provide: container creation, container read, container replace, sub-cache invalidation hook, render-tree → surface, mount/unmount.
-- **Two optional functions:** server-render-to-string, hydration.
-- **One lifecycle function:** start.
-- **Single-adapter-per-process.** A process binds one adapter at boot; multi-adapter coexistence is post-v1.
+- **Six required functions** the adapter must provide:
+  - `make-state-container` — create a reactive container holding an `app-db` value.
+  - `read-container` — read the current value (pure).
+  - `replace-container!` — mutate the container with a new value (the only mutation primitive; invalidation rides this).
+  - `make-derived-value` — construct a derived (memoised) container from one or more sources.
+  - `render` — render a render-tree onto the substrate's surface; return an unmount fn.
+  - `render-to-string` — pure render to an HTML string. **JVM-runnable and required even for Q3=no (no-SSR) ports** — do not treat it as optional.
+- **Two optional functions** (the core falls back when absent):
+  - `subscribe-container` — register a change-listener for invalidation. Fallback: core runs invalidation inline within `replace-container!`.
+  - `register-context-provider` — return a context-provider component that scopes a frame to a subtree. Fallback: explicit-frame-as-argument threaded by the user's view code.
+- **One lifecycle function:** `dispose-adapter!` — tear down: release listeners, caches, host resources. (Boot wiring is `install-adapter!`, a core entry point — not part of the adapter's own surface; there is no "start" function.)
+- **Single-adapter-per-process.** A process binds one adapter at boot via `install-adapter!`; multi-adapter coexistence is post-v1.
 - **Revertibility constraint on adapters.** Adapter-internal state must be derivable from the frame value. No "shadow state" inside the adapter that the frame value can't reproduce on revert. Per [`spec/006-ReactiveSubstrate.md` §Revertibility constraints on adapters](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#revertibility-constraints-on-adapters).
 - **Subscription cache invalidation contract.** Per [`spec/006-ReactiveSubstrate.md` §Subscription cache — contract and operational semantics](https://day8.github.io/re-frame2/spec/006-ReactiveSubstrate/#subscription-cache--contract-and-operational-semantics).
 
@@ -205,7 +214,7 @@ For each capability the port declared `yes` for in D3, walk the matching EP. Sug
 
 ### EP 014 — HTTP (if claimed)
 
-**Read.** [`spec/014-HTTPRequests.md`](https://day8.github.io/re-frame2/spec/014-HTTPRequests/) plus [Pattern-RemoteData](https://day8.github.io/re-frame2/spec/Pattern-RemoteData/) and [Pattern-ManagedHTTP](https://day8.github.io/re-frame2/spec/Pattern-Forms/).
+**Read.** [`spec/014-HTTPRequests.md`](https://day8.github.io/re-frame2/spec/014-HTTPRequests/) plus [Pattern-RemoteData](https://day8.github.io/re-frame2/spec/Pattern-RemoteData/) and [Managed-Effects](https://day8.github.io/re-frame2/spec/Managed-Effects/) (the managed-fx lifecycle that HTTP rides on).
 
 ### EP 007 — Stories (if D3 Q5 = yes)
 

--- a/skills/re-frame2-implementor/references/reference-impl-tour.md
+++ b/skills/re-frame2-implementor/references/reference-impl-tour.md
@@ -31,7 +31,7 @@ implementation/
 │       ├── emit.cljc        EP 009 — trace emit sites
 │       ├── error.cljc       EP 009 — structured error contract
 │       ├── substrate/       EP 006 — substrate contract + reference substrate
-│       │   ├── adapter.cljc   the six-function substrate contract
+│       │   ├── adapter.cljc   the nine-entry substrate contract (6 req + 2 opt + dispose)
 │       │   └── plain_atom.cljc plain-atom reference substrate (JVM / SSR / headless)
 │       └── test_support.cljc EP 008 — test fixtures + helpers
 ├── adapters/                EP 006 — React-binding substrate adapters
@@ -78,14 +78,14 @@ The per-feature directories ship as **separate artefacts** in the published libr
 
 ### EP 006 — Reactive substrate (`core/src/re_frame/substrate/` + `adapters/`)
 
-**What you'll find.** The substrate contract is defined in-core at `core/src/re_frame/substrate/adapter.cljc`, with a dependency-free reference substrate alongside it at `core/src/re_frame/substrate/plain_atom.cljc` — `clojure.core/atom`, hand-rolled signal graph, no render trigger (JVM / SSR / headless). The React-binding adapters then ship as sibling artefacts under `adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters are browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The in-core plain-atom substrate and every adapter implement the same six-function contract.
+**What you'll find.** The substrate contract is defined in-core at `core/src/re_frame/substrate/adapter.cljc`, with a dependency-free reference substrate alongside it at `core/src/re_frame/substrate/plain_atom.cljc` — `clojure.core/atom`, hand-rolled signal graph, no render trigger (JVM / SSR / headless). The React-binding adapters then ship as sibling artefacts under `adapters/` — `reagent`, `reagent-slim`, `uix`, `helix` (plus `test-react` for the test harness). The Reagent-family adapters are browser-facing — `r/atom` as the container, Reagent `r/reaction` for subs, React for the render trigger. The in-core plain-atom substrate and every adapter implement the same nine-entry contract (boot wiring is the core's `install-adapter!` / `dispose-adapter!`).
 
 **What's CLJS-specific.**
 
 - Reagent's auto-tracked deref-during-render dependency capture. Your host's React binding supplies the equivalent over its `useSyncExternalStore` (UIx / Helix: a `use-subscribe` hook; TS-React / Fable.React / Feliz / ReasonReact / Halogen-React / Kotlin-React: the same pattern).
 - The component-lifecycle integration uses Reagent's lifecycle methods. Other substrates plug into their own.
 
-**What's pattern-required.** The six required functions + two optional + one lifecycle. Single-adapter-per-process. Adapter-internal state derivable from the frame value (revertibility constraint).
+**What's pattern-required.** The six required functions (`make-state-container`, `read-container`, `replace-container!`, `make-derived-value`, `render`, `render-to-string` — note `render-to-string` is required, JVM-runnable, even for no-SSR ports) + two optional (`subscribe-container`, `register-context-provider`) + one lifecycle (`dispose-adapter!`); install via the core's `install-adapter!`. Single-adapter-per-process. Adapter-internal state derivable from the frame value (revertibility constraint).
 
 ### EP 004 — Views (`core/src/re_frame/views.cljs`)
 
@@ -123,7 +123,7 @@ EP 013 implementation. Substrate-independent; the contract lives in 013.
 
 ### `http/`
 
-EP 014 implementation + the Managed-HTTP pattern. The `:http` fx wraps a request lifecycle through a registered state machine. Substantial — read `Pattern-ManagedHTTP.md` first.
+EP 014 implementation + the managed-HTTP pattern. The `:http` fx wraps a request lifecycle through a registered state machine. Substantial — read `014-HTTPRequests.md` (and `Managed-Effects.md` for the managed-fx lifecycle it rides on) first.
 
 ### `machines/`
 
@@ -151,7 +151,7 @@ EP 011 implementation. Pure hiccup → HTML emitter (~200 lines) for the server 
 
 - **Phase 1.** As a sanity check on Phase 1 decisions — "the CLJS reference picked X for F5; I'm picking Y because my host gives me Z." The tour grounds the choice.
 - **Phase 2, per EP.** As a starting point for "where would I look to see how to handle the awkward case in EP N?" Open the matching directory above; read the corresponding source file.
-- **Spec gaps.** When a spec section is ambiguous and the tour shows the reference made a specific choice — that's not the spec's choice, that's the reference's. Draft a GitHub issue against `day8/re-frame2` asking for the spec to clarify, show the engineer the draft, wait for explicit OK before filing (see [`cardinal-rules.md` §§8–9](cardinal-rules.md) for the filing pattern and the per-issue approval gate).
+- **Spec gaps.** When a spec section is ambiguous and the tour shows the reference made a specific choice — that's not the spec's choice, that's the reference's. File it as a GitHub issue per [`cardinal-rules.md` §§8–9](cardinal-rules.md).
 
 ## When NOT to consult the tour
 

--- a/skills/re-frame2-implementor/spec/authoring-prompt.md
+++ b/skills/re-frame2-implementor/spec/authoring-prompt.md
@@ -21,7 +21,7 @@ A self-contained prompt that re-authors the `re-frame2-implementor` skill from t
 >
 > ```
 > skills/re-frame2-implementor/
-> ├── SKILL.md (router; ~250 lines)
+> ├── SKILL.md (router; ~100-150 lines — keep it lean, push detail into leaves)
 > ├── README.md (~80 lines)
 > ├── LICENSE (mirror skills/re-frame-migration/LICENSE)
 > ├── package.json (npm metadata; mirror re-frame-migration shape)

--- a/skills/re-frame2-implementor/spec/design.md
+++ b/skills/re-frame2-implementor/spec/design.md
@@ -108,19 +108,19 @@ Reverse cross-links (this skill → the application-side skills) live in SKILL.m
 
 ```
 skills/re-frame2-implementor/
-├── SKILL.md (router; ~250 lines)
+├── SKILL.md (router)
 ├── README.md (human-facing intro)
 ├── LICENSE (MIT)
 ├── package.json (npm metadata)
 ├── .claude-plugin/plugin.json (Claude Code plugin metadata)
 ├── references/
-│ ├── kickoff-prompt.md (paste-ready prompt; ~80 lines)
-│ ├── phase-1-decisions.md (Phase 1 walkthrough; ~200 lines)
-│ ├── decision-record.md (fill-in template; ~120 lines)
-│ ├── phase-2-impl-order.md (EP-by-EP order; ~250 lines)
-│ ├── reference-impl-tour.md (CLJS tour, descriptive; ~150 lines)
-│ ├── conformance.md (harness shape, diagnosis; ~140 lines)
-│ └── output-format.md (agent-output shape; ~120 lines)
+│ ├── kickoff-prompt.md (paste-ready prompt)
+│ ├── phase-1-decisions.md (Phase 1 walkthrough)
+│ ├── decision-record.md (fill-in template)
+│ ├── phase-2-impl-order.md (EP-by-EP order)
+│ ├── reference-impl-tour.md (CLJS tour, descriptive)
+│ ├── conformance.md (harness shape, diagnosis)
+│ └── output-format.md (agent-output shape)
 └── spec/
  ├── design.md (this file)
  ├── inputs.md (canonical inputs)


### PR DESCRIPTION
Remediation bead **rf2-ee38b.30** — consolidated 3-lens (correctness / completeness / clarity) fixes scoped to `skills/re-frame2-implementor`.

## Headline P1s
- **EP 006 substrate contract was wrong.** `render-to-string` is REQUIRED (skill demoted it to optional); the optional pair is `subscribe-container` + `register-context-provider` (skill named the non-existent "server-render-to-string, hydration"); the lifecycle fn is `dispose-adapter!` (skill called it "start"). A port author would have built the wrong adapter surface. Rewritten verbatim against `spec/006-ReactiveSubstrate.md` §The adapter API contract + `core/src/re_frame/substrate/adapter.cljc`; the `reference-impl-tour.md` echo corrected to match.
- **`output-format.md` reverted to `bd <id>`** for spec gaps, contradicting the skill's whole GitHub-issue discipline and locked decisions L6/L7. Switched to `day8/re-frame2#<n>` form.
- **Conformance leaf** now carries the mandatory `known-skipped-capabilities` harness contract (fail-on-unknown-capability), the `:fixture/spec-version` versioning obligation, the full Mode-B `:call` op set (incl. `:reg-machine` registration-error taxonomy), and the missing capability families `:flow/*`, `:rf.http/managed`, `:fsm/final-states`, `:fsm/registration-validation` (also added to D7 in `decision-record.md` + `phase-1-decisions.md`).

## Other fixes
- Phantom `Pattern-ManagedHTTP` cross-refs replaced with `014-HTTPRequests` + `Managed-Effects` (2 leaves).
- EP 001 note: `:machine-action` is a fixture-harness key, not a runtime registry kind.
- Clarity/minimalism: folded duplicate pinning rule 10 into rule 1 (eleven rules → ten); trimmed anti-patterns that merely inverted numbered rules; reduced spec-gap/approval restatements in leaves to one-line pointers to `cardinal-rules` §§8–9; README "seven skills" → "eight"; dropped stale `~250 lines` LoC tags + unused `Bash(gh pr *)` grant; aligned sample transcript fixture count.

## Verification
- EP-006 + conformance facts checked against current `spec/006-ReactiveSubstrate.md`, `spec/conformance/README.md`, `implementation/adapters/README.md`, and `core/.../substrate/adapter.cljc`.
- `python scripts/check_doc_slugs.py` → exit 0 (no broken targets/anchors).

## Out of scope / for the mayor
- The completeness P1 about `docs/skills/re-frame2-implementor.md` + `skills/README.md:130` still advertising Rust / native UI / terminal / Python (contradicting the deliberate 8-host JS→React scope) lives **outside** this skill dir — flagged for a cross-surface fix.
- Cross-skill-shared dedup deferred to the final shared bead per task instruction.