### PR TITLE
fix(ci): authenticate setup-clojure with GITHUB_TOKEN to stop rate-limit flakes (rf2-90yva)

### DIFF
--- a/.github/workflows/expensive-tests.yml
+++ b/.github/workflows/expensive-tests.yml
@@ -25,6 +25,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -100,6 +101,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -149,6 +151,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -147,6 +147,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release-causa.yml
+++ b/.github/workflows/release-causa.yml
@@ -125,6 +125,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -168,6 +169,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -256,6 +257,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -376,6 +378,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -126,6 +126,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -154,6 +155,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -197,6 +199,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -241,6 +244,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -286,6 +290,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -331,6 +336,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -376,6 +382,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -423,6 +430,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -460,6 +468,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -497,6 +506,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -534,6 +544,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -582,6 +593,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -637,6 +649,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -738,6 +751,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -787,6 +801,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -843,6 +858,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -902,6 +918,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -955,6 +972,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1016,6 +1034,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1081,6 +1100,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (Story/Causa shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1181,6 +1201,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (shadow-cljs deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1252,6 +1273,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1296,6 +1318,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1341,6 +1364,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1383,6 +1407,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # rf2-80y2h: mcp-base now carries a CLJS test target (shadow-cljs
       # :node-test build) covering the `.cljc` `:cljs` reader-conditional
@@ -1451,6 +1476,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # rf2-ir6a0 — Node.js is required for the
       # `emitted_test_run_test.clj` slice (compiles + runs the emitted
@@ -1539,6 +1565,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -1592,6 +1619,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -1677,6 +1705,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -1792,6 +1821,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -1869,6 +1899,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -1897,6 +1928,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           bb: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run re-frame2-pair structural tests
         working-directory: skills/re-frame2-pair
@@ -1962,6 +1994,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
         with:
           cli: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Maven / gitlibs (playground SCI bundle deps)
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5


### PR DESCRIPTION
## Problem

The recurring CI flakiness this session (re-run 6-8x, worsening) was **not** a flaky test. All 43 `DeLaGuardo/setup-clojure` steps across the six workflows made **unauthenticated** GitHub-releases-API calls to download tools (clojure / clj-kondo / babashka). Under a burst of concurrent CI runs these hit GitHub's **60-req/hr anonymous rate limit**, failing the "Set up Clojure CLI" step with `##[error]Bad credentials` and cascading to `actions/checkout` `fatal: could not read Username for 'https://github.com'` as git auth degraded in the same window.

Confirmed from failing logs (run 26336068339 job 77529890771): the failing step is exactly **Set up Clojure CLI** with `Bad credentials`. A concurrent run (26336058084) failed at `actions/checkout` (`could not read Username`) in the same ~30s window — the same incident cascade, not a separate checkout/submodule/ref config issue (checkout is `submodules: false`, standard main-repo fetch, default token; config is correct).

## Fix

Add `github-token: ${{ secrets.GITHUB_TOKEN }}` to **every** setup-clojure step's `with:` block (preserving existing `cli:` / `bb:` inputs) so the action authenticates its releases-API calls and uses the 1000-req/hr authenticated quota.

**43 steps fixed** across:
- `test.yml` (33)
- `expensive-tests.yml` (3)
- `release.yml` (3)
- `release-causa.yml` (2)
- `lint.yml` (1)
- `template-release.yml` (1)

Diff is 43 insertions, 0 deletions — every added line is a `github-token` line.

## Validation

- `grep` confirms 43 setup-clojure steps and 43 `github-token` lines (1:1 per file); a multiline negative-lookahead search confirms **zero** token-less setup-clojure steps remain.
- All six workflow files parse cleanly as YAML (PyYAML; `actionlint` not available in this environment).
- The rate-limit fix cannot be verified locally — this is the well-established remedy; correctness = every setup-clojure step now carries the token + valid YAML.

Closes rf2-90yva.