### PR TITLE
refactor(ssr): dedup resolve-version + payload assembly into payload-policy (rf2-8wrzz.4)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -36,7 +36,9 @@
   each (see the `:require` list): `cookie` (RFC 6265 Set-Cookie),
   `headers` (pair-vec → Ring header-map collapse + content-type
   default), `shell` (`default-html-shell` + shared envelope helpers),
-  `payload` (`build-payload` / `resolve-version`), `lifecycle` (frame
+  `payload` (`build-payload` — the non-streaming wrapper over the
+  shared `re-frame.ssr.payload-policy` version-resolution + assembly),
+  `lifecycle` (frame
   teardown, root-view / head resolution, required-opt validation,
   `default-on-error`), `pipeline` (the 4-step request pipeline +
   accumulator → Ring-map materialiser), `trust` (trusted-shell-hook

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj
@@ -9,56 +9,27 @@
   policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9) —
   see that namespace for the contract. The Ring host adapter validates
   the policy at handler-construction time via `validate-policy-opts!`
-  so misconfigured deployments fail at boot, not at first request."
-  (:require [re-frame.late-bind :as late-bind]
-            [re-frame.ssr.payload-policy :as payload-policy]))
+  so misconfigured deployments fail at boot, not at first request.
+
+  Version resolution (`:rf/version`) and the canonical four-key payload
+  assembly live once in `re-frame.ssr.payload-policy` (rf2-8wrzz.4),
+  shared verbatim with the streaming SSR path
+  (`re-frame.ssr.streaming/build-final-payload`). This namespace owns
+  only the non-streaming wrapper: project the handed-in `app-db` per the
+  policy, then assemble."
+  (:require [re-frame.ssr.payload-policy :as payload-policy]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private default-pattern-protocol-version
-  "The v1 pattern-protocol version stamp (per Spec-Schemas
-  §`:rf/hydration-payload` line 1839 — \"integer; v1 = 1\"). Used as the
-  terminal fallback in `resolve-version` so the canonical payload key
-  is always present (Malli `:int` slot, not `:optional`)."
-  1)
-
-(defn resolve-version
-  "Pick the `:rf/version` value to ship in the hydration payload. The
-  resolution order is:
-
-    1. An explicit `:version` opt from the caller (host-supplied stamp;
-       wins so test fixtures and apps that ship their own version source
-       stay in control).
-    2. The framework-global `:rf2/runtime-version` late-bind hook — the
-       same source the client-side `:rf.ssr/check-version` fx reads. When
-       the host registers this hook at boot, both sides of the wire pin
-       the same value with no further wiring (per Spec 011 §The hydration
-       payload + §fx-input shape + Conventions §Late-bind hook key
-       grammar).
-    3. `default-pattern-protocol-version` (v1 = 1) — the canonical schema
-       slot is required (per Spec-Schemas §`:rf/hydration-payload`), so a
-       terminal numeric fallback is structurally necessary. The
-       check-version fx still no-ops cleanly on the client when neither
-       side has the hook registered (matched value → no mismatch).
-
-  Both sides of the wire read `:version` through the same hook so a host
-  that doesn't pass `:version` explicitly still pins a value the client
-  agrees with (the inline `(or version 1)` it replaced silently defeated
-  the version-mismatch check; rf2-asmj1 S8 / rf2-l8fi6)."
-  [explicit-version]
-  (or explicit-version
-      (when-let [f (late-bind/get-fn :rf2/runtime-version)]
-        (f))
-      default-pattern-protocol-version))
 
 (defn build-payload
   "Per Spec 011 §The hydration payload — emit the four canonical keys
   (`:rf/version`, `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`)
   plus the optional `:rf/schema-digest`. Schema-digest is supplied
   by the caller when their app participates in the schema-digest
-  check; nil otherwise. Version source-of-truth: `resolve-version`
-  above — caller opt wins, falling back to the `:rf2/runtime-version`
-  late-bind hook so server and client read from the same source.
+  check; nil otherwise. Version source-of-truth:
+  `re-frame.ssr.payload-policy/resolve-version` — caller opt wins,
+  falling back to the `:rf2/runtime-version` late-bind hook so server
+  and client read from the same source.
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
   policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
@@ -67,11 +38,15 @@
   shipping the whole `app-db`). Absence of both throws
   `:rf.error/ssr-missing-payload-policy`. The host adapter validates
   at handler-construction time so misconfigured deployments fail at
