### PR TITLE
chore(examples): drop redundant ^:export on example entry fns (rf2-s75mr)

### DIFF
--- a/examples/TESTING.md
+++ b/examples/TESTING.md
@@ -81,7 +81,17 @@ cljs.test summary prints). But the convention examples follow is:
 
 > **Do not perform DOM mount side effects at namespace-load time.**
 > Defer `create-root` (or your substrate's equivalent) to the example's
-> `^:export run` fn.
+> `run` fn.
+
+Each example's `run` fn is its bundle entry point, wired as the
+`:init-fn` of the example's shadow-cljs build target in
+[`implementation/shadow-cljs.edn`](../implementation/shadow-cljs.edn)
+(e.g. `:examples/realworld` → `:init-fn realworld.core/run`). shadow-cljs
+emits a call to that fn as the bundle's bootstrap, resolving the symbol
+*inside* the compiled bundle — so the fn needs **no** `^:export` metadata.
+`^:export` only matters for symbols called by name from outside the bundle
+(hand-written HTML/JS via `window....`); the example host pages just load
+`main.js` and let the `:init-fn` fire, so no example needs it.
 
 The shape every Reagent example uses:
 
@@ -90,7 +100,9 @@ The shape every Reagent example uses:
 ;; once `run` has materialised it.
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+;; Bundle entry point — wired as this example's :init-fn in
+;; implementation/shadow-cljs.edn. No ^:export needed (see above).
+(defn run []
   (rf/init! adapter)
   ;; ... per-example app boot ...
   (when (exists? js/document)
@@ -146,7 +158,8 @@ non-overlapping.
 A new example added to the `test:browser` surface needs:
 
 1. **Namespace-load side effects only register, never mount.** All DOM
-   creation lives in `^:export run`. Per the convention above.
+   creation lives in the example's `run` fn (the bundle's `:init-fn`).
+   Per the convention above.
 2. **A prefixed id namespace.** Pick a stem (your example's folder name
    in `kebab-case` is a good default) and stick to it for every
    `reg-event-*`, `reg-sub`, `reg-machine`, `reg-frame`, schema, etc.

--- a/examples/helix/counter_helix/core.cljs
+++ b/examples/helix/counter_helix/core.cljs
@@ -68,7 +68,7 @@
 (defonce root
   (react-dom-client/createRoot (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])

--- a/examples/helix/login_helix/core.cljs
+++ b/examples/helix/login_helix/core.cljs
@@ -253,7 +253,7 @@
 (defonce react-root
   (react-dom-client/createRoot (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! helix-adapter/adapter)
   (rf/reg-frame :rf/default

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -239,7 +239,7 @@
 (defonce root
   (react-dom-client/createRoot (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   (rf/init! helix-adapter/adapter)
   (rf/dispatch-sync [:monitor/initialise])
   (.render root ($ monitor)))

--- a/examples/reagent/7Guis/cells/cells.cljs
+++ b/examples/reagent/7Guis/cells/cells.cljs
@@ -263,7 +263,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cells/initialise])

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.cljs
@@ -229,7 +229,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:drawer/initialise])

--- a/examples/reagent/7Guis/crud/crud.cljs
+++ b/examples/reagent/7Guis/crud/crud.cljs
@@ -196,7 +196,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:crud/initialise])

--- a/examples/reagent/7Guis/flight_booker/flight_booker.cljs
+++ b/examples/reagent/7Guis/flight_booker/flight_booker.cljs
@@ -187,7 +187,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:flight/initialise])

--- a/examples/reagent/7Guis/temperature/temperature.cljs
+++ b/examples/reagent/7Guis/temperature/temperature.cljs
@@ -148,7 +148,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:temp/initialise])

--- a/examples/reagent/7Guis/timer/timer.cljs
+++ b/examples/reagent/7Guis/timer/timer.cljs
@@ -166,7 +166,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:timer/initialise])

--- a/examples/reagent/boot/core.cljs
+++ b/examples/reagent/boot/core.cljs
@@ -124,7 +124,7 @@
 ;; `create-root` calls onto the same shared `#app` element.
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
 

--- a/examples/reagent/counter_slim_and_fast/core.cljs
+++ b/examples/reagent/counter_slim_and_fast/core.cljs
@@ -83,7 +83,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Slim adapter — the difference from `examples/reagent/counter` is
   ;; right here. Same `rf/init!` signature; different adapter Var.
   (rf/init! reagent-slim-adapter/adapter)

