### PR TITLE
fix(skills): re-frame2 — add Flows leaf + remediate 3-lens review findings

### DIFF
--- a/skills/re-frame2/README.md
+++ b/skills/re-frame2/README.md
@@ -27,15 +27,15 @@ skills/re-frame2/
 ├── .claude-plugin/
 │   └── plugin.json                   Claude Code plugin metadata.
 ├── references/
-│   ├── fundamentals/                 events, fx, cofx, subs, frames, schemas, event-state-cycle, project-structure.
-│   ├── state-machines/               reg-machine, regions, tags, invoke, cancellation.
-│   ├── tooling/                      Stories, routing.
-│   └── cross-cutting/                Testing, API cheatsheet.
+│   ├── fundamentals/                 events, fx, cofx, subs, flows, frames, schemas, event-state-cycle, project-structure.
+│   ├── state-machines/               reg-machine, regions, tags, spawn, cancellation.
+│   ├── tooling/                      stories, routing, story-recorder, story-mcp-loop, causa.
+│   └── cross-cutting/                testing, api-cheatsheet, privacy-and-elision, production-observability, ssr-authoring.
 ├── patterns/                         One leaf per canonical pattern (9 leaves).
 └── decision-trees/                   pick-a-pattern, slice-or-machine.
 ```
 
-The leaves cover fundamentals, state-machines, tooling, cross-cutting, project-structure, the nine canonical patterns, and the two decision trees. An integration pass reconciles the loading map and adds derived-from-implementation footers.
+The leaves cover fundamentals, state-machines, tooling, cross-cutting, project-structure, the nine canonical patterns, and the two decision trees. Footers pin each leaf to the implementation it derives from, re-verified after refactors.
 
 ## Install
 
@@ -80,7 +80,7 @@ The skill's `description` triggers on natural-language references to re-frame2 s
 
 ## Status
 
-**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/`, `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The integration pass reconciled the loading map and added derived-from-implementation footers pinned at main `89bd9c3`. The boot example is linked; the evals harness and the `examples/reagent/{websocket,long_running_work}/` worked examples remain in flight but are not blockers for skill use.
+**Alpha.** All scaffolding and leaves are populated: `references/fundamentals/` (including the Flows leaf), `references/state-machines/`, `references/tooling/`, `references/cross-cutting/`, the nine canonical patterns under `patterns/`, and both decision trees (`pick-a-pattern`, `slice-or-machine`). The loading map is reconciled and the derived-from-implementation footers are pinned at main `89bd9c3`. All worked examples the leaves cite — including `examples/reagent/{websocket,long_running_work,flows}/` — have shipped; the evals harness is the only in-flight item and is not a blocker for skill use.
 
 ## License
 

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -2,16 +2,16 @@
 name: re-frame2
 description: >
   Writes re-frame2 ClojureScript application code — events, subscriptions,
-  effects, frames, state machines (reg-machine, parallel regions, tags,
-  invoke), schemas, stories, routing, tests, and the canonical patterns
+  effects, flows, frames, state machines (reg-machine, parallel regions,
+  tags, spawn), schemas, stories, routing, tests, and the canonical patterns
   (RemoteData, Forms, Boot, WebSocket, NineStates, ManagedHTTP,
   AsyncEffect, LongRunningWork, StaleDetection). Use whenever the user
   mentions re-frame2, reg-event-db, reg-event-fx, reg-sub, reg-fx,
-  reg-cofx, reg-view, reg-machine, reg-route, reg-story, reg-app-schema,
-  dispatch, subscribe, app-db, frames, regions, tags, the nine UI
-  states, managed HTTP, RemoteData lifecycles, writing tests for a
-  re-frame2 app, or state-machine-for-HTTP shapes — even when re-frame2
-  is not named explicitly. **Authoring only** (writing new code).
+  reg-cofx, reg-flow, reg-view, reg-machine, reg-route, reg-story,
+  reg-app-schema, dispatch, subscribe, app-db, flows, frames, regions,
+  tags, the nine UI states, managed HTTP, RemoteData lifecycles, writing
+  tests for a re-frame2 app, or state-machine-for-HTTP shapes — even when
+  re-frame2 is not named explicitly. **Authoring only** (writing new code).
   **Do not use** for: live-app inspection (use `re-frame2-pair`),
   greenfield project bootstrap (use `re-frame2-setup`), v1→v2 migration
   (use `re-frame-migration`), or porting re-frame2 itself (use
@@ -48,7 +48,7 @@ Authors re-frame2 ClojureScript application code. Router skill: this file carrie
 
 ## When to load
 
-`.cljs` / `.cljc` authoring of: event handlers, subscriptions, state machines, views, schemas, routes, stories, or the canonical patterns. References to `reg-event-*`, `reg-sub`, `reg-fx`, `reg-machine`, `dispatch`, `subscribe`, `app-db`, frames, regions, tags, or pattern names are sufficient triggers — re-frame2 need not be named.
+`.cljs` / `.cljc` authoring of: event handlers, subscriptions, flows, state machines, views, schemas, routes, stories, or the canonical patterns. References to `reg-event-*`, `reg-sub`, `reg-fx`, `reg-flow`, `reg-machine`, `dispatch`, `subscribe`, `app-db`, flows, frames, regions, tags, or pattern names are sufficient triggers — re-frame2 need not be named.
 
 ## When NOT to use
 
@@ -96,46 +96,13 @@ Patterns compose; a screen can use Forms on submit, RemoteData for the request, 
 
 ## Testing your views
 
-When the user asks how to test a re-frame2 view — "does the screen show the right thing?", "does the button dispatch the right event?" — suggest the **hiccup-walk pattern**, not a browser-mount.
-
-1. Dispatch events via `rf/dispatch-sync` into the test frame (standard re-frame2 testing surface).
-2. Call the view-fn directly. It returns hiccup; that's just data.
-3. Walk the hiccup with `re-frame.test-helpers` (`find-by-testid` / `text-content` / `invoke-handler`).
-
-```clojure
-(:require [re-frame.core :as rf]
-          [re-frame.test-helpers :as h])
-
-(deftest counter-view-shows-and-fires
-  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
-    (let [tree (counter-view {:n 0})
-          btn  (h/find-by-testid tree "counter-inc")]
-      (h/invoke-handler btn :on-click nil)
-      (is (= 1 (:n (rf/get-frame-db f)))))))
-```
-
-**Single-frame vs. multi-frame.** Application tests use ONE frame — the host frame. Views, events, subs, asserts all reference the same frame. Multi-frame test harnesses exist (e.g. `tools/causa/.../e2e_multi_frame.cljs`) but they are for **observer / tool code** — code that runs in one frame and watches another. Do NOT propose a multi-frame harness for testing a regular application view.
-
-**State alone is not enough.** State-only assertions (`(is (= 2 (:n db)))`) catch handler bugs but miss two classes:
-- *State-correct, view-broken* — handler updated db, view reads wrong path / forgets a branch.
-- *Wrong-frame dispatch* — `:on-click` dispatches into the wrong frame; host-frame state never changes.
-
-The hiccup-walk + invoke-handler pattern catches both, on JVM and Node-CLJS, with no browser. Full pattern walkthrough lives at [`docs/guide/15-testing.md` §Asserting the view shows the right thing](../../docs/guide/15-testing.md).
-
-The `h/testid` authoring helper standardises the attrs fragment at view call sites:
-
-```clojure
-[:button (h/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])})
- "+"]
-```
-
-Use it whenever you write a new view that wants a test handle.
+When the user asks how to test a re-frame2 view — "does the screen show the right thing?", "does the button dispatch the right event?" — suggest the **hiccup-walk pattern** (call the view-fn, walk the returned hiccup by `:data-testid` with `re-frame.test-helpers`), not a browser-mount. State-only assertions miss view-broken and wrong-frame-dispatch bugs that the walk catches. Full recipe — the `with-app-fixture` / `expect-text` / `wait-until` trio, the lower-level walk helpers, the single-frame discipline, and the `h/testid` authoring helper — lives in [`references/cross-cutting/testing.md`](references/cross-cutting/testing.md).
 
 ## Where the depth lives
 
 Load at most two leaves per task. If a task seems to need three, it likely spans patterns and should be broken up.
 
-**Fundamentals — `references/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
+**Fundamentals — `references/fundamentals/`**: `events.md`, `fx.md`, `cofx.md`, `subs.md`, `flows.md` (`reg-flow` — materialised computed state; the flow-vs-sub decision), `schemas.md`, `frames.md`, `event-state-cycle.md`, `project-structure.md`.
 
 **State machines — `references/state-machines/`**: `reg-machine.md` (declaration + the xstate→re-frame2 translation key), `regions.md` (parallel), `tags.md`, `spawn.md` (child machines), `cancellation.md`. Standing mental model across all of these: think in xstate, then map onto re-frame2 — see `reg-machine.md` for the full mapping table and deliberate-divergence flags.
 

--- a/skills/re-frame2/decision-trees/slice-or-machine.md
+++ b/skills/re-frame2/decision-trees/slice-or-machine.md
@@ -19,7 +19,7 @@ re-frame2 gives you three places to put state. The right choice usually falls ou
 
 Before walking the tree, rule out the cases where there is no state shape to choose.
 
-1. **Is this a pure derivation?** If the value is a function of other values already in `app-db`, it is a `reg-sub`, not a slice. No state shape needed.
+1. **Is this a pure derivation?** If the value is a function of other values already in `app-db`, default to a `reg-sub`, not a slice — no state shape needed. *But* if the derived value is **part of the application's state** — it must survive SSR hydration / time-travel revert / `app-db` serialisation, OR be read by downstream event handlers, machine actions, schemas, or other derivations as plain `app-db` data — it is a **flow** (Spec 013), not a sub. Flows are rare; default to a sub unless one of those reasons forces the value into `app-db`. See [`../references/fundamentals/flows.md`](../references/fundamentals/flows.md) §Flow vs subscription.
 2. **Is this a transient cofx value?** If the value is computed at dispatch time and used inside one event (e.g. `:rf/now`, a generated id), it is a registered cofx, not state.
 3. **Is this a machine's `:data`?** Per [`spec/005-StateMachines.md` §Naming](../../../spec/005-StateMachines.md), each machine carries its own private `:data` map distinct from `app-db`. Extended state local to a machine lives in `:data`, not in a slice.
 

