### PR TITLE
feat(causa): reconcile Routes panel to Figma 3-section stack (rf2-ad7zx.7)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -1,80 +1,75 @@
 (ns day8.re-frame2-causa.panels.routing
-  "Routing tab — topology-plus-overlay shape (rf2-3kjlo).
+  "Routing tab — three stacked sections (rf2-ad7zx.7, reconciled to the
+  Figma design `tools/causa/design-reference/components/RoutesPanel.tsx`
+  + spec/021 §7.2).
 
-  ## Two verbs, two homes (Mike's decision, 2026-05-19)
+  ## Three stacked sections (post-rf2-ad7zx.7 reshape)
 
-  Routes appears in BOTH Dynamic AND Static surfaces with different
-  verbs:
+  The prior 'Active route tree first + This-epoch KV' shape is
+  superseded. The panel now reads top → bottom as three stacked
+  sections, each separated from the next by a 1px hairline:
 
-    - **Static Routes** — browse-all + Simulate-URL + per-row inline
-      expand + hermetic Simulate-navigation preview. Lives at
-      `static/routes/panel.cljs`.
-    - **Dynamic Routing** — topology-plus-overlay (this ns) per
-      spec/021 §7. The full route tree is ALWAYS visible; the focused
-      epoch's nav activity overlays as a `:to` / `:from` / `:here`
-      marker on the relevant nodes. A 'This epoch' detail block below
-      the tree surfaces Phase / From / To / Match / Events.
+      ┌─ ROUTING · epoch #38 ─────────────────────── [◀ Prev] [Next ▶] ─┐
+      │▌ stripe: mode accent (orange in Dynamic)                        │
+      │                                                                 │
+      │ CURRENT ROUTE                                                   │
+      │   :user/profile    params {:id 42}    /users/42                 │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ NAVIGATION THIS EPOCH    (event-driven · quiet when not a nav)  │
+      │   :dashboard ──► :user/profile  params {:id 42}  transitioned   │
+      │ ─────────────────────────────────────────────────────────────  │
+      │ ROUTE TABLE   (registered · current highlighted · tree)        │
+      │   :home               /                                         │
+      │   :dashboard          /dashboard                                │
+      │   ▾ :users            /users                                    │
+      │       :user/profile   /users/:id            ◀ current          │
+      │   :settings           /settings                                 │
+      │                                                                 │
+      │ Empty (no route activity this epoch): CURRENT ROUTE + ROUTE     │
+      │   TABLE still render; NAVIGATION THIS EPOCH reads 'No route     │
+      │   activity in this epoch.'                                      │
+      └─────────────────────────────────────────────────────────────────┘
 
-  ## Topology-plus-overlay shape (post-rf2-3kjlo reshape)
+  ## Section 1 — CURRENT ROUTE (always shown)
 
-      ┌─ ROUTING · epoch #38 ────────────────────────── [◀ Prev] [Next ▶] ─┐
-      │ Stripe: yellow (:yellow)                                            │
-      │                                                                     │
-      │ Active route tree                                                   │
-      │  /                                                                  │
-      │  ├─ /cart      ◉  (active this epoch — :on-match)                   │
-      │  │  └─ /cart/:id                                                    │
-      │  ├─ /orders                                                         │
-      │  │  └─ /orders/:order-id                                            │
-      │  └─ /settings                                                       │
-      │                                                                     │
-      │ This epoch                                                          │
-      │   Phase     :on-match                                               │
-      │   From      /                                                       │
-      │   To        /cart                                                   │
-      │   Match     {:route :cart}                                          │
-      │   Events    [:rf.route/transitioned] [:cart/route-entered]                 │
-      │                                                                     │
-      │ Empty (no route activity this epoch):                               │
-      │   Shows tree with current active node highlighted; 'This epoch'     │
-      │   reads 'No route activity in this epoch.'                          │
-      └─────────────────────────────────────────────────────────────────────┘
+  The active route **id** (mode-accent, bold), its **params**, and the
+  **matched path / URL**. The 'where am I'. Renders even when the
+  focused epoch carried no navigation. When the host has no active
+  route slice the section reads a calm caption.
 
-  ## Per-epoch overlay markers
+  ## Section 2 — NAVIGATION THIS EPOCH (event-driven lens)
 
-  The overlay paints inline alongside each topology row via
-  `routing-helpers/assign-markers`:
+  When the focused event navigated: **FROM route ──► TO route**, the
+  **params**, and the **outcome** (transitioned · blocked · cancelled ·
+  not-found · fragment-changed; coloured by result). Quiet when the
+  focused event isn't a navigation — reads 'No route activity in this
+  epoch.' (the topology-plus-overlay contract: the table below still
+  shows the full registered graph).
 
-    - `:to` (green stripe) — the focused cascade navigated TO this
-      route (the new HERE)
-    - `:from` (cyan stripe) — the focused cascade navigated AWAY from
-      this route
-    - `:here` (yellow dot) — the current active route when no
-      navigation happened this epoch
+  ## Section 3 — ROUTE TABLE (registered route graph as a tree)
 
-  When the focused epoch has NO routing activity (`:activity` is nil)
-  the tree still renders with `:here` only; the 'This epoch' block
-  reads 'No route activity in this epoch.'
+  All registered routes (id → path pattern) drawn as an indented tree
+  when nested (`├─ └─` branch glyphs; flat list otherwise), with the
+  **current route highlighted** (mode-accent row + `◀ current` marker)
+  and the focused navigation's FROM→TO marked on it. The overlay
+  glyphs `◉ TO` / `◇ FROM` paint inline on the matching rows.
 
   ## Focus contract (rf2-h0120 alignment)
 
   The panel reads `:rf.causa/focus` per spec/018; that sub already
