### PR TITLE
feat(causa): revert orange identity to Figma blue/neutral palette (rf2-ad7zx.13)

### DIFF
--- a/tools/causa/design-reference/README.md
+++ b/tools/causa/design-reference/README.md
@@ -24,10 +24,11 @@ When implementing Causa (CLJS / hiccup) against this:
 
 1. **Translate faithfully** — match this layout, these components, this structure. Do **not**
    redesign, "improve", or revert to the prior Causa look.
-2. **Swap the colour identity to ORANGE.** The export shipped a generic GitHub-blue accent
-   (`--devtools-active: #0969da`); the real identity is **orange** per
-   [`../spec/022-Design-Tokens.md`](../spec/022-Design-Tokens.md) (`accent #F97316`/`#EA580C`,
-   `accent-static` cyan for Static mode). The blue is the *only* deliberate divergence.
+2. **Keep the Figma blue/neutral colour identity (rf2-ad7zx.13).** The export ships a
+   GitHub-style blue accent (`--devtools-active: #539bf5` dark / `#0969da` light); that single
+   blue **is** the identity per [`../spec/022-Design-Tokens.md`](../spec/022-Design-Tokens.md)
+   (`accent #539bf5`/`#0969da`). There is no per-mode colour swap — match the export's palette
+   exactly.
 3. **Where the prior spec (007-UX-IA / 021-Dynamic-Panel-Designs) differs from this design,
    the Figma design wins** — they reconcile to it. The lone carve-out is functional semantic
    colours the mock didn't render (redacted / pair-origin / perf tiers), kept because the

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -97,10 +97,10 @@ Wireframe at default (reconciled to the Figma design — `design-reference/App.t
 The four layers, top to bottom:
 
 1. **L1 — Two ribbons (rf2-4vp5j).** A **chrome ribbon** carries the **`❖ Causa`
-   logo/wordmark** (always orange `brand`), then scope selectors (`Frame ▾` view-scope
+   logo/wordmark** (the single blue `accent`), then scope selectors (`Frame ▾` view-scope
    dropdown + `Dynamic / Static ▾` **mode dropdown**) on the left, and chrome actions
    (`⚙` settings + `✕` close) on the right. Below it an **events ribbon** carries the spine
-   + filter chrome: `Events:` label · nav (`◀` `▶` `⏭`) · the focus chip (`🎯 focus`, mode
+   + filter chrome: `Events:` label · nav (`◀` `▶` `⏭`) · the focus chip (`🎯 focus`, the
    accent) · the active filter pills (each removable, `×`) + a `[+]` add-pill · and `Clear
    Filters` at the far right. (`⛶` popout is omitted — silent-by-default until the
    second-window UX lands.) LIVE/RETRO surfaces in the L2 event-list spine itself; the chrome
@@ -114,8 +114,8 @@ The four layers, top to bottom:
 3. **L3 — Tab bar (40px).** Seven tabs in the order the Figma export fixes:
    **Event · app-db · Views · Trace · Machine · Routes · Issues**. Letter mnemonics:
    `e` `a` `v` `t` `m` `r` `i`. Each tab renders its **label only** (no `◉`/`○` glyph — Figma
-   design rf2-ad7zx); the **active tab fills with the mode `accent`** (orange in Dynamic, cyan in
-   Static) + white text, inactive tabs are plain with a hover background. (The Figma export labels
+   design rf2-ad7zx); the **active tab fills with the single `accent`** (GitHub blue) + white
+   text, inactive tabs are plain with a hover background. (The Figma export labels
    the reactive tab `Views` and the machines tab `Machine`; the spec elsewhere uses the
    rf2-e33ad display label `View` and `Machines`. The export wins on the rendered label per
    rf2-ad7zx; the internal panel-registry keys stay `:views` / `:machines`.) Routes was promoted
@@ -157,7 +157,7 @@ source of truth.
 | Property | Default | Purpose |
 |---|---|---|
 | `--rf-causa-inline-width` | `560px` | `flex-basis` of the inline host. Default bumped 420 → 560 under rf2-9ovfb. |
-| `--rf-causa-accent` | `#F97316` | Causa's brand **orange** (matches `brand` / `accent` in §Colour system; rf2-ad7zx — the brand moved violet → orange). Published on `:root` in the recommended host snippet so host stylesheets can colour their own dev chrome to harmonise with Causa (rf2-9ovfb). |
+| `--rf-causa-accent` | `#539bf5` | Causa's single **GitHub blue** accent (matches `accent` in §Colour system; rf2-ad7zx.13). Published on `:root` in the recommended host snippet so host stylesheets can colour their own dev chrome to harmonise with Causa (rf2-9ovfb). |
 
 Override either property anywhere up the cascade; the closest
 declaration wins as usual. The published spelling is also exported
@@ -260,9 +260,9 @@ the two scope dropdowns, then the chrome actions at the far right.
 
 | Cluster | Side | Content | Keys |
 |---|---|---|---|
-| **Logo** | left | `❖ Causa` wordmark — the brand anchor, **always orange** (`brand`), semibold. | — |
+| **Logo** | left | `❖ Causa` wordmark — the brand anchor, the single blue `accent`, semibold. | — |
 | **Frame** | left | `Frame ▾` dropdown (multi-frame); flat `Frame: :rf/default` label when single-frame. **Single-select VIEW SCOPE** (rf2-4vp5j — not a filter; not persisted). Tool frames hidden unless Settings → View → "Show tool frames in picker" toggle on. | — |
-| **Mode** | left | `Dynamic / Static ▾` dropdown — compact, understated (occasional use); the mode-accent stripe carries the mode signal. | `Cmd/Ctrl-Shift-M` |
+| **Mode** | left | `Dynamic / Static ▾` dropdown — compact, understated (occasional use); the dropdown's active option + `data-active-mode` carry the mode signal (the chrome stripe is the single blue accent in both modes — rf2-ad7zx.13). | `Cmd/Ctrl-Shift-M` |
 | **Right-icons** | right | `⚙` settings popup · `✕` close shell (`:rf.causa/close-shell`). `⛶` popout is omitted (reserved for the second-window UX — silent by default). | `,` or `s` · `Esc` |
 
 The silent-by-default `🔇 N` mute + `● N` REDACTED indicators are **functional surfaces painted
@@ -556,7 +556,7 @@ walkthrough locks the list (rf2-ttnst):
 | # | Tab | Mnemonic | Content |
 |---|---|---|---|
 | 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) |
-| 2 | **Theme** | `t` | Dark / Light (the accent follows the mode — orange in Dynamic, cyan in Static, per §Colour system; per-tab default-expansion knob dropped) |
+| 2 | **Theme** | `t` | Dark / Light (a single GitHub-blue accent in both modes, per §Colour system; per-tab default-expansion knob dropped) |
 | 3 | **Filters** | `f` | Active filter pills mirror · auto-filter-UI quick-open |
 | 4 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
 | 5 | **Buffer** | `b` | `:buffer/retained-epochs` · `:trace-buffer/keep` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
@@ -579,7 +579,7 @@ typing into numeric knobs is not interrupted.
 | Actions tab + factory-reset BIG RED BUTTON | Factory-reset stays code-only (`config/reset-settings!`) — a destructive UI button has no use case the confirm modal beneath "Clear buffer" does not already cover. |
 | Density Comfy tier | Two tiers cover the rhythm need; the third was a styling-pass aspiration with no observed demand. |
 | Per-tab default expansion (`:bookish` / `:dense`) | Each tab owns its expansion default; no global knob. |
-| Accent user-swap | The accent is fixed by mode (orange Dynamic / cyan Static, per §Colour system); light/dark theme is the only user colour axis. |
+| Accent user-swap | The accent is a single fixed GitHub blue (per §Colour system); light/dark theme is the only user colour axis. |
 | Sub-output diff layout (`:unified` / `:split` toggle) | Fixed unified. |
 | Section-grouping threshold | Fixed defaults; not user-tuneable. |
 | Popout as its own tab | Folds into General's Panel-position sub-section. |
@@ -751,43 +751,43 @@ high-contrast.
 ### Dark theme tokens
 
 ```
-Surfaces:  bg-0 #0E0F12  (backdrop)
-           bg-1 #15171B  (sidebar, top strip)
-           bg-2 #1B1E24  (panels)
-           bg-3 #232730  (popovers)
-           bg-active #2A2F3D  (hover, selected)
+Surfaces:  bg-0 #161616  (backdrop)
+           bg-1 #1c1c1c  (sidebar, top strip — Figma --devtools-chrome-bg)
+           bg-2 #242424  (panels)
+           bg-3 #2a2a2a  (popovers — Figma --devtools-hover)
+           bg-active #2a2a2a  (hover, selected)
 
-Borders:   subtle #232730  · default #2F3441  · strong #444B5B
+Borders:   subtle #2a2a2a  · default #373737 (Figma --devtools-border)
 
-Text:      primary #E8EAF0  · secondary #A8AEC0  · tertiary #6B7080  · disabled #494E5A
+Text:      primary #e6edf3 (Figma --devtools-text)  · secondary #adbac7  · tertiary #8b949e (Figma --devtools-text-muted)
 
-Accents:   orange  #F97316  BRAND, current epoch, Dynamic-mode accent (the identity — rf2-ad7zx)
-           cyan    #43C3D0  Static-mode accent; :story / :test origin; info
+Accents:   blue    #539bf5  ACCENT — active tab, chrome stripe, selected, focus ring, changed (the identity — rf2-ad7zx.13)
+           info    #79c0ff  fixed cool categorical blue; :story / :test origin; spine-paused; syntax-number
            indigo  #5570FF  :pair-origin
-           green   #4ADE80  success, additions, machine-active
-           yellow  #FBBF24  warnings, schema-replaced-with-default, :rf/large elision
-           amber   #FB923C  long-task / perf-slow (renamed from `orange` to free the brand name)
+           green   #3fb950  success, additions, machine-active
+           yellow  #d29922  warnings, schema-replaced-with-default, :rf/large elision
+           amber   #FB923C  long-task / perf-slow (functional perf-amber)
            red     #F87171  errors, schema-violations, hydration-mismatches
            magenta #E879F9  classification: :rf/redacted
 
-Perf:      fast     #4ADE80  (<16ms)
-           medium   #FBBF24  (16-50)
+Perf:      fast     #3fb950  (<16ms)
+           medium   #d29922  (16-50)
            slow     #FB923C  (50-100)
            blocking #F87171  (>100ms, INP threshold)
 ```
 
-**Brand identity = orange (rf2-ad7zx).** The brand / current-epoch / **Dynamic**-mode accent
-moved **violet → orange** (`#F97316`). The mode signal is **orange in Dynamic, cyan in
-Static** (active tab, mode stripe, active states); the logo / wordmark is **always orange**.
-The retired `violet #7C5CFF` is freed; the prior long-task `orange #FB923C` is renamed
-`amber`. Every accent is a single CSS-custom-property token, so the identity is a one-line
-change per token. The orange-identity decision + the cross-panel **visual-encoding rules**
-live in [022-Design-Tokens](022-Design-Tokens.md); the **full palette above is
-authoritative**. (Impl ripple — the ~357 token call sites that read `(:violet …)` etc. —
-is scoped under rf2-ad7zx.)
+**Accent identity = GitHub-style blue (rf2-ad7zx.13).** The accent is the single GitHub blue
+(`#539bf5` dark / `#0969da` light) the Figma export ships (`design-reference/styles/devtools.css`).
+There is **one** accent — active tab, chrome stripe, active states, focus ring, the L4 header
+stripe, and the logo / wordmark all read it. The **Dynamic / Static MODE stays functional** (it
+gates motion) but **no longer drives accent colour**: the shell reads the same blue in either
+mode. The earlier orange-identity scheme (an always-orange `brand` + per-mode orange/cyan accent
+swap) is **removed**. Every accent is a single CSS-custom-property token, so the identity is a
+one-line change per token. The accent decision + the cross-panel **visual-encoding rules** live
+in [022-Design-Tokens](022-Design-Tokens.md); the **full palette above is authoritative**.
 
-Light theme inverts lightness (`bg-0 #FAFBFC`, `bg-1 #F1F3F6`, `bg-2
-#FFFFFF`); accents darken slightly to maintain contrast.
+Light theme inverts lightness (`bg-0 #fbfbfb`, `bg-1 #f5f5f5`, `bg-2
+#ffffff`); the accent darkens to `#0969da` to maintain contrast.
 
 ### CSS custom-property surface (rf2-on4cm)
 
@@ -851,25 +851,23 @@ lives in `theme/global-styles/grain-css`; injection is via a single
 `<style id="rf-causa-grain">` block, idempotent + id-keyed DOM
 probe.
 
-### L4 panel accent stripe (mode accent — Figma design rf2-ad7zx)
+### L4 panel accent stripe (single accent — Figma design rf2-ad7zx.13)
 
-Every L4 panel renders a **3-px left-border** on its `<h1>` in the **mode `accent`** (orange in
-Dynamic, cyan in Static). The prior per-panel **domain-colour** mapping (`:event` violet ·
-`:app-db`/`:views` cyan · `:trace` orange · `:machines` green · `:routing` yellow · `:issues`
-red) is **superseded**: the Figma export carries a **single accent identity** (App.tsx's active
-tab + every panel reads `--devtools-active` → the mode accent), so the stripe is the mode signal,
-not a per-panel domain colour. This keeps the whole devtool reading orange in Dynamic / cyan in
-Static, with surfaces neutral so the accent pops.
+Every L4 panel renders a **3-px left-border** on its `<h1>` in the **single `accent`** (GitHub
+blue). The prior per-panel **domain-colour** mapping (`:event` violet · `:app-db`/`:views` cyan ·
+`:trace` orange · `:machines` green · `:routing` yellow · `:issues` red) is **superseded**: the
+Figma export carries a **single accent identity** (App.tsx's active tab + every panel reads
+`--devtools-active` → the accent), so the stripe is a consistent signal, not a per-panel domain
+colour. Surfaces stay neutral so the blue accent pops.
 
 Domain colour still does load-bearing work **inside** each panel where it is semantic — `error`
 red in Issues, machine `green`, route `yellow`, the op-family colour-bands in Trace (§021 §5.2),
-the per-panel header icons (§021 §17.1.5) — but the **header stripe** is the mode accent.
+the per-panel header icons (§021 §17.1.5) — but the **header stripe** is the single accent.
 
 The helper `theme/tokens/accent-stripe-style` emits the inline-style map (`:border-left "3px
 solid <accent>"` + `:padding-left "10px"`); per-panel call sites merge it into the `<h1>`
