### PR TITLE
fix(causa): chrome/ribbon/tab/event-list onto authority reference (rf2-3f2di)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -642,8 +642,10 @@
 ;;   asking for Causa to interrupt them)
 ;; - panel-position default `:right-rail` (matches the existing
 ;;   `:rf.causa/layout-host-selector` inline-host posture)
-;; - theme default `:dark` (Causa is a dev tool — the canvas-and-
-;;   chrome palette in `theme/tokens.cljc` is the dark one)
+;; - theme default `:light` (rf2-3f2di — the authoritative reference
+;;   `tools/causa/design-reference/causa_devtools_reference.cljs` renders
+;;   light by default; Causa boots onto the same default. Both palettes
+;;   exist in `theme/tokens.cljc` and the user can flip to dark.)
 ;; - text-size default 13 (matches `theme/tokens.cljc :type-scale
 ;;   :body` — the popup's slider is the one knob that scales every
 ;;   subsequent inline-style reads via the published CSS custom
@@ -772,7 +774,7 @@
                ;; chrome on demand. Additive to the OS detection —
                ;; both paths produce the same painted chrome.
                :use-system-colors?      false}
-   :theme     :dark                                  ; :dark | :light
+   :theme     :light                                 ; :light | :dark (rf2-3f2di — light default per the authority reference)
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:retained-epochs                    200
                :trace-buffer/keep                  1000

--- a/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
@@ -1,12 +1,20 @@
 (ns day8.re-frame2-causa.filters.pills
   "Top-ribbon IN/OUT filter pills for Causa (rf2-ak4ms).
 
-  Per `tools/causa/spec/018-Event-Spine.md` §3 + §7 the L1 ribbon
-  carries a filter cluster — IN pills (green `+`) + OUT pills (magenta
-  `×`) + trailing `[ + ]` add-pill. Clicking any pill opens the rich
-  edit popup (see `filters/edit_popup.cljs`); clicking `×` on a pill
-  removes it without round-tripping through the popup. The trailing
-  add-pill opens the popup empty + defaulted to IN.
+  Per `tools/causa/spec/018-Event-Spine.md` §3 + §7 the ribbon carries
+  a filter cluster — IN pills (green-bordered `+`) + OUT pills (red-
+  bordered `×`) per the authoritative reference events-ribbon
+  (rf2-3f2di A6). Clicking any pill opens the rich edit popup (see
+  `filters/edit_popup.cljs`); clicking `×` on a pill removes it without
+  round-tripping through the popup. The `[ + ]` add-pill opens the popup
+  empty + defaulted to IN.
+
+  ## rf2-3f2di A5 — two-bar split
+
+  The committed pills (`pills-view`) live on bar-2 (the events ribbon);
+  the add(+) affordance (`add-pill`) is mounted separately on bar-1 (the
+  chrome ribbon) beside the `Filters:` label, matching the reference
+  chrome-ribbon / events-ribbon split.
 
   ## Replaces #1397's window.prompt stub
 
@@ -47,7 +55,12 @@
   (case mode :in "+" :out "×"))
 
 (defn- pill-tone [mode]
-  (case mode :in (:green tokens) :out (:magenta tokens)))
+  ;; rf2-3f2di A6 — green-bordered include (`:in`) pills, red-bordered
+  ;; exclude (`:out`) pills, per the authoritative reference events-ribbon
+  ;; (`border: 1px solid var(--devtools-success)` for include,
+  ;; `--devtools-error` for exclude). Supersedes the prior magenta OUT
+  ;; tone; `:success`/`:error` are the reference's green/red tokens.
+  (case mode :in (:success tokens) :out (:error tokens)))
 
 (defn- format-pattern
   "Render the pill's pattern text. Keywords render with their leading
@@ -115,13 +128,18 @@
         body-text   (pill-display pill)]
     [:span {:data-testid testid
             :data-pill-kind (name kind)
+            ;; rf2-3f2di A6 — reference events-ribbon pill shape:
+            ;; `border-radius 4px`, `border 1px solid <tone>` (green for
+            ;; include, red for exclude), transparent bg, tone-coloured
+            ;; text + an `x` to remove.
             :style {:display        "inline-flex"
                     :align-items    "center"
                     :gap            "4px"
                     :border         (str "1px solid " tone)
+                    :background     "transparent"
                     :color          tone
                     :padding        "1px 4px 1px 8px"
-                    :border-radius  "10px"
+                    :border-radius  "4px"
                     :font-family    mono-stack
                     :font-size      (:caption type-scale)
                     :white-space    "nowrap"}}
@@ -176,9 +194,15 @@
 
 ;; ---- add-pill affordance -------------------------------------------------
 
-(defn- add-pill
-  "Trailing `[ + ]` affordance — opens the edit popup empty +
-  defaulted to IN per spec/018 §7 'Trailing +'."
+(defn add-pill
+  "The `[ + ]` add-filter affordance — opens the edit popup empty +
+  defaulted to IN per spec/018 §7 'Trailing +'.
+
+  rf2-3f2di A5 — promoted to the bar-1 chrome ribbon (beside the
+  `Filters:` label) per the authoritative reference chrome-ribbon, which
+  carries the add(+) on bar-1 while the committed pills live on bar-2
+  (the events ribbon). Public so the shell mounts it directly in the
+  chrome ribbon's left cluster."
   []
   [:button {:data-testid "rf-causa-filter-add"
             :on-click    #(rf/dispatch
@@ -199,7 +223,7 @@
                           :color         (:text-tertiary tokens)
                           :cursor        "pointer"
                           :padding       "2px 8px"
-                          :border-radius "10px"
+                          :border-radius "4px"
                           :font-family   sans-stack
                           :font-size     (:caption type-scale)
                           :white-space   "nowrap"}}
@@ -219,22 +243,27 @@
          " / OUT: " out-n " " (word out-n))))
 
 (defn pills-view
-  "The full ribbon filter cluster — IN pills, then OUT pills, then the
-  add-pill. Reads `:rf.causa/active-filters` via the caller; the
-  caller is expected to be inside a `reg-view` so subscribes resolve
-  to `:rf/causa`."
+  "The committed filter pills cluster — green-bordered IN pills, then
+  red-bordered OUT pills (rf2-3f2di A6). Reads `:rf.causa/active-filters`
+  via the caller; the caller is expected to be inside a `reg-view` so
+  subscribes resolve to `:rf/causa`.
+
+  rf2-3f2di A5 — the add(+) affordance is NO LONGER part of this
+  cluster: per the authoritative reference the committed pills live on
+  bar-2 (the events ribbon) while the add(+) sits on bar-1 (the chrome
+  ribbon, beside the `Filters:` label). The shell mounts `add-pill`
+  directly in the chrome ribbon's left cluster and `pills-view` in the
+  events ribbon."
   [{:keys [filters]}]
   [:div {:data-testid "rf-causa-ribbon-filters"
          :title (counts-tooltip filters)
          :style {:display     "flex"
                  :align-items "center"
                  :gap         "6px"
-                 :flex        "1 1 auto"
                  :flex-wrap   "wrap"}}
    (for [[idx p] (map-indexed vector (:in filters))]
      ^{:key (str "in-" idx)}
      [pill {:mode :in :pill p :idx idx}])
    (for [[idx p] (map-indexed vector (:out filters))]
      ^{:key (str "out-" idx)}
-     [pill {:mode :out :pill p :idx idx}])
-   [add-pill]])
+     [pill {:mode :out :pill p :idx idx}])])

--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -14,10 +14,11 @@
     portals) inherits the value.
 
   - **theme** — toggled as a CSS class on the Causa shell root.
-    `rf-causa-theme-light` vs `rf-causa-theme-dark`. Default panels
-    sit on the dark tokens; the light-theme variant is a follow-on
-    styling pass — the class lands so a future stylesheet can
-    target it.
+    `rf-causa-theme-light` vs `rf-causa-theme-dark`. Default is
+    `:light` (rf2-3f2di — the authoritative reference renders light by
+    default); both palettes resolve via the `var(--rf-causa-*)` block
+    `theme/global-styles/themes-css` emits, so the class toggle flips
+    the whole shell in one assignment.
 
   - **panel-position** — routes to existing mount-layer fns:
     `:right-rail` is the default inline mount; `:popout` opens the
@@ -231,7 +232,7 @@
   `<html>` element with `rf-causa-theme-<name>`. No-op when neither
   element is present."
   [theme]
-  (let [klass (str theme-class-prefix (name (or theme :dark)))]
+  (let [klass (str theme-class-prefix (name (or theme :light)))]
     (doseq [el [(shell-root-element) (html-root-element)]
             :when el]
       (let [cl (.-classList el)]

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -397,9 +397,11 @@
 
 (def ^:private l2-time-col-min-width
   "Min-width / right-aligned slot for the `timestamp` column — shared
-  by the header `timestamp` label and every row's relative-time chip so
-  the two right-align on the same edge."
-  "44px")
+  by the header `timestamp` label and every row's absolute-time value so
+  the two right-align on the same edge. Sized (rf2-3f2di A8) to hold the
+  `HH:MM:SS.mmm` absolute clock string (`12:30:05.123`) without
+  wrapping; the prior 44px held only the relative `1s`/`now` chip."
+  "76px")
 
 (def ^:private l2-duration-col-min-width
   "Min-width / right-aligned slot for the trailing `duration` column
@@ -474,12 +476,48 @@
         (< s 86400)       (str (quot s 3600) "h")
         :else             (str (quot s 86400) "d")))))
 
+(defn- pad2
+  "Left-pad an integer to two digits with a leading zero. Pure-data;
+  JVM-portable."
+  [n]
+  (if (< n 10) (str "0" n) (str n)))
+
+(defn- pad3
+  "Left-pad an integer to three digits with leading zeros (for the
+  millisecond field). Pure-data; JVM-portable."
+  [n]
+  (cond
+    (< n 10)  (str "00" n)
+    (< n 100) (str "0" n)
+    :else     (str n)))
+
+(defn format-clock-time
+  "CLJS-side helper (rf2-3f2di A8). Given an epoch-ms (the cascade's
+  dispatched `:time`), returns the ABSOLUTE wall-clock string the L2
+  `timestamp` column renders — `HH:MM:SS.mmm` (e.g. `12:30:05.123`) per
+  the authoritative reference event-list (`tools/causa/design-reference/
+  causa_devtools_reference.cljs`, which renders absolute timestamps like
+  `12:30:05.123`, NOT relative `1s`/`now` chips).
+
+  Uses the LOCAL-time components (`getHours` / `getMinutes` /
+  `getSeconds` / `getMilliseconds`) so the column reads in the operator's
+  timezone. Returns the empty string when `then-ms` is nil or `js/Date`
+  is unavailable so the caller can decide whether to render anything."
+  [then-ms]
+  (if (or (nil? then-ms) (not (exists? js/Date)))
+    ""
+    (let [d (js/Date. then-ms)]
+      (str (pad2 (.getHours d)) ":"
+           (pad2 (.getMinutes d)) ":"
+           (pad2 (.getSeconds d)) "."
+           (pad3 (.getMilliseconds d))))))
+
 (defn format-absolute-time
   "CLJS-side helper. Given an epoch-ms (the cascade's dispatched
   `:time`), returns an absolute-time tooltip string for the chip's
   `:title` attribute. Used as the power-user reveal that complements
-  the relative chip — clicking the row still opens the Event lens, but
-  a hover shows the precise walltime + epoch-ms.
+  the `HH:MM:SS.mmm` clock column — clicking the row still opens the
+  Event lens, but a hover shows the full ISO walltime + epoch-ms.
 
   Returns the empty string when `then-ms` is nil so the caller can
   decide whether to attach the tooltip."
