### PR TITLE
feat(causa): reconcile Trace panel to Figma op-family rows (rf2-ad7zx.8)

### DIFF
--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -818,13 +818,16 @@ history buffer.").
 
 | Sub | Reads |
 |---|---|
-| `:rf.causa/trace-feed` | The focused epoch record's `:trace-events`, resolved via `:rf.causa/focus` (`:epoch-id`) + `:rf.causa/epoch-history`. No filtering. Returns `{:rows :total :rendered :epoch-id :empty-kind}` (`:rendered` = `:total` since there is no filter). |
+| `:rf.causa/trace-feed` | The focused epoch record's `:trace-events`, resolved via `:rf.causa/focus` (`:epoch-id`) + `:rf.causa/epoch-history`. No filtering. Returns `{:rows :nodes :total :rendered :epoch-id :empty-kind}` (`:rendered` = `:total` since there is no filter). `:rows` is the flat oldest-first projection (each row carries `:op-family` · `:rel-time` · `:duration-ms` · `:parent-dispatch-id`). `:nodes` is the structural display tree the view paints: contiguous reactive emits fold into one `:reactive-group` node (`{:summary {:subs N :renders M} :children [...]}`), and every node carries a causal-nesting `:depth` (rf2-ad7zx.8). |
+| `:rf.causa/trace-expanded-row-ids` | The set of trace `:id`s whose payload is expanded inline (per-row click). |
+| `:rf.causa/trace-expanded-group-ids` | The set of reactive-aftermath group ids that are expanded (group click — rf2-ad7zx.8). |
 
 ### §5.4 Cross-panel navigation
 
 | Click | Navigates to |
 |---|---|
 | Row → expand payload | Inline in panel (no nav — toggles membership in `:rf.causa/trace-expanded-row-ids`) |
+| Reactive-aftermath group → expand | Inline in panel (no nav — toggles membership in `:rf.causa/trace-expanded-group-ids`, revealing the collapsed `:rf.sub/run` / `:rf.view/render` children; rf2-ad7zx.8) |
 | Source-coord chip | Opens the source coord in the editor (`:rf.causa/open-in-editor`) |
 | Right-click a destroy-event row / `⟲ cascade` button | Opens the cancellation-cascade popover for that row's dispatch-id |
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -8,12 +8,22 @@
 
   ## What this panel shows
 
-  A scrollable, timestamped ribbon scoped to the spine's focused
-  epoch. Each row carries:
+  A scrollable, relative-timestamped ribbon scoped to the spine's
+  focused epoch. Per the Figma design (rf2-ad7zx.8 — spec/021 §5.2 +
+  `design-reference/components/TracePanel.tsx`) each row carries:
 
-      timestamp · op-type-dot · operation · description · source-coord
+      relative-time · readable plain-language description · duration
 
-  Clicking a row toggles its inline payload expansion (no nav).
+  with the op-FAMILY colour rendered as a **3px left-border band**
+  (dispatch = mode accent · db = changed · fx = warning · reactive =
+  dim · machine = chart tone) — NOT an op-type dot. Child dispatches
+  **indent** under their parent cascade (causal nesting), and the
+  post-cascade reactive aftermath **collapses** under one expandable
+  `▸ reactive aftermath (N subs, M renders)` group so the core
+  dominoes stand out.
+
+  Clicking a row toggles its inline payload expansion (no nav);
+  clicking the reactive group toggles its children.
 
   ## Epoch-scoped feed (rf2-td380)
 
@@ -107,8 +117,52 @@
       :panel-id  :trace
       :render-id (str "trace-row-" id)})])
 
