### PR TITLE
fix(skills): re-frame2-setup — reconcile manual recipe to tools/template

### DIFF
--- a/skills/re-frame2-setup/README.md
+++ b/skills/re-frame2-setup/README.md
@@ -1,6 +1,6 @@
 # re-frame2-setup
 
-> ↑ [`skills/`](../) — index of all six re-frame2 skills.
+> ↑ [`skills/`](../) — index of all re-frame2 skills.
 
 A `Skill` that helps `Claude Code` **scaffold a fresh [re-frame2](https://github.com/day8/re-frame2) ClojureScript project** — from an empty directory to a working, mounted counter.
 
@@ -41,7 +41,7 @@ The canonical seven-step greenfield path:
 1. Discover the current re-frame2 VERSION (the eleven artefacts ship in lockstep; Causa rides the same line).
 2. Add the day-one deps to `deps.edn` — `day8/re-frame2` + `day8/re-frame2-reagent` + `day8/re-frame2-schemas` + `day8/re-frame2-causa`, plus an explicit `reagent/reagent`.
 3. Add `react`, `react-dom`, `shadow-cljs` to `package.json`. Run `npm install`.
-4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app (with the Causa `:devtools/preloads` wiring), plus `public/index.html` carrying the `[data-rf-causa-host]` column.
+4. Write a minimal `shadow-cljs.edn` for a single-page Reagent app (with the Causa `:devtools/preloads` wiring), plus `resources/public/index.html` carrying the `[data-rf-causa-host]` column.
 5. Write the entry namespace — `(rf/init! reagent-adapter/adapter)`, the Reagent root, `(defn ^:export init [] ...)`.
 6. Write the first counter — registered event, registered sub, `reg-view`-defined view, mount.
 7. Run `shadow-cljs watch app`. Visit the dev server. Click the buttons. Done.

--- a/skills/re-frame2-setup/references/deps-versions.md
+++ b/skills/re-frame2-setup/references/deps-versions.md
@@ -27,7 +27,7 @@ Picking a re-frame2 VERSION for your project means picking it once and using it 
 | `day8/re-frame2-reagent` | substrate | **Always (for a Reagent app).** The Reagent adapter map. |
 | `day8/re-frame2-uix` | substrate | Instead of `-reagent` if you target UIx. |
 | `day8/re-frame2-helix` | substrate | Instead of `-reagent` if you target Helix. |
-| `day8/re-frame2-schemas` | per-feature | **Day one** (the template attaches a whole-app-db schema). Required whenever you call `reg-app-schema` / `reg-event-schema`; without it CLJS schema validation soft-passes per Spec 010. |
+| `day8/re-frame2-schemas` | per-feature | **Day one** (the template attaches a whole-app-db schema). Required whenever you call `reg-app-schema` / `reg-app-schemas`; without it CLJS schema validation soft-passes per Spec 010. |
 | `day8/re-frame2-machines` | per-feature | When you call `reg-machine` or `make-machine-handler`. |
 | `day8/re-frame2-routing` | per-feature | When you dispatch `:rf.route/*` events or register routes. |
 | `day8/re-frame2-flows` | per-feature | When you call `reg-flow`. |
@@ -35,7 +35,7 @@ Picking a re-frame2 VERSION for your project means picking it once and using it 
 | `day8/re-frame2-ssr` | per-feature | When you call `render-to-string` server-side. |
 | `day8/re-frame2-epoch` | per-feature | When you call `epoch-history` or `restore-epoch` (also pulled in transitively by `re-frame2-pair`). |
 
-The eleven above are the **publishable** lockstep set. Two more local roots ride the same version but sit outside the publishable count: `day8/reagent-slim` (an alternate slim Reagent substrate) and `day8/re-frame2-ssr-ring` (a Ring adaptor over `-ssr`) — niche, not part of greenfield. Separately, the in-app devtools panel `day8/re-frame2-causa` ships on the same version line and is a **day-one** dep in the template (see the day-one shape below); it is tooling, not one of the eleven library artefacts.
+These eleven are the **publishable** lockstep set. (Two niche local roots — `day8/reagent-slim` and `day8/re-frame2-ssr-ring` — ride the same version but aren't part of greenfield.) Separately, the in-app devtools panel `day8/re-frame2-causa` ships on the same version line and is a **day-one** dep in the template (see the day-one shape below); it is tooling, not one of the eleven library artefacts.
 
 **Greenfield day-one shape.** This skill matches the [deps-new generator template](../README.md#relationship-to-the-generator-template) so the manual route and the one-command route land on the same scaffold. The template ships **four** re-frame2 coords on day one — core + the Reagent adapter, plus `day8/re-frame2-schemas` (the starter app attaches a whole-app-db schema; without this artefact CLJS soft-passes per Spec 010) and `day8/re-frame2-causa` (the in-app devtools panel, wired via `:devtools/preloads` and Causa-priority by default) — plus an explicit `reagent/reagent` pin.
 
@@ -52,6 +52,8 @@ For the author's reference (so they can pick), three sources, in order of author
 3. **The GitHub releases page** — `https://github.com/day8/re-frame2/releases` shows the tags. The latest tag is `v<VERSION>`.
 
 For the bleeding edge (e.g. chasing a fix that hasn't released yet), the author can use a `:git/url` + `:git/sha` coord instead of `:mvn/version`. Niche; the skill takes the SHA from the author and writes it in — it does not pick.
+
+(The generator template ships a **pinned baseline** — it hardcodes `:rf2-version`, `:shadow-version`, and `:react-version` in its `hooks.clj` so the one-command route hands you a known-good set with no discovery step. The version-discovery discipline above applies to the **manual** route and to later upgrades; the template route gives you a fixed pin you can bump.)
 
 **Never invent a version. Never silently pick `latest`.** Both are accidents the policy exists to prevent. If the author hasn't supplied a VERSION, stop and ask before editing any dep file.
 
@@ -85,17 +87,23 @@ re-frame2 itself ships no npm code — but Reagent depends on React, and shadow-
 ```json
 {
   "name": "your-app",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "watch":   "shadow-cljs watch app",
+    "release": "shadow-cljs release app"
+  },
   "devDependencies": {
-    "shadow-cljs": "<from pinned implementation/package.json>",
-    "react":       "<from pinned implementation/package.json>",
-    "react-dom":   "<from pinned implementation/package.json>"
+    "shadow-cljs": "<from pinned implementation/package.json>"
+  },
+  "dependencies": {
+    "react":     "<from pinned implementation/package.json>",
+    "react-dom": "<from pinned implementation/package.json>"
   }
 }
 ```
 
-Read `<path-to-re-frame2>/implementation/package.json` (verified pinned checkout — see [`../SKILL.md`](../SKILL.md) cardinal rule 1) and copy the `shadow-cljs` / `react` / `react-dom` versions verbatim. This is the **default path** and the safer baseline; pinning what the framework itself builds against avoids surprise breakage and silent exposure to newly published packages.
+`shadow-cljs` is a build-only tool, so it lives in `devDependencies`. `react` / `react-dom` are runtime dependencies of the shipped app (Reagent renders against them), so they live in `dependencies` — this matches the generator template's `package.json`. Read `<path-to-re-frame2>/implementation/package.json` (verified pinned checkout — see [`../SKILL.md`](../SKILL.md) cardinal rule 1) and copy the `shadow-cljs` / `react` / `react-dom` versions verbatim. This is the **default path** and the safer baseline; pinning what the framework itself builds against avoids surprise breakage and silent exposure to newly published packages.
 
 **Latest-from-npm is opt-in only.** If the author explicitly asks for the newest versions, run `npm view shadow-cljs version` / `npm view react version` / `npm view react-dom version` and **show the result for confirmation before writing it into `package.json`**. Do not auto-substitute. Reagent 2.x requires React 19; flag any pick below 19 as a conflict and stop.
 

--- a/skills/re-frame2-setup/references/entry-namespace.md
+++ b/skills/re-frame2-setup/references/entry-namespace.md
@@ -101,12 +101,30 @@ src/your_app/
 
 then `(:require [your-app.events] [your-app.subs] [your-app.views :as views])` in `core.cljs` so the registrations happen at load time. Use `[views/root-view]` in `rdc/render`. The folder shape is a convention; re-frame2 has no opinion about it.
 
+When you split this way, the `[re-frame.views]` require **and** the `(:require-macros [re-frame.core :refer [reg-view]])` move into `views.cljs` (they belong wherever the `reg-view` forms live, not in `core.cljs`). This matches the template, whose `core.cljs` requires neither — only the side-effecting `[your-app.views :as views]` — while `views.cljs` carries `[re-frame.views]` + the `reg-view` macro-require. The single-file counter in `first-counter.md` keeps all three in `core.cljs` because the views live there.
+
 ## UIx / Helix greenfield
 
 This skill scaffolds against **Reagent** (the default reference substrate). For a UIx or Helix greenfield app the wiring is the same shape with three substitutions:
 
 - **deps.edn** — swap `day8/re-frame2-reagent` for `day8/re-frame2-uix` (or `-helix`), and swap the substrate npm/Maven deps: UIx uses `com.pitch/uix.core` + `com.pitch/uix.dom`; Helix uses `lilactown/helix`. (Drop the `reagent/reagent` pin.)
-- **entry ns** — require `[re-frame.adapter.uix :as uix-adapter]` (or `re-frame.adapter.helix`), pass `uix-adapter/adapter` to `rf/init!`, and mount with the substrate's own root API (`uix.dom/create-root` + `render-root` for UIx) instead of `reagent.dom.client`.
+- **entry ns** — require `[re-frame.adapter.uix :as uix-adapter]` (or `re-frame.adapter.helix`), pass `uix-adapter/adapter` to `rf/init!`, and mount with the substrate's own root API instead of `reagent.dom.client`. For UIx that's `uix.dom/create-root` + `uix.dom/render-root`, and the view must be wrapped in the `$` element macro from `uix.core`:
+  ```clojure
+  (ns your-app.core
+    (:require [uix.core             :refer [$]]
+              [uix.dom              :as uix-dom]
+              [re-frame.core        :as rf]
+              [re-frame.adapter.uix :as uix-adapter]
+              [your-app.views       :as views]))
+
+  (defonce root (uix-dom/create-root (js/document.getElementById "app")))
+
+  (defn ^:export init []
+    (rf/init! uix-adapter/adapter)
+    (rf/dispatch-sync [:counter/initialise])
+    (uix-dom/render-root ($ views/counter-app) root))
+  ```
+  (Helix uses `(.render root ($ views/counter-app))` against a `react-dom/client` root, with `$` from `helix.core` — see the template's `_helix/core.cljs`.)
 - everything else (events, subs, schemas, Causa wiring, `dispatch-sync` seed, `:init-fn ...core/init`) is identical across substrates.
 
 The fastest path for a non-Reagent greenfield is the **generator template**, which ships complete `_uix/` and `_helix/` variants — invoke `clojure -Tnew create :template io.github.day8/re-frame2-template :name acme/my-app :substrate :uix` (or `:helix`) and you get a working UIx/Helix counter without hand-wiring the substitutions above. See [the generator-template section](../README.md#relationship-to-the-generator-template).

--- a/skills/re-frame2-setup/references/first-counter.md
+++ b/skills/re-frame2-setup/references/first-counter.md
@@ -108,7 +108,7 @@ shadow-cljs watch app
 
 Wait for the compile to land. The terminal prints something like `[:app] Build completed.`
 
-Visit `http://localhost:8020/` (or whatever `:http-port` you set in `shadow-cljs.edn`).
+Visit `http://localhost:8280/` (the template's port — or whatever you set in `:dev-http` in `shadow-cljs.edn`).
 
 You should see:
 
@@ -118,17 +118,24 @@ You should see:
 
 Click `+` — the number becomes `1`. Click `-` — back to `0`. Refresh the page — back to `0` (state lives in app-db, which resets on full reload).
 
+First-run failures, in roughly the order you'll hit them:
+- **`shadow-cljs: command not found` / `Cannot find module`** — `npm install` hasn't run (or you ran `npx shadow-cljs` before installing). Run `npm install`, then retry `npx shadow-cljs watch app`.
+- **Page loads but the browser console shows `main.js` 404 (`GET /js/main.js 404`)** — `:output-dir`, `:asset-path`, and `index.html`'s `<script src>` disagree. The template serves `resources/public` with `:output-dir "resources/public/js"` + `:asset-path "/js"` + `<script src="/js/main.js">`; if you changed any one, change the others to match.
+- **Blank page, no console errors** — `index.html` is missing `<main id="app">`, or the entry ns looks up a different id than `index.html` declares.
+
 If you see a blank page, open the browser console. Most failures land there with a clear error:
 - `Cannot read property 'getElementById' of undefined` — script ran before DOM was ready; check `index.html` loads `main.js` at the *bottom* of `<body>`.
 - `Could not find frame :rf/default` — `rf/init!` didn't run before render. Check `init` is the `:init-fn` shadow-cljs is calling.
 - `No subscription handler registered for: :count` — registrations didn't run. If you split into multiple namespaces, make sure `core.cljs` `:require`s them so they load.
+
+**No schema errors? That's expected.** This counter attaches no app-db schema, so even with `day8/re-frame2-schemas` on the classpath there's nothing to validate — CLJS soft-passes (Spec 010). Validation only fires once you `reg-app-schema` a schema; until then the absence of errors means "no schema attached," not "validation ran and passed."
 
 ## What to do next
 
 **Setup is done.** From here, **switch skills**:
 
 - **Writing more code (events, subs, machines, schemas, frames, fx, flows, routing, SSR)** — load the **`re-frame2`** skill. It covers the API surface in modular files; you can load just the pieces relevant to what you're building.
-- **Inspecting the running app live from the REPL** — install the **`re-frame2-pair`** skill. It attaches over nREPL, lets you walk app-db, dispatch from the REPL, hot-swap handlers, time-travel through epoch history. nREPL is a remote-evaluation surface: keep it dev-only and bound to localhost (shadow-cljs's default). Never expose the nREPL port on `0.0.0.0` or a shared / public interface — anything that can connect can evaluate arbitrary code in the running JVM.
+- **Inspecting the running app live from the REPL** — install the **`re-frame2-pair`** skill. It attaches over nREPL, lets you walk app-db, dispatch from the REPL, hot-swap handlers, time-travel through epoch history. nREPL stays dev-only and bound to localhost — see SKILL.md cardinal rule 6.
 
 Both skills are independent of this one and can be loaded individually.
 

--- a/skills/re-frame2-setup/references/shadow-cljs.md
+++ b/skills/re-frame2-setup/references/shadow-cljs.md
@@ -16,99 +16,105 @@ The minimal `shadow-cljs.edn` build for a greenfield re-frame2 Reagent single-pa
 ## Minimal `shadow-cljs.edn`
 
 ```clojure
-{:source-paths ["src"]
+{:deps   {:aliases [:shadow]}           ;; pull classpath from deps.edn's :shadow alias
+ :source-paths ["src"]
 
- :dependencies []                       ;; deps come from deps.edn
+ :dev-http {8280 "resources/public"}    ;; dev server: serve resources/public on :8280
 
  :builds
  {:app
   {:target     :browser
-   :output-dir "public/js"
+   :output-dir "resources/public/js"
    :asset-path "/js"
    :modules    {:main {:init-fn your-app.core/init}}}}}
 ```
 
-The smallest greenfield build entry. Three things matter for re-frame2:
+The greenfield build entry, matching the generator template. Four things matter for re-frame2:
 
-1. **`:dependencies []`.** shadow-cljs reads `deps.edn` automatically. Don't duplicate the `day8/re-frame2-*` coordinates here; that's where they'd shadow each other if their VERSION ever drifted.
-2. **`:init-fn your-app.core/init`.** shadow-cljs calls this symbol at bundle-init time. The function must be exported (`(defn ^:export init [] ...)`). This is the entry point that calls `(rf/init! reagent-adapter/adapter)` — see `entry-namespace.md`. (`init` matches the generator template; the symbol name is yours to choose, as long as `:init-fn` points at it.)
-3. **One module.** A single-page re-frame2 app needs exactly one `:modules` entry. Code-splitting is possible later but not part of greenfield.
+1. **`:deps {:aliases [:shadow]}`.** shadow-cljs reads the classpath from `deps.edn` via the `:shadow` alias — don't duplicate the `day8/re-frame2-*` coordinates here. The alias is where the JVM-side build deps live: it supplies `thheller/shadow-cljs` + `org.clojure/tools.namespace` and `:extra-paths ["test" "dev"]`. The template defines it in `deps.edn`:
+   ```clojure
+   :aliases
+   {:shadow
+    {:extra-paths ["test" "dev"]
+     :extra-deps  {thheller/shadow-cljs        {:mvn/version "<shadow-version>"}
+                   org.clojure/tools.namespace {:mvn/version "1.5.0"}}
+     :main-opts   ["-m" "shadow.cljs.devtools.cli"]}}
+   ```
+2. **`:dev-http {8280 "resources/public"}`.** The top-level dev-server form (current shadow-cljs idiom). It serves `resources/public/` on port `8280` — `index.html` lives at `resources/public/index.html`. The template uses `8280`; reuse it so a teammate on the template route sees the same number.
+3. **`:init-fn your-app.core/init`.** shadow-cljs calls this symbol at bundle-init time. The function must be exported (`(defn ^:export init [] ...)`). This is the entry point that calls `(rf/init! reagent-adapter/adapter)` — see `entry-namespace.md`. (`init` matches the generator template; the symbol name is yours to choose, as long as `:init-fn` points at it — see `entry-namespace.md`.)
+4. **One module.** A single-page re-frame2 app needs exactly one `:modules` entry. Code-splitting is possible later but not part of greenfield.
 
-Substitute `your-app.core/init` with whatever your entry namespace + entry symbol actually is. If you call your namespace `myapp.core` and your entry fn `start`, this becomes `:init-fn myapp.core/start`.
+The template also ships a second `:test {:target :node-test ...}` build under `:builds` (for `cljs.test` runners) and `:source-paths ["src" "test" "dev"]`. That test build is out of scope for this skill (it stops at "the counter mounts"), but it's there in the scaffold — don't be surprised comparing the two.
 
 The build id (`:app` above) is the name you give the build for `shadow-cljs watch <build-id>`. Use anything that reads naturally; `:app` is convention.
 
 ## The `index.html` that loads the bundle
 
-A re-frame2 app needs an HTML page that loads the compiled JS and has a mount point. Drop this at `public/index.html`:
+A re-frame2 app needs an HTML page that loads the compiled JS and has a mount point. Drop this at `resources/public/index.html` (matching `:dev-http`'s serve root), with the styles in an external `resources/public/css/app.css`:
 
 ```html
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>your-app</title>
-  <style>
-    :root { --rf-causa-accent: #7C5CFF; } /* brand-accent var — host stylesheets read var(--rf-causa-accent) to tint dev chrome */
-    body { margin: 0; }
-    .app-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] {
-      flex: 0 0 var(--rf-causa-inline-width, 560px);
-      min-width: 320px;
-      box-sizing: border-box;            /* the border lives inside the
-                                            documented width */
-      border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
-    }
-    #app { flex: 1; min-width: 0; }
-    /* Resize from anywhere up the cascade: */
-    /*   :root { --rf-causa-inline-width: 720px; } */
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Strict default-safe CSP: same-origin JS/CSS only, no inline
+       script/style. The template ships this; serve the same policy
+       via a response header in production. -->
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
+  <title>your-app — re-frame2</title>
+  <link rel="stylesheet" href="/css/app.css">
 </head>
 <body>
-  <div class="app-shell">
+  <div class="rf2-app-shell">
+    <aside class="rf2-causa-host" data-rf-causa-host></aside>
     <main id="app"></main>
-    <aside data-rf-causa-host></aside>
   </div>
   <script src="/js/main.js"></script>
 </body>
 </html>
 ```
 
-Four contractual bits:
+`resources/public/css/app.css` (the minimal layout — three rules carry the host-column contract):
+
+```css
+body { font: 16px/1.4 system-ui, sans-serif; margin: 0; }
+.rf2-app-shell { display: flex; min-height: 100vh; }
+.rf2-causa-host { flex: 0 0 420px; min-width: 320px; }
+#app { flex: 1; min-width: 0; padding: 2em; }
+```
+
+Five contractual bits:
 
 - **`<main id="app"></main>`** — the app mount point. Whatever id you use here, the entry ns must call `(js/document.getElementById "<same-id>")`. By convention it's `"app"`.
-- **`<aside data-rf-causa-host></aside>`** — Causa's default true-inline devtools host. Keep it as a right-side layout column beside `#app` when you enable `day8.re-frame2-causa.preload` (DOM order: `<main>` first, `<aside>` second — flex flow puts the aside on the right); otherwise Causa logs an actionable missing-host diagnostic and exposes the same status through `window.day8.re_frame2_causa.status()`.
-- **`.app-shell` flex CSS** — the host app owns sizing and layout. The minimal contract is a right column (`flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0; }`). Two complementary resize mechanisms ship together: (1) **CSS variable** — override `--rf-causa-inline-width` anywhere up the cascade (e.g. `:root { --rf-causa-inline-width: 720px; }`) to set the initial width (host-owned; default is 560px); (2) **Causa drag handle** — auto-injected by Causa (see `spec/007-UX-IA.md` §Resize affordance) on the panel's outer edge, persisted across reloads via `configure! :settings :general :panel-width-px`, double-click to reset. No `resize: horizontal` / `overflow: auto` on the host — Causa owns the handle, the consumer's CSS surface stays minimal. A consumer that prefers the browser-native handle opts out by setting `resize: horizontal` on the host (yield-to-consumer detection). The snippet also publishes `--rf-causa-accent` (default `#7C5CFF`) on `:root` so host stylesheets can colour their own dev chrome to match Causa.
-- **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows.
-- **`/js/main.js` is an absolute path from site root.** That's correct for shadow-cljs's dev server.
+- **`<aside class="rf2-causa-host" data-rf-causa-host></aside>`** — Causa's default true-inline devtools host, the **left** layout column beside `#app`. Order it **first** in the DOM (`<aside>` then `<main>`) so flex flow places Causa on the left, matching the template. When `day8.re-frame2-causa.preload` is enabled Causa auto-opens into this host; if it's missing, Causa logs an actionable diagnostic, also reachable via `window.day8.re_frame2_causa.status()`.
+- **`.rf2-causa-host` flex CSS** — the host app owns sizing. The contract is a fixed-width column (`flex: 0 0 420px; min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0 }`). Causa injects its own drag handle on the panel's outer edge (persisted across reloads, double-click to reset), so the consumer's CSS stays this minimal. To change the default width, edit `flex-basis` here; the full resize-affordance / theming surface is the `re-frame2-causa` skill's territory, not greenfield's.
+- **CSP + external stylesheet.** The CSP meta tag declares `style-src 'self'`, which blocks inline `<style>`/`style=` attributes — so styles live in `css/app.css`, not inline. Keep them out of the HTML to stay CSP-clean (and matching the template).
+- **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows. The absolute path from site root is correct for shadow-cljs's dev server.
 
 ## `:devtools` block (hot-reload + Causa)
 
-Add `:devtools` to enable shadow-cljs's hot-reload + dev server, and to load the Causa devtools panel — both wired by default in the generator template:
+The top-level `:dev-http` (above) already starts the dev server. Add a `:devtools` block per build for hot-reload + the Causa devtools panel — both wired this way in the generator template:
 
 ```clojure
 :builds
 {:app
  {:target     :browser
-  :output-dir "public/js"
+  :output-dir "resources/public/js"
   :asset-path "/js"
   :modules    {:main {:init-fn your-app.core/init}}
-  :devtools   {:http-port 8020
-               :http-root "public"
-               :watch-dir "public"
-               :after-load your-app.core/init
+  :devtools   {:after-load your-app.core/init
                :preloads   [day8.re-frame2-causa.preload]}}}
 ```
 
-- `:http-port` — port the dev server listens on. `8020` is convention; pick anything free.
-- `:http-root "public"` — the dev server serves files from this directory. Your `index.html` lives at `public/index.html`.
-- `:watch-dir "public"` — shadow-cljs reloads the browser when any file under here changes (including the compiled `main.js`).
-- `:after-load your-app.core/init` — re-run the entry fn after each hot reload so the freshly-loaded code re-installs the adapter and re-renders.
+- `:after-load your-app.core/init` — re-run the entry fn after each hot reload so the freshly-loaded code re-installs the adapter and re-renders. **Note:** if `init` also runs `(rf/dispatch-sync [:your-app/initialise])` (the seed event — see `entry-namespace.md`), `:after-load` re-runs that seed on **every** hot reload, resetting `app-db` to its initial state each save. For a counter that means the count jumps back to 0 on every reload. If preserving in-progress state across reloads matters, point `:after-load` at a separate fn that re-renders **without** re-seeding (calls `rdc/render` but not `dispatch-sync`).
 - `:preloads [day8.re-frame2-causa.preload]` — loads the Causa in-app devtools panel in dev/watch builds. `:preloads` (and the whole `:devtools` block) are cut from `release` builds automatically, so Causa never ships to production.
+- The dev server itself comes from the top-level `:dev-http {8280 "resources/public"}` (not from a `:http-port`/`:http-root` inside `:devtools` — that's the older style; the template uses the top-level `:dev-http` form).
 
-With this block in place, `shadow-cljs watch app` starts the dev server. Visit `http://localhost:8020/` and the browser auto-refreshes on every recompile.
+With this block in place, `shadow-cljs watch app` starts the dev server. Visit `http://localhost:8280/` and the browser auto-refreshes on every recompile.
 
-re-frame2's *core* does not need a preload for hot-reload — shadow-cljs's default behaviour is enough. **Causa is the one default preload:** because Causa is a day-one dep (see `deps-versions.md`), the template wires `day8.re-frame2-causa.preload` here, and the page must provide the `[data-rf-causa-host]` layout column shown above. The Causa preload registers listeners/keybindings and auto-opens into that app-provided host after `rf/init!` installs the substrate adapter; there is no lazy/manual-only launch step. If you genuinely want a Causa-free build, drop the `:preloads` entry and the `day8/re-frame2-causa` dep together.
+re-frame2's *core* does not need a preload for hot-reload — shadow-cljs's default behaviour is enough. **Causa is the one default preload:** because Causa is a day-one dep (see `deps-versions.md`), the template wires `day8.re-frame2-causa.preload` here. It auto-opens into the `[data-rf-causa-host]` column from the `index.html` above after `rf/init!` installs the substrate adapter (there is no lazy/manual-only launch step). If you genuinely want a Causa-free build, drop the `:preloads` entry and the `day8/re-frame2-causa` dep together.
 
 ## Production build (`release`)
 
@@ -128,7 +134,7 @@ If you want to pin the port explicitly (e.g. for editor integrations), add a top
 
 A few things you might pull in by reflex from other CLJS framework setups that re-frame2 specifically does not require:
 
-- **No *framework* preload required** — re-frame2's core has no preload analogue to re-frame v1. The one default preload is Causa's devtools (`day8.re-frame2-causa.preload`, wired in `:devtools/preloads`); its default surface is the `[data-rf-causa-host]` true-inline panel on app load. Overlay/body-padding chrome is optional debug tooling, not the default, and pop-out remains available from the mounted panel.
-- **No `:closure-defines`** for re-frame2 itself in dev. The single exception is opting into the performance-API instrumentation (Spec 009 §Performance instrumentation) — set `re-frame.performance/enabled? true` only if the author asks for it explicitly. Default dev is fine.
+- **No *framework* preload required** — re-frame2's core has no preload analogue to re-frame v1. The one default preload is Causa's devtools (`day8.re-frame2-causa.preload`, wired in `:devtools/preloads` — see the `index.html` section above for the host column it opens into).
+- **No `:closure-defines`** for re-frame2 itself in dev. The single exception is opting into the performance-API instrumentation (Spec 009 §Performance instrumentation) — add `:compiler-options {:closure-defines {re-frame.performance/enabled? true}}` to the build only if the author asks for it explicitly. Default dev is fine.
 - **No special compiler options** for dev. `{:compiler-options {:warnings {...}}}` is up to the author.
 - **No SSR build entry** unless the author wants SSR. SSR is opt-in via `day8/re-frame2-ssr` (separate per-feature artefact); the SSR build is a separate `:target :node-script` (or `:target :browser` running in a static-render harness). Out of scope for greenfield.


### PR DESCRIPTION
Remediates **rf2-ee38b.32** (consolidated 3-lens review of `skills/re-frame2-setup`). The skill's central "manual setup lands on the same shape as the generator template" promise was broken in many concrete, user-visible ways. Every divergence was re-verified against the **current** `tools/template/` output (post its own remediation merge).

## Correctness / completeness (reconcile to template)
- **package.json** — `react`/`react-dom` moved to runtime `dependencies`; `shadow-cljs` stays in `devDependencies`.
- **Dev server** — top-level `:dev-http {8280 "resources/public"}` on port **8280** (was `8020` via `:devtools` `:http-root`/`:watch-dir`).
- **index.html** — aside-first DOM order (Causa = **left** column), external `css/app.css` + `.rf2-app-shell`/`.rf2-causa-host` classes + CSP meta; dropped the inline `<style>` (the template CSP `style-src 'self'` blocks it).
- **shadow-cljs.edn** — `:deps {:aliases [:shadow]}` wiring, `resources/public/js` output dir, leaner `:devtools {:after-load … :preloads …}`, noted the `:test` node-test build.
- **UIx mount API** — `(uix-dom/render-root ($ views/counter-app) root)` with `[uix.core :refer [$]]`; added the Helix `$`/`.render` note.
- Dropped non-existent **`reg-event-schema`** → `reg-app-schema` / `reg-app-schemas`.
- Added missing **first-run pitfalls**: missing `npm install`, output-dir/script-src 404, CSP + external stylesheet, schema soft-pass.
- Flagged **`:after-load init` re-seed** clobbering app-db on hot reload.
- `re-frame.views` + `reg-view` macro-require move with views into `views.cljs` for the split case.
- Noted the template ships a **hardcoded version pin**.

## Clarity / minimalism
- Deduped the Causa layout-host contract within `shadow-cljs.md`; trimmed the ~20-line rambling resize-affordance bullet.
- Fixed README **"six skills"** breadcrumb → version-agnostic.
- Trimmed nREPL repetition in `first-counter.md`; tightened the lockstep-artefacts aside.

## Deferred for the final shared bead
Cross-skill-shared dedup — the lockstep-preamble / nREPL-localhost warning / init-vs-run caveat that recur across **sibling** skills — left for the consolidated shared-content bead.

## Gate
- `python scripts/check_doc_slugs.py` → pass.
- No broken links; corrected an inaccurate `spec/007-UX-IA.md` prose citation (the file lives under `tools/causa/spec/`) by pointing at the `re-frame2-causa` skill instead.
- All leaves remain under the 250 L / 16 KB ceiling.

Closes rf2-ee38b.32.