### PR TITLE
feat(causa): reconcile chrome ribbon + events ribbon + events list to Figma (rf2-ad7zx.12)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -296,17 +296,36 @@
 ;; ---- view ----------------------------------------------------------------
 
 (rf/reg-view frame-switcher-view
-  "L1 ribbon frame-switcher — STRICTLY single-select per spec/018 §1
-  Non-goals + §3 Frame dropdown + Round-3 rf2-i74n7. No 'All frames
-  (merged)' option; no `:multiple` attribute on the `<select>`.
-  Excludes `:rf/causa` by default per spec/018 §8 I1. When the only
-  available frame is the current selection, the dropdown collapses to
-  a flat label (no chevron — no click target).
+  "L1 chrome-ribbon frame-switcher — the `Frame ▾` dropdown BUTTON per
+  the Figma design-reference (`design-reference/components/ChromeRibbon
+  .tsx`) + spec/018 §3 Frame dropdown. STRICTLY single-select (spec/018
+  §1 Non-goals + Round-3 rf2-i74n7): no 'All frames (merged)' option, no
+  `:multiple` attribute. Excludes `:rf/causa` by default per spec/018 §8
+  I1.
 
-  Reads `:rf.causa/current-frame` + `:rf.causa/available-frames`;
-  writes via `:rf.causa/select-frame <frame-id>` — the canonical
-  contract documented at ns-top. Other frame-aware features (Cmd-K
-  palette, future panels) reach through the same surface.
+  ## Figma shape (rf2-ad7zx.12)
+
+  The control reads `Frame ▾` — the literal word `Frame` followed by a
+  chevron, NOT the selected value inline (`Frame: :step-deck`). The
+  current selection is surfaced INSIDE the option list (the active
+  option is `:value`-bound + carries a `✓`), not as the button label,
+  matching Chrome DevTools' device-toolbar + the Figma chrome ribbon.
+
+  Implementation is the overlay pattern: a styled `Frame ▾` button face
+  is the visible affordance; a native `<select>` is layered transparently
+  on top so keyboard + screen-reader navigation + the native option
+  popup all work out of the box (rf2-lbutp). The `<select>` carries the
+  `aria-label` so assistive tech announces 'Select frame, combobox'.
+
+  When fewer than two frames are pickable the button still renders (the
+  chrome ALWAYS shows a Frame control per Figma — the prior 'collapse to
+  a flat label' branch is gone, rf2-ad7zx.12), but the overlaid select is
+  disabled so there is no inert popup.
+
+  Reads `:rf.causa/current-frame` + `:rf.causa/available-frames`; writes
+  via `:rf.causa/select-frame <frame-id>` — the canonical contract
+  documented at ns-top. Other frame-aware features (Cmd-K palette, future
+  panels) reach through the same surface.
 
   `reg-view`-registered (rf2-in6l2) so its rendered React component
   carries `:contextType frame-context` and the closest enclosing
@@ -315,40 +334,64 @@
   [_props]
   (let [selected-frame  @(rf/subscribe [:rf.causa/current-frame])
         frames          @(rf/subscribe [:rf.causa/available-frames])
-        label-style     {:color       (:text-primary tokens)
-                         :font-family sans-stack
-                         :font-size   (:body type-scale)}]
-    (if (<= (count frames) 1)
-      [:span {:data-testid "rf-causa-ribbon-frame"
-              :style (merge label-style {:color (:text-secondary tokens)})}
-       (str "Frame: " (or selected-frame (first frames) ":rf/default"))]
-      ;; rf2-lbutp — native `<select>` is keyboard- and screen-
-      ;; reader-accessible by default, but assistive tech needs an
-      ;; accessible NAME to read on focus. The visible "Frame:"
-      ;; prefix lives inside each `<option>`, not as a sibling
-      ;; `<label>`, so the picker arrives "blank, combobox" without
-      ;; this `aria-label`. Matches the convention the audit
-      ;; flagged (#16) — frame-switcher gets an explicit accessible
-      ;; name.
-      [:select {:data-testid "rf-causa-ribbon-frame-picker"
-                :aria-label  "Select frame"
-                :value       (str (or selected-frame (first frames)))
-                :on-change   (fn [^js e]
-                               (let [v   (.. e -target -value)
-                                     kw  (when (and v (.startsWith v ":"))
-                                           (keyword (subs v 1)))]
-                                 (when kw
-                                   (rf/dispatch [:rf.causa/select-frame kw]
-                                                {:frame :rf/causa}))))
-                :style       (merge label-style
-                               {:background    (:bg-2 tokens)
-                                :border        (str "1px solid "
-                                                    (:border-default tokens))
-                                :border-radius "4px"
-                                :padding       "2px 6px"})}
-       (for [f frames]
-         ^{:key (str f)}
-         [:option {:value (str f)} (str "Frame: " f)])])))
+        active          (or selected-frame (first frames))
+        pickable?       (> (count frames) 1)]
+    [:div {:data-testid "rf-causa-ribbon-frame"
+           :title       (if active
+                          (str "Frame scope: " active " — pick a frame to scope the inspector")
+                          "Frame scope")
+           :style {:position      "relative"
+                   :display       "inline-flex"
+                   :align-items   "center"
+                   :gap           "4px"
+                   :background    (:bg-2 tokens)
+                   :border        (str "1px solid " (:border-default tokens))
+                   :border-radius "4px"
+                   :padding       "2px 8px"
+                   :color         (:text-primary tokens)
+                   :font-family   sans-stack
+                   :font-size     (:body-tight type-scale)
+                   :line-height   "1.3"
+                   :cursor        (if pickable? "pointer" "default")
+                   :flex-shrink   0}}
+     ;; Figma `Frame ▾` button face — the literal word + a chevron. The
+     ;; selected value is surfaced inside the option list, never on the
+     ;; button (rf2-ad7zx.12).
+     [:span {:data-testid "rf-causa-ribbon-frame-label"} "Frame"]
+     [:span {:data-testid "rf-causa-ribbon-frame-chevron"
+             :aria-hidden "true"
+             :style {:font-size (:caption type-scale)
+                     :color     (:text-secondary tokens)
+                     :line-height "1"}}
+      "▾"]
+     ;; rf2-lbutp — native `<select>` layered transparently over the
+     ;; button face so keyboard + screen-reader + the native option
+     ;; popup all work; the visible `Frame ▾` is the design affordance.
+     [:select {:data-testid "rf-causa-ribbon-frame-picker"
+               :aria-label  "Select frame"
+               :disabled    (not pickable?)
+               :value       (str active)
+               :on-change   (fn [^js e]
+                              (let [v   (.. e -target -value)
+                                    kw  (when (and v (.startsWith v ":"))
+                                          (keyword (subs v 1)))]
+                                (when kw
+                                  (rf/dispatch [:rf.causa/select-frame kw]
+                                               {:frame :rf/causa}))))
+               :style       {:position   "absolute"
+                             :top        0
+                             :left       0
+                             :width      "100%"
+                             :height     "100%"
+                             :opacity    0
+                             :cursor     (if pickable? "pointer" "default")
+                             :border     "none"
+                             :margin     0
+                             :padding    0}}
+      (for [f frames]
+        ^{:key (str f)}
+        [:option {:value (str f)}
+         (str (if (= f active) "✓ " "  ") f)])]]))
 
 ;; ---- install -------------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
