### PR TITLE
fix(causa): L4 tab strip to Figma button-bar, not radios (rf2-ad7zx.16)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -1845,17 +1845,28 @@
 ;; ---- L3 tab bar ----------------------------------------------------------
 
 (defn- tab-button
-  "One tab in the L3 tab bar. `●` for active per spec/018 §5 Tab
-  strip rendering; `○` for inactive. The mnemonic letter is exposed
-  via the `title` attribute.
+  "One tab in the L3 tab bar — a Figma button-bar tab, NOT a radio
+  glyph (rf2-ad7zx.16). Each tab is a rounded button; the ACTIVE tab
+  is a filled `:accent` background with white text; inactive tabs are
+  transparent with secondary-ink text and a subtle `:hover` background
+  fill (the hover rule lives in `theme/global-styles/motion-css`,
+  keyed off the `rf-causa-tab-*` testid, since inline styles can't
+  carry a `:hover` pseudo-class). Mirrors
+  `tools/causa/design-reference/components/Tabs.tsx` +
+  `App.tsx` TabsList (`px-3 py-1.5 rounded`,
+  `data-[state=active]:bg-[var(--devtools-active)]` =`:accent`,
+  `data-[state=active]:text-white`,
+  `hover:bg-[var(--devtools-hover)]` =`:hover`). The mnemonic letter is
+  exposed via the `title` attribute. The decorative `●/○` radio glyph
+  is GONE — fill + text colour carry the selected signal.
 
   `aria-label` wraps the visible label as `Causa <tab-label> tab` so the
   button's accessible name never collides with host-app role queries
   (Playwright's `getByRole('button', {name: '-'})` matched the old
   `App-db` tab when only `title` was set). This wrapping is why the
   app-db tab can safely carry the lowercase library label `app-db`
-  (rf2-okvit) despite the `-` glyph — the accessible name is
-  `Causa app-db tab`, not the bare `app-db`.
+  (rf2-okvit) — the accessible name is `Causa app-db tab`, not the bare
+  `app-db`.
 
   Per rf2-lvf8t (rf2-q7who Thread B) each button carries `role='tab'`
   and `aria-selected={active?}` so the tab strip exposes the proper
@@ -1863,9 +1874,7 @@
   rather than generic buttons and reads the selected state correctly;
   `getByRole('tab')` lookups in host integration tests resolve here."
   [{:keys [id label mnem active?]}]
-  (let [glyph    (if active? "◉" "○")
-        color    (if active? (:text-primary tokens) (:text-secondary tokens))
-        ;; rf2-plajx — stable per-tab id so the controlled L4 panel's
+  (let [;; rf2-plajx — stable per-tab id so the controlled L4 panel's
         ;; `aria-labelledby` resolves to this button's accessible name.
         tab-id   (str "rf-causa-tab-button-" (name id))
         panel-id (str "rf-causa-tabpanel-" (name id))]
@@ -1877,28 +1886,24 @@
               :on-click      #(rf/dispatch [:rf.causa/select-tab id] {:frame :rf/causa})
               :title         (str label " (" mnem ")")
               :aria-label    (str "Causa " label " tab")
-              :style {:background    "transparent"
+              :style {;; Active tab → filled accent background + white
+                      ;; text (Figma `data-[state=active]:bg-…/text-white`);
+                      ;; inactive → transparent with secondary ink. The
+                      ;; `:hover` fill for inactive tabs is applied via the
+                      ;; scoped CSS rule in motion-css.
+                      :background    (if active? (:accent tokens) "transparent")
                       :border        "none"
-                      :border-bottom (if active?
-                                       (str "2px solid " (:accent tokens))
-                                       "2px solid transparent")
-                      :color         color
+                      :border-radius "6px"          ; Tailwind `rounded`
+                      :color         (if active?
+                                       (:white tokens)
+                                       (:text-secondary tokens))
                       :cursor        "pointer"
-                      :padding       "6px 12px"
+                      :padding       "6px 12px"     ; Tailwind `px-3 py-1.5`
                       :font-family   sans-stack
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
-                      :white-space   "nowrap"}}
-     ;; rf2-vxpq1 — the ●/○ glyph is decorative; the visible label
-     ;; carries the tab's accessible name. `aria-hidden="true"`
-     ;; suppresses the unicode-name announcement ("heavy black
-     ;; circle" / "white circle").
-     [:span {:aria-hidden "true"
-             :style {:color (if active?
-                              (:accent tokens)
-                              (:text-tertiary tokens))
-                     :margin-right "4px"}}
-      glyph]
+                      :white-space   "nowrap"
+                      :transition    "background-color 120ms ease-out, color 120ms ease-out"}}
      label]))
 
 (rf/reg-view tab-bar

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -793,6 +793,18 @@
     "    45deg,\n"
     "    rgba(236, 72, 153, 0.30) 0 6px,\n"
     "    rgba(236, 72, 153, 0.10) 6px 12px) !important;\n"
+    "}\n"
+    ;; rf2-ad7zx.16 — L3 tab-bar hover. The Figma button-bar
+    ;; (`design-reference/components/Tabs.tsx` + App.tsx TabsList) gives
+    ;; inactive tabs a subtle `hover:bg-[var(--devtools-hover)]` fill;
+    ;; the active tab keeps its filled `:accent` background. Inline
+    ;; styles can't carry a `:hover` pseudo-class, so the hover lift is a
+    ;; scoped CSS rule keyed off the `rf-causa-tab-*` testid. The
+    ;; `[aria-selected="false"]` predicate scopes it to inactive tabs so
+    ;; hovering the active tab doesn't override its accent fill.
+    "[data-testid^=\"rf-causa-tab-\"][aria-selected=\"false\"]:hover {\n"
+    "  background-color: " (:hover tokens/tokens) ";\n"
+    "  color: " (:text-primary tokens/tokens) ";\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
@@ -348,23 +348,31 @@
         (is (some? glyph)
             "the decorative `●` glyph carries aria-hidden=\"true\"")))))
 
