### PR TITLE
fix(skills): re-frame2-causa — relabel Dynamic tabs, drop removed Trace filter UI, document chrome

### DIFF
--- a/skills/re-frame2-causa/.claude-plugin/plugin.json
+++ b/skills/re-frame2-causa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "re-frame2-causa",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Causa — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (8 Dynamic event-spine tabs + 5 Static registry-browse tabs); defers driving / implementing Causa to sibling skills.",
+  "description": "Read-only tour skill for Causa — the re-frame2 in-app devtools panel. Teaches launch modes, the Dynamic ↔ Static mode toggle, and the tab inventory (7 Dynamic event-spine tabs + 5 Static registry-browse tabs); defers driving / implementing Causa to sibling skills.",
   "skills": [
     "./SKILL.md"
   ],

--- a/skills/re-frame2-causa/README.md
+++ b/skills/re-frame2-causa/README.md
@@ -5,7 +5,7 @@
 `re-frame2-causa` is a Claude Code **tour skill** for [Causa](https://github.com/day8/re-frame2/tree/main/tools/causa) — the re-frame2 in-app devtools panel. It answers two questions, and only two:
 
 1. **How do I launch Causa?** — the inline panel, the pop-out, the programmatic `init!`, the wired hotkeys, and the Dynamic ↔ Static mode toggle.
-2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 8 Dynamic event-spine tabs and the 5 Static registry-browse tabs.
+2. **Which tab shows X?** — a one-line purpose for each tab across both modes: the 7 Dynamic event-spine tabs and the 5 Static registry-browse tabs.
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source, redaction-indicator semantics) are out of scope for this iteration — see `SKILL.md` §Out of scope for what to do when one of those comes up.
 
@@ -19,7 +19,8 @@ Causa is the **human-facing** panel; for an AI agent surface against the running
 
 - `SKILL.md` — the skill itself
 - `references/launch-modes.md` — full launch-mode decision tree (preload vs `init!`, suppress-auto-open, `:rf.causa/layout-host-selector`, host-CSS-variable resize, pop-out lifecycle, wired hotkeys)
-- `references/panels.md` — the full tab tour in depth (8 Dynamic event-spine tabs + 5 Static registry-browse tabs, shared components, iconography, deeper "open it when…" guidance)
+- `references/panels.md` — the full tab tour in depth (7 Dynamic event-spine tabs + 5 Static registry-browse tabs, deeper "open it when…" guidance)
+- `references/shared-components.md` — the components every L4 panel reuses (`data_display/render`, `film_strip/header`, `focus_resolver`) + the tab-icon / L2-badge / cross-panel-arrow glyph reference
 - `evals/evals.json` — trigger-eval fixtures (should-trigger + should-not-trigger entries, per skill-creator's description-optimisation contract)
 - `.claude-plugin/plugin.json` — Claude Code Plugin packaging metadata
 - `package.json` — npm packaging metadata (skill is also distributable as an Agent Skill)
@@ -34,7 +35,7 @@ This skill does **not** depend on or reference `re-frame-10x`. Causa is the stru
 
 ## Status
 
-Pre-alpha. The Causa surface itself is pre-alpha (some tabs are partial — the Machines tab renders through the shared xyflow styling under `panels/machines/`, still stabilising; Schemas / Hydration only render when the relevant feature is wired into the host; several Static tabs carry placeholder beads). The skill hedges accordingly: when a user asks about an in-progress surface it says so and points at the spec.
+Pre-alpha. The Causa surface itself is pre-alpha (some tabs are partial — the Machines tab renders through the shared xyflow styling under `panels/machines/`, still stabilising; Schemas / Hydration only render when the relevant feature is wired into the host; the Static Machines Sim engine is still stabilising). The Static catalogues themselves are full registry browsers, not stubs. The skill hedges accordingly: when a user asks about an in-progress surface it says so and points at the spec.
 
 A future `re-frame2-causa-implementor` sibling skill is deferred to post-alpha until the Causa surface stabilises.
 

--- a/skills/re-frame2-causa/SKILL.md
+++ b/skills/re-frame2-causa/SKILL.md
@@ -39,13 +39,18 @@ This skill answers two questions, and only two:
  programmatic entry points, the wired hotkeys, the Dynamic ↔ Static
  mode toggle.
 2. **Which tab shows X?** — a one-line purpose for each tab Causa ships,
- across both modes: the 8 Dynamic event-spine tabs (per spec/018 §5)
+ across both modes: the 7 Dynamic event-spine tabs (per spec/018 §5)
  and the 5 Static registry-browse tabs (per spec/007-UX-IA.md §Static
  mode).
+3. **What's the chrome around the tabs for?** — the first-screen
+ navigation primitives the user meets immediately: the time-travel
+ scrubber / rewind / pins, the filter-pill cluster, the command
+ palette, the Settings popup, and Share-URL / per-cascade export.
 
-Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source,
-redaction-indicator semantics) are **out of scope** in this iteration —
-see the *Out of scope* section below for what to do when one comes up.
+Deep workflow recipes (find-wrong-sub, redaction-marker grammar,
+click-to-source / open-in-editor internals) are **out of scope** in this
+iteration — see the *Out of scope* section below for what to do when one
+comes up.
 
 ---
 
@@ -71,7 +76,7 @@ the `Cmd/Ctrl+Shift+M` chord:
 - **Dynamic** — the event-coupled spine. A 4-layer chrome (L1 ribbon ·
  L2 event list · L3 tab bar · L4 detail). Every tab is a *lens on the
  one focused event* — pick an event in the L2 list and every tab
- rebinds. This is "what happened in **this** epoch?". 8 tabs.
+ rebinds. This is "what happened in **this** epoch?". 7 tabs.
 - **Static** — event-INDEPENDENT browse of what's *registered*. A
  3-layer chrome (no L2 spine — Static has no event focus). Every tab is
  a registry catalogue: every machine, every route, every schema, every
@@ -96,7 +101,7 @@ situation.
 | User wants to … | Use | How |
 |---|---|---|
 | Inspect the runtime while developing locally | **Default true-inline panel** | Add the preload + a `[data-rf-causa-host]` column in the app layout. Causa auto-opens on page load. |