@@ -502,26 +540,27 @@
     (when (number? t) t)))
 
 (defn relative-time-chip
-  "Render the L2 row's right-aligned relative-time chip. `now-ms` is the
-  anchor supplied by the L2 view — sourced from the
-  `:rf.causa/relative-time-now-ms` sub (dispatched-time of the most
-  recent cascade, per rf2-0s2at; flips on event arrival, not on a
-  per-second tick). Renders nothing when the cascade carries no
-  dispatched-time stamp."
-  [cascade now-ms]
+  "Render the L2 row's right-aligned `timestamp` column. Per rf2-3f2di
+  A8 this renders the ABSOLUTE wall-clock time (`HH:MM:SS.mmm`, e.g.
+  `12:30:05.123`) per the authoritative reference event-list — NOT a
+  relative `1s`/`now` chip. The `now-ms` anchor is no longer consumed for
+  the label (absolute time needs no anchor); the parameter is retained
+  for call-site stability and ignored. The chip's `:title` carries the
+  full ISO walltime + epoch-ms as the power-user reveal.
+
+  Renders nothing when the cascade carries no dispatched-time stamp."
+  [cascade _now-ms]
   (when-let [then-ms (cascade-dispatched-time-ms cascade)]
-    (let [now      (or now-ms (interop/now-ms))
-          label    (format-relative-time now then-ms)
-          tooltip  (format-absolute-time then-ms)]
+    (let [label   (format-clock-time then-ms)
+          tooltip (format-absolute-time then-ms)]
       [:span {:data-testid     "rf-causa-row-time-chip"
               :data-then-ms    (str then-ms)
               :title           tooltip
               ;; rf2-ad7zx.15 — the trailing time column. Shares the
               ;; header `timestamp` column's right-aligned min-width slot
-              ;; (`l2-time-col-min-width`) so the chip right-aligns under
+              ;; (`l2-time-col-min-width`) so the value right-aligns under
               ;; the header label. Spacing from the preceding column comes
-              ;; from the row's shared flex `gap` — no extra `margin-left`,
-              ;; which used to push the chip 4px past the header column.
+              ;; from the row's shared flex `gap`.
               :style {:color         (:text-tertiary tokens)
                       :flex-shrink   0
                       :font-family   mono-stack
@@ -591,34 +630,38 @@
     snap is a true no-op. When at head but PAUSED (frozen inspection)
     `»` stays enabled — pressing it resumes LIVE, which is not a no-op.
 
-  ## rf2-cplj8 — borderless lucide chevron buttons
+  ## rf2-3f2di A2 — blue-filled chevron buttons
 
-  Per the Figma EventsRibbon the nav cluster is three BORDERLESS
-  icon-buttons (`p-1 rounded hover:bg`) carrying thin
-  ChevronLeft/Right/ChevronsRight icons — NOT bordered unicode
-  triangles. Inline SVG is not idiomatic in this pure-hiccup view, so
-  the buttons keep glyphs but swap the chunky filled triangles
-  (`◀ ▶ ⏭`) for the angle-quotation chevrons (`‹ › »`, U+2039 / U+203A
-  / U+00BB) which read as lucide's thin strokes. The bordered pill
-  becomes a square rounded hit-area with a testid-keyed `hover:bg`
-  (the `:hover` lift lives in `theme/global-styles/motion-css`).
+  Per the authoritative reference chrome-ribbon
+  (`tools/causa/design-reference/causa_devtools_reference.cljs`) the nav
+  cluster is three FILLED `:accent` buttons (blue bg, white icon,
+  `p-1 rounded`, hover lifts opacity 0.9 → 1) carrying the
+  ChevronLeft/Right/ChevronsRight glyphs — NOT borderless icon-buttons,
+  NOT bordered unicode triangles. Inline SVG is not idiomatic in this
+  pure-hiccup view, so the buttons keep glyphs but swap the chunky
+  filled triangles (`◀ ▶ ⏭`) for the angle-quotation chevrons
+  (`‹ › »`, U+2039 / U+203A / U+00BB) which read as the reference's thin
+  strokes. (rf2-3f2di supersedes the rf2-cplj8 borderless treatment.)
 
-  ## Disabled appearance (rf2-x5tro / rf2-cplj8)
+  ## Disabled appearance (rf2-x5tro / rf2-3f2di)
 
   A disabled button must READ as inert, not merely block clicks. With
-  the borderless treatment there is no border/background to dim, so the
-  inert signal is the muted `:text-tertiary` ink + reduced opacity +
-  `cursor: not-allowed`. The native `:disabled` attribute (plus the
-  dropped `:on-click` per rf2-fzbrw) blocks interaction; the inline
-  style + `aria-disabled` carry the visual + a11y signal.
+  the blue-filled treatment the inert signal is a strong opacity drop
+  (the filled blue fades) + `cursor: not-allowed`. The native
+  `:disabled` attribute (plus the dropped `:on-click` per rf2-fzbrw)
+  blocks interaction; the inline style + `aria-disabled` carry the
+  visual + a11y signal.
 
   (rf2-htik0 P1 — earlier wiring had the head/tail boundaries flipped
   so the disabled glyph dimmed the wrong button.)"
   [{:keys [at-head? at-tail? live?]}]
   (let [head-disabled? (boolean (and at-head? live?))
-        btn-style {:background      "transparent"
+        ;; rf2-3f2di A2 — filled `:accent` buttons (reference chrome-
+        ;; ribbon): blue bg, white icon, 4px radius, hover opacity lift
+        ;; (the `:hover` rule lives in `theme/global-styles/motion-css`).
+        btn-style {:background      (:accent tokens)
                    :border          "none"
-                   :color           (:text-primary tokens)
+                   :color           (:white tokens)
                    :cursor          "pointer"
                    :opacity         1
                    :padding         "0"
@@ -631,12 +674,10 @@
                    :font-family     sans-stack
                    :font-size       "15px"
                    :line-height     "1"}
-        ;; rf2-cplj8 — borderless inert state: no border/bg to dim, so
-        ;; the muted ink + reduced opacity + `not-allowed` cursor carry
-        ;; the signal. The native `:disabled` attribute already blocks
-        ;; clicks at the DOM layer (rf2-fzbrw).
-        disabled-style {:color   (:text-tertiary tokens)
-                        :opacity 0.4
+        ;; rf2-3f2di — filled inert state: the blue fill fades + the
+        ;; `not-allowed` cursor carries the signal. The native
+        ;; `:disabled` attribute already blocks clicks (rf2-fzbrw).
+        disabled-style {:opacity 0.4
                         :cursor  "not-allowed"}]
     [:div {:data-testid "rf-causa-ribbon-nav"
            :style {:display "flex" :align-items "center" :gap "2px"}}
@@ -917,23 +958,68 @@
                :style       icon-style}
       [:span {:aria-hidden "true"} "✕"]]]))
 
+(defn nav-boundary-state
+  "Pure helper (rf2-3f2di A5) — compute the `{:at-head? :at-tail? :live?
+  :focused-cascade}` state the nav cluster + focus button consume, from
+  the already-resolved sub values. Extracted so the chrome ribbon (which
+  now hosts the nav cluster per the authority reference) and any test
+  can derive the boundary state without re-subscribing. Mirrors the
+  boundary walk the events ribbon previously did inline.
+
+  - `focus` — `:rf.causa/focus` (carries `:dispatch-id` + `:mode` +
+    `:paused?`).
+  - `cascades` — `:rf.causa/filtered-cascades` (frame view-scope + pills
+    + mutes already applied).
+  - `focus-set` — `:rf.causa/focus-set` (when active, nav walks ONLY the
+    in-focus subset).
+  - `show-ungrouped?` — `:rf.causa/show-ungrouped?` (the L2 visibility
+    predicate must agree with what the user sees).
+
+  Pure-data → map; JVM-runnable so the boundary logic is testable
+  without a CLJS runtime."
+  [{:keys [focus cascades focus-set show-ungrouped?]}]
+  (let [focused-id      (:dispatch-id focus)
+        event-cascades  (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
+        ;; rf2-cplj8 — the currently-focused cascade drives the always-
+        ;; present blue `focus` button; falls back to the most-recent
+        ;; event-cascade so the button is actionable in default LIVE-at-
+        ;; head (where `focused-id` is nil — the spine auto-tracks head).
+        focused-cascade (or (some #(when (= focused-id (:dispatch-id %)) %)
+                                  event-cascades)
+                            (last event-cascades))
+        ids             (if focus-set
+                          (fh/in-focus-ids event-cascades focus-set)
+                          (mapv :dispatch-id event-cascades))
+        at-head?        (or (empty? ids)
+                            (= focused-id (last ids))
+                            (and (nil? focused-id) (not focus-set)))
+        at-tail?        (or (empty? ids)
+                            (= focused-id (first ids)))
+        live?           (and (= :live (:mode focus))
+                             (not (:paused? focus)))]
+    {:at-head?        at-head?
+     :at-tail?        at-tail?
+     :live?           live?
+     :focused-cascade focused-cascade}))
+
 (rf/reg-view ribbon
-  "L1 **chrome ribbon** — the top stratum per rf2-4vp5j's two-ribbon
-  redesign. Compact (`:top-strip-height`, lowered to 40px) because it
-  now carries only scope SELECTORS on the left and chrome ACTIONS on
-  the right:
+  "L1 **chrome ribbon** (bar-1) — reconciled to the authoritative
+  reference chrome-ribbon (`tools/causa/design-reference/causa_devtools_
+  reference.cljs`, rf2-3f2di A4/A5). 34px tall (`:top-strip-height`).
 
-    - **LEFT** — the Frame dropdown (`frame-switcher/frame-switcher-
-      view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`).
-      Both share one compact control style so they read as a single
-      selector stratum.
-    - **RIGHT** — the mute (🔇 N) + REDACTED (● N) silent-by-default
-      indicators, then the `⚙` settings + `✕` close icon-buttons.
+    - **LEFT** — the `Events` label (the reference leads with it; the
+      `❖ Causa` wordmark was DROPPED per A4), the `[◀ ▶ ⏭]` blue-filled
+      nav cluster (A2), the always-present blue `focus` button + the
+      focus-chip (Causa spine controls, grouped with the nav), then the
+      `Filters:` label + the `[ + ]` add-pill (A5).
+    - **RIGHT** — the Frame dropdown (`frame-switcher/frame-switcher-
+      view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`)
+      + the mute (🔇 N) / REDACTED (● N) silent-by-default indicators +
+      the `⚙` settings · `✕` close icon-buttons.
 
-  The nav cluster (`[◀ ▶ ⏭]`), the focus-chip, and the filter pills
-  moved DOWN to the events ribbon (`events-ribbon`) — they are
-  spine/filter chrome, not scope selectors. Moving them out is what
-  buys the compacted height.
+  The committed filter pills (green/red) live on bar-2 (the events
+  ribbon, `events-ribbon`); only the add(+) sits up here, matching the
+  reference's chrome-ribbon (add) / events-ribbon (pills) split.
 
   The 2-px left-edge accent stripe (rf2-o5f5f.1 mode-signal mechanism
   #2 — the single GitHub-blue accent in both modes, rf2-ad7zx.13) stays
@@ -949,7 +1035,20 @@
         ;; count sub (not the raw set) means the ribbon re-renders only
         ;; when the count changes; the indicator's click opens the
         ;; unmute manager.
-        muted-count    @(rf/subscribe [:rf.causa/muted-event-ids-count])]
+        muted-count    @(rf/subscribe [:rf.causa/muted-event-ids-count])
+        ;; rf2-3f2di A5 — the nav cluster + focus button + focus-chip +
+        ;; pills moved UP to the chrome ribbon per the authority
+        ;; reference, so the chrome ribbon now subscribes to the spine /
+        ;; filter state the events ribbon used to own.
+        focus          @(rf/subscribe [:rf.causa/focus])
+        cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
+        focus-set      @(rf/subscribe [:rf.causa/focus-set])
+        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
+        {:keys [at-head? at-tail? live? focused-cascade]}
+        (nav-boundary-state {:focus           focus
+                             :cascades        cascades
+                             :focus-set       focus-set
+                             :show-ungrouped? show-ungrouped?})]
     [:div {:data-testid "rf-causa-ribbon"
            :style {:display          "flex"
                    :align-items      "center"
@@ -971,48 +1070,53 @@
                                           (static-shell/stripe-hex-for-mode :dynamic))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
-     ;; LEFT cluster — the `❖ Causa` wordmark, then the scope selectors
-     ;; (Frame + Dynamic/Static), one shared compact control style so the
-     ;; selectors read as one stratum.
+     ;; LEFT cluster — `Events` label · nav · focus button · focus-chip ·
+     ;; `Filters:` · add(+). Per the authority reference chrome-ribbon
+     ;; (rf2-3f2di A4/A5). The `❖ Causa` wordmark was dropped (A4); the
+     ;; cluster now leads with the `Events` label.
      [:div {:data-testid "rf-causa-ribbon-selectors"
-            :style {:display "flex" :align-items "center" :gap "8px"}}
-      ;; rf2-ad7zx.12 + rf2-cplj8 — the `❖ Causa` wordmark, top-left of the
-      ;; chrome ribbon per the Figma design-reference (the `chrome-ribbon`
-      ;; component in `design-reference/causa_devtools_reference.cljs`).
-      ;; Semibold, `:body-tight`, NEUTRAL
-      ;; `:text-primary` ink (`text-[var(--devtools-text)]`) — the Figma
-      ;; ChromeRibbon renders the wordmark + glyph in the chrome text
-      ;; colour, NOT the `:accent` blue. The single accent is reserved for
-      ;; ACTIVE/selected affordances (tab fill, focus button); spending it
-      ;; on the static wordmark dilutes that signal. `aria-hidden` on the
-      ;; decorative `❖` glyph keeps the wordmark from announcing its
-      ;; unicode name.
-      [:div {:data-testid "rf-causa-ribbon-logo"
-             :style {:display      "flex"
-                     :align-items  "center"
-                     :gap          "5px"
-                     :color        (:text-primary tokens)
-                     :font-family  sans-stack
-                     :font-size    (:body-tight type-scale)
-                     :font-weight  600
-                     :white-space  "nowrap"
-                     :user-select  "none"}}
-       [:span {:aria-hidden "true"} "❖"]
-       [:span "Causa"]]
+            :style {:display "flex" :align-items "center" :gap "13px"
+                    :flex-wrap "wrap"}}
+      ;; rf2-3f2di A4 — `Events` label leads the left cluster (reference
+      ;; chrome-ribbon left side: `text-[var(--devtools-text)] font-medium`).
+      [:span {:data-testid "rf-causa-ribbon-events-label"
+              :style {:color       (:text-primary tokens)
+                      :font-family sans-stack
+                      :font-weight 500
+                      :white-space "nowrap"}}
+       "Events"]
+      ;; rf2-3f2di A2/A5 — blue-filled nav cluster, promoted to bar-1.
+      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail? :live? live?}]
+      ;; Causa spine controls — the always-present blue `focus` button
+      ;; (focuses the selected cascade's dimension) + the focus-chip
+      ;; (state display of the active focus-set). Grouped with the nav
+      ;; cluster because they are spine navigation, not scope selectors.
+      [ribbon-focus-button {:focused-cascade focused-cascade}]
+      [ribbon-focus-chip {:focus-set focus-set}]
+      ;; rf2-3f2di A5 — `Filters:` label + the add(+) affordance (the
+      ;; committed pills live on bar-2). Reference chrome-ribbon left
+      ;; side: `Filters:` muted label then the `+` add button.
+      [:span {:data-testid "rf-causa-ribbon-filters-label"
+              :style {:color       (:text-secondary tokens)
+                      :font-family sans-stack
+                      :white-space "nowrap"}}
+       "Filters:"]
+      [filter-pills/add-pill]]
+     ;; RIGHT cluster — scope selectors (Frame + Dynamic/Static) then the
+     ;; silent-by-default indicators + chrome actions. Per the authority
+     ;; reference chrome-ribbon right side (rf2-3f2di A5).
+     [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
       ;; L1 frame-switcher slot (rf2-iwwou) — single contractually-
       ;; anchored surface. The view itself reads `:rf.causa/current-
       ;; frame` + `:rf.causa/available-frames` and writes via
-      ;; `:rf.causa/select-frame` — no ad-hoc frame access from the
-      ;; ribbon. See `frame_switcher.cljs` for the contract. The frame
-      ;; is a view SCOPE, not a filter (rf2-4vp5j Workstream C).
+      ;; `:rf.causa/select-frame`. The frame is a view SCOPE, not a
+      ;; filter (rf2-4vp5j Workstream C).
       [frame-switcher/frame-switcher-view]
-      ;; Dynamic/Static dropdown (rf2-4vp5j) — compact, understated;
-      ;; the accent stripe carries the mode signal so the control
-      ;; itself stays quiet. Always rendered (the `:rf.causa/static-
-      ;; mode?` feature gate was removed per rf2-8l3uk).
-      [mode-pill/mode-pill]]
-     ;; RIGHT cluster — silent-by-default indicators + chrome actions.
-     [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+      ;; Dynamic/Static dropdown (rf2-4vp5j) — compact, understated; the
+      ;; accent stripe carries the mode signal so the control stays
+      ;; quiet. Always rendered (the `:rf.causa/static-mode?` feature
+      ;; gate was removed per rf2-8l3uk).
+      [mode-pill/mode-pill]
       ;; rf2-ikuwt — mute indicator (🔇 N) renders inline next to the
       ;; REDACTED indicator. Both are silent-by-default surfaces that
       ;; only paint when their count is positive. Click → unmute
@@ -1640,18 +1744,18 @@
 ;; one-click reset (`:rf.causa/clear-all-filters`).
 
 (defn filters-hidden-message
-  "Pure hiccup. The `N events hidden by filters` count — the RIGHT-side
-  signal of the events ribbon, sitting beside `Clear Filters`. Renders
-  nil unless the hidden count is positive (`:visible?`). Keeps rf2-jvghz's
-  prominent yellow accent. Counts pill/mute suppression ONLY — the frame
-  is a view scope, never counted as hidden (rf2-4vp5j Workstream C).
+  "Pure hiccup. The `N events filtered out` warning count — the LEADING
+  signal of the events ribbon (bar-2), sitting before the committed
+  filter pills. Renders nil unless the hidden count is positive
+  (`:visible?`). Counts pill/mute suppression ONLY — the frame is a view
+  scope, never counted as hidden (rf2-4vp5j Workstream C).
 
-  rf2-ad7zx.18 — per the Figma mock (the `events-ribbon` component in
-  `design-reference/causa_devtools_reference.cljs`) the hidden-state is a plain count beside `Clear
-  Filters`; it no longer re-renders the active pills/mute as cause chips.
-  The committed pills already live in the LEFT cluster (via
-  `ribbon-filter-pills` → `filters.pills/pills-view`); re-rendering them
-  here duplicated every pill in front of `Clear Filters`."
+  rf2-3f2di A5 — reconciled to the authoritative reference events-ribbon
+  (`tools/causa/design-reference/causa_devtools_reference.cljs`): the
+  warning reads `\"N events filtered out\"` in the `:warning` colour
+  (reference `--devtools-warning`, `font-medium`), leading the bar-2
+  cluster ahead of the green/red pills. (Supersedes the prior rf2-jvghz
+  `N events hidden by filters` yellow chip on the right.)"
   [{:keys [hidden visible?] :as _summary}]
   (when visible?
     [:div {:data-testid "rf-causa-filters-hidden-indicator"
@@ -1662,8 +1766,8 @@
                    :font-size   (:caption type-scale)
                    :color       (:text-primary tokens)}}
      [:span {:data-testid "rf-causa-filters-hidden-count"
-             :style {:font-weight 600 :color (:yellow tokens) :white-space "nowrap"}}
-      (str hidden " event" (when (not= 1 hidden) "s") " hidden by filters")]]))
+             :style {:font-weight 500 :color (:warning tokens) :white-space "nowrap"}}
+      (str hidden " event" (when (not= 1 hidden) "s") " filtered out")]]))
 
 (defn- clear-filters-button
   "Restrained outline `Clear Filters` button — resets pills + mutes (NOT
@@ -1687,75 +1791,43 @@
    "Clear Filters"])
 
 (rf/reg-view events-ribbon
-  "L1.5 **events ribbon** (rf2-4vp5j) — the second stratum below the
-  chrome ribbon. LEFT → RIGHT: `Events:` label · the `[◀ ▶ ⏭]` nav
-  cluster · the focus-chip · the active filter pills + add-pill widget.
-  FAR RIGHT (only when a filter is active): the `N hidden` message +
-  the `Clear Filters` button.
+  "L1.5 **events ribbon** (bar-2) — reconciled to the authoritative
+  reference events-ribbon (`tools/causa/design-reference/causa_devtools_
+  reference.cljs`, rf2-3f2di A5/A6). The second stratum below the chrome
+  ribbon. LEFT → RIGHT:
 
-  The nav cluster, focus-chip, and filter pills moved here from the
-  chrome ribbon (they are spine/filter chrome, not scope selectors).
-  Boundary detection for the nav cluster is computed here against the
-  same `l2-cascade-visible?` visible-row set the L2 list renders.
+    - the `N events filtered out` warning text (when N > 0), in the
+      `:warning` colour;
+    - the committed green-bordered IN pills + red-bordered OUT pills
+      (`filter-pills/pills-view`, A6);
+    - FAR RIGHT (only when a filter is active): the `Clear Filters`
+      button (Causa wiring — one-click reset of every pill + mute).
 
-  Visibility of the right-side action cluster (rf2-4vp5j Decision 3):
-    - both absent in the clean/default state (no pills, no mutes);
+  The nav cluster, focus button, focus-chip, and the add(+) affordance
+  moved UP to the chrome ribbon (bar-1) per the reference's chrome-ribbon
+  / events-ribbon split (rf2-3f2di A5). This bar now carries ONLY the
+  filtered-out warning + the committed pills + the reset action.
+
+  Visibility (rf2-4vp5j Decision 3, preserved):
+    - the bar renders its background/hairline always (it is a fixed
+      stratum), but its content is empty in the clean/default state (no
+      pills, no warning, no Clear Filters);
     - `Clear Filters` shows when ANY filter is active (`:any-active?`);
-    - the `N hidden` message shows beside it only when N > 0
-      (`:visible?`) — an active filter that hides nothing → button
-      present, message absent.
+    - the `N filtered out` warning shows only when N > 0 (`:visible?`).
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`. A distinct `bg-2` background + `border-subtle` hairline
   separate it from the chrome ribbon's `bg-1` as a distinct layer."
   []
-  (let [focus           @(rf/subscribe [:rf.causa/focus])
-        ;; rf2-4vp5j — boundary detection walks the FILTERED cascade
-        ;; list (frame view-scope + pills + mutes) so the `[◀ ▶]`
-        ;; disabled glyphs match exactly what the user sees in L2.
-        cascades        @(rf/subscribe [:rf.causa/filtered-cascades])
-        focus-set       @(rf/subscribe [:rf.causa/focus-set])
-        filters         @(rf/subscribe [:rf.causa/active-filters])
+  (let [filters         @(rf/subscribe [:rf.causa/active-filters])
         hidden-summary  @(rf/subscribe [:rf.causa/hidden-by-filters])
-        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
-        ;; bucket. The boundary walk MUST agree with what the user
-        ;; sees in L2, so it composes against the same
-        ;; `l2-cascade-visible?` predicate the L2 list uses.
-        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
-        focused-id      (:dispatch-id focus)
-        event-cascades  (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
-        ;; rf2-cplj8 — the currently-focused cascade drives the always-
-        ;; present blue `focus` button: it focuses on THIS cascade's
-        ;; inferred dimension (the ribbon-level counterpart of the per-row
-        ;; gutter gesture). Falls back to the most-recent event-cascade so
-        ;; the button is actionable in the default LIVE-at-head state where
-        ;; `focused-id` is nil (the spine auto-tracks head without pinning).
-        focused-cascade (or (some #(when (= focused-id (:dispatch-id %)) %)
-                                  event-cascades)
-                            (last event-cascades))
-        ;; rf2-a1z3b — when a focus-set is active the nav buttons walk
-        ;; ONLY the in-focus subset; boundary predicates honour that.
-        ids             (if focus-set
-                          (fh/in-focus-ids event-cascades focus-set)
-                          (mapv :dispatch-id event-cascades))
-        at-head?        (or (empty? ids)
-                            (= focused-id (last ids))
-                            (and (nil? focused-id) (not focus-set)))
-        at-tail?        (or (empty? ids)
-                            (= focused-id (first ids)))
-        ;; rf2-x5tro — `⏭` is a true no-op only when the spine is
-        ;; already tracking head LIVE (`:live` mode + unpaused). At
-        ;; head but PAUSED, `⏭` resumes LIVE, so it stays enabled.
-        live?           (and (= :live (:mode focus))
-                             (not (:paused? focus)))
         any-active?     (:any-active? hidden-summary)]
     [:div {:data-testid "rf-causa-events-ribbon"
            :role        "toolbar"
-           :aria-label  "Causa events"
+           :aria-label  "Causa filters"
            :style {:display          "flex"
                    :align-items      "center"
-                   :justify-content  "space-between"
-                   :gap              "12px"
+                   :gap              "13px"
                    :min-height       (:events-ribbon-height layout)
                    :flex-wrap        "wrap"
                    :padding          "0 12px"
@@ -1763,31 +1835,19 @@
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
-     ;; LEFT cluster — label · nav · focus button · focus-chip · pills.
-     [:div {:data-testid "rf-causa-events-ribbon-left"
-            :style {:display "flex" :align-items "center"
-                    :flex-wrap "wrap" :gap "8px"}}
-      [:span {:data-testid "rf-causa-events-ribbon-label"
-              :style {:color       (:text-secondary tokens)
-                      :font-size   (:body-tight type-scale)
-                      :white-space "nowrap"}}
-       "Events:"]
-      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail? :live? live?}]
-      ;; rf2-cplj8 — the always-present blue `focus` button (Figma
-      ;; EventsRibbon) sits right after the nav cluster, before the
-      ;; state-display focus-chip. It focuses on the current selection's
-      ;; dimension; the chip then surfaces the resulting focus-set.
-      [ribbon-focus-button {:focused-cascade focused-cascade}]
-      [ribbon-focus-chip {:focus-set focus-set}]
-      [ribbon-filter-pills {:filters filters}]]
-     ;; RIGHT cluster — hidden-count message + Clear Filters. Both
-     ;; absent in the clean state; rendered together only when a filter
-     ;; is active (Clear always when active; message only when N > 0).
+     ;; rf2-3f2di A5 — the `N events filtered out` warning leads the
+     ;; bar-2 cluster (reference events-ribbon left side), ahead of the
+     ;; pills. Renders only when N > 0.
+     (filters-hidden-message hidden-summary)
+     ;; rf2-3f2di A6 — the committed green/red filter pills.
+     [ribbon-filter-pills {:filters filters}]
+     ;; rf2-4vp5j Decision 3 — Clear Filters on the far right, only when
+     ;; a filter is active. `margin-left: auto` pushes it to the trailing
+     ;; edge regardless of pill count.
      (when any-active?
        [:div {:data-testid "rf-causa-events-ribbon-actions"
               :style {:display "flex" :align-items "center" :gap "8px"
                       :margin-left "auto"}}
-        (filters-hidden-message hidden-summary)
         [clear-filters-button]])]))
 
 ;; rf2-ad7zx.12 + rf2-lnod7 — the L2 list's column-header row, reconciled
@@ -1998,22 +2058,30 @@
 ;; ---- L3 tab bar ----------------------------------------------------------
 
 (defn- tab-button
-  "One tab in the L3 tab bar — a Figma button-bar tab, NOT a radio
-  glyph (rf2-ad7zx.16). Each tab is a rounded button; the ACTIVE tab
-  is a filled `:accent` background with white text; inactive tabs are
-  transparent with NEUTRAL muted ink (`:text-tertiary` = Figma
-  `--devtools-text-muted`, the `text-muted-foreground` of Tabs;
-  rf2-cplj8) and a subtle `:hover` background
-  fill (the hover rule lives in `theme/global-styles/motion-css`,
-  keyed off the `rf-causa-tab-*` testid, since inline styles can't
-  carry a `:hover` pseudo-class). Mirrors
-  `tools/causa/design-reference/causa_devtools_reference.cljs` (the `tabs`
-  component + the main layout's TabsList) (`px-3 py-1.5 rounded`,
-  `data-[state=active]:bg-[var(--devtools-active)]` =`:accent`,
-  `data-[state=active]:text-white`,
-  `hover:bg-[var(--devtools-hover)]` =`:hover`). The mnemonic letter is
-  exposed via the `title` attribute. The decorative `●/○` radio glyph
-  is GONE — fill + text colour carry the selected signal.
+  "One tab in the L3 tab bar — an UNDERLINE tab per the authoritative
+  reference (`tools/causa/design-reference/causa_devtools_reference.cljs`,
+  the `main-app` tab-strip, rf2-3f2di A1), NOT a radio glyph and NOT a
+  filled-accent pill. Each tab is a borderless button on a transparent
+  background:
+
+  - the ACTIVE tab carries a 2px `border-bottom` in `:accent` and the
+    NORMAL text colour (`:text-primary` = the reference
+    `text-[var(--devtools-text)]`) — the underline, not a filled fill,
+    is the selected signal;
+  - INACTIVE tabs are transparent with a 2px TRANSPARENT bottom border
+    (so the active underline never shifts the row by 2px) and NEUTRAL
+    muted ink (`:text-tertiary` = the reference `--devtools-text-muted`,
+    the `text-muted-foreground` of the reference Tabs).
+
+  The subtle `:hover` background fill lives in
+  `theme/global-styles/motion-css` (keyed off the `rf-causa-tab-*`
+  testid, since inline styles can't carry a `:hover` pseudo-class). The
+  mnemonic letter is exposed via the `title` attribute. The decorative
+  `●/○` radio glyph is GONE — the underline + text colour carry the
+  selected signal.
+
+  rf2-3f2di — the prior rf2-ad7zx.16 filled-accent pill (bg `:accent`,
+  white text) is superseded by the reference's underline treatment.
 
   `aria-label` wraps the visible label as `Causa <tab-label> tab` so the
   button's accessible name never collides with host-app role queries
@@ -2041,31 +2109,38 @@
               :on-click      #(rf/dispatch [:rf.causa/select-tab id] {:frame :rf/causa})
               :title         (str label " (" mnem ")")
               :aria-label    (str "Causa " label " tab")
-              :style {;; Active tab → filled accent background + white
-                      ;; text (Figma `data-[state=active]:bg-…/text-white`);
-                      ;; inactive → transparent with neutral muted ink
-                      ;; (`:text-tertiary`, rf2-cplj8). The `:hover` fill for
-                      ;; inactive tabs is applied via the scoped CSS rule in
-                      ;; motion-css.
-                      :background    (if active? (:accent tokens) "transparent")
+              :style {;; rf2-3f2di A1 — UNDERLINE tab per the authority
+                      ;; reference. ACTIVE → transparent bg, normal text
+                      ;; ink, 2px `:accent` bottom border (the underline);
+                      ;; INACTIVE → transparent bg, neutral muted ink, 2px
+                      ;; TRANSPARENT bottom border (so the active
+                      ;; underline never shifts the row 2px). The `:hover`
+                      ;; fill for inactive tabs is applied via the scoped
+                      ;; CSS rule in motion-css.
+                      :background    "transparent"
                       :border        "none"
-                      :border-radius "6px"          ; Tailwind `rounded`
-                      ;; rf2-cplj8 — inactive tabs use NEUTRAL muted ink
-                      ;; (`:text-tertiary` = Figma `--devtools-text-muted`,
-                      ;; the `text-muted-foreground` the Tabs TabsList
-                      ;; carries) rather than the brighter blue-ish
-                      ;; `:text-secondary`. The muted ink lets the active
-                      ;; tab's filled-accent fill be the only bright signal.
+                      ;; The selected signal is the 2px accent underline
+                      ;; (reference `main-app` tab-strip:
+                      ;; `border-bottom: 2px solid var(--devtools-active)`
+                      ;; when active, `2px solid transparent` otherwise).
+                      :border-bottom (if active?
+                                       (str "2px solid " (:accent tokens))
+                                       "2px solid transparent")
+                      ;; ACTIVE → normal text ink (reference
+                      ;; `text-[var(--devtools-text)]` = `:text-primary`);
+                      ;; INACTIVE → neutral muted ink (`:text-tertiary` =
+                      ;; reference `--devtools-text-muted`).
                       :color         (if active?
-                                       (:white tokens)
+                                       (:text-primary tokens)
                                        (:text-tertiary tokens))
                       :cursor        "pointer"
-                      :padding       "6px 12px"     ; Tailwind `px-3 py-1.5`
+                      :padding       "0 16px"       ; reference `px-4`, full-height
+                      :height        "100%"
                       :font-family   sans-stack
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
                       :white-space   "nowrap"
-                      :transition    "background-color 120ms ease-out, color 120ms ease-out"}}
+                      :transition    "border-color 120ms ease-out, color 120ms ease-out"}}
      label]))
 
 (rf/reg-view tab-bar
@@ -2090,11 +2165,15 @@
     [:div {:data-testid "rf-causa-tab-bar"
            :role        "tablist"
            :aria-label  "Causa panel tabs"
+           ;; rf2-3f2di A1 — `align-items: stretch` + `gap: 0` so the
+           ;; full-height underline tabs (reference `main-app` tab-strip)
+           ;; sit flush and their 2px accent bottom-border lands on the
+           ;; bar's bottom edge. Height matches the 34px ribbon rhythm.
            :style {:display       "flex"
-                   :align-items   "center"
-                   :gap           "4px"
-                   :height        "40px"
-                   :padding       "0 8px"
+                   :align-items   "stretch"
+                   :gap           "0"
+                   :height        "34px"
+                   :padding       "0 12px"
                    :background    (:bg-1 tokens)
                    :border-top    (str "1px solid " (:border-subtle tokens))
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
@@ -2208,14 +2287,17 @@
 ;; discipline as the rest of the shell.
 
 (rf/reg-view dynamic-chrome
-  "The Dynamic chrome wrapped as a single component. Per rf2-4vp5j the
-  top splits into two strata — the **chrome ribbon** (`ribbon`: Frame +
-  Dynamic/Static dropdowns, `⚙`/`✕`) and the **events ribbon**
-  (`events-ribbon`: `Events:` + nav + focus-chip + pills, and the
-  hidden-count + Clear Filters on the right) — above the L2 event list,
-  L3 tab bar, and L4 detail panel. Extracted from the inline
-  composition in `shell-view` so the Static surface can swap in
-  alongside it via the mode composer (rf2-o5f5f.1).
+  "The Dynamic chrome wrapped as a single component. Per rf2-3f2di the
+  top splits into two strata reconciled to the authority reference — the
+  **chrome ribbon** (`ribbon`, bar-1: `Events` label + blue-filled nav +
+  focus button + focus-chip + `Filters:` + add(+) on the left; Frame +
+  Dynamic/Static dropdowns + indicators + `⚙`/`✕` on the right) and the
+  **events ribbon** (`events-ribbon`, bar-2: the `N events filtered out`
+  warning + the green/red committed pills, with Clear Filters on the
+  right when active) — above the L2 event list, L3 tab bar, and L4
+  detail panel. Extracted from the inline composition in `shell-view` so
+  the Static surface can swap in alongside it via the mode composer
+  (rf2-o5f5f.1).
 
   Per rf2-in6l2 `reg-view`-registered for parity with every other
   shell region."

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -175,15 +175,16 @@
 ;; Emit one CSS custom-property block per theme keyed by the theme
 ;; class the shell carries (`rf-causa-theme-dark` / `rf-causa-theme-
 ;; light`). Properties land at `:root` for the active theme so any
-;; descendant can read them via `var(--rf-causa-bg-1)`. The dark
-;; block also publishes at `:root` *unconditionally* as a default —
-;; until the shell mounts (or under a host that never adds a theme
-;; class) the dark palette is the safe fallback.
+;; descendant can read them via `var(--rf-causa-bg-1)`. The LIGHT
+;; block also publishes at `:root` *unconditionally* as a default
+;; (rf2-3f2di) — until the shell mounts (or under a host that never
+;; adds a theme class) the light palette is the safe fallback, matching
+;; the authoritative reference's light-by-default render.
 ;;
-;; The 357 inline-style call sites keep reading dark hexes through
-;; `(:bg-1 tokens)` for now; the v1.0 styling pass migrates each one
-;; through to the CSS-variable surface so the toggle takes effect
-;; everywhere.
+;; The inline-style call sites resolve the `var(--rf-causa-*)` strings
+;; through `(:bg-1 tokens)`; the active theme class on the shell root
+;; (`apply-theme!`, default `:light` per config) decides which palette
+;; the browser substitutes at paint time.
 
 (def ^:private themes-style-id
   "rf-causa-themes")
@@ -204,10 +205,12 @@
        (apply str)))
 
 (defn- themes-css
-  "Build the per-theme CSS block. The dark palette publishes at `:root`
-  (the safe fallback) AND at `.rf-causa-theme-dark` (so the class
-  toggle has a matched landing). The light palette publishes at
-  `.rf-causa-theme-light` so the class toggle activates it.
+  "Build the per-theme CSS block. The LIGHT palette publishes at `:root`
+  (the safe fallback — rf2-3f2di flipped the default from dark to light
+  so the pre-mount fallback matches the authoritative reference, which
+  renders light by default) AND at `.rf-causa-theme-light` (so the class
+  toggle has a matched landing). The dark palette publishes at
+  `.rf-causa-theme-dark` so the class toggle activates it.
 
   `--rf-causa-accent` is the SINGLE accent token (GitHub blue `#539bf5`
   dark / `#0969da` light — the Figma export's `--devtools-active`).
@@ -216,11 +219,12 @@
   accent, so the whole shell reads the same blue accent in both modes."
   [themes]
   (str
-    ;; Default — :root carries the dark palette so any descendant
-    ;; reading `var(--rf-causa-bg-1)` resolves it even before the
-    ;; shell class is attached.
+    ;; Default — :root carries the LIGHT palette (rf2-3f2di) so any
+    ;; descendant reading `var(--rf-causa-bg-1)` resolves the light
+    ;; default even before the shell class is attached, matching the
+    ;; authoritative reference's light-by-default render.
     ":root {\n"
-    (palette->declarations (:dark themes))
+    (palette->declarations (:light themes))
     "}\n"
     ;; Explicit class blocks — `apply-theme!` (settings/effects.cljs)
     ;; writes one of these classes on the shell + `<html>` root.

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -441,17 +441,24 @@
   in earlier Causa redesigns and the now-unused `:sidebar-width` /
   `:bottom-rail-height` tokens were retired in Round-3 rf2-g9pee).
 
-  Per rf2-4vp5j the top of the shell splits into TWO strata: the
-  **chrome ribbon** (`:top-strip-height`, made compact — 32px per the
-  Figma ChromeRibbon `h-8`, rf2-cplj8 — it now carries only the Frame +
-  Dynamic/Static dropdowns on the left and the settings/close icons on
-  the right; nav, focus-chip and filter pills moved down) and the
-  **events ribbon** (`:events-ribbon-height`, carrying `Events:` + nav +
-  focus-chip + pills on the left and the hidden-count + Clear Filters on
-  the right). The compacted chrome height reclaims vertical canvas for
-  the L2 event list."
-  {:top-strip-height     "32px"
-   :events-ribbon-height "36px"})
+  Per rf2-4vp5j the top of the shell splits into TWO strata, reconciled
+  to the authoritative reference (`tools/causa/design-reference/causa_
+  devtools_reference.cljs`, rf2-3f2di) where every bar is a uniform
+  34px (`chrome-ribbon` / `events-ribbon` `:height \"34px\"`):
+
+  - the **chrome ribbon** (`:top-strip-height`, 34px) — bar-1, carrying
+    the `Events` label + the `[◀ ▶ ⏭]` nav cluster + `Filters:` + the
+    add(+) on the left, and the Frame dropdown + Dynamic/Static dropdown
+    + settings + close on the right (the reference chrome-ribbon
+    layout).
+  - the **events ribbon** (`:events-ribbon-height`, 34px) — bar-2,
+    carrying the `N events filtered out` warning text + the green/red
+    filter pills (the reference events-ribbon layout).
+
+  The reference's uniform 34px rhythm (rf2-3f2di) supersedes the prior
+  32px/36px split (rf2-cplj8)."
+  {:top-strip-height     "34px"
+   :events-ribbon-height "34px"})
 
 ;; ---- motion (rf2-5kfxe.5) ----------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/hidden_indicator_cljs_test.cljs
