### PR TITLE
docs(api): fix docs/api drift vs spec + impl (rf2-8wrzz.12)

### DIFF
--- a/docs/api/01-core.md
+++ b/docs/api/01-core.md
@@ -250,13 +250,13 @@ This is the surface every re-frame2 app touches. You're answering "what events c
   (reg-flow flow)
   (reg-flow flow opts)
   ```
-- **Description**: Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. See [05 — Flows](05-flows.md).
+- **Description**: Register a derived flow — `{:id :inputs :output :path}` — that auto-recomputes when its inputs change and writes the result into `:path` in `app-db`. `:inputs` is a positional vector of `app-db` paths; the values arrive as positional args to `:output`. See [05 — Flows](05-flows.md).
 - **Example**:
   ```clojure
   (rf/reg-flow
     {:id     :cart/total
-     :inputs {:items [:cart :items]}
-     :output (fn [{:keys [items]}] (reduce + (map :price items)))
+     :inputs [[:cart :items]]
+     :output (fn [items] (reduce + (map :price items)))
      :path   [:cart :total]})
   ```
 

--- a/docs/api/09-ssr.md
+++ b/docs/api/09-ssr.md
@@ -156,7 +156,8 @@ All server-only — `:platforms #{:server}`. These build the response accumulato
 | `[:rf.server/append-header {:name :value}]` | per `:rf.fx.server/append-header-args` | 011 |
 | `[:rf.server/set-cookie :rf.server/cookie]` | structured cookie map | 011 |
 | `[:rf.server/delete-cookie {:name ?:path ?:domain}]` | — | 011 |
-| `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML | 011 |
+| `[:rf.server/redirect {:location ?:status}]` | default `:status 302`; truncates HTML. **Caller-trusted** `:location`. | 011 |
+| `[:rf.server/safe-redirect {:location ?:relative-only? ?:allow}]` | The caller-untrusted variant — parses `:location`, rejects `javascript:` / `data:` / `vbscript:` schemes, and enforces `:relative-only?` / `:allow` allowlist before setting `:redirect`. Open-redirect mitigation for attacker-controlled `?next=` strings. | 011 |
 
 ## Standard SSR subs
 

--- a/docs/api/10-testing.md
+++ b/docs/api/10-testing.md
@@ -236,15 +236,17 @@ The view-assertion surface treats a view as what it is — a function that retur
 (rf/reg-view cart-row
   [item]
   [:tr (th/testid (str "cart-row-" (:id item)))
-    [:td (:name item)]
+    [:td (th/testid "cart-row-name") (:name item)]
     [:td.qty (:qty item)]
-    [:button {:on-click #(rf/dispatch [::remove (:id item)])} "remove"]])
+    [:button (th/testid "cart-row-remove" {:on-click #(rf/dispatch [::remove (:id item)])})
+     "remove"]])
 
 (deftest cart-row-renders-and-dispatches
-  (let [tree (cart-row {:id 1 :name "widget" :qty 3})
-        node (th/find-by-testid (th/expand-tree tree) "cart-row-1")]
-    (is (= "widget" (th/text-content (th/find-by-attr node :td.name nil))))
-    (is (fn? (th/extract-handler (th/find-by-attr node :button nil) :on-click)))))
+  (let [tree (th/expand-tree (cart-row {:id 1 :name "widget" :qty 3}))
+        name-cell  (th/find-by-testid tree "cart-row-name")
+        remove-btn (th/find-by-testid tree "cart-row-remove")]
+    (is (= "widget" (th/text-content name-cell)))
+    (is (fn? (th/extract-handler remove-btn :on-click)))))
 ```
 
 No JSDOM; no `act()`; no JSON serialisation; no DOM walk. The hiccup is data; the assertions walk data.

--- a/docs/api/11-instrumentation.md
+++ b/docs/api/11-instrumentation.md
@@ -8,7 +8,7 @@ This chapter covers the event-emit listener surface, the error-emit listener sur
 
 ## Event-emit (always-on, production-survivable)
 