--- a/examples/reagent/flows/core.cljs
+++ b/examples/reagent/flows/core.cljs
@@ -268,7 +268,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:cart/initialise])

--- a/examples/reagent/long_running_work/core.cljs
+++ b/examples/reagent/long_running_work/core.cljs
@@ -101,7 +101,7 @@
 
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:app/initialise])

--- a/examples/reagent/managed_http_counter/core.cljs
+++ b/examples/reagent/managed_http_counter/core.cljs
@@ -231,7 +231,7 @@
 (defonce root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:counter/initialise])

--- a/examples/reagent/nine_states/core.cljs
+++ b/examples/reagent/nine_states/core.cljs
@@ -688,7 +688,7 @@
 
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   ;; Install the demo override so `:rf.http/managed` calls route to the

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -275,7 +275,7 @@
 
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+(defn run []
   (rf/init! reagent-adapter/adapter)
   (rf/dispatch-sync [:notebook/initialise])
   (when (exists? js/document)

--- a/examples/reagent/realworld/core.cljs
+++ b/examples/reagent/realworld/core.cljs
@@ -379,7 +379,7 @@
       token (assoc-in [:request :headers "Authorization"]
                       (str "Token " token)))))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   ;; Override :rf.http/managed on the default frame so all the realworld

--- a/examples/reagent/routing/core.cljs
+++ b/examples/reagent/routing/core.cljs
@@ -149,7 +149,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:routing.app/initialise])

--- a/examples/reagent/ssr/core.cljc
+++ b/examples/reagent/ssr/core.cljc
@@ -277,7 +277,7 @@
      (rdc/create-root (js/document.getElementById "app"))))
 
 #?(:cljs
-   (defn ^:export run []
+   (defn run []
      ;; Boot the runtime against the Reagent substrate. Idempotent — the
      ;; first call installs the adapter and creates :rf/default; subsequent
      ;; calls (e.g. shadow-cljs hot reloads) are no-ops.

--- a/examples/reagent/ssr_streaming/core.cljc
+++ b/examples/reagent/ssr_streaming/core.cljc
@@ -194,7 +194,7 @@
      (rdc/create-root (js/document.getElementById "app"))))
 
 #?(:cljs
