### PR TITLE
refactor(substrate): extract React-adapter assembly into spine + core/adapter fixes

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -14,12 +14,7 @@
   comes from `re-frame.adapter.context` so a mixed-substrate app's
   frame-provider chain composes across substrates."
   (:require [helix.hooks         :as helix-hooks]
-            [re-frame.disposable :as rf-disposable]
-            [re-frame.frame      :as frame]
-            [re-frame.late-bind  :as late-bind]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.spine   :as spine]
-            [re-frame.adapter.context :as adapter-context]))
+            [re-frame.substrate.spine   :as spine]))
 
 ;; ---- shared spine wiring --------------------------------------------------
 
@@ -47,7 +42,12 @@
   React context, or `:rf/default` when no frame-provider sits above.
   Decision 2 mandates every React-shaped adapter resolves the same
   context, so a Helix subtree under a Reagent or UIx frame-provider
-  sees the right frame and vice versa."
+  sees the right frame and vice versa.
+
+  React-context tier only. For the full resolution chain
+  (dynamic-var → React-context → :rf/default) use `(rf/current-frame)`;
+  the routed `:adapter/current-frame` hook (registered via
+  `spine/make-react-adapter`) covers that chain. Per rf2-84myk."
   (:use-current-frame spine-fns))
 
 (def frame-provider
@@ -116,95 +116,13 @@
   See Spec 006 §CLJS reference: Helix as alternative substrate.
   Implements the same nine-fn contract as re-frame.adapter.reagent
   and re-frame.adapter.uix. Per rf2-agql there is no default-adapter
-  registry — adapter wiring is explicit at the call site."
-  {:kind                      :rf.adapter/helix
-   :make-state-container      (:make-state-container      spine-fns)
-   :read-container            (:read-container            spine-fns)
-   :replace-container!        (:replace-container!        spine-fns)
-   :subscribe-container       (:subscribe-container       spine-fns)
-   :make-derived-value        (:make-derived-value        spine-fns)
-   :render                    (:render                    spine-fns)
-   :render-to-string          (:render-to-string          spine-fns)
-   :register-context-provider (:register-context-provider spine-fns)
-   :dispose-adapter!          (:dispose-adapter!          spine-fns)})
+  registry — adapter wiring is explicit at the call site.
 
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when the Helix adapter is the (rf/init!)-
-;; installed one; otherwise it chains to the previously-registered
-;; handler.
-;;
-;; Hook-specific rationale (Helix-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf. Helix renders function
-;;     components — they have no class-component (.-context cmp) slot,
-;;     so the shared impl in `re-frame.adapter.context` reads
-;;     `_currentValue` directly. Helix's own `use-current-frame` hook
-;;     is sugar over the same read, so subscribe / dispatch and
-;;     `use-context` agree on the active frame. Chain-bottom fallback
-;;     is `frame/current-frame`.
-;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. Spine-
-;;     produced derived values reify the re-frame-owned
-;;     `re-frame.disposable/IDisposable` (no Reagent coupling). The
-;;     adapter wires straight to the protocol fns. Pre-rf2-jicu2 these
-;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
-;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
-;;     every Helix-only release bundle for a single defprotocol slot.
-;;     The remaining reactive-substrate hooks (`:adapter/ratom`,
-;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`)
-;;     are intentionally NOT published by the Helix adapter — Helix
-;;     ships no reactive-atom primitive (per rf2-2qit) and
-;;     `re-frame.interop`'s reactive-atom surfaces have zero production
-;;     call sites under Helix; publishing those hooks would force the
-;;     Helix bundle to carry reagent.core (transitively reagent.ratom)
-;;     for code it never executes.
-;;   :adapter/after-render — rf2-334d9. Backed by `React.useLayoutEffect`
-;;     via the spine's after-render machinery (see
-;;     `re-frame.substrate.spine/make-after-render-hook` +
-;;     `make-after-render-sentinel`). `after-render` is a React-
-;;     lifecycle question (when does the next commit complete?), not a
-;;     reactive-atom one — so the "no reactive primitive" rationale
-;;     that excludes the four hooks above does NOT apply. Pre-rf2-334d9
-;;     `(rf/after-render f)` under the Helix adapter was a silent
-;;     no-op; publish closes that correctness bug under the pre-alpha
-;;     masterpiece posture.
-;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
-;;     injection via React.cloneElement (the inline hiccup-walk in
-;;     views.cljs would mis-classify React-element output as a non-DOM
-;;     root). Production-elision: `wrap-view`'s body sits inside an
-;;     `interop/debug-enabled?` gate so closure-folds under :advanced +
-;;     goog.DEBUG=false (per Spec 009 §Production builds).
-(substrate-adapter/route-hook! adapter :adapter/current-frame
-  adapter-context/function-component-current-frame
-  #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  rf-disposable/-add-on-dispose)
-(substrate-adapter/route-hook! adapter :adapter/dispose!
-  rf-disposable/-dispose)
-(substrate-adapter/route-hook! adapter :adapter/wrap-view
-  wrap-view)
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  (:after-render-hook spine-fns))
-
-;; Per rf2-4edk: contribute a clear of THIS adapter's warn-once cache to
-;; the chained `:adapter/clear-warn-once-caches!` hook. The hook is
-;; chained — each adapter (helix, uix) and re-frame.views all contribute
-;; a clear-step; `make-reset-runtime-fixture` invokes the top of the chain
-;; and every contributor's reset runs (unlike `:adapter/current-frame`
-;; etc. this hook is NOT routed through the installed adapter — every
-;; loaded adapter's cache must clear because test bundles can mount
-;; different adapters across tests and each adapter's defonce persists).
-;; Production behaviour is unchanged: the warn-once defonce is still
-;; per-process for users; only test-time clearing is new.
-(spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)
-
-;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit` invokes
-;; `:reagent/set-hiccup-emitter!` at ns-load; every loaded React-shaped
-;; adapter contributes its own install step so a single
-;; `(require '[re-frame.ssr])` auto-wires every adapter's
-;; render-to-string slot. Hook key is historical (Reagent published it
-;; first per rf2-uo7v); behaviour is adapter-agnostic. Per rf2-y9spn
-;; this restores parity with the Reagent and UIx adapters — without
-;; this line a Helix-only SSR bundle silently no-ops the emitter slot
-;; under `(require '[re-frame.ssr])`.
-(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
+  Assembled by `spine/make-react-adapter` (rf2-ee38b.1): the 9-key
+  substrate map, the five React-hook `route-hook!` calls, and the two
+  chained installs (warn-once clear + SSR emitter) all live once in the
+  spine — the Helix and UIx adapter wiring is byte-identical, so this
+  single call replaces the former hand-copied block (which had drifted in
+  prose against the UIx twin). The per-hook rationale lives at
+  `spine/make-react-adapter`."
+  (spine/make-react-adapter spine-fns :rf.adapter/helix))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
@@ -44,3 +44,8 @@
 
 (deftest after-render-runs-callback-after-next-commit-helix
   (suite/assert-after-render-runs-after-commit cfg))
+
+;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
+;; (hydrateRoot) had no React-hook coverage; close it for UIx + Helix.
+(deftest render-hydrate-branch-mounts-without-remount-helix
+  (suite/assert-render-hydrate-branch-mounts-without-remount cfg))

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -12,10 +12,6 @@
   (:require [reagent2.core             :as r]
             [reagent2.ratom            :as ratom]
             [reagent2.dom.client       :as rdc]
-            [re-frame.disposable       :as rf-disposable]
-            [re-frame.frame            :as frame]
-            [re-frame.late-bind        :as late-bind]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]))
 