-(deftest runtime-tab-glyph-is-aria-hidden
-  (testing "rf2-vxpq1 — the ●/○ glyph on every L3 tab button carries
-            aria-hidden so AT users hear only the tab label, not the
-            unicode name."
+(deftest runtime-tab-has-no-decorative-glyph
+  (testing "rf2-ad7zx.16 (supersedes rf2-vxpq1) — the L3 tab strip is now
+            the Figma button-bar (filled-accent active button + white
+            text), NOT a radio-glyph row. The previous `●/○` decorative
+            glyph (which had to carry aria-hidden so AT heard only the
+            label) is GONE entirely — selection is signalled by the
+            button fill + colour, not a unicode circle. So the tab button
+            carries NO decorative glyph at all, and AT users hear only
+            the visible label by construction."
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (let [tree     (shell/shell-view)
+      (let [tree      (shell/shell-view)
             event-tab (find-by-testid tree "rf-causa-tab-event")
-            glyph    (some (fn [node]
-                             (when (and (vector? node)
-                                        (= :span (first node))
-                                        (map? (second node))
-                                        (= "true" (:aria-hidden (second node))))
-                               node))
-                           (hiccup-seq event-tab))]
-        (is (some? glyph)
-            "L3 tab's ●/○ glyph carries aria-hidden=\"true\"")))))
+            glyph     (some (fn [node]
+                              (when (and (vector? node)
+                                         (= :span (first node))
+                                         (map? (second node))
+                                         (= "true" (:aria-hidden (second node))))
+                                node))
+                            (hiccup-seq event-tab))
+            tab-text  (apply str (filter string? (hiccup-seq event-tab)))]
+        (is (nil? glyph)
+            "L3 tab carries no aria-hidden decorative-glyph span")
+        (is (not (re-find #"[◉○●]" tab-text))
+            "L3 tab carries no radio-circle glyph in its text")))))
 
 ;; -------------------------------------------------------------------------
 ;; (7) rf2-vxpq1 — static placeholder uses <h2> not <h1>

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -511,6 +511,65 @@
                 (str "after select-tab :machines, tab " tab-id
                      " aria-selected reflects the new active tab"))))))))
 
