### PR TITLE
fix(re-frame2-pair): fail loud on no-runtime-for-build + auto-detect running build (rf2-ivlb3)

### DIFF
--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -109,6 +109,26 @@ preload installs. If the marker is missing the op refuses with
 page refresh drops the runtime, but the preload re-installs it on
 the next bundle load; no manual reconnect step.
 
+### `eval-cljs`: build resolution + fail-loud preflight
+
+`eval-cljs` resolves which shadow-cljs build to evaluate against and
+preflights the runtime sentinel *before* eval'ing, so a runtime-absent
+build can never return a misleading `{:ok? true :value nil}` (the old
+footgun: shadow's `cljs-eval` against a non-running build yields a
+blank value indistinguishable from a genuine `nil`).
+
+- **Auto-detect:** with no `build` arg, `eval-cljs` detects the running
+  shadow build (`shadow.cljs.devtools.api/active-builds`). Exactly one
+  running ⇒ it's used; the resolved id is echoed back as `:build`.
+- **Fail loud:** a runtime-absent build (or zero/many running builds
+  with no explicit `build`) returns
+  `{:ok? false :reason :no-runtime-for-build :build <id> :running-builds [...] :hint "..."}`
+  — never `:ok? true :value nil`. The `:running-builds` list shows which
+  build to target via `build: "<id>"`.
+
+The same resolution + preflight logic backs the legacy `scripts/`
+bash shim's `eval` op.
+
 ## When the MCP server is degraded
 
 If shadow-cljs isn't running yet when the MCP server boots, it still

--- a/skills/re-frame2-pair/scripts/ops.clj
+++ b/skills/re-frame2-pair/scripts/ops.clj
@@ -345,6 +345,91 @@
   [build-id]
   (cljs-eval-value build-id "(re-frame2-pair.runtime/health)"))
 
