### PR TITLE
fix(causa): Routes panel 3-section layout Figma fidelity (rf2-zxxy1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -7,11 +7,12 @@
 
   The prior 'Active route tree first + This-epoch KV' shape is
   superseded. The panel now reads top → bottom as three stacked
-  sections, each separated from the next by a 1px hairline:
+  sections, each separated from the next by a 1px hairline. Per
+  spec/021 §14.1 (rf2-6xezz) the panel carries no self-naming heading
+  and no per-panel header icon — content opens directly on the CURRENT
+  ROUTE section (the L4 tab strip is the single source of panel
+  identity, and the Figma `RoutesPanel.tsx` opens the same way):
 
-      ┌─ ROUTING · epoch #38 ─────────────────────── [◀ Prev] [Next ▶] ─┐
-      │▌ stripe: the single GitHub-blue accent                          │
-      │                                                                 │
       │ CURRENT ROUTE                                                   │
       │   :user/profile    params {:id 42}    /users/42                 │
       │ ─────────────────────────────────────────────────────────────  │
@@ -49,10 +50,14 @@
   ## Section 3 — ROUTE TABLE (registered route graph as a tree)
 
   All registered routes (id → path pattern) drawn as an indented tree
-  when nested (`├─ └─` branch glyphs; flat list otherwise), with the
-  **current route highlighted** (mode-accent row + `◀ current` marker)
-  and the focused navigation's FROM→TO marked on it. The overlay
-  glyphs `◉ TO` / `◇ FROM` paint inline on the matching rows.
+  when nested — nested routes left-indent by depth and their parent
+  rows carry a `▾` disclosure chevron (leaf rows get an aligned
+  spacer), matching the Figma `RoutesPanel.tsx` `ChevronRight` +
+  per-level `paddingLeft`. The tree is always fully expanded (§7.1:
+  depth ≤ 4). The **current route is highlighted** (mode-accent row +
+  `◀ current` marker) and the focused navigation's FROM→TO is marked on
+  it — the overlay glyphs `◉ TO` / `◇ FROM` paint inline on the
+  matching rows.
 
   ## Focus contract (rf2-h0120 alignment)
 
@@ -76,7 +81,6 @@
             [day8.re-frame2-causa.panel-registry :as panel-registry]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
-             :as t
              :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- accent -------------------------------------------------------------
@@ -258,27 +262,43 @@
     :from {:glyph "◇" :colour (:info tokens)          :label "FROM"}
     nil))
 
-(defn- tree-prefix
-  "Compose the `├─ └─` branch prefix for a route-table row at the given
-  depth. Depth-0 rows render with no prefix; deeper rows render
-  `<spacer>(└─|├─) ` — `└─` for last-sibling rows, `├─` otherwise.
-  Same box-drawing scheme the spec mockup uses (§7.2). Routing trees
-  are shallow (≤ 4 levels per §7.1) so the depth indentation + branch
-  glyphs alone read cleanly."
-  [depth last-at-depth?]
-  (if (zero? depth)
-    ""
-    (let [indent (apply str (repeat (dec depth) "  "))
-          branch (if last-at-depth? "└─ " "├─ ")]
-      (str indent branch))))
+(defn- depth->indent
+  "Left indent for a route-table row at the given depth. Mirrors the
+  Figma `RoutesPanel.tsx` `paddingLeft: level * 2 + 0.5rem` — depth-0
+  rows sit at the base 0.5rem, each nesting level adds 2rem. The
+  structure reads off indentation alone (per §17.4: tree nesting is
+  whitespace, not box-drawing text glyphs)."
+  [depth]
+  (str (+ 0.5 (* 2 depth)) "rem"))
+
+(defn- disclosure-cell
+  "The leading cell of a route-table row. Parent routes (those with
+  nested children) paint a `▾` disclosure chevron — the routing tree is
+  always fully expanded per §7.1 (depth ≤ 4), so the chevron is a
+  static affordance signalling 'this route has children', matching the
+  Figma `ChevronRight` parent glyph + the spec mockup's `▾ :users`.
+  Leaf rows render an aligned spacer so every id column lines up
+  (Figma `{!route.children && <span className=\"w-3\" />}`)."
+  [has-children? testid]
+  (if has-children?
+    [:span {:data-testid (str testid "-chevron")
+            :aria-hidden "true"
+            :style       {:color       (:text-tertiary tokens)
+                          :font-size   "10px"
+                          :min-width   "12px"
+                          :user-select "none"}}
+     "▾"]
+    [:span {:aria-hidden "true"
+            :style       {:min-width "12px"}}]))
 
 (defn- route-table-row
   "Render one route in the ROUTE TABLE. The current route's row rides
   the mode accent (highlight background + accent id + `◀ current`
-  marker); other rows are quiet. The FROM/TO overlay glyph paints to
-  the right of the path when the focused epoch navigated to/from this
-  route."
-  [{:keys [row depth last-at-depth?]}]
+  marker); other rows are quiet. Nested routes indent by depth and
+  their parent rows carry a `▾` disclosure chevron (leaves get an
+  aligned spacer). The FROM/TO overlay glyph paints to the right of
+  the path when the focused epoch navigated to/from this route."
+  [{:keys [row depth has-children?]}]
   (let [{:keys [route-id path doc marker]} row
         current?  (= marker :here)
         glyph     (marker-glyph marker)
@@ -291,7 +311,7 @@
            :style {:display      "flex"
                    :align-items  "center"
                    :gap          "8px"
-                   :padding      "3px 8px"
+                   :padding      (str "3px 8px 3px " (depth->indent depth))
                    :border-radius "3px"
                    :font-family  mono-stack
                    :font-size    "12px"
@@ -300,10 +320,8 @@
                    :background   (cond
                                    current?         (:bg-active tokens)
                                    (= marker :to)   (:bg-active tokens)
-                                   :else            "transparent")
-                   :white-space  "pre"}}
-     [:span {:style {:color (:text-tertiary tokens)}}
-      (tree-prefix depth last-at-depth?)]
+                                   :else            "transparent")}}
+     (disclosure-cell has-children? testid)
      [:span {:data-testid (str testid "-id")
              :style       {:min-width "8rem"
                            :color     (if current? mode-accent
@@ -354,44 +372,6 @@
              ^{:key (str (-> entry :row :route-id))}
              (route-table-row entry)))]))
 
