### PR TITLE
fix(causa): Views/Trace/Issues panel Figma fidelity (rf2-tha26)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -102,8 +102,15 @@
                          ;; Flip the visible tab to Event so the row
                          ;; pivot lands in the event lens.
                          (rf/dispatch [:rf.causa/select-tab :event] {:frame :rf/causa}))
+          ;; rf2-tha26 — the category column is a FIXED width (≈ Figma
+          ;; `w-36`) so the description column is the SOLE flexible track
+          ;; (`1fr` = the reference's `flex-1`). The prior `0.6fr`
+          ;; category shared the flexible width with the description, so
+          ;; a long category starved the description into a `:r…`
+          ;; ellipsis even when the row had room — the description now
+          ;; fills all the space the fixed columns leave.
           :style       {:display       "grid"
-                        :grid-template-columns "78px minmax(110px, 0.6fr) 1fr auto 18px"
+                        :grid-template-columns "78px 144px minmax(0, 1fr) auto 18px"
                         :gap           "16px"
                         :align-items   "center"
                         :padding       "8px 12px"
@@ -173,6 +180,25 @@
                        :font-size "13px"
                        :text-align "center"}}
         "·"])]))
+
+;; ---- footer hint --------------------------------------------------------
+
+(defn- footer-hint
+  "Reference footer hint (rf2-tha26 ·
+  `design-reference/components/IssuesPanel.tsx`). Spells out the row's
+  two affordances — click the row pivots to the Event panel (the
+  cascade that produced the issue); click `↗` opens the responsible
+  handler at `file:line`. Rendered below the feed (feed branch only) so
+  it shares the focused-epoch lens with the rows it describes."
+  []
+  [:div {:data-testid "rf-causa-issues-footer-hint"
+         :style       {:margin-top  "16px"
+                       :padding-top "16px"
+                       :border-top  (str "1px solid " (:border-default tokens))
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"}}
+   "click a row → Event panel (the cascade) · click ↗ → source file:line"])
 
 ;; ---- empty states -------------------------------------------------------
 
@@ -264,14 +290,16 @@
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted epoch-id)
         :no-issues     (empty-state-no-issues)
-        nil            (overflow/capped-list
-                         issues
-                         {:panel-id "issues"
-                          :ul-attrs {:data-testid "rf-causa-issues-feed"
-                                     :style       {:list-style "none"
-                                                   :margin     0
-                                                   :padding    0}}
-                          :row-fn   issue-row}))]]))
+        nil            [:<>
+                        (overflow/capped-list
+                          issues
+                          {:panel-id "issues"
+                           :ul-attrs {:data-testid "rf-causa-issues-feed"
+                                      :style       {:list-style "none"
+                                                    :margin     0
+                                                    :padding    0}}
+                           :row-fn   issue-row})
+                        (footer-hint)])]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/reactive_panel_view.cljs
@@ -69,25 +69,36 @@
 
 ;; ---- section chrome -----------------------------------------------------
 
-(def ^:private section-label-style
-  "Uppercase muted caption preceding each section (REACTIVE FLOW /
-  UNMOUNTED VIEWS / DESTROYED SUBSCRIPTIONS), echoing the Figma
-  `devtools-caption uppercase tracking-wide` heading."
-  {:padding        "0 0 8px 0"
-   :font-family    sans-stack
-   :font-size      "10px"
-   :font-weight    600
-   :letter-spacing "0.6px"
-   :text-transform "uppercase"
-   :color          (:text-tertiary tokens)})
+(defn- section-label-style
+  "Muted caption preceding each section, echoing the Figma
+  `devtools-caption tracking-wide` heading.
+
+  rf2-tha26 — the PRIMARY `Reactive Flow` heading renders in TITLE CASE
+  (`:title-case?`), not the all-caps the secondary teardown captions
+  (`Unmounted Views` / `Destroyed Subscriptions`) keep. The Figma
+  reference uppercases every caption via CSS, but the title-case
+  `Reactive Flow` reads as the panel's headline rather than a shout —
+  the all-caps render flattened it into the same register as the
+  smaller teardown sections."
+  [title-case?]
+  (cond-> {:padding        "0 0 8px 0"
+           :font-family    sans-stack
+           :font-size      "10px"
+           :font-weight    600
+           :letter-spacing "0.6px"
+           :color          (:text-tertiary tokens)}
+    (not title-case?) (assoc :text-transform "uppercase")))
 
 (defn- section-label
-  "Uppercase section caption. testid:
-  `rf-causa-reactive-section-<id>-label`."
-  [id title]
-  [:div {:data-testid (str "rf-causa-reactive-section-" id "-label")
-         :style       section-label-style}
-   title])
+  "Section caption. testid: `rf-causa-reactive-section-<id>-label`.
+  `:title-case?` (rf2-tha26) renders the literal title without the
+  CSS uppercase transform — used for the primary `Reactive Flow`
+  heading."
+  ([id title] (section-label id title nil))
+  ([id title {:keys [title-case?]}]
+   [:div {:data-testid (str "rf-causa-reactive-section-" id "-label")
+          :style       (section-label-style title-case?)}
+    title]))
 
 ;; ---- pure formatters ---------------------------------------------------
 
