### PR TITLE
fix(causa): Event-list restores duration column + ui-origin source tag (rf2-lnod7)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/l2_timeline.cljc
@@ -114,22 +114,35 @@
   [origin]
   (get origin-glyphs origin))
 
-(defn origin-source-tag
-  "Pure-data SOURCE column label (rf2-ad7zx.12). The Figma EventList
-  (`design-reference/components/EventList.tsx`) renders a left-most
-  `source` column as a short text tag — `fx` / `view` / `timer` /
-  `machine` in the mock. Causa's real source axis is the closed-enum
-  dispatch-origin (`:rf/dispatch-origin`), so the tag is the bare
-  origin name (`router` / `http` / `timer` / `fx-emit` / …).
+(def ui-source-tag
+  "SOURCE-column label for the default app-code origin. The Figma
+  EventList (`design-reference/components/EventList.tsx`) renders a
+  concrete `source` tag for EVERY row — the mock's `view` rows are the
+  UI-triggered dispatches (the common case). Causa's closed-enum source
+  axis names that origin `:user`; the visible column label for it is
+  `ui` (the dispatch came from app/UI code, not a substrate)."
+  "ui")
 
-  `:user` is the default app-code origin; the Figma mock never tagged
-  the common case loudly, and Causa's silent-by-default posture keeps
-  the `:user` source column blank rather than cluttering every row with
-  the dominant value. Returns nil for `:user`, unknown, and nil origins
-  so the renderer omits the tag — the column reads as a sparse signal,
-  exactly the rows whose source is NOT plain app code."
+(defn origin-source-tag
+  "Pure-data SOURCE column label (rf2-ad7zx.12, rf2-lnod7). The Figma
+  EventList (`design-reference/components/EventList.tsx`) renders a
+  left-most `source` column as a short text tag — `fx` / `view` /
+  `timer` / `machine` in the mock — and tags EVERY row, never a blank
+  cell. Causa's real source axis is the closed-enum dispatch-origin
+  (`:rf/dispatch-origin`): substrate origins render the bare origin
+  name (`router` / `http` / `timer` / `fx-emit` / …) and the default
+  app-code origin (`:user`, plus nil/unknown for synthetic or pre-
+  origin-tag cascades) renders `ui`.
+
+  Pre-rf2-lnod7 this returned nil for `:user`, which left the source
+  column BLANK for the dominant ui-origin rows — the gap audit
+  (rf2-4297k) flagged that http-origin rows showed their tag while
+  default rows showed nothing. Tagging every row with a concrete
+  source (the reference's posture) restores the column's signal.
+  Never throws."
   [origin]
-  (when (and origin (not= :user origin))
+  (if (or (nil? origin) (= :user origin))
+    ui-source-tag
     (name origin)))
 
 (defn origin-prefix-title
@@ -138,6 +151,49 @@
   [origin]
   (when (origin-prefix-glyph origin)
     (get origin-titles origin)))
+
+;; ---- 1b. duration column (rf2-lnod7) ------------------------------------
+;;
+;; The Figma EventList's fourth (right-most) column is `duration` — the
+;; handler's wall-time, right-aligned, rendered as `1.2 ms` / `0.4 ms`.
+;; Causa stamps the handler's elapsed time on the cascade's `:handler`
+;; trace event (`:rf.event/run-end`) under `[:tags :duration-ms]` — the
+;; SAME field the L4 Event-detail cascade-outcome reads. Surfacing it on
+;; the L2 row restores the reference's four-column layout; the column was
+;; clipped off the live list pre-rf2-lnod7 (gap audit rf2-4297k).
+
+(defn cascade-duration-ms
+  "Pluck the handler wall-time (ms) from a cascade's `:handler` trace
+  event (`[:handler :tags :duration-ms]`). Returns the number or nil
+  when the slot is absent / non-numeric (synthetic fixtures, cascades
+  whose handler trace predates duration tagging). Nil-safe at every
+  level; pure data, JVM-runnable."
+  [cascade]
+  (when (map? cascade)
+    (let [d (get-in cascade [:handler :tags :duration-ms])]
+      (when (number? d) d))))
+
+(defn format-duration-ms
+  "Format a handler duration (ms) for the L2 `duration` column, matching
+  the Figma EventList's `1.2 ms` / `0.4 ms` style — one decimal place
+  plus a ` ms` suffix. The platform formatter (`format \"%.1f\"` on the
+  JVM, `.toFixed` in CLJS) does the rounding so both runtimes agree.
+  Returns nil for a nil/non-numeric input so the renderer leaves the
+  cell empty (a cascade with no measured handler time has nothing to
+  show). Pure data, JVM-runnable."
+  [duration-ms]
+  (when (number? duration-ms)
+    (str
+     #?(:clj  (format "%.1f" (double duration-ms))
+        :cljs (.toFixed (js/Number duration-ms) 1))
+     " ms")))
+
+(defn cascade-duration-label
+  "Convenience: read + format a cascade's handler duration in one step.
+  Returns the `N.N ms` string or nil when the cascade carries no
+  measured handler time. Pure data, JVM-runnable."
+  [cascade]
+  (format-duration-ms (cascade-duration-ms cascade)))
 
 ;; ---- 2. activity badges -------------------------------------------------
 ;;

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -395,10 +395,19 @@
   "52px")
 
 (def ^:private l2-time-col-min-width
-  "Min-width / right-aligned slot for the trailing time column — shared
+  "Min-width / right-aligned slot for the `timestamp` column — shared
   by the header `timestamp` label and every row's relative-time chip so
   the two right-align on the same edge."
   "44px")
+
+(def ^:private l2-duration-col-min-width
+  "Min-width / right-aligned slot for the trailing `duration` column
+  (rf2-lnod7) — shared by the header `duration` label and every row's
+  handler-duration cell so the two right-align on the same edge. The
+  Figma EventList's fourth column; restored after the gap audit
+  (rf2-4297k) found it clipped off the live list's right edge. Sized to
+  hold `1234.5 ms` without wrapping."
+  "60px")
 
 (def ^:private l2-col-gap
   "Inter-column gap for both the header row and every data row. ONE
@@ -520,6 +529,32 @@
                       :text-align    "right"
                       :white-space   "nowrap"}}
        label])))
