### PR TITLE
feat(causa): reconcile Views panel to Figma reactive-flow graph (rf2-ad7zx.6)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_flow_graph.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_flow_graph.cljc
@@ -1,0 +1,247 @@
+(ns day8.re-frame2-causa.panels.reactive-flow-graph
+  "Pure layout for the Views panel's left → right REACTIVE FLOW graph
+  (rf2-ad7zx.6 · spec/021 §3.2 · Figma `design-reference/components/
+  ViewsPanel.tsx`).
+
+  The Views panel renders the reactive cascade as a node-and-edge graph,
+  not the prior three stacked tables. The cascade is a DAG flowing
+  left → right across four columns:
+
+      col 0  app-db        — a single source node at the far left
+      col 1  Level-1 subs  — extractors (read app-db directly)
+      col 2  Level-2+ subs — derived (`:<-` composition; OPTIONAL layer)
+      col 3  views         — the right-most focus; each (rerendered)
+
+  ## Why a pure layout ns
+
+  Mirrors `chart/timing-waterfall`: a pure data → geometry function
+  (`layout`) that the view ns renders as inline-SVG hiccup, and a
+  `clojure -M:test` suite exercises on the JVM without a browser. The
+  layout owns ALL geometry (node x/y/w/h, edge endpoints, the changed/
+  unchanged edge style) so the renderer is a flat positional walk and
+  the structure is unit-testable apart from SVG paint.
+
+  This is a CAUSA-NATIVE SVG graph — NOT xyflow. The Machine panel's
+  xyflow integration (spec/021 §6) is a separate, interactive,
+  draggable surface; the reactive-flow graph is a static cause/timing
+  snapshot per the spec + reference, so it stays pure-SVG.
+
+  ## Edge encoding (spec/021 §3.2 · spec/022 — colour/edge, NOT glyphs)
+
+  - **changed / recomputed** node → its outgoing edges are SOLID,
+    accent-coloured, arrow-headed, and PROPAGATE downstream.
+  - **unchanged / short-circuited** node → its edges are DASHED, dim,
+    and visually CUT (downstream did not re-run). Each `:edge` carries
+    `:changed?` so the renderer picks the stroke/dash/marker.
+
+  ## Data-availability constraints (spec/021 §3.5)
+
+  1. app-db → Level-1 is a PLAIN fan-out (re-frame subs read app-db
+     imperatively; no per-path edges) — one source node, one edge per
+     Level-1 sub.
+  2. The sub→view edges come from the `:sub-readers` map (`{sub-id
+     [view-id ...]}`) the substrate's per-view deref-set yields. A sub
+     read by ≥2 views is SHARED — its node carries `:shared-count`.
+  3. `:rf.view/triggered-by` (the per-view cause sub) + `:rf.view/
+     elapsed-ms` (render timing) ride each view row (rf2-8wrzz.1); the
+     view node carries them through for the renderer's cause + timing
+     labels.
+
+  Pure data → geometry; JVM-portable (`.cljc`)."
+  (:require [clojure.string :as str]))
+
+;; ---- geometry constants ------------------------------------------------
+
+(def node-w
+  "Default node width (px). Views are a touch wider to fit the
+  `(rerendered)` sub-label."
+  120)
+
+(def view-node-w 140)
+(def node-h 30)
+(def view-node-h 40)
+
+(def ^:private row-gap 14)            ; vertical gap between sibling nodes in a column
+(def ^:private col-gap 70)            ; horizontal gap between columns
+(def ^:private pad-x 20)              ; left/right canvas padding
+(def ^:private pad-y 16)              ; top canvas padding
+(def ^:private appdb-w 80)
+
+;; Column x-origins. app-db sits at pad-x; each subsequent column starts
+;; after the previous column's widest node + the inter-column gap. The
+;; Level-1 / Level-2 columns use `node-w`; views use `view-node-w`.
+(def ^:private col-x
+  {:appdb pad-x
+   :l1    (+ pad-x appdb-w col-gap)
+   :l2    (+ pad-x appdb-w col-gap node-w col-gap)
+   :view  (+ pad-x appdb-w col-gap node-w col-gap node-w col-gap)})
+
+;; ---- pure helpers ------------------------------------------------------
+
+(defn- id->str
+  [id]
+  (cond
+    (nil? id)     ""
+    (keyword? id) (str id)
+    :else         (pr-str id)))
+
+(defn- slug
+  "CSS-selector-safe testid suffix — id punctuation flattened to `_`."
+  [id]
+  (when id (str/replace (str id) #"[^a-zA-Z0-9_]" "_")))
+
+(defn- stack-y
+  "Vertical centre-y for the i-th node in a column of `n` nodes, using
+  `h` per node, vertically centred around `canvas-mid`. Returns the node
+  TOP-y (not centre) so the renderer positions the `<rect>` directly."
+  [i h canvas-mid n]
+  (let [block-h (- (* n (+ h row-gap)) row-gap)
+        top     (- canvas-mid (/ block-h 2.0))]
+    (+ top (* i (+ h row-gap)))))
+
+(defn- col-nodes
+  "Build the node maps for one sub column (`:l1` / `:l2`). Each row is the
+  panel's sub-row map (`{:sub-id :changed? :inputs? :coord? :readers?}`).
+  `shared` is the set of sub-ids read by ≥2 views (the shared-sub set)."
+  [rows kind canvas-mid shared]
+  (let [x (get col-x kind)
+        n (count rows)]
+    (vec
+      (for [[i row] (map-indexed vector rows)
+            :let [sid (:sub-id row)]]
+        {:kind        kind
+         :id          sid
+         :slug        (slug sid)
+         :label       (id->str sid)
+         :changed?    (boolean (:changed? row))
+         :inputs      (vec (:inputs row))
+         :readers     (vec (:readers row))
+         :coord       (:coord row)
+         :shared-count (when (contains? shared sid)
+                         (count (:readers row)))
+         :x           x
+         :y           (stack-y i node-h canvas-mid n)
+         :w           node-w
+         :h           node-h}))))
+
+(defn- view-nodes
+  "Build the view-column node maps. `view-rows` are render rows
+  (`:action` ∈ #{:mount :rerender}; unmounts list separately). Each
+  carries `:triggered-by` + `:elapsed-ms` (rf2-8wrzz.1) through for the
+  renderer's cause + timing labels."
+  [view-rows canvas-mid]
+  (let [x (get col-x :view)
+        n (count view-rows)]
+    (vec
+      (for [[i row] (map-indexed vector view-rows)
+            :let [vid (:view-id row)]]
+        {:kind         :view
+         :id           vid
+         :slug         (slug vid)
+         :label        (id->str vid)
+         :action       (:action row)
+         :triggered-by (:triggered-by row)
+         :elapsed-ms   (:elapsed-ms row)
+         :reason       (:reason row)
+         :x            x
+         :y            (stack-y i view-node-h canvas-mid n)
+         :w            view-node-w
+         :h            view-node-h}))))
+
+;; ---- public layout -----------------------------------------------------
+
+(defn shared-sub-set
+  "Set of sub-ids read by TWO OR MORE views this cascade — the shared-
+  subscription set. Reads each sub row's `:readers` (the views that
+  deref it, from `:sub-readers` rf2-y23uw). Pure."
+  [sub-rows]
+  (into #{}
+        (comp (filter (fn [r] (> (count (:readers r)) 1)))
+              (map :sub-id))
+        sub-rows))
+
+(defn layout
+  "Compute the full node + edge geometry for the reactive-flow graph.
+
+  Input is the panel's projected reactive-data slice:
+
+      {:level-1-subs [{:sub-id :changed? :coord? :readers?} ...]
+       :level-2-subs [{:sub-id :changed? :inputs :coord? :readers?} ...]
+       :view-rows    [{:view-id :action :reason :triggered-by? :elapsed-ms?} ...]}
+
+  Returns:
+
+      {:width   <px>
+       :height  <px>
+       :appdb   {:x :y :w :h}
+       :nodes   {:l1 [node ...] :l2 [node ...] :view [node ...]}
+       :edges   [{:from-id :to-id :x1 :y1 :x2 :y2 :changed? :kind} ...]
+       :empty?  <bool>}      ; true when no subs ran AND no views rendered
+
+  Edge `:kind` ∈ #{:appdb-l1 :sub-sub :sub-view}; `:changed?` drives the
+  solid-accent vs dashed-dim/cut styling. View rows with `:action
+  :unmount` are excluded from the graph (they list in the UNMOUNTED
+  VIEWS section). Pure fn — JVM-runnable."
+  [{:keys [level-1-subs level-2-subs view-rows]}]
+  (let [l1-rows   (vec (or level-1-subs []))
+        l2-rows   (vec (or level-2-subs []))
+        ;; unmounts list in their own section — the graph shows the
+        ;; live render cascade only.
+        v-rows    (filterv #(not= :unmount (:action %)) (or view-rows []))
+        shared    (shared-sub-set (concat l1-rows l2-rows))
+        ;; Tallest column drives the canvas height so every column
+        ;; centres on one mid-line.
+        max-rows  (max 1 (count l1-rows) (count l2-rows) (count v-rows))
+        canvas-h  (+ (* 2 pad-y)
+                     (max node-h
+                          (- (* max-rows (+ view-node-h row-gap)) row-gap)))
+        canvas-mid (/ canvas-h 2.0)
+        appdb     {:x (get col-x :appdb)
+                   :y (- canvas-mid (/ node-h 2.0))
+                   :w appdb-w :h node-h}
+        l1        (col-nodes l1-rows :l1 canvas-mid shared)
+        l2        (col-nodes l2-rows :l2 canvas-mid shared)
+        views     (view-nodes v-rows canvas-mid)
+        ;; index nodes by id for edge endpoint resolution. l1 + l2 share
+        ;; the sub-id key space; views key on view-id.
+        sub-by-id  (into {} (map (juxt :id identity)) (concat l1 l2))
+        view-by-id (into {} (map (juxt :id identity)) views)
+        ;; right-mid / left-mid anchor of a node (edges run rect→rect).
+        rmid      (fn [n] [(+ (:x n) (:w n)) (+ (:y n) (/ (:h n) 2.0))])
+        lmid      (fn [n] [(:x n) (+ (:y n) (/ (:h n) 2.0))])
+        ;; 1. app-db → each Level-1 sub (plain fan-out; cut if unchanged).
+        appdb-edges
+        (for [n l1
+              :let [[x1 y1] (rmid appdb) [x2 y2] (lmid n)]]
+          {:from-id :appdb :to-id (:id n)
+           :x1 x1 :y1 y1 :x2 x2 :y2 y2
+           :changed? (:changed? n) :kind :appdb-l1})
+        ;; 2. input-sub → Level-2 sub (the `:<-` composition chain).
+        ;;    Edge changed when the UPSTREAM input sub changed.
+        sub-sub-edges
+        (for [n l2
+              input (:inputs n)
+              :let [src (get sub-by-id input)]
+              :when src
+              :let [[x1 y1] (rmid src) [x2 y2] (lmid n)]]
+          {:from-id input :to-id (:id n)
+           :x1 x1 :y1 y1 :x2 x2 :y2 y2
+           :changed? (:changed? src) :kind :sub-sub})
+        ;; 3. sub → view (the reader edge; shared subs fan out to N views).
+        ;;    Edge changed when the SUB changed (drove the re-render).
+        sub-view-edges
+        (for [n (concat l1 l2)
+              vid (:readers n)
+              :let [tgt (get view-by-id vid)]
+              :when tgt
+              :let [[x1 y1] (rmid n) [x2 y2] (lmid tgt)]]
+          {:from-id (:id n) :to-id vid
+           :x1 x1 :y1 y1 :x2 x2 :y2 y2
+           :changed? (:changed? n) :kind :sub-view})
+        edges (vec (concat appdb-edges sub-sub-edges sub-view-edges))]
+    {:width   (+ (get col-x :view) view-node-w pad-x)
+     :height  canvas-h
+     :appdb   appdb
+     :nodes   {:l1 l1 :l2 l2 :view views}
+     :edges   edges
+     :empty?  (and (empty? l1-rows) (empty? l2-rows) (empty? v-rows))}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_subs.cljs
@@ -185,11 +185,19 @@
 
   Each row:
 
-    {:view-id   <kw/id>
-     :render-key <[view-id token]>
-     :action    :mount | :rerender | :unmount
-     :reason    {:kind :reactive :subs [...]} | {:kind :structural}
-                | {:kind :none}                 ; unmount}
+    {:view-id      <kw/id>
+     :render-key   <[view-id token]>
+     :action       :mount | :rerender | :unmount
+     :reason       {:kind :reactive :subs [...]} | {:kind :structural}
+                   | {:kind :none}                 ; unmount
+     :triggered-by <sub-id>?    ; rf2-8wrzz.1 — the SINGLE cause sub
+     :elapsed-ms   <number>?}   ; rf2-8wrzz.1 — render wall-clock
+
+  `:triggered-by` (the per-view re-render cause) + `:elapsed-ms` (render
+  timing) ride the `:rf.view/rendered` op from rf2-8wrzz.1; the flow
+  graph (spec/021 §3.2) uses them to label each sub→view edge's cause +
+  the view node's timing. Both are absent on a structural re-render /
+  outside a cascade — the slot is simply omitted.
 
   `changed-set` is the set of changed sub-ids this cascade (from
   `changed-sub-id-set`). nil-safe: missing tags / absent fields degrade
@@ -205,12 +213,16 @@
                     (nil? view-id) nil
 
                     (= :rf.view/rendered op)
-                    (let [mount?     (true? (:rf.view/mount? tags))
-                          deref-subs (:rf.view/deref-subs tags)]
-                      {:view-id    view-id
-                       :render-key (:rf.view/render-key tags)
-                       :action     (if mount? :mount :rerender)
-                       :reason     (compute-view-reason deref-subs changed-set)})
+                    (let [mount?       (true? (:rf.view/mount? tags))
+                          deref-subs   (:rf.view/deref-subs tags)
+                          triggered-by (:rf.view/triggered-by tags)
+                          elapsed-ms   (:rf.view/elapsed-ms tags)]
+                      (cond-> {:view-id    view-id
+                               :render-key (:rf.view/render-key tags)
+                               :action     (if mount? :mount :rerender)
+                               :reason     (compute-view-reason deref-subs changed-set)}
+                        (some? triggered-by) (assoc :triggered-by triggered-by)
+                        (some? elapsed-ms)   (assoc :elapsed-ms elapsed-ms)))
 
                     (= :rf.view/unmounted op)
                     {:view-id    view-id
@@ -220,6 +232,49 @@
 
                     :else nil))))
         (or trace-events [])))
+
+;; ---- reactive teardown sections (spec/021 §3.2 · Figma design) ------------
+
+(defn unmounted-views
+  "Project the epoch's UNMOUNTED VIEWS section rows (spec/021 §3.2 ·
+  Figma `ViewsPanel.tsx`). One row per `:rf.view/unmounted` op this
+  cascade — views whose component instance tore down this epoch.
+
+  Reads the same `:rf.view/unmounted` teardown op `view-rows` reads for
+  its `:unmount` action; surfaced here as a dedicated section per the
+  Figma design (the graph shows the live cascade; teardown lists below
+  it). Each row `{:view-id <kw/id>}`. First-seen order, de-duplicated by
+  view-id so two instances of one view tearing down list once. nil-safe;
+  ops without a `:view-id` are skipped."
+  [trace-events]
+  (->> (or trace-events [])
+       (keep (fn [ev]
+               (when (= :rf.view/unmounted (op-kw ev))
+                 (let [tags (:tags ev)]
+                   (or (:rf.view/id tags) (:rf.view/id ev))))))
+       (distinct)
+       (mapv (fn [view-id] {:view-id view-id}))))
+
+(defn destroyed-subscriptions
+  "Project the epoch's DESTROYED SUBSCRIPTIONS section rows (spec/021
+  §3.2) — subs cleaned up when their last reader unmounted.
+
+  Reads the `:rf.sub/disposed` teardown op (the sub-dispose op spec/021
+  §3.5 pairs with view-unmount). Data-availability honesty: the live
+  build does not yet emit a sub-dispose trace op (the sub-cache disposes
+  reactions silently on last-reader teardown — see subs/cache.cljc), so
+  this projection is empty until that op lands. When it does, each
+  `:rf.sub/disposed` op anchors a row `{:sub-id <kw/id>}`. First-seen
+  order, de-duplicated. nil-safe; ops without a `:sub-id` are skipped."
+  [trace-events]
+  (->> (or trace-events [])
+       (keep (fn [ev]
+               (when (= :rf.sub/disposed (op-kw ev))
+                 (let [tags (:tags ev)]
+                   (or (:rf.sub/id tags) (:sub-id tags)
+                       (:rf.sub/id ev) (:sub-id ev))))))
+       (distinct)
+       (mapv (fn [sub-id] {:sub-id sub-id}))))
 
 ;; ---- shared-subscription edges (rf2-y23uw) --------------------------------
 
