### PR TITLE
fix(routing): popstate drives the url-owner frame so Back/Forward restores the route (rf2-6qgbs.4)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -846,6 +846,30 @@
   \"\" & html-attrs} & children]`. Per Spec 012 §Linking from views."}
   route-link  rf-routing/route-link)
 
+(def ^{:doc "Read the current browser URL as an app-relative string
+  `pathname + search + hash` (CLJS), or `\"/\"` on the JVM / SSR. The
+  projection `install-history-listener!` feeds to
+  `:rf.route/handle-url-change`. Per Spec 012 §URL changes are events.
+  Implementation ships in `day8/re-frame2-routing`."}
+  current-url  rf-routing/current-url)
+
+(def ^{:doc "Install a browser `popstate` listener that drives the
+  URL-owning frame: Back/Forward dispatches `:rf.route/handle-url-change`
+  to `(url-owner-frame-id)` (resolved at pop time), so the owner's
+  `:rf/route` slice and rendered body restore — whether the owner is
+  `:rf/default` or a non-default `:url-bound? true` frame (rf2-6qgbs.4).
+  Also syncs the initial URL on install. Idempotent (hot-reload safe).
+  CLJS-only. The inbound counterpart of the outbound `:rf.nav/push-url`
+  gate. Per Spec 012 §Multi-frame routing. Implementation ships in
+  `day8/re-frame2-routing`."}
+  install-history-listener!  rf-routing/install-history-listener!)
+
+(def ^{:doc "Tear down the `popstate` listener installed by
+  `install-history-listener!`. No-op when none is installed. CLJS-only.
+  Per Spec 012 §Multi-frame routing. Implementation ships in
+  `day8/re-frame2-routing`."}
+  remove-history-listener!  rf-routing/remove-history-listener!)
+
 ;; ---- machine helpers ------------------------------------------------------
 ;;
 ;; Plain-fn `reg-machine*` for code-gen pipelines / conformance corpus

--- a/implementation/core/src/re_frame/core_routing.cljc
+++ b/implementation/core/src/re_frame/core_routing.cljc
@@ -55,6 +55,34 @@
    :ex-data {:route-id id}}
   ([id] :delegate))
 
+(defwrapper current-url
+  "Per Spec 012 §URL changes are events. Read the current browser URL as
+  an app-relative string `pathname + search + hash` (CLJS), or `\"/\"`
+  when no `window.location` is available (SSR / node). Late-bound via
+  `:routing/current-url`."
+  {:hook :routing/current-url :artefact routing-artefact :on-absent :throw}
+  ([] :delegate))
+
+(defwrapper install-history-listener!
+  "Per Spec 012 §Multi-frame routing (rf2-6qgbs.4). Install a `window`
+  `popstate` listener that dispatches `:rf.route/handle-url-change` to the
+  current URL-owning frame (`url-owner-frame-id`, resolved at pop time),
+  then sync the current URL into that frame's `:rf/route` slice. This is
+  the inbound (browser → app) counterpart of the outbound
+  `:rf.nav/push-url` gate: Back/Forward restores the owner frame's route,
+  whether the owner is `:rf/default` or a non-default `:url-bound? true`
+  frame. Idempotent (re-install replaces the listener — hot-reload safe).
+  CLJS-only. Late-bound via `:routing/install-history-listener!`."
+  {:hook :routing/install-history-listener! :artefact routing-artefact :on-absent :throw}
+  ([] :delegate))
+
+(defwrapper remove-history-listener!
+  "Per Spec 012 §Multi-frame routing. Tear down the `popstate` listener
+  installed by `install-history-listener!`. No-op when none is installed.
+  CLJS-only. Late-bound via `:routing/remove-history-listener!`."
+  {:hook :routing/remove-history-listener! :artefact routing-artefact :on-absent :throw}
+  ([] :delegate))
+
 (defwrapper route-link
   "Per Spec 012 §Linking from views and API.md `route-link` row.
   Registered view at `:route/link` — renders an `<a href=...>` from a

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -288,6 +288,15 @@
    {:key         :routing/route-link
     :producer-ns 're-frame.routing
     :description "Reagent / SSR `[rf/route-link ...]` view component renderer."}
+   {:key         :routing/current-url
+    :producer-ns 're-frame.routing
+    :description "Read the current browser URL as pathname+search+hash (CLJS) / \"/\" (JVM)."}
+   {:key         :routing/install-history-listener!
+    :producer-ns 're-frame.routing
+    :description "Wire a popstate listener that drives the URL-owner frame on Back/Forward (rf2-6qgbs.4). CLJS-only."}
+   {:key         :routing/remove-history-listener!
+    :producer-ns 're-frame.routing
+    :description "Tear down the popstate listener installed by install-history-listener!. CLJS-only."}
 
    ;; ---- re-frame.http-managed (rf2-5kpd / rf2-6y3q / rf2-wvkn / rf2-ijm7) ----
    ;; The three stub-family hooks publish from `re-frame.http-test-support`

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -2014,6 +2014,108 @@ unknown strategies as :preserve (no-op)."}
        (trace/emit! :rf.fx :rf.fx/skipped-on-platform
                     {:fx-id :rf.nav/scroll :strategy strategy}))))
 