@@ -114,6 +114,24 @@
   [origin]
   (get origin-glyphs origin))
 
+(defn origin-source-tag
+  "Pure-data SOURCE column label (rf2-ad7zx.12). The Figma EventList
+  (`design-reference/components/EventList.tsx`) renders a left-most
+  `source` column as a short text tag — `fx` / `view` / `timer` /
+  `machine` in the mock. Causa's real source axis is the closed-enum
+  dispatch-origin (`:rf/dispatch-origin`), so the tag is the bare
+  origin name (`router` / `http` / `timer` / `fx-emit` / …).
+
+  `:user` is the default app-code origin; the Figma mock never tagged
+  the common case loudly, and Causa's silent-by-default posture keeps
+  the `:user` source column blank rather than cluttering every row with
+  the dominant value. Returns nil for `:user`, unknown, and nil origins
+  so the renderer omits the tag — the column reads as a sparse signal,
+  exactly the rows whose source is NOT plain app code."
+  [origin]
+  (when (and origin (not= :user origin))
+    (name origin)))
+
 (defn origin-prefix-title
   "Hover-title text for a given origin, or nil when the origin has
   no prefix to title."

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -786,10 +786,30 @@
                                           (static-shell/stripe-hex-for-mode :dynamic))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
-     ;; LEFT cluster — scope selectors (Frame + Dynamic/Static), one
-     ;; shared compact control style so they read as one stratum.
+     ;; LEFT cluster — the `❖ Causa` wordmark, then the scope selectors
+     ;; (Frame + Dynamic/Static), one shared compact control style so the
+     ;; selectors read as one stratum.
      [:div {:data-testid "rf-causa-ribbon-selectors"
             :style {:display "flex" :align-items "center" :gap "8px"}}
+      ;; rf2-ad7zx.12 — the `❖ Causa` wordmark, top-left of the chrome
+      ;; ribbon per the Figma design-reference (`design-reference/
+      ;; components/ChromeRibbon.tsx`). Semibold, `:body-tight`, the
+      ;; ALWAYS-orange `:brand` token (the diamond glyph + the word stay
+      ;; orange in both Dynamic and Static modes — it is the product
+      ;; identity, not the mode accent). `aria-hidden` on the decorative
+      ;; `❖` glyph keeps the wordmark from announcing its unicode name.
+      [:div {:data-testid "rf-causa-ribbon-logo"
+             :style {:display      "flex"
+                     :align-items  "center"
+                     :gap          "5px"
+                     :color        (:brand tokens)
+                     :font-family  sans-stack
+                     :font-size    (:body-tight type-scale)
+                     :font-weight  600
+                     :white-space  "nowrap"
+                     :user-select  "none"}}
+       [:span {:aria-hidden "true"} "❖"]
+       [:span "Causa"]]
       ;; L1 frame-switcher slot (rf2-iwwou) — single contractually-
       ;; anchored surface. The view itself reads `:rf.causa/current-
       ;; frame` + `:rf.causa/available-frames` and writes via
@@ -964,6 +984,12 @@
       (rf/dispatch [:rf.causa/set-focus dimension value (:dispatch-id cascade)]
                    {:frame :rf/causa}))))
 
