### PR TITLE
docs(spec): reconcile drift in 005/014/021 against impl (rf2-8wrzz.5/.6/.7)

### DIFF
--- a/spec/005-StateMachines.md
+++ b/spec/005-StateMachines.md
@@ -284,7 +284,7 @@ Precedence inside the standard transition lookup, **at each level**:
 1. Explicit event match at this level.
 2. `:*` wildcard at this level.
 
-The wildcard fires after specific matches **at the same level**. Only if neither matches does the runtime walk up to the next level and try again — so `:*` at the leaf shadows an explicit match on the parent for the same event. The full leaf-up-to-root walk is canonically specified at [§Transition resolution — deepest-wins with parent fallthrough](#transition-resolution--deepest-wins-with-parent-fallthrough); for a flat machine the path is one level deep and the two-step rule above is the whole story. If no level matches, the snapshot is unchanged and the runtime emits a single `:rf.warning/machine-unhandled-event` trace (see [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough) for the canonical name; consistent with the other `:rf.warning/machine-*` advisory categories).
+The wildcard fires after specific matches **at the same level**. Only if neither matches does the runtime walk up to the next level and try again — so `:*` at the leaf shadows an explicit match on the parent for the same event. The full leaf-up-to-root walk is canonically specified at [§Transition resolution — deepest-wins with parent fallthrough](#transition-resolution--deepest-wins-with-parent-fallthrough); for a flat machine the path is one level deep and the two-step rule above is the whole story. If no level matches, the snapshot is unchanged and the runtime emits a single `:rf.error/machine-unhandled-event` trace (see [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough) for the canonical name; consistent with the other `:rf.error/machine-*` advisory categories).
 
 ### Self-transitions (external vs internal)
 
@@ -1025,7 +1025,7 @@ To resolve an event, the runtime walks the active path from **leaf up to root**,
 6. Top-level (root) `:on` — explicit match.
 7. Top-level `:on` — `:*` wildcard.
 
-If no level matches, the snapshot is unchanged and the runtime emits `:rf.warning/machine-unhandled-event` (see [009](009-Instrumentation.md)). This is the canonical name; older drafts used `:rf.machine.event/unhandled` — that form is superseded.
+If no level matches, the snapshot is unchanged and the runtime emits `:rf.error/machine-unhandled-event` (see [009](009-Instrumentation.md)). This is the canonical name; older drafts used `:rf.warning/machine-unhandled-event` and `:rf.machine.event/unhandled` — those forms are superseded.
 
 The deepest-wins rule means a child state can **override** a parent's transition for the same event by declaring its own. Combined with parent fallthrough, this is how hierarchy factors common behaviour to the parent (every authenticated descendant inherits `:logout`) while still allowing local override.
 
@@ -1165,10 +1165,10 @@ Every event delivered to a parallel-region machine is **broadcast** to every reg
 Three outcomes per region:
 
 - **Region's state has a matching `:on` entry whose guard passes.** That region transitions: exit cascade → action → entry cascade. `:fx` accumulated by the region's actions joins the macrostep's `:fx` vector.
-- **Region's state has no matching `:on` entry.** That region's `:state` is unchanged. No `:rf.warning/machine-unhandled-event` fires *unless every region declines the event* (see below).
+- **Region's state has no matching `:on` entry.** That region's `:state` is unchanged. No `:rf.error/machine-unhandled-event` fires *unless every region declines the event* (see below).
 - **Region's matching `:on` entry has a guard that returns false.** Same as "no match" — region stays put, no warning fires for that region alone.
 
-If **every region** declines the event (no region matched a transition), the machine as a whole emits `:rf.warning/machine-unhandled-event` exactly once, matching the flat-machine semantics. If **any** region handled the event, the snapshot commits with that region's transition applied and the warning is suppressed.
+If **every region** declines the event (no region matched a transition), the machine as a whole emits `:rf.error/machine-unhandled-event` exactly once, matching the flat-machine semantics. If **any** region handled the event, the snapshot commits with that region's transition applied and the warning is suppressed.
 
 The post-broadcast snapshot's `:state` is the map of region-name → that region's new state value. Regions that didn't transition keep their prior value in place.
 
@@ -1572,7 +1572,7 @@ A state may have multiple in-flight transition triggers concurrently:
 2. The transition's exit cascade runs (per [§Entry/exit cascading along the LCA](#entryexit-cascading-along-the-lca)).
 3. As part of the exit cascade, the runtime advances the exited node's per-path `:rf/after-epoch` entry — every other in-flight `:after` timer from the just-exited state goes stale on its eventual firing.
 4. Any `:spawn`-spawned child is destroyed via `:rf.machine/destroy` (the desugared `:exit` action). Per the [§Cancellation cascade — in-flight `:rf.http/managed` aborts](#cancellation-cascade--in-flight-rfhttpmanaged-aborts) contract (rf2-wvkn), in-flight `:rf.http/managed` requests inside the destroyed child cascade to abort — `:after` firing is one trigger of the same cancellation cascade as a parent-destroys-child shutdown.
-5. User-dispatched events queued for the just-exited state but not yet drained are processed by the now-current state's `:on` map (which may handle them, route to `:*` wildcard, or emit `:rf.warning/machine-unhandled-event`).
+5. User-dispatched events queued for the just-exited state but not yet drained are processed by the now-current state's `:on` map (which may handle them, route to `:*` wildcard, or emit `:rf.error/machine-unhandled-event`).
 
 The cancellation cascade is **uniform across triggers** — the runtime does not distinguish "the timer fired" from "the user dispatched" from "the child completed" at the cascade level; each is just an event at the parent's handler boundary that resolves to a transition out of the state. The `:rf.machine.timer/stale-after` traces ([§Trace events](#trace-events)) are how observers see "this `:after` was racing and lost."
 
@@ -1777,7 +1777,7 @@ For a parent state with `:spawn {:machine-id :child …}` (or for a hand-emitted
 5. **`:rf.machine/spawn` fx handler runs.** The child's spec is resolved (registered `:machine-id` or inline `:definition`); `synthesise-initial-snapshot` produces the child's initial snapshot with `:rf/bootstrap-pending? true`, the runtime-stamped `:data` keys (`:rf/self-id`, `:rf/parent-id`, `:rf/spawn-id` — per [§Runtime stamps](#runtime-stamps-on-the-spawned-actors-data-rf2-ijm7)), and the user-supplied initial `:data` merged on top; the snapshot is installed at `[:rf/machines <spawned-id>]`; the child's event handler is registered at the spawned-id. The runtime spawn-registry slot at `[:rf/spawned <parent-id> <invoke-id>]` is written for the declarative-`:spawn` case.
 6. **Child's first event is dispatched** — `[<spawned-id> <:start arg>]` when the spawn args carried `:start`, otherwise the synthetic `[<spawned-id> [:rf.machine/spawned]]` (per rf2-ijm7). The two paths are mutually exclusive; the child receives exactly one of the two as its first event, never both.
 7. **Child's initial-entry cascade fires** (per [§Initial-state `:entry` fires on machine bootstrap (rf2-0z73)](#initial-state-entry-fires-on-machine-bootstrap-rf2-0z73)). For a flat child the single initial state's `:entry` runs; for a compound child every `:entry` along the initial chain runs shallowest-first. This cascade runs **before** the first event's `:on` lookup, so `:entry`-emitted `:fx` is concatenated ahead of the first event's transition fx. `:rf/bootstrap-pending?` is cleared by the same drain.
-8. **Child processes the first event.** The event vector arrived in step 6 is now resolved through the child's `:on` map (deepest-wins per [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough)). For the synthetic `[:rf.machine/spawned]` path with no matching handler this resolves as a benign no-op (`:rf.warning/machine-unhandled-event` is NOT emitted for `:rf.machine/spawned` — it's the canonical kick-off shape).
+8. **Child processes the first event.** The event vector arrived in step 6 is now resolved through the child's `:on` map (deepest-wins per [§Transition resolution](#transition-resolution--deepest-wins-with-parent-fallthrough)). For the synthetic `[:rf.machine/spawned]` path with no matching handler this resolves as a benign no-op (`:rf.error/machine-unhandled-event` is NOT emitted for `:rf.machine/spawned` — it's the canonical kick-off shape).
 
 The same skeleton applies to `:spawn-all`'s N children (per [§Spawn-and-join via `:spawn-all`](#spawn-and-join-via-spawn-all)) with steps 2–5 fanning out once per child and a single join-bookkeeping write at `[:rf/spawned <parent-id> <invoke-all-id>]`.
 

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -103,7 +103,7 @@ The `:request` map carries the wire shape. Keys are minimal and chosen to be hos
 | `:params` | no | map | Query-string params. Encoded URL-safely; merged onto `:url`. Per Spec 012 §URL-encoding rules. |
 | `:body` | no | clj coll / string / `FormData` / `Blob` / `ArrayBuffer` / **thunk `(fn [] body)`** | The request body. See [§Body encoding](#body-encoding). A thunk is invoked at request-send time (after backoff delays elapse), so very-large payloads aren't held in memory between dispatch and send and retries can re-invoke for a fresh handle. |
 | `:request-content-type` | no | `:json` / `:form` / `:text` / explicit MIME / `nil` | Sugar for setting `Content-Type` + serialising `:body`. `:json` runs `pr-str → JSON.stringify` (CLJS) / Cheshire (JVM). `:form` URL-encodes a clj map. |
-| `:credentials` | no | `:omit` / `:same-origin` / `:include` | Default: `:same-origin`. |
+| `:credentials` | no | `:omit` / `:same-origin` / `:include` | Default: `:same-origin`. CLJS-only; JVM ignores (see [§JVM transport](#jvm-transport--degraded-behaviour-for-cljs-only-options)). |
 | `:mode` | no | `:cors` / `:no-cors` / `:same-origin` / `:navigate` | CLJS-only; Fetch passthrough. JVM ignores. |
 | `:redirect` | no | `:follow` / `:error` / `:manual` | Default: `:follow`. |
 | `:cache` | no | Fetch cache directive | CLJS-only passthrough. |
@@ -112,7 +112,7 @@ The `:request` map carries the wire shape. Keys are minimal and chosen to be hos
 
 #### JVM transport — degraded behaviour for CLJS-only options
 
-Five keys on the args map / request envelope are **CLJS-only** — semantically meaningful against the browser Fetch API and ignored by the JVM's `java.net.http.HttpClient`-backed transport. A request that carries any of them on the JVM proceeds normally; the option is **silently no-op** and the runtime emits one `:rf.http/cljs-only-key-ignored-on-jvm` warning trace per occurrence so consumers (Causa, Story, off-box monitors) can spot the degraded code path:
+Six keys on the args map / request envelope are **CLJS-only** — semantically meaningful against the browser Fetch API and ignored by the JVM's `java.net.http.HttpClient`-backed transport. A request that carries any of them on the JVM proceeds normally; the option is **silently no-op** and the runtime emits one `:rf.http/cljs-only-key-ignored-on-jvm` warning trace per occurrence so consumers (Causa, Story, off-box monitors) can spot the degraded code path:
 
 | Key | Where | JVM behaviour |
 |---|---|---|
@@ -121,8 +121,9 @@ Five keys on the args map / request envelope are **CLJS-only** — semantically 
 | `:cache` | `:request` map | Ignored. The Fetch cache directive has no `HttpClient` equivalent. |
 | `:referrer` | `:request` map | Ignored. Browser-only request-context. |
 | `:integrity` | `:request` map | Ignored. Subresource-integrity is a browser-only verification path. |
+| `:credentials` | `:request` map | Ignored. The browser same-origin/`:include` cookie model has no faithful `HttpClient` analogue — the shared client configures no `CookieHandler`, so cookies are neither sent nor stored regardless of the value. (Unlike `:redirect`, which IS honoured on the JVM via the redirect-policy client.) |
 
-The trace event's `:tags` carry the key name, the request URL, and `:sensitive?` from the request envelope per [§Privacy](#privacy); a request whose URL falls under the query-param denylist or whose handler is marked `:sensitive?` has the URL redacted on the way to the trace surface. The trace is informational only — there is no `:rf.error/*` for this path, and the request is not classified as a failure. Cross-host portable code SHOULD avoid these five keys when JVM support matters, or feature-flag them at the call site. See also [§`:rf.http/cors` is CLJS-only](#rfhttpcors-is-cljs-only) for the symmetric failure-category asymmetry.
+The trace event's `:tags` carry the key name, the request URL, and `:sensitive?` from the request envelope per [§Privacy](#privacy); a request whose URL falls under the query-param denylist or whose handler is marked `:sensitive?` has the URL redacted on the way to the trace surface. The trace is informational only — there is no `:rf.error/*` for this path, and the request is not classified as a failure. Cross-host portable code SHOULD avoid these six keys when JVM support matters, or feature-flag them at the call site. See also [§`:rf.http/cors` is CLJS-only](#rfhttpcors-is-cljs-only) for the symmetric failure-category asymmetry.
 
 ### Body encoding
 

--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -72,14 +72,14 @@ Causa's chrome is two zones, one purpose each:
 ┌──────────────────────────────────────────────────────────────────────┐
 │  L1 ribbon · L2 epoch timeline                ← MOVING BETWEEN epochs│
 ├──────────────────────────────────────────────────────────────────────┤
-│  L4 panels (8 lenses on the focused epoch)    ← DEPTH INTO one epoch │
+│  L4 panels (7 lenses on the focused epoch)    ← DEPTH INTO one epoch │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
 **Top** carries the only cross-epoch signal — the L2 epoch timeline + its
 per-row badges (`⚠ ◆ 🌐 ⚡ 💧 🌊 ⏲`) and the dispatch-origin tag prefix
 (`user / fx / route / hyd / ws / timer / tool / internal`). **Bottom** is
-eight L4 panels each answering "what happened in this epoch?" through its
+seven L4 panels each answering "what happened in this epoch?" through its
 own lens. **No third axis. No cross-epoch L4 panels.**
 
 ### §1.1 The epoch — eight steps, two perspectives
@@ -1511,7 +1511,7 @@ h1/h2 face.
 
 ## §15 What's deliberately NOT in this design
 
-- **No 4th L4 panel.** The 8-panel set is the contract; sub-layer
+- **No 4th L4 panel.** The 7-panel set is the contract; sub-layer
   surfaces inline in Reactive + App-db (§3.3).
 - **No cross-epoch L4 views.** Per §1.2. Aggregate signals live on L2
   badges only.
@@ -1669,8 +1669,8 @@ The mockups in §1-§9 already pick these. §17.1.5 binds them.
 |---|---|---|
 | ⚠ | Issue (error or warning) emitted this epoch | `:red` |
 | ◆ | State machine transition this epoch | `:green` |
-| 🌐 | Route navigation this epoch | `:yellow` |
-| ⚡ | HTTP request lifecycle touched | `:orange` |
+| 🌐 | HTTP request lifecycle touched (managed-HTTP settle / response) | `:orange` |
+| ⚡ | fx-emit child — dispatched from a parent's `do-fx` | `:magenta` |
 | 💧 | SSR hydration phase | `:cyan` |
 | 🌊 | A flow recomputed | `:accent-violet` |
 | ⏲ | Timer-triggered dispatch | `:text-tertiary` |


### PR DESCRIPTION
Reconciles three spec-vs-impl drifts. Impl is ground truth for every claim; each was verified against the actual files before/while editing.

## Reconcile 1 — spec/005-StateMachines.md (rf2-8wrzz.6)
Unhandled-event trace id corrected to the canonical `:rf.error/` form.

- **Before:** `:rf.warning/machine-unhandled-event` (and `:rf.warning/machine-*` in the "consistent with" note).
- **After:** `:rf.error/machine-unhandled-event` at every occurrence (§wildcard precedence ~L287, §Transition resolution L1028, parallel-region L1168/L1171, in-flight-trigger L1575, spawn-child L1780). The "older drafts used `:rf.warning/...`" supersession note is retained at L1028.
- **Verified:** `spec/009-Instrumentation.md` L1348 catalogues this as `:rf.error/machine-unhandled-event` (op-type `:error`); every `machine-*` category in 009 is `:rf.error/`. Impl emits it via `trace/emit-error! :rf.error/machine-unhandled-event` in `implementation/machines/src/re_frame/machines/transition.cljc` (L1543) and `parallel.cljc` (L373).

## Reconcile 2 — spec/014-HTTPRequests.md (rf2-8wrzz.5)
Added the `:credentials` row to the JVM-degradation table (matching http PR #1984's degradation trace).

- **Before:** "Five keys" CLJS-only; no `:credentials` row; `:credentials` arg-table row said only "Default: `:same-origin`".
- **After:** "Six keys"; new row — `:credentials` → "Ignored. The browser same-origin/`:include` cookie model has no faithful `HttpClient` analogue — the shared client configures no `CookieHandler`, so cookies are neither sent nor stored regardless of the value. (Unlike `:redirect`, which IS honoured on the JVM via the redirect-policy client.)"; arg-table row now flags CLJS-only with a link to the degradation section.
- **Verified:** `implementation/http/src/re_frame/http_transport.cljc` `check-cljs-only-keys!` (L516) iterates `[:mode :cache :referrer :integrity :credentials]` and emits `:rf.http/cljs-only-key-ignored-on-jvm`; the L507-515 comment states the no-CookieHandler rationale verbatim. The `:redirect` contrast holds — `redirect->policy` (L297) maps `:redirect` to a `HttpClient.Redirect` policy that IS honoured on JVM.

## Reconcile 3 — tools/causa/spec/021-Dynamic-Panel-Designs.md (rf2-8wrzz.7)
(a) L4 lens count 8 → 7; (b) §17.1.5 L2 badge map corrected.

- **Before (a):** "8 lenses" / "eight L4 panels" (§1); "The 8-panel set is the contract" (§15).
- **After (a):** 7 lenses / seven panels / "7-panel set".
- **Verified (a):** `tools/causa/src/day8/re_frame2_causa/registry.cljs` L318-319 — "Seven valid ids per spec/018 §5: `:event :app-db :views :trace :machines :routing :issues`". The §17.1.5 panel-accent table already lists exactly those 7. ("eight steps" in §1.1 is the epoch's step count, a different concept — left unchanged.)
- **Before (b):** 🌐 = "Route navigation" (`:yellow`); ⚡ = "HTTP request lifecycle" (`:orange`).
- **After (b):** 🌐 = "HTTP request lifecycle touched (managed-HTTP settle / response)" (`:orange`); ⚡ = "fx-emit child — dispatched from a parent's `do-fx`" (`:magenta`).
- **Verified (b):** `tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc` — `activity-badge-glyphs` maps `:http?` → 🌐 and `:fx-emit?` → ⚡ (L230-231); `activity-badge-order` is `[:error? :machine? :http? :fx-emit? :timer?]` — there is no route badge in the L2 cluster at all. The impl renders the whole cluster in one uniform `:yellow` span (`shell.cljs` L1353), so the per-badge "Token" column is design-intent only; ⚡ was set to `:magenta` (an impl palette token unused elsewhere in the doc) instead of the prior worker's `:accent-violet`, which collided with the existing 🌊 flow badge in the same table.

## Gates
- `python scripts/check_doc_slugs.py` → exit 0.
- `mkdocs build --strict` (after staging `spec/` → `docs/spec/` per CI's docs.yml) → built clean, exit 0, no WARNING/ERROR. NOTE: `tools/causa/spec/021` is OUTSIDE the mkdocs `docs_dir` (only `docs/`, plus the CI-staged `spec/` + `migration/`), so mkdocs does not validate 021 — its two edited tables were verified to render sanely by inspection (well-formed 3-column markdown, no token collisions).