### PR TITLE
fix(story-mcp): close rendered-hiccup privacy leak + 3-lens remediation (rf2-ee38b.17)

### DIFF
--- a/tools/story-mcp/README.md
+++ b/tools/story-mcp/README.md
@@ -86,11 +86,12 @@ tools/story-mcp/
     ├── server.cljc                               ; dispatcher + -main + run-loop
     └── tools/                                    ; tool implementations (rf2-3ukix split)
         ├── cap.cljc                              ; invoke-tool dispatcher + token-cap egress
+        ├── cursor.cljc                           ; Docs list-* pagination (consumes mcp-base.cursor)
         ├── registry.cljc                         ; tool-registry + descriptors + by-name
         ├── helpers.cljc                          ; result builders, args coercers, scrubbers
         ├── schemas.cljc                          ; recurring JSON-schema fragments
         ├── dev.cljc                              ; get-story-instructions, preview-variant, list-substrates
-        ├── docs.cljc                             ; list-stories, get-story, get-variant, list-tags, list-modes, list-assertions, variant->edn
+        ├── docs.cljc                             ; list-stories, get-story, get-variant, list-tags, list-modes, list-decorators, list-assertions, variant->edn, get-docs-markdown
         ├── testing.cljc                          ; run-variant, snapshot-identity, run-a11y, read-failures
         ├── write.cljc                            ; gated: register-variant, unregister-variant
         └── recorder.cljc                         ; gated: record-as-variant

