### PR TITLE
fix(testbed/step-deck): tab clicks navigate + url-bound frame (rf2-6qgbs.3)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -1781,12 +1781,19 @@
   (when (map? config)
     (:url-bound? config)))
 
-(defn- url-owner-frame-id
+(defn url-owner-frame-id
   "Return the single frame allowed to mutate browser history. The default
   frame owns the URL unless it explicitly opts out; otherwise the first
   explicit non-default `:url-bound? true` frame wins deterministically.
   Duplicate registrations still emit `:rf.error/duplicate-url-binding`,
-  but this predicate enforces the one-owner rule at fx time."
+  but this predicate enforces the one-owner rule at fx time.
+
+  Public (rather than `defn-`) so the ownership-resolution contract is
+  directly assertable — in particular the single-non-default-owner case
+  the step-deck testbed relies on (rf2-6qgbs.3): when `:rf/default` opts
+  OUT (`:url-bound? false`) a non-default `:url-bound? true` frame becomes
+  the owner. A reimplemented gate cannot catch a regression in THIS
+  resolution; the test must reach the real fn."
   []
   (let [frames       (registrar/registrations :frame)
         default-meta (get frames :rf/default)]

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -2806,6 +2806,48 @@
       (is (empty? @pushed)
           "non-URL-bound frame's push is suppressed by the gated fx"))))
 