-  auto-resolves head-fallback via `spine/compose-focus` (when no user
-  focus is set, `:dispatch-id` snaps to the head focusable cascade).
-  No inline head-fallback needed at this layer — the spine sub IS the
-  head-fallback.
+  auto-resolves head-fallback via `spine/compose-focus`. No inline
+  head-fallback needed at this layer.
 
   ## Pure hiccup (rf2-tijr)
 
   Same contract as every other Causa panel — the view is pure hiccup,
   no Reagent / UIx / Helix references. Frame isolation comes from the
   enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`.
-  Every `subscribe` / `dispatch` here resolves to `:rf/causa`.
 
   ## Helpers
 
   Pure-data projection (`project-topology`, `epoch-routing-activity`,
-  `project-topology-data`, plus the legacy lens helpers) lives in
+  `project-topology-data`, plus the lens helpers) lives in
   `routing_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
@@ -84,76 +79,241 @@
              :as t
              :refer [tokens mono-stack sans-stack]]))
 
-;; ---- visual primitives --------------------------------------------------
+;; ---- mode accent --------------------------------------------------------
+;;
+;; The Dynamic Routing panel's mode accent is the orange `:accent` token
+;; (per `panel-domain->token`). Both the CURRENT ROUTE id and the
+;; current row in the ROUTE TABLE ride this hue so the operator's eye
+;; ties the two surfaces together (RoutesPanel.tsx `--devtools-active`).
+
+(def ^:private mode-accent (:accent tokens))
+
+;; ---- shared section primitive -------------------------------------------
+
+(defn- section-caption
+  "Uppercase, tracked, muted section caption — the Figma
+  `devtools-caption uppercase tracking-wide text-muted` idiom
+  (RoutesPanel.tsx). Plain caption, no collapse glyph; the panel's
+  three sections are always visible per spec §7.2."
+  [label testid]
+  [:div {:data-testid testid
+         :style       {:color          (:text-tertiary tokens)
+                       :font-family    sans-stack
+                       :font-size      "10px"
+                       :font-weight    600
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"
+                       :margin-bottom  "8px"}}
+   label])
+
+(defn- section
+  "Wrap a section caption + body. `first?` omits the top hairline (the
+  first section sits flush under the header). Sections after the first
+  carry a 1px solid `border-top` hairline — the RoutesPanel.tsx
+  `border-t border-[var(--devtools-border)]` separator."
+  [{:keys [first? testid]} caption body]
+  [:section {:data-testid testid
+             :style       (cond-> {:padding "12px 16px"}
+                            (not first?)
+                            (assoc :border-top
+                                   (str "1px solid " (:border-subtle tokens))))}
+   caption
+   body])
+
+;; ---- §1 CURRENT ROUTE ---------------------------------------------------
+
+(defn- current-route-section
+  "§1 — the active route id (mode-accent, bold), its params, and the
+  matched path. Always renders. When no active slice is present reads a
+  calm caption (the host has no current route)."
+  [{:keys [current]}]
+  (let [{:keys [id params path]} current]
+    (section
+      {:first? true :testid "rf-causa-routing-current"}
+      (section-caption "Current route" "rf-causa-routing-current-caption")
+      (if (nil? id)
+        [:div {:data-testid "rf-causa-routing-current-empty"
+               :style       {:color       (:text-tertiary tokens)
+                             :font-family sans-stack
+                             :font-style  "italic"
+                             :font-size   "12px"}}
+         "No active route."]
+        [:div {:style {:display      "flex"
+                       :align-items  "center"
+                       :gap          "12px"
+                       :flex-wrap    "wrap"
+                       :font-family  mono-stack
+                       :font-size    "12px"
+                       :color        (:text-primary tokens)}}
+         [:span {:data-testid "rf-causa-routing-current-id"
+                 :style       {:color       mode-accent
+                               :font-weight 600}}
+          (str id)]
+         [:span {:style {:color (:text-tertiary tokens)}} "params"]
+         [:span {:data-testid "rf-causa-routing-current-params"}
+          (pr-str (or params {}))]
+         (when path
+           [:span {:data-testid "rf-causa-routing-current-path"
+                   :style       {:color (:text-tertiary tokens)}}
+            path])]))))
+
+;; ---- §2 NAVIGATION THIS EPOCH -------------------------------------------
+
+(defn- nav-outcome
+  "Resolve the {:label :colour} outcome chip for the focused epoch's
+  navigation activity. Maps the routing phase (per
+  `routing-helpers/epoch-routing-activity`) onto the spec §7.2 outcome
+  vocabulary, coloured by result:
+
+    - :on-match           → 'transitioned' (green — a route landed)
+    - :navigation-blocked → 'blocked'      (warning — a guard refused)
+    - :fragment-changed   → 'fragment changed' (accent-static — anchor)
+    - navigated? but no destination resolved → 'not-found' (error)"
+  [{:keys [phase]} navigated? to-id]
+  (cond
+    (= phase :on-match)
+    {:label "transitioned" :colour (:green tokens)}
+
+    (= phase :navigation-blocked)
+    {:label "blocked" :colour (:warning tokens)}
+
+    (= phase :fragment-changed)
+    {:label "fragment changed" :colour (:accent-static tokens)}
+
+    (and navigated? (nil? to-id))
+    {:label "not-found" :colour (:error tokens)}
+
+    navigated?
+    {:label "transitioned" :colour (:green tokens)}
+
+    :else nil))
+
+(defn- navigation-section
+  "§2 — the event-driven lens. When the focused epoch navigated:
+  FROM ──► TO + params + an outcome chip coloured by result. Quiet
+  caption ('No route activity in this epoch.') when the focused event
+  isn't a navigation — the topology-plus-overlay contract keeps the
+  ROUTE TABLE below visible regardless."
+  [{:keys [activity from-id to-id navigated? current]}]
+  (section
+    {:first? false :testid "rf-causa-routing-nav"}
+    (section-caption "Navigation this epoch" "rf-causa-routing-nav-caption")
+    (if (or navigated? (some? activity))
+      (let [outcome (nav-outcome activity navigated? to-id)
+            params  (or (:match activity) (:params current))]
+        [:div {:data-testid "rf-causa-routing-nav-row"
+               :style       {:display     "flex"
+                             :align-items "center"
+                             :gap         "8px"
+                             :flex-wrap   "wrap"
+                             :font-family mono-stack
+                             :font-size   "12px"
+                             :color       (:text-primary tokens)}}
+         [:span {:data-testid "rf-causa-routing-nav-from"
+                 :style       {:color (if from-id
+                                        (:accent-static tokens)
+                                        (:text-tertiary tokens))}}
+          (if from-id (str from-id) "—")]
+         [:span {:style {:color (:text-tertiary tokens)}} "──►"]
+         [:span {:data-testid "rf-causa-routing-nav-to"
+                 :style       {:color       (if to-id mode-accent
+                                              (:text-tertiary tokens))
+                               :font-weight 600}}
+          (if to-id (str to-id) "—")]
+         (when params
+           [:<>
+            [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+             "params"]
+            [:span {:data-testid "rf-causa-routing-nav-params"}
+             (pr-str params)]])
+         (when outcome
+           [:<>
+            [:span {:style {:color (:text-tertiary tokens) :margin-left "8px"}}
+             "outcome:"]
+            [:span {:data-testid "rf-causa-routing-nav-outcome"
+                    :style       {:color       (:colour outcome)
+                                  :font-weight 600}}
+             (:label outcome)]])])
+      [:div {:data-testid "rf-causa-routing-no-activity"
+             :style       {:color       (:text-tertiary tokens)
+                           :font-family sans-stack
+                           :font-style  "italic"
+                           :font-size   "12px"}}
+       "No route activity in this epoch."])))
+
+;; ---- §3 ROUTE TABLE -----------------------------------------------------
 
 (defn- marker-glyph
-  "Resolve the marker glyph + colour for a topology row. Returns a
+  "Resolve the overlay glyph + colour for a route-table row. Returns a
   `{:glyph :colour :label}` map; nil when the row carries no marker.
 
-  Per spec/021 §7.2 + §17.1.5:
-    - `:to` → green `◉` dot (navigation destination)
-    - `:from` → cyan `◇` outline diamond (navigation origin)
-    - `:here` → yellow `●` (current active route, no nav this epoch)"
+  Per spec/021 §7.2:
+    - `:to`   → green `◉` dot (navigation destination)
+    - `:from` → `◇` outline diamond (navigation origin)
+    - `:here` is folded into the mode-accent row highlight + the
+      `◀ current` marker (it is not painted as a glyph)."
   [marker]
   (case marker
-    :to   {:glyph "◉" :colour (:green tokens) :label "TO"}
-    :from {:glyph "◇" :colour (:accent-static tokens)  :label "FROM"}
-    :here {:glyph "●" :colour (:yellow tokens) :label "HERE"}
+    :to   {:glyph "◉" :colour (:green tokens)         :label "TO"}
+    :from {:glyph "◇" :colour (:accent-static tokens) :label "FROM"}
     nil))
 
 (defn- tree-prefix
-  "Compose the `├─ └─ │` prefix for a topology row at the given depth.
-
-  Depth-0 rows render with no prefix; deeper rows render
-  `<spacer>(└─|├─) ` — `└─` for last-sibling rows, `├─` for non-last.
-  This is the same box-drawing scheme the spec mockup uses (§7.2).
-
-  Pragmatic v1: the inter-depth `│` continuation pipes are omitted —
-  routing trees are shallow (≤ 4 levels per spec §7.1) so the depth
-  indentation + branch glyphs alone read cleanly. A future bead can
-  refine the prefix once the inspector has live route topologies to
-  tune against."
+  "Compose the `├─ └─` branch prefix for a route-table row at the given
+  depth. Depth-0 rows render with no prefix; deeper rows render
+  `<spacer>(└─|├─) ` — `└─` for last-sibling rows, `├─` otherwise.
+  Same box-drawing scheme the spec mockup uses (§7.2). Routing trees
+  are shallow (≤ 4 levels per §7.1) so the depth indentation + branch
+  glyphs alone read cleanly."
   [depth last-at-depth?]
-  (cond
-    (zero? depth) ""
-    :else         (let [indent (apply str (repeat (dec depth) "  "))
-                        branch (if last-at-depth? "└─ " "├─ ")]
-                    (str indent branch))))
+  (if (zero? depth)
+    ""
+    (let [indent (apply str (repeat (dec depth) "  "))
+          branch (if last-at-depth? "└─ " "├─ ")]
+      (str indent branch))))
 