+
+(defn duration-cell
+  "Render the L2 row's trailing `duration` column (rf2-lnod7) — the
+  Figma EventList's fourth column. Right-aligned handler wall-time
+  (`1.2 ms`), sourced from the cascade's `:handler` trace event via
+  `l2-timeline/cascade-duration-label`. Shares the header `duration`
+  column's right-aligned min-width slot (`l2-duration-col-min-width`)
+  so the value right-aligns under the header label; spacing from the
+  preceding timestamp column comes from the row's shared flex `gap`.
+
+  ALWAYS renders the cell span (occupying its column width) so the
+  columns stay aligned row-to-row; when the cascade carries no measured
+  handler duration the cell is simply blank rather than collapsing the
+  column."
+  [cascade]
+  (let [label (l2-timeline/cascade-duration-label cascade)]
+    [:span {:data-testid   "rf-causa-row-duration"
+            :data-duration (str (l2-timeline/cascade-duration-ms cascade))
+            :style {:color         (:text-tertiary tokens)
+                    :flex-shrink   0
+                    :font-family   mono-stack
+                    :font-size     (:caption type-scale)
+                    :min-width     l2-duration-col-min-width
+                    :text-align    "right"
+                    :white-space   "nowrap"}}
+     label]))
 
 ;; ---- Relative-time anchor (rf2-0s2at) ------------------------------------
 ;;
@@ -1390,20 +1425,22 @@
               gutter-click (assoc :on-click gutter-click))
       (or focus-marker
           [:span {:style {:color glyph-col}} glyph])]