+(deftest single-non-default-frame-owns-url-when-default-opts-out
+  (testing "a non-default frame becomes the URL owner when :rf/default opts
+            OUT (:url-bound? false) and the non-default opts IN
+            (:url-bound? true) — the step-deck ownership contract
+            (rf2-6qgbs.3, Spec 012 §Multi-frame routing)"
+    ;; The step-deck mounts its content in the NON-DEFAULT :step-deck
+    ;; frame and wants it to own the URL. A bare `:step-deck {:url-bound?
+    ;; true}` is NOT enough: the auto-registered :rf/default frame's
+    ;; missing `:url-bound?` reads as default-true, so it keeps winning the
+    ;; ownership tie and :step-deck's navs never push the URL. Releasing
+    ;; the default (`:url-bound? false`) hands ownership to :step-deck.
+    (rf/reg-frame :rf/default {:url-bound? false})
+    (rf/reg-frame :step-deck  {:url-bound? true})
+    (is (= :step-deck (routing/url-owner-frame-id))
+        "with :rf/default opted out, the lone :url-bound? true frame owns the URL")
+
+    ;; End-to-end through the real production :rf.nav/push-url fx: the
+    ;; owner pushes, a non-owner is suppressed. We re-register the fx with
+    ;; a spy that consults the REAL `url-owner-frame-id` (NOT a
+    ;; reimplemented gate — a reimplemented gate cannot catch a regression
+    ;; in the resolution itself, which is the bug rf2-6qgbs.3 surfaced).
+    (rf/reg-route :route/home {:path "/home"})
+    (let [pushed (atom [])]
+      (rf/reg-fx :rf.nav/push-url
+                 {:platforms #{:server :client}
+                  :doc       "test re-registration consulting the production
+                              url-owner-frame-id resolver"}
+                 (fn [{:keys [frame]} url]
+                   (when (= (or frame :rf/default) (routing/url-owner-frame-id))
+                     (swap! pushed conj {:frame frame :url url}))))
+
+      ;; :step-deck is the owner → its nav pushes the URL.
+      (rf/dispatch-sync [:rf.route/navigate :route/home] {:frame :step-deck})
+      (is (= [{:frame :step-deck :url "/home"}] @pushed)
+          ":step-deck owns the URL, so its navigate pushes /home")
+
+      ;; :rf/default opted out → its nav is suppressed (no longer the owner).
+      (reset! pushed [])
+      (rf/dispatch-sync [:rf.route/navigate :route/home] {:frame :rf/default})
+      (is (empty? @pushed)
+          ":rf/default opted out of URL ownership, so its push is suppressed"))))
+
 ;; ===========================================================================
 ;; rf2-aleg9 — match-against direct function-boundary tests
 ;; (follow-on from rf2-q1z1u F8)

--- a/tools/causa/testbeds/step_deck/core.cljs
+++ b/tools/causa/testbeds/step_deck/core.cljs
@@ -45,13 +45,18 @@
 
   ## Single, URL-bound frame
 
-  The step-deck registers ONE frame and lets it own the browser URL
-  (the default — `:url-bound? true`). Because there is exactly one
-  routed frame, tab navigation (`:rf.route/navigate`, fired by the
-  panel's tab bar) syncs the address bar and the back button with no
-  two-frame URL race (contrast the two-frame testbed, which registers
-  both frames non-url-bound per Spec 012 §Multi-frame routing). Open
-  `/machine` directly and the frame lands on the Machine tab.
+  The step-deck registers ONE content frame (`:step-deck`) and makes it
+  the sole owner of the browser URL. Per Spec 012 §Multi-frame routing a
+  non-default frame is `:url-bound? false` by default, so this mount must
+  do TWO things to claim the URL (rf2-6qgbs.3): register `:rf/default`
+  `:url-bound? false` to release the auto-registered default frame's
+  implicit ownership, then register `:step-deck` `:url-bound? true` so it
+  becomes the one explicit URL owner. Because there is then exactly one
+  routed, url-bound frame, tab navigation (`:rf.route/navigate`, fired by
+  the panel's tab bar) syncs the address bar and the back button with no
+  two-frame URL race (contrast the two-frame testbed, which keeps BOTH
+  frames non-url-bound). Open `/machine` directly and the frame lands on
+  the Machine tab.
 
   ## Shared testdeck modules — reused verbatim
 
@@ -246,11 +251,29 @@
   ;; the right project-root on its first paint of any chip.
   (causa-config/configure! {:rf.causa/project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
-  ;; Register the single frame URL-bound (the default). With exactly one
-  ;; routed frame there is no URL race — tab nav (the panel's
-  ;; `:rf.route/navigate`) syncs the address bar and back button. The
-  ;; `:on-create` boot (`:testdeck/initialise`, registered once globally
-  ;; in `testdeck.panel`) seeds the frame's app-db for all four tabs and
-  ;; lands it on the default tab.
-  (rf/reg-frame frame-id {:on-create [:testdeck/initialise]})
+  ;; URL ownership (Spec 012 §Multi-frame routing). The content lives in
+  ;; the NON-DEFAULT frame :step-deck, but a non-default frame defaults to
+  ;; `:url-bound? false` — its route changes would stay in-memory and the
+  ;; address bar would never move (rf2-6qgbs.3). The step-deck is
+  ;; single-frame and OWNS the URL, so it must be the one URL-bound frame:
+  ;;
+  ;;   - :rf/default is registered `:url-bound? false` to RELEASE the
+  ;;     implicit ownership the auto-registered default frame holds. Without
+  ;;     this opt-out `url-owner-frame-id` keeps awarding the URL to
+  ;;     :rf/default (its missing `:url-bound?` reads as default-true), so a
+  ;;     bare `:step-deck {:url-bound? true}` would lose the tie.
+  ;;   - :step-deck is registered `:url-bound? true` so it becomes the sole
+  ;;     URL owner: `:rf.nav/push-url` now fires for its tab nav and the
+  ;;     address bar + back button track the active tab.
+  ;;
+  ;; With default opted out and exactly one explicit owner there is no
+  ;; two-frame URL race (contrast `two-frame-isolation.core`, which keeps
+  ;; BOTH frames non-url-bound for per-frame in-memory routing). The
+  ;; `:on-create` boot (`:testdeck/initialise`, registered once globally in
+  ;; `testdeck.panel`) seeds the frame's app-db for all four tabs and lands
+  ;; it on the default tab — its `[:rf.route/navigate …]` now also pushes
+  ;; the initial `/counter` URL.
+  (rf/reg-frame :rf/default {:url-bound? false})
+  (rf/reg-frame frame-id {:url-bound? true
+                          :on-create  [:testdeck/initialise]})
   (rdc/render react-root [root]))


### PR DESCRIPTION
## Summary

The step-deck testbed (rf2-6qgbs.3): clicking a feature tab switched the panel body but the address bar never moved — it looked like clicking did nothing. Verified in a real Chromium browser; turned out to be a single bug.

## Root cause

The step-deck mounts its content in the NON-DEFAULT frame `:step-deck`. Per Spec 012 §Multi-frame routing a non-default frame defaults to `:url-bound? false`, so its `:rf.route/navigate` updated the in-memory `:rf/route` slice (the body DID switch) but `:rf.nav/push-url` no-opped — the URL stayed `/`.

The reported "tab clicks dont dispatch" bug (BUG A) does **not** exist: a real-browser probe shows every tab click fires `[:rf.route/navigate <id>]` and the `:step-deck` route slice changes on each click. The shared panel's injected, frame-aware `dispatch` resolves `:step-deck` correctly in both the single-frame and two-frame mounts. The only defect was the URL not syncing (BUG B).

Note: a bare `:step-deck {:url-bound? true}` is not sufficient — the auto-registered `:rf/default` frame's missing `:url-bound?` reads as default-true in `url-owner-frame-id`, so `:rf/default` keeps winning the ownership tie.

## Fix

- `tools/causa/testbeds/step_deck/core.cljs` — register `:rf/default {:url-bound? false}` to release the implicit default ownership, and `:step-deck {:url-bound? true}` so it becomes the sole URL owner. Corrected the docstring that wrongly claimed the default is `:url-bound? true`.
- `implementation/routing/src/re_frame/routing.cljc` — make `url-owner-frame-id` public so the ownership-resolution contract is directly assertable.
- `implementation/routing/test/re_frame/routing_test.clj` — regression test pinning the ownership-transfer contract (default opts out + non-default opts in -> non-default owns the URL) end-to-end through the real production `:rf.nav/push-url` fx.

## Verification (real Chromium)

Step-deck after fix: boot URL `/counter`; clicking Machine -> `/machine`, Routing -> `/routing` (readout `:testdeck/routing`), Async -> `/async`; body switches on every click.

Two-frame testbed unchanged: ABOVE -> Machine, BELOW -> Async independently; URL frozen at `/` (both frames stay non-url-bound).

## Gates

- `npm run test:cljs` — 4244 tests / 13214 assertions, 0 failures
- tools/causa `clojure -M:test` — 872 tests / 2930 assertions, 0 failures
- routing JVM `clojure -M:test` — 121 tests / 550 assertions, 0 failures (incl. new test)
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- clj-kondo — 0 errors (6 pre-existing warnings, none in changed regions)