### PR TITLE
fix(elision): wire :elision configure case + :rf.size/threshold-bytes (rf2-le2qu)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -1278,6 +1278,10 @@
     :epoch-history {:depth N}                       ring depth (default 50; 0 disables)
     :trace-buffer  {:depth N}                       ring depth (default 200; 0 disables)
     :sub-cache     {:grace-period-ms N}             dispose grace (default 50ms)
+    :elision       {:rf.size/threshold-bytes N}     wire-elision size threshold
+                                                    (default 16384; 0 disables runtime
+                                                    auto-detect — only declared / schema
+                                                    entries elide)
   Unknown keys silently no-op. Per-frame settings live on frame metadata.
   Per Tool-Pair §How AI tools attach.
 
@@ -1292,6 +1296,7 @@
     :trace-buffer  (when-let [f (late-bind/get-fn :trace.tooling/configure-trace-buffer!)]
                      (f opts))
     :sub-cache     (subs-cache/configure! opts)
+    :elision       (elision/configure! opts)
     nil))
 
 (def ^{:doc "Install the substrate adapter for this process. Once. A

--- a/implementation/core/src/re_frame/elision.cljc
+++ b/implementation/core/src/re_frame/elision.cljc
@@ -15,7 +15,49 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(def ^:private large-warning-bytes 16384)
+;; ---- runtime size threshold ----------------------------------------------
+;;
+;; Per API.md §Size-elision wire-boundary walker and §Configure keys, the
+;; runtime auto-detect threshold for the `:rf.warning/large-value-unschema'd`
+;; advisory is configurable. Precedence (normative, API.md L507):
+;;
+;;   explicit `:rf.size/threshold-bytes` opt  >  `(rf/configure :elision …)`  >  default
+;;
+;; A threshold of 0 disables runtime auto-detect entirely (only declared /
+;; schema-marked entries elide); the unschema'd-large warning never fires.
+;; The default mirrors the documented `{:rf.size/threshold-bytes 16384}`.
+
+(def ^:private default-threshold-bytes 16384)
+
+(defonce ^:private config
+  ;; Map shape so future :elision configure-keys land additively, matching
+  ;; `re-frame.subs.cache/config`.
+  (atom {:rf.size/threshold-bytes default-threshold-bytes}))
+
+(defn configure!
+  "Update the elision configuration. Supports
+  `{:rf.size/threshold-bytes N}` — a non-negative integer runtime
+  auto-detect size threshold for the `:rf.warning/large-value-unschema'd`
+  advisory (0 disables runtime auto-detect; only declared / schema-marked
+  entries elide). Per API.md §Configure keys (`:elision`) and Spec 009
+  §Size elision in traces. Routed from `re-frame.core/configure`."
+  [opts]
+  (when (map? opts)
+    (swap! config merge (select-keys opts [:rf.size/threshold-bytes])))
+  nil)
+
+(defn current-config
+  "Return the current elision configuration map. Public for tests and
+  tools that want to display the configured runtime size threshold."
+  []
+  @config)
+
+(defn- configured-threshold-bytes
+  "The configured runtime size threshold, falling back to the documented
+  default when no `configure` call has set it."
+  []
+  (let [v (:rf.size/threshold-bytes @config)]
+    (if (some? v) v default-threshold-bytes)))
 
 (defonce ^:private warned-unschema'd
   (atom #{}))
@@ -241,9 +283,14 @@
         (when (and (string? v)
                    (not large-decl)
                    (not sensitive?))
-          (let [bytes (pr-str-bytes v)]
-            (when (> bytes large-warning-bytes)
-              (warn-large-unschema'd! (:frame-id ctx) path bytes))))
+          (let [threshold (:threshold-bytes ctx)]
+            ;; A threshold of 0 disables runtime auto-detect entirely —
+            ;; no `pr-str-bytes` walk, no warning. Per API.md §Configure
+            ;; keys (`:elision` — "0 disables runtime auto-detect").
+            (when (pos? threshold)
+              (let [bytes (pr-str-bytes v)]
+                (when (> bytes threshold)
+                  (warn-large-unschema'd! (:frame-id ctx) path bytes))))))
         v))))
 
 (defn elide-wire-value
@@ -251,15 +298,19 @@
   wire egress. Sensitive wins over large when both declarations match."
   ([v] (elide-wire-value v nil))
   ([v opts]
-   (let [frame-id (or (:frame opts) (frame/current-frame) :rf/default)
-         reg      (registry-of frame-id)
-         ctx      {:frame-id           frame-id
-                   :large              (or (:declarations reg) {})
-                   :sensitive          (or (:sensitive-declarations reg) {})
-                   :include-large?     (true? (:rf.size/include-large? opts))
-                   :include-sensitive? (true? (:rf.size/include-sensitive? opts))
-                   :include-digests?   (true? (:rf.size/include-digests? opts))
-                   :as-of-epoch        (:as-of-epoch opts)}]
+   (let [frame-id  (or (:frame opts) (frame/current-frame) :rf/default)
+         reg       (registry-of frame-id)
+         ;; Precedence (API.md L507): explicit opt > configured > default.
+         threshold (let [opt (:rf.size/threshold-bytes opts)]
+                     (if (some? opt) opt (configured-threshold-bytes)))
+         ctx       {:frame-id           frame-id
+                    :large              (or (:declarations reg) {})
+                    :sensitive          (or (:sensitive-declarations reg) {})
+                    :include-large?     (true? (:rf.size/include-large? opts))
+                    :include-sensitive? (true? (:rf.size/include-sensitive? opts))
+                    :include-digests?   (true? (:rf.size/include-digests? opts))
+                    :threshold-bytes    threshold
+                    :as-of-epoch        (:as-of-epoch opts)}]
      (walk v (vec (:path opts)) ctx))))
 
 (defn marker?

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -9,6 +9,7 @@
                        day8/re-frame2-epoch artefact via late-bind)
     :trace-buffer   — retain-N trace ring buffer depth (Spec 009)
     :sub-cache      — sub-cache deferred-disposal grace period (Spec 006)
+    :elision        — wire-elision runtime size threshold (Spec 009)
 
   This test pins the keys that ARE configurable and asserts that
   everything else is a silent no-op — `configure` returns `nil` and
@@ -21,6 +22,7 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.subs.cache :as subs-cache]
+            [re-frame.elision :as elision]
             [re-frame.trace :as trace]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -36,7 +38,8 @@
        (finally
          ;; Restore defaults so we do not leak tweaks into other suites.
          (rf/configure :trace-buffer {:depth 200})
-         (subs-cache/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50})
+         (rf/configure :elision {:rf.size/threshold-bytes 16384}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -50,7 +53,11 @@
   (testing ":sub-cache is wired"
     (rf/configure :sub-cache {:grace-period-ms 123})
     (is (= 123 (:grace-period-ms (subs-cache/current-config)))
-        ":sub-cache {:grace-period-ms N} reaches the subs config")))
+        ":sub-cache {:grace-period-ms N} reaches the subs config"))
+  (testing ":elision is wired (rf2-le2qu)"
+    (rf/configure :elision {:rf.size/threshold-bytes 4096})
+    (is (= 4096 (:rf.size/threshold-bytes (elision/current-config)))
+        ":elision {:rf.size/threshold-bytes N} reaches the elision config")))
 
 (deftest configure-unknown-key-is-silent-no-op
   (testing "rf2-mmlci — unknown keys silently no-op; configure returns nil"

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -20,6 +20,9 @@
   (rf/init! plain-atom/adapter)
   (require 're-frame.elision :reload)
   (require 're-frame.schemas :reload)
+  ;; `config` is a `defonce` (survives `:reload`); restore the documented
+  ;; default so a configure tweak in one test does not leak into the next.
+  (elision/configure! {:rf.size/threshold-bytes 16384})
   (test-fn))
 
 (use-fixtures :each reset-runtime)
@@ -90,6 +93,113 @@
                                 (:operation %))
                             @traces))))
     (rf/unregister-listener! :elision-test/once)))
+
+;; ---------------------------------------------------------------------------
+;; Runtime size-threshold configuration (rf2-le2qu).
+;;
+;; Per API.md §Size-elision wire-boundary walker (L507) and §Configure keys
+;; (`:elision`), the runtime auto-detect threshold for the
+;; `:rf.warning/large-value-unschema'd` advisory is configurable, with
+;; normative precedence:
+;;
+;;   explicit `:rf.size/threshold-bytes` opt  >  `(rf/configure :elision …)`  >  16384
+;;
+;; A threshold of 0 disables runtime auto-detect (only declared / schema
+;; entries elide; the unschema'd-large warning never fires).
+;; ---------------------------------------------------------------------------
+
+(defn- count-unschema'd-warnings [traces]
+  (count (filter #(= :rf.warning/large-value-unschema'd (:operation %))
+                 @traces)))
+
+(deftest default-threshold-is-16384
+  ;; A string just under the documented 16384-byte default does not warn;
+  ;; one just over does. Pins the default when neither opt nor configure set.
+  (let [under   (apply str (repeat 16000 "x"))      ; ~16002 pr-str bytes? -> under cap
+        over    (apply str (repeat 20000 "x"))
+        traces  (collect-traces! :elision-test/default-thresh)]
+    ;; `under` here is genuinely under 16384 bytes once quoted (16000 chars
+    ;; + 2 quote bytes = 16002), so no warning.
+    (rf/elide-wire-value {:a {:small under}})
+    (is (= 0 (count-unschema'd-warnings traces))
+        "value under the 16384 default does not trip the auto-detect warning")
+    (rf/elide-wire-value {:b {:big over}})
+    (is (= 1 (count-unschema'd-warnings traces))
+        "value over the 16384 default trips the warning")
+    (rf/unregister-listener! :elision-test/default-thresh)))
+
+(deftest configured-threshold-takes-effect
+  ;; rf2-le2qu — the IMPL gap: `(rf/configure :elision {:rf.size/threshold-bytes N})`
+  ;; must lower (or raise) the runtime auto-detect threshold. A 100-byte
+  ;; threshold makes a small string trip the warning that the 16384 default
+  ;; would have ignored.
+  (let [small  (apply str (repeat 300 "y"))         ; ~302 bytes — under default, over 100
+        traces (collect-traces! :elision-test/configured)]
+    ;; Baseline: under the default, no warning.
+    (rf/elide-wire-value {:a {:s small}})
+    (is (= 0 (count-unschema'd-warnings traces))
+        "300-byte string is under the 16384 default — no warning")
+    ;; Lower the configured threshold; now the same shape warns.
+    (rf/configure :elision {:rf.size/threshold-bytes 100})
+    (rf/elide-wire-value {:b {:s small}})
+    (is (= 1 (count-unschema'd-warnings traces))
+        "after (configure :elision {:rf.size/threshold-bytes 100}) the 300-byte string warns")
+    (rf/unregister-listener! :elision-test/configured)))
+
+(deftest configure-threshold-reaches-elision-config
+  ;; The configure case stores the value where elision reads it — direct
+  ;; assertion against the elision config, mirroring the :sub-cache shape
+  ;; of configure-test.
+  (rf/configure :elision {:rf.size/threshold-bytes 4096})
+  (is (= 4096 (:rf.size/threshold-bytes (elision/current-config)))
+      "(configure :elision {:rf.size/threshold-bytes N}) reaches the elision config"))
+
+(deftest explicit-opt-wins-over-configured
+  ;; Precedence: an explicit `:rf.size/threshold-bytes` on the call wins
+  ;; over the configured value. Configure a tiny threshold (would warn),
+  ;; then pass a large explicit opt on the call (must NOT warn).
+  (let [s      (apply str (repeat 300 "z"))          ; ~302 bytes
+        traces (collect-traces! :elision-test/opt-wins)]
+    (rf/configure :elision {:rf.size/threshold-bytes 50})
+    ;; Configured 50 alone would warn for a 302-byte string; but the
+    ;; explicit per-call opt of 100000 raises the bar above it.
+    (rf/elide-wire-value {:a {:s s}} {:rf.size/threshold-bytes 100000})
+    (is (= 0 (count-unschema'd-warnings traces))
+        "explicit :rf.size/threshold-bytes opt (100000) overrides configured (50) — no warning")
+    ;; And conversely an explicit small opt wins over a large configured value.
+    (rf/configure :elision {:rf.size/threshold-bytes 1000000})
+    (rf/elide-wire-value {:b {:s s}} {:rf.size/threshold-bytes 100})
+    (is (= 1 (count-unschema'd-warnings traces))
+        "explicit :rf.size/threshold-bytes opt (100) overrides configured (1000000) — warns")
+    (rf/unregister-listener! :elision-test/opt-wins)))
+
+(deftest threshold-zero-disables-runtime-auto-detect
+  ;; Per API.md §Configure keys — "0 disables runtime auto-detect (only
+  ;; declared / schema entries elide)". With threshold 0, even a very large
+  ;; unschema'd string never trips the warning.
+  (let [big    (apply str (repeat 5000 "ABCDEFGH")) ; ~40002 bytes — well over default
+        traces (collect-traces! :elision-test/zero)]
+    (rf/configure :elision {:rf.size/threshold-bytes 0})
+    (rf/elide-wire-value {:a {:big big}})
+    (is (= 0 (count-unschema'd-warnings traces))
+        "threshold 0 disables runtime auto-detect — no warning even for a 40KB string")
+    ;; Sanity: a per-call explicit 0 also disables, overriding a configured non-zero.
+    (rf/configure :elision {:rf.size/threshold-bytes 100})
+    (rf/elide-wire-value {:b {:big big}} {:rf.size/threshold-bytes 0})
+    (is (= 0 (count-unschema'd-warnings traces))
+        "explicit threshold-bytes 0 opt disables runtime auto-detect for that call")
+    (rf/unregister-listener! :elision-test/zero)))
+
+(deftest configured-threshold-does-not-affect-declared-elision
+  ;; The threshold governs ONLY the runtime auto-detect warning for
+  ;; unschema'd values — schema-declared `:large?` paths still elide to a
+  ;; marker regardless of threshold (including threshold 0).
+  (rf/reg-app-schema [:doc] [:string {:large? true :hint "blob"}])
+  (rf/populate-elision-from-schemas!)
+  (rf/configure :elision {:rf.size/threshold-bytes 0})
+  (let [out (rf/elide-wire-value {:doc "x"})]
+    (is (elision/marker? (:doc out))
+        "schema-declared :large? paths elide independent of the runtime threshold")))
 
 (deftest schema-sensitive-path-redacts
   (rf/reg-app-schema [:auth]


### PR DESCRIPTION
## Documented contract

`:elision` is a normatively-documented `configure` key:

- **API.md §Configure keys** — `:elision` ⇒ `{:rf.size/threshold-bytes N}`, default `16384`, "0 disables runtime auto-detect (only declared / schema entries elide)".
- **API.md §Size-elision wire-boundary walker** (the `elide-wire-value` row) — the precedence is explicit: *"`:rf.size/threshold-bytes` falls back to `(rf/configure :elision ...)` then `16384`."* i.e. **explicit opt > configured > default**.
- **Conventions.md**, **Privacy.md** (default `16384`, "0 disables runtime auto-detect"), **009 §Size elision in traces** — all document the same key.

## The two impl gaps (rf2-le2qu)

(a) `re-frame.core/configure` had **no `:elision` case** — it handled `:epoch-history`, `:trace-buffer`, `:sub-cache` but passing `:elision` silently no-op'd.
(b) `re-frame.elision` hard-coded `(def ^:private large-warning-bytes 16384)` and honoured neither an explicit `:rf.size/threshold-bytes` opt nor a configured fallback.

## Fix + precedence

- `elision.cljc`: replaced the hard-coded const with `default-threshold-bytes` + a `defonce config` atom and `configure!` / `current-config` fns, mirroring `re-frame.subs.cache`. `elide-wire-value` resolves the threshold with the documented precedence (**explicit `:rf.size/threshold-bytes` opt > `(rf/configure :elision …)` > `16384`**) and threads it into the walker via `ctx`. A threshold of `0` short-circuits the runtime auto-detect entirely (no `pr-str-bytes` walk, no `:rf.warning/large-value-unschema'd` warning).
- The threshold governs **only** the unschema'd-large runtime advisory; schema-declared `:large?` paths still elide to the marker regardless of threshold.
- `core.cljc`: added `:elision (elision/configure! opts)` to the `configure` `case` (matching the direct-call `:sub-cache` sibling, since `elision` is already required), plus a docstring row.

## Tests

- `configure_test.clj` — adds `:elision` to the known-configurable-keys assertion (`(configure :elision {:rf.size/threshold-bytes 4096})` reaches `elision/current-config`) and to the fixture default-restore; docstring updated.
- `elision_test.clj` — new regressions: default 16384 (under no-warn / over warn); configured threshold takes effect (lowers the bar so a small string warns); configure reaches the elision config; explicit-opt precedence both directions; threshold 0 disables runtime auto-detect (configured and per-call opt); configured threshold does not affect schema-declared elision. Fixture restores the default (config is `defonce`, survives `:reload`).

## Gates (all pass)

- `clojure -M:test` (core JVM, runs the new `.clj` tests): **734 tests, 3463 assertions, 0 failures, 0 errors**.
- Clean `shadow-cljs compile node-test` (1006 compiled, 0 warnings) then `node out/node-test.js`: **4184 tests, 12768 assertions, 0 failures, 0 errors**.
- `npm run test:elision`: **PASS — production 36/36 absent; control 36/36 present**.
- `npm run test:bundle-isolation`: **PASS — bundle-isolation (33 sentinels absent) + uix-helix-reagent-free**.

Spec/docs already document the feature; this is impl-only. No spec edits (`spec/006` / `spec/009` left untouched per in-flight worker ownership).