+;; ---- browser-history listener (popstate → url-owner frame) ----------------
+;;
+;; Per Spec 012 §URL changes are events / §Multi-frame routing. The
+;; runtime does not own a window `popstate` listener — apps install it.
+;; Historically an app hand-rolled
+;;
+;;   (.addEventListener js/window "popstate"
+;;     (fn [_] (rf/dispatch [:rf.route/handle-url-change (current-url)])))
+;;
+;; which dispatches the URL-change event WITHOUT a `:frame`, so it lands
+;; on `:rf/default`. That is correct only while `:rf/default` owns the
+;; URL. When a non-default frame opts into URL binding
+;; (`(reg-frame :my-frame {:url-bound? true})`, with `:rf/default`
+;; releasing ownership via `{:url-bound? false}` — the single-non-default
+;; owner case, rf2-6qgbs.3), the PUSH side correctly routes through that
+;; frame (`url-owner-frame-id` gates `:rf.nav/push-url`), but a
+;; default-targeted popstate dispatch would update `:rf/default`'s
+;; (frozen) slice instead of the owner's — so Back/Forward never restored
+;; the visible route (rf2-6qgbs.4).
+;;
+;; `install-history-listener!` resolves the URL owner AT POP TIME via
+;; `url-owner-frame-id` and dispatches the URL change to THAT frame. It is
+;; symmetric with `:rf.nav/push-url`: the same single owner drives both
+;; directions. For the default-owned app the owner resolves to
+;; `:rf/default`, so existing apps behave identically; for a url-bound
+;; non-default frame Back/Forward now restores its route slice and body.
+
+(defn current-url
+  "Read the current browser URL as an app-relative string
+  `pathname + search + hash`. CLJS-only — returns `\"/\"` when no
+  `window.location` is available (SSR / node). Public so apps that wire
+  their own history listener can recover the same projection
+  `install-history-listener!` uses."
+  []
+  #?(:cljs
+     (if (and (exists? js/window) (.-location js/window))
+       (let [loc (.-location js/window)]
+         (str (.-pathname loc) (.-search loc) (.-hash loc)))
+       "/")
+     :clj "/"))
+
+#?(:cljs
+   (defonce ^:private history-listener-atom
+     ;; Holds the installed popstate handler so a re-install
+     ;; (`install-history-listener!` called twice — e.g. hot-reload)
+     ;; replaces rather than stacks listeners.
+     (atom nil)))
+
+#?(:cljs
+   (defn install-history-listener!
+     "Install a `window` `popstate` listener that drives the URL-owning
+     frame, then sync the current URL into that frame's `:rf/route` slice.
+
+     Per Spec 012 §Multi-frame routing the popstate dispatch is targeted
+     at `(url-owner-frame-id)` resolved AT POP TIME, so it tracks whichever
+     single frame currently owns the URL — `:rf/default` for the common
+     case, or a non-default `:url-bound? true` frame (rf2-6qgbs.4). This is
+     the inbound (browser → app) counterpart of the outbound `:rf.nav/push-url`
+     gate: one owner, both directions.
+
+     Idempotent: re-installing replaces the previously-installed listener
+     (hot-reload safe). Returns `nil`. CLJS-only; the JVM half is a no-op
+     (`:require`-able from `.cljc` boot code without a reader conditional).
+
+     Both the initial sync and each popstate use `dispatch-sync!`: a
+     `popstate` event always fires on the browser's macrotask loop, never
+     nested inside a re-frame drain, so the run-to-completion update is
+     safe and the slice (and rendered body) restore synchronously within
+     the same browser turn — no intermediate paint on the stale route.
+     This mirrors the locked routing-history contract (the
+     `popstate-via-window-listener-cljs` test dispatches `dispatch-sync`)."
+     []
+     (let [w (when (exists? js/window) js/window)]
+       (when w
+         (when-let [prev @history-listener-atom]
+           (try (.removeEventListener w "popstate" prev)
+                (catch :default _ nil)))
+         (let [handler (fn [_event]
+                         (router/dispatch-sync! [:rf.route/handle-url-change (current-url)]
+                                                {:frame (url-owner-frame-id)}))]
+           (.addEventListener w "popstate" handler)
+           (reset! history-listener-atom handler)))
+       ;; Initial sync: hydrate the owner's slice from the current URL so
+       ;; a deep link / reload lands on the right route on first paint.
+       (router/dispatch-sync! [:rf.route/handle-url-change (current-url)]
+                              {:frame (url-owner-frame-id)})
+       nil)))
+
+#?(:cljs
+   (defn remove-history-listener!
+     "Tear down the `popstate` listener installed by
+     `install-history-listener!`. No-op when none is installed. Useful for
+     test isolation and frame-teardown in single-page hosts that rotate
+     URL owners."
+     []
+     (let [w (when (exists? js/window) js/window)]
+       (when (and w @history-listener-atom)
+         (try (.removeEventListener w "popstate" @history-listener-atom)
+              (catch :default _ nil))
+         (reset! history-listener-atom nil))
+       nil)))
+
 ;; ---- framework-shipped subs over the slice -------------------------------
 ;; Per Spec 012. Subs live in this artefact (not re-frame.core) so apps
 ;; that don't pull day8/re-frame2-routing carry no `:rf.route/*` strings