+;; ---- row layout constants (rf2-ad7zx.8) --------------------------------
+
+(def ^:private indent-px
+  "Causal-nesting indent per depth level (spec/021 §5.2 — child
+  dispatches indent under their parent cascade)."
+  20)
+
+(defn- op-row-cells
+  "The inner grid of one op row — relative timestamp · readable
+  description · per-op duration. Per spec/021 §5.2 the Figma row is
+  `t+N.Nms · readable description · duration` with the op-family band
+  as a 3px LEFT-BORDER on the row container (not a dot). The duration
+  column shows elapsed for event/view rows; reactive point-in-time
+  emits leave it blank."
+  [{:keys [rel-time time description duration-ms] :as _row} row-test-id]
+  [:div {:data-testid (str row-test-id "-summary")
+         :style       {:display       "grid"
+                       :grid-template-columns "84px minmax(0, 1fr) auto"
+                       :gap           "12px"
+                       :align-items   "center"
+                       :padding       "6px 16px"}}
+   ;; Relative timestamp (`t+N.Nms`); absolute clock as the hover title.
+   [:span {:data-testid (str row-test-id "-time")
+           :title       (or (h/format-time time) "")
+           :style {:color (:text-tertiary tokens)
+                   :font-size "11px"
+                   :white-space "nowrap"}}
+    (or rel-time "—")]
+   ;; Readable plain-language description (the dense default line).
+   [:span {:data-testid (str row-test-id "-description")
+           :style       {:color         (:text-primary tokens)
+                         :overflow      "hidden"
+                         :text-overflow "ellipsis"
+                         :white-space   "nowrap"}
+           :title       description}
+    description]
+   ;; Per-op duration column (blank for point-in-time reactive emits).
+   [:span {:data-testid (str row-test-id "-duration")
+           :style {:color (:text-tertiary tokens)
+                   :font-size "11px"
+                   :white-space "nowrap"
+                   :text-align "right"}}
+    (or (h/format-duration duration-ms) "")]])
+
 (defn- trace-row
-  "One row in the trace ribbon.
+  "One op row in the trace ribbon.
 
   Per rf2-z4fza: the React `:key` is the row's stable trace `:id`
   (via `h/row-key`). The earlier shape keyed on a tuple that mixed
@@ -118,6 +172,14 @@
   EVERY push. Same discipline class as rf2-kgn0c's `v:<variant-id>`
   cell-keying in the story workspace.
 
+  Per rf2-ad7zx.8 (spec/021 §5.2 · design-reference/TracePanel.tsx):
+  the op-family colour is a **3px left-border band** on the row
+  container (dispatch = mode accent · db = changed · fx = warning ·
+  reactive = dim · machine = chart tone) — NOT an op-type dot. Child
+  dispatches **indent** under their parent cascade via `:depth`. The
+  row body is the readable plain-language description with a per-op
+  duration column at the right.
+
   Per spec/021 §5.4 + rf2-7dyi8 the row-click behaviour is **inline
   payload expansion** (NOT pivot to event-detail) — the Trace panel
   is already scoped to the focused epoch (rf2-ycoct), so pivoting
@@ -125,20 +187,22 @@
   membership in `:rf.causa/trace-expanded-row-ids`; expanded rows
   render the shared data-display renderer below the row inside the
   same `<li>` so the React-key + scroll-anchoring discipline holds."
-  [{:keys [id time op-type operation description
-           source-coord dispatch-id]
+  [{:keys [id operation source-coord dispatch-id op-family depth]
     :as row}
    {:keys [expanded?]}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
-        dot-colour  (h/op-type-colour op-type)
+        band-colour (h/op-family-colour row)
+        depth*      (or depth 0)
         ;; rf2-59e7k — destroy-event rows surface a 'Show cancellation
-        ;; cascade' action button next to the source-coord cell. The
-        ;; classifier mirrors helpers/destroy-operations so the trace
-        ;; ns has no upward dep on the cascade view.
+        ;; cascade' action button. The classifier mirrors
+        ;; helpers/destroy-operations so the trace ns has no upward dep
+        ;; on the cascade view.
         destroy?    (cch/destroy-event? {:operation operation})]
     [:li {:key         (h/row-key row)
           :data-testid row-test-id
           :data-rf-causa-expanded (boolean expanded?)
+          :data-rf-causa-op-family (some-> op-family name)
+          :data-rf-causa-depth depth*
           :on-click    (fn []
                          ;; rf2-7dyi8 — toggle inline payload expansion
                          ;; rather than pivoting to event-detail (spec
@@ -154,104 +218,141 @@
                                  [:rf.causa/cancellation-cascade-open
                                   {:kind :dispatch-id :id dispatch-id}]
                                  {:frame :rf/causa})))
-          :style       {:display        "block"
+          :style       {:display        "flex"
+                        :align-items    "stretch"
+                        ;; op-family colour band as a 3px LEFT-BORDER.
+                        :border-left    (str "3px solid " band-colour)
                         :border-bottom  (str "1px solid "
                                              (:border-subtle tokens))
                         :background     (when expanded? (:bg-1 tokens))
+                        ;; Causal-nesting indent (cascade tree).
+                        :margin-left    (str (* depth* indent-px) "px")
                         :cursor         "pointer"
                         :color          (:text-primary tokens)
                         :font-family    mono-stack
                         :font-size      "12px"
                         :line-height    1.35}}
-     ;; Row grid — the dense single-line summary per spec/021 §5.2.
-     ;; Held in an inner div so the optional payload can render as a
-     ;; sibling inside the same `<li>` without breaking the row's
-     ;; React-key stability discipline (rf2-z4fza).
-     [:div {:data-testid (str row-test-id "-summary")
-            :style       {:display       "grid"
-                          :grid-template-columns
-                          "84px 14px minmax(140px, 1fr) 2fr auto auto"
-                          :gap           "10px"
-                          :align-items   "center"
-                          :padding       "6px 16px"}}
-     ;; Timestamp
-     [:span {:data-testid (str row-test-id "-time")
-             :style {:color (:text-tertiary tokens)
-                     :font-size "11px"
-                     :white-space "nowrap"}}
-      (or (h/format-time time) "—")]
-     ;; op-type dot
-     [:span {:data-testid (str row-test-id "-op-type-dot")
-             :title       (str op-type)
-             :style       {:color dot-colour
-                           :font-weight 700
-                           :text-align "center"}}
-      "●"]
-     ;; Operation
-     [:span {:data-testid (str row-test-id "-operation")
-             :style       {:color         (:accent tokens)
-                           :overflow      "hidden"
-                           :text-overflow "ellipsis"
-                           :white-space   "nowrap"}
-             :title       (str operation)}
-      (or (some-> operation str) "—")]
-     ;; Description
-     [:span {:data-testid (str row-test-id "-description")
-             :style       {:color         (:text-secondary tokens)
-                           :overflow      "hidden"
-                           :text-overflow "ellipsis"
-                           :white-space   "nowrap"}
-             :title       description}
-      description]
-     ;; Source-coord (when present)
-     (if source-coord
-       [:button {:data-testid (str row-test-id "-source-coord")
-                 :on-click    (fn [e]
-                                (.stopPropagation e)
-                                (rf/dispatch [:rf.causa/open-in-editor
-                                              {:source-coord source-coord}] {:frame :rf/causa}))
-                 :style       {:background  "transparent"
-                               :color       (:accent tokens)
-                               :border      (str "1px solid " (:border-subtle tokens))
-                               :padding     "1px 6px"
-                               :border-radius "3px"
-                               :cursor      "pointer"
-                               :font-family mono-stack
-                               :font-size   "10px"}}
-        source-coord]
-       [:span {:style {:color (:text-tertiary tokens)
-                       :font-size "10px"}}
-        "—"])
-     ;; rf2-59e7k cancellation-cascade action (destroy rows only).
-     ;; Opens the popover focused on this row's dispatch-id. Right-
-     ;; clicking the row anywhere is the same action — this button is
-     ;; the visible affordance for the same shortcut.
-     (if destroy?
-       [:button {:data-testid (str row-test-id "-cancellation-cascade")
-                 :title       "Show cancellation cascade"
-                 :on-click    (fn [e]
-                                (.stopPropagation e)
-                                (rf/dispatch
-                                  [:rf.causa/cancellation-cascade-open
-                                   {:kind :dispatch-id :id dispatch-id}]
-                                  {:frame :rf/causa}))
-                 :style       {:background  "transparent"
-                               :color       (or (:red tokens)
-                                                (:text-secondary tokens))
-                               :border      (str "1px solid " (:border-subtle tokens))
-                               :padding     "1px 6px"
-                               :border-radius "3px"
-                               :cursor      "pointer"
-                               :font-family mono-stack
-                               :font-size   "10px"}}
-        "⟲ cascade"]
-       [:span {:style {:color (:text-tertiary tokens)
-                       :font-size "10px"
-                       :min-width "10px"}}
-        ""])]
-     ;; rf2-7dyi8 — inline payload expansion. Consumes the shared
-     ;; rf2-jgip1 data-display renderer (#1739, landed in main).
-     (when expanded? (render-payload row))]))
+     [:div {:style {:flex 1 :min-width 0}}
+      ;; Row grid + the per-row actions, held in an inner div so the
+      ;; optional payload renders as a sibling inside the same `<li>`
+      ;; without breaking the row's React-key discipline (rf2-z4fza).
+      [:div {:style {:display "flex" :align-items "center"}}
+       [:div {:style {:flex 1 :min-width 0}}
+        (op-row-cells row row-test-id)]
+       ;; Source-coord chip (when present).
+       (when source-coord
+         [:button {:data-testid (str row-test-id "-source-coord")
+                   :on-click    (fn [e]
+                                  (.stopPropagation e)
+                                  (rf/dispatch [:rf.causa/open-in-editor
+                                                {:source-coord source-coord}] {:frame :rf/causa}))
+                   :style       {:background  "transparent"
+                                 :color       (:accent tokens)
+                                 :border      (str "1px solid " (:border-subtle tokens))
+                                 :padding     "1px 6px"
+                                 :margin-right "8px"
+                                 :border-radius "3px"
+                                 :cursor      "pointer"
+                                 :font-family mono-stack
+                                 :font-size   "10px"}}
+          source-coord])
+       ;; rf2-59e7k cancellation-cascade action (destroy rows only).
+       (when destroy?
+         [:button {:data-testid (str row-test-id "-cancellation-cascade")
+                   :title       "Show cancellation cascade"
+                   :on-click    (fn [e]
+                                  (.stopPropagation e)
+                                  (rf/dispatch
+                                    [:rf.causa/cancellation-cascade-open
+                                     {:kind :dispatch-id :id dispatch-id}]
+                                    {:frame :rf/causa}))
+                   :style       {:background  "transparent"
+                                 :color       (or (:red tokens)
+                                                  (:text-secondary tokens))
+                                 :border      (str "1px solid " (:border-subtle tokens))
+                                 :padding     "1px 6px"
+                                 :margin-right "8px"
+                                 :border-radius "3px"
+                                 :cursor      "pointer"
+                                 :font-family mono-stack
+                                 :font-size   "10px"}}
+          "⟲ cascade"])]
+      ;; rf2-7dyi8 — inline payload expansion. Consumes the shared
+      ;; rf2-jgip1 data-display renderer (#1739, landed in main).
+      (when expanded? (render-payload row))]]))
+
+;; ---- reactive-aftermath collapse group (rf2-ad7zx.8) -------------------
+
+(defn- reactive-group-row
+  "Render one collapsed reactive-aftermath group — the spec/021 §5.2
+  `▸ reactive aftermath (N subs, M renders)` row. Clicking toggles the
+  group open via `:rf.causa/toggle-trace-group-expand`; expanded groups
+  render their child reactive rows (subs ran · views rendered) inline
+  inside the same `<li>` so the React-key + scroll discipline holds.
+  The group rides the dim op-family band so the core dominoes stand
+  out."
+  [{:keys [id rel-time summary children depth] :as _group}
+   {:keys [expanded? expanded-row-ids]}]
+  (let [grp-test-id (str "rf-causa-trace-group-" id)
+        depth*      (or depth 0)
+        {:keys [subs renders]} summary
+        band-colour (h/op-family-colour {:op-family :reactive})]
+    [:li {:key         (str "g:" id)
+          :data-testid grp-test-id
+          :data-rf-causa-expanded (boolean expanded?)
+          :data-rf-causa-op-family "reactive"
+          :on-click    (fn []
+                         (rf/dispatch [:rf.causa/toggle-trace-group-expand id]
+                                      {:frame :rf/causa}))
+          :style       {:display       "block"
+                        :border-left   (str "3px solid " band-colour)
+                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        :margin-left   (str (* depth* indent-px) "px")
+                        :cursor        "pointer"
+                        :color         (:text-secondary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     [:div {:data-testid (str grp-test-id "-summary")
+            :style {:display "grid"
+                    :grid-template-columns "84px minmax(0, 1fr)"
+                    :gap "12px"
+                    :align-items "center"
+                    :padding "6px 16px"}}
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-size "11px"
+                      :white-space "nowrap"}}
+       (or rel-time "—")]
+      [:span {:style {:color (:text-secondary tokens)}}
+       (str (if expanded? "▾" "▸")
+            " reactive aftermath ("
+            subs " sub" (when (not= 1 subs) "s") ", "
+            renders " render" (when (not= 1 renders) "s") ")")]]
+     ;; Expanded — render the child reactive rows inline.
+     (when expanded?
+       [:div {:data-testid (str grp-test-id "-children")
+              :style {:padding-left "16px"
+                      :background (:bg-1 tokens)}}
+        (for [child children]
+          ^{:key (h/row-key child)}
+          (trace-row child
+                     {:expanded? (contains? (or expanded-row-ids #{})
+                                            (:id child))}))])]))
+
+(defn- trace-node
+  "Render one display node — either a `:reactive-group` collapse group
+  or a plain op row. The view feeds the structural `:nodes` projection
+  (rf2-ad7zx.8) through this so the reactive-aftermath group, causal
+  nesting, and op-family bands all render from one pure-data tree."
+  [node {:keys [expanded-row-ids expanded-group-ids] :as _state}]
+  (if (= :reactive-group (:kind node))
+    (reactive-group-row node
+                        {:expanded? (contains? (or expanded-group-ids #{})
+                                               (:id node))
+                         :expanded-row-ids expanded-row-ids})
+    (trace-row node
+               {:expanded? (contains? (or expanded-row-ids #{})
+                                      (:id node))})))
 
 ;; ---- empty states -------------------------------------------------------
 
@@ -341,7 +442,7 @@
   lifecycle-status colour — ONE bar driven by `event-status-colour`,
   the same fn the L2 row + Event header consume."
   []
-  (let [{:keys [rows empty-kind] :as _data}
+  (let [{:keys [nodes empty-kind] :as _data}
         @(rf/subscribe [:rf.causa/trace-feed])
         ;; rf2-b76v4 — pull the focused cascade + focus map so the
         ;; cascade-status timeline bar can render with the canonical
@@ -353,16 +454,16 @@
         focused-cascade (when focused-id
                           (some #(when (= focused-id (:dispatch-id %)) %)
                                 cascades))
-        ;; rf2-7dyi8 — per-row inline payload expansion set. The
-        ;; trace-row hiccup reads `expanded?` from the closure built
-        ;; here so the row-fn keeps the single-arg shape `overflow/
-        ;; capped-list` requires.
+        ;; rf2-7dyi8 — per-row inline payload expansion set; rf2-ad7zx.8
+        ;; — per-group reactive-aftermath expansion set. The node-fn
+        ;; reads both from the closure built here so it keeps the
+        ;; single-arg shape `overflow/capped-list` requires.
         expanded-ids   @(rf/subscribe [:rf.causa/trace-expanded-row-ids])
-        row-with-state (fn [row]
-                         (trace-row row
-                                    {:expanded?
-                                     (contains? (or expanded-ids #{})
-                                                (:id row))}))]
+        expanded-groups @(rf/subscribe [:rf.causa/trace-expanded-group-ids])
+        node-with-state (fn [node]
+                          (trace-node node
+                                      {:expanded-row-ids   expanded-ids
+                                       :expanded-group-ids expanded-groups}))]
     [:section {:data-testid "rf-causa-trace"
                :style       {:height         "100%"
                              :display        "flex"
@@ -385,13 +486,13 @@
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted)
         nil            (overflow/capped-list
-                         rows
+                         nodes
                          {:panel-id "trace"
                           :ul-attrs {:data-testid "rf-causa-trace-feed"
                                      :style       {:list-style "none"
                                                    :margin     0
                                                    :padding    0}}
-                          :row-fn   row-with-state}))]]))
+                          :row-fn   node-with-state}))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -464,7 +565,27 @@
 
   (rf/reg-event-db :rf.causa/clear-trace-expand
     (fn [db _event]
-      (dissoc db :trace-expanded-row-ids)))
+      (dissoc db :trace-expanded-row-ids :trace-expanded-group-ids)))
+
+  ;; ---- rf2-ad7zx.8 — reactive-aftermath collapse groups --------------
+  ;;
+  ;; Per spec/021 §5.2 the post-cascade reactive emits collapse under
+  ;; one expandable `▸ reactive aftermath (N subs, M renders)` group so
+  ;; the core dominoes stand out. The expanded-group set lives in app-db
+  ;; (keyed by the group's stable `react-grp:<id>` id) so the toggle
+  ;; survives sub-recomputes, exactly as the per-row expansion set does.
+
+  (rf/reg-sub :rf.causa/trace-expanded-group-ids
+    (fn [db _query]
+      (get db :trace-expanded-group-ids #{})))
+
+  (rf/reg-event-db :rf.causa/toggle-trace-group-expand
+    (fn [db [_ group-id]]
+      (let [current (get db :trace-expanded-group-ids #{})]
+        (assoc db :trace-expanded-group-ids
+               (if (contains? current group-id)
+                 (disj current group-id)
+                 (conj current group-id))))))
 
   ;; rf2-2moh1 — register the Dynamic Trace tab with the internal L4
   ;; tab registry.

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -40,6 +40,79 @@
             [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.theme.tokens :as tokens]))
 
+;; ---- op-family classification (rf2-ad7zx.8) -----------------------------
+;;
+;; The Figma Trace design (`design-reference/components/TracePanel.tsx`)
+;; bands each row with a 3px op-FAMILY-coloured left border — FIVE
+;; families, not the full op-type vocabulary:
+;;
+;;     :dispatch  — the event side (`:rf.event/dispatched` / run-start /
+;;                  run-end). Mode accent (orange / cyan).
+;;     :db        — `:rf.event/db-changed`. The "changed" tone.
+;;     :fx        — the effect side (`:rf.fx/*`). Warning tone.
+;;     :reactive  — the post-cascade reactive aftermath (`:rf.sub/*` /
+;;                  `:rf.view/*`). Dim tone — collapses under one group.
+;;     :machine   — `:rf.machine/*`. The machine/chart tone.
+;;
+;; Plus the two severity tiers (`:error` / `:warning`) which keep their
+;; canonical semantic colours so a failure never hides under a family
+;; band. Unknown ops fall back to `:dispatch`-adjacent neutral.
+
+(defn op-family
+  "Classify a projected row (or raw event) into one of the Figma op
+  families: `:dispatch` · `:db` · `:fx` · `:reactive` · `:machine`,
+  with the `:error` / `:warning` severity tiers preserved. Reads
+  `:op-type` + `:operation` (the operation discriminates db-changed
+  from the rest of the event family). Pure data → keyword;
+  JVM-testable."
+  [{:keys [op-type operation] :as _row-or-ev}]
+  (cond
+    (= op-type :error)                 :error
+    (= op-type :warning)               :warning
+    (= operation :rf.event/db-changed) :db
+    (= op-type :rf.event)              :dispatch
+    (= op-type :rf.fx)                 :fx
+    (= op-type :rf.sub)                :reactive
+    (= op-type :rf.view)               :reactive
+    (= op-type :rf.machine)            :machine
+    :else                              :dispatch))
+
+(def op-family->token
+  "Pure semantic map from op-family keyword to a `theme/tokens` token
+  keyword. The hex (CSS-var) resolution happens via
+  `op-family-colour`. Keeping the semantic mapping separate from the
+  var lookup keeps the map pure data + the palette consolidated
+  (rf2-5kfxe.4 discipline).
+
+  Family → token (spec/021 §5.2 · design-reference/TracePanel.tsx):
+
+    :dispatch → :accent         (mode accent — orange / cyan)
+    :db       → :accent-static  (the cyan 'changed/recompute' partner,
+                                 visually distinct from the orange
+                                 event accent now that events ride it)
+    :fx       → :warning        (the effect/warning tone)
+    :reactive → :dim            (dimmed / inert reactive aftermath)
+    :machine  → :green          (the machine-domain tone — Causa's
+                                 machine surfaces are green)
+    :error    → :red
+    :warning  → :yellow"
+  {:dispatch :accent
+   :db       :accent-static
+   :fx       :warning
+   :reactive :dim
+   :machine  :green
+   :error    :red
+   :warning  :yellow})
+
+(defn op-family-colour
+  "Resolve the 3px left-border colour for a row's op family. Routes the
+  family through `op-family` then `op-family->token` then
+  `theme/tokens`. Falls back to `:text-secondary` for an unknown
+  family. Pure data → CSS-var string; JVM-testable."
+  [row-or-ev]
+  (get tokens/tokens
+       (get op-family->token (op-family row-or-ev) :text-secondary)))
+
 ;; ---- short-description ---------------------------------------------------
 
 (defn short-description
@@ -71,6 +144,104 @@
     (if (and detail (not (str/blank? (str detail))))
       (str op-str " — " detail)
       op-str)))
+
+;; ---- readable plain-language description (rf2-ad7zx.8) -------------------
+;;
+;; Per spec/021 §5.1 (density note) + §5.2 (Figma readable rows) each op
+;; renders as a PLAIN-LANGUAGE line, not its raw op-type keyword:
+;;
+;;     dispatched [:counter-inc]
+;;     db changed [:counter] 1 → 2
+;;     fx :dispatch → [:title/flow [:rf/init]]
+;;     machine :title/flow idle → loading
+;;
+;; The raw `:operation` + tag-map remains the click-to-expand detail
+;; (rf2-7dyi8) — this is the single dense default line. `short-
+;; description` (above) stays the fallback for ops the readable builder
+;; doesn't recognise, so no op ever renders as a blank row.
+
+(defn- pr-str-safe
+  "pr-str that never throws (defends against un-printable trace
+  payloads); returns nil on failure. Pure data → string-or-nil."
+  [x]
+  (try (pr-str x)
+       (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+(def ^:private tags-absent
+  "Sentinel for 'tag key absent' so a literal `nil` db value (a valid
+  app-db value) is distinguished from a missing tag."
+  ::tags-absent)
+
+(defn- name-or-str
+  "Render a state token compactly — `(name kw)` for keywords (so a
+  machine state reads `idle` not `:idle`), `str` otherwise. Pure."
+  [x]
+  (if (keyword? x) (name x) (str x)))
+
+(defn readable-description
+  "Build the Figma plain-language row body for one trace event. Maps
+  the op family + the reliably-present tags to a human line:
+
+    :dispatch (dispatched) → `dispatched <event-vec>`
+    :db                    → `db changed <path>? <old> → <new>?`
+    :fx                    → `fx <fx-id> → <fx-arg>?`
+    :machine               → `machine <machine-id> <from> → <to>`
+    :reactive (sub)        → `sub ran <sub-id>`
+    :reactive (view)       → `rendered <render-key>`
+
+  Falls back to `short-description` for ops outside this vocabulary
+  (run-start/run-end markers, errors, registry events, …) so the row
+  is never blank. Pure data → string; JVM-testable."
+  [{:keys [operation tags] :as ev}]
+  (let [family (op-family ev)
+        ev-vec (when (vector? (:rf.event/v tags)) (:rf.event/v tags))]
+    (or
+      (case family
+        :db
+        (let [path (or (:rf.db/path tags) (:path tags))
+              old  (get tags :rf.db/old tags-absent)
+              new  (get tags :rf.db/new tags-absent)]
+          (cond
+            (and (not= old tags-absent) (not= new tags-absent))
+            (str "db changed"
+                 (when path (str " " (pr-str-safe path)))
+                 " " (pr-str-safe old) " → " (pr-str-safe new))
+            path (str "db changed " (pr-str-safe path))
+            :else "db changed"))
+
+        :machine
+        (let [mid  (or (:machine-id tags) (:rf/machine-id tags))
+              from (get tags :from tags-absent)
+              to   (get tags :to tags-absent)]
+          (when mid
+            (str "machine " mid
+                 (when (and (not= from tags-absent) (not= to tags-absent))
+                   (str " " (name-or-str from) " → " (name-or-str to))))))
+
+        :fx
+        (let [fx-id (or (:rf.fx/id tags) (:rf.fx/effect-id tags))]
+          (when fx-id
+            (str "fx " fx-id
+                 (when-let [arg (or (:rf.fx/arg tags) (:rf.fx/value tags))]
+                   (str " → " (pr-str-safe arg))))))
+
+        :reactive
+        (cond
+          (some? (:rf.sub/id tags))
+          (str "sub ran " (:rf.sub/id tags))
+          (some? (:rf.view/render-key tags))
+          (str "rendered " (pr-str-safe (:rf.view/render-key tags)))
+          (some? (:rf.view/id tags))
+          (str "rendered " (:rf.view/id tags))
+          :else nil)
+
+        :dispatch
+        (when (and (= operation :rf.event/dispatched) ev-vec)
+          (str "dispatched " (pr-str-safe ev-vec)))
+
+        nil)
+      ;; Fallback — the existing terse `operation — detail` line.
+      (short-description ev))))
 
 ;; ---- source-coord projection --------------------------------------------
 
@@ -104,6 +275,44 @@
   [ev]
   (get-in ev [:tags :rf.event/origin]))
 
+(defn duration-ms
+  "Per-op elapsed time, in ms, when the trace event reports it.
+
+  Reads (in priority order) `[:tags :elapsed-ms]` — the wall-clock
+  duration the event-emit / view-render envelopes stamp (Spec 009
+  §Record shape; `re-frame.views` for `:rf.view/rendered`) — then a
+  top-level `:elapsed-ms` fallback. Returns nil otherwise: reactive
+  point-in-time emits (`:rf.sub/run`, bare `:rf.view/render`) carry no
+  elapsed, so the view renders a timestamp rather than a duration
+  (spec/021 §5.2). Pure data → number-or-nil; JVM-testable."
+  [ev]
+  (let [e (or (get-in ev [:tags :elapsed-ms])
+              (:elapsed-ms ev))]
+    (when (number? e) e)))
+
+(defn- fmt-1
+  "Format a number to EXACTLY one decimal place — `0.4`, `12.0`,
+  `0.0` — so the duration / relative-time columns read with a stable
+  rhythm (the Figma `0.4 ms` / `t+0.0ms` form). Portable: CLJS `str`
+  of a whole-number double drops the `.0`, so we round to tenths then
+  build the `<int>.<tenth>` string by hand. Pure data → string."
+  [n]
+  (let [tenths (#?(:clj Math/round :cljs js/Math.round) (* (double n) 10.0))
+        neg?   (neg? tenths)
+        a      (#?(:clj Math/abs :cljs js/Math.abs) tenths)
+        whole  (quot a 10)
+        frac   (rem a 10)]
+    (str (when neg? "-") whole "." frac)))
+
+(defn format-duration
+  "Render an elapsed-ms number as a compact `N.N ms` string (matching
+  the Figma `0.4 ms` form, one decimal place). Returns nil for nil /
+  non-number input so the duration column can render empty. Pure data
+  → string-or-nil; JVM-testable."
+  [ms]
+  (when (number? ms)
+    (str (fmt-1 ms) " ms")))
+
 (defn project-row
   "Project one raw trace event into the panel's row shape:
 
@@ -111,6 +320,7 @@
        :time            <ms>
        :op-type         <kw>
        :operation       <kw>
+       :op-family       <:dispatch/:db/:fx/:reactive/:machine/:error/:warning>
        :severity        <:error/:warning/:info-or-nil>
        :source          <kw-or-nil>
        :origin          <kw-or-nil>
@@ -118,10 +328,20 @@
        :event-id        <kw-or-nil>
        :handler-id      <kw-or-nil>
        :dispatch-id     <int-or-nil>
-       :description     <string>
+       :parent-dispatch-id <int-or-nil>     ;; causal-nesting parent
+       :description     <string>            ;; readable plain-language line
        :source-coord    <string-or-nil>
-       :tags            <map>                ;; full tags for the detail view
+       :duration-ms     <num-or-nil>        ;; per-op elapsed (when present)
+       :tags            <map>               ;; full tags for the detail view
        :raw             <trace-event>}
+
+  Per rf2-ad7zx.8 the `:description` is now the Figma plain-language
+  line (`readable-description`); the prior terse `operation — detail`
+  form remains its fallback. `:op-family` drives the 3px left-border
+  band and the reactive-aftermath grouping. `:duration-ms` carries the
+  op's elapsed timing when the trace event reports it (event run-end,
+  view render); reactive point-in-time emits leave it nil so the view
+  shows a timestamp, not a duration (spec/021 §5.2).
 
   Pure data → data; JVM-testable."
   [{:keys [id time op-type operation source tags] :as ev}]
@@ -129,6 +349,7 @@
    :time            time
    :op-type         op-type
    :operation       operation
+   :op-family       (op-family ev)
    ;; :severity is the synonym axis Spec 009 documents — set when the
    ;; op-type is one of the three severity tiers, nil otherwise.
    :severity        (case op-type
@@ -142,8 +363,10 @@
    :event-id        (get-in ev [:tags :rf.trace/event-id])
    :handler-id      (get-in ev [:tags :handler-id])
    :dispatch-id     (get-in ev [:tags :rf.trace/dispatch-id])
-   :description     (short-description ev)
+   :parent-dispatch-id (get-in ev [:tags :rf.trace/parent-dispatch-id])
+   :description     (readable-description ev)
    :source-coord    (source-coord ev)
+   :duration-ms     (duration-ms ev)
    :tags            tags
    :raw             ev})
 
@@ -152,6 +375,158 @@
   chronological order (oldest first). Pure data → data."
   [events]
   (mapv project-row events))
