### PR TITLE
fix(template): reconcile Causa/schema spec drift + strengthen tests (rf2-ee38b.23)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/deps.edn
@@ -43,4 +43,14 @@
   ;; .cljfmt.edn.
   :cljfmt
   {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.13.1"}}
-   :main-opts  ["-m" "cljfmt.main"]}}}
+   :main-opts  ["-m" "cljfmt.main"]}
+
+  ;; clj-kondo — `clojure -M:clj-kondo --lint src test`. Runs the linter
+  ;; via the JVM dep so no native `clj-kondo` binary install is needed
+  ;; (parity with the :cljfmt alias above). lefthook + CI invoke this
+  ;; alias. If you prefer the faster native binary, install it per
+  ;; https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md
+  ;; and point lefthook.yml's clj-kondo hook at the bare `clj-kondo`.
+  :clj-kondo
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
+   :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/tools/template/resources/day8/re_frame2_template/_helix/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_helix/shadow-cljs.edn
@@ -16,11 +16,12 @@
    :output-dir "resources/public/js"
    :asset-path "/js"
    :modules    {:main {:init-fn {{namespace}}.core/init}}
+   ;; shadow's :browser target re-runs the module :init-fn after each
+   ;; hot reload by default — no :after-load hook needed.
    ;; :devtools/preloads loads Causa into the [data-rf-causa-host]
    ;; left layout column in dev watch/compile builds. Skipped under
    ;; :release.
-   :devtools   {:after-load {{namespace}}.core/init
-                :preloads   [day8.re-frame2-causa.preload]}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
   :test
   {:target    :node-test

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps.edn
@@ -43,4 +43,14 @@
   ;; .cljfmt.edn. Pinned to the current cljfmt CLI line.
   :cljfmt
   {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.13.1"}}
-   :main-opts  ["-m" "cljfmt.main"]}}}
+   :main-opts  ["-m" "cljfmt.main"]}
+
+  ;; clj-kondo — `clojure -M:clj-kondo --lint src test`. Runs the linter
+  ;; via the JVM dep so no native `clj-kondo` binary install is needed
+  ;; (parity with the :cljfmt alias above). lefthook + CI invoke this
+  ;; alias. If you prefer the faster native binary, install it per
+  ;; https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md
+  ;; and point lefthook.yml's clj-kondo hook at the bare `clj-kondo`.
+  :clj-kondo
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
+   :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/deps_with_story.edn
@@ -50,4 +50,14 @@
   ;; .cljfmt.edn. Pinned to the current cljfmt CLI line.
   :cljfmt
   {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.13.1"}}
-   :main-opts  ["-m" "cljfmt.main"]}}}
+   :main-opts  ["-m" "cljfmt.main"]}
+
+  ;; clj-kondo — `clojure -M:clj-kondo --lint src test`. Runs the linter
+  ;; via the JVM dep so no native `clj-kondo` binary install is needed
+  ;; (parity with the :cljfmt alias above). lefthook + CI invoke this
+  ;; alias. If you prefer the faster native binary, install it per
+  ;; https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md
+  ;; and point lefthook.yml's clj-kondo hook at the bare `clj-kondo`.
+  :clj-kondo
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
+   :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/tools/template/resources/day8/re_frame2_template/_reagent/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/shadow-cljs.edn
@@ -16,12 +16,13 @@
    :output-dir "resources/public/js"
    :asset-path "/js"
    :modules    {:main {:init-fn {{namespace}}.core/init}}
+   ;; shadow's :browser target re-runs the module :init-fn after each
+   ;; hot reload by default — no :after-load hook needed.
    ;; :devtools/preloads loads Causa in dev watch/compile builds.
    ;; Once rf/init! installs the adapter, Causa auto-mounts into
    ;; resources/public/index.html's [data-rf-causa-host] left column.
    ;; Cut from release builds automatically.
-   :devtools   {:after-load {{namespace}}.core/init
-                :preloads   [day8.re-frame2-causa.preload]}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
   :test
   {:target    :node-test

--- a/tools/template/resources/day8/re_frame2_template/_shared/clj-kondo/config.edn
+++ b/tools/template/resources/day8/re_frame2_template/_shared/clj-kondo/config.edn
@@ -7,4 +7,8 @@
 ;; `reg-view`, ...) are recognised by clj-kondo's built-in support
 ;; for clojure.core-style defining forms — no hook lib required for
 ;; the canonical counter shape.
+;;
+;; Run the linter with `clojure -M:clj-kondo --lint src test` (the
+;; :clj-kondo deps alias runs it via the JVM dep — no native binary
+;; install needed). lefthook's pre-commit hook calls the same alias.
 {}

--- a/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/deps.edn
@@ -45,4 +45,14 @@
   ;; .cljfmt.edn.
   :cljfmt
   {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.13.1"}}
-   :main-opts  ["-m" "cljfmt.main"]}}}
+   :main-opts  ["-m" "cljfmt.main"]}
+
+  ;; clj-kondo — `clojure -M:clj-kondo --lint src test`. Runs the linter
+  ;; via the JVM dep so no native `clj-kondo` binary install is needed
+  ;; (parity with the :cljfmt alias above). lefthook + CI invoke this
+  ;; alias. If you prefer the faster native binary, install it per
+  ;; https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md
+  ;; and point lefthook.yml's clj-kondo hook at the bare `clj-kondo`.
+  :clj-kondo
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}
+   :main-opts  ["-m" "clj-kondo.main"]}}}

--- a/tools/template/resources/day8/re_frame2_template/_uix/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_uix/shadow-cljs.edn
@@ -16,11 +16,12 @@
    :output-dir "resources/public/js"
    :asset-path "/js"
    :modules    {:main {:init-fn {{namespace}}.core/init}}