-     ;; rf2-ad7zx.12 — the `source` COLUMN, reconciled to the Figma
-     ;; EventList. A fixed-width cell aligned under the header's `source`
-     ;; label, carrying the dispatch-origin as a short text tag plus its
-     ;; glyph (`R fx-emit` etc). `:user` stays blank (silent-by-default —
-     ;; the dominant app-code origin doesn't clutter every row); the
-     ;; cell still occupies its column width so the `event id` column
-     ;; stays left-aligned across rows. `:ungrouped` rows render an empty
-     ;; spacer cell (no dispatch envelope, no origin to surface). The
+     ;; rf2-ad7zx.12 + rf2-lnod7 — the `source` COLUMN, reconciled to the
+     ;; Figma EventList. A fixed-width cell aligned under the header's
+     ;; `source` label, carrying the dispatch-origin as a short text tag
+     ;; plus its glyph (`R fx-emit` etc). The reference tags EVERY row, so
+     ;; the default app-code origin (`:user`, plus nil/unknown synthetic
+     ;; cascades) renders `ui` rather than a blank cell — the gap audit
+     ;; (rf2-4297k) flagged the pre-rf2-lnod7 blank ui-origin column.
+     ;; `:ungrouped` rows still render an empty spacer cell (no dispatch
+     ;; envelope, no origin to surface) while occupying the column width
+     ;; so the `event id` column stays left-aligned across rows. The
      ;; `:title` carries the closed-enum value as a hover affordance
      ;; (rf2-gf58j origin glyphs preserved as the leading mark).
      [:span {:data-testid (when (and source-tag (not ungrouped?))
-                            (str "rf-causa-row-origin-" (name origin)))
+                            (str "rf-causa-row-origin-" source-tag))
              :data-rf-causa-origin (when (and source-tag (not ungrouped?))
-                                     (name origin))
+                                     source-tag)
              :title (when (and source-tag (not ungrouped?)) origin-title)
              :style {:flex-shrink 0
                      :width l2-source-col-width
@@ -1453,13 +1490,16 @@
                 badges-tooltip (assoc :title badges-tooltip))
         (for [b badges]
           ^{:key b} [:span b])])
-     ;; Relative-time chip (rf2-vbbq0). Right-aligned per Mike's design
-     ;; (2026-05-19 Q10) — "active-cascade-visibility" calls for the chip
-     ;; to ride on the row body rather than hide behind a hover tooltip.
-     ;; The chip itself carries an absolute-time `:title` tooltip as the
-     ;; power-user reveal. Rendered LAST so it sits flush right against
-     ;; the row's trailing edge.
-     (relative-time-chip cascade now-ms)]))
+     ;; Relative-time chip (rf2-vbbq0) — the `timestamp` column. Right-
+     ;; aligned per Mike's design (2026-05-19 Q10): "active-cascade-
+     ;; visibility" calls for the chip to ride on the row body rather
+     ;; than hide behind a hover tooltip. The chip carries an absolute-
+     ;; time `:title` tooltip as the power-user reveal.
+     (relative-time-chip cascade now-ms)
+     ;; Duration cell (rf2-lnod7) — the trailing `duration` column,
+     ;; restoring the Figma EventList's fourth column. Handler wall-time
+     ;; (`1.2 ms`), right-aligned, flush against the row's trailing edge.
+     (duration-cell cascade)]))
 
 ;; ---- events ribbon (rf2-4vp5j) -----------------------------------------
 ;;
@@ -1620,21 +1660,25 @@
         (filters-hidden-message hidden-summary)
         [clear-filters-button]])]))
 
-;; rf2-ad7zx.12 — the L2 list's column-header row, reconciled to the
-;; Figma EventList (`design-reference/components/EventList.tsx`). The
-;; Figma mock renders a sticky header naming the four columns the rows
-;; align to: `source` · `event id` · `timestamp` · `duration`. The
+;; rf2-ad7zx.12 + rf2-lnod7 — the L2 list's column-header row, reconciled
+;; to the Figma EventList (`design-reference/components/EventList.tsx`).
+;; The Figma mock renders a sticky header naming the FOUR columns the
+;; rows align to: `source` · `event id` · `timestamp` · `duration`. The
 ;; header was MISSING pre-Figma (the list was a bare row stack), which