-  boot, not at first request."
-  [frame-id app-db render-hash {:keys [version schema-digest] :as policy-opts}]
-  (let [db-slice (payload-policy/apply-policy app-db policy-opts)]
-    (cond-> {:rf/version     (resolve-version version)
-             :rf/frame-id    frame-id
-             :rf/app-db      db-slice
-             :rf/render-hash render-hash}
-      schema-digest (assoc :rf/schema-digest schema-digest))))
+  boot, not at first request.
+
+  The non-streaming wrapper over the shared
+  `re-frame.ssr.payload-policy/build-payload`: it is handed `app-db`
+  directly (the streaming path reads it from the live frame instead),
+  projects it, then assembles the canonical payload."
+  [frame-id app-db render-hash {:as policy-opts}]
+  (payload-policy/build-payload
+   frame-id
+   (payload-policy/apply-policy app-db policy-opts)
+   render-hash
+   policy-opts))

--- a/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
+++ b/implementation/ssr/src/re_frame/ssr/payload_policy.cljc
@@ -68,8 +68,27 @@
   `stream-handler`) validates the policy at handler-construction time
   via `validate-policy-opts!` so misconfigured deployments fail at
   boot rather than at first request — the canonical fail-closed
-  pattern."
-  (:refer-clojure :exclude [resolve]))
+  pattern.
+
+  ---- Version resolution + payload assembly ----
+
+  This namespace is also the single home for the hydration-payload's
+  `:rf/version` resolution (`resolve-version`) and the canonical
+  four-key payload assembly (`build-payload`). Both streaming and
+  non-streaming SSR construct the identical `:rf/hydration-payload`
+  shape and pin `:rf/version` from the identical source-of-truth: the
+  caller's explicit `:version` opt, falling back to the
+  `:rf2/runtime-version` late-bind hook the client-side
+  `:rf.ssr/check-version` fx reads, falling back to the v1 pattern-
+  protocol stamp. The two call sites differ only in how they source
+  `app-db` (the non-streaming path is handed it; the streaming path
+  reads it from the live frame after every continuation drains), so
+  each owns a thin wrapper over `build-payload`:
+
+    `re-frame.ssr.ring.payload/build-payload`     - non-streaming SSR
+    `re-frame.ssr.streaming/build-final-payload`  - streaming SSR"
+  (:refer-clojure :exclude [resolve])
+  (:require [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -172,3 +191,71 @@
     ;; arm and the construction arm produce the same structured error
     ;; shape — tests can assert on one keyword and cover both surfaces.
     (validate-policy-opts! opts)))