-| Put Causa on a second monitor with the app full-screen | **Pop-out window** | `(causa/popout!)` from CLJS, or `window.day8.re_frame2_causa.popout_BANG_` from devtools. |
+| Put Causa on a second monitor with the app full-screen | **Pop-out window** | `(causa/popout!)` from CLJS, or `window.day8.re_frame2_causa.popout_BANG_()` (call it — note the parens) from devtools. |
 | Mount Causa from code (no preload, or alternative wiring) | **Programmatic `init!`** | Call `(causa/init! opts)` after `rf/init!`. Idempotent. |
 | Browse what's *registered* instead of one dispatch | **Static mode** | Flip the L1 mode pill or press `Cmd/Ctrl+Shift+M`. Static drops the event spine and shows the 5 registry-browse tabs. |
 | Have an AI agent inspect the runtime | **re-frame2-pair-mcp** | Configure `tools/re-frame2-pair-mcp/` in the agent host — the raw nREPL pair-programming companion is the AI access path. Out of scope for this skill — see [`tools/re-frame2-pair-mcp/`](../../tools/re-frame2-pair-mcp/). |
@@ -130,6 +135,59 @@ Source of truth:
 
 ---
 
+## The chrome around the tabs
+
+Beyond the tabs, the first screen carries navigation primitives the user
+meets immediately. One line each — cite the spec/source, don't reproduce
+it.
+
+- **LIVE vs RETRO spine.** The L2 spine live-tails new events at the head
+ (**LIVE**) until you pick a historical event or pause, which drops to
+ **RETRO** (inspecting a past epoch). `Space` pauses/resumes LIVE; `L`
+ snaps back to LIVE; the head row pulses while live. Spec
+ [`007-UX-IA.md` §L1](../../tools/causa/spec/007-UX-IA.md).
+- **Time-travel scrubber · rewind · pins.** The ribbon `[◀ ▶ ⏭]` cluster
+ + the L2 list walk history **without disturbing the live app** —
+ scrubbing is *passive* (panels rebase; `app-db` does NOT move). Rewind
+ is *explicit and confirmed*: `r` (rewind) / `Shift+r` (hard rewind with
+ a failure-mode modal) calls `(rf/restore-epoch …)`; `*` pins a labelled
+ snapshot that survives the ring buffer ageing out. This passive-by-
+ default / rewind-opt-in posture is the load-bearing inversion from
+ re-frame-10x v1. Spec
+ [`002-Time-Travel.md`](../../tools/causa/spec/002-Time-Travel.md).
+- **Filter pills.** The L1.5 events ribbon carries IN / OUT pills, a mute
+ set, an `N events hidden by filters` count, and `Clear Filters`. Pills
+ are transient and reset on load. Each pill is a typed predicate
+ (`:event-id-pattern` / `:machine` / `:http-correlation` / `:fx`). Spec
+ [`020-Filter-Predicates.md`](../../tools/causa/spec/020-Filter-Predicates.md);
+ source `src/filters/`. *(These are L1-ribbon filters — distinct from the
+ Trace panel, which has no filtering.)*
+- **Command palette (`Cmd/Ctrl+K`).** A fuzzy-ranked surface over six
+ source kinds — **panel jumps · recent events · frame switch · registered
+ handlers · settings · command verbs**. Mode-aware (Dynamic vs Static),
+ recency-boosted; `Ctrl+Enter` pops out a poppable item. Command verbs
+ include Clear trace buffer, Clear epoch history, Snapshot app-db, Toggle
+ theme, Cycle reduced-motion, Cycle density, Jump to Settings, Toggle
+ mode, Open pop-out. Source
+ [`palette/sources.cljc`](../../tools/causa/src/day8/re_frame2_causa/palette/sources.cljc).
+- **Settings popup (`,` / `s`).** A 6-tab modal — **General · Theme ·
+ Filters · Keybindings · Buffer · Diff** — tuning density, panel
+ position/width, theme, reduced-motion, epoch-history depth, trace-buffer
+ keep, and app-db diff thresholds. This runtime popup (not `init!` opts)
+ is where `:theme` / `:density` / buffer-depth actually get tuned. Source
+ [`settings/view.cljs`](../../tools/causa/src/day8/re_frame2_causa/settings/view.cljs).
+- **Share-URL + per-cascade export.** **Share** encodes the current Causa
+ context (focused machine · scrubber position · selected tab) into a flat,
+ human-legible query-string URL a teammate can paste back. **Per-cascade
+ export** ("Export this epoch") emits one self-contained EDN document
+ (copy-to-clipboard / download-as-file) for triaging a single cascade in
+ isolation. (Note: there is no *whole-session* export per Lock 4 — these
+ are the narrower share units.) Source
+ [`share.cljs`](../../tools/causa/src/day8/re_frame2_causa/share.cljs)
+ + [`export/cascade.cljc`](../../tools/causa/src/day8/re_frame2_causa/export/cascade.cljc).
+
+---
+
 ## The tabs — what each surfaces
 
 <a id="the-tabs--what-each-surfaces"></a>
@@ -143,8 +201,8 @@ layout, iconography, stripe tokens, and "open it when…" depth see
 ### Dynamic mode — 7 lenses on the focused event
 
 The L3 tab bar holds **7 lenses on the focused event**, in the order set
-by spec/018 §5 (mnemonics `e a v t m r i`): **Event · App DB · View ·
-Trace · Machines · Routing · Issues**. Cross-epoch
+by spec/018 §5 (mnemonics `e a v t m r i`): **Event · app-db · Views ·
+Trace · Machines · Routes · Issues**. Cross-epoch
 signal lives on the L2 timeline above (badges + stripes); every tab
 answers "what happened in **this** epoch?" through its own lens. To
 browse a machine's full topology cold (spine-INDEPENDENT — picker +
@@ -154,11 +212,11 @@ mode** and open its Machines tab.
 | Tab | Mnem · Icon · Stripe | One-line purpose | When you'd open it |
 |---|---|---|---|
 | **Event** *(hero)* | `e` · `⚡` · violet | The six-step handling pipeline for the focused dispatch: DISPATCH → COEFFECTS → HANDLER → EFFECTS RETURNED → EFFECTS APPLIED → FLOWS RECOMPUTED. | Default landing view. "What did this event do?" / "What fx fired?" / "Did the flow recompute?" |