-;; ---- header --------------------------------------------------------------
-
-(defn- header
-  [{:keys [navigated? to-id silent?]}]
-  [:div {:data-testid "rf-causa-routing-header"
-         :style       {:display         "flex"
-                       :align-items     "baseline"
-                       :justify-content "space-between"
-                       :padding         "12px 16px 8px 16px"
-                       :border-bottom   (str "1px solid " (:border-subtle tokens))
-                       :font-family     sans-stack}}
-   [:div
-    ;; Per rf2-6xezz / rf2-rb6js the panel no longer renders a heading
-    ;; that names itself — the L4 tab strip is the single source of
-    ;; panel identity. The icon + orientation paragraph stay as chrome.
-    [:div {:style {:display     "flex"
-                   :align-items "center"
-                   :gap         "8px"}}
-     ;; rf2-ezx8w — spec/021 §17.1.5 per-panel header icon. 🌐 in the
-     ;; routing domain colour via panel-icon-style.
-     [:span {:data-testid "rf-causa-routing-panel-icon"
-             :aria-hidden "true"
-             :style       (t/panel-icon-style :routing)}
-      (:routing t/panel-icon)]]
-    [:p {:style {:margin      "4px 0 0 0"
-                 :color       (:text-tertiary tokens)
-                 :font-size   "11px"
-                 :line-height 1.4}}
-     "Where am I, what navigated this epoch, and the full registered "
-     "route graph. For the route catalogue browse + Simulate-URL surface, "
-     "switch to Static mode."]]
-   (when (and navigated? to-id (not silent?))
-     [:span {:data-testid "rf-causa-routing-nav-summary"
-             :style       {:color       (:green tokens)
-                           :font-size   "11px"
-                           :font-family mono-stack}}
-      (str "→ " to-id)])])
-
 ;; ---- empty (no routes registered) ---------------------------------------
 
 (defn- silent-state
@@ -430,6 +410,12 @@
                                 tree, current row highlighted + FROM/TO
                                 overlay glyphs.
 
+  Content starts immediately at the CURRENT ROUTE section — per spec/021
+  §14.1 (rf2-6xezz) every L4 panel scrubs its self-naming heading + the
+  per-panel header icon (the L4 tab strip is the single source of panel
+  identity). This matches the Figma `RoutesPanel.tsx`, which opens
+  directly on the CURRENT ROUTE section with no header chrome.
+
   When the host has no routes registered the panel renders the
   silent-by-default caption (no sections)."
   []
@@ -445,7 +431,6 @@
                              :font-family    sans-stack
                              :font-size      "14px"
                              :overflow       "auto"}}
