### PR TITLE
fix(examples): notebook — correct stale CSS comment to real path (rf2-8wrzz.10)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -686,9 +686,9 @@
 
   ;; rf2-t7t6f — Reagent design-led example. Three-pane editorial layout
   ;; (documents tree + markdown editor + live preview) proving Reagent
-  ;; builds substantive UIs, not just counters. Pairs with the Reagent
-  ;; 'Editorial Warm' visual identity (rf2-nfg15) from
-  ;; examples/_shared/css/reagent.css.
+  ;; builds substantive UIs, not just counters. Pairs with the shared
+  ;; 'Editorial Warm' visual identity (rf2-v4fpe Option 2) from
+  ;; examples/_shared/css/style.css.
   :examples/notebook
   {:target     :browser
    :output-dir "out/examples/notebook"


### PR DESCRIPTION
## Stale reference

The `:examples/notebook` build comment in `implementation/shadow-cljs.edn` cited:

- a **non-existent** CSS path `examples/_shared/css/reagent.css` (the real shared stylesheet is `examples/_shared/css/style.css`; `_shared/css/` contains only `style.css` + `structure.css`, no `reagent.css`)
- the **superseded** per-substrate identity bead `rf2-nfg15`

The notebook example's `examples/reagent/notebook/index.html` actually links `_shared/css/style.css`, and its inline `<style>` block documents the same. Same class of bug as the helix comment fixed in #2005.

## Fix

Comment-only correction, matching the #2005 helix fix shape and the sibling dashboard-uix / process-monitor-helix comments:

```
- ;; 'Editorial Warm' visual identity (rf2-nfg15) from
- ;; examples/_shared/css/reagent.css.
+ ;; 'Editorial Warm' visual identity (rf2-v4fpe Option 2) from
+ ;; examples/_shared/css/style.css.
```

No other build target touched (`:machines-viz-viewer` and all others untouched). No build effect — comment only.

## Gates

- `clojure.edn` parse of `shadow-cljs.edn`: **OK** (59 builds intact, `:examples/notebook` present)
- `npm run test:bundle-isolation`: **PASS** — 3 example targets compiled (0 warnings); bundle-isolation 16 artefact entries / 33 sentinels absent / 3 budgets ok; uix-helix-reagent-free PASS