+
+;; ---- version resolution + payload assembly -------------------------------
+;;
+;; Single home for the hydration-payload `:rf/version` resolution and the
+;; canonical four-key payload map, shared verbatim by the streaming and
+;; non-streaming SSR paths (rf2-8wrzz.4 — previously duplicated in
+;; `re-frame.ssr.ring.payload` and `re-frame.ssr.streaming`).
+
+(def ^:private default-pattern-protocol-version
+  "The v1 pattern-protocol version stamp (per Spec-Schemas
+  §`:rf/hydration-payload` — \"integer; v1 = 1\"). Terminal fallback in
+  `resolve-version` so the canonical `:rf/version` key is always present
+  (Malli `:int` slot, not `:optional`)."
+  1)
+
+(defn resolve-version
+  "Pick the `:rf/version` value to ship in the hydration payload. The
+  resolution order is:
+
+    1. An explicit `:version` opt from the caller (host-supplied stamp;
+       wins so test fixtures and apps that ship their own version source
+       stay in control).
+    2. The framework-global `:rf2/runtime-version` late-bind hook — the
+       same source the client-side `:rf.ssr/check-version` fx reads. When
+       the host registers this hook at boot, both sides of the wire pin
+       the same value with no further wiring (per Spec 011 §The hydration
+       payload + §fx-input shape + Conventions §Late-bind hook key
+       grammar).
+    3. `default-pattern-protocol-version` (v1 = 1) — the canonical schema
+       slot is required (per Spec-Schemas §`:rf/hydration-payload`), so a
+       terminal numeric fallback is structurally necessary. The
+       check-version fx still no-ops cleanly on the client when neither
+       side has the hook registered (matched value → no mismatch).
+
+  Both sides of the wire read `:version` through the same hook so a host
+  that doesn't pass `:version` explicitly still pins a value the client
+  agrees with (the inline `(or version 1)` it replaced silently defeated
+  the version-mismatch check; rf2-asmj1 S8 / rf2-l8fi6 non-streaming,
+  rf2-via0g streaming)."
+  [explicit-version]
+  (or explicit-version
+      (when-let [f (late-bind/get-fn :rf2/runtime-version)]
+        (f))
+      default-pattern-protocol-version))
+
+(defn build-payload
+  "Assemble the canonical `:rf/hydration-payload` map per Spec 011 §The
+  hydration payload — the four canonical keys (`:rf/version`,
+  `:rf/frame-id`, `:rf/app-db`, `:rf/render-hash`) plus the optional
+  `:rf/schema-digest`.
+
+  The `:rf/app-db` slice is the already-projected `db-slice` — callers
+  run `apply-policy` (the fail-closed allowlist / whole-app-db contract,
+  rf2-gtgf9) and hand the result here. `:rf/version` is resolved via
+  `resolve-version` (caller's `:version` opt → `:rf2/runtime-version`
+  hook → v1 stamp). Schema-digest is supplied by the caller when their
+  app participates in the schema-digest check; nil otherwise.
+
+  Shared verbatim by both SSR paths (rf2-8wrzz.4): the non-streaming
+  `re-frame.ssr.ring.payload/build-payload` and the streaming
+  `re-frame.ssr.streaming/build-final-payload`, which differ only in how
+  they source `app-db` before projecting it."
+  [frame-id db-slice render-hash {:keys [version schema-digest]}]
+  (cond-> {:rf/version     (resolve-version version)
+           :rf/frame-id    frame-id
+           :rf/app-db      db-slice
+           :rf/render-hash render-hash}
+    schema-digest (assoc :rf/schema-digest schema-digest)))

--- a/implementation/ssr/src/re_frame/ssr/streaming.cljc
+++ b/implementation/ssr/src/re_frame/ssr/streaming.cljc
@@ -463,37 +463,6 @@
            :delta   nil
            :failed? true})))))
 
-(def ^:private default-pattern-protocol-version
-  "The v1 pattern-protocol version stamp (per Spec-Schemas
-  §`:rf/hydration-payload` — \"integer; v1 = 1\"). Terminal fallback in
-  `resolve-version` so the canonical `:rf/version` key is always present
-  (Malli `:int` slot, not `:optional`)."
-  1)
-
-(defn resolve-version
-  "Pick the `:rf/version` value for the streaming hydration payload.
-  Resolution order, identical to the non-streaming
-  `re-frame.ssr.ring.payload/resolve-version`:
-
-    1. an explicit `:version` opt from the caller (host-supplied stamp),
-    2. the framework-global `:rf2/runtime-version` late-bind hook — the
-       same source the client-side `:rf.ssr/check-version` fx reads, so
-       both sides of the wire pin one value with no extra wiring,
-    3. `default-pattern-protocol-version` (v1 = 1) as the terminal
-       numeric fallback (the schema slot is required).
-
-  Audit rf2-asmj1 S8 fixed the non-streaming path; rf2-via0g extends the
-  same fix here. The streaming path previously hard-coded `(or version 1)`
-  inline, which silently disagreed with whatever the client-side
-  `:rf2/runtime-version` hook returned and defeated the
-  `:rf.ssr/version-mismatch` check on every host that hadn't passed
-  `:version` explicitly."
-  [explicit-version]
-  (or explicit-version
-      (when-let [f (late-bind/get-fn :rf2/runtime-version)]
-        (f))
-      default-pattern-protocol-version))
-
 (defn build-final-payload
   "After every continuation has drained, construct the canonical
   `:rf/hydration-payload` for the `__rf_payload` final chunk. The
@@ -502,11 +471,17 @@
 
   Mirrors `re-frame.ssr.ring.payload/build-payload`'s shape so the
   client-side bootstrap can read either streaming or non-streaming
-  payloads with the same code path. Version source-of-truth:
-  `resolve-version` above — caller opt wins, falling back to the
-  `:rf2/runtime-version` late-bind hook so server and client read from
-  the same source (rf2-via0g, mirroring the non-streaming rf2-asmj1 S8
-  fix).
+  payloads with the same code path. Both are thin wrappers over the
+  shared `re-frame.ssr.payload-policy/build-payload` (rf2-8wrzz.4):
+  version resolution (`:rf/version`) and the four-key assembly live
+  once there. The streaming path differs only in sourcing `app-db` —
+  it reads the live frame's `app-db` after every continuation has
+  drained, where the non-streaming path is handed it directly.
+
+  Version source-of-truth: `re-frame.ssr.payload-policy/resolve-version`
+  — caller opt wins, falling back to the `:rf2/runtime-version`
+  late-bind hook so server and client read from the same source
+  (rf2-via0g, mirroring the non-streaming rf2-asmj1 S8 fix).
 
   The `:rf/app-db` slice is projected per the explicit, fail-closed
   policy in `re-frame.ssr.payload-policy/apply-policy` (rf2-gtgf9):
@@ -516,14 +491,13 @@
   `:rf.error/ssr-missing-payload-policy`. The Ring host adapter
   validates at handler-construction time so misconfigured deployments
   fail at boot rather than at first request."
-  [frame-id render-hash {:keys [version schema-digest] :as policy-opts}]
-  (let [app-db   (frame/frame-app-db-value frame-id)
-        db-slice (payload-policy/apply-policy app-db policy-opts)]
-    (cond-> {:rf/version     (resolve-version version)
-             :rf/frame-id    frame-id
-             :rf/app-db      db-slice
-             :rf/render-hash render-hash}
-      schema-digest (assoc :rf/schema-digest schema-digest))))
+  [frame-id render-hash {:as policy-opts}]
+  (let [app-db (frame/frame-app-db-value frame-id)]
+    (payload-policy/build-payload
+     frame-id
+     (payload-policy/apply-policy app-db policy-opts)
+     render-hash
+     policy-opts)))
 
 ;; ---- late-bind hook registration -----------------------------------------
 ;;