--- a/skills/re-frame2/patterns/async-effect.md
+++ b/skills/re-frame2/patterns/async-effect.md
@@ -2,6 +2,8 @@
 
 The canonical "external work + dispatched reply" shape every async-effecting feature follows in re-frame2.
 
+> **Mental-model anchor:** this is the **redux-thunk / RTK-Query** shape — kick off async work from an action, then dispatch a follow-up action with the result. In re-frame2 the async work is an **fx** (effect-as-data) and the reply is a **dispatched event**, keeping handlers pure.
+
 This pattern is the *foundation* the **managed external effect** umbrella specialises. A managed effect (`:rf.http/managed`, `:rf.ws/*`, state-machine `:spawn`, `:rf.server/*`, `:rf.flow/*`) is an async effect with an eight-property contract layered on top — framework-owned lifecycle, structured failure taxonomy, retry/abort/teardown semantics, trace-bus observability. Author an ad-hoc async fx with this leaf; reach for [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) when authoring a *new* framework-owned surface (managed timers, managed background jobs, managed IndexedDB) that should inherit the umbrella's checklist.
 
 ## When to load this leaf

--- a/skills/re-frame2/patterns/forms.md
+++ b/skills/re-frame2/patterns/forms.md
@@ -2,6 +2,8 @@
 
 The standard form-lifecycle convention. A 7-key slice (or one machine region) carries the form runtime — **draft / submitted / submit-attempted? / status / errors / touched / submit-error** — and seven events drive the lifecycle (**initialise / edit-field / blur-field / submit / submit-success / submit-error / reset**). Per-field error visibility hinges on a single rule: show a field's error when the field is in `:touched` OR `:submit-attempted?` is `true`.
 
+> **Mental-model anchor:** this is the **Formik / React-Hook-Form** model — `draft` / `touched` / `errors` / `isSubmitting` (here `:status`) map one-to-one onto the slice keys. Map that intuition onto the re-frame2 events + subs below.
+
 Forms is an **app-side** lifecycle slice composed on top of a **managed external effect** — almost always `:rf.http/managed` for the submit. The slice carries draft/touched/errors; the submit fx is framework-owned. See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; the `:errors` vs `:submit-error` split here is exactly the seam where the umbrella's structured failure taxonomy hands off to app-level field-error UI.
 
 ## When to load this leaf
@@ -36,25 +38,31 @@ Password, TOTP, recovery-code, and similar secret fields are a **different lifec
 Worked auth example — minimal diff from the slice form above:
 
 ```clojure
+;; `(rf/path :auth :login)` focuses the handler's :db onto the [:auth :login]
+;; slice — the body reads/writes slice-relative paths ([:draft], [:status]),
+;; NOT full app-db paths, and the returned :db is spliced back into the slice.
+;; The slot's `:sensitive? true` schema metadata is what drives trace/error
+;; redaction; `path` itself only focuses the slice. The handler body still
+;; sees the real password via the unredacted :event coeffect.
 (rf/reg-event-fx :form.login/submit
-  [(rf/path :auth :login)]                                      ;; schema redaction maps draft.password to payload password
-  (fn [{:keys [db]} _]
-    (let [draft  (get-in db [:auth :login :draft])
+  [(rf/path :auth :login)]
+  (fn [{:keys [db]} _]                          ;; db here IS the [:auth :login] slice
+    (let [draft  (:draft db)
           errors (validate-against LoginForm draft)
-          db'    (assoc-in db [:auth :login :submit-attempted?] true)]
+          db'    (assoc db :submit-attempted? true)]
       (if (empty? errors)
         {:db (-> db'
-                 (assoc-in [:auth :login :status]              :submitting)
-                 (assoc-in [:auth :login :errors]              {})
-                 (assoc-in [:auth :login :submit-error]        nil)
+                 (assoc :status       :submitting)
+                 (assoc :errors       {})
+                 (assoc :submit-error nil)
                  ;; Clear the password out of :draft on submit — handler still
                  ;; has it via :event coeffect; app-db drops it.
-                 (assoc-in [:auth :login :draft :password]     nil))
+                 (assoc-in [:draft :password] nil))
          :fx [[:rf.http/managed
                {:request    {:method :post :url "/api/login" :body draft}
                 :on-success [:form.login/submit-success]
                 :on-failure [:form.login/submit-error]}]]}
-        {:db (assoc-in db' [:auth :login :errors] errors)}))))
+        {:db (assoc db' :errors errors)}))))
 ```
 
 For 2FA flows, the same shape applies to the TOTP / recovery-code field. The `[:auth :2fa-verify :draft :totp-code]` path is schema `:sensitive? true` and cleared after submit.
