### PR TITLE
fix(causa): Frame dropdown interactive with a single frame (rf2-ad7zx.14)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -166,7 +166,7 @@ Carries only scope selectors (left) and chrome actions (right):
 
 | Cluster | Side | Content | Keys |
 |---|---|---|---|
-| **Frame** | left | `Frame: :app/main ▾` dropdown (multi-frame); flat `Frame: :rf/default` label when single-frame. **Single-select VIEW SCOPE** (rf2-4vp5j — not a filter). Tool frames hidden unless Settings → View → "Show tool frames in picker" toggle on. | — |
+| **Frame** | left | `Frame ▾` dropdown — ALWAYS rendered (rf2-ad7zx.12); the selected value is surfaced INSIDE the option list (the active option carries a `✓`), not inlined on the button. Interactive whenever ≥1 frame is available (rf2-ad7zx.14): a single-frame host gets a working 1-entry dropdown listing that lone frame; only the zero-frame state disables the control. **Single-select VIEW SCOPE** (rf2-4vp5j — not a filter). Tool frames hidden unless Settings → View → "Show tool frames in picker" toggle on. | — |
 | **Mode** | left | `Dynamic ▾` / `Static ▾` **dropdown** (`<select>`) — compact, understated; shares the frame picker's control weight (rf2-4vp5j). The 2-px left-edge accent stripe (violet Dynamic / cyan Static) carries the mode SIGNAL so the control itself recedes. | `Cmd/Ctrl-Shift-M` |
 | **Indicators** | right | Silent-by-default `🔇 N` mute indicator + `● N` REDACTED indicator (each painted only when its count > 0). | — |
 | **Right-icons** | right | `⚙` settings popup · `✕` close shell | `,` or `s` · `Esc` |