@@ -200,7 +200,10 @@
       (is (some? indicator) "banner renders when rows are hidden")
       (is (some? (find-by-testid tree "rf-causa-filters-hidden-clear"))
           "Clear filters button present")
-      (is (re-find #"1 event hidden by filters" (text-of count-node))))))
+      ;; rf2-3f2di A5 — the bar-2 warning reads `N events filtered out`
+      ;; (authority reference events-ribbon), superseding the prior
+      ;; `N events hidden by filters` copy.
+      (is (re-find #"1 event filtered out" (text-of count-node))))))
 
 (deftest hidden-message-does-not-duplicate-the-committed-pills
   (testing "rf2-ad7zx.18 — per the Figma EventsRibbon mock the hidden-state

--- a/tools/causa/test/day8/re_frame2_causa/filters/pills_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/pills_cljs_test.cljs
@@ -11,6 +11,7 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.filters.pills :as pills]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.theme.tokens :refer [tokens]]
             [day8.re-frame2-causa.test-support :as causa-test-support]))
 
 (defn- causa-init! []
@@ -68,18 +69,29 @@
        (apply str)))
 
 ;; -------------------------------------------------------------------------
-;; (1) Empty filters — no pills, just the add-pill
+;; (1) Empty filters — no committed pills in the cluster
+;;
+;; rf2-3f2di A5 — the add(+) affordance moved OUT of `pills-view` (which
+;; now renders ONLY committed pills, on bar-2) up to the chrome ribbon
+;; (bar-1). `pills-view` on empty buckets renders an empty cluster; the
+;; add-pill is exercised standalone via `pills/add-pill`.
 ;; -------------------------------------------------------------------------
 
-(deftest empty-filters-render-only-add-pill
+(deftest empty-filters-render-empty-cluster
   (causa-setup!)
   (let [tree (pills/pills-view {:filters {:in [] :out []}})]
     (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
-        "cluster always present")
-    (is (some? (find-by-testid tree "rf-causa-filter-add"))
-        "add-pill always present")
+        "cluster element always present")
+    (is (nil? (find-by-testid tree "rf-causa-filter-add"))
+        "add-pill is NOT part of the committed-pills cluster (moved to bar-1)")
     (is (empty? (find-all-by-testid-prefix tree "rf-causa-filter-pill-"))
         "no pill rows when both buckets are empty")))
+
+(deftest add-pill-renders-standalone
+  (causa-setup!)
+  (let [tree (pills/add-pill)]
+    (is (some? (find-by-testid tree "rf-causa-filter-add"))
+        "add-pill renders the `[ + ]` affordance standalone (bar-1 mount)")))
 
 ;; -------------------------------------------------------------------------
 ;; (2) IN + OUT pills render with correct testids
@@ -104,6 +116,40 @@
     (is (some? pill))
     (is (re-find #":auth/\*" (text-nodes pill))
         "pill renders the pattern")))
