### PR TITLE
fix(causa): Add-filter dialog copy to Mike's wording + spec/018 sync (rf2-ad7zx.19)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -995,23 +995,44 @@ ACTIVE FILTERS = (match-any-IN) AND NOT (match-any-OUT)
 
 Pill `✎` icon (pencil) = "click to edit." Whole pill is the clickable target.
 
-### Click-pill → edit popup
+### Add-filter dialog (click-pill → edit popup)
+
+The dialog copy is normative (rf2-ad7zx.19). The Add-filter form (the
+trailing-`+` / `:add` source) reads exactly:
 
 ```
-┌─ Edit filter ──────────────────────┐
-│ Mode    ◉ IN   ○ OUT               │
-│                                    │
-│ Pattern                            │
-│   :auth/*                          │
-│   (keyword · glob · namespace)     │
-│                                    │
-│ ──────────────────────────────────  │
-│ [Delete]      [Cancel]    [Apply]  │
-└────────────────────────────────────┘
+┌─ Filter events ─────────────────────────────────┐
+│ Action                                          │
+│   (•) Show only matching events                 │
+│   ( ) Hide matching events                      │
+│                                                 │
+│ Match events containing                         │
+│   [ :auth/*, :mouse-move, /login ]              │
+│   Matches keywords, namespaces, globs, or text. │
+│   Examples: :auth/*, :auth, :mouse-move, /login │
+│                                                 │
+│ ───────────────────────────────────────────────  │
+│                       [Cancel]    [Add filter]  │
+└─────────────────────────────────────────────────┘
 ```
 
-- **Mode toggle** flips IN ↔ OUT without delete/recreate.
-- **Pattern field** accepts: exact keyword (`:auth/login`), glob (`:auth/*`, `:order.cart/*`), namespace (`:order/*` matches namespace `order`), substring (`/login`).
+- **Title** is `Filter events` on the trailing-`+` (`:add`) source.
+  The `:pill` (edit existing) source titles `Edit filter` and exposes
+  the `[Delete]` button; the `:context` (right-click) source titles
+  `Add filter for this event`.
+- **Action radios** — `Show only matching events` (IN) /
+  `Hide matching events` (OUT) — toggle the mode (IN ↔ OUT) without
+  delete/recreate. The wording is presentation; the underlying
+  IN/OUT slot semantics are unchanged (§7 matcher algebra).
+- **`Match events containing` field** accepts: exact keyword
+  (`:auth/login`), glob (`:auth/*`, `:order.cart/*`), namespace
+  (`:order/*` matches namespace `order`), substring (`/login`). The
+  input placeholder is `:auth/*, :mouse-move, /login`; the two-line
+  helper under it reads `Matches keywords, namespaces, globs, or
+  text.` then `Examples: :auth/*, :auth, :mouse-move, /login`.
+- **Buttons** — `[Cancel]` discards the draft; the primary button is
+  `Add filter` on the `:add`/`:context` sources and `Apply` on the
+  `:pill` edit source.
 - **Event-id is the only scope.** The dialog produces exactly the `{:pattern <kw-or-str>}` shape keyed off the cascade's event-id (rf2-o8pjv). There is no match-scope selector — the matcher honours event-id exclusively.
 - **Trailing `+`** opens the same popup with empty pattern + default mode = IN.
 

--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -2,18 +2,25 @@
   "Edit popup for IN/OUT filter pills (rf2-ak4ms).
 
   Per `tools/causa/spec/018-Event-Spine.md` §7 'Click-pill → edit
-  popup' the popup is a modal overlay with:
+  popup' the popup is a modal overlay with (Add-filter copy shown;
+  the title flips to 'Edit filter' on the :pill source and 'Add
+  filter for this event' on the :context source):
 