@@ -373,7 +428,9 @@
          changed-set   (changed-sub-id-set ran)
          readers       (sub-readers trace-events)
          {:keys [level-1 level-2]} (partition-subs-by-level ran topology readers)
-         v-rows        (view-rows trace-events changed-set)]
+         v-rows        (view-rows trace-events changed-set)
+         unmounted     (unmounted-views trace-events)
+         destroyed     (destroyed-subscriptions trace-events)]
      {:subs-ran        ran
       :subs-skipped    skipped
       :views-rendered  renders
@@ -381,10 +438,14 @@
       :level-2-subs    level-2
       :sub-readers     readers
       :view-rows       v-rows
+      :unmounted-views unmounted
+      :destroyed-subs  destroyed
       :counts          {:subs-ran         (count ran)
                         :subs-skipped     (count skipped)
                         :views-rendered   (count renders)
                         :view-rows        (count v-rows)
+                        :unmounted-views  (count unmounted)
+                        :destroyed-subs   (count destroyed)
                         :flows-recomputed flows-comp
                         :flows-skipped    flows-skipped}})))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -1,215 +1,107 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-view
-  "Root view for the Views panel (rf2-e33ad / rf2-8ve8z · Mike-direction
-  2026-05-21 · prior beads: rf2-wyvf2, rf2-isun6 · chrome cleanup
+  "Root view for the Views panel (rf2-ad7zx.6 · Figma reconcile · prior
+  beads: rf2-e33ad / rf2-8ve8z / rf2-wyvf2 / rf2-isun6 · chrome cleanup
   rf2-fhh34).
 
-  Renders the reactive cascade flowing toward the UI as THREE STACKED
-  TABLES, top→bottom mirroring the cascade (rf2-8ve8z, phase-B of the
-  Views-tab redesign; phase-A landed the substrate captures in
-  rf2-9hoos):
+  Renders the reactive cascade as a left → right REACTIVE FLOW graph —
+  an inline-SVG node-and-edge canvas (NOT the prior three stacked
+  tables). Reconciled to `tools/causa/spec/021-Dynamic-Panel-Designs.md`
+  §3.2 + `tools/causa/design-reference/components/ViewsPanel.tsx` (the
+  later iteration, authoritative over the §3.1.1 table iteration).
 
-      Level 1 Subscriptions   one row per Level 1 sub that ran this
-                              cascade. Columns:
-                                name | changed | read by | code
-                              `changed` is the accent flag from the
-                              `:value-changed?` projection; `read by`
-                              (rf2-y23uw) lists the views that deref this
-                              sub this cascade — the shared-subscription
-                              edge from `:sub-readers`; `code` is a
-                              jump-to-source [code] chip from the static
-                              topology coord.
+  ## Shape (spec/021 §3.2)
 
-      Level 2+ Subscriptions  one row per composed sub that ran.
-                              Columns:
-                                name | changed | inputs | read by | code
-                              `inputs` lists the input-sub names ONE PER
-                              LINE (the static `:<-` chain from
-                              `sub-topology`); `read by` is the shared-sub
-                              edge as in Level 1.
+  Four columns, left → right:
 
-      Views                   one row per view render / unmount this
-                              cascade. Columns:
-                                name | action | reason
-                                      `name` is hoverable (reuses the
-                                      pink diagonal-stripe DOM highlight,
-                                      rf2-8l03l); `action` is mount /
-                                      rerender / unmount; `reason` is the
-                                      changed subs THIS view reads (a
-                                      reactive render) or the literal
-                                      `← parent re-render` (a structural
-                                      render — UNNAMED, permanent).
+      app-db        a single source node at the far left
+      Level-1 subs  extractors (read app-db) — plain fan-out from app-db
+      Level-2+ subs derived (`:<-` composition; OPTIONAL layer)
+      views         the right-most focus; each (rerendered)
 
-  The Level 1 / Level 2+ split comes from
-  `re-frame.subs.tooling/sub-topology` (`:inputs []` = Level 1); the
-  view action + reason come from phase-A's `:mount?` / `:deref-subs`
-  fields on `:rf.view/rendered` + the new `:rf.view/unmounted` op. All
-  the data wiring lives in `reactive-panel-subs/project-record` — this
-  ns is pure presentation over the projected `:rf.causa/reactive-data`
-  shape.
+  Node + edge encoding (colour/edge first per spec/022 — NOT glyphs):
 
-  ## Hover-highlight (rf2-e33ad / rf2-8l03l)
+  - **changed / recomputed** node → filled tint + accent border + bold
+    label; outgoing edges SOLID accent arrows that PROPAGATE downstream.
+  - **unchanged / short-circuited** node → transparent fill + dashed dim
+    outline + dim label; edges DASHED grey + visually CUT (no arrowhead).
+  - **view** node → success-tinted box labelled `(rerendered)`; carries
+    its per-view `:triggered-by` cause + `:elapsed-ms` timing
+    (rf2-8wrzz.1) as a sub-label.
+  - **shared subscription** → a sub read by ≥2 views fans out to N view
+    nodes; the node carries a `×N` annotation.
 
-  Hovering a Views-table NAME cell toggles the
-  `.rf-causa-view-highlight` class (rf2-8l03l) onto the rendered view's
-  root DOM node (matched by `data-rf-view` — the attribute the framework
-  already stamps per Spec 006 §View tagging contract). The class
-  (theme/global-styles) paints a translucent PINK DIAGONAL-STRIPE
-  barber-pole via `background-image` — pink-on-fainter-pink so it reads
-  on both light and dark app surfaces, translucent so the view's content
-  shows through. The highlight is background-only — NO border / outline /
-  shadow that would perturb layout. Cleared on mouseleave by removing
-  the class (no residue).
+  Below the graph two list sections record the epoch's reactive
+  teardown (Figma design):
+
+  - **UNMOUNTED VIEWS** — views whose component unmounted this epoch.
+  - **DESTROYED SUBSCRIPTIONS** — subs cleaned up when their last reader
+    unmounted (data-availability honest: empty until the sub-dispose op
+    lands — see reactive-panel-subs/destroyed-subscriptions).
+
+  A legend closes the panel with three swatches: changed (propagates) ·
+  no change (short-circuits) · unmounted / destroyed.
+
+  ## Why pure-SVG, not xyflow
+
+  The Machine panel's xyflow integration (spec/021 §6) is a separate,
+  interactive, draggable surface. The reactive-flow graph is a static
+  cause/timing snapshot per the spec + reference, so it is a CAUSA-NATIVE
+  pure-SVG graph — geometry computed by the JVM-testable
+  `reactive-flow-graph/layout`, rendered here as hiccup. Mirrors
+  `chart/timing-waterfall`.
+
+  ## Hover-highlight (rf2-e33ad / rf2-8l03l — preserved)
+
+  Hovering a view NODE toggles the `.rf-causa-view-highlight` class onto
+  the rendered view's root DOM node (matched by `data-rf-view` — the
+  attribute the framework stamps per Spec 006). The class paints a
+  translucent pink diagonal-stripe `background-image` (theme/global-
+  styles) — background-only, NO border / outline / shadow that would
+  perturb layout. Cleared on mouseleave.
 
   Pure hiccup — frame isolation via the enclosing