+
+(deftest pills-use-green-include-red-exclude-borders
+  (testing "rf2-3f2di A6 — include (`:in`) pills are GREEN-bordered
+            (`:success` = reference --devtools-success) and exclude
+            (`:out`) pills are RED-bordered (`:error` =
+            --devtools-error), each with a transparent background and a
+            tone-coloured border + a remove `×`, per the authority
+            reference events-ribbon."
+    (causa-setup!)
+    (let [tree   (pills/pills-view {:filters {:in  [{:pattern ":auth/*"}]
+                                              :out [{:pattern ":mouse-move"}]}})
+          in     (find-by-testid tree "rf-causa-filter-pill-in-0")
+          out    (find-by-testid tree "rf-causa-filter-pill-out-0")
+          in-st  (:style (second in))
+          out-st (:style (second out))]
+      ;; include = green border + green ink + transparent bg.
+      (is (= (str "1px solid " (:success tokens)) (:border in-st))
+          "include pill is green-bordered (:success)")
+      (is (= (:success tokens) (:color in-st))
+          "include pill ink is green")
+      (is (= "transparent" (:background in-st))
+          "include pill background is transparent")
+      ;; exclude = red border + red ink + transparent bg.
+      (is (= (str "1px solid " (:error tokens)) (:border out-st))
+          "exclude pill is red-bordered (:error)")
+      (is (= (:error tokens) (:color out-st))
+          "exclude pill ink is red")
+      (is (= "transparent" (:background out-st))
+          "exclude pill background is transparent")
+      ;; each carries a remove `×` button.
+      (is (some? (find-by-testid tree "rf-causa-filter-pill-in-0-remove"))
+          "include pill has a remove `×`")
+      (is (some? (find-by-testid tree "rf-causa-filter-pill-out-0-remove"))
+          "exclude pill has a remove `×`"))))
 
 ;; -------------------------------------------------------------------------
 ;; (3) Click pill body → dispatches :rf.causa/open-edit-popup
