### PR TITLE
feat(causa): reconcile App-db panel to Figma flat-hairline rows (rf2-ad7zx.11)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -298,15 +298,36 @@
   [db]
   (apply dissoc (or db {}) reserved-app-db-keys))
 
+(def no-diff
+  "Sentinel `:before` value meaning 'no pre-image available, render
+  current-state (no `← changed` annotation)'. Distinct from a real
+  `nil` before-image (a slot that was genuinely absent / nil before the
+  cascade) so the renderer can tell 'don't diff' apart from 'diff
+  against nil'. Pure data."
+  ::no-diff)
+
 (defn- instances-of
   "Decompose a map-of-instances reserved-area value into an ordered
-  vector of `{:id <instance-id> :value <per-instance-state>}` maps,
-  sorted by `(pr-str id)` for stable render order. Returns `[]` when
-  the value is absent / not a map / empty. Pure data → data."
-  [area-value]
+  vector of `{:id <instance-id> :value <per-instance-state>
+  :before <prior-per-instance-state-or-no-diff>}` maps, sorted by
+  `(pr-str id)` for stable render order. Returns `[]` when the value is
+  absent / not a map / empty.
+
+  `before-area` is the SAME reserved-area value from the cascade's
+  `db-before` (or `no-diff` when no pre-image is threaded). Each
+  instance's `:before` is the prior value at that instance id, so the
+  renderer can carry the inline `← changed` annotation (spec/021 §4.3).
+  When `before-area` is `no-diff` every instance is tagged `no-diff` —
+  current-state only. Pure data → data."
+  [area-value before-area]
   (if (and (map? area-value) (seq area-value))
     (->> area-value
-         (map (fn [[id v]] {:id id :value v}))
+         (map (fn [[id v]]
+                {:id     id
+                 :value  v
+                 :before (if (= no-diff before-area)
+                           no-diff
+                           (get before-area id no-diff))}))
          (sort-by (comp pr-str :id))
          vec)
     []))
@@ -333,32 +354,58 @@
   `:kind :instances` + an `:instances` vector (one entry per id);
   every other reserved area is `:kind :singleton` + a `:value`.
 
+  ## Inline diff (spec/021 §4.3, rf2-ad7zx.11)
+
+  Every section ALSO carries a `:before` slot — the SAME slice from the
+  cascade's `db-before` (the TOP user-domain section, each instance, each
+  singleton). The renderer threads `:before` + `:value` into the shared
+  §10 diff renderer so changed nodes carry the inline `← changed from X`
+  annotation in place (ancestor chain force-expanded). When no pre-image
+  is threaded — the 1-arity form, or LIVE-at-boot with no prior epoch —
+  `:before` is the `no-diff` sentinel and the renderer falls back to the
+  plain current-state inspector (no annotation). A `:before` that equals
+  `:value` is a real (non-diff) match — the renderer skips the
+  annotation but stays on the diff engine, which renders identically to
+  current-state for unchanged trees.
+
   Pure data → data. JVM-runnable. nil-safe throughout (absent db,
-  empty db, absent reserved keys, empty registries)."
-  [db]
-  (let [db (or db {})]
-    {:top   (user-domain-db db)
-     :areas (vec
-              (for [area reserved-area-order]
-                (let [present?    (contains? db area)
-                      area-value  (get db area)]
-                  (if (contains? map-of-instances-areas area)
-                    (let [instances (instances-of area-value)]
-                      {:area      area
-                       :kind      :instances
-                       :empty?    (empty? instances)
-                       :instances instances})
-                    {:area   area
-                     :kind   :singleton
-                     ;; A singleton is empty when the key is absent, or
-                     ;; present-but-nil, or present-but-empty-collection
-                     ;; (e.g. `{}` pending-nav). Scalars / non-empty
-                     ;; collections are non-empty.
-                     :empty? (or (not present?)
-                                 (nil? area-value)
-                                 (and (coll? area-value)
-                                      (empty? area-value)))
-                     :value  area-value}))))}))
+  empty db, absent reserved keys, empty registries, absent before-db)."
+  ([db] (current-state-sections db no-diff))
+  ([db db-before]
+   (let [db          (or db {})
+         diff?       (not= no-diff db-before)
+         before-db   (if diff? (or db-before {}) no-diff)
+         before-area (fn [area]
+                       (if diff?
+                         (get before-db area no-diff)
+                         no-diff))]
+     {:top   (user-domain-db db)
+      :before-top (if diff?
+                    (user-domain-db before-db)
+                    no-diff)
+      :areas (vec
+               (for [area reserved-area-order]
+                 (let [present?    (contains? db area)
+                       area-value  (get db area)]
+                   (if (contains? map-of-instances-areas area)
+                     (let [instances (instances-of area-value
+                                                    (before-area area))]
+                       {:area      area
+                        :kind      :instances
+                        :empty?    (empty? instances)
+                        :instances instances})
+                     {:area   area
+                      :kind   :singleton
+                      ;; A singleton is empty when the key is absent, or
+                      ;; present-but-nil, or present-but-empty-collection
+                      ;; (e.g. `{}` pending-nav). Scalars / non-empty
+                      ;; collections are non-empty.
+                      :empty? (or (not present?)
+                                  (nil? area-value)
+                                  (and (coll? area-value)
+                                       (empty? area-value)))
+                      :value  area-value
+                      :before (before-area area)}))))})))
 
 ;; ---- 'Show me when this changed' walker ---------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs
@@ -31,8 +31,31 @@
   segment-inspector, Event lens, Static panels) keeps the default-on
   copy gesture.
 
+  ## Flat-hairline layout (spec/021 §4.2-4.3, Figma · rf2-ad7zx.11)
+
+  Reconciled to `tools/causa/design-reference/components/AppDbPanel.tsx`:
+  sections render FLAT — an uppercase caption label over the value body,
+  with adjacent sections separated by a 1px hairline (`border-t`), NOT
+  bordered cards. The old `:bg-3` card + radius + per-section header-rule
+  chrome is gone; the panel reads as one continuous scroll keyed by
+  caption labels.
+
+  ## Inline `← changed` annotation (spec/021 §4.3)
+
+  Each section carries a `:before` slice (from the cascade's `db-before`,
+  threaded by `app-db-diff-helpers/current-state-sections`'s 2-arity).
+  When a pre-image is present and differs, the value body routes through
+  the shared §10 diff renderer (`edn/diff`), which carries the inline
+  `← changed from X` annotation in place on the changed nodes and
+  force-expands the ancestor chain so the operator never expands to find
+  a change. When no pre-image is threaded (`no-diff` sentinel — LIVE at
+  boot, 1-arity model) the body falls back to the plain current-state
+  inspector (`edn/inspect`). The keyword-accent inside the diff renderer
+  is already orange (owned by rf2-ad7zx.3) — not touched here.
+
   Pure hiccup; reuses Causa's theme tokens so light/dark resolve."
   (:require [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
@@ -40,36 +63,38 @@
 ;; ---- shared section chrome ----------------------------------------------
 
 (defn- section-shell
-  "A titled card surface used by every current-state section. `title`
-  is hiccup (so callers can colour the reserved-area / instance-id
-  label); `testid` hooks the section for tests; `body` is the section's
-  content hiccup. Reuses Causa's `:bg-3` card + subtle-border chrome so
-  light/dark resolve via the token CSS variables."
-  [{:keys [testid title body]}]
+  "A flat current-state section (spec/021 §4.2, Figma). `title` is hiccup
+  (so callers can colour the reserved-area / instance-id label);
+  `testid` hooks the section for tests; `body` is the section's content
+  hiccup; `first?` suppresses the leading hairline on the panel's top
+  section.
+
+  Renders FLAT — an uppercase caption label over the value body, no card
+  surface. Adjacent sections are separated by a 1px hairline drawn as a
+  `border-top` on every section after the first (Figma's `border-t`
+  dividers). Reuses Causa's token CSS variables so light/dark resolve."
+  [{:keys [testid title body first?]}]
   [:section {:data-testid testid
-             :style       {:margin        "12px"
-                           :background    (:bg-3 tokens)
-                           :border        (str "1px solid " (:border-subtle tokens))
-                           :border-radius "4px"
-                           :overflow      "hidden"}}
-   [:header {:style {:display         "flex"
-                     :align-items     "center"
-                     :gap             "8px"
-                     :padding         "6px 12px"
-                     :border-bottom   (str "1px solid " (:border-subtle tokens))
-                     :font-family     sans-stack
-                     :font-size       "11px"
-                     :font-weight     600
-                     :text-transform  "uppercase"
-                     :letter-spacing  "0.5px"
-                     :color           (:text-secondary tokens)}}
+             :style       (cond-> {:padding "12px 12px 4px"}
+                            (not first?)
+                            (assoc :border-top
+                                   (str "1px solid " (:border-subtle tokens))))}
+   [:h3 {:style {:display         "flex"
+                 :align-items     "center"
+                 :gap             "8px"
+                 :margin          "0 0 8px"
+                 :font-family     sans-stack
+                 :font-size       "11px"
+                 :font-weight     600
+                 :text-transform  "uppercase"
+                 :letter-spacing  "0.5px"
+                 :color           (:text-secondary tokens)}}
     [:span {:style {:overflow      "hidden"
                     :text-overflow "ellipsis"
                     :white-space   "nowrap"
                     :flex          1}}
      title]]
-   [:div {:style {:padding "8px 12px"}}
-    body]])
+   [:div body]])
 
 (defn- empty-body
   "Empty-state placeholder body for an absent / empty section. `label`
@@ -82,40 +107,61 @@
    label])
 
 (defn- value-body
-  "Render a current-state VALUE via the canonical EDN widget's
-  cljs-devtools inspect path (re-frame-10x look). `render-id` keeps
-  adjacent inspects' testids independent across the panel.
+  "Render a current-state VALUE, with the inline `← changed` diff
+  annotation when a pre-image is supplied (spec/021 §4.3). `render-id`
+  keeps adjacent renders' testids independent across the panel.
 
   `f/display-value` runs first so giant string leaves collapse to the
-  `:rf.size/large-elided` display marker before cljs-devtools renders —
-  the same display-side bound the old slice renderer applied. This keeps
-  a 20 KiB payload from flooding the inspector (and from leaking the raw
-  bytes into the rendered text); the data-classification sentinels
-  (`:rf/redacted` / `:rf/large`) still get their bespoke chip chrome via
-  `edn/inspect`.
+  `:rf.size/large-elided` display marker before rendering — the same
+  display-side bound the old slice renderer applied. This keeps a 20 KiB
+  payload from flooding the inspector (and from leaking the raw bytes
+  into the rendered text).
 
-  `:copy? false` (rf2-ilubp) opts this render out of the EDN widget's
-  universal ⎘ copy gesture — the app-db tab is a clean current-state
-  view, not a per-block toolbox. Other EDN-widget surfaces keep it on."
-  [value render-id]
-  (edn/inspect (f/display-value value)
-               (str "app-db-state/" render-id)
-               {:copy? false}))
+  ## Diff vs current-state routing
+
+  When `before` is the `h/no-diff` sentinel (no pre-image threaded —
+  LIVE at boot / 1-arity model) the value renders through the canonical
+  cljs-devtools current-state inspect path (`edn/inspect`,
+  re-frame-10x look), with `:copy? false` (rf2-ilubp) so the app-db tab
+  stays a clean current-state view with no per-block ⎘ copy gesture.
+
+  When a real pre-image is present the value renders through the shared
+  §10 diff renderer (`edn/diff`), which carries the inline
+  `← changed from X` annotation in place on changed nodes and
+  force-expands the ancestor chain (spec/021 §4.3 + §10.4). App-db's
+  depth heuristic is depth-3-collapsed by default (§10.4). The
+  keyword-accent inside `edn/diff` is already orange (owned by
+  rf2-ad7zx.3)."
+  [value before render-id]
+  (let [node-key (str "app-db-state/" render-id)]
+    (if (= h/no-diff before)
+      (edn/inspect (f/display-value value)
+                   node-key
+                   {:copy? false})
+      (edn/diff {:before        (f/display-value before)
+                 :after         (f/display-value value)
+                 :panel-id      :app-db
+                 :render-id     node-key
+                 :default-depth 3}))))
 
 ;; ---- top (user-domain) section ------------------------------------------
 
 (defn top-section
   "The TOP section — the app-db MINUS every reserved `:rf/*` key (the
   user-domain app-db). Renders the whole user-domain value as a