-;; is the gap Mike flagged ("does not match the Figma mock"). The
-;; column widths mirror the row layout below: a fixed leading FOCUS
-;; gutter (14px, unlabeled — it is a Causa affordance the mock didn't
-;; have), a fixed `source` tag column, the flexible `event id` column,
-;; then the right-aligned `timestamp`/`duration` cluster.
+;; is the gap Mike flagged ("does not match the Figma mock"); the gap
+;; audit (rf2-4297k) then found the `duration` column clipped off the
+;; right edge — only three columns rendered. The column widths mirror
+;; the row layout below: a fixed leading FOCUS gutter (14px, unlabeled —
+;; it is a Causa affordance the mock didn't have), a fixed `source` tag
+;; column, the flexible `event id` column, then the right-aligned
+;; `timestamp` chip and `duration` cells.
 
 (defn- l2-column-header
-  "Sticky column-header row for the L2 event list (rf2-ad7zx.12, Figma
-  EventList). Caption-weight, muted, on the chrome surface so it reads
-  as chrome rather than data. Pure hiccup."
+  "Sticky column-header row for the L2 event list (rf2-ad7zx.12 + rf2-
+  lnod7, Figma EventList). Names the FOUR columns the rows align to —
+  `source` · `event id` · `timestamp` · `duration`. Caption-weight,
+  muted, on the chrome surface so it reads as chrome rather than data.
+  Pure hiccup."
   []
   (let [cell {:color       (:text-tertiary tokens)
               :font-family sans-stack
@@ -1676,7 +1720,14 @@
      [:span {:data-testid "rf-causa-event-list-col-timestamp"
              :style (merge cell {:flex-shrink 0 :text-align "right"
                                  :min-width l2-time-col-min-width})}
-      "timestamp"]]))
+      "timestamp"]
+     ;; rf2-lnod7 — the fourth Figma column. Restored after the gap
+     ;; audit (rf2-4297k) found the live header carried only three
+     ;; columns and the duration was clipped off the right edge.
+     [:span {:data-testid "rf-causa-event-list-col-duration"
+             :style (merge cell {:flex-shrink 0 :text-align "right"
+                                 :min-width l2-duration-col-min-width})}
+      "duration"]]))
 
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,

