### PR TITLE
fix(machines-viz): wire viewer build target + correct Mermaid require

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1098,4 +1098,29 @@
   {:target     :browser
    :output-dir "out/examples/adapter-testbeds/helix"
    :asset-path "."
-   :modules    {:main {:init-fn adapter-testbed-helix.core/init}}}}}
+   :modules    {:main {:init-fn adapter-testbed-helix.core/init}}}
+
+  ;; ============================================================================
+  ;; Machines-Viz read-only viewer (rf2-8wrzz.2 — wires PR #2013's viewer
+  ;; entry into an emittable bundle).
+  ;;
+  ;; tools/machines-viz/public/viewer.html is a statically-hostable single
+  ;; page that decodes a `#machine=<base64url>` URL fragment and renders the
+  ;; encoded chart read-only (per tools/machines-viz/spec/API.md §Read-only
+  ;; viewer). It loads a sibling `viewer.js` via `<script src="viewer.js">`
+  ;; and then calls `window.day8.re_frame2_machines_viz.viewer.run()` itself,
+  ;; so this build only needs to COMPILE the entry ns and preserve its
+  ;; `^:export run` symbol — NOT auto-invoke an :init-fn (that would double-
+  ;; render). The single `:viewer` module emits `viewer.js`; co-locate it
+  ;; with viewer.html at serve/release time (same staging pattern as the
+  ;; examples, whose hand-written index.html lives in the source tree and is
+  ;; placed next to the bundle by the orchestrator).
+  ;;
+  ;; Bundle-isolation holds: machines-viz is a tool jar, so emitting a tool
+  ;; bundle from this consumer build introduces no production-bundle leak
+  ;; (nothing under implementation/ :requires the viewer ns).
+  :machines-viz-viewer
+  {:target     :browser
+   :output-dir "out/machines-viz-viewer"
+   :asset-path "."
+   :modules    {:viewer {:entries [day8.re-frame2-machines-viz.viewer]}}}}}

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -676,7 +676,7 @@ payload from the element's bound props + the live snapshot.
 ### Mermaid `stateDiagram-v2`
 
 ```clojure
-(:require [day8.re-frame2-machines-viz.mermaid :as mermaid]
+(:require [re-frame.machines.mermaid :as mermaid]
           [day8.re-frame2-machines-viz.export  :as export])
 
 (mermaid/emit definition)
@@ -914,7 +914,7 @@ day8.re-frame2-machines-viz.adapters.uix/MachineChart   ; rf2-yg9he — UIx shel
 day8.re-frame2-machines-viz.adapters.helix/MachineChart ; rf2-yg9he — Helix shell ($-mountable)
 day8.re-frame2-machines-viz.share/encode-share-url
 day8.re-frame2-machines-viz.share/decode-share-url
-day8.re-frame2-machines-viz.mermaid/emit          ; pure fn — definition → string
+re-frame.machines.mermaid/emit                    ; pure fn — definition → string (lives in implementation/machines per rf2-yamkm)
 day8.re-frame2-machines-viz.scxml/spec->scxml     ; v1.1 — pure fn
 day8.re-frame2-machines-viz.scxml/scxml->spec     ; v1.1 — pure fn
 day8.re-frame2-machines-viz.ai-generate/generate-machine ; v1.1 — pluggable LLM seam


### PR DESCRIPTION
## Summary

Two tightly-related fixes on the `tools/machines-viz` artefact.

### Task A — wire the viewer build target (rf2-8wrzz.2, P2)

The read-only viewer logic shipped + was tested in PR #2013 but was never **built** — no shadow-cljs target emitted the `viewer.js` that `tools/machines-viz/public/viewer.html` loads via `<script src="viewer.js">`.

- Added a minimal `:machines-viz-viewer` `:browser` target to `implementation/shadow-cljs.edn` (the established place machines-viz builds from — its `src`+`test` paths are already on that classpath; machines-viz has no own shadow-cljs config).
- The single `:viewer` module compiles the `day8.re-frame2-machines-viz.viewer` entry ns and emits `viewer.js`.
- Uses `:entries` (not `:init-fn`): `viewer.html` invokes `window.day8.re_frame2_machines_viz.viewer.run()` itself after the bundle loads, so an `:init-fn` would auto-call `run` and double-render. The `^:export run` symbol is preserved through `:advanced`.
- Output lands in gitignored `out/machines-viz-viewer/` with `:asset-path "."` — same staging pattern as the examples (hand-written host page in the source tree, co-located with the bundle at serve/release time). The built `viewer.js` is **not** committed.
- The shadow-cljs.edn change is purely additive: one new target stanza + an explanatory comment. No other lines touched (the rf2-8wrzz.10 CSS comment is left for that bead).

### Task B — fix the Mermaid require in API.md (rf2-8wrzz.8, P3)

`tools/machines-viz/spec/API.md` §Mermaid cited `day8.re-frame2-machines-viz.mermaid/emit`, which does not resolve. Confirmed via grep: the real emitter lives in `implementation/machines` as **`re-frame.machines.mermaid/emit`** (per rf2-yamkm; it is exactly what `export.cljs` requires as `[re-frame.machines.mermaid :as mermaid]`). Corrected both the §Mermaid `:require` block and the public-API summary line.

## Gate results

- **Build** — `npx shadow-cljs release machines-viz-viewer`: `Build completed. (159 files, 94 compiled, 1 warnings, 30.32s)`, exit 0. The lone warning is a pre-existing `:infer-warning` in `chart.cljs:443` (externs inference; unrelated to this change). `out/machines-viz-viewer/viewer.js` (2.1 MB) emitted; verified the bundle's Closure export idiom builds the global path `["day8","re_frame2_machines_viz","viewer","run"]` — exactly what `viewer.html` calls.
- **Tests** — `clojure -M:test` (machines-viz JVM/CLJC suite): `Ran 196 tests containing 480 assertions. 0 failures, 0 errors.`
- **mkdocs** — N/A: `mkdocs.yml` has `docs_dir: docs`; the machines-viz `spec/API.md` is outside the docs site, so the mkdocs/slug gates do not apply to this edit.

## Test plan

- [x] `npx shadow-cljs release machines-viz-viewer` succeeds and emits `viewer.js`
- [x] Bundle exposes `window.day8.re_frame2_machines_viz.viewer.run` (the symbol `viewer.html` calls)
- [x] `clojure -M:test` for machines-viz passes
- [x] API.md §Mermaid require now resolves (`re-frame.machines.mermaid/emit`)