+;; rf2-ad7zx.12 — shared fixed width for the L2 `source` column so the
+;; column-header label (`l2-column-header`) and every row's origin tag
+;; (`event-row`) align on the same left edge. Declared above both use
+;; sites (event-row sits earlier in the file than the header / list).
+(def ^:private l2-source-col-width "52px")
+
 (defn- event-row
   "One row in the L2 event list. Single line per spec/018 §4 Row
   anatomy + Round-3 rf2-cmtkw — minimal default render.
@@ -1040,6 +1066,9 @@
         origin         (l2-timeline/dispatch-origin-of cascade)
         origin-prefix  (l2-timeline/origin-prefix-glyph origin)
         origin-title   (l2-timeline/origin-prefix-title origin)
+        ;; rf2-ad7zx.12 — the Figma `source` column tag (origin name as
+        ;; text; nil for :user / unknown so the cell stays blank).
+        source-tag     (l2-timeline/origin-source-tag origin)
         badges         (l2-timeline/activity-badges cascade)
         badges-tooltip (l2-timeline/activity-badges-tooltip cascade)
         ev-id       (event-id-of-cascade cascade)
@@ -1306,23 +1335,36 @@
               gutter-click (assoc :on-click gutter-click))
       (or focus-marker
           [:span {:style {:color glyph-col}} glyph])]
