### PR TITLE
fix(causa): events-ribbon hidden-message no longer duplicates filter pills (rf2-ad7zx.18)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -1483,65 +1483,31 @@
 ;; silently suppress L2 rows; this ribbon makes them a VISIBLE cause +
 ;; one-click reset (`:rf.causa/clear-all-filters`).
 
-(defn- filter-cause-chip
-  "One small chip naming an active suppressing surface (a pill or the
-  mute set) inside the hidden-count message. Frame is NOT a cause —
-  it is a view scope (rf2-4vp5j Workstream C)."
-  [{:keys [testid tone label title]}]
-  [:span {:data-testid testid
-          :title       title
-          :style {:display        "inline-flex"
-                  :align-items    "center"
-                  :gap            "3px"
-                  :border         (str "1px solid " tone)
-                  :color          tone
-                  :padding        "0 5px"
-                  :border-radius  "8px"
-                  :font-family    mono-stack
-                  :font-size      (:caption type-scale)
-                  :white-space    "nowrap"}}
-   label])
-
 (defn filters-hidden-message
-  "Pure hiccup. The `N events hidden by filters` message + its pill /
-  mute cause chips — the RIGHT-side signal of the events ribbon. Renders
+  "Pure hiccup. The `N events hidden by filters` count — the RIGHT-side
+  signal of the events ribbon, sitting beside `Clear Filters`. Renders
   nil unless the hidden count is positive (`:visible?`). Keeps rf2-jvghz's
   prominent yellow accent. Counts pill/mute suppression ONLY — the frame
-  is a view scope, never counted as hidden (rf2-4vp5j Workstream C)."
-  [{:keys [hidden visible? pills muted-count] :as _summary}]
+  is a view scope, never counted as hidden (rf2-4vp5j Workstream C).
+
+  rf2-ad7zx.18 — per the Figma mock (`design-reference/components/
+  EventsRibbon.tsx`) the hidden-state is a plain count beside `Clear
+  Filters`; it no longer re-renders the active pills/mute as cause chips.
+  The committed pills already live in the LEFT cluster (via
+  `ribbon-filter-pills` → `filters.pills/pills-view`); re-rendering them
+  here duplicated every pill in front of `Clear Filters`."
+  [{:keys [hidden visible?] :as _summary}]
   (when visible?
     [:div {:data-testid "rf-causa-filters-hidden-indicator"
            :role        "status"
            :style {:display     "inline-flex"
                    :align-items "center"
-                   :flex-wrap   "wrap"
-                   :gap         "6px"
                    :font-family sans-stack
                    :font-size   (:caption type-scale)
                    :color       (:text-primary tokens)}}
      [:span {:data-testid "rf-causa-filters-hidden-count"
              :style {:font-weight 600 :color (:yellow tokens) :white-space "nowrap"}}
-      (str hidden " event" (when (not= 1 hidden) "s") " hidden by filters")]
-     ;; Cause chips — the active pills + the mute set (NOT the frame).
-     (into [:span {:data-testid "rf-causa-filters-hidden-causes"
-                   :style {:display "flex" :align-items "center"
-                           :flex-wrap "wrap" :gap "4px"}}]
-           (concat
-             (for [[idx {:keys [mode label glyph]}] (map-indexed vector pills)]
-               ^{:key (str "pill-" idx)}
-               [filter-cause-chip
-                {:testid (str "rf-causa-filters-hidden-pill-" idx)
-                 :tone   (if (= mode :out) (:magenta tokens) (:green tokens))
-                 :title  (str (name mode) " filter pill")
-                 :label  (str (if (= mode :out) "× " "+ ")
-                              (when glyph (str glyph ":")) label)}])
-             (when (pos? muted-count)
-               [^{:key "muted"}
-                [filter-cause-chip
-                 {:testid "rf-causa-filters-hidden-muted"
-                  :tone   (:text-secondary tokens)
-                  :title  "Muted event-ids hidden from the spine"
-                  :label  (str "🔇 " muted-count)}]])))]))
+      (str hidden " event" (when (not= 1 hidden) "s") " hidden by filters")]]))
 
 (defn- clear-filters-button
   "Restrained outline `Clear Filters` button — resets pills + mutes (NOT

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
@@ -87,6 +87,17 @@
             node))
         (hiccup-seq tree)))
 