-  current-state tree. Empty-state when the user-domain app-db is empty
-  (e.g. boot value / reserved-keys-only db)."
-  [top]
-  (section-shell
-    {:testid "rf-causa-app-db-state-top"
-     :title  [:span "app-db"]
-     :body   (if (and (map? top) (empty? top))
-               (empty-body "app-db has no user-domain keys yet.")
-               (value-body top "top"))}))
+  current-state / diff tree. Empty-state when the user-domain app-db is
+  empty (e.g. boot value / reserved-keys-only db). `before` is the
+  prior user-domain value (or `h/no-diff`); `first?` suppresses the
+  panel-leading hairline."
+  ([top] (top-section top h/no-diff true))
+  ([top before first?]
+   (section-shell
+     {:testid "rf-causa-app-db-state-top"
+      :first? first?
+      :title  [:span "app-db"]
+      :body   (if (and (map? top) (empty? top))
+                (empty-body "app-db has no user-domain keys yet.")
+                (value-body top before "top"))})))
 
 ;; ---- reserved-area sections ---------------------------------------------
 
@@ -130,11 +176,15 @@
 (defn instance-section
   "One fan-out sub-section for a single instance of a map-of-instances
   reserved area — section title = the instance id. Used per machine
-  (`:rf/machines`) and per parent (`:rf/spawned`)."
-  [area {:keys [id value]}]
+  (`:rf/machines`) and per parent (`:rf/spawned`). The instance carries
+  its own `:before` pre-image so the body diff-annotates the changed
+  snapshot in place. Each instance section draws the leading hairline
+  (it is never the panel's first section — the TOP precedes it)."
+  [area {:keys [id value] :as inst}]
   (section-shell
     {:testid (str "rf-causa-app-db-state-instance-"
                   (pr-str area) "-" (pr-str id))
+     :first? false
      :title  [:span
               (area-label area)
               [:span {:style {:margin "0 6px" :color (:text-tertiary tokens)}}
@@ -142,7 +192,8 @@
               [:span {:style {:font-family mono-stack
                               :color       (:text-primary tokens)}}
                (pr-str id)]]
-     :body   (value-body value (str (pr-str area) "/" (pr-str id)))}))
+     :body   (value-body value (get inst :before h/no-diff)
+                         (str (pr-str area) "/" (pr-str id)))}))
 
 (defn instances-area
   "Render a map-of-instances reserved area (`:rf/machines`,
@@ -153,6 +204,7 @@
   (if empty?
     (section-shell
       {:testid (str "rf-causa-app-db-state-area-" (pr-str area))
+       :first? false
        :title  (area-label area)
        :body   (empty-body
                  (case area
@@ -168,10 +220,13 @@
   "Render a singleton-slice reserved area (`:rf/route`,
   `:rf/system-ids`, `:rf/pending-navigation`, `:rf/elision`) as ONE
   section. The section title is the singular slice name (e.g. `route`
-  for `:rf/route`). Empty/absent slices render the empty-state body."
-  [{:keys [area empty? value]}]
+  for `:rf/route`). Empty/absent slices render the empty-state body;
+  populated slices carry their `:before` pre-image for the inline diff
+  annotation."
+  [{:keys [area empty? value] :as area-entry}]
   (section-shell
     {:testid (str "rf-causa-app-db-state-area-" (pr-str area))
+     :first? false
      :title  (area-label area)
      :body   (if empty?
                (empty-body
@@ -181,7 +236,8 @@
                    :rf/pending-navigation "No navigation pending."
                    :rf/elision            "No elision declarations."
                    "Empty."))
-               (value-body value (pr-str area)))}))
+               (value-body value (get area-entry :before h/no-diff)
+                           (pr-str area)))}))
 
 (defn area-section
   "Dispatch one reserved-area section entry (from
@@ -201,11 +257,15 @@
   "Render the full current-state inspector body for the section model
   `current-state-sections` produces: the TOP user-domain section
   followed by one section group per reserved `:rf/*` area (in
-  `:areas` order). Pure hiccup; nil-safe (a nil model degrades to an
-  empty TOP + no areas)."
-  [{:keys [top areas]}]
+  `:areas` order). Adjacent sections are separated by 1px hairlines —
+  the TOP is the panel's first section (no leading hairline); every
+  reserved-area section after it draws the divider (spec/021 §4.2).
+  Each section threads its `:before` pre-image so changed nodes carry
+  the inline `← changed` annotation (spec/021 §4.3). Pure hiccup;
+  nil-safe (a nil model degrades to an empty TOP + no areas)."
+  [{:keys [top areas] :as model}]
   (into [:div {:data-testid "rf-causa-app-db-state"}
-         (top-section top)]
+         (top-section top (get model :before-top h/no-diff) true)]
         (for [{:keys [area] :as area-entry} areas]
           (with-meta (area-section area-entry)
                      {:key (pr-str area)}))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -304,21 +304,34 @@
         (h/epochs-touching-path history focused-path)
         [])))
 