-`:style`. This is the same mode-accent signal as the Static-mode 2-px ribbon-edge stripe (§Static
-mode below) — the L1 stripe is the mode signal at chrome, this is the mode signal at the L4
-header.
+`:style`. This is the same accent as the chrome's 2-px ribbon-edge stripe (§Static mode below) —
+the L1 stripe is the accent at chrome, this is the accent at the L4 header.
 
 (rf2-4v67l — `:chrome-a11y` was dropped alongside the panel itself.
 A11y dogfooding is now Story's concern per rf2-18t6p + rf2-qgms1.)
@@ -886,7 +884,7 @@ glance.
 | Added | `+` | green | `success` |
 | Removed | `-` | red | `error` |
 | Modified | `~` | amber | `warning` |
-| Children (recursive descent) | `◴` | mode accent | `accent` (orange in Dynamic) |
+| Children (recursive descent) | `◴` | accent | `accent` (GitHub blue) |
 | Same (rendered for context) | (space) | tertiary | `:text-tertiary` |
 
 The gutter is a single shared idiom across the App-db diff, the
@@ -1071,7 +1069,7 @@ Every value display in every tab's L4 detail panel uses
 
 - `inspect <value>` — the hero: expandable inspector. Maps `{ … }`,
   vecs `[ … ]`, sets `#{ … }`, lists `( … )`. **Keywords are the single
-  coloured type — the mode `accent`** (orange in Dynamic, cyan in Static), per
+  coloured type — the single `accent`** (GitHub blue), per
   [022-Design-Tokens](022-Design-Tokens.md) §Visual encoding + the §021 §10.1
   minimal-coloring lock; other scalars (strings / numbers / booleans / nil) render
   in `text-primary` mono, unchanged values in `dim`. Expand carets per node;
@@ -1097,7 +1095,7 @@ The cljs-devtools-shaped surface (rf2-x9fzk):
 
 **Colour palette** (mapped onto Causa's theme tokens so the renderer
 reads as native shell chrome): **keywords are the single coloured type —
-the mode `accent`** (orange in Dynamic, cyan in Static), per the §021 §10.1
+the single `accent`** (GitHub blue), per the §021 §10.1
 minimal-coloring lock + [022-Design-Tokens](022-Design-Tokens.md); other
 scalars render in `text-primary` mono, `dim` for unchanged. Punctuation +
 meta render in `text-tertiary` / `text-secondary` to recede.
@@ -1626,12 +1624,12 @@ they telegraph the mode without the user needing to look at the dropdown:
    Lives in both modes (it's the toggle, not the indicator). Cmd-Shift-M
    (the global chord) fires the same `:rf.causa/toggle-mode` event so
    chord and dropdown share the handler. The mode SIGNAL is carried by
-   the accent stripe (#2) so the control itself recedes.
-2. **2-px left-edge ribbon stripe** — the mode `accent`: **orange**
-   (`accent-dynamic`) in Dynamic, **cyan** (`accent-static`) in Static
-   (per §Colour system + [022-Design-Tokens](022-Design-Tokens.md)). At
-   runtime the `.mode-dynamic` / `.mode-static` root class points `accent`
-   at the right token, so the stripe is a one-token signal.
+   the dropdown's active option + `data-active-mode` (the stripe is the
+   single accent in both modes — rf2-ad7zx.13).
+2. **2-px left-edge ribbon stripe** — the single `accent` (**GitHub blue**)
+   in both modes (per §Colour system + [022-Design-Tokens](022-Design-Tokens.md);
+   rf2-ad7zx.13 — the Figma export carries one accent, no per-mode colour
+   swap). The stripe is a one-token chrome-edge accent.
 3. **Motion dampening** — Dynamic ships the LIVE pulse + machine-active
    pulse + 180ms tab fade. Static drops the continuous pulses entirely
    and collapses the 180ms tab fade to instant (so cluster swaps land
@@ -1726,12 +1724,12 @@ motion — live ONCE in the HCM token registry (`theme/tokens.cljc`,
 `theme/global-styles/*`) and apply across both modes. Visual cohesion
 between Dynamic and Static is achieved at the token layer, not by
 shell-ns reuse. The mode-signal mechanism (mode dropdown, 2-px ribbon
-stripe colour, motion-dampening, chrome silhouette — see §Mode-signal
-mechanism above) reads from tokens; the divergence is in which tokens
-each shell selects (Dynamic's orange `accent-dynamic` stripe vs Static's
-cyan `accent-static` stripe — aliased through `accent` by the mode root
-class), not in the token system itself. **Zero new tokens introduced per
-mode** is the standing constraint.
+stripe, motion-dampening, chrome silhouette — see §Mode-signal mechanism
+above) reads from tokens. Post rf2-ad7zx.13 both shells paint the same
+single `accent` (GitHub blue) stripe — the divergence is in motion +
+chrome silhouette, NOT in stripe colour (the Figma export carries one
+accent). **Zero new tokens introduced per mode** is the standing
+constraint.
 
 **Cycle-avoidance rule.** When one shell needs to reach into another
 mode's chrome (the canonical case today: Static's ribbon needs the

--- a/tools/causa/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/causa/spec/021-Dynamic-Panel-Designs.md
@@ -211,7 +211,7 @@ Steps are numbered **dynamically** — an absent optional section consumes no nu
 visible steps always read `1..N` contiguously. Section labels are uppercase caption-weight,
 muted (`var(--text-secondary)`); the numbered circles + the rail carry the ordering.
 
-The **mode-accent stripe** (orange in Dynamic, cyan in Static) sits at the panel's edge.
+The **mode-accent stripe** (the single GitHub-blue accent, both modes) sits at the panel's edge.
 
 Optional sections (COEFFECTS, AFTER INTERCEPTORS, FLOWS) are **shown only when present** —
 absence is conveyed by omission, not an empty-state line. A throwing handler therefore simply
@@ -249,7 +249,7 @@ flows, and fx):
 
 ```
 ┌─ EVENT · :counter-inc · epoch #42 ─────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)                 │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)                 │
 │                                                                          │
 │  rail                                                                     │
 │   │                                                                       │
@@ -464,7 +464,7 @@ fans out to two views; two Level-1 subs short-circuited):
 
 ```
 ┌─ VIEW · epoch #42 ───────────────────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)               │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)               │
 │                                                                         │
 │ REACTIVE FLOW                                            unchanged ┄┄    │
 │ ┌─────────────────────────────────────────────────────────────────────┐ │
@@ -640,7 +640,7 @@ panel's left edge.
 
 ```
 ┌─ APP-DB · epoch #42 ────────────────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)             │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)             │
 │                                                                       │
 │ APP STATE                                                             │
 │   ▾ {:counter 2, :user {:name "Alice" :role :admin}}                  │
@@ -882,7 +882,7 @@ for the work cost of rebuilding auto-layout / zoom-pan-fit from scratch.
 | Convention | xyflow implementation |
 |---|---|
 | Nested state containment | xyflow's group/parent-node mechanic. Parent state renders as a containing rect; child states are nested xyflow nodes whose `parentNode` references the parent. |
-| Transition edge animation | xyflow's `animated: true` edge prop. Color via Causa palette (`:accent` — the mode accent, orange in Dynamic — for "fired this epoch"; `:text-tertiary` for "registered but not fired this epoch"). |
+| Transition edge animation | xyflow's `animated: true` edge prop. Color via Causa palette (`:accent` — the single GitHub-blue accent — for "fired this epoch"; `:text-tertiary` for "registered but not fired this epoch"). |
 | Current-state highlight pulse | Custom node CSS class that applies the `pulse` keyframe (~1.2s ease-in-out; CSS-variable interpolated through `--rf-causa-motion-scale` so `prefers-reduced-motion` collapses it). Pulse outline color = `:green` (the panel-domain accent). |
 | Auto-layout | xyflow's built-in `getLayoutedElements` helper (dagre algorithm). One-shot layout on first render; cached per machine-id; recomputed only when topology changes. |
 | Zoom + pan + fit | xyflow's built-in `Controls` component (re-styled to match Causa's button chrome). Default zoom: fit-on-mount with 20px padding. `[− 100% +] [Fit][Reset]` chrome already shown in the existing mockups maps 1:1 to xyflow's `Controls`. |
@@ -908,7 +908,7 @@ panel, not a generic xyflow diagram):
  :region-container   {:background "transparent"
                       :border (str "1px dashed " (:border-default tokens))}
  :edge-registered    {:stroke (:text-tertiary tokens) :stroke-width 1}
- :edge-fired-this-epoch {:stroke (:accent tokens) :stroke-width 2  ; mode accent (orange in Dynamic)
+ :edge-fired-this-epoch {:stroke (:accent tokens) :stroke-width 2  ; the single GitHub-blue accent
                          :animated true}
  :edge-label         {:fill (:text-secondary tokens)
                       :font-family mono-stack
@@ -938,7 +938,7 @@ the nodes and edges with Causa palette tokens.
 
 ```
 ┌─ MACHINES · epoch #87 ──────────────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)             │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)             │
 │                                                                       │
 │ machine :title/flow            (no activity this epoch · current ●)   │
 │ ┌─[Canvas]─────────────────────────────────────[− 100% +] [Fit][Reset]│
@@ -967,7 +967,7 @@ accent; the fired transition edge carries its **event label + guard + action inl
 
 ```
 ┌─ MACHINES · epoch #42 (machine :title/flow [:rf/init]) ─ [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)                   │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)                   │
 │ machine :title/flow                                                          │
 │ ┌─[Canvas]────────────────────────────────────────[− 100% +] [Fit][Reset]──┐│
 │ │ ┌─ active (compound) ──────────────────────────────────┐                  ││
@@ -1059,7 +1059,7 @@ superseded). Section order, top → bottom, each separated by a 1px hairline:
 
 ```
 ┌─ ROUTING · epoch #38 ──────────────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)            │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)            │
 │                                                                      │
 │ CURRENT ROUTE                                                        │
 │   :user/profile    params {:id 42}    /users/42                      │
@@ -1135,7 +1135,7 @@ Silent-by-default — a clean epoch shows a calm positive state, not an error lo
 
 ```
 ┌─ ISSUES · epoch #42 ────────────────────────────── [◀ Prev] [Next ▶] ─┐
-│▌ stripe: mode accent (orange in Dynamic · cyan in Static)             │
+│▌ stripe: mode accent (one GitHub-blue accent, both modes)             │
 │                                                                       │
 │ ▌ ERROR     handler-exception   :counter-inc threw …       12:30:05 ↗ │  ← red border
 │ ▌ WARNING   missing-doc         sub ::counter has no :doc   12:30:05 ↗ │  ← amber border
@@ -1290,7 +1290,7 @@ Sparse case — bare scalar (string fx result):
 
 ### §10.3 Keyword accent color (B.9 spec · orange identity — rf2-ad7zx)
 
-**Decision: the mode `accent`** (orange in Dynamic, cyan in Static — the locked identity per
+**Decision: the single `accent`** (GitHub blue — the locked identity per
 [022-Design-Tokens](022-Design-Tokens.md) + [007 §Colour system](007-UX-IA.md#colour-system)).
 EDN keyword **data values** are the single coloured type in the renderer; they read in the mode
 accent, keeping the keyword token visually consistent across L1 filter pills, L2 spine rows, L3
@@ -1726,25 +1726,25 @@ deliberately drew per rf2-5kfxe.9). The L4 surfaces are mono.
 
 All hex resolves through `theme/tokens` (dark) / theme-CSS-variables (light + HCM). Reconciled
 to the Figma export + the locked tokens in [022-Design-Tokens](022-Design-Tokens.md): the brand
-/ active / changed signal is the **mode `accent`** (orange in Dynamic, cyan in Static); the prior
+/ active / changed signal is the **mode `accent`** (the single GitHub-blue accent, both modes); the prior
 `:accent-violet` is retired.
 
 | Role | Token | Note |
 |---|---|---|
-| **Keyword accent** (data values · the only colored type) | `accent` (mode accent) | per §10.3 + 022 — orange in Dynamic, cyan in Static |
+| **Keyword accent** (data values · the only colored type) | `accent` | per §10.3 + 022 — the single GitHub-blue accent |
 | **Changed-value highlight** (left-margin marker + accent color) | `changed` (= `accent`) + cascade-gutter glyph (`+` green / `-` red / `~` amber / `◴` accent) | gutter glyph is the structural signal; the accent is the row tint |
 | **Dim-for-unchanged values** | `unchanged` / `dim` (`:text-tertiary`) | per 022 — `unchanged` is an alias of `dim` |
-| **Settled-success** (fx settled, no error) | `success` (`#4ADE80` / `#3FB950`) | per 022 |
-| **Settled-error** (fx settled with error · issues panel ERROR) | `error` (`#F87171`) for ink; `:red-deep` (`#a83a3a`) for button fills | per 022 |
-| **In-flight** (fx still running, e.g. `⏳ #h-142`) | `warning` (`#FBBF24`) — matches the perf-scale "medium / in-progress" tone | |
+| **Settled-success** (fx settled, no error) | `success` (`#3fb950` / `#1a7f37`) | per 022 |
+| **Settled-error** (fx settled with error · issues panel ERROR) | `error` (`#f85149`) for ink; `:red-deep` (`#a83a3a`) for button fills | per 022 |
+| **In-flight** (fx still running, e.g. `⏳ #h-142`) | `warning` (`#d29922`) — matches the perf-scale "medium / in-progress" tone | |
 | **Stale** (epoch evicted from buffer; placeholder text) | `:text-tertiary` on `:bg-2` | |
-| **Border subtle** (between adjacent rows in a list) | `border-subtle` (`#232730`) | |
-| **Border default** (around cards / canvases) | `border-default` (`#2F3441`) | |
-| **Border strong** (focused-row outline before focus-ring overlay) | `#444B5B` (per §007) | |
-| **Background — panel canvas** | `:bg-2` (`#1B1E24`) | |
-| **Background — hover row** | `hover` / `:bg-active` (`#2A2F3D`) | |
-| **Background — popover** | `:bg-3` (`#232730`) | |
-| **L4 panel header stripe** | the **mode `accent`** (orange in Dynamic, cyan in Static) | rf2-ad7zx — the per-panel domain-colour stripe (§007 Per-L4 panel accent stripe) is superseded by the single mode-accent identity, matching the Figma export's one-accent design (App.tsx active-tab `--devtools-active`). |
+| **Border subtle** (between adjacent rows in a list) | `border-subtle` (`#2a2a2a`) | |
+| **Border default** (around cards / canvases) | `border-default` (`#373737`) | |
+| **Border strong** (focused-row outline before focus-ring overlay) | `border-default` (`#373737`, per §007) | |
+| **Background — panel canvas** | `:bg-2` (`#242424`) | |
+| **Background — hover row** | `hover` / `:bg-active` (`#2a2a2a`) | |
+| **Background — popover** | `:bg-3` (`#2a2a2a`) | |
+| **L4 panel header stripe** | the **mode `accent`** (the single GitHub-blue accent, both modes) | rf2-ad7zx — the per-panel domain-colour stripe (§007 Per-L4 panel accent stripe) is superseded by the single mode-accent identity, matching the Figma export's one-accent design (App.tsx active-tab `--devtools-active`). |
 | **Cross-panel arrow / `⤴` link** | `accent` 600-weight | |
 | **Film-strip back/forward chevron** | `:text-secondary` default · `:text-primary` on hover | |
 
@@ -1984,7 +1984,7 @@ counterpart of the green `rf-causa-machine-pulse`).
 |---|---|---|---|---|
 | `--` (dashed `:text-tertiary`) | `:text-tertiary` | 1px | no | Registered transition, not fired this epoch |
 | `──` (solid `:text-tertiary`) | `:text-tertiary` | 1px | no | Same as above, but represents the most-recent traversal in the buffer |
-| `══` (thick + animated) | `accent` (mode accent — orange in Dynamic) | 2px | yes | Transition fired this epoch (the overlay) |
+| `══` (thick + animated) | `accent` (the single GitHub-blue accent) | 2px | yes | Transition fired this epoch (the overlay) |
 
 Edge label: `:micro` (`~10px`) JetBrains Mono in `:text-secondary`,
 rendered inline on the edge (xyflow's `label` prop), not in a side
@@ -2068,7 +2068,7 @@ xyflow-adapter bead (§17.5) implements against:
                          :stroke-dasharray "4 4"}
    :registered-traversed {:stroke      (:text-tertiary tokens)
                           :stroke-width 1}
