### PR TITLE
fix(causa): Event-panel EVENT HANDLER source renders legibly at all widths (rf2-l7ha9)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -537,7 +537,11 @@
   [meta]
   (let [src (handler-source-string meta)]
     [:div {:data-testid "rf-causa-event-detail-handler-source"
+           ;; `min-width:0` keeps the shrink-permission unbroken right down
+           ;; to the syntax-highlighted `<pre>`, so it scrolls within the
+           ;; panel rather than clipping at narrow widths (rf2-l7ha9).
            :style {:margin-top "4px"
+                   :min-width "0"
                    :padding-left "16px"}}
      [:div {:data-testid "rf-causa-event-detail-handler-source-arrow"
             :style {:color        (:text-tertiary tokens)
@@ -1001,7 +1005,15 @@
   [n id title body]
   [:section {:data-testid (str "rf-causa-event-detail-section-" id)
              :data-step-number (str n)
+             ;; `min-width:0` lets this flex item (the pipeline is a flex
+             ;; column) shrink below its content's intrinsic width, so a
+             ;; wide handler-source `<pre>` scrolls within the panel
+             ;; instead of expanding the column past the panel edge
+             ;; (rf2-l7ha9). Flex items default to `min-width:auto`, which
+             ;; refuses to shrink — that is what clips the EVENT HANDLER
+             ;; source at narrow widths.
              :style {:position "relative"
+                     :min-width "0"
                      :padding  "0 12px 0 12px"}}
    ;; Numbered step circle — filled muted with a white numeral, pulled
    ;; left onto the rail (spec/021 §2.2 — "filled muted with white
@@ -1034,8 +1046,12 @@
                   :color          (:text-secondary tokens)}}
     title]
    [:div {:data-testid (str "rf-causa-event-detail-section-" id "-body")
+          ;; `min-width:0` propagates the shrink-permission down to the
+          ;; handler-source `<pre>` so its `overflow-x:auto` engages
+          ;; within the panel (rf2-l7ha9).
           :style {:font-family mono-stack
                   :font-size   "12px"
+                  :min-width   "0"
                   :color       (:text-primary tokens)}}
     body]])
 

--- a/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/edn_widget/widget.cljs
@@ -507,6 +507,18 @@
                      :border-radius "3px"
                      :padding     "8px 10px"
                      :margin      0
+                     ;; Clamp to the containing block + scroll long lines
+                     ;; WITHIN the panel rather than overflowing it. Without
+                     ;; `max-width:100%` the `white-space:pre` block grows to
+                     ;; its longest line's intrinsic width, expanding every
+                     ;; flex ancestor (the Event-panel pipeline is a flex
+                     ;; column) past the panel edge — the first line is then
+                     ;; clipped left under the step-rail gutter and later
+                     ;; lines run off the right (rf2-l7ha9). The `min-width:0`
+                     ;; companion lives on the flex-item ancestors so this
+                     ;; `overflow-x:auto` can actually engage.
+                     :max-width   "100%"
+                     :box-sizing  "border-box"
                      :overflow-x  "auto"
                      :white-space "pre"}}
        (into [:code]

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -1334,6 +1334,38 @@
         (is (or (some? body) (some? placeholder))
             "step [3] source slot renders one of body / placeholder")))))
 
+(deftest handler-source-not-clipped-at-narrow-panel-widths
+  (testing "rf2-l7ha9 — the EVENT HANDLER source must stay legible at narrow
+            panel widths. The pipeline is a flex column, so every flex-item
+            ancestor of the handler-source `<pre>` carries `min-width:0`;
+            without it the `white-space:pre` block grows to its longest
+            line's intrinsic width and expands the column past the panel
+            edge, clipping the first line and running later lines off the
+            right. We assert the shrink-permission chain end-to-end."
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :widget/wide-src
+        {:rf.handler/source "(reg-event-db :widget/wide-src (fn [db _] (update db :counter/value inc)))"}
+        (fn [db _] db)))
+    (seed-buffer! (cascade-evs 100 [:widget/wide-src {:id 1}] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree         (event-detail/Panel)
+            step-section (find-by-testid tree
+                           "rf-causa-event-detail-section-handler")
+            section-body (find-by-testid tree
+                           "rf-causa-event-detail-section-handler-body")
+            source-div   (find-by-testid tree
+                           "rf-causa-event-detail-handler-source")
+            min-width    (fn [node] (some-> node second :style :min-width))]
+        (is (some? step-section)
+            "the EVENT HANDLER step renders")
+        (is (= "0" (min-width step-section))
+            "the step-section flex item can shrink below content width")
+        (is (= "0" (min-width section-body))
+            "the section body propagates the shrink-permission")
+        (is (= "0" (min-width source-div))
+            "the handler-source container keeps the shrink-permission to the pre")))))
+
 ;; ---- (14) DB CHANGES step — app-db diff via data-display renderer -----
 
 (deftest db-changes-step-present-in-pipeline-no-committed-footer

--- a/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/edn_widget/widget_cljs_test.cljs
@@ -422,6 +422,23 @@
                             (walk-hiccup out))]
         (is (some? code-node))))))
 