@@ -2198,6 +2300,13 @@ unknown strategies as :preserve (no-op)."}
 (late-bind/set-fn! :routing/route-url          route-url)
 (late-bind/set-fn! :routing/reset-counters!    reset-counters!)
 (late-bind/set-fn! :routing/route-sub-fn       route-sub-fn)
+(late-bind/set-fn! :routing/current-url        current-url)
+
+;; Browser-history wiring (popstate → url-owner frame). CLJS-only; the
+;; JVM build has no `window` so the install/remove fns are not defined
+;; there (SSR feeds the request URL via `:rf.route/handle-url-change`).
+#?(:cljs (late-bind/set-fn! :routing/install-history-listener! install-history-listener!))
+#?(:cljs (late-bind/set-fn! :routing/remove-history-listener!  remove-history-listener!))
 
 ;; route-link is exposed on both platforms so .cljc render trees
 ;; resolve identically server- and client-side.

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -56,6 +56,33 @@
 
 (defn- install-window-stub! []
   (let [state (new-history-stub)
+        location #js {:origin   "https://app.example"
+                      :href     "https://app.example/"
+                      :pathname "/"
+                      :search   ""
+                      :hash     ""}
+        ;; Keep `location` in sync with the current history entry, the way
+        ;; a real browser updates `window.location` on pushState / back /
+        ;; forward. `install-history-listener!`'s popstate handler reads
+        ;; the new URL off `window.location` (not the test's state atom),
+        ;; so the stub MUST reflect the navigation here for the
+        ;; listener-driven Back/Forward tests (rf2-6qgbs.4). Splits the
+        ;; entry into pathname / search / hash so `current-url` reassembles
+        ;; the same string.
+        sync-location!
+        (fn []
+          (let [{:keys [entries index]} @state
+                url    (nth entries index)
+                [path+ hash]   (let [i (.indexOf url "#")]
+                                 (if (neg? i) [url ""]
+                                     [(subs url 0 i) (subs url i)]))
+                [path search]  (let [i (.indexOf path+ "?")]
+                                 (if (neg? i) [path+ ""]
+                                     [(subs path+ 0 i) (subs path+ i)]))]
+            (set! (.-pathname location) path)
+            (set! (.-search location) search)
+            (set! (.-hash location) hash)
+            (set! (.-href location) (str (.-origin location) url))))
         ;; Synthetic event factory the stub passes to listeners.
         mk-event (fn [type]
                    #js {:type type})
@@ -71,25 +98,29 @@
                                 (let [kept (subvec entries 0 (inc index))]
                                   (-> s
                                       (assoc :entries (conj kept url))
-                                      (update :index inc))))))
+                                      (update :index inc)))))
+                       (sync-location!))
                      :replaceState
                      (fn [_state _title url]
                        (swap! state assoc-in
-                              [:entries (:index @state)] url))
+                              [:entries (:index @state)] url)
+                       (sync-location!))
                      :back
                      (fn []
                        (swap! state
                               (fn [{:keys [index] :as s}]
                                 (if (pos? index)
                                   (assoc s :index (dec index))
-                                  s))))
+                                  s)))
+                       (sync-location!))
                      :forward
                      (fn []
                        (swap! state
                               (fn [{:keys [entries index] :as s}]
                                 (if (< index (dec (count entries)))
                                   (assoc s :index (inc index))
-                                  s))))
+                                  s)))
+                       (sync-location!))
                      :go
                      (fn [delta]
                        (swap! state
@@ -98,12 +129,8 @@
                                   (if (and (>= next 0)
                                            (< next (count entries)))
                                     (assoc s :index next)
-                                    s)))))}
-        location #js {:origin   "https://app.example"
-                      :href     "https://app.example/"
-                      :pathname "/"
-                      :search   ""
-                      :hash     ""}
+                                    s))))
+                       (sync-location!))}
         window  #js {:history history
                      :location location
                      :scrollX 0
