### PR TITLE
feat(causa): reconcile Issues panel to Figma severity table (rf2-ad7zx.9)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels.cljs
@@ -74,7 +74,7 @@
   | **trace** | `:rf.causa/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events`, rf2-td380) | `:rf.causa/toggle-trace-row-expand` · `:rf.causa/open-in-editor` |
   | **machine-inspector** | `:rf.causa/machine-chart-data` · `:rf.causa/active-timers-for-focused-machine` · `:rf.causa/machine-scrubber-position` | scrubber events · `:rf.causa/focus-cascade` |
   | **routing** | `:rf.causa/registered-routes` · `:rf.causa/current-route-slice` · `:rf.causa/routing-tab-data` | route-simulation events |
-  | **issues-ribbon** | `:rf.causa/issues-ribbon` (composite over focused epoch's `:trace-events` + filter chips per spec/021 §8) | `:rf.causa.issues/toggle-severity` · `:rf.causa.issues/toggle-prefix` · `:rf.causa.issues/clear-filters` |
+  | **issues-ribbon** | `:rf.causa/issues-ribbon` (composite over focused epoch's `:trace-events` — pure rows, no filtering, per spec/021 §8) | `:rf.causa/select-tab` · `:rf.causa/open-in-editor` |
   | **segment-inspector** | `:rf.causa/segment-inspector-open?` · `:rf.causa/segment-inspector-value` | `:rf.causa/close-segment-inspector` |
   | **cancellation-cascade** (side-panel + popover) | `:rf.causa/cancellation-cascade-for-focused-machine` · `:rf.causa/cancellation-cascade-for-focused-event` · `:rf.causa/cancellation-cascade-popover-open?` · `:rf.causa/modal-positioning` | `:rf.causa/cancellation-cascade-close` |
   | **managed-fx** | `:rf.causa/managed-fx-for-focused-event` | `:rf.causa/focus-event` |

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.panels.issues-ribbon
-  "Issues panel — focused-epoch lens (rf2-jio48, per spec/021 §8).
+  "Issues panel — focused-epoch lens (rf2-jio48; Figma reconcile
+  rf2-ad7zx.9, per spec/021 §8).
 
   Per `tools/causa/spec/021-Dynamic-Panel-Designs.md` §1.2 every L4
   panel is focused-epoch-scoped — the Issues panel reads ONLY the
@@ -12,28 +13,33 @@
   timeline carries per-row issue badges (spec/021 §1.2) for cross-epoch
   navigation; this panel is the per-epoch lens.
 
-  ## What this panel shows
+  ## What this panel shows (Figma design — rf2-ad7zx)
 
-  Each issue trace event from the focused epoch lands as one row. Per
-  spec/021 §8.2 + §0 (density-is-binding) rows render:
+  Reconciled to `design-reference/components/IssuesPanel.tsx` + spec/021
+  §8.2 — each issue trace event from the focused epoch lands as ONE row:
 
-      timestamp · category · severity · short description · jump-to-source
+      ▌ SEVERITY  category   short description        timestamp  ↗
 
-  Click a row → the parent dispatch is selected (`:rf.causa/select-
-  dispatch-id`) and the user pivots to the Event panel for the cascade
-  that produced the issue. Click the source-coord chip → the editor
-  opens at that line (via the `:rf.causa/open-in-editor` event — the
-  actual editor jump rides on the open-in-editor module).
+  where the leading `▌` is a 3px LEFT-BORDER coloured by severity, the
+  SEVERITY badge is uppercase TEXT (ERROR / WARNING / ADVISORY) in its
+  severity colour, the category is muted, the description is primary,
+  and the timestamp is mono + RIGHT-aligned. The trailing `↗` opens
+  the responsible handler at `file:line`.
 
-  ## Filter axes (per spec/021 §8)
+  Click a row → flips the visible tab to Event so the user pivots to
+  the Event panel for the cascade that produced the issue. Click the
+  `↗` source affordance → the editor opens at that line (via the
+  `:rf.causa/open-in-editor` event — the actual editor jump rides on
+  the open-in-editor module).
 
-      severity         — error / warning / advisory  (chip row)
-      category-prefix  — :rf.error/* vs :rf.warning/* etc.  (chip row)
+  ## No filtering (rf2-ad7zx.9)
 
-  Each axis is independent; empty filter sets disable the axis. The
-  legacy `since-ms` axis is gone — focused-epoch scope makes it
-  meaningless (an epoch's lifetime is shorter than any time window
-  the operator would type).
+  The Figma design renders pure rows with NO filter chrome — the
+  focused epoch IS the scope, and issues are rare-but-high-signal so
+  every one reads inline at a glance. The legacy severity / prefix
+  filter-chip header, the per-epoch counts, the clear-filters control,
+  and the `:no-matches` empty state are dropped, mirroring the Trace
+  panel's no-filter reconcile (rf2-gkczt).
 
   ## Empty states (per spec/021 §8.2 + §10.7)
 
@@ -46,9 +52,7 @@
                       'Epoch evicted from buffer.
                        Increase :epoch-history to retain more.'
     :no-issues      → 'No issues in this epoch.' — positive state
-                      per spec/021 §8.2 (single-line empty).
-    :no-matches     → issues exist but the active filters hide them
-                      all. Carries a 'Clear filters' affordance.
+                      per spec/021 §8.2 (single calm line).
 
   ## Pure hiccup (rf2-tijr)
 
@@ -59,149 +63,36 @@
 
   ## Helpers
 
-  All pure-data logic — severity classification, category-prefix
-  projection, filter application, empty-state classification —
-  lives in `issues_ribbon_helpers.cljc` so the algebra runs under
-  the JVM unit-test target."
+  All pure-data logic — severity classification, category projection,
+  empty-state classification — lives in `issues_ribbon_helpers.cljc`
+  so the algebra runs under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.theme.tokens
-             :as t
-             :refer [tokens mono-stack sans-stack display-stack]]))
-
-;; ---- chip helpers -------------------------------------------------------
-
-(defn- chip
-  "One toggleable filter chip. `active?` drives the highlighted
-  styling. `on-click` fires the relevant toggle event-db."
-  [{:keys [label active? on-click test-id colour]}]
-  [:button {:data-testid test-id
-            :on-click    on-click
-            :style       {:background    (if active?
-                                           (:bg-active tokens)
-                                           "transparent")
-                          :color         (if active?
-                                           (:text-primary tokens)
-                                           (or colour (:text-secondary tokens)))
-                          :border        (str "1px solid "
-                                              (if active?
-                                                (or colour (:border-default tokens))
-                                                (:border-subtle tokens)))
-                          :border-radius "999px"
-                          :padding       "2px 10px"
-                          :cursor        "pointer"
-                          :font-family   sans-stack
-                          :font-size     "11px"
-                          :font-weight   (if active? 600 400)
-                          :letter-spacing "0.2px"
-                          :margin-right  "6px"
-                          :margin-bottom "4px"}}
-   label])
-
-(defn- severity-chips
-  "Filter chip row for the three severity buckets. Each chip toggles
-  membership in the active severity set."
-  [active-severities counts]
-  (into [:div {:data-testid "rf-causa-issues-severity-chips"
-               :style       {:display "flex" :flex-wrap "wrap"}}]
-        (for [severity h/severity-order
-              :let [active? (contains? active-severities severity)
-                    n       (get counts severity 0)
-                    colour  (h/severity-colour severity)]]
-          (chip {:label    (str (h/severity-label severity)
-                                " · "
-                                n)
-                 :active?  active?
-                 :colour   colour
-                 :test-id  (str "rf-causa-issues-severity-chip-"
-                                (name severity))
-                 :on-click #(rf/dispatch [:rf.causa.issues/toggle-severity
-                                          severity] {:frame :rf/causa})}))))
-
-(defn- prefix-chips
-  "Filter chip row for the distinct category prefixes present in the
-  focused epoch's issues. Per spec/009 the prefix carries the domain
-  provenance — a programmer filtering for `:rf.ssr/*` is asking 'just
-  SSR issues'."
-  [active-prefixes prefixes]
-  (when (seq prefixes)
-    (into [:div {:data-testid "rf-causa-issues-prefix-chips"
-                 :style       {:display "flex" :flex-wrap "wrap"
-                               :margin-top "4px"}}]
-          (for [prefix prefixes
-                :let [active? (contains? active-prefixes prefix)]]
-            (chip {:label    prefix
-                   :active?  active?
-                   :colour   (:accent tokens)
-                   :test-id  (str "rf-causa-issues-prefix-chip-" prefix)
-                   :on-click #(rf/dispatch [:rf.causa.issues/toggle-prefix
-                                            prefix] {:frame :rf/causa})})))))
-
-;; ---- header strip -------------------------------------------------------
-
-(defn- header
-  "Panel header — title + per-epoch counts + filter chips.
-
-  Per spec/021 §8.2 the header line is
-
-      ┌─ ISSUES · epoch #42 ────────────────... ─┐
-
-  When no epoch is focused (or evicted) the epoch chip is omitted —
-  the panel body carries the explanatory placeholder."
-  [{:keys [epoch-id total rendered severity-counts active-severities
-           active-prefixes distinct-prefixes any-filter?]}]
-  [:header {:style {:padding "12px 16px 6px 16px"
-                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-   [:div {:style {:display     "flex"
-                  :align-items "baseline"
-                  :gap         "12px"}}
-    ;; rf2-6xezz — Mike-direction 2026-05-21: the large h1 "Issues"
-     ;; heading is scrubbed; the L4 tab strip is the panel-name
-     ;; source-of-truth. The epoch + counts strip below stays.
-    (when (some? epoch-id)
-      [:span {:data-testid "rf-causa-issues-epoch-chip"
-              :style {:font-size   "11px"
-                      :color       (:text-secondary tokens)
-                      :font-family mono-stack
-                      :letter-spacing "0.2px"}}
-       (str "epoch #" epoch-id)])
-    [:span {:data-testid "rf-causa-issues-counts"
-            :style {:font-size   "11px"
-                    :color       (:text-tertiary tokens)
-                    :font-family mono-stack}}
-     (str rendered " / " total " in view")]
-    (when any-filter?
-      [:button {:data-testid "rf-causa-issues-clear-filters"
-                :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
-                :style       {:margin-left "auto"
-                              :background  "transparent"
-                              :color       (:accent tokens)
-                              :border      (str "1px solid " (:border-default tokens))
-                              :padding     "2px 8px"
-                              :border-radius "3px"
-                              :cursor      "pointer"
-                              :font-family sans-stack
-                              :font-size   "11px"}}
-       "Clear filters"])]
-   [:div {:style {:margin-top "8px"}}
-    (severity-chips active-severities severity-counts)
-    (prefix-chips active-prefixes distinct-prefixes)]])
+             :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- per-row -------------------------------------------------------------
 
 (defn- issue-row
-  "One row in the issues feed. Click the row → pivot to the Event
-  panel. Click the source-coord chip → open in editor.
+  "One row in the issues feed, reconciled to the Figma design
+  (`design-reference/components/IssuesPanel.tsx` + spec/021 §8.2):
 
+      ▌ SEVERITY  category   short description       timestamp  ↗
+
+  The leading `▌` is a 3px severity-coloured LEFT-BORDER; the SEVERITY
+  cell is an uppercase TEXT badge in its severity colour; the category
+  is muted; the description fills; the timestamp is mono + RIGHT-aligned;
+  and `↗` is the open-in-editor source affordance.
+
+  Click the row → pivot to the Event panel. Click `↗` → open in editor.
   Within a focused-epoch lens the parent cascade is the focused epoch
   itself, so the row pivot lands on the panel that already drives the
   focus — the click is a convenience surface, not a cascade switch.
   Source-coord click stops propagation so the source affordance stays
   distinct from the row pivot."
-  [{:keys [id time severity operation category-prefix description
-           source-coord]
+  [{:keys [id time severity category description source-coord]
     :as _issue}]
   (let [row-test-id (str "rf-causa-issues-row-" id)
         colour      (h/severity-colour severity)]
@@ -212,48 +103,56 @@
                          ;; pivot lands in the event lens.
                          (rf/dispatch [:rf.causa/select-tab :event] {:frame :rf/causa}))
           :style       {:display       "grid"
-                        :grid-template-columns "84px 18px minmax(120px, 1fr) 2fr auto"
-                        :gap           "10px"
+                        :grid-template-columns "78px minmax(110px, 0.6fr) 1fr auto 18px"
+                        :gap           "16px"
                         :align-items   "center"
-                        :padding       "6px 16px"
-                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :padding       "8px 12px"
+                        :border        (str "1px solid " (:border-default tokens))
+                        :border-left   (str "3px solid " colour)
+                        :border-radius "4px"
+                        :margin-bottom "8px"
                         :cursor        "pointer"
                         :color         (:text-primary tokens)
-                        :font-family   mono-stack
+                        :font-family   sans-stack
                         :font-size     "12px"
                         :line-height   1.35}}
-     ;; Timestamp
-     [:span {:data-testid (str row-test-id "-time")
-             :style {:color (:text-tertiary tokens)
-                     :font-size "11px"
-                     :white-space "nowrap"}}
-      (or (h/format-time time) "—")]
-     ;; Severity glyph
+     ;; Severity TEXT badge (uppercase, in its severity colour)
      [:span {:data-testid (str row-test-id "-severity")
-             :title       (h/severity-label severity)
-             :style       {:color colour
-                           :font-weight 700
-                           :text-align "center"}}
-      (h/severity-glyph severity)]
-     ;; Category prefix
+             :title       (name severity)
+             :style       {:color          colour
+                           :font-weight    600
+                           :font-size      "10px"
+                           :letter-spacing "0.4px"
+                           :white-space    "nowrap"}}
+      (h/severity-badge-label severity)]
+     ;; Category (muted)
      [:span {:data-testid (str row-test-id "-category")
-             :style       {:color       (:accent tokens)
-                           :overflow    "hidden"
+             :style       {:color         (:text-tertiary tokens)
+                           :overflow      "hidden"
                            :text-overflow "ellipsis"
-                           :white-space "nowrap"}
-             :title       (str operation)}
-      (or category-prefix "—")]
-     ;; Description
+                           :white-space   "nowrap"}
+             :title       (str category)}
+      (or category "—")]
+     ;; Description (primary)
      [:span {:data-testid (str row-test-id "-description")
-             :style       {:color (:text-secondary tokens)
-                           :overflow "hidden"
+             :style       {:color         (:text-primary tokens)
+                           :overflow      "hidden"
                            :text-overflow "ellipsis"
-                           :white-space "nowrap"}
+                           :white-space   "nowrap"}
              :title       description}
       description]
-     ;; Source-coord (when present)
+     ;; Timestamp (mono, muted, RIGHT-aligned)
+     [:span {:data-testid (str row-test-id "-time")
+             :style {:color       (:text-tertiary tokens)
+                     :font-family mono-stack
+                     :font-size   "11px"
+                     :text-align  "right"
+                     :white-space "nowrap"}}
+      (or (h/format-time time) "—")]
+     ;; Source-coord affordance (`↗`, when present)
      (if source-coord
        [:button {:data-testid (str row-test-id "-source")
+                 :title       source-coord
                  :on-click    (fn [e]
                                 ;; Stop propagation so the row's pivot
                                 ;; handler doesn't also fire — the
@@ -264,16 +163,16 @@
                                               {:source-coord source-coord}] {:frame :rf/causa}))
                  :style       {:background  "transparent"
                                :color       (:accent tokens)
-                               :border      (str "1px solid " (:border-subtle tokens))
-                               :padding     "1px 6px"
-                               :border-radius "3px"
+                               :border      "none"
+                               :padding     0
                                :cursor      "pointer"
-                               :font-family mono-stack
-                               :font-size   "10px"}}
-        source-coord]
+                               :font-size   "13px"
+                               :line-height 1}}
+        "↗"]
        [:span {:style {:color (:text-tertiary tokens)
-                       :font-size "10px"}}
-        "—"])]))
+                       :font-size "13px"
+                       :text-align "center"}}
+        "·"])]))
 
 ;; ---- empty states -------------------------------------------------------
 
@@ -282,11 +181,12 @@
   in this epoch.' line alone is the body; positive-state."
   []
   [:div {:data-testid "rf-causa-issues-empty-no-issues"
-         :style       {:padding     "24px"
+         :style       {:padding     "32px"
+                       :text-align  "center"
                        :font-family sans-stack
                        :font-size   "13px"
                        :line-height 1.5
-                       :color       (:text-secondary tokens)}}
+                       :color       (:text-tertiary tokens)}}
    "No issues in this epoch."])
 
 (defn- empty-state-no-focus
@@ -294,7 +194,8 @@
   terse line so the panel-skeleton doesn't look broken."
   []
   [:div {:data-testid "rf-causa-issues-empty-no-focus"
-         :style       {:padding     "24px"
+         :style       {:padding     "32px"
+                       :text-align  "center"
                        :font-family sans-stack
                        :font-size   "13px"
                        :line-height 1.5
@@ -306,8 +207,8 @@
 
   Triggered when the operator scrubs onto an epoch whose record has
   been evicted from the framework's `:epoch-history` ring buffer.
-  Every panel surfaces the same three-line block per §10.7 so the
-  operator's experience is uniform across the four-tab L4 surface."
+  Every panel surfaces the same block per §10.7 so the operator's
+  experience is uniform across the L4 surface."
   [epoch-id]
   [:div {:data-testid "rf-causa-issues-empty-epoch-evicted"
          :style       {:padding     "24px"
@@ -336,35 +237,6 @@
                 :font-size "12px"}}
     "Settings → General → Epoch history."]])
 
-(defn- empty-state-no-matches
-  "Issues exist in the focused epoch but the active filters hide them
-  all. Carries a Clear filters affordance."
-  []
-  [:div {:data-testid "rf-causa-issues-empty-no-matches"
-         :style       {:padding     "24px"
-                       :font-family sans-stack
-                       :font-size   "13px"
-                       :line-height 1.5
-                       :color       (:text-secondary tokens)}}
-   [:p {:style {:margin "0 0 12px 0"
-                :color (:text-primary tokens)
-                :font-weight 600}}
-    "No issues match the active filters."]
-   [:p {:style {:margin "0 0 12px 0"
-                :color (:text-tertiary tokens)}}
-    "Adjust the severity / prefix chips above to widen the view."]
-   [:button {:data-testid "rf-causa-issues-empty-clear-filters"
-             :on-click    #(rf/dispatch [:rf.causa.issues/clear-filters] {:frame :rf/causa})
-             :style       {:background "transparent"
-                           :color      (:accent tokens)
-                           :border     (str "1px solid " (:border-default tokens))
-                           :padding    "4px 10px"
-                           :border-radius "3px"
-                           :cursor     "pointer"
-                           :font-family sans-stack
-                           :font-size  "12px"}}
-    "Clear filters"]])
-
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
@@ -374,14 +246,11 @@
   Per spec/021 §1.2 the panel is focused-epoch-scoped — there is no
   global firehose / aggregate view, and no `:ungrouped` escape-hatch
   lane (those navigation needs live on the L2 timeline's per-row
-  badges per §1.2)."
+  badges per §1.2). No filter chrome (rf2-ad7zx.9) — pure rows per
+  the Figma design."
   []
-  (let [{:keys [issues total rendered severity-counts distinct-prefixes
-                filters epoch-id empty-kind]
-         :as _data}
-        @(rf/subscribe [:rf.causa/issues-ribbon])
-        {:keys [severities prefixes]} filters
-        any-filter? (boolean (or (seq severities) (seq prefixes)))]
+  (let [{:keys [issues epoch-id empty-kind] :as _data}
+        @(rf/subscribe [:rf.causa/issues-ribbon])]
     [:section {:data-testid "rf-causa-issues-ribbon"
                :style       {:height         "100%"
                              :display        "flex"
@@ -390,20 +259,11 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     (header {:epoch-id           epoch-id
-              :total              total
-              :rendered           rendered
-              :severity-counts    severity-counts
-              :active-severities  (or severities #{})
-              :active-prefixes    (or prefixes #{})
-              :distinct-prefixes  distinct-prefixes
-              :any-filter?        any-filter?})
-     [:div {:style {:flex 1 :overflow "auto"}}
+     [:div {:style {:flex 1 :overflow "auto" :padding "16px"}}
       (case empty-kind
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted epoch-id)
         :no-issues     (empty-state-no-issues)
-        :no-matches    (empty-state-no-matches)
         nil            (overflow/capped-list
                          issues
                          {:panel-id "issues"
@@ -417,19 +277,17 @@
 
 (defn install!
   "Idempotent install for the Issues panel's Causa-side registrations
-  (rf2-jio48 rebuild per spec/021 §8)."
+  (rf2-jio48 rebuild; Figma reconcile rf2-ad7zx.9, per spec/021 §8)."
   []
   ;; ---- spec/021 §8 — Issues panel (focused-epoch lens) --------------------
   ;;
   ;; Per spec/021 §1.2 every L4 panel is focused-epoch-scoped. The
   ;; Issues panel reads the focused epoch's `:trace-events`, projects
   ;; the issue subset (errors + warnings + advisories) per spec/009
-  ;; §Error event catalogue, applies the chip-filter axes, and renders.
+  ;; §Error event catalogue, and renders one row per issue.
   ;;
-  ;; Filter axes per spec/021 §8:
-  ;;
-  ;;   :severities  #{:error :warning :advisory}
-  ;;   :prefixes    #{\"rf.error\" \"rf.warning\" \"rf.ssr\" ...}
+  ;; No filtering (rf2-ad7zx.9) — the Figma design renders pure rows;
+  ;; the focused epoch IS the scope.
   ;;
   ;; Empty-kind discriminator (drives the view's branching):
   ;;
@@ -438,69 +296,28 @@
   ;;                     (per :epoch-history capping); the view paints
   ;;                     the canonical placeholder per spec/021 §10.7
   ;;   :no-issues      — focused epoch carries no issues
-  ;;   :no-matches     — issues exist but chip filters hide them all
   ;;   nil             — render the feed
 
-  ;; Active filter state — the panel reads the two slots through one
-  ;; sub so the view re-renders atomically when filters change.
-  (rf/reg-sub :rf.causa/issues-filters
-    (fn [db _query]
-      {:severities (get db :issues-active-severities #{})
-       :prefixes   (get db :issues-active-prefixes #{})}))
-
   ;; Composite — produces every slot the view consumes. Reactive
-  ;; surface: focus + epoch-history + filter state. The helper's
-  ;; `project-feed` does the heavy lifting; the sub is a thin wrapper
-  ;; that classifies focus status (no-focus / focused / evicted),
-  ;; looks up the focused epoch record, and threads it through.
+  ;; surface: focus + epoch-history. The helper's `project-feed` does
+  ;; the heavy lifting; the sub is a thin wrapper that classifies focus
+  ;; status (no-focus / focused / evicted), looks up the focused epoch
+  ;; record, and threads it through.
   ;;
   ;; Per spec/021 §1.2 the panel is focused-epoch-scoped — the sub
   ;; joins on `:rf.causa/focus`'s `:epoch-id` against the per-frame
-  ;; `:rf.causa/epoch-history`, NOT the global trace bus. Cascade-
-  ;; scope filtering is gone (the record IS the scope); chip filters
-  ;; (severity / prefix) AND on top of the focused-epoch view.
+  ;; `:rf.causa/epoch-history`, NOT the global trace bus. The epoch
+  ;; record IS the scope.
   (rf/reg-sub :rf.causa/issues-ribbon
     :<- [:rf.causa/focus]
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/issues-filters]
-    (fn [[focus epoch-history filters] _query]
+    (fn [[focus epoch-history] _query]
       (let [focus-epoch-id (:epoch-id focus)
             focus-status   (h/resolve-focus-status focus-epoch-id
                                                    epoch-history)
             record         (h/find-epoch-record focus-epoch-id
                                                 epoch-history)]
-        (h/project-feed record filters focus-status))))
-
-  ;; ---- Issues panel events --------------------------------------------
-
-  ;; Toggle a severity chip in/out of the active filter set. Per
-  ;; spec/021 §8 each axis is independent.
-  (rf/reg-event-db :rf.causa.issues/toggle-severity
-    (fn [db [_ severity]]
-      (let [current (get db :issues-active-severities #{})]
-        (assoc db :issues-active-severities
-               (if (contains? current severity)
-                 (disj current severity)
-                 (conj current severity))))))
-
-  ;; Toggle a category-prefix chip. Same shape as the severity
-  ;; toggle — multi-select set; empty set = no restriction.
-  (rf/reg-event-db :rf.causa.issues/toggle-prefix
-    (fn [db [_ prefix]]
-      (let [current (get db :issues-active-prefixes #{})]
-        (assoc db :issues-active-prefixes
-               (if (contains? current prefix)
-                 (disj current prefix)
-                 (conj current prefix))))))
-
-  ;; Clear every filter axis in one shot. The Clear filters
-  ;; affordance in the header + the no-matches empty state both
-  ;; fire this.
-  (rf/reg-event-db :rf.causa.issues/clear-filters
-    (fn [db _event]
-      (-> db
-          (dissoc :issues-active-severities)
-          (dissoc :issues-active-prefixes))))
+        (h/project-feed record focus-status))))
 
   ;; rf2-2moh1 — register the Dynamic Issues tab with the internal L4
   ;; tab registry. Order 7 — Routing sits at order 6 (rf2-nrbs9).

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -1,17 +1,17 @@
 (ns day8.re-frame2-causa.panels.issues-ribbon-helpers
-  "Pure-data helpers for Causa's Issues panel (rf2-jio48 rebuild).
+  "Pure-data helpers for Causa's Issues panel (rf2-jio48 rebuild;
+  Figma reconcile rf2-ad7zx.9).
 
   ## Why a separate `.cljc` ns
 
   The panel view in `issues_ribbon.cljs` paints the per-row issue feed
-  and dispatches into the Causa frame. The *logic* — filter the focused
+  and dispatches into the Causa frame. The *logic* — project the focused
   epoch's `:trace-events` to the issue subset (errors + warnings +
-  hydration mismatches + schema violations), project each trace event
-  into a flat row shape, derive severity / category-prefix groupings,
-  and apply the two chip-filter axes (severity / category-prefix) —
-  is pure data → data. Splitting the algebra into `.cljc` so it runs
-  under the JVM unit-test target (`clojure -M:test`) is required by
-  the standing rule `feedback_jvm_interop_must_work.md`.
+  hydration mismatches + schema violations) and project each trace event
+  into a flat row shape — is pure data → data. Splitting the algebra
+  into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
 
   ## Substrate (per `spec/009-Instrumentation.md` §Error event catalogue)
 
@@ -39,11 +39,16 @@
   ## Severity
 
   Spec 009's `:op-type` field is the universal severity discriminator.
-  The panel ladders it onto three buckets:
+  The panel ladders it onto three tiers (per spec/021 §8.2 +
+  spec/022 §Semantic & change, strongest first):
 
-      :error    — `:op-type :error`
-      :warning  — `:op-type :warning`
-      :advisory — `:op-type :info`
+      :error    — `:op-type :error`     → `error` (red), strongest
+      :warning  — `:op-type :warning`   → `warning` (amber)
+      :advisory — `:op-type :info`      → `advisory` (cool blue; calm)
+
+  Each row reads its 3px LEFT-BORDER + uppercase TEXT badge in its
+  severity colour per the Figma design
+  (`design-reference/components/IssuesPanel.tsx`).
 
   Lifecycle / success-path traces (`:op-type` `:rf.event`, `:rf.fx`,
   `:rf.frame`, `:rf.sub/*`, `:rf.view/*`, etc.) are NOT issues and never reach
@@ -54,17 +59,18 @@
   The panel groups by the keyword namespace of `:operation`. Per
   Spec 009 a consumer routing on the prefix gets the domain
   provenance (`:rf.error/*` vs `:rf.warning/*` vs `:rf.ssr/*` ...).
-  The helper exposes `category-prefix` as the canonical projection.
+  The helper exposes `category-prefix` as the canonical projection,
+  used for the row's muted `category` cell.
 
-  ## Filter axes (per spec/021 §8 + §0 density rule)
+  ## No filtering (rf2-ad7zx.9)
 
-      severity         — #{:error :warning :advisory}
-      category-prefix  — #{\"rf.error\" \"rf.warning\" \"rf.ssr\" ...}
-
-  Each axis is independent; empty filters disable the axis. The
-  legacy `since-ms` axis is gone: per spec/021 §1.2 every L4 panel
-  is focused-epoch-scoped, and an epoch's lifetime is shorter than
-  any time window a `since-ms` filter could narrow.
+  The Figma design (spec/021 §8.2 +
+  `design-reference/components/IssuesPanel.tsx`) renders pure rows
+  with NO filter chrome — the focused epoch IS the scope, and issues
+  are rare-but-high-signal so every one reads inline. The legacy
+  severity / category-prefix chip-filter axes, the `since-ms` axis,
+  and the `:no-matches` empty state are gone, mirroring the Trace
+  panel's no-filter reconcile (rf2-gkczt).
 
   ## Focused-epoch scope (spec/021 §1.2 + §8)
 
@@ -72,8 +78,8 @@
   the global trace bus. The composite is fed the epoch record looked
   up by `:rf.causa/focus`'s `:epoch-id` against `:rf.causa/epoch-
   history`; the helper extracts the record's `:trace-events`, projects
-  the issue subset, applies the chip filters, and computes the row
-  shape + histograms over the resulting slice.
+  the issue subset, and computes the row shape over the resulting
+  slice.
 
   When the operator scrubs onto an epoch evicted from the history
   ring buffer (history capped per the framework's `:epoch-history`
@@ -98,13 +104,6 @@
             [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-causa.theme.tokens :as tokens]))
-
-;; ---- defaults ------------------------------------------------------------
-
-(def severity-order
-  "Render order for severity in the chip-row. Errors first because
-  they're the most urgent; advisories last."
-  [:error :warning :advisory])
 
 ;; ---- severity classification --------------------------------------------
 
@@ -132,8 +131,8 @@
 
 (def severity->token
   "Pure semantic map from severity keyword to token keyword. Mirrors
-  spec/007-UX-IA.md §Issues ribbon. Splitting the semantic map from
-  the hex lookup keeps the data pure + tokens consolidated
+  spec/021 §8.2 + spec/022 §Semantic & change. Splitting the semantic
+  map from the hex lookup keeps the data pure + tokens consolidated
   (rf2-5kfxe.4)."
   {:error    :error
    :warning  :warning
@@ -143,30 +142,25 @@
   "Map a severity keyword to its swatch colour. Resolves the semantic
   token keyword through `theme/tokens` so the palette has exactly one
   source of truth (rf2-5kfxe.4). Falls back to `:text-tertiary` for
-  unknown severities."
+  unknown severities.
+
+  Drives BOTH the row's 3px left-border and the uppercase text badge
+  per the Figma design."
   [severity]
   (get tokens/tokens
        (get severity->token severity :text-tertiary)))
 
-(defn severity-glyph
-  "Single-character glyph the per-row severity dot renders. Pure
-  data → string; JVM-testable. Chosen for low-vision contrast: filled
-  triangle for errors, hollow circle for warnings, dot for advisories."
+(defn severity-badge-label
+  "Uppercase severity label for the per-row TEXT badge — `ERROR` /
+  `WARNING` / `ADVISORY` per the Figma design
+  (`design-reference/components/IssuesPanel.tsx`). Pure data → string;
+  JVM-testable."
   [severity]
   (case severity
-    :error    "▲"
-    :warning  "●"
-    :advisory "·"
-    "○"))
-
-(defn severity-label
-  "Human-readable label for the severity chip. Pure data → string."
-  [severity]
-  (case severity
-    :error    "error"
-    :warning  "warning"
-    :advisory "advisory"
-    (str severity)))
+    :error    "ERROR"
+    :warning  "WARNING"
+    :advisory "ADVISORY"
+    (str/upper-case (str (name (or severity :unknown))))))
 
 ;; ---- category-prefix projection -----------------------------------------
 
@@ -183,11 +177,25 @@
   (when (keyword? operation)
     (namespace operation)))
 
+(defn category-label
+  "Project a trace event onto the row's muted `category` cell — the
+  unqualified name of `:operation` (e.g. `handler-exception`,
+  `hydration-mismatch`). Per the Figma design the category column is
+  the terse op name, NOT the full namespaced keyword (the prefix
+  rides the description / source coord). Falls back to the
+  category-prefix when `:operation` has no name, then to nil. Pure
+  data → string-or-nil; JVM-testable."
+  [{:keys [operation] :as ev}]
+  (cond
+    (keyword? operation) (name operation)
+    (some? operation)    (str operation)
+    :else                (category-prefix ev)))
+
 ;; ---- short description --------------------------------------------------
 
 (defn short-description
-  "Build the per-row one-line description. Per the panel's contract
-  rows render: `timestamp · category · severity · short description`.
+  "Build the per-row one-line description. Per the Figma design rows
+  render: `severity · category · short description · timestamp · ↗`.
   The description is the `:operation` keyword + (when available) a
   terse summary lifted from `:tags`.
 
@@ -240,7 +248,8 @@
        :severity        <:error :warning :advisory>
        :op-type         <kw>
        :operation       <kw>
-       :category-prefix <string-or-nil>
+       :category        <string-or-nil>  ;; muted category cell
+       :category-prefix <string-or-nil>  ;; domain provenance
        :description     <string>
        :source-coord    <string-or-nil>
        :recovery        <kw-or-nil>
@@ -256,6 +265,7 @@
      :severity        (op-type->severity op-type)
      :op-type         op-type
      :operation       operation
+     :category        (category-label ev)
      :category-prefix (category-prefix ev)
      :description     (short-description ev)
      :source-coord    (source-coord ev)
@@ -276,51 +286,6 @@
 ;; keep working without churn. Body lives in `common-helpers`.
 (def now-ms common/now-ms)
 
-;; ---- filter application -------------------------------------------------
-
-(defn passes-severity?
-  "True iff `issue`'s severity is in the active filter set, or if
-  the filter set is empty (= no severity restriction). Pure data →
-  bool; JVM-testable."
-  [active-severities {:keys [severity] :as _issue}]
-  (or (empty? active-severities)
-      (contains? active-severities severity)))
-
-(defn passes-category-prefix?
-  "True iff `issue`'s category-prefix is in the active filter set,
-  or if the filter set is empty. Pure data → bool; JVM-testable."
-  [active-prefixes {:keys [category-prefix] :as _issue}]
-  (or (empty? active-prefixes)
-      (contains? active-prefixes category-prefix)))
-
-(defn apply-filters
-  "Apply the two chip-filter axes to `issues`. Pure data → vector;
-  JVM-testable. Each axis is independent — empty filter sets disable
-  the axis.
-
-  `filters` is `{:severities #{...} :prefixes #{...}}`."
-  [issues filters]
-  (let [{:keys [severities prefixes]} filters]
-    (filterv
-      (fn [issue]
-        (and (passes-severity? severities issue)
-             (passes-category-prefix? prefixes issue)))
-      issues)))
-
-;; ---- category-prefix enumeration ----------------------------------------
-
-(defn distinct-prefixes
-  "Return the distinct category-prefixes present in `issues` in
-  first-seen order. The view uses this to populate the prefix-filter
-  chip row only with prefixes that have at least one issue — empty
-  prefix chips would be noise. Pure data → vector; JVM-testable."
-  [issues]
-  (into []
-        (comp (map :category-prefix)
-              (remove nil?)
-              (distinct))
-        issues))
-
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed
@@ -331,9 +296,10 @@
   is the looked-up `:rf/epoch-record` from `:rf.causa/epoch-history`
   whose `:epoch-id` matches the focused `:epoch-id` from
   `:rf.causa/focus`. Walks the record's `:trace-events` via
-  `project-issues`, applies chip filters via `apply-filters`, and
-  computes the severity histogram + distinct-prefix axis over the
-  projection.
+  `project-issues` and renders newest-first.
+
+  No filtering (rf2-ad7zx.9) — the Figma design renders pure rows; the
+  focused epoch IS the scope.
 
   `focus-status` is one of:
     :no-focus       — no focused epoch AND no history (cold start
@@ -345,15 +311,11 @@
 
   Returns:
 
-      {:issues               [<row> ...]      ;; post-filter, newest first
-       :total                <int>            ;; pre-filter issue count
-       :rendered             <int>            ;; post-chip-filter count
-       :severity-counts      {severity count} ;; over the focused epoch
-       :distinct-prefixes    [<prefix> ...]   ;; over the focused epoch
-       :filters              <pass-through>
-       :epoch-id             <int-or-nil>     ;; the focused epoch's id
-       :empty-kind           <:no-issues / :no-focus / :epoch-evicted /
-                              :no-matches / nil>}
+      {:issues     [<row> ...]      ;; newest first
+       :total      <int>            ;; issue count
+       :rendered   <int>            ;; = total (no filtering)
+       :epoch-id   <int-or-nil>     ;; the focused epoch's id
+       :empty-kind <:no-issues / :no-focus / :epoch-evicted / nil>}
 
   `:empty-kind` discriminates the empty-state branches:
 
@@ -370,38 +332,24 @@
       :no-issues      — focused epoch carries no issues. Render the
                         positive 'No issues in this epoch.' line per
                         spec/021 §8.2.
-      :no-matches     — issues exist in the focused epoch but the
-                        active chip filters hide them all. View
-                        paints 'No issues match filters' with a
-                        clear-filters affordance.
-      nil             — at least one issue passed; render the feed."
-  [epoch-record filters focus-status]
+      nil             — at least one issue; render the feed."
+  [epoch-record focus-status]
   (let [record-present?  (= :focused focus-status)
         trace-events     (when record-present?
                            (:trace-events epoch-record))
         all-issues       (project-issues (or trace-events []))
-        filtered         (apply-filters all-issues filters)
         ;; Newest first for display parity with the legacy ribbon.
-        sorted-display   (vec (reverse filtered))
-        severity-counts  (reduce
-                           (fn [acc {:keys [severity]}]
-                             (update acc severity (fnil inc 0)))
-                           {}
-                           all-issues)
+        sorted-display   (vec (reverse all-issues))
         empty-kind       (cond
                            (= focus-status :no-focus)      :no-focus
                            (= focus-status :epoch-evicted) :epoch-evicted
                            (empty? all-issues)             :no-issues
-                           (empty? filtered)               :no-matches
                            :else                           nil)]
-    {:issues            sorted-display
-     :total             (count all-issues)
-     :rendered          (count filtered)
-     :severity-counts   severity-counts
-     :distinct-prefixes (distinct-prefixes all-issues)
-     :filters           filters
-     :epoch-id          (:epoch-id epoch-record)
-     :empty-kind        empty-kind}))
+    {:issues     sorted-display
+     :total      (count all-issues)
+     :rendered   (count all-issues)
+     :epoch-id   (:epoch-id epoch-record)
+     :empty-kind empty-kind}))
 
 ;; ---- film-strip filter slot (spec/021 §8.5 stretch) ---------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -16,13 +16,14 @@
     1. **op-type → severity mapping** — every issue op-type maps to
        the correct severity bucket; non-issue op-types return nil.
     2. **issue-event?** — classifies trace events.
-    3. **category-prefix** — projects `:operation`'s keyword namespace.
+    3. **category-prefix / category-label** — project `:operation`'s
+       keyword namespace + unqualified name (the Figma row cell).
     4. **project-issue** — projects raw trace events onto row cells.
-    5. **filter axes** — severity / prefix are independent; empty
-       filters disable the axis.
+    5. **severity-badge-label** — uppercase ERROR/WARNING/ADVISORY badge.
     6. **project-feed** — top-level composite over a focused epoch
-       record; empty-kind classifier (incl. :no-focus, :epoch-evicted,
-       :no-issues, :no-matches branches per spec/021 §10.7).
+       record; empty-kind classifier (:no-focus, :epoch-evicted,
+       :no-issues branches per spec/021 §10.7). No filtering
+       (rf2-ad7zx.9 — pure rows per the Figma design).
     7. **resolve-focus-status / find-epoch-record** — focus + history
        resolver.
     8. **epoch-has-issues?** — film-strip filter-fn callback.
@@ -103,22 +104,22 @@
 (deftest severity-colour-mapping-honours-tokens
   (testing "each severity gets the shell.cljs token-equivalent colour
             (resolved through `theme/tokens` so the rf2-0fr6v
-            `:text-tertiary` contrast bump round-trips automatically)"
+            `:text-tertiary` contrast bump round-trips automatically).
+            Drives both the row's 3px left-border and the text badge
+            per the Figma design (rf2-ad7zx.9)."
     (is (= (:error    tokens/tokens) (h/severity-colour :error)))
     (is (= (:warning  tokens/tokens) (h/severity-colour :warning)))
     (is (= (:advisory tokens/tokens) (h/severity-colour :advisory)))
     (is (= (:text-tertiary tokens/tokens) (h/severity-colour :unknown)))))
 
-(deftest severity-label-stable
-  (is (= "error"    (h/severity-label :error)))
-  (is (= "warning"  (h/severity-label :warning)))
-  (is (= "advisory" (h/severity-label :advisory))))
-
-(deftest severity-glyph-stable
-  (is (= "▲" (h/severity-glyph :error)))
-  (is (= "●" (h/severity-glyph :warning)))
-  (is (= "·" (h/severity-glyph :advisory)))
-  (is (= "○" (h/severity-glyph :unknown))))
+(deftest severity-badge-label-uppercase
+  (testing "rf2-ad7zx.9 — the per-row TEXT badge is uppercase
+            ERROR / WARNING / ADVISORY per the Figma design
+            (design-reference/components/IssuesPanel.tsx)"
+    (is (= "ERROR"    (h/severity-badge-label :error)))
+    (is (= "WARNING"  (h/severity-badge-label :warning)))
+    (is (= "ADVISORY" (h/severity-badge-label :advisory)))
+    (is (= "UNKNOWN"  (h/severity-badge-label :unknown)))))
 
 ;; ---- (2) issue-event? -------------------------------------------------
 
@@ -162,58 +163,35 @@
       (is (= :error                     (:severity row)))
       (is (= :error                     (:op-type row)))
       (is (= :rf.error/handler-exception    (:operation row)))
+      (is (= "handler-exception"        (:category row))
+          "rf2-ad7zx.9 — the muted category cell is the unqualified op name")
       (is (= "rf.error"                 (:category-prefix row)))
       (is (re-find #"kaboom"            (:description row)))
       (is (some?                        (:raw row))))))
 
-;; ---- (5) filter application -----------------------------------------
+;; ---- (5) category-label / category-prefix ----------------------------
+;;
+;; rf2-ad7zx.9 — the chip-filter helpers (`passes-severity?`,
+;; `passes-category-prefix?`, `apply-filters`) and the
+;; `distinct-prefixes` enumeration were removed with the Issues panel's
+;; filter-chrome reconcile to the Figma design (pure rows, no filtering
+;; — spec/021 §8.2). The Figma row's muted `category` cell is the
+;; unqualified op name; `category-prefix` still carries the domain
+;; provenance (used for the row's title affordance).
 
-(deftest passes-severity-empty-filter-passes-all
-  (is (true? (h/passes-severity? #{} {:severity :error}))))
-
-(deftest passes-severity-filters-by-membership
-  (is (true?  (h/passes-severity? #{:error} {:severity :error})))
-  (is (false? (h/passes-severity? #{:error} {:severity :warning}))))
-
-(deftest passes-category-prefix-empty-filter-passes-all
-  (is (true? (h/passes-category-prefix? #{} {:category-prefix "rf.error"}))))
-
-(deftest passes-category-prefix-filters-by-membership
-  (is (true?  (h/passes-category-prefix? #{"rf.error"}
-                                         {:category-prefix "rf.error"})))
-  (is (false? (h/passes-category-prefix? #{"rf.error"}
-                                         {:category-prefix "rf.ssr"}))))
-
-(deftest apply-filters-composes-axes-intersectively
-  (let [issues [{:id 1 :severity :error    :category-prefix "rf.error"}
-                {:id 2 :severity :warning  :category-prefix "rf.error"}
-                {:id 3 :severity :error    :category-prefix "rf.ssr"}
-                {:id 4 :severity :advisory :category-prefix "rf.info"}]]
-    (testing "no filters → every issue passes"
-      (is (= 4 (count (h/apply-filters issues {})))))
-    (testing "severity only narrows"
-      (is (= #{1 3} (set (map :id (h/apply-filters issues
-                                                   {:severities #{:error}}))))))
-    (testing "prefix only narrows"
-      (is (= #{1 2} (set (map :id (h/apply-filters issues
-                                                   {:prefixes #{"rf.error"}}))))))
-    (testing "severity AND prefix"
-      (is (= #{1} (set (map :id (h/apply-filters
-                                  issues
-                                  {:severities #{:error}
-                                   :prefixes   #{"rf.error"}}))))))))
-
-;; ---- (6) distinct-prefixes ----------------------------------------
-
-(deftest distinct-prefixes-first-seen-order
-  (let [issues [{:category-prefix "rf.error"}
-                {:category-prefix "rf.ssr"}
-                {:category-prefix "rf.error"}
-                {:category-prefix "rf.warning"}
-                {:category-prefix nil}
-                {:category-prefix "rf.ssr"}]]
-    (is (= ["rf.error" "rf.ssr" "rf.warning"]
-           (h/distinct-prefixes issues)))))
+(deftest category-label-is-unqualified-op-name
+  (testing "the muted category cell is the operation's unqualified name"
+    (is (= "handler-exception"
+           (h/category-label (error-ev 1 :rf.error/handler-exception))))
+    (is (= "hydration-mismatch"
+           (h/category-label (warning-ev 2 :rf.ssr/hydration-mismatch))))
+    (is (= "note"
+           (h/category-label (advisory-ev 3 :rf.info/note)))))
+  (testing "falls back to the literal string for a non-keyword op"
+    (is (= "literal-string"
+           (h/category-label {:operation "literal-string"}))))
+  (testing "nil operation yields nil"
+    (is (nil? (h/category-label {:operation nil})))))
 
 ;; ---- (7) resolve-focus-status + find-epoch-record -------------------
 
@@ -277,7 +255,7 @@
 ;; ---- (8) project-feed top-level composite ---------------------------
 
 (deftest project-feed-no-focus-renders-empty
-  (let [feed (h/project-feed nil {} :no-focus)]
+  (let [feed (h/project-feed nil :no-focus)]
     (is (= []  (:issues feed)))
     (is (= 0   (:total feed)))
     (is (= 0   (:rendered feed)))
@@ -287,14 +265,14 @@
 (deftest project-feed-evicted-renders-canonical-placeholder
   (testing "spec/021 §10.7 — :epoch-evicted is the discriminator the
             view branches on to render the canonical placeholder."
-    (let [feed (h/project-feed nil {} :epoch-evicted)]
+    (let [feed (h/project-feed nil :epoch-evicted)]
       (is (= :epoch-evicted (:empty-kind feed)))
       (is (= 0 (:total feed))))))
 
 (deftest project-feed-no-issues-empty-trace-events
   (testing "focused epoch with empty :trace-events → :no-issues"
     (let [record (epoch-record 42 [])
-          feed   (h/project-feed record {} :focused)]
+          feed   (h/project-feed record :focused)]
       (is (= [] (:issues feed)))
       (is (= 0  (:total feed)))
       (is (= :no-issues (:empty-kind feed)))
@@ -304,7 +282,7 @@
   (testing "trace-events with no issue ops → :no-issues"
     (let [record (epoch-record 42 [(non-issue-ev 1)
                                    (non-issue-ev 2)])
-          feed   (h/project-feed record {} :focused)]
+          feed   (h/project-feed record :focused)]
       (is (= [] (:issues feed)))
       (is (= :no-issues (:empty-kind feed))))))
 
@@ -317,7 +295,7 @@
                     (warning-ev 3 :rf.warning/recoverable)
                     (non-issue-ev 4)
                     (advisory-ev 5 :rf.info/note)])
-          feed   (h/project-feed record {} :focused)]
+          feed   (h/project-feed record :focused)]
       (is (= 3 (:total feed)))
       (is (= 3 (:rendered feed)))
       (is (= #{1 3 5} (set (map :id (:issues feed)))))
@@ -338,7 +316,7 @@
           focus-epoch-id   nil
           focus-status     (h/resolve-focus-status focus-epoch-id hist)
           record           (h/find-epoch-record   focus-epoch-id hist)
-          feed             (h/project-feed record {} focus-status)]
+          feed             (h/project-feed record focus-status)]
       (is (= :focused focus-status))
       (is (= 6 (:epoch-id record)) "head record is the most-recent epoch")
       (is (nil? (:empty-kind feed))
@@ -380,19 +358,18 @@
     (let [record (epoch-record 2 [(non-issue-ev 1)
                                   (hydration-mismatch-ev 9)
                                   (non-issue-ev 2)])
-          feed   (h/project-feed record {} :focused)]
+          feed   (h/project-feed record :focused)]
       (is (nil? (:empty-kind feed)) "feed renders, not an empty state")
       (is (= 1 (:total feed)))
       (is (= 1 (:rendered feed)))
       (is (= [9] (mapv :id (:issues feed))))
       (let [row (first (:issues feed))]
         (is (= :error               (:severity row)))
+        (is (= "hydration-mismatch" (:category row)))
         (is (= "rf.ssr"             (:category-prefix row)))
         (is (= :rf.ssr/hydration-mismatch (:operation row)))
         (is (re-find #"Hydration mismatch" (:description row))))
-      (is (= 2 (:epoch-id feed)) "feed epoch-id reflects the focused cascade")
-      (is (= {:error 1} (:severity-counts feed)))
-      (is (= ["rf.ssr"] (:distinct-prefixes feed))))))
+      (is (= 2 (:epoch-id feed)) "feed epoch-id reflects the focused cascade"))))
 
 (deftest project-feed-hydration-mismatch-head-fallback-sub-call-site
   (testing "rf2-djuf3 — the panel's sub call-site shape: nil focus +
@@ -404,89 +381,60 @@
           focus-epoch-id nil
           focus-status   (h/resolve-focus-status focus-epoch-id hist)
           record         (h/find-epoch-record   focus-epoch-id hist)
-          feed           (h/project-feed record {} focus-status)]
+          feed           (h/project-feed record focus-status)]
       (is (= :focused focus-status))
       (is (= 2 (:epoch-id record)))
       (is (nil? (:empty-kind feed)))
       (is (= [9] (mapv :id (:issues feed)))))))
 
 (deftest project-feed-always-renders-feed-or-empty-state
-  (testing "rf2-djuf3 invariant — under EVERY focus-status the panel sub
+  (testing "rf2-djuf3 invariant (rf2-ad7zx.9 — :no-matches dropped with
+            the filter chrome) — under EVERY focus-status the panel sub
             yields a renderable shape: either the feed (empty-kind nil)
-            or exactly one of the four empty-state discriminators. The
+            or exactly one of the three empty-state discriminators. The
             feature-gate scenario waits on this union; an unhandled
             empty-kind would silently render nothing."
-    (let [renderable? #{nil :no-focus :epoch-evicted :no-issues :no-matches}]
+    (let [renderable? #{nil :no-focus :epoch-evicted :no-issues}]
       (testing ":no-focus → :no-focus empty-state"
-        (is (= :no-focus (:empty-kind (h/project-feed nil {} :no-focus)))))
+        (is (= :no-focus (:empty-kind (h/project-feed nil :no-focus)))))
       (testing ":epoch-evicted → :epoch-evicted empty-state"
         (is (= :epoch-evicted
-               (:empty-kind (h/project-feed nil {} :epoch-evicted)))))
+               (:empty-kind (h/project-feed nil :epoch-evicted)))))
       (testing ":focused + no issues → :no-issues empty-state"
         (is (= :no-issues
-               (:empty-kind (h/project-feed (epoch-record 1 []) {} :focused)))))
-      (testing ":focused + issues hidden by filters → :no-matches empty-state"
-        (is (= :no-matches
-               (:empty-kind (h/project-feed
-                              (epoch-record 1 [(hydration-mismatch-ev 9)])
-                              {:severities #{:advisory}}
-                              :focused)))))
+               (:empty-kind (h/project-feed (epoch-record 1 []) :focused)))))
       (testing ":focused + visible issue → feed (empty-kind nil)"
         (is (nil? (:empty-kind (h/project-feed
                                  (epoch-record 1 [(hydration-mismatch-ev 9)])
-                                 {}
                                  :focused)))))
       (testing "every branch's empty-kind is in the view's renderable set"
-        (doseq [[record filters status]
-                [[nil {} :no-focus]
-                 [nil {} :epoch-evicted]
-                 [(epoch-record 1 []) {} :focused]
-                 [(epoch-record 1 [(hydration-mismatch-ev 9)])
-                  {:severities #{:advisory}} :focused]
-                 [(epoch-record 1 [(hydration-mismatch-ev 9)]) {} :focused]]]
+        (doseq [[record status]
+                [[nil :no-focus]
+                 [nil :epoch-evicted]
+                 [(epoch-record 1 []) :focused]
+                 [(epoch-record 1 [(hydration-mismatch-ev 9)]) :focused]]]
           (is (contains? renderable?
-                         (:empty-kind (h/project-feed record filters status)))))))))
+                         (:empty-kind (h/project-feed record status)))))))))
 
 (deftest project-feed-newest-first
   (testing "the feed reverses the trace-events stream — newest first"
     (let [record (epoch-record 1 [(error-ev   1 :rf.error/a {:time 100})
                                   (warning-ev 2 :rf.warning/b {:time 200})
                                   (error-ev   3 :rf.error/c {:time 300})])
-          feed   (h/project-feed record {} :focused)]
+          feed   (h/project-feed record :focused)]
       (is (= [3 2 1] (mapv :id (:issues feed)))))))
 
-(deftest project-feed-empty-kind-no-matches-when-filters-hide-all
-  (testing "issues exist in the focused epoch but the chip filters hide
-            them all → :no-matches"
-    (let [record (epoch-record 1 [(error-ev 1 :rf.error/handler-exception)])
-          feed   (h/project-feed record {:severities #{:advisory}} :focused)]
-      (is (= 1 (:total feed)))
-      (is (= 0 (:rendered feed)))
-      (is (= :no-matches (:empty-kind feed))))))
-
-(deftest project-feed-histograms-are-epoch-scoped
-  (testing "severity-counts and distinct-prefixes reflect the focused
-            epoch's :trace-events — NOT a global stream"
-    (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-exception)
-                                  (warning-ev 2 :rf.warning/recoverable)
-                                  (error-ev   3 :rf.ssr/hydration-mismatch)])
-          feed   (h/project-feed record {} :focused)]
-      (is (= {:error 2 :warning 1} (:severity-counts feed)))
-      (is (= ["rf.error" "rf.warning" "rf.ssr"]
-             (:distinct-prefixes feed))))))
-
-(deftest project-feed-chip-filter-anding
-  (testing "chip filters AND on top of the focused-epoch projection"
+(deftest project-feed-no-filtering-renders-every-issue
+  (testing "rf2-ad7zx.9 — the panel renders pure rows with NO filtering;
+            every issue in the focused epoch surfaces, :rendered = :total"
     (let [record (epoch-record 1 [(error-ev   1 :rf.error/handler-exception)
                                   (warning-ev 2 :rf.warning/missing-doc)
-                                  (error-ev   3 :rf.ssr/hydration-mismatch)])
-          feed   (h/project-feed record
-                                 {:severities #{:error}
-                                  :prefixes   #{"rf.error"}}
-                                 :focused)]
-      (is (= 3 (:total feed)))
-      (is (= 1 (:rendered feed)))
-      (is (= [1] (map :id (:issues feed)))))))
+                                  (advisory-ev 3 :rf.info/note)
+                                  (error-ev   4 :rf.ssr/hydration-mismatch)])
+          feed   (h/project-feed record :focused)]
+      (is (= 4 (:total feed)))
+      (is (= 4 (:rendered feed)))
+      (is (= #{1 2 3 4} (set (map :id (:issues feed))))))))
 
 ;; ---- (9) film-strip filter-fn slot ----------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -1,15 +1,16 @@
 (ns day8.re-frame2-causa.panels.issues-ribbon-view-cljs-test
   "CLJS-side wiring + view tests for Causa's Issues panel
-  (rf2-jio48 rebuild; spec/021 §8).
+  (rf2-jio48 rebuild; Figma reconcile rf2-ad7zx.9; spec/021 §8).
 
   ## What's under test (in addition to the pure-data tests in
   `issues_ribbon_helpers_cljs_test.cljc`)
 
     1. **Registry wires the composite sub** under
-       `:rf.causa/issues-ribbon` + every filter event.
+       `:rf.causa/issues-ribbon`.
 
-    2. **Render contract** — the section + header + chip rows +
-       counts + data-testid wiring matches the production view tree.
+    2. **Render contract** — the section + feed + per-row cells +
+       data-testid wiring matches the production view tree. NO filter
+       chrome (rf2-ad7zx.9 — the Figma design renders pure rows).
 
     3. **Focused-epoch scope** (spec/021 §1.2 + §8) — when the spine
        focuses an epoch the panel surfaces ONLY that epoch's
@@ -20,25 +21,24 @@
        paints the canonical placeholder block.
 
     5. **Empty states** — `:no-focus`, `:no-issues` (positive),
-       `:epoch-evicted` (placeholder), `:no-matches` (filters hide
-       everything) each render their distinct container.
+       `:epoch-evicted` (placeholder) each render their distinct
+       container.
 
     6. **Sub-driven rendering** — when issues live in the focused
        epoch the panel renders one `<li>` per issue.
 
-    7. **Severity filter** — `:rf.causa.issues/toggle-severity` adds/
-       removes severities from the active set and the rendered rows
-       narrow to match.
+    7. **Per-row Figma chrome** — each row carries a 3px
+       severity-coloured LEFT-BORDER, an uppercase TEXT severity badge
+       in its severity colour, a muted category cell, a description, a
+       RIGHT-aligned mono timestamp, and an `↗` source affordance.
 
-    8. **Prefix filter** — `:rf.causa.issues/toggle-prefix` works the
-       same way for category prefixes.
+    8. **No filter chrome** — the severity / prefix chip rows, the
+       per-epoch counts, and the clear-filters control are GONE
+       (rf2-ad7zx.9).
 
     9. **Row interactions** — clicking a row pivots to event-detail;
-       clicking the source chip fires :open-in-editor and does NOT
+       clicking the source `↗` fires :open-in-editor and does NOT
        also pivot.
-
-   10. **Frame isolation** — the panel's filter state lives on
-       `:rf/causa`, never on `:rf/default`.
 
   ## Pure hiccup
 
@@ -51,7 +51,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
-            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]))
@@ -122,35 +122,38 @@
 ;; ---- (1) registry wiring ------------------------------------------------
 
 (deftest registry-installs-issues-panel-handlers
-  (testing "register-causa-handlers! installs the rf2-jio48 rebuild's
-            composite sub + every supporting event"
+  (testing "register-causa-handlers! installs the composite sub"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/issues-ribbon))
-        ":rf.causa/issues-ribbon sub registered")
-    (is (some? (registrar/handler :sub :rf.causa/issues-filters))
-        ":rf.causa/issues-filters sub registered")
-    (is (some? (registrar/handler :event :rf.causa.issues/toggle-severity))
-        ":rf.causa.issues/toggle-severity event registered")
-    (is (some? (registrar/handler :event :rf.causa.issues/toggle-prefix))
-        ":rf.causa.issues/toggle-prefix event registered")
-    (is (some? (registrar/handler :event :rf.causa.issues/clear-filters))
-        ":rf.causa.issues/clear-filters event registered")))
+        ":rf.causa/issues-ribbon sub registered")))
+
+(deftest legacy-filter-machinery-is-gone
+  (testing "rf2-ad7zx.9 dropped the filter chrome — the chip-filter sub +
+            events MUST NOT register (the Figma design renders pure rows)"
+    (registry/register-causa-handlers!)
+    (is (nil? (registrar/handler :sub :rf.causa/issues-filters))
+        ":rf.causa/issues-filters sub NOT registered post-reconcile")
+    (is (nil? (registrar/handler :event :rf.causa.issues/toggle-severity))
+        "toggle-severity event NOT registered post-reconcile")
+    (is (nil? (registrar/handler :event :rf.causa.issues/toggle-prefix))
+        "toggle-prefix event NOT registered post-reconcile")
+    (is (nil? (registrar/handler :event :rf.causa.issues/clear-filters))
+        "clear-filters event NOT registered post-reconcile")))
 
 (deftest legacy-since-ms-axis-is-gone
-  (testing "rf2-jio48 dropped the since-ms axis (focused-epoch scoping
-            makes it meaningless) — `:rf.causa.issues/set-since-seconds`
-            MUST NOT register"
+  (testing "the since-ms axis (dropped at rf2-jio48) stays gone —
+            `:rf.causa.issues/set-since-seconds` MUST NOT register"
     (registry/register-causa-handlers!)
     (is (nil? (registrar/handler :event :rf.causa.issues/set-since-seconds))
-        "since-seconds event NOT registered post-rebuild")))
+        "since-seconds event NOT registered")))
 
 (deftest legacy-ungrouped-lane-sub-is-gone
-  (testing "rf2-jio48 dropped the `:ungrouped` lane (focused-epoch
-            scoping renders it redundant — L2 row badges per spec/021
-            §1.2 carry the cross-epoch navigation)"
+  (testing "the `:ungrouped` lane (dropped at rf2-jio48) stays gone —
+            L2 row badges per spec/021 §1.2 carry the cross-epoch
+            navigation"
     (registry/register-causa-handlers!)
     (is (nil? (registrar/handler :sub :rf.causa.issues/ungrouped))
-        ":ungrouped lane sub NOT registered post-rebuild")))
+        ":ungrouped lane sub NOT registered")))
 
 ;; ---- (2) defaults & render contract -----------------------------------
 
@@ -171,25 +174,29 @@
     (rf/with-frame :rf/causa
       (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-ribbon"))
-            "panel container present")
-        (is (some? (find-by-testid tree "rf-causa-issues-counts"))
-            "counts span in header present")
-        (is (some? (find-by-testid tree "rf-causa-issues-severity-chips"))
-            "severity chip row present")
-        ;; rf2-6xezz · Mike-direction 2026-05-21 — the per-panel header
-        ;; icon lived inside the deleted h1 heading. The L4 tab is now
-        ;; the panel-name source-of-truth.
-        (is (nil? (find-by-testid tree "rf-causa-issues-panel-icon"))
-            "panel header icon is gone (lived in the scrubbed h1)")))))
+            "panel container present")))))
 
-(deftest since-input-removed
-  (testing "rf2-jio48 dropped the since-ms axis — the since input MUST
-            NOT render in the header"
+(deftest no-filter-chrome-renders
+  (testing "rf2-ad7zx.9 — the panel renders NO filter chrome: no chip
+            rows, no counts, no clear-filters control (the Figma design
+            renders pure rows)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (is (nil? (find-by-testid (issues-ribbon/Panel)
-                                "rf-causa-issues-since-input"))
-          "since-ms input is gone post-rebuild"))))
+      (seed-history!
+        [(mk-epoch 1 11 [(mk-issue {:id 1 :op-type :error
+                                    :operation :rf.error/handler-exception})])])
+      (focus! 11)
+      (let [tree (issues-ribbon/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-issues-severity-chips"))
+            "severity chip row gone")
+        (is (nil? (find-by-testid tree "rf-causa-issues-prefix-chips"))
+            "prefix chip row gone")
+        (is (nil? (find-by-testid tree "rf-causa-issues-counts"))
+            "per-epoch counts gone")
+        (is (nil? (find-by-testid tree "rf-causa-issues-clear-filters"))
+            "clear-filters control gone")
+        (is (nil? (find-by-testid tree "rf-causa-issues-epoch-chip"))
+            "header epoch chip gone")))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 
@@ -241,27 +248,6 @@
         (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
             "no feed list when the focused epoch has been evicted")))))
 
-(deftest empty-state-no-matches-renders-when-filters-hide-all
-  (testing "with issues in the focused epoch but a chip filter that
-            matches nothing the panel renders the :no-matches empty-
-            state with clear-filters button"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (seed-history!
-        [(mk-epoch 1 11
-                   [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-exception})])])
-      (focus! 11)
-      ;; Toggle in a severity the issue doesn't carry — filter excludes it.
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :advisory])
-      (let [tree (issues-ribbon/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-issues-empty-no-matches"))
-            ":no-matches empty-state container present")
-        (is (some? (find-by-testid tree "rf-causa-issues-empty-clear-filters"))
-            "clear-filters button surfaces in :no-matches state")
-        (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
-            "no feed list when no rows survive filtering")))))
-
 ;; ---- (4) sub-driven rendering -------------------------------------------
 
 (deftest feed-list-renders-when-focused-epoch-has-issues
@@ -284,27 +270,11 @@
         (is (some? (find-by-testid tree "rf-causa-issues-row-2"))
             "row for issue id 2 present")))))
 
-(deftest header-surfaces-focused-epoch-id
-  (testing "the header carries the focused epoch's id chip so the
-            operator sees which epoch is in view"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (seed-history!
-        [(mk-epoch 42 142
-                   [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-exception})])])
-      (focus! 142)
-      (let [tree (issues-ribbon/Panel)
-            chip (find-by-testid tree "rf-causa-issues-epoch-chip")]
-        (is (some? chip)
-            "epoch chip rendered when focus resolves")
-        (is (re-find #"#42" (last chip))
-            "chip surfaces the focused :epoch-id")))))
+;; ---- (5) per-row Figma chrome (rf2-ad7zx.9) ----------------------------
 
-;; ---- (5) per-row chrome ---------------------------------------------
-
-(deftest each-row-surfaces-severity-glyph-and-category
-  (testing "every row surfaces the severity glyph + the category prefix"
+(deftest each-row-surfaces-figma-cells
+  (testing "every row surfaces the severity badge + category +
+            description + RIGHT-aligned timestamp"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (seed-history!
@@ -313,73 +283,19 @@
                                :operation :rf.error/handler-exception})])])
       (focus! 11)
       (let [tree (issues-ribbon/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-issues-row-3-time"))
-            "row timestamp span present")
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-severity"))
-            "row severity glyph present")
+            "row severity badge present")
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-category"))
-            "row category prefix span present")
+            "row category cell present")
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-description"))
-            "row description span present")))))
+            "row description cell present")
+        (is (some? (find-by-testid tree "rf-causa-issues-row-3-time"))
+            "row timestamp cell present")))))
 
-(deftest severity-chip-row-renders-three-buckets
-  (testing "the severity chip-row renders one chip per bucket in
-            severity-order — error / warning / advisory"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (let [tree (issues-ribbon/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-error")))
-        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-warning")))
-        (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-advisory")))))))
-
-(deftest prefix-chip-row-suppressed-when-no-issues
-  (testing "the prefix chip-row only renders when at least one issue
-            carries a prefix — with an empty focused epoch the chip-
-            row is suppressed"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (seed-history! [(mk-epoch 1 11 [])])
-      (focus! 11)
-      (is (nil? (find-by-testid (issues-ribbon/Panel)
-                                "rf-causa-issues-prefix-chips"))
-          "no prefix chip-row when focused epoch carries no issues"))))
-
-(deftest prefix-chip-row-renders-when-issues-have-prefixes
-  (testing "with an issue carrying a category prefix the chip-row
-            renders the corresponding prefix chip"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (seed-history!
-        [(mk-epoch 1 11
-                   [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-exception})])])
-      (focus! 11)
-      (let [tree (issues-ribbon/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-issues-prefix-chips"))
-            "prefix chip-row renders once at least one prefix exists")
-        (is (some? (find-by-testid tree "rf-causa-issues-prefix-chip-rf.error"))
-            "rf.error prefix chip surfaces")))))
-
-;; ---- (6) severity filter ------------------------------------------------
-
-(deftest toggle-severity-mutates-causa-frame
-  (testing ":rf.causa.issues/toggle-severity toggles set membership on
-            the Causa frame"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (= #{:error}
-             (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
-      (is (= #{:error :warning}
-             (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (= #{:warning}
-             (:severities @(rf/subscribe [:rf.causa/issues-filters])))
-          "second toggle removes the severity"))))
-
-(deftest severity-filter-narrows-rendered-rows
-  (testing "an active severity filter cuts the row list down to matching rows"
+(deftest severity-badge-is-uppercase-text-in-severity-colour
+  (testing "rf2-ad7zx.9 — the severity cell is an uppercase TEXT badge
+            (ERROR / WARNING / ADVISORY) coloured by severity, NOT a
+            glyph"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (seed-history!
@@ -387,64 +303,61 @@
                    [(mk-issue {:id 1 :op-type :error
                                :operation :rf.error/handler-exception})
                     (mk-issue {:id 2 :op-type :warning
-                               :operation :rf.warning/recoverable})
+                               :operation :rf.warning/missing-doc})
                     (mk-issue {:id 3 :op-type :info
                                :operation :rf.info/note})])])
       (focus! 11)
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
-      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
-        (is (= 3 (:total data)))
-        (is (= 1 (:rendered data)))
-        (is (= [2] (mapv :id (:issues data))))))))
+      (let [tree (issues-ribbon/Panel)
+            badge (fn [id] (find-by-testid tree (str "rf-causa-issues-row-" id "-severity")))]
+        (is (= "ERROR"    (last (badge 1))) "error badge text uppercase")
+        (is (= "WARNING"  (last (badge 2))) "warning badge text uppercase")
+        (is (= "ADVISORY" (last (badge 3))) "advisory badge text uppercase")
+        (is (= (h/severity-colour :error)
+               (-> (badge 1) second :style :color))
+            "error badge painted in the error severity colour")
+        (is (= (h/severity-colour :warning)
+               (-> (badge 2) second :style :color))
+            "warning badge painted in the warning severity colour")
+        (is (= (h/severity-colour :advisory)
+               (-> (badge 3) second :style :color))
+            "advisory badge painted in the advisory severity colour")))))
 
-;; ---- (7) prefix filter --------------------------------------------------
-
-(deftest toggle-prefix-mutates-causa-frame
-  (testing ":rf.causa.issues/toggle-prefix toggles set membership on
-            the Causa frame"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
-      (is (= #{"rf.error"}
-             (:prefixes @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
-      (is (= #{} (:prefixes @(rf/subscribe [:rf.causa/issues-filters])))
-          "second toggle removes the prefix"))))
-
-(deftest prefix-filter-narrows-rendered-rows
-  (testing "an active prefix filter cuts the row list down to matching prefixes"
+(deftest each-row-carries-severity-left-border
+  (testing "rf2-ad7zx.9 — each row carries a 3px severity-coloured
+            LEFT-BORDER per the Figma design"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (seed-history!
         [(mk-epoch 1 11
                    [(mk-issue {:id 1 :op-type :error
                                :operation :rf.error/handler-exception})
-                    (mk-issue {:id 2 :op-type :error
-                               :operation :rf.ssr/hydration-mismatch})])])
+                    (mk-issue {:id 2 :op-type :info
+                               :operation :rf.info/note})])])
       (focus! 11)
-      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.ssr"])
-      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
-        (is (= 1 (:rendered data)))
-        (is (= [2] (mapv :id (:issues data))))))))
+      (let [tree (issues-ribbon/Panel)
+            row  (fn [id] (find-by-testid tree (str "rf-causa-issues-row-" id)))]
+        (is (= (str "3px solid " (h/severity-colour :error))
+               (-> (row 1) second :style :border-left))
+            "error row left-border is 3px in the error colour")
+        (is (= (str "3px solid " (h/severity-colour :advisory))
+               (-> (row 2) second :style :border-left))
+            "advisory row left-border is 3px in the advisory colour")))))
 
-(deftest clear-filters-button-renders-when-filter-active
-  (testing "the header's Clear filters button surfaces iff at least one
-            filter axis is active"
+(deftest timestamp-is-right-aligned-mono
+  (testing "rf2-ad7zx.9 — the timestamp cell is mono + RIGHT-aligned
+            (Figma drops the legacy left-aligned timestamp)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (seed-history!
-        [(mk-epoch 1 11 [(mk-issue {:id 1 :op-type :error
+        [(mk-epoch 1 11 [(mk-issue {:id 7 :op-type :error
                                     :operation :rf.error/handler-exception})])])
       (focus! 11)
-      (is (nil? (find-by-testid (issues-ribbon/Panel)
-                                "rf-causa-issues-clear-filters"))
-          "no Clear filters button when no axis is active")
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (some? (find-by-testid (issues-ribbon/Panel)
-                                 "rf-causa-issues-clear-filters"))
-          "Clear filters button surfaces once a severity is active"))))
+      (let [tree (issues-ribbon/Panel)
+            ts   (find-by-testid tree "rf-causa-issues-row-7-time")]
+        (is (= "right" (-> ts second :style :text-align))
+            "timestamp is right-aligned")))))
 
-;; ---- (8) focused-epoch scope (spec/021 §1.2 + §8) ---------------------
+;; ---- (6) focused-epoch scope (spec/021 §1.2 + §8) ---------------------
 
 (deftest issues-panel-scopes-to-focused-epoch
   (testing "with two epochs in history the composite renders only
@@ -492,28 +405,7 @@
       (let [data-b @(rf/subscribe [:rf.causa/issues-ribbon])]
         (is (= [2] (mapv :id (:issues data-b))))))))
 
-(deftest issues-panel-focused-epoch-ands-with-chip-filters
-  (testing "user chip filters AND on top of focused-epoch scope —
-            both axes restrict the rendered feed"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (seed-history!
-        [(mk-epoch 1 11
-                   [(mk-issue {:id 1 :op-type :error
-                               :operation :rf.error/handler-exception})
-                    (mk-issue {:id 2 :op-type :warning
-                               :operation :rf.warning/recoverable})])
-         (mk-epoch 2 12
-                   [(mk-issue {:id 3 :op-type :error
-                               :operation :rf.error/handler-exception})])])
-      (focus! 11)
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])]
-        (is (= 2 (:total data)) "focused-epoch scope: 2 in epoch 1")
-        (is (= 1 (:rendered data)) "severity chip narrows to 1")
-        (is (= [1] (mapv :id (:issues data))))))))
-
-;; ---- (9) row interactions ------------------------------------------------
+;; ---- (7) row interactions ------------------------------------------------
 
 (deftest row-click-pivots-to-event-tab
   (testing "clicking an issue row dispatches :rf.causa/select-tab :event
@@ -539,7 +431,7 @@
             "select-tab fired to flip the visible tab to Event")))))
 
 (deftest source-coord-click-fires-open-in-editor
-  (testing "clicking the source-coord chip fires :rf.causa/open-in-editor;
+  (testing "clicking the source-coord `↗` fires :rf.causa/open-in-editor;
             stopPropagation prevents the row's pivot from also firing"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
@@ -558,7 +450,7 @@
           (let [tree    (issues-ribbon/Panel)
                 node    (find-by-testid tree "rf-causa-issues-row-8-source")
                 handler (:on-click (second node))]
-            (is (some? node) "source-coord chip rendered")
+            (is (some? node) "source-coord `↗` rendered")
             (when handler
               (handler #js {:stopPropagation #(reset! stop-evt true)}))))
         (is (some (fn [ev]
@@ -569,25 +461,6 @@
             ":rf.causa/open-in-editor fired with the projected coord")
         (is @stop-evt "stopPropagation was called so the row's pivot
                        handler doesn't also fire")))))
-
-;; ---- (10) frame isolation ----------------------------------------------
-
-(deftest issues-filter-state-does-not-leak-into-default-frame
-  (testing "the panel's filter state lives on :rf/causa, never :rf/default"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"]))
-    (let [causa-db   (frame/frame-app-db-value :rf/causa)
-          default-db (frame/frame-app-db-value :rf/default)]
-      (is (= #{:error} (:issues-active-severities causa-db))
-          "severities land on Causa")
-      (is (= #{"rf.error"} (:issues-active-prefixes causa-db))
-          "prefixes land on Causa")
-      (is (nil? (:issues-active-severities default-db))
-          "severities did NOT leak into :rf/default")
-      (is (nil? (:issues-active-prefixes default-db))
-          "prefixes did NOT leak into :rf/default"))))
 
 ;; ---- evicted-focus helper ---------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
@@ -1,11 +1,12 @@
 (ns day8.re-frame2-causa.panels.reactivity.issues-reactivity-cljs-test
   "Sub-reactivity guard for the Issues panel's primary composite
-  (rf2-dhoc9, updated for rf2-jio48 rebuild).
+  (rf2-dhoc9, updated for rf2-jio48 rebuild; rf2-ad7zx.9 Figma reconcile).
 
   Per spec/021 §1.2 the Issues panel is focused-epoch-scoped — the
-  composite re-fires when either the focused epoch flips (via
-  `:rf.causa/focus`'s `:epoch-id`) or the user toggles a chip
-  filter. This test pins both invariants."
+  composite re-fires when the focused epoch flips (via
+  `:rf.causa/focus`'s `:epoch-id`). The filter axis was dropped at
+  rf2-ad7zx.9 (the Figma design renders pure rows, no filtering), so
+  focus is now the single reactive input."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
 
@@ -50,39 +51,9 @@
         (is (= [2] (mapv :id (:issues feed-2)))
             "feed-2 surfaces epoch :e2's issues")))))
 
-(deftest issues-filters-axis-re-fires-on-filter-change
-  (testing "`:rf.causa/issues-filters` re-fires when a filter axis
-            flips; this guards the second reactive input to the
-            composite alongside the focus axis."
-    (h/setup-causa-frame!)
-    (h/seed-cascades! cascades)
-    (let [filters-1 (h/read-sub :rf.causa/issues-filters)]
-      (is (= #{} (:severities filters-1)))
-      (h/dispatch-causa! [:rf.causa.issues/toggle-severity :error])
-      (let [filters-2 (h/read-sub :rf.causa/issues-filters)]
-        (is (= #{:error} (:severities filters-2))
-            "severity toggle wrote the active-severities set")
-        (is (not= filters-1 filters-2)
-            "issues-filters sub re-fired on toggle")))))
-
-(deftest issues-ribbon-composes-focus-and-filters
-  (testing "`:rf.causa/issues-ribbon` recomposes when EITHER input
-            changes (focus OR filters). Pin the composition by
-            changing both in sequence and asserting the composite
-            map changes after each."
-    (h/setup-causa-frame!)
-    (h/seed-cascades! cascades)
-    (h/seed-epoch-history! epoch-records)
-    (h/focus-cascade! :c1)
-    (let [feed-a (h/read-sub :rf.causa/issues-ribbon)]
-      ;; Change focus.
-      (h/focus-cascade! :c2)
-      (let [feed-b (h/read-sub :rf.causa/issues-ribbon)]
-        (is (not= feed-a feed-b)
-            "focus flip changed the composite (focused-epoch axis)"))
-      ;; Then change a filter.
-      (h/dispatch-causa! [:rf.causa.issues/toggle-severity :warning])
-      (let [feed-c (h/read-sub :rf.causa/issues-ribbon)]
-        (is (not= (h/read-sub :rf.causa/issues-ribbon) feed-a)
-            "filter toggle changed the composite too")
-        (is (some? feed-c))))))
+;; rf2-ad7zx.9 — `issues-filters-axis-re-fires-on-filter-change` and
+;; `issues-ribbon-composes-focus-and-filters` were removed with the
+;; Issues panel's filter-chrome reconcile to the Figma design (pure
+;; rows, no filtering — spec/021 §8.2). The `:rf.causa/issues-filters`
+;; sub + the chip-toggle events no longer exist; focus is the single
+;; reactive input, pinned by `issues-ribbon-sub-tracks-focus-flip`.

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -168,7 +168,9 @@
    :rf.causa/view-scope-frame-slot
    :rf.causa/target-frame-slot
    :rf.causa/focused-slice-path
-   :rf.causa/issues-filters
+   ;; rf2-ad7zx.9 — the `:rf.causa/issues-filters` sub was dropped with
+   ;; the Issues panel's filter-chrome reconcile to the Figma design
+   ;; (pure rows, no filtering — spec/021 §8.2).
    :rf.causa/issues-ribbon
    :rf.causa/machine-definitions
    :rf.causa/machine-definitions-override
@@ -358,9 +360,10 @@
    :rf.causa.data-inspector/request-large-confirm
    :rf.causa.data-inspector/set-expanded
    :rf.causa.data-inspector/toggle-expanded
-   :rf.causa.issues/clear-filters
-   :rf.causa.issues/toggle-prefix
-   :rf.causa.issues/toggle-severity
+   ;; rf2-ad7zx.9 — the `:rf.causa.issues/toggle-severity` /
+   ;; `toggle-prefix` / `clear-filters` events were dropped with the
+   ;; Issues panel's filter-chrome reconcile to the Figma design (pure
+   ;; rows, no filtering — spec/021 §8.2).
    :rf.causa/add-filter
    ;; rf2-59e7k — Cancellation-cascade visualiser events. Per
    ;; `tools/causa/spec/019-Cross-Cutting-Insight.md` §M.3.
@@ -1033,14 +1036,10 @@
       (is (false? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
       (is (nil? @(rf/subscribe [:rf.causa/segment-inspector-path]))))))
 
-(deftest sub-issues-filters-default-disabled
-  (testing ":rf.causa/issues-filters has empty axes on a fresh frame"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (let [filters @(rf/subscribe [:rf.causa/issues-filters])]
-        (is (= #{} (:severities filters)))
-        (is (= #{} (:prefixes filters)))
-        (is (nil? (:since-ms filters)))))))
+;; rf2-ad7zx.9 — `sub-issues-filters-default-disabled` was removed with
+;; the Issues panel's filter-chrome reconcile to the Figma design (pure
+;; rows, no filtering — spec/021 §8.2). The `:rf.causa/issues-filters`
+;; sub no longer exists.
 
 (deftest sub-reactive-show-unchanged-defaults-false
   (testing ":rf.causa/reactive-show-unchanged? defaults to false
@@ -1157,31 +1156,11 @@
       (rf/dispatch-sync [:rf.causa/select-epoch nil])
       (is (nil? @(rf/subscribe [:rf.causa/selected-epoch-id]))))))
 
-(deftest event-toggle-issues-severity-roundtrip
-  (testing ":rf.causa.issues/toggle-severity adds + removes a chip"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (= #{:error} (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :warning])
-      (is (= #{:error :warning}
-             (:severities @(rf/subscribe [:rf.causa/issues-filters]))))
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (= #{:warning}
-             (:severities @(rf/subscribe [:rf.causa/issues-filters])))))))
-
-(deftest event-clear-issues-filters
-  (testing ":rf.causa.issues/clear-filters drops both chip-filter axes
-            (rf2-jio48 — since-ms axis dropped with focused-epoch
-            re-scoping; spec/021 §8)"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (rf/dispatch-sync [:rf.causa.issues/toggle-prefix "rf.error"])
-      (rf/dispatch-sync [:rf.causa.issues/clear-filters])
-      (let [f @(rf/subscribe [:rf.causa/issues-filters])]
-        (is (= #{} (:severities f)))
-        (is (= #{} (:prefixes f)))))))
+;; rf2-ad7zx.9 — `event-toggle-issues-severity-roundtrip` and
+;; `event-clear-issues-filters` were removed with the Issues panel's
+;; filter-chrome reconcile to the Figma design (pure rows, no filtering
+;; — spec/021 §8.2). The `:rf.causa.issues/toggle-severity` /
+;; `toggle-prefix` / `clear-filters` events no longer exist.
 
 (deftest event-reactive-toggle-unchanged-flips-slot
   (testing ":rf.causa/reactive-toggle-unchanged toggles the panel's

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -243,16 +243,26 @@ async function clickSourceCoordChip(page, { panel, sourceIncludes = [] }) {
     if (!root) return { clicked: false, reason: 'Causa root missing', candidates: [] };
     const selector = selectors[targetPanel] || 'button[data-testid*="source"]';
     const buttons = Array.from(root.querySelectorAll(selector));
+    // rf2-ad7zx.9 — the Issues panel's source affordance is now an `↗`
+    // icon (per the Figma design); the `file:line` coord rides the
+    // button's `title` attribute, not its text. Prefer `title` when it
+    // carries the coord (icon affordances), falling back to textContent
+    // for the trace / hydration chips that still render the coord inline.
+    const coordOf = (button) => {
+      const title = (button.getAttribute('title') || '').trim();
+      const text = (button.textContent || '').trim();
+      return title || text;
+    };
     const candidates = buttons.map((button) => {
       const rect = button.getBoundingClientRect();
       return {
         testId: button.getAttribute('data-testid'),
-        text: (button.textContent || '').trim(),
+        text: coordOf(button),
         visible: rect.width > 0 && rect.height > 0,
       };
     });
     const target = buttons.find((button) => {
-      const text = (button.textContent || '').trim();
+      const text = coordOf(button);
       const visible = button.getBoundingClientRect().width > 0 &&
         button.getBoundingClientRect().height > 0;
       return visible && targetNeedles.every((needle) => !needle || text.includes(needle));
@@ -264,7 +274,7 @@ async function clickSourceCoordChip(page, { panel, sourceIncludes = [] }) {
         candidates: candidates.slice(0, 20),
       };
     }
-    const sourceCoord = (target.textContent || '').trim();
+    const sourceCoord = coordOf(target);
     const testId = target.getAttribute('data-testid');
     target.click();
     return { clicked: true, panel: targetPanel, sourceCoord, testId, candidates: candidates.slice(0, 20) };

--- a/tools/causa/testbeds/panel_gallery/fixtures_issues.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_issues.cljs
@@ -3,10 +3,9 @@
   rebuild for new 6-tab Causa shape).
 
   The issues-ribbon panel reads its rows from
-  `:rf.causa/issues-ribbon`, a composite over:
-
-    - `:rf.causa/trace-buffer`     — the raw trace ring buffer
-    - `:rf.causa/issues-filters`   — {:severities :prefixes :since-ms}
+  `:rf.causa/issues-ribbon`, a composite over the focused epoch's
+  `:trace-events` (focus + epoch-history; no filtering — rf2-ad7zx.9
+  reconciled the panel to the Figma design's pure-rows shape).
 
   Each variant seeds via `:rf.causa/sync-trace-buffer` (same as the
   trace panel) — the panel's projection keeps only events whose
@@ -14,10 +13,6 @@
   `issues_ribbon_helpers/issue-event?`). All other events are dropped
   silently, so a buffer of mixed event-types still drives the issues
   feed.
-
-  Where a variant needs to demonstrate the active-filter state it
-  dispatches `:rf.causa.issues/toggle-severity` /
-  `:rf.causa.issues/toggle-prefix` after the seed.
 
   ## Issue-event shape
 

--- a/tools/causa/testbeds/panel_gallery/gallery_issues.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_issues.cljs
@@ -64,8 +64,9 @@
   ;; ----- 4. hydration-mismatch ---------------------------------------
   (story/reg-variant :story.causa.issues/hydration-mismatch
     {:doc        "Two `:rf.ssr/hydration-mismatch` warnings + one
-                 HTTP error. Prefix chip row surfaces the `:rf.ssr`
-                 prefix as its own axis with ≥2 chips."
+                 HTTP error. The rows surface the `hydration-mismatch`
+                 + `request-timeout` categories with their severity
+                 left-borders."
      :events     [[:rf.causa/sync-trace-buffer (fixtures/ssr-hydration-mismatch-buffer)]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
@@ -101,8 +102,9 @@
   ;; ----- 8. severity mix --------------------------------------------
   (story/reg-variant :story.causa.issues/severity-mix
     {:doc        "Six issues — two of each severity. Exercises the
-                 chip-row counts at exact balance so the chip ladder
-                 is readable at a glance."
+                 three severity tiers (error / warning / advisory)
+                 side-by-side so the left-border + badge colours are
+                 readable at a glance."
      :events     [[:rf.causa/sync-trace-buffer (fixtures/severity-mix-buffer)]]
      :tags       #{:dev :state/small}
      :substrates #{:reagent}})


### PR DESCRIPTION
## What

Reconciles the Causa **Issues panel** to the Figma design (`tools/causa/spec/021-Dynamic-Panel-Designs.md` §8.2 + `design-reference/components/IssuesPanel.tsx`).

**Per-row Figma table** (one row per issue):
- 3px **severity-coloured left-border**
- uppercase **TEXT severity badge** (ERROR / WARNING / ADVISORY) in its severity colour (was a glyph)
- **muted category** cell (unqualified op name)
- description (primary)
- **RIGHT-aligned mono timestamp** (was left)
- `↗` open-in-editor source affordance

**Filter chrome dropped entirely** — the Figma design renders pure rows; the focused epoch IS the scope. Mirrors the Trace panel's no-filter reconcile (rf2-gkczt).

## Changes

- **view** (`issues_ribbon.cljs`): remove the severity/prefix filter-chip header, per-epoch counts, clear-filters control, and the `:no-matches` empty state; restructure the row to the severity table.
- **install!**: drop the `:rf.causa/issues-filters` sub + the `:rf.causa.issues/toggle-severity` / `toggle-prefix` / `clear-filters` events; the composite reads focus + epoch-history only.
- **helpers** (`issues_ribbon_helpers.cljc`): drop the chip-filter algebra (`apply-filters`, `passes-*`, `distinct-prefixes`, `severity-order`, `severity-glyph`) + the severity-counts histogram; `project-feed` loses its `filters` arg and `:no-matches` branch; add `severity-badge-label` + `category-label`.
- **dependent updates**: helpers/view/reactivity/registry-snapshot tests; `panels.cljs` doc table; gallery fixtures/docs; the feature-matrix source-coord bridge (the `↗` icon carries the coord in its `title` attr).

## Gates

| Gate | Result |
|---|---|
| `npm run test:cljs` | 4177 tests, 0 failures |
| tools/causa `clojure -M:test` | 838 tests, 0 failures |
| `npm run test:causa-feature-gate` (smoke) | 0 failures |
| clj-kondo (changed files) | 0 errors, 0 new warnings |

Refs rf2-ad7zx.9 (parent epic rf2-ad7zx — Causa visual redesign).