### PR TITLE
fix(causa): align events-list headers with row columns per EventList.tsx (rf2-ad7zx.15)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -362,6 +362,55 @@
       http?    (conj "🌐")
       machine? (conj "🤖"))))
 
+;; rf2-ad7zx.15 — ONE shared column layout for the L2 event list, so the
+;; column-header row (`l2-column-header`) and every data row (`event-row`)
+;; reference the SAME constants and align column-for-column under the
+;; Figma EventList (`design-reference/components/EventList.tsx`). The
+;; header was hand-authored with copied numbers in rf2-ad7zx.12 and drifted
+;; out of alignment (Mike, live step-deck verify); these defs make the
+;; two surfaces literally share the same column structure.
+;;
+;; Layout (left → right), matching the Figma EventList columns plus Causa's
+;; leading focus gutter (a Causa affordance the mock didn't carry):
+;;
+;;   [gutter 14px] gap [source 52px] gap [event id flex-1] gap [time →right]
+;;
+;; Both surfaces use the SAME flex container gap + horizontal padding, and
+;; a matching `1px solid transparent` border so the row's focused/ungrouped
+;; border (which paints 1px) never shifts the data 1px right of the header
+;; (default content-box would otherwise offset every bordered row).
+;;
+;; Declared here — above the relative-time chip (which references the time
+;; column width) and above `event-row` / `l2-column-header`, all later in
+;; the file — so the symbols resolve at every use site (CLJS top-level
+;; defs must precede use).
+(def ^:private l2-gutter-col-width
+  "Width of the leading FOCUS gutter cell — shared by the header spacer
+  and every row's gutter so the `source` column starts at the same x."
+  "14px")
+
+(def ^:private l2-source-col-width
+  "Fixed width for the `source` column so the header label and every
+  row's origin tag align on the same left edge."
+  "52px")
+
+(def ^:private l2-time-col-min-width
+  "Min-width / right-aligned slot for the trailing time column — shared
+  by the header `timestamp` label and every row's relative-time chip so
+  the two right-align on the same edge."
+  "44px")
+
+(def ^:private l2-col-gap
+  "Inter-column gap for both the header row and every data row. ONE
+  value keeps the columns lined up across the two surfaces."
+  "6px")
+
+(def ^:private l2-row-h-padding
+  "Horizontal padding for both the header row and every data row — the
+  left value sets where the gutter starts, the right where the time
+  column ends. Shared so neither surface drifts."
+  "6px")
+
 ;; ---- Relative-time chip (rf2-vbbq0 / rf2-0s2at) --------------------------
 ;;
 ;; Each L2 row carries a small right-aligned chip showing how long ago the
@@ -457,12 +506,17 @@
       [:span {:data-testid     "rf-causa-row-time-chip"
               :data-then-ms    (str then-ms)
               :title           tooltip
+              ;; rf2-ad7zx.15 — the trailing time column. Shares the
+              ;; header `timestamp` column's right-aligned min-width slot
+              ;; (`l2-time-col-min-width`) so the chip right-aligns under
+              ;; the header label. Spacing from the preceding column comes
+              ;; from the row's shared flex `gap` — no extra `margin-left`,
+              ;; which used to push the chip 4px past the header column.
               :style {:color         (:text-tertiary tokens)
                       :flex-shrink   0
                       :font-family   mono-stack
                       :font-size     (:caption type-scale)
-                      :margin-left   "4px"
-                      :min-width     "30px"
+                      :min-width     l2-time-col-min-width
                       :text-align    "right"
                       :white-space   "nowrap"}}
        label])))
@@ -984,12 +1038,6 @@
       (rf/dispatch [:rf.causa/set-focus dimension value (:dispatch-id cascade)]
                    {:frame :rf/causa}))))
 