-(defn- topology-row
-  "Render one route in the topology tree. The full row is mono so the
-  `├─ └─` glyphs line up; the marker (when present) renders to the
-  right of the path with its colour-coded glyph."
+(defn- route-table-row
+  "Render one route in the ROUTE TABLE. The current route's row rides
+  the mode accent (highlight background + accent id + `◀ current`
+  marker); other rows are quiet. The FROM/TO overlay glyph paints to
+  the right of the path when the focused epoch navigated to/from this
+  route."
   [{:keys [row depth last-at-depth?]}]
-  (let [{:keys [route-id path marker doc]} row
-        glyph (marker-glyph marker)
-        testid (str "rf-causa-routing-topology-row-"
-                    (when route-id (name route-id)))]
-    [:div {:data-testid testid
+  (let [{:keys [route-id path doc marker]} row
+        current?  (= marker :here)
+        glyph     (marker-glyph marker)
+        testid    (str "rf-causa-routing-table-row-"
+                       (when route-id (name route-id)))]
+    [:div {:data-testid   testid
            :data-route-id (when route-id (str route-id))
            :data-marker   (when marker (name marker))
+           :data-current  (when current? "true")
            :style {:display      "flex"
                    :align-items  "center"
                    :gap          "8px"
-                   :padding      "2px 16px"
+                   :padding      "3px 8px"
+                   :border-radius "3px"
                    :font-family  mono-stack
                    :font-size    "12px"
-                   :color        (:text-primary tokens)
-                   :background   (when (= marker :to)
-                                   (:bg-active tokens))
-                   :border-left  (str "2px solid "
-                                      (if glyph
-                                        (:colour glyph)
-                                        "transparent"))
+                   :color        (if current? mode-accent (:text-primary tokens))
+                   :font-weight  (if current? 600 400)
+                   :background   (cond
+                                   current?         (:bg-active tokens)
+                                   (= marker :to)   (:bg-active tokens)
+                                   :else            "transparent")
                    :white-space  "pre"}}
      [:span {:style {:color (:text-tertiary tokens)}}
       (tree-prefix depth last-at-depth?)]
-     [:span {:style {:color       (:text-primary tokens)
-                     :font-weight (if (= marker :to) 600 400)}}
+     [:span {:data-testid (str testid "-id")
+             :style       {:min-width "8rem"
+                           :color     (if current? mode-accent
+                                       (:text-primary tokens))}}
+      (str route-id)]
+     [:span {:data-testid (str testid "-path")
+             :style       {:color (:text-tertiary tokens)}}
       path]
      (when glyph
-       [:span {:data-testid (str "rf-causa-routing-topology-marker-"
-                                 (name marker))
+       [:span {:data-testid (str "rf-causa-routing-table-marker-" (name marker))
                :style       {:color       (:colour glyph)
                              :font-size   "11px"
                              :font-weight 600
@@ -165,127 +325,34 @@
                        :font-size   "11px"
                        :font-style  "italic"
                        :margin-left "8px"}}
-        doc])]))
+        doc])
+     (when current?
+       [:span {:data-testid "rf-causa-routing-table-current-marker"
+               :style       {:margin-left "auto"
+                             :color       mode-accent
+                             :font-family sans-stack
+                             :font-size   "10px"
+                             :font-weight 600
+                             :text-transform "uppercase"
+                             :letter-spacing "0.5px"}}
+        "◀ current"])]))
 
-(defn- topology-tree
-  "Render the full topology — the always-visible base layer per
-  spec/021 §7.2. Empty topology vector ⇒ render nothing (the silent-
-  by-default contract per rf2-g3ghh; the surrounding panel renders
-  its empty section instead)."
+(defn- route-table-section
+  "§3 — the full registered route graph as a tree (always visible per
+  the topology-plus-overlay contract). Empty topology vector ⇒ the
+  surrounding panel renders the silent state instead."
   [topology]
-  [:div {:data-testid "rf-causa-routing-topology"
-         :style       {:padding "8px 0"}}
-   [:div {:style {:padding        "0 16px 6px 16px"
-                  :color          (:text-tertiary tokens)
-                  :font-family    sans-stack
-                  :font-size      "10px"
-                  :text-transform "uppercase"
-                  :letter-spacing "0.5px"}}
-    "Active route tree"]
-   (into [:<>]
-         (for [entry topology]
-           ^{:key (str (-> entry :row :route-id))}
-           (topology-row entry)))])
-
-;; ---- "This epoch" detail block ------------------------------------------
-
-(defn- epoch-detail-row
-  "Render one `Label  value` row in the 'This epoch' grid."
-  [label value-hiccup label-testid value-testid]
-  [:<>
-   [:span {:data-testid label-testid
-           :style {:color       (:text-tertiary tokens)
-                   :font-family sans-stack
-                   :font-size   "11px"}}
-    label]
-   [:span {:data-testid value-testid
-           :style {:color       (:text-primary tokens)
-                   :font-family mono-stack
-                   :font-size   "12px"}}
-    value-hiccup]])
-
-(defn- this-epoch-block
-  "Render the 'This epoch' detail block per spec/021 §7.2.
-
-  When `:activity` is nil renders the empty-state caption (' No route
-  activity in this epoch. ') — the topology still renders above (per
-  the topology-plus-overlay contract).
-
-  When `:activity` is present surfaces Phase / From / To / Match /
-  Events using the topology-row marker colors so the overlay reads
-  consistently across the tree + this block."
-  [{:keys [activity from-id to-id current navigated?]}]
-  [:div {:data-testid "rf-causa-routing-this-epoch"
-         :style       {:border-top  (str "1px solid " (:border-subtle tokens))
-                       :padding     "10px 16px 12px 16px"
-                       :font-family sans-stack
-                       :font-size   "12px"}}
-   [:div {:style {:color          (:text-tertiary tokens)
-                  :font-size      "10px"
-                  :text-transform "uppercase"
-                  :letter-spacing "0.5px"
-                  :margin-bottom  "6px"}}
-    "This epoch"]
-   (if (nil? activity)
-     [:div {:data-testid "rf-causa-routing-no-activity"
-            :style       {:color      (:text-tertiary tokens)
-                          :font-style "italic"
-                          :font-size  "12px"}}
-      "No route activity in this epoch."]
-     (let [{:keys [phase events match]} activity]
-       [:div {:style {:display               "grid"
-                      :grid-template-columns "80px 1fr"
-                      :row-gap               "4px"
-                      :column-gap            "12px"
-                      :align-items           "baseline"}}
-        (epoch-detail-row
-          "Phase"
-          [:span {:style {:color (:yellow tokens) :font-weight 600}}
-           (pr-str phase)]
-          "rf-causa-routing-detail-phase-label"
-          "rf-causa-routing-detail-phase")
-        (epoch-detail-row
-          "From"
-          (if from-id
-            [:span {:style {:color (:accent-static tokens)}}
-             (str from-id)]
-            [:span {:style {:color (:text-tertiary tokens)}} "—"])
-          "rf-causa-routing-detail-from-label"
-          "rf-causa-routing-detail-from")
-        (epoch-detail-row
-          "To"
-          (if to-id
-            [:span {:style {:color (:green tokens) :font-weight 600}}
-             (str to-id)]
-            [:span {:style {:color (:text-tertiary tokens)}} "—"])
-          "rf-causa-routing-detail-to-label"
-          "rf-causa-routing-detail-to")
-        (epoch-detail-row
-          "Match"
-          (if (and navigated? (seq match))
-            [:span (pr-str match)]
-            [:span {:style {:color (:text-tertiary tokens)}}
-             (if (and navigated? current)
-               (pr-str (or (:params current) {}))
-               "—")])
-          "rf-causa-routing-detail-match-label"
-          "rf-causa-routing-detail-match")
-        (epoch-detail-row
-          "Events"
-          (if (seq events)
-            (into [:span {:style {:display "inline-flex" :gap "6px"
-                                  :flex-wrap "wrap"}}]
-                  (for [[idx ev] (map-indexed vector events)]
-                    ^{:key idx}
-                    [:span {:style {:color       (:accent tokens)
-                                    :background  (:bg-1 tokens)
-                                    :padding     "1px 6px"
-                                    :border-radius "2px"
-                                    :font-size   "11px"}}
-                     (pr-str ev)]))
-            [:span {:style {:color (:text-tertiary tokens)}} "—"])
-          "rf-causa-routing-detail-events-label"
-          "rf-causa-routing-detail-events")]))])
+  (section
+    {:first? false :testid "rf-causa-routing-table"}
+    (section-caption "Route table" "rf-causa-routing-table-caption")
+    [:div {:data-testid "rf-causa-routing-table-body"
+           :style       {:display        "flex"
+                         :flex-direction "column"
+                         :gap            "2px"}}
+     (into [:<>]
+           (for [entry topology]
+             ^{:key (str (-> entry :row :route-id))}
+             (route-table-row entry)))]))
 
 ;; ---- header --------------------------------------------------------------
 
@@ -299,17 +366,14 @@
                        :border-bottom   (str "1px solid " (:border-subtle tokens))
                        :font-family     sans-stack}}
    [:div
-    ;; rf2-5kfxe.8 — domain-coloured accent stripe (:yellow for
-    ;; Routing — side-channel attention tone, distinguished from
-    ;; app-db's main colour). Per rf2-6xezz / rf2-rb6js the panel no
-    ;; longer renders a heading that names itself ("Routing") — the L4
-    ;; tab strip is the single source of panel identity. The icon +
-    ;; description paragraph stay as orientation chrome.
+    ;; Per rf2-6xezz / rf2-rb6js the panel no longer renders a heading
+    ;; that names itself — the L4 tab strip is the single source of
+    ;; panel identity. The icon + orientation paragraph stay as chrome.
     [:div {:style {:display     "flex"
                    :align-items "center"
                    :gap         "8px"}}
-     ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. 🌐 in
-     ;; :yellow (Routing's domain colour via panel-domain->token).
+     ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. 🌐 in the
+     ;; routing domain colour via panel-icon-style.
      [:span {:data-testid "rf-causa-routing-panel-icon"
              :aria-hidden "true"
              :style       (t/panel-icon-style :routing)}
@@ -318,14 +382,9 @@
                  :color       (:text-tertiary tokens)
                  :font-size   "11px"
                  :line-height 1.4}}
-     "Full topology of registered routes with focused-epoch overlay. "
-     [:span {:style {:color (:green tokens) :font-weight 600}} "◉ TO"]
-     " / "
-     [:span {:style {:color (:accent-static tokens) :font-weight 600}} "◇ FROM"]
-     " / "
-     [:span {:style {:color (:yellow tokens) :font-weight 600}} "● HERE"]
-     " mark the per-epoch navigation overlay. For the full route catalogue browse + "
-     "Simulate-URL surface, switch to Static mode."]]
+     "Where am I, what navigated this epoch, and the full registered "
+     "route graph. For the route catalogue browse + Simulate-URL surface, "
+     "switch to Static mode."]]
    (when (and navigated? to-id (not silent?))
      [:span {:data-testid "rf-causa-routing-nav-summary"
              :style       {:color       (:green tokens)
@@ -355,17 +414,24 @@
     [:code {:style {:color       (:accent tokens)
                     :font-family mono-stack}}
      "re-frame.routing/reg-route"]
-    " — the topology will render once the host installs them."]])
+    " — the route table will render once the host installs them."]])
 
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Routing tab's root view — topology-plus-overlay shape per
-  spec/021 §7. Subscribes to `:rf.causa/routing-tab-data` and renders
-  the full route topology with a per-epoch overlay; below the tree
-  the 'This epoch' block surfaces Phase / From / To / Match / Events
-  (or 'No route activity in this epoch.' when the focused cascade
-  carries no routing trace events)."
+  "The Routing tab's root view — three stacked sections per spec/021 §7.2
+  (reconciled to RoutesPanel.tsx). Subscribes to
+  `:rf.causa/routing-tab-data` and renders, top → bottom:
+
+    1. CURRENT ROUTE          — active id + params + matched path.
+    2. NAVIGATION THIS EPOCH  — FROM ──► TO + params + outcome
+                                (quiet when the focused event isn't a nav).
+    3. ROUTE TABLE            — the full registered route graph as a
+                                tree, current row highlighted + FROM/TO
+                                overlay glyphs.
+
+  When the host has no routes registered the panel renders the
+  silent-by-default caption (no sections)."
   []
   (let [{:keys [silent? topology activity from-id to-id navigated? current]
          :as _data}
@@ -377,17 +443,19 @@
                              :background     (:bg-2 tokens)
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
-                             :font-size      "14px"}}
+                             :font-size      "14px"
+                             :overflow       "auto"}}
      (header {:navigated? navigated? :to-id to-id :silent? silent?})
      (if silent?
        (silent-state)
        [:<>
-        (topology-tree topology)
-        (this-epoch-block {:activity   activity
-                           :from-id    from-id
-                           :to-id      to-id
-                           :current    current
-                           :navigated? navigated?})])]))
+        (current-route-section {:current current})
+        (navigation-section {:activity   activity
+                             :from-id    from-id
+                             :to-id      to-id
+                             :navigated? navigated?
+                             :current    current})
+        (route-table-section topology)])]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -1,17 +1,24 @@
 (ns day8.re-frame2-causa.panels.routing-cljs-test
   "CLJS-side wiring + view tests for Causa's Dynamic Routing tab —
-  the topology-plus-overlay shape (rf2-3kjlo, refining rf2-o5f5f.3).
+  the three-section stack (rf2-ad7zx.7, reconciled to RoutesPanel.tsx
+  + spec/021 §7.2; refining rf2-3kjlo / rf2-o5f5f.3).
 
-  ## Scope (post-rf2-3kjlo)
+  ## Scope (post-rf2-ad7zx.7)
 
-  The Dynamic Routing tab is a topology-plus-overlay surface per
-  spec/021 §7: the FULL routing tree is always visible (registered
-  routes nested by `:parent` meta); the focused epoch's nav activity
-  overlays as a `:to` / `:from` / `:here` marker on the relevant
-  nodes. A 'This epoch' detail block below the tree surfaces
-  Phase / From / To / Match / Events; when the focused cascade
-  carries no routing activity, the tree still renders with `:here`
-  only and the detail block reads 'No route activity in this epoch.'.
+  The Dynamic Routing tab renders three stacked sections per spec/021
+  §7.2, top → bottom:
+
+    1. CURRENT ROUTE          — active id (mode-accent, bold) + params
+                                + matched path. Always shown.
+    2. NAVIGATION THIS EPOCH  — FROM ──► TO + params + outcome chip
+                                (coloured by result). Quiet caption
+                                ('No route activity in this epoch.')
+                                when the focused event isn't a nav.
+    3. ROUTE TABLE            — the full registered route graph as a
+                                tree (always visible per the topology-
+                                plus-overlay contract); current row
+                                highlighted + `◀ current` marker;
+                                FROM/TO overlay glyphs on matching rows.
 
   The browse + search + Simulate-URL surface lives on the Static
   Routes panel (see `static/routes/panel_cljs_test.cljs`).
@@ -19,28 +26,27 @@
   ## What's under test
 
     1. **Registry wires the subs** — every sub the panel reads gets
-       installed by `register-causa-handlers!`. The promoted browse /
-       search / Simulate-URL slots (now under
-       `:rf.causa.static.routes/*`) are NOT registered by
-       `routing/install!` anymore.
+       installed by `register-causa-handlers!`.
 
-    2. **Topology always renders** — when routes are registered, the
-       topology root + each route row render regardless of focused-
-       epoch activity.
+    2. **Three sections always render** — when routes are registered,
+       CURRENT ROUTE + NAVIGATION THIS EPOCH + ROUTE TABLE all render.
 
-    3. **Per-epoch overlay** — when the focused cascade carries a
-       `:rf.route.nav-token/allocated` emit, the destination row
-       gets a `:to` marker; the prior route (when distinct) gets a
-       `:from` marker; the 'This epoch' block surfaces the phase.
+    3. **Route table always renders** — every registered route gets a
+       table row regardless of focused-epoch activity.
 
-    4. **No-activity branch** — when focused cascade has no routing
-       trace events, 'This epoch' reads the empty caption and the
-       topology still renders.
+    4. **Per-epoch overlay** — when the focused cascade carries a
+       `:rf.route.nav-token/allocated` emit, the destination row gets a
+       `:to` marker, the NAVIGATION section surfaces FROM ──► TO + an
+       outcome chip, and the prior route (when distinct) gets `:from`.
 
-    5. **Silent state** — when no routes registered, panel renders the
-       silent-by-default caption (no topology, no detail block).
+    5. **No-activity branch** — when focused cascade has no routing
+       trace events, NAVIGATION reads the empty caption, CURRENT ROUTE
+       + ROUTE TABLE still render, and the current row is highlighted.
 
-    6. **Frame isolation** — every read targets `:rf/causa`'s frame."
+    6. **Silent state** — when no routes registered, panel renders the
+       silent-by-default caption (no sections).
+
+    7. **Frame isolation** — every read targets `:rf/causa`'s frame."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -90,12 +96,14 @@
             node))
         (hiccup-seq tree)))
 