@@ -289,7 +300,12 @@
                      :font-family sans-stack :font-size "12px"}}
        "No subs subscribed to changed paths · no views re-rendered."]
       [:div {:data-testid "rf-causa-reactive-graph-card"
-             :style {:border (str "1px solid " (:border-default tokens))
+             ;; rf2-tha26 — the card edge reads as a real rounded-lg
+             ;; card frame. The plain `:border-default` (#373737) hairline
+             ;; was near-invisible against the card's `:bg-1` fill on the
+             ;; dark theme; a `:dim`-tinted edge gives the SVG canvas a
+             ;; clearly-bounded card the operator can read at a glance.
+             :style {:border (str "1px solid " (tk/with-alpha :dim 45))
                      :border-radius "8px"
                      :padding "16px"
                      :background (:bg-1 tokens)
@@ -451,7 +467,7 @@
         [:div {:data-testid "rf-causa-reactive-pipeline"
                :style {:padding "16px"}}
          [:section {:data-testid "rf-causa-reactive-flow-section"}
-          (section-label "flow" "Reactive Flow")
+          (section-label "flow" "Reactive Flow" {:title-case? true})
           (flow-graph data)]
          (unmounted-views-section data)
          (destroyed-subs-section data)

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -222,8 +222,19 @@
                         :align-items    "stretch"
                         ;; op-family colour band as a 3px LEFT-BORDER.
                         :border-left    (str "3px solid " band-colour)
-                        :border-bottom  (str "1px solid "
-                                             (:border-subtle tokens))
+                        ;; rf2-tha26 — Figma rounded hover-pill rows
+                        ;; (`design-reference/components/TracePanel.tsx`):
+                        ;; rows are discrete pills (`rounded` +
+                        ;; `space-y-0.5`) lit by a `hover:bg` fill rather
+                        ;; than flat rows divided by hairlines. Inline
+                        ;; styles can't carry a `:hover` pseudo-class, so
+                        ;; the hover fill is a scoped CSS rule in
+                        ;; theme/global-styles keyed off the row testid;
+                        ;; here we round the corners + add the 2px inter-
+                        ;; row rhythm. An expanded row keeps its tinted
+                        ;; fill so the open payload reads as one unit.
+                        :border-radius  "4px"
+                        :margin-bottom  "2px"
                         :background     (when expanded? (:bg-1 tokens))
                         ;; Causal-nesting indent (cascade tree).
                         :margin-left    (str (* depth* indent-px) "px")
@@ -306,7 +317,10 @@
                                       {:frame :rf/causa}))
           :style       {:display       "block"
                         :border-left   (str "3px solid " band-colour)
-                        :border-bottom (str "1px solid " (:border-subtle tokens))
+                        ;; rf2-tha26 — rounded hover-pill rhythm matching
+                        ;; the op rows (the group is a trace row too).
+                        :border-radius "4px"
+                        :margin-bottom "2px"
                         :margin-left   (str (* depth* indent-px) "px")
                         :cursor        "pointer"
                         :color         (:text-secondary tokens)
@@ -353,6 +367,25 @@
     (trace-row node
                {:expanded? (contains? (or expanded-row-ids #{})
                                       (:id node))})))
+
+;; ---- footer legend ------------------------------------------------------
+
+(defn- footer-legend
+  "Reference footer legend (rf2-tha26 ·
+  `design-reference/components/TracePanel.tsx`). Names the two reading
+  conventions of the ribbon — rows are colour-banded by op-family
+  (the 3px left border), and clicking a row expands its raw
+  `:operation` + tags payload inline. Rendered below the feed (feed
+  branch only)."
+  []
+  [:div {:data-testid "rf-causa-trace-footer-legend"
+         :style       {:margin     "16px 16px 0 16px"
+                       :padding-top "16px"
+                       :border-top (str "1px solid " (:border-default tokens))
+                       :color      (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size  "11px"}}
+   "colour-banded by op-family · click a row → expand raw :operation + tags"])
 
 ;; ---- empty states -------------------------------------------------------
 
@@ -485,14 +518,16 @@
         :no-events     (empty-state-no-events)
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted)
-        nil            (overflow/capped-list
-                         nodes
-                         {:panel-id "trace"
-                          :ul-attrs {:data-testid "rf-causa-trace-feed"
-                                     :style       {:list-style "none"
-                                                   :margin     0
-                                                   :padding    0}}
-                          :row-fn   node-with-state}))]]))
+        nil            [:<>
+                        (overflow/capped-list
+                          nodes
+                          {:panel-id "trace"
+                           :ul-attrs {:data-testid "rf-causa-trace-feed"
+                                      :style       {:list-style "none"
+                                                    :margin     0
+                                                    :padding    "8px 16px 0 16px"}}
+                           :row-fn   node-with-state})
+                        (footer-legend)])]]))
 
 ;; ---- registration entry --------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -805,6 +805,24 @@
     "[data-testid^=\"rf-causa-tab-\"][aria-selected=\"false\"]:hover {\n"
     "  background-color: " (:hover tokens/tokens) ";\n"
     "  color: " (:text-primary tokens/tokens) ";\n"