+(defn- count-by-testid
+  "How many nodes in the expanded tree carry `testid` — used to assert a
+  committed pill renders EXACTLY once (rf2-ad7zx.18: the hidden-message
+  no longer re-renders the pills as cause chips)."
+  [tree testid]
+  (count (filter (fn [node]
+                   (and (vector? node)
+                        (map? (second node))
+                        (= testid (:data-testid (second node)))))
+                 (hiccup-seq tree))))
+
 (defn- text-of
   "Concatenate the string leaves under a node — good enough to assert
   the count message reads as expected."
@@ -189,9 +200,33 @@
       (is (some? indicator) "banner renders when rows are hidden")
       (is (some? (find-by-testid tree "rf-causa-filters-hidden-clear"))
           "Clear filters button present")
-      (is (some? (find-by-testid tree "rf-causa-filters-hidden-pill-0"))
-          "the OUT pill is named as the cause")
       (is (re-find #"1 event hidden by filters" (text-of count-node))))))
+
+(deftest hidden-message-does-not-duplicate-the-committed-pills
+  (testing "rf2-ad7zx.18 — per the Figma EventsRibbon mock the hidden-state
+            is a plain count beside `Clear Filters`. The committed pill must
+            render EXACTLY ONCE (in the LEFT cluster via pills-view); the
+            hidden-message must NOT re-render it as a cause chip."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:a]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:b]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 3 [:noise/tick]))
+    (frame-dispatch [:rf.causa/add-filter :out {:pattern :noise/tick}])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        ;; the committed OUT pill renders ONCE — in the left cluster.
+        (is (= 1 (count-by-testid tree "rf-causa-filter-pill-out-0"))
+            "the committed pill renders exactly once (left cluster)")
+        ;; the duplicate cause-chip cluster is gone.
+        (is (nil? (find-by-testid tree "rf-causa-filters-hidden-causes"))
+            "no duplicate cause-chip cluster in the hidden-message")
+        (is (nil? (find-by-testid tree "rf-causa-filters-hidden-pill-0"))
+            "no duplicate pill chip in the hidden-message")
+        ;; the count + Clear Filters survive (Figma mock).
+        (is (some? (find-by-testid tree "rf-causa-filters-hidden-count"))
+            "the hidden count is kept")
+        (is (some? (find-by-testid tree "rf-causa-filters-hidden-clear"))
+            "Clear Filters is kept")))))
 
 (deftest indicator-absent-when-nothing-hidden
   (causa-setup!)


### PR DESCRIPTION
## What

Adding a filter rendered the committed pill **twice**: once correctly in the LEFT cluster (via `ribbon-filter-pills` -> `filters.pills/pills-view`) and a confusing duplicate in front of **Clear Filters**. Root cause: `filters-hidden-message` (`tools/causa/src/day8/re_frame2_causa/shell.cljs`) re-rendered every active pill (and the mute set) as "cause chips" beside the `N events hidden by filters` count.

## Fix

Per the Figma mock (`tools/causa/design-reference/components/EventsRibbon.tsx`), the hidden-state is a plain count beside `Clear Filters` with **no pill re-render**. So:

- Removed the cause-chip cluster (`rf-causa-filters-hidden-causes` — the per-pill loop + the mute chip).
- Removed the now-unused `filter-cause-chip` helper.
- Kept the yellow-accent count text and the `Clear Filters` button (matching the mock).

The `:rf.causa/hidden-by-filters` sub model is unchanged (still carries `:pills` / `:muted-count` for the sub-composition tests); only the view stopped re-rendering them. Colour tokens already Figma blue/neutral — untouched.

## Test

- Dropped the obsolete cause-chip assertion in `indicator-renders-count-and-clear-when-hidden`.
- Added `hidden-message-does-not-duplicate-the-committed-pills`: asserts the committed OUT pill renders **exactly once** (left cluster, `rf-causa-filter-pill-out-0`), the cause-chip cluster is gone, and count + Clear Filters survive.

## Gates

- `npm run test:cljs` — 4242 tests, 0 failures
- tools/causa `clojure -M:test` — 873 tests, 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures
- clj-kondo (v2026.04.15, `--fail-level error`) — 0 errors, 0 warnings

Closes rf2-ad7zx.18.