-| **App DB** | `a` · `◐` · cyan | Two-zone: DIFF (changed paths for this epoch) + STATE (full db at end of epoch via lazy tree). Hover any changed path for downstream-subs popover. | "What just changed in app-db?" / "What's downstream of `[:cart :items]`?" |
-| **View** | `v` · `◉` · cyan | The reactive cascade as a depth-first DAG: subs recomputed (step 7) + views re-rendered (step 8) with `caused-by ← sub ← path` causation on every leaf. (Display label is **View**, renamed from `Views`/`Reactive`; the internal tab id stays `:views`.) | "Why didn't my view update?" / "Trace the recompute chain for `:cart/total`." / "Which views re-rendered this epoch?" |
-| **Trace** | `t` · `⬢` · orange | Raw Spec 009 trace events for the focused epoch — one mono row per op, filterable by `[op-type ▾] [tag ▾]`, payload expands inline. | "Show me every raw op in this epoch." / "Is `:rf.fx/*` firing as expected?" |
+| **app-db** | `a` · `◐` · cyan | Two-zone: DIFF (changed paths for this epoch) + STATE (full db at end of epoch via lazy tree). Hover any changed path for downstream-subs popover. (Display label is lowercase **app-db** to match the library's app-db naming; internal tab id `:app-db`.) | "What just changed in app-db?" / "What's downstream of `[:cart :items]`?" |
+| **Views** | `v` · `◉` · cyan | The reactive cascade as a depth-first DAG: subs recomputed (step 7) + views re-rendered (step 8) with `caused-by ← sub ← path` causation on every leaf. (Display label is **Views** — the all-plural-domain-noun convention, Mike-direction 2026-05-21, after a `Reactive → View → Views` rename chain; the internal tab id stays `:views`.) | "Why didn't my view update?" / "Trace the recompute chain for `:cart/total`." / "Which views re-rendered this epoch?" |
+| **Trace** | `t` · `⬢` · orange | Raw Spec 009 trace events for the focused epoch — one mono row per op; the focused epoch IS the scope (no filter chips), click any row to expand its payload inline. | "Show me every raw op in this epoch." / "Is `:rf.fx/*` firing as expected?" |
 | **Machines** | `m` · `◆` · green | **Event-driven.** Per-machine topology + transition highlight + guards / actions / cancellation cascade for the focused event. BLANK when the focused event had no machine activity; per-machine prev/next walks the spine. To browse a machine's full topology cold (picker + zoom / pan / fit, spine-INDEPENDENT), use **Static mode**'s Machines tab. | "What did this event do to my machines?" / "What transition fired?" / "What guards passed/failed?" |
-| **Routing** | `r` · `🌐` · yellow | Flat focused-event lens: current matched route + params/query/fragment + a **Simulate-URL** input that ranks every registered route, with per-event glyphs `◆ HERE` / `◆ FROM` / `◆ TO`. Silent when no routes registered. | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
+| **Routes** | `r` · `🌐` · yellow | Flat focused-event lens: current matched route + params/query/fragment + a **Simulate-URL** input that ranks every registered route, with per-event glyphs `◉ TO` / `◇ FROM` / `● HERE`. Silent when no routes registered. (Display label **Routes**, plural-noun convention; internal tab id `:routing`.) | "What route am I on?" / "Did the route change this epoch?" / "What params resolved?" |
 | **Issues** | `i` · `⚠` · red | Per-epoch errors + warnings + schema violations + hydration mismatches + perf-budget overruns + app console errors, unified. Head-fallback to most-recent epoch when the spine is at head. | "Anything broken in this epoch?" / "Show me all schema failures here." / "What warnings fired?" |
 
 > **Note — there is no Chrome A11y tab.** Earlier drafts of this skill
@@ -177,7 +235,7 @@ Interceptors**.
 | Tab | Mnem | One-line purpose | When you'd open it |
 |---|---|---|---|
 | **Machines** *(default)* | `m` | Registry browse of every registered machine + topology + a 4-mode sub-strip (incl. the Sim engine). The "show me all my machines" entry point. | "What machines are registered?" / "Browse my checkout machine's chart without picking an event." |
-| **Routes** | `r` | Every registered route + a Simulate-URL input (promoted from the Dynamic Routing lens). | "List all my routes." / "Which route would `/orders/42` match?" |
+| **Routes** | `r` | Every registered route + a Simulate-URL input (promoted from the Dynamic Routes lens). | "List all my routes." / "Which route would `/orders/42` match?" |
 | **Schemas** | `c` | Every registered schema + sample data + jump-to-source. | "What schemas are registered?" / "Show me the shape of `:order/schema`." |
 | **Flows** | `f` | Catalogue of every registered flow. | "What flows are registered?" |
 | **Interceptors** | `i` | Pure-browse lens over the registered interceptor chains. | "What interceptors run, and in what order?" |
@@ -190,13 +248,13 @@ tabs only ever show the focused event.
 
 Six panels from the pre-rebuild inventory (Subscriptions, Effects,
 Flows, Performance, Schemas, Hydration) are **not** separate Dynamic
-tabs. Their content is surfaced through the Dynamic 8 (per
+tabs. Their content is surfaced through the Dynamic 7 (per
 [`references/panels.md` §What's deliberately NOT here](references/panels.md#whats-deliberately-not-here)
 + spec/021 §15) — and the registry catalogues live in Static mode:
 
 | Retired panel | Where its content lives now |
 |---|---|
-| **Subscriptions** | **View** (cascade tree, step 7) + **App DB** (downstream-subs hover popover on changed paths) |
+| **Subscriptions** | **Views** (cascade tree, step 7) + **app-db** (downstream-subs hover popover on changed paths) |
 | **Effects** (`fx`) | **Event** step 4 (returned) + step 5 (applied) + **Trace** (raw `:rf.fx/*` ops) |
 | **Flows** | **Event** step 6 (FLOWS RECOMPUTED), per event · **Static → Flows** for the registry catalogue |
 | **Performance** | L2 row stripe colours (cross-epoch budget signal) + per-step `:time` inside **Trace** |
@@ -215,12 +273,15 @@ When a user asks about any of the following, this skill does not have
 the answer — point them at the spec doc or pair-tool surface and stop
 short of improvising.
 
-- **Workflow recipes** (find-wrong-sub, scrub-bad-epoch,
- redaction-indicator semantics, click-to-source / "open in editor"
- details, pop-out lifecycle gotchas). Source of truth:
+- **Deep workflow recipes** (find-wrong-sub walker, redaction-marker
+ grammar, click-to-source / "open in editor" internals, pop-out lifecycle
+ gotchas, branch-and-explore). Source of truth:
  [`tools/causa/spec/007-UX-IA.md`](../../tools/causa/spec/007-UX-IA.md)
  and the per-panel specs (`tools/causa/spec/00N-*.md`). A future
  iteration may codify these as recipes; today the spec is the answer.
+ (First-screen chrome — scrubber/rewind/pins, filter pills, the command
+ palette, Settings, Share/export — is **in scope**: see §The chrome
+ around the tabs above.)
 - **Driving Causa programmatically** (hot-swap a sub via REPL, time-
  travel from CLJS, dispatch into the runtime from a tool). Route to
  the [`re-frame2-pair`](../re-frame2-pair/SKILL.md) skill — Causa
@@ -243,9 +304,11 @@ short of improvising.
  renders through the shared xyflow styling at
  `panels/machines/xyflow_style.cljs`, still
  stabilising; Issues only populates the schema / hydration rows when the
- host has those features wired; several Static tabs carry placeholder
- beads). When a user asks about an in-progress surface, say so and point
- at the spec.
+ host has those features wired; the Static Machines Sim engine is still
+ stabilising). The Static catalogues themselves (Machines / Routes /
+ Schemas / Flows / Interceptors) are full registry browsers, not stubs.
+ When a user asks about an in-progress surface, say so and point at the
+ spec.
 - **Don't invent hotkeys.** Four families are globally wired today —
  `Ctrl+Shift+C` (toggle shell), `Cmd/Ctrl+Shift+M` (mode toggle),
  `Cmd/Ctrl+K` (command palette), plus the focus-gated bare keys

--- a/skills/re-frame2-causa/evals/evals.json
+++ b/skills/re-frame2-causa/evals/evals.json
@@ -2,7 +2,7 @@
  "skill_name": "re-frame2-causa",
  "schema_version": "1",
  "convention": "anthropics/skills/skill-creator evals.json — trigger-only fixture per references/schemas.md. Each entry carries `should_trigger` so skill-creator's description-optimisation loop can score train/held-out trigger accuracy.",
- "notes": "Positives (should_trigger: true) target the launch + tab-routing surface of skill SKILL.md across both modes (Dynamic event-spine + Static registry browse) and the wired hotkeys (incl. the Dynamic <-> Static mode toggle). Negatives target adjacent surfaces (re-frame2-pair drives Causa; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering.",
+ "notes": "Positives (should_trigger: true) target the launch + tab-routing surface of skill SKILL.md across both modes (Dynamic event-spine + Static registry browse), the wired hotkeys (incl. the Dynamic <-> Static mode toggle), and the first-screen chrome around the tabs (time-travel scrubber/rewind, filter pills, command palette, Settings, Share/export). Negatives target adjacent surfaces (re-frame2-pair drives Causa; re-frame2 authors host apps; spec discussion belongs to SKILL-REDIRECT) so the loop catches over-triggering.",
  "evals": [
  {"id": 1, "name": "launch-default", "should_trigger": true, "prompt": "How do I open Causa in my re-frame2 dev build?"},
  {"id": 2, "name": "launch-popout", "should_trigger": true, "prompt": "I want Causa on a second monitor — what's the call to pop it out into its own window?"},
@@ -16,6 +16,9 @@
  {"id": 10, "name": "static-mode-name", "should_trigger": true, "prompt": "What is Causa's Static mode and how is it different from the normal event view?"},
  {"id": 11, "name": "panel-route-schema", "should_trigger": true, "prompt": "I'm getting schema violations — which Causa panel surfaces them and when did each one start?"},
  {"id": 12, "name": "panel-route-hydration", "should_trigger": true, "prompt": "My SSR hydration is mismatching — does Causa have a panel for that?"},
+ {"id": 21, "name": "chrome-rewind", "should_trigger": true, "prompt": "How do I go back in time in Causa — scrub through history and rewind to an earlier epoch?"},
+ {"id": 22, "name": "chrome-filters", "should_trigger": true, "prompt": "Some of my events are missing from the Causa list and it says 'N hidden by filters' — how do I clear the filters?"},
+ {"id": 23, "name": "chrome-palette", "should_trigger": true, "prompt": "What can I type into Causa's command palette when I press Cmd+K?"},
  {"id": 13, "name": "neg-drive-causa", "should_trigger": false, "prompt": "Use Causa to dispatch [:cart/apply-coupon \"SPRING25\"] and tell me what happens.", "rationale": "Driving Causa from a REPL is re-frame2-pair's surface, not the read-only tour."},
  {"id": 14, "name": "neg-implement-panel", "should_trigger": false, "prompt": "I want to add a new Causa panel for WebSocket connection lifecycle — walk me through the panel-facade/leaf split.", "rationale": "Implementing Causa is out of scope; route to tools/causa/spec/."},
  {"id": 15, "name": "neg-author-app", "should_trigger": false, "prompt": "Write a re-frame2 reg-event-fx that posts a login form and dispatches :login-success / :login-failure.", "rationale": "Authoring application code is re-frame2's job."},

--- a/skills/re-frame2-causa/package.json
+++ b/skills/re-frame2-causa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@day8/re-frame2-causa",
   "version": "0.1.0-alpha.1",
-  "description": "Read-only tour skill for Causa — the re-frame2 in-app devtools panel. Teaches how to launch Causa (true-inline, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 8 Dynamic event-spine tabs and 5 Static registry-browse tabs — surfaces the data you're looking for.",
+  "description": "Read-only tour skill for Causa — the re-frame2 in-app devtools panel. Teaches how to launch Causa (true-inline, pop-out, programmatic, hotkeys, Dynamic ↔ Static mode toggle) and which tab — across the 7 Dynamic event-spine tabs and 5 Static registry-browse tabs — surfaces the data you're looking for.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/skills/re-frame2-causa/references/panels.md
+++ b/skills/re-frame2-causa/references/panels.md
@@ -14,42 +14,16 @@ palette tokens, density. Tab order is set declaratively via `reg-l4-tab!`
 `:order` and rendered by `shell.cljs` (Dynamic) / `static/shell.cljs`
 (Static).
 
-## Two modes, two chrome shapes
+## Two modes
 
-Causa runs in one mode at a time — flip with the L1 mode pill or
-`Cmd/Ctrl+Shift+M` (per §007 §Static mode).
-
-**Dynamic** — the event-coupled spine. Four layers; every tab is a lens
-on the one focused event:
-
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│ L1 ribbon · L2 event timeline ← MOVING BETWEEN events│
-├──────────────────────────────────────────────────────────────────────┤
-│ L3 tab bar (7 tabs) · L4 detail (lens on focused event) ← DEPTH IN  │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-**Top** carries the only cross-epoch signal. Every Dynamic L4 tab answers
-"what happened in this epoch?" through its own lens. **No third
-axis. No other cross-epoch L4 panels** (§021 §1.2 — binding). (The
-spine-INDEPENDENT browse-all machine canvas lives under **Static mode**'s
-Machines tab, not on the Dynamic spine — §007 §Layout.)
-
-**Static** — event-INDEPENDENT registry browse. Three layers (no L2
-spine); every tab is a catalogue of what's registered in the picked
-frame:
-
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│ L1 ribbon (mode pill · frame picker · icons)                          │
-├──────────────────────────────────────────────────────────────────────┤
-│ L3 tab bar (5 tabs) · L4 detail (registry catalogue) ← WHAT EXISTS   │
-└──────────────────────────────────────────────────────────────────────┘
-```
-
-The 8 Dynamic tabs are covered in §Panel-by-panel below; the 5 Static
-tabs in §Static mode — registry browse.
+The two-mode model (Dynamic event-spine 4-layer chrome · Static registry
+3-layer chrome, flipped by the L1 mode pill or `Cmd/Ctrl+Shift+M`) is
+covered in [`SKILL.md` §Two modes](../SKILL.md#two-modes). This leaf is
+the per-panel tour: the 7 Dynamic tabs in §Panel-by-panel below, the 5
+Static tabs in §Static mode — registry browse. One binding constraint to
+restate: **no cross-epoch L4 panels** — every Dynamic L4 tab is a lens on
+the one focused epoch; aggregate signal lives on L2 badges only (§021
+§1.2 — binding).
 
 ### L2 timeline grammar
 
@@ -58,9 +32,14 @@ The L2 timeline above the panels carries:
 - **Dispatch-origin prefix glyph** per row — one of
  `:user :router :websocket :http :ssr :fx-emit :timer :test-harness :tool :internal`
  (per Spec 002; §021 §1.5 is the universal classifier).
-- **Activity badge cluster** per row: `⚠` issue · `◆` machine
- transition · `🌐` route nav · `⚡` HTTP lifecycle · `⏲` timer-triggered.
- Glyphs from §021 §17.1.5; HCM remap is automatic (colour is never alone).
+- **Activity badge cluster** per row (live impl `l2_timeline.cljc`
+ `activity-badge-glyphs`, render order issue → machine → HTTP → fx-emit →
+ timer): `⚠` issue (error) · `◆` machine transition · `🌐` HTTP activity ·
+ `⚡` fx-emit child dispatch · `⏲` timer-triggered. HCM remap is automatic
+ (colour is never alone). *(Spec §021 §17.1.5's row-badge table also
+ documents `💧` SSR-hydration + `🌊` flow-recomputed as normative-but-not-
+ yet-in-the-cluster, and maps `🌐`/`⚡` to route/HTTP — a pre-alpha spec-vs-
+ impl drift; the live tool above is authoritative.)*
 
 Implementation lives at
 [`panels/l2_timeline.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc).
@@ -79,13 +58,17 @@ affordance in the focused-epoch header (`002-Time-Travel.md`).
 ## Panel-by-panel (Dynamic mode)
 
 Seven Dynamic tabs, in their fixed L3-tab order (§018 §5; mnemonics
-`e a v t m r i`): **Event · App DB · View · Trace · Machines ·
-Routing · Issues.**
+`e a v t m r i`): **Event · app-db · Views · Trace · Machines ·
+Routes · Issues.** (Display labels are the all-plural-domain-noun set,
+Mike-direction 2026-05-21; internal tab ids stay `:event :app-db :views
+:trace :machines :routing :issues`.)
 