@@ -39,8 +35,7 @@
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
-    {:substrate-name    "reagent-slim"
-     ;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
+    {;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
      ;; test bundle / log / inspector can attribute a watch to the slim
      ;; adapter rather than confusing it with a stock-Reagent watch.
      :gensym-prefix-sub "rf-reagent-slim-sub-"
@@ -58,24 +53,11 @@
                          :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
 (def set-hiccup-emitter!
-  "Install the hiccup → HTML fn used by render-to-string. Idempotent.
+  "Install the hiccup → HTML fn used by render-to-string. Last call wins.
   Per rf2-uo7v / IMPL-SPEC §2.1: published through the late-bind hook
   `:reagent/set-hiccup-emitter!` so the SSR seam at re-frame.ssr
   resolves it at load time without a static :require."
   (:set-hiccup-emitter! spine-fns))
-
-;; ---- context provider -----------------------------------------------------
-
-(defn- register-context-provider [_frame-keyword]
-  ;; Implementation lives in re-frame.views (CLJS-only). The frame-
-  ;; keyword arg is ignored — `build-frame-provider` is 0-arity
-  ;; (rf2-4y60); the returned component takes the frame keyword at
-  ;; render time. Per IMPL-SPEC §9.4: the views.cljs ns continues to
-  ;; back the frame-provider; the rewrite doesn't replace it. Kept as
-  ;; adapter-side wiring (not in the shared ratom-spine) because it is
-  ;; the Reagent-component-shaped frame-provider, distinct from the
-  ;; React-hook spine's hook-shaped one.
-  (views/build-frame-provider))
 
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:
@@ -90,83 +72,41 @@
 
   The container quartet, renderer, render-to-string and dispose body
   come from `spine/make-ratom-spine` (rf2-rzex9, shared with the bridge
-  Reagent adapter under an injected `reagent2.*` op set);
-  `register-context-provider` stays adapter-local (Reagent-component-
-  shaped frame-provider via `re-frame.views`)."
-  {:kind                      :rf.adapter/reagent-slim
-   :make-state-container      (:make-state-container spine-fns)
-   :read-container            (:read-container       spine-fns)
-   :replace-container!        (:replace-container!   spine-fns)
-   :subscribe-container       (:subscribe-container  spine-fns)
-   :make-derived-value        (:make-derived-value   spine-fns)
-   :render                    (:render               spine-fns)
-   :render-to-string          (:render-to-string     spine-fns)
-   :register-context-provider register-context-provider
-   :dispose-adapter!          (:dispose-adapter!     spine-fns)})
-
-;; Per rf2-uo7v + IMPL-SPEC §9.2: publish the hiccup-emitter installer
-;; through the chained late-bind hook table so re-frame.ssr (in
-;; day8/re-frame2-ssr) resolves it at its ns-load. Without this, an
-;; app pulling in the SSR seam would have to manually call
-;; `(reagent-slim/set-hiccup-emitter! ssr/render-to-string)` —
-;; the late-bind table makes that wiring automatic when both
-;; artefacts are on the classpath.
-(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
-
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
-;; one; otherwise it chains to the previously-registered handler.
-;;
-;; Hook-specific rationale (slim-adapter notes):
-;;   :adapter/current-frame  — rf2-d4sf + IMPL-SPEC §9.6. The rewrite
-;;     preserves the bridge's class-component (.-context cmp) shape, so
-;;     re-frame.views/current-frame works unchanged with reagent-slim's
-;;     class components. Chain-bottom fallback is frame/current-frame.
-;;   :adapter/current-component — rf2-wbnl. Wires
-;;     reagent2.core/current-component so re-frame.views resolves the
-;;     in-flight component from the slim substrate (stock Reagent's
-;;     reader would return nil for slim-rendered components).
-;;   :adapter/ratom etc. — rf2-s36l. Wires reagent2.* impls so
-;;     re-frame.interop's reactive-substrate calls dispatch onto
-;;     reagent2.ratom/IDisposable / IReactiveAtom — without this seam
-;;     the very first (interop/add-on-dispose! ...) under the slim
-;;     adapter threw because reagent2.ratom/Reaction does NOT reify
-;;     stock Reagent's IDisposable.
-(substrate-adapter/route-hook! adapter :adapter/current-frame
-  views/current-frame
-  #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/current-component
-  r/current-component)
-(substrate-adapter/route-hook! adapter :adapter/ratom
-  r/atom)
-(substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/make-reaction
-  ratom/make-reaction)
-;; rf2-jicu2: spine-produced derived values (from UIx/Helix substrates
-;; in a cross-substrate test bundle) reify the re-frame-owned
-;; `re-frame.disposable/IDisposable`; reagent-slim's own Reactions
-;; reify `reagent2.ratom/IDisposable`. The dispatcher protocol-checks
-;; both shapes — the re-frame-owned one first because it is the new
-;; path; falls through to reagent2's protocol for slim-native
-;; reactions.
-(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  (fn add-on-dispose!-dispatch [a f]
-    (cond
-      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-add-on-dispose a f)
-      (satisfies? ratom/IDisposable a)         (ratom/add-on-dispose! a f)
-      :else                                    nil)))
-(substrate-adapter/route-hook! adapter :adapter/dispose!
-  (fn dispose!-dispatch [a]
-    (cond
-      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-dispose a)
-      (satisfies? ratom/IDisposable a)         (ratom/dispose! a)
-      :else                                    nil)))
-(substrate-adapter/route-hook! adapter :adapter/reactive?
-  ratom/reactive?
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  r/after-render)
+  Reagent adapter under an injected `reagent2.*` op set); the adapter
+  map + the nine-call ratom-family `route-hook!` table + the chained
+  SSR-emitter install are assembled by `spine/make-ratom-adapter`
+  (rf2-ee38b.1, also shared with the bridge adapter under an injected
+  `reagent2.*` hook-ops set). `register-context-provider` is passed in
+  (NOT spine-built) because it is the Reagent-component-shaped frame-
+  provider from `re-frame.views`, distinct from the React-hook spine's
+  hook-shaped one — keeping the core spine free of a spine→views edge.
+  CRITICAL: bundle isolation is preserved — the `:hook-ops` are injected
+  `reagent2.*` impls, so the spine names no reactive-atom ns (the
+  `test:reagent-slim:bundle-isolation` gate by construction). Per-hook
+  rationale lives at `spine/make-ratom-adapter`."
+  (spine/make-ratom-adapter
+    spine-fns
+    {:kind :rf.adapter/reagent-slim
+     ;; The frame-keyword arg is ignored — `build-frame-provider` is
+     ;; 0-arity (rf2-4y60); the returned component takes the frame keyword
+     ;; at render time. Per IMPL-SPEC §9.4: views.cljs continues to back
+     ;; the frame-provider; the rewrite doesn't replace it.
+     :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
+     ;; Injected reagent2.* ops for the ratom-family late-bind hooks.
+     ;; Wiring reagent2.* impls is load-bearing (rf2-s36l): without this
+     ;; seam the first (interop/add-on-dispose! ...) under the slim
+     ;; adapter threw because reagent2.ratom/Reaction does NOT reify stock
+     ;; Reagent's IDisposable. rf2-jicu2: the dual-IDisposable dispatch
+     ;; (re-frame-owned first, then reagent2's) is handled inside
+     ;; make-ratom-adapter — this adapter supplies the substrate-side
+     ;; `disposable?` predicate + `add-on-dispose!` / `dispose!` impls.
+     :hook-ops {:current-frame     views/current-frame
+                :current-component r/current-component
+                :atom              r/atom
+                :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
+                :make-reaction     ratom/make-reaction
+                :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
+                :add-on-dispose!   ratom/add-on-dispose!
+                :dispose!          ratom/dispose!
+                :reactive?         ratom/reactive?
+                :after-render      r/after-render}}))

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -59,8 +59,11 @@
 
 (def ^:private re-tag
   "Regex for parsing CSS-style id and class from a Reagent tag keyword.
-   `[#.]?[^#.]+` matched repeatedly captures `tag`, optional `#id`,
-   and any number of `.class` segments."
+   Captures `tag`, an optional `#id`, then optional `.class.class…`
+   shorthand — in THAT order. `#id` MUST precede the `.class` segments
+   (the `:div#id.a.b` form); the class-before-id form (`:div.a#id`) does
+   NOT match and yields a nil tag. This mirrors stock Reagent's own
+   id-before-class regex (a documented constraint, not a regression)."
   #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
 
 ;; Note on field name `className` (rather than `class`): in JS-target
@@ -79,12 +82,18 @@
   are no class shorthand parts. The `id` field is non-nil only when the
   tag has a `#id` shorthand part. `tag` is the bare element name string.
 
+  CONSTRAINT (matches stock Reagent): `#id` must precede the `.class`
+  segments. The id-before-class form is supported; the class-before-id
+  form (`:div.a#id`) is NOT — `re-tag` returns nil for it and the result
+  carries a nil tag. Use `:div#id.a.b`, never `:div.a.b#id`.
+
   Examples:
 
-    (parse-tag :div)         → HiccupTag{tag \"div\" id nil class nil}
-    (parse-tag :div.cls)     → HiccupTag{tag \"div\" id nil class \"cls\"}
+    (parse-tag :div)         → HiccupTag{tag \"div\" id nil  class nil}
+    (parse-tag :div.cls)     → HiccupTag{tag \"div\" id nil  class \"cls\"}
     (parse-tag :div#id)      → HiccupTag{tag \"div\" id \"id\" class nil}
-    (parse-tag :div.a.b#id)  → HiccupTag{tag \"div\" id \"id\" class \"a b\"}"
+    (parse-tag :div#id.a.b)  → HiccupTag{tag \"div\" id \"id\" class \"a b\"}
+    (parse-tag :div.a.b#id)  → HiccupTag{tag nil   id nil  class nil}  ; NOT supported"
   [hiccup-tag]
   (let [[_ tag id class-shorthand]
         (re-matches re-tag (name hiccup-tag))

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -342,20 +342,35 @@
       (._run this true)))
 
   (_try-capture [this f]
+    ;; Mirror stock Reagent: on the success branch SET `state` to the
+    ;; recomputed value here (and return it); on the throw branch capture
+    ;; the error in BOTH `state` and `caught`. `_run` must NOT overwrite
+    ;; `state` in check mode (`(when-not check (set! state res))`) — doing
+    ;; so clobbers the captured error (`_try-capture`'s catch returns the
+    ;; value of `(set! dirty? false)`, i.e. `false`, not the error), so a
+    ;; throwing queued/flush! recompute would leave `state` = false instead
+    ;; of the error AND notify watchers of a spurious `false` change
+    ;; (rf2-ee38b.15 P2). Returning the new state keeps `_run`'s
+    ;; `notify-w … res` reflecting the recompute on the success path.
     (try
       (set! caught nil)
-      (deref-capture f this)
+      (set! state (deref-capture f this))
       (catch :default e
         (set! state e)
         (set! caught e)
-        (set! dirty? false))))
+        (set! dirty? false)
+        e)))
 
   (_run [this check]
     (let [oldstate state
           res      (if check
                      (._try-capture this f)
                      (deref-capture f this))]
-      (set! state res)
+      ;; In check mode `_try-capture` has already set `state` (success or
+      ;; error path); only the unchecked path sets it here. See the
+      ;; rationale on `_try-capture` (rf2-ee38b.15 P2).
+      (when-not check
+        (set! state res))
       ;; Equality memoisation per IMPL-SPEC §3.2: use = (not identical?)
       ;; because Reaction bodies produce new data structures every run.
       ;; Skip notify-watches when the recomputed value is = the old one.

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -67,6 +67,23 @@
     (let [parsed (template/parse-tag :input)]
       (is (= "input" (.-tag parsed))))))
 
+(deftest parse-tag-id-before-class-supported
+  (testing ":div#id.a.b — id MUST precede classes (the supported form)"
+    (let [parsed (template/parse-tag :div#id.a.b)]
+      (is (= "div" (.-tag parsed)))
+      (is (= "id" (.-id parsed)))
+      (is (= "a b" (.-className parsed))))))
+
+(deftest parse-tag-class-before-id-not-supported
+  ;; rf2-ee38b.15: the regex requires `#id` before `.class` (matches stock
+  ;; Reagent). The class-before-id form (`:div.a#id`) does NOT match —
+  ;; `re-matches` returns nil and the result carries a nil tag. Pin the
+  ;; constraint so the docstring and the code can never silently disagree.
+  (testing ":div.a#id — class-before-id is NOT supported (nil tag)"
+    (let [parsed (template/parse-tag :div.a#id)]
+      (is (nil? (.-tag parsed))
+          "class-before-id yields a nil tag, not a parsed element"))))
+
 ;; ---------------------------------------------------------------------------
 ;; cached-prop-name — kebab→camel + special cases
 ;; ---------------------------------------------------------------------------

--- a/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/ratom_cljs_test.cljs
@@ -331,6 +331,54 @@
       (is (= [30] @r-vals)))))
 
 ;; ---------------------------------------------------------------------------
+;; throwing Reaction body — the check=true (_queued-run / flush!) error path
+;; rf2-ee38b.15 P2 regression pin
+;; ---------------------------------------------------------------------------
+
+(deftest throwing-reaction-checked-recompute-preserves-error
+  ;; Pre-rf2-ee38b.15, `_run` did `(set! state res)` unconditionally; on the
+  ;; check=true error path `_try-capture` had already set `state` to the
+  ;; caught error, but `_run` then clobbered it with the catch-block's
+  ;; return value (`false`), AND `notify-w` fired with that spurious `false`.
+  ;; The fix: `_try-capture` sets state on the success branch; `_run` only
+  ;; sets state when NOT check.
+  ;;
+  ;; Drive the checked (`_queued-run` → `_run this true`) path: a no-auto-run
+  ;; inner reaction, subscribed to its source by deref'ing it inside an
+  ;; outer reaction. The outer's auto-run is a NO-OP fn so the inner's
+  ;; error-recompute notify does NOT cascade into an outer re-deref (which
+  ;; would rethrow the captured error out of flush! — correct behaviour, but
+  ;; not what this test isolates).
+  (testing "a throwing Reaction body on the checked recompute path"
+    (let [a            (ratom/atom 1)
+          ;; Inner reaction throws once a crosses a threshold.
+          inner        (ratom/make-reaction
+                         (fn []
+                           (when (> @a 1)
+                             (throw (ex-info "boom" {:a @a})))
+                           @a))
+          ;; Outer derefs inner once (wiring outer→inner and, via inner's
+          ;; own _run, inner→a). NO-OP auto-run: on inner's change the outer
+          ;; just marks, never re-derefs the errored inner.
+          outer        (ratom/make-reaction (fn [] @inner)
+                                            :auto-run (fn [_this] nil))
+          watch-fires  (atom [])]
+      ;; Force initial run paths (a=1 ⇒ inner=1, no throw).
+      @outer
+      (is (= 1 @inner) "precondition: inner computes cleanly at a=1")
+      ;; Watch the INNER reaction so we can detect a spurious notify.
+      (add-watch inner :w (fn [_ _ _ nu] (swap! watch-fires conj nu)))
+      ;; Cross the threshold ⇒ inner's queued/checked recompute throws.
+      (reset! a 2)
+      (ratom/flush!)
+      (testing "the captured error rethrows on deref (not a clobbered false)"
+        (is (thrown-with-msg? cljs.core/ExceptionInfo #"boom" @inner)))
+      (testing "watchers are NOT notified of a spurious `false` value change"
+        (is (not (some false? @watch-fires))
+            "the error recompute must not notify watchers with the catch
+             block's `false` return")))))
+
+;; ---------------------------------------------------------------------------
 ;; reaction macro — 5-line indirection
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -6,10 +6,6 @@
   (:require [reagent.core :as r]
             [reagent.ratom :as ratom]
             [reagent.dom.client :as rdc]
-            [re-frame.disposable :as rf-disposable]
-            [re-frame.frame :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
@@ -28,8 +24,7 @@
 
 (def ^:private spine-fns
   (spine/make-ratom-spine
-    {:substrate-name    "Reagent"
-     ;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
+    {;; Substrate-scoped gensym prefix (rf2-l4dmr) so a cross-substrate
      ;; test bundle / log / inspector can attribute a watch to the
      ;; Reagent adapter rather than confusing it with a slim watch.
      :gensym-prefix-sub "rf-reagent-sub-"
@@ -47,26 +42,12 @@
                          :rdc/unmount         (fn [root] (rdc/unmount root))}}))
 
 (def set-hiccup-emitter!
-  "Install the hiccup → HTML fn used by render-to-string. Idempotent.
+  "Install the hiccup → HTML fn used by render-to-string. Last call wins.
   Reagent ships server-side rendering via reagent.dom.server — but in
   CLJS browser builds we don't typically render-to-string; install the
   emitter via this fn (or let the SSR seam resolve the late-bind hook)
   if you need it in CLJS."
   (:set-hiccup-emitter! spine-fns))
-
-;; ---- context provider -----------------------------------------------------
-
-(defn- register-context-provider [_frame-keyword]
-  ;; Implementation lives in re-frame.views (CLJS-only). The frame-
-  ;; keyword arg is ignored — `build-frame-provider` is 0-arity
-  ;; (rf2-4y60); the returned component takes the frame keyword at
-  ;; render time. The arg stays in the substrate signature per
-  ;; Spec 006 §Frame-provider via React context. Kept as adapter-side
-  ;; wiring (not in the shared ratom-spine) because it is the Reagent-
-  ;; component-shaped frame-provider, distinct from the React-hook
-  ;; spine's hook-shaped one — and so the core spine carries no
-  ;; spine→views dependency edge.
-  (views/build-frame-provider))
 
 (def adapter
   "The Reagent adapter map. Pass to `(rf/init! ...)` to install:
@@ -80,94 +61,37 @@
 
   The container quartet, renderer, render-to-string and dispose body
   come from `spine/make-ratom-spine` (rf2-rzex9, shared with
-  reagent-slim); `register-context-provider` stays adapter-local
-  (Reagent-component-shaped frame-provider via `re-frame.views`)."
-  {:kind                      :rf.adapter/reagent
-   :make-state-container      (:make-state-container spine-fns)
-   :read-container            (:read-container       spine-fns)
-   :replace-container!        (:replace-container!   spine-fns)
-   :subscribe-container       (:subscribe-container  spine-fns)
-   :make-derived-value        (:make-derived-value   spine-fns)
-   :render                    (:render               spine-fns)
-   :render-to-string          (:render-to-string     spine-fns)
-   :register-context-provider register-context-provider
-   :dispose-adapter!          (:dispose-adapter!     spine-fns)})
-
-;; Chained SSR emitter install (rf2-4z7bp / parity rf2-cl1qv):
-;; `re-frame.ssr.emit` invokes `:reagent/set-hiccup-emitter!` at
-;; ns-load; every loaded React-shaped adapter (Reagent, reagent-slim,
-;; UIx, Helix) contributes its own install step so a single
-;; `(require '[re-frame.ssr])` auto-wires every adapter's
-;; render-to-string slot. The directory entry for this hook is
-;; `:chained? true` and lists all four adapters as producers — using
-;; `chain-fn!` (not `set-fn!`) is load-order-independent: any adapter
-;; loading after the others composes onto the existing chain instead
-;; of clobbering it. Per rf2-uo7v ssr ships in day8/re-frame2-ssr;
-;; this adapter cannot statically `:require [re-frame.ssr]` without
-;; dragging the SSR namespace into every Reagent bundle. When ssr is
-;; absent the hook is never consumed and render-to-string raises the
-;; "no-hiccup-emitter-bound" error on first call. Per Spec 006
-;; §Adapter shipping convention (rf2-0hxm).
-(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
-
-;; Each late-bind hook below is routed through `(substrate-adapter/
-;; current-adapter)` per rf2-0d35 via `substrate-adapter/route-hook!`
-;; (see that fn's docstring for the routing contract). The wrapper runs
-;; this adapter's impl ONLY when this adapter is the (rf/init!)-installed
-;; one; otherwise it chains to the previously-registered handler.
-;;
-;; Hook-specific rationale:
-;;   :adapter/current-frame  — rf2-d4sf. React-context tier of the
-;;     3-tier resolution chain. Reagent path uses (.-context cmp) on
-;;     the in-flight Reagent component (class-component machinery), so
-;;     `reg-view*`-wrapped components route to the surrounding
-;;     provider's frame while plain Reagent fns fall through to
-;;     :rf/default — that narrowness makes the
-;;     plain-fn-under-non-default-frame-once warning meaningful.
-;;     Chain-bottom fallback is `frame/current-frame` so headless /
-;;     pre-init shape is preserved.
-;;   :adapter/current-component — rf2-wbnl. Reads stock Reagent's
-;;     in-flight component without hard-binding re-frame.views to
-;;     reagent.core; the slim adapter wires this hook to
-;;     reagent2.core/current-component.
-;;   :adapter/ratom etc. — rf2-s36l. The reactive-substrate surfaces
-;;     consumed by `re-frame.interop`. UIx and Helix adapters reify
-;;     stock reagent.ratom/IDisposable on their derived values, so
-;;     they wire these hooks to the same stock-Reagent impls.
-(substrate-adapter/route-hook! adapter :adapter/current-frame
-  views/current-frame
-  #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/current-component
-  r/current-component)
-(substrate-adapter/route-hook! adapter :adapter/ratom
-  r/atom)
-(substrate-adapter/route-hook! adapter :adapter/ratom?
-  (fn ratom?-impl [x] (satisfies? ratom/IReactiveAtom x))
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/make-reaction
-  ratom/make-reaction)
-;; rf2-jicu2: a Reagent-installed app may still hold a spine-produced
-;; derived value (e.g. inherited through a cross-substrate test bundle
-;; that pre-loaded UIx/Helix machinery). Dispatch handles BOTH shapes —
-;; the re-frame-owned `re-frame.disposable/IDisposable` (spine derived
-;; values) and Reagent's own `reagent.ratom/IDisposable` (Reagent
-;; reactions). Protocol-checks the re-frame-owned one first because it
-;; is the new path; falls through to Reagent's protocol for
-;; Reagent-native reactions.
-(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  (fn add-on-dispose!-dispatch [a f]
-    (cond
-      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-add-on-dispose a f)
-      (satisfies? ratom/IDisposable a)         (ratom/add-on-dispose! a f)
-      :else                                    nil)))
-(substrate-adapter/route-hook! adapter :adapter/dispose!
-  (fn dispose!-dispatch [a]
-    (cond
-      (satisfies? rf-disposable/IDisposable a) (rf-disposable/-dispose a)
-      (satisfies? ratom/IDisposable a)         (ratom/dispose! a)
-      :else                                    nil)))
-(substrate-adapter/route-hook! adapter :adapter/reactive?
-  ratom/reactive?
-  (constantly false))
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  r/after-render)
+  reagent-slim); the adapter map + the nine-call ratom-family
+  `route-hook!` table + the chained SSR-emitter install are assembled by
+  `spine/make-ratom-adapter` (rf2-ee38b.1, also shared with reagent-slim).
+  `register-context-provider` is passed in (NOT spine-built) because it
+  is the Reagent-component-shaped frame-provider from `re-frame.views`,
+  distinct from the React-hook spine's hook-shaped one — keeping the core
+  spine free of a spine→views dependency edge. The `:hook-ops` are
+  injected stock-`reagent.*` impls so the spine never names a reactive-
+  atom ns (bundle isolation, identical to `make-ratom-spine`'s
+  `:ratom-ops` contract). Per-hook rationale lives at
+  `spine/make-ratom-adapter`."
+  (spine/make-ratom-adapter
+    spine-fns
+    {:kind :rf.adapter/reagent
+     ;; The frame-keyword arg is ignored — `build-frame-provider` is
+     ;; 0-arity (rf2-4y60); the returned component takes the frame keyword
+     ;; at render time. The arg stays in the substrate signature per
+     ;; Spec 006 §Frame-provider via React context.
+     :register-context-provider (fn [_frame-keyword] (views/build-frame-provider))
+     ;; Injected stock-Reagent ops for the ratom-family late-bind hooks.
+     ;; rf2-jicu2: the dual-IDisposable dispatch (re-frame-owned first,
+     ;; then the substrate's) is handled inside make-ratom-adapter — this
+     ;; adapter supplies only the substrate-side `disposable?` predicate +
+     ;; `add-on-dispose!` / `dispose!` impls.
+     :hook-ops {:current-frame     views/current-frame
+                :current-component r/current-component
+                :atom              r/atom
+                :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
+                :make-reaction     ratom/make-reaction
+                :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
+                :add-on-dispose!   ratom/add-on-dispose!
+                :dispose!          ratom/dispose!
+                :reactive?         ratom/reactive?
+                :after-render      r/after-render}}))

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -13,12 +13,7 @@
   `uix.core` macros expand to these)."
   (:require [uix.core          :as uix]
             [uix.hooks.alpha   :as uix-hooks]
-            [re-frame.disposable :as rf-disposable]
-            [re-frame.frame    :as frame]
-            [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.substrate.spine   :as spine]
-            [re-frame.adapter.context :as adapter-context]))
+            [re-frame.substrate.spine   :as spine]))
 
 ;; ---- shared spine wiring --------------------------------------------------
 
@@ -119,82 +114,12 @@
   See Spec 006 §CLJS reference: UIx as alternative substrate.
   Implements the same nine-fn contract as re-frame.adapter.reagent.
   Per rf2-agql there is no default-adapter registry — adapter wiring
-  is explicit at the call site."
-  {:kind                      :rf.adapter/uix
-   :make-state-container      (:make-state-container      spine-fns)
-   :read-container            (:read-container            spine-fns)
-   :replace-container!        (:replace-container!        spine-fns)
-   :subscribe-container       (:subscribe-container       spine-fns)
-   :make-derived-value        (:make-derived-value        spine-fns)
-   :render                    (:render                    spine-fns)
-   :render-to-string          (:render-to-string          spine-fns)
-   :register-context-provider (:register-context-provider spine-fns)
-   :dispose-adapter!          (:dispose-adapter!          spine-fns)})
+  is explicit at the call site.
 
-;; Late-bind hooks below route through `substrate-adapter/route-hook!`
-;; (per rf2-0d35 — see its docstring for the routing contract): each
-;; impl runs ONLY when the UIx adapter is the (rf/init!)-installed
-;; one; otherwise chains to the previously-registered handler.
-;;
-;; Hook-specific UIx-adapter notes:
-;;   :adapter/current-frame  — rf2-d4sf. Function components have no
-;;     class-component (.-context cmp) slot, so the shared impl in
-;;     `re-frame.adapter.context` reads `_currentValue` directly. This
-;;     is the WIDER surface — `(rf/current-frame)` reaches the
-;;     dynamic-var-fallback chain via this hook; the per-adapter
-;;     `use-current-frame` hook above is the NARROWER React-context-
-;;     tier-only read (per rf2-84myk).
-;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. Spine-
-;;     produced derived values reify the re-frame-owned
-;;     `re-frame.disposable/IDisposable` (no Reagent coupling). The
-;;     adapter wires straight to the protocol fns. Pre-rf2-jicu2 these
-;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
-;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
-;;     every UIx-only release bundle for a single defprotocol slot.
-;;     The remaining reactive-substrate hooks (`:adapter/ratom`,
-;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`)
-;;     are intentionally NOT published by the UIx adapter — UIx ships
-;;     no reactive-atom primitive (per rf2-3yij) and
-;;     `re-frame.interop`'s reactive-atom surfaces have zero production
-;;     call sites under UIx; publishing those hooks would force the UIx
-;;     bundle to carry reagent.core (transitively reagent.ratom) for
-;;     code it never executes.
-;;   :adapter/after-render — rf2-334d9. Backed by `React.useLayoutEffect`
-;;     via the spine's after-render machinery (see
-;;     `re-frame.substrate.spine/make-after-render-hook` +
-;;     `make-after-render-sentinel`). `after-render` is a React-
-;;     lifecycle question (when does the next commit complete?), not a
-;;     reactive-atom one — so the "no reactive primitive" rationale
-;;     that excludes the four hooks above does NOT apply. Pre-rf2-334d9
-;;     `(rf/after-render f)` under the UIx adapter was a silent no-op;
-;;     publish closes that correctness bug under the pre-alpha
-;;     masterpiece posture.
-;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
-;;     injection via React.cloneElement (the views.cljs inline
-;;     hiccup-walk would mis-classify React-element output as a
-;;     non-DOM root). Production-elided via `interop/debug-enabled?`
-;;     per Spec 009 §Production builds.
-(substrate-adapter/route-hook! adapter :adapter/current-frame
-  adapter-context/function-component-current-frame
-  #(frame/current-frame))
-(substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
-  rf-disposable/-add-on-dispose)
-(substrate-adapter/route-hook! adapter :adapter/dispose!
-  rf-disposable/-dispose)
-(substrate-adapter/route-hook! adapter :adapter/wrap-view
-  wrap-view)
-(substrate-adapter/route-hook! adapter :adapter/after-render
-  (:after-render-hook spine-fns))
-
-;; Chained warn-once clear (rf2-4edk): every loaded adapter's
-;; per-process defonce must be cleared between tests, so this hook is
-;; chained (not routed by installed-adapter identity).
-(spine/install-clear-warn-once-step! clear-warned-non-dom-roots!)
-
-;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit`
-;; invokes `:reagent/set-hiccup-emitter!` at ns-load; every loaded
-;; React-shaped adapter contributes its own install step so a single
-;; `(require '[re-frame.ssr])` auto-wires every adapter's
-;; render-to-string slot. Hook key is historical (Reagent published
-;; it first per rf2-uo7v); behaviour is adapter-agnostic.
-(late-bind/chain-fn! :reagent/set-hiccup-emitter! set-hiccup-emitter!)
+  Assembled by `spine/make-react-adapter` (rf2-ee38b.1): the 9-key
+  substrate map, the five React-hook `route-hook!` calls, and the two
+  chained installs (warn-once clear + SSR emitter) all live once in the
+  spine — the UIx and Helix adapter wiring is byte-identical, so this
+  single call replaces the former hand-copied block. The per-hook
+  rationale lives at `spine/make-react-adapter`."
+  (spine/make-react-adapter spine-fns :rf.adapter/uix))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -42,3 +42,8 @@
 
 (deftest after-render-runs-callback-after-next-commit-uix
   (suite/assert-after-render-runs-after-commit cfg))
+
+;; rf2-ee38b.1 — the spine `make-render` :hydrate? true branch
+;; (hydrateRoot) had no React-hook coverage; close it for UIx + Helix.
+(deftest render-hydrate-branch-mounts-without-remount-uix
+  (suite/assert-render-hydrate-branch-mounts-without-remount cfg))

--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -389,8 +389,8 @@
                                 :recovery      :no-recovery
                                 :from-fixture? true}))
 
-    ;; :get and :reduce-input are sub-body ops; the realise-sub-handler
-    ;; reads them separately. Treated as no-op here.
+    ;; :get and :reduce-input are sub-body ops; `realise-sub` reads them
+    ;; separately. Treated as no-op here.
     :get       ctx
     :reduce-input ctx
     :db-get    ctx
@@ -603,9 +603,3 @@
                      v))
                  nil
                  steps))})))
