### PR TITLE
feat(examples): single-frame step-deck testbed reusing testdeck modules (rf2-6qgbs.2)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -216,7 +216,15 @@
             ;; main.js falls through to out/examples/two-frame-isolation
             ;; per the same cascade as :testbeds/panel-gallery above.
             8030 ["../tools/causa/testbeds/two_frame_isolation"
-                  "out/examples/two-frame-isolation"]}
+                  "out/examples/two-frame-isolation"]
+            ;; Single-frame step-deck testbed (rf2-6qgbs.2). The
+            ;; single-frame counterpart to two-frame-isolation; mounts
+            ;; the SAME shared testdeck modules once. Source dir first so
+            ;; the hand-written index.html resolves at `/`; the compiled
+            ;; main.js falls through to out/examples/step-deck per the
+            ;; same cascade as the entries above.
+            8031 ["../tools/causa/testbeds/step_deck"
+                  "out/examples/step-deck"]}
 
  :builds
  {:node-test
@@ -582,6 +590,25 @@
    :output-dir "out/examples/two-frame-isolation"
    :asset-path "."
    :modules    {:main {:init-fn two-frame-isolation.core/run}}
+   :devtools   {:preloads [re-frame2-pair.runtime
+                           day8.re-frame2-causa.preload]}}
+
+  ;; Single-frame step-deck testbed (rf2-6qgbs.2) — the single-frame
+  ;; counterpart to :examples/two-frame-isolation above. Mounts the SAME
+  ;; shared testdeck modules (tools/causa/testbeds/testdeck/) ONCE, in
+  ;; one URL-bound frame, wrapped in an action→check card framing. A TEST
+  ;; surface — no deliberate bugs, no teaching layers, no anti-pattern
+  ;; demos (feedback_testbeds_are_test_surfaces).
+  ;;
+  ;; Sources live under tools/causa/testbeds/step_deck/; the Causa
+  ;; preload auto-mounts inline so every lens reads the single
+  ;; :step-deck frame. Served at http://localhost:8031 via the top-level
+  ;; `:dev-http` map.
+  :examples/step-deck
+  {:target     :browser
+   :output-dir "out/examples/step-deck"
+   :asset-path "."
+   :modules    {:main {:init-fn step-deck.core/run}}
    :devtools   {:preloads [re-frame2-pair.runtime
                            day8.re-frame2-causa.preload]}}
 

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -264,12 +264,15 @@ coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage
 reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/causa/testbeds/` —
-`two_frame_isolation`, `feature_matrix`, `panel_gallery`,
+`two_frame_isolation`, `step_deck`, `feature_matrix`, `panel_gallery`,
 `perf_counter` — covering the canonical multi-frame isolation surface
 (`two_frame_isolation`: one app · two frames · Counter / Machine
 (websocket) / Routing / Async&errors tabs navigated as routes ·
 per-frame trace / events / issues / cascades · Causa target-frame
 round-trip; built from the shared `testdeck/` modules), the
+single-frame step-deck (`step_deck`: the same shared `testdeck/`
+modules mounted once, in one URL-bound frame, as action→check cards —
+the step-by-step counterpart to `two_frame_isolation`), the
 deterministic feature-matrix sweep across panels + shell + launch
 modes + redaction + 20-event load, the Panel-view gallery, and the
 performance probe.

--- a/tools/causa/testbeds/step_deck/README.md
+++ b/tools/causa/testbeds/step_deck/README.md
@@ -1,0 +1,153 @@
+# `tools/causa/testbeds/step_deck/`
+
+Single-frame **step-deck** testbed (rf2-6qgbs.2) — a clean,
+step-by-step surface for exercising re-frame2 features one frame at a
+time, paired with a **Causa** instance on the right. The single-frame
+counterpart to the two-frame isolation testbed (rf2-6qgbs.1): both
+mount the **same** shared `testdeck/` modules; this one mounts the
+panel **once**.
+
+## The shape
+
+```
+┌──────────────────────────────────┬──────────────────┐
+│  Step-deck (one frame)           │                  │
+│  ┌────────────────────────────┐  │   Causa          │
+│  │ [Counter][Machine][Routing]│  │   (inline)       │
+│  │ [Async & errors]           │  │                  │
+│  ├────────────────────────────┤  │   one frame —    │
+│  │ ACTION   (the controls)    │  │   no frame       │
+│  │   ↓                        │  │   picker needed; │
+│  │ CHECK    (live observable) │  │   every lens     │
+│  └────────────────────────────┘  │   reads :step-deck│
+└──────────────────────────────────┴──────────────────┘
+```
+
+One `frame-provider`, one frame id (`:step-deck`). The exercise is
+straightforward: pick a tab, **act** on its controls, read the
+**check** strip below, and corroborate it against the matching Causa
+lens on the right. No diverging second frame to track.
+
+## Action → check cards
+
+The step-deck wraps the shared panel in an **ACTION → CHECK** framing:
+
+- **ACTION** — the panel's own controls (the buttons / inputs the
+  `testdeck.*` modules already register). Do this.
+- **CHECK** — a one-line live readout of the active tab's canonical
+  observable, read from the **same** testdeck subs the panel reads,
+  annotated with the Causa lens that corroborates it. Observe this.
+
+The CHECK strip is **not** a second copy of the tab logic — it
+subscribes to the same per-frame subs (`:counter/value`, `:ws/state`,
+`:testdeck/active-tab`, `:testdeck.async/status`, …) and states, in
+one line, what changed and where to look in Causa.
+
+## Shared testdeck modules — reused, not rebuilt
+
+The app code path is the **shared testdeck** (`testdeck.*`, under
+`tools/causa/testbeds/testdeck/`). This testbed reuses them verbatim
+and supplies only the single-frame harness + the action→check framing:
+
+| Namespace          | Owns                                                                       |
+|--------------------|----------------------------------------------------------------------------|
+| `testdeck.routes`  | Route table + tab inventory. Tabs ARE routes; nav is `:rf.route/navigate`. |
+| `testdeck.counter` | Counter: L2 sub create/destroy, changeable-arg `show-greater-than-N` view, `now` cofx, clean handler-exception path. |
+| `testdeck.machine` | Interactive websocket connection state machine (connect / disconnect / send) with nested states + guards + actions. |
+| `testdeck.async`   | Async fx (~600ms slow request) + error surfacing.                          |
+| `testdeck.panel`   | The reusable tabbed app shell + per-frame `:on-create` boot event.         |
+
+This testbed (`step-deck.core`) supplies only the single-frame harness:
+it mounts `testdeck.panel/panel` **once**, in one URL-bound
+frame-provider, inside an action→check card, plus the Causa host.
+
+## Single, URL-bound frame
+
+The step-deck registers exactly **one** frame and lets it own the
+browser URL (the default — `:url-bound? true`). Because there is one
+routed frame, tab navigation (`:rf.route/navigate`, fired by the
+panel's tab bar) syncs the address bar and the back button with no
+two-frame URL race. Contrast the two-frame testbed, which registers
+both frames **non-url-bound** per `spec/012-Routing.md` §Multi-frame
+routing. Open `/machine` directly and the frame lands on the Machine
+tab.
+
+## Test surface, not tutorial
+
+No deliberate bugs, no teaching layers, no anti-pattern demos
+(`feedback_testbeds_are_test_surfaces`). The slow async fetch
+(`testdeck.async`, ~600ms) and the clean handler-exception path
+(`testdeck.counter`, `:counter/throw`) are FEATURES being exercised —
+they light up Causa's Issues lens legitimately. Regression coverage
+lives in the substrate contract tests + the Causa feature-matrix gate;
+this testbed is test-free (rf2-8cevm).
+
+## What to try in Causa
+
+Open the page; Causa auto-mounts inline on the right. Every lens reads
+the single `:step-deck` frame — no frame picker needed.
+
+1. **Counter, step by step.** On the Counter tab, click `+` three
+   times. The CHECK strip shows `:counter/value` move and
+   `:counter/greater-than? 5` flip once it exceeds 5; Causa's App-db
+   and Views lenses corroborate.
+
+2. **L2 sub create/destroy.** Toggle "show parity" off then on.
+   Causa's Views lens shows the `:counter/parity` L2 node disappear and
+   reappear; the CHECK strip's `:counter/show-parity?` flips.
+
+3. **Machine you drive.** On the Machine tab, click Connect.
+   `:ws/connection` walks `:connecting → :authenticating → :connected`
+   in the Machines lens; the CHECK strip's `:ws/state` follows. Send a
+   message, then Disconnect.
+
+4. **Tabs are routes.** Switch tabs and watch the address bar change
+   (this frame owns the URL). The CHECK strip and Causa's Routing lens
+   both report `:testdeck/active-tab`.
+
+5. **Issues, legitimately.** Click Fetch on the Async & errors tab
+   (~600ms slow effect → one Issue). Or click "throw" on the Counter
+   tab → a clean `:rf.error/handler-exception` Issue.
+
+## Files
+
+- `core.cljs` — the single-frame harness + mount + action→check
+  framing. Mounts the shared `testdeck.panel` once in a URL-bound
+  frame-provider.
+- `index.html` — minimal static host with the standard
+  `[data-rf-causa-host]` aside so the Causa preload auto-mounts inline.
+
+## Running
+
+From `implementation/`:
+
+```bash
+npx shadow-cljs watch :examples/step-deck
+```
+
+Served at http://localhost:8031 via the top-level `:dev-http` map.
+
+## Build target
+
+`:examples/step-deck` (defined in
+[`implementation/shadow-cljs.edn`](../../../../implementation/shadow-cljs.edn)).
+The Causa preload (`day8.re-frame2-causa.preload`) is wired in
+`:devtools/:preloads` — every dev build auto-mounts Causa inline on
+load.
+
+## Cross-references
+
+- [`spec/006-ReactiveSubstrate.md`](../../../../spec/006-ReactiveSubstrate.md)
+  §The cache is held inside the frame container — the per-frame sub
+  cache this single frame holds.
+- [`spec/002-Frames.md`](../../../../spec/002-Frames.md) — frame
+  lifecycle, `reg-frame`, `:on-create`, frame-provider context.
+- [`spec/005-StateMachines.md`](../../../../spec/005-StateMachines.md)
+  — the machine substrate the `:ws/connection` machine exercises.
+- [`spec/012-Routing.md`](../../../../spec/012-Routing.md) §Multi-frame
+  routing — the `:url-bound?` ownership rule (this testbed is the
+  single-url-owner case).
+- [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md)
+  — the slow-effect Issue surface the async fx exercises.
+- [`two_frame_isolation/`](../two_frame_isolation/) — the two-frame
+  sibling that mounts the same `testdeck.*` modules in two frames.

--- a/tools/causa/testbeds/step_deck/core.cljs
+++ b/tools/causa/testbeds/step_deck/core.cljs
@@ -1,0 +1,256 @@
+(ns step-deck.core
+  "Single-frame STEP-DECK testbed (rf2-6qgbs.2) — a clean, step-by-step
+  surface for exercising re-frame2 features one frame at a time, paired
+  with a Causa instance on the right.
+
+  ## Shape
+
+  ONE page, two columns of attention:
+
+    ┌──────────────────────────┬──────────────┐
+    │  STEP-DECK (one frame)   │              │
+    │  ┌────────────────────┐  │   Causa      │
+    │  │ tabs: Counter …    │  │   (inline)   │
+    │  ├────────────────────┤  │              │
+    │  │ ACTION  → CHECK     │  │   one frame  │
+    │  │ (do this) (observe) │  │   — no       │
+    │  └────────────────────┘  │   frame      │
+    └──────────────────────────┴──────────────┘   picker
+                                                   needed
+
+  Where the two-frame isolation testbed (`two-frame-isolation.core`,
+  rf2-6qgbs.1) mounts the shared `testdeck.panel` TWICE to prove
+  per-frame isolation, the step-deck mounts it ONCE — the single-frame
+  counterpart. It is the surface you reach for when you want to drive a
+  feature step-by-step and watch the result without the cognitive load
+  of two diverging frames.
+
+  ## Action → check cards
+
+  The step-deck wraps the shared panel in an ACTION → CHECK framing.
+  Each feature tab is presented as a step:
+
+    - ACTION  — the panel's own controls (the buttons / inputs the
+      testdeck modules already register). DO this.
+    - CHECK   — a live readout of the canonical observable for that
+      tab, derived from the SAME testdeck subs. OBSERVE this, and
+      cross-check it against the matching Causa lens on the right.
+
+  The CHECK strip is not a second copy of the tab logic — it reads the
+  same per-frame subs the panel reads (`:counter/value`, `:ws/state`,
+  `:testdeck/active-tab`, `:testdeck.async/status`) and states, in one
+  line, what just changed and where to corroborate it in Causa. The
+  ACTION surface IS the imported `testdeck.panel/panel`; nothing about
+  the tab set, the controls, or the routing is reimplemented here.
+
+  ## Single, URL-bound frame
+
+  The step-deck registers ONE frame and lets it own the browser URL
+  (the default — `:url-bound? true`). Because there is exactly one
+  routed frame, tab navigation (`:rf.route/navigate`, fired by the
+  panel's tab bar) syncs the address bar and the back button with no
+  two-frame URL race (contrast the two-frame testbed, which registers
+  both frames non-url-bound per Spec 012 §Multi-frame routing). Open
+  `/machine` directly and the frame lands on the Machine tab.
+
+  ## Shared testdeck modules — reused verbatim
+
+  The app code path is the shared testdeck (`testdeck.*`, under
+  `tools/causa/testbeds/testdeck/`). Loading those namespaces installs
+  their late-bind hooks and registers every handler / sub / route /
+  view ONCE globally; the step-deck supplies only the single-frame
+  harness + the action→check framing:
+
+    - `testdeck.routes`  — route table + tab inventory (tabs ARE routes)
+    - `testdeck.counter` — L2 sub create/destroy, changeable-arg
+                           show-greater-than-N view, `now` cofx, clean
+                           handler-exception path
+    - `testdeck.machine` — interactive websocket connection machine
+    - `testdeck.async`   — async fx (~600ms slow request) + error surface
+    - `testdeck.panel`   — the reusable tabbed app shell + per-frame
+                           `:on-create` boot
+
+  ## Test surface, not tutorial
+
+  No deliberate bugs, no teaching layers, no anti-pattern demos
+  (feedback_testbeds_are_test_surfaces). The slow async fetch and the
+  clean handler-exception path on the Counter tab are FEATURES being
+  exercised — they light up Causa's Issues lens legitimately. This
+  testbed is test-free (rf2-8cevm); regression coverage lives in the
+  substrate contract tests + the Causa feature-matrix gate."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            ;; Loading these namespaces installs their late-bind hooks
+            ;; and registers every testdeck handler / sub / route / view
+            ;; ONCE globally. The panel is the shared app code path the
+            ;; step-deck mounts (the same one the two-frame testbed does).
+            [re-frame.routing]
+            [testdeck.routes]
+            [testdeck.counter]
+            [testdeck.machine]
+            [testdeck.async]
+            [testdeck.panel :as panel]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; rf2-6jyf6 — Causa's `configure!` to seed `:project-root`
+            ;; so the Event lens 'open' chip resolves a classpath-relative
+            ;; `:file` slot to an absolute on-disk URI.
+            [day8.re-frame2-causa.config :as causa-config])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; FRAME ID — exactly one, URL-bound
+;; ============================================================================
+
+(def frame-id :step-deck)
+
+;; The label the testdeck panel threads through every `:data-testid` and
+;; through the per-tab CHECK readout below. One frame, one label.
+(def ^:private frame-label "step")
+
+;; ============================================================================
+;; CHECK STRIP — the canonical observable per tab (live, per-frame subs)
+;; ============================================================================
+;;
+;; Each step pairs an ACTION (the panel's controls) with a CHECK: a
+;; one-line live readout of the tab's canonical observable, read from
+;; the SAME testdeck subs the panel reads. The CHECK never recomputes
+;; or duplicates tab logic — it states what to observe and where to
+;; corroborate it in Causa.
+
+(def ^:private mono
+  {:font-family "ui-monospace, SFMono-Regular, Menlo, monospace"})
+
+(defn- check-line
+  "One CHECK row: an observable name, its live value, and the Causa lens
+  that corroborates it. Pure presentation over already-subscribed data."
+  [observable value lens]
+  [:div {:style {:display "flex" :gap "8px" :align-items "baseline"
+                 :margin "2px 0"}}
+   [:span {:style {:font-size "11px" :color "#777" :min-width "11em"}}
+    observable]
+   [:span {:style (merge mono {:font-weight "bold" :color "#333"
+                               :min-width "5em"})}
+    (str value)]
+   [:span {:style {:font-size "11px" :color "#aaa"}}
+    "↔ Causa " lens]])
+
+(reg-view check-strip
+  "The CHECK half of the active step. Switches on the per-frame active
+  tab and renders the canonical live observable(s) for that tab, drawn
+  from the testdeck subs the panel itself reads. Reuse, not duplication:
+  these are the same subscriptions, surfaced as a 'what to observe' card."
+  []
+  (let [active @(subscribe [:testdeck/active-tab])]
+    [:div {:data-testid (str frame-label "-check-strip")
+           :style {:border-top "1px dashed #ddd" :margin-top "0.75em"
+                   :padding-top "0.5em"}}
+     [:div {:style {:font-size "11px" :font-weight "bold" :color "#7C5CFF"
+                    :text-transform "uppercase" :letter-spacing "0.04em"
+                    :margin-bottom "0.25em"}}
+      "Check"]
+     (case active
+       :testdeck/counter
+       [:div
+        (check-line ":counter/value" @(subscribe [:counter/value]) "App-db")
+        (check-line ":counter/greater-than? 5"
+                    @(subscribe [:counter/greater-than? 5]) "Views")
+        (check-line ":counter/show-parity?"
+                    @(subscribe [:counter/show-parity?]) "Views (L2 create/destroy)")]
+
+       :testdeck/machine
+       [:div
+        (check-line ":ws/state" @(subscribe [:ws/state]) "Machines")
+        (check-line ":ws/connected?" @(subscribe [:ws/connected?]) "Machines")
+        (check-line ":ws/connections" @(subscribe [:ws/connections]) "App-db")]
+
+       :testdeck/routing
+       [:div
+        (check-line ":testdeck/active-tab" active "Routing")]
+
+       :testdeck/async
+       [:div
+        (check-line ":testdeck.async/status"
+                    @(subscribe [:testdeck.async/status]) "Issues (slow fx)")
+        (check-line ":testdeck.async/count"
+                    @(subscribe [:testdeck.async/count]) "App-db")]
+
+       [:div (check-line ":testdeck/active-tab" active "Routing")])]))
+
+;; ============================================================================
+;; ROOT VIEW — one step-card wrapping the shared panel
+;; ============================================================================
+
+(reg-view step-card
+  "ACTION → CHECK card. The ACTION surface is the imported
+  `testdeck.panel/panel` (the tab set + every control, registered once
+  by the testdeck modules). The CHECK strip below reports the active
+  tab's canonical observable. Nothing about the tabs is reimplemented."
+  []
+  [:section {:data-testid (str frame-label "-step-card")
+             :style {:border        "1px solid #d8d2ff"
+                     :border-radius "8px"
+                     :padding       "0.75em 1em"
+                     :background    "#fcfbff"
+                     :margin        "0.5em 0"}}
+   [:div {:style {:font-size "11px" :font-weight "bold" :color "#7C5CFF"
+                  :text-transform "uppercase" :letter-spacing "0.04em"
+                  :margin-bottom "0.25em"}}
+    "Action"]
+   ;; ACTION — the shared panel, mounted ONCE in this frame.
+   [panel/panel frame-label]
+   ;; CHECK — the canonical live observable for the active tab.
+   [check-strip]])
+
+(reg-view root []
+  [:div {:data-testid "step-deck-root"
+         :style {:font-family "system-ui, sans-serif"
+                 :padding     "1em"
+                 :max-width   "640px"}}
+   [:header {:style {:margin-bottom "1em"}}
+    [:h2 {:style {:margin 0}} "Step-deck"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "One frame, step by step. Each tab is a feature to drive: "
+     [:strong "act"] " on the controls, then read the "
+     [:strong "check"] " strip below and corroborate it against the "
+     "matching Causa lens on the right. Tabs are routes — switching a "
+     "tab updates the address bar (this frame owns the URL)."]]
+   [:div {:style {:display "flex" :flex-direction "column"}}
+    [rf/frame-provider {:frame frame-id}
+     [step-card]]]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent /
+  blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Causa-API surface)."
+  [param-name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search (js/URLSearchParams.))
+          v      (.get params param-name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
+(defn ^:export run []
+  ;; Configure Causa BEFORE `rf/init!` so the preload's auto-open reads
+  ;; the right project-root on its first paint of any chip.
+  (causa-config/configure! {:rf.causa/project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the single frame URL-bound (the default). With exactly one
+  ;; routed frame there is no URL race — tab nav (the panel's
+  ;; `:rf.route/navigate`) syncs the address bar and back button. The
+  ;; `:on-create` boot (`:testdeck/initialise`, registered once globally
+  ;; in `testdeck.panel`) seeds the frame's app-db for all four tabs and
+  ;; lands it on the default tab.
+  (rf/reg-frame frame-id {:on-create [:testdeck/initialise]})
+  (rdc/render react-root [root]))

--- a/tools/causa/testbeds/step_deck/index.html
+++ b/tools/causa/testbeds/step_deck/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: step-deck (Causa demo)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Causa (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
+    :root { --rf-causa-accent: #7C5CFF; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-causa-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
@
## Summary

Single-frame **step-deck** testbed (rf2-6qgbs.2) — the single-frame counterpart to the two-frame isolation testbed (rf2-6qgbs.1, #2030). Mounts the **shared** `testdeck.*` modules (`routes` / `counter` / `machine` / `async` / `panel`) **once**, in one URL-bound frame, wrapped in an **ACTION → CHECK** card framing, paired with a Causa instance on the right.

The CHECK strip is reuse, not duplication: it reads the same per-frame subs the panel reads (`:counter/value`, `:ws/state`, `:testdeck/active-tab`, `:testdeck.async/status`, …) and annotates each with the Causa lens that corroborates it. The tab set, controls, and routing are the imported `testdeck.panel/panel` — nothing is reimplemented.

## What landed

- `tools/causa/testbeds/step_deck/{core.cljs,index.html,README.md}` — single-frame harness + mount + action→check framing.
- `implementation/shadow-cljs.edn` — `:examples/step-deck` build target (Causa preload wired) + `:dev-http` port 8031.
- `tools/causa/README.md` — catalog ref updated to list `step_deck`.

## Design notes

- **One URL-bound frame.** Exactly one routed frame, so tab nav (`:rf.route/navigate`) syncs the address bar with no two-frame URL race (contrast two-frame, which registers both frames non-url-bound per Spec 012 §Multi-frame routing).
- **Test surface, not tutorial.** No deliberate bugs, no teaching layers, no anti-pattern demos. The slow async fetch and the clean handler-exception path are FEATURES being exercised. Test-free per rf2-8cevm.

## Gates

- `npm run test:cljs` — 4196 tests, 12820 assertions, 0 failures, 0 errors.
- `shadow-cljs compile :examples/step-deck` — build completed clean (only the pre-existing machines-viz infer-warning, unrelated).
- clj-kondo — 0 errors, 0 warnings on the new file.
- `test:examples` — not applicable (covers `examples/`; this testbed is test-free under `tools/causa/testbeds/`).

Reused testdeck modules: `testdeck.routes`, `testdeck.counter`, `testdeck.machine`, `testdeck.async`, `testdeck.panel`.
@