### PR TITLE
fix(causa): balance event-panel brackets in design-reference reference (rf2-jzcne)

### DIFF
--- a/tools/causa/design-reference/causa_devtools_reference.cljs
+++ b/tools/causa/design-reference/causa_devtools_reference.cljs
@@ -498,7 +498,7 @@
         [:span {:style {:color "var(--devtools-text)"}} "→ [:title/flow [:rf/init]]"]]
        [:div {:style {:display "flex" :align-items "flex-start" :gap "8px"}}
         [:span {:style {:color "var(--devtools-text-muted)"}} ":http-xhrio"]
-        [:span {:style {:color "var(--devtools-text)"}} "→ {:method :get, :uri \"/api/data\"}"]]]]]]]])
+        [:span {:style {:color "var(--devtools-text)"}} "→ {:method :get, :uri \"/api/data\"}"]]]]]]])
 
 ;; ============================================================================
 ;; App-DB Panel Component (simplified)


### PR DESCRIPTION
## Summary

The `event-panel` form in the authoritative reagent look-and-feel reference (`tools/causa/design-reference/causa_devtools_reference.cljs`) had a bracket imbalance — a paste artefact. The `(defn event-panel [] ...)` form opening at line 355 was being closed by a stray `]` at line 501 (clj-kondo had flagged the `(` at 355 / `]` at 501 mismatch).

The closing run on line 501 was `]]]]]]]])` (8 `]` + 1 `)`) where the nesting requires `]]]]]]])` (7 `]` + 1 `)`):

- 4 `]` close section 5 (span, row div, mono container div, section)
- 3 `]` close the three enclosing wrappers (sections-flex div, position-relative div, devtools-body div)
- 1 `)` closes the `(defn`

The extra 8th `]` mismatch-closed the defn paren. Removed exactly one stray `]`.

## Change

Line 501:
- before: `...api/data\"}"]]]]]]]])`
- after:  `...api/data\"}"]]]]]]])`

No change to the rendered hiccup structure / visual meaning — delimiter imbalance only. The `causa.devtools` ns name is unchanged.

## Verification

This file is excluded from clj-kondo + Splint (rf2-7sxsz), so reader validity is the real proof. Ran the Clojure reader over all top-level forms:

```
OK forms= 19
```

All 19 top-level forms parse with no reader exception.

CLJS test gate (`npm --prefix implementation run test:cljs`): **4276 tests, 13420 assertions, 0 failures, 0 errors.** (The file is not compiled, so it cannot regress the build; this just confirms nothing else broke.)

Closes rf2-jzcne.