-
-(defn realise-sub-handler
-  "Backwards-compatible: returns just the body fn. Prefer realise-sub when
-  layer-2+ registration is needed."
-  [steps]
-  (:body (realise-sub steps)))

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -124,11 +124,6 @@
   (let [platforms (:platforms meta #{:client :server})]
     (contains? platforms active-platform)))
 
-;; Local alias kept for internal call sites' readability — `(fx-runs-on-
-;; platform? meta plat)` reads better at `do-fx` than `(runs-on-platform?
-;; meta plat)` where the fx-vs-cofx context is implicit.
-(def ^:private fx-runs-on-platform? runs-on-platform?)
-
 ;; ---- do-fx ----------------------------------------------------------------
 
 (declare dispatch-fx-handler)
@@ -492,7 +487,7 @@
       ;; honours both registry hits and the fn-value override branch
       ;; without a second lookup.
       (if-let [meta resolved-meta]
-      (if (fx-runs-on-platform? meta active-platform)
+      (if (runs-on-platform? meta active-platform)
         ;; Per Spec 010 §Validation order step 5 (rf2-xp2o3): before the
         ;; fx handler runs, validate its args against any `:schema` on
         ;; the fx's registration meta. The schemas artefact is optional
@@ -617,58 +612,63 @@
   fx does not halt the rest).
 
   Per Spec 002 §Per-frame and per-call overrides: an fx-id override map
-  may be provided. Each [fx-id args] is rewritten through that map
-  before lookup.
+  may be provided via `opts`. Each [fx-id args] is rewritten through that
+  map before lookup.
 
-  The 5-arity passes the originating event vector through to user-
-  registered fx handlers as `:event` on their ctx — needed by Spec 014
-  §Reply addressing (the fx captures the originating event-id from the
-  dispatch envelope's cofx).
+  Optional `opts` map (rf2-ee38b.1 — collapsed the former six-step nil-
+  padding arity ladder, which threaded these positionally one accreted
+  arg at a time, into a single keyword-keyed map):
 
-  The 6-arity additionally threads the originating dispatch envelope
-  through to reserved-fx defmethods (and exposes it at `(:envelope m)`
-  on user-fx ctx) per Spec 002 §The binary fx-handler signature (line
-  603) and §Drain-loop pseudocode (lines 916, 961-963). Reserved-fx
-  bodies for `:dispatch` and `:dispatch-later` read the envelope to
-  propagate inheritable keys onto the child dispatch per §Cascade
-  propagation.
+    :overrides        an fx-id override map (Spec 002 §Per-frame and
+                      per-call overrides). Each [fx-id args] is rewritten
+                      through it before lookup. Defaults to `{}`.
+    :origin-event     the originating event vector, passed through to
+                      user-registered fx handlers as `:event` on their
+                      ctx — needed by Spec 014 §Reply addressing (the fx
+                      captures the originating event-id from the dispatch
+                      envelope's cofx).
+    :parent-envelope  the originating dispatch envelope, threaded to
+                      reserved-fx defmethods (and exposed at `(:envelope
+                      m)` on user-fx ctx) per Spec 002 §The binary
+                      fx-handler signature (line 603) + §Drain-loop
+                      pseudocode (lines 916, 961-963). Reserved-fx bodies
+                      for `:dispatch` / `:dispatch-later` read it to
+                      propagate inheritable keys onto the child dispatch
+                      per §Cascade propagation.
+    :effects          the originating handler's full effects map (the
+                      closed `{:db ... :fx ...}` shape). Used ONLY to
+                      stamp shape info onto the terminating
+                      `:event/do-fx` trace marker's `:tags` (rf2-twt7m
+                      Change 2): `:fx` (the vector returned) and
+                      `:db-present?` (boolean, true iff the handler
+                      returned a `:db` slot). NOT threaded into per-fx
+                      invocations — fx handlers already receive the
+                      effects shape they need via per-fx args. Absent ⇒
+                      the trace marker degrades gracefully (no `:fx` /
+                      `:db-present?` slots).
+    :coeffects        the handler's final coeffects map (rf2-jhhqt). The
+                      USER-INJECTED subset (everything outside
+                      `framework-coeffect-keys`) is stamped onto the
+                      `:event/do-fx` marker's `:tags` under `:coeffects`
+                      so the Causa Event lens's COEFFECTS section can
+                      render values without a second emit. The filter
+                      mirrors the INTERCEPTORS section's filter-out-
+                      framework-defaults posture; the stamp is absent
+                      entirely (not an empty map) when zero user
+                      coeffects were injected. `trace/emit!` is itself
+                      DCE-gated so prod CLJS bundles elide both the
+                      projection and the emit.
 
-  The 7-arity additionally accepts the originating handler's full
-  effects map (the closed `{:db ... :fx ...}` shape, per Spec 002
-  §The binary fx-handler signature). It is used only to stamp shape
-  info onto the terminating `:event/do-fx` trace marker's `:tags`
-  (rf2-twt7m Change 2): `:fx` (the vector returned) and
-  `:db-present?` (boolean, true iff the handler returned a `:db`
-  slot). The map itself is NOT threaded into per-fx invocations —
-  fx handlers already receive the effects shape they need via per-
-  fx args. Callers without an effects map (e.g. machine-exit fx
-  walks) use a lower arity; the trace marker degrades gracefully
-  (no `:fx` / `:db-present?` slots on the emit).
-
-  The 8-arity additionally accepts the handler's final coeffects map
-  (per rf2-jhhqt). The USER-INJECTED subset (everything outside
-  `framework-coeffect-keys`) is stamped onto the `:event/do-fx`
-  marker's `:tags` under `:coeffects` so the Causa Event lens's
-  COEFFECTS section can render values without a second emit. The
-  filter mirrors the INTERCEPTORS section's filter-out-framework-
-  defaults posture; the stamp is absent entirely (not an empty map)
-  when zero user coeffects were injected — `trace/emit!` itself is
-  DCE-gated so prod CLJS bundles elide both the projection and the
-  emit."
+  The 3-arity (no `opts`) is the bare machine-exit / cascade-fx walk
+  shape; the router supplies the full opts map once per drained event."
   ([frame-id fx-vec active-platform]
-   (do-fx frame-id fx-vec active-platform {} nil nil nil nil))
-  ([frame-id fx-vec active-platform overrides]
-   (do-fx frame-id fx-vec active-platform overrides nil nil nil nil))
-  ([frame-id fx-vec active-platform overrides origin-event]
-   (do-fx frame-id fx-vec active-platform overrides origin-event nil nil nil))
-  ([frame-id fx-vec active-platform overrides origin-event parent-envelope]
-   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope nil nil))
-  ([frame-id fx-vec active-platform overrides origin-event parent-envelope effects]
-   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope effects nil))
-  ([frame-id fx-vec active-platform overrides origin-event parent-envelope effects coeffects]
+   (do-fx frame-id fx-vec active-platform nil))
+  ([frame-id fx-vec active-platform
+    {:keys [overrides origin-event parent-envelope effects coeffects]}]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
-       (handle-one-fx frame-id pair active-platform overrides origin-event parent-envelope)))
+       (handle-one-fx frame-id pair active-platform (or overrides {})
+                      origin-event parent-envelope)))
    ;; Per rf2-twt7m Change 2: stamp `:fx` + `:db-present?` onto the
    ;; `:event/do-fx` marker's `:tags` when the caller supplied the
    ;; effects map. The full `:db` VALUE is NOT stamped — slice

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -583,23 +583,32 @@
   child dispatches. User fxs see it at `(:envelope m)`.
 
   Per rf2-twt7m Change 2: the full effects map is also threaded to
-  `do-fx` (the 7-arity) so the terminating `:event/do-fx` trace
+  `do-fx` (the `:effects` opt) so the terminating `:event/do-fx` trace
   marker can stamp `:fx` (the returned vector) and `:db-present?`
   (whether the handler returned a `:db` slot). The value of `:db`
   is NOT stamped — App-db diff traces already carry slice changes.
 
   Per rf2-jhhqt: the handler's final coeffects map is also threaded
-  to `do-fx` (the 8-arity) so the terminating `:event/do-fx` trace
-  marker can stamp `:coeffects` with the user-injected subset (the
-  framework defaults `:db` `:event` `:frame` `:source` `:trace-id`
+  to `do-fx` (the `:coeffects` opt) so the terminating `:event/do-fx`
+  trace marker can stamp `:coeffects` with the user-injected subset
+  (the framework defaults `:db` `:event` `:frame` `:source` `:trace-id`
   are filtered out inside `do-fx`). Powers the Event lens's COEFFECTS
-  section without a second emit."
+  section without a second emit.
+
+  Per rf2-ee38b.1: the former positional do-fx arity ladder collapsed
+  into a single `opts` map — this is the sole caller threading the full
+  set of optionals."
   [effects coeffects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
     (let [active-platform (or (-> frame-record :config :platform)
                               interop/platform)
           event           (:event envelope)]
-      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope effects coeffects))))
+      (fx/do-fx frame fx-vec active-platform
+                {:overrides       fx-overrides
+                 :origin-event    event
+                 :parent-envelope envelope
+                 :effects         effects
+                 :coeffects       coeffects}))))
 
 ;; ---- process-event* phases ------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -40,6 +40,7 @@
             [re-frame.interop    :as interop]
             [re-frame.late-bind  :as late-bind]
             [re-frame.subs       :as subs]
+            [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.adapter.context :as adapter-context]))
 
 ;; ---- epoch scheduler (glitch-freedom; Spec 006 §Invalidation algorithm) ----
@@ -204,6 +205,31 @@
 ;; only re-emits when the recomputed value differs from the cached one
 ;; by =. The derived container itself does not memoise; per the same
 ;; spec section that's the cache's job, not the substrate's.
+;;
+;; Laziness (rf2-ee38b.1 P2). The derived value MUST NOT run `compute-fn`
+;; at construction time. `compute-fn` here is the core's memo wrapper —
+;; it runs the user sub body and (in dev) emits `:rf.sub/run` via
+;; `validate-and-trace`, and for a layer-2+ sub eagerly derefs the whole
+;; `:<-` input chain. Reagent (`ratom/make-reaction`, lazy until first
+;; deref) and the plain-atom adapter (recompute-on-deref) both defer the
+;; first body invocation to first read. The spine MUST match: seeding
+;; `prev-state` with `(recompute)` at construction (the pre-rf2-ee38b.1
+;; shape) ran the body once per `subscribe` even when the reaction is
+;; never deref'd, emitting a subscribe-time `:rf.sub/run` rather than a
+;; deref-time one — an observable cross-adapter divergence (extra body
+;; invocation count, different trace timing, side-effecting bodies firing
+;; before any render reads them) contradicting Spec 006 §No-op via value
+;; equality's "body runs on demand" intent. The fix seeds `prev-state`
+;; with the `unset` sentinel; the first flush (or deref) is the first
+;; real recompute, and the sentinel `not=` any real value so the first
+;; post-construction change always notifies — the same first-change-
+;; notifies semantics Reagent gives.
+
+(def ^:private unset
+  "Sentinel for a derived value whose baseline has not yet been computed.
+  Distinct object identity so it can never `=` a real derived value (incl.
+  `nil`/`false`), making the first flush after construction always notify."
+  (js-obj))
 
 (defn build-recompute-fn
   "Arity-specialised recompute-closure factory for a derived value.
@@ -268,22 +294,42 @@
           notify         (fn [prev nu]
                            (when (not= prev nu)
                              (run! (fn [w] (w prev nu)) (vals @watchers))))
-          ;; Baseline derived value. Seeded from the *derived* value at
-          ;; construction time, not the raw source. The flush thunk
-          ;; compares prev-derived against the recomputed derived value;
-          ;; if we seeded from `(deref s)` (the raw source), the first
-          ;; source change would spuriously notify whenever the derived
-          ;; projection differs in identity from the raw source — e.g.
-          ;; `(odd? x)`, counts, `:k` lookups, projections — even when the
-          ;; derived value itself is `=`.
+          ;; Baseline derived value. LAZY (rf2-ee38b.1 P2): seeded with the
+          ;; `unset` sentinel rather than `(recompute)`, so `compute-fn`
+          ;; (the memo wrapper running the user sub body) is NOT invoked at
+          ;; construction/subscribe time — matching Reagent's lazy
+          ;; `make-reaction` and the plain-atom recompute-on-deref adapters.
+          ;; The body runs on demand: the FIRST `-deref` (which the sub-
+          ;; cache performs to read the subscription's value) establishes
+          ;; the baseline, and a `replace-container!` change after that
+          ;; notifies `[prev-derived new-derived]` exactly as before. If a
+          ;; change flushes before any deref ever happened (no reader),
+          ;; `prev-state` is still `unset`; `unset` `not=` any real value
+          ;; (incl. nil/false) so the first flush still notifies — the same
+          ;; first-change-notifies semantics Reagent gives. (Seeding from
+          ;; the *derived* value, never the raw source, still holds: the
+          ;; flush thunk compares the recomputed derived value against the
+          ;; prior derived value / sentinel, so a projection like
+          ;; `(odd? x)` / counts / `:k` lookups never spuriously notifies on
+          ;; a same-`=` re-derive.)
           ;;
           ;; `prev-state` / `dirty?` are written and read only on the
           ;; single-threaded JS event loop and never escape this closure —
           ;; `volatile!` is the right primitive, no CAS cost. `dirty?`
           ;; dedups re-marks within an epoch: a multi-input derived value
           ;; whose N sources all fire enqueues exactly one flush thunk.
-          prev-state     (volatile! (recompute))
+          prev-state     (volatile! unset)
           dirty?         (volatile! false)
+          ;; First-deref baseline seed (rf2-ee38b.1 P2). Pure pull-based
+          ;; recompute, but on the FIRST deref it also records the value as
+          ;; `prev-state` so the next change's notification carries the real
+          ;; prior derived value (not the `unset` sentinel). Subsequent
+          ;; derefs do not touch `prev-state` — the flush path owns it.
+          deref-derived  (fn deref-derived []
+                           (let [v (recompute)]
+                             (when (identical? unset @prev-state)
+                               (vreset! prev-state v))
+                             v))
           flush!         (fn flush! []
                            (vreset! dirty? false)
                            (let [new-derived  (recompute)
@@ -305,7 +351,7 @@
           (add-watch s k (fn [_ _ _ _] (mark-dirty!)))))
       (reify
         IDeref
-        (-deref [_] (recompute))
+        (-deref [_] (deref-derived))
         ;; Watch surface — `(subscribe-container derived on-change)` rides
         ;; on this through the standard core helper, and the sub-cache's
         ;; per-entry recompute layer keys watches by gensym so the
@@ -1225,6 +1271,106 @@
      ;; this via substrate-adapter/route-hook!.
      :after-render-hook           after-render-hook}))
 
+;; ---- React-hook adapter assembly (UIx + Helix) ----------------------------
+;;
+;; rf2-ee38b.1 / rf2-ee38b.13 / rf2-ee38b.14. `make-react-spine` already
+;; eliminated the substrate LOGIC drift (one factory, N adapters). The
+;; per-adapter WIRING — the 9-key adapter map, the five `route-hook!`
+;; calls, and the two chained installs — was still hand-copied byte-for-
+;; byte between `uix.cljs` and `helix.cljs` (the clarity-lens twin
+;; finding), carrying ~90 lines of identical rationale prose and a
+;; standing drift hazard: any new routed hook had to be copied into both
+;; files in lockstep (a Helix-only SSR-parity fix per rf2-y9spn already
+;; showed the two drifting before being re-synced). `make-react-adapter`
+;; folds that wiring here — the adapter file shrinks to "build spine-fns,
+;; publish the public Vars, call make-react-adapter". The route-hook block
+;; carries zero per-adapter variation; the ONLY input is the spine-fns map
+;; (already built per-substrate) and the `:kind` discriminator keyword.
+;;
+;; Hook routing (per rf2-0d35 — see `substrate-adapter/route-hook!` for
+;; the routing contract): each impl runs ONLY when this adapter is the
+;; (rf/init!)-installed one; otherwise chains to the previously-registered
+;; handler.
+;;   :adapter/current-frame — rf2-d4sf. Function components have no
+;;     class-component (.-context cmp) slot, so the shared impl in
+;;     `re-frame.adapter.context` reads `_currentValue` directly. This is
+;;     the WIDER surface — `(rf/current-frame)` reaches the dynamic-var-
+;;     fallback chain via this hook; the per-adapter `use-current-frame`
+;;     hook is the NARROWER React-context-tier-only read (rf2-84myk).
+;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. Spine-
+;;     produced derived values reify the re-frame-owned
+;;     `re-frame.disposable/IDisposable` (no Reagent coupling); the
+;;     adapter wires straight to the protocol fns. The reactive-substrate
+;;     hooks (`:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`,
+;;     `:adapter/reactive?`) are intentionally NOT published — the React-
+;;     hook substrates ship no reactive-atom primitive (rf2-3yij / rf2-2qit)
+;;     and `re-frame.interop`'s reactive-atom surfaces have zero production
+;;     call sites under them; publishing those hooks would force the bundle
+;;     to carry reagent.core (transitively reagent.ratom) for code it never
+;;     executes.
+;;   :adapter/after-render — rf2-334d9. Backed by `React.useLayoutEffect`
+;;     via the spine's after-render machinery. `after-render` is a React-
+;;     lifecycle question (when does the next commit complete?), not a
+;;     reactive-atom one — so the "no reactive primitive" rationale that
+;;     excludes the four hooks above does NOT apply. Pre-rf2-334d9
+;;     `(rf/after-render f)` under these adapters was a silent no-op.
+;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord injection
+;;     via React.cloneElement (the views.cljs inline hiccup-walk would
+;;     mis-classify React-element output as a non-DOM root). Production-
+;;     elided via `interop/debug-enabled?` per Spec 009 §Production builds.
+
+(defn make-react-adapter
+  "Assemble a React-hook adapter (UIx / Helix) from a `make-react-spine`
+  result map plus the substrate's `:kind` discriminator keyword.
+
+  Builds the 9-key substrate adapter map, routes the five React-hook
+  late-bind hooks against it (`substrate-adapter/route-hook!`), and wires
+  the two chained installs (warn-once clear + SSR hiccup-emitter). Returns
+  the adapter map. SIDE-EFFECTING: the route-hook! / chain-fn! calls run
+  at call time (the adapter ns evaluates `(make-react-adapter spine-fns
+  :rf.adapter/uix)` at load), exactly as the hand-written wiring did.
+
+  Single source of truth (rf2-ee38b.1): UIx and Helix call this with the
+  same shape — the only inputs are their already-substrate-specific
+  `spine-fns` map and `:kind`. The former hand-copied route-hook block +
+  chained installs (byte-identical across the twins) now live once."
+  [spine-fns kind]
+  (let [adapter {:kind                      kind
+                 :make-state-container      (:make-state-container      spine-fns)
+                 :read-container            (:read-container            spine-fns)
+                 :replace-container!        (:replace-container!        spine-fns)
+                 :subscribe-container       (:subscribe-container       spine-fns)
+                 :make-derived-value        (:make-derived-value        spine-fns)
+                 :render                    (:render                    spine-fns)
+                 :render-to-string          (:render-to-string          spine-fns)
+                 :register-context-provider (:register-context-provider spine-fns)
+                 :dispose-adapter!          (:dispose-adapter!          spine-fns)}]
+    (substrate-adapter/route-hook! adapter :adapter/current-frame
+      adapter-context/function-component-current-frame
+      #(frame/current-frame))
+    (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+      rf-disposable/-add-on-dispose)
+    (substrate-adapter/route-hook! adapter :adapter/dispose!
+      rf-disposable/-dispose)
+    (substrate-adapter/route-hook! adapter :adapter/wrap-view
+      (:wrap-view spine-fns))
+    (substrate-adapter/route-hook! adapter :adapter/after-render
+      (:after-render-hook spine-fns))
+    ;; Chained warn-once clear (rf2-4edk): chained (NOT routed by installed-
+    ;; adapter identity) — every loaded adapter's per-process defonce must
+    ;; clear between tests because a bundle can mount different adapters
+    ;; across tests.
+    (install-clear-warn-once-step! (:clear-warned-non-dom-roots! spine-fns))
+    ;; Chained SSR emitter install (rf2-4z7bp): `re-frame.ssr.emit` invokes
+    ;; `:reagent/set-hiccup-emitter!` at ns-load; every loaded React-shaped
+    ;; adapter contributes its own install step so a single
+    ;; `(require '[re-frame.ssr])` auto-wires every adapter's render-to-
+    ;; string slot. Hook key is historical (Reagent published it first per
+    ;; rf2-uo7v); behaviour is adapter-agnostic.
+    (late-bind/chain-fn! :reagent/set-hiccup-emitter!
+                         (:set-hiccup-emitter! spine-fns))
+    adapter))
+
 ;; ---- ratom-family spine (Reagent + reagent-slim) --------------------------
 ;;
 ;; The Reagent and reagent-slim adapters are the SAME shape under a