--- a/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/l2_timeline_cljs_test.cljc
@@ -93,9 +93,11 @@
 ;; ---- 2b. origin → source-tag (Figma `source` column, rf2-ad7zx.12) -------
 
 (deftest origin-source-tag-test
-  (testing ":user is blank — the dominant app-code origin doesn't clutter
-            every row's source column (silent-by-default)"
-    (is (nil? (l2/origin-source-tag :user))))
+  (testing ":user renders the `ui` tag (rf2-lnod7) — the reference tags
+            EVERY row; the dominant app-code origin reads `ui` rather than
+            a blank cell (the gap audit rf2-4297k flagged the blank)"
+    (is (= "ui" (l2/origin-source-tag :user)))
+    (is (= "ui" l2/ui-source-tag)))
 
   (testing "every non-user closed-enum value renders its bare name as the tag"
     (is (= "router"       (l2/origin-source-tag :router)))
@@ -108,8 +110,10 @@
     (is (= "internal"     (l2/origin-source-tag :internal)))
     (is (= "websocket"    (l2/origin-source-tag :websocket))))
 
-  (testing "unknown / nil → nil (defence-in-depth, never throws)"
-    (is (nil? (l2/origin-source-tag nil)))
+  (testing "nil → the `ui` default (rf2-lnod7) so synthetic / pre-origin-
+            tag cascades still render a concrete source rather than blank;
+            never throws"
+    (is (= "ui" (l2/origin-source-tag nil)))
     ;; an unknown keyword still yields its name — the column is the bare
     ;; origin axis, not gated on the closed-enum glyph map.
     (is (= "unknown-axis" (l2/origin-source-tag :unknown-axis)))))
@@ -128,6 +132,55 @@
     (is (re-find #":router"      (l2/origin-prefix-title :router)))
     (is (re-find #":fx-emit"     (l2/origin-prefix-title :fx-emit)))
     (is (re-find #":websocket"   (l2/origin-prefix-title :websocket)))))
+
+;; ---- 3b. duration column (Figma `duration` column, rf2-lnod7) ------------
+
+(defn- cascade-with-duration
+  "Build a synthetic cascade whose `:handler` (`:rf.event/run-end`) trace
+  event carries the given handler `:duration-ms`. Mirrors the shape
+  `re-frame.trace.projection/group-cascades` buckets into `:handler`."
+  [duration-ms]
+  {:dispatch-id 7
+   :event       [:poll/tick]
+   :handler     {:operation :rf.event/run-end
+                 :op-type   :rf.event
+                 :tags      {:duration-ms duration-ms
+                             :rf.trace/dispatch-id 7}}})
+
+(deftest cascade-duration-ms-test
+  (testing "reads :duration-ms from [:handler :tags :duration-ms]"
+    (is (= 1.234 (l2/cascade-duration-ms (cascade-with-duration 1.234))))
+    (is (= 0     (l2/cascade-duration-ms (cascade-with-duration 0)))))
+
+  (testing "nil-safe on missing / non-numeric slots"
+    (is (nil? (l2/cascade-duration-ms nil)))
+    (is (nil? (l2/cascade-duration-ms {})))
+    (is (nil? (l2/cascade-duration-ms {:handler nil})))
+    (is (nil? (l2/cascade-duration-ms {:handler {:tags {}}})))
+    (is (nil? (l2/cascade-duration-ms (cascade-with-duration "1.2"))))
+    (is (nil? (l2/cascade-duration-ms "not a cascade")))))
+
+(deftest format-duration-ms-test
+  (testing "formats to one decimal place + ` ms` (Figma EventList style)"
+    (is (= "1.2 ms"    (l2/format-duration-ms 1.234)))
+    (is (= "0.4 ms"    (l2/format-duration-ms 0.4)))
+    (is (= "0.6 ms"    (l2/format-duration-ms 0.62)))
+    (is (= "0.0 ms"    (l2/format-duration-ms 0)))
+    (is (= "12.0 ms"   (l2/format-duration-ms 12)))
+    (is (= "1234.5 ms" (l2/format-duration-ms 1234.5))))
+
+  (testing "nil for nil / non-numeric (cell stays empty), never throws"
+    (is (nil? (l2/format-duration-ms nil)))
+    (is (nil? (l2/format-duration-ms "1.2")))))
+
+(deftest cascade-duration-label-test
+  (testing "read + format in one step"
+    (is (= "1.2 ms" (l2/cascade-duration-label (cascade-with-duration 1.234))))
+    (is (= "0.4 ms" (l2/cascade-duration-label (cascade-with-duration 0.4)))))
+
+  (testing "nil when no measured handler duration"
+    (is (nil? (l2/cascade-duration-label {})))
+    (is (nil? (l2/cascade-duration-label nil)))))
 
 ;; ---- 4. cascade activity flags ------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -682,6 +682,19 @@
                   :frame       :rf/default
                   :rf.trace/dispatch-id id}})
 
+(defn- run-end-trace-ev
+  "A `:rf.event/run-end` trace event carrying a handler `:duration-ms`,
+  bucketed into the cascade's `:handler` slot by `group-cascades`. Used
+  to drive the L2 row's trailing `duration` column (rf2-lnod7)."
+  [id duration-ms]
+  {:id           (+ id 1000)
+   :op-type      :rf.event
+   :operation    :rf.event/run-end
+   :tags         {:frame                :rf/default
+                  :rf.trace/dispatch-id id
+                  :rf.trace/phase       :run-end
+                  :duration-ms          duration-ms}})
+
 (deftest event-list-renders-empty-state-on-cold-start
   (testing "empty cascade list shows the spec/018 §4 empty-state hint"
     (causa-setup!)
@@ -702,10 +715,12 @@
             "one row per cascade")))))
 
 (deftest event-list-renders-figma-column-header
-  (testing "rf2-ad7zx.12 — the L2 list carries the Figma EventList
-            column-header row (source · event id · timestamp) above the
-            rows. It was MISSING pre-Figma (Mike: 'does not match the
-            Figma mock'). Rendered only with rows present."
+  (testing "rf2-ad7zx.12 + rf2-lnod7 — the L2 list carries the Figma
+            EventList column-header row naming ALL FOUR columns (source ·
+            event id · timestamp · duration) above the rows. It was
+            MISSING pre-Figma (Mike: 'does not match the Figma mock') and
+            the `duration` column was clipped off the right edge until the
+            gap audit (rf2-4297k). Rendered only with rows present."
     (causa-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/causa
@@ -717,7 +732,13 @@
         (is (some? (find-by-testid tree "rf-causa-event-list-col-event-id"))
             "the `event id` column label is present")
         (is (some? (find-by-testid tree "rf-causa-event-list-col-timestamp"))
-            "the `timestamp` column label is present")))))
+            "the `timestamp` column label is present")
+        (is (some? (find-by-testid tree "rf-causa-event-list-col-duration"))
+            "the `duration` column label is present (rf2-lnod7)")
+        (is (re-find #"duration"
+                     (text-nodes (find-by-testid
+                                   tree "rf-causa-event-list-col-duration")))
+            "the `duration` header label reads `duration`")))))
 
 (defn- style-of
   "Read the inline `:style` map off a hiccup node (`[tag attrs …]`)."
@@ -828,20 +849,70 @@
 (deftest event-row-source-tag-surfaces-non-user-origin
   (testing "rf2-ad7zx.12 — a non-:user dispatch-origin renders a text
             SOURCE tag (the Figma `source` column) carrying the origin
-            name. :user rows stay blank (silent-by-default)."
+            name."
     (causa-setup!)
     ;; A :timer-origin cascade — the source column should read `timer`.
     (trace-bus/collect-trace!
       (assoc-in (dispatch-trace-ev 1 [:poll/tick])
                 [:tags :rf/dispatch-origin] :timer))
-    ;; A plain (:user / untagged) cascade — source column blank.
-    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:foo/bar]))
     (rf/with-frame :rf/causa
       (let [tree    (shell/shell-view)
             tagged  (find-by-testid tree "rf-causa-row-origin-timer")]
         (is (some? tagged) "the :timer row carries an origin source tag")
         (is (re-find #"timer" (text-nodes tagged))
             "the source tag reads the origin name `timer`")))))