-A minimal always-on listener surface that survives `:advanced` + `goog.DEBUG=false` and delivers one tight record per processed event. The intended consumers are hosted observability back-ends (Datadog, Honeycomb, Sentry, …). **Parallel to (not a fallback for) the dev-only trace surface; per-event only — no per-sub, per-fx, or per-`:event/db-changed` records.**
+A minimal always-on listener surface that survives `:advanced` + `goog.DEBUG=false` and delivers one tight record per processed event. The intended consumers are hosted observability back-ends (Datadog, Honeycomb, Sentry, …). **Parallel to (not a fallback for) the dev-only trace surface; per-event only — no per-sub, per-fx, or per-`:rf.event/db-changed` records.**
 
 Record shape: `{:event :event-id :frame :time :outcome :elapsed-ms}`. The `:event` slot is passed through `elide-wire-value` (see below) once before fan-out, so schema-marked `:sensitive?` paths land as `:rf/redacted` and `:large?` paths land as `:rf.size/large-elided`.
 


### PR DESCRIPTION
## Summary

Drift audit of the entire `docs/api/` tree against the current `spec/` (normative) and `implementation/` reality, following the prior `05-flows.md` fix. All 16 API docs cross-checked; 4 fixed, 12 verified clean.

## Per-file audit

| File | Result |
|---|---|
| README.md | clean |
| 01-core.md | **fixed** |
| 02-views.md | clean |
| 03-effects.md | clean |
| 04-machines.md | clean |
| 05-flows.md | clean (prior fix holds) |
| 06-routing.md | clean |
| 07-http.md | clean |
| 08-schemas.md | clean |
| 09-ssr.md | **fixed** |
| 10-testing.md | **fixed** |
| 11-instrumentation.md | **fixed** |
| 12-registrar.md | clean |
| 13-lifecycle.md | clean |
| 14-adapters.md | clean |
| 15-removed.md | clean |

## Fixes (before -> after)

- **01-core.md** `reg-flow` example used the **dropped** map-keyed `:inputs` shape:
  - before: `:inputs {:items [:cart :items]}` + `:output (fn [{:keys [items]}] ...)`
  - after: `:inputs [[:cart :items]]` + `:output (fn [items] ...)` (positional vector per spec/013 + `flows.cljc` `read-inputs`, matching the already-fixed 05-flows.md).

- **09-ssr.md** server-only fx table was **missing** `:rf.server/safe-redirect`:
  - added the seventh `:rf.server/*` fx (ships in `implementation/ssr/src/re_frame/ssr/response.cljc`, normative in spec/011 §HTTP response contract). Also tagged `:rf.server/redirect` as caller-trusted to disambiguate the pair.

- **10-testing.md** view-assertion example **could not run**:
  - before: `(th/find-by-attr node :td.name nil)` / `(th/find-by-attr node :button nil)` — `find-by-attr` matches attribute *values*, not tags, and there is no `find-by-tag` helper.
  - after: nodes located via `find-by-testid` (testids added to the `:td` and `:button` in the view, using the canonical 2-arity `testid` helper per the impl docstring).

- **11-instrumentation.md** pre-migration trace spelling:
  - before: `:event/db-changed`
  - after: `:rf.event/db-changed` (the `:rf.*` single-root trace contract; spec/009 uses `:rf.event/db-changed` throughout).

## Spec-vs-impl gaps found (for follow-up beads — NOT fixed here, out of scope)

The `:elision` `configure` key is normative in spec (API.md, Conventions.md, Privacy.md, 009) and the docs correctly document it, but the **implementation** is incomplete:
1. `re-frame.core/configure` has no `:elision` case — it silently no-ops (only `:epoch-history`, `:trace-buffer`, `:sub-cache` are handled).
2. `elide-wire-value` does not consume `:rf.size/threshold-bytes` from opts nor fall back to `(configure :elision ...)`; it uses a hard-coded `large-warning-bytes 16384` constant only for the unschema'd-large-string warning.

Docs match the normative spec, so no doc change was made; these are impl follow-ups.

## Gates

- `python -m mkdocs build --strict` -> exit 0, no WARNING/ERROR (pre-existing INFO "not in nav" notices for spec/ files only).
- `python scripts/check_doc_slugs.py` -> exit 0.

## Test plan

- [x] mkdocs build --strict passes
- [x] check_doc_slugs.py passes
- [ ] reviewer spot-checks the four before->after fixes against spec/013, spec/011, `test_helpers.cljc`, spec/009