### PR TITLE
feat(causa): restyle Machine panel xyflow to Figma (rf2-ad7zx.10)

### DIFF
--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -1959,8 +1959,21 @@ operators will see.
 |---|---|---|
 | Rounded rect (`border-radius: 6px`) | Standard state | `:standard` |
 | Rounded rect + 2px solid `:green` outer + 1px `:bg-2` inner gap (double-ring) | Final state | `:final` |
-| Rounded rect + 2px solid `:green` + 1.2s pulse | Current state (most recent visit) | `:current` |
+| **Double-circle** (`border-radius: 50%`) in the mode `:accent` — 3px accent border + concentric inner-gap + inner-ring (stacked `inset` box-shadows) + 1.2s breathing pulse | Current / TO state (most recent visit) | `:current` |
+| Dashed/dim circle (`border-radius: 50%`, `2px dashed :text-tertiary`, transparent fill) | FROM state — source of the focused fired transition | `:from` |
+| Rounded rect with dashed border (`2px dashed :border-default`) wrapping the focused FROM/TO pair | `active (compound)` focused-transition container | `:compound` |
 | Rounded rect with dashed border (`1px dashed :border-default`) | Parallel-region container | `:region` |
+
+Per §6.2 Case C (Figma reconcile · rf2-ad7zx.10): the FROM/TO pair are
+**circle** nodes inside a dashed `:compound` container; the FROM is
+dashed/dim, the TO/current is the mode-accent double-circle. `:current`
+takes precedence over `:from` (a self-transition reads as active, not
+dimmed). `:compound` is distinct from `:region` — the former is the
+single focused-transition lens, the latter is the parallel-region sibling
+container. The accent double-circle replaces the former green single
+ring so the active node reads as the Stately/xstate convention the Figma
+fixes; it animates via `rf-causa-machine-pulse-active` (the accent
+counterpart of the green `rf-causa-machine-pulse`).
 
 #### §17.4.3 Edge styles
 
@@ -1995,7 +2008,7 @@ xyflow-adapter bead (§17.5) implements against:
 
 (ns day8.re-frame2-causa.machines.xyflow-style
   (:require [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack type-scale duration-css]]))