-;; rf2-ad7zx.12 — shared fixed width for the L2 `source` column so the
-;; column-header label (`l2-column-header`) and every row's origin tag
-;; (`event-row`) align on the same left edge. Declared above both use
-;; sites (event-row sits earlier in the file than the header / list).
-(def ^:private l2-source-col-width "52px")
-
 (defn- event-row
   "One row in the L2 event list. Single line per spec/018 §4 Row
   anatomy + Round-3 rf2-cmtkw — minimal default render.
@@ -1243,8 +1291,17 @@
                   :data-rf-causa-status   (name status-kw)
                   :style {:display       "flex"
                           :align-items   "center"
-                          :gap           "6px"
-                          :padding       "1px 6px"
+                          ;; rf2-ad7zx.15 — shared column gap + horizontal
+                          ;; padding so the data columns line up under the
+                          ;; header's columns. Vertical padding stays 1px
+                          ;; (row density); only the column-defining axes
+                          ;; (gap + h-padding) are shared with the header.
+                          ;; `border-box` matches the header so the 1px
+                          ;; border below resolves identically on both
+                          ;; surfaces (no 1px column drift).
+                          :box-sizing    "border-box"
+                          :gap           l2-col-gap
+                          :padding       (str "1px " l2-row-h-padding)
                           :height        "22px"
                           :line-height   "20px"
                           :cursor        "pointer"
@@ -1297,7 +1354,7 @@
      ;; the cascade timeline). The thread is `align-self: stretch` so
      ;; it spans the full row height edge-to-edge.
      [:span (cond-> {:data-testid (str "rf-causa-row-gutter-" (str id))
-                     :style       {:width        "14px"
+                     :style       {:width        l2-gutter-col-width
                                    :flex-shrink  0
                                    :display      "inline-flex"
                                    :align-items  "center"
@@ -1623,19 +1680,29 @@
               :white-space "nowrap"}]
     [:div {:data-testid "rf-causa-event-list-header"
            :role        "row"
+           ;; rf2-ad7zx.15 — the header shares the EXACT column structure
+           ;; of the data rows (`event-row`): same flex `gap`, same
+           ;; horizontal `padding`, and the SAME per-column widths via the
+           ;; shared `l2-*-col-*` constants. It also carries a matching
+           ;; `1px solid transparent` border so the rows' focused/ungrouped
+           ;; 1px border (content-box) never offsets the data columns 1px
+           ;; right of the header. Result: source / event id / timestamp
+           ;; sit directly above their data columns (Figma EventList).
            :style {:position      "sticky"
                    :top           0
                    :z-index       1
                    :display       "flex"
                    :align-items   "center"
-                   :gap           "6px"
-                   :padding       "2px 6px"
+                   :box-sizing    "border-box"
+                   :gap           l2-col-gap
+                   :padding       (str "2px " l2-row-h-padding)
+                   :border        "1px solid transparent"
                    :background    (:bg-1 tokens)
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
-     ;; Leading focus-gutter spacer — keeps the header columns aligned
-     ;; with the rows' 14px focus gutter (the gutter itself is a Causa
-     ;; affordance, unlabeled in the header).
-     [:span {:aria-hidden "true" :style {:width "14px" :flex-shrink 0}}]
+     ;; Leading focus-gutter spacer — same width as the rows' focus gutter
+     ;; (the gutter itself is a Causa affordance, unlabeled in the header).
+     [:span {:aria-hidden "true"
+             :style {:width l2-gutter-col-width :flex-shrink 0}}]
      [:span {:data-testid "rf-causa-event-list-col-source"
              :style (merge cell {:width l2-source-col-width :flex-shrink 0})}
       "source"]
@@ -1644,7 +1711,7 @@
       "event id"]
      [:span {:data-testid "rf-causa-event-list-col-timestamp"
              :style (merge cell {:flex-shrink 0 :text-align "right"
-                                 :min-width "30px"})}
+                                 :min-width l2-time-col-min-width})}
       "timestamp"]]))
 
 (rf/reg-view event-list

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -660,6 +660,101 @@
         (is (some? (find-by-testid tree "rf-causa-event-list-col-timestamp"))
             "the `timestamp` column label is present")))))
 