+
+(deftest event-row-source-tag-surfaces-ui-origin
+  (testing "rf2-lnod7 — a default (:user / untagged) ui-origin row renders
+            a concrete `ui` SOURCE tag rather than a blank cell. The gap
+            audit (rf2-4297k) flagged that http-origin rows showed their
+            tag while ui-origin rows rendered blank; the reference tags
+            EVERY row, so the dominant app-code origin reads `ui`."
+    (causa-setup!)
+    ;; A plain (:user / untagged) cascade — source column reads `ui`.
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            ui-tag (find-by-testid tree "rf-causa-row-origin-ui")]
+        (is (some? ui-tag)
+            "the default ui-origin row carries a non-blank source tag")
+        (is (re-find #"ui" (text-nodes ui-tag))
+            "the source tag reads `ui` for the default app-code origin")))))
+
+(deftest event-row-renders-duration-value
+  (testing "rf2-lnod7 — a row whose cascade carries a measured handler
+            duration renders the trailing `duration` column value
+            (`N.N ms`), restoring the Figma EventList's fourth column."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:poll/tick]))
+    (trace-bus/collect-trace! (run-end-trace-ev 1 1.234))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            cell (find-by-testid tree "rf-causa-row-duration")]
+        (is (some? cell) "the row's duration cell renders")
+        (is (re-find #"1\.2 ms" (text-nodes cell))
+            "the duration value reads the handler wall-time as `1.2 ms`")))))
+
+(deftest event-list-duration-column-aligns-header-and-row
+  (testing "rf2-lnod7 — the header `duration` label and the row's
+            duration cell share the SAME right-aligned min-width slot so
+            the value sits directly under the header label."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:poll/tick]))
+    (trace-bus/collect-trace! (run-end-trace-ev 1 0.4))
+    (rf/with-frame :rf/causa
+      (let [tree       (shell/shell-view)
+            h-duration (find-by-testid tree "rf-causa-event-list-col-duration")
+            r-duration (find-by-testid tree "rf-causa-row-duration")]
+        (is (some? h-duration) "header duration column renders")
+        (is (some? r-duration) "row duration cell renders")
+        (is (= (:min-width (style-of h-duration))
+               (:min-width (style-of r-duration)))
+            "header `duration` min-width == row duration-cell min-width")
+        (is (= "right"
+               (:text-align (style-of h-duration))
+               (:text-align (style-of r-duration)))
+            "header duration and row duration both right-align")))))
 
 (deftest event-row-gutter-carries-cascade-chain-thread
   (testing "rf2-5kfxe.10 — every L2 event-row gutter carries an inset


### PR DESCRIPTION
## What

Fixes two confirmed Causa Event-list column defects found by the visual gap audit (rf2-4297k), reconciling the L2 event list to the Figma reference (`tools/causa/design-reference/components/EventList.tsx`).

### (a) Duration column restored

The reference EventList is **four** columns — `source · event id · timestamp · duration` — but the live L2 list rendered only three; the duration was clipped off the right edge.

- `l2-column-header` (shell.cljs) gains a fourth right-aligned `duration` header cell.
- Every row gains a `duration-cell` rendering the handler wall-time (`1.2 ms`), read from the cascade's `:handler` trace event (`[:handler :tags :duration-ms]` — the same field the L4 Event-detail outcome reads).
- The `event id` column flexes (`flex: 1 1 auto; min-width: 0`) so all four columns fit without clipping; a shared `l2-duration-col-min-width` keeps the header label and row cell right-aligned on the same edge.
- New pure, JVM-portable helpers in `panels.l2-timeline`: `cascade-duration-ms`, `format-duration-ms`, `cascade-duration-label`.

### (b) Source tag for ui-origin rows

`origin-source-tag` returned `nil` for `:user` (the default app-code / UI origin), so http / timer / fx rows showed their tag while the dominant ui-origin rows rendered a **blank** source cell.

- The reference tags every row; `:user` (plus nil/unknown synthetic cascades) now renders `ui`.
- Substrate origins keep their existing bare-name tags — no regression to http / fx / timer / machine.

## Tests

- `panels/l2_timeline_cljs_test.cljc` — duration-helper coverage + updated source-tag contract.
- `shell_cljs_test.cljs` — four-column header, a row's duration value, header/row duration alignment, non-blank `ui` source tag.

## Verification

- `tools/causa` JVM suite: 876 tests / 2935 assertions, 0 failures.
- `npm run test:cljs`: 4257 tests / 13342 assertions, 0 failures (renders `shell/shell-view` and asserts the duration cell + ui tag in the DOM tree).
- `npm run test:causa-feature-gate`: 13 scenarios, 0 failures, all 12 surfaces compiled 0 warnings.
- `examples/step-deck` shadow build: 0 warnings.
- clj-kondo: 0 errors / 0 warnings on touched lines.

Closes rf2-lnod7.