@@ -160,7 +206,8 @@
     (with-redefs [rf/dispatch* (fn
                                  ([ev]       (swap! dispatches conj ev) nil)
                                  ([ev _opts] (swap! dispatches conj ev) nil))]
-      (let [tree (pills/pills-view {:filters {:in [] :out []}})
+      ;; rf2-3f2di A5 — the add-pill is now a standalone bar-1 affordance.
+      (let [tree (pills/add-pill)
             add  (find-by-testid tree "rf-causa-filter-add")
             handler (:on-click (second add))]
         (is (some? add))

--- a/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
@@ -37,7 +37,9 @@
     (is (= :right-rail
               (config/get-setting :general :panel-position)))
     (is (= false  (config/get-setting :general :auto-open-on-error?)))
-    (is (= :dark  (config/get-setting :theme nil)))
+    ;; rf2-3f2di B2 — theme default flipped dark → light to match the
+    ;; authoritative reference's light-by-default render.
+    (is (= :light (config/get-setting :theme nil)))
     ;; rf2-3zyyx — epoch-history default matches the substrate's
     ;; `re-frame.epoch.state/default-depth` so a fresh install carries
     ;; the same ring depth Causa observed before the knob was surfaced.
@@ -115,10 +117,12 @@
 
 (deftest reset-clears-everything
   (config/update-setting! :general :text-size 18)
-  (config/update-setting! :theme nil :light)
+  ;; rf2-3f2di B2 — flip away from the new `:light` default so reset has
+  ;; a non-default value to revert.
+  (config/update-setting! :theme nil :dark)
   (config/reset-settings!)
   (is (= 13 (config/get-setting :general :text-size)))
-  (is (= :dark (config/get-setting :theme nil)))
+  (is (= :light (config/get-setting :theme nil)))
   (is (nil? (storage-payload))
       "localStorage payload cleared on reset"))
 
@@ -163,4 +167,5 @@
   ;; Other general slots keep their defaults
   (is (= :right-rail (config/get-setting :general :panel-position)))
   (is (= false (config/get-setting :general :auto-open-on-error?)))
-  (is (= :dark (config/get-setting :theme nil))))
+  ;; rf2-3f2di B2 — the theme default is now `:light`.
+  (is (= :light (config/get-setting :theme nil))))

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -215,24 +215,23 @@
 ;; -------------------------------------------------------------------------
 
 (deftest ribbon-mounts-all-clusters-across-two-strata
-  (testing "rf2-4vp5j — the top of the shell is TWO strata. The chrome
-            ribbon carries the Frame + Dynamic/Static selectors (left)
-            and the right-icons cluster; the events ribbon carries the
-            nav cluster + filter pills (moved down from the old single
-            ribbon). All clusters still mount somewhere in the shell
-            tree."
+  (testing "rf2-3f2di A5 — the top of the shell is TWO strata. The chrome
+            ribbon (bar-1) carries the nav cluster + Frame + Dynamic/Static
+            selectors + right-icons; the events ribbon (bar-2) carries the
+            committed filter pills. All clusters mount somewhere in the
+            shell tree."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)]
         (is (some? (find-by-testid tree "rf-causa-ribbon-nav"))
-            "nav cluster present (now in the events ribbon)")
+            "nav cluster present (now in the chrome ribbon, bar-1)")
         (is (or (find-by-testid tree "rf-causa-ribbon-frame")
                 (find-by-testid tree "rf-causa-ribbon-frame-picker"))
             "frame selector present (label or dropdown) in the chrome ribbon")
         (is (some? (find-by-testid tree "rf-causa-mode-pill"))
             "Dynamic/Static mode dropdown present in the chrome ribbon")
         (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
-            "filter cluster present (now in the events ribbon)")
+            "committed filter cluster present (now in the events ribbon, bar-2)")
         (is (some? (find-by-testid tree "rf-causa-ribbon-icons"))
             "right-icons cluster present in the chrome ribbon")))))
 
@@ -261,16 +260,33 @@
 ;; (2b) Two-ribbon redesign — chrome ribbon + events ribbon (rf2-4vp5j)
 ;; -------------------------------------------------------------------------
 