--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -23,7 +23,7 @@
 
 The MCP protocol revision string is pinned at `2025-06-18` (see
 [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §protocol-version-pin).
-The pin lives in `re-frame.story-mcp.config/mcp-protocol-version`;
+The pin lives in `re-frame.story-mcp.config/protocol-version`;
 the `initialize` response advertises this version. Bumping the pin
 is a deliberate Story-MCP change — Story's own stage marker is
 independent.
@@ -61,7 +61,7 @@ The server uses the standard JSON-RPC 2.0 error codes:
 | `-32700` | Parse error | Malformed JSON. The reply carries `id: null`; the run-loop survives and continues reading. |
 | `-32600` | Invalid request | The frame is JSON but not a valid JSON-RPC request shape. |
 | `-32601` | Method not found | Unknown method name. |
-| `-32602` | Invalid params | `tools/call` arguments fail input-schema validation. |
+| `-32602` | Invalid params | `tools/call` `name` is missing or not a string. Argument-shape failures do NOT surface here — each tool self-validates (`required-arg` / `coerce-body`) and returns an `isError: true` tool result, not a protocol error. |
 | `-32603` | Internal error | An unexpected exception during dispatch. |
 
 **Tool-execution errors** (a tool ran, but its semantic failed —

--- a/tools/story-mcp/spec/003-Write-Surface-Gating.md
+++ b/tools/story-mcp/spec/003-Write-Surface-Gating.md
@@ -25,8 +25,8 @@ Two tools sit behind the gate (see
 - `register-variant`
 - `unregister-variant`
 
-Read tools are never gated. The 14 Dev / Docs / Testing tools work
-regardless of `allow-writes?`.
+Read tools are never gated. The 16 Dev / Docs / Testing tools (Dev 3 +
+Docs 9 + Testing 4) work regardless of `allow-writes?`.
 
 ## How the gate fails
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -256,8 +256,12 @@ unrecoverable exception.
 
 **Input.** `{:variant-id keyword (required)}`.
 
-**Output.** `{:violations [map] :hint? string}`. JVM-standalone
-hosts return `{:violations [] :hint "axe-core requires the in-browser panel."}`.
+**Output.** `{:variant-id keyword :violations [map] :note string|nil}`.
+The shared-process (CLJS co-hosted) deploy returns the accumulated
+violations + `:note nil`; JVM-standalone hosts can't run axe-core and
+return `{:variant-id <kw> :violations [] :note "a11y is CLJS-only; this
+JVM-standalone deploy can't run axe-core. Run the panel in-browser; the
+violations atom is read by this tool."}`.
 
 ### `read-failures`
 

--- a/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/protocol.cljc
@@ -91,20 +91,13 @@
 (defn notification?
   "Per JSON-RPC 2.0 §4.1, a notification is a request without an `id`.
   Notifications get no response. Assumes keys have been keywordised
-  (parse-json does this)."
+  (parse-json does this). This predicate is the single home for the
+  request-vs-notification rule — `server/dispatch` calls it rather than
+  re-spelling the `(not (contains? message :id))` check inline
+  (rf2-ee38b.17)."
   [message]
   (and (map? message)
        (not (contains? message :id))))
-
-(defn request?
-  "True iff `message` has the JSON-RPC request shape (`jsonrpc:\"2.0\"`,
-  `method` present, `id` present). The `id` MAY be a number, string, or
-  null per the spec — we accept any non-vector / non-map scalar."
-  [message]
-  (and (map? message)
-       (= "2.0" (:jsonrpc message))
-       (contains? message :method)
-       (contains? message :id)))
 
 (defn valid-envelope?
   "True iff `message` is a syntactically-valid JSON-RPC 2.0 request OR

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -131,9 +131,10 @@
     ;; request without an `id`. We accept the canonical handshake-
     ;; completion notification (`notifications/initialized`) and any
     ;; other notification silently — the absence of `:id` is the
-    ;; complete dispatch rule. No defensive arm needed in the
-    ;; method `case` below.
-    (not (contains? message :id))
+    ;; complete dispatch rule (`proto/notification?` is its single
+    ;; home; rf2-ee38b.17). No defensive arm needed in the method
+    ;; `case` below.
+    (proto/notification? message)
     nil
 
     :else

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/cursor.cljc
@@ -7,36 +7,35 @@
   continuation. The default `:limit` MUST keep the response under the
   cap (5,000 tokens).
 
-  ## Why story-mcp's cursor differs from pair-mcp's
+  ## Shared codec, story-specific shape (rf2-ee38b.17)
 
-  Pair-MCP's cursors (`tools/re-frame2-pair-mcp/tools/cursor.cljs`) carry
-  an `:after-id` epoch-id because epochs live in a bounded ring buffer
-  — staleness matters: when enough new epochs land between calls that
-  the ring rotates past the cursor's id, the server returns
-  `:rf.mcp/cursor-stale` so the agent can recover. The cursor is opaque
-  base64-encoded EDN to keep the encoding implementation-detail.
+  The base64 codec, the tagged-literal-rejecting EDN reader, the 1 KB
+  size cap, the `::malformed` recovery posture, the `:limit` clamp, and
+  the `cursor-stale-result` envelope all live in
+  `re-frame.mcp-base.cursor` — one cross-MCP implementation shared with
+  re-frame2-pair-mcp (the clarity review's `mcp-base` deferral premise
+  went stale once story-mcp shipped its own copy). This ns now owns
+  only what is genuinely story-specific:
 
-  Story-MCP's registries (`stories`, `tags`, `modes`, `decorators`,
-  `assertions`) are append-mostly stable structures — no ring rotation,
-  no buffer eviction. A stable sort over the id-set + integer offset
-  is sufficient. We still wrap the offset in an opaque base64 cursor
-  so the wire shape matches pair-mcp's contract — an agent that
-  learned `:cursor`/`:next-cursor` on pair-mcp uses the same slot here.
+    - the cursor PAYLOAD shape (`{:v :offset :total :sig}`) + its
+      `valid?` predicate,
+    - the whole-set `fingerprint` drift detector,
+    - the `default-limit` / `max-limit` numbers, and
+    - the `page` windowing logic.
 
-  ## Cursor shape
+  ## Why story-mcp's cursor SHAPE differs from pair-mcp's
 
-  Opaque base64 of a pr-str'd EDN map:
-
-      {:v 1
-       :offset N             ; 0-based index into the stable-sorted seq
-       :total  N             ; total count at the time the cursor was minted
-       :sig    \"<digest>\"} ; cheap whole-set fingerprint
-
-  The `:sig` slot lets us detect a registry that materially changed
-  between calls (e.g. a new `register-variant` landed between the
-  first list-stories page and the second). When the live signature
-  doesn't match the cursor's, we return `:rf.mcp/cursor-stale` —
-  same vocab as pair-mcp's ring-rotation case. The agent restarts.
+  Pair-MCP's cursors carry an `:after-id` epoch-id because epochs live
+  in a bounded ring buffer — staleness matters when the ring rotates
+  past the cursor's id. Story-MCP's registries (`stories`, `tags`,
+  `modes`, `decorators`, `assertions`) are append-mostly stable
+  structures — no ring rotation, no buffer eviction. A stable sort over
+  the id-set + integer offset is sufficient; the `:sig` fingerprint
+  detects a registry that materially changed between cursor mint and
+  dereference (e.g. a `register-variant` landed between two pages of
+  `list-stories`). When the live signature doesn't match the cursor's,
+  we return `:rf.mcp/cursor-stale` — same vocab as pair-mcp's
+  ring-rotation case. The agent restarts.
 
   ## When pagination kicks in
 
@@ -61,12 +60,8 @@
        :limit 25
        :has-more? false
        :next-cursor nil}"
-  (:require [clojure.edn :as edn]
-            [clojure.string :as str]
-            [re-frame.mcp-base.args :as args]
-            [re-frame.mcp-base.vocab :as vocab]
-            [re-frame.story-mcp.tools.helpers :as h])
-  #?(:clj (:import (java.util Base64))))
+  (:require [re-frame.mcp-base.cursor :as base-cursor]
+            [re-frame.story-mcp.tools.helpers :as h]))
 
 (def ^:const default-limit
   "Default page size for the Docs `list-*` tools. Sized to keep the
@@ -85,22 +80,6 @@
   registry should need on a single page."
   200)
 
-(defn- b64-encode
-  "Base64-encode a UTF-8 string. JVM-only (story-mcp's canonical
-  deploy)."
-  [^String s]
-  #?(:clj  (-> (Base64/getEncoder)
-               (.encodeToString (.getBytes s "UTF-8")))
-     :cljs (-> (js/Buffer.from s "utf8")
-               (.toString "base64"))))
-
-(defn- b64-decode
-  "Decode a base64 string back to UTF-8."
-  [^String s]
-  #?(:clj  (String. (.decode (Base64/getDecoder) s) "UTF-8")
-     :cljs (-> (js/Buffer.from s "base64")
-               (.toString "utf8"))))
-
 (defn- fingerprint
   "Cheap whole-set fingerprint — a sorted-hash of the id-set. We use
   this to detect a registry that materially changed between cursor
@@ -112,67 +91,49 @@
   [ids]
   (str (hash (vec (sort-by str ids)))))
 