-     ;; rf2-gf58j — dispatch-origin prefix. Renders a per-origin
-     ;; glyph (`R` / `🌐` / `💧` / `⚡` / `⏲` / `T` / `🔧` / `i` /
-     ;; `🌊`) before the event-id when the origin is non-`:user`;
-     ;; `:user` stays silent so the common case doesn't clutter the
-     ;; row. The `:title` carries the closed-enum value as a hover
-     ;; affordance. Suppressed for the `:ungrouped` pseudo-cascade
-     ;; (no real dispatch envelope, no origin tag to surface).
-     (when (and origin-prefix (not ungrouped?))
-       [:span {:data-testid (str "rf-causa-row-origin-" (name origin))
-               :data-rf-causa-origin (name origin)
-               :title origin-title
-               :style {:flex-shrink 0
-                       :color (:accent tokens)
-                       :font-size (:caption type-scale)
-                       :min-width "12px"
-                       :text-align "center"}}
-        origin-prefix])
+     ;; rf2-ad7zx.12 — the `source` COLUMN, reconciled to the Figma
+     ;; EventList. A fixed-width cell aligned under the header's `source`
+     ;; label, carrying the dispatch-origin as a short text tag plus its
+     ;; glyph (`R fx-emit` etc). `:user` stays blank (silent-by-default —
+     ;; the dominant app-code origin doesn't clutter every row); the
+     ;; cell still occupies its column width so the `event id` column
+     ;; stays left-aligned across rows. `:ungrouped` rows render an empty
+     ;; spacer cell (no dispatch envelope, no origin to surface). The
+     ;; `:title` carries the closed-enum value as a hover affordance
+     ;; (rf2-gf58j origin glyphs preserved as the leading mark).
+     [:span {:data-testid (when (and source-tag (not ungrouped?))
+                            (str "rf-causa-row-origin-" (name origin)))
+             :data-rf-causa-origin (when (and source-tag (not ungrouped?))
+                                     (name origin))
+             :title (when (and source-tag (not ungrouped?)) origin-title)
+             :style {:flex-shrink 0
+                     :width l2-source-col-width
+                     :display "inline-flex"
+                     :align-items "center"
+                     :gap "3px"
+                     :overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space "nowrap"
+                     :color (:accent tokens)
+                     :font-family sans-stack
+                     :font-size (:caption type-scale)}}
+      (when (and source-tag (not ungrouped?))
+        (list
+         (when origin-prefix ^{:key "g"} [:span {:aria-hidden "true"} origin-prefix])
+         ^{:key "t"} [:span source-tag]))]
      ;; Round-3 rf2-cmtkw — minimal default row renders ONLY the
      ;; bare event-id keyword (e.g. `:cart/add-item`). The full event
      ;; vector with args moves to the row's hover tooltip + the L4
@@ -1557,6 +1599,54 @@
         (filters-hidden-message hidden-summary)
         [clear-filters-button]])]))
 
+;; rf2-ad7zx.12 — the L2 list's column-header row, reconciled to the
+;; Figma EventList (`design-reference/components/EventList.tsx`). The
+;; Figma mock renders a sticky header naming the four columns the rows
+;; align to: `source` · `event id` · `timestamp` · `duration`. The
+;; header was MISSING pre-Figma (the list was a bare row stack), which
+;; is the gap Mike flagged ("does not match the Figma mock"). The
+;; column widths mirror the row layout below: a fixed leading FOCUS
+;; gutter (14px, unlabeled — it is a Causa affordance the mock didn't
+;; have), a fixed `source` tag column, the flexible `event id` column,
+;; then the right-aligned `timestamp`/`duration` cluster.
+
+(defn- l2-column-header
+  "Sticky column-header row for the L2 event list (rf2-ad7zx.12, Figma
+  EventList). Caption-weight, muted, on the chrome surface so it reads
+  as chrome rather than data. Pure hiccup."
+  []
+  (let [cell {:color       (:text-tertiary tokens)
+              :font-family sans-stack
+              :font-size   (:caption type-scale)
+              :font-weight 500
+              :text-transform "lowercase"
+              :white-space "nowrap"}]
+    [:div {:data-testid "rf-causa-event-list-header"
+           :role        "row"
+           :style {:position      "sticky"
+                   :top           0
+                   :z-index       1
+                   :display       "flex"
+                   :align-items   "center"
+                   :gap           "6px"
+                   :padding       "2px 6px"
+                   :background    (:bg-1 tokens)
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     ;; Leading focus-gutter spacer — keeps the header columns aligned
+     ;; with the rows' 14px focus gutter (the gutter itself is a Causa
+     ;; affordance, unlabeled in the header).
+     [:span {:aria-hidden "true" :style {:width "14px" :flex-shrink 0}}]
+     [:span {:data-testid "rf-causa-event-list-col-source"
+             :style (merge cell {:width l2-source-col-width :flex-shrink 0})}
+      "source"]
+     [:span {:data-testid "rf-causa-event-list-col-event-id"
+             :style (merge cell {:flex "1 1 auto" :min-width "0"})}
+      "event id"]
+     [:span {:data-testid "rf-causa-event-list-col-timestamp"
+             :style (merge cell {:flex-shrink 0 :text-align "right"
+                                 :min-width "30px"})}
+      "timestamp"]]))
+
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
   latest-on-bottom, ~8 visible at the tightened 22px row height