-  `[rf/frame-provider {:frame :rf/causa}]` in the shell. Subs read on
-  `:rf.causa/*` (panel state) and the dynamically-bound focus via the
-  spine."
+  `[rf/frame-provider {:frame :rf/causa}]` in the shell."
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
-            [day8.re-frame2-causa.theme.tokens
+            [day8.re-frame2-causa.panels.reactive-flow-graph :as graph]
+            [day8.re-frame2-causa.theme.tokens :as tk
              :refer [tokens mono-stack sans-stack]]))
 
-;; ---- truncation budget (rf2-8ve8z · Spec 009 cascade-cap posture) -------
-;;
-;; A full-page cascade can run hundreds of subs / fire hundreds of view
-;; renders. The substrate already caps `:rf.view/rendered` emits at 100
-;; per cascade (re-frame.views/view-rendered-cap). The panel mirrors
-;; that ceiling for table rows and applies a tighter inline budget to
-;; the per-row list columns (inputs / reason subs) so a wide composed
-;; sub or a many-reason render stays a single legible row. Overflow is
-;; surfaced honestly with a muted `+N more` affordance, never silently
-;; dropped.
-
-(def ^:private max-table-rows
-  "Max rows rendered per table before a `+N more` overflow row. Mirrors
-  the substrate's per-cascade view-render cap (100)."
-  100)
-
-(def ^:private max-inline-list
-  "Max items rendered inline in a per-row list column (inputs / reason
-  changed-subs) before a `+N more` suffix. Keeps a wide sub row
-  legible — the full set is in the underlying data."
-  6)
-
-;; ---- styling primitives -------------------------------------------------
+;; ---- section chrome -----------------------------------------------------
 
 (def ^:private section-label-style
-  "Bare title-case label preceding each table. NOT a large h1/h2 heading;
-  12px sans-stack semibold (rf2-fhh34 chrome cleanup — the titles read as
-  written: `Level 1 Subscriptions` / `Level 2+ Subscriptions` / `Views`,
-  no uppercase transform, no count badge)."
-  {:padding       "8px 12px 4px 12px"
-   :font-family   sans-stack
-   :font-size     "12px"
-   :font-weight   600
-   :color         (:text-secondary tokens)})
-
-(def ^:private empty-row-style
-  {:padding     "2px 12px 6px 24px"
-   :color       (:text-tertiary tokens)
-   :font-style  "italic"
-   :font-family sans-stack
-   :font-size   "11px"})
-
-;; ---- table styling (rf2-8ve8z) -----------------------------------------
-
-(def ^:private table-style
-  {:width          "100%"
-   :border-collapse "collapse"
-   :margin         "2px 12px 4px 24px"
-   :font-family    mono-stack
-   :font-size      "12px"
-   :table-layout   "auto"})
-
-(def ^:private th-style
-  "Column header cell. Muted sans label echoing the section-label
-  primitive so the table reads as part of the pipeline rhythm."
-  {:text-align     "left"
-   :padding        "2px 12px 4px 0"
+  "Uppercase muted caption preceding each section (REACTIVE FLOW /
+  UNMOUNTED VIEWS / DESTROYED SUBSCRIPTIONS), echoing the Figma
+  `devtools-caption uppercase tracking-wide` heading."
+  {:padding        "0 0 8px 0"
    :font-family    sans-stack
    :font-size      "10px"
    :font-weight    600
-   :letter-spacing "0.4px"
+   :letter-spacing "0.6px"
    :text-transform "uppercase"
-   :color          (:text-tertiary tokens)
-   :white-space    "nowrap"
-   :vertical-align "bottom"})
+   :color          (:text-tertiary tokens)})
 
-(def ^:private td-style
-  {:padding        "3px 12px 3px 0"
-   :color          (:text-primary tokens)
-   :vertical-align "top"})
-
-(def ^:private name-cell-style
-  "The `name` column — the sub-id / view-id. Violet accent + semibold so
-  the identifier leads the row."
-  (assoc td-style :color (:accent tokens) :font-weight 600
-                  :white-space "nowrap"))
-
-(def ^:private changed-yes-style
-  "The `changed` flag when the sub's value changed this cascade — a clear
-  accent so the eye lands on it."
-  {:color (:accent tokens) :font-weight 600})
-
-(def ^:private changed-no-style
-  "The `changed` placeholder when unchanged — muted so the eye skips it."
-  {:color (:text-tertiary tokens) :opacity "0.5"})
-
-(def ^:private overflow-style
-  "Muted `+N more` affordance for honest truncation."
-  {:color       (:text-tertiary tokens)
-   :font-style  "italic"
-   :font-family sans-stack
-   :font-size   "10px"})
-
-;; ---- action / reason styling (rf2-8ve8z) -------------------------------
-
-(def ^:private action->token
-  "Map a view action to its accent token. mount = green (a new thing
-  appears), rerender = the mode `accent` (the standard change accent,
-  shared with the sub `changed` flag — `changed` = mode accent per
-  §021 §10.3 / spec/022), unmount = red (a thing goes away)."
-  {:mount    :green
-   :rerender :accent
-   :unmount  :red})
-
-(defn- action-style
-  [action]
-  {:color       (get tokens (get action->token action :text-secondary))
-   :font-weight 600
-   :font-family sans-stack
-   :font-size   "10px"
-   :letter-spacing "0.3px"
-   :text-transform "uppercase"})
-
-(def ^:private structural-reason-style
-  "The literal `← parent re-render` text — muted so a structural render
-  reads as quieter than a reactive one (which carries named subs)."
-  {:color       (:text-tertiary tokens)
-   :font-style  "italic"})
-
-(def ^:private reactive-reason-sub-style
-  "A changed-sub name in a reactive view's reason cell."
-  {:color (:accent tokens)})
-
-(def ^:private none-reason-style
-  "The em-dash placeholder for an unmount row's empty reason."
-  {:color (:text-tertiary tokens) :opacity "0.5"})
+(defn- section-label
+  "Uppercase section caption. testid:
+  `rf-causa-reactive-section-<id>-label`."
+  [id title]
+  [:div {:data-testid (str "rf-causa-reactive-section-" id "-label")
+         :style       section-label-style}
+   title])
 
 ;; ---- pure formatters ---------------------------------------------------
 
 (defn- format-id
   [id]
   (cond
-    (nil? id)        ""
-    (keyword? id)    (str id)
-    :else            (pr-str id)))
+    (nil? id)     ""
+    (keyword? id) (str id)
+    :else         (pr-str id)))
 
 (defn- view-display-name
-  "Resolve a view's human-friendly name. Per Mike-direction 2026-05-21
-  the `reg-view :name` slot wins; fall back to the registry id
-  keyword's name segment (the var-name encoded as the kw). Returns
-  the string the panel renders."
+  "Resolve a view's human-friendly name. The `reg-view :name` slot wins;
+  fall back to the registry id keyword's name. Returns the string the
+  panel renders."
   [view-id meta]
   (let [registered-name (:name meta)]
     (cond
@@ -223,364 +115,299 @@
       (pr-str view-id))))
 
 (defn- id-slug
-  "Stable testid suffix for a sub-id / view-id — kw/symbol punctuation
-  flattened to `_` so the row + chip testids are CSS-selector safe."
+  "Stable testid suffix — kw/symbol punctuation flattened to `_`."
   [id]
   (when id (string/replace (str id) #"[^a-zA-Z0-9_]" "_")))
 
-;; ---- pipeline chrome ---------------------------------------------------
-
-(defn- section-label
-  "Bare label that precedes each table. testid:
-  `rf-causa-reactive-section-<id>-label`."
-  [id title]
-  [:div {:data-testid (str "rf-causa-reactive-section-" id "-label")
-         :style       section-label-style}
-   title])
-
-(defn- empty-row
-  "Render a muted placeholder for an empty table. Empty states are
-  ALWAYS visible so the pipeline rhythm holds (Mike-direction
-  2026-05-21)."
-  [testid label]
-  [:div {:data-testid testid
-         :style empty-row-style}
-   label])
-
-;; ---- [code] open-chip helpers -----------------------------------------
-
-(defn- code-chip
-  "Render an open-in-editor pill matching the Event panel's `coord-chip`
-  shape — a clickable `ns:line` jump-to-source affordance. Dispatches
-  `:rf.causa/open-in-editor`. Returns nil when there is no usable
-  `:file`."
-  [coord testid]
-  (when (and (map? coord) (seq (:file coord)))
-    (let [ns-seg (some-> (:ns coord) str)
-          line   (:line coord)
-          label  (cond
-                   (and ns-seg line) (str ns-seg ":" line)
-                   ns-seg            ns-seg
-                   line              (str ":" line)
-                   :else             "[code]")]
-      [:button {:data-testid testid
-                :title       (str "Open " (:file coord)
-                                  (when line (str ":" line)))
-                :on-click    (fn [e]
-                               (.stopPropagation e)
-                               (rf/dispatch [:rf.causa/open-in-editor
-                                             {:source-coord coord}]
-                                            {:frame :rf/causa}))
-                :style       {:background  "transparent"
-                              :color       (:accent tokens)
-                              :border      (str "1px solid " (:border-default tokens))
-                              :padding     "1px 6px"
-                              :border-radius "3px"
-                              :cursor      "pointer"
-                              :font-family mono-stack
-                              :font-size   "10px"
-                              :white-space "nowrap"}}
-       label])))
-
-(defn- view-coord
-  "Look up the source coord for a registered view id via the registry
-  meta read. Returns the structured coord."
-  [view-id]
-  (let [meta (rf/handler-meta :view view-id)
-        file (:file meta)]
-    (when (string? file)
-      {:file file :line (:line meta) :column (:column meta) :ns (:ns meta)})))
+(defn- elapsed-label
+  "Format a render's `:elapsed-ms` for the view-node sub-label. Sub-ms
+  rounds to one decimal; ≥1ms rounds to whole ms. nil → nil."
+  [ms]
+  (when (number? ms)
+    (if (< ms 1)
+      (str (/ (Math/round (* ms 10.0)) 10.0) "ms")
+      (str (Math/round ms) "ms"))))
 
 ;; ---- hover-highlight (rf2-e33ad / rf2-8l03l) --------------------------
 ;;
-;; Hover a Views-table NAME cell → stamp a distinctive background-only
-;; highlight on the rendered view's root DOM node (matched via the
-;; `data-rf-view` attribute the framework already stamps per Spec 006).
-;; Cleared on mouseleave.
-;;
-;; Mechanism (rf2-8l03l): toggle the Causa-namespaced
-;; `.rf-causa-view-highlight` class. The class rule (in
-;; `theme/global-styles` `motion-css`) paints a TRANSLUCENT PINK
-;; DIAGONAL-STRIPE barber-pole via `background-image` over the view's
-;; own background — pink-on-fainter-pink so it reads on BOTH light and
-;; dark app surfaces, translucent so the view's content shows through.
-;; A class toggle is cleaner than the old inline stash/restore: the
-;; `background-image` gradient layers OVER the view's own
-;; `background-color` without destroying it, and `clear-highlight!`
-;; simply removes the class to fully restore the node — no
-;; `data-rf-causa-prior-bg` stash, no residue.
-;;
-;; Why background-only: NO border / outline / shadow that would
-;; perturb layout. Per Mike-direction 2026-05-21 (rf2-e33ad) the hover
-;; signal must NOT shift surrounding pixels — a `background-image`
-;; paints inside the existing box with zero reflow.
+;; Hover a view node → stamp the pink diagonal-stripe highlight class on
+;; the rendered view's root DOM node (matched via `data-rf-view`).
+;; Cleared on mouseleave. Background-only — no layout perturbation.
 
-(def ^:private highlight-class
-  "Causa-namespaced class toggled onto the hovered view's `data-rf-view`
-  node. The matching CSS rule (theme/global-styles) paints the pink
-  diagonal-stripe `background-image`."
-  "rf-causa-view-highlight")
+(def ^:private highlight-class "rf-causa-view-highlight")
 
 (defn- highlight-selector
-  "Build the DOM selector for a view-id. Per Spec 006 the attribute
-  value is `(str id)` — so `:rf.foo/bar` is stored as `:rf.foo/bar`."
+  "DOM selector for a view-id (Spec 006 stores `(str id)`)."
   [view-id]
-  (str "[data-rf-view='" (str view-id) "']"))
+  (str "[data-rf-view='" view-id "']"))
 
 (defn- apply-highlight!
-  "Toggle the pink diagonal-stripe highlight class onto every DOM node
-  matching `view-id`. CLJS-only side effect."
   [view-id]
   (when (and (exists? js/document) view-id)
     (let [nodes (.querySelectorAll js/document (highlight-selector view-id))]
       (.forEach nodes
-                (fn [^js node]
-                  (.add (.-classList node) highlight-class)))
+                (fn [^js node] (.add (.-classList node) highlight-class)))
       nil)))
 
 (defn- clear-highlight!
-  "Remove the highlight class from every DOM node matching `view-id`,
-  fully restoring the node to its original look. CLJS-only side effect."
   [view-id]
   (when (and (exists? js/document) view-id)
     (let [nodes (.querySelectorAll js/document (highlight-selector view-id))]
       (.forEach nodes
-                (fn [^js node]
-                  (.remove (.-classList node) highlight-class)))
+                (fn [^js node] (.remove (.-classList node) highlight-class)))
       nil)))
 