+    "}\n"
+    ;; rf2-tha26 — Trace-panel rounded hover-pill rows. The Figma
+    ;; `design-reference/components/TracePanel.tsx` renders each trace
+    ;; row as a discrete `rounded` pill lit by a
+    ;; `hover:bg-[var(--devtools-hover)]` fill (no flat hairline
+    ;; dividers). Inline styles can't carry a `:hover` pseudo-class
+    ;; (mirrors the L3 tab-bar + EDN-copy hover handling above), so the
+    ;; hover fill is a scoped CSS rule keyed off the row `<li>`'s testid.
+    ;; The `li` qualifier scopes the rule to the ROW pills only — the
+    ;; per-row inner cells share the `rf-causa-trace-row-` testid prefix
+    ;; (e.g. `…-summary`, `…-time`) so an unqualified prefix selector
+    ;; would tint them too. The reactive-aftermath collapse GROUP
+    ;; (`rf-causa-trace-group-`) is a trace row too, so it lights the
+    ;; same way. The op-family 3px left-border + the rounded corners are
+    ;; the per-row inline styles; this rule only adds the hover fill.
+    "li[data-testid^=\"rf-causa-trace-row-\"]:hover,\n"
+    "li[data-testid^=\"rf-causa-trace-group-\"]:hover {\n"
+    "  background-color: " (:hover tokens/tokens) ";\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -357,6 +357,62 @@
         (is (= "right" (-> ts second :style :text-align))
             "timestamp is right-aligned")))))
 
+;; ---- (5b) Figma fidelity — rf2-tha26 -----------------------------------
+
+(deftest description-column-fills-available-width
+  (testing "rf2-tha26 — the description column is the SOLE flexible track
+            (`minmax(0, 1fr)` = Figma `flex-1`); the category column is a
+            FIXED width so a long category no longer starves the
+            description into a `:r…` ellipsis when the row has room"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 11 [(mk-issue {:id 1 :op-type :error
+                                    :operation :rf.error/handler-exception})])])
+      (focus! 11)
+      (let [tree (issues-ribbon/Panel)
+            cols (-> (find-by-testid tree "rf-causa-issues-row-1")
+                     second :style :grid-template-columns)]
+        (is (string? cols) "row uses a grid template")
+        (is (re-find #"minmax\(0, 1fr\)" cols)
+            "the description track is `minmax(0, 1fr)` (fills the row)")
+        ;; The category column is a fixed width — NOT a fractional track
+        ;; that competes with the description for flexible space.
+        (is (re-find #"144px" cols)
+            "the category column is a fixed width (Figma w-36)")
+        (is (not (re-find #"0\.6fr" cols))
+            "the prior fractional category track (`0.6fr`) is gone")))))
+
+(deftest footer-hint-renders-below-the-feed
+  (testing "rf2-tha26 — the Figma footer hint renders below the feed
+            naming the row affordances (click a row → Event panel · click
+            ↗ → source file:line)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 11 [(mk-issue {:id 1 :op-type :error
+                                    :operation :rf.error/handler-exception})])])
+      (focus! 11)
+      (let [tree (issues-ribbon/Panel)
+            hint (find-by-testid tree "rf-causa-issues-footer-hint")]
+        (is (some? hint) "footer hint renders in the feed branch")
+        (is (= "click a row → Event panel (the cascade) · click ↗ → source file:line"
+               (last hint))
+            "footer hint carries the reference copy")))))
+
+(deftest footer-hint-absent-in-empty-states
+  (testing "rf2-tha26 — the footer hint is scoped to the feed branch; it
+            does NOT render when the panel shows an empty-state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history! [(mk-epoch 1 11 [])])
+      (focus! 11)
+      (let [tree (issues-ribbon/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-issues-empty-no-issues"))
+            "empty-state renders")
+        (is (nil? (find-by-testid tree "rf-causa-issues-footer-hint"))
+            "footer hint absent in the empty-state branch")))))
+
 ;; ---- (6) focused-epoch scope (spec/021 §1.2 + §8) ---------------------
 
 (deftest issues-panel-scopes-to-focused-epoch

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactive_panel_view_cljs_test.cljs
@@ -112,6 +112,50 @@
       (is (= "Reactive Flow" (text-of tree "rf-causa-reactive-section-flow-label"))
           "graph section heading is `Reactive Flow`"))))
 