-(deftest chrome-ribbon-carries-only-selectors-and-icons
-  (testing "rf2-4vp5j Workstream A — the chrome ribbon (rf-causa-ribbon)
-            carries the Frame + Dynamic/Static selectors on the left and
-            the right-icons cluster; the nav cluster + focus-chip +
-            filter pills moved OUT to the events ribbon."
+(deftest chrome-ribbon-carries-events-nav-filters-and-selectors
+  (testing "rf2-3f2di A4/A5 — reconciled to the authority reference
+            chrome-ribbon. The chrome ribbon (rf-causa-ribbon) now leads
+            with the `Events` label, then the nav cluster + focus
+            controls + `Filters:` + the add(+) on the left, and carries
+            the Frame + Dynamic/Static selectors + the right-icons
+            cluster on the right. The committed filter pills moved DOWN to
+            the events ribbon (bar-2)."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [ribbon (shell/ribbon nil)]
         (is (some? (find-by-testid ribbon "rf-causa-ribbon-selectors"))
-            "left selector cluster present")
+            "left cluster present")
+        ;; A4 — the `Events` label leads the left cluster (the `❖ Causa`
+        ;; wordmark was dropped).
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-events-label"))
+            "`Events` label leads the chrome ribbon")
+        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-logo"))
+            "the `❖ Causa` wordmark is GONE (A4)")
+        ;; A2/A5 — the nav cluster + add(+) now live in the chrome ribbon.
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-nav"))
+            "nav cluster IS in the chrome ribbon (A5)")
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-filters-label"))
+            "`Filters:` label in the chrome ribbon (A5)")
+        (is (some? (find-by-testid ribbon "rf-causa-filter-add"))
+            "the add(+) affordance is in the chrome ribbon (A5)")
+        ;; right cluster — scope selectors + icons.
         (is (or (find-by-testid ribbon "rf-causa-ribbon-frame")
                 (find-by-testid ribbon "rf-causa-ribbon-frame-picker"))
             "Frame selector in the chrome ribbon")
@@ -278,50 +294,60 @@
             "Dynamic/Static mode dropdown in the chrome ribbon")
         (is (some? (find-by-testid ribbon "rf-causa-ribbon-icons"))
             "right-icons cluster in the chrome ribbon")
-        ;; spine/filter chrome moved DOWN to the events ribbon
-        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-nav"))
-            "nav cluster is NOT in the chrome ribbon")
+        ;; the COMMITTED pills are NOT in the chrome ribbon (they live on
+        ;; bar-2); only the add(+) is up here.
         (is (nil? (find-by-testid ribbon "rf-causa-ribbon-filters"))
-            "filter pills are NOT in the chrome ribbon")
-        (is (nil? (find-by-testid ribbon "rf-causa-focus-chip"))
-            "focus-chip is NOT in the chrome ribbon")))))
+            "committed filter pills are NOT in the chrome ribbon")))))
 
-(deftest chrome-ribbon-carries-causa-logo-top-left
-  (testing "rf2-ad7zx.12 — the chrome ribbon's LEFT cluster opens with
-            the `❖ Causa` wordmark per the Figma design-reference
-            (the chrome-ribbon component in causa_devtools_reference.cljs).
-            It was MISSING pre-Figma (the ribbon
-            jumped straight to the Frame selector). The wordmark renders
-            inside the selector cluster, before the Frame dropdown."
+(deftest chrome-ribbon-leads-with-events-label-not-logo
+  (testing "rf2-3f2di A4 — the chrome ribbon's LEFT cluster opens with an
+            `Events` label per the authority reference chrome-ribbon; the
+            `❖ Causa` wordmark was DROPPED. The label renders inside the
+            left cluster, ahead of the nav cluster."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [ribbon    (shell/ribbon nil)
             selectors (find-by-testid ribbon "rf-causa-ribbon-selectors")
-            logo      (find-by-testid ribbon "rf-causa-ribbon-logo")]
-        (is (some? logo) "the `❖ Causa` wordmark renders in the chrome ribbon")
-        (is (some? selectors) "the selector cluster is present")
-        (is (re-find #"❖" (text-nodes logo))
-            "the diamond `❖` glyph is present")
-        (is (re-find #"Causa" (text-nodes logo))
-            "the `Causa` wordmark text is present")))))
+            label     (find-by-testid ribbon "rf-causa-ribbon-events-label")]
+        (is (some? label) "the `Events` label renders in the chrome ribbon")
+        (is (some? selectors) "the left cluster is present")
+        (is (re-find #"Events" (text-nodes label))
+            "the label text reads `Events`")
+        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-logo"))
+            "the `❖ Causa` wordmark is gone (A4)")
+        (is (not (re-find #"❖" (text-nodes ribbon)))
+            "no diamond `❖` glyph anywhere in the chrome ribbon")))))
 
-(deftest events-ribbon-carries-label-nav-and-pills
-  (testing "rf2-4vp5j Workstream B — the events ribbon
-            (rf-causa-events-ribbon) carries the `Events:` label, the
-            nav cluster, and the filter pills on the left."
+(deftest events-ribbon-carries-warning-and-committed-pills
+  (testing "rf2-3f2di A5/A6 — reconciled to the authority reference
+            events-ribbon (bar-2). It carries the `N events filtered out`
+            warning + the committed green/red filter pills. The nav
+            cluster + add(+) moved UP to the chrome ribbon (bar-1)."
     (causa-setup!)
+    ;; one filtered-out event so the warning + a pill render. Raw
+    ;; collect-trace! maps (matching the neighbouring filter tests) so the
+    ;; test doesn't forward-reference the later `dispatch-trace-ev` helper.
+    (trace-bus/collect-trace! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
+    (trace-bus/collect-trace! {:id 2 :op-type :rf.event :operation :rf.event/dispatched
+                               :tags {:rf.event/v [:noise/tick] :frame :rf/default :rf.trace/dispatch-id 2}})
     (rf/with-frame :rf/causa
-      (let [tree (shell/shell-view)
+      (rf/dispatch-sync [:rf.causa/add-filter :out {:pattern :noise/tick}]))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
             ribbon (find-by-testid tree "rf-causa-events-ribbon")]
         (is (some? ribbon) "events ribbon mounts as its own stratum")
-        (is (some? (find-by-testid tree "rf-causa-events-ribbon-label"))
-            "`Events:` label present")
-        (is (re-find #"Events:" (text-nodes ribbon))
-            "the label text reads `Events:`")
-        (is (some? (find-by-testid tree "rf-causa-ribbon-nav"))
-            "nav cluster present in the events ribbon")
-        (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
-            "filter pills present in the events ribbon")))))
+        ;; A6 — the committed pills cluster lives here.
+        (is (some? (find-by-testid ribbon "rf-causa-ribbon-filters"))
+            "committed filter pills present in the events ribbon")
+        ;; A5 — the nav cluster + add(+) are NOT here (moved to bar-1).
+        (is (nil? (find-by-testid ribbon "rf-causa-ribbon-nav"))
+            "nav cluster is NOT in the events ribbon (moved to bar-1)")
+        (is (nil? (find-by-testid ribbon "rf-causa-filter-add"))
+            "the add(+) is NOT in the events ribbon (moved to bar-1)")
+        ;; the bar-2 warning reads `N events filtered out`.
+        (is (re-find #"filtered out" (text-nodes ribbon))
+            "the `N events filtered out` warning renders on bar-2")))))
 
 (deftest events-ribbon-actions-absent-when-no-filters
   (testing "rf2-4vp5j Decision 3 — with no pills + no mutes, the events
@@ -512,67 +538,70 @@
                 (str "after select-tab :machines, tab " tab-id
                      " aria-selected reflects the new active tab"))))))))
 
-(deftest tab-bar-is-figma-button-bar-not-radios
-  (testing "rf2-ad7zx.16 — the L3 tab strip renders as the Figma
-            button-bar (design-reference/causa_devtools_reference.cljs —
-            the tabs component + the main layout's
-            TabsList), NOT radio-circle glyphs. Each tab is a rounded
-            button; the ACTIVE tab carries a filled `:accent` background
-            with white text; inactive tabs are transparent with
-            secondary ink. The decorative `●/◉/○` radio glyph that the
-            previous tab-button rendered is GONE."
+(deftest tab-bar-is-underline-not-pill-or-radios
+  (testing "rf2-3f2di A1 — the L3 tab strip renders as UNDERLINE tabs per
+            the authority reference (`main-app` tab-strip), NOT a filled-
+            accent pill and NOT radio-circle glyphs. Each tab is a
+            borderless transparent button; the ACTIVE tab carries a 2px
+            `:accent` bottom border + NORMAL text ink; inactive tabs are
+            transparent with a 2px TRANSPARENT bottom border + neutral
+            muted ink."
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (let [tree (shell/shell-view)]
-        ;; (a) NO radio-circle glyphs anywhere in the tab strip. The
-        ;; old tab-button stamped a `◉` (active) / `○` (inactive) span;
-        ;; the L2 gutter glyph `◉/◌` lives in event rows, NOT in the
-        ;; tab buttons — so we assert per-button.
+      (let [tree (shell/shell-view)
+            accent-underline (str "2px solid " (:accent tokens))]
+        ;; (a) NO radio-circle glyphs anywhere in the tab strip.
         (doseq [tab-id expected-tab-ids]
           (let [btn  (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
                 txt  (text-nodes btn)]
             (is (some? btn) (str "tab button for " tab-id " present"))
             (is (not (re-find #"[◉○●]" txt))
                 (str "tab " tab-id " carries no radio-circle glyph"))))
-        ;; (b) Every tab is a rounded button (`rounded` → border-radius).
+        ;; (b) Every tab is a borderless transparent button — NOT a
+        ;; filled pill. No border-radius (the underline, not a rounded
+        ;; fill, is the shape).
         (doseq [tab-id expected-tab-ids]
           (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
                 style (:style (second btn))]
             (is (= :button (first btn))
                 (str "tab " tab-id " is a <button>"))
-            (is (some? (:border-radius style))
-                (str "tab " tab-id " is rounded (border-radius set)"))))
-        ;; (c) The ACTIVE tab (default :event) is a filled-accent button
-        ;; with white text — the Figma `data-[state=active]:bg-…/text-white`.
+            (is (= "transparent" (:background style))
+                (str "tab " tab-id " background is transparent (no filled pill)"))
+            (is (nil? (:border-radius style))
+                (str "tab " tab-id " carries no border-radius (underline, not pill)"))))
+        ;; (c) The ACTIVE tab (default :event) carries the 2px accent
+        ;; underline + normal text ink — NOT a filled accent bg / white text.
         (let [active (find-by-testid tree "rf-causa-tab-event")
               style  (:style (second active))]
-          (is (= (:accent tokens) (:background style))
-              "active tab background is the filled :accent token")
-          (is (= (:white tokens) (:color style))
-              "active tab text is white"))
-        ;; (d) INACTIVE tabs are transparent with NEUTRAL muted ink
-        ;; (rf2-cplj8 — `:text-tertiary`, Figma `text-muted-foreground`,
-        ;; NOT the brighter blue-ish `:text-secondary`).
+          (is (= accent-underline (:border-bottom style))
+              "active tab has a 2px :accent bottom border (the underline)")
+          (is (= (:text-primary tokens) (:color style))
+              "active tab text is the normal :text-primary ink")
+          (is (not= (:accent tokens) (:background style))
+              "active tab background is NOT a filled :accent pill"))
+        ;; (d) INACTIVE tabs are transparent with a TRANSPARENT 2px bottom
+        ;; border + NEUTRAL muted ink.
         (doseq [tab-id (remove #{:event} expected-tab-ids)]
           (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
                 style (:style (second btn))]
-            (is (= "transparent" (:background style))
-                (str "inactive tab " tab-id " background is transparent"))
+            (is (= "2px solid transparent" (:border-bottom style))
+                (str "inactive tab " tab-id " bottom border is transparent"))
             (is (= (:text-tertiary tokens) (:color style))
                 (str "inactive tab " tab-id " text is neutral muted ink"))))))
-    ;; (e) After switching the active tab, the filled-accent treatment
-    ;; follows the new selection (and the old tab reverts to transparent).
+    ;; (e) After switching the active tab, the underline follows the new
+    ;; selection (and the old tab reverts to a transparent underline).
     (select-tab! :machines)
     (rf/with-frame :rf/causa
       (let [tree   (shell/shell-view)
+            accent-underline (str "2px solid " (:accent tokens))
             mach   (:style (second (find-by-testid tree "rf-causa-tab-machines")))
             event  (:style (second (find-by-testid tree "rf-causa-tab-event")))]
-        (is (= (:accent tokens) (:background mach))
-            "newly-active :machines tab fills with :accent")
-        (is (= (:white tokens) (:color mach))
-            "newly-active :machines tab text is white")
-        (is (= "transparent" (:background event))
-            "previously-active :event tab reverts to transparent")))))
+        (is (= accent-underline (:border-bottom mach))
+            "newly-active :machines tab gains the accent underline")
+        (is (= (:text-primary tokens) (:color mach))
+            "newly-active :machines tab text is the normal ink")
+        (is (= "2px solid transparent" (:border-bottom event))
+            "previously-active :event tab reverts to a transparent underline")))))
 
 (deftest tab-click-dispatches-select-tab
   (testing "spec/018 §5 — clicking a tab fires :rf.causa/select-tab"
@@ -1371,14 +1400,13 @@
             "⏭ ENABLED — paused-at-head, pressing it resumes LIVE")))))
 
 (deftest ribbon-nav-disabled-button-has-inert-styling
-  (testing "rf2-x5tro + rf2-cplj8 — a disabled nav button READS as inert,
-            not just cursor: not-allowed. Post rf2-cplj8 the nav buttons
-            are BORDERLESS lucide-style chevrons (Figma EventsRibbon) so
-            there is no border/background to dim — the inert signal is
-            the muted :text-tertiary ink + reduced opacity + not-allowed
-            cursor. The active button has a transparent borderless base
-            (`border: none`), so a disabled button must stay borderless
-            too. Asserted on ⏭ at head + live."
+  (testing "rf2-x5tro + rf2-3f2di A2 — a disabled nav button READS as
+            inert, not just cursor: not-allowed. With the blue-filled
+            treatment (reference chrome-ribbon) the inert signal is a
+            strong opacity drop (the filled blue fades) + not-allowed
+            cursor. The button keeps its filled :accent base + white icon
+            + borderless box; only the opacity recedes. Asserted on ⏭ at
+            head + live."
     (causa-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/causa
@@ -1389,15 +1417,15 @@
         (is (some? active) "nav cluster renders")
         (is (true? (:disabled (second head)))
             "⏭ disabled at head + live (single event, fresh focus)")
-        ;; The proper inert appearance — borderless, muted, recessed.
-        (is (= "transparent" (:background style))
-            "disabled nav button stays transparent (borderless treatment)")
+        ;; The proper inert appearance — filled but faded.
+        (is (= (:accent tokens) (:background style))
+            "disabled nav button keeps the filled :accent base")
         (is (= "none" (:border style))
-            "disabled nav button has NO border box — borderless lucide style")
-        (is (= (:text-tertiary tokens) (:color style))
-            "disabled ink drops to text-tertiary")
+            "disabled nav button has NO border box — borderless filled style")
+        (is (= (:white tokens) (:color style))
+            "disabled icon stays white (the opacity drop carries the fade)")
         (is (= 0.4 (:opacity style))
-            "disabled opacity reduced so the button recedes")
+            "disabled opacity reduced so the filled blue recedes")
         (is (= "not-allowed" (:cursor style))
             "cursor: not-allowed telegraphs the no-op")))))
 