+;; ---------------------------------------------------------------------------
+;; Running-build enumeration + fail-loud build resolution (rf2-ivlb3).
+;;
+;; Mirrors `tools/re-frame2-pair-mcp/src/.../tools/probe.cljs`'s
+;; `running-builds` / `resolve-build!` / `resolve-and-preflight!`. Both
+;; transports MUST fail loud: eval'ing against a build with no live
+;; re-frame2-pair runtime returns a blank cljs-eval value that
+;; `cljs-eval-value` reads as nil — indistinguishable from a genuine
+;; nil. The preflight + auto-detect removes the footgun on both paths.
+;; ---------------------------------------------------------------------------
+
+(defn- running-builds
+  "Enumerate shadow-cljs build ids with a live watch worker, as a vector
+   of keywords. JVM-side call — `active-builds` lives on the shadow API,
+   not in the CLJS heap, so it works even when no build has the runtime
+   preloaded (that's the point: it tells the operator which builds ARE
+   running). Returns [] on any error (old shadow, socket hiccup)."
+  []
+  (try
+    (let [res (jvm-eval "(try (vec (shadow.cljs.devtools.api/active-builds)) (catch Throwable _ []))")
+          v   (some-> (:value res) safe-edn)]
+      (if (vector? v) v []))
+    (catch Exception _ [])))
+
+(defn- auto-detect-hint [running]
+  (cond
+    (empty? running)
+    (str "no shadow-cljs build is running. Start your dev build "
+         "(`shadow-cljs watch <build>`) before eval'ing.")
+
+    (= 1 (count running))
+    (str "pass --build=" (first running) " or set SHADOW_CLJS_BUILD_ID.")
+
+    :else
+    (str "multiple shadow-cljs builds are running " (vec running)
+         "; pass --build=<one-of-them> or set SHADOW_CLJS_BUILD_ID.")))
+
+(defn- resolve-build!
+  "Resolve the build to eval against, or throw a structured ex-info.
+
+     - explicit `--build=` / SHADOW_CLJS_BUILD_ID  ⇒ honour it verbatim
+       (preflight catches a typo / non-running build).
+     - exactly one running build                   ⇒ auto-detect it.
+     - zero or many running                        ⇒ throw
+       `:no-runtime-for-build` enumerating `:running-builds`.
+
+   `explicit?` is true when `build` came from a real `--build=` / env
+   value rather than the bare `:app` fallback — we auto-detect ONLY
+   when the build is the bare default (`explicit?` false)."
+  [build explicit?]
+  (if (and build explicit?)
+    build
+    (let [running (running-builds)]
+      (if (= 1 (count running))
+        (first running)
+        (throw (ex-info "cannot auto-detect a single running build"
+                        {:reason         :no-runtime-for-build
+                         :build          (when explicit? build)
+                         :running-builds running
+                         :hint           (str (auto-detect-hint running)
+                                              " The default 'app' build is not running.")}))))))
+
+(defn- resolve-and-preflight!
+  "Resolve the build then confirm a live re-frame2-pair runtime sentinel
+   for it. Returns the resolved build-id; throws a structured ex-info
+   (`:reason :no-runtime-for-build`, carrying `:running-builds`) when the
+   build can't be eval'd. NEVER returns for a runtime-absent build, so
+   the caller can't emit `:ok? true :value nil` for an eval that didn't
+   run."
+  [build explicit?]
+  (let [build-id (resolve-build! build explicit?)]
+    (if (runtime-preloaded? build-id)
+      build-id
+      (let [running (running-builds)]
+        (throw (ex-info "no re-frame2-pair runtime for build"
+                        {:reason         :no-runtime-for-build
+                         :build          build-id
+                         :running-builds running
+                         :hint           (str "build " build-id " has no live "
+                                              "re-frame2-pair runtime. "
+                                              (auto-detect-hint running)
+                                              " (Or add the :devtools :preloads "
+                                              "[re-frame2-pair.runtime] entry — see "
+                                              "skills/re-frame2-pair/SKILL.md §Setup.)")}))))))
+
 (defn- discover [args]
   (ensure-port!)
   (let [build-id (build-id-from-args args)]
@@ -394,18 +479,37 @@
 ;; Subcommand: eval
 ;; ---------------------------------------------------------------------------
 
+(defn- explicit-build?
+  "True iff the caller passed an explicit `--build=` flag or set
+   $SHADOW_CLJS_BUILD_ID — vs. relying on the bare `:app` fallback in
+   `default-build-id`. The eval-path resolver (rf2-ivlb3) auto-detects
+   the running build ONLY when the build is the bare default."
+  [args]
+  (boolean (or (some #(str/starts-with? % "--build=") args)
+               (System/getenv "SHADOW_CLJS_BUILD_ID"))))
+
 (defn- eval-op [args]
   (ensure-port!)
   (when (empty? args) (die :missing-form :hint "usage: eval '<form>' [--build=app]"))
-  (let [form     (first args)
-        build-id (build-id-from-args (rest args))]
+  (let [form      (first args)
+        rest-args (rest args)
+        build-id  (build-id-from-args rest-args)
+        explicit? (explicit-build? rest-args)]
     (try
-      (emit {:ok? true :value (cljs-eval-value build-id form)})
+      ;; rf2-ivlb3: resolve the build (auto-detect the single running one
+      ;; when no explicit --build was passed) and confirm a live runtime
+      ;; BEFORE eval'ing. Never emit `:ok? true :value nil` for a build
+      ;; with no runtime — that's indistinguishable from a genuine nil.
+      (let [resolved (resolve-and-preflight! build-id explicit?)]
+        (emit {:ok? true :value (cljs-eval-value resolved form) :build resolved}))
       (catch Exception e
-        (emit {:ok? false
-               :reason (or (:reason (ex-data e)) :eval-error)
-               :message (.getMessage e)
-               :data (dissoc (ex-data e) :reason)})))))
+        (let [data (ex-data e)]
+          (if (= :no-runtime-for-build (:reason data))
+            (emit (merge {:ok? false} data))
+            (emit {:ok? false
+                   :reason (or (:reason data) :eval-error)
+                   :message (.getMessage e)
+                   :data (dissoc (or data {}) :reason)})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Subcommand: dispatch

--- a/skills/re-frame2-pair/tests/shim/shim_test.clj
+++ b/skills/re-frame2-pair/tests/shim/shim_test.clj
@@ -136,7 +136,10 @@
 (def healthy-cases
   {:default "nil"
    :matches
-   {;; sentinel probe
+   {;; running-build enumeration (rf2-ivlb3) — JVM-side eval; exactly
+    ;; one build running so eval auto-detects it without --build.
+    "active-builds" "[:app]"
+    ;; sentinel probe
     "(some? (and (exists? js/globalThis)" "true"
     ;; health
     "(re-frame2-pair.runtime/health)"
@@ -169,8 +172,25 @@
 
 (def missing-preload-cases
   ;; sentinel probe returns false → ops.clj emits :runtime-not-preloaded
+  ;; (discover) / :no-runtime-for-build (eval). A build IS running
+  ;; (active-builds → [:app]) but it has no live runtime sentinel.
   {:default "nil"
-   :matches {"(some? (and (exists? js/globalThis)" "false"}})
+   :matches {"active-builds" "[:app]"
+             "(some? (and (exists? js/globalThis)" "false"}})
+
+(def no-running-build-cases
+  ;; rf2-ivlb3: zero shadow builds running. eval can't auto-detect a
+  ;; build → :no-runtime-for-build with empty :running-builds.
+  {:default "nil"
+   :matches {"active-builds" "[]"
+             "(some? (and (exists? js/globalThis)" "false"}})
+
+(def multi-build-cases
+  ;; rf2-ivlb3: two builds running, none passed via --build → eval can't
+  ;; pick one → :no-runtime-for-build enumerating both.
+  {:default "nil"
+   :matches {"active-builds" "[:app :examples/step-deck]"
+             "(some? (and (exists? js/globalThis)" "true"}})
 
 ;; ---------------------------------------------------------------------------
 ;; Tests
@@ -196,6 +216,56 @@
             (is (map? edn))
             (is (true? (:ok? edn)))
             (is (= 3 (:value edn)))))))))
+
+(deftest eval-cljs-no-runtime-for-build
+  (testing "ops eval against a build with no live runtime → :no-runtime-for-build (NOT :ok? true :value nil)"
+    ;; rf2-ivlb3: the original bug returned {:ok? true :value nil} for
+    ;; EVERY form (including (count ...), which can never be nil) when
+    ;; the resolved build had no live re-frame2-pair runtime. The fix
+    ;; must fail loud instead.
+    (with-stub missing-preload-cases
+      (fn [cwd]
+        (let [r   (run-shim cwd "eval" "(count [1 2 3])")
+              edn (parse-edn (:stdout r))]
+          (is (map? edn))
+          (is (false? (:ok? edn)) "must NOT report success for a runtime-absent eval")
+          (is (= :no-runtime-for-build (:reason edn)))
+          (is (= [:app] (:running-builds edn)) "enumerates the running build(s)")
+          (is (string? (:hint edn)) "hint present")
+          (is (not (contains? edn :value))
+              "no :value slot — a runtime-absent eval did not run"))))))
+
+(deftest eval-cljs-no-running-build
+  (testing "ops eval with zero builds running → :no-runtime-for-build, empty :running-builds"
+    (with-stub no-running-build-cases
+      (fn [cwd]
+        (let [r   (run-shim cwd "eval" "(count [1 2 3])")
+              edn (parse-edn (:stdout r))]
+          (is (false? (:ok? edn)))
+          (is (= :no-runtime-for-build (:reason edn)))
+          (is (= [] (:running-builds edn))))))))
+
+(deftest eval-cljs-auto-detect-single-build
+  (testing "ops eval with no --build auto-detects the single running build"
+    ;; healthy-cases: active-builds → [:app], sentinel → true. The shim
+    ;; must auto-detect :app and return the resolved build in the result.
+    (with-stub healthy-cases
+      (fn [cwd]
+        (let [r   (run-shim cwd "eval" "(+ 1 2)")
+              edn (parse-edn (:stdout r))]
+          (is (true? (:ok? edn)))
+          (is (= 3 (:value edn)))
+          (is (= :app (:build edn)) "resolved build echoed back"))))))
+
+(deftest eval-cljs-multi-build-ambiguous
+  (testing "ops eval with multiple builds, none passed → :no-runtime-for-build listing all"
+    (with-stub multi-build-cases
+      (fn [cwd]
+        (let [r   (run-shim cwd "eval" "(+ 1 2)")
+              edn (parse-edn (:stdout r))]
+          (is (false? (:ok? edn)))
+          (is (= :no-runtime-for-build (:reason edn)))
+          (is (= [:app :examples/step-deck] (:running-builds edn))))))))
 
 (deftest discover-healthy
   (testing "ops discover with healthy preload → returns {:ok? true ...}"

--- a/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
+++ b/skills/re-frame2-pair/tests/shim/stub_nrepl.clj
@@ -134,6 +134,10 @@
   (let [code     (get req "code" "")
         ;; ops.clj wraps every cljs-eval as
         ;;   (shadow.cljs.devtools.api/cljs-eval :app "<form>" {})
+        ;; but JVM-side evals (e.g. the running-build enumeration
+        ;;   (vec (shadow.cljs.devtools.api/active-builds))
+        ;; from rf2-ivlb3) are sent raw, with no inner string literal.
+        cljs?    (str/includes? code "cljs-eval")
         ;; Extract the inner form (best-effort substring) for table lookup.
         inner    (let [start (.indexOf ^String code "\"")
                        end   (.lastIndexOf ^String code "\"")]
@@ -141,11 +145,15 @@
                      (subs code (inc start) end)
                      code))
         canned   (canned-value-for cases inner)
-        wrapped  (wrap-shadow-result canned)
+        ;; cljs-eval results are wrapped in shadow's `{:results [...]}`
+        ;; shape; a bare JVM eval returns its value verbatim (the canned
+        ;; edn-string IS the pr-str'd value). ops.clj's `running-builds`
+        ;; reads `(:value res)` directly, so it must see the raw vector.
+        value    (if cljs? (wrap-shadow-result canned) canned)
         msg-id   (get req "id" "0")
         session  (get req "session" "stub-session")]
     (send-response out {"id" msg-id "session" session
-                        "value" wrapped})
+                        "value" value})
     (send-response out {"id" msg-id "session" session
                         "status" ["done"]})))
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -37,8 +37,9 @@
   @allow-eval?)
 
 (defn eval-cljs-tool [conn args]
-  (let [form     (wire/arg args :form)
-        build-id (wire/arg-build args)]
+  (let [form      (wire/arg args :form)
+        build-id  (wire/arg-build args)
+        explicit? (wire/arg-build-explicit? args)]
     (cond
       (not @allow-eval?)
       (js/Promise.resolve
@@ -54,7 +55,14 @@
                         :hint "usage: eval-cljs {form '<cljs-form>' [build :app]}"}))
 
       :else
-      (-> (probe/ensure-runtime! conn build-id)
-          (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
-          (.then (fn [v] (wire/ok-text {:ok? true :value v})))
+      ;; rf2-ivlb3: resolve the build (auto-detect the single running one
+      ;; when no explicit :build was passed) and confirm a live runtime
+      ;; BEFORE eval'ing. Never emit `:ok? true :value nil` for a build
+      ;; with no runtime — that's indistinguishable from a genuine nil.
+      (-> (probe/resolve-and-preflight! conn build-id explicit?)
+          (.then (fn [resolved-build]
+                   (-> (nrepl/cljs-eval-value conn resolved-build form)
+                       (.then (fn [v] (wire/ok-text {:ok?   true
+                                                     :value v
+                                                     :build resolved-build}))))))
           (.catch (fn [err] (probe/err->result :eval-error err)))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -27,8 +27,29 @@
   Negative results are NOT cached: a missing preload usually surfaces
   on the very first call, and re-probing on each subsequent call
   lets a freshly-added preload land without a server restart (e.g.
-  the user edits `shadow-cljs.edn` and shadow-cljs hot-reloads)."
-  (:require [re-frame2-pair-mcp.nrepl :as nrepl]
+  the user edits `shadow-cljs.edn` and shadow-cljs hot-reloads).
+
+  ## Build resolution + fail-loud preflight (rf2-ivlb3)
+
+  `eval-cljs` (and any future read/eval tool) must NOT eval against a
+  build with no live re-frame2-pair runtime — doing so returns
+  `{:ok? true :value nil}` (shadow's `cljs-eval` against a non-running
+  build yields a blank value, which `cljs-eval-value` reads as nil),
+  indistinguishable from a form that genuinely returns nil. ~30 min of
+  dead-end debugging in the wild.
+
+  Two helpers close the footgun:
+
+    - `running-builds` enumerates the shadow-cljs builds with a live
+      watch worker (`shadow.cljs.devtools.api/active-builds`, a JVM-side
+      call) so the operator never has to guess `--build`.
+    - `resolve-and-preflight!` resolves the build (explicit arg wins;
+      otherwise auto-detect the single running build) and confirms the
+      runtime sentinel for it. On a runtime-absent build it rejects with
+      a structured `:no-runtime-for-build` ex-info enumerating the
+      running builds — never a silent `:ok? true :value nil`."
+  (:require [cljs.reader]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
@@ -104,6 +125,132 @@
                    (ex-info "re-frame2-pair runtime not preloaded"
                             {:reason :runtime-not-preloaded
                              :hint   preload-missing-hint})))))))
