### PR TITLE
fix(causa): Event panel DB CHANGES renders only changed paths (rf2-mn3gt)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -65,6 +65,7 @@
             [re-frame.core :as rf]
             [day8.re-frame2-causa.views.edn-widget.widget :as edn]
             [day8.re-frame2-causa.panel-registry :as panel-registry]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
@@ -1038,20 +1039,132 @@
                   :color       (:text-primary tokens)}}
     body]])
 
-;; ---- §2 step DB CHANGES — app-db diff via data-display ----------------
+;; ---- §2 step DB CHANGES — flat changed-paths diff list ----------------
+;;
+;; Per spec/021 §2.2 step 4 (line 229) the DB CHANGES section is the
+;; app-db diff rendered as a FLAT list of changed paths ONLY:
+;;
+;;     ~ [path] old → new        (modified)
+;;     + [path] value            (added)
+;;     - [path]                  (removed)
+;;
+;; one line per changed path with the cascade diff glyph (`~` modified ·
+;; `+` added · `-` removed). It is **slice-centric, not tree-centric**
+;; (spec/004-App-DB-Diff.md §43/§69): it never renders untouched
+;; top-level keys nor the whole tree. The prior implementation routed
+;; the raw `:db-before` / `:db-after` snapshots through `edn/diff` — the
+;; §10 tree renderer — which paints the WHOLE app-db with changes
+;; highlighted (untouched keys dimmed in place). That violated 004 and
+;; the §2.2 mockups; rf2-mn3gt switches the section to the flat
+;; changed-paths projection.
+;;
+;; The changed-paths set is the SAME structural-sharing diff the App-db
+;; tab consumes — the `:rf.causa/selected-epoch-diff` sub (cached per
+;; `:epoch-id` via `app_db_diff_subs/install!`), which derives
+;; `{:op :path :before :after}` triples from the focused epoch record's
+;; `:db-before` / `:db-after`. The Event-panel section is the inline
+;; (`~ [path] old → new`) projection of that diff, NOT a second
+;; derivation. The §10 widget still owns leaf-value rendering — each
+;; value renders through `edn/inspect-inline` (the one-line, sentinel-
+;; aware §10 facade).
 
 (defn- db-fx-evicted?
   "True when the focused epoch has aged out of the buffer — the
   `:rf.causa/selected-epoch-record` sub returns nil but a non-nil
-  selection exists. Drives the data-display renderer's evicted-epoch
-  placeholder (§10.7)."
+  selection exists. Drives the evicted-epoch placeholder (§10.7)."
   [selected-record selected-id]
   (and (some? selected-id) (nil? selected-record)))
 
