### PR TITLE
fix(story-mcp): write-back :play-script + get-story-instructions outputSchema

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-story.cjs
+++ b/tools/mcp-conformance/test/end-to-end-story.cjs
@@ -141,16 +141,20 @@ runWithWatchdog(
     // write gate, so they cover the success path here with zero extra
     // setup. Each routes through the SDK's `CallToolResultSchema` parse.
     //
-    // NOTE: `get-story-instructions` is deliberately NOT walked here. It
-    // declares an `:outputSchema` but returns text-only (no
-    // structuredContent), so the SDK's high-level `callTool` rejects it
-    // with `-32600` ("has an output schema but did not return structured
-    // content"). That is a latent story-mcp tool defect surfaced by this
-    // very broadening (the tool was never SDK-driven before) — tracked
-    // separately, out of scope for the conformance-harness bead. The
-    // `list-*` reads below DO emit structuredContent and are the clean
-    // success-envelope coverage.
-    for (const readTool of ['list-substrates', 'list-modes', 'list-tags']) {
+    // `get-story-instructions` is walked here too (rf2-vyacl). It
+    // declares an `:outputSchema`, so the SDK's high-level `callTool`
+    // REJECTS a result with no structuredContent with `-32600` ("has an
+    // output schema but did not return structured content"). The handler
+    // now emits a matching `{:instructions <text>}` structuredContent
+    // (mirroring re-frame2-pair-mcp's sibling `get-re-frame2-pair-
+    // instructions`), so the SDK parse passes — this assertion pins that
+    // the latent defect stays fixed across the wire.
+    for (const readTool of [
+      'get-story-instructions',
+      'list-substrates',
+      'list-modes',
+      'list-tags',
+    ]) {
       const r = await client.callTool({ name: readTool, arguments: {} });
       if (r.isError) {
         throw new Error(
@@ -168,8 +172,8 @@ runWithWatchdog(
       }
     }
     console.log(
-      'OK   closed-world reads (list-substrates/list-modes/list-tags) ' +
-        '-> success envelopes',
+      'OK   closed-world reads (get-story-instructions/list-substrates/' +
+        'list-modes/list-tags) -> success envelopes',
     );
 
     // 3. register-variant — body as an EDN string so JSON's lack of

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -360,9 +360,14 @@ contract per
 [`tools/story/spec/005-SOTA-Features.md`](../../story/spec/005-SOTA-Features.md)
 §Test Codegen.
 
-Optional `:write-back` re-registers the source variant with
-`:play <captured-events>` via `reg-variant*` (preserving the
-existing `:component`, `:args`, `:decorators`, etc.). This branch is
+Optional `:write-back` re-registers the source variant with the
+captured recording translated to a live `:play-script` body via
+`reg-variant*` (preserving the existing `:component`, `:args`,
+`:decorators`, etc.). The translation routes through
+`re-frame.story/recording->play-script` — each captured event becomes
+a `[:dispatch ...]` step under `:play-script {:script [...]}`, the
+canonical AND ONLY phase-4 replay slot (per rf2-0wrud; the legacy
+`:play` slot was removed and no runner executes it). This branch is
 gated behind the same `allow-writes?` flag as `register-variant`; the
 read-only path (snippet only) needs no gate.
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -366,7 +366,7 @@ Bridges `re-frame.story`'s recorder primitives (per
  :doc            string  (optional)                ; embedded in snippet
  :extends        keyword (optional)                ; defaults to :variant-id
  :alias          string  (optional, default "story")
- :write-back     boolean (optional, default false) ; re-register with :play <captured>
+ :write-back     boolean (optional, default false) ; re-register with :play-script <captured>
 }
 ```
 

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -24,7 +24,7 @@
     "\n"
     "  (reg-story   :story.<path>              { :doc :component :decorators :args :argtypes\n"
     "                                            :tags :modes :substrates :platforms :variants })\n"
-    "  (reg-variant :story.<path>/<variant>    { :doc :extends :events :play :args :argtypes\n"
+    "  (reg-variant :story.<path>/<variant>    { :doc :extends :events :play-script :args :argtypes\n"
     "                                            :tags :decorators :loaders :loaders-complete-when\n"
     "                                            :args->events :platforms :substrates :modes })\n"
     "  (reg-workspace :Workspace.<path>/<name> { :doc :layout :variants :content :render :modes })\n"
@@ -47,8 +47,8 @@
     "    dispatched?, state-is, no-warnings, effect-emitted.\n"
     "\n"
     "Lifecycle (`run-variant`): four phases — loaders → events → render\n"
-    "→ play. `:rf.assert/*` events in `:play` accumulate records on the\n"
-    "frame; they do NOT throw on failure. `assertions-passing?` is the\n"
+    "→ play. `:rf.assert/*` steps in `:play-script` accumulate records on\n"
+    "the frame; they do NOT throw on failure. `assertions-passing?` is the\n"
     "vacuous-pass predicate (empty assertions vector is green).\n"
     "\n"
     "Snapshots: `snapshot-identity` hashes the canonical (variant ×\n"
@@ -56,9 +56,20 @@
     "across hosts; use for visual-regression keying.\n"))
 
 (defn tool-get-story-instructions
-  "Dev: return the Story authoring conventions in agent-friendly form."
+  "Dev: return the Story authoring conventions in agent-friendly form.
+
+  Emits BOTH the `:content` text slot AND a matching
+  `:structuredContent` map (rf2-vyacl). The descriptor declares an
+  `:outputSchema` (`s/default-output-schema`); the official MCP SDK's
+  high-level `callTool` REJECTS a tool that declares an output schema
+  but returns no `:structuredContent` with JSON-RPC -32600. Mirroring
+  re-frame2-pair-mcp's sibling `get-re-frame2-pair-instructions` (which
+  routes through `wire/ok-text` and always emits structuredContent), we
+  carry the prose under `:instructions` so the structured slot satisfies
+  the permissive `additionalProperties: true` envelope schema."
   [_args]
-  (h/text-result story-instructions-text))
+  (let [payload {:instructions story-instructions-text}]
+    (h/text-result story-instructions-text payload)))
 
 (defn tool-preview-variant
   "Dev: given a variant id, return the canvas state + share URL.

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/docs.cljc
@@ -246,12 +246,20 @@
 
 (defn tool-variant->edn
   "Docs: round-trippable EDN of a registered variant. Identical payload
-  to `get-variant` but framed as EDN-only — the `structuredContent`
-  slot is omitted so agents that want strict EDN parse the text."
+  to `get-variant`; the text slot is the byte-stable `pr-str` EDN
+  (keyword keys preserved) for agents that want strict EDN diffing.
+
+  Emits a matching `:structuredContent` too (rf2-vyacl). The descriptor
+  declares an `:outputSchema`; the official MCP SDK's high-level
+  `callTool` REJECTS an outputSchema-declaring tool that returns no
+  structuredContent with JSON-RPC -32600. (Same latent defect class as
+  `get-story-instructions` — `variant->edn` was the only other tool
+  still text-only.) The structured slot carries the same body map; the
+  text slot remains the byte-stable EDN source of truth."
   [args]
   (h/with-variant args
     (fn [_vk body]
-      (h/text-result (h/pr-edn body)))))
+      (h/text-result (h/pr-edn body) body))))
 
 (defn- md-h1 [s] (str "# " s "\n\n"))
 (defn- md-h2 [s] (str "\n## " s "\n\n"))
@@ -376,7 +384,7 @@
     :category       :docs
     :description    (str "Return one variant's full body (the resolved EDN, with `:extends` already applied at registration time). "
                          "Examples: "
-                         "1. Hit: {:variant-id \":story.cart/full\"} -> {:id :story.cart/full :body {:doc \"...\" :args {:item-count 3} :play [...] :tags #{:dev}}}. "
+                         "1. Hit: {:variant-id \":story.cart/full\"} -> {:id :story.cart/full :body {:doc \"...\" :args {:item-count 3} :play-script {:script [...]} :tags #{:dev}}}. "
                          "2. With extends already applied: {:variant-id \":story.cart/full-with-discount\"} -> {:body {... merged from :story.cart/full ...}}. "
                          "3. Miss: {:variant-id \":story.no/such\"} -> {:isError true :content [{:text \"Variant not found: :story.no/such\"}]}.")
     :typicalTokens  1000
@@ -454,7 +462,7 @@
                          "Examples: "
                          "1. Default: {} -> {:canonical [{:id :rf.assert/path-equals :payload \"[path expected]\" :semantics \"(= (get-in @app-db path) expected)\"} ...] :registered [:rf.assert/dispatched? :rf.assert/effect-emitted ...]}. "
                          "2. With budget knob: {:max-tokens 1000} -> same shape, tighter cap. "
-                         "3. Pair with run-variant: discover the assertion vocab here, then write :play sequences referencing those event ids. "
+                         "3. Pair with run-variant: discover the assertion vocab here, then write :play-script sequences referencing those event ids. "
                          "4. Paginated: {:limit 5} -> {:canonical [...7...] :registered [...5...] :total 14 :limit 5 :has-more? true :next-cursor \"<base64>\"}.")
     :typicalTokens  500
     :inputSchema    {:type "object"
@@ -466,9 +474,9 @@
 
    {:name           "variant->edn"
     :category       :docs
-    :description    (str "Round-trippable EDN of a registered variant. Text result only (no structuredContent); use this when you want byte-stable EDN. "
+    :description    (str "Round-trippable EDN of a registered variant. The text slot is the byte-stable pr-str EDN (keyword keys preserved); a matching :structuredContent carries the same body map. Use the text slot when you want byte-stable EDN for diffing. "
                          "Examples: "
-                         "1. Hit: {:variant-id \":story.cart/full\"} -> {:doc \"...\" :args {:item-count 3} :tags #{:dev} :play [...]} (as pr-str EDN text). "
+                         "1. Hit: {:variant-id \":story.cart/full\"} -> {:doc \"...\" :args {:item-count 3} :tags #{:dev} :play-script {:script [...]}} (as pr-str EDN text). "
                          "2. Byte-stable for diffing two registries: same input always emits same text bytes (no JSON re-projection). "
                          "3. Miss: {:variant-id \":story.no/such\"} -> {:isError true :content [{:text \"Variant not found: :story.no/such\"}]}.")
     :typicalTokens  1000

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -12,8 +12,10 @@
   suppression) — see `re-frame.story.recorder/recordable-event?`.
 
   Optional `:write-back` re-registers the source variant with the
-  captured `:play` slot — gated by the same `allow-writes?` flag as
-  `register-variant` (`tools.write/assert-writes-allowed`). This is
+  captured recording translated to a live `:play-script` slot (the
+  canonical AND ONLY phase-4 replay surface per rf2-0wrud) — gated by
+  the same `allow-writes?` flag as `register-variant`
+  (`tools.write/assert-writes-allowed`). This is
   the self-healing-loop hook the spec mentions: agent drives canvas →
   tool returns snippet AND patches the variant in place.
 
@@ -62,23 +64,34 @@
      :cljs (.now js/Date)))
 
 (defn- write-back!
-  "Re-register the target variant with the captured `:play` body.
-  Preserves the source variant's existing body keys (so `:component`,
-  `:args`, `:decorators` survive) and overwrites `:play` with the
-  captured `events`. Stamps `:origin :story-mcp` per
-  `spec/Cross-Cutting-Designs.md §5` — the write-back produces a new
-  variant body and the origin tag identifies the MCP write surface as
-  its producer.
+  "Re-register the target variant with the captured recording as a live
+  `:play-script` body. Preserves the source variant's existing body keys
+  (so `:component`, `:args`, `:decorators` survive) and overwrites
+  `:play-script` with the translated, replayable script.
+
+  Per rf2-50jzf the legacy `:play` slot was REMOVED for `:play-script`
+  in rf2-0wrud — `:play-script` is the canonical AND ONLY phase-4
+  replay surface (tools/story schemas.cljc). Writing a `:play` key
+  would pass the open variant `:map` validation but no runner executes
+  it, so a written-back recording would silently never replay. We
+  translate the captured `events` via `story/recording->play-script`
+  (the live runtime counterpart to `gen-play-snippet`'s text output)
+  and write that under `:play-script`.
+
+  Stamps `:origin :story-mcp` per `spec/Cross-Cutting-Designs.md §5` —
+  the write-back produces a new variant body and the origin tag
+  identifies the MCP write surface as its producer.
 
   Returns the structured success result on the happy path, or an
   `error-result` whose `:structuredContent` merges the base recorder
   payload, the failure flag, and the registrar's `ex-data`."
   [base body events target-vid]
   (try
-    (let [id      (story/reg-variant*
-                    target-vid
-                    (assoc body :play events :origin config/origin))
-          payload (assoc base :written-back? true :new-variant-id id)]
+    (let [play-script (story/recording->play-script events)
+          id          (story/reg-variant*
+                        target-vid
+                        (assoc body :play-script play-script :origin config/origin))
+          payload     (assoc base :written-back? true :new-variant-id id)]
       (h/text-result (h/pr-edn payload) payload))
     (catch #?(:clj Throwable :cljs :default) e
       (h/error-result (str "Write-back failed: " (ex-message e))
@@ -108,8 +121,9 @@
                               rejected with a structured error
                               (rf2-4yuhi).
     :new-variant-id optional — when `:write-back` is true, register the
-                              captured `:play` body as a NEW variant
-                              with this id. Defaults to the source
+                              captured recording (translated to a live
+                              `:play-script` body) as a NEW variant with
+                              this id. Defaults to the source
                               `:variant-id` (overwrites in place).
     :doc           optional — docstring to embed in the snippet.
     :extends       optional — variant id to embed as the snippet's
@@ -119,8 +133,10 @@
     :alias         optional — short ns alias in the rendered form
                               (default `\"story\"`).
     :write-back    optional — when true, also re-register the variant
-                              via `reg-variant*` with `:play <captured>`.
-                              Requires `allow-writes?` (same gate as
+                              via `reg-variant*` with the captured
+                              recording translated to a live
+                              `:play-script` body. Requires
+                              `allow-writes?` (same gate as
                               `register-variant`). Wire-key shape per
                               rf2-pmwgn: no `?` — Anthropic's input-
                               schema property-name regex rejects it.
@@ -247,7 +263,7 @@
   per IMPL-SPEC §7.3."
   [{:name           "record-as-variant"
     :category       :write
-    :description    (str "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back` re-registers the variant with the captured `:play` slot — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`). Wire-key shape per rf2-pmwgn: input-schema property keys MUST omit the trailing `?` (Anthropic regex); the response key `:written-back?` is not bound by the same rule. "
+    :description    (str "Bridge the recorder's start → capture → snippet pipeline across the MCP boundary. Starts a recording against the source variant's frame, blocks for `:duration-ms`, stops, returns the `(reg-variant ...)` snippet `gen-play-snippet` emits. Optional `:write-back` re-registers the variant with the captured recording translated to a live `:play-script` slot (the canonical replay surface) — GATED behind `:rf.story-mcp/allow-writes?` (same gate as `register-variant`). Wire-key shape per rf2-pmwgn: input-schema property keys MUST omit the trailing `?` (Anthropic regex); the response key `:written-back?` is not bound by the same rule. "
                          "Examples: "
                          "1. Snippet-only record (no write-back): {:variant-id \":story.cart/full\" :duration-ms 2000} -> {:variant-id :story.cart/full :play-snippet \"(story/reg-variant :story.cart/full {:extends :story.cart/full :play-script {:auto-run? true :script [[:dispatch-sync [:cart/add ...]]]}})\" :recorded-event-count 4 :duration-ms 2012 :captured [[:cart/add ...]] :written-back? false}. "
                          "2. With write-back (gate must be open): {:variant-id \":story.cart/full\" :duration-ms 1000 :write-back true :new-variant-id \":story.cart/recorded\"} -> {... :written-back? true :new-variant-id :story.cart/recorded}. "
@@ -261,7 +277,7 @@
                                                                     "Hard ceiling " max-duration-ms "ms — the MCP server's request loop is single-threaded so "
                                                                     "this call blocks unrelated tools for the full window; abusive durations are rejected (rf2-4yuhi).")}
                                  :new-variant-id (assoc s/kw-or-string
-                                                   :description "When `:write-back` is true, register the captured `:play` body under this id. Defaults to the source `:variant-id` (overwrites in place).")
+                                                   :description "When `:write-back` is true, register the captured recording (translated to a live `:play-script` body) under this id. Defaults to the source `:variant-id` (overwrites in place).")
                                  :doc            {:type "string"
                                                   :description "Optional docstring embedded in the rendered snippet."}
                                  :extends        (assoc s/kw-or-string
@@ -269,7 +285,7 @@
                                  :alias          {:type "string"
                                                   :description "Short ns alias for the rendered form (default \"story\")."}
                                  :write-back     {:type "boolean"
-                                                  :description (str "When true, also re-register the variant with the captured `:play`. Requires `allow-writes?`. "
+                                                  :description (str "When true, also re-register the variant with the captured recording as a live `:play-script` body. Requires `allow-writes?`. "
                                                                     "Wire-key shape: no `?` per Anthropic's `^[a-zA-Z0-9_.-]{1,64}$` input-schema property-name regex (rf2-pmwgn).")}})
                   :required ["variant-id"]
                   :additionalProperties false}

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -371,6 +371,27 @@
       (is (re-find #":rf.assert" text))
       (is (re-find #"snapshot-identity" text)))))
 
+(deftest get-story-instructions-emits-structured-content
+  ;; rf2-vyacl — the descriptor declares an `:outputSchema`, so the
+  ;; official MCP SDK's high-level callTool REJECTS a result with no
+  ;; `:structuredContent` (JSON-RPC -32600). The handler MUST emit a
+  ;; structuredContent slot. Mirrors re-frame2-pair-mcp's sibling
+  ;; `get-re-frame2-pair-instructions` (which always emits structured
+  ;; content via `wire/ok-text`).
+  (testing "the result carries a non-nil :structuredContent matching the text"
+    (let [r (invoke "get-story-instructions" {})]
+      (is (success? r))
+      (is (some? (:structuredContent r))
+          "an outputSchema-declaring tool MUST return structuredContent (SDK -32600)")
+      (is (= (-> r :content first :text)
+             (-> r :structuredContent :instructions))
+          "structuredContent mirrors the text slot under :instructions")))
+  (testing "the descriptor declares an outputSchema — the invariant that makes structuredContent mandatory"
+    (let [d (some #(when (= "get-story-instructions" (:name %)) %)
+                  registry/tool-registry)]
+      (is (map? (:outputSchema d))
+          "get-story-instructions declares an :outputSchema, so it MUST emit structuredContent"))))
+
 (deftest preview-variant-happy
   (let [r (invoke "preview-variant" {:variant-id "story.button/primary"
                                      :base-url "http://localhost:8000/"})
@@ -510,7 +531,15 @@
       (let [text (-> r :content first :text)
             back (clojure.edn/read-string text)]
         (is (map? back))
-        (is (= "Primary button." (:doc back)))))))
+        (is (= "Primary button." (:doc back))))))
+  (testing "rf2-vyacl: variant->edn ALSO emits structuredContent (it declares an outputSchema, so the SDK requires it)"
+    ;; `variant->edn` was the only other tool besides get-story-instructions
+    ;; that returned text-only while declaring an :outputSchema — the same
+    ;; -32600 latent defect. It now mirrors the body into structuredContent.
+    (let [r (invoke "variant->edn" {:variant-id "story.button/primary"})]
+      (is (some? (:structuredContent r))
+          "an outputSchema-declaring tool MUST return structuredContent (SDK -32600)")
+      (is (= "Primary button." (-> r :structuredContent :doc))))))
 
 ;; rf2-i0kyy — `get-docs-markdown` is the agent-paste shape.
 (deftest get-docs-markdown-renders-story-and-variants
@@ -1140,15 +1169,27 @@
                     {:variant-id  "story.button/primary"
                      :duration-ms 100
                      :write-back  true})
-          s (:structuredContent r)]
+          s (:structuredContent r)
+          n (:recorded-event-count s)]
       (is (success? r))
       (is (true? (:written-back? s)))
       (is (= :story.button/primary (:new-variant-id s)))
-      ;; Source variant's :play slot now carries the captured events.
-      (is (= [[:counter/inc] [:counter/inc]]
-             (:play (story/variant->edn :story.button/primary))))
-      ;; Pre-existing body keys survive (e.g. :doc).
-      (is (= "Primary button." (:doc (story/variant->edn :story.button/primary)))))))
+      (is (pos? n) "the recorder captured at least one event")
+      ;; rf2-50jzf: the source variant's `:play-script` slot now carries
+      ;; the captured events as a LIVE, replayable script — NOT the dead
+      ;; `:play` slot the schema dropped in rf2-0wrud (which no runner
+      ;; executes). Each captured event becomes a `[:dispatch ...]` step.
+      ;; The exact count is derived from `:recorded-event-count` because
+      ;; the live-recorder capture races the :duration-ms window.
+      (let [body (story/variant->edn :story.button/primary)]
+        (is (nil? (:play body))
+            "the legacy dead :play slot must NOT be written")
+        (is (= {:script    (vec (repeat n [:dispatch [:counter/inc]]))
+                :auto-run? true}
+               (:play-script body))
+            "write-back emits the canonical :play-script slot the runner replays")
+        ;; Pre-existing body keys survive (e.g. :doc).
+        (is (= "Primary button." (:doc body)))))))
 
 (deftest record-as-variant-write-back-new-id
   (testing ":new-variant-id lands the capture under a fresh id"
@@ -1159,13 +1200,83 @@
                      :new-variant-id "story.button/recorded"
                      :duration-ms    100
                      :write-back     true})
-          s (:structuredContent r)]
+          s (:structuredContent r)
+          n (:recorded-event-count s)]
       (is (success? r))
       (is (true? (:written-back? s)))
       (is (= :story.button/recorded (:new-variant-id s)))
-      (is (= [[:counter/inc]] (:play (story/variant->edn :story.button/recorded))))
+      (is (pos? n) "the recorder captured at least one event")
+      ;; rf2-50jzf: capture lands under the live `:play-script` slot
+      ;; (count derived from `:recorded-event-count` — capture races the
+      ;; :duration-ms window).
+      (is (= {:script (vec (repeat n [:dispatch [:counter/inc]])) :auto-run? true}
+             (:play-script (story/variant->edn :story.button/recorded))))
+      (is (nil? (:play (story/variant->edn :story.button/recorded))))
       ;; Source variant is untouched.
+      (is (nil? (:play-script (story/variant->edn :story.button/primary))))
       (is (nil? (:play (story/variant->edn :story.button/primary)))))))
+
+(deftest record-as-variant-write-back-round-trips-and-replays
+  (testing "rf2-50jzf: a written-back recording's :play-script ACTUALLY replays"
+    ;; The headline acceptance criterion for rf2-50jzf — the previous
+    ;; write-back wrote a dead `:play` slot the schema dropped in
+    ;; rf2-0wrud, so a round-tripped recording silently never replayed.
+    ;; This test closes the loop end-to-end: record real dispatches →
+    ;; write them back under a fresh variant → run THAT variant through
+    ;; the MCP `run-variant` tool → assert the captured dispatches fired
+    ;; against the frame's app-db (proving the slot the runner executes
+    ;; is the one write-back wrote).
+    ;;
+    ;; The live-recorder capture races the tool's :duration-ms window
+    ;; (the worker may push 1–N of the driven events before
+    ;; `stop-recording!` closes the window), so the EXPECTED replay count
+    ;; is derived from `:recorded-event-count` rather than hard-coded —
+    ;; the invariant under test is "`:n` after replay == number of
+    ;; captured `:test/bump` steps", which holds regardless of how many
+    ;; the race captured. We require at least one capture so the replay
+    ;; path is genuinely exercised.
+    (config/set-allow-writes! true)
+    ;; A real event-db handler whose effect is observable in app-db.
+    (rf/reg-event-db :test/bump (fn [db _] (update db :n (fnil inc 0))))
+    (drive-events-during-recording [[:test/bump] [:test/bump] [:test/bump]])
+    (let [rec (invoke "record-as-variant"
+                      {:variant-id     "story.button/primary"
+                       :new-variant-id "story.button/replayed"
+                       :duration-ms    100
+                       :write-back     true})
+          s   (:structuredContent rec)
+          n   (:recorded-event-count s)]
+      (is (success? rec))
+      (is (true? (:written-back? s)))
+      (is (pos? n) "the recorder captured at least one :test/bump step")
+      ;; The written-back body carries the LIVE :play-script slot —
+      ;; n `[:dispatch [:test/bump]]` steps, NOT the dead `:play` slot.
+      (let [body (story/variant->edn :story.button/replayed)]
+        (is (nil? (:play body)) "no dead :play slot is written")
+        (is (= {:script    (vec (repeat n [:dispatch [:test/bump]]))
+                :auto-run? true}
+               (:play-script body))
+            "write-back emits the live :play-script slot, one :dispatch step per captured event"))
+      ;; Run the written-back variant: the replayed :test/bump dispatches
+      ;; must land on the frame's app-db. This is the load-bearing
+      ;; distinction — a dead `:play` slot is never executed by any runner,
+      ;; so :n would be nil; the live `:play-script` slot replays, so :n is
+      ;; a positive count.
+      ;;
+      ;; The recorder emits `:dispatch` (ASYNC) steps (per
+      ;; play-export/event->step), and on the JVM run-variant queues them
+      ;; via `rf/dispatch*` without an inter-step yield (runner_events
+      ;; run-loop! :clj branch). So the exact settled :n is not
+      ;; deterministic — what IS deterministic is the qualitative replay:
+      ;; the dead-slot bug leaves :n nil, the fix leaves :n a positive
+      ;; integer no greater than the captured count.
+      (let [run    (invoke "run-variant" {:variant-id "story.button/replayed"})
+            rs     (:structuredContent run)
+            run-n  (get-in rs [:app-db :n])]
+        (is (success? run))
+        (is (and (integer? run-n) (pos? run-n) (<= run-n n))
+            (str "the recording replayed — :test/bump dispatches incremented :n to "
+                 (pr-str run-n) " (captured " n "); a dead :play slot would leave :n nil"))))))
 
 (deftest record-as-variant-snippet-honours-doc-and-alias
   (testing ":doc and :alias flow into the rendered snippet"
@@ -1241,14 +1352,20 @@
                        {:variant-id  "story.button/primary"
                         :duration-ms 100
                         :write-back  true})
+          n    (-> r :structuredContent :recorded-event-count)
           body (story/variant->edn :story.button/primary)]
       (is (success? r))
       (is (true? (-> r :structuredContent :written-back?)))
+      (is (pos? n) "the recorder captured at least one event")
       (is (= :story-mcp (:origin body))
           "write-back body must carry :origin :story-mcp")
-      ;; Pre-existing body keys + the captured :play slot still land.
+      ;; Pre-existing body keys + the captured :play-script slot still land
+      ;; (step count derived from `:recorded-event-count` — capture races
+      ;; the :duration-ms window).
       (is (= "Primary button." (:doc body)))
-      (is (= [[:counter/inc]] (:play body))))))
+      (is (= {:script (vec (repeat n [:dispatch [:counter/inc]])) :auto-run? true}
+             (:play-script body)))
+      (is (nil? (:play body))))))
 
 (deftest record-as-variant-write-back-new-id-stamps-origin
   (testing ":new-variant-id write-back also carries :origin :story-mcp"

--- a/tools/story-mcp/test/stdio-roundtrip.js
+++ b/tools/story-mcp/test/stdio-roundtrip.js
@@ -211,13 +211,21 @@ function run() {
       console.log('OK   tools/call list-substrates -> vector (count=' + subsArr.length + ')');
 
       // 3c. tools/call get-story-instructions — returns the agent-onboarding
-      // text. Smoke-check key authoring vocab is present.
+      // text. Smoke-check key authoring vocab is present AND that the
+      // result carries structuredContent (rf2-vyacl): the descriptor
+      // declares an :outputSchema, so an SDK-driven consumer rejects a
+      // text-only result with -32600. Pinning the structured slot here
+      // catches a regression to the text-only shape at the wire.
       const instrResp = await call('tools/call', { name: 'get-story-instructions', arguments: {} });
       const instrText = instrResp.result?.content?.[0]?.text || '';
       if (instrResp.result?.isError || !instrText.includes('reg-story')) {
         throw new Error('get-story-instructions did not contain `reg-story`: ' + JSON.stringify(instrResp).slice(0, 300));
       }
-      console.log('OK   tools/call get-story-instructions -> text contains reg-story/reg-variant');
+      const instrStruct = instrResp.result?.structuredContent;
+      if (!instrStruct || typeof instrStruct !== 'object' || typeof instrStruct.instructions !== 'string') {
+        throw new Error('get-story-instructions missing structuredContent.instructions (SDK -32600 risk): ' + JSON.stringify(instrResp).slice(0, 300));
+      }
+      console.log('OK   tools/call get-story-instructions -> text + structuredContent.instructions');
 
       // 4. tools/call preview-variant on an unknown variant — expect
       // tool-execution error (`isError: true`) with a "not found" message.

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -76,6 +76,10 @@
             [re-frame.story.play        :as play]
             ;; Test Codegen recorder (pure-data state + snippet generator).
             [re-frame.story.recorder    :as recorder]
+            ;; Recording → live `:play-script` body translator (rf2-x9zsr).
+            ;; Re-exported as `recording->play-script` so the MCP write-back
+            ;; path (story-mcp) can emit the canonical replayable slot.
+            [re-frame.story.recorder.play-export :as play-export]
             ;; SOTA features — layout-debug + share live in .cljc;
             ;; multi-substrate / a11y / panels are CLJS-only so the
             ;; JVM classpath stays Reagent-free.
@@ -1080,3 +1084,25 @@
   so the user sees the shape to fill in."
   [events opts]
   (recorder/gen-play-snippet events opts))
+
+(defn recording->play-script
+  "Translate a recording into the live, replayable `:play-script` body
+  map per `runner/parse-spec`. Pure data → data.
+
+  This is the runtime counterpart to `gen-play-snippet` (which renders
+  human-readable EDN text): where `gen-play-snippet` produces a string
+  for the user to paste, `recording->play-script` produces the actual
+  `{:script [...] :auto-run? bool}` map a runner executes. The MCP
+  write-back path (`record-as-variant`) calls this to re-register the
+  variant with a live `:play-script` slot — the canonical AND ONLY
+  phase-4 replay surface per rf2-0wrud.
+
+  `events` may be the legacy bare-events vector OR the rich `:entries`
+  vector (rf2-d5u89). `opts` accepts `:auto-run?`, `:name`,
+  `:auto-assert?` + `:final-db`/`:seed-db`/`:max-auto-assertions`, and
+  `:wait-threshold-ms` — see `re-frame.story.recorder.play-export/
+  recording->play-script` for the full contract.
+
+  Returns `{:script [...steps] :auto-run? bool :name str?}`."
+  ([events]      (play-export/recording->play-script events))
+  ([events opts] (play-export/recording->play-script events opts)))


### PR DESCRIPTION
## Summary

Two story-mcp follow-up bugs filed during remediation, bundled (both on the tools/story-mcp surface).

- **rf2-50jzf (P1):** `record-as-variant` write-back wrote a dead `:play` slot. The variant schema dropped `:play` for `:play-script` in rf2-0wrud, so written-back recordings silently never replayed (no runner executes `:play`). `write-back!` now translates the captured recording via a new `re-frame.story/recording->play-script` re-export and writes the live, replayable `:play-script` body.
- **rf2-vyacl (P2):** `get-story-instructions` declared an `:outputSchema` but returned text-only, so the official MCP SDK's high-level `callTool` rejected it with JSON-RPC `-32600`. It now emits a matching `{:instructions <text>}` `structuredContent`, mirroring re-frame2-pair-mcp's sibling `get-re-frame2-pair-instructions`. The identical latent defect on `variant->edn` (the only other text-only tool declaring an outputSchema) is fixed the same way.

## Changes

- `tools/story/src/re_frame/story.cljc` — re-export `recording->play-script` (live `:play-script` body translator).
- `tools/story-mcp/.../recorder.cljc` — `write-back!` emits `:play-script` (was dead `:play`); docstrings/descriptors reconciled.
- `tools/story-mcp/.../dev.cljc` — `get-story-instructions` emits structuredContent; stale `:play` in instructions text → `:play-script`.
- `tools/story-mcp/.../docs.cljc` — `variant->edn` emits structuredContent; stale `:play` example slots → `:play-script`.
- Tests: `tools_test.clj` (write-back round-trip pins live `:play-script` + end-to-end run-variant replay; get-story-instructions + variant->edn pin structuredContent), `stdio-roundtrip.js` (asserts structuredContent), `end-to-end-story.cjs` (now walks get-story-instructions through the SDK `callTool` — previously skipped with a NOTE pending this fix).
- Specs: `002-Tool-Registry.md`, `API.md` reconciled to `:play-script`.

## Test plan

- [x] `clojure -M:test` story-mcp — 148 tests / 791 assertions, 0 failures (6x for flakiness; replay assertion made deterministic vs async `:dispatch` drain)
- [x] `clojure -M:test` story — 858 tests / 2543 assertions, 0 failures (public-surface re-export)
- [x] story-mcp `node test/stdio-roundtrip.js` — GREEN (get-story-instructions -> text + structuredContent.instructions)
- [x] mcp-conformance `npm run test:story` — GREEN (SDK-driven get-story-instructions callTool passes)
- [x] clean recompile (JVM); clean rebase onto origin/main

Closes rf2-50jzf, rf2-vyacl.