@@ -1250,9 +1396,6 @@
   "Build the per-substrate ratom-family substrate surfaces given the
   substrate's ratom ops and gensym prefix:
 
-      :substrate-name    — string (currently informational; the ratom
-                           family has no warn-non-dom-root surface, that
-                           lives in re-frame.views for these adapters)
       :gensym-prefix-sub — gensym prefix for `subscribe-container` watch
                            keys (substrate-scoped per rf2-l4dmr so logs /
                            inspectors attribute a watch to its substrate)
@@ -1377,3 +1520,135 @@
                                    (set-hiccup-emitter! emitter-cell f))
      :active-roots-cell          active-roots-cell
      :emitter-cell               emitter-cell}))
+
+;; ---- ratom-family adapter assembly (Reagent + reagent-slim) ---------------
+;;
+;; rf2-ee38b.1 / rf2-ee38b.12 / rf2-ee38b.15. `make-ratom-spine` hoisted
+;; the substrate-surface drift (container quartet, renderer, dispose body,
+;; SSR emitter) but left the SECOND half — the `set-hiccup-emitter!` chain
+;; install, the `register-context-provider` wiring, the 9-key adapter map,
+;; and the entire nine-call `route-hook!` table — hand-copied byte-for-byte
+;; between `reagent.cljs` and `reagent_slim.cljs` (the clarity-lens twin
+;; finding across both ratom beads). The two `cond` dispatch closures
+;; (`add-on-dispose!`/`dispose!`) carry zero substrate-specific text — only
+;; which `ratom` ns binds the alias differs. `make-ratom-adapter` folds
+;; that wiring here, mirroring `make-react-adapter`.
+;;
+;; CRITICAL — slim bundle isolation. As with `make-ratom-spine`, this
+;; helper MUST NOT `:require` stock `reagent.*` (or `reagent2.*`). The
+;; reactive-atom-family ops the hook table needs — `current-component`,
+;; `atom`, `after-render`, `make-reaction`, the `ratom?`/`disposable?`
+;; predicates, and the `add-on-dispose!`/`dispose!`/`reactive?` fns — are
+;; INJECTED via the `:hook-ops` map (predicate/dispatch lambdas over the
+;; substrate's protocols), so the spine never names a reactive-atom ns.
+;; Each adapter passes its `reagent.*` / `reagent2.*` impls.
+
+(defn make-ratom-adapter
+  "Assemble a ratom-family adapter (Reagent / reagent-slim) from a
+  `make-ratom-spine` result map plus the substrate's config:
+
+      :kind      — the adapter's `:kind` discriminator keyword
+      :register-context-provider
+                 — the views-backed (Reagent-component-shaped) provider fn
+                   `(fn [_frame-keyword] (views/build-frame-provider))`.
+                   Passed in (NOT spine-built) so the core spine carries no
+                   spine→views dependency edge.
+      :hook-ops  — the injected reactive-atom-family ops the late-bind
+                   hook table routes (bundle-isolation: lambdas only, the
+                   spine names no reactive-atom ns):
+          :current-frame      — (fn []) → React-context-tier current frame
+                                (`views/current-frame`)
+          :current-component  — (fn []) → the in-flight component
+          :atom               — (fn [v]) → reactive atom
+          :ratom?             — (fn [x]) → boolean (IReactiveAtom check)
+          :make-reaction      — (fn [thunk]) → reaction
+          :disposable?        — (fn [x]) → boolean (substrate IDisposable
+                                check), used by the dual-protocol dispatch
+          :add-on-dispose!    — (fn [a f]) → register a substrate-reaction
+                                dispose hook
+          :dispose!           — (fn [a]) → dispose a substrate reaction
+          :reactive?          — (fn []) → boolean
+          :after-render       — (fn [f]) → schedule post-render callback
+
+  Builds the 9-key adapter map, wires the chained SSR emitter install, and
+  routes the nine ratom-family late-bind hooks against the adapter. The two
+  dual-protocol dispatch hooks (`:adapter/add-on-dispose!` / `:adapter/
+  dispose!`) protocol-check the re-frame-owned
+  `re-frame.disposable/IDisposable` FIRST (spine-produced derived values
+  from a cross-substrate test bundle, rf2-jicu2) then fall through to the
+  substrate's own disposable (`:disposable?` / `:add-on-dispose!` /
+  `:dispose!`). Returns the adapter map. SIDE-EFFECTING at call time
+  (chain-fn! / route-hook!), exactly as the hand-written wiring was.
+
+  Single source of truth (rf2-ee38b.1): Reagent and reagent-slim call this
+  with the same shape — only their injected `:hook-ops` and `:kind` differ.
+  The former hand-copied route-hook block now lives once."
+  [spine-fns {:keys [kind register-context-provider hook-ops]}]
+  (let [{:keys [current-frame current-component atom ratom? make-reaction
+                disposable? add-on-dispose! dispose! reactive? after-render]}
+        hook-ops
+        adapter {:kind                      kind
+                 :make-state-container      (:make-state-container spine-fns)
+                 :read-container            (:read-container       spine-fns)
+                 :replace-container!        (:replace-container!   spine-fns)
+                 :subscribe-container       (:subscribe-container  spine-fns)
+                 :make-derived-value        (:make-derived-value   spine-fns)
+                 :render                    (:render               spine-fns)
+                 :render-to-string          (:render-to-string     spine-fns)
+                 :register-context-provider register-context-provider
+                 :dispose-adapter!          (:dispose-adapter!     spine-fns)}]
+    ;; Chained SSR emitter install (rf2-4z7bp / parity rf2-cl1qv): every
+    ;; loaded React-shaped adapter contributes its install step so a single
+    ;; `(require '[re-frame.ssr])` auto-wires every adapter's render-to-
+    ;; string slot. `chain-fn!` (not `set-fn!`) is load-order-independent.
+    (late-bind/chain-fn! :reagent/set-hiccup-emitter!
+                         (:set-hiccup-emitter! spine-fns))
+    ;; Each hook routes through `(substrate-adapter/current-adapter)` per
+    ;; rf2-0d35 via `route-hook!`: this adapter's impl runs ONLY when it is
+    ;; the (rf/init!)-installed one; otherwise it chains to the previously-
+    ;; registered handler.
+    ;;   :adapter/current-frame — rf2-d4sf. The React-context tier of the
+    ;;     3-tier chain; the ratom family uses the class-component
+    ;;     (.-context cmp) shape via `views/current-frame`. Chain-bottom
+    ;;     fallback is `frame/current-frame` so headless / pre-init shape is
+    ;;     preserved.
+    ;;   :adapter/current-component — rf2-wbnl. Reads the substrate's
+    ;;     in-flight component without hard-binding re-frame.views to it.
+    ;;   :adapter/ratom etc. — rf2-s36l. The reactive-substrate surfaces
+    ;;     consumed by `re-frame.interop`.
+    ;;   :adapter/add-on-dispose! / :adapter/dispose! — rf2-jicu2. A
+    ;;     ratom-installed app may still hold a spine-produced derived value
+    ;;     (inherited through a cross-substrate test bundle). Dispatch
+    ;;     handles BOTH shapes — the re-frame-owned IDisposable (spine
+    ;;     derived values, checked first) and the substrate's own
+    ;;     IDisposable.
+    (substrate-adapter/route-hook! adapter :adapter/current-frame
+      current-frame
+      #(frame/current-frame))
+    (substrate-adapter/route-hook! adapter :adapter/current-component
+      current-component)
+    (substrate-adapter/route-hook! adapter :adapter/ratom
+      atom)
+    (substrate-adapter/route-hook! adapter :adapter/ratom?
+      ratom?
+      (constantly false))
+    (substrate-adapter/route-hook! adapter :adapter/make-reaction
+      make-reaction)
+    (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
+      (fn add-on-dispose!-dispatch [a f]
+        (cond
+          (satisfies? rf-disposable/IDisposable a) (rf-disposable/-add-on-dispose a f)
+          (disposable? a)                          (add-on-dispose! a f)
+          :else                                    nil)))
+    (substrate-adapter/route-hook! adapter :adapter/dispose!
+      (fn dispose!-dispatch [a]
+        (cond
+          (satisfies? rf-disposable/IDisposable a) (rf-disposable/-dispose a)
+          (disposable? a)                          (dispose! a)
+          :else                                    nil)))
+    (substrate-adapter/route-hook! adapter :adapter/reactive?
+      reactive?
+      (constantly false))
+    (substrate-adapter/route-hook! adapter :adapter/after-render
+      after-render)
+    adapter))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -75,6 +75,10 @@
   (`-dom-cljs-test$`)."
   (:require ["react" :as React]
             ["react-dom/client" :as react-dom-client]
+            ;; Test-only: react-dom/server gives matching SSR markup for the
+            ;; hydrate-branch assertion (rf2-ee38b.1). Lives in the suite
+            ;; (a test ns), never in a production bundle.
+            ["react-dom/server" :as react-dom-server]
             [cljs.test :refer-macros [is testing async]]
             [clojure.string :as str]
             [re-frame.core :as rf]
@@ -1170,6 +1174,15 @@
         unsub ((:subscribe-container adapter)
                container
                (fn [prev nu] (swap! calls conj [prev nu])))]
+    ;; rf2-ee38b.1: derived values are now LAZY (no eager compute at
+    ;; construction). Deref once at subscribe time to establish the watch
+    ;; baseline — exactly what the real sub-cache does on subscribe (it
+    ;; reads the subscription's initial value). Without this, the first
+    ;; source change would notify against the `unset` sentinel rather than
+    ;; the prior derived value, defeating the rf2-66hb no-spurious-first-
+    ;; notify guarantee. Production's useSyncExternalStore likewise calls
+    ;; getSnapshot (a deref) at subscribe.
+    @container
     {:calls calls :unsub unsub}))
 
 (defn assert-derived-baseline-projections
@@ -1905,6 +1918,53 @@
           (finally
             (when-let [u @unmount]
               (try (u) (catch :default _ nil))))))))))