+
+;; ---- relative timing (rf2-ad7zx.8) --------------------------------------
+;;
+;; Per spec/021 §5.2 the Figma row leads with a RELATIVE timestamp
+;; (`t+0.0ms`) — elapsed since the epoch's first trace event — not the
+;; absolute wall clock. Relative time scans the epoch's shape (the gaps
+;; between dominoes) at a glance, where absolute HH:MM:SS.mmm does not.
+
+(defn epoch-t0
+  "The earliest `:time` across `rows` (the epoch's domino-trail
+  origin). Returns nil when no row carries a numeric `:time`. Pure."
+  [rows]
+  (let [ts (keep :time rows)]
+    (when (seq ts) (apply min ts))))
+
+(defn format-rel-time
+  "Render `t` (absolute ms) relative to `t0` as the Figma `t+N.Nms`
+  form. Falls back to nil when either is non-numeric so the view can
+  render an em-dash. Pure data → string-or-nil; JVM-testable."
+  [t t0]
+  (when (and (number? t) (number? t0))
+    (str "t+" (fmt-1 (- t t0)) "ms")))
+
+(defn with-rel-times
+  "Stamp `:rel-time` (the `t+N.Nms` string, relative to the epoch's
+  first event) onto every row. Pure data → rows; JVM-testable."
+  [rows]
+  (let [t0 (epoch-t0 rows)]
+    (mapv (fn [row]
+            (assoc row :rel-time (format-rel-time (:time row) t0)))
+          rows)))
+
+;; ---- reactive-aftermath collapse group (rf2-ad7zx.8) --------------------
+;;
+;; Per spec/021 §5.2 the many post-cascade reactive emits (`:rf.sub/run`
+;; / `:rf.view/render`) COLLAPSE under one expandable group row —
+;; `▸ reactive aftermath (N subs, M renders)` — so the core dominoes
+;; (dispatch · db · fx · machine) stand out. A contiguous run of
+;; `:reactive`-family rows folds into ONE group node carrying the run's
+;; children; the view renders the summary and toggles the children.
+
+(defn- reactive-row?
+  "True when a projected row belongs to the reactive aftermath family."
+  [row]
+  (= :reactive (:op-family row)))
+
+(defn reactive-summary
+  "Summarise a run of reactive rows as `{:subs N :renders M}` — subs ran
+  vs views rendered. Pure data → map; JVM-testable."
+  [rows]
+  {:subs    (count (filter #(= :rf.sub (:op-type %)) rows))
+   :renders (count (filter #(= :rf.view (:op-type %)) rows))})
+
+(defn group-reactive-aftermath
+  "Fold each CONTIGUOUS run of reactive-family rows (in the given
+  oldest-first order) into a single group node:
+
+      {:kind        :reactive-group
+       :id          \"react-grp:<first-row-id>\"   ;; stable React key
+       :op-family   :reactive
+       :rel-time    <first child's rel-time>
+       :summary     {:subs N :renders M}
+       :children    [<reactive row> ...]}
+
+  Non-reactive rows pass through unchanged (each carries an implicit
+  `:kind :op` when the view reads it). Causal structure is preserved —
+  the runs are folded in place, so a reactive tail between two event-
+  side rows stays between them. Pure data → nodes; JVM-testable."
+  [rows]
+  (->> rows
+       (partition-by reactive-row?)
+       (mapcat (fn [run]
+                 (if (reactive-row? (first run))
+                   [{:kind      :reactive-group
+                     :id        (str "react-grp:" (:id (first run)))
+                     :op-family :reactive
+                     :rel-time  (:rel-time (first run))
+                     :summary   (reactive-summary run)
+                     :children  (vec run)}]
+                   run)))
+       vec))
+
+;; ---- causal nesting (rf2-ad7zx.8) ---------------------------------------
+;;
+;; Per spec/021 §5.2 child dispatches INDENT under their parent (the
+;; cascade tree) so structure is visible even in the raw view. A row's
+;; `:parent-dispatch-id` (the `:rf.trace/parent-dispatch-id` tag) names
+;; the in-flight dispatch that spawned it. We compute a per-row indent
+;; DEPTH from the dispatch lineage so the view can offset each row —
+;; the spec's `└─ dispatched [:title/loaded]` indented child.
+
+(defn nesting-depths
+  "Map each row's `:dispatch-id` → its nesting depth, walking the
+  `:parent-dispatch-id` chain. A root dispatch (no parent, or a parent
+  not present in this epoch) is depth 0; each hop down the lineage adds
+  one. Rows with no `:dispatch-id` (the reactive tail) are not keyed —
+  callers default them to 0. Pure data → map; JVM-testable."
+  [rows]
+  (let [own-ids (into #{} (keep :dispatch-id rows))
+        ;; dispatch-id → parent-dispatch-id (first row that names each)
+        parent  (reduce (fn [m {:keys [dispatch-id parent-dispatch-id]}]
+                          (cond-> m
+                            (and dispatch-id
+                                 (not (contains? m dispatch-id)))
+                            (assoc dispatch-id parent-dispatch-id)))
+                        {}
+                        rows)
+        depth   (fn depth [did seen]
+                  (let [p (get parent did)]
+                    (if (and p (contains? own-ids p) (not (contains? seen p)))
+                      (inc (depth p (conj seen did)))
+                      0)))]
+    (into {} (map (fn [did] [did (depth did #{})]) own-ids))))
+
+(defn with-nesting-depth
+  "Stamp `:depth` onto every node — the causal-nesting indent level.
+  Reads the dispatch-lineage depth map; reactive groups inherit the
+  depth of their first child (so a nested cascade's reactive tail
+  indents with it). Pure data → nodes; JVM-testable."
+  [nodes]
+  (let [op-rows (mapcat (fn [n]
+                          (if (= :reactive-group (:kind n))
+                            (:children n)
+                            [n]))
+                        nodes)
+        depths  (nesting-depths op-rows)
+        depth-of (fn [row] (get depths (:dispatch-id row) 0))]
+    (mapv (fn [n]
+            (if (= :reactive-group (:kind n))
+              (assoc n :depth (depth-of (first (:children n))))
+              (assoc n :depth (depth-of n))))
+          nodes)))
+
+(defn build-display-nodes
+  "Top-level structural projection — turn the epoch's oldest-first
+  projected rows into the Figma display node list:
+
+    1. stamp relative `t+N.Nms` times,
+    2. fold contiguous reactive runs into collapse groups,
+    3. stamp causal-nesting depth onto every node.
+
+  Returns a vector of nodes, each either an `:op` row (the projected
+  trace row, with `:rel-time` + `:depth`) or a `:reactive-group` node
+  (with `:summary` + `:children` + `:rel-time` + `:depth`). The view
+  reads `:kind` to discriminate. Oldest-first so causal nesting reads
+  top-down (parent then indented child), matching the Figma. Pure data
+  → nodes; JVM-testable."
+  [rows]
+  (-> rows
+      with-rel-times
+      group-reactive-aftermath
+      with-nesting-depth))
 
 ;; ---- epoch-scoped feed projection (the panel reads this) ----------------
 
@@ -180,11 +555,21 @@
 
   Returns:
 
-      {:rows        [<row> ...]   ;; the epoch's domino trail, newest first
+      {:rows        [<row> ...]   ;; the epoch's domino trail, OLDEST first
+       :nodes       [<node> ...]  ;; structural display tree (rf2-ad7zx.8):
+                                  ;; reactive-aftermath collapse groups +
+                                  ;; relative times + causal-nesting depth
        :total       <int>         ;; the epoch's trace-event count
        :rendered    <int>         ;; same as :total (no filtering, rf2-gkczt)
        :epoch-id    <int-or-nil>  ;; the focused epoch's id
        :empty-kind  <:no-events / :no-focus / :epoch-evicted / nil>}
+
+  Per rf2-ad7zx.8 the rows render OLDEST-first (chronological) so the
+  Figma causal nesting reads top-down — a parent dispatch then its
+  indented `└─` child — and the reactive aftermath collapses under one
+  group between the core dominoes. `:nodes` is the structural tree the
+  view paints; `:rows` is the flat oldest-first projection (kept for
+  cross-panel consumers + tests).
 
   `:empty-kind` discriminates the empty-state branches:
 
@@ -201,16 +586,19 @@
   (let [record-present? (= :focused focus-status)
         trace-events    (when record-present?
                           (:trace-events epoch-record))
-        rows            (project-rows (or trace-events []))
-        ;; Newest first for display parity with the issues ribbon.
-        display-rows    (vec (reverse rows))
+        ;; Oldest-first (chronological) — the Figma causal nesting reads
+        ;; top-down (parent → indented child) and the reactive aftermath
+        ;; collapses between the core dominoes (rf2-ad7zx.8).
+        rows            (with-rel-times (project-rows (or trace-events [])))
+        nodes           (build-display-nodes (project-rows (or trace-events [])))
         n               (count rows)
         empty-kind      (cond
                           (= focus-status :no-focus)      :no-focus
                           (= focus-status :epoch-evicted) :epoch-evicted
                           (zero? n)                       :no-events
                           :else                           nil)]
-    {:rows       display-rows
+    {:rows       rows
+     :nodes      nodes
      :total      n
      :rendered   n
      :epoch-id   (:epoch-id epoch-record)

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -154,12 +154,14 @@
       (is (= 17 (:epoch-id feed)))
       (is (nil? (:empty-kind feed))))))
 
-(deftest project-feed-from-epoch-rows-newest-first
-  (testing "rows render newest-first for display parity with the issues
-            ribbon (the epoch's :trace-events are oldest-first)"
+(deftest project-feed-from-epoch-rows-oldest-first
+  (testing "rf2-ad7zx.8: rows now render OLDEST-first (chronological)
+            so the Figma causal nesting reads top-down — a parent
+            dispatch then its indented child — and the reactive
+            aftermath collapses between the core dominoes"
     (let [epoch (domino-trail-epoch)
           feed  (h/project-feed-from-epoch epoch :focused)]
-      (is (= [7 6 5 4 3 2 1] (mapv :id (:rows feed)))))))
+      (is (= [1 2 3 4 5 6 7] (mapv :id (:rows feed)))))))
 
 (deftest project-feed-from-epoch-no-events
   (testing "a focused epoch with empty :trace-events → :no-events"
@@ -231,6 +233,219 @@
   (let [rows [{:id 1} {:id 2} {:id 3}]]
     (is (= {:id 2} (h/find-row rows 2)))
     (is (nil? (h/find-row rows 99)))))
+
+;; ---- (4b) op-family classification — rf2-ad7zx.8 -----------------------
+;;
+;; Per spec/021 §5.2 + design-reference/components/TracePanel.tsx each
+;; row bands a 3px op-FAMILY-coloured left-border — FIVE families plus
+;; the two severity tiers — not the full op-type vocabulary.
+
+(deftest op-family-classifies-the-five-figma-families
+  (testing "dispatch family — the event side (run-start / run-end /
+            dispatched), minus db-changed"
+    (is (= :dispatch (h/op-family {:op-type :rf.event
+                                   :operation :rf.event/dispatched})))
+    (is (= :dispatch (h/op-family {:op-type :rf.event
+                                   :operation :rf.event/run-end}))))
+  (testing "db family — the db-changed operation specifically"
+    (is (= :db (h/op-family {:op-type :rf.event
+                             :operation :rf.event/db-changed}))))
+  (testing "fx family — the effect side"
+    (is (= :fx (h/op-family {:op-type :rf.fx :operation :rf.fx/handled}))))
+  (testing "reactive family — both subs and views"
+    (is (= :reactive (h/op-family {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= :reactive (h/op-family {:op-type :rf.view
+                                   :operation :rf.view/render}))))
+  (testing "machine family"
+    (is (= :machine (h/op-family {:op-type :rf.machine
+                                  :operation :rf.machine/transition}))))
+  (testing "severity tiers are preserved — a failure never hides under
+            a family band"
+    (is (= :error   (h/op-family {:op-type :error :operation :rf.error/x})))
+    (is (= :warning (h/op-family {:op-type :warning :operation :rf.warn/x}))))
+  (testing "unknown op-types fall back to :dispatch-adjacent neutral"
+    (is (= :dispatch (h/op-family {:op-type :totally-made-up})))))
+
+(deftest project-row-carries-op-family
+  (let [row (h/project-row (ev {:id 1 :op-type :rf.event
+                                :operation :rf.event/db-changed}))]
+    (is (= :db (:op-family row))
+        "project-row stamps :op-family for the left-border band")))
+
+(deftest op-family-colour-maps-each-family-to-a-distinct-token
+  ;; Post rf2-on4cm the colours are CSS-variable strings (`tokens/tokens`).
+  ;; Compare against the var-map so the test pins the indirection.
+  (is (= (:accent tokens/tokens)
+         (h/op-family-colour {:op-type :rf.event :operation :rf.event/dispatched})))
+  (is (= (:accent-static tokens/tokens)
+         (h/op-family-colour {:op-type :rf.event :operation :rf.event/db-changed})))
+  (is (= (:warning tokens/tokens)
+         (h/op-family-colour {:op-type :rf.fx :operation :rf.fx/handled})))
+  (is (= (:dim tokens/tokens)
+         (h/op-family-colour {:op-type :rf.sub :operation :rf.sub/run})))
+  (is (= (:green tokens/tokens)
+         (h/op-family-colour {:op-type :rf.machine :operation :rf.machine/transition})))
+  (is (= (:red tokens/tokens)
+         (h/op-family-colour {:op-type :error :operation :rf.error/x})))
+  (testing "the five op-family bands resolve to distinct colours"
+    (let [bands (mapv (fn [[ot op]] (h/op-family-colour {:op-type ot :operation op}))
+                      [[:rf.event :rf.event/dispatched]
+                       [:rf.event :rf.event/db-changed]
+                       [:rf.fx :rf.fx/handled]
+                       [:rf.sub :rf.sub/run]
+                       [:rf.machine :rf.machine/transition]])]
+      (is (= 5 (count (distinct bands)))
+          "dispatch / db / fx / reactive / machine bands are all distinct"))))
+
+;; ---- (4c) readable plain-language description — rf2-ad7zx.8 ------------
+
+(deftest readable-description-figma-plain-language
+  (testing "dispatch → 'dispatched <event-vec>'"
+    (is (= "dispatched [:counter/inc]"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                  :tags {:rf.event/v [:counter/inc]}})))))
+  (testing "machine → 'machine <id> <from> → <to>' (states without colons)"
+    (is (= "machine :title/flow idle → loading"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.machine :operation :rf.machine/transition
+                  :tags {:machine-id :title/flow :from :idle :to :loading}})))))
+  (testing "sub → 'sub ran <id>'"
+    (is (= "sub ran :app/counter"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.sub :operation :rf.sub/run
+                  :tags {:rf.sub/id :app/counter}})))))
+  (testing "fx → 'fx <id>'"
+    (is (= "fx :dispatch"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.fx :operation :rf.fx/handled
+                  :tags {:rf.fx/id :dispatch}})))))
+  (testing "unknown op falls back to short-description (never blank)"
+    (is (= ":rf.event/run-end"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.event :operation :rf.event/run-end
+                  :tags {}}))))))
+
+;; ---- (4d) duration — rf2-ad7zx.8 --------------------------------------
+
+(deftest duration-ms-reads-elapsed
+  (testing "duration-ms pulls :elapsed-ms from tags"
+    (is (= 0.4 (h/duration-ms (ev {:id 1 :op-type :rf.view
+                                   :operation :rf.view/render
+                                   :tags {:elapsed-ms 0.4}})))))
+  (testing "reactive point-in-time emits carry no elapsed → nil"
+    (is (nil? (h/duration-ms (ev {:id 1 :op-type :rf.sub
+                                  :operation :rf.sub/run
+                                  :tags {:rf.sub/id :x}}))))))
+
+(deftest format-duration-figma-form
+  (is (= "0.4 ms" (h/format-duration 0.4)))
+  (is (= "12.0 ms" (h/format-duration 12)))
+  (is (nil? (h/format-duration nil)))
+  (is (nil? (h/format-duration "nope"))))
+
+;; ---- (4e) relative timing — rf2-ad7zx.8 -------------------------------
+
+(deftest relative-time-figma-form
+  (testing "epoch-t0 is the earliest row time"
+    (is (= 100 (h/epoch-t0 [{:time 300} {:time 100} {:time 200}])))
+    (is (nil? (h/epoch-t0 [{:time nil} {:time nil}]))))
+  (testing "format-rel-time renders 't+N.Nms' relative to t0"
+    (is (= "t+0.0ms" (h/format-rel-time 100 100)))
+    (is (= "t+2.0ms" (h/format-rel-time 102 100)))
+    (is (nil? (h/format-rel-time nil 100))))
+  (testing "with-rel-times stamps :rel-time on every row"
+    (let [rows (h/with-rel-times [{:time 100} {:time 103}])]
+      (is (= ["t+0.0ms" "t+3.0ms"] (mapv :rel-time rows))))))
+
+;; ---- (4f) reactive-aftermath collapse group — rf2-ad7zx.8 -------------
+
+(deftest reactive-aftermath-collapses-to-one-group
+  (testing "a contiguous run of reactive rows folds into one group node
+            carrying the (N subs, M renders) summary + the children"
+    (let [rows  (h/project-rows (:trace-events (domino-trail-epoch)))
+          nodes (h/group-reactive-aftermath rows)
+          groups (filter #(= :reactive-group (:kind %)) nodes)]
+      (is (= 1 (count groups))
+          "the trailing 2 subs + 1 render fold into ONE group")
+      (let [g (first groups)]
+        (is (= {:subs 2 :renders 1} (:summary g))
+            "summary counts subs ran vs views rendered")
+        (is (= 3 (count (:children g)))
+            "the group carries its 3 child reactive rows")
+        (is (= :reactive (:op-family g)))
+        (is (string? (:id g))))
+      (testing "the core dominoes (dispatch/db/fx) stay as flat op rows"
+        (is (= 4 (count (remove #(= :reactive-group (:kind %)) nodes)))
+            "4 event-side rows remain ungrouped")))))
+
+(deftest reactive-runs-fold-in-place-preserving-causal-structure
+  (testing "a reactive run BETWEEN two event-side rows stays between
+            them — the fold is per-contiguous-run, not a global sweep"
+    (let [rows  [{:id 1 :op-type :rf.event :op-family :dispatch}
+                 {:id 2 :op-type :rf.sub   :op-family :reactive}
+                 {:id 3 :op-type :rf.event :op-family :dispatch}
+                 {:id 4 :op-type :rf.sub   :op-family :reactive}
+                 {:id 5 :op-type :rf.view  :op-family :reactive}]
+          nodes (h/group-reactive-aftermath rows)]
+      (is (= [:op :reactive-group :op :reactive-group]
+             (mapv #(or (:kind %) :op) nodes))
+          "two separate reactive runs → two separate groups, in place"))))
+
+;; ---- (4g) causal nesting — rf2-ad7zx.8 --------------------------------
+
+(deftest causal-nesting-indents-child-dispatches
+  (testing "a child dispatch (parent-dispatch-id → an in-epoch dispatch)
+            gets depth 1; the root dispatch is depth 0"
+    (let [rows  [{:dispatch-id 1 :parent-dispatch-id nil}
+                 {:dispatch-id 2 :parent-dispatch-id 1}
+                 {:dispatch-id 3 :parent-dispatch-id 2}]
+          depths (h/nesting-depths rows)]
+      (is (= 0 (get depths 1)))
+      (is (= 1 (get depths 2)))
+      (is (= 2 (get depths 3)))))
+  (testing "a parent not present in this epoch ⇒ the child is a root
+            (depth 0) — the lineage walk only counts in-epoch hops"
+    (let [depths (h/nesting-depths [{:dispatch-id 5 :parent-dispatch-id 99}])]
+      (is (= 0 (get depths 5)))))
+  (testing "with-nesting-depth stamps :depth onto op nodes"
+    (let [nodes (h/with-nesting-depth
+                  [{:kind :op :dispatch-id 1 :parent-dispatch-id nil}
+                   {:kind :op :dispatch-id 2 :parent-dispatch-id 1}])]
+      (is (= [0 1] (mapv :depth nodes))))))
+
+(deftest build-display-nodes-end-to-end
+  (testing "build-display-nodes folds rel-times + reactive group +
+            nesting depth in one pass; oldest-first ordering"
+    (let [rows  (h/project-rows (:trace-events (domino-trail-epoch)))
+          nodes (h/build-display-nodes rows)]
+      ;; 4 event-side op rows + 1 reactive group = 5 nodes.
+      (is (= 5 (count nodes)))
+      (is (= 1 (count (filter #(= :reactive-group (:kind %)) nodes))))
+      (is (every? #(contains? % :depth) nodes)
+          "every node carries a causal-nesting :depth")
+      (is (every? (fn [n]
+                    (if (= :reactive-group (:kind n))
+                      (some? (:rel-time n))
+                      (contains? n :rel-time)))
+                  nodes)
+          "every node carries a relative time"))))
+
+;; ---- (4h) feed exposes :nodes — rf2-ad7zx.8 ---------------------------
+
+(deftest project-feed-from-epoch-exposes-structural-nodes
+  (testing "the feed carries the structural :nodes tree the Figma view
+            paints (reactive group + nesting + bands) AND the flat
+            oldest-first :rows"
+    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
+      (is (contains? feed :nodes))
+      (is (= 5 (count (:nodes feed)))
+          "4 event-side op rows + 1 reactive-aftermath group")
+      (is (= 1 (count (filter #(= :reactive-group (:kind %)) (:nodes feed)))))
+      (testing "rows are OLDEST-first now (Figma reads top-down for
+                causal nesting), with rel-times stamped"
+        (is (= [1 2 3 4 5 6 7] (mapv :id (:rows feed))))
+        (is (every? #(contains? % :rel-time) (:rows feed)))))))
 
 ;; ---- (5) op-type-colour ------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -242,8 +242,11 @@
             "per-row chip cell is gone")))))
 
 (deftest feed-list-renders-when-focused-epoch-has-events
-  (testing "rf2-td380: with a focused epoch the panel renders the <ul>
-            feed with one <li> per row"
+  (testing "rf2-td380 + rf2-ad7zx.8: with a focused epoch the panel
+            renders the <ul> feed; the core dominoes (dispatch/fx) are
+            top-level op rows and the reactive aftermath (the
+            nil-dispatch-id :rf.sub/run) collapses under one group
+            (spec/021 §5.2)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (seed-history!
@@ -258,10 +261,18 @@
             rows (find-all-by-testid-prefix tree "rf-causa-trace-row-")]
         (is (some? (find-by-testid tree "rf-causa-trace-feed"))
             "feed <ul> present")
-        (is (some? (find-by-testid tree "rf-causa-trace-row-3"))
-            "the async nil-dispatch-id reactive row is present (rf2-td380)")
-        (is (>= (count rows) 3)
-            "at least one rendered node per row")))))
+        (is (some? (find-by-testid tree "rf-causa-trace-row-1"))
+            "the dispatch op row is a top-level row")
+        (is (some? (find-by-testid tree "rf-causa-trace-row-2"))
+            "the fx op row is a top-level row")
+        ;; The async nil-dispatch-id :rf.sub/run folds into the reactive
+        ;; aftermath collapse group — NOT a top-level row (rf2-ad7zx.8).
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-3"))
+            "the reactive sub row is collapsed (not a top-level row)")
+        (is (some? (find-by-testid tree "rf-causa-trace-group-react-grp:3"))
+            "a reactive-aftermath collapse group renders for the sub run")
+        (is (>= (count rows) 2)
+            "the two core-domino op rows render")))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 
@@ -445,6 +456,161 @@
         (is @stop-evt "stopPropagation was called so the row's pivot
                        handler doesn't also fire")))))
 
+;; ---- (5b) Figma structural surfaces — rf2-ad7zx.8 ----------------------
+
+(defn- node-attrs
+  "The attribute map of the rendered <li> with the given data-testid."
+  [tree testid]
+  (some-> (find-by-testid tree testid) second))
+
+(deftest op-rows-band-by-op-family-left-border
+  (testing "rf2-ad7zx.8: each op row carries a 3px op-family LEFT-BORDER
+            (not an op-type dot) and a data-rf-causa-op-family attr"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                               :dispatch-id 1})
+                    (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+                               :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        ;; The legacy op-type dot is gone.
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-1-op-type-dot"))
+            "op-type dot is removed (rf2-ad7zx.8)")
+        (is (= "dispatch" (:data-rf-causa-op-family
+                            (node-attrs tree "rf-causa-trace-row-1")))
+            "dispatch row carries the dispatch op-family")
+        (is (= "db" (:data-rf-causa-op-family
+                      (node-attrs tree "rf-causa-trace-row-2")))
+            "db-changed row carries the db op-family")
+        (is (= "fx" (:data-rf-causa-op-family
+                      (node-attrs tree "rf-causa-trace-row-3")))
+            "fx row carries the fx op-family")
+        (let [border (get-in (node-attrs tree "rf-causa-trace-row-1")
+                             [:style :border-left])]
+          (is (and (string? border) (re-find #"^3px solid " border))
+              "the op-family band is a 3px left-border on the row"))))))
+
+(deftest op-rows-render-relative-time-and-duration-columns
+  (testing "rf2-ad7zx.8: rows lead with a relative t+N.Nms time and
+            carry a duration column (elapsed for event/view rows)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 1000 :dispatch-id 1})
+                    (-> (mk-trace {:id 2 :op-type :rf.view :operation :rf.view/render
+                                   :time 1002})
+                        (assoc-in [:tags :elapsed-ms] 0.4))])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (= "t+0.0ms" (->> (find-by-testid tree "rf-causa-trace-row-1-time")
+                              last))
+            "first row reads t+0.0ms relative to the epoch origin")
+        ;; The view-render row carries its elapsed duration; it folds into
+        ;; the reactive group, so expand the group to read its child cell.
+        (rf/dispatch-sync [:rf.causa/toggle-trace-group-expand "react-grp:2"])
+        (let [tree (trace/Panel)
+              dur  (->> (find-by-testid tree "rf-causa-trace-row-2-duration")
+                       last)]
+          (is (= "0.4 ms" dur)
+              "the view-render row shows its 0.4 ms elapsed duration"))))))
+
+(deftest reactive-aftermath-group-renders-and-toggles
+  (testing "rf2-ad7zx.8: the reactive aftermath collapses under one
+            expandable group; toggling it renders the child reactive
+            rows inline"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :rf.sub :operation :rf.sub/run :time 110})
+                    (mk-trace {:id 3 :op-type :rf.sub :operation :rf.sub/run :time 111})
+                    (mk-trace {:id 4 :op-type :rf.view :operation :rf.view/render :time 120})])])
+      (focus! 1)
+      ;; Collapsed by default — the group renders, children do not.
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-trace-group-react-grp:2"))
+            "reactive-aftermath group renders")
+        (is (nil? (find-by-testid tree "rf-causa-trace-row-2"))
+            "child reactive rows are collapsed by default"))
+      ;; Expand the group → children render.
+      (rf/dispatch-sync [:rf.causa/toggle-trace-group-expand "react-grp:2"])
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-trace-group-react-grp:2-children"))
+            "expanded group renders its children container")
+        (is (some? (find-by-testid tree "rf-causa-trace-row-2"))
+            "a child reactive row renders when the group is expanded")))))
+
+(deftest reactive-group-click-fires-toggle-event
+  (testing "rf2-ad7zx.8: clicking the reactive group dispatches
+            :rf.causa/toggle-trace-group-expand with the group's id"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :rf.sub :operation :rf.sub/run :time 110})])])
+      (focus! 1)
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]    (swap! dispatches conj ev) nil)
+                                     ([ev _o] (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/Panel)
+                grp     (find-by-testid tree "rf-causa-trace-group-react-grp:2")
+                handler (:on-click (second grp))]
+            (is (some? grp) "reactive group node present")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/toggle-trace-group-expand "react-grp:2"] %)
+                  @dispatches)
+            "group click fires the toggle event with the group id")))))
+
+(deftest toggle-trace-group-expand-event-mutates-set
+  (testing "rf2-ad7zx.8: :rf.causa/toggle-trace-group-expand toggles
+            membership in :trace-expanded-group-ids"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-trace-group-expand "react-grp:5"])
+      (is (= #{"react-grp:5"}
+             @(rf/subscribe [:rf.causa/trace-expanded-group-ids]))
+          "first toggle adds the group id")
+      (rf/dispatch-sync [:rf.causa/toggle-trace-group-expand "react-grp:5"])
+      (is (= #{} @(rf/subscribe [:rf.causa/trace-expanded-group-ids]))
+          "toggling again removes it"))))
+
+(deftest child-dispatch-rows-indent-via-depth
+  (testing "rf2-ad7zx.8: a child dispatch (parent-dispatch-id → a parent
+            in the same epoch) renders with a causal-nesting depth attr
+            and a margin-left indent"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(-> (mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                                   :time 100 :dispatch-id 1}))
+                    ;; child dispatch — parent-dispatch-id points at 1
+                    (-> (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/dispatched
+                                   :time 110 :dispatch-id 2})
+                        (assoc-in [:tags :rf.trace/parent-dispatch-id] 1))])])
+      (focus! 1)
+      (let [tree    (trace/Panel)
+            parent  (node-attrs tree "rf-causa-trace-row-1")
+            child   (node-attrs tree "rf-causa-trace-row-2")]
+        (is (= 0 (:data-rf-causa-depth parent)) "root dispatch is depth 0")
+        (is (= 1 (:data-rf-causa-depth child))  "child dispatch is depth 1")
+        (is (= "0px" (get-in parent [:style :margin-left]))
+            "root row has no indent")
+        (is (not= "0px" (get-in child [:style :margin-left]))
+            "child row is indented under its parent (cascade tree)")))))
+
 ;; ---- (6) frame isolation ------------------------------------------------
 
 (deftest trace-expand-state-does-not-leak-into-default-frame
@@ -485,14 +651,18 @@
             component"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
+      ;; All three are core-domino op rows (event/fx/db-changed) so they
+      ;; render as top-level rows — the reactive aftermath collapses into
+      ;; a group (rf2-ad7zx.8), so this test uses non-reactive rows to
+      ;; exercise the per-row key discipline directly.
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
                                :time 100 :dispatch-id 1})
                     (mk-trace {:id 22 :op-type :rf.fx :operation :rf.fx/handled
                                :time 200 :dispatch-id 1})
