### PR TITLE
fix(causa): Event-panel DISPATCH box + FROM source-link (rf2-l3h1m)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -363,6 +363,11 @@
   step 1 these are the SAME step (the prior split DISPATCH SITE / EVENT
   sub-sections are merged; rf2-ad7zx.5).
 
+  The dispatched event vector renders in a BOXED block (`bg-muted p-3
+  rounded` in the mock; raised `:bg-3` fill + subtle border + 3px radius
+  here) per `EventPanel.tsx` (rf2-l3h1m) — the same surface family as the
+  §3 EVENT HANDLER source code-block.
+
   The FROM row matches `EventPanel.tsx`'s dispatch presentation
   (rf2-ad7zx.17): `FROM:` then the dispatch SOURCE rendered as a single
   accent-coloured click-to-source link (`view ↗`) — the `↗`
@@ -377,10 +382,23 @@
         label      (or (some-> source name) "unknown")
         linked?    (and (map? coord) (seq (:file coord)))]
     [:div
-     ;; The dispatched event vector.
+     ;; The dispatched event vector — rendered in a boxed `bg-muted p-3
+     ;; rounded` block per `EventPanel.tsx`'s DISPATCH presentation
+     ;; (rf2-l3h1m). The surface treatment (raised `:bg-3` fill, subtle
+     ;; border, 3px radius) mirrors the §3 EVENT HANDLER source code-block
+     ;; (`edn/code-block`) so the two pipeline steps read as a consistent
+     ;; family of boxed payloads. `min-width:0` keeps the inner inspector
+     ;; free to shrink so a wide vector scrolls within the box rather than
+     ;; clipping at narrow panel widths.
      [:div {:data-testid "rf-causa-event-detail-event-vector"
-            :style {:font-weight 600
-                    :margin-bottom "4px"}}
+            :style {:background    (:bg-3 tokens)
+                    :border        (str "1px solid " (:border-subtle tokens))
+                    :border-radius "3px"
+                    :padding       "8px 10px"
+                    :margin-bottom "4px"
+                    :min-width     "0"
+                    :overflow-x    "auto"
+                    :font-weight   600}}
       (edn/inspect event-vec "event-detail/event")]
      ;; FROM: <source> ↗ — the dispatch-origin as a single
      ;; click-to-source link (EventPanel.tsx shape; rf2-ad7zx.17).

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -456,6 +456,27 @@
         (is (some? (find-by-testid tree "rf-causa-event-detail-event-vector"))
             "event vector rendered inside the DISPATCH step")))))
 
+(deftest dispatch-event-vector-renders-in-boxed-block
+  (testing "rf2-l3h1m — the DISPATCH event vector renders in a BOXED block
+            (`bg-muted p-3 rounded` in EventPanel.tsx; raised `:bg-3` fill
+            + subtle border + radius here), not inline/unboxed. The box
+            carries a background fill, a border, and a non-zero
+            border-radius so it reads as the same surface family as the
+            §3 EVENT HANDLER source code-block."
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree     (event-detail/Panel)
+            box      (find-by-testid tree "rf-causa-event-detail-event-vector")
+            style    (:style (second box))]
+        (is (some? box) "event vector box rendered")
+        (is (some? (:background style)) "box carries a background fill")
+        (is (some? (:border style)) "box carries a border")
+        (is (and (some? (:border-radius style))
+                 (not= "0" (:border-radius style)))
+            "box has a non-zero border-radius (rounded)")
+        (is (some? (:padding style)) "box carries inner padding")))))
+
 ;; ---- (5) AFTER INTERCEPTORS step — optional, omitted when empty -------
 
 (deftest after-interceptors-step-absent-when-zero-non-standard


### PR DESCRIPTION
Improves Causa Event-panel visual fidelity to its Figma mock (`design-reference/components/EventPanel.tsx`) for the DISPATCH pipeline step. Bead: rf2-l3h1m (P3).

## What changed (panels/event_detail.cljs only)

**DISPATCH box.** The dispatched event vector now renders inside a boxed block — raised `:bg-3` fill, a `:border-subtle` 1px border, a 3px radius, and `8px 10px` inner padding. This is the Causa equivalent of the mock's `bg-muted p-3 rounded`. Previously the vector rendered inline/unboxed with only `font-weight: 600`. The surface treatment deliberately mirrors the §3 EVENT HANDLER source code-block (`edn/code-block`) so the two pipeline steps read as one consistent boxed-payload family. `min-width:0` + `overflow-x:auto` let a wide vector scroll within the box rather than clip at narrow panel widths.

**FROM source-link.** The `FROM: <source>` click-to-source affordance — the source label rendered as an accent link with the trailing `↗` external-link chip, plus a graceful plain-text fallback when no `:rf.trace/call-site` coord was captured — was already wired in #2049 and is covered by existing regressions. Left intact; only the docstring was refreshed to also describe the new box.

**Untouched:** the EVENT HANDLER source code-block layout (fixed in #2056) is not modified.

## Tests

Adds CLJS regression `dispatch-event-vector-renders-in-boxed-block` — asserts the DISPATCH vector container carries a background fill, a border, a non-zero `border-radius`, and inner padding. Existing FROM linked/plain regressions (`dispatch-from-row-matches-eventpanel-tsx-source-link`, `dispatch-from-row-without-call-site-renders-plain-source-no-chip`) retained.

## Gates (all from the worker worktree)

- clj-kondo on both touched files: 0 errors, 0 warnings
- tools/causa `clojure -M:test`: 876 tests, 0 failures
- `npm --prefix implementation run test:cljs`: 4260 tests, 0 failures
- `npm --prefix implementation run test:causa-feature-gate`: 13 scenarios, 0 failures (exit 0)
- `examples/step-deck` shadow build: 0 warnings

Closes rf2-l3h1m.