-;; ---- shared cell renderers --------------------------------------------
+;; ---- [code] open-chip --------------------------------------------------
 
-(defn- changed-cell
-  "The `changed` column — a clear accent ✓ when the sub's value changed
-  this cascade; otherwise a muted · placeholder."
-  [changed?]
-  [:td {:style td-style}
-   (if changed?
-     [:span {:style changed-yes-style} "✓"]
-     [:span {:style changed-no-style} "·"])])
+(defn- open-source!
+  "Dispatch the jump-to-source effect for a topology coord."
+  [coord e]
+  (when e (.stopPropagation e))
+  (rf/dispatch [:rf.causa/open-in-editor {:source-coord coord}]
+               {:frame :rf/causa}))
 
-(defn- code-cell
-  "The `code` column — the jump-to-source chip, or a muted em-dash when
-  the topology carries no source coord (nil-safe degrade)."
-  [coord testid]
-  [:td {:style td-style}
-   (or (code-chip coord testid)
-       [:span {:style changed-no-style} "—"])])
+;; ---- SVG paint helpers -------------------------------------------------
 
-(defn- overflow-line
-  "Render a `+N more` line when `total` exceeds `shown`. Returns nil
-  otherwise."
-  [shown total]
-  (when (> total shown)
-    [:div {:style overflow-style} (str "+" (- total shown) " more")]))
+(def ^:private arrow-id "rf-causa-reactive-arrow-changed")
 
-(defn- readers-cell
-  "The `read by` column (rf2-y23uw) — the views that deref THIS sub this
-  cascade (the shared-subscription edge), one per line, honestly
-  truncated with `+N more`. A muted em-dash when no rendered view read
-  the sub (e.g. an upstream-input sub a composed sub reads but no view
-  derefs directly)."
-  [readers]
-  (let [n     (count readers)
-        shown (take max-inline-list readers)]
-    [:td {:style td-style}
-     (if (seq readers)
-       (into [:div {:style {:display "flex" :flex-direction "column"
-                            :gap "1px"}}]
-             (concat
-               (for [[i v] (map-indexed vector shown)]
-                 ^{:key i} [:span {:style {:color (:text-secondary tokens)}}
-                            (format-id v)])
-               [(overflow-line max-inline-list n)]))
-       [:span {:style changed-no-style} "—"])]))
+(defn- arrow-defs
+  "The single arrowhead marker — accent-coloured, used only by changed
+  (propagating) edges. Unchanged edges are visually CUT (no arrowhead)."
+  []
+  [:defs
+   [:marker {:id arrow-id :markerWidth 9 :markerHeight 7
+             :refX 8 :refY 3.5 :orient "auto"}
+    [:polygon {:points "0 0, 9 3.5, 0 7" :fill (:accent tokens)}]]])
 
-;; ---- table 1: Level 1 subs --------------------------------------------
+(defn- edge
+  "Render one cascade edge. Changed → solid accent line + arrowhead
+  (propagates). Unchanged → dashed dim line, NO arrowhead (cut)."
+  [{:keys [from-id to-id x1 y1 x2 y2 changed? kind]} i]
+  ^{:key (str "edge-" kind "-" i)}
+  [:line (cond-> {:data-testid (str "rf-causa-reactive-edge-" (name kind))
+                  :data-edge-changed (str (boolean changed?))
+                  :data-edge-from (str from-id)
+                  :data-edge-to (str to-id)
+                  :x1 x1 :y1 y1 :x2 x2 :y2 y2}
+           changed?       (assoc :stroke (:accent tokens)
+                                 :stroke-width 2
+                                 :marker-end (str "url(#" arrow-id ")"))
+           (not changed?) (assoc :stroke (:dim tokens)
+                                 :stroke-width 1
+                                 :stroke-dasharray "4,3"))])
 
-(defn- level-1-row
-  "One Level 1 sub row: name | changed | read by | code.
+(defn- appdb-node
+  "The single app-db source node at the far left."
+  [{:keys [x y w h]}]
+  [:g {:data-testid "rf-causa-reactive-appdb-node"}
+   [:rect {:x x :y y :width w :height h :rx 4
+           :fill (:bg-3 tokens)
+           :stroke (:border-default tokens) :stroke-width 1.5}]
+   [:text {:x (+ x (/ w 2)) :y (+ y (/ h 2) 4)
+           :text-anchor "middle" :fill (:text-primary tokens)
+           :font-size 12 :font-family mono-stack}
+    "app-db"]])
 
-  testids:
-    row       `rf-causa-reactive-l1-row-<slug>`
-    code chip `rf-causa-reactive-l1-code-<slug>`"
-  [{:keys [sub-id changed? coord readers]}]
-  (let [slug (id-slug sub-id)]
-    [:tr {:data-testid (str "rf-causa-reactive-l1-row-" slug)
-          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
-     [:td {:style name-cell-style} (format-id sub-id)]
-     (changed-cell changed?)
-     (readers-cell readers)
-     (code-cell coord (str "rf-causa-reactive-l1-code-" slug))]))
+(defn- sub-node
+  "Render a Level-1 / Level-2 sub node. Changed → filled tint + accent
+  border + bold; unchanged → transparent + dashed dim outline + dim
+  label. A shared sub (read by ≥2 views) carries a `×N` annotation.
+  Clicking the node jumps to the sub's registration source."
+  [{:keys [id slug label changed? shared-count coord x y w h kind]}]
+  (let [click (when coord (fn [e] (open-source! coord e)))]
+    [:g (cond-> {:data-testid (str "rf-causa-reactive-node-" (name kind) "-" slug)
+                 :data-node-changed (str (boolean changed?))
+                 :data-node-id (str id)}
+          click (assoc :on-click click
+                       :style {:cursor "pointer"}))
+     [:rect (cond-> {:x x :y y :width w :height h :rx 4}
+              changed?       (assoc :fill (tk/with-alpha :accent 12)
+                                    :stroke (:accent tokens) :stroke-width 2)
+              (not changed?) (assoc :fill "transparent"
+                                    :stroke (:dim tokens) :stroke-width 1
+                                    :stroke-dasharray "4,2"))]
+     [:text {:x (+ x (/ w 2)) :y (+ y (/ h 2) 4)
+             :text-anchor "middle"
+             :fill (if changed? (:accent tokens) (:dim tokens))
+             :font-size 11 :font-family mono-stack
+             :font-weight (if changed? 600 400)}
+      label]
+     (when (and shared-count (> shared-count 1))
+       [:text {:data-testid (str "rf-causa-reactive-shared-" slug)
+               :x (+ x w -4) :y (- y 3)
+               :text-anchor "end" :fill (:text-tertiary tokens)
+               :font-size 9 :font-family sans-stack}
+        (str "×" shared-count)])]))
 
-(defn- level-1-section
+(defn- view-node
+  "Render a view node — the cascade leaf + focus. Success-tinted box
+  labelled `(rerendered)` (or `(mounted)`); carries the per-view
+  `:triggered-by` cause + `:elapsed-ms` timing as a sub-label
+  (rf2-8wrzz.1). Hovering toggles the pink DOM highlight (rf2-8l03l)."
+  [{:keys [id slug label action triggered-by elapsed-ms x y w h]}]
+  (let [meta      (when id (rf/handler-meta :view id))
+        disp-name (view-display-name id meta)
+        coord     (when (string? (:file meta))
+                    {:file (:file meta) :line (:line meta) :ns (:ns meta)})
+        sub-label (str "(" (if (= :mount action) "mounted" "rerendered") ")")
+        cause     (when triggered-by (str "← " (format-id triggered-by)))
+        timing    (elapsed-label elapsed-ms)
+        meta-line (->> [cause timing] (remove nil?) (string/join " · "))]
+    [:g {:data-testid (str "rf-causa-reactive-view-node-" slug)
+         :data-node-id (str id)
+         :data-rf-causa-view-id (str id)
+         :on-mouse-enter (fn [_e] (apply-highlight! id))
+         :on-mouse-leave (fn [_e] (clear-highlight! id))
+         :on-click       (when coord (fn [e] (open-source! coord e)))
+         :style {:cursor (if coord "pointer" "default")}}
+     [:rect {:x x :y y :width w :height h :rx 4
+             :fill (tk/with-alpha :success 12)
+             :stroke (:success tokens) :stroke-width 2}]
+     ;; view name
+     [:text {:x (+ x (/ w 2)) :y (+ y 16)
+             :text-anchor "middle" :fill (:success tokens)
+             :font-size 11 :font-family mono-stack :font-weight 600}
+      (if (and (string? disp-name) (seq disp-name)) disp-name label)]
+     ;; (rerendered) + cause/timing sub-label
+     [:text {:data-testid (str "rf-causa-reactive-view-meta-" slug)
+             :x (+ x (/ w 2)) :y (+ y 28)
+             :text-anchor "middle" :fill (:text-tertiary tokens)
+             :font-size 9 :font-family sans-stack}
+      (if (seq meta-line) (str sub-label "  " meta-line) sub-label)]]))
+
+;; ---- REACTIVE FLOW graph -----------------------------------------------
+
+(defn- flow-graph
+  "Render the left → right reactive-flow SVG canvas from the pure
+  `graph/layout` geometry."
   [data]
-  (let [rows (:level-1-subs data)
-        n    (count rows)]
-    [:<>
-     (section-label "l1" "Level 1 Subscriptions")
-     (if (seq rows)
-       [:table {:data-testid "rf-causa-reactive-l1-table"
-                :style       table-style}
-        [:thead
-         [:tr
-          [:th {:style th-style} "name"]
-          [:th {:style th-style} "changed"]
-          [:th {:style th-style} "read by"]
-          [:th {:style th-style} "code"]]]
-        (into [:tbody]
-              (concat
-                (for [[i r] (map-indexed vector (take max-table-rows rows))]
-                  (with-meta (level-1-row r) {:key i}))
-                (when (> n max-table-rows)
-                  [[:tr {:data-testid "rf-causa-reactive-l1-overflow"}
-                    [:td {:colSpan 4 :style (assoc td-style :padding-left "0")}
-                     (overflow-line max-table-rows n)]]])))]
-       (empty-row "rf-causa-reactive-l1-empty" "(no Level 1 subs ran)"))]))
+  (let [g (graph/layout data)]
+    (if (:empty? g)
+      [:div {:data-testid "rf-causa-reactive-graph-empty"
+             :style {:padding "8px 0 16px 0"
+                     :color (:text-tertiary tokens)
+                     :font-family sans-stack :font-size "12px"}}
+       "No subs subscribed to changed paths · no views re-rendered."]
+      [:div {:data-testid "rf-causa-reactive-graph-card"
+             :style {:border (str "1px solid " (:border-default tokens))
+                     :border-radius "8px"
+                     :padding "16px"
+                     :background (:bg-1 tokens)
+                     :overflow-x "auto"}}
+       [:svg {:data-testid "rf-causa-reactive-flow-svg"
+              :width (:width g) :height (:height g)
+              :viewBox (str "0 0 " (:width g) " " (:height g))
+              :style {:display "block" :max-width "100%"}}
+        (arrow-defs)
+        ;; edges first so nodes paint over them
+        (into [:g {:data-testid "rf-causa-reactive-edges"}]
+              (map-indexed (fn [i e] (edge e i)) (:edges g)))
+        (appdb-node (:appdb g))
+        (into [:g {:data-testid "rf-causa-reactive-l1-nodes"}]
+              (map (fn [n] ^{:key (:slug n)} [sub-node n]) (-> g :nodes :l1)))
+        (into [:g {:data-testid "rf-causa-reactive-l2-nodes"}]
+              (map (fn [n] ^{:key (:slug n)} [sub-node n]) (-> g :nodes :l2)))
+        (into [:g {:data-testid "rf-causa-reactive-view-nodes"}]
+              (map (fn [n] ^{:key (:slug n)} [view-node n]) (-> g :nodes :view)))]])))
 
-;; ---- table 2: Level 2+ subs -------------------------------------------
+;; ---- teardown list sections (UNMOUNTED VIEWS / DESTROYED SUBS) ---------
 
-(defn- inputs-cell
-  "The `inputs` column — input-sub names ONE PER LINE, honestly
-  truncated with `+N more`. Muted em-dash when there are no inputs
-  (defensive — a Level 2+ row always has at least one)."
-  [inputs]
-  (let [n     (count inputs)
-        shown (take max-inline-list inputs)]
-    [:td {:style td-style}
-     (if (seq inputs)
-       (into [:div {:style {:display "flex" :flex-direction "column"
-                            :gap "1px"}}]
-             (concat
-               (for [[i input] (map-indexed vector shown)]
-                 ^{:key i} [:span {:style {:color (:text-secondary tokens)}}
-                            (format-id input)])
-               [(overflow-line max-inline-list n)]))
-       [:span {:style changed-no-style} "—"])]))
+(def ^:private list-card-style
+  {:border (str "1px solid " (:border-default tokens))
+   :border-radius "8px"
+   :background (:bg-1 tokens)
+   :overflow "hidden"})
 
-(defn- level-2-row
-  "One Level 2+ sub row: name | changed | inputs | read by | code.
+(defn- list-row
+  "One teardown-list row: a small tinted swatch + identifier + a muted
+  trailing tag, matching the Figma `divide-y` list rows."
+  [{:keys [testid swatch-token primary tag]}]
+  [:div {:data-testid testid
+         :style {:display "flex" :align-items "center" :gap "12px"
+                 :padding "8px 14px"
+                 :border-top (str "1px solid " (:border-subtle tokens))
+                 :font-family mono-stack :font-size "12px"}}
+   [:span {:style {:width "14px" :height "14px" :border-radius "3px"
+                   :flex "0 0 auto"
+                   :background (tk/with-alpha swatch-token 20)}}]
+   [:span {:style {:flex 1 :color (:text-primary tokens)}} primary]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family sans-stack :font-size "10px"}}
+    tag]])
 