+
+;; ---- hydrate render branch (rf2-ee38b.1 — closes the React-hook spine
+;;       hydrate test gap that Reagent/reagent-slim already cover) ----------
+
+(defn assert-render-hydrate-branch-mounts-without-remount
+  "rf2-ee38b.13 / rf2-ee38b.14: the spine `make-render` `:hydrate? true`
+  branch (`react-dom/client/hydrateRoot`) was untested for the React-hook
+  substrates while Reagent/reagent-slim both exercise it. This closes the
+  gap once for BOTH UIx and Helix.
+
+  The probe ELEMENT is pre-rendered to matching SSR markup with React's own
+  `react-dom/server/renderToString` (a test-only require — the same element
+  the client hydrates, so no hydration-mismatch warning), the markup is
+  planted into a fresh mount node, then `substrate-adapter/render …
+  {:hydrate? true}` drives the spine's hydrate branch to adopt the existing
+  DOM. We assert the spine's hydrate path returns a working unmount thunk
+  (root tracked in `active-roots-cell` + drained) and that the hydrated
+  subtree's DOM survives — i.e. `hydrateRoot` adopted the markup rather than
+  throwing or blanking the node.
+
+  cfg keys:
+    :probe-element  a thunk returning a fresh substrate probe ELEMENT (the
+                    same `$`-built element the after-render twin uses)"
+  [{:keys [name probe-element]}]
+  (testing (str name " — render :hydrate? true branch adopts SSR markup (rf2-ee38b.1)")
+    (with-browser-act
+     (fn [act-fn]
+      (let [mount-node (make-mount-node!)
+            ;; Same element the client will hydrate ⇒ matching markup ⇒ no
+            ;; hydration mismatch. renderToString is React's, not the
+            ;; hiccup emitter (which takes hiccup, not React elements).
+            markup     (.renderToString react-dom-server (probe-element))
+            unmount    (atom nil)]
+        (set! (.-innerHTML mount-node) markup)
+        (try
+          (act-fn (fn []
+                    (reset! unmount
+                            (substrate-adapter/render
+                              (probe-element) mount-node {:hydrate? true}))))
+          (is (fn? @unmount)
+              "hydrate render returns an unmount thunk (root tracked)")
+          (is (pos? (.-length (.-childNodes mount-node)))
+              "hydrated subtree's DOM is present (hydrateRoot adopted the
+               markup, did not blank the node)")
+          (finally
+            (when-let [u @unmount]
+              (try (act-fn (fn [] (u))) (catch :default _ nil))))))))))
 
 ;; ---- use-subscribe (rf2-518sp / rf2-7g959 / rf2-mwft2 / rf2-rcgsc) --------
 ;;

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -50,6 +50,27 @@
      :replace!     replace!
      :root         root}))
 