@@ -1664,7 +1754,13 @@
                        :font-family sans-stack
                        :font-size (:body type-scale)}}
          "No events."]
-        (into [:ul {:style {:list-style "none" :margin 0 :padding 0
+        ;; rf2-ad7zx.12 — the Figma column-header row above the row
+        ;; stack. Rendered only with rows present so the empty state
+        ;; stays a clean "No events." message.
+        (list
+         ^{:key "header"} [l2-column-header]
+         (into ^{:key "rows"}
+               [:ul {:style {:list-style "none" :margin 0 :padding 0
                             :display "flex" :flex-direction "column"
                             :gap "2px"}}]
               (for [cascade event-cascades]
@@ -1679,7 +1775,7 @@
                             ;; can read `:mode` (RETRO → :stale) and
                             ;; `:paused?` (paused-by-tool → :cyan).
                             :focus       focus
-                            :now-ms      now-ms}])))]]))
+                            :now-ms      now-ms}]))))]]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
@@ -286,21 +286,33 @@
             node))
         (hiccup-seq tree)))
 
-(deftest view-collapses-to-label-when-only-one-frame
-  (testing "the view renders a flat label (no dropdown) when only one
-            distinct frame is available — there's nothing to pick"
+(deftest view-renders-frame-dropdown-button-always
+  (testing "rf2-ad7zx.12 — the Figma chrome ribbon ALWAYS shows a
+            `Frame ▾` dropdown button (logo + Frame + Dynamic/Static is
+            the chrome). Even with a single pickable frame the button
+            renders; only the overlaid <select> goes disabled so there's
+            no inert popup."
     (dispatch-trace 1 :app/main)
     (setup!)
     (rf/with-frame :rf/causa
-      (let [tree (frame-switcher/frame-switcher-view {})]
-        (is (some? (find-by-testid tree "rf-causa-ribbon-frame"))
-            "label-only branch renders")
-        (is (nil? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
-            "no <select> when only one frame is selectable")))))
+      (let [tree   (frame-switcher/frame-switcher-view {})
+            button (find-by-testid tree "rf-causa-ribbon-frame")
+            label  (find-by-testid tree "rf-causa-ribbon-frame-label")
+            picker (find-by-testid tree "rf-causa-ribbon-frame-picker")]
+        (is (some? button) "the Frame dropdown button always renders")
+        (is (some? label) "the literal `Frame` label renders (not the value inline)")
+        (is (= "Frame" (last label))
+            "the button reads `Frame`, NOT `Frame: <value>` (Mike's flag)")
+        (is (some? (find-by-testid tree "rf-causa-ribbon-frame-chevron"))
+            "the `▾` chevron renders, marking it a dropdown")
+        (is (some? picker) "the native <select> overlay is present for a11y")
+        (is (true? (:disabled (second picker)))
+            "single-frame — the overlaid select is disabled (no inert popup)")))))
 
 (deftest view-renders-dropdown-when-multiple-frames
-  (testing "the view renders a strictly-single-select <select> when
-            multiple distinct frames are present"
+  (testing "the view renders a strictly-single-select <select> overlay
+            when multiple distinct frames are present; the visible
+            affordance stays the `Frame ▾` button (rf2-ad7zx.12)"
     (dispatch-trace 1 :app/main)
     (dispatch-trace 2 :app/admin)
     (setup!)
@@ -311,7 +323,11 @@
         (is (= :select (first picker))
             "it's a <select>, not a custom multi-select")
         (is (nil? (:multiple (second picker)))
-            "strictly single-select — no :multiple attribute")))))
+            "strictly single-select — no :multiple attribute")
+        (is (not (:disabled (second picker)))
+            "multi-frame — the select is enabled so the popup opens")
+        (is (= "Frame" (last (find-by-testid tree "rf-causa-ribbon-frame-label")))
+            "the button still reads `Frame` (the value is not inlined)")))))
 
 ;; -------------------------------------------------------------------------
 ;; (7) Storage-key plumbing — per-instance isolation