@@ -230,7 +230,7 @@ When the Settings "Show tool frames in picker" power-user toggle is on, tool fra
 └────────────────────────┘
 ```
 
-Single-frame apps collapse the dropdown to a flat label (`Frame: :rf/default`) — no chevron, no click target.
+Single-frame apps still get the full `Frame ▾` dropdown — it is interactive and opens a 1-entry list naming that lone frame (rf2-ad7zx.14). The earlier "collapse to a flat label" behaviour is gone (rf2-ad7zx.12 always renders the dropdown). Only a zero-frame state disables the overlaid `<select>` (no inert popup).
 
 ### Filter pills
 

--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -317,10 +317,13 @@
   popup all work out of the box (rf2-lbutp). The `<select>` carries the
   `aria-label` so assistive tech announces 'Select frame, combobox'.
 
-  When fewer than two frames are pickable the button still renders (the
-  chrome ALWAYS shows a Frame control per Figma — the prior 'collapse to
-  a flat label' branch is gone, rf2-ad7zx.12), but the overlaid select is
-  disabled so there is no inert popup.
+  The button ALWAYS renders (the chrome shows a Frame control per Figma
+  — the prior 'collapse to a flat label' branch is gone, rf2-ad7zx.12).
+  The overlaid select is interactive whenever there is at least one frame
+  (rf2-ad7zx.14): a native `<select>` with a lone option still opens and
+  shows it, so a single-frame host (e.g. the step-deck, with one
+  `:step-deck` frame) gets a working 1-entry dropdown. Only a zero-frame
+  state disables the control.
 
   Reads `:rf.causa/current-frame` + `:rf.causa/available-frames`; writes
   via `:rf.causa/select-frame <frame-id>` — the canonical contract
@@ -335,7 +338,12 @@
   (let [selected-frame  @(rf/subscribe [:rf.causa/current-frame])
         frames          @(rf/subscribe [:rf.causa/available-frames])
         active          (or selected-frame (first frames))
-        pickable?       (> (count frames) 1)]
+        ;; rf2-ad7zx.14 — interactive whenever there is >=1 frame. A native
+        ;; <select> with one option opens + shows it (not inert), which is
+        ;; what Mike expects in the step-deck (a single :step-deck frame).
+        ;; The prior `(> (count frames) 1)` left the control disabled (and
+        ;; click-dead) with a lone frame. STRICTLY single-select.
+        pickable?       (pos? (count frames))]
     [:div {:data-testid "rf-causa-ribbon-frame"
            :title       (if active
                           (str "Frame scope: " active " — pick a frame to scope the inspector")

--- a/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
@@ -289,16 +289,20 @@
 (deftest view-renders-frame-dropdown-button-always
   (testing "rf2-ad7zx.12 — the Figma chrome ribbon ALWAYS shows a
             `Frame ▾` dropdown button (logo + Frame + Dynamic/Static is
-            the chrome). Even with a single pickable frame the button
-            renders; only the overlaid <select> goes disabled so there's
-            no inert popup."
+            the chrome). rf2-ad7zx.14 — with a SINGLE frame the overlaid
+            <select> is ENABLED (a native select with one option opens +
+            shows it; it is not inert) and lists that lone frame as its
+            only option, carrying its `✓`."
     (dispatch-trace 1 :app/main)
     (setup!)
     (rf/with-frame :rf/causa
-      (let [tree   (frame-switcher/frame-switcher-view {})
-            button (find-by-testid tree "rf-causa-ribbon-frame")
-            label  (find-by-testid tree "rf-causa-ribbon-frame-label")
-            picker (find-by-testid tree "rf-causa-ribbon-frame-picker")]
+      (let [tree    (frame-switcher/frame-switcher-view {})
+            button  (find-by-testid tree "rf-causa-ribbon-frame")
+            label   (find-by-testid tree "rf-causa-ribbon-frame-label")
+            picker  (find-by-testid tree "rf-causa-ribbon-frame-picker")
+            options (filter (fn [n]
+                              (and (vector? n) (= :option (first n))))
+                            (hiccup-seq tree))]
         (is (some? button) "the Frame dropdown button always renders")
         (is (some? label) "the literal `Frame` label renders (not the value inline)")
         (is (= "Frame" (last label))
@@ -306,8 +310,17 @@
         (is (some? (find-by-testid tree "rf-causa-ribbon-frame-chevron"))
             "the `▾` chevron renders, marking it a dropdown")
         (is (some? picker) "the native <select> overlay is present for a11y")
-        (is (true? (:disabled (second picker)))
-            "single-frame — the overlaid select is disabled (no inert popup)")))))
+        (is (not (:disabled (second picker)))
+            "rf2-ad7zx.14 — single-frame: the overlaid select is ENABLED so
+             clicking it opens a 1-entry dropdown (not inert)")
+        (is (nil? (:multiple (second picker)))
+            "strictly single-select — no :multiple attribute even with one frame")
+        (is (= 1 (count options))
+            "exactly one option — the lone available frame")
+        (is (= ":app/main" (:value (second (first options))))
+            "the single option is bound to the available frame's value")
+        (is (= "✓ :app/main" (last (first options)))
+            "the lone frame is the active selection, carrying its checkmark")))))
 
 (deftest view-renders-dropdown-when-multiple-frames
   (testing "the view renders a strictly-single-select <select> overlay


### PR DESCRIPTION
## Problem

Mike (live step-deck verify): the chrome ribbon's **Frame dropdown** (added by rf2-ad7zx.12) does nothing on click when there's a single observable frame.

**Root cause:** `frame_switcher.cljs` set `pickable? (> (count frames) 1)` and the overlaid native `<select>` carried `:disabled (not pickable?)`. With ≤1 available frame the select was disabled and click-dead. In the step-deck there's exactly one observable app frame (`:step-deck`; `:rf/causa` filtered as internal, `:rf/default` has no cascades) → `:rf.causa/available-frames` = `[:step-deck]` → disabled → inert.

## Fix

`pickable?` is now `(pos? (count frames))`. A native `<select>` with a single option opens and shows it (not inert), so a single-frame host gets a working 1-entry dropdown listing that lone frame (with its `✓`). Only a zero-frame state disables the control. Stays **strictly single-select** (no `:multiple`).

## Changes

- **`frame_switcher.cljs`** — `pickable?` predicate + docstring (the "disabled so no inert popup" note now reads "interactive whenever ≥1 frame; only zero-frame disables").
- **`frame_switcher_cljs_test.cljs`** — the single-frame view test (`view-renders-frame-dropdown-button-always`) now asserts the select is **enabled**, single-select, and lists exactly one option bound to the active frame with its checkmark.
- **`spec/018 §3`** (L1 chrome ribbon Frame row + single-frame note) — updated to allow a single-entry interactive dropdown; the stale collapse-to-flat-label wording (already removed in code by rf2-ad7zx.12) is gone.

## Gates

- `npm run test:cljs` — 4244 tests / 13218 assertions, 0 failures.
- `tools/causa` `clojure -M:test` — 872 tests / 2930 assertions, 0 failures.
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures.
- clj-kondo — 0 errors (the 2 `config`-unused warnings pre-exist on base; unrelated).
- `examples/step-deck` build — 0 warnings.

Disjoint from in-flight rf2-ad7zx.13 (theme/colour) and rf2-6qgbs.3 (testbed routing): no overlapping files.