+             :refer [tokens mono-stack type-scale duration-css with-alpha]]))
 
 (def node-style
   {:standard {:background    (:bg-2 tokens)
@@ -2013,16 +2026,35 @@ xyflow-adapter bead (§17.5) implements against:
               :font-family   mono-stack
               :font-size     (:body-tight type-scale)
               :padding       "6px 10px"}
-   :current  {:background    (:bg-2 tokens)
-              :border        (str "2px solid " (:green tokens))
-              :border-radius "6px"
-              :color         (:text-primary tokens)
+   ;; Figma reconcile (rf2-ad7zx.10 · §6.2 Case C): the TO/current state
+   ;; is a mode-accent DOUBLE-CIRCLE, not a green single ring.
+   :current  {:width         "64px"  :height "64px"
+              :border-radius "50%"   ; circle, not rounded-rect
+              :background    (with-alpha :accent 10)
+              :border        (str "3px solid " (:accent tokens))
+              ;; concentric double-ring: inner gap + inner ring
+              :box-shadow    (str "inset 0 0 0 3px " (:bg-1 tokens) ", "
+                                  "inset 0 0 0 5px " (:accent tokens))
+              :color         (:accent tokens)
               :font-family   mono-stack
-              :font-size     (:body-tight type-scale)
-              :padding       "6px 10px"
-              :animation     (str "rf-causa-machine-pulse "
+              :font-weight   600
+              :animation     (str "rf-causa-machine-pulse-active "
                                   (duration-css 1200)
                                   " ease-in-out infinite")}
+   ;; FROM state — dashed/dim circle (source of the focused transition).
+   :from     {:width         "64px"  :height "64px"
+              :border-radius "50%"
+              :background    "transparent"
+              :border        (str "2px dashed " (:text-tertiary tokens))
+              :color         (:text-tertiary tokens)
+              :font-family   mono-stack}
+   ;; `active (compound)` container bounding the focused FROM/TO pair.
+   :compound {:background    "transparent"
+              :border        (str "2px dashed " (:border-default tokens))
+              :border-radius "8px"
+              :color         (:text-tertiary tokens)
+              :font-family   mono-stack
+              :font-size     (:micro type-scale)}
    :region   {:background    "transparent"
               :border        (str "1px dashed " (:border-default tokens))
               :border-radius "8px"}})
@@ -2042,10 +2074,15 @@ xyflow-adapter bead (§17.5) implements against:
    :font-size   (:micro type-scale)})
 ```
 
-The `rf-causa-machine-pulse` keyframe lives in the existing
-`theme/global_styles motion-css` block — added alongside the existing
-diff-flash + fade keyframes per the same `prefers-reduced-motion`
-collapsing mechanic.
+The `rf-causa-machine-pulse` keyframe (the green legacy pulse) and the
+`rf-causa-machine-pulse-active` keyframe (the mode-accent double-circle
+pulse the `:current` node now uses per the Figma reconcile · rf2-ad7zx.10)
+both live in the existing `theme/global_styles motion-css` block — added
+alongside the existing diff-flash + fade keyframes per the same
+`prefers-reduced-motion` collapsing mechanic. The active keyframe
+re-states the concentric inner-gap + inner-ring on every stop (box-shadow
+sets the whole property each frame) and rides `--rf-causa-accent` so the
+halo tracks the mode (orange Dynamic / cyan Static).
 
 ### §17.5 Follow-on bead candidates (visual layer)
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -743,7 +743,10 @@
   ;; tab registry.
   (panel-registry/reg-l4-tab!
     {:id    :machines
-     :label "Machines"
+     ;; rf2-ad7zx.10 — Figma App.tsx labels the Dynamic L4 tab "Machine"
+     ;; (singular · the focused-epoch lens is on ONE machine's topology).
+     ;; The internal id stays `:machines` (mnemonic + routing unchanged).
+     :label "Machine"
      :mnem  "m"
      :modes #{:dynamic}
      :order 4

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/topology.cljs
@@ -279,14 +279,29 @@
 ;; ---- node-kind resolution (per spec §17.4.2) ----------------------------
 
 (defn node-kind
-  "Resolve the xyflow node kind for a node given the current-state
-  path. Precedence: `:current` > `:final` > `:standard`."
-  [{:keys [path final?]} current-state-path]
-  (let [cur (normalise-path current-state-path)]
-    (cond
-      (and cur (= cur path)) :current
-      final?                 :final
-      :else                  :standard)))
+  "Resolve the xyflow node kind for a node given the current-state path
+  + (optionally) the focused transition's FROM-state path. Precedence:
+  `:current` > `:from` > `:final` > `:standard`.
+
+  Per spec/021 §6.2 Case C (Figma reconcile · rf2-ad7zx.10) the source
+  state of the focused fired transition renders as the dashed/dim
+  `:from` circle; the TO / live state renders as the `:current`
+  double-circle (which therefore wins when a state is BOTH the FROM and
+  the current — a self-transition reads as active, not dimmed).
+
+  The 2-arity (no `from-state-path`) keeps the pre-Case-C precedence
+  (`:current` > `:final` > `:standard`) so existing callers are
+  unchanged."
+  ([node current-state-path]
+   (node-kind node current-state-path nil))
+  ([{:keys [path final?]} current-state-path from-state-path]
+   (let [cur  (normalise-path current-state-path)
+         from (normalise-path from-state-path)]
+     (cond
+       (and cur  (= cur path))  :current
+       (and from (= from path)) :from
+       final?                   :final
+       :else                    :standard))))
 
 ;; ---- edge-kind resolution (per spec §17.4.3) ----------------------------
 
@@ -317,6 +332,12 @@
     :current-state-path  — the path of the state the machine is
                            currently in (optional; precedence rules
                            in the ns docstring).
+    :from-state-path     — the path of the focused fired transition's
+                           SOURCE state (optional). Marks that node as
+                           the dashed/dim `:from` circle per spec/021
+                           §6.2 Case C (Figma reconcile · rf2-ad7zx.10).
+                           `:current` wins when a state is both FROM and
+                           current (self-transition reads as active).
     :fired-edge-ids      — set of edge-ids fired in the focused
                            epoch (optional).
     :traversed-edge-ids  — set of edge-ids traversed at some point
@@ -332,8 +353,8 @@
 
   Style fns are injected (not called inline) so this ns stays pure
   data — view-only deps live in the view ns."
-  [{:keys [definition current-state-path fired-edge-ids traversed-edge-ids
-           node-style-fn edge-style-fn edge-animated-fn]
+  [{:keys [definition current-state-path from-state-path fired-edge-ids
+           traversed-edge-ids node-style-fn edge-style-fn edge-animated-fn]
     :or   {node-style-fn    (fn [_kind] nil)
            edge-style-fn    (fn [_kind] nil)
            edge-animated-fn (fn [_kind] false)}}]
@@ -342,7 +363,7 @@
                                               (some-> definition :initial vector))]
     {:nodes
      (mapv (fn [n]
-             (let [kind (node-kind n current-state-path)
+             (let [kind (node-kind n current-state-path from-state-path)
                    id   (node-id-for-path (:path n))
                    pos  (get positions (:path n) {:x grid-margin :y grid-margin})]
                {:id       id
@@ -412,6 +433,43 @@
                         "__"
                         (name ev*))))))
        set))
+
+(defn- from-path-from-trace
+  "Pull the `:from` (source) state path off a `:rf.machine/transition`
+  trace event. Tolerant of the same three shapes as `to-path-from-trace`:
+
+    1. Modern runtime: `:tags {:before {:state ...}}`.
+    2. Legacy/test fixtures: top-level `:from` or `:tags :from`.
+    3. Pre-rf2-hwuki: `:payload :from`.
+
+  Returns the normalised path vector or nil."
+  [ev]
+  (let [before-state (get-in ev [:tags :before :state])
+        from         (or (get-in ev [:tags :from])
+                         (:from ev)
+                         (get-in ev [:payload :from]))]
+    (normalise-path (or before-state from))))
+
+(defn from-state-from-traces
+  "Resolve the FROM (source) state path for `machine-id` from the
+  `:rf.machine/transition` trace events vector. Returns the `:from`
+  path of the most recent matching trace, or nil. Pure.
+
+  Per spec/021 §6.2 Case C (Figma reconcile · rf2-ad7zx.10): the
+  focused fired transition's source state renders as the dashed/dim
+  `:from` circle. The view layer pairs this with
+  `current-state-from-traces` (the TO / `:current` double-circle).
+
+  Reads modern (`:tags :before :state`) + legacy (`:from`,
+  `:payload :from`) shapes — see `from-path-from-trace`."
+  [trace-events machine-id]
+  (let [matching (filter (fn [ev]
+                           (and (= :rf.machine/transition (:operation ev))
+                                (or (nil? machine-id)
+                                    (= machine-id (get-in ev [:tags :machine-id])))))
+                         (or trace-events []))]
+    (when-let [last-ev (last matching)]
+      (from-path-from-trace last-ev))))
 
 (defn- to-path-from-trace
   "Pull the `:to` state path off a `:rf.machine/transition` trace

--- a/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machines/xyflow_style.cljs
@@ -14,52 +14,116 @@
   ## Token integration
 
   Reads from `theme/tokens` so a future palette swap (dark → light,
-  HCM remap, etc.) flows through unchanged. Per spec §17.4.5 the
-  catalogue covers:
+  HCM remap, etc.) flows through unchanged. Per spec §17.4.5 +
+  §6.2 Case C (Figma reconcile — rf2-ad7zx.10) the catalogue covers:
 
     - Node fill / border / radius per kind (`:standard`, `:final`,
-      `:current`, `:region`).
+      `:current`, `:from`, `:compound`, `:region`).
     - Edge stroke / width / dash per kind (`:registered`,
       `:registered-traversed`, `:fired-this-epoch`).
     - Edge-label font, size, fill.
+
+  ## Figma reconcile (rf2-ad7zx.10 · §6.2 Case C ·
+  design-reference/components/MachinePanel.tsx)
+
+  The later Figma iteration draws the focused FROM/TO transition as
+  circle nodes inside a dashed `active (compound)` container:
+
+    - `:from`     — the source state of the fired transition. Dashed,
+                    dimmed circle (`:text-tertiary`); reads as the state
+                    we came FROM without competing with the active TO.
+    - `:current`  — the TO / live state. A **double-circle** (concentric
+                    ring) painted in the mode `:accent` (orange Dynamic /
+                    cyan Static), with the breathing pulse. This replaces
+                    the former single-border + green pulse so the TO node
+                    reads as the Stately/xstate active-node convention the
+                    Figma fixes.
+    - `:compound` — the dashed `active (compound)` grouping container that
+                    bounds the focused FROM/TO pair. Distinct from
+                    `:region` (parallel-region siblings); the compound
+                    container is the single focused-transition lens.
 
   Pure-data only — no DOM / React side effects."
   (:require [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens mono-stack type-scale]]))
 
-;; ---- node-shape conventions (§17.4.2) -----------------------------------
+;; ---- node-shape conventions (§17.4.2 + §6.2 Case C) --------------------
+
+(def ^:private state-base
+  "Shared base for the textual state nodes (`:standard` / `:final`)."
+  {:font-family   mono-stack
+   :font-size     (:body-tight type-scale)
+   :color         (:text-primary tokens)
+   :padding       "6px 10px"
+   :border-radius "6px"
+   :background    (:bg-2 tokens)})
+
+(def ^:private circle-base
+  "Shared base for the Figma circle nodes (`:from` / `:current`).
+  Square aspect + `border-radius: 50%` reproduces the SVG `<circle>`
+  the design-reference draws for the focused FROM/TO pair, rendered
+  through an xyflow HTML node rather than hand-rolled SVG (B.4.1 lock —
+  topology stays xyflow)."
+  {:font-family     mono-stack
+   :font-size       (:body-tight type-scale)
+   :display         "flex"
+   :align-items     "center"
+   :justify-content "center"
+   :width           "64px"
+   :height          "64px"
+   :border-radius   "50%"
+   :text-align      "center"})
 
 (defn node-style
   "Resolve the xyflow `:style` map for a node of kind `kind`. Kinds
-  per spec §17.4.2:
+  per spec §17.4.2 + §6.2 Case C (Figma reconcile · rf2-ad7zx.10):
 
     :standard — rounded rect, 1px `:border-default` outline.
     :final    — rounded rect + 2px `:green` outer (double-ring).
-    :current  — rounded rect + 2px `:green` + 1.2s pulse animation.
+    :current  — DOUBLE-CIRCLE concentric active node in the mode
+                `:accent`, with the breathing pulse (Figma TO/current).
+    :from     — dashed/dim circle (`:text-tertiary`); the source state
+                of the focused fired transition (Figma FROM).
+    :compound — dashed `active (compound)` grouping container that bounds
+                the focused FROM/TO pair.
     :region   — parallel-region container; dashed border.
 
   Unknown kinds fall back to `:standard`."
   [kind]
-  (let [base {:font-family   mono-stack
-              :font-size     (:body-tight type-scale)
-              :color         (:text-primary tokens)
-              :padding       "6px 10px"
-              :border-radius "6px"
-              :background    (:bg-2 tokens)}]
-    (case kind
-      :final    (assoc base
-                       :border      (str "2px solid " (:green tokens))
-                       :box-shadow  (str "inset 0 0 0 1px " (:bg-2 tokens)))
-      :current  (assoc base
-                       :border      (str "2px solid " (:green tokens))
-                       :animation   "rf-causa-machine-pulse 1.2s ease-in-out infinite")
-      :region   {:background    "transparent"
-                 :border        (str "1px dashed " (:border-default tokens))
-                 :border-radius "8px"}
-      ;; :standard + unknown fallback
-      (assoc base
-             :border (str "1px solid " (:border-default tokens))))))
+  (case kind
+    :final    (assoc state-base
+                     :border      (str "2px solid " (:green tokens))
+                     :box-shadow  (str "inset 0 0 0 1px " (:bg-2 tokens)))
+    :current  (assoc circle-base
+                     :color       (:accent tokens)
+                     :font-weight 600
+                     :background  (t/with-alpha :accent 10)
+                     :border      (str "3px solid " (:accent tokens))
+                     ;; Double-circle (concentric ring): the inner gap +
+                     ;; inner ring are painted as stacked box-shadows so
+                     ;; the TO node reads as the Stately active double-
+                     ;; circle. The breathing pulse layers a fading accent
+                     ;; halo on top via the accent pulse keyframe.
+                     :box-shadow  (str "inset 0 0 0 3px " (:bg-1 tokens) ", "
+                                       "inset 0 0 0 5px " (:accent tokens))
+                     :animation   "rf-causa-machine-pulse-active 1.2s ease-in-out infinite")
+    :from     (assoc circle-base
+                     :color            (:text-tertiary tokens)
+                     :background       "transparent"
+                     :border           (str "2px dashed " (:text-tertiary tokens)))
+    :compound {:background    "transparent"
+               :border        (str "2px dashed " (:border-default tokens))
+               :border-radius "8px"
+               :color         (:text-tertiary tokens)
+               :font-family   mono-stack
+               :font-size     (:micro type-scale)}
+    :region   {:background    "transparent"
+               :border        (str "1px dashed " (:border-default tokens))
+               :border-radius "8px"}
+    ;; :standard + unknown fallback
+    (assoc state-base
+           :border (str "1px solid " (:border-default tokens)))))
 
 ;; ---- edge styles (§17.4.3) ----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -509,6 +509,33 @@
     "    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0);\n"
     "  }\n"
     "}\n"
+    ;; rf2-ad7zx.10 — active-state DOUBLE-CIRCLE pulse (spec/021
+    ;; §6.2 Case C + §17.4.2). The Figma reconcile draws the focused
+    ;; TO / current state as a concentric double-circle in the mode
+    ;; accent (orange Dynamic / cyan Static), not the former green
+    ;; single ring. The `:current` node (`panels/machines/xyflow_style`)
+    ;; carries `:animation rf-causa-machine-pulse-active 1.2s …`.
+    ;;
+    ;; box-shadow sets the WHOLE property each frame, so the keyframe
+    ;; must re-state the STATIC concentric rings (inner `:bg-1` gap +
+    ;; inner accent ring — matching the `:current` node's base
+    ;; box-shadow) on every stop, then ADD the breathing outer halo as
+    ;; the trailing layer. `--rf-causa-accent` tracks the active mode so
+    ;; the halo is orange in Dynamic and cyan in Static. Runs through
+    ;; `--rf-causa-motion-scale` like the green pulse, so the
+    ;; `prefers-reduced-motion` seam collapses it to a resolved frame.
+    "@keyframes rf-causa-machine-pulse-active {\n"
+    "  0%, 100% {\n"
+    "    box-shadow: inset 0 0 0 3px var(--rf-causa-bg-1),\n"
+    "                inset 0 0 0 5px var(--rf-causa-accent),\n"
+    "                0 0 0 0 color-mix(in srgb, var(--rf-causa-accent) 45%, transparent);\n"
+    "  }\n"
+    "  50% {\n"
+    "    box-shadow: inset 0 0 0 3px var(--rf-causa-bg-1),\n"
+    "                inset 0 0 0 5px var(--rf-causa-accent),\n"
+    "                0 0 0 5px color-mix(in srgb, var(--rf-causa-accent) 0%, transparent);\n"
+    "  }\n"
+    "}\n"
     ;; rf2-fxde5 — global `:focus-visible` focus ring. Causa-wide
     ;; keyboard-only focus indicator scoped to descendants of the
     ;; shell roots (`[data-testid="rf-causa-shell"]` for Dynamic,

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/topology_cljs_test.cljs
@@ -119,6 +119,37 @@
     (is (= :current
            (topology/node-kind {:path [:foo] :final? false} :foo)))))
 
+;; rf2-ad7zx.10 — :from node kind (Figma §6.2 Case C). The source state
+;; of the focused fired transition renders as the dashed/dim :from circle.
+
+(deftest node-kind-from-precedence
+  (testing ":current wins over :from (self-transition reads as active)"
+    (is (= :current
+           (topology/node-kind {:path [:foo] :final? false} [:foo] [:foo]))))
+  (testing ":from when it is the transition source + not current"
+    (is (= :from
+           (topology/node-kind {:path [:foo] :final? false} [:bar] [:foo]))))
+  (testing ":from wins over :final"
+    (is (= :from
+           (topology/node-kind {:path [:foo] :final? true} [:bar] [:foo]))))
+  (testing ":final when neither current nor from"
+    (is (= :final
+           (topology/node-kind {:path [:foo] :final? true} [:bar] [:baz]))))
+  (testing ":standard otherwise"
+    (is (= :standard
+           (topology/node-kind {:path [:foo] :final? false} [:bar] [:baz])))))
+
+(deftest node-kind-2-arity-unchanged
+  (testing "the 2-arity keeps the pre-Case-C precedence (no :from)"
+    (is (= :current (topology/node-kind {:path [:foo] :final? true} [:foo])))
+    (is (= :final   (topology/node-kind {:path [:foo] :final? true} [:bar])))
+    (is (= :standard (topology/node-kind {:path [:foo] :final? false} nil)))))
+
+(deftest node-kind-from-accepts-keyword
+  (testing "from-state-path may be a bare keyword"
+    (is (= :from
+           (topology/node-kind {:path [:foo] :final? false} nil :foo)))))
+
 ;; ---- edge-kind ----------------------------------------------------------
 
 (deftest edge-kind-precedence
@@ -185,6 +216,26 @@
       (is (= :standard (-> by-label (get "empty") :data :kind)))
       (is (= :final    (-> by-label (get "submitting") :data :kind))
           "final state stays final when not current"))))
+
+(deftest project-applies-from-state-overlay
+  (testing "from-state-path marks the source node as :from (Figma §6.2 Case C)"
+    (let [out      (topology/project
+                     {:definition         (toy-definition)
+                      :current-state-path [:populated]
+                      :from-state-path    [:empty]})
+          by-label (into {} (map (juxt #(-> % :data :label) identity)
+                                 (:nodes out)))]
+      (is (= :from    (-> by-label (get "empty") :data :kind))
+          "the transition source renders as :from")
+      (is (= :current (-> by-label (get "populated") :data :kind))
+          "the TO / current node stays :current")
+      (is (= :final   (-> by-label (get "submitting") :data :kind))
+          "untouched final stays final")))
+  (testing "no from-state-path → no :from nodes (back-compat)"
+    (let [out   (topology/project {:definition (toy-definition)
+                                   :current-state-path [:populated]})
+          kinds (set (map #(-> % :data :kind) (:nodes out)))]
+      (is (not (contains? kinds :from))))))
 
 (deftest project-applies-fired-edge-overlay
   (testing "fired-edge-ids set marks matching edges :fired-this-epoch"
@@ -269,6 +320,38 @@
                    :tags      {:machine-id :foo}
                    :from      :a :to :b :event :go}]]
       (is (= [:b] (topology/current-state-from-traces events :foo))))))
+
+;; rf2-ad7zx.10 — from-state-from-traces (Figma §6.2 Case C). Resolves
+;; the SOURCE state of the focused fired transition for the :from circle.
+
+(deftest from-state-from-traces-resolves-latest
+  (testing "picks the :from of the LAST matching :rf.machine/transition"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      [:a] :to [:b] :event :go-b}
+                  {:operation :rf.machine/transition
+                   :tags      {:machine-id :foo}
+                   :from      [:b] :to [:c] :event :go-c}]]
+      (is (= [:b] (topology/from-state-from-traces events :foo))))))
+
+(deftest from-state-from-traces-reads-modern-before-shape
+  (testing "modern runtime shape: :tags {:before {:state ...}}"
+    (let [events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :cart
+                               :before     {:state :empty}
+                               :after      {:state :populated}}}]]
+      (is (= [:empty] (topology/from-state-from-traces events :cart))))))
+
+(deftest from-state-from-traces-scopes-and-empty
+  (testing "scopes by machine-id"
+    (let [events [{:operation :rf.machine/transition
+                   :tags {:machine-id :other} :from [:x] :to [:y] :event :w}
+                  {:operation :rf.machine/transition
+                   :tags {:machine-id :foo} :from [:a] :to [:b] :event :ours}]]
+      (is (= [:a] (topology/from-state-from-traces events :foo)))))
+  (testing "nil / empty → nil"
+    (is (nil? (topology/from-state-from-traces [] :foo)))
+    (is (nil? (topology/from-state-from-traces nil :foo)))))
 
 (deftest extract-fired-edge-ids-shape
   (testing "extracts edge-ids matching the from→to via event triple"

--- a/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machines/xyflow_style_cljs_test.cljs
@@ -1,7 +1,9 @@
 (ns day8.re-frame2-causa.panels.machines.xyflow-style-cljs-test
   "Style-map tests for the xyflow per-node + per-edge style provider
-  (rf2-uwvyj · spec/021 §17.4.2 + §17.4.3 + §17.4.5)."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (rf2-uwvyj · spec/021 §17.4.2 + §17.4.3 + §17.4.5 + §6.2 Case C ·
+  Figma reconcile rf2-ad7zx.10)."
+  (:require [clojure.string :as str]
+            [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-causa.panels.machines.xyflow-style :as xstyle]
             [day8.re-frame2-causa.theme.tokens :as t :refer [tokens]]))
 
@@ -20,17 +22,57 @@
     (is (some? (:box-shadow s))
         "final state has the inner gap box-shadow (double-ring)")))
 
-(deftest node-style-current-applies-pulse-animation
+(deftest node-style-current-is-accent-double-circle-with-pulse
+  ;; rf2-ad7zx.10 — Figma reconcile (§6.2 Case C). The TO / current
+  ;; state is a DOUBLE-CIRCLE in the mode accent (orange Dynamic / cyan
+  ;; Static), not the former green single ring.
   (let [s (xstyle/node-style :current)]
-    (is (= (str "2px solid " (:green tokens)) (:border s)))
-    (is (some? (:animation s)))
-    (is (re-find #"rf-causa-machine-pulse" (str (:animation s)))
-        "uses the spec-named pulse keyframe")))
+    (testing "circular shape (border-radius 50%) per Figma Case C"
+      (is (= "50%" (:border-radius s))))
+    (testing "mode-accent border + text"
+      (is (= (str "3px solid " (:accent tokens)) (:border s)))
+      (is (= (:accent tokens) (:color s))))
+    (testing "concentric double-ring via stacked inset box-shadows"
+      (is (str/includes? (str (:box-shadow s)) "inset")
+          "inner gap + inner ring rendered as inset box-shadows")
+      (is (str/includes? (str (:box-shadow s)) (:bg-1 tokens))
+          "inner gap painted in :bg-1")
+      (is (str/includes? (str (:box-shadow s)) (:accent tokens))
+          "inner ring painted in the mode accent"))
+    (testing "breathing pulse via the active keyframe"
+      (is (re-find #"rf-causa-machine-pulse-active" (str (:animation s)))
+          "uses the accent double-circle pulse keyframe"))))
+
+(deftest node-style-from-is-dashed-dim-circle
+  ;; rf2-ad7zx.10 — Figma reconcile (§6.2 Case C). The FROM (source)
+  ;; state of the focused transition is a dashed/dim circle.
+  (let [s (xstyle/node-style :from)]
+    (is (= "50%" (:border-radius s)) "circular per Figma Case C")
+    (is (= "transparent" (:background s)) "dim — no fill")
+    (is (re-find #"dashed" (str (:border s))) "dashed border")
+    (is (str/includes? (str (:border s)) (:text-tertiary tokens))
+        "dimmed in :text-tertiary")
+    (is (= (:text-tertiary tokens) (:color s)) "dimmed label")))
+
+(deftest node-style-compound-is-dashed-container
+  ;; rf2-ad7zx.10 — the `active (compound)` grouping container that
+  ;; bounds the focused FROM/TO pair (§6.2 Case C).
+  (let [s (xstyle/node-style :compound)]
+    (is (= "transparent" (:background s)))
+    (is (re-find #"dashed" (str (:border s))))
+    (is (str/includes? (str (:border s)) (:border-default tokens)))))
 
 (deftest node-style-region-is-dashed-transparent
   (let [s (xstyle/node-style :region)]
     (is (= "transparent" (:background s)))
     (is (re-find #"dashed" (str (:border s))))))
+
+(deftest node-style-region-distinct-from-compound
+  ;; The parallel-region container (:region) and the focused-transition
+  ;; grouping container (:compound) are SEPARATE kinds — the audit flagged
+  ;; that :region was being borrowed for the compound role.
+  (is (not= (xstyle/node-style :region)
+            (xstyle/node-style :compound))))
 
 (deftest node-style-unknown-falls-back-to-standard
   (is (= (xstyle/node-style :standard)

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -142,6 +142,30 @@
                    css)
           "midpoint box-shadow expands to 4px halo with 0 alpha"))))
 
+;; ---- rf2-ad7zx.10 — active double-circle pulse keyframe ----------------
+
+(deftest motion-css-declares-active-double-circle-pulse
+  (testing "rf2-ad7zx.10 / spec/021 §6.2 Case C — the Figma TO/current
+            state is a DOUBLE-CIRCLE in the mode accent. The
+            `:current` xyflow node references
+            `rf-causa-machine-pulse-active`; the keyframe MUST exist so
+            the animation resolves rather than no-op'ing, AND it must
+            re-state the static concentric rings on every stop (since
+            box-shadow sets the whole property each frame) plus add the
+            breathing accent halo."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"@keyframes\s+rf-causa-machine-pulse-active" css)
+          "keyframes block named rf-causa-machine-pulse-active exists")
+      ;; Concentric rings restated on the resting frame.
+      (is (re-find #"inset 0 0 0 3px var\(--rf-causa-bg-1\)" css)
+          "inner gap ring painted in --rf-causa-bg-1")
+      (is (re-find #"inset 0 0 0 5px var\(--rf-causa-accent\)" css)
+          "inner accent ring painted in --rf-causa-accent (mode-tracking)")
+      ;; Breathing outer halo rides the accent var (orange Dynamic / cyan
+      ;; Static) — NOT the green token the legacy pulse uses.
+      (is (re-find #"color-mix\(in srgb, var\(--rf-causa-accent\)" css)
+          "outer halo color-mixes the mode accent, not :green"))))
+
 ;; ---- rf2-5kfxe.5 — prefers-reduced-motion seam --------------------------
 
 (deftest motion-css-declares-root-motion-scale-default


### PR DESCRIPTION
Reconciles the **Machine panel** xyflow style maps to the Figma Case C design (spec/021 §6.2 + `design-reference/components/MachinePanel.tsx`). RESTYLE within xyflow only — the engine + topology stay xyflow (B.4.1 lock + Mike's machine-topology carve-out). No engine replacement.

## xyflow restyle deltas (`panels/machines/xyflow_style.cljs`)
- **`:from` node kind** — dashed/dim circle (`:text-tertiary`, transparent fill, `border-radius: 50%`): the source state of the focused fired transition (the audit's missing FROM-dim kind).
- **`:current` double-circle** — now a mode-`:accent` concentric double-circle (inner-gap + inner-ring via stacked `inset` box-shadows) instead of the former green single border (~the old :55-56). Keeps the breathing pulse.
- **`:compound` container wired** — the dashed `active (compound)` grouping container that bounds the focused FROM/TO pair, kept distinct from the parallel-region `:region` kind (which the audit flagged was being borrowed).
- **New `rf-causa-machine-pulse-active` keyframe** (`theme/global_styles`) — restates the static concentric rings every frame (box-shadow sets the whole property) and rides `--rf-causa-accent` so the halo tracks the mode (orange Dynamic / cyan Static).

## Projector wiring (`panels/machines/topology.cljs`)
- `node-kind` gains a `:from` arm (precedence `:current > :from > :final > :standard`; self-transition reads as active). 3-arity + back-compat 2-arity.
- `project` accepts `:from-state-path`; new `from-state-from-traces` helper resolves the transition source (modern `:tags :before :state` + legacy shapes).

## Shell / tab label scrub
- Dynamic L4 tab label **`Machines` → `Machine`** (singular, per Figma `App.tsx`). Lives at `machine_inspector.cljs:746` (the source of the registry label the shell renders); internal `:machines` id + mnemonic unchanged. (Only worker touching this surface.)

## Spec
- §17.4.2 node-shape table + §17.4.5 style-map sketch + keyframe note updated for the new node kinds and the accent double-circle.

## Gates
- `npm run test:cljs` — **PASS** (4209 tests / 13017 assertions, 0 failures).
- tools/causa `clojure -M:test` — **PASS** (846 tests / 2825 assertions, 0 failures).
- `npm run test:causa-feature-gate` — server-dependent scenarios fail on local `http-server` spawn (code=1 / ERR_CONNECTION_REFUSED); all 12 surfaces (incl. deep-machine) **compiled clean**, and the two non-server scenarios pass. Local infra, not a regression.
- machines-viz gate not required (no shared machine-rendering files touched).
- clj-kondo not installed in this environment; CLJS compiler clean (unresolved-symbol/arity caught by the test build).