### PR TITLE
fix(causa): typed pills match causal-parent cascade under epoch-per-event (rf2-a1eld)

### DIFF
--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -116,16 +116,17 @@
   Event lens) can read top-level hoisted slots like
   `:rf.trace/call-site` (per rf2-twt7m Change 1) without reaching
   back into the raw trace buffer."
-  {:dispatch-id nil
-   :frame       nil
-   :event       nil
-   :dispatched  nil
-   :handler     nil
-   :fx          nil
-   :effects     []
-   :subs        []
-   :renders     []
-   :other       []})
+  {:dispatch-id        nil
+   :parent-dispatch-id nil
+   :frame              nil
+   :event              nil
+   :dispatched         nil
+   :handler            nil
+   :fx                 nil
+   :effects            []
+   :subs               []
+   :renders            []
+   :other              []})
 
 (def ^:private default-frame :rf/default)
 
@@ -198,8 +199,22 @@
   rf2-twt7m Change 1)."
   [acc ev]
   (case (domino-bucket ev)
-    :event   (assoc acc :event      (get-in ev [:tags :rf.event/v])
-                       :dispatched  ev)
+    :event   (assoc acc :event              (get-in ev [:tags :rf.event/v])
+                       :dispatched         ev
+                       ;; Surface the causal-parent link once at the
+                       ;; projection (Spec 009 §Dispatch correlation /
+                       ;; rf2-ryri7): the `:rf.event/dispatched` trace
+                       ;; carries `:rf.trace/parent-dispatch-id` (the
+                       ;; in-flight cascade that emitted this dispatch —
+                       ;; an `:fx :dispatch` parent, a machine-internal
+                       ;; dispatch, etc.). Under epoch-per-event every
+                       ;; child event is its own cascade; this slot is
+                       ;; the only edge linking a cascade to its spawning
+                       ;; cascade. Consumers (Causa typed pills, the
+                       ;; causality breadcrumb) walk it to relate a
+                       ;; cascade to its causal ancestors. nil for a
+                       ;; root cascade (a user / external dispatch).
+                       :parent-dispatch-id (get-in ev [:tags :rf.trace/parent-dispatch-id]))
     :handler (assoc acc :handler ev)
     :fx      (assoc acc :fx ev)
     :effect  (update acc :effects conj ev)
@@ -230,6 +245,11 @@
   Returns a vector of maps shaped:
 
       {:dispatch-id <cascade-id-or-:ungrouped>
+       :parent-dispatch-id <cascade-id or nil> ;; causal-parent link from
+                                              ;;   :rf.trace/parent-dispatch-id
+                                              ;;   (the cascade that emitted
+                                              ;;   this dispatch); nil for a
+                                              ;;   root / external dispatch
        :frame       <frame-id-or-nil>
        :event       <event-vector or nil>     ;; from :rf.event/dispatched :tags
        :dispatched  <trace-event or nil>      ;; the full :rf.event/dispatched

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -166,12 +166,36 @@
             collection-shaped defaults"
     (let [[c] (p/group-cascades [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                   :tags {:rf.trace/dispatch-id 1 :rf.event/v [:e]}}])]
-      (is (= #{:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other}
+      (is (= #{:dispatch-id :parent-dispatch-id :frame :event :dispatched
+               :handler :fx :effects :subs :renders :other}
              (set (keys c))))
       (is (vector? (:effects c)))
       (is (vector? (:subs c)))
       (is (vector? (:renders c)))
       (is (vector? (:other c))))))