+   ;; shadow's :browser target re-runs the module :init-fn after each
+   ;; hot reload by default — no :after-load hook needed.
    ;; :devtools/preloads loads Causa into the [data-rf-causa-host]
    ;; left layout column in dev watch/compile builds. Skipped under
    ;; :release.
-   :devtools   {:after-load {{namespace}}.core/init
-                :preloads   [day8.re-frame2-causa.preload]}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
   :test
   {:target    :node-test

--- a/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
+++ b/tools/template/resources/day8/re_frame2_template/root/.github/workflows/ci.yml
@@ -8,8 +8,10 @@
 #     shadow-cljs.edn (no browser; pure cljs.test under Node).
 #
 # Add steps as your project grows:
-#   - `clojure -M:cljfmt check` (the scaffold ships .cljfmt.edn)
-#   - clj-kondo (the scaffold ships .clj-kondo/config.edn)
+#   - `clojure -M:cljfmt check src test` (the scaffold ships .cljfmt.edn)
+#   - `clojure -M:clj-kondo --lint src test` (the scaffold ships a
+#     :clj-kondo deps alias + .clj-kondo/config.edn — no native binary
+#     install needed)
 #   - `npx shadow-cljs release app` to gate the release bundle
 #
 # Action pins use SHA + version-comment per GitHub's hardening

--- a/tools/template/resources/day8/re_frame2_template/root/README.md
+++ b/tools/template/resources/day8/re_frame2_template/root/README.md
@@ -25,8 +25,10 @@ file save) are fast.
 ## Hot reload
 
 `shadow-cljs watch` rebuilds on every file save and re-invokes
-`{{namespace}}.core/init` (the `:devtools/after-load` hook in
-`shadow-cljs.edn`). The entry fn is **idempotent**: re-frame2's
+`{{namespace}}.core/init` — shadow's `:browser` target re-runs the
+module's `:init-fn` automatically after each hot reload, so no
+`:after-load` hook is needed. The entry fn is **idempotent**:
+re-frame2's
 `rf/init!` accepts being called repeatedly, the registrar
 re-registers in place, and `dispatch-sync [:counter/initialise]`
 re-seeds app-db.
@@ -55,6 +57,39 @@ Stack traces in dev also get click-to-source via the
 `:rf.trace/trigger-handler` preload — clicking a frame in the dev
 console jumps straight to the offending form.
 