-(defn- all-by-testid [tree testid]
-  (filter (fn [node]
-            (and (vector? node)
-                 (map? (second node))
-                 (= testid (:data-testid (second node)))))
-          (hiccup-seq tree)))
+(defn- node-text
+  "Concatenate every string descendant of a hiccup node — used to
+  assert on a row's rendered text without coupling to its exact
+  child structure."
+  [node]
+  (->> (hiccup-seq node)
+       (filter string?)
+       (apply str)))
 
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)
@@ -161,10 +169,10 @@
       (is (= 7 (count panels))
           "exactly 7 entries — Event / App DB / Views / Trace / Machines / Routing / Issues (rf2-4v67l removed the Chrome A11y dogfood in favour of Story's shipped panel; rf2-ga16q removed the Machines Canvas tab — its browse-all canvas relocated to the Static Machines sub-tab)"))))
 
-;; ---- (2) topology base layer (always visible) ---------------------------
+;; ---- (2) three sections render (always-visible base layer) --------------
 
-(deftest panel-renders-topology-when-routes-registered
-  (testing "topology base layer renders for every registered route"
+(deftest panel-renders-three-sections-when-routes-registered
+  (testing "CURRENT ROUTE + NAVIGATION + ROUTE TABLE all render top → bottom"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -179,19 +187,46 @@
             "header always renders")
         ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
         (is (some? (find-by-testid tree "rf-causa-routing-panel-icon"))
-            "panel header icon (🌐 in :yellow) present")
-        (is (some? (find-by-testid tree "rf-causa-routing-topology"))
-            "topology always renders when routes are registered")
-        ;; Each route gets a topology-row entry.
+            "panel header icon (🌐) present")
+        ;; §1 CURRENT ROUTE
+        (is (some? (find-by-testid tree "rf-causa-routing-current"))
+            "§1 CURRENT ROUTE section renders")
+        (is (some? (find-by-testid tree "rf-causa-routing-current-id"))
+            "current route id renders")
+        ;; §2 NAVIGATION THIS EPOCH
+        (is (some? (find-by-testid tree "rf-causa-routing-nav"))
+            "§2 NAVIGATION THIS EPOCH section renders")
+        ;; §3 ROUTE TABLE
+        (is (some? (find-by-testid tree "rf-causa-routing-table"))
+            "§3 ROUTE TABLE section renders")
+        ;; Each route gets a table row.
         (doseq [rid (keys cart-routes)]
           (is (some? (find-by-testid tree
-                       (str "rf-causa-routing-topology-row-" (name rid))))
-              (str "topology row rendered for " rid)))
-        (is (some? (find-by-testid tree "rf-causa-routing-this-epoch"))
-            "'This epoch' detail block always renders")))))
+                       (str "rf-causa-routing-table-row-" (name rid))))
+              (str "route-table row rendered for " rid)))))))
+
+(deftest current-route-section-shows-id-params-path
+  (testing "§1 surfaces the active id, params, and matched path"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {:id 42} :path "/cart"}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)
+            id   (find-by-testid tree "rf-causa-routing-current-id")
+            params (find-by-testid tree "rf-causa-routing-current-params")
+            path (find-by-testid tree "rf-causa-routing-current-path")]
+        (is (some? id) "current id present")
+        (is (re-find #":route/cart" (node-text id)) "id text shows :route/cart")
+        (is (some? params) "current params present")
+        (is (re-find #":id 42" (node-text params)) "params text shows {:id 42}")
+        (is (some? path) "matched path present")
+        (is (re-find #"/cart" (node-text path)) "path text shows /cart")))))
 
 (deftest panel-renders-silent-when-no-routes
-  (testing "no routes registered → silent caption + no topology"
+  (testing "no routes registered → silent caption + no sections"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
@@ -203,15 +238,17 @@
             "header still renders")
         (is (some? (find-by-testid tree "rf-causa-routing-silent"))
             "silent caption rendered for empty registrar")
-        (is (nil? (find-by-testid tree "rf-causa-routing-topology"))
-            "topology NOT rendered when no routes registered")
-        (is (nil? (find-by-testid tree "rf-causa-routing-this-epoch"))
-            "'This epoch' block NOT rendered when silent")))))
+        (is (nil? (find-by-testid tree "rf-causa-routing-table"))
+            "ROUTE TABLE NOT rendered when no routes registered")
+        (is (nil? (find-by-testid tree "rf-causa-routing-current"))
+            "CURRENT ROUTE NOT rendered when silent")
+        (is (nil? (find-by-testid tree "rf-causa-routing-nav"))
+            "NAVIGATION NOT rendered when silent")))))
 
 ;; ---- (3) no-activity branch (focused epoch with no routing trace) -------
 
 (deftest panel-renders-no-activity-when-cascade-has-no-routing
-  (testing "focused cascade with no routing trace events → topology renders + 'No route activity'"
+  (testing "no routing trace events → CURRENT ROUTE + ROUTE TABLE render; NAVIGATION quiet; current row highlighted"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -220,20 +257,22 @@
                          {:id :route/cart :params {} :query {}}]
                         {:frame :rf/causa})
       (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-topology"))
-            "topology renders unconditionally")
+        (is (some? (find-by-testid tree "rf-causa-routing-current"))
+            "CURRENT ROUTE renders")
+        (is (some? (find-by-testid tree "rf-causa-routing-table"))
+            "ROUTE TABLE renders unconditionally")
         (is (some? (find-by-testid tree "rf-causa-routing-no-activity"))
-            "'No route activity' caption rendered")
-        ;; current-route highlight as `:here`
-        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-here"))
-            "current route gets :here marker when no nav this epoch")
-        (is (nil? (find-by-testid tree "rf-causa-routing-detail-phase"))
-            "phase detail NOT rendered when no activity")))))
+            "NAVIGATION reads 'No route activity in this epoch.'")
+        ;; current-route row highlight (:here marker → mode-accent row).
+        (is (some? (find-by-testid tree "rf-causa-routing-table-current-marker"))
+            "current route gets the '◀ current' marker when no nav this epoch")
+        (is (nil? (find-by-testid tree "rf-causa-routing-nav-outcome"))
+            "no outcome chip when no activity")))))
 
 ;; ---- (4) per-epoch overlay (focused cascade with nav-token emit) --------
 