+
+(deftest group-cascades-surfaces-parent-dispatch-id
+  (testing "the :parent-dispatch-id slot is read off the dispatched
+            event's :rf.trace/parent-dispatch-id tag — the causal-parent
+            link an :fx :dispatch / machine-internal child carries under
+            epoch-per-event (Spec 009 §Dispatch correlation)"
+    (let [evs [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                :tags {:rf.trace/dispatch-id        20
+                       :rf.trace/parent-dispatch-id 10
+                       :rf.event/v                  [:form/validate]}}]
+          [c] (p/group-cascades evs)]
+      (is (= 20 (:dispatch-id c)))
+      (is (= 10 (:parent-dispatch-id c))
+          "the spawning cascade's id is surfaced on the child cascade"))))
+
+(deftest group-cascades-root-cascade-has-nil-parent
+  (testing "a root (user / external) dispatch carries no
+            :rf.trace/parent-dispatch-id tag, so :parent-dispatch-id is nil"
+    (let [evs [{:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                :tags {:rf.trace/dispatch-id 10 :rf.event/v [:user/click]}}]
+          [c] (p/group-cascades evs)]
+      (is (= 10 (:dispatch-id c)))
+      (is (nil? (:parent-dispatch-id c))))))
 
 (deftest group-cascades-dispatched-slot-carries-full-trace-event
   (testing "the :dispatched slot preserves the full :rf.event/dispatched

--- a/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
@@ -63,6 +63,24 @@
   Mixing typed + keyword pills in the same bucket is supported and
   exercised by tests.
 
+  ## Causal-parent matching under epoch-per-event (rf2-a1eld)
+
+  Under epoch-per-event each dequeued event — including `:fx :dispatch`
+  children and machine-internal transitions — is its OWN cascade. A
+  `:machine` / `:http-correlation` / `:fx` IN pill matching only the
+  cascade carrying its tag would lose the link to the PARENT event that
+  spawned the transition (now a sibling cascade). The projection
+  surfaces the causal-parent link once as `:parent-dispatch-id`; a
+  directly-matching cascade pulls in its whole SPAWNING LINEAGE — every
+  causal ancestor walked UP that link to the root user event — so a
+  typed pill on a child transition cascade ALSO keeps the spawning
+  event's cascade. `keep = matching cascades ∪ their ancestors`. The
+  walk is in `cascade-self-and-ancestors` (cycle-guarded,
+  root-terminated); `filter-cascades` builds the
+  `{dispatch-id → cascade}` index once and folds the IN-kept id set
+  in `in-kept-id-set`. OUT (hide) pills stay cascade-local so a hide
+  never silently drops the ancestor that spawned the hidden child.
+
   Pure data → bool. JVM-runnable so the test corpus exercises every
   kind without a CLJS runtime."
   (:require [day8.re-frame2-causa.filters.matcher :as event-matcher]))
@@ -222,27 +240,128 @@
     (when (seq pills)
       (some #(cascade-matches-pill? cascade %) pills))))
 
+;; ---- causal-parent walk (rf2-a1eld) -------------------------------------
+;;
+;; Under epoch-per-event each dequeued event — including `:fx :dispatch`
+;; children and machine-internal transitions — is its OWN cascade
+;; (`re-frame.trace.projection/group-cascades` keys one record per
+;; `:rf.trace/dispatch-id`). A `:machine` / `:http` / `:fx` typed pill
+;; matching ONLY the cascade carrying its tag therefore loses the link
+;; to the PARENT event that spawned the transition (the spawning event
+;; lives in a sibling cascade now). 'Filter to this machine' must
+;; surface the spawning event's cascade too, not just the machine's
+;; bare epoch.
+;;
+;; The projection surfaces the causal-parent link once per cascade as
+;; `:parent-dispatch-id` (read off the dispatched event's
+;; `:rf.trace/parent-dispatch-id` tag — the in-flight cascade that
+;; emitted this dispatch). A MATCHING cascade pulls in its whole
+;; SPAWNING LINEAGE: a `:machine` pill matches the transition CHILD
+;; cascade, and we ALSO keep that child's ancestors (the spawning event
+;; up to the root user event) — `keep = matching cascades ∪ their
+;; ancestors`. Cascades key by `[frame dispatch-id]`; the parent link
+;; is dispatch-id only (parent + child always share a frame under
+;; epoch-per-event), so we index by dispatch-id and walk by id.
+
+(defn index-by-dispatch-id
+  "Build a `{dispatch-id → cascade}` index for ancestor walking. The
+  `:ungrouped` pseudo-cascade and any cascade with a nil dispatch-id
+  are excluded — they are not addressable causal nodes. Pure data."
+  [cascades]
+  (persistent!
+    (reduce (fn [acc cascade]
+              (let [id (:dispatch-id cascade)]
+                (if (and (some? id) (not= :ungrouped id))
+                  (assoc! acc id cascade)
+                  acc)))
+            (transient {})
+            cascades)))
+
+(defn cascade-self-and-ancestors
+  "Return `cascade` followed by its causal ancestors, walking the
+  `:parent-dispatch-id` link up to the root through `index` (a
+  `{dispatch-id → cascade}` map). Cycle-guarded (a malformed trace
+  with a parent loop terminates) and root-terminated (nil parent /
+  missing parent ends the walk). Pure data → vector, self-first."
+  [cascade index]
+  (loop [c    cascade
+         seen #{}
+         acc  []]
+    (if (or (nil? c)
+            (contains? seen (:dispatch-id c)))
+      acc
+      (let [parent-id (:parent-dispatch-id c)]
+        (recur (when (some? parent-id) (get index parent-id))
+               (conj seen (:dispatch-id c))
+               (conj acc c))))))
+
+(defn in-kept-id-set
+  "Compute the set of `:dispatch-id`s kept by the IN pills (rf2-a1eld).
+  A cascade that DIRECTLY matches any IN pill pulls in its whole
+  spawning lineage — itself plus every causal ancestor (walked via
+  `index`). The union is what surfaces the spawning event's cascade
+  alongside the machine/http/fx transition cascade under
+  epoch-per-event. nil / empty `in` returns nil (the 'no IN filter,
+  keep everything' signal — distinct from an empty set, which means
+  'IN active but nothing matched'). Pure data → set-or-nil."
+  [cascades index in]
+  (when (seq in)
+    (reduce (fn [kept cascade]
+              (if (cascade-matches-any? cascade in)
+                (into kept
+                      (map :dispatch-id)
+                      (cascade-self-and-ancestors cascade index))
+                kept))
+            #{}
+            cascades)))
+
 (defn keep-cascade?
   "True iff `cascade` survives the active filter per spec/018 §7:
 
-      keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
+      keep = (no-IN-pills OR in-kept) AND NOT (matches-OUT)
 
   Mirrors `matcher/keep-cascade?` but routes through the typed-
   predicate dispatch so IN and OUT pills can be a mix of keyword
-  patterns + typed predicates. Pure data; JVM-runnable."
-  [cascade {:keys [in out]}]
-  (let [in-ok?  (or (empty? in)
-                    (cascade-matches-any? cascade in))
-        out-hit (cascade-matches-any? cascade out)]
-    (and in-ok? (not out-hit))))
+  patterns + typed predicates.
+
+  `in-kept-ids` is the precomputed set from `in-kept-id-set` — the
+  dispatch-ids kept by the IN pills, INCLUDING the spawning ancestors
+  of every directly-matching cascade (rf2-a1eld). nil `in-kept-ids`
+  means no IN filter is active (keep every cascade subject to OUT). The
+  OUT test stays cascade-local — a hide pill suppresses only the
+  cascade carrying its tag, never its ancestors (so hiding a child's fx
+  does not silently drop the originating user event).
+
+  Pure data; JVM-runnable. The legacy single-cascade arity falls back
+  to direct (ancestor-free) IN matching for callers without the full
+  cascade set."
+  ([cascade {:keys [in out]}]
+   (let [in-ok?  (or (empty? in)
+                     (cascade-matches-any? cascade in))
+         out-hit (cascade-matches-any? cascade out)]
+     (and in-ok? (not out-hit))))
+  ([cascade in-kept-ids {:keys [out]}]
+   (let [in-ok?  (or (nil? in-kept-ids)
+                     (contains? in-kept-ids (:dispatch-id cascade)))
+         out-hit (cascade-matches-any? cascade out)]
+     (and in-ok? (not out-hit)))))
 
 (defn filter-cascades
   "Apply `filters` to `cascades`, returning the surviving subseq in
   order. Pure — no I/O, no atoms read. Drop-in replacement for
   `matcher/filter-cascades` that routes through typed-predicate
-  dispatch."
+  dispatch.
+
+  Builds a `{dispatch-id → cascade}` index once, computes the IN-kept
+  id set (each directly-matching cascade pulls in its spawning
+  ancestors, rf2-a1eld), then keeps cascades whose id is in that set
+  and which no OUT pill suppresses — so a typed pill on a child
+  transition cascade also keeps the spawning event's cascade under
+  epoch-per-event."
   [cascades filters]
-  (filterv #(keep-cascade? % filters) cascades))
+  (let [index    (index-by-dispatch-id cascades)
+        kept-ids (in-kept-id-set cascades index (:in filters))]
+    (filterv #(keep-cascade? % kept-ids filters) cascades)))
 
 ;; ---- pill labels (presentation hooks) -----------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
@@ -253,6 +253,135 @@
     (is (= [1 3] (mapv :dispatch-id
                        (typed/filter-cascades [c1 c2 c3] filters))))))
 
+;; ---- causal-parent matching under epoch-per-event (rf2-a1eld) ------------
+;;
+;; Under epoch-per-event the spawning event and the machine/http/fx
+;; transition it triggers are SEPARATE cascades linked by
+;; `:parent-dispatch-id` (the projection surfaces it off the dispatched
+;; event's `:rf.trace/parent-dispatch-id` tag). A typed IN pill on the
+;; CHILD transition cascade must also keep the PARENT spawning cascade —
+;; the whole lineage back to the originating user event.
+
+(defn- mk-child-cascade
+  "A cascade carrying both a `:dispatch-id` and the causal-parent link."
+  [{:keys [dispatch-id parent-dispatch-id] :as opts}]
+  (-> (mk-cascade (dissoc opts :dispatch-id :parent-dispatch-id))
+      (assoc :dispatch-id dispatch-id
+             :parent-dispatch-id parent-dispatch-id)))
+
+(deftest machine-pill-keeps-spawning-parent-cascade
+  (testing "a :machine pill on the machine-transition CHILD cascade also
+            keeps the PARENT event that spawned the transition (rf2-a1eld)"
+    (let [;; parent: the user event that spawned the transition. Carries
+          ;; NO machine tag of its own — it only matches via the child.
+          parent  (mk-child-cascade {:dispatch-id 10
+                                     :event       [:user/submit-form]})
+          ;; child: the machine transition, its own epoch under
+          ;; epoch-per-event, linked back to the parent.
+          child   (mk-child-cascade {:dispatch-id        20
+                                     :parent-dispatch-id 10
+                                     :event             [:rf.machine/transition]
+                                     :effects           [(tagged {:machine-id :form})]})
+          ;; unrelated cascade — no machine, no link → dropped.
+          other   (mk-child-cascade {:dispatch-id 30
+                                     :event       [:other/thing]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          kept    (mapv :dispatch-id
+                        (typed/filter-cascades [parent child other] filters))]
+      (is (= [10 20] kept)
+          "both the spawning parent AND the machine child survive; the
+           unrelated cascade is dropped"))))
+
+(deftest http-pill-keeps-spawning-parent-cascade
+  (testing "an :http-correlation pill on the response CHILD cascade also
+            keeps the PARENT event that issued the request (rf2-a1eld)"
+    (let [parent  (mk-child-cascade {:dispatch-id 100
+                                     :event       [:user/load-page]})
+          child   (mk-child-cascade {:dispatch-id        200
+                                     :parent-dispatch-id 100
+                                     :event             [:rf.http/response]
+                                     :other             [(tagged {:correlation-id "abc-123"})]})
+          other   (mk-child-cascade {:dispatch-id 300
+                                     :event       [:other/thing]})
+          filters {:in  [{:kind :http-correlation
+                          :params {:correlation-id "abc-123"}}]
+                   :out []}
+          kept    (mapv :dispatch-id
+                        (typed/filter-cascades [parent child other] filters))]
+      (is (= [100 200] kept)
+          "both the request-issuing parent AND the http child survive"))))
+
+(deftest fx-pill-keeps-spawning-parent-cascade
+  (testing "an :fx pill on the fx-triggering CHILD cascade also keeps the
+            PARENT event that spawned it (rf2-a1eld)"
+    (let [parent  (mk-child-cascade {:dispatch-id 1
+                                     :event       [:user/click]})
+          child   (mk-child-cascade {:dispatch-id        2
+                                     :parent-dispatch-id 1
+                                     :event             [:do/work]
+                                     :effects           [(tagged {:rf.fx/id :rf.http/managed})]})
+          other   (mk-child-cascade {:dispatch-id 3
+                                     :event       [:other/thing]})
+          filters {:in  [{:kind :fx :params {:fx-id :rf.http/managed}}]
+                   :out []}
+          kept    (mapv :dispatch-id
+                        (typed/filter-cascades [parent child other] filters))]
+      (is (= [1 2] kept)
+          "both the spawning parent AND the fx child survive"))))
+
+(deftest typed-pill-walks-full-chain-to-root
+  (testing "the ancestor walk is whole-chain: a :machine pill on a deep
+            grandchild surfaces every cascade up to the root user event
+            (rf2-a1eld design call — strict superset, no over-matching)"
+    (let [root  (mk-child-cascade {:dispatch-id 1
+                                   :event       [:user/click]})
+          mid   (mk-child-cascade {:dispatch-id        2
+                                   :parent-dispatch-id 1
+                                   :event             [:fx/dispatched-child]})
+          leaf  (mk-child-cascade {:dispatch-id        3
+                                   :parent-dispatch-id 2
+                                   :event             [:rf.machine/transition]
+                                   :effects           [(tagged {:machine-id :form})]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          kept    (mapv :dispatch-id
+                        (typed/filter-cascades [root mid leaf] filters))]
+      (is (= [1 2 3] kept)
+          "root → mid → leaf all survive via the whole-chain walk"))))
+
+(deftest out-pill-stays-cascade-local-does-not-drop-ancestor
+  (testing "an OUT (hide) pill suppresses only the cascade carrying its
+            tag, never an ancestor — hiding a child's fx must not silently
+            drop the originating user event (rf2-a1eld)"
+    (let [parent  (mk-child-cascade {:dispatch-id 1
+                                     :event       [:user/click]})
+          child   (mk-child-cascade {:dispatch-id        2
+                                     :parent-dispatch-id 1
+                                     :event             [:do/work]
+                                     :effects           [(tagged {:rf.fx/id :noisy/fx})]})
+          filters {:in  []
+                   :out [{:kind :fx :params {:fx-id :noisy/fx}}]}
+          kept    (mapv :dispatch-id
+                        (typed/filter-cascades [parent child] filters))]
+      (is (= [1] kept)
+          "only the tagged child is hidden; the parent survives"))))
+
+(deftest parent-walk-cycle-guarded
+  (testing "a malformed trace with a parent loop terminates the walk
+            rather than spinning (rf2-a1eld defensive guard)"
+    (let [a (mk-child-cascade {:dispatch-id 1 :parent-dispatch-id 2
+                               :event [:a]})
+          b (mk-child-cascade {:dispatch-id 2 :parent-dispatch-id 1
+                               :event       [:b]
+                               :effects     [(tagged {:machine-id :form})]})
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out []}
+          ;; both match (a reaches b via its parent link; b matches
+          ;; directly) and the walk does NOT hang on the 1↔2 cycle.
+          kept    (mapv :dispatch-id (typed/filter-cascades [a b] filters))]
+      (is (= [1 2] kept)))))
+
 ;; ---- pill-label / pill-glyph --------------------------------------------
 
 (deftest pill-label-per-kind


### PR DESCRIPTION
## What

Defect #2 of rf2-jvghz. Under the epoch-per-event model each dequeued event — including `:fx :dispatch` children and machine-internal transitions — is its OWN cascade (`group-cascades` keys one record per `:rf.trace/dispatch-id`). A `:machine` / `:http-correlation` / `:fx` typed IN pill matched only the cascade carrying its tag, losing the link to the PARENT event that spawned the transition (now a sibling cascade). "Filter to this machine" showed the machine's bare epoch but not the spawning event's cascade.

## Mechanism

Extend the cascade projection's parent linkage **once** rather than special-casing each pill type:

1. `re-frame.trace.projection/group-cascades` now surfaces `:parent-dispatch-id` on every cascade record, read off the dispatched event's `:rf.trace/parent-dispatch-id` tag (the in-flight cascade that emitted the dispatch). Additive, non-breaking.
2. `filters/typed_predicates` builds a `{dispatch-id → cascade}` index once and folds an IN-kept id set: a directly-matching cascade pulls in its whole **spawning lineage** — itself plus every causal ancestor walked up to the root user event. `keep = matching cascades ∪ their ancestors`.

The walk (`cascade-self-and-ancestors`) is cycle-guarded and root-terminated. OUT (hide) pills stay cascade-local so a hide never silently drops the ancestor that spawned the hidden child.

## Design call (a fork the bead flagged)

Whole-chain-to-root vs. single hop: chose **whole chain**. It is a strict superset with no over-matching risk (parent pointers form a forest — each cascade has at most one parent), and is consistent with Causa's existing causal-breadcrumb model (DESIGN-RATIONALE §"Event detail as hero" walks `:parent-dispatch-id` to a mini-graph). A deep `:fx :dispatch` tree fragments into many epochs under epoch-per-event, so surfacing the full lineage back to the originating user action is the complete causal story.

## Tests

- `projection_test.cljc`: `:parent-dispatch-id` surfaced from the tag; nil for root cascades; updated the shape-stability key set.
- `typed_predicates_test.cljc`: a `:machine` / `:http` / `:fx` pill on a transition cascade now also keeps the spawning parent cascade; whole-chain walk surfaces root → mid → leaf; OUT pills stay cascade-local; cycle-guard terminates.

## Gates

- `tools/causa` `clojure -M:test`: 846 tests, 2731 assertions, 0 failures.
- `implementation/core` `clojure -M:test`: 740 tests, 0 failures.
- `implementation/` `npm run test:cljs`: 4193 tests, 0 failures (shared wire shape touched).
- clj-kondo: 0 errors (one pre-existing unused-binding warning in `first-id`, unrelated).

Closes rf2-a1eld.