@@ -181,7 +189,7 @@ Realworld ships both shapes side-by-side. `:auth :login-form`, `:auth :register-
 - **Machine form**: `examples/reagent/realworld/settings.cljs` — single-region `reg-machine` with `:neutral / :incorrect / :submitting / :correct`.
 - **Compose with NineStates**: `examples/reagent/nine_states/core.cljs` — `:form` region as one axis of a parallel machine, with the `Incorrect` / `Correct` rendering folded into the page's render-priority.
 
-## Pillar 5 — why error visibility hinges on `submit-attempted? OR touched`
+## Why error visibility hinges on `submit-attempted? OR touched`
 
 Three options exist for "when do per-field errors show?":
 

--- a/skills/re-frame2/patterns/nine-states.md
+++ b/skills/re-frame2/patterns/nine-states.md
@@ -113,7 +113,7 @@ The root view branches once, in a `case`, on the resolved keyword. Disabled-attr
 
 `examples/reagent/nine_states/core.cljs` — the full machine declaration, render-priority table, `:ui/render` selector, per-state views, and headless tests per state. Read it in full for the implementation-as-shipped shape, including how the form slice composes with the `:form` region.
 
-## Pillar 5 — why this shape vs. a `cond` in the view
+## Why a render-priority vector beats a `cond` in the view
 
 The render-priority **vector** is the load-bearing move. A priority `cond` in the root view encodes the same priority in **control flow** (clause order); the vector encodes it in **data**. The data shape lets a test pretty-print it, a code review compare two pages side-by-side, and a tooling pass read the priority without parsing the view's body. The selector sub re-runs only when the tag union changes; Reagent dedups on the resolved keyword; the root view re-renders only when the winning render changes — not every time a non-winning region advances.
 

--- a/skills/re-frame2/patterns/remote-data.md
+++ b/skills/re-frame2/patterns/remote-data.md
@@ -2,6 +2,8 @@
 
 The standard request-lifecycle convention. A 5-key slice (or one machine region) tracks **status / data / error / loaded-at / attempt**, and four events drive the lifecycle (**load / loaded / load-failed / reset**). The load-bearing distinction is `:loading` (truly empty, first fetch) vs `:fetching` (revalidate with existing data) — they look identical to a careless UI but feel very different to a user.
 
+> **Mental-model anchor:** this is the **SWR / React-Query "stale-while-revalidate"** shape — the `:loading` vs `:fetching` split IS the SWR distinction (show a spinner on an empty page; keep stale data visible while refreshing). Map that intuition onto the re-frame2 slice below.
+
 RemoteData is the **app-side** lifecycle slice that sits on top of a **managed external effect** — typically `:rf.http/managed`, but the shape composes with any framework-owned surface (`:rf.ws/*` request-reply messages, state-machine `:spawn`'d loaders, `:rf.server/*` per-request fxs). See [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) for the umbrella; this leaf names what the *receiving* state looks like once the umbrella's reply lands.
 
 ## When to load this leaf
@@ -12,7 +14,7 @@ The prompt mentions: fetching data from a server, an HTTP request lifecycle, a l
 
 The pattern composes:
 
-- **`reg-app-schema`** — schema-binds the slice path so the slice's shape is enforced at boundaries (per Pillar — schemas at boundaries, not everywhere).
+- **`reg-app-schema`** — schema-binds the slice path so the slice's shape is enforced at boundaries (per cardinal rule 4 — schemas at boundaries, not everywhere).
 - **`reg-event-fx` for `:feature/load`** — dispatches the HTTP effect; picks `:loading` vs `:fetching` based on whether prior `:data` exists; bumps `:attempt`.
 - **`reg-event-db` for `:feature/loaded` / `:feature/load-failed`** — folds the reply into the slice. On failure, **prior `:data` is kept**; only `:status` and `:error` change.
 - **`:rf.http/managed` fx** (or the host's HTTP fx) — issues the request; its `:on-success` and `:on-failure` dispatch the lifecycle events.
@@ -119,7 +121,7 @@ Realworld ships both shapes side-by-side. `articles`, `feed`, `article`, `commen
 - **Machine form**: `examples/reagent/realworld/tags.cljs` — popular-tags list, single-region `reg-machine`, tag-shaped view queries.
 - **Compose with NineStates**: `examples/reagent/nine_states/core.cljs` — `:data` region as one axis of a parallel machine, with cardinality cascade (`:empty` / `:one` / `:some` / `:too-many`).
 
-## Pillar 5 — why `:loading` vs `:fetching` is non-negotiable
+## Why `:loading` vs `:fetching` is non-negotiable
 
 The split exists for one reason: the UI for an empty page mid-load is a spinner; the UI for a page that already has data and is refreshing is not. Without the split, every revalidation flashes a spinner over loaded content. The pattern's `:loading?` and `:fetching?` subs hide the distinction from view code that doesn't care, while making it cheap for view code that does.
 

--- a/skills/re-frame2/patterns/stale-detection.md
+++ b/skills/re-frame2/patterns/stale-detection.md
@@ -56,6 +56,15 @@ A search-as-you-type input where each keystroke spawns a lookup; only the latest
                     :on-success [:search/results-received next-epoch]
                     :on-error   [:search/load-failed       next-epoch]}]]})))
 
+;; A user-registered feature fx that wraps the trace-emit fn. There is no
+;; `:rf/trace-event` fx — `rf/emit-trace-event!` is a fn, and `:rf/*` is
+;; reserved for the framework. Register your own feature-prefixed fx and
+;; call the fn from inside it. Signature is (op-type operation tags).
+(rf/reg-fx :search/log-stale
+  (fn [_ {:keys [carried current]}]
+    (rf/emit-trace-event! :info :search/stale-result
+                          {:carried carried :current current})))
+
 (rf/reg-event-fx :search/results-received
   (fn handler-search-results-received [{:keys [db]} [_ carried-epoch results]]
     (let [current-epoch (get-in db [:search :epoch] 0)]
@@ -64,9 +73,8 @@ A search-as-you-type input where each keystroke spawns a lookup; only the latest
                  (assoc-in [:search :status] :loaded)
                  (assoc-in [:search :results] results))}
         ;; Mismatch — supersede. Drop the result; emit a trace event.
-        {:fx [[:rf/trace-event {:operation :search/stale-result
-                                :tags      {:carried carried-epoch
-                                            :current current-epoch}}]]}))))
+        {:fx [[:search/log-stale {:carried carried-epoch
+                                  :current current-epoch}]]}))))
 ```
 
 Three load-bearing points:

--- a/skills/re-frame2/references/cross-cutting/ssr-authoring.md
+++ b/skills/re-frame2/references/cross-cutting/ssr-authoring.md
@@ -121,6 +121,17 @@ All three are catalogued in [`009 §Error event catalogue`](../../../../spec/009
 
 These are **trace** events — DCE-eligible in CLJS production builds. To ship them off-box, wire `register-error-listener!` per [`production-observability.md`](production-observability.md); the error-emit substrate carries `:rf.ssr/*` records through to production.
 
+## Streaming SSR (advanced — most apps skip this)
+
+When the page shell + header should render immediately while slow subtrees stream in as their data resolves, mark each streamed subtree with the `:rf/suspense-boundary` hiccup marker. The server emits the shell plus per-subtree fallback hiccup first, then streams each subtree's real content as its fetch resolves; the client hydrates per-subtree as each chunk arrives (interleaved, not all-at-once). Inline-fallback failure semantics apply per boundary.
+
+```clojure
+[:rf/suspense-boundary {:fallback [card-skeleton]}
+ [slow-card card-id]]                         ;; renders the fallback until the card's data resolves, then streams in
+```
+
+Worked example: `examples/reagent/ssr_streaming/core.cljc` (a three-slow-card dashboard) — read it for the `:rf/suspense-boundary` marker, per-card fallback hiccup, inline-fallback failure semantics, and interleaved per-subtree hydration. Spec: [`spec/011-SSR.md §Streaming`](../../../../spec/011-SSR.md#streaming-ssr). For the parallel data-fetch fan-out an SSR request needs, see `Pattern-SSR-Loaders` (reachable via `boot.md`'s `:spawn-all` fan-out shape). Low priority — skip unless the task is explicitly streaming SSR.
+
 ## Common gotchas
 
 - **`reg-head` fns subscribe like sub fns.** Inside the fn, `(subscribe ...)` derefs against the static `app-db` value (same path as views via `compute-sub`). No reactive deref.

--- a/skills/re-frame2/references/cross-cutting/testing.md
+++ b/skills/re-frame2/references/cross-cutting/testing.md
@@ -92,7 +92,7 @@ Two fns — one per shape — sharing a name root with the `:rf.assert/*` Story 
 (ts/assert-db-equals   {:n 0} {:frame :stories})        ;; same for the full-db form
 ```
 
-`assert-path-equals` mirrors the `:rf.assert/path-equals` event used inside Story `:play` blocks; the shared name root is deliberate so a reader navigating between the two surfaces does not need a translation table. `assert-db-equals` is the companion full-db form (no `:rf.assert/*` event analog — the event-family is path-keyed).
+`assert-path-equals` mirrors the `:rf.assert/path-equals` event used inside Story `:play-script` blocks; the shared name root is deliberate so a reader navigating between the two surfaces does not need a translation table. `assert-db-equals` is the companion full-db form (no `:rf.assert/*` event analog — the event-family is path-keyed).
 
 Failure reports through `clojure.test/is` with both expected and actual, so the diagnostic is one line. For ad-hoc reads outside an assertion:
 
@@ -173,7 +173,31 @@ This is the dominant shape for an app-developer e2e view test — it compresses 
 
 `opts`: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label` (timeout-message tag). **Per-platform shape** (matching `poll-until`): on **JVM** it is synchronous — returns the truthy value, throws `ex-info` (`:rf.error/id :rf.error/wait-until-timeout`) on timeout. On **CLJS** it returns a `js/Promise` — resolves with the truthy value, rejects on timeout; compose with `cljs.test/async`. For sync cascades, `expect-text` after `dispatch-sync` is enough — only reach for `wait-until` when the cascade is genuinely async. It is not a substitute for timer-semantics sleeps (grace-period elapse, throttle/debounce window).
 
-The lower-level walk helpers (`find-by-testid`, `find-all-by-testid`, `text-content`, `invoke-handler`, and the `testid` attrs-authoring helper) are documented in SKILL.md §Testing your views — use them directly when you need the `:on-click`-fires-the-right-event assertion or a tree that no fixture stashed.
+### Lower-level walk helpers — the hiccup-walk pattern
+
+When a fixture didn't stash the tree, or you need the `:on-click`-fires-the-right-event assertion rather than a text check, walk the hiccup directly. The view-fn returns hiccup; that's just data. Dispatch via `dispatch-sync` into the test frame, call the view-fn, then walk the returned tree by `:data-testid`:
+
+```clojure
+(deftest counter-view-shows-and-fires
+  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+    (let [tree (counter-view {:n 0})
+          btn  (h/find-by-testid tree "counter-inc")]
+      (h/invoke-handler btn :on-click nil)              ;; fire the handler as the DOM would
+      (is (= 1 (:n (rf/get-frame-db f)))))))
+```
+
+- `find-by-testid` / `find-all-by-testid` — locate node(s) by `:data-testid`.
+- `text-content` — the rendered text under a node.
+- `invoke-handler` — call an attr handler (`:on-click`, `:on-change`, …) with an event arg, as the DOM would.
+- `testid` — the **authoring** helper that standardises the attrs fragment at view call sites; use it whenever you write a new view that wants a test handle:
+
+```clojure
+[:button (h/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])}) "+"]
+```
+
+**Why walk the view, not just assert state?** State-only assertions (`(is (= 2 (:n db)))`) catch handler bugs but miss two classes the hiccup-walk catches — *state-correct, view-broken* (handler updated db, view reads the wrong path / forgets a branch) and *wrong-frame dispatch* (`:on-click` dispatches into the wrong frame; host-frame state never changes). Both surface on JVM and Node-CLJS with no browser.
+
+**Single-frame discipline.** Application view tests use ONE frame — the host frame. Views, events, subs, and asserts all reference the same frame. Multi-frame harnesses (e.g. `tools/causa/.../e2e_multi_frame.cljs`) are for **observer / tool code** that watches another frame — never for a regular application view. Full walkthrough at [`docs/guide/15-testing.md` §Asserting the view shows the right thing](../../../../docs/guide/15-testing.md).
 
 ## Machine snapshots and tag queries
 
@@ -210,8 +234,12 @@ For `:rf.http/managed`, install per-call stubs around the body:
 
 ```clojure
 (rf/with-managed-request-stubs
-  {[:get "/api/items"] {:reply :ok :body {:items [...]}}
-   [:post "/api/cart"] {:reply :failure :status 500}}
+  ;; :reply is a MAP — {:ok <value>} for success, {:failure {:kind ...}} for
+  ;; failure. The runtime branches on (contains? reply :ok) / (:failure);
+  ;; a bare keyword like :reply :ok matches nothing and falls through to the
+  ;; "no stub matched" transport failure.
+  {[:get "/api/items"] {:reply {:ok {:items [...]}}}
+   [:post "/api/cart"] {:reply {:failure {:kind :rf.http/http-5xx :status 500}}}}
   (rf/dispatch-sync [:cart/fetch])
   (ts/assert-path-equals [:cart :status] :ready))
 ```

--- a/skills/re-frame2/references/fundamentals/event-state-cycle.md
+++ b/skills/re-frame2/references/fundamentals/event-state-cycle.md
@@ -64,32 +64,34 @@ Sanity-checking a mental model: tracing what happens between `(rf/dispatch ...)`
 
 ## Canonical mini-example
 
-From `examples/reagent/counter/core.cljs`, one dispatch exercises the whole cycle:
+From `examples/reagent/todomvc/events.cljs`, one dispatch exercises the whole cycle — `:db` commits, an fx persists, and a sub recomputes:
 
 ```clojure
 ;; (1) dispatch
-(rf/dispatch-sync [:counter/initialise])
+(rf/dispatch [:todo/delete 3])
 
-;; (6) handler returns the fx-map
-(rf/reg-event-fx :counter/initialise
-  (fn [_ctx _event]
-    {:db {:count 5}
-     :fx [[:counter/log :initialised]]}))
+;; (6) handler returns the fx-map  (commits :db AND fires an fx)
+(rf/reg-event-fx :todo/delete
+  (fn [{:keys [db]} [_ id]]
+    (let [next-db (update db :todos dissoc id)]
+      {:db next-db
+       :fx [[:todo.storage/save (:todos next-db)]]})))
 
-;; (9) the fx walks; :counter/log is user-registered
-(rf/reg-fx :counter/log
-  (fn [_ctx args] (swap! counter-log conj args)))
+;; (9) the fx walks; :todo.storage/save is user-registered
+(rf/reg-fx :todo.storage/save
+  (fn [_ctx todos] (persist-to-local-storage! todos)))
 
 ;; (10) the sub recomputes; view re-renders
-(rf/reg-sub :count
-  (fn [db _query] (:count db)))
+(rf/reg-sub :todo/todos
+  :<- [:todo/sorted-todos]
+  (fn [sorted-todos _] (vals sorted-todos)))
 ```
 
-After this single `dispatch-sync`:
+After this single dispatch:
 
-- `app-db` is `{:count 5}` (step 8).
-- `counter-log` holds `[:initialised]` (step 9).
-- Any view subscribed to `[:count]` re-renders with `5` (steps 10-11).
+- `app-db`'s `:todos` no longer contains id `3` (step 8).
+- localStorage has the persisted remaining items (step 9).
+- Any view subscribed to `[:todo/todos]` re-renders without the deleted item (steps 10-11).
 
 ## Errors carry the triggering handler's source-coord
 

--- a/skills/re-frame2/references/fundamentals/events.md
+++ b/skills/re-frame2/references/fundamentals/events.md
@@ -43,22 +43,30 @@ Dispatch is non-blocking — events queue and drain run-to-completion. `dispatch
 
 ## Canonical mini-example
 
-From `examples/reagent/counter/core.cljs`:
+From `examples/reagent/counter/core.cljs` — the simplest shape, `reg-event-db`:
 
 ```clojure
-(rf/reg-event-fx :counter/initialise
-  (fn [_ctx _event]
-    {:db {:count 5}
-     :fx [[:counter/log :initialised]]}))
+(rf/reg-event-db :counter/initialise
+  (fn [_db _event] {:counter/value 5}))
 
 (rf/reg-event-db :counter/inc
-  (fn [db _event] (update db :count inc)))
+  (fn [db _event] (update db :counter/value inc)))
 
 (rf/reg-event-db :counter/dec
-  (fn [db _event] (update db :count dec)))
+  (fn [db _event] (update db :counter/value dec)))
 ```
 
-The `:db` and `:fx` keys are the **only** legal top-level keys in an `fx`-handler return map (see [fx.md](fx.md) for the closed-shape rationale). The `_ctx` parameter is the coeffect map — `{:db <current-db-value> :event <event-vec>}` by default, plus anything `inject-cofx` injected (see [cofx.md](cofx.md)).
+`reg-event-db` returns the new `app-db` directly. When a handler also needs to fire effects, use `reg-event-fx`, which returns an **effect map**. From `examples/reagent/todomvc/events.cljs`, an `fx`-handler that commits `:db` and persists via an fx:
+
+```clojure
+(rf/reg-event-fx :todo/delete
+  (fn [{:keys [db]} [_ id]]
+    (let [next-db (update db :todos dissoc id)]
+      {:db next-db
+       :fx [[:todo.storage/save (:todos next-db)]]})))
+```
+
+The `:db` and `:fx` keys are the **only** legal top-level keys in an `fx`-handler return map (see [fx.md](fx.md) for the closed-shape rationale). The coeffect first argument is the cofx map — `{:db <current-db-value> :event <event-vec>}` by default, plus anything `inject-cofx` injected (see [cofx.md](cofx.md)).
 
 ## Common gotchas
 

--- a/skills/re-frame2/references/fundamentals/flows.md
+++ b/skills/re-frame2/references/fundamentals/flows.md
@@ -1,0 +1,127 @@
+# Flows
+
+## When to load
+
+Authoring `reg-flow` / `clear-flow`, or deciding whether a derived value should be a **flow** or a **subscription**. The prompt mentions a flow, `reg-flow`, a "materialised" / "computed" `app-db` value (`:total` from `:items`, `:area` from `:width × :height`, `:can-submit?` from validity + network state), `on-changes`, a value that must survive SSR hydration / time-travel, or a runtime-toggleable derivation (a wizard step, a feature gate).
+
+> **Restraint first.** Flows are a focused convenience for a *small* number of cases. **When in doubt, use a subscription** — it is lighter, sub-cache-native, and pays no `app-db` write. A typical app has dozens of subs and one-to-a-handful of flows. Tens of flows is a smell that subs or machines are being misused.
+
+## Mental-model anchor
+
+re-frame2 flows are the v2 incarnation of **re-frame v1's `on-changes` interceptor** — same compute-on-input-change semantics. Two deliberate differences map cleanly:
+
+| v1 `on-changes` | re-frame2 flow |
+|---|---|
+| Wired into a *specific event's* interceptor chain at registration time | Registered against a **frame** in the runtime; runs after *every* drain |
+| Inputs are a positional list → output fn | `:inputs` is a vector of app-db paths → positional `:output` fn (same shape) |
+| Cannot be toggled at runtime | Toggle via `:rf.fx/reg-flow` / `:rf.fx/clear-flow` from a handler |
+
+If you can already picture it as `on-changes`, you have the model; the divergence is "registered + runtime-toggleable" instead of "baked into one event".
+
+## Flow vs subscription — the decision
+
+A flow's output lives in **`app-db` at a known `:path`**; a sub's value lives in the per-frame **sub-cache** and is consumed only by views. Reach for a flow only when **all** of these hold:
+
+- The derived value is **part of the application's state**, not just a view-render input.
+- Other event handlers, machine actions, or schemas need to read it as plain `app-db` data.
+- It should **survive** SSR hydration, time-travel revert, or `app-db` serialisation (sub-cache contents do not survive the wire).
+- The derivation is **stable enough to be worth registering** — not a one-off computed inside a single handler.
+
+Use a **subscription** when the value is consumed only by views. Use a **state machine** when the value has discrete states / lifecycle. Compute **inline** when it is only relevant inside one handler. See [`../../decision-trees/slice-or-machine.md`](../../decision-trees/slice-or-machine.md) §Step 0 for the routing.
+
+## Canonical signature
+
+```clojure
+(rf/reg-flow
+  {:id     :rectangle/area              ;; unique; feature-prefixed (never :rf/*)
+   :inputs [[:width] [:height]]         ;; vector of app-db paths
+   :output (fn [w h] (* w h))           ;; pure: (in-1, in-2, ...) → output value
+   :path   [:area]                      ;; where the output is written in app-db
+   :doc    "Rectangle area from :width and :height."   ;; optional
+   :schema [:int]})                     ;; optional Malli schema for the output
+
+(rf/reg-flow flow {:frame :scratch})    ;; optional 2nd arg: explicit frame
+(rf/clear-flow :rectangle/area)         ;; dissoc-in's the output :path
+(rf/clear-flow :rectangle/area {:frame :scratch})
+```
+
+`:inputs` order matches the positional args to `:output`. `reg-flow` returns the flow's `:id` (family-wide reg-* convention). Flows ship in `day8/re-frame2-flows` — the consuming ns must `(:require [re-frame.flows])` to publish the artefact's late-bind hooks, or `rf/reg-flow` raises `:rf.error/flows-artefact-missing` (same require-to-register convention as schemas / machines / routing).
+
+## Canonical mini-example
+
+From `examples/reagent/flows/core.cljs` — a cart whose subtotal and total are materialised into `app-db` so the checkout handler reads `[:cart :total]` as plain data:
+
+```clojure
+(defn- line-total [{:keys [price qty]}] (* price qty))
+
+(rf/reg-flow
+  {:id     :cart/subtotal
+   :inputs [[:cart :items]]
+   :output (fn [items] (reduce + 0 (map line-total items)))
+   :path   [:cart :subtotal]})
+
+;; :cart/total reads ANOTHER flow's output ([:cart :subtotal]) plus the
+;; runtime-toggleable discount rate. The runtime derives the dependency edge
+;; from the path overlap and topologically sorts so :cart/subtotal always
+;; runs first — both settle in one post-drain walk.
+(rf/reg-flow
+  {:id     :cart/total
+   :inputs [[:cart :subtotal] [:cart :discount-rate]]
+   :output (fn [subtotal discount-rate]
+             (Math/round (* subtotal (- 1 (or discount-rate 0)))))
+   :path   [:cart :total]})
+
+;; Reading a flow's output inside a handler — the central reason :total is a
+;; flow and not a sub: a sub's value lives in the view-facing cache and is
+;; awkward to read from a handler.
+(rf/reg-event-fx :checkout/place-order
+  (fn [{:keys [db]} _]
+    (let [total (get-in db [:cart :total])]
+      {:fx [[:cart/order-placed total]]})))
+```
+
+## Runtime toggle via fx
+
+Two reserved fx-ids register / clear a flow mid-event. They route to the **dispatching frame** automatically — no `:frame` arg to set. This is how feature gates and wizard steps engage / disengage a derivation v1's `on-changes` could not:
+
+```clojure
+(rf/reg-event-fx :cart/apply-discount
+  (fn [_ _]
+    {:fx [[:rf.fx/reg-flow {:id     :cart/discount-rate
+                            :inputs [[:cart :discount-engaged?]]
+                            :output (fn [_] 0.10)
+                            :path   [:cart :discount-rate]}]
+          [:dispatch [:cart/touch true]]]}))   ;; nudge a re-walk (see Sequencing)
+
+(rf/reg-event-fx :cart/remove-discount
+  (fn [_ _]
+    {:fx [[:rf.fx/clear-flow :cart/discount-rate]   ;; dissoc-in's [:cart :discount-rate]
+          [:dispatch [:cart/touch false]]]}))
+```
+
+## How flows run (drain integration)
+
+Flow evaluation happens **after `:db` commits and before `:fx` walks**, once per event drain, over **this frame's** registered flows only:
+
+1. Handler's `:db` commits; sub-cache invalidates.
+2. `run-flows!` walks the frame's flows in **topologically-sorted** order (dependency derived from `:path`/`:inputs` overlap). Each flow recomputes only if its input values changed by `=` since last run; the first walk of a newly-registered flow always fires.
+3. `:fx` walks — so an `:fx` entry that reads `app-db` sees flow outputs (e.g. `[:dispatch [:react-to-area-change]]` works cleanly).
+
+## Common gotchas
+
+- **Default to a sub.** Most derived values are subs. Reach for a flow only when the four conditions above all hold — flows pay an `app-db` write per recompute.
+- **Flows publish ZERO framework subs.** A flow's `:path` IS the contract surface; consumers read it via any sub they register over the path (`(rf/reg-sub :cart/total (fn [db _] (get-in db [:cart :total])))`) or read it straight off `app-db` in a handler. There is no `:rf.flow/<id>` sub.
+- **One-drain registration lag.** A flow registered via `:rf.fx/reg-flow` first runs on the *next* drain — its initial output appears one event after registration. Dispatch a synthetic nudge event if you need the value immediately (the cart example dispatches `:cart/touch`).
+- **Cycles throw at registration.** If A depends on B and B on A, `reg-flow` throws `:rf.error/flow-cycle` with `:cycle` (an ordered vector with a closing repeat, e.g. `[:a :b :a]`).
+- **`clear-flow` vacates the path.** It `dissoc-in`s the `:path` (no opt-out). Copy the value elsewhere first if you need to keep it.
+- **`:output` must be pure and deterministic.** Same inputs → same output. A throw surfaces as `:rf.error/flow-eval-exception`; prior flows' writes are preserved, the failing flow's output is not written, and the cascade halts.
+- **Feature-prefix the `:id` and `:path`.** Never `:rf/*` (reserved). The two fx-ids `:rf.fx/reg-flow` / `:rf.fx/clear-flow` are the framework's; your flow's id is yours.
+- **Frame-scoped.** A flow belongs to one frame; the same id can register against two frames with different `:output`/`:path`. `clear-flow` and `destroy-frame!` teardown are frame-local.
+
+## Deeper material
+
+Per-frame topsort + cycle-detection contract, the four-rule failure semantics, the `:rf.flow/*` trace taxonomy, `:sensitive?` inheritance, frame-destroy teardown, and the v1-alpha-flows migration table: `SKILL-REDIRECT.md` → **EP — Flows (013)**, **EP — Instrumentation (009)**. The managed-external-effects umbrella `:rf.flow/*` belongs to: [`spec/Managed-Effects.md`](../../../../spec/Managed-Effects.md).
+
+---
+
+*Derived from `spec/013-Flows.md`, `implementation/flows/src/re_frame/` (the `day8/re-frame2-flows` artefact), and the worked example `examples/reagent/flows/core.cljs` @ main `89bd9c3`. Re-verify line/shape after flow-runtime changes.*

--- a/skills/re-frame2/references/fundamentals/frames.md
+++ b/skills/re-frame2/references/fundamentals/frames.md
@@ -28,11 +28,11 @@ Frames are mutable runtime objects, not values. User code holds keywords and let
 (rf/get-frame-db :frame-id)         ;; underlying container (for tools / tests)
 ```
 
-Verified in `implementation/core/src/re_frame/frame.cljc:146` (`reg-frame`), `:185` (`make-frame`), `:195` (`destroy-frame!`). The public macro layer is `core.cljc:287-304`.
+Verified in `re-frame.frame` (`reg-frame`, `make-frame`, `destroy-frame!`). The public macro layer is in `re-frame.core`.
 
 ## Frame resolution chain
 
-Three tiers (`frame.cljc:38-51`, `core.cljc:899-909`):
+Three tiers (the frame-resolution chain in `re-frame.frame` / `re-frame.core`):
 
 1. **`*current-frame*` dynamic var** — bound by `with-frame`.
 2. **React context** (CLJS only) — read via the `:adapter/current-frame` late-bind hook, populated by the installed adapter under a `frame-provider`.
@@ -82,7 +82,7 @@ And configuring `:rf/default` at app boot:
 
 ## Frame metadata — what goes in it
 
-The metadata map (`frame.cljc:99-130`) accepts:
+The metadata map (`reg-frame` in `re-frame.frame`) accepts:
 
 - `:doc` — one-sentence what-and-why.
 - `:preset` — one of `:default :test :story :ssr-server`; expands at registration into a fixed metadata bundle.
@@ -105,9 +105,9 @@ Wraps a Reagent / Helix / UIx subtree so descendants resolve `current-frame` to 
 
 ## Common gotchas
 
-- **`reg-frame` is atomic and hot-reload safe.** First call creates and runs `:on-create`; subsequent calls perform a **surgical update** of metadata only — existing app-db, sub-cache, queue, machine snapshots all preserved (`frame.cljc:152-183`). Use `reset-frame!` for a full destroy+recreate.
+- **`reg-frame` is atomic and hot-reload safe.** First call creates and runs `:on-create`; subsequent calls perform a **surgical update** of metadata only — existing app-db, sub-cache, queue, machine snapshots all preserved (`reg-frame` in `re-frame.frame`). Use `reset-frame!` for a full destroy+recreate.
 - **`destroy-frame!` cascades.** Per active machine snapshot, the runtime emits *one* `:rf.machine.lifecycle/destroyed` trace carrying `:reason :parent-frame-destroyed` under `:tags` (the unified lifecycle channel — same op-type used at `reg-machine`'s `:created` emit); in-flight HTTP requests get an abort hook; sub-cache reactions all dispose. Subsequent dispatch / subscribe raises `:rf.error/frame-destroyed`. See [009 §`:op-type` vocabulary](../../../../spec/009-Instrumentation.md#op-type-vocabulary).
-- **`with-frame` is a CLJS macro AND a JVM-friendly fn.** The macro form (`re-frame.core/with-frame`) wraps an expression; the fn form (`core.cljc:932`) takes a thunk — use the fn from JVM tests / SSR / REPL.
+- **`with-frame` works on both CLJS and the JVM.** The `re-frame.core/with-frame` macro expands on both platforms — use it from JVM tests / SSR / REPL as well as CLJS. For programmatic frame-pinning where a macro is awkward, bind the current-frame dynamic var directly (see the frame-resolution chain above).
 - **Wrapping plain Reagent fns in a non-default `frame-provider` doesn't bind the frame.** Use `reg-view` so the `:contextType` wiring picks up the provider. Watch for the once-per-handler warning.
 - **`:rf/default` is implicit.** Don't re-`reg-frame :rf/default` unless you specifically want to attach metadata to it — calling it without any is a no-op.
 
@@ -117,4 +117,4 @@ Frame presets in detail, machine-instance teardown contract, the React-context c
 
 ---
 
-*Derived from `implementation/core/src/re_frame/frame.cljc`, `implementation/core/src/re_frame/core.cljc`, and `implementation/reagent/src/re_frame/adapter/reagent.cljs` @ main `89bd9c3`. Re-verify line numbers after frame-resolution or adapter-late-bind changes.*
+*Derived from `re-frame.frame`, `re-frame.core`, and `re-frame.adapter.reagent` @ main `89bd9c3`. Citations are symbol-level; re-verify symbol homes after frame-resolution or adapter-late-bind changes.*

--- a/skills/re-frame2/references/fundamentals/subs.md
+++ b/skills/re-frame2/references/fundamentals/subs.md
@@ -42,18 +42,18 @@ The query-vector is `[sub-id & args]`. Its first element is the sub id; args rid
 From `examples/reagent/todomvc/subs.cljs`:
 
 ```clojure
-(rf/reg-sub :sorted-todos
+(rf/reg-sub :todo/sorted-todos
   (fn [db _]
     (:todos db)))                   ;; layer-1: reads app-db
 
-(rf/reg-sub :todos
-  :<- [:sorted-todos]
+(rf/reg-sub :todo/todos
+  :<- [:todo/sorted-todos]
   (fn [sorted-todos _]
     (vals sorted-todos)))           ;; layer-2: chained
 
-(rf/reg-sub :visible-todos
-  :<- [:todos]
-  :<- [:showing]
+(rf/reg-sub :todo/visible-todos
+  :<- [:todo/todos]
+  :<- [:todo/showing]
   (fn [[todos showing] _]
     (let [predicate (case showing
                       :active    (complement :completed)
@@ -61,6 +61,8 @@ From `examples/reagent/todomvc/subs.cljs`:
                       identity)]
       (filter predicate todos))))   ;; layer-2 multi-input
 ```
+
+Every id is feature-prefixed (`:todo/*`) per cardinal rule 7 — the canonical subs in the example never use bare unprefixed ids.
 
 A layer-1 sub touches `app-db` and recomputes when the value it reads changes by `=`. Layer-2+ subs read other subs' values; they recompute when any input signal changes. The signal graph is built lazily — a sub registers as a callable, and the reactive cache materialises on first `subscribe`.
 

--- a/skills/re-frame2/references/state-machines/cancellation.md
+++ b/skills/re-frame2/references/state-machines/cancellation.md
@@ -17,7 +17,7 @@ When the runtime destroys a spawned actor by **any** trigger, every in-flight `:
 5. **Imperative `[:rf.machine/destroy <actor-id>]`** from a user-authored action.
 6. **Frame destroy** — `frame.cljc`'s frame-exit walk destroys each surviving machine, firing the same hook per actor.
 
-The hook is at `:http/abort-on-actor-destroy` (`implementation/machines/src/re_frame/machines.cljc:2410`); the http artefact registers the abort fn at ns-load time. When `re-frame.http-managed` is not on the classpath the hook resolves to nil and the destroy proceeds without HTTP-abort — apps that don't issue managed-HTTP requests pay nothing.
+The hook is at `:http/abort-on-actor-destroy` (`re-frame.machines.lifecycle-fx.finalize` / `frame-destroy`); the http artefact registers the abort fn at ns-load time. When `re-frame.http-managed` is not on the classpath the hook resolves to nil and the destroy proceeds without HTTP-abort — apps that don't issue managed-HTTP requests pay nothing.
 
 ## The abort surfaces
 
@@ -67,7 +67,7 @@ If the child machine itself owns the resource, the child's leaf-state `:exit` (o
   :on    {:disconnect :idle}}}
 ```
 
-When the parent destroys the child, the child's exit cascade fires `:ws/close` before the snapshot is dissoc'd. The destroy fx (`machines.cljc:2470`) runs the standard exit cascade on the actor's current configuration before unregistering the handler.
+When the parent destroys the child, the child's exit cascade fires `:ws/close` before the snapshot is dissoc'd. The destroy fx (`re-frame.machines.lifecycle-fx.destroy`) runs the standard exit cascade on the actor's current configuration before unregistering the handler.
 
 ### Parent-side `:exit` on the `:spawn`-bearing state
 
@@ -105,4 +105,4 @@ For the full cancellation contract — trace events, the late-bind hook surface,
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (destroy fx + abort hook seam) and `implementation/core/src/re_frame/frame.cljc` (frame-destroy walk) @ main `89bd9c3`. Re-verify after cancellation-cascade or `:rf.http/managed` abort-hook changes.*
+*Derived from the `re-frame.machines.lifecycle-fx.*` sub-namespaces (`destroy` fx, `finalize` / `frame-destroy` abort-hook seam) and `re-frame.frame` (frame-destroy walk) @ main `89bd9c3`. Citations are symbol-level (machines.cljc was split); re-verify after cancellation-cascade or `:rf.http/managed` abort-hook changes.*

--- a/skills/re-frame2/references/state-machines/reg-machine.md
+++ b/skills/re-frame2/references/state-machines/reg-machine.md
@@ -39,9 +39,9 @@ The deliberate-divergence rows are catalogued in Spec 005 §Lessons from xstate 
 (rf/reg-machine machine-id machine-map)
 ```
 
-`reg-machine` is a macro that stamps source coords at the call site and registers the machine as a `:event` handler whose registration metadata carries `:rf/machine? true` (`implementation/core/src/re_frame/core.cljc:634`; the underlying registration fn is `re-frame.machines/reg-machine*`, `implementation/machines/src/re_frame/machines.cljc:2028`). The machine **is** an event handler — dispatch `[machine-id [:event-name & args]]` to drive it.
+`reg-machine` is a macro (in `re-frame.core`) that stamps source coords at the call site and registers the machine as a `:event` handler whose registration metadata carries `:rf/machine? true`. The underlying registration fn `reg-machine*` lives in `re-frame.machines.lifecycle-fx.registration` (re-exported via the `re-frame.machines` facade and `re-frame.core-machines`). The machine **is** an event handler — dispatch `[machine-id [:event-name & args]]` to drive it.
 
-The `day8/re-frame2-machines` artefact must be on the classpath and `re-frame.machines` required at app boot; without it, calls throw `:rf.error/machines-artefact-missing` (`core.cljc:701`).
+The `day8/re-frame2-machines` artefact must be on the classpath and `re-frame.machines` required at app boot; without it, calls throw `:rf.error/machines-artefact-missing` (the late-bind guard in `re-frame.core-machines`).
 
 ## Declaration shape
 
@@ -116,7 +116,7 @@ The value under an `:on` event keyword is one of:
               {:target :z}]}}
 ```
 
-The transition's `:target` may be a single keyword (sibling-level) or a vector path (absolute, for cross-level transitions). Per `machines.cljc:344` (`normalise-on-clause`).
+The transition's `:target` may be a single keyword (sibling-level) or a vector path (absolute, for cross-level transitions). Per `normalise-on-clause` in `re-frame.machines.transition`.
 
 ## Guards / actions — keyword reference or inline fn
 
@@ -132,11 +132,11 @@ The transition's `:target` may be a single keyword (sibling-level) or a vector p
 {:on {:start {:guard :has-input? :target :working}}}
 ```
 
-Per the inspectability bias (`SKILL.md` cardinal rule 5 / Spec 005 §Inspectability bias): named entries surface in `:rf.machine/*` trace events as the registered keyword, not as an opaque `#object[Function ...]`. Reach for the inline form only when the body is trivial.
+Per the inspectability bias (Spec 005 §Inspectability bias): named entries surface in `:rf.machine/*` trace events as the registered keyword, not as an opaque `#object[Function ...]`. Reach for the inline form only when the body is trivial.
 
 ### Guard / action contract
 
-Both fns receive `(data event)` — `:data` directly, not the snapshot wrapper. Actions return `{:data new-data :fx [...]}` (either key optional); guards return truthy/falsey. See `implementation/machines/src/re_frame/machines.cljc:146` (`call-guard`) and `:156` (`call-action`).
+Both fns receive `(data event)` — `:data` directly, not the snapshot wrapper. Actions return `{:data new-data :fx [...]}` (either key optional); guards return truthy/falsey. See `call-guard` and `call-action` in `re-frame.machines.transition`.
 
 A 3-arity escape hatch `^:rf.machine/wants-ctx (fn [data event {:state ... :meta ...}] ...)` exists for introspecting the snapshot's discrete state, but reach for it only when 2-arity cannot express what you need (Spec 005 §3-arity escape hatch). The metadata flag is the explicit opt-in; without it the runtime calls the fn as 2-arity.
 
@@ -149,7 +149,7 @@ The framework ships two subs:
 @(rf/machine-has-tag? :my/feature :loading)            ;; tag containment-bit
 ```
 
-`sub-machine` is sugar over `(subscribe [:rf/machine machine-id])` and returns the snapshot map `{:state ... :data ... :tags ...}`. `machine-has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` — see `tags.md`. Both live in `implementation/core/src/re_frame/core.cljc:1076-1098`.
+`sub-machine` is sugar over `(subscribe [:rf/machine machine-id])` and returns the snapshot map `{:state ... :data ... :tags ...}`. `machine-has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` — see `tags.md`. Both live in `re-frame.core-machines` (re-exported from `re-frame.core`).
 
 Project off the snapshot with ordinary `reg-sub`:
 
@@ -171,7 +171,7 @@ Project off the snapshot with ordinary `reg-sub`:
 - **`:rf.machine/*` and `:rf/*` are reserved.** Names like `:rf.machine/spawn`, `:rf/machines`, `:rf/spawned`, `:rf/after-epoch` belong to the runtime. Pick your own feature prefix for event keywords.
 - **Guards see `:data`, not the snapshot.** `(fn [data event] ...)` — the body inspects `(:input data)`, not `(get-in snap [:data :input])`. Same for actions.
 - **Actions return an effect map.** `{:data new-data}` (or `{:fx [...]}` or both). Returning a bare data map silently does nothing; `nil` is a no-op.
-- **Use `reg-machine` (macro), not `reg-machine*` (fn).** The macro stamps per-element source coords that tools rely on (`core.cljc:634`, Spec 005 §Source-coord stamping). Reach for `reg-machine*` only for programmatic registration with computed ids.
+- **Use `reg-machine` (macro), not `reg-machine*` (fn).** The macro stamps per-element source coords that tools rely on (`re-frame.core` macro layer, Spec 005 §Source-coord stamping). Reach for `reg-machine*` only for programmatic registration with computed ids.
 - **Re-registration replaces.** Last-write-wins, per the standard registrar semantics; the prior snapshot at `[:rf/machines <id>]` survives (the snapshot is in `app-db`, the spec is in the registrar). Hot-reload survives a machine re-declaration.
 
 ## Deeper material
@@ -180,4 +180,4 @@ For the full transition-table grammar, guard/action effect-map shape, hierarchic
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (registration + transition table) and `implementation/core/src/re_frame/core.cljc` (the `reg-machine` macro + `sub-machine` / `machine-has-tag?` sugar) @ main `89bd9c3`. Re-verify line numbers after machine-registration refactors.*
+*Derived from the `re-frame.machines.*` sub-namespaces (`transition`, `lifecycle-fx.registration`, …) and `re-frame.core` / `re-frame.core-machines` (the `reg-machine` macro + `sub-machine` / `machine-has-tag?` sugar) @ main `89bd9c3`. Citations are symbol-level (machines.cljc was split into sub-namespaces); re-verify symbol homes after machine-registration refactors.*

--- a/skills/re-frame2/references/state-machines/regions.md
+++ b/skills/re-frame2/references/state-machines/regions.md
@@ -88,7 +88,7 @@ Verbatim from `examples/reagent/realworld/tags.cljs:71-142`. The slice's separat
 (rf/reg-machine :ui/nine-states nine-states-machine)
 ```
 
-From `examples/reagent/nine_states/core.cljs:197-333`. Three orthogonal axes, one machine. `(rf/dispatch [:ui/nine-states [:fetch-started]])` reaches **every** region; the `:data` region advances; the `:form` and `:mode` regions ignore the event (their `:on` tables don't list it). The runtime is validated by `validate-parallel!` (`implementation/machines/src/re_frame/machines.cljc:1725`).
+From `examples/reagent/nine_states/core.cljs` (the `nine-states-machine` declaration). Three orthogonal axes, one machine. `(rf/dispatch [:ui/nine-states [:fetch-started]])` reaches **every** region; the `:data` region advances; the `:form` and `:mode` regions ignore the event (their `:on` tables don't list it). The runtime is validated by `validate-parallel!` (`re-frame.machines.lifecycle-fx.validation`).
 
 ## Snapshot shape with parallel regions
 
@@ -101,16 +101,16 @@ For a parallel machine the snapshot's `:state` is a **map** keyed by region-name
 ;;                    :tags  #{:data/loading :form/neutral :mode/active}}
 ```
 
-`:data` is shared across regions (same map). `:tags` is the union of every active state's `:tags` set across every region. Per Spec 005 §Parallel regions §Snapshot shape and `machines.cljc:295` (Stage 2 broadens the tag union to cover all active regions).
+`:data` is shared across regions (same map). `:tags` is the union of every active state's `:tags` set across every region. Per Spec 005 §Parallel regions §Snapshot shape and `compute-tags` in `re-frame.machines.parallel` (broadens the tag union to cover all active regions).
 
 ## Common gotchas
 
-- **`:type :parallel` is mutually exclusive with root `:initial` / `:states`.** Use one or the other at the top level. Registration throws `:rf.error/machine-parallel-bad-shape` if both are present (`machines.cljc:1746`).
-- **Each region needs its own `:initial`.** Region bodies are themselves transition tables; a missing `:initial` keyword is a registration-time error (`machines.cljc:1762`).
-- **Region names are keywords.** `:regions {:data {...} :form {...}}` — not strings, not symbols. Validated at registration (`machines.cljc:1750`).
-- **No nested parallel regions in v1.** A region body declaring its own `:type :parallel` throws `:rf.error/machine-parallel-nested-not-supported` (`machines.cljc:1758`).
+- **`:type :parallel` is mutually exclusive with root `:initial` / `:states`.** Use one or the other at the top level. Registration throws `:rf.error/machine-parallel-bad-shape` if both are present (validated in `re-frame.machines.lifecycle-fx.validation`).
+- **Each region needs its own `:initial`.** Region bodies are themselves transition tables; a missing `:initial` keyword is a registration-time error (`re-frame.machines.lifecycle-fx.validation`).
+- **Region names are keywords.** `:regions {:data {...} :form {...}}` — not strings, not symbols. Validated at registration (`re-frame.machines.lifecycle-fx.validation`).
+- **No nested parallel regions in v1.** A region body declaring its own `:type :parallel` throws `:rf.error/machine-parallel-nested-not-supported` (`re-frame.machines.lifecycle-fx.validation`).
 - **Broadcast is to every region.** One event-keyword goes to every region's `:on` table; regions whose tables don't list that event are no-ops for that dispatch. Don't broadcast a region-private event with a generic name — namespace it (`:form/submit-valid`, not `:submit-valid`) to make the per-region intent visible.
-- **`:after` and `:spawn` are scoped per region.** Each region carries its own `:after`-epoch counter at `[:data :rf/after-epoch-by-region <region-name>]` — a sibling region's transition does NOT invalidate this region's in-flight `:after` timers (`machines.cljc:362`, Spec 005 §Per-region `:always` / `:after` / `:spawn` scoping).
+- **`:after` and `:spawn` are scoped per region.** Each region carries its own `:after`-epoch counter at `[:data :rf/after-epoch-by-region <region-name>]` — a sibling region's transition does NOT invalidate this region's in-flight `:after` timers (per-region scoping in `re-frame.machines.transition`, Spec 005 §Per-region `:always` / `:after` / `:spawn` scoping).
 
 ## When to reach for parallel regions vs N machines
 
@@ -122,4 +122,4 @@ For the full parallel-regions contract — broadcast routing, per-region scoping
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (parallel-regions validator, broadcast, tag union) @ main `89bd9c3`, and the worked examples `examples/reagent/realworld/tags.cljs` and `examples/reagent/nine_states/core.cljs`. Re-verify after parallel-regions or broadcast-routing changes.*
+*Derived from the `re-frame.machines.*` sub-namespaces (`lifecycle-fx.validation` for the parallel-regions validator, `parallel` / `transition` for broadcast + tag union) @ main `89bd9c3`, and the worked examples `examples/reagent/realworld/tags.cljs` and `examples/reagent/nine_states/core.cljs`. Citations are symbol-level (machines.cljc was split); re-verify after parallel-regions or broadcast-routing changes.*

--- a/skills/re-frame2/references/state-machines/spawn.md
+++ b/skills/re-frame2/references/state-machines/spawn.md
@@ -19,7 +19,7 @@ Reach for this leaf when a state hosts an asynchronous activity whose lifetime m
            :failed    :auth-failed}}}
 ```
 
-Spec 005 §Declarative `:spawn` §Worked example (verbatim shape). While the parent machine sits in `:authenticating`, an actor of `:rf.http/managed` exists at `[:rf/machines <id>]`. The runtime spawns it on entry and destroys it on exit (Spec 005 §Desugaring rules; implementation at `implementation/machines/src/re_frame/machines.cljc:796-872`).
+Spec 005 §Declarative `:spawn` §Worked example (verbatim shape). While the parent machine sits in `:authenticating`, an actor of `:rf.http/managed` exists at `[:rf/machines <id>]`. The runtime spawns it on entry and destroys it on exit (Spec 005 §Desugaring rules; implementation in `re-frame.machines.lifecycle-fx.registration` desugar + `re-frame.machines.lifecycle-fx.destroy`).
 
 ## `:spawn` spec keys
 
@@ -33,7 +33,7 @@ Spec 005 §Declarative `:spawn` §Worked example (verbatim shape). While the par
 | `:spawn-id` | explicit id instead of gensym (per-state singleton) | optional |
 | `:id-prefix` | base for the gensym'd actor id; defaults to `:machine-id` | optional |
 
-Verbatim from Spec 005 §Spec-spec keys (`spec/005-StateMachines.md:1821`). The runtime stamps `:rf/parent-id` (the parent's registration id) + `:rf/spawn-id` (the absolute prefix-path of the `:spawn`-bearing state node) onto the spawn args so the destroy fx can locate the actor on exit.
+Verbatim from Spec 005 §Spec-spec keys. The runtime stamps `:rf/parent-id` (the parent's registration id) + `:rf/spawn-id` (the absolute prefix-path of the `:spawn`-bearing state node) onto the spawn args so the destroy fx can locate the actor on exit.
 
 ## Final states — `:final?` / `:on-done` / `:output-key`
 
@@ -97,7 +97,7 @@ Per Spec 005 §Final states (`spec/005-StateMachines.md`) for the full sub-decis
 
 ## Composition with explicit `:entry` / `:exit`
 
-A state may declare both `:spawn` AND user-supplied `:entry` / `:exit`. Ordering is **wire-level concatenation**: user-entry runs first, then the auto-spawn; user-exit runs first, then the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`; `machines.cljc:889`). The user's `:exit` action gets to read the actor's final snapshot before auto-destroy clears it.
+A state may declare both `:spawn` AND user-supplied `:entry` / `:exit`. Ordering is **wire-level concatenation**: user-entry runs first, then the auto-spawn; user-exit runs first, then the auto-destroy (Spec 005 §Composition with explicit `:entry` / `:exit`; `re-frame.machines.lifecycle-fx.exit-cascade`). The user's `:exit` action gets to read the actor's final snapshot before auto-destroy clears it.
 
 ## `:spawn-all` — spawn-and-join
 
@@ -123,17 +123,17 @@ When the parent needs to fan out N children and resume on a join condition (boot
 
 Child id is the `:id` field inside each `:children` entry (NOT the `:machine-id`); each child dispatches `[:child/done :cfg & extra]` (or `:child/error`) back to the parent. The runtime intercepts these at the parent's machine boundary, updates join-state at `[:rf/spawned <parent-id> <invoke-id>]`, evaluates the join condition, and fires the resolved parent event — automatically cancelling surviving siblings (`:cancel-on-decision?` defaults to `true`).
 
-Validation happens at registration (`machines.cljc:1653`): `:on-child-done` / `:on-child-error` are required keywords, `:on-all-complete` is required when `:join :all` (the default), `:on-some-complete` is required for `:any` / `{:n N}` / `{:fn pred}`.
+Validation happens at registration (`re-frame.machines.lifecycle-fx.validation`): `:on-child-done` / `:on-child-error` are required keywords, `:on-all-complete` is required when `:join :all` (the default), `:on-some-complete` is required for `:any` / `{:n N}` / `{:fn pred}`.
 
 ## Common gotchas
 
-- **Pick exactly one of `:machine-id` or `:definition`.** Registration rejects both forms or neither (`spec/005-StateMachines.md:1920`).
+- **Pick exactly one of `:machine-id` or `:definition`.** Registration rejects both forms or neither (Spec 005 §Spec-spec keys; validated in `re-frame.machines.lifecycle-fx.validation`).
 - **No `:timeout-ms` on `:spawn` or `:spawn-all`.** Wall-clock guards live on the parent state's `:after`. Use `:after {30000 :timeout-target}` — when the timer fires, the standard exit cascade destroys the in-flight child and the parent transitions. The `:timeout-ms` slot is dropped; registration throws `:rf.error/spawn-timeout-ms-removed`.
 - **`:on-spawn` is advisory.** The runtime tracks the spawn-id at `[:rf/spawned <parent-id> <invoke-id>]` itself — you no longer need `:on-spawn` to write the id under any specific `:data` slot for destroy to work. Most apps still set `:on-spawn (fn [{data :data id :id}] (assoc data :pending id))` so other transitions can address the child by name.
-- **`:data` is a literal map or `(fn [snap ev] data)` — not arbitrary code.** When the fn form is used, it runs at state entry against the post-action snapshot (`machines.cljc:782`). If it throws, the transition halts with `:rf.error/machine-action-exception` and the snapshot does NOT commit.
+- **`:data` is a literal map or `(fn [snap ev] data)` — not arbitrary code.** When the fn form is used, it runs at state entry against the post-action snapshot (spawn desugar in `re-frame.machines.lifecycle-fx.registration`). If it throws, the transition halts with `:rf.error/machine-action-exception` and the snapshot does NOT commit.
 - **`:start` runs after spawn; if absent the runtime dispatches a synthetic `[:rf.machine/spawned]`.** Every spawned actor receives `[:rf.machine/spawned]` if no `:start` was declared — generic child machines can declare a leaf `:on :rf.machine/spawned :target ...` transition that fires the actor's first work on entry.
 - **Path convention for `:on-spawn`:** the callback receives `:data` directly. Write `(assoc data :pending id)`, not `(assoc-in snap [:data :pending] id)`. Uniform with `:guard` and `:action`.
-- **One `:spawn` per state.** Multiple children per state → refactor into a compound state where each substate invokes one of the actors, or use `:spawn-all`. Validated at registration; `:spawn` + `:spawn-all` together throws `:rf.error/machine-spawn-all-with-spawn` (`machines.cljc:1669`).
+- **One `:spawn` per state.** Multiple children per state → refactor into a compound state where each substate invokes one of the actors, or use `:spawn-all`. Validated at registration; `:spawn` + `:spawn-all` together throws `:rf.error/machine-spawn-all-with-spawn` (`re-frame.machines.lifecycle-fx.validation`).
 
 ## Deeper material
 
@@ -141,4 +141,4 @@ For the full declarative-`:spawn` desugaring rules, composition with hierarchica
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (declarative-`:spawn` desugar, `:spawn-all` join engine, `:on-spawn` stamping) @ main `89bd9c3`, and `spec/conformance/fixtures/spawn-all-*` fixtures. Re-verify after `:spawn`/`:spawn-all` runtime changes.*
+*Derived from the `re-frame.machines.lifecycle-fx.*` sub-namespaces (`registration` desugar, `join` engine, `destroy` / `exit-cascade`, `validation`) @ main `89bd9c3`, and `spec/conformance/fixtures/spawn-all-*` fixtures. Citations are symbol-level (machines.cljc was split); re-verify after `:spawn`/`:spawn-all` runtime changes.*

--- a/skills/re-frame2/references/state-machines/tags.md
+++ b/skills/re-frame2/references/state-machines/tags.md
@@ -8,7 +8,7 @@ Reach for this leaf when a view needs to ask "is the machine in any in-flight st
 
 ## Canonical declaration
 
-A state node carries a `:tags` slot whose value is a **set of keywords**. There is no separate registration call; the slot is just a key on the state node, processed by the runtime via `compute-tags` (`implementation/machines/src/re_frame/machines.cljc:311`):
+A state node carries a `:tags` slot whose value is a **set of keywords**. There is no separate registration call; the slot is just a key on the state node, processed by the runtime via `compute-tags` (`re-frame.machines.transition`):
 
 ```clojure
 {:loading
@@ -33,9 +33,9 @@ The runtime maintains a derived `:tags` slot on the snapshot — the **union** o
 
 - **Flat machine** — the single active state's `:tags` set.
 - **Compound (hierarchical)** — the union along the path from root to active leaf.
-- **Parallel-region machine** — the union across every active state in every region (`machines.cljc:295`).
+- **Parallel-region machine** — the union across every active state in every region (`compute-tags` in `re-frame.machines.parallel`).
 
-If the union is empty the slot is **elided** entirely (snapshot-size optimisation, `machines.cljc:327` `commit-tags`). The `:rf/machine-snapshot` schema marks `:tags` as `{:optional true}` — both presence (with non-empty set) and absence are valid.
+If the union is empty the slot is **elided** entirely (snapshot-size optimisation, `commit-tags` in `re-frame.machines.transition`). The `:rf/machine-snapshot` schema marks `:tags` as `{:optional true}` — both presence (with non-empty set) and absence are valid.
 
 ## Querying — `rf/machine-has-tag?`
 
@@ -44,13 +44,13 @@ If the union is empty the slot is **elided** entirely (snapshot-size optimisatio
 @(rf/machine-has-tag? :ui/nine-states :mode/read-only)
 ```
 
-`machine-has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` (`implementation/core/src/re_frame/core.cljc:1084`). The underlying sub (`machines.cljc:2122`) reads `[:rf/machines <id> :tags]` and tests `contains?`. Returns `false` for unknown or not-yet-initialised machines.
+`machine-has-tag?` is sugar over `(subscribe [:rf/machine-has-tag? machine-id tag])` (`re-frame.core-machines`, re-exported from `re-frame.core`). The underlying `:rf/machine-has-tag?` sub (registered in `re-frame.machines`) reads `[:rf/machines <id> :tags]` and tests `contains?`. Returns `false` for unknown or not-yet-initialised machines.
 
 The sub is **derived directly off the snapshot's `:tags` slot** — a view that only cares about whether a specific tag is present re-renders only when the containment-bit flips, not on every snapshot mutation. `reg-sub`'s built-in equality dedup carries it.
 
 ## Canonical worked example
 
-From `examples/reagent/nine_states/core.cljs:487-512` — a render-priority table consults the tag union and resolves to one render-model keyword:
+From `examples/reagent/nine_states/core.cljs` (the `render-priority` table + `:ui/render` sub) — a render-priority table consults the tag union and resolves to one render-model keyword:
 
 ```clojure
 (def render-priority
@@ -83,7 +83,7 @@ The render-priority table is plain data — adding a tenth case is one row.
 
 ## Common gotchas
 
-- **Tags are **sets of keywords** on state nodes — not on transitions, not on the snapshot's `:data`.** A vector or single keyword is coerced to a set (`machines.cljc:303`), but the canonical form is `#{:foo :bar}`.
+- **Tags are **sets of keywords** on state nodes — not on transitions, not on the snapshot's `:data`.** A vector or single keyword is coerced to a set (`compute-tags` in `re-frame.machines.transition`), but the canonical form is `#{:foo :bar}`.
 - **The state declares intent, not identity.** `:tags #{:loading}` is OK; `:tags #{:my-feature/loading-state}` is overkill. Use the **per-axis** intent (`:data/loading`, `:form/in-flight`, `:mode/read-only`) so views can ask one tag-question that spans multiple states.
 - **Tags compose, but state-keywords don't.** Two states in different regions can both carry `:in-flight` — the union picks them up correctly. Don't try to query the **state-keyword** directly across regions; the snapshot's `:state` is a region-name → state-keyword map (parallel machines) or a single keyword (flat), and view code shouldn't branch on either shape. Branch on tags.
 - **`machine-has-tag?` is a subscription.** Inside a view it's `@(rf/machine-has-tag? ...)`. Inside an event handler it's a `subscribe` deref or a `compute-sub` call (in tests). Don't reach for it inside a `reg-event-db` body — read the snapshot's `:tags` set directly off `db` via `(get-in db [:rf/machines machine-id :tags])` if you need to branch inside an event.
@@ -102,4 +102,4 @@ For the full state-tags contract — declaration shape, snapshot semantics, the 
 
 ---
 
-*Derived from `implementation/machines/src/re_frame/machines.cljc` (`compute-tags`, `commit-tags`, parallel-tag-union, `:rf/machine-has-tag?` sub) and `implementation/core/src/re_frame/core.cljc` (`machine-has-tag?` sugar) @ main `89bd9c3`. Re-verify after tag-union or `machine-has-tag?` changes.*
+*Derived from `re-frame.machines.transition` / `re-frame.machines.parallel` (`compute-tags`, `commit-tags`, parallel-tag-union), the `:rf/machine-has-tag?` sub in `re-frame.machines`, and `re-frame.core-machines` (`machine-has-tag?` sugar) @ main `89bd9c3`. Citations are symbol-level (machines.cljc was split); re-verify after tag-union or `machine-has-tag?` changes.*

--- a/skills/re-frame2/spec/authoring-prompt.md
+++ b/skills/re-frame2/spec/authoring-prompt.md
@@ -32,6 +32,7 @@ A self-contained prompt that re-authors the `re-frame2` skill from this `spec/` 
 > │   │   ├── fx.md                (reg-fx, :fx vector shape)
 > │   │   ├── cofx.md              (reg-cofx, inject-cofx)
 > │   │   ├── subs.md              (reg-sub, layered subs, dynamic args, machine subs)
+> │   │   ├── flows.md             (reg-flow, materialised computed state, flow-vs-sub)
 > │   │   ├── schemas.md           (reg-app-schema, boundary validation)
 > │   │   ├── frames.md            (frame ids, default frame, per-frame config)
 > │   │   ├── event-state-cycle.md (the 12-step walk)

--- a/skills/re-frame2/spec/design.md
+++ b/skills/re-frame2/spec/design.md
@@ -92,10 +92,10 @@ skills/re-frame2/
 ├── package.json                 (npm metadata)
 ├── examples-map.md              (pattern → worked-example cross-ref)
 ├── references/
-│   ├── fundamentals/            (events, fx, cofx, subs, schemas, frames, event-state-cycle, project-structure)
-│   ├── state-machines/          (reg-machine, regions, tags, invoke, cancellation)
-│   ├── tooling/                 (stories, routing)
-│   └── cross-cutting/           (testing, api-cheatsheet)
+│   ├── fundamentals/            (events, fx, cofx, subs, flows, schemas, frames, event-state-cycle, project-structure)
+│   ├── state-machines/          (reg-machine, regions, tags, spawn, cancellation)
+│   ├── tooling/                 (stories, routing, story-recorder, story-mcp-loop, causa)
+│   └── cross-cutting/           (testing, api-cheatsheet, privacy-and-elision, production-observability, ssr-authoring)
 ├── patterns/                    (one leaf per canonical pattern)
 ├── decision-trees/              (pick-a-pattern, slice-or-machine)
 ├── evals/                       (eval harness inputs)
@@ -105,11 +105,11 @@ skills/re-frame2/
     └── authoring-prompt.md      (one-shot reauthor prompt)
 ```
 
-Each reference / pattern / decision-tree leaf is ≤250 lines, target ~150. A typical authoring session reads SKILL.md (~180) + one reference leaf (~150) + one pattern leaf (~150) ≈ ~480 LoC — well under any reasonable context budget.
+Each reference / pattern / decision-tree leaf targets ~150 lines; in practice they range ~80–260, with `testing.md` the one deliberate over-ceiling leaf (it owns the full view-test recipe SKILL.md routes to). A typical authoring session reads SKILL.md (~180) + one reference leaf + one pattern leaf ≈ ~480 LoC — well under any reasonable context budget.
 
 ## 6. Discovery surface (frontmatter `description`)
 
-The `description` is "pushy" per Anthropic best practice — it lists every re-frame2 surface that should trigger discovery: `reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, `frames`, `regions`, `tags`, `managed HTTP`, `RemoteData lifecycles`, plus the natural-language framing "writing tests for a re-frame2 app". The description also explicitly carves out the adjacent skills (`re-frame2-pair`, `re-frame2-setup`) so the AI routes correctly.
+The `description` is "pushy" per Anthropic best practice — it lists every re-frame2 surface that should trigger discovery: `reg-event-db`, `reg-event-fx`, `reg-sub`, `reg-fx`, `reg-cofx`, `reg-flow`, `reg-view`, `reg-machine`, `reg-route`, `reg-story`, `reg-app-schema`, `dispatch`, `subscribe`, `app-db`, `flows`, `frames`, `regions`, `tags`, `managed HTTP`, `RemoteData lifecycles`, plus the natural-language framing "writing tests for a re-frame2 app". The description also explicitly carves out the adjacent skills (`re-frame2-pair`, `re-frame2-setup`) so the AI routes correctly.
 
 ## 7. Anti-patterns the skill explicitly resists
 


### PR DESCRIPTION
## Summary

Remediates **rf2-ee38b.29** — the consolidated correctness + completeness + clarity sweep of `skills/re-frame2` (the primary authoring skill). All fixes are scoped within `skills/re-frame2/`. The cross-skill `skills/shared` dedup is deliberately left for the separate final bead.

### Completeness (P1 — the headline gap)
- **New `references/fundamentals/flows.md`** — `reg-flow` / `clear-flow`, the flow-vs-sub decision, runtime toggle via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`, drain integration, gotchas. Anchored on `spec/013-Flows.md` and the just-merged `examples/reagent/flows/` exemplar. Mental-model anchor: re-frame v1's `on-changes`.
- **Flows added to activation triggers** — `SKILL.md` `description` + "When to load" + depth map now list `reg-flow` / flows (was a v1 capability the skill couldn't self-activate on).
- **slice-or-machine decision tree** gains a Flow branch (derived value that is part of app-db state → flow, not sub).
- **Streaming-SSR** section added to `ssr-authoring.md` pointing at `examples/reagent/ssr_streaming/`.

### Clarity (P1)
- Removed the **phantom "Pillar 5"** headings in `remote-data` / `forms` / `nine-states` (only four pillars exist) → self-describing headings; fixed the `remote-data.md` "per Pillar" → cardinal rule 4.
- Fixed the **mis-numbered "cardinal rule 5"** citation in `reg-machine.md` (inspectability bias is Spec 005, not a cardinal rule).
- Compressed `SKILL.md` "Testing your views" to a pointer; the full recipe now lives in `testing.md` (router/leaf de-dup).

### Correctness (P2 — snippet errors that would mislead)
- `events.md` + `event-state-cycle.md`: counter example now matches the real `reg-event-db` shape; the `:db`+`:fx` teaching uses a real todomvc fx-handler (dropped the fabricated `:counter/log` fx + wrong db key).
- `subs.md`: todomvc sub ids now prefixed `:todo/*` (was violating Rule 7).
- `testing.md`: `with-managed-request-stubs` `:reply` is now a map (`{:ok ..}` / `{:failure {:kind ..}}`) per the impl.
- `stale-detection.md`: replaced the non-existent `:rf/trace-event` fx with a user-registered fx wrapping `emit-trace-event!`.
- `forms.md`: auth submit handler body made consistent with its `(rf/path :auth :login)` interceptor.

### Cross-ref rot (P3)
- Demoted stale `machines.cljc` / `core.cljc` / `frame.cljc` `file:line` citations to symbol-level references (machines.cljc was split into sub-namespaces; names were right, lines moved).
- `invoke` → `spawn` leaf-name fixes (README / design / SKILL description).
- Refreshed stale README/design status (websocket/long_running_work/flows shipped) + leaf-size figures.
- Added per-pattern JS mental-model anchors (RemoteData→SWR, Forms→Formik/RHF, AsyncEffect→redux-thunk/RTK-Query).

Cross-refs rf2-ee38b.29.

## Test plan
- [x] `python scripts/check_doc_slugs.py` (+ `--self-test`) — pass
- [x] `python scripts/check_skill_mcp_drift.py` — pass
- [x] `python scripts/check_skill_redirect_anchors.py` — pass
- [x] No broken internal links introduced; all Flows facts verified against `spec/013-Flows.md` + `examples/reagent/flows/core.cljs`