-(deftest panel-paints-to-marker-when-cascade-navigated
-  (testing "focused cascade with nav-token emit → :to marker + Phase :on-match"
+(deftest panel-paints-to-marker-and-outcome-when-cascade-navigated
+  (testing "nav-token emit → :to marker on the table row + NAVIGATION FROM/TO + transitioned outcome"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -253,24 +292,27 @@
                           {:frame :rf/causa})
         (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
       (let [tree (routing/Panel)]
-        ;; Topology still renders.
-        (is (some? (find-by-testid tree "rf-causa-routing-topology")))
-        ;; :to marker present on the destination row.
-        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-to"))
-            ":to marker rendered on destination route in the topology")
+        ;; ROUTE TABLE still renders.
+        (is (some? (find-by-testid tree "rf-causa-routing-table")))
+        ;; :to overlay glyph present on the destination table row.
+        (is (some? (find-by-testid tree "rf-causa-routing-table-marker-to"))
+            ":to overlay glyph rendered on destination route in the table")
         ;; Header summary surfaces the TO id.
         (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
             "header carries → TO summary chip")
-        ;; This-epoch detail block surfaces Phase :on-match.
-        (is (some? (find-by-testid tree "rf-causa-routing-detail-phase"))
-            "'Phase' value rendered in This-epoch block")
-        (is (some? (find-by-testid tree "rf-causa-routing-detail-to"))
-            "'To' value rendered in This-epoch block")
+        ;; NAVIGATION section surfaces FROM ──► TO + outcome.
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-to"))
+            "NAVIGATION TO id rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-outcome"))
+            "NAVIGATION outcome chip rendered")
+        (let [outcome (find-by-testid tree "rf-causa-routing-nav-outcome")]
+          (is (re-find #"transitioned" (node-text outcome))
+              "outcome reads 'transitioned' for an :on-match nav"))
         (is (nil? (find-by-testid tree "rf-causa-routing-no-activity"))
             "empty-state caption NOT rendered when activity present")))))
 
 (deftest panel-paints-from-and-to-when-prior-slice-differs
-  (testing "focused cascade with distinct prior slice → both :from and :to markers"
+  (testing "distinct prior slice → both :from and :to markers + FROM in NAVIGATION"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
@@ -289,9 +331,12 @@
                           {:frame :rf/causa})
         (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
       (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-from"))
-            ":from marker rendered on origin route")
-        (is (some? (find-by-testid tree "rf-causa-routing-topology-marker-to"))
-            ":to marker rendered on destination route")
-        (is (some? (find-by-testid tree "rf-causa-routing-detail-from"))
-            "'From' value rendered in This-epoch block")))))
+        (is (some? (find-by-testid tree "rf-causa-routing-table-marker-from"))
+            ":from overlay glyph rendered on origin route in the table")
+        (is (some? (find-by-testid tree "rf-causa-routing-table-marker-to"))
+            ":to overlay glyph rendered on destination route in the table")
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-from"))
+            "NAVIGATION FROM id rendered")
+        (let [from (find-by-testid tree "rf-causa-routing-nav-from")]
+          (is (re-find #":route/cart" (node-text from))
+              "FROM reads the prior route :route/cart"))))))