-   (defn ^:export run []
+   (defn run []
      (rf/init! reagent-slim-adapter/adapter)
      (when-let [payload (read-server-payload)]
        (rf/dispatch-sync [:rf/hydrate payload]))

--- a/examples/reagent/state_machine_walkthrough/views.cljs
+++ b/examples/reagent/state_machine_walkthrough/views.cljs
@@ -98,7 +98,7 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   ;; Install the canned-failure override on the default frame so every

--- a/examples/reagent/todomvc/core.cljs
+++ b/examples/reagent/todomvc/core.cljs
@@ -33,7 +33,7 @@
 (defn- current-path []
   (hash->path (.. js/window -location -hash)))
 
-(defn ^:export run []
+(defn run []
   ;; Pass the adapter spec map directly — no registry.
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:todo/initialise])

--- a/examples/reagent/websocket/core.cljs
+++ b/examples/reagent/websocket/core.cljs
@@ -133,7 +133,7 @@
 
 (defonce react-root (atom nil))
 
-(defn ^:export run []
+(defn run []
   (rf/init! reagent-slim-adapter/adapter)
   (rf/dispatch-sync [:ws.app/initialise])
   (when (exists? js/document)

--- a/examples/reagent/websocket/messages.cljs
+++ b/examples/reagent/websocket/messages.cljs
@@ -73,7 +73,7 @@
 
 (defonce ^:private mock-server-state (atom {:sockets {} :sync? false}))
 
-(defn ^:export set-mock-sync!
+(defn set-mock-sync!
   "Toggle the mock server between async (default, microtask-delivered)
    and sync (immediate-delivery) modes. Sync mode is used by the
    headless tests so `rf/dispatch-sync` observes the full
@@ -81,7 +81,7 @@
   [sync?]
   (swap! mock-server-state assoc :sync? sync?))
 
-(defn ^:export reset-mock-server!
+(defn reset-mock-server!
   "Clear every stored mock socket. Used by the headless test fixture
    to ensure each test starts with a fresh mock-server side-table —
    without this, the `:sockets` map accumulates across tests and
@@ -185,7 +185,7 @@
       (rf/dispatch-sync [actor-id [kind payload]])
       (rf/dispatch       [actor-id [kind payload]]))))
 
-(defn ^:export send-server-push!
+(defn send-server-push!
   "Deliver a synthetic server push to every live mock socket. Used by
    the Playwright spec and the example's 'Trigger server push' button
    to demonstrate the inbound translation path."
@@ -194,7 +194,7 @@
     (when @open?
       (deliver-external! actor-id :received body))))
 
-(defn ^:export simulate-disconnect!
+(defn simulate-disconnect!
   "Force every live mock socket closed, triggering the reconnect
    cascade in the parent. Used by the 'Drop connection' button."
   []


### PR DESCRIPTION
## Summary

Completes the `^:export` tidy across the examples tree (PR #2016 did the
Reagent counter + login examples). Every example's run/entry fn is wired
as its bundle's `:init-fn` in `implementation/shadow-cljs.edn`, so
shadow-cljs emits a call to it and resolves the symbol *inside* the
compiled bundle — no Closure export name is needed. The host `index.html`
pages just load `main.js` and let the `:init-fn` fire; none call
`window.<example>.run()` from outside the bundle. So `^:export` on these
fns is dead weight.

## `^:export` removed (verified redundant)

All 23 example run/entry fns — each confirmed against its `:init-fn` in
`implementation/shadow-cljs.edn`:

- Helix: `counter_helix/core.cljs`, `login_helix/core.cljs`, `process_monitor_helix/core.cljs`
- Reagent: `boot/core.cljs`, `counter_slim_and_fast/core.cljs`, `flows/core.cljs`, `long_running_work/core.cljs`, `managed_http_counter/core.cljs`, `nine_states/core.cljs`, `notebook/core.cljs`, `realworld/core.cljs`, `routing/core.cljs`, `ssr/core.cljc`, `ssr_streaming/core.cljc`, `state_machine_walkthrough/views.cljs`, `todomvc/core.cljs`, `websocket/core.cljs`
- Reagent 7Guis: `cells/cells.cljs`, `circle_drawer/circle_drawer.cljs`, `crud/crud.cljs`, `flight_booker/flight_booker.cljs`, `temperature/temperature.cljs`, `timer/timer.cljs`

Plus the four websocket mock seams in `reagent/websocket/messages.cljs`
(`set-mock-sync!`, `reset-mock-server!`, `send-server-push!`,
`simulate-disconnect!`) — these are called only via fully-qualified CLJS
symbol from the example's own `views.cljs` (button handlers) and its
headless tests; no JS calls them via `window`, and no `*.spec.cjs` exists
under `examples/` (examples are test-free, rf2-8cevm). All resolved
inside the bundle, so `^:export` was redundant on them too.

## `^:export` kept

None. Every occurrence in the examples tree was verified redundant and
removed. The UIx examples already carried no `^:export`.

## TESTING.md fix

`examples/TESTING.md` still documented `^:export run` as "the shape every
Reagent example uses" (around L84/L86/L93/L149). Corrected to reflect the
`:init-fn` reality: the `run` fn is the bundle entry point wired via
`:init-fn`, needs no `^:export`, and the convention code sample now shows
`(defn run [] ...)` with an explanatory note on why `^:export` is not
needed.

## Gate result

`shadow-cljs release` of a representative set of edited examples (a Helix
one, several Reagent ones incl. the websocket example with the mock seams,
and the `.cljc` SSR code path) — all built clean under full Closure
advanced optimisation, every `:init-fn` symbol resolved:

```
[:examples/realworld]     Build completed. (200 files, 140 compiled, 0 warnings, 17.71s)
[:examples/counter-helix] Build completed. (135 files,  79 compiled, 0 warnings,  6.86s)
[:examples/todomvc]       Build completed. (131 files,  76 compiled, 0 warnings,  6.60s)
[:examples/websocket]     Build completed. (157 files,  97 compiled, 0 warnings,  6.50s)
[:examples/ssr]           Build completed. (173 files, 113 compiled, 0 warnings,  6.92s)
```

(Two pre-existing, unrelated warnings — a JSDoc-tag note in
`http/src/re_frame/http_privacy_headers.cljc` and an unreachable-code
note in `todomvc/db.cljs` — predate this change and are outside scope.)

## Test plan

- [x] `shadow-cljs release` of representative edited examples — 0 errors, `:init-fn` resolves
- [ ] CI examples gate