+;; ---- laziness (rf2-ee38b.1 P2) --------------------------------------------
+
+(deftest make-derived-value-is-lazy-no-compute-at-construction
+  (testing "constructing a derived value does NOT invoke compute-fn until
+            the first deref — matching Reagent's lazy make-reaction and the
+            plain-atom recompute-on-deref adapters (rf2-ee38b.1 P2). The
+            React-hook spine formerly seeded prev-state eagerly with
+            `(recompute)`, running the user sub body (and emitting
+            :rf.sub/run) at subscribe-time rather than deref-time."
+    (let [{:keys [make-derived root]} (build-graph)
+          runs (atom 0)
+          d    (make-derived [root] (fn [db] (swap! runs inc) (:a db)))]
+      (is (= 0 @runs)
+          "compute-fn NOT invoked at construction — body runs on demand")
+      (is (= 1 @d) "first deref computes the value")
+      (is (= 1 @runs) "compute-fn ran exactly once, on first deref")
+      ;; A second deref is pull-based (recompute) — also runs the body, but
+      ;; the point of the contract is ZERO runs before the first read.
+      @d
+      (is (= 2 @runs) "subsequent derefs recompute (pull-based), as before"))))
+
 ;; ---- single-input layer-1 (regression guard) ------------------------------
 
 (deftest layer-1-single-input-notifies-once
@@ -58,6 +79,11 @@
     (let [{:keys [make-derived replace! root]} (build-graph)
           l1     (make-derived [root] (fn [db] (:a db)))
           notes  (atom [])]
+      ;; rf2-ee38b.1: derived values are LAZY — the first deref establishes
+      ;; the baseline (the sub-cache always reads the value on subscribe).
+      ;; Deref before the change so the notification carries the real prior
+      ;; derived value rather than the `unset` sentinel.
+      (is (= 1 @l1) "baseline deref establishes prev-state")
       (add-watch l1 :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
       (replace! root {:a 2 :b 10})
       (is (= [[1 2]] @notes)
@@ -70,6 +96,9 @@
     (let [{:keys [make-derived replace! root]} (build-graph)
           l1     (make-derived [root] (fn [db] (:a db)))
           notes  (atom 0)]
+      ;; rf2-ee38b.1: deref to establish the lazy baseline before watching,
+      ;; mirroring the sub-cache's read-on-subscribe.
+      (is (= 1 @l1) "baseline deref establishes prev-state")
       (add-watch l1 :w (fn [_ _ _ _] (swap! notes inc)))
       ;; :b changes; :a — the only slice l1 reads — does not.
       (replace! root {:a 1 :b 99})
@@ -175,6 +204,8 @@
           src          (atom 5)
           l1     (make-derived [src] (fn [x] (* x 10)))
           notes  (atom [])]
+      ;; rf2-ee38b.1: deref to establish the lazy baseline before watching.
+      (is (= 50 @l1) "baseline deref establishes prev-state")
       (add-watch l1 :w (fn [_ _ prev nu] (swap! notes conj [prev nu])))
       (reset! src 6)
       (is (= [[50 60]] @notes)


### PR DESCRIPTION
Coordinated cross-cutting remediation across five review beads that share the `re_frame/substrate/spine.cljs` surface — done together so parallel workers can't collide. Closes rf2-ee38b.1 (core), .12 (reagent), .13 (uix), .14 (helix), .15 (reagent-slim).

## The extraction (headline clarity finding)

`make-react-spine` / `make-ratom-spine` already eliminated the substrate **logic** drift; the per-adapter **wiring** was still hand-copied byte-for-byte. Two new spine factories fold it in:

- **`make-react-adapter spine-fns kind`** (UIx + Helix): builds the 9-key adapter map, routes the five React-hook `route-hook!` calls, and wires the two chained installs (warn-once clear + SSR emitter). `uix.cljs` / `helix.cljs` collapse to one call each. ~90 lines of identical rationale prose now live once at the factory.
- **`make-ratom-adapter spine-fns {:kind :register-context-provider :hook-ops}`** (Reagent + reagent-slim): folds the verbatim nine-call `route-hook!` table, including the dual-`IDisposable` `cond` dispatch closures. **Bundle isolation preserved** — the reactive-atom-family ops are injected via `:hook-ops` (predicate/dispatch lambdas), so the spine names no `reagent.*` / `reagent2.*` ns, exactly like the existing `:ratom-ops` contract. `register-context-provider` is passed in (not spine-built) to keep the core spine free of a spine→views edge.

Net: the four adapter files lost ~500 lines collectively; the spine gained ~300 (factories + rationale + laziness). The per-adapter public Vars stay (intentional ns-qualified ergonomics).

## Eager/lazy resolution (correctness P2)

The React-hook spine's `make-derived-value` seeded `prev-state` with `(recompute)` at construction — running the user sub body (and emitting `:rf.sub/run`) at **subscribe-time** rather than deref-time, an observable divergence from Reagent (lazy `make-reaction`) and plain-atom (recompute-on-deref). Reconciled by making the spine **lazy**: `prev-state` seeds with an `unset` sentinel; the **first deref** establishes the baseline (exactly what the sub-cache / `useSyncExternalStore` `getSnapshot` does on subscribe), so a value-equal first change still doesn't spuriously notify; if a change ever flushes before any read, `unset` `not=` any real value so it notifies (Reagent's first-change-notifies semantics). Verified against Spec 006 §Invalidation. New `make-derived-value-is-lazy-no-compute-at-construction` test pins it; the rf2-66hb watch-baseline suite + glitch-free suite were updated to deref the baseline at subscribe (the realistic path).

## reagent-slim Reaction bug (P2 latent)

`Reaction._run` did `(set! state res)` unconditionally; on the `check=true` (queued/`flush!`) error path `_try-capture` had already set `state` to the caught error, then `_run` clobbered it with the catch block's `false` return AND `notify-w` fired with that spurious `false`. Fixed to mirror stock Reagent (`_try-capture` sets `state` on success; `_run` only sets when `not check`). New throwing-Reaction queued/flush! test.

## Core clarity

- Deleted dead `realise-sub-handler` (zero call sites; self-described back-compat shim).
- Collapsed the `do-fx` six-step nil-padding arity ladder to `3-arity + opts map` (`:overrides :origin-event :parent-envelope :effects :coeffects`); router is the sole full-opts caller, machine-exit walk uses the 3-arity.
- Inlined single-use `fx-runs-on-platform?`.

## Per-adapter leftovers

- reagent: `:substrate-name` dead config dropped (unused by `make-ratom-spine`); verbose `register-context-provider` inlined.
- reagent-slim: `set-hiccup-emitter!` docstring "Idempotent" → "Last call wins"; `parse-tag` docstring corrected + a test pinning the id-before-class constraint (matches stock; not a regression).
- uix/helix: Helix `use-current-frame` docstring synced to the fuller UIx wording (twin drift); the missing **hydrate render-branch test** added once in `react-shared-suite`, forwarded from both UIx + Helix entry files.

## Deferred P3

`:rf.error/derived-container-replaced` (reagent, Spec 006:163) — specified but implemented nowhere in the stack; out of scope for this wiring/correctness pass. Follow-up: file a dedicated bead to implement the error-on-replace contract across adapters (a behavioural addition, not a wiring fix).

## Test plan

- [x] core JVM `clojure -M:test` (728 tests)
- [x] CLJS node `npm run test:cljs` clean recompile (4157 tests)
- [x] browser tests (112 tests) — exercises the new hydrate test + React-hook spine DOM paths
- [x] `npm run test:bundle-isolation` + `npm run test:reagent-slim:bundle-isolation` (critical — slim stays stock-Reagent-free)
- [x] `npm run test:elision` (36/36 sentinels absent in prod)
- [x] `npm run test:perf-bundle`
- [x] machines / routing / epoch JVM (do-fx callers)