+(defn- style-of
+  "Read the inline `:style` map off a hiccup node (`[tag attrs …]`)."
+  [node]
+  (get-in node [1 :style]))
+
+(deftest event-list-header-shares-row-column-layout
+  (testing "rf2-ad7zx.15 — the column-header row and the data rows share
+            ONE column structure (per design-reference/components/
+            EventList.tsx). The header's `source` / `event id` /
+            `timestamp` columns MUST sit directly above the rows' columns,
+            so the header cells and the row cells reference the same fixed
+            widths, the same leading gutter width, and the containers
+            share the same flex gap + horizontal padding. rf2-ad7zx.12 had
+            hand-copied numbers that drifted out of alignment (Mike, live
+            step-deck verify)."
+    (causa-setup!)
+    ;; A cascade with a dispatched-time so the row renders its trailing
+    ;; relative-time chip (the column the header's `timestamp` aligns to),
+    ;; and a :timer origin so the `source` column tag renders.
+    (trace-bus/collect-trace!
+      (-> (dispatch-trace-ev 1 [:poll/tick])
+          (assoc :time 1000)
+          (assoc-in [:tags :rf/dispatch-origin] :timer)))
+    (rf/with-frame :rf/causa
+      (let [tree        (shell/shell-view)
+            ;; header cells
+            header      (find-by-testid tree "rf-causa-event-list-header")
+            h-source    (find-by-testid tree "rf-causa-event-list-col-source")
+            h-event-id  (find-by-testid tree "rf-causa-event-list-col-event-id")
+            h-timestamp (find-by-testid tree "rf-causa-event-list-col-timestamp")
+            ;; row cells (the :timer row)
+            row         (first (find-all-by-testid-prefix
+                                 tree "rf-causa-event-row-"))
+            r-gutter    (first (find-all-by-testid-prefix
+                                 tree "rf-causa-row-gutter-"))
+            r-source    (find-by-testid tree "rf-causa-row-origin-timer")
+            r-event-id  (find-by-testid tree "rf-causa-row-event-id")
+            r-time      (find-by-testid tree "rf-causa-row-time-chip")
+            ;; the header's leading gutter spacer is the first :span child
+            ;; of the header div (aria-hidden, no testid).
+            h-gutter    (some (fn [n]
+                                (when (and (vector? n)
+                                           (map? (second n))
+                                           (= "true" (:aria-hidden (second n))))
+                                  n))
+                              header)]
+        ;; sanity — every cell we compare exists
+        (is (some? header)      "header row renders")
+        (is (some? row)         "the :timer data row renders")
+        (is (some? r-source)    "the row's source-tag cell renders")
+        (is (some? r-time)      "the row's time chip renders (it carries :time)")
+        ;; SOURCE column — header label width == row tag width
+        (is (= (:width (style-of h-source))
+               (:width (style-of r-source)))
+            "header `source` column width == row source-tag width")
+        ;; GUTTER — header spacer width == row gutter width (so the
+        ;; `source` column starts at the same x on both surfaces)
+        (is (= (:width (style-of h-gutter))
+               (:width (style-of r-gutter)))
+            "header gutter spacer width == row gutter width")
+        ;; EVENT-ID column — both flex-grow with min-width 0
+        (is (= (:flex (style-of h-event-id))
+               (:flex (style-of r-event-id)))
+            "header `event id` column and row event-id both flex-grow")
+        ;; TIMESTAMP / time column — header label min-width == chip min-width,
+        ;; both right-aligned, so the timestamp header sits over the chip
+        (is (= (:min-width (style-of h-timestamp))
+               (:min-width (style-of r-time)))
+            "header `timestamp` min-width == row time-chip min-width")
+        (is (= "right"
+               (:text-align (style-of h-timestamp))
+               (:text-align (style-of r-time)))
+            "header timestamp and row time chip both right-align")
+        ;; the chip carries NO extra margin-left (it used to push the chip
+        ;; 4px past the header column — the shared flex gap is the spacing)
+        (is (nil? (:margin-left (style-of r-time)))
+            "row time chip has no margin-left that would drift it past the header")
+        ;; CONTAINER — header + row share the same column gap + h-padding
+        (let [h-style (style-of header)
+              r-style (style-of row)]
+          (is (= (:gap h-style) (:gap r-style))
+              "header + row share the same flex column gap")
+          ;; both pad 6px horizontally (vertical may differ); compare the
+          ;; trailing px token which both build from l2-row-h-padding.
+          (is (re-find #"6px$" (str (:padding h-style)))
+              "header right padding is the shared 6px")
+          (is (re-find #"6px$" (str (:padding r-style)))
+              "row right padding is the shared 6px")
+          ;; both account for a 1px border via border-box so a bordered
+          ;; (focused/ungrouped) row never shifts 1px right of the header
+          (is (= "border-box" (:box-sizing h-style))
+              "header is border-box")
+          (is (= "border-box" (:box-sizing r-style))
+              "row is border-box"))))))
+
 (deftest event-list-omits-column-header-when-empty
   (testing "rf2-ad7zx.12 — the empty state stays a clean `No events.`
             message with no column-header chrome above it."


### PR DESCRIPTION
## What

The L2 timeline's column-header row (added in rf2-ad7zx.12) used a hand-authored column layout with copied numbers that drifted out of alignment with the data rows below — the `source` / `event id` / `timestamp` headers did not sit directly above their data columns (Mike, live step-deck verify). The Figma EventList (`tools/causa/design-reference/components/EventList.tsx`) is the guide: the header row and the data rows must share **one** column structure.

## Fix

Unify on shared column-layout constants in `shell.cljs` so the header row and every data row literally reference the same structure:

- New `l2-gutter-col-width` / `l2-source-col-width` / `l2-time-col-min-width` / `l2-col-gap` / `l2-row-h-padding` defs (declared once, above every use site). Header spacer + row gutter share the gutter width; header `source` + row source-tag share the source width; header `timestamp` + row time-chip share the right-aligned time min-width; both containers share the flex `gap` + horizontal `padding`.
- Drop the time-chip's extra `margin-left: 4px` (it pushed the chip past the header's timestamp column); spacing now comes from the shared flex `gap`.
- Both surfaces are `box-sizing: border-box` and the header carries a matching `1px solid transparent` border so a focused/ungrouped row's 1px border never offsets the data columns 1px right of the header.

## Test

Extend `shell_cljs_test` with `event-list-header-shares-row-column-layout` asserting the header and a sample row share the same source / gutter / time column widths, the same flex `gap` + horizontal `padding`, `border-box` on both, and no chip `margin-left`.

## Gates

- `npm run test:cljs` → 4245 tests / 13229 assertions, 0 failures
- `tools/causa` `clojure -M:test` → 872 tests / 2930 assertions, 0 failures
- `npm run test:causa-feature-gate` → 13 scenarios, 0 failures
- clj-kondo → 0 errors, no new findings (pre-existing infos/warning unchanged)
- `examples/step-deck` build → 440 files, 0 warnings

## Scope

Stays in `l2_timeline`'s view surface (`shell.cljs`) + its test. Disjoint from in-flight rf2-ad7zx.13 (theme), rf2-ad7zx.14 (frame_switcher), rf2-6qgbs.3 (testbed) — no orange/theme tokens touched.