### PR TITLE
feat(causa): orange token migration (rf2-ad7zx.3)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
@@ -114,10 +114,10 @@
   [phase slowest?]
   (cond
     slowest?                  (:yellow tokens/tokens)
-    (= phase :issued)         (:accent-violet tokens/tokens)
+    (= phase :issued)         (:accent tokens/tokens)
     (contains? #{:elapsed :ttfb :download :receive :compute}
-               phase)         (:cyan tokens/tokens)
-    :else                     (:cyan tokens/tokens)))
+               phase)         (:accent-static tokens/tokens)
+    :else                     (:accent-static tokens/tokens)))
 
 (defn render
   "Render a wire-timing map as a hiccup SVG waterfall.

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -104,9 +104,9 @@
 
 (def default-accent-css-var
   "Name of the CSS custom property carrying Causa's brand-accent
-  colour (the violet `#7C5CFF` from `theme/tokens.cljc` /
-  `spec/007-UX-IA.md` §Colour system / `:accent-violet`). Published
-  per rf2-9ovfb so:
+  colour (the orange `#F97316` from `theme/tokens.cljc` /
+  `spec/007-UX-IA.md` §Colour system / `:brand` — the brand moved
+  violet → orange per rf2-ad7zx). Published per rf2-9ovfb so:
 
     - Host application stylesheets can colour their own dev chrome
       to match Causa (e.g. a resize-handle inset shadow, a dock-
@@ -119,7 +119,7 @@
 
           background: rgb(from var(--rf-causa-accent) r g b / 0.35);
 
-      (or pre-CSS-4: `rgba(124, 92, 255, 0.35)` — equivalent to the
+      (or pre-CSS-4: `rgba(249, 115, 22, 0.35)` — equivalent to the
       published hex at 35% alpha, the value Pitch8 eyeballed for
       resize-drag accents).
 
@@ -133,17 +133,21 @@
   "--rf-causa-accent")
 
 (def default-accent
-  "Default value Causa publishes for `--rf-causa-accent` — the
-  violet from `theme/tokens.cljc` (`:accent-violet`). Resolved
-  through the canonical `dark-palette` map so the brand hex has
-  exactly one source of truth (rf2-5kfxe.4). Matches the accent
-  catalogued in `spec/007-UX-IA.md` §Colour system.
+  "Default value Causa publishes for `--rf-causa-accent` — the brand
+  orange from `theme/tokens.cljc` (`:brand`, `#F97316`; the brand
+  moved violet → orange per rf2-ad7zx). Resolved through the canonical
+  `dark-palette` map so the brand hex has exactly one source of truth
+  (rf2-5kfxe.4). Matches the accent catalogued in `spec/007-UX-IA.md`
+  §Colour system.
 
   Reads `dark-palette` (the literal hex map) rather than `tokens`
   because `tokens` exposes CSS-variable strings (`var(--rf-causa-…)`)
   post rf2-on4cm; this constant is the VALUE that gets published
-  INTO the CSS variable, not a reference to it."
-  (:accent-violet tokens/dark-palette))
+  INTO the CSS variable, not a reference to it. Uses `:brand` (the
+  always-orange token) rather than `:accent` so the host-published
+  default is the brand identity, independent of the runtime
+  Dynamic/Static mode flip."
+  (:brand tokens/dark-palette))
 
 (def default-layout-host-snippet
   ;; DOM order is `<main>` first, host `<aside>` second — flex flow
@@ -180,7 +184,7 @@
 </div>
 
 <style>
-  :root { --rf-causa-accent: #7C5CFF; }
+  :root { --rf-causa-accent: #F97316; }
   body { margin: 0; }
   .app-shell { display: flex; min-height: 100vh; }
   [data-rf-causa-host] {

--- a/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
@@ -28,15 +28,16 @@
 
   2. **Inline diff highlighting** — when callers pass `:before` +
      `:after`, the renderer paints a left-margin gutter (green `+` /
-     red `-` / yellow `~` / violet `◴`) on the changed branches and
-     annotates `← changed from <prior>`. **No side-by-side
+     red `-` / yellow `~` / mode-accent `◴`) on the changed branches
+     and annotates `← changed from <prior>`. **No side-by-side
      before|after** — diff is annotation on a single rendered state
      (§10.1.2). Unchanged values dim to `:text-tertiary`.
 
-  3. **Minimal type colouring** — keywords get the violet accent (the
-     only coloured type). Strings / numbers / nil / booleans / symbols
-     render mono in `:text-primary`. Aids EDN-shape recognition
-     without colour-noise (§10.3).
+  3. **Minimal type colouring** — keywords get the mode `accent`
+     (orange in Dynamic / cyan in Static — the only coloured type).
+     Strings / numbers / nil / booleans / symbols render mono in
+     `:text-primary`. Aids EDN-shape recognition without colour-noise
+     (§10.3).
 
   4. **Clickable paths** — every key segment is a click target. Clicking
      emits `[:rf.causa/navigate-to-path <path> opts]`; the parent
@@ -155,7 +156,7 @@
   {:added    :green
    :removed  :red
    :modified :yellow
-   :children :accent-violet
+   :children :accent
    :same     :text-tertiary})
 
 (defn gutter-colour
@@ -268,9 +269,9 @@
 
 (defn keyword-style
   "Inline style map for a keyword leaf. Public so unit-tests can assert
-  the violet token resolves through `tokens`."
+  the mode `accent` token resolves through `tokens`."
   []
-  {:color       (:accent-violet tokens)
+  {:color       (:accent tokens)
    :font-family mono-stack})
 
 (defn mono-style
@@ -376,7 +377,7 @@
             :style                {:cursor                "pointer"
                                    :font-family           mono-stack
                                    :color                 (if keyword?
-                                                            (:accent-violet tokens)
+                                                            (:accent tokens)
                                                             (:text-primary tokens))
                                    :text-decoration       "underline"
                                    :text-decoration-style "dotted"

--- a/tools/causa/src/day8/re_frame2_causa/diff/hiccup_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/hiccup_render.cljs
@@ -16,15 +16,15 @@
                             inline + recurse into children-diff
     - `:element-moved`    → render `↻` chip with from/to index +
                             optionally recurse into :inner-diff
-    - `:fn-ref-changed`   → render distinct violet `(fn ref changed)`
-                            chip (only emitted when toggle on)
+    - `:fn-ref-changed`   → render distinct mode-accent `(fn ref
+                            changed)` chip (only emitted when toggle on)
 
   Output is a hiccup tree the caller drops into any DOM-ish surface
   (the Views panel drilldown, the hydration debugger pane, etc.).
 
   ## Colour tokens (§5.4)
 
-  Element-moved + fn-ref-changed both use `:accent-violet` (distinct
+  Element-moved + fn-ref-changed both use the mode `:accent` (distinct
   from `:modified`'s `:yellow`) so the eye reads 'this is something
   other than a plain modification'."
   (:require [day8.re-frame2-causa.diff.hiccup :as hd]
@@ -46,7 +46,7 @@
   [node]
   (cond
     (some? (:key node))
-    [:span {:style {:color       (:accent-violet tokens)
+    [:span {:style {:color       (:accent tokens)
                     :font-family mono-stack
                     :font-size   "11px"
                     :margin-right "6px"}}
@@ -101,13 +101,13 @@
       [:div {:style {:display "flex" :gap "6px"
                      :color (:text-tertiary tokens)
                      :font-family mono-stack :font-size "12px"}}
-       [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+       [:span {:style {:color (:accent tokens)}} (pr-str k)]
        (inspect-value (:value attr-node) nkey)]
 
       :added
       (gutter "+" (:green tokens)
               [:div {:style {:display "flex" :gap "6px"}}
-               [:span {:style {:color (:accent-violet tokens)
+               [:span {:style {:color (:accent tokens)
                                :font-family mono-stack
                                :font-size "12px"}}
                 (pr-str k)]
@@ -120,7 +120,7 @@
       (gutter "-" (:red tokens)
               [:div {:style {:display "flex" :gap "6px"
                              :text-decoration "line-through"}}
-               [:span {:style {:color (:accent-violet tokens)
+               [:span {:style {:color (:accent tokens)
                                :font-family mono-stack
                                :font-size "12px"}}
                 (pr-str k)]
@@ -133,7 +133,7 @@
       (gutter "~" (:yellow tokens)
               [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
                              :align-items "baseline"}}
-               [:span {:style {:color (:accent-violet tokens)
+               [:span {:style {:color (:accent tokens)
                                :font-family mono-stack
                                :font-size "12px"}}
                 (pr-str k)]
@@ -152,15 +152,15 @@
                 (inspect-value (:after attr-node) (str nkey "/after"))]])
 
       :fn-ref-changed
-      (gutter "◴" (:accent-violet tokens)
+      (gutter "◴" (:accent tokens)
               [:div {:style {:display "flex" :gap "6px"
                              :align-items "baseline"}}
-               [:span {:style {:color (:accent-violet tokens)
+               [:span {:style {:color (:accent tokens)
                                :font-family mono-stack
                                :font-size "12px"}}
                 (pr-str k)]
                [:span {:data-testid "rf-causa-diff-fn-ref-changed-chip"
-                       :style {:color (:accent-violet tokens)
+                       :style {:color (:accent tokens)
                                :font-family mono-stack
                                :font-size "11px"
                                :font-style "italic"}}
@@ -258,12 +258,12 @@
            :style {:display "flex"
                    :flex-direction "column"
                    :margin "2px 0"}}
-     (gutter "↻" (:accent-violet tokens)
+     (gutter "↻" (:accent tokens)
              [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
                             :align-items "baseline"
                             :font-family mono-stack :font-size "12px"}}
               (key-or-index-label node)
-              [:span {:style {:color (:accent-violet tokens)
+              [:span {:style {:color (:accent tokens)
                               :font-weight 600}}
                (str "moved")]
               [:span {:style {:color (:text-tertiary tokens)
@@ -329,13 +329,13 @@
 
 (defn- render-fn-ref-changed-leaf
   [node nkey]
-  (gutter "◴" (:accent-violet tokens)
+  (gutter "◴" (:accent tokens)
           [:div {:data-testid "rf-causa-diff-fn-ref-changed-chip"
                  :style {:display "flex" :gap "6px"
                          :align-items "baseline"
                          :font-family mono-stack
                          :font-size "12px"
-                         :color (:accent-violet tokens)
+                         :color (:accent tokens)
                          :font-style "italic"}}
            (key-or-index-label node)
            "(fn ref changed)"]))
@@ -351,7 +351,7 @@
                          children-diff (recursive)
     `:element-moved`   — render `↻` chip with from/to index, optional
                          inner-diff
-    `:fn-ref-changed`  — render distinct violet `(fn ref changed)`
+    `:fn-ref-changed`  — render distinct mode-accent `(fn ref changed)`
                          chip (only emitted when toggle on)
 
   Plus the generic scalar cases (`:same` / `:added` / `:removed` /

--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -83,7 +83,7 @@
   {:added    :green
    :removed  :red
    :modified :yellow
-   :children :accent-violet
+   :children :accent          ; `◴` children-changed → mode accent (§10.3 / §022)
    :same     :text-tertiary})
 
 (defn- gutter-colour
@@ -147,18 +147,18 @@
 
   Hover styling — a dotted underline + pointer cursor — makes the
   segments discoverable as click targets without screaming through the
-  diff body. The colour stays the same accent-violet that all path
+  diff body. The colour stays the same mode `accent` that all path
   text uses, so the inline path still scans as a single phrase when
   the user isn't pointing at it."
   [section-path]
   (if (empty? section-path)
     [:span {:data-testid (str "rf-causa-diff-section-path-"
                               (pr-str section-path))
-            :style       {:color (:accent-violet tokens)}}
+            :style       {:color (:accent tokens)}}
      "(root)"]
     (into [:span {:data-testid (str "rf-causa-diff-section-path-"
                                     (pr-str section-path))
-                  :style       {:color (:accent-violet tokens)
+                  :style       {:color (:accent tokens)
                                 :display "inline-flex"
                                 :flex-wrap "wrap"
                                 :gap "2px"}}]
@@ -178,7 +178,7 @@
                       :title       (str "Inspect app-db at "
                                         (pr-str prefix))
                       :style       {:cursor          "pointer"
-                                    :color           (:accent-violet tokens)
+                                    :color           (:accent tokens)
                                     :text-decoration "underline"
                                     :text-decoration-style "dotted"
                                     :text-underline-offset "2px"
@@ -216,14 +216,14 @@
                flow-part))))
 
 (defn- origin-tag-tone
-  "Pick the chip's accent colour. Flow writes use `:accent-violet`
+  "Pick the chip's accent colour. Flow writes use the mode `:accent`
   (mirrors §8 FLOWS row colour in the Event lens); pure-fx writes use
   the muted `:text-tertiary` (handler `:db` is the ambient writer);
   mixed uses `:yellow` to flag the coalesced case."
   [tag]
   (case (:kind tag)
     :fx    (:text-tertiary tokens)
-    :flow  (:accent-violet tokens)
+    :flow  (:accent tokens)
     :mixed (:yellow tokens)))
 
 (defn- origin-tag-tooltip
@@ -420,7 +420,7 @@
   the value sits inline with its identifier."
   [child]
   (when-let [k (at/child-key child)]
-    [:span {:style {:color       (:accent-violet tokens)
+    [:span {:style {:color       (:accent tokens)
                     :font-family mono-stack
                     :font-size   "12px"
                     :margin-right "6px"}}

--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -127,15 +127,15 @@
 
 (defn- btn-style [{:keys [primary? danger?]}]
   {:background    (cond
-                    primary? (:accent-violet tokens)
+                    primary? (:accent tokens)
                     :else    "transparent")
    :border        (str "1px solid "
                        (cond
                          danger?  (:red tokens)
-                         primary? (:accent-violet tokens)
+                         primary? (:accent tokens)
                          :else    (:border-default tokens)))
    :color         (cond
-                    primary? (:bg-0 tokens)      ; readable on violet
+                    primary? (:bg-0 tokens)      ; readable on the accent
                     danger?  (:red tokens)
                     :else    (:text-primary tokens))
    :padding       "6px 14px"

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -755,7 +755,7 @@
   (:text-secondary tokens/dark-palette))
 
 (def ^:private opener-gone-overlay-accent
-  (:accent-violet tokens/dark-palette))
+  (:accent tokens/dark-palette))
 
 (def ^:private sans-stack
   tokens/sans-stack)

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -64,7 +64,7 @@
   ;; variable migration is the v1 styling pass.
   {:chip {:padding         "1px 8px"
           :background      "transparent"
-          :color           (:accent-violet tokens)
+          :color           (:accent tokens)
           :border          (str "1px solid " (:border-default tokens))
           :border-radius   "3px"
           :cursor          "pointer"

--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -56,9 +56,14 @@
 
 ;; ---- per-source visual style --------------------------------------------
 
+;; Per-source categorical legend (rf2-ad7zx). `:command` is the primary
+;; action category → the mode `accent` (orange Dynamic / cyan Static);
+;; `:panel` keeps a fixed cyan (`accent-static`) so it stays a distinct
+;; category against the now-orange command accent. yellow/green/magenta
+;; are functional categorical hues, untouched.
 (def ^:private source-colour
-  {:command          (:accent-violet tokens)
-   :panel            (:cyan tokens)
+  {:command          (:accent tokens)
+   :panel            (:accent-static tokens)
    :setting          (:yellow tokens)
    :recent-event     (:green tokens)
    :frame            (:magenta tokens)
@@ -227,7 +232,7 @@
    (when (sources/popoutable? item)
      [:span {:style (merge (hint-style)
                            {:margin-left "8px"
-                            :color (:accent-violet tokens)})}
+                            :color (:accent tokens)})}
       "⇱"])])
 
 ;; ---- key handling -------------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
@@ -121,10 +121,10 @@
 
 (defn- area-label
   "Render a reserved-area section title — the bare `:rf/*` key in the
-  accent-violet keyword colour."
+  mode `accent` keyword colour."
   [area]
   [:span {:style {:font-family mono-stack
-                  :color       (:accent-violet tokens)}}
+                  :color       (:accent tokens)}}
    (pr-str area)])
 
 (defn instance-section

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
@@ -189,7 +189,7 @@
                   :align-items "baseline"
                   :gap         "8px"}}
    [:span {:style {:color (:text-secondary tokens)}} "app-db at"]
-   [:code {:style {:color       (:accent-violet tokens)
+   [:code {:style {:color       (:accent tokens)
                    :font-family mono-stack
                    :font-size   "12px"}}
     (if (seq path)

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -62,7 +62,7 @@
   follows the active theme."
   [kind]
   (case kind
-    :parent-decision (:cyan tokens)              ; blue-ish in the dark theme
+    :parent-decision (:accent-static tokens)     ; fixed cyan/blue category (≠ mode accent)
     :child-teardown  (or (:accent-orange tokens)
                          (:warning-amber tokens)
                          (:yellow tokens))
@@ -282,7 +282,7 @@
                               {:frame :rf/causa}))
              :style       {:background "transparent"
                            :border (str "1px solid " (:border-default tokens))
-                           :color (:accent-violet tokens)
+                           :color (:accent tokens)
                            :font-family sans-stack
                            :font-size "11px"
                            :padding "3px 10px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
@@ -34,26 +34,30 @@
 
       Status            Token            Hex (dark)  When
       ----------------  ---------------  ----------  -----------------------
-      :in-flight        :accent-violet   #7C5CFF     cascade still building
+      :in-flight        :accent          #F97316     cascade still building
                                                      (LIVE head, not yet
-                                                     settled). Mirrors
-                                                     Causa's existing
-                                                     causal-chain accent.
+                                                     settled). The mode
+                                                     accent (orange in
+                                                     Dynamic / cyan in
+                                                     Static) — the LIVE
+                                                     head IS the current-
+                                                     epoch accent (§007).
       :settled-success  :green           #4ADE80     handler ran, no
                                                      exception, no warnings.
       :settled-error    :red             #F87171     handler threw, or an
                                                      :rf.error/* trace
                                                      landed in the cascade.
-      :paused-by-tool   :cyan            #43C3D0     spine paused
+      :paused-by-tool   :accent-static   #43C3D0     spine paused
                                                      (LIVE+paused) — e.g.
                                                      a tool has claimed
                                                      the buffer. TanStack
                                                      uses purple for
-                                                     paused; we already
-                                                     own violet for the
-                                                     causal chain so we
-                                                     pick cyan as the
-                                                     peer accent. Magenta
+                                                     paused; the in-flight
+                                                     head now owns the mode
+                                                     accent, so paused picks
+                                                     the fixed cyan
+                                                     `accent-static` as a
+                                                     distinct peer. Magenta
                                                      is reserved for the
                                                      `▥` whole-redacted
                                                      row marker.
@@ -136,10 +140,10 @@
   lookup keeps the map pure-data + tokens consolidated — mirrors the
   `tier->token` / `op-type->token` shape used elsewhere in the
   codebase."
-  {:in-flight       :accent-violet
+  {:in-flight       :accent
    :settled-success :green
    :settled-error   :red
-   :paused-by-tool  :cyan
+   :paused-by-tool  :accent-static   ; fixed cyan — distinct from :in-flight (mode accent)
    :stale           :yellow})
 
 ;; ---- classification ------------------------------------------------------
@@ -175,7 +179,7 @@
 
   Pure data → keyword; JVM-runnable."
   [state]
-  (get status->token (classify-status state) :accent-violet))
+  (get status->token (classify-status state) :accent))
 
 (defn event-status-colour
   "Resolve the cascade's lifecycle state to a hex colour string,
@@ -192,7 +196,7 @@
 
   Pure data → string; JVM-runnable."
   [state]
-  (get tokens/tokens (event-status-token state) (:accent-violet tokens/tokens)))
+  (get tokens/tokens (event-status-token state) (:accent tokens/tokens)))
 
 ;; ---- convenience: cascade → state map -----------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -269,7 +269,7 @@
   [status]
   (case status
     :ok          (:green tokens)
-    :overridden  (:accent-violet tokens)
+    :overridden  (:accent tokens)
     :skipped     (:text-tertiary tokens)
     :error       (:red tokens)
     (:text-secondary tokens)))
@@ -400,12 +400,12 @@
                       :border-bottom (str "1px solid " (:border-subtle tokens))
                       :font-family   sans-stack
                       :font-size     "13px"}}
-     ;; spec/021 §17.1.5 — Event panel header icon: ⚡ in
-     ;; :accent-violet. Renders to the LEFT of the lifecycle status
-     ;; dot.
+     ;; spec/021 §17.1.5 — Event panel header icon: ⚡ in the mode
+     ;; :accent (orange Dynamic / cyan Static). Renders to the LEFT of
+     ;; the lifecycle status dot.
      [:span {:data-testid "rf-causa-event-detail-panel-icon"
              :aria-hidden "true"
-             :style {:color (:accent-violet tokens)
+             :style {:color (:accent tokens)
                      :font-weight 600
                      :font-size "14px"}}
       "⚡"]
@@ -428,7 +428,7 @@
                       :stale           "stale (replayed / RETRO)"
                       (name status-kw))}]
      [:span {:data-testid "rf-causa-event-detail-outcome-event-id"
-             :style {:color (:accent-violet tokens)
+             :style {:color (:accent tokens)
                      :font-family mono-stack
                      :font-weight 600}}
       (pr-str event-id)]
@@ -455,7 +455,10 @@
      ;; per Mike-direction 2026-05-21.
      (when ssr?
        [:span {:data-testid "rf-causa-event-detail-outcome-ssr-badge"
-               :style {:color (:cyan tokens)
+               ;; SSR origin badge — fixed info cyan (`accent-static`,
+               ;; the §007 :story/:test/info hue), kept distinct from the
+               ;; mode accent so it always reads as an origin marker.
+               :style {:color (:accent-static tokens)
                        :font-family mono-stack
                        :font-weight 700
                        :font-size "11px"
@@ -489,7 +492,7 @@
                                            {:source-coord coord}]
                                           {:frame :rf/causa}))
               :style       {:background  "transparent"
-                            :color       (:cyan tokens)
+                            :color       (:accent tokens)
                             :border      (str "1px solid " (:border-default tokens))
                             :padding     "1px 8px"
                             :border-radius "3px"
@@ -570,7 +573,7 @@
            :style {:display "flex"
                    :align-items "flex-start"
                    :padding "2px 0"}}
-     [:span {:style {:color (:accent-violet tokens)
+     [:span {:style {:color (:accent tokens)
                      :min-width "180px"
                      :margin-right "12px"}}
       (pr-str id)]
@@ -607,7 +610,7 @@
            :style {:display "flex"
                    :align-items "center"
                    :padding "2px 0"}}
-     [:span {:style {:color (:accent-violet tokens)
+     [:span {:style {:color (:accent tokens)
                      :margin-right "12px"
                      :min-width "180px"}}
       (pr-str id)]
@@ -658,8 +661,8 @@
   "Renders the `↳ source` block under the handler flavour+coord row.
   Per Mike-direction 2026-05-21 (rf2-n4ad0) the handler source now
   routes through the canonical EDN widget's `code-block` for
-  syntax-highlighted rendering (keywords violet, strings green,
-  numbers cyan, builtins violet). When the substrate meta hasn't
+  syntax-highlighted rendering (keywords + builtins in the mode accent,
+  strings green, numbers cyan). When the substrate meta hasn't
   yet been captured (e.g. before rf2-xgfuy lands, or in a production
   goog.DEBUG=false build) the row renders the `<source not yet
   captured>` placeholder per the task brief."
@@ -709,7 +712,7 @@
       [:div
        [:div {:style {:display "flex" :align-items "center"}}
         [:span {:data-testid "rf-causa-event-detail-handler-flavour"
-                :style {:color (:cyan tokens)
+                :style {:color (:accent tokens)
                         :font-weight 600
                         :margin-right "8px"}}
          flavour]
@@ -737,7 +740,7 @@
          :style {:display "flex"
                  :align-items "flex-start"
                  :padding "2px 0"}}
-   [:span {:style {:color (:accent-violet tokens)
+   [:span {:style {:color (:accent tokens)
                    :min-width "180px"
                    :margin-right "12px"}}
     label]
@@ -755,7 +758,7 @@
    [:button {:on-click #(rf/dispatch [:rf.causa/select-tab :issues]
                                      {:frame :rf/causa})
              :style {:background  "transparent"
-                     :color       (:accent-violet tokens)
+                     :color       (:accent tokens)
                      :border      (str "1px solid " (:border-default tokens))
                      :padding     "1px 8px"
                      :border-radius "3px"
@@ -843,7 +846,7 @@
                     :align-items "center"
                     :gap "10px"
                     :flex-wrap "wrap"}}
-      [:span {:style {:color (:accent-violet tokens)
+      [:span {:style {:color (:accent tokens)
                       :min-width "160px"}}
        (pr-str fx-id)]
       (when duration-ms (tier-dot duration-ms))
@@ -1038,7 +1041,7 @@
                       :font-size   "12px"}}
        (if via? "↳" "▸")]
       [:span {:data-testid (str "rf-causa-event-detail-flow-row-id-" suffix)
-              :style {:color       (:accent-violet tokens)
+              :style {:color       (:accent tokens)
                       :font-weight 600
                       :min-width   "160px"}}
        (pr-str flow-id)]
@@ -1064,7 +1067,7 @@
                       :font-size   "11px"}}
        "wrote"]
       [:span {:data-testid (str "rf-causa-event-detail-flow-row-write-path-" suffix)
-              :style {:color       (:cyan tokens)
+              :style {:color       (:accent tokens)
                       :margin-right "12px"}}
        (pr-str write-path)]
       [:span {:style {:color    (:text-primary tokens)
@@ -1090,7 +1093,7 @@
                               :flex 1
                               :word-break "break-word"}}]
               (for [p read-paths]
-                [:span {:style {:color (:cyan tokens)
+                [:span {:style {:color (:accent tokens)
                                 :margin-right "8px"}}
                  (pr-str p)]))
         [:span {:data-testid (str "rf-causa-event-detail-flow-row-read-absent-" suffix)
@@ -1285,8 +1288,8 @@
   rf2-zv9r9).
 
   Layout follows the §2.2 mockup verbatim — a one-way pipeline with
-  explicit `▼` arrows between steps. Stripe colour `:accent-violet`
-  applied at the outer container per §17.1.3.
+  explicit `▼` arrows between steps. Stripe colour is the mode
+  `:accent` applied at the outer container per §17.1.3.
 
   Steps (top → bottom):
     [1] DISPATCH          event-id + payload + :rf/dispatch-origin
@@ -1330,8 +1333,9 @@
     [:div {:data-testid "rf-causa-event-detail-cascade"
            :data-dispatch-id (str dispatch-id)
            :data-frame (str frame)
-           ;; §17.1.3 — Event panel domain stripe is :accent-violet.
-           :style {:border-left (str "3px solid " (:accent-violet tokens))}}
+           ;; §17.1.3 / spec/022 — Event panel header stripe is the mode
+           ;; :accent (orange Dynamic / cyan Static).
+           :style {:border-left (str "3px solid " (:accent tokens))}}
      (cascade-outcome-line cascade)
 
      ;; rf2-n4ad0 — vertical-flow pipeline body. Wraps every section in
@@ -1455,7 +1459,7 @@
                      :font-family  mono-stack
                      :font-size    "13px"
                      :color        (:text-primary tokens)}}
-   [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
+   [:span {:style {:color (:accent tokens) :margin-right "8px"}}
     (str "#" dispatch-id)]
    (when frame
      [:span {:style {:color (:text-tertiary tokens) :margin-right "8px"}}
@@ -1512,11 +1516,11 @@
                              :font-family sans-stack
                              :font-size "13px"}}
          "Selected dispatch-id "
-         [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+         [:code {:style {:color (:accent tokens) :font-family mono-stack}}
           (str selected-dispatch-id)]
          (when selected-dispatch-frame
            [:span " in frame "
-            [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+            [:code {:style {:color (:accent tokens) :font-family mono-stack}}
              (str selected-dispatch-frame)]])
          " is no longer in the trace buffer. Pick another cascade from the event list."]
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
@@ -111,7 +111,7 @@
   [node]
   (cond
     (some? (:key node))
-    [:span {:style {:color (:accent-violet tokens)
+    [:span {:style {:color (:accent tokens)
                     :font-family mono-stack
                     :font-size "11px"
                     :margin-right "6px"}}
@@ -144,7 +144,7 @@
       [:div {:style {:display "flex" :gap "6px"
                      :color (:text-tertiary tokens)
                      :font-family mono-stack :font-size "12px"}}
-       [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+       [:span {:style {:color (:accent tokens)}} (pr-str k)]
        (inspect-value (:value attr-node) nkey)]
 
       ;; :added = attr present on CLIENT only. Server pane shows it as
@@ -157,7 +157,7 @@
                        :color (:text-tertiary tokens)
                        :font-family mono-stack :font-size "12px"
                        :opacity 0.6}}
-         [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+         [:span {:style {:color (:accent tokens)}} (pr-str k)]
          (absent-chip (pr-str (:value attr-node)))]
 
         :client
@@ -165,7 +165,7 @@
                :style {:display "flex" :gap "6px"
                        :padding-left "6px"
                        :border-left (str "3px solid " (:green tokens))}}
-         [:span {:style {:color (:accent-violet tokens)
+         [:span {:style {:color (:accent tokens)
                          :font-family mono-stack :font-size "12px"}}
           (pr-str k)]
          [:span {:style {:color (:green tokens)
@@ -180,7 +180,7 @@
                :style {:display "flex" :gap "6px"
                        :padding-left "6px"
                        :border-left (str "3px solid " (:red tokens))}}
-         [:span {:style {:color (:accent-violet tokens)
+         [:span {:style {:color (:accent tokens)
                          :font-family mono-stack :font-size "12px"}}
           (pr-str k)]
          [:span {:style {:color (:red tokens)
@@ -193,7 +193,7 @@
                        :color (:text-tertiary tokens)
                        :font-family mono-stack :font-size "12px"
                        :opacity 0.6}}
-         [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+         [:span {:style {:color (:accent tokens)}} (pr-str k)]
          (absent-chip (pr-str (:value attr-node)))])
 
       :modified
@@ -202,7 +202,7 @@
                      :align-items "baseline"
                      :padding-left "6px"
                      :border-left (str "3px solid " (:yellow tokens))}}
-       [:span {:style {:color (:accent-violet tokens)
+       [:span {:style {:color (:accent tokens)
                        :font-family mono-stack :font-size "12px"}}
         (pr-str k)]
        [:span {:style {:color (:yellow tokens)
@@ -224,11 +224,11 @@
              :style {:display "flex" :gap "6px"
                      :align-items "baseline"
                      :padding-left "6px"
-                     :border-left (str "3px solid " (:accent-violet tokens))}}
-       [:span {:style {:color (:accent-violet tokens)
+                     :border-left (str "3px solid " (:accent tokens))}}
+       [:span {:style {:color (:accent tokens)
                        :font-family mono-stack :font-size "12px"}}
         (pr-str k)]
-       [:span {:style {:color (:accent-violet tokens)
+       [:span {:style {:color (:accent tokens)
                        :font-family mono-stack :font-size "11px"
                        :font-style "italic"}}
         "(fn ref changed)"]]
@@ -321,10 +321,10 @@
                    :margin "2px 0"}}
      [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
                     :padding-left "6px"
-                    :border-left (str "3px solid " (:accent-violet tokens))
+                    :border-left (str "3px solid " (:accent tokens))
                     :font-family mono-stack :font-size "12px"}}
       (key-or-index-label node)
-      [:span {:style {:color (:accent-violet tokens)
+      [:span {:style {:color (:accent tokens)
                       :font-weight 600}}
        "moved"]
       [:span {:style {:color (:text-tertiary tokens)
@@ -416,10 +416,10 @@
          :style {:display "flex" :gap "6px"
                  :align-items "baseline"
                  :padding-left "6px"
-                 :border-left (str "3px solid " (:accent-violet tokens))
+                 :border-left (str "3px solid " (:accent tokens))
                  :font-family mono-stack
                  :font-size "12px"
-                 :color (:accent-violet tokens)
+                 :color (:accent tokens)
                  :font-style "italic"}}
    (key-or-index-label node)
    "(fn ref changed)"])

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -134,7 +134,7 @@
                 :let [active? (contains? active-prefixes prefix)]]
             (chip {:label    prefix
                    :active?  active?
-                   :colour   (:accent-violet tokens)
+                   :colour   (:accent tokens)
                    :test-id  (str "rf-causa-issues-prefix-chip-" prefix)
                    :on-click #(rf/dispatch [:rf.causa.issues/toggle-prefix
                                             prefix] {:frame :rf/causa})})))))
@@ -177,7 +177,7 @@
                 :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
                 :style       {:margin-left "auto"
                               :background  "transparent"
-                              :color       (:cyan tokens)
+                              :color       (:accent tokens)
                               :border      (str "1px solid " (:border-default tokens))
                               :padding     "2px 8px"
                               :border-radius "3px"
@@ -237,7 +237,7 @@
       (h/severity-glyph severity)]
      ;; Category prefix
      [:span {:data-testid (str row-test-id "-category")
-             :style       {:color       (:accent-violet tokens)
+             :style       {:color       (:accent tokens)
                            :overflow    "hidden"
                            :text-overflow "ellipsis"
                            :white-space "nowrap"}
@@ -263,7 +263,7 @@
                                 (rf/dispatch [:rf.causa/open-in-editor
                                               {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
-                               :color       (:cyan tokens)
+                               :color       (:accent tokens)
                                :border      (str "1px solid " (:border-subtle tokens))
                                :padding     "1px 6px"
                                :border-radius "3px"
@@ -356,7 +356,7 @@
    [:button {:data-testid "rf-causa-issues-empty-clear-filters"
              :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
              :style       {:background "transparent"
-                           :color      (:cyan tokens)
+                           :color      (:accent tokens)
                            :border     (str "1px solid " (:border-default tokens))
                            :padding    "4px 10px"
                            :border-radius "3px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -135,9 +135,9 @@
   spec/007-UX-IA.md §Issues ribbon. Splitting the semantic map from
   the hex lookup keeps the data pure + tokens consolidated
   (rf2-5kfxe.4)."
-  {:error    :red
-   :warning  :yellow
-   :advisory :cyan})
+  {:error    :error
+   :warning  :warning
+   :advisory :advisory})
 
 (defn severity-colour
   "Map a severity keyword to its swatch colour. Resolves the semantic

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -185,7 +185,7 @@
                                       "transparent")
                      :border        "none"
                      :color         (if active?
-                                      (:accent-violet tokens)
+                                      (:accent tokens)
                                       (:text-tertiary tokens))
                      :font-family   sans-stack
                      :font-size     "10px"
@@ -245,12 +245,12 @@
                           per-node testid.
     :from-highlight     — focused-event lens origin state. Optional;
                           a state-id keyword or path vector. xyflow
-                          renders the originating state with a
-                          dashed violet border.
+                          renders the originating state with a dashed
+                          mode-accent border.
     :to-highlight       — focused-event lens landing state. Optional;
                           xyflow renders the landing state with an
-                          emphasised cyan border. Wins over
-                          `:current-state`.
+                          emphasised fixed-cyan (`accent-static`)
+                          border. Wins over `:current-state`.
     :current-state      — live snapshot state for the active-state
                           highlight. Optional; nil renders no
                           highlight.

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -211,11 +211,11 @@
       (when microstep?
         [:span {:style {:color (:text-tertiary tokens) :font-size "10px"}}
          "↳"])
-      [:strong {:style {:color (:accent-violet tokens)}}
+      [:strong {:style {:color (:accent tokens)}}
        (h/format-machine-id machine-id)]
       [:span {:style {:color (:text-secondary tokens)}}
        (h/format-state from-state)]
-      [:span {:style {:color (:cyan tokens)}} "→"]
+      [:span {:style {:color (:accent tokens)}} "→"]
       [:span {:style {:color (:text-primary tokens) :font-weight 600}}
        (h/format-state to-state)]
       (when event
@@ -330,7 +330,7 @@
        :title       (str "Previous event touching " (h/format-machine-id machine-id))
        :style       {:background "transparent"
                      :border (str "1px solid " (:border-default tokens))
-                     :color (:accent-violet tokens)
+                     :color (:accent tokens)
                      :font-family sans-stack
                      :font-size "11px"
                      :padding "3px 10px"
@@ -345,7 +345,7 @@
        :title       (str "Next event touching " (h/format-machine-id machine-id))
        :style       {:background "transparent"
                      :border (str "1px solid " (:border-default tokens))
-                     :color (:accent-violet tokens)
+                     :color (:accent tokens)
                      :font-family sans-stack
                      :font-size "11px"
                      :padding "3px 10px"
@@ -426,7 +426,7 @@
     "No machines registered."]
    [:p {:style {:margin 0 :font-size "12px"}}
     "Register a machine with "
-    [:code {:style {:font-family mono-stack :color (:accent-violet tokens)}}
+    [:code {:style {:font-family mono-stack :color (:accent tokens)}}
      "rf/reg-machine"]
     " to populate this panel."]])
 
@@ -442,7 +442,7 @@
     :title       "Share this view (URL with focus + mode + scrubber)"
     :style       {:background "transparent"
                   :border (str "1px solid " (:border-default tokens))
-                  :color (:accent-violet tokens)
+                  :color (:accent tokens)
                   :font-family sans-stack
                   :font-size "11px"
                   :font-weight 600

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
@@ -32,8 +32,9 @@
   ## Edge kinds (per spec §17.4.3)
 
     - `:fired-this-epoch`     — edge keys in the `fired-edges` set
-                                are rendered with the animated violet
-                                stroke.
+                                are rendered with the animated mode-
+                                accent stroke (orange Dynamic / cyan
+                                Static, rf2-ad7zx).
     - `:registered-traversed` — edge keys in the `traversed-edges`
                                 set (most-recent traversal in the
                                 buffer, but NOT this epoch).

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
@@ -72,16 +72,17 @@
     :registered-traversed — solid `:text-tertiary` 1px (most-recent
                             traversal in the buffer; not fired this
                             epoch).
-    :fired-this-epoch     — solid `:accent-violet` 2px. The
-                            `:animated true` xyflow prop is set
-                            alongside (see `topology.cljs`).
+    :fired-this-epoch     — solid mode `:accent` 2px (orange Dynamic /
+                            cyan Static, rf2-ad7zx). The `:animated
+                            true` xyflow prop is set alongside (see
+                            `topology.cljs`).
 
   Unknown kinds fall back to `:registered`."
   [kind]
   (case kind
     :registered-traversed {:stroke       (:text-tertiary tokens)
                            :stroke-width 1}
-    :fired-this-epoch     {:stroke       (:accent-violet tokens)
+    :fired-this-epoch     {:stroke       (:accent tokens)
                            :stroke-width 2}
     ;; :registered + unknown fallback
     {:stroke           (:text-tertiary tokens)

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
@@ -115,10 +115,10 @@
   via the panel's `tokens` map."
   {:ok         :green
    :error      :red
-   :in-flight  :cyan
-   :overridden :accent-violet
+   :in-flight  :accent-static            ; fixed cyan — distinct from the accent-coloured :overridden/:stub
+   :overridden :accent
    :skipped    :text-tertiary
-   :stub       :accent-violet})
+   :stub       :accent})
 
 (def status->glyph
   "Status → shape-glyph (colour-blind-safe parallel signal)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -146,8 +146,8 @@
                     :margin-left   "8px"
                     :border-radius "3px"
                     :background    "rgba(124, 92, 255, 0.15)"
-                    :border        (str "1px solid " (:accent-violet tokens))
-                    :color         (:accent-violet tokens)
+                    :border        (str "1px solid " (:accent tokens))
+                    :color         (:accent tokens)
                     :font-family   mono-stack
                     :font-size     "10px"
                     :font-weight   700
@@ -175,7 +175,7 @@
                    :padding       "1px 8px"
                    :border-radius "3px"
                    :background    "rgba(67, 195, 208, 0.12)"
-                   :color         (:cyan tokens)
+                   :color         (:accent-static tokens)
                    :font-family   mono-stack
                    :font-size     "11px"
                    :font-weight   700
@@ -190,7 +190,7 @@
                                   [:rf.causa/filter-by-fx fx-id]
                                   {:frame :rf/causa})))
            :title "Right-click to filter the event list to events triggering this fx"
-           :style {:color (:accent-violet tokens)
+           :style {:color (:accent tokens)
                    :font-family mono-stack
                    :font-size "12px"
                    :font-weight 600
@@ -276,7 +276,7 @@
                                           {:frame :rf/causa})
                :style       {:background  "transparent"
                              :border      (str "1px solid " (:border-default tokens))
-                             :color       (:accent-violet tokens)
+                             :color       (:accent tokens)
                              :font-family mono-stack
                              :font-size   "10px"
                              :padding     "2px 8px"
@@ -320,7 +320,7 @@
                      :font-family mono-stack
                      :font-size "12px"
                      :color (:text-primary tokens)}}
-        [:span {:style {:color (:accent-violet tokens)}}
+        [:span {:style {:color (:accent tokens)}}
          (pr-str path)]])]))
 
 ;; ---- one record's panel ------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -143,13 +143,13 @@
 (def ^:private name-cell-style
   "The `name` column — the sub-id / view-id. Violet accent + semibold so
   the identifier leads the row."
-  (assoc td-style :color (:accent-violet tokens) :font-weight 600
+  (assoc td-style :color (:accent tokens) :font-weight 600
                   :white-space "nowrap"))
 
 (def ^:private changed-yes-style
   "The `changed` flag when the sub's value changed this cascade — a clear
   accent so the eye lands on it."
-  {:color (:cyan tokens) :font-weight 600})
+  {:color (:accent tokens) :font-weight 600})
 
 (def ^:private changed-no-style
   "The `changed` placeholder when unchanged — muted so the eye skips it."
@@ -166,10 +166,11 @@
 
 (def ^:private action->token
   "Map a view action to its accent token. mount = green (a new thing
-  appears), rerender = cyan (the standard change accent shared with the
-  sub `changed` flag), unmount = red (a thing goes away)."
+  appears), rerender = the mode `accent` (the standard change accent,
+  shared with the sub `changed` flag — `changed` = mode accent per
+  §021 §10.3 / spec/022), unmount = red (a thing goes away)."
   {:mount    :green
-   :rerender :cyan
+   :rerender :accent
    :unmount  :red})
 
 (defn- action-style
@@ -189,7 +190,7 @@
 
 (def ^:private reactive-reason-sub-style
   "A changed-sub name in a reactive view's reason cell."
-  {:color (:cyan tokens)})
+  {:color (:accent tokens)})
 
 (def ^:private none-reason-style
   "The em-dash placeholder for an unmount row's empty reason."
@@ -271,7 +272,7 @@
                                              {:source-coord coord}]
                                             {:frame :rf/causa}))
                 :style       {:background  "transparent"
-                              :color       (:cyan tokens)
+                              :color       (:accent tokens)
                               :border      (str "1px solid " (:border-default tokens))
                               :padding     "1px 6px"
                               :border-radius "3px"
@@ -503,8 +504,8 @@
 (defn- reason-cell
   "The `reason` column for a Views-table row.
 
-    :reactive   → the changed subs THIS view reads (cyan names, honestly
-                  truncated with `+N more`).
+    :reactive   → the changed subs THIS view reads (mode-accent names,
+                  honestly truncated with `+N more`).
     :structural → the literal `← parent re-render` — UNNAMED. We never
                   name the parent (permanent, rf2-8ve8z).
     :none       → unmount row → a muted em-dash."

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -97,7 +97,7 @@
   [marker]
   (case marker
     :to   {:glyph "◉" :colour (:green tokens) :label "TO"}
-    :from {:glyph "◇" :colour (:cyan tokens)  :label "FROM"}
+    :from {:glyph "◇" :colour (:accent-static tokens)  :label "FROM"}
     :here {:glyph "●" :colour (:yellow tokens) :label "HERE"}
     nil))
 
@@ -247,7 +247,7 @@
         (epoch-detail-row
           "From"
           (if from-id
-            [:span {:style {:color (:cyan tokens)}}
+            [:span {:style {:color (:accent-static tokens)}}
              (str from-id)]
             [:span {:style {:color (:text-tertiary tokens)}} "—"])
           "rf-causa-routing-detail-from-label"
@@ -277,7 +277,7 @@
                                   :flex-wrap "wrap"}}]
                   (for [[idx ev] (map-indexed vector events)]
                     ^{:key idx}
-                    [:span {:style {:color       (:accent-violet tokens)
+                    [:span {:style {:color       (:accent tokens)
                                     :background  (:bg-1 tokens)
                                     :padding     "1px 6px"
                                     :border-radius "2px"
@@ -321,7 +321,7 @@
      "Full topology of registered routes with focused-epoch overlay. "
      [:span {:style {:color (:green tokens) :font-weight 600}} "◉ TO"]
      " / "
-     [:span {:style {:color (:cyan tokens) :font-weight 600}} "◇ FROM"]
+     [:span {:style {:color (:accent-static tokens) :font-weight 600}} "◇ FROM"]
      " / "
      [:span {:style {:color (:yellow tokens) :font-weight 600}} "● HERE"]
      " mark the per-epoch navigation overlay. For the full route catalogue browse + "
@@ -352,7 +352,7 @@
     "No routes registered in the host app."]
    [:span {:style {:color (:text-tertiary tokens)}}
     "Register routes via "
-    [:code {:style {:color       (:accent-violet tokens)
+    [:code {:style {:color       (:accent tokens)
                     :font-family mono-stack}}
      "re-frame.routing/reg-route"]
     " — the topology will render once the host installs them."]])

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -189,7 +189,7 @@
       "●"]
      ;; Operation
      [:span {:data-testid (str row-test-id "-operation")
-             :style       {:color         (:accent-violet tokens)
+             :style       {:color         (:accent tokens)
                            :overflow      "hidden"
                            :text-overflow "ellipsis"
                            :white-space   "nowrap"}
@@ -211,7 +211,7 @@
                                 (rf/dispatch [:rf.causa/open-in-editor
                                               {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
-                               :color       (:cyan tokens)
+                               :color       (:accent tokens)
                                :border      (str "1px solid " (:border-subtle tokens))
                                :padding     "1px 6px"
                                :border-radius "3px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -263,12 +263,16 @@
   keeps the map pure-data + tokens consolidated (rf2-5kfxe.4)."
   {:error                :red
    :warning              :yellow
-   :info                 :cyan
-   :rf.event             :accent-violet
-   :rf.event/db-changed  :accent-violet
+   ;; op-family colour bands (spec/007 §Colour system). Events ride the
+   ;; mode `accent` (the spine); the sub family + info keep a fixed cyan
+   ;; (`accent-static`) so the two bands stay visually distinct now that
+   ;; the event band is the orange accent (rf2-ad7zx).
+   :info                 :accent-static
+   :rf.event             :accent
+   :rf.event/db-changed  :accent
    :rf.fx                :green
-   :rf.sub/run           :cyan
-   :rf.sub/create        :cyan
+   :rf.sub/run           :accent-static
+   :rf.sub/create        :accent-static
    :rf.view/render       :magenta
    :rf.frame             :text-secondary})
 

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -343,13 +343,15 @@
    :cursor           "col-resize"
    :background       "transparent"
    ;; Hairline guide on the leftmost pixel so the affordance is
-   ;; visible against any host-app background. `~33% alpha` of the
-   ;; accent violet (the historical "#7C5CFF55" tail-suffix). Built
-   ;; via `tokens/with-alpha` so the alpha composites with the
-   ;; ACTIVE-theme variable (rf2-on4cm) — light mode lands on the
-   ;; light accent at 33% alpha, dark on the dark accent at 33% alpha.
+   ;; visible against any host-app background. `~33% alpha` of the mode
+   ;; accent (orange in Dynamic / cyan in Static; the historical
+   ;; "#7C5CFF55" violet tail-suffix is retired with the orange
+   ;; identity, rf2-ad7zx). Built via `tokens/with-alpha` so the alpha
+   ;; composites with the ACTIVE-theme + ACTIVE-mode variable
+   ;; (rf2-on4cm) — light/dark + Dynamic/Static all land on the live
+   ;; accent at 33% alpha.
    :box-shadow       (str "inset 1px 0 0 0 "
-                          (t/with-alpha :accent-violet 33))
+                          (t/with-alpha :accent 33))
    ;; Above the chrome's panels but below the modals; modals use
    ;; max-int z-index so we won't fight them.
    :z-index          1000

--- a/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
@@ -25,7 +25,7 @@
 
   Dropped vs. the earlier spec catalogue (per Mike 2026-05-19
   §0ter.4 walkthrough): Actions tab + factory-reset BIG RED BUTTON,
-  density Comfy tier, per-tab default expansion knob, accent-violet
+  density Comfy tier, per-tab default expansion knob, accent
   user swap, sub-output diff layout toggle, section-grouping
   threshold, Popout as its own tab. The Telemetry tab was removed
   earlier (rf2-jh9ws) — Causa ships no telemetry endpoint and the

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -118,7 +118,7 @@
    :font-weight      (if active? 600 400)
    :border           "none"
    :border-bottom    (str "2px solid "
-                          (if active? (:accent-violet tokens) "transparent"))
+                          (if active? (:accent tokens) "transparent"))
    :border-top-left-radius "4px"
    :border-top-right-radius "4px"
    :margin-bottom    "-1px"})
@@ -164,7 +164,7 @@
    :border-radius    "3px"})
 
 (defn- primary-button-style []
-  {:background       (:accent-violet tokens)
+  {:background       (:accent tokens)
    :color            (:white tokens)
    :border           "none"
    :padding          "6px 14px"
@@ -725,7 +725,7 @@
        "diff. Flip this on when diagnosing memoization issues (a "
        "child re-renders because the parent passes a new fn every "
        "time); identity-different fns will surface as a distinct "
-       "violet `(fn ref changed)` chip."]]]))
+       "accent-coloured `(fn ref changed)` chip."]]]))
 
 ;; ---- section: Keybindings (rf2-ttnst) -----------------------------------
 ;;

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -129,7 +129,7 @@
         tone    (cond
                   copied? (:green tokens)
                   failed? (:red tokens)
-                  :else   (:accent-violet tokens))]
+                  :else   (:accent tokens))]
     [:button
      {:data-testid    "rf-causa-share-modal-copy"
       :data-status    (name (or copy-status :idle))
@@ -140,7 +140,7 @@
                        :border "none"
                        ;; rf2-5kfxe.4 — token-grade dark text for the
                        ;; copy button surface (button background is
-                       ;; the green/violet tone, so contrast wants
+                       ;; the green/accent tone, so contrast wants
                        ;; the deepest bg colour as the foreground).
                        :color (:bg-0 tokens)
                        :font-family sans-stack
@@ -190,7 +190,7 @@
                       downloaded? (:green tokens)
                       failed?     (:red tokens)
                       (not available?) (:bg-2 tokens)
-                      :else       (:accent-violet tokens))]
+                      :else       (:accent tokens))]
     [:button
      {:data-testid "rf-causa-share-modal-export-cascade-copy"
       :data-status (name (or status :idle))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -205,14 +205,14 @@
   Event tab detail (which has plenty of room).
 
   - `event-id` is the first element of the event vector.
-  - Renders in the accent-violet colour so it pops out of the row.
+  - Renders in the mode `accent` colour so it pops out of the row.
   - When the cascade carries no event vector, falls back to a
     `<no event>` chip in the secondary text colour. (Per rf2-639lc
     the L2 event list filters those cascades out via
     `cascade-has-event?`; the fallback is defence-in-depth.)"
   [event-vec]
   (if (vector? event-vec)
-    [:span {:style {:color       (:accent-violet tokens)
+    [:span {:style {:color       (:accent tokens)
                     :font-weight 500}}
      (pr-str (first event-vec))]
     [:span {:style {:color      (:text-secondary tokens)
@@ -659,7 +659,7 @@
                            :gap            "4px"
                            :padding        "2px 6px 2px 8px"
                            :background     (:bg-active tokens)
-                           :border         (str "1px solid " (:accent-violet tokens))
+                           :border         (str "1px solid " (:accent tokens))
                            :border-radius  "10px"
                            :font-family    sans-stack
                            :font-size      (:body type-scale)
@@ -671,7 +671,7 @@
        ;; accessible meaning. `aria-hidden` suppresses the unicode-
        ;; name announcement ("direct hit").
        [:span {:aria-hidden "true"
-               :style {:color (:accent-violet tokens)
+               :style {:color (:accent tokens)
                        :font-weight 600}}
         "🎯"]                ;; 🎯 (UTF-16 surrogate pair for portability)
        [:span {:data-testid "rf-causa-focus-chip-label"
@@ -750,8 +750,9 @@
   buys the compacted height.
 
   The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
-  #2 — violet Dynamic / cyan Static) stays as the at-a-glance mode cue,
-  so the understated mode dropdown can recede without losing the signal.
+  #2 — orange Dynamic / cyan Static, rf2-ad7zx) stays as the at-a-glance
+  mode cue, so the understated mode dropdown can recede without losing
+  the signal.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -774,13 +775,13 @@
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
                    ;; rf2-o5f5f.1 — mode-signal mechanism #2: a 2-px
                    ;; left-edge stripe in the active mode's accent
-                   ;; (violet in Dynamic, cyan in Static). Painted on
-                   ;; the ribbon so it lines up with the top-of-shell
-                   ;; edge regardless of the L2 resize-handle. The
-                   ;; stripe-hex helper closes over the current
-                   ;; palette (light vs dark theme via CSS custom
-                   ;; properties); cyan is already in the palette so
-                   ;; zero new tokens introduced.
+                   ;; (orange in Dynamic, cyan in Static — rf2-ad7zx).
+                   ;; Painted on the ribbon so it lines up with the
+                   ;; top-of-shell edge regardless of the L2 resize-
+                   ;; handle. The stripe-hex helper reads the per-mode
+                   ;; `:accent-dynamic` / `:accent-static` token through
+                   ;; the current palette (light vs dark via CSS custom
+                   ;; properties).
                    :border-left      (str "2px solid "
                                           (static-shell/stripe-hex-for-mode :dynamic))
                    :font-family      sans-stack
@@ -1056,7 +1057,7 @@
         status-kw    (event-status/classify-status status-state)
         status-hex   (event-status/event-status-colour status-state)
         glyph-col   (cond
-                      focused?                                (:cyan tokens)
+                      focused?                                (:accent tokens)
                       (= "x" glyph)                           (:red tokens)
                       (= "▥" glyph)                           (:magenta tokens)
                       :else                                   (:text-tertiary tokens))
@@ -1071,7 +1072,7 @@
                       ungrouped? (:bg-2 tokens)
                       :else      "transparent")
         border      (cond
-                      focused?   (str "1px solid " (:cyan tokens))
+                      focused?   (str "1px solid " (:accent tokens))
                       ungrouped? (str "1px dashed " (:border-subtle tokens))
                       :else      "1px solid transparent")
         ;; rf2-b76v4 — the lifecycle-status accent rides as a 2px inset
@@ -1108,8 +1109,8 @@
                        in-focus?  "◌"          ;; open marker for in-focus non-pivot rows
                        :else      nil)
         focus-marker-col (cond
-                           pivot?    (:accent-violet tokens)
-                           in-focus? (:accent-violet tokens)
+                           pivot?    (:accent tokens)
+                           in-focus? (:accent tokens)
                            :else     (:text-tertiary tokens))]
     ;; Density (rf2-htik0 Bug 2): height 22px + padding "1px 6px" tightens
     ;; the row from the earlier 28px / "4px 8px" spec-baseline. Causa is
@@ -1260,8 +1261,8 @@
      ;; from also firing.
      ;;
      ;; rf2-5kfxe.10 — cascade-chain timeline gutter. The gutter cell
-     ;; carries a 1px violet inset border on its LEFT EDGE so stacked
-     ;; rows render as a continuous vertical thread — visually
+     ;; carries a 1px mode-accent inset border on its LEFT EDGE so
+     ;; stacked rows render as a continuous vertical thread — visually
      ;; expressing the spine's timeline rather than reading as a flat
      ;; list. `:ungrouped` rows break the thread (the bucket isn't on
      ;; the cascade timeline). The thread is `align-self: stretch` so
@@ -1288,7 +1289,7 @@
                                    :box-shadow   (if ungrouped?
                                                    "none"
                                                    (str "inset 1px 0 0 0 "
-                                                        (:accent-violet tokens)))}
+                                                        (:accent tokens)))}
                      :title       (cond
                                     pivot?
                                     (str "Clear focus on " (fh/dimension-label focus-set))
@@ -1317,7 +1318,7 @@
                :data-rf-causa-origin (name origin)
                :title origin-title
                :style {:flex-shrink 0
-                       :color (:accent-violet tokens)
+                       :color (:accent tokens)
                        :font-size (:caption type-scale)
                        :min-width "12px"
                        :text-align "center"}}
@@ -1718,7 +1719,7 @@
               :style {:background    "transparent"
                       :border        "none"
                       :border-bottom (if active?
-                                       (str "2px solid " (:accent-violet tokens))
+                                       (str "2px solid " (:accent tokens))
                                        "2px solid transparent")
                       :color         color
                       :cursor        "pointer"
@@ -1733,7 +1734,7 @@
      ;; circle" / "white circle").
      [:span {:aria-hidden "true"
              :style {:color (if active?
-                              (:accent-violet tokens)
+                              (:accent tokens)
                               (:text-tertiary tokens))
                      :margin-right "4px"}}
       glyph]
@@ -1975,8 +1976,19 @@
     (when (not= current-positioning modal-positioning)
       (rf/dispatch-sync [:rf.causa/set-modal-positioning modal-positioning]
                         {:frame :rf/causa})))
-  [rf/frame-provider {:frame :rf/causa}
+  ;; rf2-ad7zx / spec/022 — the lens mode (`:rf.causa/mode` =
+  ;; :dynamic | :static) drives the `mode-dynamic` / `mode-static`
+  ;; root class. `theme/global-styles/mode-accent-css` re-points
+  ;; `--rf-causa-accent` at the orange (Dynamic) or cyan (Static)
+  ;; accent off this class, so the whole shell's chrome accent flips
+  ;; off ONE token while the brand wordmark stays orange in either
+  ;; mode. Subscribed via the explicit `:rf/causa` frame (same shape
+  ;; as the modal-positioning read above — `shell-view` sits outside
+  ;; its own frame-provider).
+  (let [lens-mode @(rf/subscribe :rf/causa [:rf.causa/mode])]
+   [rf/frame-provider {:frame :rf/causa}
    [:div {:data-testid "rf-causa-shell"
+          :class (str "mode-" (name (or lens-mode :dynamic)))
           ;; rf2-plajx — Causa shell root is a landmark. A 40%-
           ;; viewport overlay rendered as a bare `<div>` is invisible
           ;; to screen-reader landmark navigation (JAWS R-key /
@@ -2092,4 +2104,4 @@
     ;; popup's subscribes resolve through the shell's `:rf/causa`
     ;; frame-provider; closed-state cost is one subscribe + a when-
     ;; gate.
-    [app-db-segment-inspector/Popup]]])
+    [app-db-segment-inspector/Popup]]]))

--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -224,7 +224,7 @@
    [:div {:style {:display     "flex"
                   :align-items "baseline"
                   :gap         "8px"}}
-    [:span {:style {:color       (:accent-violet tokens)
+    [:span {:style {:color       (:accent tokens)
                     :font-weight 500
                     :min-width   "180px"}}
      (pr-str flow-id)]

--- a/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/interceptors/panel.cljs
@@ -176,7 +176,7 @@
      [:div {:style {:display     "flex"
                     :align-items "baseline"
                     :gap         "8px"}}
-      [:span {:style {:color       (:accent-violet tokens)
+      [:span {:style {:color       (:accent tokens)
                       :font-weight 500
                       :flex        1}}
        id-text]

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/browse_list.cljs
@@ -91,7 +91,7 @@
               :font-size     (:caption type-scale)
               :padding       "2px 10px"
               :white-space   "nowrap"}}
-     "Sort: " [:strong {:style {:color (:cyan tokens)}} label]]))
+     "Sort: " [:strong {:style {:color (:accent tokens)}} label]]))
 
 ;; ---- per-row chips ------------------------------------------------------
 
@@ -145,14 +145,14 @@
                               :width         "5px"
                               :height        "5px"
                               :border-radius "50%"
-                              :background    (:cyan tokens)}}]))
+                              :background    (:accent tokens)}}]))
 
       :count
       [:span {:data-testid "rf-causa-static-machines-row-pips-count"
               :title       (str count " live instances")
               :style {:font-family mono-stack
                       :font-size   (:micro type-scale)
-                      :color       (:cyan tokens)
+                      :color       (:accent tokens)
                       :margin-left "6px"}}
        (str ">" h/pip-cap " " count " live")])))
 
@@ -172,7 +172,7 @@
     :style {:background    "transparent"
             :border        (str "1px solid " (:border-default tokens))
             :border-radius "10px"
-            :color         (:accent-violet tokens)
+            :color         (:accent tokens)
             :cursor        "pointer"
             :font-family   sans-stack
             :font-size     (:micro type-scale)
@@ -215,13 +215,13 @@
               :white-space   "nowrap"
               :overflow      "hidden"
               :text-overflow "ellipsis"}}
-     [:span {:style {:color (if active? (:cyan tokens) (:text-tertiary tokens))
+     [:span {:style {:color (if active? (:accent tokens) (:text-tertiary tokens))
                      :flex  "0 0 12px"}}
       glyph]
      [:span {:data-testid "rf-causa-static-machines-row-id"
              :style {:font-family   mono-stack
                      :font-size     (:body-tight type-scale)
-                     :color         (:accent-violet tokens)
+                     :color         (:accent tokens)
                      :overflow      "hidden"
                      :text-overflow "ellipsis"
                      :max-width     "120px"}}
@@ -245,7 +245,7 @@
    [:p {:style {:margin 0}}
     "Register a machine with "
     [:code {:style {:font-family mono-stack
-                    :color       (:accent-violet tokens)}}
+                    :color       (:accent tokens)}}
      "rf/reg-machine"]
     " to populate this list."]])
 

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
@@ -76,7 +76,7 @@
                          :color (:text-primary tokens)}
                         (try (t/accent-stripe-style :machines) (catch :default _ {})))}
     [:span {:style {:font-family mono-stack
-                    :color (:accent-violet tokens)}}
+                    :color (:accent tokens)}}
      (str machine-id)]]
    (when (some? source-coord)
      [:span {:data-testid "rf-causa-static-machines-detail-source-coord"
@@ -95,7 +95,7 @@
            :style {:font-family mono-stack
                    :font-size (:caption type-scale)
                    :color (if (and (number? live-count) (pos? live-count))
-                            (:cyan tokens)
+                            (:accent tokens)
                             (:text-tertiary tokens))
                    :margin-left "auto"}}
     (str (or live-count 0) " live")]])
@@ -114,10 +114,10 @@
     :style {:background    "transparent"
             :border        (str "1px solid "
                                 (if active?
-                                  (:cyan tokens)
+                                  (:accent tokens)
                                   (:border-default tokens)))
             :border-radius "10px"
-            :color         (if active? (:cyan tokens) (:text-secondary tokens))
+            :color         (if active? (:accent tokens) (:text-secondary tokens))
             :cursor        "pointer"
             :font-family   sans-stack
             :font-size     (:caption type-scale)

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/instances_jump.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/instances_jump.cljs
@@ -85,10 +85,10 @@
       :style {:background    "transparent"
               :border        (str "1px solid "
                                   (if active?
-                                    (:cyan tokens)
+                                    (:accent tokens)
                                     (:border-default tokens)))
               :border-radius "10px"
-              :color         (:accent-violet tokens)
+              :color         (:accent tokens)
               :cursor        "pointer"
               :font-family   sans-stack
               :font-size     (:caption type-scale)
@@ -98,7 +98,7 @@
      label
      (when suffix
        [:span {:data-testid "rf-causa-static-machines-pill-instances-badge"
-               :style {:color (:cyan tokens)
+               :style {:color (:accent tokens)
                        :margin-left "4px"
                        :font-family sans-stack}}
         suffix])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs
@@ -264,10 +264,10 @@
     :style {:background    "transparent"
             :border        (str "1px solid "
                                 (if active?
-                                  (:cyan tokens)
+                                  (:accent tokens)
                                   (:border-default tokens)))
             :border-radius "10px"
-            :color         (if active? (:cyan tokens) (:text-secondary tokens))
+            :color         (if active? (:accent tokens) (:text-secondary tokens))
             :cursor        "pointer"
             :font-family   sans-stack
             :font-size     (:caption type-scale)
@@ -769,7 +769,7 @@
                          :font-size (:body type-scale)}}
        "No introspectable definition for "
        [:code {:style {:font-family mono-stack
-                       :color (:accent-violet tokens)}}
+                       :color (:accent tokens)}}
         (str machine-id)]
        " — Sim cannot clone what isn't there."]
 

--- a/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
@@ -28,9 +28,9 @@
   belongs. The reshape collapses it to a compact `<select>` that shares
   the frame picker's weight (`bg-2` fill, `border-default` hairline,
   4px radius). The MODE SIGNAL is carried elsewhere — the chrome
-  ribbon's 2-px left-edge accent stripe (violet Dynamic / cyan Static,
-  `static/shell/stripe-hex-for-mode`) — so the control itself can
-  recede without losing the at-a-glance mode cue.
+  ribbon's 2-px left-edge accent stripe (orange Dynamic / cyan Static,
+  `static/shell/stripe-hex-for-mode` — rf2-ad7zx) — so the control
+  itself can recede without losing the at-a-glance mode cue.
 
   ## Why a single registered view
 

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
@@ -9,8 +9,8 @@
   Routing lens via `routing-helpers/filter-rows`.
 
   Per row:
-    - path / pattern (mono violet)
-    - route-id keyword (mono violet, smaller)
+    - path / pattern (mono mode-accent)
+    - route-id keyword (mono mode-accent, smaller)
     - source-coord chip (when present)
     - doc-string ellipsis
 
@@ -34,10 +34,10 @@
   [kind]
   (let [{:keys [letter colour title]}
         (case kind
-          :on-match  {:letter "M" :colour (:cyan tokens)          :title ":on-match"}
+          :on-match  {:letter "M" :colour (:accent-static tokens) :title ":on-match"}
           :can-leave {:letter "L" :colour (:yellow tokens)        :title ":can-leave"}
           :tags      {:letter "T" :colour (:magenta tokens)       :title ":tags"}
-          :parent    {:letter "P" :colour (:accent-violet tokens) :title ":parent"}
+          :parent    {:letter "P" :colour (:accent tokens) :title ":parent"}
           nil)]
     (when letter
       [:span {:data-testid (str "rf-causa-static-routes-badge-" (name kind))
@@ -120,7 +120,7 @@
                       :color         (:text-primary tokens)
                       :background    (if expanded? (:bg-2 tokens) "transparent")
                       :border-left   (if expanded?
-                                       (str "2px solid " (:cyan tokens))
+                                       (str "2px solid " (:accent tokens))
                                        "2px solid transparent")
                       :border-radius "2px"
                       :line-height   "20px"}}
@@ -158,7 +158,7 @@
                           :min-width   "12px"
                           :user-select "none"}}
      (if expanded? "▾" "▸")]
-    [:span {:style {:color       (:accent-violet tokens)
+    [:span {:style {:color       (:accent tokens)
                    :font-weight 500
                    :min-width   "160px"}}
      path]

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
@@ -88,7 +88,7 @@
   (when (vector? on-match)
     (let [ev-id (first on-match)]
       [:span {:data-testid "rf-causa-static-routes-on-match-chip"}
-       (chip (str ev-id) (:cyan tokens))])))
+       (chip (str ev-id) (:accent tokens))])))
 
 (defn- segment-keys-from-meta
   "Extract segment keys from the route meta's `:rf.route/compiled`
@@ -115,9 +115,9 @@
                                         {:frame :rf/causa}))
             :title       "Open Dynamic Routing scoped to this route"
             :style       {:background    "transparent"
-                          :border        (str "1px solid " (:accent-violet tokens))
+                          :border        (str "1px solid " (:accent tokens))
                           :border-radius "3px"
-                          :color         (:accent-violet tokens)
+                          :color         (:accent tokens)
                           :padding       "1px 6px"
                           :margin-left   "8px"
                           :font-family   sans-stack
@@ -139,9 +139,9 @@
                                          route-id]
                                         {:frame :rf/causa}))
             :style       {:background    (if sim-open? (:bg-active tokens) "transparent")
-                          :border        (str "1px solid " (:cyan tokens))
+                          :border        (str "1px solid " (:accent tokens))
                           :border-radius "3px"
-                          :color         (:cyan tokens)
+                          :color         (:accent tokens)
                           :padding       "2px 8px"
                           :font-family   sans-stack
                           :font-size     "11px"
@@ -186,8 +186,8 @@
                     :flex-wrap     "wrap"
                     :gap           "6px"
                     :margin-bottom "6px"}}
-      (chip (str route-id) (:accent-violet tokens))
-      (when path (chip path (:cyan tokens)))
+      (chip (str route-id) (:accent tokens))
+      (when path (chip path (:accent tokens)))
       (on-match-summary on-match)
       (source-coord-chip meta)
       [sim-nav-toggle route-id sim-open?]

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_nav.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_nav.cljs
@@ -64,7 +64,7 @@
            :style       {:padding       "10px 16px"
                          :margin        "8px 0 4px 24px"
                          :background    (:bg-1 tokens)
-                         :border-left   (str "2px solid " (:cyan tokens))
+                         :border-left   (str "2px solid " (:accent tokens))
                          :border-radius "2px"
                          :display       "grid"
                          :grid-template-columns "100px 1fr"

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_url.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_url.cljs
@@ -66,7 +66,7 @@
                    :font-size   "10px"
                    :min-width   "50px"}}
     (if winner? "WINNER" "")]
-   [:span {:style {:color     (:accent-violet tokens)
+   [:span {:style {:color     (:accent tokens)
                    :min-width "140px"}}
     path]
    [:span {:style {:color     (:text-tertiary tokens)

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -219,7 +219,7 @@
   [kind]
   (let [{:keys [letter colour]}
         (case kind
-          :app-db {:letter "A" :colour (:cyan tokens)}
+          :app-db {:letter "A" :colour (:accent-static tokens)}
           :event  {:letter "E" :colour (:magenta tokens)}
           :sub    {:letter "S" :colour (:yellow tokens)}
           {:letter "?" :colour (:text-tertiary tokens)})]
@@ -264,7 +264,7 @@
                     :align-items "baseline"
                     :gap         "8px"}}
       (kind-badge kind)
-      [:span {:style {:color       (:accent-violet tokens)
+      [:span {:style {:color       (:accent tokens)
                       :font-weight 500
                       :min-width   "200px"}}
        id-text]

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -85,13 +85,14 @@
 
   The parent epic locks four signals that telegraph Static state:
 
-    1. **Mode pill** at ribbon-left — accent-violet active segment,
+    1. **Mode pill** at ribbon-left — mode-`accent` active segment,
        200ms cross-fade. Owned by `static/mode_pill.cljs`. The pill
        lives at ribbon-left in BOTH modes (it's the toggle, not the
        indicator).
-    2. **2-px left-edge ribbon stripe** — `:accent-violet` in Dynamic,
-       `:cyan` in Static. Owned by both shells via the explicit
-       `mode-stripe-colour` arg passed into the ribbon's outer div.
+    2. **2-px left-edge ribbon stripe** — `:accent-dynamic` (orange) in
+       Dynamic, `:accent-static` (cyan) in Static. Owned by both shells
+       via the explicit `mode-stripe-colour` arg passed into the
+       ribbon's outer div.
     3. **Motion dampening** — Dynamic ships the LIVE pulse + machine-
        active pulse + 180ms tab fade. Static drops the continuous
        pulses entirely; the 180ms tab fade collapses to 0ms (instant)
@@ -171,21 +172,29 @@
   "Token-key for the Dynamic mode's 2-px left-edge ribbon stripe per
   the parent-epic mode-signal mechanism (signal #2). Held as a token
   KEY (not the resolved hex) so per-theme palette switching (rf2-
-  5kfxe.6 light theme) flows through naturally."
-  :accent-violet)
+  5kfxe.6 light theme) flows through naturally.
+
+  The Dynamic stripe is the orange `:accent-dynamic` token (the brand-
+  orange identity, rf2-ad7zx / spec/022). It reads the per-MODE token
+  directly — not the runtime `:accent` alias — because the stripe IS
+  the mode signal, so it must always paint the Dynamic accent
+  regardless of which mode is active when the stripe is rendered."
+  :accent-dynamic)
 
 (def static-stripe-token
   "Token-key for the Static mode's 2-px left-edge ribbon stripe per
-  the parent-epic mode-signal mechanism (signal #2). Cyan is already
-  in the palette (rf2-5kfxe.6) at hex #43C3D0 — no new token
-  introduced, per the rf2-zhrwo audit constraint 'Zero new tokens'."
-  :cyan)
+  the parent-epic mode-signal mechanism (signal #2). The cyan
+  `:accent-static` token (#43C3D0 dark / #2A8B96 light, spec/022) —
+  the per-MODE Static accent, read directly rather than via the
+  runtime `:accent` alias so the stripe always paints the Static
+  accent as the mode signal."
+  :accent-static)
 
 (defn stripe-token-for-mode
-  "Pure helper. Returns the token KEY (`:accent-violet` / `:cyan`)
-  the L1 ribbon should paint as its 2-px left-edge stripe for the
-  given mode. JVM-portable so the test corpus can cover the round-
-  trip without a CLJS runtime."
+  "Pure helper. Returns the token KEY (`:accent-dynamic` /
+  `:accent-static`) the L1 ribbon should paint as its 2-px left-edge
+  stripe for the given mode. JVM-portable so the test corpus can cover
+  the round-trip without a CLJS runtime."
   [mode]
   (case mode
     :static  static-stripe-token
@@ -306,7 +315,7 @@
               :style {:background    "transparent"
                       :border        "none"
                       :border-bottom (if active?
-                                       (str "2px solid " (:cyan tokens))
+                                       (str "2px solid " (:accent tokens))
                                        "2px solid transparent")
                       :color         color
                       :cursor        "pointer"
@@ -318,7 +327,7 @@
      ;; rf2-vxpq1 — `aria-hidden` on decorative ●/○ glyph.
      [:span {:aria-hidden "true"
              :style {:color (if active?
-                              (:cyan tokens)
+                              (:accent tokens)
                               (:text-tertiary tokens))
                      :margin-right "4px"}}
       glyph]
@@ -364,9 +373,10 @@
     - A muted hint paragraph naming the upcoming content.
 
   The card is a single `<section>` painted on `bg-2` with a thin
-  `:cyan` accent stripe — mirrors the Dynamic panels' per-domain
-  stripe convention (`tokens/accent-stripe-style`) but uses cyan as
-  the Static-mode accent."
+  mode-`accent` stripe — mirrors the Dynamic panels' header-stripe
+  convention (`tokens/accent-stripe-style`). The runtime `:accent`
+  alias resolves to the Static-mode cyan here (the surface only
+  renders under `.mode-static`)."
   [{:keys [label placeholder-bead id]}]
   [:section {:data-testid (str "rf-causa-static-placeholder-" (name id))
              :style {:padding       "16px"
@@ -384,11 +394,11 @@
                   :font-weight   600
                   :margin        "0 0 8px 0"
                   :padding-left  "10px"
-                  :border-left   (str "3px solid " (:cyan tokens))}}
+                  :border-left   (str "3px solid " (:accent tokens))}}
     label]
    [:p {:style {:color  (:text-secondary tokens)
                 :margin "0 0 12px 0"}}
-    [:strong {:style {:color (:cyan tokens)}}
+    [:strong {:style {:color (:accent tokens)}}
      placeholder-bead]
     " will fill this."]
    [:p {:style {:color  (:text-tertiary tokens)

--- a/tools/causa/src/day8/re_frame2_causa/theme/data_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/data_inspector.cljs
@@ -56,13 +56,19 @@
 ;; ---- colour palette (cljs-devtools-flavoured against our tokens) -----
 
 (def ^:private colour
-  "Per-leaf colour mapping. Keywords purple, strings green, numbers
-  cyan, nil grey, booleans orange, default text-primary. Mapped onto
-  Causa's existing token palette so the renderer reads as native shell
-  chrome rather than a third-party widget."
-  {:keyword (:accent-violet tokens)
+  "Per-leaf colour mapping for the L4 data-VALUE renderer. EDN keyword
+  data values read in the mode `accent` (orange in Dynamic, cyan in
+  Static — the single mode-coloured data type per §021 §10.3 /
+  spec/022). The remaining leaf types keep their distinct categorical
+  syntax hues so the structural tree stays legible: strings green,
+  numbers a fixed cyan (`accent-static`, kept distinct from the now-
+  orange keyword accent), nil grey, booleans orange, symbols magenta,
+  default text-primary. Mapped onto Causa's token palette so the
+  renderer reads as native shell chrome rather than a third-party
+  widget."
+  {:keyword (:accent tokens)
    :string  (:green tokens)
-   :number  (:cyan tokens)
+   :number  (:accent-static tokens)
    :nil     (:text-tertiary tokens)
    :boolean (:orange tokens)
    :symbol  (:magenta tokens)

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -203,11 +203,45 @@
        (map (fn [[k v]] (str "  " (token-key->css-var k) ": " v ";\n")))
        (apply str)))
 
+(def ^:private mode-accent-css
+  "Mode-accent runtime alias (rf2-ad7zx / spec/022 §Colour identity).
+
+  `--rf-causa-accent` is the SINGLE token every chrome accent reads
+  (active tab · mode stripe · selected states · focus ring ·
+  changed/recompute · L4 header stripe). The dark/light palette blocks
+  publish its default = the Dynamic (orange) accent. These two root-
+  class rules re-point it per the current MODE so the whole shell reads
+  orange in Dynamic and cyan in Static, while `--rf-causa-brand` (the
+  logo/wordmark) stays orange in either mode.
+
+  The class is written on BOTH the `<html>` root and the shell node
+  (mount.cljs / the shells), so a higher-specificity single-class
+  selector outranks the `:root` default. The `:where()` wrapper keeps
+  specificity at zero so the theme-class palette blocks (which also set
+  `--rf-causa-accent` via `palette->declarations`) do not win over the
+  mode flip — `:where(.mode-static)` and the bare `.mode-static` shell
+  node both resolve, and the assignment is identical, so either landing
+  works."
+  (str
+    ;; Dynamic mode (default) — accent follows the orange Dynamic accent.
+    ".mode-dynamic, :root.mode-dynamic {\n"
+    "  --rf-causa-accent: var(--rf-causa-accent-dynamic);\n"
+    "}\n"
+    ;; Static mode — accent follows the cyan Static accent. Brand stays
+    ;; orange (it reads --rf-causa-brand, untouched here).
+    ".mode-static, :root.mode-static {\n"
+    "  --rf-causa-accent: var(--rf-causa-accent-static);\n"
+    "}\n"))
+
 (defn- themes-css
   "Build the per-theme CSS block. The dark palette publishes at `:root`
   (the safe fallback) AND at `.rf-causa-theme-dark` (so the class
   toggle has a matched landing). The light palette publishes at
-  `.rf-causa-theme-light` so the class toggle activates it."
+  `.rf-causa-theme-light` so the class toggle activates it. The
+  `mode-accent-css` block then re-points `--rf-causa-accent` at the
+  Dynamic / Static accent under the `.mode-dynamic` / `.mode-static`
+  root class (rf2-ad7zx / spec/022) so the whole shell turns orange in
+  Dynamic, cyan in Static, off ONE token."
   [themes]
   (str
     ;; Default — :root carries the dark palette so any descendant
@@ -223,7 +257,9 @@
     "}\n"
     ".rf-causa-theme-light {\n"
     (palette->declarations (:light themes))
-    "}\n"))
+    "}\n"
+    ;; Mode-accent alias — flips --rf-causa-accent orange↔cyan by mode.
+    mode-accent-css))
 
 (defn- inject-themes-style!
   "Append the per-theme `<style>` block to `<head>`. Idempotent —
@@ -503,13 +539,14 @@
     ;; its own palette (Canvas / CanvasText / Highlight / …), which
     ;; collapses every author-encoded signal across the Causa chrome:
     ;;
-    ;;   - L1 ribbon mode stripe (violet/cyan accent on the left edge)
-    ;;   - L2 row focused border (cyan)
+    ;;   - L1 ribbon mode stripe (orange Dynamic / cyan Static accent
+    ;;     on the left edge)
+    ;;   - L2 row focused border (mode accent)
     ;;   - L2 row status accent (the 2px inset box-shadow on the
     ;;     trailing edge — box-shadow itself is also dropped in HCM)
-    ;;   - L2 row gutter causal-chain thread (1px violet inset)
-    ;;   - L4 panel-domain accent stripes (3px left border in each
-    ;;     panel's hue — violet/cyan/orange/green/yellow/red)
+    ;;   - L2 row gutter causal-chain thread (1px mode-accent inset)
+    ;;   - L4 panel header accent stripes (3px left border — the mode
+    ;;     accent: orange Dynamic / cyan Static, rf2-ad7zx)
     ;;   - Focus-visible amber outline (the #FBBF24 hex above; the UA
     ;;     forces this to its own Highlight regardless of author intent)
     ;;   - Secondary / tertiary text (drifted greys collapse to a
@@ -555,14 +592,14 @@
     "  [data-testid=\"rf-causa-palette-backdrop\"] *:focus-visible {\n"
     "    outline-color: Highlight !important;\n"
     "  }\n"
-    ;; L1 ribbon mode stripe (violet runtime / cyan static) → Highlight.
+    ;; L1 ribbon mode stripe (orange Dynamic / cyan Static) → Highlight.
     ;; The 2px left border is the operator's "which mode am I in"
     ;; signal; preserve it as the user's selected-emphasis hue.
     "  [data-testid=\"rf-causa-ribbon\"] {\n"
     "    border-left-color: Highlight !important;\n"
     "  }\n"
     ;; L2 focused event row — `aria-pressed=\"true\"` rides on the
-    ;; focused row's `<li>`. The 1px solid cyan border becomes a
+    ;; focused row's `<li>`. The 1px solid mode-accent border becomes a
     ;; Highlight outline (outline composes over the existing border
     ;; without disturbing layout; HCM strips inline background, so
     ;; the row's fill becomes Canvas + the Highlight outline reads
@@ -599,7 +636,7 @@
     "  [data-rf-causa-status=\"paused-by-tool\"] {\n"
     "    box-shadow: inset -2px 0 0 0 GrayText !important;\n"
     "  }\n"
-    ;; L2 row gutter — the 1px causal-chain thread (violet) and the
+    ;; L2 row gutter — the 1px causal-chain thread (mode accent) and the
     ;; focus markers (⦿ / ◌) need a system-token landing. The gutter
     ;; <span> doesn't carry a testid hook, so we target the
     ;; row-gutter testid pattern. The inset box-shadow becomes
@@ -609,8 +646,8 @@
     "    box-shadow: inset 1px 0 0 0 Highlight !important;\n"
     "    color: Highlight !important;\n"
     "  }\n"
-    ;; L4 panel domain accent stripes (3px left border on the panel
-    ;; <h1>) — every panel hue (violet/cyan/orange/green/yellow/red)
+    ;; L4 panel header accent stripes (3px left border on the panel
+    ;; <h1>) — the mode accent (orange Dynamic / cyan Static)
     ;; collapses to CanvasText so the stripe still paints as a
     ;; visible left edge. Panels remain visually distinguishable by
     ;; their L3 tab label and their content; the stripe drops its
@@ -1442,7 +1479,7 @@
   (str
     ".react-flow {\n"
     "  --xy-edge-stroke-default: " (:border-default tokens/tokens) ";\n"
-    "  --xy-edge-stroke-selected-default: " (:cyan tokens/tokens) ";\n"
+    "  --xy-edge-stroke-selected-default: " (:accent tokens/tokens) ";\n"
     "  --xy-node-background-color-default: " (:bg-2 tokens/tokens) ";\n"
     "  --xy-node-color-default: " (:text-primary tokens/tokens) ";\n"
     "  --xy-node-border-default: 1px solid " (:border-default tokens/tokens) ";\n"

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -81,9 +81,32 @@
    :text-secondary "#A8AEC0"
    :text-tertiary  "#8990A0"
 
-   ;; ── accents + semantic ──
-   :accent-violet  "#7C5CFF"
-   :cyan           "#43C3D0"
+   ;; ── brand + mode accents (orange identity — rf2-ad7zx / spec/022) ──
+   ;; `brand` is the logo/wordmark colour and is ALWAYS orange in either
+   ;; mode. `accent-dynamic` / `accent-static` are the per-mode accents;
+   ;; `accent` is the RUNTIME ALIAS the `.mode-dynamic` / `.mode-static`
+   ;; root class points at the active mode's accent (active tab · mode
+   ;; stripe · selected states · focus ring · changed/recompute). Its
+   ;; default value here is the Dynamic (orange) accent — `themes-css`
+   ;; re-points the `--rf-causa-accent` variable at `accent-static`
+   ;; under `.mode-static` so the whole shell turns cyan in Static.
+   :brand          "#F97316"
+   :accent-dynamic "#F97316"
+   :accent-static  "#43C3D0"
+   :accent         "#F97316"   ; runtime alias → accent-dynamic by default
+
+   ;; ── semantic + change (spec/022 §Semantic & change) ──
+   :error          "#F85149"
+   :warning        "#FBBF24"   ; warnings; also the filter "N hidden" chrome
+   :advisory       "#79A6D2"   ; lowest Issues severity — calm, cool, ≠ warning
+   :success        "#3FB950"
+   :dim            "#6E7681"   ; dimmed / inert / unchanged
+   :hover          "#232730"   ; hover background (= bg-3)
+
+   ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
+   ;; These do REAL semantic work — perf tiers, machine state, route
+   ;; side-channel, redaction, op-family legends — and are NOT collapsed
+   ;; into the brand/mode accent.
    :green          "#4ADE80"
    :yellow         "#FBBF24"
    :orange         "#FB923C"
@@ -98,7 +121,7 @@
    ;; stays AA-grade.
    :red-deep       "#a83a3a"
 
-   ;; Universal white — readable on the violet accent + the deep
+   ;; Universal white — readable on the brand/mode accent + the deep
    ;; reds. Catalogued here so the few "white text on coloured
    ;; surface" spots (primary / danger buttons) flow through tokens
    ;; like every other colour.
@@ -140,10 +163,24 @@
    :text-secondary "#4B5160"
    :text-tertiary  "#8B92A1"
 
-   ;; ── accents + semantic ── (each ~15-20% darker than the dark
-   ;; palette to maintain ≥4.5:1 contrast on the white canvas)
-   :accent-violet  "#5538D8"
-   :cyan           "#2A8B96"
+   ;; ── brand + mode accents (orange identity — rf2-ad7zx / spec/022) ──
+   ;; Each ~15-20% darker than the dark palette to maintain ≥4.5:1 large-
+   ;; text contrast on the white canvas. `accent` default = the Dynamic
+   ;; (orange) accent; `.mode-static` re-points it at `accent-static`.
+   :brand          "#EA580C"
+   :accent-dynamic "#EA580C"
+   :accent-static  "#2A8B96"
+   :accent         "#EA580C"   ; runtime alias → accent-dynamic by default
+
+   ;; ── semantic + change (spec/022 §Semantic & change) ──
+   :error          "#CF222E"
+   :warning        "#B07A05"
+   :advisory       "#3B6EA5"
+   :success        "#1A7F37"
+   :dim            "#8C959F"
+   :hover          "#E6E9EE"
+
+   ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    :green          "#2F9E5C"
    :yellow         "#B07A05"
    :orange         "#C2570F"
@@ -171,7 +208,7 @@
    :light light-palette})
 
 (defn css-var
-  "Map a token key (`:bg-1`, `:accent-violet`, …) to the canonical
+  "Map a token key (`:bg-1`, `:accent`, …) to the canonical
   `\"var(--rf-causa-<key>)\"` CSS string consumed by inline `:style`
   maps + SVG paint properties. Pure data → string; JVM-portable.
 
@@ -195,10 +232,10 @@
   CSS string. The CSS-Color-4 idiom for compositing a palette token
   with an alpha channel without forking the hex — Chrome 111+, Safari
   16.2+, Firefox 113+. Use this where the old code did string
-  concatenation with a two-digit alpha suffix (`(str (:accent-violet
+  concatenation with a two-digit alpha suffix (`(str (:accent
   tokens) \"55\")`).
 
-  `k`  - palette key (`:accent-violet`, …)
+  `k`  - palette key (`:accent`, …)
   `pct` - opacity percentage (0-100). The `transparent` partner makes
           the result equivalent to that fractional alpha.
 
@@ -469,56 +506,55 @@
 ;; ---- L4 panel domain colours (rf2-5kfxe.8) -----------------------------
 
 (def panel-domain->token
-  "Pure semantic map from L4 tab keyword → token keyword used as the
-  panel's domain colour. Each panel renders a 3px left-border on its
-  `<h1>` in this colour so panels are distinguishable at a glance
-  without restructuring the header chrome.
+  "Pure semantic map from L4 tab keyword → token keyword for the
+  panel's header stripe colour.
 
-  Choices mirror the existing semantic colour usage across panels:
+  ## Orange identity (rf2-ad7zx / spec/022 · spec/007 §L4 panel accent
+  stripe)
 
-    :event     → :accent-violet  (the causal-chain accent everywhere
-                                  in the Event lens)
-    :app-db    → :cyan           (the App-db diff already uses cyan
-                                  for highlighted state)
-    :views     → :cyan           (Views is a peer of App-db; both
-                                  read state, hence the shared hue —
-                                  same way the spec groups them)
-    :trace     → :orange         (Trace = events 'in flight'; orange
-                                  is the firing/heat tone in the
-                                  perf scale)
-    :machines  → :green          (machine state lands in green for
-                                  'final' across the inspector)
-    :routing   → :yellow         (routing is the side-channel
-                                  attention tone — distinguishes
-                                  from app-db's main colour)
-    :issues    → :red            (issues = errors; semantic red)
+  The prior per-panel DOMAIN-colour mapping (`:event` violet ·
+  `:app-db`/`:views` cyan · `:trace` orange · `:machines` green ·
+  `:routing` yellow · `:issues` red) is **superseded**. The Figma
+  export carries a SINGLE accent identity — every panel's 3px header
+  stripe reads the mode `accent` (orange in Dynamic, cyan in Static),
+  so the stripe is the MODE signal, not a per-panel domain colour. This
+  keeps the whole devtool reading orange in Dynamic / cyan in Static,
+  with surfaces neutral so the accent pops.
 
-  (rf2-4v67l — the Chrome A11y entry was removed alongside the panel
-  itself; a11y dogfooding is now Story's concern per rf2-18t6p +
-  rf2-qgms1.)
+  Every tab therefore maps to the runtime `:accent` alias. Domain
+  colour still does load-bearing work INSIDE each panel where it is
+  semantic (`error` red in Issues, machine `green`, route `yellow`,
+  the op-family bands in Trace, the per-panel header icons §021
+  §17.1.5) — but the HEADER STRIPE is the mode accent.
+
+  The map is retained (rather than collapsed to a constant) so the
+  per-tab inventory stays explicit and a future per-panel signal can
+  re-diverge a single entry without restructuring call sites.
 
   JVM-portable pure data → keyword. Call sites do
-  `(get tokens (panel-domain->token tab))` to materialise the hex."
-  {:event           :accent-violet
-   :app-db          :cyan
-   :views           :cyan
-   :trace           :orange
-   :machines        :green
-   :routing         :yellow
-   :issues          :red})
+  `(get tokens (panel-domain->token tab))` to materialise the
+  CSS-variable string."
+  {:event           :accent
+   :app-db          :accent
+   :views           :accent
+   :trace           :accent
+   :machines        :accent
+   :routing         :accent
+   :issues          :accent})
 
 (defn panel-accent
-  "Resolve the L4 panel's accent CSS-variable string from the canonical
-  `panel-domain->token` map through `tokens`. Falls back to the
-  `:accent-violet` variable for unknown tab keywords so the stripe
-  always renders.
+  "Resolve the L4 panel's header-stripe accent CSS-variable string —
+  the mode `accent` (orange in Dynamic, cyan in Static) per spec/007
+  §L4 panel accent stripe + spec/022. Falls back to the `:accent`
+  variable for unknown tab keywords so the stripe always renders.
 
   Returns a `\"var(--rf-causa-<key>)\"` string post rf2-on4cm — the
   active theme class scope on the shell root decides which palette's
-  hex resolves at paint time."
+  hex resolves at paint time, and the `.mode-dynamic` / `.mode-static`
+  root class decides whether `--rf-causa-accent` is orange or cyan."
   [tab]
   (get tokens
-       (get panel-domain->token tab :accent-violet)))
+       (get panel-domain->token tab :accent)))
 
 (defn accent-stripe-style
   "Build an inline-style map that paints the per-panel accent as a

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -379,13 +379,13 @@
   token-type classification. Public for unit tests."
   [tok-type]
   (case tok-type
-    :keyword  :accent-violet
+    :keyword  :accent
     :string   :green
-    :number   :cyan
+    :number   :accent-static          ; fixed cyan syntax hue, distinct from the keyword accent
     :comment  :text-tertiary
     :symbol   :text-primary
     :paren    :text-tertiary
-    :builtin  :accent-violet
+    :builtin  :accent
     :text-primary))
 
 (def clojure-builtins

--- a/tools/causa/test/day8/re_frame2_causa/data_display/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/data_display/render_cljs_test.cljs
@@ -147,20 +147,20 @@
   (is (= :green         (r/op->gutter-tone-key :added)))
   (is (= :red           (r/op->gutter-tone-key :removed)))
   (is (= :yellow        (r/op->gutter-tone-key :modified)))
-  (is (= :accent-violet (r/op->gutter-tone-key :children)))
+  (is (= :accent (r/op->gutter-tone-key :children)))
   (is (= :text-tertiary (r/op->gutter-tone-key :same)))
   (testing "gutter-colour resolves through tokens"
     (is (= (:green   tokens) (r/gutter-colour :added)))
     (is (= (:red     tokens) (r/gutter-colour :removed)))
     (is (= (:yellow  tokens) (r/gutter-colour :modified)))
-    (is (= (:accent-violet tokens) (r/gutter-colour :children)))))
+    (is (= (:accent tokens) (r/gutter-colour :children)))))
 
 ;; ---- scalar rendering --------------------------------------------------
 
 (deftest scalar-keyword-uses-violet
   (let [hiccup (r/render-scalar :cart)]
     (is (= :span (first hiccup)))
-    (is (= (:accent-violet tokens) (:color (node-style hiccup))))
+    (is (= (:accent tokens) (:color (node-style hiccup))))
     (is (= ":cart" (collect-text hiccup)))))
 
 (deftest scalar-string-renders-mono-with-quotes
@@ -326,7 +326,7 @@
 (deftest path-segment-keyword-uses-violet-colour
   (let [hiccup (r/path-segment {:k :user :path [:user]
                                 :panel-id :app-db :render-id "r"})]
-    (is (= (:accent-violet tokens) (:color (node-style hiccup))))))
+    (is (= (:accent tokens) (:color (node-style hiccup))))))
 
 (deftest path-segment-non-keyword-uses-text-primary
   (let [hiccup (r/path-segment {:k 0 :path [:items 0]

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
@@ -44,15 +44,15 @@
            (set (keys esc/status->token))))))
 
 (deftest status-token-map-mirrors-tanstack-anchors
-  (testing "rf2-b76v4 — the per-status token assignments mirror the
-            TanStack devtool's semantic anchors with one peer-pick
-            substitution (paused-by-tool → :cyan rather than purple,
-            because Causa already owns :accent-violet for the causal
-            chain)."
-    (is (= :accent-violet  (esc/status->token :in-flight)))
+  (testing "rf2-b76v4 / rf2-ad7zx — the per-status token assignments
+            mirror the TanStack devtool's semantic anchors. The LIVE
+            head (`:in-flight`) IS the current-epoch accent → the mode
+            `:accent` (orange Dynamic / cyan Static); `:paused-by-tool`
+            takes the fixed cyan `:accent-static` as a distinct peer."
+    (is (= :accent         (esc/status->token :in-flight)))
     (is (= :green          (esc/status->token :settled-success)))
     (is (= :red            (esc/status->token :settled-error)))
-    (is (= :cyan           (esc/status->token :paused-by-tool)))
+    (is (= :accent-static  (esc/status->token :paused-by-tool)))
     (is (= :yellow         (esc/status->token :stale)))))
 
 (deftest every-status-resolves-to-a-non-nil-hex
@@ -183,18 +183,18 @@
     (is (= :red (esc/event-status-token {:outcome :error})))
     (is (= :green (esc/event-status-token {:outcome :ok})))
     (is (= :yellow (esc/event-status-token {:mode :retro})))
-    (is (= :cyan (esc/event-status-token {:paused? true})))
-    (is (= :accent-violet (esc/event-status-token {})))))
+    (is (= :accent-static (esc/event-status-token {:paused? true})))
+    (is (= :accent (esc/event-status-token {})))))
 
 (deftest event-status-colour-fallback
   (testing "unknown status (shouldn't happen via the classifier, but
-            defence-in-depth) falls back to :accent-violet so the
+            defence-in-depth) falls back to the mode :accent so the
             row still renders a visible colour rather than nil."
     ;; Defence-in-depth check: an out-of-band status keyword routed
     ;; through the resolver fn surface still returns a usable hex.
     ;; We test by reaching into the public API with a deliberately-
     ;; malformed state shape — every key unrecognised — and ensure
-    ;; the violet fallback rides.
+    ;; the accent fallback rides.
     (is (string? (esc/event-status-colour {:outcome :unknown :mode :unknown})))))
 
 ;; ---- cascade → state projection ----------------------------------------
@@ -259,19 +259,19 @@
             light hex resolves at paint time); we compare against the
             same var-map (`tokens/tokens`)."
     (let [palette tokens/tokens]
-      (is (= (:accent-violet palette)
+      (is (= (:accent palette)
              (esc/event-status-colour {:in-flight? true}))
-          "in-flight rides violet — the project's causal-chain accent")
+          "in-flight rides the mode accent — the current-epoch accent")
       (is (= (:green palette)
              (esc/event-status-colour {:outcome :ok}))
           "settled-success rides green")
       (is (= (:red palette)
              (esc/event-status-colour {:outcome :error}))
           "settled-error rides red")
-      (is (= (:cyan palette)
+      (is (= (:accent-static palette)
              (esc/event-status-colour {:paused? true}))
-          "paused-by-tool rides cyan (TanStack's purple was already
-           Causa's :accent-violet)")
+          "paused-by-tool rides the fixed cyan accent-static (distinct
+           from the in-flight mode accent)")
       (is (= (:yellow palette)
              (esc/event-status-colour {:mode :retro}))
           "stale rides yellow"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -1163,9 +1163,10 @@
         (is (empty? label-strings)
             "no 'cascade #NNN' label appears anywhere in the rendered lens")))))
 
-(deftest cascade-container-carries-violet-stripe-per-section-17
-  (testing "rf2-zv9r9 — per spec/021 §17.1.3 the Event panel stripe is
-            :accent-violet (#7C5CFF). Rendered as a 3px left border on
+(deftest cascade-container-carries-accent-stripe-per-section-17
+  (testing "rf2-zv9r9 / rf2-ad7zx — per spec/021 §17.1.3 + spec/022 the
+            Event panel header stripe is the mode :accent (orange in
+            Dynamic, cyan in Static). Rendered as a 3px left border on
             the outer cascade container."
     (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/causa
@@ -1181,7 +1182,7 @@
 
 (deftest panel-header-icon-rendered-per-section-17-1-5
   (testing "rf2-zv9r9 — per spec/021 §17.1.5 the Event panel header
-            carries the ⚡ icon in :accent-violet to the left of the
+            carries the ⚡ icon in the mode :accent to the left of the
             lifecycle status dot"
     (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/causa

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -104,9 +104,9 @@
   (testing "each severity gets the shell.cljs token-equivalent colour
             (resolved through `theme/tokens` so the rf2-0fr6v
             `:text-tertiary` contrast bump round-trips automatically)"
-    (is (= (:red    tokens/tokens) (h/severity-colour :error)))
-    (is (= (:yellow tokens/tokens) (h/severity-colour :warning)))
-    (is (= (:cyan   tokens/tokens) (h/severity-colour :advisory)))
+    (is (= (:error    tokens/tokens) (h/severity-colour :error)))
+    (is (= (:warning  tokens/tokens) (h/severity-colour :warning)))
+    (is (= (:advisory tokens/tokens) (h/severity-colour :advisory)))
     (is (= (:text-tertiary tokens/tokens) (h/severity-colour :unknown)))))
 
 (deftest severity-label-stable

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
@@ -51,9 +51,9 @@
     (is (nil? (:stroke-dasharray s))
         "traversed edges are solid, not dashed")))
 
-(deftest edge-style-fired-this-epoch-is-thick-violet
+(deftest edge-style-fired-this-epoch-is-thick-accent
   (let [s (xstyle/edge-style :fired-this-epoch)]
-    (is (= (:accent-violet tokens) (:stroke s)))
+    (is (= (:accent tokens) (:stroke s)))
     (is (= 2 (:stroke-width s)))))
 
 (deftest edge-animated-only-for-fired-this-epoch

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -242,8 +242,8 @@
   ;; specific palette's hex.
   (is (= (:red    tokens/tokens)  (h/op-type-colour :error)))
   (is (= (:yellow tokens/tokens)  (h/op-type-colour :warning)))
-  (is (= (:cyan   tokens/tokens)  (h/op-type-colour :info)))
-  (is (= (:accent-violet tokens/tokens) (h/op-type-colour :rf.event)))
+  (is (= (:accent-static tokens/tokens) (h/op-type-colour :info)))
+  (is (= (:accent tokens/tokens) (h/op-type-colour :rf.event)))
   (is (= (:green  tokens/tokens)  (h/op-type-colour :rf.fx)))
   (is (= (:magenta tokens/tokens) (h/op-type-colour :rf.view/render)))
   ;; Defensive fallback.

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -181,6 +181,24 @@
         (is (some? (find-by-testid tree "rf-causa-detail-panel-event"))
             "L4 detail panel present (default :event tab)")))))
 
+(deftest shell-root-carries-lens-mode-class
+  (testing "rf2-ad7zx / spec/022 — the shell root carries the
+            `mode-dynamic` / `mode-static` class driven by
+            `:rf.causa/mode`. `theme/global-styles/mode-accent-css`
+            re-points `--rf-causa-accent` off this class, so the whole
+            chrome accent flips orange↔cyan with the mode (the brand
+            wordmark stays orange in either mode)."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-mode :dynamic])
+      (let [shell (find-by-testid (shell/shell-view) "rf-causa-shell")]
+        (is (= "mode-dynamic" (:class (second shell)))
+            "Dynamic mode → mode-dynamic root class"))
+      (rf/dispatch-sync [:rf.causa/set-mode :static])
+      (let [shell (find-by-testid (shell/shell-view) "rf-causa-shell")]
+        (is (= "mode-static" (:class (second shell)))
+            "Static mode → mode-static root class")))))
+
 (deftest shell-no-longer-mounts-legacy-sidebar
   (testing "spec/018 §2 'no L0' rewrite — the legacy sidebar is gone.
             None of the historical sidebar-item testids may surface."
@@ -628,10 +646,11 @@
              without consuming layout width")
         (is (re-find #"1px 0 0 0" shadow)
             "1px wide, left edge — a vertical line")
-        (is (re-find #"var\(--rf-causa-accent-violet\)" shadow)
-            "violet accent — Causa's spine colour, resolved through the
-             theme's CSS variable so the light theme picks up the
-             corresponding light-palette hex (rf2-on4cm)")))))
+        (is (re-find #"var\(--rf-causa-accent\)" shadow)
+            "mode accent — Causa's spine colour (orange Dynamic / cyan
+             Static, rf2-ad7zx), resolved through the theme's CSS
+             variable so the light theme + mode flip pick up the
+             corresponding hex (rf2-on4cm)")))))
 
 (deftest event-list-suppresses-ungrouped-cascade-placeholder
   (testing "per rf2-639lc Bug 1 the L2 list filters out the `:ungrouped`

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -382,15 +382,17 @@
 ;; (6) Mode-signal mechanism — stripe colour helper
 ;; -------------------------------------------------------------------------
 
-(deftest stripe-token-dynamic-violet-static-cyan
+(deftest stripe-token-dynamic-orange-static-cyan
   (testing "mode-signal mechanism #2 — 2-px left-edge stripe is
-            :accent-violet in Dynamic, :cyan in Static. No new tokens
-            introduced per the rf2-zhrwo audit constraint."
-    (is (= :accent-violet (static-shell/stripe-token-for-mode :dynamic)))
-    (is (= :cyan          (static-shell/stripe-token-for-mode :static)))
+            :accent-dynamic (orange) in Dynamic, :accent-static (cyan)
+            in Static (rf2-ad7zx / spec/022). The stripe reads the per-
+            MODE token directly (not the runtime :accent alias) because
+            it IS the mode signal."
+    (is (= :accent-dynamic (static-shell/stripe-token-for-mode :dynamic)))
+    (is (= :accent-static  (static-shell/stripe-token-for-mode :static)))
     ;; Unknown / nil values fall back to dynamic
-    (is (= :accent-violet (static-shell/stripe-token-for-mode :nonsense)))
-    (is (= :accent-violet (static-shell/stripe-token-for-mode nil)))))
+    (is (= :accent-dynamic (static-shell/stripe-token-for-mode :nonsense)))
+    (is (= :accent-dynamic (static-shell/stripe-token-for-mode nil)))))
 
 ;; -------------------------------------------------------------------------
 ;; (7) Mode dropdown — compact single-select (rf2-4vp5j reshape)

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -442,6 +442,23 @@
       (is (re-find #"\.rf-causa-theme-dark\s*\{[^}]*--rf-causa-bg-1:\s*#15171B" css))
       (is (re-find #"\.rf-causa-theme-light\s*\{[^}]*--rf-causa-bg-1:\s*#F1F3F6" css)))))
 
+(deftest themes-css-emits-mode-accent-alias
+  (testing "rf2-ad7zx / spec/022 — the themes-css block appends the
+            mode-accent runtime alias: `.mode-dynamic` re-points
+            `--rf-causa-accent` at the orange `--rf-causa-accent-
+            dynamic`; `.mode-static` re-points it at the cyan
+            `--rf-causa-accent-static`. This is the SINGLE-token swap
+            that turns the whole chrome orange in Dynamic / cyan in
+            Static off one variable."
+    (let [css (@#'gs/themes-css {:dark  {:bg-1 "#15171B"}
+                                  :light {:bg-1 "#F1F3F6"}})]
+      (is (re-find #"\.mode-dynamic[^{]*\{[^}]*--rf-causa-accent:\s*var\(--rf-causa-accent-dynamic\)"
+                   css)
+          ".mode-dynamic points --rf-causa-accent at accent-dynamic")
+      (is (re-find #"\.mode-static[^{]*\{[^}]*--rf-causa-accent:\s*var\(--rf-causa-accent-static\)"
+                   css)
+          ".mode-static points --rf-causa-accent at accent-static"))))
+
 (deftest themes-css-uses-rf-causa-prefix
   (testing "every variable name is namespaced under `--rf-causa-` so
             host stylesheets can't accidentally collide with Causa's

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -128,7 +128,9 @@
             the corresponding dark-palette accent (sanity-check: the
             light hexes are not the same string as their dark
             counterparts)."
-    (doseq [k [:accent-violet :cyan :green :yellow :orange :red :magenta]]
+    (doseq [k [:brand :accent-dynamic :accent-static :accent
+               :error :warning :advisory :success
+               :green :yellow :orange :red :magenta]]
       (is (not= (get t/dark-palette k)
                 (get t/light-palette k))
           (str k " differs between the two palettes")))))
@@ -152,23 +154,23 @@
             `tokens` map is `{k (css-var k)}` over every key in
             `dark-palette`."
     (is (= "var(--rf-causa-bg-1)" (t/css-var :bg-1)))
-    (is (= "var(--rf-causa-accent-violet)" (t/css-var :accent-violet)))
+    (is (= "var(--rf-causa-accent)" (t/css-var :accent)))
     (doseq [k (keys t/dark-palette)]
       (is (= (t/css-var k) (get t/tokens k))
           (str k " resolves through css-var")))))
 
 (deftest with-alpha-builds-color-mix-string
   (testing "rf2-on4cm — `with-alpha` is the canonical helper for the
-            alpha-tail-suffix idiom (`(str (:accent-violet tokens)
+            alpha-tail-suffix idiom (`(str (:accent tokens)
             \"55\")`). Returns a `color-mix(in srgb, var(--rf-causa-<key>)
             <pct>%, transparent)` string. CSS-Color-4 is the cross-
             browser path that composes alpha against an arbitrary
             CSS-variable colour."
-    (let [out (t/with-alpha :accent-violet 33)]
+    (let [out (t/with-alpha :accent 33)]
       (is (string? out))
       (is (re-find #"^color-mix\(in srgb" out)
           "starts with color-mix(in srgb")
-      (is (re-find #"var\(--rf-causa-accent-violet\)" out)
+      (is (re-find #"var\(--rf-causa-accent\)" out)
           "references the canonical CSS variable")
       (is (re-find #"33%" out)
           "carries the requested percentage")
@@ -197,11 +199,12 @@
           (str "tab " tab " resolves via token " token-kw)))))
 
 (deftest panel-accent-falls-back-for-unknown-tab
-  (testing "unknown tab → :accent-violet (the brand fallback). The
-            stripe always renders rather than disappearing."
-    (is (= (:accent-violet t/tokens)
+  (testing "unknown tab → :accent (the mode-accent fallback per
+            rf2-ad7zx / spec/022). The stripe always renders rather
+            than disappearing."
+    (is (= (:accent t/tokens)
            (t/panel-accent :unknown-tab-kw)))
-    (is (= (:accent-violet t/tokens)
+    (is (= (:accent t/tokens)
            (t/panel-accent nil)))))
 
 (deftest accent-stripe-style-emits-3px-left-border
@@ -570,10 +573,10 @@
         (is (= 600 (:font-weight s)))))))
 
 (deftest panel-icon-style-falls-back-for-unknown
-  (testing "unknown tab → :accent-violet (same fallback as panel-
-            accent). The icon always paints rather than dropping to a
-            colourless stroke."
-    (is (= (:accent-violet t/tokens)
+  (testing "unknown tab → :accent (same mode-accent fallback as panel-
+            accent, rf2-ad7zx). The icon always paints rather than
+            dropping to a colourless stroke."
+    (is (= (:accent t/tokens)
            (:color (t/panel-icon-style :unknown-tab-kw))))))
 
 (deftest causa-and-machines-viz-mono-and-sans-stacks-match

--- a/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
@@ -90,8 +90,8 @@
     (is (= "var(--rf-causa-bg-1)" (tokens/css-var :bg-1)))
     (is (= "var(--rf-causa-text-tertiary)"
            (tokens/css-var :text-tertiary)))
-    (is (= "var(--rf-causa-accent-violet)"
-           (tokens/css-var :accent-violet)))))
+    (is (= "var(--rf-causa-accent)"
+           (tokens/css-var :accent)))))
 
 (deftest panel-accent-returns-css-variable-string
   (testing "rf2-on4cm — `panel-accent` materialises the panel-domain
@@ -171,7 +171,7 @@
             is replaced by `tokens/with-alpha` which builds a CSS-Color-4
             color-mix(...) string that composites the active theme's
             CSS variable with `transparent`."
-    (doseq [k [:accent-violet :red :green :cyan :yellow]
+    (doseq [k [:accent :red :green :accent-static :yellow]
             pct [10 33 50 75]]
       (let [v (tokens/with-alpha k pct)]
         (is (string? v))

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -422,18 +422,18 @@
                             (walk-hiccup out))]
         (is (some? code-node))))))
 
-(deftest code-block-keyword-token-uses-accent-violet
+(deftest code-block-keyword-token-uses-accent
   (let [out      (w/code-block {:source ":foo"})
         spans    (walk-hiccup out)
-        violet?  (fn [n]
+        accent?  (fn [n]
                    (let [c (some-> n second :style :color)]
-                     (= c (:accent-violet tokens))))
+                     (= c (:accent tokens))))
         kw-span  (some #(when (and (vector? %)
                                    (= :span (first %))
-                                   (violet? %)) %)
+                                   (accent? %)) %)
                        spans)]
     (is (some? kw-span)
-        "keyword tokens render with accent-violet colour")))
+        "keyword tokens render with the mode accent colour")))
 
 (deftest code-block-string-token-uses-green
   (let [out     (w/code-block {:source "\"hi\""})
@@ -501,12 +501,12 @@
 ;; ---- highlight-clojure-token mapping -------------------------------------
 
 (deftest highlight-clojure-token-mapping
-  (is (= :accent-violet (w/highlight-clojure-token :keyword)))
+  (is (= :accent        (w/highlight-clojure-token :keyword)))
   (is (= :green         (w/highlight-clojure-token :string)))
-  (is (= :cyan          (w/highlight-clojure-token :number)))
+  (is (= :accent-static (w/highlight-clojure-token :number)))
   (is (= :text-tertiary (w/highlight-clojure-token :comment)))
   (is (= :text-primary  (w/highlight-clojure-token :symbol)))
-  (is (= :accent-violet (w/highlight-clojure-token :builtin)))
+  (is (= :accent        (w/highlight-clojure-token :builtin)))
   ;; Unknown token-type falls through to text-primary.
   (is (= :text-primary  (w/highlight-clojure-token :unknown))))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -490,7 +490,7 @@
                 [:> Background {:variant (.-Dots BackgroundVariant)
                                 :gap (:dot-grid-spacing-px chart-vc)
                                 :size (:dot-grid-radius-px chart-vc)
-                                :color (tokens/with-alpha :accent-violet 0.4)}])
+                                :color (tokens/with-alpha :accent 0.4)}])
               (when show-controls?
                 [:> Controls {:showZoom true
                               :showFitView true

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -71,8 +71,8 @@
 (defn- edge-stroke
   [{:keys [active? focused?]}]
   (cond
-    focused? (:cyan tokens/tokens)
-    active?  (:cyan tokens/tokens)
+    focused? (:accent-static tokens/tokens)
+    active?  (:accent-static tokens/tokens)
     :else    (:border-default tokens/tokens)))
 
 (defn- edge-stroke-width

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -102,18 +102,18 @@
   [{:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
     sim?            (tokens/with-alpha :yellow         0.18)
-    to-highlight?   (tokens/with-alpha :cyan           0.22)
-    from-highlight? (tokens/with-alpha :accent-violet  0.14)
-    active?         (tokens/with-alpha :cyan           0.18)
+    to-highlight?   (tokens/with-alpha :accent-static           0.22)
+    from-highlight? (tokens/with-alpha :accent  0.14)
+    active?         (tokens/with-alpha :accent-static           0.18)
     :else           (:bg-2 tokens/tokens)))
 
 (defn- node-stroke
   [{:keys [active? from-highlight? to-highlight? sim? final?]}]
   (cond
     sim?            (:yellow tokens/tokens)
-    to-highlight?   (:cyan tokens/tokens)
-    from-highlight? (:accent-violet tokens/tokens)
-    active?         (:cyan tokens/tokens)
+    to-highlight?   (:accent-static tokens/tokens)
+    from-highlight? (:accent tokens/tokens)
+    active?         (:accent-static tokens/tokens)
     final?          (:green tokens/tokens)
     :else           (:border-default tokens/tokens)))
 
@@ -228,7 +228,7 @@
                      :user-select      "none"
                      :box-shadow       (when active-affordance?
                                          (str "0 0 0 2px "
-                                              (tokens/with-alpha :cyan 0.18)))
+                                              (tokens/with-alpha :accent-static 0.18)))
                      :transition       "border-color 120ms ease, background 120ms ease"}}
        ;; Final-state double-ring (outer)
        (when final?
@@ -320,8 +320,8 @@
                      :min-width        (str projection/compound-node-min-width "px")
                      :min-height       (str projection/compound-node-min-height "px")
                      :padding-top      (str compound-pad-y "px")
-                     :background       (tokens/with-alpha :accent-violet 0.06)
-                     :border           (str "1px dashed " (:accent-violet tokens/tokens))
+                     :background       (tokens/with-alpha :accent 0.06)
+                     :border           (str "1px dashed " (:accent tokens/tokens))
                      :border-radius    (str compound-radius "px")
                      :pointer-events   "none"}}
        [:div {:style {:position    "absolute"
@@ -330,7 +330,7 @@
                      :font-family sans-stack
                      :font-size   (str compound-title-px "px")
                      :font-weight 600
-                     :color       (:accent-violet tokens/tokens)}}
+                     :color       (:accent tokens/tokens)}}
         label]])))
 
 ;; ---- initial marker node ------------------------------------------------
@@ -345,7 +345,7 @@
            :style {:width            "12px"
                    :height           "12px"
                    :border-radius    "50%"
-                   :background       (:accent-violet tokens/tokens)}}
+                   :background       (:accent tokens/tokens)}}
      [:> Handle {:type "source" :position pos-right
                  :style {:opacity 0}}]]))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -47,10 +47,10 @@
   "Deterministic colour rotation for parallel-region boundaries
   (rf2-lkwev). Distinct from the tag-pill palette: regions are
   structural zones (not per-state badges), so the rotation leads with
-  `:accent-violet` (the structural-container colour the compound-node
+  `:accent` (the structural-container colour the compound-node
   chrome already uses) and spreads across cool/warm so adjacent
   regions read as distinct orthogonal zones."
-  [:accent-violet :cyan :orange :green :magenta :yellow])
+  [:accent :accent-static :orange :green :magenta :yellow])
 
 (defn region-boundary-color-key
   "Map a region's index to a stable token key from

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/cancellation_cascade.cljs
@@ -62,7 +62,7 @@
   `:destroy` / `:abort` / `:cleanup` / `:exit`."
   [{:keys [kind]}]
   (case kind
-    :exit    ["⏏" :accent-violet]
+    :exit    ["⏏" :accent]
     :destroy ["✖" :red]
     :abort   ["⊘" :orange]
     :cleanup ["⌫" :text-tertiary]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/overlays/spawn_all_join.cljs
@@ -128,7 +128,7 @@
                    :padding        "8px 10px"
                    :pointer-events "auto"
                    :background     (tokens/css-var :bg-2)
-                   :border         (str "1px solid " (tokens/css-var :accent-violet))
+                   :border         (str "1px solid " (tokens/css-var :accent))
                    :border-radius  "8px"
                    :box-shadow     "0 4px 14px rgba(0,0,0,0.35)"
                    :font-family    tokens/sans-stack}}
@@ -136,7 +136,7 @@
      [:div {:style {:display "flex" :align-items "center" :gap "6px"
                     :margin-bottom "4px"
                     :font-size "11px" :font-weight 700
-                    :color (tokens/css-var :accent-violet)}}
+                    :color (tokens/css-var :accent)}}
       [:span {:style {:font-family tokens/mono-stack}} "∷"]
       ":spawn-all"]
      ;; Join condition + resolution

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
@@ -115,7 +115,7 @@
 
     :width   (default 60)
     :height  (default 16)
-    :stroke              — line colour (default `:cyan` token)
+    :stroke              — line colour (default `:accent-static` token)
     :testid              — overrides the root data-testid
     :max-sample          — pin the y-axis ceiling
     :label               — a11y. Overrides the default `aria-label`.
@@ -128,7 +128,7 @@
   ([samples {:keys [width height stroke testid max-sample label]
              :or   {width  60
                     height 16
-                    stroke (:cyan tokens/tokens)
+                    stroke (:accent-static tokens/tokens)
                     testid "rf-mv-chart-sparkline"}}]
    (let [n        (count samples)
          max-v    (or max-sample

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -231,7 +231,7 @@
                       ;; component reads the `:selfLoop` flag.
                       self-loop?   (= (:source e) (:target e))
                       marker-color (if (or focused? from-active?)
-                                     (:cyan tokens/tokens)
+                                     (:accent-static tokens/tokens)
                                      (:border-default tokens/tokens))
                       ;; A `:*` wildcard `:on` arm is a real transition
                       ;; but NOT a fireable event (Spec 005 §Wildcard —

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -83,8 +83,24 @@
    ;; locks this value to Causa's at the .cljc test surface.
    :text-tertiary  "#8990A0"
 
-   :accent-violet  "#7C5CFF"
-   :cyan           "#43C3D0"
+   ;; brand + mode accents (orange identity — rf2-ad7zx / spec/022).
+   ;; Mirrors Causa's `theme/tokens` at the values level; `accent`
+   ;; defaults to the Dynamic (orange) accent — the host re-points it
+   ;; per the `.mode-dynamic`/`.mode-static` root class.
+   :brand          "#F97316"
+   :accent-dynamic "#F97316"
+   :accent-static  "#43C3D0"
+   :accent         "#F97316"
+
+   ;; semantic + change (spec/022 §Semantic & change)
+   :error          "#F85149"
+   :warning        "#FBBF24"
+   :advisory       "#79A6D2"
+   :success        "#3FB950"
+   :dim            "#6E7681"
+   :hover          "#232730"
+
+   ;; functional categorical hues (spec/022 carve-out)
    :green          "#4ADE80"
    :yellow         "#FBBF24"
    :orange         "#FB923C"
@@ -120,8 +136,21 @@
    :text-secondary "#4B5160"
    :text-tertiary  "#8B92A1"
 
-   :accent-violet  "#5538D8"
-   :cyan           "#2A8B96"
+   ;; brand + mode accents (orange identity — rf2-ad7zx / spec/022)
+   :brand          "#EA580C"
+   :accent-dynamic "#EA580C"
+   :accent-static  "#2A8B96"
+   :accent         "#EA580C"
+
+   ;; semantic + change
+   :error          "#CF222E"
+   :warning        "#B07A05"
+   :advisory       "#3B6EA5"
+   :success        "#1A7F37"
+   :dim            "#8C959F"
+   :hover          "#E6E9EE"
+
+   ;; functional categorical hues
    :green          "#2F9E5C"
    :yellow         "#B07A05"
    :orange         "#C2570F"
@@ -266,12 +295,12 @@
 
 (def tag-pill-palette
   "Deterministic colour rotation for state-tag pills (rf2-m1b88).
-  Skips `:red` and `:accent-violet` — both are reserved for chart
-  semantics (`:red` for cancellation glyphs, `:accent-violet` for the
-  initial-state marker + FROM-highlight). The remaining five spread
-  across cool/warm/neutral so a typical 2-4 tag count reads
-  distinctly."
-  [:cyan :green :yellow :orange :magenta])
+  Skips `:red`, `:accent` and `:accent-static` — all reserved for
+  chart semantics (`:red` for cancellation glyphs, the mode `:accent`
+  for the initial-state marker + FROM-highlight, `:accent-static` for
+  the TO-highlight / active state). The remaining five spread across
+  cool/warm/neutral so a typical 2-4 tag count reads distinctly."
+  [:advisory :green :yellow :orange :magenta])
 
 (defn- char-code
   "Portable char → int. JVM uses `int`; CLJS reaches for

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -10,23 +10,23 @@
 ;; ---- with-alpha (rf2-pyvmr) --------------------------------------------
 
 (deftest with-alpha-builds-rgba-string-from-hex-token
-  (testing "with-alpha resolves :cyan (#43C3D0) to rgba(67, 195, 208, alpha)"
-    (let [s (tokens/with-alpha :cyan 0.5)]
+  (testing "with-alpha resolves :accent-static (#43C3D0) to rgba(67, 195, 208, alpha)"
+    (let [s (tokens/with-alpha :accent-static 0.5)]
       (is (= "rgba(67, 195, 208, 0.5)" s)))))
 
 (deftest with-alpha-resolves-zero-alpha
   (testing "with-alpha accepts alpha=0 — used by callers that compute
             opacity dynamically"
     (is (re-find #"^rgba\(\d+, \d+, \d+, 0\)$"
-                 (tokens/with-alpha :accent-violet 0)))))
+                 (tokens/with-alpha :accent 0)))))
 
 (deftest with-alpha-roundtrips-palette-shift
   (testing "with-alpha resolves through a custom palette so callers
             (theming hosts) can swap the palette without forking the
             chart"
-    (let [custom {:cyan "#000000"}]
+    (let [custom {:accent-static "#000000"}]
       (is (= "rgba(0, 0, 0, 0.25)"
-             (tokens/with-alpha :cyan 0.25 custom))))))
+             (tokens/with-alpha :accent-static 0.25 custom))))))
 
 ;; ---- tag-pill-color (rf2-m1b88) ----------------------------------------
 
@@ -38,11 +38,11 @@
     (is (= (tokens/tag-pill-color :auth/ok) (tokens/tag-pill-color :auth/ok)))))
 
 (deftest tag-pill-color-skips-reserved-tokens
-  (testing "tag-pill-color never returns :red or :accent-violet —
-            both are reserved for chart semantics"
-    ;; Walk every palette entry; assert none is :red / :accent-violet.
+  (testing "tag-pill-color never returns :red, :accent or :accent-static
+            — all reserved for chart semantics (rf2-ad7zx)"
+    ;; Walk every palette entry; assert none is reserved.
     (is (every? (fn [t]
-                  (not (#{:red :accent-violet} (tokens/tag-pill-color t))))
+                  (not (#{:red :accent :accent-static} (tokens/tag-pill-color t))))
                 [:risky :paid :auth/ok :final :loading :error
                  :rec :checkout :session/active :flow/start]))))
 
@@ -77,8 +77,8 @@
             arg; this test pins the LIGHT-palette path so chart code
             can resolve tints against the light theme without forking
             the helper."
-    (let [s (tokens/with-alpha :cyan 0.5 tokens/light-palette)]
-      ;; Light :cyan is #2A8B96 → rgba(42, 139, 150, 0.5)
+    (let [s (tokens/with-alpha :accent-static 0.5 tokens/light-palette)]
+      ;; Light :accent-static is #2A8B96 → rgba(42, 139, 150, 0.5)
       (is (= "rgba(42, 139, 150, 0.5)" s)))))
 
 ;; ---- css-var (rf2-uv1on) -----------------------------------------------
@@ -95,14 +95,14 @@
 (deftest css-var-name-matches-causa-convention
   (testing "the variable name mirrors Causa's `var(--rf-causa-<key>)`
             so the chart + host paint from ONE :root palette"
-    (is (str/starts-with? (tokens/css-var :cyan)
-                          "var(--rf-causa-cyan"))))
+    (is (str/starts-with? (tokens/css-var :accent-static)
+                          "var(--rf-causa-accent-static"))))
 
 (deftest css-var-falls-back-to-supplied-palette-hex
   (testing "css-var resolves the fallback hex from the supplied palette
             arg (light theme), not just the dark default"
-    (is (= "var(--rf-causa-cyan, #2A8B96)"
-           (tokens/css-var :cyan tokens/light-palette)))))
+    (is (= "var(--rf-causa-accent-static, #2A8B96)"
+           (tokens/css-var :accent-static tokens/light-palette)))))
 
 (deftest css-var-no-fallback-for-unknown-key
   (testing "an unknown token has no hex → bare var() (host MUST define


### PR DESCRIPTION
Migrates Causa's colour call-sites from the retired `:accent-violet`/`:cyan` identity to the orange identity tokens locked in `tools/causa/spec/022-Design-Tokens.md` (epic rf2-ad7zx — the foundational visual layer of the orange redesign).

## Token scheme (single-token, so Static stays trivially swappable)

- `brand` — always orange (`#F97316` / `#EA580C`), logo/wordmark
- `accent-dynamic` — orange Dynamic-mode accent
- `accent-static` — cyan Static-mode accent (`#43C3D0` / `#2A8B96`)
- `accent` — runtime alias; the `.mode-dynamic` / `.mode-static` root class re-points `--rf-causa-accent` at the active mode's accent (active tab, mode stripe, selected states, focus ring, changed/recompute, L4 header stripe)
- `error` / `warning` / `advisory` / `success` / `dim` / `hover` — semantic tokens per 022

Generic chrome accents (violet was the Dynamic accent everywhere; cyan the Static peer) now route through the mode `accent`. The per-panel domain-colour stripe map collapses to the mode accent per spec/007 §L4 panel accent stripe. The lens mode (`:rf.causa/mode`) drives the `mode-dynamic` / `mode-static` class on the shell root; `theme/global-styles` emits the mode-accent alias block that flips orange↔cyan off one variable.

## Functional accents kept distinct (022 carve-out + spec/007)

Issues severity (`error`/`warning`/`advisory`), event `:paused-by-tool`, fx `:in-flight`, FROM/TO machine highlights, op-family bands, EDN/code number syntax, perf tiers, redaction, pair-origin — routed to `accent-static` or a dedicated semantic token rather than collapsed into the brand accent.

## Cross-tool

`machines-viz` palette mirrored to the same key-set (rf2-z7ms8 drift gate) and its chart semantics migrated (FROM/initial → accent, TO/active → accent-static). `config` default-accent + host snippet now publish orange.

## Mode-swap verification

New unit tests assert the shell root carries `mode-dynamic` / `mode-static` driven by `:rf.causa/mode`, and that `themes-css` emits the `.mode-dynamic`/`.mode-static` → `--rf-causa-accent` alias. Verified the orange(Dynamic)/cyan(Static) swap works via the root-class alias.

## Gates

- `npm run test:cljs` — PASS (4195 tests, 0 failures)
- `clojure -M:test` (tools/causa) — PASS (846 tests, 0 failures)
- `clojure -M:test` (tools/machines-viz) — PASS (196 tests, 0 failures)
- `npm run test:causa-feature-gate` — PASS (13 scenarios, 0 failures)
- `npm run test:bundle-isolation` — PASS
- clj-kondo — 0 errors

71 files changed.