--- a/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
@@ -90,6 +90,30 @@
              :test-harness :tool :internal :websocket}
            (set (keys l2/origin-glyphs))))))
 
+;; ---- 2b. origin → source-tag (Figma `source` column, rf2-ad7zx.12) -------
+
+(deftest origin-source-tag-test
+  (testing ":user is blank — the dominant app-code origin doesn't clutter
+            every row's source column (silent-by-default)"
+    (is (nil? (l2/origin-source-tag :user))))
+
+  (testing "every non-user closed-enum value renders its bare name as the tag"
+    (is (= "router"       (l2/origin-source-tag :router)))
+    (is (= "http"         (l2/origin-source-tag :http)))
+    (is (= "ssr"          (l2/origin-source-tag :ssr)))
+    (is (= "fx-emit"      (l2/origin-source-tag :fx-emit)))
+    (is (= "timer"        (l2/origin-source-tag :timer)))
+    (is (= "test-harness" (l2/origin-source-tag :test-harness)))
+    (is (= "tool"         (l2/origin-source-tag :tool)))
+    (is (= "internal"     (l2/origin-source-tag :internal)))
+    (is (= "websocket"    (l2/origin-source-tag :websocket))))
+
+  (testing "unknown / nil → nil (defence-in-depth, never throws)"
+    (is (nil? (l2/origin-source-tag nil)))
+    ;; an unknown keyword still yields its name — the column is the bare
+    ;; origin axis, not gated on the closed-enum glyph map.
+    (is (= "unknown-axis" (l2/origin-source-tag :unknown-axis)))))
+
 ;; ---- 3. origin → title text ---------------------------------------------
 
 (deftest origin-prefix-title-test

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -286,6 +286,24 @@
         (is (nil? (find-by-testid ribbon "rf-causa-focus-chip"))
             "focus-chip is NOT in the chrome ribbon")))))
 
+(deftest chrome-ribbon-carries-causa-logo-top-left
+  (testing "rf2-ad7zx.12 — the chrome ribbon's LEFT cluster opens with
+            the `❖ Causa` wordmark per the Figma design-reference
+            (ChromeRibbon.tsx). It was MISSING pre-Figma (the ribbon
+            jumped straight to the Frame selector). The wordmark renders
+            inside the selector cluster, before the Frame dropdown."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [ribbon    (shell/ribbon nil)
+            selectors (find-by-testid ribbon "rf-causa-ribbon-selectors")
+            logo      (find-by-testid ribbon "rf-causa-ribbon-logo")]
+        (is (some? logo) "the `❖ Causa` wordmark renders in the chrome ribbon")
+        (is (some? selectors) "the selector cluster is present")
+        (is (re-find #"❖" (text-nodes logo))
+            "the diamond `❖` glyph is present")
+        (is (re-find #"Causa" (text-nodes logo))
+            "the `Causa` wordmark text is present")))))
+
 (deftest events-ribbon-carries-label-nav-and-pills
   (testing "rf2-4vp5j Workstream B — the events ribbon
             (rf-causa-events-ribbon) carries the `Events:` label, the
@@ -623,6 +641,53 @@
             rows (find-all-by-testid-prefix tree "rf-causa-event-row-")]
         (is (= 2 (count rows))
             "one row per cascade")))))