-  testids:
-    row       `rf-causa-reactive-l2-row-<slug>`
-    code chip `rf-causa-reactive-l2-code-<slug>`"
-  [{:keys [sub-id changed? inputs coord readers]}]
-  (let [slug (id-slug sub-id)]
-    [:tr {:data-testid (str "rf-causa-reactive-l2-row-" slug)
-          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
-     [:td {:style name-cell-style} (format-id sub-id)]
-     (changed-cell changed?)
-     (inputs-cell inputs)
-     (readers-cell readers)
-     (code-cell coord (str "rf-causa-reactive-l2-code-" slug))]))
-
-(defn- level-2-section
+(defn- unmounted-views-section
   [data]
-  (let [rows (:level-2-subs data)
-        n    (count rows)]
-    [:<>
-     (section-label "l2" "Level 2+ Subscriptions")
+  (let [rows (:unmounted-views data)]
+    [:section {:data-testid "rf-causa-reactive-unmounted-section"
+               :style {:margin-top "24px"}}
+     (section-label "unmounted" "Unmounted Views")
      (if (seq rows)
-       [:table {:data-testid "rf-causa-reactive-l2-table"
-                :style       table-style}
-        [:thead
-         [:tr
-          [:th {:style th-style} "name"]
-          [:th {:style th-style} "changed"]
-          [:th {:style th-style} "inputs"]
-          [:th {:style th-style} "read by"]
-          [:th {:style th-style} "code"]]]
-        (into [:tbody]
-              (concat
-                (for [[i r] (map-indexed vector (take max-table-rows rows))]
-                  (with-meta (level-2-row r) {:key i}))
-                (when (> n max-table-rows)
-                  [[:tr {:data-testid "rf-causa-reactive-l2-overflow"}
-                    [:td {:colSpan 5 :style (assoc td-style :padding-left "0")}
-                     (overflow-line max-table-rows n)]]])))]
-       (empty-row "rf-causa-reactive-l2-empty" "(no Level 2+ subs ran)"))]))
+       (into [:div {:data-testid "rf-causa-reactive-unmounted-list"
+                    :style list-card-style}]
+             (for [{:keys [view-id]} rows
+                   :let [meta (when view-id (rf/handler-meta :view view-id))
+                         nm   (view-display-name view-id meta)]]
+               ^{:key (str view-id)}
+               [list-row {:testid (str "rf-causa-reactive-unmounted-row-"
+                                       (id-slug view-id))
+                          :swatch-token :error
+                          :primary nm
+                          :tag "unmounted"}]))
+       [:div {:data-testid "rf-causa-reactive-unmounted-empty"
+              :style {:padding "2px 0" :color (:text-tertiary tokens)
+                      :font-style "italic" :font-family sans-stack
+                      :font-size "11px"}}
+        "(no views unmounted)"])]))
 