-     (header {:navigated? navigated? :to-id to-id :silent? silent?})
      (if silent?
        (silent-state)
        [:<>

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
@@ -475,10 +475,17 @@
   vector — the data shape the Routing panel's tree-render consumes.
 
   Returns `[{:row <row-from-project-routes>
-             :depth <int>           ;; 0 for roots, +1 per :parent hop
+             :depth <int>           ;; 0 for roots, +1 per :parent hop;
+                                    ;; the view turns depth into a left
+                                    ;; indent (RoutesPanel.tsx
+                                    ;; `paddingLeft: level * 2 + 0.5rem`)
              :last-at-depth? <bool> ;; true when this row is the last
-                                    ;; sibling at its depth (used by
-                                    ;; the view to pick `└─` vs `├─`)
+                                    ;; sibling at its depth
+             :has-children? <bool>  ;; true when this route is a parent
+                                    ;; of nested routes — the view paints
+                                    ;; a `▾` disclosure chevron (Figma
+                                    ;; `ChevronRight`); leaves get an
+                                    ;; aligned spacer instead
              } ...]`
 
   Routes with `:parent` references that resolve to a registered
@@ -516,7 +523,8 @@
                               (reduce into []))]
                      (into [{:row            row
                              :depth          depth
-                             :last-at-depth? (boolean last-sibling?)}]
+                             :last-at-depth? (boolean last-sibling?)
+                             :has-children?  (boolean (seq children))}]
                            child-rows)))))
         last-root-idx (dec (count roots))]
     (->> roots

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -183,11 +183,13 @@
       (let [tree (routing/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routing"))
             "panel root present")
-        (is (some? (find-by-testid tree "rf-causa-routing-header"))
-            "header always renders")
-        ;; rf2-ezx8w · spec/021 §17.1.5 — per-panel header icon.
-        (is (some? (find-by-testid tree "rf-causa-routing-panel-icon"))
-            "panel header icon (🌐) present")
+        ;; spec/021 §14.1 (rf2-6xezz) — every L4 panel scrubs its
+        ;; self-naming heading + per-panel header icon; content opens
+        ;; directly on CURRENT ROUTE (matching Figma RoutesPanel.tsx).
+        (is (nil? (find-by-testid tree "rf-causa-routing-header"))
+            "no panel header (heading + icon scrubbed per §14.1)")
+        (is (nil? (find-by-testid tree "rf-causa-routing-panel-icon"))
+            "no per-panel header icon (🌐 removed per §14.1)")
         ;; §1 CURRENT ROUTE
         (is (some? (find-by-testid tree "rf-causa-routing-current"))
             "§1 CURRENT ROUTE section renders")
@@ -203,7 +205,22 @@
         (doseq [rid (keys cart-routes)]
           (is (some? (find-by-testid tree
                        (str "rf-causa-routing-table-row-" (name rid))))
-              (str "route-table row rendered for " rid)))))))
+              (str "route-table row rendered for " rid)))
+        ;; Tree disclosure: :route/checkout is a parent (cart-routes nests
+        ;; :route/payment + :route/confirm under it) so its row carries
+        ;; the `▾` disclosure chevron (Figma ChevronRight on parent rows).
+        ;; Row test-ids use (name route-id), so :route/checkout → checkout.
+        (let [chevron (find-by-testid
+                        tree "rf-causa-routing-table-row-checkout-chevron")]
+          (is (some? chevron)
+              "parent route :route/checkout renders a disclosure chevron")
+          (is (re-find #"▾" (node-text chevron))
+              "chevron glyph is ▾ (always-expanded tree)"))
+        ;; Leaf routes carry NO chevron — the leading cell is an aligned
+        ;; spacer instead.
+        (is (nil? (find-by-testid
+                    tree "rf-causa-routing-table-row-cart-chevron"))
+            "leaf route :route/cart renders no disclosure chevron")))))
 
 (deftest current-route-section-shows-id-params-path
   (testing "§1 surfaces the active id, params, and matched path"
@@ -234,8 +251,8 @@
       (let [tree (routing/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routing"))
             "panel root present")
-        (is (some? (find-by-testid tree "rf-causa-routing-header"))
-            "header still renders")
+        (is (nil? (find-by-testid tree "rf-causa-routing-header"))
+            "no panel header even in the silent state (scrubbed per §14.1)")
         (is (some? (find-by-testid tree "rf-causa-routing-silent"))
             "silent caption rendered for empty registrar")
         (is (nil? (find-by-testid tree "rf-causa-routing-table"))
@@ -297,9 +314,10 @@
         ;; :to overlay glyph present on the destination table row.
         (is (some? (find-by-testid tree "rf-causa-routing-table-marker-to"))
             ":to overlay glyph rendered on destination route in the table")
-        ;; Header summary surfaces the TO id.
-        (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
-            "header carries → TO summary chip")
+        ;; The header (+ its → TO summary chip) is gone per §14.1; the
+        ;; NAVIGATION THIS EPOCH section is now the sole TO surface.
+        (is (nil? (find-by-testid tree "rf-causa-routing-nav-summary"))
+            "no header summary chip (header scrubbed per §14.1)")
         ;; NAVIGATION section surfaces FROM ──► TO + outcome.
         (is (some? (find-by-testid tree "rf-causa-routing-nav-to"))
             "NAVIGATION TO id rendered")

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
@@ -512,7 +512,20 @@
       (is (true? (get last-by-id :route/payment))
           ":route/payment is the last sibling at depth 1 under /checkout")
       (is (false? (get last-by-id :route/confirm))
-          ":route/confirm is not the last sibling at depth 1"))))
+          ":route/confirm is not the last sibling at depth 1")))
+
+  (testing "has-children? flags parent routes (the view's `▾` chevron)"
+    (let [topology (h/project-topology parented-routes)
+          kids-by-id (into {} (map (juxt #(-> % :row :route-id) :has-children?))
+                           topology)]
+      (is (true? (get kids-by-id :route/checkout))
+          ":route/checkout has nested children → has-children? true")
+      (is (false? (get kids-by-id :route/payment))
+          ":route/payment is a leaf → has-children? false")
+      (is (false? (get kids-by-id :route/admin))
+          ":route/admin is a leaf → has-children? false")
+      (is (every? #(contains? % :has-children?) topology)
+          "every topology entry carries a :has-children? flag"))))
 
 (deftest project-topology-orphan-parent-test
   (testing "rows whose :parent points to an unregistered route become roots"
@@ -631,7 +644,16 @@
         (is (= :here (get marker-by-id :route/cart))
             ":route/cart carries :here marker (current slice id)")
         (is (nil? (get marker-by-id :route/admin))
-            "non-current routes carry no marker")))))
+            "non-current routes carry no marker"))
+      ;; :has-children? survives the data composite (the view reads it
+      ;; off the topology entry to paint the `▾` chevron).
+      (let [kids-by-id (into {}
+                            (map (juxt #(-> % :row :route-id) :has-children?))
+                            (:topology data))]
+        (is (true? (get kids-by-id :route/checkout))
+            ":route/checkout keeps :has-children? through the composite")
+        (is (false? (get kids-by-id :route/cart))
+            "leaf route keeps :has-children? false through the composite")))))
 
 (deftest project-topology-data-overlay-test
   (testing "focused cascade caused navigation → :to overlay + :on-match phase"


### PR DESCRIPTION
## What

Reconcile the Dynamic **Routes** panel populated layout to the Figma reference (`design-reference/components/RoutesPanel.tsx`) + spec/021 §7.2 / §14.1, closing the fidelity gaps the rf2-ad7zx.7 reshape left.

The three titled sections (CURRENT ROUTE · NAVIGATION THIS EPOCH · ROUTE TABLE) and the `◀ current` marker were already in place; this PR finishes the match:

- **Header scrub.** The globe-emoji per-panel icon + orientation paragraph were the lone L4 holdout against §14.1 (rf2-6xezz) — every panel scrubs its self-naming heading and the per-panel header icons are removed (the L4 tab strip is the panel-identity source). Content now opens directly on the CURRENT ROUTE section, exactly like the Figma reference. The redundant header `→ TO` summary chip (duplicated NAVIGATION THIS EPOCH) goes with it.
- **ROUTE TABLE tree.** Switched from literal `├─ └─` box-drawing text glyphs to depth indentation + a `▾` disclosure chevron on parent rows (leaf rows get an aligned spacer), matching the Figma `ChevronRight` + the spec mockup's `▾ :users`. Per §17.4 the box-drawing characters in the ASCII mockups are narrative shorthand, not literal HTML text — nesting reads off indentation. The tree stays always-expanded (§7.1, depth ≤ 4).

`project-topology` now decorates each entry with `:has-children?` (survives the `project-topology-data` composite) so the view picks chevron-vs-spacer.

## Tests

- Helper (`.cljc`, JVM-covered): `:has-children?` on parents/leaves through both `project-topology` and the composite.
- View (`.cljs`): three section headings render; populated route table lists routes with `◀ current`; parent route renders a `▾` chevron (leaf does not); silent state renders with no routes; header + icon + nav-summary are absent.

## Verification

Audit could not exercise a populated route table; this PR did, live against the routed **step-deck** testbed (`examples/step-deck`, 4 registered `:testdeck/*` routes). All checks passed — the 3 sections render, the route table is populated (async / counter / machine / routing), and the current route (`:testdeck/counter`) carries the `◀ current` marker, with no panel header / globe icon.

## Gates (from worktree)

- `tools/causa` `clojure -M:test` — 876 tests, **0 failures, 0 errors**
- `npm --prefix implementation run test:cljs` — 4259 tests, **0 failures, 0 errors**
- `npm --prefix implementation run test:causa-feature-gate` — **13/13 scenarios pass**
- clj-kondo on touched files — **0 errors, 0 warnings**
- `examples/step-deck` shadow build — **clean (0 warnings)**

Closes rf2-zxxy1.