+(deftest reactive-flow-heading-is-title-case-not-all-caps
+  (testing "rf2-tha26 — the primary `Reactive Flow` heading renders in
+            TITLE case (no CSS uppercase transform), not the all-caps
+            `REACTIVE FLOW` the prior shared section-label forced; the
+            secondary teardown captions keep their uppercase register."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {} :level-1-subs [] :level-2-subs [] :view-rows []
+       :unmounted-views [] :destroyed-subs []})
+    (let [tree (view/reactive-panel)
+          flow (th/find-by-testid tree "rf-causa-reactive-section-flow-label")
+          unmnt (th/find-by-testid tree
+                                   "rf-causa-reactive-section-unmounted-label")]
+      (is (not= "uppercase" (get-in flow [1 :style :text-transform]))
+          "the `Reactive Flow` heading is NOT CSS-uppercased (title case)")
+      ;; The literal title is already title case (rf2-ad7zx.6); with no
+      ;; uppercase transform it renders title case as authored.
+      (is (= "Reactive Flow" (text-of tree "rf-causa-reactive-section-flow-label"))
+          "the literal heading text reads in title case")
+      (is (= "uppercase" (get-in unmnt [1 :style :text-transform]))
+          "the secondary teardown caption keeps its uppercase register"))))
+
+(deftest reactive-graph-card-carries-visible-border
+  (testing "rf2-tha26 — the reactive-graph card paints a visible rounded
+            card border (the prior `:border-default` hairline was near-
+            invisible on the dark theme)."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (seed-reactive-data!
+      {:has-cascade? true :frame :rf/app :focus {:current :ep-1}
+       :counts {}
+       :level-1-subs [{:sub-id :cart/state :changed? true}]
+       :level-2-subs [] :view-rows []})
+    (let [tree (view/reactive-panel)
+          card (th/find-by-testid tree "rf-causa-reactive-graph-card")
+          border (get-in card [1 :style :border])]
+      (is (some? card) "the graph card renders")
+      (is (string? border) "the card carries a border")
+      (is (re-find #"^1px solid " border) "the border is a 1px solid edge")
+      (is (= "8px" (get-in card [1 :style :border-radius]))
+          "the card keeps its rounded-lg corner radius"))))
+
 (deftest changed-node-and-edge-encoding
   (testing "rf2-ad7zx.6 — a changed sub node carries data-node-changed
             true; its app-db→sub edge is a changed (propagating) edge."

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -611,6 +611,62 @@
         (is (not= "0px" (get-in child [:style :margin-left]))
             "child row is indented under its parent (cascade tree)")))))
 