+(def ^:private op->glyph
+  "The cascade diff glyph per op (spec/021 §2.2 line 244-245 / §10.3).
+  Mirrors `diff/render.cljs`'s gutter glyphs — `~` modified · `+`
+  added · `-` removed."
+  {:added    "+"
+   :modified "~"
+   :removed  "-"})
+
+(def ^:private op->tone
+  "Glyph + path colour per op, per spec/021 §10.3 cascade-gutter token
+  mapping: `+` green (success) · `-` red (error) · `~` amber (warning)."
+  {:added    :green
+   :modified :yellow
+   :removed  :red})
+
+(defn- path-suffix
+  "Stable testid suffix for a changed path — a `pr-str` of the path
+  vector with characters that break a data-testid selector folded to
+  `_`. e.g. `[:counter]` → `:counter`, `[:cart :items]` →
+  `:cart_:items`."
+  [path]
+  (-> (string/join " " (map pr-str path))
+      (string/replace #"\s+" "_")))
+
+(defn- db-change-row
+  "Render one changed-path row in the flat DB CHANGES list. `triple` is
+  one `app-db-diff-helpers/diff-paths` triple
+  (`{:op :path :before :after}`). Shape per spec/021 §2.2 mockup
+  (lines 272-275):
+
+      ~ [:counter]  1 → 2
+      + [:last-updated]  #inst \"…\"
+      - [:stale]
+
+  The glyph + path colour follow the op tone (§10.3). The value
+  rendering routes through the §10 widget (`edn/inspect-inline`) so the
+  data-classification sentinels + the cljs-devtools leaf look are
+  shared with every other Causa surface. A `:modified` row shows
+  `before → after`; an `:added` row shows the added value; a `:removed`
+  row shows the path alone (per line 229 — `- [path]`)."
+  [{:keys [op path before after]}]
+  (let [suffix     (path-suffix path)
+        glyph      (get op->glyph op "?")
+        tone       (get tokens (get op->tone op) (:text-secondary tokens))
+        path-label (f/format-edn (vec path))]
+    [:div {:data-testid (str "rf-causa-event-detail-db-change-row-" suffix)
+           :data-op     (name op)
+           :style {:display      "flex"
+                   :align-items  "baseline"
+                   :flex-wrap    "wrap"
+                   :gap          "8px"
+                   :padding      "2px 0"}}
+     [:span {:data-testid (str "rf-causa-event-detail-db-change-glyph-" suffix)
+             :style {:flex        "0 0 12px"
+                     :color       tone
+                     :font-family mono-stack
+                     :font-weight 700
+                     :text-align  "center"
+                     :user-select "none"}}
+      glyph]
+     [:span {:data-testid (str "rf-causa-event-detail-db-change-path-" suffix)
+             :style {:color       tone
+                     :font-family mono-stack}}
+      path-label]
+     (case op
+       :modified
+       [:span {:style {:display     "inline-flex"
+                       :align-items "baseline"
+                       :flex-wrap   "wrap"
+                       :gap         "6px"
+                       :min-width   0}}
+        [:span {:style {:color           (:text-tertiary tokens)
+                        :text-decoration "line-through"}}
+         (edn/inspect-inline before)]
+        [:span {:style {:color (:text-tertiary tokens)}} "→"]
+        [:span {:style {:color (:text-primary tokens)}}
+         (edn/inspect-inline after)]]
+
+       :added
+       [:span {:style {:color (:text-primary tokens) :min-width 0}}
+        (edn/inspect-inline after)]
+
+       ;; :removed — path alone (spec/021 line 229: `- [path]`).
+       nil)]))
+
 (defn- db-changes-body
-  "Step DB CHANGES body — the app-db diff for the focused epoch, via the
-  shared data-display renderer (`edn/diff` with `:diff? true` against
-  the epoch's `:db-before` / `:db-after` snapshots).
+  "Step DB CHANGES body — the app-db diff for the focused epoch as a
+  FLAT changed-paths list (spec/021 §2.2 step 4 · spec/004 §slice-
+  centric). One `~`/`+`/`-` row per changed path; NO untouched
+  top-level keys, NO whole-tree render.
 
   Per spec/021 §2.2 this step is the app-db diff ALONE — the prior
   combined `:db + :fx` shape (and the `db now committed for epoch #N`
@@ -1060,21 +1173,26 @@
 
   Reads:
     `:rf.causa/selected-epoch-record` — `{:epoch-id … :db-before …
-                                          :db-after …}` produced by
-                                          app_db_diff_subs/install!.
-
-  Per the spec §10 contract the renderer is configured with
-  `:diff? true` + `:default-depth 3` (App-db's setting) + a stable
-  `:render-id` so per-node expansion is sticky across re-renders.
+        :db-after …}` — used only for the eviction / empty-state
+        decision (was the epoch evicted? did the epoch carry snapshots
+        at all?).
+    `:rf.causa/selected-epoch-diff` — the CACHED structural-sharing
+        changed-paths triples (`app_db_diff_subs/install!`), the same
+        derivation the App-db tab consumes (spec/004 §Changed-paths
+        derivation, O(changed paths) not O(db size), cached per
+        `:epoch-id`). The Event-panel section is the inline projection
+        of THIS diff, not a re-derivation.
 
   Returns the body hiccup (mounted inside a `step-section`)."
   [{:keys [dispatch-id] :as _cascade}]
   (let [record    @(rf/subscribe [:rf.causa/selected-epoch-record])
-        epoch-id  (:epoch-id record)
+        triples   @(rf/subscribe [:rf.causa/selected-epoch-diff])
         db-before (:db-before record)
         db-after  (:db-after record)
+        had-snap? (or (some? db-before) (some? db-after))
         evicted?  (db-fx-evicted? record dispatch-id)]
-    (if evicted?
+    (cond
+      evicted?
       [:div {:data-testid "rf-causa-event-detail-db-changes-evicted"
              :style {:padding "6px 0"
                      :color (:text-tertiary tokens)
@@ -1082,25 +1200,26 @@
                      :font-family sans-stack
                      :font-size "12px"}}
        "Epoch evicted from buffer — increase :epoch-history to retain more."]
+
+      ;; The focused epoch carried db snapshots AND the structural diff
+      ;; found changed paths — render the flat list (changed paths only).
+      (and (some? record) had-snap? (seq triples))
       [:div {:data-testid "rf-causa-event-detail-db-diff"
-             :style {:padding "4px 0"}}
-       (if (and (some? record) (or (some? db-before) (some? db-after)))
-         ;; rf2-9wsdy — embedded App-DB diff via the canonical EDN
-         ;; widget's diff variant. Same engine under the hood; the
-         ;; widget facade makes the call-site read as "this is THE
-         ;; app-db diff renderer".
-         (edn/diff
-           {:before        db-before
-            :after         db-after
-            :panel-id      :event-db-changes
-            :render-id     (str "epoch-" (or epoch-id dispatch-id "x"))
-            :default-depth 3})
-         [:div {:data-testid "rf-causa-event-detail-db-changes-empty"
-                :style {:color (:text-tertiary tokens)
-                        :font-style "italic"
-                        :font-family sans-stack
-                        :font-size "12px"}}
-          "no app-db change this epoch"])])))
+             :style {:padding     "4px 0"
+                     :font-family mono-stack
+                     :font-size   "12px"}}
+       (into [:div]
+             (for [{:keys [path] :as triple} triples]
+               (with-meta (db-change-row triple)
+                          {:key (pr-str path)})))]
+
+      :else
+      [:div {:data-testid "rf-causa-event-detail-db-changes-empty"
+             :style {:color (:text-tertiary tokens)
+                     :font-style "italic"
+                     :font-family sans-stack
+                     :font-size "12px"}}
+       "no app-db change this epoch"])))
 
 ;; ---- the lens (numbered vertical-flow pipeline · spec/021 §2.2) --------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -34,6 +34,7 @@
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.app-db-diff-subs :as app-db-diff-subs]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]))
 
 ;; ---- fixtures -----------------------------------------------------------
@@ -42,7 +43,11 @@
   (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
   (config/set-show-sensitive! false)
-  (config/reset-suppressed-count!))
+  (config/reset-suppressed-count!)
+  ;; rf2-mn3gt — the DB CHANGES section consumes the cached
+  ;; `:rf.causa/selected-epoch-diff` triples; reset the per-`:epoch-id`
+  ;; diff cache so the changed-paths assertions are reproducible.
+  (reset! app-db-diff-subs/diff-cache {}))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -101,6 +106,40 @@
   (frame/reg-frame :rf/causa {})
   (doseq [ev evs]
     (trace-bus/collect-trace! ev)))
+
+;; rf2-mn3gt — seed the Causa frame's `:epoch-history` slot so the DB
+;; CHANGES section's `:rf.causa/selected-epoch-diff` sub resolves to a
+;; real `:rf/epoch-record` with `:db-before` / `:db-after` snapshots.
+;; The record carries a literal `:dispatch-id` so `epoch-id-for-cascade`
+;; links the focused cascade to the epoch (see `spine/epoch-id-for-cascade`
+;; — synthetic records that omit `:trace-events` match on the literal
+;; `:dispatch-id` slot). MUST be dispatched BEFORE
+;; `:rf.causa/select-dispatch-id`, which reads `:epoch-history` at
+;; dispatch-time to resolve the focus epoch-id.
+
+(rf/reg-event-db :rf.causa-test/seed-epoch-history
+  (fn [db [_ records]]
+    (assoc db :epoch-history (vec records))))
+
+(defn- mk-epoch-record
+  "Build a minimal `:rf/epoch-record` for the DB CHANGES diff sub. The
+  literal `:dispatch-id` links the record to the focused cascade."
+  [epoch-id dispatch-id event db-before db-after]
+  {:epoch-id      epoch-id
+   :dispatch-id   dispatch-id
+   :frame         :rf/default
+   :committed-at  0
+   :event-id      (first event)
+   :trigger-event event
+   :db-before     db-before
+   :db-after      db-after
+   :trace-events  []})
+
+(defn- seed-epoch-history!
+  "Seed `:epoch-history` on the Causa frame (must run inside
+  `(rf/with-frame :rf/causa …)`)."
+  [records]
+  (rf/dispatch-sync [:rf.causa-test/seed-epoch-history records]))
 
 (defn- expand-fn-component
   [node]
@@ -1345,3 +1384,164 @@
       (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-db-changes"))
             "the step renders even when no epoch record is registered")))))
+
+;; ---- (15) rf2-mn3gt — DB CHANGES renders ONLY changed paths -----------
+;;
+;; Per spec/021 §2.2 step 4 (line 229) + the dense/sparse mockups (lines
+;; 272-275, 307-309) the DB CHANGES section is a FLAT changed-paths list
+;; (`~ [path] old → new` · `+ [path] value` · `- [path]`), NOT a
+;; tree-centric whole-app-db render. spec/004-App-DB-Diff.md is the
+;; normative source: slice-centric not tree-centric (§43), never renders
+;; the whole tree by default (§69). Pre-fix the section routed the raw
+;; db-before / db-after snapshots through `edn/diff` (the §10 tree
+;; renderer) which paints EVERY top-level key with the change highlighted
+;; — these tests pin the flat changed-only projection and fail against
+;; that prior shape.
+
+(defn- db-change-row-testids
+  "Collect the changed-path ROW testids the DB CHANGES section rendered,
+  in document order."
+  [tree]
+  (->> (hiccup-seq tree)
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (let [tid (str (or (:data-testid (second node)) ""))]
+                   (when (str/starts-with?
+                           tid "rf-causa-event-detail-db-change-row-")
+                     tid)))))
+       (distinct)
+       (vec)))
+
+(defn- collect-strings
+  "Concatenate every string leaf reachable under `node` (after fn-
+  component expansion). Used to assert which keys / values appear in the
+  rendered DB CHANGES body."
+  [node]
+  (->> (hiccup-seq node)
+       (filter string?)
+       (apply str)))
+
+(deftest db-changes-renders-only-changed-paths-not-whole-tree
+  (testing "rf2-mn3gt — for a focused epoch with a small known diff
+            against a LARGE app-db, the DB CHANGES section renders EXACTLY
+            the changed-path rows (one `~`/`+`/`-` line per change) and
+            does NOT render the untouched top-level keys / the whole
+            tree. This fails against the prior `edn/diff` whole-tree
+            render, which paints every top-level key."
+    (let [;; A large app-db: many untouched top-level keys + one slice
+          ;; that mutates, one slice that's added, one removed. `db-after`
+          ;; is derived from `db-before` via assoc/dissoc so the untouched
+          ;; sub-maps stay pointer-identical — exactly the structural
+          ;; sharing a real handler (`(-> db (update …) (dissoc …))`)
+          ;; produces, and which the changed-paths diff relies on.
+          db-before {:counter      1
+                     :user         {:id 42 :name "Ada" :roles #{:admin}}
+                     :session      {:token "t-1" :expires 9999}
+                     :cart         {:items [{:id 7 :qty 1}]}
+                     :prefs        {:theme :dark :density :cosy}
+                     :nav          {:route :home :params {}}
+                     :stale-flag   true
+                     :http         {:in-flight {} :history [1 2 3]}}
+          db-after  (-> db-before
+                        (assoc :counter 2)                       ;; ~ modified
+                        (dissoc :stale-flag)                     ;; - removed
+                        (assoc :last-updated "2026-05-23T12:30:05"))] ;; + added
+      (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+      (rf/with-frame :rf/causa
+        (seed-epoch-history!
+          [(mk-epoch-record :ep-1 100 [:counter/inc] db-before db-after)])
+        (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+        ;; Sanity: the section renders the flat diff (not the evicted /
+        ;; empty branch).
+        (let [tree (event-detail/Panel)
+              diff (find-by-testid tree "rf-causa-event-detail-db-diff")
+              rows (db-change-row-testids tree)
+              body-text (collect-strings
+                          (find-by-testid
+                            tree "rf-causa-event-detail-section-db-changes-body"))]
+          (is (some? diff)
+              "DB CHANGES renders the flat diff body (not evicted/empty)")
+          ;; EXACTLY the three changed paths — modified :counter, removed
+          ;; :stale-flag, added :last-updated. No more, no fewer.
+          (is (= 3 (count rows))
+              (str "exactly 3 changed-path rows; got " (pr-str rows)))
+          (is (= #{"rf-causa-event-detail-db-change-row-:counter"
+                   "rf-causa-event-detail-db-change-row-:stale-flag"
+                   "rf-causa-event-detail-db-change-row-:last-updated"}
+                 (set rows))
+              "rows are the three changed paths")
+          ;; The untouched top-level keys MUST NOT appear anywhere in the
+          ;; rendered DB CHANGES body — this is the slice-centric vs
+          ;; tree-centric assertion that fails against the whole-tree
+          ;; render.
+          (doseq [untouched [":user" ":session" ":cart" ":prefs"
+                             ":nav" ":http"]]
+            (is (not (str/includes? body-text untouched))
+                (str "untouched key " untouched
+                     " must NOT render in the changed-paths list"))))))))
+
+(deftest db-changes-row-glyphs-and-old-new-shape
+  (testing "rf2-mn3gt — each changed-path row carries the correct diff
+            glyph (`~` modified · `+` added · `-` removed) per its op,
+            and a `~` row shows `old → new` per spec/021 line 229."
+    (let [db-before {:counter 1 :user {:id 42} :stale true}
+          db-after  (-> db-before
+                        (assoc :counter 2)        ;; ~ modified
+                        (dissoc :stale)           ;; - removed
+                        (assoc :greeting "hi"))]  ;; + added
+      (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+      (rf/with-frame :rf/causa
+        (seed-epoch-history!
+          [(mk-epoch-record :ep-1 100 [:counter/inc] db-before db-after)])
+        (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+        (let [tree (event-detail/Panel)
+              mod-row  (find-by-testid
+                         tree "rf-causa-event-detail-db-change-row-:counter")
+              add-row  (find-by-testid
+                         tree "rf-causa-event-detail-db-change-row-:greeting")
+              rem-row  (find-by-testid
+                         tree "rf-causa-event-detail-db-change-row-:stale")
+              mod-glyph (collect-strings
+                          (find-by-testid
+                            tree "rf-causa-event-detail-db-change-glyph-:counter"))
+              add-glyph (collect-strings
+                          (find-by-testid
+                            tree "rf-causa-event-detail-db-change-glyph-:greeting"))
+              rem-glyph (collect-strings
+                          (find-by-testid
+                            tree "rf-causa-event-detail-db-change-glyph-:stale"))
+              mod-text  (collect-strings mod-row)]
+          (is (some? mod-row) "modified row present")
+          (is (some? add-row) "added row present")
+          (is (some? rem-row) "removed row present")
+          (is (= "~" mod-glyph) "modified glyph is ~")
+          (is (= "+" add-glyph) "added glyph is +")
+          (is (= "-" rem-glyph) "removed glyph is -")
+          (is (= "modified" (:data-op (second mod-row))) "modified row tagged :data-op")
+          (is (= "added" (:data-op (second add-row))) "added row tagged :data-op")
+          (is (= "removed" (:data-op (second rem-row))) "removed row tagged :data-op")
+          ;; `~` row shows old → new (the arrow + both values present).
+          (is (str/includes? mod-text "→")
+              "modified row shows the old → new arrow")
+          (is (str/includes? mod-text "1") "modified row shows the old value")
+          (is (str/includes? mod-text "2")
+              "modified row shows the new value"))))))
+
+(deftest db-changes-shows-empty-state-when-no-paths-changed
+  (testing "rf2-mn3gt — a focused epoch whose db-before equals db-after
+            renders the `no app-db change this epoch` empty state, NOT a
+            whole-tree dump."
+    (let [db {:counter 1 :user {:id 42} :session {:token "t"}}]
+      (seed-buffer! (cascade-evs 100 [:noop] 0))
+      (rf/with-frame :rf/causa
+        (seed-epoch-history!
+          [(mk-epoch-record :ep-1 100 [:noop] db db)])
+        (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+        (let [tree (event-detail/Panel)]
+          (is (some? (find-by-testid
+                       tree "rf-causa-event-detail-db-changes-empty"))
+              "empty-state renders when nothing changed")
+          (is (nil? (find-by-testid tree "rf-causa-event-detail-db-diff"))
+              "no flat-diff body when nothing changed")
+          (is (empty? (db-change-row-testids tree))
+              "no changed-path rows when nothing changed"))))))


### PR DESCRIPTION
## What

The Event panel''s **DB CHANGES** section (spec/021 §2.2 step 4) rendered the WHOLE app-db tree with changes highlighted (tree-centric). The spec requires it to render ONLY the changed paths as a flat diff list.

## Bug

`db-changes-body` routed the focused epoch''s raw `:db-before` / `:db-after` snapshots through `edn/diff` — the §10 tree renderer — which paints every top-level key (untouched ones dimmed in place). That violates:

- **spec/004-App-DB-Diff.md**: slice-centric not tree-centric (§43); never renders the whole tree by default (§69); changed-paths via structural-sharing diff, O(changed paths) not O(db size) (§75-90).
- **spec/021 §2.2 step 4** (line 229) + the dense/sparse mockups (lines 272-275, 307-309), which show a flat list: `~ [path] old → new` · `+ [path] value` · `- [path]`.

## Fix

The section now consumes the cached `:rf.causa/selected-epoch-diff` triples — the **same** structural-sharing changed-paths derivation the App-db tab uses (cached per `:epoch-id` in `app_db_diff_subs`) — and emits exactly one row per changed path in the inline `~`/`+`/`-` form (line 229). Leaf values still render through the §10 widget (`edn/inspect-inline`), so the §10 contract is reused for value rendering, not whole-tree rendering. Untouched keys / the whole tree are never drawn; the empty / evicted branches are preserved.

No second derivation is introduced — the Event-panel section is the inline projection of the App-db tab''s diff.

## Tests

Added CLJS regression tests in `event_detail_cljs_test.cljs`:

- `db-changes-renders-only-changed-paths-not-whole-tree` — a focused epoch with a small known diff against a large app-db renders EXACTLY the 3 changed-path rows and does NOT render the 6 untouched top-level keys.
- `db-changes-row-glyphs-and-old-new-shape` — correct `~`/`+`/`-` glyph + `:data-op` per op + `old → new` on a modified row.
- `db-changes-shows-empty-state-when-no-paths-changed` — no-change epoch renders the empty state, not a tree dump.

Sanity-checked: the tests **fail** against the prior whole-tree render (the section produced 9 sub-path rows incl. untouched keys / no `db-change-row` testids) and **pass** after the fix.

## Gates

- `npm --prefix implementation run test:cljs`: 4251 tests, 13311 assertions, **0 failures, 0 errors**
- `npm --prefix implementation run test:causa-feature-gate`: 13 scenarios, **0 failures** (exit 0)
- clj-kondo on both touched files: **0 errors, 0 warnings**
- `examples/step-deck` shadow build: **0 warnings**

Files: `tools/causa/src/.../panels/event_detail.cljs`, `tools/causa/test/.../panels/event_detail_cljs_test.cljs`.