+## Story playground (if scaffolded with `:include-story? true`)
+
+If you generated this app with `:include-story? true`, the scaffold
+ships a [Story](https://github.com/day8/re-frame2/tree/main/tools/story)
+playground — a Storybook-class component workbench — alongside the
+live counter. Two surfaces share `#app`, one at a time, via hash
+routing on the same `:app` build:
+
+- **`#/`** — the live counter app.
+- **`#/stories`** — the Story shell: every registered story / variant /
+  workspace, with the `:rf.assert/*` play steps and the canonical
+  tag set.
+
+`npx shadow-cljs watch app` serves both — no second build. Visit
+<http://localhost:8280/#/stories> for the playground and
+<http://localhost:8280/#/> for the live app; reloading either hash
+lands on the right surface.
+
+The story registrations live in `src/{{nested-dirs}}/stories.cljs`
+(emitted next to `events.cljs` / `subs.cljs` / `views.cljs`). It uses
+the four shipped `reg-*` macros — `reg-story`, `reg-variant`,
+`reg-tag`, `reg-workspace` — referencing the counter's existing
+event / sub / view ids. Add more `reg-variant` / `reg-tag` /
+`reg-decorator` / `reg-mode` calls there as your app grows. Under a
+`release` build the Story body code elides via
+`:closure-defines {re-frame.story.config/enabled? false}`, so it
+costs nothing in production.
+
+Story is Reagent-only in this template release; UIx + Helix variants
+follow once Story's adapter coverage matches Reagent's. If you did
+**not** opt in, none of the above is present and you can ignore this
+section.
+
 ## Build for release
 
 ```sh
@@ -77,10 +112,22 @@ The scaffold loads only same-origin JS/CSS and has no inline
 script/style, so the strict default policy holds without weakening:
 
 ```
-Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
 X-Content-Type-Options: nosniff
 Referrer-Policy: strict-origin-when-cross-origin
 ```
+
+**`connect-src` — tighten it in production.** The shipped
+`index.html` meta CSP sets `connect-src 'self' ws: wss:` so
+shadow-cljs's hot-reload websocket connects in **development** (it can
+route to a different port than the page, which `'self'` alone would
+block). Production has no hot-reload websocket, so the production
+header above drops `ws: wss:` and pins `connect-src` to `'self'`. If
+your app calls a **cross-origin API** (XHR/fetch to a different
+origin), `'self'` will block it — add that origin explicitly, e.g.
+`connect-src 'self' https://api.example.com`. The strict default
+silently forbids any cross-origin request you haven't whitelisted, so
+add API origins here as you wire them up.
 
 If you add a CDN, embed in an iframe, inline a `<style>` block, or
 load an analytics snippet, **explicitly widen the policy** for that
@@ -90,7 +137,7 @@ Example **nginx** server block:
 
 ```nginx
 location / {
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" always;
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'" always;
   add_header X-Content-Type-Options "nosniff" always;
   add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 }
@@ -100,7 +147,7 @@ Example **Caddy** Caddyfile snippet:
 
 ```caddyfile
 header {
-  Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+  Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
   X-Content-Type-Options "nosniff"
   Referrer-Policy "strict-origin-when-cross-origin"
 }

--- a/tools/template/resources/day8/re_frame2_template/root/lefthook.yml
+++ b/tools/template/resources/day8/re_frame2_template/root/lefthook.yml
@@ -14,8 +14,15 @@
 #     lefthook install
 #
 # Pre-commit gates below run cljfmt (formatter) and clj-kondo (linter)
-# on the .cljc / .clj / .cljs files staged for commit. Both are fast
-# (<1s on this scaffold); add `parallel: true` if your project grows.
+# on the .cljc / .clj / .cljs files staged for commit. Both run via
+# deps.edn aliases (`:cljfmt` / `:clj-kondo`) so no extra binary
+# install is needed beyond the Clojure CLI you already have. Both are
+# fast (<1s on this scaffold); add `parallel: true` if your project
+# grows.
+#
+# Prefer the faster native clj-kondo binary? Install it per
+# https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md
+# and change the clj-kondo `run:` below to `clj-kondo --lint {staged_files}`.
 #
 # Skip on a one-off (NOT recommended — fix the issue instead):
 #
@@ -29,4 +36,4 @@ pre-commit:
       stage_fixed: true
     clj-kondo:
       glob: "*.{clj,cljc,cljs}"
-      run: clj-kondo --lint {staged_files}
+      run: clojure -M:clj-kondo --lint {staged_files}

--- a/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
+++ b/tools/template/resources/day8/re_frame2_template/root/resources/public/index.html
@@ -5,12 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Default-safe Content Security Policy. The scaffold only loads
          same-origin JS/CSS and has no inline script/style, so this
-         strict baseline holds without weakening. For production,
-         prefer serving the same policy via a Content-Security-Policy
-         response header (see README "Production hardening"); the meta
-         tag here is the fall-back when no server-side header is set. -->
+         strict baseline holds without weakening. `connect-src` admits
+         the same origin plus ws:/wss: so shadow-cljs's hot-reload
+         websocket connects in dev (it can route to a different port
+         than the page, which 'self' alone would block). For
+         production, prefer serving the same policy via a
+         Content-Security-Policy response header AND tighten
+         `connect-src` to your real API origin(s) — drop `ws: wss:`
+         unless you use websockets in production (see README
+         "Production hardening"). The meta tag here is the fall-back
+         when no server-side header is set. -->
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
+          content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
     <title>{{name}} — re-frame2</title>
     <link rel="stylesheet" href="/css/app.css">
   </head>

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -75,18 +75,26 @@ choice swaps:
 - `views.cljs` — the counter view. Reagent uses plain hiccup;
   UIx uses `$` with `defui`; Helix uses `defnc` and `d/...`
   elements.
-- `deps.edn` — the substrate-adapter coord changes:
+- `deps.edn` — only the substrate-adapter coord changes:
   `day8/re-frame2-reagent`, `day8/re-frame2-uix`, or
-  `day8/re-frame2-helix`. The runtime coord `day8/re-frame2` is
-  identical across variants.
+  `day8/re-frame2-helix`. The remaining runtime coords are identical
+  across variants: `day8/re-frame2` (core), `day8/re-frame2-schemas`
+  (so `schema.cljs`'s whole-app-db schema validates rather than
+  soft-passing per Spec 010), and `day8/re-frame2-causa` (the in-app
+  devtools panel — see
+  [002 §Causa devtools](002-Generated-Shape.md#causa-devtools)).
 - `shadow-cljs.edn` and `package.json` — react / react-dom pins
   are identical; the substrate's own npm dep (where applicable)
-  is added.
+  is added. The `:app` build's `:devtools {:preloads …}` carries
+  `day8.re-frame2-causa.preload` identically across variants.
 
 The substrate-agnostic shell — `events.cljs`, `subs.cljs`,
-`README.md`, `.gitignore`, `resources/public/index.html` — lives
-under the `_shared/` resource sub-tree and is emitted identically
-across all three variants.
+`schema.cljs`, `README.md`, `.gitignore`,
+`resources/public/index.html` — lives under the `_shared/` resource
+sub-tree and is emitted identically across all three variants.
+`schema.cljs` is substrate-agnostic: the whole-app-db Malli schema
+and `reg-app-schema` registration are the same regardless of view
+library.
 
 ## The counter throughline
 

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -10,8 +10,8 @@ For substrate `:reagent` (the default):
 
 ```
 my-app/
-├── deps.edn                  re-frame2 + Reagent adapter + shadow-cljs
-├── shadow-cljs.edn           :app (watch/release) + :test builds
+├── deps.edn                  re-frame2 + Reagent adapter + schemas + Causa + shadow-cljs
+├── shadow-cljs.edn           :app (watch/release) + :test builds; Causa preload on :app
 ├── package.json              react + react-dom + shadow-cljs
 ├── README.md                 "run shadow-cljs watch app; open localhost:8280"
 ├── .gitignore
@@ -23,11 +23,13 @@ my-app/
 ├── .github/workflows/
 │   └── ci.yml                baseline CI — JDK 21 + Clojure CLI + Node 22 + `npm test`
 ├── resources/public/
-│   ├── index.html            host page; loads /js/main.js + /css/app.css
-│   └── css/app.css           three-rule plain stylesheet
+│   ├── index.html            host page; loads /js/main.js + /css/app.css;
+│   │                         ships the [data-rf-causa-host] devtools column
+│   └── css/app.css           plain stylesheet incl. the .rf2-app-shell layout
 ├── src/my_app/
 │   ├── core.cljs             entry point — mounts the view
 │   ├── events.cljs           :counter/initialise, :counter/increment
+│   ├── schema.cljs           whole-app-db Malli schema + reg-app-schema
 │   ├── subs.cljs             :counter/value
 │   └── views.cljs            the counter view
 ├── test/my_app/
@@ -38,6 +40,14 @@ my-app/
     └── scratch.cljs          REPL scratch ns for (rf/dispatch …)
                               experiments against the running app
 ```
+
+The runtime deps line carries four re-frame2 coords:
+`day8/re-frame2` (core), the substrate adapter
+(`day8/re-frame2-reagent`), `day8/re-frame2-schemas` (so the
+`schema.cljs` whole-app-db schema validates rather than soft-passing
+per Spec 010), and `day8/re-frame2-causa` (the in-app devtools panel,
+preloaded on the `:app` build — see [§Causa devtools](#causa-devtools)
+below). All four ride the same `{{rf2-version}}` pin.
 
 `shadow-cljs.edn` ships `:source-paths ["src" "test" "dev"]` so the
 `:test` build (`:target :node-test`, `:ns-regexp "-test$"`) picks
@@ -69,6 +79,34 @@ shape the developer reads about in [Guide chapter 03 — Your first
 app](../../../docs/guide/03-first-app.md) and the canonical
 [`examples/reagent/counter`](../../../examples/reagent/counter/)
 example.
+
+## Causa devtools
+
+Every generated app ships [Causa](../../causa/) — the in-app devtools
+panel — **on by default in development**. Three wiring points land,
+identically across all three substrates:
+
+- **deps.edn** carries the `day8/re-frame2-causa` runtime coord at the
+  same `{{rf2-version}}` pin as the core coord (Causa publishes in
+  lockstep).
+- **shadow-cljs.edn** preloads `day8.re-frame2-causa.preload` under the
+  `:app` build's `:devtools {:preloads …}` key. shadow honours
+  `:devtools` only under `watch` / `compile`, never `release`, so the
+  preload is automatically absent from production bundles — no manual
+  guarding needed.
+- **index.html + app.css** reserve the layout: a
+  `[data-rf-causa-host]` `<aside>` column inside a `.rf2-app-shell`
+  flex container, with `.rf2-causa-host` fixed at `420px` and `#app`
+  taking the remaining width. Once `rf/init!` installs the adapter,
+  Causa auto-mounts into that column.
+
+Causa is default-on because the scaffold's headline promise is
+"save and see it live" — the dispatch log, app-db diff, causality
+graph, and time-travel scrubber are the on-ramp's primary feedback
+surface. See [DESIGN-RATIONALE §9](DESIGN-RATIONALE.md#9--causa-on-by-default)
+for the WHY and the release-elision guarantee. The generated
+`README.md` documents the runtime experience (the
+`Ctrl+Shift+C` toggle, what each panel shows).
 
 ## Resource tree (template-side)
 

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -337,6 +337,60 @@ The inverse — strict on input shape, forgiving on value set
 delivers the Reagent variant instead of the requested UIx, and
 the user finds out at `shadow-cljs watch app` time.
 
+## §9 — Causa on by default (rf2-y9zqc)
+
+**Decision.** Every generated app ships [Causa](../../causa/) — the
+in-app devtools panel — wired on by default for development: the
+`day8/re-frame2-causa` runtime coord in `deps.edn`, the
+`day8.re-frame2-causa.preload` in `shadow-cljs.edn`'s `:app`
+`:devtools {:preloads …}`, and the `[data-rf-causa-host]` layout
+column in `index.html` / `app.css`.
+
+**Alternatives considered.**
+
+| Option | What it is | Outcome |
+|---|---|---|
+| A — Causa on by default | Wired into every scaffold; auto-mounts in dev. | **Selected.** |
+| B — Causa behind a `:include-causa?` flag | Opt-in, like `:include-story?`. | Rejected. |
+| C — No Causa; document how to add it | A README note pointing at the Causa coord. | Rejected. |
+
+**Why default-on (unlike Story).**
+
+- **Causa is the scaffold's primary feedback surface.** The
+  headline promise is "save and see it live." Causa's dispatch
+  log, app-db diff, causality graph, and time-travel scrubber are
+  exactly the "what just happened" feedback a first-run user needs;
+  it is to re-frame2 what the browser devtools are to a web app —
+  not an optional extra. The on-ramp should ship it wired, not as a
+  homework assignment.
+- **Zero production cost.** shadow honours the `:devtools` key only
+  under `watch` / `compile`, never `release`, so the preload is
+  automatically absent from the production bundle. Unlike a runtime
+  dep that ships, Causa's body code never reaches a `release` build —
+  there is no bundle-size argument for opt-in. (The bundle-isolation
+  gate in the reference repo proves Causa's dev-only namespaces don't
+  leak into production; the scaffold inherits the same property.)
+- **Stable, panel-complete surface.** Causa's panel set and host
+  contract are settled (`[data-rf-causa-host]` is the documented
+  mount point). It does not move the way Story's authoring surface
+  still does, so default-on doesn't force every scaffold to track a
+  churning API.
+
+**Why this differs from §4 (Story default-off).** Story is a
+*Storybook-class authoring tool* — useful only to teams who write
+stories, with a still-moving `reg-*` surface and a real runtime dep
+(`qrcode-generator`) that ships in `dependencies`. Causa is a
+*devtools panel* — useful to every developer from the first save,
+with zero production footprint and a settled contract. The two
+tools sit on opposite sides of the default line for exactly those
+reasons: cost-to-the-uninterested and surface-stability.
+
+**Why not a flag (option B).** A `:include-causa?` flag would add a
+branch nobody should turn off (the cost of leaving it on is zero in
+production) and complicate the scaffold's flag matrix for no benefit.
+The right default is "on"; a flag implies a meaningful "off" that
+doesn't exist here.
+
 ## Retired — clj-new-over-deps-new
 
 > This was the v1 decision (through 2026-05). Superseded by §1 above
@@ -397,7 +451,7 @@ that no longer applies.
 - [001-Substrate-Variants.md](001-Substrate-Variants.md) — the
   current shipped variants + future variants surface.
 - [002-Generated-Shape.md](002-Generated-Shape.md) — resource tree
-  + substitution variables.
+  + substitution variables + the Causa devtools wiring (§9).
 - [003-DepsNew-Rebuild-Plan.md](003-DepsNew-Rebuild-Plan.md) — the
   migration plan that established the current shape (clj-new +
   Clojars → deps-new + git-coord).

--- a/tools/template/src/day8/re_frame2_template/hooks.clj
+++ b/tools/template/src/day8/re_frame2_template/hooks.clj
@@ -74,15 +74,13 @@
 ;; -- :include-story? coercion ----------------------------------------------
 
 (defn- coerce-include-story?
-  "Coerce the `:include-story?` arg to a boolean. Accepts true / false /
-   nil; rejects anything else with a clear message. The flag is
-   Reagent-only in v1 — caller-level guard checks the substrate."
+  "Coerce the `:include-story?` arg to a boolean. The only accepted
+   values are literal `true` / `false` / `nil` (nil ⇒ false); anything
+   else throws with a clear message. The flag is Reagent-only in v1 —
+   caller-level guard checks the substrate."
   [raw]
-  (cond
-    (nil? raw)          false
-    (true? raw)         true
-    (false? raw)        false
-    :else
+  (if (contains? #{nil true false} raw)
+    (boolean raw)
     (throw (ex-info ":rf.error/template-bad-include-story-flag"
                     {:rf.error/id :rf.error/template-bad-include-story-flag
                      :where     'template/coerce-include-story?
@@ -155,39 +153,41 @@
    otherwise coerce the keyword to a string)."
   [data]
   (let [substrate       (coerce-substrate (:substrate data))
-        include-story?  (coerce-include-story? (:include-story? data))
-        _               (when (and include-story? (not= substrate :reagent))
-                          (throw (ex-info
-                                   ":rf.error/template-include-story-reagent-only"
-                                   {:rf.error/id :rf.error/template-include-story-reagent-only
-                                    :where     'template/data-fn
-                                    :recovery  :fix-registration
-                                    :reason    (str ":include-story? is Reagent-only in v1 "
-                                                    "(got :substrate " substrate
-                                                    "). UIx + Helix variants follow once "
-                                                    "Story's adapter coverage matches "
-                                                    "Reagent's.")
-                                    :substrate substrate
-                                    :include-story? include-story?})))
-        substrate-nm    (name substrate)
-        top             (:top data)
-        main            (:main data)
-        top-file        (->file-path top)
-        main-file       (->file-path main)
-        top-ns          (->ns-form top)
-        main-ns         (->ns-form main)]
-    {:substrate           substrate-nm
-     :substrate-kw        substrate
-     :include-story?      include-story?
-     :namespace           (str top-ns "." main-ns)
-     :nested-dirs         (str top-file "/" main-file)
-     :substrate-badge-url (case substrate
-                            :reagent "https://img.shields.io/badge/substrate-Reagent-1abc9c.svg"
-                            :uix     "https://img.shields.io/badge/substrate-UIx-3498db.svg"
-                            :helix   "https://img.shields.io/badge/substrate-Helix-9b59b6.svg")
-     :rf2-version         "0.0.1.alpha"
-     :shadow-version      "3.4.10"
-     :react-version       "19.2.0"}))
+        include-story?  (coerce-include-story? (:include-story? data))]
+    ;; Reagent-only guard — hoisted above the name-derivation `let` so the
+    ;; data map build below has no side-effecting binding.
+    (when (and include-story? (not= substrate :reagent))
+      (throw (ex-info
+               ":rf.error/template-include-story-reagent-only"
+               {:rf.error/id :rf.error/template-include-story-reagent-only
+                :where     'template/data-fn
+                :recovery  :fix-registration
+                :reason    (str ":include-story? is Reagent-only in v1 "
+                                "(got :substrate " substrate
+                                "). UIx + Helix variants follow once "
+                                "Story's adapter coverage matches "
+                                "Reagent's.")
+                :substrate substrate
+                :include-story? include-story?})))
+    (let [substrate-nm    (name substrate)
+          top             (:top data)
+          main            (:main data)
+          top-file        (->file-path top)
+          main-file       (->file-path main)
+          top-ns          (->ns-form top)
+          main-ns         (->ns-form main)]
+      {:substrate           substrate-nm
+       :substrate-kw        substrate
+       :include-story?      include-story?
+       :namespace           (str top-ns "." main-ns)
+       :nested-dirs         (str top-file "/" main-file)
+       :substrate-badge-url (case substrate
+                              :reagent "https://img.shields.io/badge/substrate-Reagent-1abc9c.svg"
+                              :uix     "https://img.shields.io/badge/substrate-UIx-3498db.svg"
+                              :helix   "https://img.shields.io/badge/substrate-Helix-9b59b6.svg")
+       :rf2-version         "0.0.1.alpha"
+       :shadow-version      "3.4.10"
+       :react-version       "19.2.0"})))
 
 ;; -- template-fn ------------------------------------------------------------
 ;;

--- a/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
+++ b/tools/template/test/day8/re_frame2_template/emitted_test_run_test.clj
@@ -228,30 +228,38 @@
   `node out/node-test.js`. Asserts both processes exit 0 and the
   expected cljs.test summary line is present.
 
+  Every variant compiles BOTH the `:app` (`:browser`) build and the
+  `:test` (`:node-test`) build. Compiling `:app` is what shadow-compiles
+  each substrate's entry point — `core.cljs`'s react-dom interop
+  (`create-root` / `render-root` / `.render`), the adapter require, and
+  the `defui` / `defnc` views. `events_test.cljs` requires only events +
+  subs, so the `:test` build alone never pulls `core.cljs` onto the
+  compile classpath; a broken UIx or Helix `core.cljs` (a wrong
+  react-dom interop call, an adapter API rename, a view that won't
+  compile) would otherwise ship green from shape + static-parse alone
+  and surface only when a user runs `npx shadow-cljs watch app`
+  (rf2-ee38b.23 / correctness L1).
+
   When `include-story?` is true the generated project is the with-story
   scaffold (`core_with_stories.cljs`, `deps_with_story.edn` with the
-  extra day8/re-frame2-story coord, `stories.cljs`). The with-story
-  variant additionally compiles the `:app` build — the only tier that
-  actually shadow-compiles the with-story branch's distinctive code.
-  `events_test.cljs` requires only events + subs, so the `:test` build
-  alone never pulls `core_with_stories.cljs` / `stories.cljs` /
-  re-frame.story onto the compile classpath; the `:app` build's
-  `:init-fn` is `core/init`, which transitively requires all three.
-  A broken with-story compile (re-frame.story API drift, a malformed
-  deps_with_story.edn, a stories.cljs that won't load) therefore fails
-  here rather than shipping green from string-presence / static-parse
-  alone (rf2-5v619, G1; this also closes the `:app`-build half of L1).
+  extra day8/re-frame2-story coord, `stories.cljs`); its `:app` build's
+  `:init-fn` (`core/init`) transitively requires `core_with_stories.cljs`
+  / `stories.cljs` / re-frame.story, so a broken with-story compile
+  (re-frame.story API drift, a malformed deps_with_story.edn, a
+  stories.cljs that won't load) fails here too rather than shipping
+  green (rf2-5v619, G1).
 
   Caller is responsible for the env-var gate — this fn always runs."
   ([substrate] (compile-and-run-emitted-test! substrate false))
   ([substrate include-story?]
    (let [root  (repo-root)
          label (variant-label substrate include-story?)
-         ;; Default path: compile only the node-test build (fast). The
-         ;; with-story variant also compiles `:app`, the only build that
-         ;; transitively pulls the with-story core + stories + Story
-         ;; coord onto the classpath.
-         compile-targets (if include-story? ["app" "test"] ["test"])
+         ;; Compile both the `:app` (:browser) build — the only build that
+         ;; pulls each substrate's entry point (`core.cljs`) and views
+         ;; onto the compile classpath — and the `:test` (:node-test)
+         ;; build that runs `events_test.cljs`. Every substrate compiles
+         ;; both, so a broken substrate entry point fails the gate.
+         compile-targets ["app" "test"]
          tmp   (tmp-dir (str "rf2-template-run-" label "-"))]
      (try
        (let [proj (run-template! tmp "acme/my-app" substrate include-story?)]
@@ -261,21 +269,18 @@
                ;; at module-resolution time) and the `:node-test` *compile*
                ;; (shadow's node target falls back to it). The `:browser`
                ;; (`:app`) compile does NOT honour NODE_PATH — it searches
-               ;; only the project-local node_modules — so the with-story
-               ;; tier hard-requires `linked?` (a real symlink/junction).
+               ;; only the project-local node_modules. Every variant now
+               ;; compiles `:app`, so all of them hard-require `linked?`
+               ;; (a real symlink/junction), not just the with-story tier.
                node-path (.getCanonicalPath (io/file root "implementation/node_modules"))
                env-over  {"NODE_PATH" node-path}]
-           (if include-story?
-             (is linked?
-                 (str "project-local node_modules must resolve for the "
-                      "`:app` (:browser) compile — it ignores NODE_PATH. "
-                      "Symlink/junction into " (.getPath proj)
-                      " failed; ensure implementation/node_modules exists "
-                      "(`npm install` in implementation/) and the OS allows "
-                      "a symlink or `mklink /J` junction."))
-             (is (or linked? (.isDirectory (io/file node-path)))
-                 (str "implementation/node_modules must exist for `node` to "
-                      "resolve React (run `npm install` in implementation/ first)")))
+           (is linked?
+               (str "project-local node_modules must resolve for the "
+                    "`:app` (:browser) compile — it ignores NODE_PATH. "
+                    "Symlink/junction into " (.getPath proj)
+                    " failed; ensure implementation/node_modules exists "
+                    "(`npm install` in implementation/) and the OS allows "
+                    "a symlink or `mklink /J` junction."))
 
            ;; --- compile -----------------------------------------------------
            (testing (str label " — shadow-cljs compile "

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -22,22 +22,15 @@
    §2.5 along with the clj-new template body)."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.java.io :as io]
-            [clojure.edn :as edn]
             [day8.re-frame2-template.test-support
-             :refer [tmp-dir delete-recursively run-template!]]))
+             :refer [tmp-dir delete-recursively run-template!
+                     read-edn file-exists?]]))
 
 ;; --- Test helpers ----------------------------------------------------------
 ;;
-;; tmp-dir / delete-recursively / template-resource-dir / run-template!
-;; live in the shared `test-support` ns (rf2-5v619, D1).
-
-(defn- read-edn [^java.io.File f]
-  (edn/read-string (slurp f)))
-
-(defn- file-exists?
-  "True if `path` (relative to `root`) exists as a regular file."
-  [^java.io.File root path]
-  (.isFile (io/file root path)))
+;; tmp-dir / delete-recursively / template-resource-dir / run-template! /
+;; read-edn / file-exists? live in the shared `test-support` ns
+;; (rf2-5v619, D1; read-edn + file-exists? lifted in rf2-ee38b.23).
 
 ;; --- The expected per-substrate shape ------------------------------------
 
@@ -253,7 +246,20 @@
                 "ci.yml runs `npm test` (delegates to shadow-cljs :node-test
                  per the emitted package.json)")
             (is (.contains ci-text "# acme/my-app")
-                "ci.yml header substitutes {{name}}"))
+                "ci.yml header substitutes {{name}}")
+            ;; deps-new's flat {{key}} substitution leaves GitHub
+            ;; `${{ … }}` expressions untouched because no subst key
+            ;; matches the spaced inner token. Pin that invariant so a
+            ;; future data key collision or substitution-engine change
+            ;; that corrupts the workflow expressions is caught here
+            ;; (rf2-ee38b.23 / correctness P3).
+            (is (.contains ci-text "${{ runner.os }}")
+                "ci.yml's GitHub `${{ runner.os }}` expression survives
+                 substitution verbatim (not eaten by deps-new {{key}}
+                 substitution)")
+            (is (.contains ci-text "${{ hashFiles('deps.edn') }}")
+                "ci.yml's GitHub `${{ hashFiles(...) }}` expression
+                 survives substitution verbatim"))
 
           ;; -- Security baseline (rf2-sh3l8) --
           (let [index-text  (slurp (io/file root "resources/public/index.html"))

--- a/tools/template/test/day8/re_frame2_template/test_support.clj
+++ b/tools/template/test/day8/re_frame2_template/test_support.clj
@@ -18,11 +18,29 @@
    on `implementation/package.json`; both files live under the same
    repo root, so the deeper marker subsumes it."
   (:require [clojure.java.io :as io]
+            [clojure.edn :as edn]
             [clojure.string :as string]
             [org.corfield.new :as deps-new])
   (:import [java.nio.file Files LinkOption Path
             FileVisitResult SimpleFileVisitor]
            [java.nio.file.attribute FileAttribute]))
+
+;; --- emitted-file readers --------------------------------------------------
+;;
+;; `read-edn` / `file-exists?` are tiny one-liners that every test which
+;; walks an emitted project re-implements. Homed here (rf2-ee38b.23,
+;; clarity P3) so the next "read the emitted deps.edn" call doesn't
+;; re-inline `slurp` + `read-string`.
+
+(defn read-edn
+  "Parse `f` (a `java.io.File`) as a single EDN value."
+  [^java.io.File f]
+  (edn/read-string (slurp f)))
+
+(defn file-exists?
+  "True if `path` (relative to `root`) exists as a regular file."
+  [^java.io.File root path]
+  (.isFile (io/file root path)))
 
 ;; --- tmp dirs --------------------------------------------------------------
 

--- a/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
+++ b/tools/template/test/day8/re_frame2_template/version_lockstep_test.clj
@@ -8,8 +8,12 @@
   of truth:
 
     - `:rf2-version`    ↔ repo-root `VERSION`
-    - `:shadow-version` ↔ `implementation/package.json` :devDependencies/shadow-cljs
-    - `:react-version`  ↔ `implementation/package.json` :devDependencies/react (and react-dom)
+    - `:shadow-version` ↔ `implementation/package.json` shadow-cljs
+    - `:react-version`  ↔ `implementation/package.json` react (and react-dom)
+
+  The package.json reader searches both `:dependencies` and
+  `:devDependencies` (first hit wins) so the guard doesn't false-fail
+  if the impl tree ever relocates a pin between the two sections.
 
   History (rf2-8v20r): the template literal `:react-version` drifted to
   `18.3.1` while `implementation/package.json` had moved to `19.2.0`.
@@ -44,34 +48,49 @@
       (throw (ex-info "VERSION file missing at repo root" {:file (.getPath f)})))
     (string/trim (slurp f))))
 
+(defn- pin-from-json-text
+  "Pull the version string for `pkg` out of a chunk of package.json text
+  (`\"pkg\": \"value\"` → `\"value\"`). Returns nil when absent. Shared
+  by both the source-of-truth reader below and the emitted-package.json
+  `extract-pin` — one regex shape, written once."
+  [text pkg]
+  (let [pin-re (re-pattern (str "\"" pkg "\":\\s*\"([^\"]+)\""))]
+    (some-> (re-find pin-re text) second)))
+
 (defn- read-package-json-pin
-  "Read a pin from `implementation/package.json`. `section` is one of
-  `:devDependencies` / `:dependencies`; `pkg` is the package name string
-  (e.g. `\"react\"`). Returns the pin string (e.g. `\"19.2.0\"`).
+  "Read a pin for `pkg` (e.g. `\"react\"`) from
+  `implementation/package.json`, searching `:dependencies` AND
+  `:devDependencies` (first hit wins). Returns the pin string (e.g.
+  `\"19.2.0\"`).
+
+  Searching both sections decouples this guard from an incidental
+  layout choice in the impl package.json: today react / react-dom /
+  shadow-cljs sit in `:devDependencies` (it is a test target, not a
+  shipped lib), but if any of them ever moves to `:dependencies` the
+  guard keeps working rather than false-failing the template suite for
+  a reason unrelated to the template (rf2-ee38b.23 / completeness +
+  correctness P3).
 
   We deliberately use a simple regex parse rather than dragging in a
   JSON library — the template test artefact has no JSON dep today, and
-  the package.json shape is stable enough that a regex (looking for
-  `\"pkg\": \"value\"` inside the section) reads simply and fails loudly
-  on shape drift."
-  [section pkg]
-  (let [text (slurp (io/file (repo-root) "implementation/package.json"))
-        ;; Find the section (`"devDependencies": { ... }`). The closing
-        ;; brace ends at the first top-level `}` after the section name.
-        section-name (case section
-                       :devDependencies "devDependencies"
-                       :dependencies    "dependencies"
-                       (throw (ex-info "Unknown section" {:section section})))
-        section-re   (re-pattern (str "\"" section-name "\":\\s*\\{([^}]*)\\}"))
-        section-body (some-> (re-find section-re text) second)
-        _            (when-not section-body
-                       (throw (ex-info (str "Couldn't find :" section-name " section in implementation/package.json")
-                                       {:section section-name})))
-        pin-re       (re-pattern (str "\"" pkg "\":\\s*\"([^\"]+)\""))
-        pin          (some-> (re-find pin-re section-body) second)]
+  the package.json shape is stable enough that a regex (the section
+  body, then `\"pkg\": \"value\"` inside it) reads simply and fails
+  loudly on shape drift."
+  [pkg]
+  (let [text     (slurp (io/file (repo-root) "implementation/package.json"))
+        section  (fn [name]
+                   ;; Find `"<name>": { ... }`; the closing brace ends at
+                   ;; the first `}` after the section name.
+                   (some-> (re-find (re-pattern (str "\"" name "\":\\s*\\{([^}]*)\\}"))
+                                    text)
+                           second))
+        pin      (some #(some-> (section %) (pin-from-json-text pkg))
+                       ["dependencies" "devDependencies"])]
     (when-not pin
-      (throw (ex-info (str "Couldn't find pin for " pkg " in :" section-name)
-                      {:pkg pkg :section section-name})))
+      (throw (ex-info (str "Couldn't find pin for " pkg
+                           " in :dependencies or :devDependencies of "
+                           "implementation/package.json")
+                      {:pkg pkg})))
     pin))
 
 ;; --- Template literal extraction ----------------------------------------
@@ -96,10 +115,10 @@
     proj-dir))
 
 (defn- extract-pin
-  "Pull `\"pkg\": \"value\"` out of the emitted package.json text."
+  "Pull `\"pkg\": \"value\"` out of the emitted package.json text.
+  Thin wrapper over the shared `pin-from-json-text`."
   [pj-text pkg]
-  (let [pin-re (re-pattern (str "\"" pkg "\":\\s*\"([^\"]+)\""))]
-    (some-> (re-find pin-re pj-text) second)))
+  (pin-from-json-text pj-text pkg))
 
 (defn- extract-rf2-version
   "Pull `'day8/re-frame2 {:mvn/version \"...\"}` out of the emitted
@@ -112,8 +131,8 @@
 
 (deftest react-version-lockstep
   (testing "Template's :react-version literal matches implementation/package.json"
-    (let [pkg-react     (read-package-json-pin :devDependencies "react")
-          pkg-react-dom (read-package-json-pin :devDependencies "react-dom")
+    (let [pkg-react     (read-package-json-pin "react")
+          pkg-react-dom (read-package-json-pin "react-dom")
           tmp           (tmp-dir "rf2-template-lockstep-react-")]
       (try
         (let [root      (emit-reagent! tmp)
@@ -138,7 +157,7 @@
 
 (deftest shadow-version-lockstep
   (testing "Template's :shadow-version literal matches implementation/package.json"
-    (let [pkg-shadow (read-package-json-pin :devDependencies "shadow-cljs")
+    (let [pkg-shadow (read-package-json-pin "shadow-cljs")
           tmp        (tmp-dir "rf2-template-lockstep-shadow-")]
       (try
         (let [root       (emit-reagent! tmp)


### PR DESCRIPTION
## Summary

Remediation of the 3-lens review for `tools/template` (bead **rf2-ee38b.23**). The generator + emitted scaffold were already correct and substantively complete; the gaps were spec-vs-impl doc drift plus a couple of test-coverage holes.

### Completeness (spec drift — impl was ahead of normative spec)
- **Causa documented in spec.** New §Causa-devtools in `spec/002-Generated-Shape.md`, per-variant deps note in `spec/001`, and a §9 Causa-on-by-default rationale in `DESIGN-RATIONALE.md` (contrasted against the §4 Story default-off decision). Causa added to the user-facing "What lands" tree.
- **schema.cljs + schemas coord** added to `spec/002`'s "What lands" tree and `spec/001`'s substrate-agnostic shell list.
- **`:include-story?` scaffold** now documented in the generated README (`#/stories` route, `stories.cljs`, release elision, Reagent-only).
- **clj-kondo ergonomics:** a `:clj-kondo` deps alias added to every generated `deps.edn` (parity with `:cljfmt`, no native binary install needed); `lefthook.yml`, the CI comment, and the `.clj-kondo/config.edn` note now point at `clojure -M:clj-kondo`.

### Correctness
- `emitted_test_run_test` compiles the `:app` (`:browser`) build for **every** substrate, not just with-story Reagent — a broken UIx/Helix `core.cljs` (react-dom interop, adapter rename, view that won't compile) now fails the gate instead of shipping green.
- Dev `index.html` CSP gains `connect-src 'self' ws: wss:` so shadow's hot-reload websocket connects; production-hardening docs updated to tighten `connect-src` to the real API origin.
- `root-content-test` pins the GitHub `${{ runner.os }}` / `${{ hashFiles(...) }}` expressions as surviving substitution verbatim.
- `version_lockstep_test` reader searches both `:dependencies` and `:devDependencies`, decoupling the guard from incidental impl `package.json` layout.

### Clarity (P3)
- `coerce-include-story?` collapsed to a set-membership check; data-fn's Reagent-only guard hoisted out of the `let` `_` binding.
- `read-edn` + `file-exists?` lifted into `test-support`; a single `pin-from-json-text` helper now backs both pin readers.
- Redundant `:after-load` dropped from all three generated `shadow-cljs.edn` (shadow's `:browser` target re-runs `:init-fn` on hot reload by default — matches the reference impl + every testbed); generated README hot-reload section reconciled.

### Skipped (correct on inspection)
- The other version-pin lockstep additions (reagent/uix/helix, clojure/cljs compiler, dev-tool pins) were left as P3 follow-up scope — the static-parse + behavioural gates already catch pins that break symbol resolution or compilation; only a "compiles-but-wrong" minor drift would slip, which is out of this bead's actionable set.

## Test plan
- [x] `clojure -M:test` in `tools/template` — 21 tests, 298 assertions, 0 failures/0 errors
- [x] `clj-kondo --lint tools/template/src tools/template/test` — 0 errors, 0 warnings
- [x] `data-fn` smoke after the refactor (uix variant resolves namespace + nested-dirs)
- [ ] CI `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` behavioural tier exercises the new per-substrate `:app` compile

Cross-ref: rf2-ee38b.23