-  ;; ---- rf2-okvit — current-state section model -------------------------
+  ;; ---- rf2-okvit / rf2-ad7zx.11 — current-state + inline-diff sections -
   ;;
-  ;; The app-db tab is a CURRENT-STATE inspector (re-frame-10x style),
-  ;; not a diff. This sub decomposes the observed frame's LIVE app-db
+  ;; The app-db tab is a CURRENT-STATE inspector (re-frame-10x style)
+  ;; that ALSO carries the focused epoch's diff inline (spec/021 §4.1 —
+  ;; "what does state LOOK LIKE — and what just changed?"). This sub
+  ;; decomposes the observed frame's LIVE app-db
   ;; (`:rf.causa/target-frame-db`, which follows the picker / focused
   ;; frame) into the section model `current-state-sections` produces:
   ;; the TOP user-domain section (app-db minus reserved keys) + one
   ;; section per reserved `:rf/*` area (machines/spawned fan out per
-  ;; instance; route + the other slices are singletons). nil-safe — an
-  ;; absent / empty db yields an empty TOP + every reserved area flagged
-  ;; `:empty?`.
+  ;; instance; route + the other slices are singletons).
+  ;;
+  ;; The focused epoch record's `:db-before` is threaded as the diff
+  ;; PRE-IMAGE (spec/021 §4.3) so each section's changed nodes carry the
+  ;; inline `← changed from X` annotation in place. When no epoch is
+  ;; focusable (cold boot, no cascades) the record is nil and the
+  ;; sections render plain current-state — `current-state-sections`
+  ;; falls back to its `no-diff` sentinel automatically.
+  ;;
+  ;; nil-safe — an absent / empty db yields an empty TOP + every
+  ;; reserved area flagged `:empty?`.
   (rf/reg-sub :rf.causa/app-db-state
     :<- [:rf.causa/target-frame-db]
-    (fn [db _query]
-      (h/current-state-sections db)))
+    :<- [:rf.causa/selected-epoch-record]
+    (fn [[db record] _query]
+      (if-let [before (:db-before record)]
+        (h/current-state-sections db before)
+        (h/current-state-sections db))))
 
   ;; rf2-fvplw — `:target-frame` in the composite output is the
   ;; *observed* frame (picker-selected / focused-cascade frame), not

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -352,6 +352,80 @@
     (let [model (h/current-state-sections {})]
       (is (= h/reserved-area-order (mapv :area (:areas model)))))))
 