### PR DESCRIPTION
## Summary

The streaming and non-streaming SSR payload builders each carried a byte-identical copy of three things:

- `default-pattern-protocol-version` (the v1 = 1 stamp)
- `resolve-version` (explicit `:version` opt -> `:rf2/runtime-version` late-bind hook -> v1 fallback)
- the canonical four-key `:rf/hydration-payload` `cond->` assembly

The two paths differ only in how they source `app-db`: `re-frame.ssr.ring.payload/build-payload` is handed it directly; `re-frame.ssr.streaming/build-final-payload` reads the live frame's `app-db` after every suspense continuation has drained.

This PR extracts the shared logic into the existing shared home `re-frame.ssr.payload-policy` (which both artefacts already `:require`) as `resolve-version` + `build-payload`. Both call sites become thin wrappers: project `app-db` per the fail-closed policy (`apply-policy`), then assemble.

Behaviour is identical — public signatures (`build-payload`, `build-final-payload`), the `:ssr.streaming/build-final-payload` late-bind registration, and every observable payload shape are preserved. No external call site referenced `resolve-version` directly; both were always reached through the public builders.

### Changed files
- `implementation/ssr/src/re_frame/ssr/payload_policy.cljc` — new shared `resolve-version` + `build-payload`; adds `re-frame.late-bind` require
- `implementation/ssr/src/re_frame/ssr/streaming.cljc` — `build-final-payload` delegates; removes the duplicated defs
- `implementation/ssr-ring/src/re_frame/ssr/ring/payload.clj` — `build-payload` delegates; removes the duplicated defs; drops now-unused `late-bind` require
- `implementation/ssr-ring/src/re_frame/ssr/ring.clj` — docstring accuracy (payload ns no longer owns `resolve-version`)

## Gates run

- `clojure -M:test` in `implementation/ssr` — **229 tests, 774 assertions, 0 failures, 0 errors**
- `clojure -M:test` in `implementation/ssr-ring` — **72 tests, 354 assertions, 0 failures, 0 errors**
- clean CLJS recompile + node tests (streaming.cljc is `.cljc`): `npx shadow-cljs compile node-test` (1006 compiled, 0 warnings) then `node out/node-test.js` — **4184 tests, 12768 assertions, 0 failures, 0 errors**