@@ -2103,6 +2131,27 @@
     (is (= "" (shell/format-relative-time 1000 nil)))
     (is (= "" (shell/format-relative-time nil  nil)))))
 
+(deftest format-clock-time-renders-hhmmssmmm
+  (testing "rf2-3f2di A8 — `format-clock-time` renders the absolute
+            wall-clock `HH:MM:SS.mmm` string the L2 `timestamp` column
+            shows (authority reference). The exact hour/minute depends on
+            the runner's timezone, so we pin the SHAPE + the
+            zero-padding (seconds + millis fields), and the round-trip
+            against a known local Date."
+    (let [d        (js/Date. 2026 4 23 9 5 3 7)  ; local 09:05:03.007
+          then-ms  (.getTime d)
+          label    (shell/format-clock-time then-ms)]
+      (is (re-find #"^\d\d:\d\d:\d\d\.\d\d\d$" label)
+          "label matches the HH:MM:SS.mmm shape with zero-padding")
+      ;; The seconds + millis fields are timezone-independent, so pin them.
+      (is (re-find #":03\.007$" label)
+          "seconds + 3-digit millis are zero-padded from a known Date"))))
+
+(deftest format-clock-time-nil-safe
+  (testing "rf2-3f2di A8 — nil short-circuits to the empty string so the
+            chip caller can decide whether to render anything."
+    (is (= "" (shell/format-clock-time nil)))))
+
 (deftest cascade-dispatched-time-ms-reads-dispatched-slot
   (testing "rf2-vbbq0 — the chip's source-of-truth for the cascade's
             walltime is `:dispatched :time`. Each trace event carries
@@ -2125,32 +2174,27 @@
   [id event-vec time-ms]
   (assoc (dispatch-trace-ev id event-vec) :time time-ms))
 
-(deftest event-row-renders-relative-time-chip
-  (testing "rf2-vbbq0 / rf2-0s2at — every L2 row carries a right-aligned
-            relative-time chip. The chip's text reflects the bucket
-            against the anchor (the dispatched-time of the MOST RECENT
-            cascade); the chip's `:title` carries the absolute walltime
+(deftest event-row-renders-absolute-time-chip
+  (testing "rf2-3f2di A8 — every L2 row's `timestamp` column renders the
+            ABSOLUTE wall-clock time (`HH:MM:SS.mmm`) per the authority
+            reference event-list, NOT a relative `1s`/`now` chip. The
+            chip's `:title` still carries the full ISO walltime + epoch-ms
             for the power-user reveal."
     (causa-setup!)
-    (let [now-ms  1000000
-          then-ms (- now-ms 5000)]  ;; 5 seconds ago
-      ;; Old cascade — what the chip-under-test is reporting against.
+    (let [then-ms 1000000]
       (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
-      ;; Fresh cascade — establishes the anchor at `now-ms`. (rf2-0s2at
-      ;; — anchor is derived from `:rf.causa/cascades` directly, not
-      ;; from a wall-clock tick.)
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
       (rf/with-frame :rf/causa
         (let [tree   (shell/shell-view)
-              chips  (find-all-by-testid tree "rf-causa-row-time-chip")
-              ;; The first cascade's chip — by `:data-then-ms`.
-              chip   (first (filter #(= (str then-ms)
-                                        (:data-then-ms (second %)))
-                                    chips))
+              chip   (find-by-testid tree "rf-causa-row-time-chip")
               attrs  (second chip)
               label  (text-nodes chip)]
           (is (some? chip) "chip renders per row")
-          (is (= "5s" label) "chip text reflects the seconds-bucket against the anchor")
+          ;; Absolute clock — matches the pure formatter for the same
+          ;; then-ms (local-time-aware so the test is timezone-stable).
+          (is (= (shell/format-clock-time then-ms) label)
+              "chip text is the absolute HH:MM:SS.mmm wall-clock time")
+          (is (re-find #"^\d\d:\d\d:\d\d\.\d\d\d$" label)
+              "chip text matches the HH:MM:SS.mmm shape")
           (is (string? (:title attrs))
               "chip carries a :title tooltip for the power-user reveal")
           (is (re-find #"epoch-ms" (:title attrs))
@@ -2158,53 +2202,27 @@
           (is (= (str then-ms) (:data-then-ms attrs))
               "chip stamps the source then-ms so tests can pin the value"))))))
 
-(deftest event-row-chip-now-bucket
-  (testing "rf2-vbbq0 / rf2-0s2at — a row that IS the most recent cascade
-            (so its dispatched-time equals the anchor) renders the 'now'
-            bucket."
+(deftest event-row-chip-is-absolute-regardless-of-recency
+  (testing "rf2-3f2di A8 — the absolute clock chip does NOT change with
+            how recently the cascade was dispatched (no relative buckets).
+            An OLD cascade and a FRESH cascade each render their own
+            absolute timestamp; neither reads `now`/`Ns`/`Nm`/`Nh`."
     (causa-setup!)
-    (let [now-ms 1000000]
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] now-ms))
+    (let [old-ms   1000000
+          fresh-ms (+ old-ms 90000)]
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] old-ms))
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] fresh-ms))
       (rf/with-frame :rf/causa
-        (let [tree (shell/shell-view)
-              chip (find-by-testid tree "rf-causa-row-time-chip")]
-          (is (= "now" (text-nodes chip))
-              "diff = 0 → 'now' bucket"))))))
-
-(deftest event-row-chip-minute-bucket
-  (testing "rf2-vbbq0 / rf2-0s2at — at t+90s the chip rolls into the
-            minute bucket and reads '1m' (not '90s'). Anchor pinned by a
-            fresher cascade."
-    (causa-setup!)
-    (let [now-ms  1000000
-          then-ms (- now-ms 90000)]
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
-      (rf/with-frame :rf/causa
-        (let [tree  (shell/shell-view)
-              chips (find-all-by-testid tree "rf-causa-row-time-chip")
-              chip  (first (filter #(= (str then-ms)
-                                       (:data-then-ms (second %)))
-                                   chips))]
-          (is (= "1m" (text-nodes chip))
-              "90s ago → '1m' (minute bucket; jitter dampened)"))))))
-
-(deftest event-row-chip-hour-bucket
-  (testing "rf2-vbbq0 / rf2-0s2at — at t+3700s the chip rolls into the
-            hour bucket and reads '1h'."
-    (causa-setup!)
-    (let [now-ms  10000000
-          then-ms (- now-ms 3700000)] ;; 3700s ≈ 1h2m
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
-      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
-      (rf/with-frame :rf/causa
-        (let [tree  (shell/shell-view)
-              chips (find-all-by-testid tree "rf-causa-row-time-chip")
-              chip  (first (filter #(= (str then-ms)
-                                       (:data-then-ms (second %)))
-                                   chips))]
-          (is (= "1h" (text-nodes chip))
-              "3700s ago → '1h'"))))))
+        (let [tree     (shell/shell-view)
+              chips    (find-all-by-testid tree "rf-causa-row-time-chip")
+              old-chip (first (filter #(= (str old-ms) (:data-then-ms (second %))) chips))
+              fr-chip  (first (filter #(= (str fresh-ms) (:data-then-ms (second %))) chips))]
+          (is (= (shell/format-clock-time old-ms) (text-nodes old-chip))
+              "old row shows its own absolute timestamp")
+          (is (= (shell/format-clock-time fresh-ms) (text-nodes fr-chip))
+              "fresh row shows its own absolute timestamp")
+          (is (not (re-find #"\b(now|\d+[smhd])\b" (text-nodes old-chip)))
+              "no relative-bucket text (now/Ns/Nm/Nh/Nd) on the old row"))))))
 
 (deftest event-row-chip-absent-when-no-dispatched-time
   (testing "rf2-vbbq0 — defence-in-depth: a synthesised cascade carrying
@@ -2267,51 +2285,55 @@
           "no `:dispatched :time` anywhere → nil anchor"))))
 
 ;; -------------------------------------------------------------------------
-;; rf2-cplj8 — chrome + ribbon + event-list + tab Figma fidelity
+;; rf2-3f2di — chrome + ribbon + event-list + tab AUTHORITY fidelity
 ;;
-;; Reconciles shell.cljs to the Figma design-reference components
-;; (ChromeRibbon / EventsRibbon / EventList / Tabs). The structural /
-;; token contracts asserted here:
-;;   (1) chrome ribbon logo → NEUTRAL :text-primary ink (not :accent);
-;;       chrome ribbon height → 32px (Figma `h-8`);
-;;       settings/close → borderless square icon-buttons.
-;;   (2) events ribbon nav cluster → BORDERLESS chevron buttons (no
-;;       border box); the always-present blue `focus` button is restored.
+;; Reconciles shell.cljs to the authoritative reference components
+;; (`tools/causa/design-reference/causa_devtools_reference.cljs`:
+;; chrome-ribbon / events-ribbon / event-list / main-app tab-strip). The
+;; structural / token contracts asserted here:
+;;   (1) chrome ribbon `Events` label → NEUTRAL :text-primary ink (A4);
+;;       chrome ribbon height → 34px (A3); settings/close → borderless
+;;       square icon-buttons.
+;;   (2) chrome ribbon nav cluster → BLUE-FILLED chevron buttons (A2);
+;;       the always-present blue `focus` button lives in the chrome
+;;       ribbon (A5).
 ;;   (3) event-list event-id column → explicitly LEFT-aligned (header +
 ;;       row); the selected/active row → subtle :hover fill, NOT a 1px
-;;       blue ring.
-;;   (4) inactive tabs → NEUTRAL muted :text-tertiary ink (covered by
-;;       `tab-bar-is-figma-button-bar-not-radios` above).
+;;       blue ring; the `timestamp` column → absolute HH:MM:SS.mmm (A8).
+;;   (4) tabs → UNDERLINE (2px accent bottom-border + normal ink for the
+;;       active tab), NOT a filled pill (A1; covered by
+;;       `tab-bar-is-underline-not-pill-or-radios` above).
 ;; -------------------------------------------------------------------------
 
-(deftest chrome-logo-uses-neutral-ink-not-accent
-  (testing "rf2-cplj8 — the `❖ Causa` wordmark renders in the NEUTRAL
-            chrome text colour (:text-primary = Figma --devtools-text),
-            NOT the :accent blue. The single accent is reserved for
-            active/selected affordances."
+(deftest chrome-events-label-uses-neutral-ink-not-accent
+  (testing "rf2-3f2di A4 — the `Events` label (which replaced the dropped
+            `❖ Causa` wordmark) renders in the NEUTRAL chrome text colour
+            (:text-primary = reference --devtools-text), NOT the :accent
+            blue. The single accent is reserved for active/selected
+            affordances."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [ribbon (shell/ribbon nil)
-            logo   (find-by-testid ribbon "rf-causa-ribbon-logo")
-            style  (:style (second logo))]
-        (is (some? logo) "the wordmark renders")
+            label  (find-by-testid ribbon "rf-causa-ribbon-events-label")
+            style  (:style (second label))]
+        (is (some? label) "the `Events` label renders")
         (is (= (:text-primary tokens) (:color style))
-            "the logo ink is the neutral :text-primary token")
+            "the label ink is the neutral :text-primary token")
         (is (not= (:accent tokens) (:color style))
-            "the logo ink is NOT the :accent blue")))))
+            "the label ink is NOT the :accent blue")))))
 