### PR DESCRIPTION
## What

Reconciles the Dynamic Routing panel render from the superseded **tree-first** shape to the **three stacked sections** per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §7.2 + `tools/causa/design-reference/components/RoutesPanel.tsx`. Structure/layout only — orange tokens already migrated on main (rf2-ad7zx.3).

## Section order (top → bottom, 1px hairline between)

1. **CURRENT ROUTE** (always shown) — active route id (mode-accent, bold) + params + matched path. "Where am I."
2. **NAVIGATION THIS EPOCH** (event-driven) — FROM ──► TO + params + an outcome chip coloured by result (`transitioned` / `blocked` / `fragment changed` / `not-found`). Quiet caption "No route activity in this epoch." when the focused event isn't a navigation.
3. **ROUTE TABLE** — the full registered route graph as a tree (always visible per the topology-plus-overlay contract), current row highlighted (mode-accent + `◀ current` marker), FROM/TO overlay glyphs (`◉ TO` / `◇ FROM`) on the matching rows. Click-to-source coord is the existing affordance.

## Notes

- Mode accent for the current id + current row reads the `:accent` token (orange in Dynamic) per `panel-domain->token`; no colour was re-done.
- The view-facing composite sub (`project-topology-data`) and all `routing_helpers.cljc` algebra are unchanged — this is a pure render reshape.
- `routing_cljs_test.cljs` updated to the new three-section test-ids (current/nav/table) + extended with CURRENT-ROUTE id/params/path and NAVIGATION outcome assertions.

## Gates

- `tools/causa` `clojure -M:test` — 846 tests, 2825 assertions, **0 failures**
- implementation `npm run test:cljs` — 4199 tests, 12994 assertions, **0 failures**
- implementation `npm run test:causa-feature-gate` — 13 scenarios / 13 matrix rows, **0 failures** (exit 0)
- clj-kondo on both changed files — **0 errors, 0 warnings**

Closes rf2-ad7zx.7.