+(defn- payload-valid?
+  "The story cursor payload shape: a versioned map carrying the integer
+  offset/total + the whole-set fingerprint. Passed to the shared
+  `base-cursor/decode-cursor` so the codec is shared while the shape
+  check stays story-specific."
+  [v]
+  (and (map? v)
+       (= 1 (:v v))
+       (integer? (:offset v))
+       (integer? (:total v))
+       (string? (:sig v))))
+
 (defn parse-limit-arg
-  "Normalise the `:limit` MCP arg into an integer in
-  `[1, max-limit]`. Default `default-limit`. Caller-supplied values
-  above `max-limit` clamp DOWN (the same posture as `run-variant`'s
-  `:timeout-ms` ceiling — a legitimate large request still works,
-  just capped)."
+  "Normalise the `:limit` MCP arg into an integer in `[1, max-limit]`,
+  default `default-limit`. Thin wrapper over the shared
+  `base-cursor/parse-limit-arg` baking story-mcp's default + ceiling."
   [raw]
-  (min max-limit (args/parse-positive-int raw default-limit)))
+  (base-cursor/parse-limit-arg raw default-limit max-limit))
 
 (defn encode-cursor
   "Encode a cursor payload as a base64 string. Returns nil when there
-  are no more entries — the absence-of-cursor IS the end-of-pagination
-  signal."
+  are no more entries (offset has reached total) — the absence-of-cursor
+  IS the end-of-pagination signal. Delegates the codec to the shared
+  `base-cursor/encode-cursor`; owns only the story-specific
+  `{:v :offset :total :sig}` shape + the end-of-page guard."
   [{:keys [offset total sig]}]
   (when (and (integer? offset) (< offset total))
-    (b64-encode (pr-str {:v 1 :offset offset :total total :sig sig}))))
+    (base-cursor/encode-cursor {:v 1 :offset offset :total total :sig sig})))
 
 (defn decode-cursor
-  "Decode a base64 cursor back to its EDN payload. Returns:
-    - `nil` if the cursor arg is absent or blank.
-    - `::malformed` if the cursor exists but doesn't decode to a
-      well-formed payload map. Callers treat `::malformed` the same as
-      `::stale` — the agent must drop the cursor and restart.
-
-  Hardened against the same EDN-reader posture as `register-variant`'s
-  body slot (`tools/write.cljc`): the `:default` reader handler throws
-  on any custom tagged literal; the input is decoded only once.
-  Cursors are short opaque tokens — anything longer than 1 KB is
-  rejected before parsing."
+  "Decode a base64 cursor back to its `{:v :offset :total :sig}` payload.
+  Returns nil for an absent/blank cursor, `::base-cursor/malformed` for
+  one that doesn't decode to a valid story payload. The codec + size cap
+  + tagged-literal rejection are shared (`base-cursor/decode-cursor`);
+  the `payload-valid?` shape check is story-specific."
   [s]
-  (cond
-    (or (nil? s) (and (string? s) (str/blank? s))) nil
-    (not (string? s)) ::malformed
-    (> (count s) 1024) ::malformed
-    :else
-    (try
-      (let [edn (b64-decode s)
-            v   (edn/read-string {:default (fn [_t _v]
-                                             ;; Caught by the surrounding try
-                                             ;; → ::malformed; the canonical
-                                             ;; :rf.error/id rides on ex-data
-                                             ;; for any consumer that inspects.
-                                             (throw (ex-info ":rf.error/story-mcp-bad-edn-tag"
-                                                             {:rf.error/id :rf.error/story-mcp-bad-edn-tag
-                                                              :where    'story-mcp/decode-cursor
-                                                              :recovery :no-recovery
-                                                              :reason   "EDN cursor carried a tagged literal — none are permitted"})))} edn)]
-        (if (and (map? v)
-                 (= 1 (:v v))
-                 (integer? (:offset v))
-                 (integer? (:total v))
-                 (string? (:sig v)))
-          v
-          ::malformed))
-      (catch #?(:clj Throwable :cljs :default) _ ::malformed))))
+  (base-cursor/decode-cursor s payload-valid?))
 
 (defn cursor-stale-result
-  "Structured cursor-stale error result. Uses the cross-MCP vocab
-  `:rf.mcp/cursor-stale` (`re-frame.mcp-base.vocab/cursor-stale-reason`)
-  — same vocab pair-mcp uses for ring-rotation staleness, so an agent
-  that learned the recovery path on pair-mcp reuses it here.
+  "Structured cursor-stale error result via the shared envelope builder.
+  Uses the cross-MCP vocab `:rf.mcp/cursor-stale` — same vocab pair-mcp
+  uses for ring-rotation staleness, so an agent that learned the
+  recovery path on pair-mcp reuses it here.
 
   In story-mcp's case staleness means the underlying id-set changed
   between cursor-mint and cursor-deref (e.g. a `register-variant`
@@ -180,13 +141,12 @@
   there is no recovery via wider window — the registry is the source
   of truth."
   [tool]
-  (h/error-result
-    (str "Cursor stale: the registry changed between pages. Drop the "
-         "cursor and restart `" tool "`.")
-    {:ok?    false
-     :reason vocab/cursor-stale-reason
-     :tool   tool
-     :hint   "Drop :cursor and re-request from offset 0."}))
+  (base-cursor/cursor-stale-result
+    h/error-result
+    tool
+    {:message (str "Cursor stale: the registry changed between pages. Drop the "
+                   "cursor and restart `" tool "`.")
+     :hint    "Drop :cursor and re-request from offset 0."}))
 
 (defn page
   "Apply pagination to a sorted seq of entries.
@@ -220,7 +180,7 @@
         live-sig      (fingerprint ids)]
     (cond
       ;; Malformed or stale cursor — same recovery (drop + restart).
-      (= cursor ::malformed)
+      (base-cursor/malformed? cursor)
       [:err (cursor-stale-result tool-name)]
 
       ;; Cursor present but the underlying set changed between mint

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -92,23 +92,20 @@
                                           :passed? false
                                           :reason (ex-message e)}]}))
             incl?      (h/include-sensitive? args)