-(deftest chrome-ribbon-height-is-figma-h8
-  (testing "rf2-cplj8 — the chrome ribbon is 32px tall (Figma ChromeRibbon
-            `h-8`), down from the previous 40px, reclaiming vertical
-            canvas. Driven by the single `:top-strip-height` layout token."
-    (is (= "32px" (:top-strip-height layout))
-        "the :top-strip-height layout token is 32px (Figma h-8)")
+(deftest chrome-ribbon-height-is-reference-34px
+  (testing "rf2-3f2di A3 — the chrome ribbon is 34px tall per the authority
+            reference chrome-ribbon (`:height \"34px\"`), up from the prior
+            32px. Driven by the single `:top-strip-height` layout token."
+    (is (= "34px" (:top-strip-height layout))
+        "the :top-strip-height layout token is 34px (reference)")
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [ribbon (shell/ribbon nil)
             style  (:style (second ribbon))]
-        (is (= "32px" (:height style))
-            "the chrome ribbon paints the 32px height")))))
+        (is (= "34px" (:height style))
+            "the chrome ribbon paints the 34px height")))))
 
 (deftest chrome-icon-buttons-are-borderless
   (testing "rf2-cplj8 — the settings + close icons are BORDERLESS square
@@ -2332,11 +2354,12 @@
             (is (= (:text-tertiary tokens) (:color style))
                 (str label " icon-button uses muted :text-tertiary ink"))))))))
 
-(deftest events-ribbon-nav-buttons-are-borderless
-  (testing "rf2-cplj8 — the events-ribbon nav cluster renders BORDERLESS
-            chevron buttons (Figma EventsRibbon `p-1 rounded`), NOT
-            bordered unicode-triangle pills. The active (enabled) button
-            carries `border: none` + transparent background."
+(deftest chrome-ribbon-nav-buttons-are-blue-filled
+  (testing "rf2-3f2di A2 — the chrome-ribbon nav cluster renders FILLED
+            `:accent` buttons (reference chrome-ribbon: blue bg, white
+            icon), NOT borderless icon-buttons and NOT bordered triangles.
+            The active (enabled) button carries `background: :accent` +
+            white icon + `border: none`."
     (causa-setup!)
     ;; Two events + focus the middle so prev/next are ENABLED (active style).
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
@@ -2352,15 +2375,21 @@
             (is (some? btn) (str tid " present"))
             (is (= "none" (:border style))
                 (str tid " is borderless (no 1px border box)"))
-            (is (= "transparent" (:background style))
-                (str tid " is transparent (hover fill via scoped CSS)"))))))))
+            (is (= (:accent tokens) (:background style))
+                (str tid " background is the filled :accent (blue)"))
+            (is (= (:white tokens) (:color style))
+                (str tid " icon is white"))))
+        ;; the nav cluster lives in the chrome ribbon (bar-1) now.
+        (is (some? (find-by-testid (find-by-testid tree "rf-causa-ribbon")
+                                   "rf-causa-ribbon-nav"))
+            "the nav cluster is mounted inside the chrome ribbon (A5)")))))
 
-(deftest events-ribbon-restores-blue-focus-button
-  (testing "rf2-cplj8 — the always-present blue `focus` button (Figma
-            EventsRibbon) is restored: a filled :accent button with white
-            text + the `focus` label, sitting in the events-ribbon left
-            cluster. Distinct from the focus-CHIP (which only appears when
-            a focus-set is active)."
+(deftest chrome-ribbon-carries-blue-focus-button
+  (testing "rf2-3f2di A5 — the always-present blue `focus` button is a
+            filled :accent button with white text + the `focus` label,
+            now sitting in the CHROME ribbon left cluster (it moved up
+            with the nav cluster). Distinct from the focus-CHIP (which
+            only appears when a focus-set is active)."
     (causa-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:cart/add-item]))
     (rf/with-frame :rf/causa
@@ -2374,10 +2403,10 @@
             "focus button text is white")
         (is (re-find #"focus" (text-nodes btn))
             "the button carries the `focus` label")
-        ;; It lives in the events ribbon, not the chrome ribbon.
-        (is (some? (find-by-testid (find-by-testid tree "rf-causa-events-ribbon")
+        ;; It lives in the chrome ribbon (bar-1) now, not the events ribbon.
+        (is (some? (find-by-testid (find-by-testid tree "rf-causa-ribbon")
                                    "rf-causa-focus-button"))
-            "the focus button is mounted inside the events ribbon")))))
+            "the focus button is mounted inside the chrome ribbon")))))
 
 (deftest focus-button-dispatches-set-focus-for-current-event
   (testing "rf2-cplj8 — clicking the blue `focus` button focuses on the

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -444,16 +444,17 @@
 ;; ---- rf2-5kfxe.6 — light theme CSS variables ---------------------------
 
 (deftest themes-css-publishes-root-defaults
-  (testing "rf2-5kfxe.6 — the :root block publishes the dark palette
-            as the default so any descendant that reads
-            `var(--rf-causa-bg-1)` resolves to the dark hex even
-            before any theme class is attached."
+  (testing "rf2-3f2di B2 — the :root block publishes the LIGHT palette
+            as the default (flipped from dark) so any descendant that
+            reads `var(--rf-causa-bg-1)` resolves to the light hex even
+            before any theme class is attached, matching the
+            authoritative reference's light-by-default render."
     (let [css (@#'gs/themes-css {:dark  {:bg-1 "#15171B" :accent-violet "#7C5CFF"}
                                   :light {:bg-1 "#F1F3F6" :accent-violet "#5538D8"}})]
-      (is (re-find #":root\s*\{[^}]*--rf-causa-bg-1:\s*#15171B" css)
-          "root block carries the dark bg-1")
-      (is (re-find #":root\s*\{[^}]*--rf-causa-accent-violet:\s*#7C5CFF" css)
-          "root block carries the dark accent-violet"))))
+      (is (re-find #":root\s*\{[^}]*--rf-causa-bg-1:\s*#F1F3F6" css)
+          "root block carries the light bg-1 default")
+      (is (re-find #":root\s*\{[^}]*--rf-causa-accent-violet:\s*#5538D8" css)
+          "root block carries the light accent-violet default"))))
 
 (deftest themes-css-emits-per-theme-class-blocks
   (testing "rf2-5kfxe.6 — `.rf-causa-theme-dark` and


### PR DESCRIPTION
Brings the Causa devtool shell onto its authoritative L&F reference
(`tools/causa/design-reference/causa_devtools_reference.cljs`). Mike-directed:
"do all except A7". Closes rf2-3f2di.

## Deltas applied

- **A1 Tab strip → underline.** Active tab = 2px `:accent` `border-bottom` +
  normal `:text-primary` ink + transparent bg (was the filled accent pill +
  white text). Inactive = transparent 2px bottom border + `:text-tertiary`
  muted ink. Full-height tabs (`align-items: stretch`, `gap 0`) so the
  underline lands on the bar's bottom edge (reference `main-app` tab-strip).
- **A2 Chrome nav buttons → blue-filled.** The `‹ › »` nav chevrons render as
  filled `:accent` buttons with white icons (reference chrome-ribbon);
  disabled = faded fill + `not-allowed`.
- **A3 Ribbon height → 34px.** `:top-strip-height` 32px → 34px;
  `:events-ribbon-height` 36px → 34px for the reference's uniform bar rhythm.
- **A4 Drop the logo.** The `❖ Causa` wordmark is gone; the left cluster
  leads with an `Events` label.
- **A5 Region restructure → 2-bar layout.** Bar-1 (chrome ribbon): `Events`
  label + blue-filled nav cluster + focus button/chip + `Filters:` + add(+) on
  the left; Frame + Dynamic/Static dropdowns + mute/REDACTED indicators +
  settings/close on the right. Bar-2 (events ribbon): `N events filtered out`
  warning + the committed green/red pills (Clear Filters on the right when a
  filter is active). The spine-boundary computation was extracted to a pure
  `nav-boundary-state` helper now consumed by the chrome ribbon. All Causa
  wiring (frame switcher, focus, filter add-popup, settings, close, mutes,
  Clear Filters) preserved.
- **A6 Filter pills → green/red.** Include pills = `:success`-bordered,
  exclude pills = `:error`-bordered, transparent bg, each with a remove `×`,
  4px radius (reference events-ribbon). `add-pill` split out as a public bar-1
  affordance; `pills-view` now renders committed pills only.
- **A8 Event-list timestamps → absolute.** New `format-clock-time` renders
  `HH:MM:SS.mmm` (e.g. `12:30:05.123`) in the L2 `timestamp` column, replacing
  the relative `1s`/`now` chip. Column widened 44px → 76px.
- **B2 Theme default → light.** config `:theme` default `:dark` → `:light`;
  the `:root` CSS-var fallback now publishes the light palette; `apply-theme!`
  fallback flipped to `:light`. Dark remains available via the class toggle.

## Skipped (per direction)

- **A7** — the app-db panel is untouched (`:RF/*` namespaced headers +
  expandable tree preserved). No `panels/app_db_*` edits.

## Tests

Updated every test that asserted the OLD look (filled-pill tab, borderless
nav, 32px, `❖ Causa` logo / `Events:` label, magenta OUT pills, relative
timestamps, dark default) to the new authority, and added new regressions:
underline-not-pill active tab, blue-filled nav (+ faded-when-disabled),
34px token, `Events` label (no logo), green/red pill borders, absolute
`HH:MM:SS.mmm` clock (+ `format-clock-time` unit tests), light default.

## Verification

- tools/causa `clojure -M:test` — 876 tests, 0 failures
- `npm run test:cljs` — 4278 tests, 0 failures
- `npm run test:causa-feature-gate` — 13 scenarios, 0 failures (render-verify)
- clj-kondo on touched files — 0 errors; 0 warnings on touched lines
- splint `--fail-on-errors` — 0 errors
- `examples/step-deck` shadow build — 0 warnings

Verified each delta's rendered styling against the reference's `chrome-ribbon`,
`events-ribbon`, `event-list`, and `main-app` tab-strip fns (matched
structure / classes / tokens / spacing; wired to Causa's real subs/events/data
rather than the reference's mock data).