### PR TITLE
chore(examples): drop redundant ^:export on Reagent counter + login run fns

### DIFF
--- a/examples/reagent/counter/core.cljs
+++ b/examples/reagent/counter/core.cljs
@@ -50,7 +50,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; rf/init! takes the adapter spec map directly. Each adapter
   ;; ns exports an `adapter` var; consumers require the ns and pass the
   ;; var explicitly. There is no default-adapter registry.

--- a/examples/reagent/login/core.cljs
+++ b/examples/reagent/login/core.cljs
@@ -356,7 +356,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
   ;; Install the demo override so `:rf.http/managed` calls route to the


### PR DESCRIPTION
## Summary

Bead **rf2-8wrzz.11** (P3) — cluster-wide completion of the `^:export` tidy for the Reagent examples.

Removed redundant `^:export` metadata from the `run` entry functions in:
- `examples/reagent/counter/core.cljs` — `(defn ^:export run [])` → `(defn run [])`
- `examples/reagent/login/core.cljs` — `(defn ^:export run [])` → `(defn run [])`

## Why it's redundant

Every example's `run` entry is invoked via shadow-cljs `:init-fn` (`counter.core/run`, `login.core/run` in `implementation/shadow-cljs.edn`). `:init-fn` resolves the symbol inside the bundle and emits a direct call — it does **not** depend on a stable Closure-mangled-free export name, and the `index.html` files load `main.js` without ever calling `*.core.run()` from HTML. No external caller relies on the export name, so the metadata was dead.

This matches the shape the UiX examples already use (`examples/uix/counter_uix/core.cljs`, `examples/uix/login_uix/core.cljs` — plain `(defn run [])`).

## Gate result

`cd implementation && npx shadow-cljs release examples/counter examples/login`
- `[:examples/counter] Build completed. (129 files, 74 compiled, 0 warnings)`
- `[:examples/login] Build completed. (171 files, 111 compiled, 0 warnings)`

Both `:init-fn` targets resolved and compiled clean. (One pre-existing Closure JSDoc parse note from `implementation/http/http_privacy_headers.cljc` — unrelated to this change.)

## Scope

`examples/` tree only (Reagent counter + login source). Nothing in core, adapters, tools, skills, spec, or other substrates.