+            raw-db     (:app-db result)
             payload    {:variant-id   vk
                         :share-url    share-url
                         :lifecycle    (:lifecycle result)
                         :elapsed-ms   (:elapsed-ms result)
-                        :app-db       (h/elide-app-db (:app-db result) vk incl?)
+                        :app-db       (h/elide-app-db raw-db vk incl?)
                         :assertions   (h/scrub-assertions (:assertions result) incl?)
-                        :rendered-hiccup (:rendered-hiccup result)
-                        :snapshot     (:snapshot result)
-                        :effective-args (:effective-args result)}]
+                        ;; Derived trees re-key the same sensitive value at a
+                        ;; non-app-db path, so the path-based walker can't
+                        ;; reach them — value-redact instead (rf2-ee38b.17).
+                        :rendered-hiccup (h/scrub-rendered (:rendered-hiccup result) raw-db vk incl?)
+                        :snapshot     (h/scrub-rendered (:snapshot result) raw-db vk incl?)
+                        :effective-args (h/scrub-rendered (:effective-args result) raw-db vk incl?)}]
         (h/text-result (h/pr-edn payload) payload)))))
-
-;; `story/registered-substrates` is CLJS-only — resolved once at ns-load
-;; via `helpers/resolve-cljs-var`. The JVM-standalone deploy reads nil
-;; and returns an empty set; the shared-process (nREPL-attached CLJS)
-;; deploy reads the var.
-(defonce ^:private registered-substrates-var
-  (h/resolve-cljs-var 'story/registered-substrates))
 
 (defn tool-list-substrates
   "Dev: what substrates can be used. Reads the registered substrate set
@@ -120,14 +117,13 @@
   set is the CLJS-side one ONLY when the server is co-hosted with the
   CLJS runtime (a shared-process deploy via nREPL). The JVM-standalone
   deploy reads an empty set — that's a correct answer for that deploy
-  (no CLJS substrates are runnable from a JVM-only host)."
+  (no CLJS substrates are runnable from a JVM-only host).
+
+  The CLJS var is resolved once, in `helpers` — `h/registered-substrates`
+  is the single accessor (rf2-ee38b.17 removed the duplicate `defonce`
+  that used to live here)."
   [_args]
-  (let [subs (try
-               (if registered-substrates-var
-                 (sort (vec (registered-substrates-var)))
-                 [])
-               (catch Throwable _ []))
-        payload {:substrates (vec subs)}]
+  (let [payload {:substrates (vec (h/registered-substrates))}]
     (h/text-result (h/pr-edn payload) payload)))
 
 ;; ---------------------------------------------------------------------------
@@ -151,7 +147,7 @@
 
    {:name           "preview-variant"
     :category       :dev
-    :description    (str "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
+    :description    (str "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. The derived `:rendered-hiccup` / `:effective-args` / `:snapshot` trees are value-redacted against the same declared-sensitive values (the secret reappears there at a non-app-db path the path walker can't reach). Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
                          "Examples: "
                          "1. Default substrate: {:variant-id \":story.cart/full\"} -> {:variant-id :story.cart/full :share-url \"...\" :lifecycle :ok :app-db {...} :assertions [] :rendered-hiccup [...]}. "
                          "2. UIx substrate + a mode: {:variant-id \":story.cart/full\" :substrate \":uix\" :active-modes [\":mode/dark\"]} -> same shape, rendered under uix + dark mode. "

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -68,14 +68,31 @@
   (try (resolve sym) (catch Throwable _ nil)))
 
 #?(:clj
-   ;; `story/registered-substrates` is CLJS-only — resolved once at ns-load
-   ;; (mirrors `tools.dev/registered-substrates-var`, the documented
-   ;; pattern). The substrate set is stable across the process lifetime, so
-   ;; `read-run-opts` (preview/run/snapshot hot path) derefs this cached var
-   ;; rather than re-resolving per call. JVM-standalone deploy reads nil and
-   ;; yields an empty set; the nREPL-attached CLJS deploy reads the var.
+   ;; `story/registered-substrates` is CLJS-only — resolved ONCE at ns-load,
+   ;; here, as the single resolution site for the whole story-mcp surface
+   ;; (rf2-ee38b.17 folded the duplicate `tools.dev/registered-substrates-var`
+   ;; into this one). The substrate set is stable across the process
+   ;; lifetime, so `read-run-opts` (preview/run/snapshot hot path) and
+   ;; `dev/tool-list-substrates` both deref the cached var rather than
+   ;; re-resolving per call. JVM-standalone deploy reads nil and yields an
+   ;; empty set; the nREPL-attached CLJS deploy reads the var.
    (defonce ^:private registered-substrates-var
      (resolve-cljs-var 'story/registered-substrates)))
+
+(defn registered-substrates
+  "The sorted vec of CLJS-registered substrate ids, or `[]` on a
+  JVM-standalone deploy (the var is unresolvable). The single accessor
+  over the cached `registered-substrates-var` — `dev/tool-list-substrates`
+  and `read-run-opts` both read through here so the CLJS var is resolved
+  exactly once at ns-load."
+  []
+  #?(:clj  (try
+             (if registered-substrates-var
+               (sort (vec (registered-substrates-var)))
+               [])
+             (catch Throwable _ []))
+     :cljs (try (sort (vec (story/registered-substrates)))
+                (catch :default _ []))))
 
 (defn text-result
   "Build a success result with a single text content item. `structured`
@@ -332,3 +349,90 @@
     include?       (vec (or records []))
     (nil? records) []
     :else          (first (sensitive/strip-sensitive records false))))
+
+;; ---------------------------------------------------------------------------
+;; Derived-tree wire-egress redaction (rf2-ee38b.17, headline P1).
+;;
+;; `elide-app-db` closes the leak for the `:app-db` slot — but the same
+;; sensitive value reappears, VERBATIM, in `:rendered-hiccup` (the variant
+;; view renders `[:input {:value <token>}]`), in `:effective-args` (the
+;; resolved arg map that fed the render), and in any `:snapshot` body. Those
+;; are derived from the same app-db, but they are NOT keyed by app-db path —
+;; the token sits at a hiccup-tree position (`[1 :value]`), not at
+;; `[:user :token]`. `elide-wire-value` matches the schema-declared SENSITIVE
+;; PATHS, so running it over a hiccup tree finds nothing: the path-based
+;; walker is structurally blind to the re-keyed copy.
+;;
+;; The sound posture for a DERIVED tree is VALUE-based redaction: collect the
+;; live values sitting at the frame's declared-`:sensitive?` app-db paths,
+;; then substitute any leaf in the derived tree that EQUALS one of them with
+;; the same `:rf/redacted` sentinel `elide-wire-value` emits. This honours
+;; the Tool-Pair §Direct-read privacy MUST intent — "live runtime state
+;; crossing the MCP egress is scrubbed" — for the rendered surface, with the
+;; same `:include-sensitive` opt-out escape hatch as `:app-db`.
+;; ---------------------------------------------------------------------------
+
+(defn- sensitive-values
+  "The set of live values sitting at `variant-id`'s declared-`:sensitive?`
+  app-db paths, read out of `app-db`. Used to value-redact derived trees
+  (rendered hiccup, effective-args, snapshot) where the same value
+  reappears at a non-app-db path the path-based walker can't reach.
+
+  Refreshes the schema-owned declarations first (the elision registry is
+  populated from `{:sensitive? true}` schema metadata, same as
+  `elide-app-db`'s pre-step). Nil / boolean values are excluded — a `nil`
+  or `false` leaf is not a secret and value-matching them would scrub
+  swathes of benign tree."
+  [app-db variant-id]
+  (refresh-elision-from-schemas! variant-id)
+  (let [decls (rf/elision-sensitive-declarations variant-id)]
+    (into #{}
+          (comp (map (fn [path] (get-in app-db (vec path) ::absent)))
+                (remove #(or (= ::absent %) (nil? %) (boolean? %))))
+          (keys decls))))
+
+(defn- redact-matching
+  "Walk `tree`, substituting any leaf `=` to a member of `secrets` with the
+  `:rf/redacted` sentinel. Recurses through maps, vectors, sets, seqs;
+  treats every other value as a leaf. Map KEYS are walked too — a secret
+  used as a key (rare, but a `{:value <token>}`-style attribute map could
+  in principle key on one) is redacted on both sides."
+  [tree secrets]
+  (cond
+    (contains? secrets tree) :rf/redacted
+    (map? tree)    (persistent!
+                     (reduce-kv (fn [acc k v]
+                                  (assoc! acc
+                                          (redact-matching k secrets)
+                                          (redact-matching v secrets)))
+                                (transient {})
+                                tree))
+    (vector? tree) (mapv #(redact-matching % secrets) tree)
+    (set? tree)    (into #{} (map #(redact-matching % secrets)) tree)
+    (seq? tree)    (map #(redact-matching % secrets) tree)
+    :else          tree))
+
+(defn scrub-rendered
+  "Value-redact a DERIVED tree (rendered hiccup, `:effective-args`, a
+  snapshot body) before wire egress. The path-based `elide-wire-value`
+  walker scrubs `:app-db` by path, but the same sensitive value reappears
+  in these derived surfaces at a non-app-db position — so we collect the
+  live values at `variant-id`'s declared-`:sensitive?` paths and substitute
+  any matching leaf in `tree` with `:rf/redacted` (rf2-ee38b.17).
+
+  Short-circuits, mirroring `elide-app-db`:
+
+    - `include? true` returns `tree` unchanged (the opt-out escape hatch).
+    - A nil `tree` or nil `app-db` returns `tree` (nothing to scrub /
+      no source of secrets).
+    - No declared-sensitive values ⇒ `tree` is returned unwalked (the
+      common case is one cheap set build, then the no-secrets early out)."
+  [tree app-db variant-id include?]
+  (cond
+    include?        tree
+    (nil? tree)     tree
+    (nil? app-db)   tree
+    :else           (let [secrets (sensitive-values app-db variant-id)]
+                      (if (empty? secrets)
+                        tree
+                        (redact-matching tree secrets)))))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -182,11 +182,12 @@
             ;;   operator chose to grow the registry). When
             ;;   `:write-back` is false the slot exists only for the
             ;;   rendered snippet's first-line `:variant-id` literal —
-            ;;   we render the caller's string as `:<string>` via
-            ;;   `read-string` ONLY when the existing variant-id grammar
-            ;;   admits it. If not, we fall back to the source `vk`.
-            ;;   This avoids interning a JVM keyword for what may be a
-            ;;   one-shot agent suggestion.
+            ;;   we resolve the caller's string via `safe-keyword`
+            ;;   against the live registered-variant set, so it renders
+            ;;   only when it ALREADY names a registered variant. An
+            ;;   unregistered suggested id falls back to the source `vk`
+            ;;   (no intern) rather than minting a fresh keyword for what
+            ;;   may be a one-shot agent suggestion.
             (let [extends     (if-let [e-arg (:extends arguments)]
                                 (or (args/safe-keyword e-arg (story/ids :variant))
                                     ;; Reject unknown :extends so the snippet
@@ -248,7 +249,7 @@
     :category       :write
     :description    (str "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`). Wire-key shape per rf2-pmwgn: input-schema property keys MUST omit the trailing `?` (Anthropic regex); the response key `:written-back?` is not bound by the same rule. "
                          "Examples: "
-                         "1. Snippet-only record (no write-back): {:variant-id \":story.cart/full\" :duration-ms 2000} -> {:variant-id :story.cart/full :play-snippet \"(story/reg-variant :story.cart/full {:extends :story.cart/full :play [[:cart/add ...]]})\" :recorded-event-count 4 :duration-ms 2012 :captured [[:cart/add ...]] :written-back? false}. "
+                         "1. Snippet-only record (no write-back): {:variant-id \":story.cart/full\" :duration-ms 2000} -> {:variant-id :story.cart/full :play-snippet \"(story/reg-variant :story.cart/full {:extends :story.cart/full :play-script {:auto-run? true :script [[:dispatch-sync [:cart/add ...]]]}})\" :recorded-event-count 4 :duration-ms 2012 :captured [[:cart/add ...]] :written-back? false}. "
                          "2. With write-back (gate must be open): {:variant-id \":story.cart/full\" :duration-ms 1000 :write-back true :new-variant-id \":story.cart/recorded\"} -> {... :written-back? true :new-variant-id :story.cart/recorded}. "
                          "3. Duration too long: {:variant-id \":story.cart/full\" :duration-ms 60000} -> {:isError true :content [{:text \":duration-ms 60000 exceeds ceiling 30000ms...\"}] :structuredContent {:rf.error :rf.story-mcp/duration-ms-too-large :duration-ms 60000 :max-allowed 30000}}.")
     :typicalTokens  1500

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -65,12 +65,16 @@
                                         :passed? false
                                         :reason (ex-message e)}]}))
             incl?    (h/include-sensitive? args)
+            raw-db   (:app-db result)
             payload  {:frame           (:frame result vk)
-                      :app-db          (h/elide-app-db (:app-db result) vk incl?)
+                      :app-db          (h/elide-app-db raw-db vk incl?)
                       :assertions      (h/scrub-assertions (:assertions result) incl?)
-                      :rendered-hiccup (:rendered-hiccup result)
+                      ;; Derived trees re-key the same sensitive value at a
+                      ;; non-app-db path, so the path-based walker can't reach
+                      ;; them — value-redact instead (rf2-ee38b.17).
+                      :rendered-hiccup (h/scrub-rendered (:rendered-hiccup result) raw-db vk incl?)
                       :elapsed-ms      (:elapsed-ms result)
-                      :snapshot        (:snapshot result)
+                      :snapshot        (h/scrub-rendered (:snapshot result) raw-db vk incl?)
                       :lifecycle       (:lifecycle result)
                       :passing?        (story/assertions-passing? result)}]
         (h/text-result (h/pr-edn payload) payload)))))
@@ -124,9 +128,11 @@
         (h/text-result (h/pr-edn payload) payload)))))
 
 (defn tool-read-failures
-  "Testing: accumulated assertion failures across recent `run-variant`
-  calls. Reads the variant frame's `:rf.story/assertions` accumulator
-  via `re-frame.story/read-assertions`.
+  "Testing: the variant frame's current accumulated assertion records
+  (as of the most recent `run-variant`). Reads the frame's
+  `:rf.story/assertions` accumulator once via
+  `re-frame.story/read-assertions` — no re-run, no cross-call history; a
+  later `run-variant` overwrites the accumulator.
 
   Useful for an agent that ran a variant a moment ago and wants to
   inspect failures without re-running.
@@ -159,7 +165,7 @@
   "Testing-category descriptors, in IMPL-SPEC §7.2 order."
   [{:name           "run-variant"
     :category       :testing
-    :description    (str "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`). The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
+    :description    (str "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`). The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. The derived `:rendered-hiccup` / `:snapshot` trees are value-redacted against the same declared-sensitive values (the secret reappears there at a non-app-db path the path walker can't reach). Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture). "
                          "Examples: "
                          "1. Green run: {:variant-id \":story.cart/full\"} -> {:frame :story.cart/full :app-db {...} :assertions [{:assertion :rf.assert/path-equals :passed? true}] :elapsed-ms 42 :passing? true :lifecycle :ok}. "
                          "2. Red run: {:variant-id \":story.cart/bad\"} -> {:assertions [{:assertion :rf.assert/sub-equals :passed? false :actual nil :expected 3}] :passing? false}. "

--- a/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/protocol_test.clj
@@ -48,9 +48,10 @@
 
 (deftest envelope-validity
   (testing "request shape"
-    (is (proto/request? {:jsonrpc "2.0" :method "tools/list" :id 1})))
+    (is (proto/valid-envelope? {:jsonrpc "2.0" :method "tools/list" :id 1}))
+    (is (not (proto/notification? {:jsonrpc "2.0" :method "tools/list" :id 1}))
+        "a message carrying :id is a request, not a notification"))
   (testing "missing id → notification"
-    (is (not (proto/request? {:jsonrpc "2.0" :method "x"})))
     (is (proto/notification? {:jsonrpc "2.0" :method "x"}))
     (is (proto/valid-envelope? {:jsonrpc "2.0" :method "x"})))
   (testing "missing jsonrpc version → invalid"

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1735,6 +1735,153 @@
           (is (= "DEEP" (get-in bypass [:nested :also-secret]))
               "nested sensitive slot rides through"))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-ee38b.17 (headline P1) — derived-tree wire-egress redaction.
+;;
+;; `elide-app-db` scrubs the `:app-db` slot by PATH. But the same sensitive
+;; value reappears, verbatim, in `:rendered-hiccup` / `:effective-args` /
+;; `:snapshot` — at a hiccup-tree position the path-based walker can't reach.
+;; `scrub-rendered` closes that leak by VALUE: it collects the live values at
+;; the frame's declared-`:sensitive?` paths and substitutes any matching leaf
+;; in the derived tree with `:rf/redacted`. These tests pin that a redacted
+;; value MUST NOT appear in the rendered-hiccup wire output, and that the
+;; `:include-sensitive` opt-out forwards it.
+;; ---------------------------------------------------------------------------
+
+(defn- tree-contains?
+  "Deep membership: true iff `needle` appears anywhere as a value inside
+  `tree` (walking maps/vectors/sets/seqs). Used to assert a secret has
+  been scrubbed OUT of a rendered tree regardless of its position."
+  [tree needle]
+  (cond
+    (= tree needle) true
+    (map? tree)     (boolean (some (fn [[k v]] (or (tree-contains? k needle)
+                                                   (tree-contains? v needle)))
+                                   tree))
+    (coll? tree)    (boolean (some #(tree-contains? % needle) tree))
+    :else           false))
+
+(deftest scrub-rendered-redacts-sensitive-value-in-derived-tree
+  (testing "a value at a declared-sensitive app-db path is redacted wherever it appears in the derived tree"
+    (with-clean-frame [vid :story.button/primary]
+      (let [db    {:public "ok" :token "TOPSECRET"}
+            ;; A rendered hiccup tree that embeds the sensitive value at
+            ;; a non-app-db position (an attribute value + a text node).
+            hiccup [:div {:class "card"}
+                    [:input {:type "password" :value "TOPSECRET"}]
+                    [:span "label: " "TOPSECRET"]]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:token])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.helpers/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (not (tree-contains? out "TOPSECRET"))
+              "the sensitive value MUST NOT survive anywhere in the derived tree")
+          (is (tree-contains? out :rf/redacted)
+              "matching leaves are replaced with the :rf/redacted sentinel")
+          (is (tree-contains? out "label: ")
+              "non-sensitive leaves are preserved")
+          (is (= "card" (get-in out [1 :class]))
+              "benign attribute values survive untouched"))))))
+
+(deftest scrub-rendered-include?-true-forwards-raw-value
+  (testing ":include? true bypasses the value-redaction walk entirely"
+    (with-clean-frame [vid :story.button/primary]
+      (let [db     {:token "TOPSECRET"}
+            hiccup [:input {:value "TOPSECRET"}]]
+        (seed-app-db! vid db)
+        (declare-sensitive! vid [:token])
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.helpers/scrub-rendered)
+              out            (scrub-rendered hiccup db vid true)]
+          (is (identical? hiccup out)
+              "include? true returns the input tree unchanged (no walk)")
+          (is (tree-contains? out "TOPSECRET")
+              "the opt-out forwards the raw sensitive value"))))))
+
+(deftest scrub-rendered-no-declarations-is-noop
+  (testing "with no declared-sensitive paths the tree is returned unwalked"
+    (with-clean-frame [vid :story.button/primary]
+      (let [db     {:public "ok"}
+            hiccup [:span "ok"]]
+        (seed-app-db! vid db)
+        (let [scrub-rendered (requiring-resolve 're-frame.story-mcp.tools.helpers/scrub-rendered)
+              out            (scrub-rendered hiccup db vid false)]
+          (is (identical? hiccup out)
+              "no secrets ⇒ no walk, input ref returned"))))))
+
+;; The two integration tests below pin the WIRING — that `preview-variant`
+;; and `run-variant` route `:rendered-hiccup` / `:effective-args` / `:snapshot`
+;; through `scrub-rendered`. They `with-redefs` `story/run-variant` to a
+;; controlled result that embeds the secret in the derived trees, so the
+;; assertion is independent of whatever the fixture's render would actually
+;; produce (the leak exists regardless of WHICH view renders the secret).
+
+(defn- secret-bearing-run-result
+  "A `run-variant`-shaped result whose :app-db carries the secret at a
+  declared-sensitive path AND whose derived trees re-embed the same value
+  at non-app-db positions."
+  [vid]
+  {:frame          vid
+   :lifecycle      :ok
+   :elapsed-ms     1
+   :app-db         {:public "ok" :token "TOPSECRET"}
+   :assertions     []
+   :rendered-hiccup [:input {:type "password" :value "TOPSECRET"}]
+   :effective-args {:label "Save" :token "TOPSECRET"}
+   :snapshot       {:db {:token "TOPSECRET"}}})
+
+(deftest preview-variant-rendered-hiccup-redacts-sensitive-by-default
+  (testing "the secret MUST NOT leak through preview-variant's derived trees"
+    (with-clean-frame [vid :story.button/primary]
+      (declare-sensitive! vid [:token])
+      (with-redefs [story/run-variant
+                    (fn [_vk _opts]
+                      (java.util.concurrent.CompletableFuture/completedFuture
+                        (secret-bearing-run-result vid)))]
+        (let [r (invoke "preview-variant" {:variant-id "story.button/primary"})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (= :rf/redacted (get-in s [:app-db :token]))
+              "app-db path-redaction still holds")
+          (is (not (tree-contains? (:rendered-hiccup s) "TOPSECRET"))
+              "rendered-hiccup MUST NOT carry the redacted value at egress")
+          (is (not (tree-contains? (:effective-args s) "TOPSECRET"))
+              "effective-args MUST NOT carry the redacted value at egress")
+          (is (not (tree-contains? (:snapshot s) "TOPSECRET"))
+              "snapshot MUST NOT carry the redacted value at egress"))))))
+
+(deftest run-variant-rendered-hiccup-redacts-sensitive-by-default
+  (testing "the secret MUST NOT leak through run-variant's derived trees"
+    (with-clean-frame [vid :story.button/primary]
+      (declare-sensitive! vid [:token])
+      (with-redefs [story/run-variant
+                    (fn [_vk _opts]
+                      (java.util.concurrent.CompletableFuture/completedFuture
+                        (secret-bearing-run-result vid)))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (= :rf/redacted (get-in s [:app-db :token])))
+          (is (not (tree-contains? (:rendered-hiccup s) "TOPSECRET"))
+              "rendered-hiccup MUST NOT carry the redacted value at egress")
+          (is (not (tree-contains? (:snapshot s) "TOPSECRET"))
+              "snapshot MUST NOT carry the redacted value at egress"))))))
+
+(deftest run-variant-rendered-hiccup-forwards-secret-when-opted-in
+  (testing ":include-sensitive true forwards the raw value through the derived trees"
+    (config/set-allow-sensitive-reads! true)
+    (with-clean-frame [vid :story.button/primary]
+      (declare-sensitive! vid [:token])
+      (with-redefs [story/run-variant
+                    (fn [_vk _opts]
+                      (java.util.concurrent.CompletableFuture/completedFuture
+                        (secret-bearing-run-result vid)))]
+        (let [r (invoke "run-variant" {:variant-id "story.button/primary"
+                                       :include-sensitive true})
+              s (:structuredContent r)]
+          (is (success? r))
+          (is (tree-contains? (:rendered-hiccup s) "TOPSECRET")
+              "opt-in surfaces the raw value in rendered-hiccup"))))))
+
 (deftest read-failures-strips-sensitive-assertion-records-by-default
   (testing "an assertion record stamped :sensitive? true is dropped at egress"
     (with-clean-frame [vid :story.button/primary]


### PR DESCRIPTION
Consolidated remediation for `tools/story-mcp` from the 3-lens review sweep. Cross-ref **rf2-ee38b.17**.

## Finding -> fix

### Headline P1 (correctness) — rendered-hiccup wire-egress privacy leak
`preview-variant` / `run-variant` routed `:app-db` through the path-based `elide-wire-value` walker but shipped `:rendered-hiccup`, `:effective-args`, and `:snapshot` **raw**. A value redacted at its app-db path reappears verbatim in the derived render tree at a non-app-db position the path walker structurally cannot reach (e.g. `[:input {:value <token>}]`).
- Added `helpers/scrub-rendered`: **value-based** redaction — collects the live values at the frame's declared-`:sensitive?` paths and substitutes any matching leaf in the derived tree with `:rf/redacted`. Same `:include-sensitive` opt-out as `:app-db`; cheap no-op when no declarations / when opted in.
- Wired into `dev/tool-preview-variant` (hiccup + effective-args + snapshot) and `testing/tool-run-variant` (hiccup + snapshot); descriptor prose updated.
- Tests pin it: direct helper tests (redact / opt-out / no-decls no-op) + `with-redefs` wiring tests asserting the secret **MUST NOT** appear in `:rendered-hiccup`/`:effective-args`/`:snapshot` at egress, and that opt-in forwards it.

### P2 (clarity) — cursor pagination duplicated mcp-base
`cursor.cljc` now consumes the just-merged shared `re-frame.mcp-base.cursor` (codec, `parse-limit-arg`, `decode-cursor`, `cursor-stale-result`, `malformed?`) and deletes the duplicated base64/EDN-reader/stale primitives. Story-specific parts (payload shape + `valid?`, `fingerprint`, `default-limit`/`max-limit`, `page`) stay.

### P2 (clarity) — registered-substrates-var resolved twice
Folded the duplicate `defonce` in `dev.cljc` into a single `helpers/registered-substrates` accessor (one resolution site).

### P2 (completeness) — API.md run-a11y shape
`{:violations :hint?}` -> actual `{:variant-id :violations :note}`; JVM-standalone note text aligned.

### P3
- Wire-protocol `-32602` row reworded (`name` not a string; arg-shape failures are `isError` tool results, not protocol errors).
- protocol-version var name fixed: `config/protocol-version` (was `mcp-protocol-version`).
- `003-Write-Surface-Gating.md` ungated count `14` -> `16`.
- `record-as-variant` snippet example `:play` -> `:play-script` + safe-keyword fallback prose corrected.
- `read-failures` docstring: single-read, no cross-call history.
- README: added `cursor.cljc` row + full 9-tool docs list.
- Deleted dead `proto/request?`; dispatcher now calls `proto/notification?` (single home for the rule); test updated.

## Skipped / out of scope (explained)
- **Shared hardened-EDN-read helper** (`write.cljc` + `cursor.cljc`): a `mcp-base.args` API addition (cross-cutting, hot-ish). The cursor copy is already gone via the dedup above; left `write.cljc`'s reader in place rather than expand mcp-base in this PR.
- **write-back! writes a dead `:play` slot**: found on inspection — the variant schema dropped `:play` for `:play-script` (rf2-0wrud), so a written-back recording silently never replays. Not in the 3-lens findings; filed **rf2-50jzf** (P1 bug).

## Cross-cutting for mayor
- `re-frame2-pair-mcp`'s `cursor.cljs` **still** hand-rolls the same codec/parse/stale primitives — it should be migrated to consume `mcp-base.cursor` too (separate bead; this PR only migrated story-mcp per the bead scope).

## Gates (worktree)
- `clojure -M:test` (story-mcp): 146 tests / 771 assertions, 0 failures.
- `node test/stdio-roundtrip.js`: GREEN.
- mcp-conformance `end-to-end-story.cjs`: GREEN.
- Clean recompile.