-      ┌─ Edit filter ──────────────────────┐
-      │ Mode    ◉ IN   ○ OUT               │
-      │                                    │
-      │ Pattern                            │
-      │   :auth/*                          │
-      │   (keyword · glob · namespace)     │
-      │                                    │
-      │ ──────────────────────────────────  │
-      │ [Delete]      [Cancel]    [Apply]  │
-      └────────────────────────────────────┘
+      ┌─ Filter events ─────────────────────────┐
+      │ Action                                  │
+      │   (•) Show only matching events         │
+      │   ( ) Hide matching events              │
+      │                                         │
+      │ Match events containing                 │
+      │   [ :auth/*, :mouse-move, /login ]      │
+      │   Matches keywords, namespaces, globs,  │
+      │   or text.                              │
+      │   Examples: :auth/*, :auth, :mouse-move,│
+      │   /login                                │
+      │                                         │
+      │ ───────────────────────────────────────  │
+      │              [Cancel]    [Add filter]   │
+      └─────────────────────────────────────────┘
 
   ## Scope
 
@@ -202,7 +209,7 @@
               :on-change #(rf/dispatch
                             [:rf.causa/edit-popup-set-mode mode]
                             {:frame :rf/causa})}]
-     (case mode :in "IN (show only)" :out "OUT (hide)")]))
+     (case mode :in "Show only matching events" :out "Hide matching events")]))
 
 (defn popup-view
   "The popup body. Caller (`filters/Modal`) gates the mount on
@@ -216,7 +223,7 @@
         title       (case (:source trigger)
                       :pill    "Edit filter"
                       :context "Add filter for this event"
-                      "Add filter")
+                      "Filter events")
         ;; Apply is enabled when the pattern is non-blank.
         can-apply?  (let [p (:pattern draft)]
                       (and (string? p) (seq (clojure.string/trim p))))]
@@ -253,20 +260,20 @@
         "✕"]]
 
       [:div {:style (section-style)}
-       [:label {:style (label-style)} "Mode"]
+       [:label {:style (label-style)} "Action"]
        [:div {:style (radio-row-style)}
         [mode-radio {:mode :in :current-mode mode}]
         [mode-radio {:mode :out :current-mode mode}]]]
 
       [:div {:style (section-style)}
        [:label {:style (label-style) :for "rf-causa-edit-popup-pattern"}
-        "Pattern"]
+        "Match events containing"]
        [:input {:data-testid  "rf-causa-edit-popup-pattern"
                 :id           "rf-causa-edit-popup-pattern"
                 :type         "text"
                 :auto-focus   true
                 :value        (or (:pattern draft) "")
-                :placeholder  ":auth/* or :mouse-move or /login"
+                :placeholder  ":auth/*, :mouse-move, /login"
                 :on-change    #(rf/dispatch
                                  [:rf.causa/edit-popup-set-pattern
                                   (.. % -target -value)]
@@ -287,8 +294,10 @@
        [:div {:style {:margin-top "4px"
                       :color (:text-tertiary tokens)
                       :font-family sans-stack
-                      :font-size (:caption type-scale)}}
-        "keyword · glob (:foo/*) · namespace (:foo) · substring"]]
+                      :font-size (:caption type-scale)
+                      :line-height 1.5}}
+        [:div "Matches keywords, namespaces, globs, or text."]
+        [:div "Examples: :auth/*, :auth, :mouse-move, /login"]]]
 
       [:div {:style (footer-style)}
        (if editing?
@@ -315,4 +324,4 @@
                   :style       (merge (btn-style {:primary? true})
                                       (when-not can-apply?
                                         {:opacity 0.4 :cursor "default"}))}
-         (if editing? "Apply" "Add")]]]]]))
+         (if editing? "Apply" "Add filter")]]]]]))

--- a/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
@@ -330,9 +330,10 @@
 ;; (9) Dialog is event-id-only (rf2-o8pjv)
 ;; -------------------------------------------------------------------------
 ;;
-;; The Add-filter dialog reduces to exactly Mode (Only include /
-;; Filter out) + Pattern + footer. The Match-scope section
-;; (event-id / event-args / source-coord / tags checkboxes) and its
+;; The Add-filter dialog reduces to exactly the Action radios (Show
+;; only matching events / Hide matching events) + the Match-events
+;; field + footer. The Match-scope section (event-id / event-args /
+;; source-coord / tags checkboxes) and its
 ;; `:rf.causa/edit-popup-toggle-scope` plumbing are excised — event-id
 ;; is the implicit, only scope.
 
@@ -353,10 +354,93 @@
         (is (some? (find-by-testid rendered "rf-causa-edit-popup-cancel"))
             "Cancel button present")
         (is (some? (find-by-testid rendered "rf-causa-edit-popup-save"))
-            "Add/Apply button present")
+            "Add filter / Apply button present")
         ;; Excised surface — no scope checkboxes of any key.
         (is (= #{} (testids-with-prefix rendered "rf-causa-edit-popup-scope-"))
             "no match-scope checkboxes render")))))
+
+;; -------------------------------------------------------------------------
+;; (10) Dialog copy is Mike's normative wording (rf2-ad7zx.19)
+;; -------------------------------------------------------------------------
+;;
+;; The Add-filter dialog copy is normative in spec/018 §7. These tests
+;; lock the exact strings — title, Action radios, field label, the
+;; two-line helper, and the buttons — so a wording drift fails CI.
+
+(defn- all-strings
+  "Every string literal in the expanded hiccup tree."
+  [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
+       (filter string?)
+       (into #{})))
+
+(defn- placeholder-values
+  "Every `:placeholder` attribute value in the expanded tree."
+  [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-tree tree))
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (:placeholder (second node)))))
+       (into #{})))
+
+(deftest add-filter-dialog-copy-is-normative
+  (testing "the Add-filter (trailing-+ / :add) dialog renders Mike's
+            exact copy per spec/018 §7"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (rf/with-frame :rf/causa
+      (let [rendered     (filters/Modal)
+            strings      (all-strings rendered)
+            placeholders (placeholder-values rendered)]
+        (is (contains? strings "Filter events")
+            "title is 'Filter events' on the :add source")
+        (is (contains? strings "Action")
+            "section label is 'Action'")
+        (is (contains? strings "Show only matching events")
+            "IN radio reads 'Show only matching events'")
+        (is (contains? strings "Hide matching events")
+            "OUT radio reads 'Hide matching events'")
+        (is (contains? strings "Match events containing")
+            "field label is 'Match events containing'")
+        (is (contains? strings "Matches keywords, namespaces, globs, or text.")
+            "helper line 1")
+        (is (contains? strings "Examples: :auth/*, :auth, :mouse-move, /login")
+            "helper line 2 (examples)")
+        (is (contains? placeholders ":auth/*, :mouse-move, /login")
+            "input placeholder")
+        (is (contains? strings "Cancel") "Cancel button")
+        (is (contains? strings "Add filter")
+            "primary button reads 'Add filter' on the :add source")))))
+
+(deftest pill-edit-dialog-keeps-edit-title-and-apply
+  (testing "editing an existing pill (:pill source) keeps 'Edit filter'
+            + 'Apply' while sharing the same Action/field copy"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup
+                     {:source :pill :mode :in :idx 0
+                      :pill {:pattern :auth/*}}])
+    (rf/with-frame :rf/causa
+      (let [strings (all-strings (filters/Modal))]
+        (is (contains? strings "Edit filter")
+            "title is 'Edit filter' on the :pill source")
+        (is (contains? strings "Apply")
+            "primary button is 'Apply' when editing")
+        (is (contains? strings "Show only matching events")
+            "Action radio copy shared with the add path")))))
+
+(deftest context-dialog-keeps-add-for-this-event-title
+  (testing "the right-click (:context) source titles 'Add filter for
+            this event' and uses the 'Add filter' primary button"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/hide-event-type :user/mouse-move])
+    (rf/with-frame :rf/causa
+      (let [strings (all-strings (filters/Modal))]
+        (is (contains? strings "Add filter for this event")
+            "title is 'Add filter for this event' on the :context source")
+        (is (contains? strings "Add filter")
+            "primary button reads 'Add filter'")
+        (is (contains? strings "Hide matching events")
+            "Action radio copy shared with the add path")))))
 
 (deftest toggle-scope-event-is-unregistered
   (testing "the `:rf.causa/edit-popup-toggle-scope` event is fully


### PR DESCRIPTION
## What

Rewords the Causa Add-filter dialog (`filters/edit_popup.cljs`) to Mike's normative copy and syncs the spec (`tools/causa/spec/018-Event-Spine.md`) so impl + spec agree. This is copy/wording only — the IN/OUT filter semantics, the `{:pattern <kw-or-str>}` pill shape, and the input behaviour are unchanged.

## Copy

| Element | Before | After |
| --- | --- | --- |
| Title (`:add`) | `Add filter` | `Filter events` |
| Section label | `Mode` | `Action` |
| IN radio | `IN (show only)` | `Show only matching events` |
| OUT radio | `OUT (hide)` | `Hide matching events` |
| Field label | `Pattern` | `Match events containing` |
| Placeholder | `:auth/* or :mouse-move or /login` | `:auth/*, :mouse-move, /login` |
| Helper | `keyword · glob (:foo/*) · namespace (:foo) · substring` | `Matches keywords, namespaces, globs, or text.` / `Examples: :auth/*, :auth, :mouse-move, /login` |
| Primary button (`:add`) | `Add` | `Add filter` |

The `:pill` (edit existing) source keeps `Edit filter` + `Apply`; the `:context` (right-click) source keeps `Add filter for this event`.

## Files

- `tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs` — dialog copy + docstring ASCII diagram.
- `tools/causa/spec/018-Event-Spine.md` — §7 "Click-pill → edit popup" rewritten as the normative "Add-filter dialog" section with the exact copy + per-source title/button rules. Scoped to the add-filter section (hot-zone file). spec/018 lives under `tools/causa/spec` and is not in the mkdocs site.
- `tools/causa/test/.../edit_popup_cljs_test.cljs` — copy-locking render tests for the `:add` / `:pill` / `:context` sources so wording drift fails CI.

## Gates

- `npm run test:cljs` — 4244 tests, 0 failures.
- `tools/causa` `clojure -M:test` — 873 tests, 0 failures.
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures.
- `examples/step-deck` shadow build — clean (0 warnings).
- clj-kondo on changed files — 0 errors.

Closes rf2-ad7zx.19.