+
+;; ---------------------------------------------------------------------------
+;; Running-build enumeration + fail-loud build resolution (rf2-ivlb3).
+;; ---------------------------------------------------------------------------
+
+(defn running-builds
+  "Enumerate the shadow-cljs build ids that currently have a live watch
+  worker, as a vector of keywords. JVM-side call — `active-builds`
+  lives on the shadow API, not in the CLJS heap, so this works even
+  when no build has the re-frame2-pair runtime preloaded (the whole
+  point: it tells the operator which builds ARE running).
+
+  Resolves to `[]` on any error (old shadow without `active-builds`,
+  socket hiccup, or a nil/stub conn in the conformance harness) — the
+  caller degrades to a hint-only error rather than crashing.
+
+  The `jvm-eval` call is wrapped in `try` so a SYNCHRONOUS throw
+  (`@nil` IDeref on a nil conn before the Promise chain even starts)
+  collapses to `[]` too — `.catch` only catches async rejections."
+  [conn]
+  (-> (try
+        (nrepl/jvm-eval
+          conn
+          "(try (vec (shadow.cljs.devtools.api/active-builds)) (catch Throwable _ []))")
+        (catch :default _ (js/Promise.resolve nil)))
+      (.then (fn [resp]
+               (let [v (some-> (:value resp) cljs.reader/read-string)]
+                 (if (vector? v) v []))))
+      (.catch (fn [_] []))))
+
+(defn- auto-detect-hint [running]
+  (cond
+    (empty? running)
+    (str "no shadow-cljs build is running. Start your dev build "
+         "(`shadow-cljs watch <build>`) before eval'ing.")
+
+    (= 1 (count running))
+    ;; Shouldn't reach here (a single running build is auto-selected),
+    ;; but keep the branch explicit.
+    (str "pass --build=" (first running) " or set SHADOW_CLJS_BUILD_ID.")
+
+    :else
+    (str "multiple shadow-cljs builds are running " (vec running)
+         "; pass --build=<one-of-them> or set SHADOW_CLJS_BUILD_ID.")))
+
+(defn resolve-build!
+  "Resolve the build to eval against. Returns a Promise.
+
+    - explicit build (operator passed `:build`)  ⇒ resolves to it
+      verbatim; the runtime-sentinel preflight catches a typo'd /
+      non-running build.
+    - exactly one running build                  ⇒ resolves to it
+      (auto-detect; the operator needn't know the id).
+    - zero or many running                       ⇒ rejects with a
+      structured `:no-runtime-for-build` ex-info enumerating
+      `:running-builds`.
+
+  `explicit?` says whether `build` came from a real `:build` arg vs.
+  the env/`:app` fallback in `wire/arg-build`. We auto-detect ONLY
+  when the build is the bare default (`explicit?` false) — an operator
+  who typed `:build foo` gets `foo`, footgun-and-all (caught by
+  preflight)."
+  [conn build explicit?]
+  (if (and build explicit?)
+    (js/Promise.resolve build)
+    (-> (running-builds conn)
+        (.then
+          (fn [running]
+            (cond
+              (= 1 (count running))
+              (first running)
+
+              :else
+              (js/Promise.reject
+                (ex-info "cannot auto-detect a single running build"
+                         {:reason         :no-runtime-for-build
+                          :build          (when explicit? build)
+                          :running-builds running
+                          :hint           (str (auto-detect-hint running)
+                                               " The default 'app' build is "
+                                               "not running.")}))))))))
+
+(defn resolve-and-preflight!
+  "The shared eval-path guard (rf2-ivlb3). Resolves the build then
+  confirms a live re-frame2-pair runtime for it. Resolves to the
+  resolved build-id on success; rejects with a structured ex-info
+  otherwise.
+
+  Reject reasons:
+    - `:no-runtime-for-build` — auto-detect found zero/many builds, OR
+      the resolved build has no runtime sentinel. Carries
+      `:running-builds` so the operator sees the right `--build`.
+    - (`:runtime-not-preloaded` is folded into `:no-runtime-for-build`
+      here — both mean \"this build can't be eval'd\"; the enriched
+      reason carries the running-build enumeration the bare preload
+      error lacked.)
+
+  NEVER resolves for a runtime-absent build, so the caller can never
+  emit `:ok? true :value nil` for an eval that didn't actually run."
+  [conn build explicit?]
+  (-> (resolve-build! conn build explicit?)
+      (.then
+        (fn [build-id]
+          (-> (runtime-preloaded? conn build-id)
+              (.then
+                (fn [ok?]
+                  (if ok?
+                    build-id
+                    ;; Resolved a concrete build but its runtime sentinel
+                    ;; is absent — enrich with the running-build list so
+                    ;; the operator sees which build to target instead.
+                    (-> (running-builds conn)
+                        (.then
+                          (fn [running]
+                            (js/Promise.reject
+                              (ex-info "no re-frame2-pair runtime for build"
+                                       {:reason         :no-runtime-for-build
+                                        :build          build-id
+                                        :running-builds running
+                                        :hint
+                                        (str "build " build-id " has no live "
+                                             "re-frame2-pair runtime. "
+                                             (auto-detect-hint running)
+                                             " (Or add the :devtools :preloads "
+                                             "[re-frame2-pair.runtime] entry — see "
+                                             "skills/re-frame2-pair/SKILL.md §Setup.)")})))))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Error helpers — surface structured `ex-info` from `ensure-runtime!`.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -109,6 +109,15 @@
   (or (arg-keyword args :build)
       (default-build-id)))
 
+(defn arg-build-explicit?
+  "True iff the caller passed an explicit `:build` arg (vs. relying on
+  the `SHADOW_CLJS_BUILD_ID` / `:app` default). The eval-path build
+  resolver (rf2-ivlb3) auto-detects the running build ONLY when the
+  build is the bare default — an operator who typed `--build=foo` gets
+  `foo` honoured verbatim."
+  [args]
+  (some? (arg-keyword args :build)))
+
 ;; ---------------------------------------------------------------------------
 ;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi; lifted to
 ;; mcp-base.envelope in rf2-ee38b.19 / rf2-ee38b.18).

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -331,17 +331,34 @@
      :reason :rf.error/eval-cljs-disabled}}
 
    {:fixture/id    :eval-cljs/happy
-    :fixture/doc   "eval-cljs with --allow-eval returns {:ok? true :value v} on a successful runtime eval."
+    :fixture/doc   "eval-cljs with --allow-eval + explicit :build returns {:ok? true :value v} on a successful runtime eval."
     :fixture/tool  "eval-cljs"
     :fixture/allow-eval? true
-    :fixture/args  {:form "(+ 1 2)"}
+    ;; Explicit :build short-circuits the rf2-ivlb3 auto-detect (which
+    ;; would jvm-eval `active-builds` — not stubbed by this cljs-eval-only
+    ;; harness). The runtime-sentinel preflight still runs.
+    :fixture/args  {:form "(+ 1 2)" :build "app"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  true]
      ["(+ 1 2)"                   3]
      [:default                    nil]]
     :fixture/expect
     {:isError? false
-     :edn-submap {:ok? true :value 3}}}
+     :edn-submap {:ok? true :value 3 :build :app}}}
+
+   {:fixture/id    :eval-cljs/no-runtime-for-build
+    :fixture/doc   "eval-cljs against a build with no live runtime fails loud (:no-runtime-for-build), never :ok? true :value nil (rf2-ivlb3)."
+    :fixture/tool  "eval-cljs"
+    :fixture/allow-eval? true
+    ;; Explicit :build so the path is deterministic against the
+    ;; cljs-eval-only stub; sentinel probe returns false → fail loud.
+    :fixture/args  {:form "(count [1 2 3])" :build "app"}
+    :fixture/eval-script
+    [["__re_frame2_pair_runtime"  false]
+     [:default                    nil]]
+    :fixture/expect
+    {:isError? false
+     :edn-submap {:ok? false :reason :no-runtime-for-build}}}
 
    {:fixture/id    :eval-cljs/missing-form
     :fixture/doc   "eval-cljs with --allow-eval but without :form surfaces :missing-form."

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/eval_cljs_test.cljs
@@ -1,0 +1,208 @@
+(ns re-frame2-pair-mcp.eval-cljs-test
+  "Unit tests for the eval-cljs tool's fail-loud + auto-detect build
+  resolution (rf2-ivlb3).
+
+  THE BUG: `eval-cljs` against a build with no live re-frame2-pair
+  runtime returned `{:ok? true :value nil}` for EVERY form — including
+  `(count ...)`, which can never be nil — because shadow's `cljs-eval`
+  against a non-running build yields a blank value that
+  `cljs-eval-value` reads as nil, indistinguishable from a genuine nil.
+  ~30 min of dead-end debugging in the wild.
+
+  THE FIX (shared with the bash shim via the same `probe` logic):
+    1. Fail loud — preflight the runtime sentinel; a runtime-absent
+       build returns `{:ok? false :reason :no-runtime-for-build ...}`
+       enumerating the running builds, NEVER `:ok? true :value nil`.
+    2. Auto-detect — when no `:build` arg is passed, detect the single
+       running shadow build instead of blindly defaulting to `:app`.
+       Exactly one running ⇒ use it; zero/many ⇒ fail loud listing them.
+
+  The runtime calls these tests intercept:
+    - `nrepl/jvm-eval`         — the `active-builds` enumeration (JVM-side).
+    - `nrepl/cljs-eval-value`  — the sentinel probe + the actual eval."
+  (:require [cljs.test :refer-macros [deftest is async use-fixtures]]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.eval-cljs :as eval-cljs]))
+
+;; eval-cljs is gated behind --allow-eval; flip it ON for the suite and
+;; restore the default OFF afterwards so we test the resolution path,
+;; not the gate (the gate has its own coverage in conformance_test).
+(use-fixtures :each
+  {:before (fn [] (eval-cljs/set-allow-eval! true))
+   :after  (fn [] (eval-cljs/set-allow-eval! false))})
+
+(def ^:private read-edn tu/extract-edn)
+(def ^:private err? tu/error?)
+
+(defn- fresh-conn []
+  (nrepl/make-conn 0 "127.0.0.1"))
+
+(defn- sentinel-probe? [form-str]
+  (and (string? form-str)
+       (re-find #"__re_frame2_pair_runtime" form-str)))
+
+(defn- with-stubbed-runtime!
+  "Install stubs over the two nREPL entry points eval-cljs touches:
+
+    - `nrepl/jvm-eval`         resolves `{:value <running-builds-edn>}`
+      where `<running-builds-edn>` is the pr-str of `running-vec`
+      (mimics shadow's `active-builds` JVM result).
+    - `nrepl/cljs-eval-value`  resolves `runtime?` for the sentinel
+      probe form, and `eval-value` for any other (the actual eval).
+
+  Restores both in `.finally` so cleanup outlives async resolution."
+  [{:keys [running-vec runtime? eval-value]} body-fn]
+  (let [orig-jvm  nrepl/jvm-eval
+        orig-cljs nrepl/cljs-eval-value
+        ;; jvm-eval returns a CLJS map {:value "..."} in production; the
+        ;; stub mirrors that shape so `running-builds`' `(:value resp)`
+        ;; read works.
+        jvm-stub  (fn
+                    ([_conn _form] (js/Promise.resolve {:value (pr-str running-vec)}))
+                    ([_conn _form _opts] (js/Promise.resolve {:value (pr-str running-vec)})))
+        cljs-stub (fn
+                    ([_conn _build form-str]
+                     (js/Promise.resolve
+                       (if (sentinel-probe? form-str) runtime? eval-value)))
+                    ([_conn _build form-str _opts]
+                     (js/Promise.resolve
+                       (if (sentinel-probe? form-str) runtime? eval-value))))]
+    (set! nrepl/jvm-eval jvm-stub)
+    (set! nrepl/cljs-eval-value cljs-stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn []
+                    (set! nrepl/jvm-eval orig-jvm)
+                    (set! nrepl/cljs-eval-value orig-cljs))))))
+
+;; ---------------------------------------------------------------------------
+;; Fail-loud — the headline regression (rf2-ivlb3).
+;; ---------------------------------------------------------------------------
+
+(deftest no-runtime-for-build-fails-loud
+  ;; A build IS running but has no live runtime sentinel. The eval MUST
+  ;; NOT return `:ok? true :value nil` — it must fail loud with
+  ;; `:no-runtime-for-build` enumerating the running builds.
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [:app] :runtime? false :eval-value nil}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn) #js {:form "(count [1 2 3])"})))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (false? (:ok? edn)) "must NOT report success")
+                   (is (= :no-runtime-for-build (:reason edn)))
+                   (is (= [:app] (:running-builds edn)) "enumerates running builds")
+                   (is (string? (:hint edn)))
+                   (is (not (contains? edn :value))
+                       "no :value slot — the eval did not run"))
+                 (done))))))
+
+(deftest no-running-build-fails-loud
+  ;; Zero shadow builds running, no :build passed → can't auto-detect.
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [] :runtime? false :eval-value nil}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn) #js {:form "(count [1 2 3])"})))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :no-runtime-for-build (:reason edn)))
+                   (is (= [] (:running-builds edn))))
+                 (done))))))
+
+(deftest multiple-builds-ambiguous-fails-loud
+  ;; Two builds running, no :build passed → can't pick one. Error lists
+  ;; both so the operator sees the right --build.
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [:app :examples/step-deck]
+                                :runtime? true :eval-value 42}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn) #js {:form "(+ 1 2)"})))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :no-runtime-for-build (:reason edn)))
+                   (is (= [:app :examples/step-deck] (:running-builds edn))))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Auto-detect — the single running build is used without a :build arg.
+;; ---------------------------------------------------------------------------
+
+(deftest auto-detects-single-running-build
+  ;; No :build arg, exactly one running build with a live runtime →
+  ;; eval runs against it; the resolved build is echoed back.
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [:examples/step-deck]
+                                :runtime? true :eval-value 3}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn) #js {:form "(+ 1 2)"})))
+        (.then (fn [r]
+                 (is (not (err? r)))
+                 (let [edn (read-edn r)]
+                   (is (true? (:ok? edn)))
+                   (is (= 3 (:value edn)))
+                   (is (= :examples/step-deck (:build edn))
+                       "auto-detected build echoed back"))
+                 (done))))))
+
+(deftest explicit-build-honoured-when-runtime-present
+  ;; An explicit :build with a live runtime → used verbatim; no
+  ;; auto-detect (running-vec deliberately differs from the requested
+  ;; build to prove it isn't consulted on the happy path).
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [:other]
+                                :runtime? true :eval-value 99}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn)
+                                      #js {:form "(+ 90 9)" :build "app"})))
+        (.then (fn [r]
+                 (is (not (err? r)))
+                 (let [edn (read-edn r)]
+                   (is (true? (:ok? edn)))
+                   (is (= 99 (:value edn)))
+                   (is (= :app (:build edn)) "explicit build used verbatim"))
+                 (done))))))
+
+(deftest explicit-build-with-no-runtime-fails-loud
+  ;; An explicit :build that has no runtime sentinel → fail loud,
+  ;; enumerating the builds that ARE running so the operator can switch.
+  (async done
+    (-> (with-stubbed-runtime! {:running-vec [:examples/step-deck]
+                                :runtime? false :eval-value nil}
+          (fn []
+            (eval-cljs/eval-cljs-tool (fresh-conn)
+                                      #js {:form "(count [1 2 3])" :build "app"})))
+        (.then (fn [r]
+                 (let [edn (read-edn r)]
+                   (is (false? (:ok? edn)))
+                   (is (= :no-runtime-for-build (:reason edn)))
+                   (is (= :app (:build edn)) "echoes the requested build")
+                   (is (= [:examples/step-deck] (:running-builds edn))
+                       "lists the builds that ARE running"))
+                 (done))))))
+
+;; ---------------------------------------------------------------------------
+;; Gate + arg validation still hold.
+;; ---------------------------------------------------------------------------
+
+(deftest gate-closed-rejects-before-touching-nrepl
+  (async done
+    (eval-cljs/set-allow-eval! false)
+    (-> (eval-cljs/eval-cljs-tool (fresh-conn) #js {:form "(+ 1 2)"})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-edn r)]
+                   (is (= :rf.error/eval-cljs-disabled (:reason edn))))
+                 (eval-cljs/set-allow-eval! true)
+                 (done))))))
+
+(deftest missing-form-rejected
+  (async done
+    (-> (eval-cljs/eval-cljs-tool (fresh-conn) #js {})
+        (.then (fn [r]
+                 (is (err? r))
+                 (let [edn (read-edn r)]
+                   (is (= :missing-form (:reason edn))))
+                 (done))))))


### PR DESCRIPTION
## Problem (rf2-ivlb3)

`eval-cljs` (the re-frame2-pair read path) returned a misleading `{:ok? true :value nil}` when the target shadow-cljs build had no live re-frame2-pair runtime — reporting **SUCCESS with a nil value**, indistinguishable from a form that genuinely returns nil. shadow's `cljs-eval` against a non-running build yields a blank value that `cljs-eval-value` reads as nil.

**Repro:** the shim defaulted the build to `app`; the running testbed build was `examples/step-deck`; eval'ing against the non-running `app` build returned `{:ok? true :value nil}` for everything — including `(count …)`, which can never be nil — costing ~30 min of dead-end debugging. Not testbed-specific: any build id != `app`, or any build missing the runtime preload, hits this.

## Fix

Shared **resolve + preflight** logic across both transports (`resolve-build!` / `resolve-and-preflight!`):

1. **Fail loud** — preflight the runtime sentinel before eval. A runtime-absent build returns `{:ok? false :reason :no-runtime-for-build :build <id> :running-builds [...] :hint "..."}` enumerating the running builds, **never** `:ok? true :value nil`.
2. **Auto-detect** — instead of blindly defaulting to `app`, enumerate the running shadow builds (`shadow.cljs.devtools.api/active-builds`). With no explicit build: exactly one running ⇒ use it; zero/many ⇒ fail loud listing them. The resolved build is echoed back as `:build`.

Applied to **both**:
- MCP server — `tools/re-frame2-pair-mcp/src/.../tools/{probe,eval_cljs,wire}.cljs`
- Legacy bash shim — `skills/re-frame2-pair/scripts/ops.clj`

## Tests

- **New** `tools/re-frame2-pair-mcp/test/.../eval_cljs_test.cljs` (9 cases): runtime-absent, no-running-build, multi-build-ambiguous, auto-detect-single, explicit-build-honoured, explicit-build-no-runtime, gate + missing-form.
- **New** conformance fixture `:eval-cljs/no-runtime-for-build`; `:eval-cljs/happy` pinned to explicit `:build` (auto-detect `jvm-eval` isn't stubbed by the cljs-eval-only harness).
- **Shim tests**: `eval-cljs-no-runtime-for-build` / `-no-running-build` / `-auto-detect-single-build` / `-multi-build-ambiguous`; `stub_nrepl` now returns raw values for JVM evals (`active-builds`).

## Gates (all green)

- MCP unit suite: `npm test` → 510 tests, 0 failures, 0 errors.
- Bash-shim suite: `bb tests/shim/shim_test.clj` → 11 tests, 0 failures.
- MCP-conformance: `test:flag-gates` GREEN; `test:re-frame2-pair` (degraded) GREEN; server build 0 warnings.
- clj-kondo `--fail-level error`: 0 errors (no new warnings).