+
+(deftest event-list-renders-figma-column-header
+  (testing "rf2-ad7zx.12 — the L2 list carries the Figma EventList
+            column-header row (source · event id · timestamp) above the
+            rows. It was MISSING pre-Figma (Mike: 'does not match the
+            Figma mock'). Rendered only with rows present."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            header (find-by-testid tree "rf-causa-event-list-header")]
+        (is (some? header) "the column-header row renders when rows exist")
+        (is (some? (find-by-testid tree "rf-causa-event-list-col-source"))
+            "the `source` column label is present")
+        (is (some? (find-by-testid tree "rf-causa-event-list-col-event-id"))
+            "the `event id` column label is present")
+        (is (some? (find-by-testid tree "rf-causa-event-list-col-timestamp"))
+            "the `timestamp` column label is present")))))
+
+(deftest event-list-omits-column-header-when-empty
+  (testing "rf2-ad7zx.12 — the empty state stays a clean `No events.`
+            message with no column-header chrome above it."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-list-empty"))
+            "empty state renders")
+        (is (nil? (find-by-testid tree "rf-causa-event-list-header"))
+            "no column header on the empty state")))))
+
+(deftest event-row-source-tag-surfaces-non-user-origin
+  (testing "rf2-ad7zx.12 — a non-:user dispatch-origin renders a text
+            SOURCE tag (the Figma `source` column) carrying the origin
+            name. :user rows stay blank (silent-by-default)."
+    (causa-setup!)
+    ;; A :timer-origin cascade — the source column should read `timer`.
+    (trace-bus/collect-trace!
+      (assoc-in (dispatch-trace-ev 1 [:poll/tick])
+                [:tags :rf/dispatch-origin] :timer))
+    ;; A plain (:user / untagged) cascade — source column blank.
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree    (shell/shell-view)
+            tagged  (find-by-testid tree "rf-causa-row-origin-timer")]
+        (is (some? tagged) "the :timer row carries an origin source tag")
+        (is (re-find #"timer" (text-nodes tagged))
+            "the source tag reads the origin name `timer`")))))
 
 (deftest event-row-gutter-carries-cascade-chain-thread
   (testing "rf2-5kfxe.10 — every L2 event-row gutter carries an inset


### PR DESCRIPTION
## Why

The panel-fidelity audit (rf2-ad7zx.4) covered only the 7 L4 panels and wrongly concluded the shell/chrome "already matched" — so the upper region (built pre-Figma by rf2-4vp5j) was never reconciled to the Figma design-reference. Mike's live verify on the step-deck testbed found concrete gaps. This is structure/layout/controls only — orange tokens already landed on main via rf2-ad7zx.3.

Reconciled faithfully against `tools/causa/design-reference/components/{ChromeRibbon,EventsRibbon,EventList}.tsx`.

## Chrome ribbon (`frame_switcher.cljs` + `shell.cljs`)

- **ADD the missing `❖ Causa` wordmark** top-left of the chrome ribbon (semibold, `body-tight`, always-orange `:brand` token — the product identity, not the mode accent).
- **Frame control is now a single-select `Frame ▾` dropdown BUTTON** — the literal word `Frame` + a chevron, NOT the value rendered inline (`Frame: :step-deck`, which Mike flagged twice). Overlay pattern: a styled button face + a transparent native `<select>` layered on top so keyboard / screen-reader / the native option popup all work. The selected value moves into the option list (`✓`), never the button label. The button always renders (the chrome always shows a Frame control per Figma); the overlaid select goes disabled when fewer than two frames are pickable.
- Dynamic/Static dropdown + ⚙ settings + ✕ close on the right are unchanged.

## Events list / L2 timeline (`shell.cljs` + `l2_timeline.cljc`)

- **ADD the Figma column-header row** (`source` / `event id` / `timestamp`) above the rows (sticky, caption-weight, muted); omitted on the empty state so `No events.` stays clean.
- The dispatch-origin is now a **fixed-width `source` COLUMN tag** (origin name as text + its glyph), aligned under the header label, replacing the inline glyph-only prefix. `:user` stays blank (silent-by-default). New pure helper `origin-source-tag`.

## Events ribbon

Already matched the Figma structure (`Events:` label / nav / focus-chip / pills / N-hidden / Clear Filters) — left functionally intact.

## Gates

- `npm run test:cljs` — 4244 tests / 0 failures (no compile warnings)
- `tools/causa clojure -M:test` — 872 tests / 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios / 0 failures (one transient http-server crash on first run; clean on re-run)

Functional behaviour (frame switching, mode swap, filters, focus) preserved. Closes rf2-ad7zx.12.