+;; ---- inline-diff section model (spec/021 §4.3, rf2-ad7zx.11) -------------
+;;
+;; The 2-arity `current-state-sections` threads a `db-before` pre-image
+;; so each section carries a `:before` slice for the inline `← changed`
+;; annotation. The 1-arity form (no pre-image) tags every section with
+;; the `no-diff` sentinel so the renderer falls back to plain
+;; current-state.
+
+(deftest current-state-sections-1-arity-is-no-diff-everywhere
+  (testing "the 1-arity form tags TOP + every section with the no-diff
+            sentinel (renderer renders plain current-state, no annotation)"
+    (let [model (h/current-state-sections
+                  {:counter 1
+                   :rf/route {:id :home}
+                   :rf/machines {:title/flow {:state :idle}}})]
+      (is (= h/no-diff (:before-top model)) "TOP carries the no-diff sentinel")
+      (doseq [a (:areas model)]
+        (if (= :instances (:kind a))
+          (doseq [inst (:instances a)]
+            (is (= h/no-diff (:before inst))
+                "each instance no-diff in 1-arity"))
+          (is (= h/no-diff (:before a))
+              "each singleton no-diff in 1-arity"))))))
+
+(deftest current-state-sections-2-arity-top-before-is-prior-user-domain
+  (testing ":before-top is the user-domain slice of db-before (reserved
+            keys stripped), so the TOP section diffs old → new"
+    (let [before {:counter 1 :rf/route {:id :home}}
+          after  {:counter 2 :rf/route {:id :home}}
+          model  (h/current-state-sections after before)]
+      (is (= {:counter 1} (:before-top model))
+          ":before-top excludes reserved keys, matching :top's shape")
+      (is (= {:counter 2} (:top model))))))
+
+(deftest current-state-sections-2-arity-instance-before-is-prior-snapshot
+  (testing "each machine instance carries its prior snapshot as :before;
+            an instance absent before-cascade gets the no-diff sentinel"
+    (let [before {:rf/machines {:title/flow {:state :idle}}}
+          after  {:rf/machines {:title/flow {:state :loaded}
+                                :auth       {:state :idle}}}
+          area   (area-by (h/current-state-sections after before) :rf/machines)
+          flow   (some #(when (= :title/flow (:id %)) %) (:instances area))
+          auth   (some #(when (= :auth (:id %)) %) (:instances area))]
+      (is (= {:state :idle} (:before flow))
+          "title/flow diffs against its prior snapshot")
+      (is (= {:state :loaded} (:value flow)))
+      (is (= h/no-diff (:before auth))
+          "a freshly-spawned machine has no pre-image → no-diff"))))
+
+(deftest current-state-sections-2-arity-singleton-before-is-prior-slice
+  (testing "a singleton slice carries its prior value as :before; an
+            absent-before singleton gets the no-diff sentinel"
+    (let [before {:rf/route {:id :home}}
+          after  {:rf/route {:id :cart} :rf/system-ids #{:app}}
+          model  (h/current-state-sections after before)
+          route  (area-by model :rf/route)
+          sysids (area-by model :rf/system-ids)]
+      (is (= {:id :home} (:before route)) "route diffs old → new")
+      (is (= {:id :cart} (:value route)))
+      (is (= h/no-diff (:before sysids))
+          "system-ids absent before-cascade → no-diff"))))
+
+(deftest current-state-sections-2-arity-nil-before-db-safe
+  (testing "a nil db-before (boot epoch — every slot is newly added) is
+            handled: before-db degrades to {}, every section's :before is
+            the no-diff sentinel for absent slots"
+    (let [model (h/current-state-sections {:counter 1 :rf/route {:id :home}}
+                                          nil)]
+      ;; nil db-before still flips diff? on (no-diff sentinel is the ONLY
+      ;; way to opt out), so the user-domain before is {} not the sentinel.
+      (is (= {} (:before-top model)))
+      (is (= h/no-diff (:before (area-by model :rf/route)))
+          "an added route slot (absent before) → no-diff"))))
+
 ;; ---- (4) 'Show me when this changed' walker -----------------------------
 
 (defn- mk-record

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_state_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_state_cljs_test.cljs
@@ -182,3 +182,93 @@
           ids   (all-testids tree)]
       (is (not-any? #(.endsWith % "-copy") ids)
           "no copy affordance on any app-db section value block"))))
+
+;; ---- flat-hairline structure (spec/021 §4.2, Figma · rf2-ad7zx.11) -------
+;;
+;; Sections render FLAT — no bordered cards. The panel's first section
+;; (TOP) draws NO leading hairline; every section after it draws a 1px
+;; `border-top` hairline as the divider (the Figma `border-t` rule).
+
+(defn- section-styles
+  "Collect the inline `:style` map of every `<section>` node in the tree."
+  [tree]
+  (->> (hiccup-seq tree)
+       (keep (fn [node]
+               (when (and (vector? node)
+                          (= :section (first node))
+                          (map? (second node)))
+                 (:style (second node)))))))
+
+(deftest sections-are-flat-not-cards
+  (testing "no section carries the old card chrome (bg / border-radius /
+            full 1px border); the flat layout uses caption + body only"
+    (let [model (h/current-state-sections
+                  {:counter 1
+                   :rf/route    {:id :home}
+                   :rf/machines {:title/flow {:state :idle}}})
+          tree  (state/state-body model)
+          styles (section-styles tree)]
+      (is (seq styles) "sections render")
+      (doseq [s styles]
+        (is (nil? (:background s)) "no card background")
+        (is (nil? (:border-radius s)) "no card radius")
+        (is (nil? (:border s)) "no full card border (hairline is border-top)")))))
+
+(deftest top-section-has-no-leading-hairline
+  (testing "the panel's first section (TOP) draws no leading hairline"
+    (let [model (h/current-state-sections {:counter 1})
+          tree  (state/state-body model)
+          top   (find-by-testid tree "rf-causa-app-db-state-top")]
+      (is (some? top))
+      (is (nil? (:border-top (:style (second top))))
+          "TOP is first → no divider above it"))))
+
+(deftest reserved-area-sections-draw-hairline-divider
+  (testing "every reserved-area section after the TOP draws a 1px
+            `border-top` hairline divider"
+    (let [model (h/current-state-sections {:counter 1})
+          tree  (state/state-body model)]
+      (doseq [area h/reserved-app-db-keys]
+        (let [sec (find-by-testid tree (str "rf-causa-app-db-state-area-"
+                                            (pr-str area)))]
+          (is (some? sec) (str "section present for " area))
+          (is (re-find #"1px solid" (str (:border-top (:style (second sec)))))
+              (str area " draws a 1px border-top hairline")))))))
+
+;; ---- inline diff annotation (spec/021 §4.3 · rf2-ad7zx.11) ---------------
+;;
+;; When a section's `:before` pre-image differs from its `:value`, the
+;; value body routes through the shared §10 diff renderer (`edn/diff`),
+;; which carries the inline `← changed from X` annotation in place. With
+;; no pre-image (the no-diff sentinel) the body stays on the plain
+;; current-state inspect path (no annotation).
+
+(deftest changed-value-carries-inline-changed-annotation
+  (testing "a changed user-domain value renders the inline
+            `← changed from <prior>` annotation in the TOP section"
+    (let [model (h/current-state-sections {:counter 2} {:counter 1})
+          tree  (state/state-body model)
+          top   (find-by-testid tree "rf-causa-app-db-state-top")]
+      (is (re-find #"← changed from 1" (pr-str top))
+          "the inline diff annotation surfaces the prior value"))))
+
+(deftest changed-machine-snapshot-carries-annotation
+  (testing "a changed machine snapshot diff-annotates in its instance
+            section (ancestor chain force-expanded so the change shows)"
+    (let [before {:rf/machines {:title/flow {:state :idle}}}
+          after  {:rf/machines {:title/flow {:state :loaded}}}
+          model  (h/current-state-sections after before)
+          tree   (state/state-body model)
+          flow   (find-by-testid
+                   tree "rf-causa-app-db-state-instance-:rf/machines-:title/flow")]
+      (is (re-find #"← changed from :idle" (pr-str flow))
+          "the machine's :state change annotates inline"))))
+
+(deftest no-diff-model-renders-current-state-no-annotation
+  (testing "the 1-arity (no pre-image) model renders plain current-state —
+            no `← changed` annotation anywhere"
+    (let [model (h/current-state-sections
+                  {:counter 2 :rf/route {:id :home}})
+          tree  (state/state-body model)]
+      (is (not (re-find #"← changed" (pr-str tree)))
+          "no diff annotation without a pre-image"))))


### PR DESCRIPTION
Reconciles the Causa **App-db panel** to `tools/causa/spec/021-Dynamic-Panel-Designs.md` §4.2-4.3 and the Figma design-reference (`tools/causa/design-reference/components/AppDbPanel.tsx`). The sectioned-by-reserved-area model already matched; this lands the two remaining deltas (LOW severity — the smallest of the panel reconciles).

## Changes

**Flat-hairline sections (§4.2).** The old card chrome (`:bg-3` background + 1px full border + radius + per-section bottom-rule header + margin box) is gone. Sections render FLAT — an uppercase caption over the value body, with adjacent sections separated by a 1px `border-top` hairline (the Figma `border-t` divider). The TOP section draws no leading hairline; every reserved-area section after it does.

**Inline `← changed` annotation (§4.3).** `current-state-sections` gains a 2-arity that threads the focused epoch's `db-before` so each section (TOP, per-machine / per-spawned instance, each singleton) carries its `:before` pre-image. Changed sections route their value body through the shared §10 diff renderer (`edn/diff`), which annotates `← changed from X` in place and force-expands the ancestor chain. With no pre-image (LIVE at boot, or the 1-arity model) sections fall back to the plain current-state inspect path. The `:rf.causa/app-db-state` sub now reads `:rf.causa/selected-epoch-record` for the pre-image.

The keyword-accent inside the diff renderer is already orange (owned by rf2-ad7zx.3) — untouched.

## Files
- `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc` — 2-arity `current-state-sections` + `no-diff` sentinel + per-section `:before` plumbing
- `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_state.cljs` — flat-hairline `section-shell`, diff-aware `value-body`, `:before` / `first?` threading
- `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs` — `:rf.causa/app-db-state` threads the epoch pre-image
- `tools/causa/test/.../app_db_diff_helpers_cljs_test.cljc` + `app_db_diff_state_cljs_test.cljs` — new unit tests

## Gates
- `npm run test:cljs` — 4209 tests, 0 failures
- `tools/causa clojure -M:test` — 851 tests, 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- clj-kondo runs in CI (not installed locally); shadow-cljs compiled with 0 warnings

Closes rf2-ad7zx.11.