-                    (mk-trace {:id 33 :op-type :rf.sub :operation :rf.sub/run
-                               :time 300})])])
+                    (mk-trace {:id 33 :op-type :rf.event :operation :rf.event/db-changed
+                               :time 300 :dispatch-id 1})])])
       (focus! 1)
       (let [tree (trace/Panel)
             k11  (:key (second (row-li-by-id tree 11)))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -327,6 +327,9 @@
    :rf.causa/trace-buffer
    ;; rf2-7dyi8 — per-row inline payload expansion state (spec/021 §5.4).
    :rf.causa/trace-expanded-row-ids
+   ;; rf2-ad7zx.8 — per-group reactive-aftermath collapse state
+   ;; (spec/021 §5.2 — collapsible reactive aftermath group).
+   :rf.causa/trace-expanded-group-ids
    ;; rf2-td380 — epoch-scoped feed (reads the focused epoch record's
    ;; `:trace-events` directly). The `:rf.causa/trace-feed-state`
    ;; buffer snapshot + `:rf.causa/trace-filters` chip-filter slot were
@@ -584,6 +587,9 @@
    ;; rf2-7dyi8 — toggle the inline payload expansion for one trace row
    ;; (per spec/021 §5.4 — Row → expand payload · Inline in panel).
    :rf.causa/toggle-trace-row-expand
+   ;; rf2-ad7zx.8 — toggle one reactive-aftermath collapse group open
+   ;; (per spec/021 §5.2 — ▸ reactive aftermath (N subs, M renders)).
+   :rf.causa/toggle-trace-group-expand
    ;; Reactive panel events (rf2-wyvf2 · spec/021 §3 · renamed from
    ;; Views per §11.5; tab key stays `:views`).
    :rf.causa/reactive-set-unchanged


### PR DESCRIPTION
Reconciles the Causa **Trace panel** STRUCTURE to `tools/causa/spec/021-Dynamic-Panel-Designs.md` §5 + `tools/causa/design-reference/components/TracePanel.tsx`. Orange tokens already on main — this is structure, not colour (bead rf2-ad7zx.8, parent epic rf2-ad7zx).

## What changed

- **Op-family colour bands as a 3px LEFT-BORDER** per row (dispatch = mode accent · db = changed · fx = warning · reactive = dim · machine = chart/machine tone), replacing the op-type dot. New `op-family` / `op-family-colour` helpers; five families resolve to distinct tokens.
- **Readable plain-language rows** — `dispatched [:counter/inc]` · `db changed …` · `machine :title/flow idle → loading` · `sub ran :app/counter` · `fx :dispatch`, with the prior terse `operation — detail` line as fallback (never blank).
- **Relative `t+N.Nms` timestamps** + a **per-op duration column** (elapsed for event/view rows; blank for point-in-time reactive emits). Always-one-decimal formatting (CLJS-portable).
- **Collapsible reactive-aftermath group** — `▸ reactive aftermath (N subs, M renders)` folds each contiguous `:rf.sub/run` / `:rf.view/render` run; click to reveal children inline.
- **Causal nesting** — child dispatches indent under their parent cascade via a dispatch-lineage depth.

The feed now exposes `:nodes` (the structural display tree the view paints) alongside oldest-first `:rows` (chronological so causal nesting reads top-down). New `:rf.causa/trace-expanded-group-ids` sub + `:rf.causa/toggle-trace-group-expand` event.

Kept: cascade-status timeline bar, inline payload expand, source-coord chip, cancellation-cascade affordance.

## Files

- `tools/causa/src/day8/re_frame2_causa/panels/trace.cljs` — view: left-border bands, duration/rel-time columns, reactive group + node renderer, group-toggle wiring.
- `tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc` — op-family, readable-description, duration, relative-time, reactive-group fold, nesting-depths, build-display-nodes.
- `tools/causa/spec/021-Dynamic-Panel-Designs.md` — §5.3/§5.4 sub-shape + nav updates.
- `…/test/…/panels/trace_helpers_cljs_test.cljc`, `…/panels/trace_view_cljs_test.cljs`, `…/registry_cljs_test.cljs` — extended + reconciled coverage.

## Gates

- `npm run test:cljs` — 4216 tests, 0 failures
- tools/causa `clojure -M:test` — 858 tests, 0 failures
- `npm run test:causa-feature-gate` (smoke) — 3 scenarios, 0 failures, 10 matrix rows
- clj-kondo — clean on changed source (the one registry-test warning is a pre-existing unused private var)