+;; ---- (5c) Figma fidelity — rf2-tha26 -----------------------------------
+
+(deftest footer-legend-renders-below-the-feed
+  (testing "rf2-tha26 — the Figma footer legend renders below the feed
+            naming the row reading conventions (colour-banded by op-family
+            · click a row → expand raw :operation + tags)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree   (trace/Panel)
+            legend (find-by-testid tree "rf-causa-trace-footer-legend")]
+        (is (some? legend) "footer legend renders in the feed branch")
+        (is (= "colour-banded by op-family · click a row → expand raw :operation + tags"
+               (last legend))
+            "footer legend carries the reference copy")))))
+
+(deftest footer-legend-absent-in-empty-states
+  (testing "rf2-tha26 — the footer legend is scoped to the feed branch; it
+            does NOT render when the panel shows an empty-state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Focused epoch with no trace events → :no-events empty-state.
+      (seed-history! [(mk-epoch 1 11 [])])
+      (focus! 11)
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-events"))
+            "empty-state renders")
+        (is (nil? (find-by-testid tree "rf-causa-trace-footer-legend"))
+            "footer legend absent in the empty-state branch")))))
+
+(deftest op-rows-are-rounded-pills-not-flat-divided
+  (testing "rf2-tha26 — Figma rounded hover-pill rows: each op row carries
+            a border-radius (rounded) + inter-row rhythm and DROPS the
+            flat hairline `border-bottom` divider; the op-family 3px
+            left-border is preserved"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree* (trace/Panel)
+            attrs (node-attrs tree* "rf-causa-trace-row-1")
+            style (:style attrs)]
+        (is (= "4px" (:border-radius style)) "row is a rounded pill")
+        (is (nil? (:border-bottom style))
+            "the flat hairline divider is gone (pills, not divided rows)")
+        (let [bl (:border-left style)]
+          (is (and (string? bl) (re-find #"^3px solid " bl))
+              "the op-family 3px left-border band is preserved"))))))
+
 ;; ---- (6) frame isolation ------------------------------------------------
 
 (deftest trace-expand-state-does-not-leak-into-default-frame


### PR DESCRIPTION
Reconciles three Dynamic-panel surfaces to their design references
(`tools/causa/design-reference/components/{ViewsPanel,TracePanel,IssuesPanel}.tsx`).
Bead: rf2-tha26 (P3, polish).

## Views / Reactive panel (`reactive_panel_view.cljs`)
- **Header title-case** — the primary "Reactive Flow" heading renders in title case rather than the CSS all-caps the shared `section-label` forced. The secondary teardown captions (Unmounted Views / Destroyed Subscriptions) keep their uppercase register. `section-label` gains an opt-in `:title-case?` arg so the headline reads as the panel's title, not a shout.
- **Visible card border** — the reactive-graph card paints a `:dim`-tinted rounded card edge; the prior `:border-default` (#373737) hairline was near-invisible against the card's `bg-1` fill on the dark theme.

## Trace panel (`trace.cljs`)
- **Rounded hover-pill rows** — `border-radius` + a 2px inter-row rhythm replace the flat hairline dividers, lit by a scoped hover-bg CSS rule (`theme/global-styles`, keyed off the row `<li>` testid — the same idiom as the existing L3 tab-bar hover). The op-family 3px left-border band is preserved; the reactive-aftermath group row rounds to match.
- **Footer legend** — adds the reference legend ("colour-banded by op-family · click a row → expand raw :operation + tags") below the feed.

## Issues panel (`issues_ribbon.cljs`)
- **Description fills available width** — the category column is now a fixed width (Figma `w-36`) so the description column is the sole flexible track (`minmax(0, 1fr)` = `flex-1`). A long category no longer starves the description into a `:r…` ellipsis when the row has room.
- **Footer hint** — adds the reference hint ("click a row → Event panel (the cascade) · click ↗ → source file:line") below the feed.

## Tests
CLJS regressions added for every assertable change:
- header title-case (no uppercase transform) + visible card border (`reactive_panel_view_cljs_test.cljs`)
- trace footer legend present + rounded pills (radius set, hairline divider gone, op-family band preserved) + footer absent in empty states (`trace_view_cljs_test.cljs`)
- issues description flex track (`minmax(0, 1fr)`, fixed category, no `0.6fr`) + footer hint present + footer absent in empty states (`issues_ribbon_view_cljs_test.cljs`)

## Gates (from worktree)
- `tools/causa` `clojure -M:test` — 876 tests, 0 fail
- `npm --prefix implementation run test:cljs` — 4267 tests, 0 fail
- `npm --prefix implementation run test:causa-feature-gate` — 13 scenarios, 0 fail (exit 0)
- clj-kondo on touched files — 0 errors, 0 warnings
- splint on touched source — exit 0 (no new warnings; 5 pre-existing informational)
- `examples/step-deck` shadow build — 440 files, 0 warnings

## Verification
Render-verified via the causa-feature-gate harness (deep-machine populates Views; deliberate-throw populates Issues) — all 13 matrix scenarios compile + pass with the panel changes live. View-tree structure asserted directly by the new pure-hiccup view tests.