@@ -373,6 +400,85 @@
       (is (= :hist/cart
              (:id (:rf/route (rf/get-frame-db :rf/default))))
           "the slice landed on /cart through the listener-driven popstate path"))))
+
+;; ---- rf2-6qgbs.4: popstate drives the URL-OWNER frame --------------------
+;;
+;; Regression for the step-deck Back/Forward bug. After rf2-6qgbs.3 a
+;; non-default frame can own the URL (`:rf/default` opts out, the
+;; non-default frame opts in). The PUSH side already routed through that
+;; owner (`:rf.nav/push-url` gate). The POP side did not — a hand-rolled
+;; popstate listener dispatched `:rf.route/handle-url-change` with no
+;; `:frame`, hitting `:rf/default` (now frozen) instead of the owner, so
+;; Back/Forward left the owner's route — and the rendered body — unchanged.
+;;
+;; `install-history-listener!` resolves `url-owner-frame-id` at pop time
+;; and targets THAT frame. The test asserts the owner frame's slice
+;; round-trips on back AND forward while `:rf/default` stays put.
+
+;; The installed popstate handler dispatches synchronously
+;; (`dispatch-sync!`) — a real `popstate` fires on the browser macrotask
+;; loop, never nested in a drain — so the route slice settles within the
+;; same turn as `dispatchEvent` and the assertions can read it directly.
+
+(deftest popstate-drives-url-owner-non-default-frame-cljs
+  (testing "rf2-6qgbs.4: install-history-listener! drives the non-default URL-owner frame on Back/Forward"
+    (register-routes!)
+    ;; Single-non-default-owner setup (the step-deck shape): default opts
+    ;; OUT, a non-default frame opts IN, so `url-owner-frame-id` resolves
+    ;; to the non-default owner.
+    (rf/reg-frame :rf/default {:url-bound? false})
+    (rf/reg-frame :sd/owner   {:url-bound? true})
+    (is (= :sd/owner (routing/url-owner-frame-id))
+        "the non-default :url-bound? true frame owns the URL after default opts out")
+
+    ;; The framework wiring under test.
+    (rf/install-history-listener!)
+
+    ;; Forward nav on the owner frame pushes the URL (owner gates push).
+    (rf/dispatch-sync [:rf.route/navigate :hist/cart]     {:frame :sd/owner})
+    (rf/dispatch-sync [:rf.route/navigate :hist/checkout] {:frame :sd/owner})
+    (is (= ["/" "/cart" "/checkout"] (:entries @*history-state*))
+        "owner-frame forward nav pushed both URLs onto the history stack")
+    (is (= :hist/checkout (:id (:rf/route (rf/get-frame-db :sd/owner))))
+        "owner slice is on /checkout before Back")
+
+    ;; --- Back: browser moves the pointer + fires popstate. ---
+    (.back (.-history js/globalThis.window))
+    (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+    (is (= :hist/cart (:id (:rf/route (rf/get-frame-db :sd/owner))))
+        "Back restored the OWNER frame's slice to /cart via the installed listener")
+    (is (nil? (:id (:rf/route (rf/get-frame-db :rf/default))))
+        ":rf/default (the non-owner) was NOT mutated by the popstate")
+
+    ;; --- Forward: pointer moves up, popstate fires again. ---
+    (.forward (.-history js/globalThis.window))
+    (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+    (is (= :hist/checkout (:id (:rf/route (rf/get-frame-db :sd/owner))))
+        "Forward restored the OWNER frame's slice back to /checkout")
+    (is (nil? (:id (:rf/route (rf/get-frame-db :rf/default))))
+        ":rf/default still untouched after Forward")
+
+    (rf/remove-history-listener!)))
+
+(deftest popstate-drives-default-owner-when-default-bound-cljs
+  (testing "rf2-6qgbs.4: install-history-listener! drives :rf/default when it is the owner (no regression)"
+    (register-routes!)
+    ;; Default-owned app: url-owner-frame-id resolves to :rf/default.
+    (is (= :rf/default (routing/url-owner-frame-id))
+        ":rf/default owns the URL by default")
+    (rf/install-history-listener!)
+
+    (rf/dispatch-sync [:rf/url-requested {:url "/cart"}])
+    (rf/dispatch-sync [:rf/url-requested {:url "/checkout"}])
+    (is (= :hist/checkout (:id (:rf/route (rf/get-frame-db :rf/default))))
+        "default slice on /checkout before Back")
+
+    (.back (.-history js/globalThis.window))
+    (.dispatchEvent js/globalThis.window #js {:type "popstate"})
+    (is (= :hist/cart (:id (:rf/route (rf/get-frame-db :rf/default))))
+        "Back restored :rf/default's slice to /cart — default-owned routing unregressed")
+
+    (rf/remove-history-listener!)))
 
 ;; =========================================================================
 ;; 3. hashchange — fragment-only round-trip

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -1055,9 +1055,18 @@ The corpus-wide `:rf.error/handler-exception` listener (`on-match-error-listener
 Each frame has its own `:rf/route` slice. Only the default frame is URL-bound. Non-default frames have independent routes that don't push to the browser URL.
 
 1. Every frame's `app-db` may have a `:rf/route` slice (it's a regular `app-db` path, not a special concept).
-2. The default frame (`:rf/default`) is **URL-bound**: `:rf.route/navigate` events on that frame fire `:rf.nav/push-url`; `popstate` listeners fire `[:rf.route/handle-url-change url] {:frame :rf/default}`. The browser URL reflects the default frame's route.
+2. The default frame (`:rf/default`) is **URL-bound** by default: `:rf.route/navigate` events on that frame fire `:rf.nav/push-url`, and `popstate` (Back/Forward) drives it. The browser URL reflects the URL-owning frame's route.
 3. Non-default frames are **not URL-bound** by default. `:rf.route/navigate` updates their `:rf/route` slice (state changes) but does not fire `:rf.nav/push-url`. This is the right default for story-variant frames, devcards, per-test fixtures.
-4. Opt-in URL binding for non-default frames via `(rf/reg-frame :my-frame {:url-bound? true})`. The runtime enforces "only one frame can own the URL at a time" — re-registering a second `:url-bound? true` frame is a `:rf.error/duplicate-url-binding` trace event.
+4. Opt-in URL binding for non-default frames via `(rf/reg-frame :my-frame {:url-bound? true})`. The runtime enforces "only one frame can own the URL at a time" — re-registering a second `:url-bound? true` frame is a `:rf.error/duplicate-url-binding` trace event. When the default frame opts out (`{:url-bound? false}`) and a single non-default frame opts in, that frame becomes the sole URL owner.
+
+### popstate drives the URL-owner frame, both directions (rf2-6qgbs.4)
+
+URL ownership is symmetric across the app↔browser boundary, and resolves to the **same single owner** in both directions:
+
+- **Outbound (app → browser).** `:rf.nav/push-url` / `:rf.nav/replace-url` consult `url-owner-frame-id` (public) and only the owner mutates browser history. A non-owner's navigation updates its own `:rf/route` slice but no-ops the history push.
+- **Inbound (browser → app).** A `popstate` listener fires `[:rf.route/handle-url-change url] {:frame (url-owner-frame-id)}` — targeted at the **current** owner resolved at pop time, NOT hard-coded to `:rf/default`. So Back/Forward restores the owner frame's `:rf/route` slice (and the body rendered off it), whether the owner is `:rf/default` or a non-default `:url-bound? true` frame.
+
+The routing artefact ships `install-history-listener!` (CLJS) — re-exported as `rf/install-history-listener!` — which wires this `popstate` listener and does the initial URL → owner-slice sync. Apps boot it once after registering frames. It is idempotent (re-install replaces the listener, hot-reload safe) and is the inbound counterpart of the `:rf.nav/push-url` gate; `rf/remove-history-listener!` tears it down. Targeting `url-owner-frame-id` at pop time means default-owned apps and url-bound-non-default-frame apps behave identically through the same helper — a popstate dispatched at the old owner (`:rf/default`) after ownership transferred would update a frozen slice and leave Back/Forward broken (the bug rf2-6qgbs.4 fixed).
 
 The story / devcard / SSR cases all benefit:
 

--- a/tools/causa/testbeds/step_deck/core.cljs
+++ b/tools/causa/testbeds/step_deck/core.cljs
@@ -276,4 +276,17 @@
   (rf/reg-frame :rf/default {:url-bound? false})
   (rf/reg-frame frame-id {:url-bound? true
                           :on-create  [:testdeck/initialise]})
+  ;; Browser Back/Forward → route (rf2-6qgbs.4). The framework's
+  ;; `install-history-listener!` wires `popstate` to dispatch
+  ;; `:rf.route/handle-url-change` against the current URL-OWNER frame
+  ;; (`:step-deck` here, resolved via `url-owner-frame-id`), so a Back/
+  ;; Forward restores BOTH the route slice and the visible tab body. It
+  ;; is the inbound counterpart of the outbound `:rf.nav/push-url` gate
+  ;; the url-bound frame already drives — same single owner, both
+  ;; directions. Installed AFTER the frames are registered so the owner
+  ;; resolves to `:step-deck`, and AFTER `:on-create` seeds the initial
+  ;; route (the listener's initial sync then no-ops on the already-correct
+  ;; slice). With `:rf/default` the same call drives default-owned apps
+  ;; identically — this is a substrate helper, not a step-deck special-case.
+  (rf/install-history-listener!)
   (rdc/render react-root [root]))


### PR DESCRIPTION
## Problem

Browser **Back/Forward did not restore the route** in the step-deck testbed. rf2-6qgbs.3 (#2045) made the non-default `:step-deck` frame the sole URL owner (default opts out, step-deck opts in), so forward tab nav pushes `/counter`, `/machine`, `/routing`, `/async`. But the reverse — `popstate` → route — did nothing.

## Root cause

The routing substrate is event/fx-driven and **does not own a `popstate` listener** (by design — apps install it). The historical hand-rolled listener dispatches `[:rf.route/handle-url-change url]` with **no `:frame`**, so it lands on `:rf/default`. After ownership transferred to `:step-deck`:

- the **PUSH** side (`:rf.nav/push-url`, gated by `url-owner-frame-id`) correctly routed through the new owner, but
- the **POP** side was broken twice over: the step-deck testbed never installed a popstate listener at all, and a default-targeted dispatch would have updated `:rf/default`'s frozen slice anyway.

## Fix (substrate-shaped — benefits any url-bound frame)

Add `install-history-listener!` to `re-frame.routing` (re-exported as `rf/install-history-listener!`). It wires `popstate` to dispatch `:rf.route/handle-url-change` against `(url-owner-frame-id)` **resolved at pop time** — the inbound counterpart of the outbound push gate. The same single owner drives both directions: `:rf/default` for default-owned apps (behaviour unchanged), or a non-default `:url-bound? true` frame. Also adds `current-url` and `remove-history-listener!`. The step-deck testbed boots the helper after registering its frames.

## Real-browser verification (chromium / Playwright)

Forward through Counter → Machine → Routing → Async, then `history.back()` x3 and `history.forward()` x2 — each restores **both** the route id (aria-current) **and** the rendered tab body to the expected tab. All assertions passed.

## Tests / gates

- Two routing CLJS regression tests: popstate drives a non-default url-owner frame on Back/Forward; popstate drives `:rf/default` when default-bound (no regression). The routing-history window stub now syncs `location` with the history pointer.
- Three late-bind directory entries added (drift gate).
- `npm run test:cljs` — 0 failures. Routing JVM `clojure -M:test` — 0 failures. Core JVM — 0 failures. tools/causa JVM — 0 failures. CLJS + JVM compiles 0 warnings.

Closes rf2-6qgbs.4.