+(deftest tab-bar-is-figma-button-bar-not-radios
+  (testing "rf2-ad7zx.16 — the L3 tab strip renders as the Figma
+            button-bar (design-reference/components/Tabs.tsx + App.tsx
+            TabsList), NOT radio-circle glyphs. Each tab is a rounded
+            button; the ACTIVE tab carries a filled `:accent` background
+            with white text; inactive tabs are transparent with
+            secondary ink. The decorative `●/◉/○` radio glyph that the
+            previous tab-button rendered is GONE."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        ;; (a) NO radio-circle glyphs anywhere in the tab strip. The
+        ;; old tab-button stamped a `◉` (active) / `○` (inactive) span;
+        ;; the L2 gutter glyph `◉/○` lives in event rows, NOT in the
+        ;; tab buttons — so we assert per-button.
+        (doseq [tab-id expected-tab-ids]
+          (let [btn  (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
+                txt  (text-nodes btn)]
+            (is (some? btn) (str "tab button for " tab-id " present"))
+            (is (not (re-find #"[◉○●]" txt))
+                (str "tab " tab-id " carries no radio-circle glyph"))))
+        ;; (b) Every tab is a rounded button (`rounded` → border-radius).
+        (doseq [tab-id expected-tab-ids]
+          (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
+                style (:style (second btn))]
+            (is (= :button (first btn))
+                (str "tab " tab-id " is a <button>"))
+            (is (some? (:border-radius style))
+                (str "tab " tab-id " is rounded (border-radius set)"))))
+        ;; (c) The ACTIVE tab (default :event) is a filled-accent button
+        ;; with white text — the Figma `data-[state=active]:bg-…/text-white`.
+        (let [active (find-by-testid tree "rf-causa-tab-event")
+              style  (:style (second active))]
+          (is (= (:accent tokens) (:background style))
+              "active tab background is the filled :accent token")
+          (is (= (:white tokens) (:color style))
+              "active tab text is white"))
+        ;; (d) INACTIVE tabs are transparent with secondary ink.
+        (doseq [tab-id (remove #{:event} expected-tab-ids)]
+          (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
+                style (:style (second btn))]
+            (is (= "transparent" (:background style))
+                (str "inactive tab " tab-id " background is transparent"))
+            (is (= (:text-secondary tokens) (:color style))
+                (str "inactive tab " tab-id " text is secondary ink"))))))
+    ;; (e) After switching the active tab, the filled-accent treatment
+    ;; follows the new selection (and the old tab reverts to transparent).
+    (select-tab! :machines)
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            mach   (:style (second (find-by-testid tree "rf-causa-tab-machines")))
+            event  (:style (second (find-by-testid tree "rf-causa-tab-event")))]
+        (is (= (:accent tokens) (:background mach))
+            "newly-active :machines tab fills with :accent")
+        (is (= (:white tokens) (:color mach))
+            "newly-active :machines tab text is white")
+        (is (= "transparent" (:background event))
+            "previously-active :event tab reverts to transparent")))))
+
 (deftest tab-click-dispatches-select-tab
   (testing "spec/018 §5 — clicking a tab fires :rf.causa/select-tab"
     (causa-setup!)


### PR DESCRIPTION
## What

The L3/L4 panel tab strip (Event / app-db / Views / Trace / Machine / Routes / Issues) rendered with **radio-button glyphs** (◉ active / ○ inactive) plus a border-bottom underline. Mike flagged this on live verify — it should be the Figma **button-bar**.

Converted `tab-button` to the Figma mock (`tools/causa/design-reference/components/Tabs.tsx` + `App.tsx` TabsList):

- Each tab is a **rounded button** (`px-3 py-1.5 rounded` → 6px border-radius, 6px/12px padding).
- The **ACTIVE tab is a filled `:accent` background with white text** (`data-[state=active]:bg-[var(--devtools-active)]` / `text-white`).
- **Inactive tabs are transparent** with secondary ink and a subtle `:hover` fill (`hover:bg-[var(--devtools-hover)]`).
- The decorative ●/◉/○ radio glyph is **gone entirely** — fill + colour carry the selected signal.

Reuses the existing Figma blue `:accent` token (rf2-ad7zx.13); no colour redo.

## Files

- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — `tab-button` button-bar conversion.
- `tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs` — scoped `:hover` rule for inactive tabs (inline styles can't carry a `:hover` pseudo-class), keyed off the `rf-causa-tab-*` testid + `aria-selected="false"`.
- `tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs` — new `tab-bar-is-figma-button-bar-not-radios`: active tab = filled-accent button + white text; inactive = transparent; no radio glyphs; fill follows selection on switch.
- `tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs` — the rf2-vxpq1 "tab glyph is aria-hidden" test is superseded (glyph removed); now asserts no decorative glyph at all.

All ARIA (`role='tab'` / `aria-selected` / `tablist`) + per-tab testids preserved.

## Gates

- `npm run test:cljs` — 4247 tests / 13251 assertions, **0 failures**
- `tools/causa` `clojure -M:test` — 873 tests / 2914 assertions, **0 failures**
- `npm run test:causa-feature-gate` — 13 scenarios, **0 failures**
- `clj-kondo --fail-level error` on changed files — **0 errors**
- `examples/step-deck` builds clean (0 warnings) — the testbed mounts Causa with the new button-bar tab strip.