+(deftest code-block-pre-clamps-and-scrolls-within-container
+  ;; rf2-l7ha9 — at narrow panel widths the EVENT HANDLER source rendered
+  ;; broken (first line clipped, later lines run off the right) because the
+  ;; `white-space:pre` block grew to its longest line's intrinsic width and
+  ;; expanded its flex ancestors past the panel edge. The `<pre>` MUST clamp
+  ;; to its containing block and scroll long lines WITHIN it.
+  (let [out   (w/code-block {:source "(reg-event-db :counter/inc (fn [db _] (update db :counter/value inc)))"})
+        style (-> out second :style)]
+    (testing "the code-block <pre> never exceeds its containing block"
+      (is (= "100%" (:max-width style))
+          "max-width:100% clamps the pre to its container")
+      (is (= "border-box" (:box-sizing style))
+          "border-box keeps padding inside the clamped width"))
+    (testing "long lines scroll within the pre rather than overflowing"
+      (is (= "auto" (:overflow-x style))
+          "overflow-x:auto keeps long handler lines scrollable in-panel"))))
+
 (deftest code-block-keyword-token-uses-accent
   (let [out      (w/code-block {:source ":foo"})
         spans    (walk-hiccup out)


### PR DESCRIPTION
## What

The Causa Event tab''s EVENT HANDLER section rendered the syntax-highlighted handler source **broken at narrow panel widths**: the first line was clipped under the step-rail gutter and later lines (e.g. `(fn [db _] (update db :counter/value inc))`) ran off the right edge, leaving the source unreadable. It rendered fine on wide panels (e.g. the http-toggle testbed) only because the longest line happened to fit.

## Diagnosis

Root cause is the classic **flexbox shrink-permission gap**, not a reveal/flash overlay (the gap-audit''s "semi-transparent overlay" hypothesis did not match — `code-block` carries no copy/flash overlay; that affordance lives only on `browse`).

The Event panel pipeline is a flex column; its flex items default to `min-width:auto`, so they refuse to shrink below their content''s intrinsic width. The handler source renders through `edn/code-block` as a `white-space:pre` block, whose intrinsic width is its longest line. That width expanded every flex ancestor past the panel edge, so the `<pre>`''s own `overflow-x:auto` never engaged and the outer scroll container clipped the content. On a wide panel the intrinsic width fit, so it looked fine — hence the width-dependent break.

## Fix

Restore the shrink-permission chain end-to-end (no width special-casing):

- `edn-widget/widget.cljs` `code-block` `<pre>`: add `max-width:100%` + `box-sizing:border-box` so it clamps to its container and scrolls long lines within it.
- `panels/event_detail.cljs`: the `step-section` flex item, its section body, and the handler-source container each gain `min-width:0` so the clamp propagates down to the `<pre>`.

The block now scrolls cleanly within the panel at all widths, matching the readable code-block intent in `EventPanel.tsx`.

## Tests

- Panel-level regression (`event_detail_cljs_test.cljs`): asserts the `min-width:0` chain (step-section -> section body -> source div) for a wide handler source.
- Widget-level regression (`widget_cljs_test.cljs`): asserts the `code-block` `<pre>` carries `max-width:100%`, `box-sizing:border-box`, and `overflow-x:auto`.

## Gates (all green)

- tools/causa `clojure -M:test`: 873 tests, 0 failures, 0 errors
- `npm --prefix implementation run test:cljs`: 4253 tests, 0 failures, 0 errors
- `npm --prefix implementation run test:causa-feature-gate`: 13 scenarios, 0 failures
- clj-kondo on touched files: 0 errors, 0 warnings (one pre-existing `info` on an untouched line)
- `examples/step-deck` shadow build: 0 warnings

Bead: rf2-l7ha9