### PR TITLE
fix(mcp-conformance): close P1 flag-vocab gap + wire-vocab clarity/dedup (rf2-ee38b.20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1817,6 +1817,16 @@ jobs:
       - name: Run story-mcp end-to-end MCP-client conformance
         run: npm run test:story
 
+      # Cross-MCP operator-opt-in CLI flag-vocabulary conformance
+      # (rf2-ee38b.20). Boots story-mcp without / with / with-a-legacy
+      # `--allow-writes` spelling and asserts the default-OFF write gate +
+      # the hard-rename-rejection rule over the MCP wire. Lives in this
+      # job because it needs `clojure` (the JVM story-mcp server), same as
+      # `test:story`. The pair-mcp `--allow-eval` wire counterpart rides
+      # the hermetic live-subscribe path in `mcp-conformance-re-frame2-pair`.
+      - name: Run cross-MCP CLI flag-vocabulary conformance
+        run: npm run test:flag-gates
+
   # ---------------------------------------------------------------------------
   # MCP conformance — JVM wire-vocab gates (rf2-rto1l).
   #

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -248,6 +248,7 @@ pair-mcp's data shape) and reads at the operator semantic level.
 |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|------------------|
 | `--allow-eval`            | Enable an arbitrary-CLJS-form evaluator tool (`eval-cljs`). Default OFF; calls return `{:ok? false :reason :rf.error/eval-cljs-disabled}` when the flag is absent. | re-frame2-pair-mcp               | rf2-zyoj2 / rf2-cxx5s |
 | `--allow-sensitive-reads` | Honour caller-supplied `:include-sensitive true` (and pair-mcp's `:elision false`) on direct-read tools. Default OFF; sensitive slots return `:rf/redacted` and large slots elide regardless of the per-call arg when the flag is absent. | re-frame2-pair-mcp, story-mcp    | rf2-2x3ql (alignment), rf2-c2dtu (pair-mcp impl), rf2-uaymx / rf2-g9fje (story-mcp impl) |
+| `--allow-writes`          | Enable the registry write surface (`register-variant` / `unregister-variant`). Default OFF; gated calls return `isError: true` + `structuredContent {:gated true :tool "<name>"}` when the flag is absent. | story-mcp                        | story-mcp IMPL-SPEC §7.3 (003-Write-Surface-Gating.md) |
 
 ### Rules
 
@@ -269,6 +270,26 @@ pair-mcp's data shape) and reads at the operator semantic level.
   surfaces that don't require cross-server lockstep. pair-mcp retains
   `raw-state-allowed?` / `:allow-raw-state?` internally even though the
   CLI flag aligned on `--allow-sensitive-reads`.
+
+### Wire-level conformance (rf2-ee38b.20)
+
+The flag table's default-OFF posture and the hard-rename rule are pinned
+end-to-end (over the real MCP wire) by the conformance harness:
+
+- **story-mcp `--allow-writes`** — `test/end-to-end-flag-gates.cjs`
+  boots story-mcp without / with / with-a-legacy spelling and asserts the
+  gate stays closed by default (`structuredContent.gated`), opens only on
+  the canonical spelling, and is NOT re-opened by an unrecognised flag
+  (the no-alias rule). Runs on CI in the `mcp-conformance-story` job.
+- **re-frame2-pair-mcp `--allow-eval`** — `test/live-re-frame2-pair-subscribe.cjs`
+  (which boots a non-degraded server WITHOUT `--allow-eval`) asserts the
+  `:rf.error/eval-cljs-disabled` envelope crosses the wire. This is the
+  one boot configuration where pair-mcp's eval gate is observable: in
+  degraded mode (no nREPL) every tool short-circuits to
+  `:nrepl-port-not-found` before the gate runs, so the wire check needs a
+  live runtime (the hermetic orchestrator provides one on CI). The
+  pair-mcp parser rename-rejection (legacy `--allow-raw-state` ⇒ gate
+  stays closed) is pinned unit-side by `raw_state_test.cljs`.
 
 ## How to extend this table
 

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -85,7 +85,18 @@ on the server side surfaces as an SDK parse-error.
   the spawned `SHADOW_CLJS_NREPL_PORT`. Closes the CI-coverage gap
   the SKIP path leaves on each.
 - `test/end-to-end-story.cjs` — story-mcp conformance (full write-loop
-  with `--allow-writes` enabled)
+  with `--allow-writes` enabled) + closed-world read-path success
+  envelopes
+- `test/end-to-end-flag-gates.cjs` — cross-MCP operator-opt-in CLI
+  flag-vocabulary conformance (rf2-ee38b.20). Boots story-mcp without /
+  with / with-a-legacy `--allow-writes` spelling and asserts the
+  default-OFF write gate (`structuredContent.gated`) + the
+  hard-rename-rejection rule (an unrecognised flag must NOT open the
+  gate) over the MCP wire — the NAMING.md §"Operator-opt-in CLI flag
+  vocabulary" contract. Needs `clojure` (the JVM story-mcp server). The
+  pair-mcp `--allow-eval` default-OFF wire counterpart rides the live
+  `live-re-frame2-pair-subscribe.cjs` path (the one boot config where
+  pair-mcp's eval gate is observable — non-degraded, no `--allow-eval`).
 
 ## How to run
 
@@ -217,7 +228,9 @@ used to add on top of a hand-rolled copy of this same loop (rf2-2mx0q),
 so CI runs one JVM boot here instead of two near-identical ones.
 
 1. Connect — `clojure -M -m re-frame.story-mcp.server --allow-writes`
-2. `tools/list` — confirm the 19 advertised tools
+2. `tools/list` — confirm the advertised catalogue per story-mcp's
+   `tool-names.json` fixture (count-free per NAMING.md §"Single source
+   of truth for tool counts")
 3. `assertDescriptorShape` — every descriptor: `inputSchema`
    (type=object + `max-tokens`) + `outputSchema` + an `annotations`
    classification hint
@@ -251,7 +264,15 @@ The `mcp-conformance-re-frame2-pair` job runs three steps in sequence:
    path with a real over-budget eval. This is the path that catches
    cap-trigger threshold drift, marker shape regressions on real
    payloads, and SDK strict-schema rejection of cap-marker shapes
-   under CI's clean ephemeral runtime — not just on Mike's machine.
+   under CI's clean ephemeral runtime — not just on Mike's machine. The
+   hermetic suite also runs `live-re-frame2-pair-subscribe.cjs`, which
+   (booting non-degraded WITHOUT `--allow-eval`) pins pair-mcp's
+   `--allow-eval` default-OFF wire envelope (`:rf.error/eval-cljs-disabled`).
+
+The `mcp-conformance-story` job runs two steps: **`test:story`** (the
+write-loop + read-path conformance) and **`test:flag-gates`** (the
+cross-MCP CLI flag-vocabulary conformance — story-mcp `--allow-writes`
+default-OFF + opt-in + hard-rename rejection). Both need `clojure`.
 
 ## Why a separate artefact?
 

--- a/tools/mcp-conformance/package.json
+++ b/tools/mcp-conformance/package.json
@@ -10,6 +10,7 @@
     "test:re-frame2-pair-live-subscribe": "node test/live-re-frame2-pair-subscribe.cjs",
     "test:re-frame2-pair-live-overflow-hermetic": "node scripts/run-live-re-frame2-pair-overflow-hermetic.cjs",
     "test:story": "node test/end-to-end-story.cjs",
+    "test:flag-gates": "node test/end-to-end-flag-gates.cjs",
     "test:exec-safety": "node --test test/exec-safety.test.cjs",
     "test": "node scripts/test-all.cjs"
   },

--- a/tools/mcp-conformance/scripts/test-all.cjs
+++ b/tools/mcp-conformance/scripts/test-all.cjs
@@ -63,6 +63,10 @@ const TESTS = [
     name: 'story-mcp end-to-end',
     argv: ['test/end-to-end-story.cjs'],
   },
+  {
+    name: 'CLI flag-vocabulary conformance (story-mcp --allow-writes default-OFF + rename rejection)',
+    argv: ['test/end-to-end-flag-gates.cjs'],
+  },
 ];
 
 function banner(line) {

--- a/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
+++ b/tools/mcp-conformance/test/end-to-end-flag-gates.cjs
@@ -1,0 +1,281 @@
+// End-to-end MCP-client conformance for the cross-MCP operator-opt-in
+// CLI flag vocabulary (NAMING.md §"Operator-opt-in CLI flag
+// vocabulary"). Source: rf2-ee38b.20 (review-remediation; the P1 gap the
+// completeness lens flagged — the flag vocabulary had no conformance
+// gate at all).
+//
+// ## What this guards
+//
+// NAMING.md pins a cross-server flag contract: same operator semantic ⇒
+// same flag spelling, every authority-gate flag DEFAULT-OFF, and a
+// "hard rename, no aliases" rule (a legacy / unrecognised spelling stops
+// being recognised at the parser; it must NOT open the gate). Before this
+// harness those claims were pinned only by each server's OWN unit
+// fixtures — the cross-server, observable-over-the-wire contract was
+// unenforced. A regression that renamed story-mcp's write gate to
+// `--enable-writes`, or that flipped a default to ON, would have passed
+// every conformance test here.
+//
+// This harness drives the contract through the official MCP SDK client —
+// the same path a real consumer (Claude Code, Continue, …) takes — for
+// the flag whose gated posture is observable WITHOUT a live runtime:
+// story-mcp's `--allow-writes`. (The pair-mcp `--allow-eval` gate is also
+// observable, but only against a live nREPL — see "Coverage boundary"
+// below; that wire check lives in `live-re-frame2-pair-subscribe.cjs`,
+// which boots a non-degraded server without `--allow-eval`.)
+//
+// ### story-mcp `--allow-writes` (default OFF, hard-rename rejection)
+//
+//   1. Boot WITHOUT the flag ⇒ `register-variant` returns
+//      `isError: true` + `structuredContent.gated === true`
+//      (the default-OFF posture). This is the security-critical claim:
+//      a fresh / CI boot cannot mutate the registry.
+//   2. Boot WITH `--allow-writes` ⇒ `register-variant` succeeds
+//      (`isError: false`, registered) — the positive control proving the
+//      flag spelling NAMING.md pins is the one the parser actually wires.
+//   3. Boot with a legacy / near-miss spelling (`--enable-writes`,
+//      `--allow-write`) ⇒ the gate stays CLOSED (`gated === true`). This
+//      is the "hard rename, no aliases" rule observed end-to-end: an
+//      unrecognised flag does NOT open the gate (the parser logs+ignores
+//      it; no back-compat alias re-enables the surface).
+//
+// ## Coverage boundary (judgment, rf2-ee38b.20)
+//
+// The completeness lens suggested "boot each server WITHOUT its opt-in
+// flag (no nREPL needed) and assert the gated tool returns the
+// disabled-default envelope." That holds for story-mcp (JVM server, no
+// degraded mode — `register-variant` always routes to the tool, which
+// checks the gate first). It does NOT hold for re-frame2-pair-mcp:
+// without a resolvable nREPL port pair-mcp boots in DEGRADED mode
+// (`server.cljs` `degraded-handler`), where EVERY `tools/call` short-
+// circuits to `:nrepl-port-not-found` before reaching the tool body — so
+// `eval-cljs` never reaches its `--allow-eval` gate and the
+// `:rf.error/eval-cljs-disabled` envelope is unreachable degraded. The
+// honest home for the pair-mcp eval-gate WIRE check is therefore the
+// live path: `live-re-frame2-pair-subscribe.cjs` already boots a
+// non-degraded server WITHOUT `--allow-eval`, so it observes the disabled
+// envelope over the wire when a runtime is attached. The pair-mcp parser
+// rename-rejection itself (`--allow-raw-state` legacy spelling ⇒ gate
+// stays closed) is pinned at the unit layer by
+// `re-frame2-pair-mcp/test/.../raw_state_test.cljs`
+// (`parse-launch-flags-old-name-rejected`) — duplicating that JVM-side
+// unit test here would buy nothing the live wire check + unit pin don't
+// already give.
+//
+// Run with: `node test/end-to-end-flag-gates.cjs` from this directory.
+// Requires `clojure` on PATH (override via $STORY_MCP_CMD). Exits 0 on
+// success, 1 on a conformance violation.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const {
+  Client,
+} = require('@modelcontextprotocol/sdk/client/index.js');
+const {
+  StdioClientTransport,
+} = require('@modelcontextprotocol/sdk/client/stdio.js');
+const { resolveTrustedExe } = require('../lib/exec-safety.cjs');
+
+const STORY_MCP_CWD = path.resolve(__dirname, '..', '..', 'story-mcp');
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+// Resolve `clojure` to a trusted absolute path outside the workspace, or
+// honour the explicit STORY_MCP_CMD override (same posture as
+// end-to-end-story.cjs — rf2-33vvc accident-gating fires only on the
+// implicit-PATH path).
+const CLOJURE = process.env.STORY_MCP_CMD
+  ? process.env.STORY_MCP_CMD
+  : resolveTrustedExe('clojure', { workspaceRoot: REPO_ROOT });
+
+// A namespaced fixture variant id — `:story.<path>/<name>` grammar the
+// registrar's `assert-id!` enforces. Distinct from the ids the sibling
+// `end-to-end-story.cjs` and the upstream `stdio-roundtrip.js` register
+// so the harnesses can't collide on a shared JVM.
+const FIXTURE_VARIANT = 'story.mcp-conformance/flag-gate.probe';
+const FIXTURE_BODY_EDN = '{:doc "flag-gate conformance probe." :tags #{:dev}}';
+
+// Cold JVM boot is ~10-30s; each gate below boots a fresh JVM (the gate
+// is a boot-time atom — we can't flip it on a running server through the
+// MCP surface, which is exactly the point). Three sequential boots fit
+// comfortably under the watchdog with margin.
+const WATCHDOG_MS = 180000;
+const CLIENT_VERSION = '0.1.0';
+
+// ---------------------------------------------------------------------------
+// Boot one story-mcp server with the given extra CLI args, run `body`
+// against the connected SDK client, and tear the transport down. Returns
+// whatever `body` resolves to. Throws on connect / body failure.
+//
+// Each call spawns a fresh JVM so the boot-time gate atom reflects ONLY
+// the args passed here — no cross-contamination between the default-OFF,
+// opt-in, and rename-rejection probes.
+// ---------------------------------------------------------------------------
+async function withStoryServer(extraArgs, body) {
+  const transport = new StdioClientTransport({
+    command: CLOJURE,
+    args: ['-M', '-m', 're-frame.story-mcp.server', ...extraArgs],
+    cwd: STORY_MCP_CWD,
+    env: { ...process.env },
+    stderr: 'pipe',
+  });
+  const client = new Client(
+    { name: 'mcp-conformance-flag-gates', version: CLIENT_VERSION },
+    { capabilities: {} },
+  );
+  transport.stderr?.on('data', (d) =>
+    process.stderr.write('[server] ' + d.toString()),
+  );
+  await client.connect(transport);
+  try {
+    return await body(client);
+  } finally {
+    try {
+      await client.close();
+    } catch (closeErr) {
+      console.error(
+        'NOTE: client.close() raised during teardown:',
+        closeErr.message,
+      );
+    }
+  }
+}
+
+function callRegisterVariant(client) {
+  return client.callTool({
+    name: 'register-variant',
+    arguments: { 'variant-id': FIXTURE_VARIANT, body: FIXTURE_BODY_EDN },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The three story-mcp `--allow-writes` conformance probes.
+// ---------------------------------------------------------------------------
+
+async function assertWriteGateClosedByDefault() {
+  await withStoryServer([], async (client) => {
+    const resp = await callRegisterVariant(client);
+    // Default-OFF: the write tool MUST refuse with a tool-execution
+    // error (NOT a JSON-RPC protocol error — the agent's conversation
+    // survives) carrying the documented `:gated true` structuredContent.
+    if (!resp.isError) {
+      throw new Error(
+        'story-mcp register-variant MUST isError when booted WITHOUT ' +
+          '--allow-writes (default-OFF posture per NAMING.md ' +
+          '§"Operator-opt-in CLI flag vocabulary"); got: ' +
+          JSON.stringify(resp),
+      );
+    }
+    const struct = resp.structuredContent || {};
+    if (struct.gated !== true) {
+      throw new Error(
+        'story-mcp write-gate-closed envelope MUST carry ' +
+          'structuredContent.gated === true; got: ' + JSON.stringify(resp),
+      );
+    }
+    const text = resp.content?.[0]?.text || '';
+    if (!/write surface disabled/i.test(text)) {
+      throw new Error(
+        'story-mcp write-gate-closed text MUST mention "Write surface ' +
+          'disabled"; got: ' + text.slice(0, 200),
+      );
+    }
+    console.log(
+      'OK   story-mcp --allow-writes default-OFF -> register-variant ' +
+        'isError + structuredContent.gated=true',
+    );
+  });
+}
+
+async function assertWriteGateOpensWithFlag() {
+  await withStoryServer(['--allow-writes'], async (client) => {
+    const resp = await callRegisterVariant(client);
+    // Positive control: the EXACT flag spelling NAMING.md pins MUST open
+    // the gate. If the parser wired a different spelling this fails.
+    if (resp.isError) {
+      throw new Error(
+        'story-mcp register-variant MUST succeed when booted WITH ' +
+          '--allow-writes (the canonical flag spelling per NAMING.md); ' +
+          'got isError: ' + JSON.stringify(resp),
+      );
+    }
+    const struct = resp.structuredContent || {};
+    if (struct.registered !== true && struct['registered?'] !== true) {
+      throw new Error(
+        'story-mcp register-variant with --allow-writes MUST report ' +
+          'registered; got: ' + JSON.stringify(resp),
+      );
+    }
+    console.log(
+      'OK   story-mcp --allow-writes opt-in -> register-variant succeeds ' +
+        '(canonical flag spelling wired)',
+    );
+    // Symmetric teardown so a shared-JVM future run starts clean.
+    try {
+      await client.callTool({
+        name: 'unregister-variant',
+        arguments: { 'variant-id': FIXTURE_VARIANT },
+      });
+    } catch (_e) {
+      // best-effort cleanup; the fresh-JVM-per-boot shape makes a stray
+      // registration harmless, but tidy up anyway.
+    }
+  });
+}
+
+async function assertLegacyFlagSpellingRejected() {
+  // "Hard rename, no aliases" (NAMING.md §Rules): a legacy / near-miss
+  // flag spelling MUST NOT open the gate. Boot with two unrecognised
+  // spellings and assert the gate stays CLOSED. The parser logs+ignores
+  // unknown flags (no back-compat alias path), so the disabled-default
+  // envelope is the observable proof the rename is hard.
+  for (const legacyFlag of ['--enable-writes', '--allow-write']) {
+    await withStoryServer([legacyFlag], async (client) => {
+      const resp = await callRegisterVariant(client);
+      if (!resp.isError || (resp.structuredContent || {}).gated !== true) {
+        throw new Error(
+          'story-mcp booted with the unrecognised flag `' + legacyFlag +
+            '` MUST keep the write gate CLOSED (hard-rename / no-alias ' +
+            'rule per NAMING.md §Rules); the gate opened (no isError / ' +
+            'gated). got: ' + JSON.stringify(resp),
+        );
+      }
+      console.log(
+        'OK   story-mcp unrecognised flag `' + legacyFlag +
+          '` rejected -> write gate stays closed (no alias)',
+      );
+    });
+  }
+}
+
+async function main() {
+  // Sanity: story-mcp must be launchable. resolveTrustedExe throws if
+  // `clojure` isn't on PATH; surface a clear message early.
+  if (!fs.existsSync(path.join(STORY_MCP_CWD, 'deps.edn'))) {
+    throw new Error('story-mcp deps.edn missing at ' + STORY_MCP_CWD);
+  }
+
+  await assertWriteGateClosedByDefault();
+  await assertWriteGateOpensWithFlag();
+  await assertLegacyFlagSpellingRejected();
+
+  console.log('\nMCP CLI FLAG-VOCABULARY CONFORMANCE GREEN');
+}
+
+// Watchdog so a hung JVM can't wedge CI. Three sequential cold boots +
+// one register round-trip each fit well under this.
+const watchdog = setTimeout(() => {
+  console.error('FAIL: watchdog timeout (' + WATCHDOG_MS + 'ms)');
+  process.exit(2);
+}, WATCHDOG_MS);
+
+main()
+  .then(() => {
+    clearTimeout(watchdog);
+    process.exit(0);
+  })
+  .catch((err) => {
+    clearTimeout(watchdog);
+    console.error('FAIL:', err && err.message ? err.message : err);
+    if (err && err.stack) console.error(err.stack);
+    process.exit(1);
+  });

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -243,11 +243,21 @@ runWithWatchdog(
             "(rf2-hj3pi dual-slot conformance); got: " + JSON.stringify(resp),
         );
       }
-      // Sanity: structured slot must be a non-null object/value.
-      if (typeof resp.structuredContent !== 'object') {
+      // Sanity: structured slot must be a JSON object (map) — NOT an
+      // array. `typeof [] === 'object'`, so the bare typeof check admits
+      // a vector `structuredContent`; the MCP `structuredContent` slot is
+      // contractually a JSON object. Reject arrays explicitly so a server
+      // that regressed to emitting a vector there is caught (rf2-ee38b.20).
+      if (
+        typeof resp.structuredContent !== 'object' ||
+        Array.isArray(resp.structuredContent)
+      ) {
         throw new Error(
-          'tool ' + label + " :structuredContent should be an object; got: " +
-            typeof resp.structuredContent,
+          'tool ' + label + " :structuredContent should be a JSON object " +
+            '(not an array); got: ' +
+            (Array.isArray(resp.structuredContent)
+              ? 'array'
+              : typeof resp.structuredContent),
         );
       }
     }

--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -22,7 +22,9 @@
 // CI for no loss of coverage:
 //
 //   1. connect (initialize + notifications/initialized via SDK)
-//   2. tools/list — confirm 19 tools advertised
+//   2. tools/list — confirm the advertised catalogue matches story-mcp's
+//      own `tool-names.json` fixture (count-free per NAMING.md
+//      §"Single source of truth for tool counts")
 //   3. register-variant — write a fixture variant
 //   4. get-variant — read it back; assert the body :doc round-trips
 //      through the EDN text payload (ex-live-server smoke #1)
@@ -128,6 +130,48 @@ runWithWatchdog(
       'OK   every tool descriptor: inputSchema(type=object,max-tokens) + outputSchema + annotations hint',
     );
 
+    // 2e. Closed-world read-path SUCCESS-envelope conformance
+    // (rf2-ee38b.20). The completeness lens noted the harness walked
+    // only the write-loop tools and asserted error-only shapes elsewhere
+    // — no story-mcp `list-*` read was ever invoked, so a success-path
+    // `CallToolResultSchema` parse / structuredContent drift on the read
+    // surface (the exact bug class this harness exists to catch) could
+    // ship unobserved. story-mcp's `list-*` reads are closed-world (no
+    // runtime needed) and return a non-error envelope regardless of the
+    // write gate, so they cover the success path here with zero extra
+    // setup. Each routes through the SDK's `CallToolResultSchema` parse.
+    //
+    // NOTE: `get-story-instructions` is deliberately NOT walked here. It
+    // declares an `:outputSchema` but returns text-only (no
+    // structuredContent), so the SDK's high-level `callTool` rejects it
+    // with `-32600` ("has an output schema but did not return structured
+    // content"). That is a latent story-mcp tool defect surfaced by this
+    // very broadening (the tool was never SDK-driven before) — tracked
+    // separately, out of scope for the conformance-harness bead. The
+    // `list-*` reads below DO emit structuredContent and are the clean
+    // success-envelope coverage.
+    for (const readTool of ['list-substrates', 'list-modes', 'list-tags']) {
+      const r = await client.callTool({ name: readTool, arguments: {} });
+      if (r.isError) {
+        throw new Error(
+          'closed-world read ' + readTool + ' MUST succeed (isError=false) ' +
+            'with no runtime; got: ' + JSON.stringify(r),
+        );
+      }
+      if (r.structuredContent === undefined || r.structuredContent === null ||
+          typeof r.structuredContent !== 'object' ||
+          Array.isArray(r.structuredContent)) {
+        throw new Error(
+          readTool + ' success envelope MUST carry a JSON-object ' +
+            ':structuredContent slot; got: ' + JSON.stringify(r),
+        );
+      }
+    }
+    console.log(
+      'OK   closed-world reads (list-substrates/list-modes/list-tags) ' +
+        '-> success envelopes',
+    );
+
     // 3. register-variant — body as an EDN string so JSON's lack of
     // keyword support doesn't dilute the assertion (Cheshire would
     // coerce {"doc": "..."} into a string-keyed map, which Story's
@@ -147,9 +191,16 @@ runWithWatchdog(
       throw new Error('register-variant failed: ' + JSON.stringify(regResp));
     }
     const regStruct = regResp.structuredContent || {};
-    if (regStruct.registered !== true && regStruct['registered?'] !== true) {
+    // Pin the SINGLE canonical key story-mcp emits: `:registered?`
+    // (Cheshire keeps the `?` on the keyword → JSON key `registered?`;
+    // pinned JVM-side by tools_test.clj `(-> reg :structuredContent
+    // :registered?)`). The earlier `registered || registered?`
+    // alternation tolerated two spellings — masking exactly the
+    // envelope-key drift the rest of this harness pins single-spelling
+    // (`unregistered?`, `passing?`, `content-hash`). rf2-ee38b.20.
+    if (regStruct['registered?'] !== true) {
       throw new Error(
-        'register-variant did not report registered=true: ' + JSON.stringify(regResp),
+        "register-variant did not report :registered? true: " + JSON.stringify(regResp),
       );
     }
     console.log('OK   register-variant -> ' + FIXTURE_VARIANT + ' registered');

--- a/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
+++ b/tools/mcp-conformance/test/live-re-frame2-pair-subscribe.cjs
@@ -37,7 +37,12 @@
 //   - `notifications/progress` method-name drift (the SDK progress
 //     router rejects a rename before invoking `onprogress`).
 //   - `progressToken` slot rename / removal (agent-host correlation
-//     break).
+//     break) — caught INDIRECTLY: the SDK routes progress frames by
+//     numeric `progressToken` correlation, so a renamed / dropped /
+//     mangled token fails to route and zero frames arrive, tripping the
+//     "at least one frame" gate. The slot is unobservable in the
+//     `onprogress` callback (the SDK strips it before invoking us), so a
+//     direct JS-side presence check would be vacuous (rf2-ee38b.20).
 //   - `_meta.data` slot shape drift (`:dropped-events`, `:dropped-bytes`,
 //     `:overflow-reason` are the documented contract slots).
 //   - subscribe entirely failing to emit a progress frame on a
@@ -78,8 +83,24 @@ const MAX_MS = 1500;
 // `js-assertProgressParams-pins-every-re-frame2-pair-progress-required-field`
 // greps for each row's literal source form. A row renamed/deleted
 // trips the JVM gate.
+//
+// `progressToken` is deliberately ABSENT from this table (rf2-ee38b.20
+// correctness fix). The MCP SDK's `_onprogress` destructures
+// `progressToken` OUT of `notification.params` before invoking this
+// callback (`@modelcontextprotocol/sdk/.../shared/protocol.js`:
+// `const { progressToken, ...params } = notification.params`), so the
+// callback NEVER sees the slot — a JS-side `params.progressToken !==
+// undefined` check would only ever observe a value the test injected
+// itself, never a server regression. The token IS verified, just below
+// the SDK's surface: the SDK routes progress frames by `Number(
+// progressToken)` correlation against the outgoing call's token, so a
+// server that renamed / dropped / mangled the slot fails to route → zero
+// frames arrive → the "at least one frame" gate at the bottom of this
+// file catches it. The Malli schema keeps `:progressToken` (the WIRE
+// genuinely carries it; the fixture test pins that shape JVM-side); only
+// the JS-callback assertion is dropped, because at THAT layer the slot is
+// unobservable.
 const REQUIRED_PARAMS = [
-  ['progressToken',  (v) => v !== undefined,         'present (opaque)'],
   ['progress',       (v) => typeof v === 'number',   'int'],
   ['message',        (v) => typeof v === 'string',   'string'],
   ['_meta',          (v) => v && typeof v === 'object', 'map'],
@@ -170,10 +191,15 @@ runWithWatchdog(
     // `_meta`, then routes matching progress notifications here.
     const frames = [];
     const onProgress = (params) => {
-      // The SDK validates and strips progressToken before invoking the
-      // callback. Reattach a sentinel so the cross-MCP assertion table
-      // still pins the slot while the SDK pins the actual token match.
-      frames.push({ ...params, progressToken: '<sdk-validated>' });
+      // The SDK strips `progressToken` out of `notification.params`
+      // before invoking this callback (and routes by it internally), so
+      // `params` here carries `progress` / `message` / `_meta` only. We
+      // store params verbatim — `progressToken` correlation is asserted
+      // implicitly by the "at least one frame arrived" gate below (a
+      // renamed / dropped token fails the SDK's numeric correlation →
+      // zero frames). See the REQUIRED_PARAMS comment for why a JS-side
+      // `progressToken` presence check would be vacuous (rf2-ee38b.20).
+      frames.push(params);
     };
 
     // Fire `subscribe` and `dispatch` concurrently. subscribe blocks
@@ -261,6 +287,46 @@ runWithWatchdog(
     }
     console.log(
       'OK   every frame validates against ReFrame2PairProgressNotificationParams',
+    );
+
+    // ---- Operator-opt-in flag-gate WIRE conformance (rf2-ee38b.20) ----
+    //
+    // This server booted WITHOUT `--allow-eval` (see transportSpec
+    // above) AND has a live runtime attached — so it is NOT in degraded
+    // mode. That is the one configuration where pair-mcp's `eval-cljs`
+    // disabled-default gate is observable over the wire: the call reaches
+    // the tool body, the `--allow-eval` gate (default OFF) short-circuits
+    // BEFORE touching nREPL, and the canonical
+    // `:rf.error/eval-cljs-disabled` envelope crosses the wire. (In
+    // degraded mode the server's `degraded-handler` short-circuits every
+    // tool to `:nrepl-port-not-found` before the gate runs, so the
+    // disabled envelope is unreachable there — see end-to-end-flag-gates
+    // .cjs "Coverage boundary" for why the pair-mcp wire check lives
+    // here, not in the no-runtime degraded harness.) This pins the
+    // cross-MCP NAMING.md §"Operator-opt-in CLI flag vocabulary"
+    // contract: `--allow-eval` default OFF ⇒ documented refusal reason.
+    const evalResp = await client.callTool({
+      name: 'eval-cljs',
+      arguments: { form: '(+ 1 2)' },
+    });
+    if (!evalResp.isError) {
+      throw new Error(
+        'eval-cljs MUST isError when the server booted WITHOUT ' +
+          '--allow-eval (default-OFF gate per NAMING.md); got: ' +
+          JSON.stringify(evalResp).slice(0, 300),
+      );
+    }
+    const evalText = evalResp.content?.[0]?.text || '';
+    if (!evalText.includes(':rf.error/eval-cljs-disabled')) {
+      throw new Error(
+        'eval-cljs default-OFF envelope MUST carry ' +
+          ':rf.error/eval-cljs-disabled (NAMING.md flag-vocabulary ' +
+          'contract); got: ' + evalText.slice(0, 300),
+      );
+    }
+    console.log(
+      'OK   eval-cljs --allow-eval default-OFF -> isError + ' +
+        ':rf.error/eval-cljs-disabled (live, non-degraded)',
     );
 
     console.log('\nRE-FRAME2-PAIR-MCP LIVE SUBSCRIBE CONFORMANCE GREEN');

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -14,10 +14,11 @@ it was dropped per rf2-hvl1g — AI agent access to Causa state flows via
 A prior false-start drop was tracked under rf2-bu21t; rf2-hvl1g is the
 final close-out.)
 
-There are **five top-level wire markers** plus one embedded fetch-handle
-tag (`:rf.elision/at`, pinned inside the `:rf.size/large-elided` body's
-`:handle` slot — not a standalone marker an agent encounters at the top
-level of a payload):
+There are **six top-level wire markers** (the `canonical-markers` table
+in `wire_vocab_test.clj` is the source of truth) plus one embedded
+fetch-handle tag (`:rf.elision/at`, pinned inside the
+`:rf.size/large-elided` body's `:handle` slot — not a standalone marker
+an agent encounters at the top level of a payload):
 
 ```
 :rf.mcp/overflow       — token-budget overflow marker
@@ -25,6 +26,7 @@ level of a payload):
 :rf.mcp/dedup-table    — structural-dedup wrapper
 :rf.mcp/diff-from      — diff-encoded :db-after marker
 :rf.size/large-elided  — size-elision wire marker
+:rf.mcp/cache-hit      — per-session response-cache hit marker
 :rf.elision/at         — embedded fetch-handle tag inside the
                          :rf.size/large-elided body's :handle slot
                          (pinned via ElisionMarkerBody, not a

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -2,13 +2,16 @@
 ;; conformance test (rf2-j2z7o).
 ;;
 ;; A pure-JVM Clojure test that pins the **cross-server wire-marker
-;; vocabulary** shared by re-frame2-pair-mcp and story-mcp:
+;; vocabulary** shared by re-frame2-pair-mcp and story-mcp (the
+;; `canonical-markers` table in wire_vocab_test.clj is the source of
+;; truth — six top-level wrapper markers):
 ;;
 ;;   :rf.mcp/overflow      — token-budget overflow (mechanism 1)
 ;;   :rf.mcp/summary       — tree-summary lazy mode (mechanism 4)
 ;;   :rf.mcp/dedup-table   — structural dedup (mechanism 5)
 ;;   :rf.mcp/diff-from     — diff-encoded epochs
 ;;   :rf.size/large-elided — size-elision wire marker
+;;   :rf.mcp/cache-hit     — per-session response-cache hit marker
 ;;   :rf.elision/at        — size-elision fetch handle
 ;;
 ;; The test asserts a single canonical schema per marker, validates

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/fixtures.clj
@@ -107,6 +107,45 @@
   #{:re-frame2-pair-mcp :story-mcp})
 
 ;; ---------------------------------------------------------------------------
+;; story-mcp source-file inventory — single source of truth (rf2-ee38b.20).
+;;
+;; Several absence-tripwires across the three conformance test namespaces
+;; grep the same canonical set of story-mcp source files (the day story-mcp
+;; adopts a cross-MCP marker / envelope slot / near-miss slot name, the
+;; tripwire flips RED). The list was duplicated verbatim across
+;; `wire_vocab_test.clj` (two deftests) and `slot_name_test.clj` — exactly
+;; the drift the gates exist to prevent, reproduced inside the gate: a new
+;; story-mcp tool file added to one tripwire's list silently escaped the
+;; others. Centralised here so "the files story-mcp ships" has one home.
+;; ---------------------------------------------------------------------------
+
+(def story-mcp-tool-source-files
+  "The story-mcp `tools/*.cljc` source files — the per-category tool
+  handlers plus the registry/cap/helpers/schemas plumbing they share.
+  This is the surface the slot-name and indicator near-miss tripwires
+  grep (the slots live in the tool bodies, not the wire framing)."
+  ["tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
+   "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"])
+
+(def story-mcp-source-files
+  "Every story-mcp source file the cross-MCP-marker absence tripwires
+  grep — the tool handlers (`story-mcp-tool-source-files`) plus the
+  wire-framing `protocol.cljc` (which an overflow/elision adoption would
+  also plausibly touch). The wire-marker tripwires use this superset;
+  the slot-name / indicator near-miss tripwires use the tool-only subset
+  (`story-mcp-tool-source-files`) since the framing layer never names a
+  slot."
+  (into ["tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"]
+        story-mcp-tool-source-files))
+
+;; ---------------------------------------------------------------------------
 ;; Source-text helper. Conformance tests grep .cljs/.cljc/.md files for
 ;; canonical literals; some absence-pins want to distinguish *emissions*
 ;; from *documentation* (docstring mentions, comment references). This

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -85,20 +85,14 @@
   [:map {:closed false} [:elided-large pos-int?]])
 
 ;; ---------------------------------------------------------------------------
-;; Helper simulation. Mirror of
-;; `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs/with-indicators`.
-;; The CLJS implementation:
-;;
-;;   (defn with-indicators
-;;     [envelope {:keys [dropped elided]}]
-;;     (cond-> envelope
-;;       (pos? (or dropped 0)) (assoc :dropped-sensitive dropped)
-;;       (pos? (or elided  0)) (assoc :elided-large      elided)))
-;;
-;; The pure-Clojure reproduction below is byte-identical in semantics.
-;; If the CLJS helper drifts, the grep step (`helper-source-pin`) trips;
-;; if the contract drifts (e.g. someone changes "omit when zero" to
-;; "always include"), the fixture grid below trips.
+;; Helper simulation. Pure-Clojure mirror of
+;; `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs/with-indicators`
+;; — byte-identical in semantics (the two-arm omit-when-zero `cond->`).
+;; The canonical CLJS source is pinned verbatim by
+;; `helper-source-shape-matches-simulation` below (the grep step), so it
+;; isn't re-pasted here. If the CLJS helper drifts, that grep trips; if
+;; the contract drifts (e.g. "omit when zero" → "always include"), the
+;; fixture grid below trips.
 ;; ---------------------------------------------------------------------------
 
 (defn- with-indicators

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -356,17 +356,11 @@
                      "tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/elision.cljs"]
          ;; story-mcp's `:include-sensitive` parsing / schema lives in
          ;; `helpers.cljc` + `schemas.cljc` (no `sensitive.cljc` —
-         ;; that's re-frame2-pair-mcp's shape). The other entries below are the
-         ;; full tools/ surface, covered for near-miss-variant defence.
-         :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"]}]
+         ;; that's re-frame2-pair-mcp's shape). The canonical story-mcp
+         ;; tool-source inventory lives in `fixtures.clj` (rf2-ee38b.20)
+         ;; so a new tool file added in one tripwire's list can't escape
+         ;; the others.
+         :story-mcp fx/story-mcp-tool-source-files}]
     (doseq [{:keys [slot]}     canonical-slots
             variant            (near-miss-variants slot)
             [server files]     impl-sources-by-server

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -7,9 +7,11 @@
   server that adopts it. (causa-mcp was dropped in rf2-bu21t — causa
   now ships as a Clojars-only library, not an MCP server.)
 
-  Five top-level markers, plus the `:rf.elision/at` fetch-handle tag
-  (embedded inside the `:rf.size/large-elided` body's `:handle` slot —
-  not a standalone marker; pinned via the elision-marker body schema):
+  Six top-level wrapper markers (the `canonical-markers` table below is
+  the source of truth — see it rather than re-counting this list),
+  plus the `:rf.elision/at` fetch-handle tag (embedded inside the
+  `:rf.size/large-elided` body's `:handle` slot — not a standalone
+  marker; pinned via the elision-marker body schema):
 
   - `:rf.mcp/overflow`      — token-budget overflow marker
                               (re-frame2-pair-mcp `tools.cljs` `overflow-payload`)
@@ -29,6 +31,11 @@
   - `:rf.size/large-elided` — size-elision wire marker
                               (spec/Spec-Schemas §`:rf/elision-marker`,
                                re-frame2-pair-mcp Principles §\"Size-elision\")
+  - `:rf.mcp/cache-hit`     — per-session response-cache hit marker
+                              (re-frame2-pair-mcp `cache.cljs`
+                              `cache-hit-payload`; literal in
+                              `mcp-base/vocab.cljc` `cache-hit-key`,
+                              rf2-i3ffz F-GAP-4)
   - `:rf.elision/at`        — size-elision fetch-handle tag, embedded
                               inside the `:rf.size/large-elided` body's
                               `:handle` slot per `ElisionMarkerBody`
@@ -982,16 +989,7 @@
   ;; docstrings without inline-emitting either. Documentation is not
   ;; an emission — this tripwire fires only on bare-code occurrences
   ;; (rf2-xx42k).
-  (let [story-files ["tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"]]
+  (let [story-files fx/story-mcp-source-files]
     (doseq [{:keys [key]} canonical-markers
             rel           story-files]
       (testing (str "story-mcp source " rel " — " key " absence")
@@ -1118,16 +1116,7 @@
   ;; `run-variant`), both envelope slots MUST land together. This
   ;; tripwire flips RED on the FIRST adoption so the reviewer can't
   ;; merge half the parity.
-  (let [story-files ["tools/story-mcp/src/re_frame/story_mcp/protocol.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
-                     "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"]
+  (let [story-files fx/story-mcp-source-files
         slots       [":dropped-sensitive" ":elided-large"]]
     (doseq [rel  story-files
             slot slots]
@@ -1432,14 +1421,26 @@
 
 (def ^:private re-frame2-pair-progress-js-required-grep-markers
   "Substrings the JS `assertProgressParams` MUST contain to pin every
-  required field on `ReFrame2PairProgressNotificationParams`. Each entry is
-  `[malli-path js-substring]` — the path for error reporting, the
-  substring as the grep target. Mirrors the ReFrame2PairOverflowBody table above:
-  a field added to the Malli schema MUST add a row here; a field
-  removed MUST remove a row."
-  [[":progressToken"
-    "'progressToken',  (v) => v !== undefined,"]
-   [":progress : int"
+  JS-OBSERVABLE required field on `ReFrame2PairProgressNotificationParams`.
+  Each entry is `[malli-path js-substring]` — the path for error
+  reporting, the substring as the grep target. Mirrors the
+  ReFrame2PairOverflowBody table above: a JS-observable field added to
+  the Malli schema MUST add a row here; one removed MUST remove a row.
+
+  `:progressToken` is INTENTIONALLY ABSENT (rf2-ee38b.20 correctness
+  fix). The MCP SDK strips `progressToken` out of `notification.params`
+  before invoking the `onprogress` callback, so the JS-side
+  `assertProgressParams` literally cannot observe the slot — a grep pin
+  here would assert a JS check that can never fail (it would only ever
+  see a value the test injected). The Malli schema still REQUIRES
+  `:progressToken` (the WIRE carries it; the fixture test
+  `re-frame2-pair-progress-fixture-conforms` + the negative-shape
+  `dissoc :progressToken` test pin that JVM-side). The slot's wire
+  presence is asserted operationally by the SDK's own numeric-token
+  routing: a renamed / dropped token fails to correlate, zero frames
+  arrive, and the live harness's \"at least one frame\" gate trips. This
+  table pins only the slots the JS callback can actually inspect."
+  [[":progress : int"
     "'progress',       (v) => typeof v === 'number',"]
    [":message : string"
     "'message',        (v) => typeof v === 'string',"]


### PR DESCRIPTION
## Finding (3-lens review of `tools/mcp-conformance`, rf2-ee38b.20)

**P1 (completeness):** the operator-opt-in CLI flag vocabulary — `NAMING.md`'s authority-gate flags (every gate **default-OFF** + a **hard-rename, no-aliases** rule) — had **no conformance gate at all**. The claims were pinned only by each server's own unit fixtures; the cross-server, observable-over-the-wire contract was unenforced. A regression that renamed story-mcp's write gate to `--enable-writes`, or flipped a default to ON, would have passed every test in the artefact. Security-critical for a conformance tool.

Plus P2/P3 correctness + clarity + minimalism findings.

## Fix

**P1 — new flag-vocabulary conformance gate**
- `test/end-to-end-flag-gates.cjs` drives story-mcp's `--allow-writes` through the official MCP SDK client (the same path a real consumer takes):
  1. **default-OFF** — boot without the flag ⇒ `register-variant` returns `isError: true` + `structuredContent.gated === true`.
  2. **opt-in positive control** — boot with `--allow-writes` ⇒ succeeds (proves the canonical spelling is the one the parser wires).
  3. **hard-rename rejection** — boot with `--enable-writes` / `--allow-write` ⇒ gate stays closed (no back-compat alias).
- pair-mcp's `--allow-eval` default-OFF **wire** check added to `live-re-frame2-pair-subscribe.cjs` (the one boot config where pair-mcp's eval gate is observable: non-degraded, no `--allow-eval` ⇒ `:rf.error/eval-cljs-disabled` crosses the wire). **Coverage boundary documented:** in degraded mode every pair-mcp tool short-circuits to `:nrepl-port-not-found` before the gate runs, so the wire check needs a live runtime; the parser rename-rejection stays pinned unit-side (`raw_state_test.cljs`).
- `NAMING.md` flag table gains the `--allow-writes` row + a "Wire-level conformance" section pointing at both gates. Wired into the `npm test` orchestrator and a new CI step in the `mcp-conformance-story` job.

**P2 — correctness**
- **progressToken vacuous check** dropped from the JS `REQUIRED_PARAMS` + the cross-encoding grep table: the SDK strips `progressToken` before the `onprogress` callback, so a JS-side presence check could only ever observe a value the test injected. Correlation is asserted operationally (a renamed/dropped token fails the SDK's numeric routing ⇒ zero frames ⇒ the "at least one frame" gate trips). Malli schema keeps `:progressToken` (the wire carries it; pinned JVM-side).
- **Read-path success envelopes** now observed: story-mcp closed-world `list-substrates` / `list-modes` / `list-tags` walked + asserted `isError:false` + JSON-object `structuredContent` (the harness previously asserted only error shapes on the read side).

**P3**
- `structuredContent` shape check tightened to reject arrays (`typeof []==='object'` admitted vectors).
- `register-variant` pinned to the single canonical `registered?` key (was a tolerant `registered || registered?` alternation masking drift).
- Collapsed the triple-encoded helper comment in `indicator_field_test.clj`.

**Clarity / minimalism**
- Stale marker count "five" ⇒ "six" (+ `:rf.mcp/cache-hit`) across `wire-vocab/README.md` / `deps.edn` / ns-docstring; "19"-tool prose ⇒ count-free, fixture-sourced phrasing.
- Hoisted the duplicated story-files literal into `fixtures.clj` (`story-mcp-source-files` + `story-mcp-tool-source-files`); rewired the three tripwires across `wire_vocab_test.clj` + `slot_name_test.clj`.

## Skipped (judgment, explained)
- **story-mcp overflow/token-cap counterpart** — story-mcp has no wire-boundary cap yet ("normative, enforcement pending"); nothing to pin at the wire today.
- **causa-mcp narrative / bead-id "conflict"** — `rf2-bu21t` (directory removal) and `rf2-hvl1g` (final close-out) are two real sequential events, and `wire-vocab/README.md` already documents the relationship; rewriting ~10 narration sites is disproportionate churn for a P3.

## Cross-cutting (filed for mayor)
- **rf2-vyacl (P2 bug):** story-mcp `get-story-instructions` declares `:outputSchema` but returns text-only — the MCP SDK's high-level `callTool` rejects it with `-32600`. Surfaced by the read-path broadening (the tool was never SDK-driven before). The conformance harness deliberately skips it pending that fix.

## Gates (clean local runs, blocking)
- **wire-vocab JVM** (`clojure -M:test` under `wire-vocab/`): **41 tests, 474 assertions, 0 failures, 0 errors.**
- **Node orchestrator** (`npm test`): **ALL CONFORMANCE TESTS GREEN** — exec-safety, re-frame2-pair e2e, story e2e (incl. new read-path), and the new flag-gate probes all OK; live-overflow / live-subscribe SKIP without an nREPL port (expected hermetic posture).
- pair-mcp + story-mcp e2e run against real compiled/booted servers. The live hermetic path was blocked locally by a stale 2-day-old process holding port 8030 (not my code; fixture compiled cleanly in 13s) — it runs on CI's clean ephemeral runtime.

Closes rf2-ee38b.20.