-Each tab shares the same chrome: panel icon (left of stripe) · panel
-title · focused-event id · `[◀ Prev] [Next ▶]` film-strip walking the
-L2 spine chronologically (per §021 §17.1.5; shared component at
+Most Dynamic tabs share the same chrome: panel icon (left of stripe) ·
+panel title · focused-event id · `[◀ Prev] [Next ▶]` film-strip walking
+the L2 spine chronologically (per §021 §17.1.5; shared component at
 [`panels/shared/film_strip/header.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc)).
+**Trace opts out of the film-strip header** (rf2-o6yqq) — the L2 events
+list already owns spine focus navigation.
 
 ### Event — `⚡` · stripe `:accent-violet` · mnem `e`
 
@@ -103,7 +86,7 @@ Six-step linear pipeline rendered top-to-bottom with explicit arrows
 
 All six steps default-expanded (the pipeline IS the punch, §021 §2 +
 §17.3). Ends with the `db committed for epoch #N` marker — the pivot
-to the View panel. Header film-strip walks the L2 spine
+to the Views panel. Header film-strip walks the L2 spine
 chronologically.
 
 **Open when:** "what did this event do?", "what fx fired?", "what did
@@ -114,7 +97,7 @@ implementation at
 [`panels/event_detail.cljs`](../../../tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs)
 + `panels/event/`.
 
-### App DB — `◐` · stripe `:cyan` · mnem `a`
+### app-db — `◐` · stripe `:cyan` · mnem `a`
 
 Question: **What does state LOOK LIKE — and what just changed?**
 
@@ -128,7 +111,7 @@ Two-zone layout (§021 §4.2):
 
 **Downstream-subs hover popover** (§021 §4.4) — hover any changed path
 to surface the subs depending on it + the views rendered + an inline
-`⤴` to jump to the View panel scrolled to those subs. Popover is
+`⤴` to jump to the Views panel scrolled to those subs. Popover is
 Causa-owned (not a browser title), keyboard-dismissable. Walks subs
 from the registry's `:input-paths` — see
 [`panels/shared/sub_input_paths.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc).
@@ -144,16 +127,20 @@ Spec: [`021-Dynamic-Panel-Designs.md` §4](../../../tools/causa/spec/021-Dynamic
 + [`004-App-DB-Diff.md`](../../../tools/causa/spec/004-App-DB-Diff.md);
 implementation at
 [`panels/app_db_diff.cljs`](../../../tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs)
-+ siblings under `panels/app_db_diff_*.cljs` +
-[`panels/app_db_diff_downstream.cljs`](../../../tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_downstream.cljs).
++ siblings (`app_db_diff_{events,format,subs,state}.cljs`); the
+downstream-subs walk lives in
+[`panels/app_db_diff_subs.cljs`](../../../tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs)
++ the shared
+[`panels/shared/sub_input_paths.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/sub_input_paths.cljc).
 
-### View — `◉` · stripe `:cyan` · mnem `v`
+### Views — `◉` · stripe `:cyan` · mnem `v`
 
 Question: **What RENDERED as a result?**
 
-The display label is **View** — it was `Views` (pre-rebuild), then
-`Reactive` (§021 §11.5), and is now `View`
-(`reactive_panel.cljs:53-57`). **The L3 tab key stays `:views`** — it's an
+The display label is **Views** — the rename chain ran `Views`
+(pre-rebuild) → `Reactive` (§021 §11.5) → `View` → back to `Views`, the
+final all-plural-domain-noun convention (Mike-direction 2026-05-21), set
+at `reactive_panel.cljs:75`. **The L3 tab key stays `:views`** — it's an
 internal id, not a user contract, so only the display label rebases.
 
 The reactive cascade (Spec 009 ops 7-8) rendered as a depth-first DAG
@@ -171,8 +158,8 @@ step 6) per §021 §3.2. The cascade nodes are exactly: db-paths (seed)
 → subs (intermediate) → views (leaf).
 
 "Show unchanged subs" toggle defaults OFF (§021 §3.4 + §11.4).
-Per-cascade clicks propagate cross-panel: sub row → App-db at that
-input path; `caused-by ← sub ← path` chip → App-db at that path.
+Per-cascade clicks propagate cross-panel: sub row → app-db at that
+input path; `caused-by ← sub ← path` chip → app-db at that path.
 
 **Open when:** "why didn't my view update?", "what re-rendered?",
 "trace the recompute chain for sub X", "which subs short-circuited?"
@@ -187,18 +174,21 @@ implementation at
 
 Question: **What raw trace events fired during this epoch?**
 
-The underlying stream that Event + View summarise. **Focused-epoch
+The underlying stream that Event + Views summarise. **Focused-epoch
 scoped** (per §021 §1.2 — no aggregate-across-epochs view) — each row
-is a single mono line `#id +Xms op-kw inline-summary`, filterable
-by `[op-type ▾] [tag ▾]` chips (panel-local; do not affect L1 ribbon).
+is a single mono line `#id +Xms op-kw inline-summary`. **No filtering
+UI** (rf2-gkczt): the focused epoch IS the scope, so the panel-local
+chip filters (and the clear-filters control) are gone — the only
+drill-down is per-row payload expand.
 
-Per-row click expands the payload inline via the shared
-[`data_display/render`](../../../tools/causa/src/day8/re_frame2_causa/data_display/render.cljs)
-component at depth-2-expanded (§021 §10.4 + §17.3). Film-strip walks
-the L2 spine — closest Causa comes to a time-step replay UX.
+Per-row click expands the payload inline via the EDN widget's current-
+state `browse` (cljs-devtools look) — type-coloured, nested, expanded.
+**No film-strip header** (rf2-o6yqq) — the L2 events list owns spine
+focus navigation.
 
-The filter vocabulary lines up with Spec 009 §Filter vocabulary
-(`:op-type`, `:dispatch-id`, plus the 13-axis tags).
+(Spec 009's `trace-buffer` filter vocabulary — `:op-type`,
+`:dispatch-id`, the tag axes — is real for the *programmatic* API but is
+**not** surfaced as Trace-panel UI.)
 
 **Open when:** "show me every raw op in this epoch", "is `:rf.fx/*`
 firing as expected?", "what order did these emit in?"
@@ -258,21 +248,16 @@ implementation at
 + `panels/machines/`.
 
 > **Browse-all machine canvas → Static mode.** The spine-INDEPENDENT
-> "what does this machine LOOK like overall?" canvas (picker on the left,
-> interactive Chart adapter on the right — zoom / pan / fit + keyboard
-> shortcuts; always shows the picked machine's *full* topology regardless
-> of the focused event) is **not a Dynamic tab**. It lives under **Static
-> mode**'s Machines tab (its Topology sub-mode). The Dynamic Machines tab
-> above is purely the event-driven lens (rf2-ga16q removed the standalone
-> Dynamic "Machines Canvas" tab; rf2-y9xmf is the event-driven rewrite).
-> Spec: [`007-UX-IA.md` §Static mode](../../../tools/causa/spec/007-UX-IA.md)
-> + [`003-Machine-Inspector.md`](../../../tools/causa/spec/003-Machine-Inspector.md);
-> implementation at
+> "what does this machine LOOK like overall?" canvas (picker + interactive
+> zoom / pan / fit, regardless of focused event) is **not a Dynamic tab** —
+> it lives under Static mode's Machines tab (Topology sub-mode); rf2-ga16q
+> removed the standalone Dynamic "Machines Canvas" tab. Impl
 > [`static/machines/topology.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/machines/topology.cljs).
 
-### Routing — `🌐` · stripe `:yellow` · mnem `r`
+### Routes — `🌐` · stripe `:yellow` · mnem `r`
 
-Question: **What did this event do to my routes?**
+Question: **What did this event do to my routes?** (Display label
+**Routes**, plural-noun convention; internal tab id `:routing`.)
 
 Same topology-plus-overlay pattern as Machines, rendered as a textual
 tree (route trees are typically ≤ 4 levels deep, so a tree with `├─ └─`
@@ -353,7 +338,7 @@ Static opens the Machines registry browse).
 | Tab | Mnem | Question it answers | Implementation |
 |---|---|---|---|
 | **Machines** *(default)* | `m` | "What machines are registered, and what do they look like?" Registry browse + topology + a 4-mode sub-strip (incl. the Sim engine). | [`static/machines/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/machines/panel.cljs) |
-| **Routes** | `r` | "What routes are registered, and which would `/x/y` match?" Registered routes + Simulate-URL (promoted from the Dynamic Routing lens). | [`static/routes/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs) |
+| **Routes** | `r` | "What routes are registered, and which would `/x/y` match?" Registered routes + Simulate-URL (promoted from the Dynamic Routes lens). | [`static/routes/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs) |
 | **Schemas** | `c` | "What schemas are registered, and what shape do they expect?" Registered schemas + sample data + jump-to-source. | [`static/schemas/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs) |
 | **Flows** | `f` | "What flows are registered?" The flows catalogue. | [`static/flows/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs) |
 | **Interceptors** | `i` | "What interceptors run, and in what order?" Pure-browse lens over the interceptor chains. | [`static/interceptors/panel.cljs`](../../../tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs) |
@@ -370,93 +355,19 @@ schemas / flows / interceptors?", "browse the whole registry", "what's
 registered in this frame?" — anything that is about the *registry* rather
 than a single dispatch.
 
-## Shared components
+## Shared components + iconography
 
-Three components are consumed by every (or nearly every) L4 panel.
-Citing them when you answer "where does X live?" beats describing the
-behaviour from each panel's perspective.
-
-### `data_display/render`
-
-The single canonical data renderer — lazy collapsible tree + inline
-diff highlighting + keyword accent + clickable paths. Lives at
-[`tools/causa/src/day8/re_frame2_causa/data_display/render.cljs`](../../../tools/causa/src/day8/re_frame2_causa/data_display/render.cljs)
-per §021 §10. Every panel that shows data — App DB, Event coeffects /
-returned effects, View sub values, Trace expanded payloads, Issues
-`ex-data` — goes through this renderer (§021 §10.6 — binding).
-
-Locked capabilities (§021 §10.1): lazy collapsible tree · inline diff
-(no side-by-side) · minimal keyword-only type coloring · clickable
-paths for **cross-panel propagation only** (no blame popover, no
-copy-path, no copy-value, no "show epoch that last changed this" —
-explicitly stripped per §021 §10.5).
-
-Lazy-expansion heuristic (§021 §10.4): depth ≤ 2 expanded · depth 3
-expanded if ≤ 10 children · depth ≥ 4 collapsed · changed children
-force ancestor chain open · per-panel `:default-depth` override (App-db
-defaults depth-3-collapsed; Event payload defaults depth-2-expanded).
-
-Operator expansion state persists in app-db
-(`:rf.causa.data-display/expansion {<path>}`) per epoch + path.
-
-### `film_strip/header`
-
-Shared `[◀ Prev] [Next ▶]` header consumed by every L4 panel. Lives
-at
-[`tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc).
-MVP: chronological walk through the L2 spine. Hit-target sizing per
-§021 §17.1.5 (28×20px, 4px vertical padding for AA target-size).
-Keyboard `←` / `→` global binding. Disabled state at spine ends.
-
-Per-panel stretch filters (e.g. "next epoch with ⚠" for Issues, "next
-route activity" for Routing, "next epoch that touched THIS machine"
-for Machines) slot into the header's filter slot.
-
-### `focus_resolver` + `find-epoch-record`
-
-Shared focus-resolution at
-[`tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc).
-Resolves the focused epoch's record from `:rf.causa/focus` (per
-[`018-Event-Spine.md`](../../../tools/causa/spec/018-Event-Spine.md))
-with the **head-fallback contract** — when no historical epoch is
-focused, every L4 panel scopes to the most-recent epoch in the buffer
-(not "no data" — head IS a valid focus). Used by Issues, View,
-App DB, Trace, Machines, Routing for symmetric "spine at head" empty
-states.
-
-The evicted-epoch placeholder (§021 §10.7 — `"Epoch evicted from
-buffer — increase :epoch-history to retain more"`) is also resolved
-here, so the film-strip ◀ / ▶ keeps working when the operator scrubs
-past an evicted row.
-
-## Iconography quick reference
-
-Per §021 §17.1.5 (binding; HCM-safe because glyph alone carries
-signal, colour is never alone):
-
-| Tab (Dynamic) | Mnem | Icon | Stripe token |
-|---|---|---|---|
-| Event | `e` | `⚡` | `:accent-violet` |
-| App DB | `a` | `◐` | `:cyan` |
-| View | `v` | `◉` | `:cyan` |
-| Trace | `t` | `⬢` | `:orange` |
-| Machines | `m` | `◆` | `:green` |
-| Routing | `r` | `🌐` | `:yellow` |
-| Issues | `i` | `⚠` | `:red` |
-
-L2 row badges: `⚠` issue · `◆` machine transition · `🌐` route nav ·
-`⚡` HTTP lifecycle · `⏲` timer dispatch.
-
-Cross-panel arrows: `⤴` jump-to-panel from popover (`:accent-violet`,
-12px) · `↳` cause-attribution chip (`:text-tertiary`, 11px) · `→`
-inline state transition (`:text-primary`, mono).
+The three components every L4 panel reuses (`data_display/render`,
+`film_strip/header`, `focus_resolver`) and the full tab-icon / L2-badge /
+cross-panel-arrow glyph reference live in
+[`shared-components.md`](shared-components.md).
 
 ## What's deliberately NOT here
 
 Per §021 §15 (Dynamic mode) + §007 §Static mode:
 
 - **No extra Dynamic L4 lens.** The 7-tab Dynamic set is the contract;
- sub-layer surfaces inline in View + the App DB hover popover (no peer
+ sub-layer surfaces inline in Views + the app-db hover popover (no peer
  Subs panel).
 - **No Chrome A11y tab.** Removed; a11y dogfooding is Story's domain.
 - **No standalone Dynamic "Machines Canvas" tab.** Removed (rf2-ga16q);
@@ -466,14 +377,14 @@ Per §021 §15 (Dynamic mode) + §007 §Static mode:
 - **No cross-epoch Dynamic L4 views.** Aggregate signals live on L2
  badges only.
 - **No pattern-view.** Deferred.
-- **No master-detail Event-vs-View coupling.** Peers, bridged by App DB.
+- **No master-detail Event-vs-Views coupling.** Peers, bridged by app-db.
 - **No simultaneous multi-frame display.** Single-frame focus (§021
  §1.6); switch focus via the L1 frame picker.
 - **No legacy panels.** Subscriptions, Effects, Flows, Performance,
  Schemas, Hydration are NOT separate Dynamic tabs. Their content is
  surfaced through the Dynamic 7 above — and the registry catalogues live
  in Static mode:
- - Subscriptions → View (cascade tree) + App DB (hover popover)
+ - Subscriptions → Views (cascade tree) + app-db (hover popover)
  - Effects → Event step 4 (returned) + step 5 (applied) + Trace (raw `:rf.fx/*` ops)
  - Flows → Event step 6 (per event) · Static → Flows (registry)
  - Performance → L2 row stripe colours + per-step `:time` in Trace

--- a/skills/re-frame2-causa/references/shared-components.md
+++ b/skills/re-frame2-causa/references/shared-components.md
@@ -1,0 +1,86 @@
+# shared-components — the chrome every L4 panel reuses + iconography
+
+Companion to [`panels.md`](panels.md). When you answer "where does X
+live?", citing the shared component beats describing the behaviour from
+each panel's perspective.
+
+## Shared components
+
+Three components are consumed by every (or nearly every) L4 panel.
+
+### `data_display/render`
+
+The single canonical data renderer — lazy collapsible tree + inline
+diff highlighting + keyword accent + clickable paths. Lives at
+[`tools/causa/src/day8/re_frame2_causa/data_display/render.cljs`](../../../tools/causa/src/day8/re_frame2_causa/data_display/render.cljs)
+per §021 §10. Every panel that shows data — app-db, Event coeffects /
+returned effects, Views sub values, Issues `ex-data` — goes through this
+renderer (§021 §10.6 — binding).
+
+Locked capabilities (§021 §10.1): lazy collapsible tree · inline diff
+(no side-by-side) · minimal keyword-only type coloring · clickable
+paths for **cross-panel propagation only** (no blame popover, no
+copy-path, no copy-value, no "show epoch that last changed this" —
+explicitly stripped per §021 §10.5).
+
+Lazy-expansion heuristic (§021 §10.4): depth ≤ 2 expanded · depth 3
+expanded if ≤ 10 children · depth ≥ 4 collapsed · changed children
+force ancestor chain open · per-panel `:default-depth` override (app-db
+defaults depth-3-collapsed; Event payload defaults depth-2-expanded).
+
+Operator expansion state persists in app-db
+(`:rf.causa.data-display/expansion {<path>}`) per epoch + path.
+
+### `film_strip/header`
+
+Shared `[◀ Prev] [Next ▶]` header consumed by most L4 panels (**Trace
+opts out** per rf2-o6yqq — the L2 list owns its spine navigation). Lives
+at
+[`tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/film_strip/header.cljc).
+MVP: chronological walk through the L2 spine. Hit-target sizing per
+§021 §17.1.5 (28×20px, 4px vertical padding for AA target-size).
+Keyboard `←` / `→` global binding. Disabled state at spine ends.
+
+Per-panel stretch filters (e.g. "next epoch with ⚠" for Issues, "next
+route activity" for Routes, "next epoch that touched THIS machine"
+for Machines) slot into the header's filter slot.
+
+### `focus_resolver` + `find-epoch-record`
+
+Shared focus-resolution at
+[`tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc`](../../../tools/causa/src/day8/re_frame2_causa/panels/shared/focus_resolver.cljc).
+Resolves the focused epoch's record from `:rf.causa/focus` (per
+[`018-Event-Spine.md`](../../../tools/causa/spec/018-Event-Spine.md))
+with the **head-fallback contract** — when no historical epoch is
+focused, every L4 panel scopes to the most-recent epoch in the buffer
+(not "no data" — head IS a valid focus). Used by Issues, Views,
+app-db, Trace, Machines, Routes for symmetric "spine at head" empty
+states.
+
+The evicted-epoch placeholder (§021 §10.7 — `"Epoch evicted from
+buffer — increase :epoch-history to retain more"`) is also resolved
+here, so the film-strip ◀ / ▶ keeps working when the operator scrubs
+past an evicted row.
+
+## Iconography quick reference
+
+Per §021 §17.1.5 (binding; HCM-safe because glyph alone carries
+signal, colour is never alone):
+
+| Tab (Dynamic) | Mnem | Icon | Stripe token |
+|---|---|---|---|
+| Event | `e` | `⚡` | `:accent-violet` |
+| app-db | `a` | `◐` | `:cyan` |
+| Views | `v` | `◉` | `:cyan` |
+| Trace | `t` | `⬢` | `:orange` |
+| Machines | `m` | `◆` | `:green` |
+| Routes | `r` | `🌐` | `:yellow` |
+| Issues | `i` | `⚠` | `:red` |
+
+L2 row badges (live impl `l2_timeline.cljc`): `⚠` issue · `◆` machine
+transition · `🌐` HTTP activity · `⚡` fx-emit child dispatch · `⏲` timer
+dispatch.
+
+Cross-panel arrows: `⤴` jump-to-panel from popover (`:accent-violet`,
+12px) · `↳` cause-attribution chip (`:text-tertiary`, 11px) · `→`
+inline state transition (`:text-primary`, mono).


### PR DESCRIPTION
Remediates **rf2-ee38b.28** — the 3-lens review sweep for `skills/re-frame2-causa`. The skill had drifted from live `tools/causa/` and actively misled users. Every tab/label/feature claim was re-verified against the live source (post-remediation-merge state).

## Correctness (P1)
- **Dynamic tab DISPLAY labels** updated to the 2026-05-21 plural-noun set: `App DB → app-db`, `View → Views`, `Routing → Routes` (internal tab ids unchanged). Verified against the live `reg-l4-tab!` calls.
- **"8 Dynamic tabs" → "7"** in all ~7 places (SKILL/README/panels/`package.json`/`plugin.json`); matches spec/018 §5 + the 7 registered tabs.
- **Trace filter UI** (`[op-type ▾][tag ▾]` chips, "13-axis tags") was removed (rf2-gkczt) and the **film-strip header** opted out (rf2-o6yqq) — both removed from the skill.
- **L2 activity-badge meanings** corrected to `l2_timeline.cljc`: 🌐 = HTTP activity, ⚡ = fx-emit child dispatch (were swapped). Spec-vs-impl drift noted inline.
- **Broken cross-ref** `app_db_diff_downstream.cljs` (file gone) repointed to the real `app_db_diff_subs.cljs` + `shared/sub_input_paths.cljc`.
- Route glyphs corrected to `◉ TO / ◇ FROM / ● HERE` per `routing.cljs`.

## Completeness
- New **§"The chrome around the tabs"** documents the first-screen primitives the out-of-scope punt wrongly excluded — LIVE/RETRO spine, time-travel scrubber/rewind/pins, filter pills, command palette (6 source kinds + verbs), Settings popup (6 tabs), Share-URL + per-cascade export. All verified against live source. Out-of-scope section rescoped to deep recipes only.
- "placeholder Static tabs" over-hedge softened (Static catalogues are full browsers, not stubs).

## Clarity / minimalism
- **panels.md split**: shared-components + iconography extracted to a new `references/shared-components.md` leaf; mode-overview preamble + duplicate Machines callout trimmed (503 → 395 L).
- `popout!` JS-console form rendered as a call (parens added).
- evals: 3 should-trigger entries added for the now-in-scope chrome.

## Gates
- `python scripts/check_doc_slugs.py` → exit 0 (no broken links).
- `package.json` / `plugin.json` / `evals.json` validate as JSON.

## For the mayor
- Cross-skill-shared dedup left for the final shared bead (per task scope — the duplication found is *within* this skill's files, which is fixed here; no `skills/shared/` candidate surfaced).
- Out-of-scope spec drifts noted but **not** actioned (separate spec beads): spec/021 §1.2 still says "8 lenses" vs spec/018 §5's "7"; spec/021 §17.1.5 row-badge table maps 🌐/⚡ to route/HTTP vs impl's HTTP/fx-emit.
- panels.md remains 395 L / 21 KB — over the 250 L / 16 KB ceiling, but the per-panel tour is the documented catalogue-shaped exception (further splitting would multiply file handles without cutting tokens-per-session). The separable shared-components material was extracted.

Closes rf2-ee38b.28.