-;; ---- table 3: Views ----------------------------------------------------
-
-(defn- reason-cell
-  "The `reason` column for a Views-table row.
-
-    :reactive   → the changed subs THIS view reads (mode-accent names,
-                  honestly truncated with `+N more`).
-    :structural → the literal `← parent re-render` — UNNAMED. We never
-                  name the parent (permanent, rf2-8ve8z).
-    :none       → unmount row → a muted em-dash."
-  [reason]
-  (let [kind (:kind reason)]
-    [:td {:style td-style}
-     (case kind
-       :reactive
-       (let [subs  (:subs reason)
-             n     (count subs)
-             shown (take max-inline-list subs)]
-         (into [:div {:style {:display "flex" :flex-direction "column"
-                              :gap "1px"}}]
-               (concat
-                 (for [[i s] (map-indexed vector shown)]
-                   ^{:key i} [:span {:style reactive-reason-sub-style}
-                              (format-id s)])
-                 [(overflow-line max-inline-list n)])))
-
-       :structural
-       [:span {:data-testid "rf-causa-reactive-view-reason-structural"
-               :style structural-reason-style}
-        "← parent re-render"]
-
-       ;; :none / unknown
-       [:span {:style none-reason-style} "—"])]))
-
-(defn- view-row
-  "One Views-table row: name | action | reason. Hover the NAME cell to
-  highlight the rendered view's DOM (rf2-8l03l). Each render/unmount of
-  a view yields one row.
-
-  testid: `rf-causa-reactive-view-row-<slug>` (index-suffixed so repeat
-  renders of the same view stay unique)."
-  [idx {:keys [view-id action reason]}]
-  (let [meta      (when view-id (rf/handler-meta :view view-id))
-        disp-name (view-display-name view-id meta)
-        slug      (id-slug view-id)
-        on-enter  (fn [_e] (apply-highlight! view-id))
-        on-leave  (fn [_e] (clear-highlight! view-id))]
-    [:tr {:data-testid (str "rf-causa-reactive-view-row-" slug "-" idx)
-          :data-rf-causa-view-id (str view-id)
-          :style       {:border-top (str "1px solid " (:border-subtle tokens))}}
-     [:td {:data-testid (str "rf-causa-reactive-view-name-" slug "-" idx)
-           :on-mouse-enter on-enter
-           :on-mouse-leave on-leave
-           :style (assoc name-cell-style :cursor "default")}
-      disp-name]
-     [:td {:style td-style}
-      [:span {:style (action-style action)} (name action)]]
-     (reason-cell reason)]))
-
-(defn- views-section
+(defn- destroyed-subs-section
   [data]
-  (let [rows (:view-rows data)
-        n    (count rows)]
-    [:<>
-     (section-label "views" "Views")
+  (let [rows (:destroyed-subs data)]
+    [:section {:data-testid "rf-causa-reactive-destroyed-section"
+               :style {:margin-top "24px"}}
+     (section-label "destroyed" "Destroyed Subscriptions")
      (if (seq rows)
-       [:table {:data-testid "rf-causa-reactive-views-table"
-                :style       table-style}
-        [:thead
-         [:tr
-          [:th {:style th-style} "name"]
-          [:th {:style th-style} "action"]
-          [:th {:style th-style} "reason"]]]
-        (into [:tbody]
-              (concat
-                (for [[i r] (map-indexed vector (take max-table-rows rows))]
-                  (with-meta (view-row i r) {:key i}))
-                (when (> n max-table-rows)
-                  [[:tr {:data-testid "rf-causa-reactive-views-overflow"}
-                    [:td {:colSpan 3 :style (assoc td-style :padding-left "0")}
-                     (overflow-line max-table-rows n)]]])))]
-       (empty-row "rf-causa-reactive-views-empty" "(no views rendered)"))]))
+       (into [:div {:data-testid "rf-causa-reactive-destroyed-list"
+                    :style list-card-style}]
+             (for [{:keys [sub-id]} rows]
+               ^{:key (str sub-id)}
+               [list-row {:testid (str "rf-causa-reactive-destroyed-row-"
+                                       (id-slug sub-id))
+                          :swatch-token :dim
+                          :primary (format-id sub-id)
+                          :tag "no readers remaining"}]))
+       [:div {:data-testid "rf-causa-reactive-destroyed-empty"
+              :style {:padding "2px 0" :color (:text-tertiary tokens)
+                      :font-style "italic" :font-family sans-stack
+                      :font-size "11px"}}
+        "(no subscriptions destroyed)"])
+     [:p {:data-testid "rf-causa-reactive-destroyed-caption"
+          :style {:margin "8px 0 0 0" :color (:text-tertiary tokens)
+                  :font-family sans-stack :font-size "10px"}}
+      "Subscriptions cleaned up when their last reader unmounted"]]))
+
+;; ---- legend ------------------------------------------------------------
+
+(defn- swatch
+  [style label]
+  [:span {:style {:display "inline-flex" :align-items "center" :gap "8px"}}
+   [:span {:style (merge {:display "inline-block" :width "12px"
+                          :height "12px" :border-radius "3px"} style)}]
+   label])
+
+(defn- legend
+  []
+  [:div {:data-testid "rf-causa-reactive-legend"
+         :style {:margin-top "24px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack :font-size "10px"}}
+   [:p {:style {:margin "0 0 6px 0"}}
+    "Views (right) are the focus — each: re-rendered + why (reactive vs parent re-render)"]
+   [:div {:style {:display "flex" :flex-wrap "wrap" :gap "16px"
+                  :align-items "center"}}
+    (swatch {:background (:accent tokens)} "changed (propagates downstream)")
+    (swatch {:background "transparent" :border (str "1px dashed " (:dim tokens))}
+            "no change (short-circuits)")
+    (swatch {:background (tk/with-alpha :error 20)} "unmounted / destroyed")]])
 
 ;; ---- empty state ------------------------------------------------------
 
@@ -602,8 +429,9 @@
   facade reg-view) via a function call so the React-context frame tier
   resolves to `:rf/causa` inside the leaf's subscribes.
 
-  Renders the three stacked tables (rf2-8ve8z) top→bottom mirroring the
-  reactive cascade: Level 1 subs → Level 2+ subs → Views."
+  Renders the left → right REACTIVE FLOW graph (rf2-ad7zx.6) followed by
+  the UNMOUNTED VIEWS + DESTROYED SUBSCRIPTIONS sections and the closing
+  legend."
   []
   (let [data @(rf/subscribe [:rf.causa/reactive-data])]
     [:section {:data-testid "rf-causa-reactive"
@@ -621,8 +449,10 @@
 
         :else
         [:div {:data-testid "rf-causa-reactive-pipeline"
-               :style {:padding-top   "8px"
-                       :padding-bottom "8px"}}
-         (level-1-section data)
-         (level-2-section data)
-         (views-section data)])]]))
+               :style {:padding "16px"}}
+         [:section {:data-testid "rf-causa-reactive-flow-section"}
+          (section-label "flow" "Reactive Flow")
+          (flow-graph data)]
+         (unmounted-views-section data)
+         (destroyed-subs-section data)
+         (legend)])]]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_flow_graph_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_flow_graph_cljs_test.cljc
@@ -1,0 +1,148 @@
+(ns day8.re-frame2-causa.panels.reactive-flow-graph-cljs-test
+  "Pure-data tests for the reactive-flow graph layout (rf2-ad7zx.6 ·
+  spec/021 §3.2 · Figma `ViewsPanel.tsx`).
+
+  Covers `shared-sub-set` (the shared-subscription detector) and `layout`
+  (the node + edge geometry the Views panel renders as inline SVG).
+  JVM-runnable — no re-frame frame, no browser."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.reactive-flow-graph :as g]))
+
+;; ---- shared-sub-set ----------------------------------------------------
+
+(deftest shared-sub-set-detects-multi-reader-subs
+  (testing "a sub read by ≥2 views is in the shared set; a 0/1-reader sub
+            is not"
+    (let [subs [{:sub-id :a :readers [:v1 :v2]}
+                {:sub-id :b :readers [:v1]}
+                {:sub-id :c :readers []}
+                {:sub-id :d :readers [:v1 :v2 :v3]}]]
+      (is (= #{:a :d} (g/shared-sub-set subs))))))
+
+(deftest shared-sub-set-nil-safe
+  (is (= #{} (g/shared-sub-set [])))
+  (is (= #{} (g/shared-sub-set [{:sub-id :x}]))))
+
+;; ---- layout: empty -----------------------------------------------------
+
+(deftest layout-empty-when-no-cascade
+  (testing "no subs + no views → :empty? true"
+    (let [out (g/layout {})]
+      (is (:empty? out))
+      (is (= [] (-> out :nodes :l1)))
+      (is (= [] (-> out :nodes :l2)))
+      (is (= [] (-> out :nodes :view)))
+      (is (= [] (:edges out))))))
+
+(deftest layout-empty-with-only-unmount-rows
+  (testing "view-rows that are all unmounts don't populate the graph"
+    (let [out (g/layout {:view-rows [{:view-id :v :action :unmount}]})]
+      (is (:empty? out))
+      (is (= [] (-> out :nodes :view))))))
+
+;; ---- layout: nodes -----------------------------------------------------
+
+(deftest layout-builds-app-db-source-node
+  (testing "app-db source node sits at the left edge with stable geometry"
+    (let [out (g/layout {:level-1-subs [{:sub-id :a :changed? true}]})]
+      (is (number? (-> out :appdb :x)))
+      (is (number? (-> out :appdb :y)))
+      (is (= g/node-h (-> out :appdb :h))))))
+
+(deftest layout-columns-are-ordered-left-to-right
+  (testing "app-db < L1 < L2 < view in x"
+    (let [out (g/layout {:level-1-subs [{:sub-id :l1 :changed? true}]
+                         :level-2-subs [{:sub-id :l2 :changed? true :inputs [:l1]}]
+                         :view-rows    [{:view-id :v :action :rerender}]})
+          l1x (-> out :nodes :l1 first :x)
+          l2x (-> out :nodes :l2 first :x)
+          vx  (-> out :nodes :view first :x)]
+      (is (< (-> out :appdb :x) l1x))
+      (is (< l1x l2x))
+      (is (< l2x vx)))))
+
+(deftest layout-preserves-changed-flags-on-nodes
+  (testing "node :changed? mirrors the input row"
+    (let [out (g/layout {:level-1-subs [{:sub-id :hot :changed? true}
+                                        {:sub-id :cold :changed? false}]})
+          nodes (-> out :nodes :l1)]
+      (is (true? (:changed? (first nodes))))
+      (is (false? (:changed? (second nodes)))))))
+
+(deftest layout-view-node-carries-cause-and-timing
+  (testing "rf2-8wrzz.1 — the view node threads :triggered-by + :elapsed-ms"
+    (let [out (g/layout {:view-rows [{:view-id :v :action :rerender
+                                      :triggered-by :sub/x :elapsed-ms 1.5}]})
+          vn  (-> out :nodes :view first)]
+      (is (= :sub/x (:triggered-by vn)))
+      (is (= 1.5 (:elapsed-ms vn)))
+      (is (= :rerender (:action vn))))))
+
+(deftest layout-marks-shared-sub-count
+  (testing "a sub read by ≥2 views carries :shared-count"
+    (let [out (g/layout {:level-1-subs [{:sub-id :s :changed? true
+                                         :readers [:v1 :v2]}]})
+          n   (-> out :nodes :l1 first)]
+      (is (= 2 (:shared-count n))))))
+
+(deftest layout-no-shared-count-for-single-reader
+  (let [out (g/layout {:level-1-subs [{:sub-id :s :changed? true :readers [:v1]}]})]
+    (is (nil? (:shared-count (-> out :nodes :l1 first))))))
+
+;; ---- layout: edges -----------------------------------------------------
+
+(deftest layout-app-db-fans-out-to-each-level-1
+  (testing "one app-db → L1 edge per Level-1 sub (plain fan-out)"
+    (let [out (g/layout {:level-1-subs [{:sub-id :a :changed? true}
+                                        {:sub-id :b :changed? false}]})
+          appdb-edges (filter #(= :appdb-l1 (:kind %)) (:edges out))]
+      (is (= 2 (count appdb-edges)))
+      (is (every? #(= :appdb (:from-id %)) appdb-edges)))))
+
+(deftest layout-app-db-edge-changed-tracks-target-sub
+  (testing "the app-db→L1 edge :changed? mirrors the target sub's state
+            (changed propagates, unchanged is cut)"
+    (let [out (g/layout {:level-1-subs [{:sub-id :a :changed? true}
+                                        {:sub-id :b :changed? false}]})
+          by-to (into {} (map (juxt :to-id identity))
+                      (filter #(= :appdb-l1 (:kind %)) (:edges out)))]
+      (is (true? (:changed? (get by-to :a))))
+      (is (false? (:changed? (get by-to :b)))))))
+
+(deftest layout-level-2-edges-wire-from-input-subs
+  (testing "a Level-2 sub draws an edge from each of its input subs;
+            edge :changed? tracks the UPSTREAM input"
+    (let [out (g/layout {:level-1-subs [{:sub-id :in :changed? true}]
+                         :level-2-subs [{:sub-id :derived :changed? true
+                                         :inputs [:in]}]})
+          sub-sub (filter #(= :sub-sub (:kind %)) (:edges out))]
+      (is (= 1 (count sub-sub)))
+      (is (= :in (:from-id (first sub-sub))))
+      (is (= :derived (:to-id (first sub-sub))))
+      (is (true? (:changed? (first sub-sub)))))))
+
+(deftest layout-sub-view-edges-from-readers
+  (testing "a sub draws an edge to each view in its :readers; a shared
+            sub fans out to N view edges"
+    (let [out (g/layout {:level-1-subs [{:sub-id :s :changed? true
+                                         :readers [:v1 :v2]}]
+                         :view-rows    [{:view-id :v1 :action :rerender}
+                                        {:view-id :v2 :action :rerender}]})
+          sub-view (filter #(= :sub-view (:kind %)) (:edges out))]
+      (is (= 2 (count sub-view)))
+      (is (= #{:v1 :v2} (set (map :to-id sub-view)))))))
+
+(deftest layout-edges-have-numeric-endpoints
+  (testing "every edge carries numeric x1/y1/x2/y2 so the SVG paints"
+    (let [out (g/layout {:level-1-subs [{:sub-id :a :changed? true :readers [:v]}]
+                         :view-rows    [{:view-id :v :action :rerender}]})]
+      (is (seq (:edges out)))
+      (is (every? (fn [e] (every? number? [(:x1 e) (:y1 e) (:x2 e) (:y2 e)]))
+                  (:edges out))))))
+
+(deftest layout-width-and-height-positive
+  (let [out (g/layout {:level-1-subs [{:sub-id :a :changed? true}]
+                       :view-rows    [{:view-id :v :action :rerender}]})]
+    (is (pos? (:width out)))
+    (is (pos? (:height out)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_subs_cljs_test.cljs
@@ -232,6 +232,54 @@
       (is (= 1 (count rows)))
       (is (= :v/ok (-> rows first :view-id))))))
 
+(deftest view-rows-carries-cause-and-timing
+  (testing "rf2-ad7zx.6 / rf2-8wrzz.1 — a :rf.view/rendered op carrying
+            :rf.view/triggered-by + :rf.view/elapsed-ms threads those
+            through onto the view row for the flow graph's cause + timing."
+    (let [ev   {:operation :rf.view/rendered
+                :tags {:rf.view/id :v/a :rf.view/render-key [:v/a 0]
+                       :rf.view/mount? false
+                       :rf.view/deref-subs [[:s1]]
+                       :rf.view/triggered-by :s1
+                       :rf.view/elapsed-ms 2.4}}
+          row  (first (subs/view-rows [ev] #{:s1}))]
+      (is (= :s1 (:triggered-by row)) "the cause sub rides the row")
+      (is (= 2.4 (:elapsed-ms row)) "the render timing rides the row"))))
+
+(deftest view-rows-omits-cause-and-timing-when-absent
+  (testing "rf2-ad7zx.6 — a structural render with no cause / timing slots
+            simply omits :triggered-by + :elapsed-ms (no nil keys)."
+    (let [row (first (subs/view-rows [(rendered-ev :v/s false [[:unchanged]])] #{}))]
+      (is (not (contains? row :triggered-by)))
+      (is (not (contains? row :elapsed-ms))))))
+
+;; ---- teardown sections (rf2-ad7zx.6) ----------------------------------
+
+(deftest unmounted-views-lists-unmount-ops
+  (testing "rf2-ad7zx.6 — UNMOUNTED VIEWS reads :rf.view/unmounted ops,
+            de-duplicated, first-seen order."
+    (let [events [(unmounted-ev :v/modal)
+                  (unmounted-ev :v/tooltip)
+                  (unmounted-ev :v/modal)]] ; dup → once
+      (is (= [{:view-id :v/modal} {:view-id :v/tooltip}]
+             (subs/unmounted-views events))))))
+
+(deftest unmounted-views-nil-safe-and-skips-non-unmount-ops
+  (is (= [] (subs/unmounted-views nil)))
+  (is (= [] (subs/unmounted-views [(rendered-ev :v/a true nil)]))))
+
+(deftest destroyed-subscriptions-reads-dispose-op-when-present
+  (testing "rf2-ad7zx.6 — DESTROYED SUBSCRIPTIONS reads :rf.sub/disposed
+            ops; absent in the live build so empty by default (data-
+            availability honesty), populated when the op lands."
+    (is (= [] (subs/destroyed-subscriptions [(rendered-ev :v/a true nil)]))
+        "no dispose op → empty (live-build reality)")
+    (let [events [{:operation :rf.sub/disposed :tags {:rf.sub/id :s/modal}}
+                  {:operation :rf.sub/disposed :tags {:sub-id :s/tip}}]]
+      (is (= [{:sub-id :s/modal} {:sub-id :s/tip}]
+             (subs/destroyed-subscriptions events))
+          "forward-compatible: reads the dispose op when present"))))
+
 ;; ---- Level 1 / Level 2+ partition -------------------------------------
 
 (def ^:private topology
@@ -357,7 +405,14 @@
       (is (= {:cart/total [:cart/Summary]} (:sub-readers p))
           ":sub-readers maps :cart/total → the views that read it")
       (is (= [:cart/Summary] (-> p :level-2-subs first :readers))
-          ":cart/total's L2 row carries its :readers"))))
+          ":cart/total's L2 row carries its :readers")
+      ;; rf2-ad7zx.6 — teardown sections compose through project-record.
+      (is (= [{:view-id :cart/Gone}] (:unmounted-views p))
+          ":unmounted-views projects the unmount op")
+      (is (= [] (:destroyed-subs p))
+          ":destroyed-subs empty (no dispose op in the live build)")
+      (is (= 1 (-> p :counts :unmounted-views)))
+      (is (= 0 (-> p :counts :destroyed-subs))))))
 
 (deftest project-record-degrades-without-topology
   (testing "rf2-8ve8z — nil topology: every sub falls to Level 1; the

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -1,13 +1,16 @@
 (ns day8.re-frame2-causa.panels.reactive-panel-view-cljs-test
-  "Tests for `reactive-panel-view` — the three-stacked-tables Views panel
-  (rf2-8ve8z, phase-B of the Views-tab redesign · prior: rf2-wyvf2 /
-  rf2-isun6 · spec/021 §3).
+  "Tests for `reactive-panel-view` — the left → right REACTIVE FLOW graph
+  Views panel (rf2-ad7zx.6 · Figma reconcile · spec/021 §3.2 · prior:
+  rf2-e33ad / rf2-8ve8z / rf2-wyvf2 / rf2-isun6).
 
   Mounts `reactive-panel` (the plain Reagent fn) and asserts the
-  structural data-testid hooks ship: panel root, header, the three
-  tables (Level 1 subs · Level 2+ subs · Views), their empty states,
-  the action / reason rendering, and the reactive-vs-structural reason
-  classifier surfaced via the seeded `:rf.causa/reactive-data`."
+  structural data-testid hooks ship: panel root, the REACTIVE FLOW SVG
+  graph (app-db source node + sub nodes + view nodes + edges), the
+  changed/unchanged node + edge encoding, the per-view cause + timing
+  labels, the UNMOUNTED VIEWS + DESTROYED SUBSCRIPTIONS sections, and the
+  closing legend. The pure graph geometry is covered by
+  reactive-flow-graph-test; the projection logic by
+  reactive-panel-subs-cljs-test."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -65,190 +68,120 @@
 
 (defn- seed-reactive-data!
   "Re-register the composite `:rf.causa/reactive-data` to return a
-  literal so the panel view renders its focused-cascade body. The view
-  is the unit under test here — the composite's projection logic is
-  covered by reactive-panel-subs-cljs-test."
+  literal so the panel view renders its focused-cascade body."
   [data]
   (rf/reg-sub :rf.causa/reactive-data (fn [_db _q] data)))
 
-;; ---- three-table structure (rf2-8ve8z) --------------------------------
+;; ---- REACTIVE FLOW graph structure (rf2-ad7zx.6) ----------------------
 
-(deftest reactive-panel-renders-three-tables
-  (testing "rf2-8ve8z — a focused cascade renders THREE stacked tables
-            (Level 1 subs · Level 2+ subs · Views), top→bottom mirroring
-            the reactive cascade. rf2-fhh34 chrome cleanup: NO chevrons
-            between sections."
+(deftest reactive-panel-renders-flow-graph-not-tables
+  (testing "rf2-ad7zx.6 — a focused cascade renders the left → right
+            REACTIVE FLOW SVG graph (app-db source node + sub nodes +
+            view nodes) and NOT the prior three stacked tables."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
-      {:has-cascade? true
-       :frame        :rf/app
-       :focus        {:current :ep-1}
-       :counts       {:subs-ran 2 :subs-skipped 0 :view-rows 1}
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {}
        :level-1-subs [{:sub-id :cart/state :changed? true
-                       :coord {:file "cart.cljs" :line 10 :ns 'cart}}]
+                       :readers [:cart/Summary]}]
        :level-2-subs [{:sub-id :cart/total :changed? true
-                       :inputs [:cart/state :cart/items]
-                       :coord {:file "cart.cljs" :line 22 :ns 'cart}}]
-       :view-rows    [{:view-id :cart/Summary :action :rerender
-                       :reason {:kind :reactive :subs [:cart/total]}}]})
+                       :inputs [:cart/state] :readers [:cart/Summary]}]
+       :view-rows [{:view-id :cart/Summary :action :rerender
+                    :reason {:kind :reactive :subs [:cart/total]}
+                    :triggered-by :cart/total :elapsed-ms 1.5}]})
     (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-l1-table")  "Level 1 table renders")
-      (is (has-testid? tree "rf-causa-reactive-l2-table")  "Level 2+ table renders")
-      (is (has-testid? tree "rf-causa-reactive-views-table") "Views table renders")
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-chevron-l1"))
-          "rf2-fhh34 — no chevron after Level 1")
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-chevron-l2"))
-          "rf2-fhh34 — no chevron after Level 2"))))
+      (is (has-testid? tree "rf-causa-reactive-flow-svg") "the SVG canvas renders")
+      (is (has-testid? tree "rf-causa-reactive-appdb-node") "app-db source node renders")
+      (is (has-testid? tree "rf-causa-reactive-node-l1-_cart_state") "Level-1 node renders")
+      (is (has-testid? tree "rf-causa-reactive-node-l2-_cart_total") "Level-2 node renders")
+      (is (has-testid? tree "rf-causa-reactive-view-node-_cart_Summary") "view node renders")
+      ;; the retired three-table testids must be GONE
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-l1-table")) "no Level-1 table")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-l2-table")) "no Level-2 table")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-views-table")) "no Views table"))))
 
-(deftest reactive-panel-section-titles-are-clean-no-counts
-  (testing "rf2-fhh34 chrome cleanup — section titles read exactly
-            `Level 1 Subscriptions` / `Level 2+ Subscriptions` / `Views`,
-            with NO `(observe app-db)` suffix and NO trailing count badge."
+(deftest reactive-panel-section-label-is-reactive-flow
+  (testing "rf2-ad7zx.6 — the graph section is headed `Reactive Flow`."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
     (let [tree (view/reactive-panel)]
-      (is (= "Level 1 Subscriptions"
-             (text-of tree "rf-causa-reactive-section-l1-label"))
-          "Level 1 title is clean — no suffix, no count")
-      (is (= "Level 2+ Subscriptions"
-             (text-of tree "rf-causa-reactive-section-l2-label"))
-          "Level 2+ title is clean — no count")
-      (is (= "Views"
-             (text-of tree "rf-causa-reactive-section-views-label"))
-          "Views title carries no count number"))))
+      (is (= "Reactive Flow" (text-of tree "rf-causa-reactive-section-flow-label"))
+          "graph section heading is `Reactive Flow`"))))
 
-(deftest reactive-panel-omits-summary-ribbon
-  (testing "rf2-fhh34 chrome cleanup — the per-cascade summary ribbon
-            (`frame · N subs ran · …`) is gone."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    (seed-reactive-data!
-      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
-       :counts {:subs-ran 2 :subs-skipped 0 :view-rows 1}
-       :level-1-subs [] :level-2-subs [] :view-rows []})
-    (let [tree (view/reactive-panel)]
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-header-meta"))
-          "summary ribbon header is removed"))))
-
-(deftest level-1-row-renders-name-and-code
-  (testing "rf2-8ve8z — a Level 1 sub row carries its name + a code chip
-            from the topology coord."
+(deftest changed-node-and-edge-encoding
+  (testing "rf2-ad7zx.6 — a changed sub node carries data-node-changed
+            true; its app-db→sub edge is a changed (propagating) edge."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-2-subs [] :view-rows []
-       :level-1-subs [{:sub-id :cart/state :changed? true
-                       :coord {:file "cart.cljs" :line 10 :ns 'cart}}]})
-    (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-l1-row-_cart_state")
-          "the Level 1 row renders with a slug testid")
-      (is (has-testid? tree "rf-causa-reactive-l1-code-_cart_state")
-          "the code chip renders from the topology coord"))))
-
-(deftest level-2-row-renders-inputs-one-per-line
-  (testing "rf2-8ve8z — a Level 2+ sub row carries name + inputs (one per
-            line) + code. The inputs column lists every input-sub name."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    (seed-reactive-data!
-      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
-       :counts {} :level-1-subs [] :view-rows []
-       :level-2-subs [{:sub-id :cart/total :changed? false
-                       :inputs [:cart/state :cart/items]
-                       :coord {:file "cart.cljs" :line 22 :ns 'cart}}]})
-    (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-l2-row-_cart_total")
-          "the Level 2+ row renders")
-      (let [row-text (text-of tree "rf-causa-reactive-l2-row-_cart_total")]
-        (is (re-find #":cart/state" row-text) "input :cart/state listed")
-        (is (re-find #":cart/items" row-text) "input :cart/items listed")))))
-
-(deftest sub-row-renders-readers-shared-sub-edge
-  (testing "rf2-y23uw — a sub row's `read by` column lists the views that
-            deref it this cascade (the shared-subscription edge); a sub no
-            view read shows a muted placeholder, not the views."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    (seed-reactive-data!
-      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
-       :counts {} :view-rows []
-       :level-1-subs [{:sub-id :cart/state :changed? true
-                       :readers [:cart/Header :cart/Summary]}]
-       :level-2-subs [{:sub-id :cart/total :changed? false
-                       :inputs [:cart/state]}]}) ; no readers → placeholder
+       :level-1-subs [{:sub-id :cart/state :changed? true}]})
     (let [tree (view/reactive-panel)
-          l1-text (text-of tree "rf-causa-reactive-l1-row-_cart_state")
-          l2-text (text-of tree "rf-causa-reactive-l2-row-_cart_total")]
-      (is (re-find #":cart/Header" l1-text)
-          "shared-sub reader :cart/Header listed in the L1 `read by` column")
-      (is (re-find #":cart/Summary" l1-text)
-          "shared-sub reader :cart/Summary listed")
-      (is (not (re-find #":cart/Header|:cart/Summary" l2-text))
-          ":cart/total has no readers → no view names in its `read by` column"))))
+          node (th/find-by-testid tree "rf-causa-reactive-node-l1-_cart_state")]
+      (is (some? node) "changed node renders")
+      (is (= "true" (get-in node [1 :data-node-changed]))
+          "changed node tagged data-node-changed=true")
+      (is (has-testid? tree "rf-causa-reactive-edges") "edge group renders"))))
 
-;; ---- view action + reason (rf2-8ve8z) ---------------------------------
+(deftest unchanged-node-renders-dim
+  (testing "rf2-ad7zx.6 — an unchanged sub node is tagged
+            data-node-changed false (renders dashed dim per the
+            encoding)."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-2-subs [] :view-rows []
+       :level-1-subs [{:sub-id :cart/title :changed? false}]})
+    (let [tree (view/reactive-panel)
+          node (th/find-by-testid tree "rf-causa-reactive-node-l1-_cart_title")]
+      (is (= "false" (get-in node [1 :data-node-changed]))
+          "unchanged node tagged data-node-changed=false"))))
 
-(deftest view-row-reactive-reason-lists-changed-subs
-  (testing "rf2-8ve8z — a reactive render's reason lists the changed subs
-            THIS view reads (the reactive classifier)."
+(deftest view-node-carries-cause-and-timing
+  (testing "rf2-ad7zx.6 / rf2-8wrzz.1 — a view node's sub-label shows the
+            per-view cause (← triggered-by) + render timing (elapsed-ms)."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs []
        :view-rows [{:view-id :cart/Summary :action :rerender
-                    :reason {:kind :reactive :subs [:cart/total :cart/count]}}]})
+                    :reason {:kind :reactive :subs [:cart/total]}
+                    :triggered-by :cart/total :elapsed-ms 2.0}]})
     (let [tree (view/reactive-panel)
-          row-text (text-of tree "rf-causa-reactive-view-row-_cart_Summary-0")]
-      (is (some? row-text) "the view row renders")
-      (is (re-find #"rerender" row-text) "action reads 'rerender'")
-      (is (re-find #":cart/total" row-text) "reason lists :cart/total")
-      (is (re-find #":cart/count" row-text) "reason lists :cart/count")
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-view-reason-structural"))
-          "a reactive render shows named subs, not the structural text"))))
+          meta (text-of tree "rf-causa-reactive-view-meta-_cart_Summary")]
+      (is (some? meta) "view-node meta label renders")
+      (is (re-find #"rerendered" meta) "labelled (rerendered)")
+      (is (re-find #":cart/total" meta) "shows the triggered-by cause sub")
+      (is (re-find #"2ms" meta) "shows the render timing"))))
 
-(deftest view-row-structural-reason-shows-parent-rerender-unnamed
-  (testing "rf2-8ve8z — a structural render (no own sub changed) shows the
-            literal `← parent re-render` — UNNAMED, never names the parent."
+(deftest shared-sub-node-carries-fan-out-annotation
+  (testing "rf2-ad7zx.6 — a sub read by ≥2 views is shared; the node
+            carries a ×N annotation + fans out to N view nodes."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
-       :counts {} :level-1-subs [] :level-2-subs []
-       :view-rows [{:view-id :cart/Wrapper :action :rerender
-                    :reason {:kind :structural}}]})
-    (let [tree (view/reactive-panel)
-          reason (text-of tree "rf-causa-reactive-view-reason-structural")]
-      (is (some? reason) "the structural reason node renders")
-      (is (= "← parent re-render" reason)
-          "the structural reason is the literal unnamed text"))))
+       :counts {} :level-2-subs []
+       :level-1-subs [{:sub-id :app/session :changed? true
+                       :readers [:app/Header :app/Sidebar]}]
+       :view-rows [{:view-id :app/Header :action :rerender :reason {:kind :structural}}
+                   {:view-id :app/Sidebar :action :rerender :reason {:kind :structural}}]})
+    (let [tree (view/reactive-panel)]
+      (is (= "×2" (text-of tree "rf-causa-reactive-shared-_app_session"))
+          "shared sub carries a ×2 annotation")
+      (is (has-testid? tree "rf-causa-reactive-view-node-_app_Header") "fans out to Header")
+      (is (has-testid? tree "rf-causa-reactive-view-node-_app_Sidebar") "fans out to Sidebar"))))
 
-(deftest view-row-action-mount-and-unmount
-  (testing "rf2-8ve8z — action renders mount / unmount; an unmount row's
-            reason is empty (no own subs to attribute)."
-    (facade/install!)
-    (frame/reg-frame :rf/causa {})
-    (seed-reactive-data!
-      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
-       :counts {} :level-1-subs [] :level-2-subs []
-       :view-rows [{:view-id :cart/Added :action :mount
-                    :reason {:kind :reactive :subs [:cart/items]}}
-                   {:view-id :cart/Gone :action :unmount
-                    :reason {:kind :none}}]})
-    (let [tree (view/reactive-panel)
-          mount-text (text-of tree "rf-causa-reactive-view-row-_cart_Added-0")
-          unmount-text (text-of tree "rf-causa-reactive-view-row-_cart_Gone-1")]
-      (is (re-find #"mount" mount-text) "mount action renders")
-      (is (re-find #"unmount" unmount-text) "unmount action renders"))))
-
-(deftest view-name-cell-carries-hover-handlers
-  (testing "rf2-8ve8z / rf2-8l03l — the Views-table NAME cell carries the
-            hover handlers driving the pink DOM highlight."
+(deftest view-node-carries-hover-handlers
+  (testing "rf2-ad7zx.6 / rf2-8l03l — the view NODE carries the hover
+            handlers driving the pink DOM highlight."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
@@ -257,28 +190,93 @@
        :view-rows [{:view-id :cart/Summary :action :rerender
                     :reason {:kind :structural}}]})
     (let [tree (view/reactive-panel)
-          name-cell (th/find-by-testid tree
-                                       "rf-causa-reactive-view-name-_cart_Summary-0")]
-      (is (some? name-cell) "the name cell renders")
-      (is (fn? (th/extract-handler name-cell :on-mouse-enter))
-          "name cell has an :on-mouse-enter handler (apply-highlight!)")
-      (is (fn? (th/extract-handler name-cell :on-mouse-leave))
-          "name cell has an :on-mouse-leave handler (clear-highlight!)"))))
+          node (th/find-by-testid tree "rf-causa-reactive-view-node-_cart_Summary")]
+      (is (some? node) "the view node renders")
+      (is (fn? (th/extract-handler node :on-mouse-enter))
+          "view node has an :on-mouse-enter handler (apply-highlight!)")
+      (is (fn? (th/extract-handler node :on-mouse-leave))
+          "view node has an :on-mouse-leave handler (clear-highlight!)"))))
 
-;; ---- empty states (always visible) ------------------------------------
-
-(deftest each-table-shows-empty-state-when-section-empty
-  (testing "rf2-8ve8z — empty states are ALWAYS visible so the pipeline
-            rhythm holds; a focused cascade with no activity shows all
-            three empty placeholders."
+(deftest sparse-cascade-shows-graph-empty-placeholder
+  (testing "rf2-ad7zx.6 — a focused cascade with no subs + no views
+            renders the graph empty placeholder (the sparse case)."
     (facade/install!)
     (frame/reg-frame :rf/causa {})
     (seed-reactive-data!
       {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
        :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
     (let [tree (view/reactive-panel)]
-      (is (has-testid? tree "rf-causa-reactive-l1-empty")    "Level 1 empty placeholder")
-      (is (has-testid? tree "rf-causa-reactive-l2-empty")    "Level 2+ empty placeholder")
-      (is (has-testid? tree "rf-causa-reactive-views-empty") "Views empty placeholder")
-      (is (nil? (th/find-by-testid tree "rf-causa-reactive-l1-table"))
-          "no Level 1 table when no Level 1 subs ran"))))
+      (is (has-testid? tree "rf-causa-reactive-graph-empty")
+          "sparse cascade shows the graph empty placeholder")
+      (is (nil? (th/find-by-testid tree "rf-causa-reactive-flow-svg"))
+          "no SVG canvas when the graph is empty"))))
+
+;; ---- UNMOUNTED VIEWS + DESTROYED SUBSCRIPTIONS (rf2-ad7zx.6) -----------
+
+(deftest unmounted-views-section-renders
+  (testing "rf2-ad7zx.6 — the UNMOUNTED VIEWS section lists views whose
+            component unmounted this epoch."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :unmounted-views [{:view-id :app/Modal} {:view-id :app/Tooltip}]})
+    (let [tree (view/reactive-panel)]
+      (is (= "Unmounted Views"
+             (text-of tree "rf-causa-reactive-section-unmounted-label"))
+          "section heading renders")
+      (is (has-testid? tree "rf-causa-reactive-unmounted-row-_app_Modal")
+          "modal unmount row renders")
+      (is (has-testid? tree "rf-causa-reactive-unmounted-row-_app_Tooltip")
+          "tooltip unmount row renders"))))
+
+(deftest unmounted-views-empty-placeholder
+  (testing "rf2-ad7zx.6 — no unmounts → the section shows its empty
+            placeholder (always visible so the rhythm holds)."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :unmounted-views []})
+    (let [tree (view/reactive-panel)]
+      (is (has-testid? tree "rf-causa-reactive-unmounted-empty")
+          "empty placeholder renders when nothing unmounted"))))
+
+(deftest destroyed-subs-section-renders-with-caption
+  (testing "rf2-ad7zx.6 — the DESTROYED SUBSCRIPTIONS section lists subs
+            cleaned up + carries the explanatory caption."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :destroyed-subs [{:sub-id :app/modal-state}]})
+    (let [tree (view/reactive-panel)]
+      (is (= "Destroyed Subscriptions"
+             (text-of tree "rf-causa-reactive-section-destroyed-label"))
+          "section heading renders")
+      (is (has-testid? tree "rf-causa-reactive-destroyed-row-_app_modal_state")
+          "destroyed sub row renders")
+      (is (= "Subscriptions cleaned up when their last reader unmounted"
+             (text-of tree "rf-causa-reactive-destroyed-caption"))
+          "the explanatory caption renders"))))
+
+;; ---- legend (rf2-ad7zx.6) ---------------------------------------------
+
+(deftest legend-renders-three-swatches
+  (testing "rf2-ad7zx.6 — the closing legend explains the encoding:
+            changed (propagates) · no change (short-circuits) · unmounted
+            / destroyed."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []})
+    (let [tree (view/reactive-panel)
+          legend-text (text-of tree "rf-causa-reactive-legend")]
+      (is (some? legend-text) "legend renders")
+      (is (re-find #"changed \(propagates" legend-text) "changed swatch labelled")
+      (is (re-find #"no change \(short-circuits" legend-text) "no-change swatch labelled")
+      (is (re-find #"unmounted / destroyed" legend-text) "teardown swatch labelled"))))


### PR DESCRIPTION
Reconciles the Causa **Views panel** render to the Figma-derived spec (spec/021 §3.2 + `design-reference/components/ViewsPanel.tsx`, the authoritative later iteration). Replaces the three stacked tables with a left → right **REACTIVE FLOW** node-and-edge SVG graph. Closes rf2-ad7zx.6.

## What changed

**SVG flow-graph approach** — a new pure, JVM-testable `reactive-flow-graph.cljc` computes the 4-column geometry (`app-db` source node → Level-1 subs → optional Level-2 subs → Views), edges, and the changed/unchanged encoding; `reactive-panel-view.cljs` renders it as inline-SVG hiccup. Mirrors the `chart/timing-waterfall` pure-layout-plus-renderer pattern. **Causa-native SVG, NOT xyflow** (the Machine panel's xyflow is a separate interactive surface; this is a static cause/timing snapshot per the spec).

Encoding (colour/edge first per spec/022 — not glyphs):
- changed / recomputed node → filled tint + accent border + bold; outgoing edges solid accent arrows that propagate downstream.
- unchanged / short-circuited node → transparent + dashed dim outline + dim label; edges dashed grey, visually **cut** (no arrowhead).
- view node → success-tinted `(rerendered)`, carrying its per-view `triggered-by` cause + `elapsed-ms` timing (rf2-8wrzz.1).
- shared sub (≥2 readers) → `×N` annotation + N view edges.

**Sections added** below the graph: **UNMOUNTED VIEWS**, **DESTROYED SUBSCRIPTIONS** (data-availability honest — empty until the sub-dispose op lands), and the closing **legend**.

`reactive-panel-subs.cljs` threads `triggered-by` + `elapsed-ms` onto view rows and adds the two teardown projections.

The panel stays named **Views** (option A). Colour unchanged (owned by rf2-ad7zx.3). Hover-highlight contract (`data-rf-view`) preserved on the view node.

## Gates
- `npm run test:cljs` — 4220 tests, 0 failures
- `tools/causa` `clojure -M:test` — 862 tests, 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- clj-kondo — clean