-   :fired-this-epoch    {:stroke       (:accent tokens)  ; mode accent (orange in Dynamic)
+   :fired-this-epoch    {:stroke       (:accent tokens)  ; the single GitHub-blue accent
                          :stroke-width 2}})  ; + xyflow :animated true
 
 (def edge-label-style

--- a/tools/causa/spec/022-Design-Tokens.md
+++ b/tools/causa/spec/022-Design-Tokens.md
@@ -7,75 +7,116 @@
 > this doc locks the **tokens** those designs reference.
 >
 > **Authority:** the **Figma design wins on look + brand** (Mike: keep the Figma design, don't
-> go off script). This doc — orange identity, brand vs. mode-accent split, type scale,
-> visual-encoding — is downstream of the **Figma export** (`ai/figma-make-export`) and takes
-> precedence on anything *visible*. [007-UX-IA §Colour system](007-UX-IA.md#colour-system)
-> keeps the **functional semantic accents** the framework needs but the mock didn't render
-> (redacted, pair-origin, perf tiers) + the CSS-custom-property surface. Keep in sync; on the
-> visible chrome the **Figma design wins**.
+> go off script). This doc — the GitHub-style blue/neutral identity, type scale,
+> visual-encoding — is downstream of the **Figma export** (`tools/causa/design-reference/styles/devtools.css`
+> + `theme.css`) and takes precedence on anything *visible*.
+> [007-UX-IA §Colour system](007-UX-IA.md#colour-system) keeps the **functional semantic accents**
+> the framework needs but the mock didn't render (redacted, pair-origin, perf tiers) + the
+> CSS-custom-property surface. Keep in sync; on the visible chrome the **Figma design wins**.
 
-## Colour identity — orange-forward
+## Colour identity — GitHub-style blue/neutral (rf2-ad7zx.13)
 
-Causa's brand colour is **orange**. Every accent is a **single token** (a CSS custom
-property at runtime; a theme key in `implementation/.../theme/tokens.cljc`) so the identity
-is a **one-line change per token** — a hard requirement, not an accident.
+Causa's accent colour is a **single GitHub-style blue** — the palette the Figma export ships.
+Every accent is a **single token** (a CSS custom property at runtime; a theme key in
+`tools/causa/.../theme/tokens.cljc`) so the identity is a **one-line change per token** — a
+hard requirement, not an accident.
 
-**Brand vs. mode accent — keep them separate:**
-- **`brand`** is the logo / wordmark colour and is **always orange**, in either mode.
-- The **mode accent** (active tab, the mode stripe, active/selected states, focus ring)
-  **follows the current mode**: orange in **Dynamic**, cyan in **Static**. At runtime a root
-  class (`.mode-dynamic` / `.mode-static`) points `accent` at `accent-dynamic` or
-  `accent-static`. So in Dynamic the whole UI reads orange (brand + accent agree); in Static
-  the logo stays orange while active states turn cyan.
+**Single accent — no per-mode colour swap:**
+- There is **one** `accent` (GitHub blue): active tab, the chrome stripe, active/selected
+  states, focus ring, the L4 panel header stripe, and `changed`/recompute highlights all read it.
+- The **Dynamic / Static MODE stays a functional mode** (it gates motion — Static drops the
+  continuous pulses + collapses the tab fade). It **no longer drives accent colour**: the shell
+  reads the same blue accent in either mode. The earlier orange-identity scheme (an always-orange
+  `brand` plus per-mode `accent-dynamic` orange / `accent-static` cyan, swapped under a
+  `.mode-dynamic` / `.mode-static` root class) is **removed**.
+- The logo / wordmark (`❖ Causa`) reads the same single `accent` blue.
 
 ### Surfaces & text (neutral; both themes)
 
 | token | role | dark | light |
 |---|---|---|---|
-| `bg-1` | deepest surface | `#15171B` | `#F1F3F6` |
-| `bg-2` | panel surface | `#1B1E24` | `#FFFFFF` |
-| `bg-3` | raised / strip | `#232730` | `#E6E9EE` |
-| `hover` | hover background | `#232730` | `#E6E9EE` |
-| `border-subtle` | hairlines | `#232730` | `#E6E9EE` |
-| `border-default` | controls | `#2F3441` | `#CFD4DC` |
-| `text-primary` | body text | `#E8EAF0` | `#15171B` |
-| `text-secondary` | labels / hints | `#A8AEC0` | `#4B5160` |
-| `dim` | dimmed / inert / **unchanged** | `#6E7681` | `#8C959F` |
+| `bg-0` | deepest recess | `#161616` | `#fbfbfb` |
+| `bg-1` | chrome surface (sidebar, top strip) | `#1c1c1c` | `#f5f5f5` |
+| `bg-2` | panel surface | `#242424` | `#ffffff` |
+| `bg-3` | raised / strip / popovers | `#2a2a2a` | `#e8e8e8` |
+| `hover` | hover background | `#2a2a2a` | `#e8e8e8` |
+| `border-subtle` | hairlines | `#2a2a2a` | `#e8e8e8` |
+| `border-default` | controls | `#373737` | `#d1d1d1` |
+| `text-primary` | body text | `#e6edf3` | `#24292f` |
+| `text-secondary` | labels / hints | `#adbac7` | `#656d76` |
+| `text-tertiary` | muted / inactive | `#8b949e` | `#8c959f` |
+| `dim` | dimmed / inert / **unchanged** | `#6e7681` | `#8c959f` |
 
-Surfaces are kept **neutral** (orange pops on neutral, and it avoids the a11y / muddy-brown
-risk of tinted darks). Warming them a hair is an optional later polish, not required.
+`bg-1` = the Figma `--devtools-chrome-bg`; `border-default` = `--devtools-border`;
+`text-primary` = `--devtools-text`; `text-tertiary` = `--devtools-text-muted`. Surfaces are
+**neutral GitHub greys** so the blue accent pops. Causa carries three text levels (the Figma
+export ships two — `--devtools-text` + `--devtools-text-muted`); `text-secondary` is a brighter
+mid (`#adbac7`, GitHub `fg.muted`) so all three clear WCAG AA on the dark surfaces — AAA for
+primary/secondary.
 
-### Brand & mode accents
+### Accent (single blue)
 
 | token | role | dark | light |
 |---|---|---|---|
-| **`brand`** | logo / wordmark — **always orange** | `#F97316` | `#EA580C` |
-| `accent-dynamic` | Dynamic-mode accent (orange) | `#F97316` | `#EA580C` |
-| `accent-static` | Static-mode accent (cyan) | `#43C3D0` | `#2A8B96` |
-| `accent` | **runtime alias** → the active mode's accent (active tab · mode stripe · selected states · focus ring) | *= accent-dynamic in Dynamic* | *= accent-static in Static* |
+| **`accent`** | the SINGLE accent — active tab · chrome stripe · selected states · focus ring · L4 header stripe · logo · changed/recompute | `#539bf5` | `#0969da` |
 
-Decision (Mike): keep cyan for Static, but it's a single token — swapping the whole identity
-is one edit per token.
+`accent` = the Figma `--devtools-active` / `--devtools-changed`. Swapping the whole identity is
+one edit per token.
 
 ### Semantic & change
 
 | token | role | dark | light |
 |---|---|---|---|
-| `error` | errors | `#F85149` | `#CF222E` |
-| `warning` | warnings (was `yellow`; also drives the filter "N hidden" chrome) | `#FBBF24` | `#B07A05` |
-| `advisory` | advisories — the lowest Issues severity (calm, cool, ≠ warning) | `#79A6D2` | `#3B6EA5` |
-| `success` | success / diff-added | `#3FB950` | `#1A7F37` |
+| `error` | errors | `#f85149` | `#cf222e` |
+| `warning` | warnings (also drives the filter "N hidden" chrome) | `#d29922` | `#9a6700` |
+| `advisory` | advisories — the lowest Issues severity (calm, cool blue) | `#79c0ff` | `#0550ae` |
+| `success` | success / diff-added | `#3fb950` | `#1a7f37` |
+| `info` | fixed cool categorical blue — distinct from `accent` (spine-paused, sub-run, route-from, syntax-number, the machine TO-highlight) | `#79c0ff` | `#0550ae` |
 | `changed` | a value/sub **changed/recomputed** (alias of `accent`, used sparingly) | *= accent* | *= accent* |
 | `unchanged` | unchanged / short-circuited (alias of `dim`) | *= dim* | *= dim* |
 
+`error`/`warning`/`success` = the Figma `--devtools-error` / `--devtools-warning` /
+`--devtools-success`.
+
 - **Issues severities:** `error` (red) · `warning` (amber) · `advisory` (cool blue) — three
-  distinct tones so the Issues panel reads at a glance. Keep `warning` clearly distinct from
-  `brand`/`accent` (orange); if they ever blur, cool the warning toward gold `#EAB308`.
+  distinct tones so the Issues panel reads at a glance.
+- **`info` vs `accent`:** both are blue, but `accent` is the **primary** chrome signal (active /
+  selected / changed) and `info` is a **fixed categorical** cool blue used where a surface needs
+  to read as a distinct peer of the primary accent (the in-flight head rides `accent`; the
+  paused head rides `info`; the dispatch op-family rides `accent`, the db / sub families ride
+  `info`). `info` shares `advisory`'s hue — both are the GitHub syntax-number blue.
 - **app-db diff:** added → `success`, removed → `error`, changed → `warning` (reuse the
   semantic tokens; no new colours).
-- **Views / recompute:** changed/recomputed highlight → `changed` (= mode `accent`); unchanged
-  / short-circuited → `unchanged` (= `dim`). Use the accent sparingly (the changed node, not
-  whole rows) so the UI doesn't over-saturate.
+- **Views / recompute:** changed/recomputed highlight → `changed` (= `accent`); unchanged /
+  short-circuited → `unchanged` (= `dim`). Use the accent sparingly (the changed node, not whole
+  rows) so the UI doesn't over-saturate.
+
+### Functional categorical hues (carve-out)
+
+These do REAL semantic work — perf tiers, machine state, route side-channel, redaction,
+op-family legends — and are **not** collapsed into the accent.
+
+| token | role | dark | light |
+|---|---|---|---|
+| `green` | success / additions / machine-active | `#3fb950` | `#1a7f37` |
+| `yellow` | warnings / schema-replaced / `:rf/large` elision | `#d29922` | `#9a6700` |
+| `orange` | functional amber — long-task / perf-slow tier | `#FB923C` | `#C2570F` |
+| `red` | errors / schema-violations / hydration-mismatches | `#F87171` | `#C84444` |
+| `magenta` | classification: `:rf/redacted` | `#E879F9` | `#B146C2` |
+
+`orange` here is the **functional perf-amber** (`#FB923C` / `#C2570F`) — it is NOT a brand
+colour and is distinct from the removed orange brand identity.
+
+### Syntax highlighting (Figma devtools.css)
+
+EDN / Clojure source rendering reads:
+
+| role | dark | light |
+|---|---|---|
+| keyword | `accent` (`#539bf5`) | `accent` (`#0969da`) |
+| string | `green` (`#3fb950`) | `green` (`#1a7f37`) |
+| number | `info` (`#79c0ff`) | `info` (`#0550ae`) |
+| comment | `text-tertiary` | `text-tertiary` |
 
 ## Type scale (anchored at 13px)
 
@@ -94,7 +135,7 @@ Carry meaning through the **strongest channel first**; treat pictographic icons 
 *secondary* reinforcement, never the primary signal:
 
 - **Node state** (recomputed vs unchanged) → **colour + emphasis on the node**: changed =
-  `changed` (mode accent) / filled; unchanged = `unchanged` (`dim`) / outline. A short text
+  `changed` (the accent) / filled; unchanged = `unchanged` (`dim`) / outline. A short text
   tag only if colour alone is ambiguous.
 - **A relationship / short-circuit** → **edge style** (a cut/short-circuited dependency is a
   dashed + greyed edge), not a glyph beside it.
@@ -106,14 +147,12 @@ Carry meaning through the **strongest channel first**; treat pictographic icons 
 
 ## Caveats & implementation
 
-- **Contrast.** `brand` / `accent` (orange) are for **fills, active states, the mode stripe,
-  and large text — not small body text** (light-theme `#EA580C` on white is borderline for
-  WCAG AA at body size). Body copy uses `text-primary` / `text-secondary`; verify any orange
-  *text* meets AA.
-- **Migration cost.** The implementation currently reads `(:accent-violet tokens)` /
-  `(:cyan tokens)` across ~357 call sites. Renaming to `:brand` / `:accent` /
-  `:accent-static` (+ `dim`, `warning`, `advisory`, `changed`/`unchanged`) is a **call-site
-  sweep** (or temporary aliases) — not free; scoped under rf2-ad7zx.
-- **Where they live.** `implementation/.../theme/tokens.cljc` (+ the runtime
-  CSS-custom-property emission, with the `.mode-dynamic` / `.mode-static` root class flipping
-  `accent`). Consumers read `(:accent tokens)` etc. so a re-skin is a token-table edit.
+- **Contrast.** `accent` (blue) is for **fills, active states, the chrome stripe, and large
+  text**. Body copy uses `text-primary` / `text-secondary`; the dark text ramp is tuned so all
+  three text levels clear WCAG 2.1 AA on `bg-1`/`bg-2` (AAA for primary/secondary).
+- **Where they live.** `tools/causa/.../theme/tokens.cljc` (+ the runtime CSS-custom-property
+  emission in `theme/global-styles`). The Dynamic/Static mode root class no longer flips the
+  accent. Consumers read `(:accent tokens)` etc. so a re-skin is a token-table edit. The
+  machines-viz chart (`tools/machines-viz/.../theme/tokens.cljc`) mirrors this palette at the
+  values level (drift-gate `causa-and-machines-viz-*-palettes-match-values`, rf2-z7ms8) so the
+  chart paints the same colours whether embedded by Causa or standalone.

--- a/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
@@ -116,8 +116,8 @@
     slowest?                  (:yellow tokens/tokens)
     (= phase :issued)         (:accent tokens/tokens)
     (contains? #{:elapsed :ttfb :download :receive :compute}
-               phase)         (:accent-static tokens/tokens)
-    :else                     (:accent-static tokens/tokens)))
+               phase)         (:info tokens/tokens)
+    :else                     (:info tokens/tokens)))
 
 (defn render
   "Render a wire-timing map as a hiccup SVG waterfall.

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -103,10 +103,10 @@
   0.9)
 
 (def default-accent-css-var
-  "Name of the CSS custom property carrying Causa's brand-accent
-  colour (the orange `#F97316` from `theme/tokens.cljc` /
-  `spec/007-UX-IA.md` §Colour system / `:brand` — the brand moved
-  violet → orange per rf2-ad7zx). Published per rf2-9ovfb so:
+  "Name of the CSS custom property carrying Causa's accent colour (the
+  GitHub blue `#539bf5` from `theme/tokens.cljc` / `spec/007-UX-IA.md`
+  §Colour system / `:accent` — the single Figma accent per
+  rf2-ad7zx.13). Published per rf2-9ovfb so:
 
     - Host application stylesheets can colour their own dev chrome
       to match Causa (e.g. a resize-handle inset shadow, a dock-
@@ -119,9 +119,8 @@
 
           background: rgb(from var(--rf-causa-accent) r g b / 0.35);
 
-      (or pre-CSS-4: `rgba(249, 115, 22, 0.35)` — equivalent to the
-      published hex at 35% alpha, the value Pitch8 eyeballed for
-      resize-drag accents).
+      (or pre-CSS-4: `rgba(83, 155, 245, 0.35)` — equivalent to the
+      published hex at 35% alpha).
 
   Causa publishes the property on `:root` in the recommended host
   snippet so the lookup resolves anywhere in the cascade. The host
@@ -133,21 +132,20 @@
   "--rf-causa-accent")
 
 (def default-accent
-  "Default value Causa publishes for `--rf-causa-accent` — the brand
-  orange from `theme/tokens.cljc` (`:brand`, `#F97316`; the brand
-  moved violet → orange per rf2-ad7zx). Resolved through the canonical
-  `dark-palette` map so the brand hex has exactly one source of truth
+  "Default value Causa publishes for `--rf-causa-accent` — the single
+  Figma accent from `theme/tokens.cljc` (`:accent`, GitHub blue
+  `#539bf5` per rf2-ad7zx.13). Resolved through the canonical
+  `dark-palette` map so the accent hex has exactly one source of truth
   (rf2-5kfxe.4). Matches the accent catalogued in `spec/007-UX-IA.md`
   §Colour system.
 
   Reads `dark-palette` (the literal hex map) rather than `tokens`
   because `tokens` exposes CSS-variable strings (`var(--rf-causa-…)`)
   post rf2-on4cm; this constant is the VALUE that gets published
-  INTO the CSS variable, not a reference to it. Uses `:brand` (the
-  always-orange token) rather than `:accent` so the host-published
-  default is the brand identity, independent of the runtime
-  Dynamic/Static mode flip."
-  (:brand tokens/dark-palette))
+  INTO the CSS variable, not a reference to it. The Dynamic/Static
+  mode no longer flips the accent colour (rf2-ad7zx.13), so the single
+  `:accent` token is the host-published default."
+  (:accent tokens/dark-palette))
 
 (def default-layout-host-snippet
   ;; DOM order is `<main>` first, host `<aside>` second — flex flow
@@ -184,7 +182,7 @@
 </div>
 
 <style>
-  :root { --rf-causa-accent: #F97316; }
+  :root { --rf-causa-accent: #539bf5; }
   body { margin: 0; }
   .app-shell { display: flex; min-height: 100vh; }
   [data-rf-causa-host] {

--- a/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/data_display/render.cljs
@@ -33,8 +33,8 @@
      before|after** — diff is annotation on a single rendered state
      (§10.1.2). Unchanged values dim to `:text-tertiary`.
 
-  3. **Minimal type colouring** — keywords get the mode `accent`
-     (orange in Dynamic / cyan in Static — the only coloured type).
+  3. **Minimal type colouring** — keywords get the single `:accent`
+     (GitHub blue — the only coloured type).
      Strings / numbers / nil / booleans / symbols render mono in
      `:text-primary`. Aids EDN-shape recognition without colour-noise
      (§10.3).

--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -56,14 +56,14 @@
 
 ;; ---- per-source visual style --------------------------------------------
 
-;; Per-source categorical legend (rf2-ad7zx). `:command` is the primary
-;; action category → the mode `accent` (orange Dynamic / cyan Static);
-;; `:panel` keeps a fixed cyan (`accent-static`) so it stays a distinct
-;; category against the now-orange command accent. yellow/green/magenta
-;; are functional categorical hues, untouched.
+;; Per-source categorical legend (rf2-ad7zx.13). `:command` is the
+;; primary action category → the single `:accent` (GitHub blue);
+;; `:panel` keeps a fixed cool blue (`:info`) so it stays a distinct
+;; category against the command accent. yellow/green/magenta are
+;; functional categorical hues, untouched.
 (def ^:private source-colour
   {:command          (:accent tokens)
-   :panel            (:accent-static tokens)
+   :panel            (:info tokens)
    :setting          (:yellow tokens)
    :recent-event     (:green tokens)
    :frame            (:magenta tokens)

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -62,7 +62,7 @@
   follows the active theme."
   [kind]
   (case kind
-    :parent-decision (:accent-static tokens)     ; fixed cyan/blue category (≠ mode accent)
+    :parent-decision (:info tokens)              ; fixed cool-blue category (≠ accent)
     :child-teardown  (or (:accent-orange tokens)
                          (:warning-amber tokens)
                          (:yellow tokens))

--- a/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
@@ -34,33 +34,32 @@
 
       Status            Token            Hex (dark)  When
       ----------------  ---------------  ----------  -----------------------
-      :in-flight        :accent          #F97316     cascade still building
+      :in-flight        :accent          #539bf5     cascade still building
                                                      (LIVE head, not yet
-                                                     settled). The mode
-                                                     accent (orange in
-                                                     Dynamic / cyan in
-                                                     Static) — the LIVE
-                                                     head IS the current-
-                                                     epoch accent (§007).
-      :settled-success  :green           #4ADE80     handler ran, no
+                                                     settled). The single
+                                                     accent (GitHub blue) —
+                                                     the LIVE head IS the
+                                                     current-epoch accent
+                                                     (§007).
+      :settled-success  :green           #3fb950     handler ran, no
                                                      exception, no warnings.
       :settled-error    :red             #F87171     handler threw, or an
                                                      :rf.error/* trace
                                                      landed in the cascade.
-      :paused-by-tool   :accent-static   #43C3D0     spine paused
+      :paused-by-tool   :info            #79c0ff     spine paused
                                                      (LIVE+paused) — e.g.
                                                      a tool has claimed
                                                      the buffer. TanStack
                                                      uses purple for
                                                      paused; the in-flight
-                                                     head now owns the mode
+                                                     head owns the primary
                                                      accent, so paused picks
-                                                     the fixed cyan
-                                                     `accent-static` as a
-                                                     distinct peer. Magenta
-                                                     is reserved for the
-                                                     `▥` whole-redacted
-                                                     row marker.
+                                                     the fixed cool blue
+                                                     `:info` as a distinct
+                                                     peer. Magenta is
+                                                     reserved for the `▥`
+                                                     whole-redacted row
+                                                     marker.
       :stale            :yellow          #FBBF24     cascade replayed via
                                                      time-travel / RETRO
                                                      mode. The TanStack
@@ -143,7 +142,7 @@
   {:in-flight       :accent
    :settled-success :green
    :settled-error   :red
-   :paused-by-tool  :accent-static   ; fixed cyan — distinct from :in-flight (mode accent)
+   :paused-by-tool  :info            ; fixed cool blue — distinct from :in-flight (accent)
    :stale           :yellow})
 
 ;; ---- classification ------------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -367,8 +367,8 @@
                       :border-bottom (str "1px solid " (:border-subtle tokens))
                       :font-family   sans-stack
                       :font-size     "13px"}}
-     ;; spec/021 §17.1.5 — Event panel header icon: ⚡ in the mode
-     ;; :accent (orange Dynamic / cyan Static).
+     ;; spec/021 §17.1.5 — Event panel header icon: ⚡ in the single
+     ;; :accent (GitHub blue).
      [:span {:data-testid "rf-causa-event-detail-panel-icon"
              :aria-hidden "true"
              :style {:color (:accent tokens)
@@ -406,10 +406,10 @@
      [:span {:style {:flex 1}}]
      (when ssr?
        [:span {:data-testid "rf-causa-event-detail-header-ssr-badge"
-               ;; SSR origin badge — fixed info cyan (`accent-static`,
-               ;; the §007 :story/:test/info hue), kept distinct from the
-               ;; mode accent so it always reads as an origin marker.
-               :style {:color (:accent-static tokens)
+               ;; SSR origin badge — fixed info blue (`:info`, the §007
+               ;; :story/:test/info hue), kept distinct from the primary
+               ;; accent so it always reads as an origin marker.
+               :style {:color (:info tokens)
                        :font-family mono-stack
                        :font-weight 700
                        :font-size "11px"
@@ -1247,8 +1247,8 @@
     [:div {:data-testid "rf-causa-event-detail-cascade"
            :data-dispatch-id (str dispatch-id)
            :data-frame (str frame)
-           ;; §17.1.3 / spec/022 — Event panel header stripe is the mode
-           ;; :accent (orange Dynamic / cyan Static).
+           ;; §17.1.3 / spec/022 — Event panel header stripe is the
+           ;; single :accent (GitHub blue).
            :style {:border-left (str "3px solid " (:accent tokens))}}
      (panel-header cascade)
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -249,7 +249,7 @@
                           mode-accent border.
     :to-highlight       — focused-event lens landing state. Optional;
                           xyflow renders the landing state with an
-                          emphasised fixed-cyan (`accent-static`)
+                          emphasised fixed cool-blue (`:info`)
                           border. Wins over `:current-state`.
     :current-state      — live snapshot state for the active-state
                           highlight. Optional; nil renders no
@@ -257,7 +257,7 @@
     :sim?               — rf2-u422r. When true the active-state
                           highlight uses the amber sim palette (so the
                           on-chart hermetic simulator reads distinct
-                          from the live cyan highlight). Forwarded to
+                          from the live cool-blue highlight). Forwarded to
                           `mv-chart/MachineChart`.
     :on-edge-click      — rf2-u422r. `(fn [#js {:eventId :fromPath
                           :toPath}] ...)` invoked when a transition

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
@@ -115,7 +115,7 @@
   via the panel's `tokens` map."
   {:ok         :green
    :error      :red
-   :in-flight  :accent-static            ; fixed cyan — distinct from the accent-coloured :overridden/:stub
+   :in-flight  :info                     ; fixed cool blue — distinct from the accent-coloured :overridden/:stub
    :overridden :accent
    :skipped    :text-tertiary
    :stub       :accent})

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -45,7 +45,7 @@
             [day8.re-frame2-causa.panels.managed-fx-helpers :as h]
             [day8.re-frame2-causa.chart.timing-waterfall :as waterfall]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack sans-stack]]
+             :refer [tokens mono-stack sans-stack with-alpha]]
             [day8.re-frame2-causa.theme.section :as section]
             [day8.re-frame2-causa.views.edn-widget.widget :as edn]))
 
@@ -174,8 +174,8 @@
                    :gap           "4px"
                    :padding       "1px 8px"
                    :border-radius "3px"
-                   :background    "rgba(67, 195, 208, 0.12)"
-                   :color         (:accent-static tokens)
+                   :background    (with-alpha :info 12)
+                   :color         (:info tokens)
                    :font-family   mono-stack
                    :font-size     "11px"
                    :font-weight   700

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -10,7 +10,7 @@
   sections, each separated from the next by a 1px hairline:
 
       ┌─ ROUTING · epoch #38 ─────────────────────── [◀ Prev] [Next ▶] ─┐
-      │▌ stripe: mode accent (orange in Dynamic)                        │
+      │▌ stripe: the single GitHub-blue accent                          │
       │                                                                 │
       │ CURRENT ROUTE                                                   │
       │   :user/profile    params {:id 42}    /users/42                 │
@@ -79,9 +79,9 @@
              :as t
              :refer [tokens mono-stack sans-stack]]))
 
-;; ---- mode accent --------------------------------------------------------
+;; ---- accent -------------------------------------------------------------
 ;;
-;; The Dynamic Routing panel's mode accent is the orange `:accent` token
+;; The Routing panel's accent is the single GitHub-blue `:accent` token
 ;; (per `panel-domain->token`). Both the CURRENT ROUTE id and the
 ;; current row in the ROUTE TABLE ride this hue so the operator's eye
 ;; ties the two surfaces together (RoutesPanel.tsx `--devtools-active`).
@@ -167,7 +167,7 @@
 
     - :on-match           → 'transitioned' (green — a route landed)
     - :navigation-blocked → 'blocked'      (warning — a guard refused)
-    - :fragment-changed   → 'fragment changed' (accent-static — anchor)
+    - :fragment-changed   → 'fragment changed' (info — anchor)
     - navigated? but no destination resolved → 'not-found' (error)"
   [{:keys [phase]} navigated? to-id]
   (cond
@@ -178,7 +178,7 @@
     {:label "blocked" :colour (:warning tokens)}
 
     (= phase :fragment-changed)
-    {:label "fragment changed" :colour (:accent-static tokens)}
+    {:label "fragment changed" :colour (:info tokens)}
 
     (and navigated? (nil? to-id))
     {:label "not-found" :colour (:error tokens)}
@@ -211,7 +211,7 @@
                              :color       (:text-primary tokens)}}
          [:span {:data-testid "rf-causa-routing-nav-from"
                  :style       {:color (if from-id
-                                        (:accent-static tokens)
+                                        (:info tokens)
                                         (:text-tertiary tokens))}}
           (if from-id (str from-id) "—")]
          [:span {:style {:color (:text-tertiary tokens)}} "──►"]
@@ -255,7 +255,7 @@
   [marker]
   (case marker
     :to   {:glyph "◉" :colour (:green tokens)         :label "TO"}
-    :from {:glyph "◇" :colour (:accent-static tokens) :label "FROM"}
+    :from {:glyph "◇" :colour (:info tokens)          :label "FROM"}
     nil))
 
 (defn- tree-prefix

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -47,7 +47,7 @@
 ;; families, not the full op-type vocabulary:
 ;;
 ;;     :dispatch  — the event side (`:rf.event/dispatched` / run-start /
-;;                  run-end). Mode accent (orange / cyan).
+;;                  run-end). The single GitHub-blue accent.
 ;;     :db        — `:rf.event/db-changed`. The "changed" tone.
 ;;     :fx        — the effect side (`:rf.fx/*`). Warning tone.
 ;;     :reactive  — the post-cascade reactive aftermath (`:rf.sub/*` /
@@ -86,10 +86,10 @@
 
   Family → token (spec/021 §5.2 · design-reference/TracePanel.tsx):
 
-    :dispatch → :accent         (mode accent — orange / cyan)
-    :db       → :accent-static  (the cyan 'changed/recompute' partner,
-                                 visually distinct from the orange
-                                 event accent now that events ride it)
+    :dispatch → :accent         (the single GitHub-blue accent)
+    :db       → :info           (the cool-blue 'changed/recompute' partner,
+                                 visually distinct from the primary
+                                 accent now that dispatch rides it)
     :fx       → :warning        (the effect/warning tone)
     :reactive → :dim            (dimmed / inert reactive aftermath)
     :machine  → :green          (the machine-domain tone — Causa's
@@ -97,7 +97,7 @@
     :error    → :red
     :warning  → :yellow"
   {:dispatch :accent
-   :db       :accent-static
+   :db       :info
    :fx       :warning
    :reactive :dim
    :machine  :green
@@ -652,15 +652,15 @@
   {:error                :red
    :warning              :yellow
    ;; op-family colour bands (spec/007 §Colour system). Events ride the
-   ;; mode `accent` (the spine); the sub family + info keep a fixed cyan
-   ;; (`accent-static`) so the two bands stay visually distinct now that
-   ;; the event band is the orange accent (rf2-ad7zx).
-   :info                 :accent-static
+   ;; single `:accent` (the spine); the sub family + info keep a fixed
+   ;; cool blue (`:info`) so the two bands stay visually distinct from
+   ;; the GitHub-blue event accent (rf2-ad7zx.13).
+   :info                 :info
    :rf.event             :accent
    :rf.event/db-changed  :accent
    :rf.fx                :green
-   :rf.sub/run           :accent-static
-   :rf.sub/create        :accent-static
+   :rf.sub/run           :info
+   :rf.sub/create        :info
    :rf.view/render       :magenta
    :rf.frame             :text-secondary})
 

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -343,13 +343,11 @@
    :cursor           "col-resize"
    :background       "transparent"
    ;; Hairline guide on the leftmost pixel so the affordance is
-   ;; visible against any host-app background. `~33% alpha` of the mode
-   ;; accent (orange in Dynamic / cyan in Static; the historical
-   ;; "#7C5CFF55" violet tail-suffix is retired with the orange
-   ;; identity, rf2-ad7zx). Built via `tokens/with-alpha` so the alpha
-   ;; composites with the ACTIVE-theme + ACTIVE-mode variable
-   ;; (rf2-on4cm) — light/dark + Dynamic/Static all land on the live
-   ;; accent at 33% alpha.
+   ;; visible against any host-app background. `~33% alpha` of the
+   ;; single `:accent` (GitHub blue; rf2-ad7zx.13). Built via
+   ;; `tokens/with-alpha` so the alpha composites with the ACTIVE-theme
+   ;; variable (rf2-on4cm) — light/dark both land on the live accent at
+   ;; 33% alpha.
    :box-shadow       (str "inset 1px 0 0 0 "
                           (t/with-alpha :accent 33))
    ;; Above the chrome's panels but below the modals; modals use

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -750,9 +750,9 @@
   buys the compacted height.
 
   The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
-  #2 — orange Dynamic / cyan Static, rf2-ad7zx) stays as the at-a-glance
-  mode cue, so the understated mode dropdown can recede without losing
-  the signal.
+  #2 — the single GitHub-blue accent in both modes, rf2-ad7zx.13) stays
+  as the chrome-edge accent; the understated mode dropdown carries the
+  mode state via its active option + `data-active-mode`.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -774,14 +774,13 @@
                    :background       (:bg-1 tokens)
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
                    ;; rf2-o5f5f.1 — mode-signal mechanism #2: a 2-px
-                   ;; left-edge stripe in the active mode's accent
-                   ;; (orange in Dynamic, cyan in Static — rf2-ad7zx).
-                   ;; Painted on the ribbon so it lines up with the
-                   ;; top-of-shell edge regardless of the L2 resize-
-                   ;; handle. The stripe-hex helper reads the per-mode
-                   ;; `:accent-dynamic` / `:accent-static` token through
-                   ;; the current palette (light vs dark via CSS custom
-                   ;; properties).
+                   ;; left-edge stripe in the single `:accent` (GitHub
+                   ;; blue — the Figma export carries one accent;
+                   ;; rf2-ad7zx.13). Painted on the ribbon so it lines up
+                   ;; with the top-of-shell edge regardless of the L2
+                   ;; resize-handle. The stripe-hex helper resolves the
+                   ;; `:accent` token through the current palette (light
+                   ;; vs dark via CSS custom properties).
                    :border-left      (str "2px solid "
                                           (static-shell/stripe-hex-for-mode :dynamic))
                    :font-family      sans-stack
@@ -794,15 +793,14 @@
       ;; rf2-ad7zx.12 — the `❖ Causa` wordmark, top-left of the chrome
       ;; ribbon per the Figma design-reference (`design-reference/
       ;; components/ChromeRibbon.tsx`). Semibold, `:body-tight`, the
-      ;; ALWAYS-orange `:brand` token (the diamond glyph + the word stay
-      ;; orange in both Dynamic and Static modes — it is the product
-      ;; identity, not the mode accent). `aria-hidden` on the decorative
+      ;; single `:accent` token (GitHub blue — the Figma export carries
+      ;; one accent; rf2-ad7zx.13). `aria-hidden` on the decorative
       ;; `❖` glyph keeps the wordmark from announcing its unicode name.
       [:div {:data-testid "rf-causa-ribbon-logo"
              :style {:display      "flex"
                      :align-items  "center"
                      :gap          "5px"
-                     :color        (:brand tokens)
+                     :color        (:accent tokens)
                      :font-family  sans-stack
                      :font-size    (:body-tight type-scale)
                      :font-weight  600
@@ -2072,13 +2070,13 @@
     (when (not= current-positioning modal-positioning)
       (rf/dispatch-sync [:rf.causa/set-modal-positioning modal-positioning]
                         {:frame :rf/causa})))
-  ;; rf2-ad7zx / spec/022 — the lens mode (`:rf.causa/mode` =
+  ;; rf2-ad7zx.13 / spec/022 — the lens mode (`:rf.causa/mode` =
   ;; :dynamic | :static) drives the `mode-dynamic` / `mode-static`
-  ;; root class. `theme/global-styles/mode-accent-css` re-points
-  ;; `--rf-causa-accent` at the orange (Dynamic) or cyan (Static)
-  ;; accent off this class, so the whole shell's chrome accent flips
-  ;; off ONE token while the brand wordmark stays orange in either
-  ;; mode. Subscribed via the explicit `:rf/causa` frame (same shape
+  ;; root class, which still gates functional behaviour (motion / pulse
+  ;; dampening in Static). Post rf2-ad7zx.13 the Figma export carries a
+  ;; SINGLE accent (GitHub blue) — the mode class no longer re-points
+  ;; `--rf-causa-accent`, so the chrome accent is the same blue in both
+  ;; modes. Subscribed via the explicit `:rf/causa` frame (same shape
   ;; as the modal-positioning read above — `shell-view` sits outside
   ;; its own frame-provider).
   (let [lens-mode @(rf/subscribe :rf/causa [:rf.causa/mode])]

--- a/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
@@ -27,10 +27,11 @@
   cadence, anchoring the eye at chrome-left where the Frame picker now
   belongs. The reshape collapses it to a compact `<select>` that shares
   the frame picker's weight (`bg-2` fill, `border-default` hairline,
-  4px radius). The MODE SIGNAL is carried elsewhere — the chrome
-  ribbon's 2-px left-edge accent stripe (orange Dynamic / cyan Static,
-  `static/shell/stripe-hex-for-mode` — rf2-ad7zx) — so the control
-  itself can recede without losing the at-a-glance mode cue.
+  4px radius). Post rf2-ad7zx.13 the Figma export carries a single
+  `:accent` (GitHub blue) — the ribbon stripe no longer changes colour
+  by mode; the `<select>`'s `data-active-mode` attribute + active option
+  carry the mode state, and the Dynamic/Static MODE remains functional
+  (it drives motion/pulse), it just no longer drives accent colour.
 
   ## Why a single registered view
 

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
@@ -34,7 +34,7 @@
   [kind]
   (let [{:keys [letter colour title]}
         (case kind
-          :on-match  {:letter "M" :colour (:accent-static tokens) :title ":on-match"}
+          :on-match  {:letter "M" :colour (:info tokens)          :title ":on-match"}
           :can-leave {:letter "L" :colour (:yellow tokens)        :title ":can-leave"}
           :tags      {:letter "T" :colour (:magenta tokens)       :title ":tags"}
           :parent    {:letter "P" :colour (:accent tokens) :title ":parent"}

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -219,7 +219,7 @@
   [kind]
   (let [{:keys [letter colour]}
         (case kind
-          :app-db {:letter "A" :colour (:accent-static tokens)}
+          :app-db {:letter "A" :colour (:info tokens)}
           :event  {:letter "E" :colour (:magenta tokens)}
           :sub    {:letter "S" :colour (:yellow tokens)}
           {:letter "?" :colour (:text-tertiary tokens)})]

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -89,10 +89,11 @@
        200ms cross-fade. Owned by `static/mode_pill.cljs`. The pill
        lives at ribbon-left in BOTH modes (it's the toggle, not the
        indicator).
-    2. **2-px left-edge ribbon stripe** — `:accent-dynamic` (orange) in
-       Dynamic, `:accent-static` (cyan) in Static. Owned by both shells
-       via the explicit `mode-stripe-colour` arg passed into the
-       ribbon's outer div.
+    2. **2-px left-edge ribbon stripe** — the single `:accent` (GitHub
+       blue) in both modes (rf2-ad7zx.13: the Figma export carries one
+       accent, no per-mode colour swap). Owned by both shells via the
+       explicit `mode-stripe-colour` arg passed into the ribbon's outer
+       div.
     3. **Motion dampening** — Dynamic ships the LIVE pulse + machine-
        active pulse + 180ms tab fade. Static drops the continuous
        pulses entirely; the 180ms tab fade collapses to 0ms (instant)
@@ -174,26 +175,24 @@
   KEY (not the resolved hex) so per-theme palette switching (rf2-
   5kfxe.6 light theme) flows through naturally.
 
-  The Dynamic stripe is the orange `:accent-dynamic` token (the brand-
-  orange identity, rf2-ad7zx / spec/022). It reads the per-MODE token
-  directly — not the runtime `:accent` alias — because the stripe IS
-  the mode signal, so it must always paint the Dynamic accent
-  regardless of which mode is active when the stripe is rendered."
-  :accent-dynamic)
+  Post rf2-ad7zx.13 the Figma export carries a SINGLE accent (GitHub
+  blue), so the stripe paints `:accent` in BOTH modes — there is no
+  per-mode accent colour swap. The Dynamic/Static MODE stays functional
+  (it drives motion/pulse), it just no longer drives stripe colour."
+  :accent)
 
 (def static-stripe-token
   "Token-key for the Static mode's 2-px left-edge ribbon stripe per
-  the parent-epic mode-signal mechanism (signal #2). The cyan
-  `:accent-static` token (#43C3D0 dark / #2A8B96 light, spec/022) —
-  the per-MODE Static accent, read directly rather than via the
-  runtime `:accent` alias so the stripe always paints the Static
-  accent as the mode signal."
-  :accent-static)
+  the parent-epic mode-signal mechanism (signal #2). Post rf2-ad7zx.13
+  this is the single `:accent` (GitHub blue) — same as Dynamic; the
+  Figma export has no per-mode accent colour swap."
+  :accent)
 
 (defn stripe-token-for-mode
-  "Pure helper. Returns the token KEY (`:accent-dynamic` /
-  `:accent-static`) the L1 ribbon should paint as its 2-px left-edge
-  stripe for the given mode. JVM-portable so the test corpus can cover
+  "Pure helper. Returns the token KEY (`:accent`) the L1 ribbon should
+  paint as its 2-px left-edge stripe for the given mode. Post
+  rf2-ad7zx.13 both modes resolve to the single `:accent` (the Figma
+  export's one blue accent). JVM-portable so the test corpus can cover
   the round-trip without a CLJS runtime."
   [mode]
   (case mode

--- a/tools/causa/src/day8/re_frame2_causa/theme/data_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/data_inspector.cljs
@@ -57,18 +57,17 @@
 
 (def ^:private colour
   "Per-leaf colour mapping for the L4 data-VALUE renderer. EDN keyword
-  data values read in the mode `accent` (orange in Dynamic, cyan in
-  Static — the single mode-coloured data type per §021 §10.3 /
-  spec/022). The remaining leaf types keep their distinct categorical
+  data values read in the single `:accent` (GitHub blue — the one
+  accent-coloured data type per §021 §10.3 / spec/022). The remaining
+  leaf types keep their distinct categorical
   syntax hues so the structural tree stays legible: strings green,
-  numbers a fixed cyan (`accent-static`, kept distinct from the now-
-  orange keyword accent), nil grey, booleans orange, symbols magenta,
-  default text-primary. Mapped onto Causa's token palette so the
-  renderer reads as native shell chrome rather than a third-party
-  widget."
+  numbers a fixed cool blue (`:info`, kept distinct from the keyword
+  accent), nil grey, booleans orange, symbols magenta, default
+  text-primary. Mapped onto Causa's token palette so the renderer reads
+  as native shell chrome rather than a third-party widget."
   {:keyword (:accent tokens)
    :string  (:green tokens)
-   :number  (:accent-static tokens)
+   :number  (:info tokens)
    :nil     (:text-tertiary tokens)
    :boolean (:orange tokens)
    :symbol  (:magenta tokens)

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -203,45 +203,17 @@
        (map (fn [[k v]] (str "  " (token-key->css-var k) ": " v ";\n")))
        (apply str)))
 
-(def ^:private mode-accent-css
-  "Mode-accent runtime alias (rf2-ad7zx / spec/022 §Colour identity).
-
-  `--rf-causa-accent` is the SINGLE token every chrome accent reads
-  (active tab · mode stripe · selected states · focus ring ·
-  changed/recompute · L4 header stripe). The dark/light palette blocks
-  publish its default = the Dynamic (orange) accent. These two root-
-  class rules re-point it per the current MODE so the whole shell reads
-  orange in Dynamic and cyan in Static, while `--rf-causa-brand` (the
-  logo/wordmark) stays orange in either mode.
-
-  The class is written on BOTH the `<html>` root and the shell node
-  (mount.cljs / the shells), so a higher-specificity single-class
-  selector outranks the `:root` default. The `:where()` wrapper keeps
-  specificity at zero so the theme-class palette blocks (which also set
-  `--rf-causa-accent` via `palette->declarations`) do not win over the
-  mode flip — `:where(.mode-static)` and the bare `.mode-static` shell
-  node both resolve, and the assignment is identical, so either landing
-  works."
-  (str
-    ;; Dynamic mode (default) — accent follows the orange Dynamic accent.
-    ".mode-dynamic, :root.mode-dynamic {\n"
-    "  --rf-causa-accent: var(--rf-causa-accent-dynamic);\n"
-    "}\n"
-    ;; Static mode — accent follows the cyan Static accent. Brand stays
-    ;; orange (it reads --rf-causa-brand, untouched here).
-    ".mode-static, :root.mode-static {\n"
-    "  --rf-causa-accent: var(--rf-causa-accent-static);\n"
-    "}\n"))
-
 (defn- themes-css
   "Build the per-theme CSS block. The dark palette publishes at `:root`
   (the safe fallback) AND at `.rf-causa-theme-dark` (so the class
   toggle has a matched landing). The light palette publishes at
-  `.rf-causa-theme-light` so the class toggle activates it. The
-  `mode-accent-css` block then re-points `--rf-causa-accent` at the
-  Dynamic / Static accent under the `.mode-dynamic` / `.mode-static`
-  root class (rf2-ad7zx / spec/022) so the whole shell turns orange in
-  Dynamic, cyan in Static, off ONE token."
+  `.rf-causa-theme-light` so the class toggle activates it.
+
+  `--rf-causa-accent` is the SINGLE accent token (GitHub blue `#539bf5`
+  dark / `#0969da` light — the Figma export's `--devtools-active`).
+  Per rf2-ad7zx.13 there is NO per-mode accent colour swap: the
+  Dynamic/Static mode is functional only and no longer re-points the
+  accent, so the whole shell reads the same blue accent in both modes."
   [themes]
   (str
     ;; Default — :root carries the dark palette so any descendant
@@ -257,9 +229,7 @@
     "}\n"
     ".rf-causa-theme-light {\n"
     (palette->declarations (:light themes))
-    "}\n"
-    ;; Mode-accent alias — flips --rf-causa-accent orange↔cyan by mode.
-    mode-accent-css))
+    "}\n"))
 
 (defn- inject-themes-style!
   "Append the per-theme `<style>` block to `<head>`. Idempotent —
@@ -511,17 +481,17 @@
     "}\n"
     ;; rf2-ad7zx.10 — active-state DOUBLE-CIRCLE pulse (spec/021
     ;; §6.2 Case C + §17.4.2). The Figma reconcile draws the focused
-    ;; TO / current state as a concentric double-circle in the mode
-    ;; accent (orange Dynamic / cyan Static), not the former green
-    ;; single ring. The `:current` node (`panels/machines/xyflow_style`)
+    ;; TO / current state as a concentric double-circle in the single
+    ;; `:accent` (GitHub blue), not the former green single ring. The
+    ;; `:current` node (`panels/machines/xyflow_style`)
     ;; carries `:animation rf-causa-machine-pulse-active 1.2s …`.
     ;;
     ;; box-shadow sets the WHOLE property each frame, so the keyframe
     ;; must re-state the STATIC concentric rings (inner `:bg-1` gap +
     ;; inner accent ring — matching the `:current` node's base
     ;; box-shadow) on every stop, then ADD the breathing outer halo as
-    ;; the trailing layer. `--rf-causa-accent` tracks the active mode so
-    ;; the halo is orange in Dynamic and cyan in Static. Runs through
+    ;; the trailing layer. `--rf-causa-accent` is the single GitHub-blue
+    ;; accent, so the halo is blue in both modes. Runs through
     ;; `--rf-causa-motion-scale` like the green pulse, so the
     ;; `prefers-reduced-motion` seam collapses it to a resolved frame.
     "@keyframes rf-causa-machine-pulse-active {\n"
@@ -566,14 +536,14 @@
     ;; its own palette (Canvas / CanvasText / Highlight / …), which
     ;; collapses every author-encoded signal across the Causa chrome:
     ;;
-    ;;   - L1 ribbon mode stripe (orange Dynamic / cyan Static accent
-    ;;     on the left edge)
-    ;;   - L2 row focused border (mode accent)
+    ;;   - L1 ribbon stripe (the single GitHub-blue accent on the left
+    ;;     edge)
+    ;;   - L2 row focused border (accent)
     ;;   - L2 row status accent (the 2px inset box-shadow on the
     ;;     trailing edge — box-shadow itself is also dropped in HCM)
-    ;;   - L2 row gutter causal-chain thread (1px mode-accent inset)
-    ;;   - L4 panel header accent stripes (3px left border — the mode
-    ;;     accent: orange Dynamic / cyan Static, rf2-ad7zx)
+    ;;   - L2 row gutter causal-chain thread (1px accent inset)
+    ;;   - L4 panel header accent stripes (3px left border — the single
+    ;;     GitHub-blue accent, rf2-ad7zx.13)
     ;;   - Focus-visible amber outline (the #FBBF24 hex above; the UA
     ;;     forces this to its own Highlight regardless of author intent)
     ;;   - Secondary / tertiary text (drifted greys collapse to a
@@ -619,9 +589,9 @@
     "  [data-testid=\"rf-causa-palette-backdrop\"] *:focus-visible {\n"
     "    outline-color: Highlight !important;\n"
     "  }\n"
-    ;; L1 ribbon mode stripe (orange Dynamic / cyan Static) → Highlight.
-    ;; The 2px left border is the operator's "which mode am I in"
-    ;; signal; preserve it as the user's selected-emphasis hue.
+    ;; L1 ribbon stripe (single GitHub-blue accent) → Highlight.
+    ;; The 2px left border is the operator's chrome-edge accent signal;
+    ;; preserve it as the user's selected-emphasis hue.
     "  [data-testid=\"rf-causa-ribbon\"] {\n"
     "    border-left-color: Highlight !important;\n"
     "  }\n"
@@ -674,7 +644,7 @@
     "    color: Highlight !important;\n"
     "  }\n"
     ;; L4 panel header accent stripes (3px left border on the panel
-    ;; <h1>) — the mode accent (orange Dynamic / cyan Static)
+    ;; <h1>) — the single GitHub-blue accent
     ;; collapses to CanvasText so the stripe still paints as a
     ;; visible left edge. Panels remain visually distinguishable by
     ;; their L3 tab label and their content; the stripe drops its

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -50,68 +50,67 @@
 ;; ---- per-theme palettes -------------------------------------------------
 
 (def dark-palette
-  "Dark-theme colour tokens lifted from `spec/007-UX-IA.md` §Dark theme
-  tokens. The default Causa palette; `tokens` is an alias of this map
-  so the 357 inline `(:bg-1 tokens)` call sites keep resolving without
-  a runtime switch (the CSS-variable migration is the v1.0 styling
-  pass)."
+  "Dark-theme colour tokens — the GitHub-style blue/neutral palette the
+  Figma export ships (`tools/causa/design-reference/styles/devtools.css`
+  + `theme.css`, rf2-ad7zx.13). The default Causa palette; `tokens` is
+  an alias of this map so the inline `(:bg-1 tokens)` call sites keep
+  resolving without a runtime switch (the CSS-variable migration is the
+  v1.0 styling pass).
+
+  ## Single accent (rf2-ad7zx.13)
+
+  The earlier orange-identity scheme (`brand`=orange, per-mode
+  `accent-dynamic`/`accent-static` with a Dynamic-orange/Static-cyan
+  swap) is removed — the Figma design carries a SINGLE accent (blue
+  `#539bf5` dark / `#0969da` light). The Dynamic/Static MODE stays as a
+  functional mode; it no longer drives accent colour."
   {;; ── surfaces ──
-   :bg-0           "#0E0F12"
-   :bg-1           "#15171B"
-   :bg-2           "#1B1E24"
-   :bg-3           "#232730"
-   :bg-active      "#2A2F3D"
+   ;; Neutral GitHub-dark ramp anchored on the Figma chrome-bg (#1c1c1c).
+   :bg-0           "#161616"   ; deepest recess (below chrome)
+   :bg-1           "#1c1c1c"   ; chrome-bg (Figma --devtools-chrome-bg)
+   :bg-2           "#242424"   ; panel surface (raised)
+   :bg-3           "#2a2a2a"   ; popovers / strip (= Figma --devtools-hover)
+   :bg-active      "#2a2a2a"
 
    ;; ── borders ──
-   :border-subtle  "#232730"
-   :border-default "#2F3441"
+   :border-subtle  "#2a2a2a"
+   :border-default "#373737"   ; Figma --devtools-border
 
-   ;; ── text ──
-   ;; `:text-tertiary` was bumped from `#6B7080` to `#8990A0`
-   ;; (rf2-0fr6v, audit finding #7). The old hex landed at ~3.5:1 on
-   ;; `:bg-1` — below WCAG 2.1 AA's 4.5:1 floor for body text. The
-   ;; token is used in ~50 inline-style call sites (relative-time
-   ;; chip, hint text, settings field hints, inactive tab labels,
-   ;; "no events" empty state, palette result-count, etc.) — most
-   ;; at the caption / micro size where the small-text 4.5:1
-   ;; threshold applies. The new hex lands at ~4.7:1 on `:bg-1`
-   ;; (passes AA) without flipping the visual rhythm — still
-   ;; reads as muted/secondary against the dark surfaces.
-   :text-primary   "#E8EAF0"
-   :text-secondary "#A8AEC0"
-   :text-tertiary  "#8990A0"
+   ;; ── text ── (Causa carries three text levels; Figma ships two
+   ;; — `--devtools-text` + `--devtools-text-muted`. Primary = Figma
+   ;; text; tertiary = Figma text-muted (#8b949e); secondary is a
+   ;; brighter mid (#adbac7, GitHub fg.muted) so all three clear WCAG
+   ;; AA on the dark surfaces — AAA for primary/secondary.)
+   :text-primary   "#e6edf3"   ; Figma --devtools-text (AAA on bg-1)
+   :text-secondary "#adbac7"   ; brighter mid (AAA ≥7:1 on bg-1)
+   :text-tertiary  "#8b949e"   ; Figma --devtools-text-muted (AA ≥4.5:1 on bg-1/bg-2)
 
-   ;; ── brand + mode accents (orange identity — rf2-ad7zx / spec/022) ──
-   ;; `brand` is the logo/wordmark colour and is ALWAYS orange in either
-   ;; mode. `accent-dynamic` / `accent-static` are the per-mode accents;
-   ;; `accent` is the RUNTIME ALIAS the `.mode-dynamic` / `.mode-static`
-   ;; root class points at the active mode's accent (active tab · mode
-   ;; stripe · selected states · focus ring · changed/recompute). Its
-   ;; default value here is the Dynamic (orange) accent — `themes-css`
-   ;; re-points the `--rf-causa-accent` variable at `accent-static`
-   ;; under `.mode-static` so the whole shell turns cyan in Static.
-   :brand          "#F97316"
-   :accent-dynamic "#F97316"
-   :accent-static  "#43C3D0"
-   :accent         "#F97316"   ; runtime alias → accent-dynamic by default
+   ;; ── accent (single blue — Figma --devtools-active / --devtools-changed) ──
+   ;; `accent` is the SINGLE accent every chrome surface reads (active
+   ;; tab · mode stripe · selected states · focus ring · changed/
+   ;; recompute · L4 header stripe). Figma has no per-mode colour swap.
+   :accent         "#539bf5"
 
-   ;; ── semantic + change (spec/022 §Semantic & change) ──
-   :error          "#F85149"
-   :warning        "#FBBF24"   ; warnings; also the filter "N hidden" chrome
-   :advisory       "#79A6D2"   ; lowest Issues severity — calm, cool, ≠ warning
-   :success        "#3FB950"
-   :dim            "#6E7681"   ; dimmed / inert / unchanged
-   :hover          "#232730"   ; hover background (= bg-3)
+   ;; ── semantic + change (Figma devtools.css) ──
+   :error          "#f85149"   ; Figma --devtools-error
+   :warning        "#d29922"   ; Figma --devtools-warning
+   :advisory       "#79c0ff"   ; lowest Issues severity — calm cool blue (= syntax-number)
+   :success        "#3fb950"   ; Figma --devtools-success
+   :dim            "#6e7681"   ; dimmed / inert / unchanged (Figma --devtools-unchanged)
+   :hover          "#2a2a2a"   ; hover background (Figma --devtools-hover, = bg-3)
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
    ;; These do REAL semantic work — perf tiers, machine state, route
    ;; side-channel, redaction, op-family legends — and are NOT collapsed
-   ;; into the brand/mode accent.
-   :green          "#4ADE80"
-   :yellow         "#FBBF24"
-   :orange         "#FB923C"
+   ;; into the accent. `:info` is the cool informational blue (Figma
+   ;; syntax-number) used as a fixed categorical hue DISTINCT from the
+   ;; primary `:accent` (e.g. spine-paused, sub-run, route-from).
+   :green          "#3fb950"
+   :yellow         "#d29922"
+   :orange         "#FB923C"   ; functional amber — long-task / perf-slow tier
    :red            "#F87171"
    :magenta        "#E879F9"
+   :info           "#79c0ff"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
    ;; ── deep variants (rf2-5kfxe.4) ──
    ;; Darker variant of `:red` used as a danger-button background. The
@@ -128,64 +127,54 @@
    :white          "#ffffff"})
 
 (def light-palette
-  "Light-theme colour tokens per `spec/007-UX-IA.md` §Colour system —
-  'Light theme inverts lightness (bg-0 #FAFBFC, bg-1 #F1F3F6, bg-2
-  #FFFFFF); accents darken slightly to maintain contrast'. (rf2-5kfxe.6)
+  "Light-theme colour tokens — the GitHub-style blue/neutral light
+  palette the Figma export ships (`design-reference/styles/devtools.css`
+  + `theme.css`, rf2-ad7zx.13).
 
   Surfaces invert (bg-0 is the *lightest* deepest-canvas tone, bg-3
-  the most saturated chrome); text inverts so primary is near-black;
-  borders subtle in greys; accents darken ~15-20% to maintain AA
-  contrast on the white canvas.
+  the chrome strip); text inverts so primary is near-black; borders are
+  light mid-greys; the single accent darkens to GitHub blue `#0969da`
+  to maintain AA contrast on the white canvas.
 
   Consumed via the per-theme CSS custom-property block emitted by
   `theme/global-styles/themes-css`. The class toggle
   (`rf-causa-theme-light` on the shell root, written by
-  `settings/effects/apply-theme!`) flips which block is in scope. The
-  357 inline-style call sites that read `(:bg-1 tokens)` continue to
-  resolve against the dark palette — the light-theme surface is the
-  CSS-variable layer until the v1.0 sweep migrates inline styles
-  through to it."
+  `settings/effects/apply-theme!`) flips which block is in scope."
   {;; ── surfaces ── (lighter as the depth increases — bg-2 is the
    ;; brightest 'top' canvas, bg-0 the gentlest 'recess')
-   :bg-0           "#FAFBFC"
-   :bg-1           "#F1F3F6"
-   :bg-2           "#FFFFFF"
-   :bg-3           "#E6E9EE"
-   :bg-active      "#DCE0E7"
+   :bg-0           "#fbfbfb"
+   :bg-1           "#f5f5f5"   ; chrome-bg (Figma --devtools-chrome-bg)
+   :bg-2           "#ffffff"   ; panel surface
+   :bg-3           "#e8e8e8"   ; popovers / strip (= Figma --devtools-hover)
+   :bg-active      "#e8e8e8"
 
-   ;; ── borders ── (lighter mid-greys; the gap between subtle and
-   ;; default mirrors the dark palette's discrimination)
-   :border-subtle  "#E6E9EE"
-   :border-default "#CFD4DC"
+   ;; ── borders ── (light mid-greys)
+   :border-subtle  "#e8e8e8"
+   :border-default "#d1d1d1"   ; Figma --devtools-border
 
    ;; ── text ── (near-black down to mid-grey)
-   :text-primary   "#15171B"
-   :text-secondary "#4B5160"
-   :text-tertiary  "#8B92A1"
+   :text-primary   "#24292f"   ; Figma --devtools-text
+   :text-secondary "#656d76"   ; Figma --devtools-text-muted
+   :text-tertiary  "#8c959f"   ; deeper muted (= Figma --devtools-unchanged)
 
-   ;; ── brand + mode accents (orange identity — rf2-ad7zx / spec/022) ──
-   ;; Each ~15-20% darker than the dark palette to maintain ≥4.5:1 large-
-   ;; text contrast on the white canvas. `accent` default = the Dynamic
-   ;; (orange) accent; `.mode-static` re-points it at `accent-static`.
-   :brand          "#EA580C"
-   :accent-dynamic "#EA580C"
-   :accent-static  "#2A8B96"
-   :accent         "#EA580C"   ; runtime alias → accent-dynamic by default
+   ;; ── accent (single blue — Figma --devtools-active / --devtools-changed) ──
+   :accent         "#0969da"
 
-   ;; ── semantic + change (spec/022 §Semantic & change) ──
-   :error          "#CF222E"
-   :warning        "#B07A05"
-   :advisory       "#3B6EA5"
-   :success        "#1A7F37"
-   :dim            "#8C959F"
-   :hover          "#E6E9EE"
+   ;; ── semantic + change (Figma devtools.css) ──
+   :error          "#cf222e"   ; Figma --devtools-error
+   :warning        "#9a6700"   ; Figma --devtools-warning
+   :advisory       "#0550ae"   ; cool advisory blue (= syntax-number)
+   :success        "#1a7f37"   ; Figma --devtools-success
+   :dim            "#8c959f"   ; Figma --devtools-unchanged
+   :hover          "#e8e8e8"   ; Figma --devtools-hover
 
    ;; ── functional categorical hues (spec/022 carve-out · spec 007) ──
-   :green          "#2F9E5C"
-   :yellow         "#B07A05"
-   :orange         "#C2570F"
+   :green          "#1a7f37"
+   :yellow         "#9a6700"
+   :orange         "#C2570F"   ; functional amber — long-task / perf-slow tier
    :red            "#C84444"
    :magenta        "#B146C2"
+   :info           "#0550ae"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
    ;; ── deep variants ──
    ;; On the light canvas the danger button stays close to the
@@ -509,23 +498,22 @@
   "Pure semantic map from L4 tab keyword → token keyword for the
   panel's header stripe colour.
 
-  ## Orange identity (rf2-ad7zx / spec/022 · spec/007 §L4 panel accent
+  ## Single accent (rf2-ad7zx.13 / spec/022 · spec/007 §L4 panel accent
   stripe)
 
   The prior per-panel DOMAIN-colour mapping (`:event` violet ·
   `:app-db`/`:views` cyan · `:trace` orange · `:machines` green ·
   `:routing` yellow · `:issues` red) is **superseded**. The Figma
-  export carries a SINGLE accent identity — every panel's 3px header
-  stripe reads the mode `accent` (orange in Dynamic, cyan in Static),
-  so the stripe is the MODE signal, not a per-panel domain colour. This
-  keeps the whole devtool reading orange in Dynamic / cyan in Static,
-  with surfaces neutral so the accent pops.
+  export carries a SINGLE accent identity (GitHub blue) — every panel's
+  3px header stripe reads `:accent`, so the stripe is a consistent
+  signal, not a per-panel domain colour. Surfaces stay neutral so the
+  blue accent pops.
 
-  Every tab therefore maps to the runtime `:accent` alias. Domain
-  colour still does load-bearing work INSIDE each panel where it is
-  semantic (`error` red in Issues, machine `green`, route `yellow`,
-  the op-family bands in Trace, the per-panel header icons §021
-  §17.1.5) — but the HEADER STRIPE is the mode accent.
+  Every tab therefore maps to the `:accent` token. Domain colour still
+  does load-bearing work INSIDE each panel where it is semantic
+  (`error` red in Issues, machine `green`, route `yellow`, the
+  op-family bands in Trace, the per-panel header icons §021 §17.1.5) —
+  but the HEADER STRIPE is the single accent.
 
   The map is retained (rather than collapsed to a constant) so the
   per-tab inventory stays explicit and a future per-panel signal can
@@ -544,14 +532,13 @@
 
 (defn panel-accent
   "Resolve the L4 panel's header-stripe accent CSS-variable string —
-  the mode `accent` (orange in Dynamic, cyan in Static) per spec/007
-  §L4 panel accent stripe + spec/022. Falls back to the `:accent`
-  variable for unknown tab keywords so the stripe always renders.
+  the single `:accent` (GitHub blue) per spec/007 §L4 panel accent
+  stripe + spec/022. Falls back to the `:accent` variable for unknown
+  tab keywords so the stripe always renders.
 
   Returns a `\"var(--rf-causa-<key>)\"` string post rf2-on4cm — the
   active theme class scope on the shell root decides which palette's
-  hex resolves at paint time, and the `.mode-dynamic` / `.mode-static`
-  root class decides whether `--rf-causa-accent` is orange or cyan."
+  hex (`#539bf5` dark / `#0969da` light) resolves at paint time."
   [tab]
   (get tokens
        (get panel-domain->token tab :accent)))

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -381,7 +381,7 @@
   (case tok-type
     :keyword  :accent
     :string   :green
-    :number   :accent-static          ; fixed cyan syntax hue, distinct from the keyword accent
+    :number   :info                   ; fixed cool-blue syntax hue, distinct from the keyword accent
     :comment  :text-tertiary
     :symbol   :text-primary
     :paren    :text-tertiary

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
@@ -44,15 +44,15 @@
            (set (keys esc/status->token))))))
 
 (deftest status-token-map-mirrors-tanstack-anchors
-  (testing "rf2-b76v4 / rf2-ad7zx — the per-status token assignments
+  (testing "rf2-b76v4 / rf2-ad7zx.13 — the per-status token assignments
             mirror the TanStack devtool's semantic anchors. The LIVE
-            head (`:in-flight`) IS the current-epoch accent → the mode
-            `:accent` (orange Dynamic / cyan Static); `:paused-by-tool`
-            takes the fixed cyan `:accent-static` as a distinct peer."
+            head (`:in-flight`) IS the current-epoch accent → the single
+            `:accent` (GitHub blue); `:paused-by-tool` takes the fixed
+            cool blue `:info` as a distinct peer."
     (is (= :accent         (esc/status->token :in-flight)))
     (is (= :green          (esc/status->token :settled-success)))
     (is (= :red            (esc/status->token :settled-error)))
-    (is (= :accent-static  (esc/status->token :paused-by-tool)))
+    (is (= :info           (esc/status->token :paused-by-tool)))
     (is (= :yellow         (esc/status->token :stale)))))
 
 (deftest every-status-resolves-to-a-non-nil-hex
@@ -183,7 +183,7 @@
     (is (= :red (esc/event-status-token {:outcome :error})))
     (is (= :green (esc/event-status-token {:outcome :ok})))
     (is (= :yellow (esc/event-status-token {:mode :retro})))
-    (is (= :accent-static (esc/event-status-token {:paused? true})))
+    (is (= :info (esc/event-status-token {:paused? true})))
     (is (= :accent (esc/event-status-token {})))))
 
 (deftest event-status-colour-fallback
@@ -268,10 +268,10 @@
       (is (= (:red palette)
              (esc/event-status-colour {:outcome :error}))
           "settled-error rides red")
-      (is (= (:accent-static palette)
+      (is (= (:info palette)
              (esc/event-status-colour {:paused? true}))
-          "paused-by-tool rides the fixed cyan accent-static (distinct
-           from the in-flight mode accent)")
+          "paused-by-tool rides the fixed cool blue :info (distinct
+           from the in-flight accent)")
       (is (= (:yellow palette)
              (esc/event-status-colour {:mode :retro}))
           "stale rides yellow"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -277,7 +277,7 @@
   ;; Compare against the var-map so the test pins the indirection.
   (is (= (:accent tokens/tokens)
          (h/op-family-colour {:op-type :rf.event :operation :rf.event/dispatched})))
-  (is (= (:accent-static tokens/tokens)
+  (is (= (:info tokens/tokens)
          (h/op-family-colour {:op-type :rf.event :operation :rf.event/db-changed})))
   (is (= (:warning tokens/tokens)
          (h/op-family-colour {:op-type :rf.fx :operation :rf.fx/handled})))
@@ -457,7 +457,7 @@
   ;; specific palette's hex.
   (is (= (:red    tokens/tokens)  (h/op-type-colour :error)))
   (is (= (:yellow tokens/tokens)  (h/op-type-colour :warning)))
-  (is (= (:accent-static tokens/tokens) (h/op-type-colour :info)))
+  (is (= (:info tokens/tokens) (h/op-type-colour :info)))
   (is (= (:accent tokens/tokens) (h/op-type-colour :rf.event)))
   (is (= (:green  tokens/tokens)  (h/op-type-colour :rf.fx)))
   (is (= (:magenta tokens/tokens) (h/op-type-colour :rf.view/render)))

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -182,12 +182,12 @@
             "L4 detail panel present (default :event tab)")))))
 
 (deftest shell-root-carries-lens-mode-class
-  (testing "rf2-ad7zx / spec/022 — the shell root carries the
-            `mode-dynamic` / `mode-static` class driven by
-            `:rf.causa/mode`. `theme/global-styles/mode-accent-css`
-            re-points `--rf-causa-accent` off this class, so the whole
-            chrome accent flips orange↔cyan with the mode (the brand
-            wordmark stays orange in either mode)."
+  (testing "rf2-ad7zx.13 — the shell root carries the `mode-dynamic` /
+            `mode-static` class driven by `:rf.causa/mode`. The class
+            still gates functional behaviour (motion / pulse dampening
+            in Static); post rf2-ad7zx.13 it no longer re-points
+            `--rf-causa-accent` — the Figma export carries a SINGLE
+            accent (GitHub blue) in both modes."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-mode :dynamic])

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -382,17 +382,17 @@
 ;; (6) Mode-signal mechanism — stripe colour helper
 ;; -------------------------------------------------------------------------
 
-(deftest stripe-token-dynamic-orange-static-cyan
-  (testing "mode-signal mechanism #2 — 2-px left-edge stripe is
-            :accent-dynamic (orange) in Dynamic, :accent-static (cyan)
-            in Static (rf2-ad7zx / spec/022). The stripe reads the per-
-            MODE token directly (not the runtime :accent alias) because
-            it IS the mode signal."
-    (is (= :accent-dynamic (static-shell/stripe-token-for-mode :dynamic)))
-    (is (= :accent-static  (static-shell/stripe-token-for-mode :static)))
-    ;; Unknown / nil values fall back to dynamic
-    (is (= :accent-dynamic (static-shell/stripe-token-for-mode :nonsense)))
-    (is (= :accent-dynamic (static-shell/stripe-token-for-mode nil)))))
+(deftest stripe-token-single-blue-accent-both-modes
+  (testing "mode-signal mechanism #2 — 2-px left-edge stripe is the
+            single :accent (GitHub blue) in BOTH modes (rf2-ad7zx.13:
+            the Figma export carries one accent, no per-mode colour
+            swap; the Dynamic/Static MODE stays functional but no longer
+            drives stripe colour)."
+    (is (= :accent (static-shell/stripe-token-for-mode :dynamic)))
+    (is (= :accent (static-shell/stripe-token-for-mode :static)))
+    ;; Unknown / nil values fall back to the same single accent
+    (is (= :accent (static-shell/stripe-token-for-mode :nonsense)))
+    (is (= :accent (static-shell/stripe-token-for-mode nil)))))
 
 ;; -------------------------------------------------------------------------
 ;; (7) Mode dropdown — compact single-select (rf2-4vp5j reshape)

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -466,22 +466,25 @@
       (is (re-find #"\.rf-causa-theme-dark\s*\{[^}]*--rf-causa-bg-1:\s*#15171B" css))
       (is (re-find #"\.rf-causa-theme-light\s*\{[^}]*--rf-causa-bg-1:\s*#F1F3F6" css)))))
 
-(deftest themes-css-emits-mode-accent-alias
-  (testing "rf2-ad7zx / spec/022 — the themes-css block appends the
-            mode-accent runtime alias: `.mode-dynamic` re-points
-            `--rf-causa-accent` at the orange `--rf-causa-accent-
-            dynamic`; `.mode-static` re-points it at the cyan
-            `--rf-causa-accent-static`. This is the SINGLE-token swap
-            that turns the whole chrome orange in Dynamic / cyan in
-            Static off one variable."
-    (let [css (@#'gs/themes-css {:dark  {:bg-1 "#15171B"}
-                                  :light {:bg-1 "#F1F3F6"}})]
-      (is (re-find #"\.mode-dynamic[^{]*\{[^}]*--rf-causa-accent:\s*var\(--rf-causa-accent-dynamic\)"
-                   css)
-          ".mode-dynamic points --rf-causa-accent at accent-dynamic")
-      (is (re-find #"\.mode-static[^{]*\{[^}]*--rf-causa-accent:\s*var\(--rf-causa-accent-static\)"
-                   css)
-          ".mode-static points --rf-causa-accent at accent-static"))))
+(deftest themes-css-has-no-per-mode-accent-swap
+  (testing "rf2-ad7zx.13 — the Figma export carries a SINGLE accent
+            (GitHub blue), so the themes-css block no longer emits a
+            per-mode accent re-point. There must be NO `.mode-dynamic` /
+            `.mode-static` rule that re-points `--rf-causa-accent` at a
+            removed `accent-dynamic` / `accent-static` variable."
+    (let [css (@#'gs/themes-css {:dark  {:bg-1 "#1c1c1c" :accent "#539bf5"}
+                                  :light {:bg-1 "#f5f5f5" :accent "#0969da"}})]
+      (is (not (re-find #"--rf-causa-accent-dynamic" css))
+          "no reference to the removed accent-dynamic variable")
+      (is (not (re-find #"--rf-causa-accent-static" css))
+          "no reference to the removed accent-static variable")
+      (is (not (re-find #"\.mode-dynamic" css))
+          "no .mode-dynamic accent re-point rule")
+      (is (not (re-find #"\.mode-static" css))
+          "no .mode-static accent re-point rule")
+      ;; The single accent is published in each theme's palette block.
+      (is (re-find #"\.rf-causa-theme-dark\s*\{[^}]*--rf-causa-accent:\s*#539bf5" css))
+      (is (re-find #"\.rf-causa-theme-light\s*\{[^}]*--rf-causa-accent:\s*#0969da" css)))))
 
 (deftest themes-css-uses-rf-causa-prefix
   (testing "every variable name is namespaced under `--rf-causa-` so

--- a/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
@@ -14,8 +14,8 @@
 
   The ladder mirrors `spec/007-UX-IA.md` §Colour system §Perf scale:
 
-      :fast      <16ms       green   #4ADE80   ●
-      :medium    16-50ms     yellow  #FBBF24   ●
+      :fast      <16ms       green   #3fb950   ●
+      :medium    16-50ms     yellow  #d29922   ●
       :slow      50-100ms    orange  #FB923C   ▲
       :blocking  >=100ms     red     #F87171   ▲    INP threshold
 
@@ -64,9 +64,9 @@
             hex source of truth) — post rf2-on4cm `tier-colour` returns
             CSS-variable strings, but the per-tier semantic mapping
             still grounds in these spec-anchored hexes."
-    (is (= "#4ADE80" (:green  tokens/dark-palette)))      ; green
-    (is (= "#FBBF24" (:yellow tokens/dark-palette)))      ; yellow
-    (is (= "#FB923C" (:orange tokens/dark-palette)))      ; orange
+    (is (= "#3fb950" (:green  tokens/dark-palette)))      ; green (Figma success)
+    (is (= "#d29922" (:yellow tokens/dark-palette)))      ; yellow (Figma warning)
+    (is (= "#FB923C" (:orange tokens/dark-palette)))      ; orange (functional amber)
     (is (= "#F87171" (:red    tokens/dark-palette))))     ; red
   (testing "unknown tier falls back to text-tertiary so the dot is
             never invisible. Resolved through `theme/tokens` so the

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -115,25 +115,38 @@
            (set (keys t/light-palette))))))
 
 (deftest light-palette-inverts-surface-lightness
-  (testing "spec/007 §Light theme — bg-0 #FAFBFC / bg-1 #F1F3F6 /
-            bg-2 #FFFFFF. The light theme inverts the lightness of
+  (testing "rf2-ad7zx.13 §Light theme (Figma) — chrome-bg #f5f5f5 /
+            panel #ffffff. The light theme inverts the lightness of
             the dark surfaces."
-    (is (= "#FAFBFC" (:bg-0 t/light-palette)))
-    (is (= "#F1F3F6" (:bg-1 t/light-palette)))
-    (is (= "#FFFFFF" (:bg-2 t/light-palette)))))
+    (is (= "#fbfbfb" (:bg-0 t/light-palette)))
+    (is (= "#f5f5f5" (:bg-1 t/light-palette)))
+    (is (= "#ffffff" (:bg-2 t/light-palette)))))
 
 (deftest light-palette-darkens-accents
-  (testing "spec/007 — 'accents darken slightly to maintain contrast'.
-            Each accent in the light palette is a darker variant of
-            the corresponding dark-palette accent (sanity-check: the
-            light hexes are not the same string as their dark
-            counterparts)."
-    (doseq [k [:brand :accent-dynamic :accent-static :accent
+  (testing "rf2-ad7zx.13 — the single accent + semantics darken on the
+            light canvas to maintain contrast. Each token in the light
+            palette is a distinct variant of its dark counterpart
+            (sanity-check: the light hexes are not the same string as
+            their dark counterparts)."
+    (doseq [k [:accent
                :error :warning :advisory :success
-               :green :yellow :orange :red :magenta]]
+               :green :yellow :orange :red :magenta :info]]
       (is (not= (get t/dark-palette k)
                 (get t/light-palette k))
           (str k " differs between the two palettes")))))
+
+(deftest single-blue-accent-no-orange-scheme
+  (testing "rf2-ad7zx.13 — the orange identity is removed: there is a
+            SINGLE accent (GitHub blue #539bf5 dark / #0969da light),
+            and the removed orange-scheme keys (:brand, :accent-dynamic,
+            :accent-static) are gone from both palettes."
+    (is (= "#539bf5" (:accent t/dark-palette)))
+    (is (= "#0969da" (:accent t/light-palette)))
+    (doseq [removed [:brand :accent-dynamic :accent-static]]
+      (is (not (contains? t/dark-palette removed))
+          (str removed " removed from dark palette"))
+      (is (not (contains? t/light-palette removed))
+          (str removed " removed from light palette")))))
 
 (deftest tokens-is-the-css-variable-surface
   (testing "rf2-on4cm — `tokens` is the CSS-variable map (post v1.0

--- a/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/var_resolution_cljs_test.cljs
@@ -171,7 +171,7 @@
             is replaced by `tokens/with-alpha` which builds a CSS-Color-4
             color-mix(...) string that composites the active theme's
             CSS variable with `transparent`."
-    (doseq [k [:accent :red :green :accent-static :yellow]
+    (doseq [k [:accent :red :green :info :yellow]
             pct [10 33 50 75]]
       (let [v (tokens/with-alpha k pct)]
         (is (string? v))

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -503,7 +503,7 @@
 (deftest highlight-clojure-token-mapping
   (is (= :accent        (w/highlight-clojure-token :keyword)))
   (is (= :green         (w/highlight-clojure-token :string)))
-  (is (= :accent-static (w/highlight-clojure-token :number)))
+  (is (= :info          (w/highlight-clojure-token :number)))
   (is (= :text-tertiary (w/highlight-clojure-token :comment)))
   (is (= :text-primary  (w/highlight-clojure-token :symbol)))
   (is (= :accent        (w/highlight-clojure-token :builtin)))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -71,8 +71,8 @@
 (defn- edge-stroke
   [{:keys [active? focused?]}]
   (cond
-    focused? (:accent-static tokens/tokens)
-    active?  (:accent-static tokens/tokens)
+    focused? (:info tokens/tokens)
+    active?  (:info tokens/tokens)
     :else    (:border-default tokens/tokens)))
 
 (defn- edge-stroke-width

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -102,18 +102,18 @@
   [{:keys [active? from-highlight? to-highlight? sim?]}]
   (cond
     sim?            (tokens/with-alpha :yellow         0.18)
-    to-highlight?   (tokens/with-alpha :accent-static           0.22)
+    to-highlight?   (tokens/with-alpha :info           0.22)
     from-highlight? (tokens/with-alpha :accent  0.14)
-    active?         (tokens/with-alpha :accent-static           0.18)
+    active?         (tokens/with-alpha :info           0.18)
     :else           (:bg-2 tokens/tokens)))
 
 (defn- node-stroke
   [{:keys [active? from-highlight? to-highlight? sim? final?]}]
   (cond
     sim?            (:yellow tokens/tokens)
-    to-highlight?   (:accent-static tokens/tokens)
+    to-highlight?   (:info tokens/tokens)
     from-highlight? (:accent tokens/tokens)
-    active?         (:accent-static tokens/tokens)
+    active?         (:info tokens/tokens)
     final?          (:green tokens/tokens)
     :else           (:border-default tokens/tokens)))
 
@@ -228,7 +228,7 @@
                      :user-select      "none"
                      :box-shadow       (when active-affordance?
                                          (str "0 0 0 2px "
-                                              (tokens/with-alpha :accent-static 0.18)))
+                                              (tokens/with-alpha :info 0.18)))
                      :transition       "border-color 120ms ease, background 120ms ease"}}
        ;; Final-state double-ring (outer)
        (when final?

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -50,7 +50,7 @@
   `:accent` (the structural-container colour the compound-node
   chrome already uses) and spreads across cool/warm so adjacent
   regions read as distinct orthogonal zones."
-  [:accent :accent-static :orange :green :magenta :yellow])
+  [:accent :info :orange :green :magenta :yellow])
 
 (defn region-boundary-color-key
   "Map a region's index to a stable token key from

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/primitives.cljc
@@ -115,7 +115,7 @@
 
     :width   (default 60)
     :height  (default 16)
-    :stroke              — line colour (default `:accent-static` token)
+    :stroke              — line colour (default `:info` token)
     :testid              — overrides the root data-testid
     :max-sample          — pin the y-axis ceiling
     :label               — a11y. Overrides the default `aria-label`.
@@ -128,7 +128,7 @@
   ([samples {:keys [width height stroke testid max-sample label]
              :or   {width  60
                     height 16
-                    stroke (:accent-static tokens/tokens)
+                    stroke (:info tokens/tokens)
                     testid "rf-mv-chart-sparkline"}}]
    (let [n        (count samples)
          max-v    (or max-sample

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -231,7 +231,7 @@
                       ;; component reads the `:selfLoop` flag.
                       self-loop?   (= (:source e) (:target e))
                       marker-color (if (or focused? from-active?)
-                                     (:accent-static tokens/tokens)
+                                     (:info tokens/tokens)
                                      (:border-default tokens/tokens))
                       ;; A `:*` wildcard `:on` arm is a real transition
                       ;; but NOT a fireable event (Spec 005 §Wildcard —

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -63,49 +63,47 @@
 ;; ---- palette -----------------------------------------------------------
 
 (def dark-palette
-  "Dark-theme colour tokens. Mirrors `day8.re-frame2-causa.theme.tokens`
-  at the values level so the chart renders identically whether embedded
-  by Causa, Story, the read-only viewer, or a user dev shell."
-  {:bg-0           "#0E0F12"
-   :bg-1           "#15171B"
-   :bg-2           "#1B1E24"
-   :bg-3           "#232730"
-   :bg-active      "#2A2F3D"
+  "Dark-theme colour tokens — the GitHub-style blue/neutral Figma
+  palette (rf2-ad7zx.13). Mirrors `day8.re-frame2-causa.theme.tokens`
+  at the values level (drift-gate `causa-and-machines-viz-dark-palettes-
+  match-values`, rf2-z7ms8) so the chart renders identically whether
+  embedded by Causa, Story, the read-only viewer, or a user dev shell.
 
-   :border-subtle  "#232730"
-   :border-default "#2F3441"
+  The orange-identity scheme (`brand`, `accent-dynamic`, `accent-static`,
+  the per-mode colour swap) is removed; the Figma export carries a
+  SINGLE accent (blue). `:info` is the cool categorical blue distinct
+  from `:accent`."
+  {:bg-0           "#161616"
+   :bg-1           "#1c1c1c"
+   :bg-2           "#242424"
+   :bg-3           "#2a2a2a"
+   :bg-active      "#2a2a2a"
 
-   :text-primary   "#E8EAF0"
-   :text-secondary "#A8AEC0"
-   ;; `:text-tertiary` mirrors Causa's rf2-0fr6v WCAG-AA bump (from
-   ;; `#6B7080` to `#8990A0`). The drift-gate test
-   ;; `causa-and-machines-viz-dark-palettes-match-values` (rf2-z7ms8)
-   ;; locks this value to Causa's at the .cljc test surface.
-   :text-tertiary  "#8990A0"
+   :border-subtle  "#2a2a2a"
+   :border-default "#373737"
 
-   ;; brand + mode accents (orange identity — rf2-ad7zx / spec/022).
-   ;; Mirrors Causa's `theme/tokens` at the values level; `accent`
-   ;; defaults to the Dynamic (orange) accent — the host re-points it
-   ;; per the `.mode-dynamic`/`.mode-static` root class.
-   :brand          "#F97316"
-   :accent-dynamic "#F97316"
-   :accent-static  "#43C3D0"
-   :accent         "#F97316"
+   :text-primary   "#e6edf3"
+   :text-secondary "#adbac7"
+   :text-tertiary  "#8b949e"
 
-   ;; semantic + change (spec/022 §Semantic & change)
-   :error          "#F85149"
-   :warning        "#FBBF24"
-   :advisory       "#79A6D2"
-   :success        "#3FB950"
-   :dim            "#6E7681"
-   :hover          "#232730"
+   ;; single accent (GitHub blue — Figma --devtools-active).
+   :accent         "#539bf5"
+
+   ;; semantic + change (Figma devtools.css)
+   :error          "#f85149"
+   :warning        "#d29922"
+   :advisory       "#79c0ff"
+   :success        "#3fb950"
+   :dim            "#6e7681"
+   :hover          "#2a2a2a"
 
    ;; functional categorical hues (spec/022 carve-out)
-   :green          "#4ADE80"
-   :yellow         "#FBBF24"
+   :green          "#3fb950"
+   :yellow         "#d29922"
    :orange         "#FB923C"
    :red            "#F87171"
    :magenta        "#E879F9"
+   :info           "#79c0ff"
 
    :red-deep       "#a83a3a"
    :white          "#ffffff"})
@@ -116,46 +114,45 @@
   so the chart renders identically whether embedded by Causa, Story,
   the read-only viewer, or a user dev shell whose host runs a light
   theme. Surfaces invert (`bg-2` is the brightest 'top' canvas, `bg-0`
-  the gentlest 'recess'); text inverts so primary is near-black;
-  accents darken ~15-20% to maintain AA contrast on a white canvas.
+  the gentlest 'recess'); text inverts so primary is near-black; the
+  single accent darkens to GitHub blue `#0969da` to maintain AA
+  contrast on a white canvas.
 
   Hosts that want the chart to render against a light background pass
   this palette through the `:palette` render option (or via the
   `:theme :light` prop on the substrate-adapter `MachineChart`
   re-exports — wiring lives downstream)."
-  {:bg-0           "#FAFBFC"
-   :bg-1           "#F1F3F6"
-   :bg-2           "#FFFFFF"
-   :bg-3           "#E6E9EE"
-   :bg-active      "#DCE0E7"
+  {:bg-0           "#fbfbfb"
+   :bg-1           "#f5f5f5"
+   :bg-2           "#ffffff"
+   :bg-3           "#e8e8e8"
+   :bg-active      "#e8e8e8"
 
-   :border-subtle  "#E6E9EE"
-   :border-default "#CFD4DC"
+   :border-subtle  "#e8e8e8"
+   :border-default "#d1d1d1"
 
-   :text-primary   "#15171B"
-   :text-secondary "#4B5160"
-   :text-tertiary  "#8B92A1"
+   :text-primary   "#24292f"
+   :text-secondary "#656d76"
+   :text-tertiary  "#8c959f"
 
-   ;; brand + mode accents (orange identity — rf2-ad7zx / spec/022)
-   :brand          "#EA580C"
-   :accent-dynamic "#EA580C"
-   :accent-static  "#2A8B96"
-   :accent         "#EA580C"
+   ;; single accent (GitHub blue — Figma --devtools-active)
+   :accent         "#0969da"
 
    ;; semantic + change
-   :error          "#CF222E"
-   :warning        "#B07A05"
-   :advisory       "#3B6EA5"
-   :success        "#1A7F37"
-   :dim            "#8C959F"
-   :hover          "#E6E9EE"
+   :error          "#cf222e"
+   :warning        "#9a6700"
+   :advisory       "#0550ae"
+   :success        "#1a7f37"
+   :dim            "#8c959f"
+   :hover          "#e8e8e8"
 
    ;; functional categorical hues
-   :green          "#2F9E5C"
-   :yellow         "#B07A05"
+   :green          "#1a7f37"
+   :yellow         "#9a6700"
    :orange         "#C2570F"
    :red            "#C84444"
    :magenta        "#B146C2"
+   :info           "#0550ae"
 
    :red-deep       "#9A3030"
    :white          "#ffffff"})
@@ -295,10 +292,10 @@
 
 (def tag-pill-palette
   "Deterministic colour rotation for state-tag pills (rf2-m1b88).
-  Skips `:red`, `:accent` and `:accent-static` — all reserved for
-  chart semantics (`:red` for cancellation glyphs, the mode `:accent`
-  for the initial-state marker + FROM-highlight, `:accent-static` for
-  the TO-highlight / active state). The remaining five spread across
+  Skips `:red`, `:accent` and `:info` — all reserved for chart
+  semantics (`:red` for cancellation glyphs, the single `:accent` for
+  the initial-state marker + FROM-highlight, `:info` for the
+  TO-highlight / active state). The remaining five spread across
   cool/warm/neutral so a typical 2-4 tag count reads distinctly."
   [:advisory :green :yellow :orange :magenta])
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/primitives_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/primitives_cljs_test.cljc
@@ -106,7 +106,7 @@
           [track arc] (circles g)]
       ;; :green tier → :green token.
       (is (str/starts-with? (:stroke (second arc)) "var(--rf-causa-green"))
-      (is (str/includes? (:stroke (second arc)) "#4ADE80")
+      (is (str/includes? (:stroke (second arc)) "#3fb950")
           "carries the dark-palette hex fallback for standalone embeds")
       ;; track circle uses the subtle border token.
       (is (str/starts-with? (:stroke (second track))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -10,9 +10,9 @@
 ;; ---- with-alpha (rf2-pyvmr) --------------------------------------------
 
 (deftest with-alpha-builds-rgba-string-from-hex-token
-  (testing "with-alpha resolves :accent-static (#43C3D0) to rgba(67, 195, 208, alpha)"
-    (let [s (tokens/with-alpha :accent-static 0.5)]
-      (is (= "rgba(67, 195, 208, 0.5)" s)))))
+  (testing "with-alpha resolves :info (#79c0ff) to rgba(121, 192, 255, alpha)"
+    (let [s (tokens/with-alpha :info 0.5)]
+      (is (= "rgba(121, 192, 255, 0.5)" s)))))
 
 (deftest with-alpha-resolves-zero-alpha
   (testing "with-alpha accepts alpha=0 — used by callers that compute
@@ -24,9 +24,9 @@
   (testing "with-alpha resolves through a custom palette so callers
             (theming hosts) can swap the palette without forking the
             chart"
-    (let [custom {:accent-static "#000000"}]
+    (let [custom {:info "#000000"}]
       (is (= "rgba(0, 0, 0, 0.25)"
-             (tokens/with-alpha :accent-static 0.25 custom))))))
+             (tokens/with-alpha :info 0.25 custom))))))
 
 ;; ---- tag-pill-color (rf2-m1b88) ----------------------------------------
 
@@ -38,11 +38,11 @@
     (is (= (tokens/tag-pill-color :auth/ok) (tokens/tag-pill-color :auth/ok)))))
 
 (deftest tag-pill-color-skips-reserved-tokens
-  (testing "tag-pill-color never returns :red, :accent or :accent-static
-            — all reserved for chart semantics (rf2-ad7zx)"
+  (testing "tag-pill-color never returns :red, :accent or :info
+            — all reserved for chart semantics (rf2-ad7zx.13)"
     ;; Walk every palette entry; assert none is reserved.
     (is (every? (fn [t]
-                  (not (#{:red :accent :accent-static} (tokens/tag-pill-color t))))
+                  (not (#{:red :accent :info} (tokens/tag-pill-color t))))
                 [:risky :paid :auth/ok :final :loading :error
                  :rec :checkout :session/active :flow/start]))))
 
@@ -58,12 +58,13 @@
            (set (keys tokens/light-palette))))))
 
 (deftest light-palette-inverts-surface-lightness
-  (testing "rf2-usord — light theme bg-0 is the LIGHTEST recess (FAFBFC)
-            while dark theme bg-0 is the DEEPEST canvas (0E0F12)."
-    (is (= "#0E0F12" (:bg-0 tokens/dark-palette)))
-    (is (= "#FAFBFC" (:bg-0 tokens/light-palette)))
-    (is (= "#E8EAF0" (:text-primary tokens/dark-palette)))
-    (is (= "#15171B" (:text-primary tokens/light-palette)))))
+  (testing "rf2-ad7zx.13 — light theme bg-0 is the LIGHTEST recess
+            (#fbfbfb) while dark theme bg-0 is the DEEPEST canvas
+            (#161616)."
+    (is (= "#161616" (:bg-0 tokens/dark-palette)))
+    (is (= "#fbfbfb" (:bg-0 tokens/light-palette)))
+    (is (= "#e6edf3" (:text-primary tokens/dark-palette)))
+    (is (= "#24292f" (:text-primary tokens/light-palette)))))
 
 (deftest palettes-map-exposes-both-themes
   (testing "rf2-usord — palettes map keys both themes by name so the
@@ -77,9 +78,9 @@
             arg; this test pins the LIGHT-palette path so chart code
             can resolve tints against the light theme without forking
             the helper."
-    (let [s (tokens/with-alpha :accent-static 0.5 tokens/light-palette)]
-      ;; Light :accent-static is #2A8B96 → rgba(42, 139, 150, 0.5)
-      (is (= "rgba(42, 139, 150, 0.5)" s)))))
+    (let [s (tokens/with-alpha :info 0.5 tokens/light-palette)]
+      ;; Light :info is #0550ae → rgba(5, 80, 174, 0.5)
+      (is (= "rgba(5, 80, 174, 0.5)" s)))))
 
 ;; ---- css-var (rf2-uv1on) -----------------------------------------------
 
@@ -88,21 +89,21 @@
             publishes the Causa CSS custom-property surface drives
             light + dark, while a standalone embed degrades to the
             dark-palette hex"
-    (is (= "var(--rf-causa-green, #4ADE80)" (tokens/css-var :green)))
-    (is (= "var(--rf-causa-text-tertiary, #8990A0)"
+    (is (= "var(--rf-causa-green, #3fb950)" (tokens/css-var :green)))
+    (is (= "var(--rf-causa-text-tertiary, #8b949e)"
            (tokens/css-var :text-tertiary)))))
 
 (deftest css-var-name-matches-causa-convention
   (testing "the variable name mirrors Causa's `var(--rf-causa-<key>)`
             so the chart + host paint from ONE :root palette"
-    (is (str/starts-with? (tokens/css-var :accent-static)
-                          "var(--rf-causa-accent-static"))))
+    (is (str/starts-with? (tokens/css-var :info)
+                          "var(--rf-causa-info"))))
 
 (deftest css-var-falls-back-to-supplied-palette-hex
   (testing "css-var resolves the fallback hex from the supplied palette
             arg (light theme), not just the dark default"
-    (is (= "var(--rf-causa-accent-static, #2A8B96)"
-           (tokens/css-var :accent-static tokens/light-palette)))))
+    (is (= "var(--rf-causa-info, #0550ae)"
+           (tokens/css-var :info tokens/light-palette)))))
 
 (deftest css-var-no-fallback-for-unknown-key
   (testing "an unknown token has no hex → bare var() (host MUST define


### PR DESCRIPTION
Mike: "the orange highlighting isn't working; go back to matching the Figma mocks." Drops the orange identity and restores the GitHub-style blue/neutral palette the Figma export ships (`tools/causa/design-reference/styles/devtools.css` + `theme.css`).

## Token source (theme/tokens.cljc + machines-viz mirror)
- **Single accent** `#539bf5` dark / `#0969da` light (Figma `--devtools-active`).
- Neutral GitHub surfaces (chrome-bg `#1c1c1c`/`#f5f5f5`, border `#373737`/`#d1d1d1`), text `#e6edf3`/`#24292f`, muted `#8b949e`/`#656d76`. Dark text ramp tuned so all three text levels clear WCAG AA (AAA for primary/secondary) on the new surfaces.
- Semantics per the Figma devtools.css (error/warning/success/syntax).
- **Removed the orange scheme:** `:brand`, `:accent-dynamic`, `:accent-static`, and the Dynamic-orange/Static-cyan mode-accent CSS swap. The Dynamic/Static **MODE stays functional** (motion/pulse dampening) but no longer drives accent colour.
- Added `:info` — a fixed cool categorical blue distinct from `:accent` — to carry the former "fixed cyan ≠ mode accent" call sites cleanly.

## Consumer remaps
Logo + L1 ribbon stripe -> `:accent`; the ~20 `:accent-static` sites (sub-run, spine-paused, route-from, syntax-number, machine TO/active highlight, op-family db band, etc.) -> `:info`. `config/default-accent` + the host snippet publish `#539bf5`. machines-viz (rf2-z7ms8 drift gate) updated to mirror the new palette.

## Specs
Rewrote `022-Design-Tokens.md` to the Figma palette; reverted the `007-UX-IA.md` accents + surfaces blocks and reconciled every mode-accent-stripe reference (single accent, no per-mode colour); reconciled `021` stripe refs + token-summary hexes; corrected the design-reference README "swap to orange" instruction.

## Zero orange remaining
`grep` of `tools/causa` + `tools/machines-viz` for `#F97316`/`#EA580C`/`#43C3D0`/`#2A8B96`/`accent-dynamic`/`accent-static`: only the intentional "removed scheme" docstrings remain. Built `examples/step-deck` (0 warnings) — bundle carries `#539bf5`/`#0969da`/`#79c0ff`, **zero** orange/cyan brand hexes.

## Gates
- `npm run test:cljs` — 4245 tests, 0 failures
- `tools/causa` `clojure -M:test` — 873 tests, 0 failures (post-rebase)
- `tools/machines-viz` `clojure -M:test` — 196 tests, 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- `npm run test:bundle-isolation` — PASS (both checks)
- clj-kondo — 0 errors (101 pre-existing warnings, none in changed files)