### PR TITLE
feat(flows): run flows immediately after the event handler (rf2-u0zz5)

### DIFF
--- a/implementation/core/src/re_frame/late_bind.cljc
+++ b/implementation/core/src/re_frame/late_bind.cljc
@@ -31,7 +31,7 @@
 ;;
 ;; `get-fn-cached` is a sticky variant of `get-fn` for hooks that are
 ;; published once at boot and never withdrawn in production
-;; (`:schemas/validate-*!`, `:flows/run-flows!`, `:epoch/settle!`,
+;; (`:schemas/validate-*!`, `:flows/run-flows-on-db`, `:epoch/settle!`,
 ;; `:epoch/capture-event`, `:event-emit/dispatch-on-event`,
 ;; `:router/dispatch!`, …). These run on every dispatch — the dispatch
 ;; cascade reads ~6+ keys per event, so a 100-event cascade was 600+
@@ -106,7 +106,7 @@
   dev-time hot-reload of an artefact re-resolves on the next dispatch.
   Use at hot-path call sites — every dispatch reads
   `:schemas/validate-event!`, `:schemas/validate-app-schema!`,
-  `:flows/run-flows!`, `:epoch/settle!`, `:epoch/capture-event`,
+  `:flows/run-flows-on-db`, `:epoch/settle!`, `:epoch/capture-event`,
   `:event-emit/dispatch-on-event`, `:router/dispatch!` — so a
   100-event cascade resolved each ~100 times before this cache."
   [hook-key]

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -110,9 +110,10 @@
    {:key         :flows/clear-flow
     :producer-ns 're-frame.flows
     :description "Remove a previously-registered flow definition (public-API + :rf.fx/clear-flow)."}
-   {:key         :flows/run-flows!
+   {:key         :flows/run-flows-on-db
     :producer-ns 're-frame.flows
-    :description "Re-evaluate every registered flow for the current frame."}
+    :design-bead "rf2-u0zz5"
+    :description "Run the frame's flows over a given db value, returning the flow-augmented db. Invoked by the router's innermost flows-after-interceptor to transform the handler's pending `:db` effect (before install + before the rest of the `:after` chain)."}
    {:key         :flows/reset-last-inputs!
     :producer-ns 're-frame.flows
     :description "Reset memoised last-input snapshots (test isolation)."}

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -424,6 +424,13 @@
   pre-handler value (per Spec 010 §Per-step recovery row 4 /
   rf2-wkxng / rf2-6m0se).
 
+  Per Spec 013 §Drain integration (rf2-u0zz5): `(:db effects)` here is
+  the FLOW-AUGMENTED value — the innermost flows-after-interceptor has
+  already rewritten the pending `:db` effect by the time the chain
+  returns. So `:event/db-changed` reflects the flow-derived db and fires
+  AFTER `:rf.flow/computed` (per Spec 009 §Canonical per-event trace
+  sequence).
+
   On rollback, a second :event/db-changed trace is emitted for the
   restored state with `:phase :rollback` so listeners (subs, 10x,
   pair-tools) observe the post-rollback app-db without ambiguity —
@@ -466,109 +473,143 @@
           false)))
     true))
 
-(defn- run-flows!
-  "Per Spec 013 §Drain integration: run flows after :db commits and
-  before :fx walks. Returns `true` on success (including the no-flows-
-  artefact short-circuit) and `false` when a flow's `:output` threw.
-  Per Spec 013 §Failure semantics rule 3: the caller MUST halt the
-  cascade on `false` — downstream `:fx` does NOT run when a flow has
-  thrown (an `:fx` entry's side effects can rely on derived state the
-  failing flow was supposed to produce).
+(def ^:private flows-after-interceptor
+  "Per Spec 013 §Drain integration (rf2-u0zz5): the framework-owned
+  OUTERMOST `:after` interceptor that runs the flow transform. The router
+  PREPENDS it to the dispatch-time `full-chain` (NOT the registered
+  handler-meta chain — see `prepare-handler-ctx`), so it is the first
+  interceptor in declaration order and therefore the LAST `:after` to
+  fire: after the rest of the `:after` chain, before `:db` install, and
+  before `:fx`.
 
-  Flow evaluation exceptions surface as :rf.error/flow-eval-exception
-  through BOTH the dev-only trace surface AND the always-on error-emit
-  substrate (per rf2-hrt5c — the security-audit fix). The drain
-  continues with the NEXT event after the substrate emit; this drain's
-  `:fx` is skipped per rf2-fslx0.
+  Outermost (not innermost) is load-bearing: the `path` std-interceptor's
+  `:after` splices the handler's slice back into the FULL db, and flows
+  read full-app-db `:inputs` paths — so the flow transform MUST run after
+  that reshape. Running flows innermost would expose them to the
+  un-spliced path slice and mis-read their inputs.
 
-  Per rf2-hrt5c: pre-fix, `:rf.error/flow-eval-exception` rode the
-  trace path only. `trace/emit-error!` is gated by
-  `interop/debug-enabled?` and DCEs to a no-op under `:advanced` +
-  `goog.DEBUG=false` — so a CLJS production build silently swallowed
-  flow-eval throws (no `:on-error` policy fire, no corpus-wide
-  listener record for off-box monitors). This routing now mirrors the
-  handler-exception path (`emit-handler-exception!`) — both fan-out
-  paths fire from one normative emission site, the trace path
-  enriches dev consumers, and the substrate path survives prod
-  elision. There is no `:handler-id` (no handler ran — the throw
-  came from the post-commit flow walk); the `:where :flow-eval`
-  discriminator distinguishes this path from the handler-exception
-  one for policy fns that key on it.
+  Its `:after` reads the chain's PENDING `:db` effect (the full,
+  fully-reshaped value — or the current app-db value when no `:db` effect
+  was produced), runs `:flows/run-flows-on-db` over that value, and writes
+  the flow-augmented db back into `(:effects ctx :db)`. The eventual `:db`
+  install and the `:fx` walk therefore observe the flow-derived db.
 
-  Per rf2-fslx0: pre-fix this fn returned nil on both success and
-  failure paths, so `commit-and-flow!` had no signal to skip `:fx`
-  on flow throws. A handler emitting `[:dispatch [:react-to-area-
-  change]]` from `:fx` would fire the child dispatch even when the
-  source flow threw — child handler runs on stale derived state,
-  side effects (HTTP / navigation / analytics) escape. Spec 013
-  §Failure semantics rule 3 + §rationale (line 202) state the
-  cascade halts at a failing flow."
-  [frame event event-id start-ms]
-  ;; Sticky hook (rf2-f72pd) — fires per-dispatch.
-  (if-let [flows-fn (late-bind/get-fn-cached :flows/run-flows!)]
-    (try
-      (flows-fn frame)
-      true
-      (catch #?(:clj Throwable :cljs :default) e
-        (let [end-ms     (interop/now-ms)
-              ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an
-              ;; integer. Round once at the substrate boundary so the
-              ;; contract holds across the JVM long / CLJS float split
-              ;; from `interop/now-ms` (mirrors `emit-handler-exception!`).
-              elapsed-ms (long (max 0 (- end-ms start-ms)))
-              msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
-              ;; Per rf2-je5p8: `evaluate-flow!`'s catch wraps the user
-              ;; throw in an ex-info carrying `:rf.flow/failed-id`.
-              ;; Extract it onto the substrate record's `:tags` so the
-              ;; always-on error-emit substrate (the only signal in CLJS
-              ;; prod where `:rf.flow/failed` DCEs) can attribute the
-              ;; `:rf.error/flow-eval-exception` to a specific flow.
-              ;; Absent slot leaves `:flow-id` nil — preserves the prior
-              ;; contract for non-wrapped throws (e.g. a hypothetical
-              ;; throw from outside `evaluate-flow!`). There is no real
-              ;; flow value to carry, so attribution is `:flow-id`-only
-              ;; per Spec 013 §Failure semantics.
-              flow-id    (some-> (ex-data e) :rf.flow/failed-id)
-              tags       (cond-> {:event-id          event-id
-                                  :event             event
-                                  :frame             frame
-                                  :where             :flow-eval
-                                  :handler-id        nil
-                                  :exception         e
-                                  :exception-message msg
-                                  :reason            "Flow evaluation threw."
-                                  :recovery          :no-recovery}
-                           flow-id (assoc :flow-id flow-id))]
-          ;; Always-on per rf2-bacs4 / rf2-hqbeh — fires in CLJS
-          ;; production builds where `trace/emit-error!` below is
-          ;; compile-time elided. The two fan-out paths (corpus-wide
-          ;; listener registry + per-frame `:on-error` policy) are
-          ;; independent and isolated; both see the
-          ;; `:rf.error/flow-eval-exception` record.
-          (error-emit/dispatch-on-error!
-            :rf.error/flow-eval-exception
-            event
-            event-id
-            frame
-            e
-            elapsed-ms
-            end-ms
-            {:operation :rf.error/flow-eval-exception
-             :op-type   :error
-             :tags      tags
-             :recovery  :no-recovery})
-          ;; Dev-side trace emission. Gated by `interop/debug-enabled?`
-          ;; inside `trace/emit-error!`; DCEs to a no-op in CLJS prod
-          ;; builds. Same payload shape as before the rf2-hrt5c fix —
-          ;; existing trace consumers are unaffected.
-          (trace/emit-error! :rf.error/flow-eval-exception
-                             {:frame frame :event event :exception e})
-          ;; Per rf2-fslx0 — Spec 013 §Failure semantics rule 3:
-          ;; signal failure so `commit-and-flow!` skips `:fx`.
-          false)))
-    ;; No flows artefact loaded — short-circuit. Treat as success
-    ;; (apps without flows don't have this cascade-halt concern).
-    true))
+  When the flows artefact is absent (`:flows/run-flows-on-db` hook nil)
+  the `:after` is a single nil-check no-op.
+
+  Failure (Spec 013 §Failure semantics): `run-flows-on-db` re-throws an
+  ex-info carrying `:rf.flow/partial-db` (prior successful flows' writes,
+  rule 1) and `:rf.flow/failed-id`. The `:after` catches it, installs the
+  partial db into `(:effects ctx :db)` so the prior writes still commit,
+  and stashes the throw under `:rf/flow-error` so `commit-and-flow!` can
+  emit `:rf.error/flow-eval-exception` and skip `:fx` (rule 3). The throw
+  is NOT recorded into `:rf/interceptor-error` — a flow-eval failure is a
+  distinct error category from a handler/interceptor exception, with its
+  own substrate routing and `:where :flow-eval` discriminator.
+
+  Frame-agnostic: a single shared interceptor value (no per-dispatch
+  allocation). The dispatching frame is read from the context coeffects
+  (`assemble-initial-ctx` stamps `:frame`)."
+  (interceptor/->interceptor
+    :id          :rf/flows
+    :rf/default? true
+    :after
+    (fn [ctx]
+      (if-let [run-on-db (late-bind/get-fn-cached :flows/run-flows-on-db)]
+        (let [frame      (:frame (:coeffects ctx))
+              effects    (:effects ctx)
+              has-db?     (contains? effects :db)
+              pending-db  (if has-db?
+                            (:db effects)
+                            (frame/frame-app-db-value frame))]
+          (try
+            (let [new-db (run-on-db frame pending-db)]
+              ;; Only publish a `:db` effect when flows actually changed
+              ;; the value OR the handler already had one — a no-flow /
+              ;; no-write event must not synthesise a spurious `:db`
+              ;; effect (which would force an app-db install + db-changed
+              ;; trace on an event that wrote nothing).
+              (if (or has-db? (not (identical? new-db pending-db)))
+                (interceptor/assoc-effect ctx :db new-db)
+                ctx))
+            (catch #?(:clj Throwable :cljs :default) e
+              ;; Rule 1: install the prior-flow-augmented db (carried on
+              ;; the ex-info) so prior successful flows' writes commit
+              ;; even as the cascade halts. Only publish a `:db` effect
+              ;; when the handler already had one OR a prior flow actually
+              ;; wrote (partial-db diverged from the pending value) — a
+              ;; first-flow throw on a no-`:db` event must not synthesise
+              ;; a spurious `:db` install + db-changed trace.
+              (let [partial-db (:rf.flow/partial-db (ex-data e))
+                    wrote?     (and (some? partial-db)
+                                    (not (identical? partial-db pending-db)))]
+                (-> (cond-> ctx
+                      (or has-db? wrote?)
+                      (interceptor/assoc-effect :db (or partial-db pending-db)))
+                    (assoc :rf/flow-error e))))))
+        ;; No flows artefact loaded — short-circuit (steady state for
+        ;; apps that never registered any flow).
+        ctx))))
+
+(defn- emit-flow-eval-exception!
+  "Surface a flow-eval throw (stashed by `flows-after-interceptor` under
+  `:rf/flow-error`) as `:rf.error/flow-eval-exception` through BOTH the
+  dev-only trace surface AND the always-on error-emit substrate (per
+  rf2-hrt5c — the security-audit fix). Per Spec 013 §Failure semantics
+  rule 3 the caller skips `:fx` after this fires; the drain continues
+  with the NEXT event.
+
+  Per rf2-hrt5c: `trace/emit-error!` is gated by `interop/debug-enabled?`
+  and DCEs under `:advanced` + `goog.DEBUG=false` — so the substrate path
+  is what survives prod elision and reaches off-box monitors. Mirrors
+  the handler-exception path (`emit-handler-exception!`). There is no
+  `:handler-id` (the throw came from the flow transform, not a handler);
+  `:where :flow-eval` discriminates this path for policy fns.
+
+  Per rf2-je5p8: `evaluate-flow!`'s catch (preserved through
+  `run-flows-on-db`'s re-wrap) carries `:rf.flow/failed-id` on the
+  ex-data; it is stamped onto the substrate record's `:tags` as
+  `:flow-id` so CLJS-prod ops (where `:rf.flow/failed` DCEs) can
+  attribute the cascade-level error to a specific flow. Attribution is
+  `:flow-id`-only — there is no real flow value to carry."
+  [e event event-id frame start-ms]
+  (let [end-ms     (interop/now-ms)
+        ;; Per rf2-bacs4 §Record shape: `:elapsed-ms` is an integer.
+        ;; Round once at the substrate boundary (JVM long / CLJS float).
+        elapsed-ms (long (max 0 (- end-ms start-ms)))
+        msg        #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))
+        flow-id    (some-> (ex-data e) :rf.flow/failed-id)
+        tags       (cond-> {:event-id          event-id
+                            :event             event
+                            :frame             frame
+                            :where             :flow-eval
+                            :handler-id        nil
+                            :exception         e
+                            :exception-message msg
+                            :reason            "Flow evaluation threw."
+                            :recovery          :no-recovery}
+                     flow-id (assoc :flow-id flow-id))]
+    ;; Always-on per rf2-bacs4 / rf2-hqbeh — fires in CLJS production
+    ;; where `trace/emit-error!` below is compile-time elided. The two
+    ;; fan-out paths (corpus-wide listener registry + per-frame
+    ;; `:on-error` policy) are independent and isolated.
+    (error-emit/dispatch-on-error!
+      :rf.error/flow-eval-exception
+      event
+      event-id
+      frame
+      e
+      elapsed-ms
+      end-ms
+      {:operation :rf.error/flow-eval-exception
+       :op-type   :error
+       :tags      tags
+       :recovery  :no-recovery})
+    ;; Dev-side trace emission. Gated by `interop/debug-enabled?` inside
+    ;; `trace/emit-error!`; DCEs in CLJS prod. Same payload shape as
+    ;; before — existing trace consumers are unaffected.
+    (trace/emit-error! :rf.error/flow-eval-exception
+                       {:frame frame :event event :exception e})))
 
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame
@@ -623,19 +664,22 @@
 ;;                               applicable) plus :rf.error/no-such-handler.
 ;;                               Lives in re-frame.router.diagnostics per
 ;;                               rf2-0ytl4 seam R-B.
-;;   prepare-handler-ctx         build the full interceptor chain + initial
+;;   prepare-handler-ctx         build the full interceptor chain (incl. the
+;;                               innermost flows-after-interceptor) + initial
 ;;                               context and the effective fx-overrides map;
 ;;                               returns a tight map consumed by run-chain
 ;;                               and commit-and-flow!
 ;;   run-chain                   execute the interceptor chain bracketed in
 ;;                               performance marks; skipped when event-payload
 ;;                               validation fails (per Spec 010 §Per-step
-;;                               recovery step 1)
-;;   commit-and-flow!            handler-exception emit (if any), :db commit,
-;;                               flows, then walk :fx in source order; returns
-;;                               the dispatch outcome keyword (:ok / :error /
-;;                               :rolled-back / :flow-error) for the event-emit
-;;                               record
+;;                               recovery step 1). Flows run HERE, inside the
+;;                               chain, as the innermost :after (rf2-u0zz5).
+;;   commit-and-flow!            handler-exception emit (if any), flow-eval
+;;                               error emit (if any), :db commit (of the
+;;                               flow-augmented db), then walk :fx in source
+;;                               order; returns the dispatch outcome keyword
+;;                               (:ok / :error / :rolled-back / :flow-error)
+;;                               for the event-emit record
 ;;   emit-cascade-trailers!      :run-end trace + always-on event-emit fan-out
 ;;   run-handler-cascade!        sequence prepare → run → commit → trailers
 ;;                               under `trace/with-handler-scope`
@@ -695,11 +739,29 @@
         ;; OUT-OF-CHAIN projection used by emit sites that fire BEFORE
         ;; the chain.
         user-paths      (privacy/user-redaction-paths base-chain)
-        full-chain      (if (seq redaction-paths)
+        redacted-chain  (if (seq redaction-paths)
                           (into [(privacy/schema-redaction-interceptor
                                    redaction-paths)]
                                 base-chain)
                           base-chain)
+        ;; Per Spec 013 §Drain integration (rf2-u0zz5): PREPEND the
+        ;; framework's flow-transform interceptor at the HEAD of the
+        ;; dispatch-time chain so its `:after` is the OUTERMOST `:after`
+        ;; — it fires after the rest of the `:after` chain (handler body
+        ;; + every user / framework `:after`) has fully reshaped the
+        ;; pending `:db` effect into the complete app-db form. This is
+        ;; load-bearing: a `(rf/path :slice)` interceptor's `:after`
+        ;; splices the handler's slice back into the FULL db, so the flow
+        ;; transform (which reads full-db `:inputs` paths) MUST run after
+        ;; that splice — i.e. outermost. The rest of the `:after` chain
+        ;; therefore precedes flows and sees its INPUT; the flow output
+        ;; reaches `:fx`, the reactive cascade, and the single `:db`
+        ;; install (all of which run after the chain). Added here
+        ;; (dispatch-time) rather than baked into the registered handler-
+        ;; meta chain so tooling that reads `(handler-meta :event id)
+        ;; :interceptors` still sees the user-authored chain with the
+        ;; handler-wrapper at its tail.
+        full-chain      (into [flows-after-interceptor] redacted-chain)
         initial-ctx     (assemble-initial-ctx envelope frame frame-record fx-overrides)
         all-paths       (into (vec redaction-paths) user-paths)]
     {:full-chain   full-chain
@@ -760,6 +822,19 @@
   `run-fx-effects!` so reserved-fx defmethods can propagate
   inheritable keys onto child dispatches.
 
+  Per Spec 013 §Drain integration (rf2-u0zz5): flows have ALREADY run
+  by the time this fn executes — the framework's innermost `:after`
+  interceptor (`flows-after-interceptor`) transformed the pending `:db`
+  effect inside the chain. So `(:db effects)` here is the FLOW-AUGMENTED
+  value, and a flow throw is signalled by `(:rf/flow-error final-ctx)`
+  rather than an inline `run-flows!` call. On a flow throw the prior
+  successful flows' writes are already in `(:db effects)` (the `:after`
+  installed the partial db), so the commit STILL fires (rule 1 — prior
+  writes preserved) but `:fx` is SKIPPED (rule 3). The error trace is
+  emitted BEFORE the commit so the stream carries
+  `:rf.flow/failed → :rf.error/flow-eval-exception → :rf.event/db-changed`
+  (per Spec 013 §Trace stream ordering on a flow throw).
+
   Returns the dispatch OUTCOME keyword for the always-on event-emit
   record (Spec 009 §Event-emit listener §Record shape):
 
@@ -768,10 +843,10 @@
                    threw; `emit-handler-exception!` has already fired.
     :rolled-back — post-commit `:db` schema validation rejected the
                    new state and the container was restored to its
-                   pre-handler value (Spec 010 row 4); flows + :fx
-                   were skipped.
+                   pre-handler value (Spec 010 row 4); :fx was skipped.
     :flow-error  — a flow's `:output` threw (Spec 013 §Failure
-                   semantics rule 3); :fx was skipped.
+                   semantics rule 3); prior-flow writes committed, :fx
+                   was skipped.
 
   All three non-`:ok` values surface to off-box observability shippers
   (Datadog / Sentry / Honeycomb) so a dispatch that rolled back its
@@ -781,30 +856,34 @@
   signal, and `commit-db-effect!` short-circuits the schema commit
   when the handler errored (no `:db` effect to validate)."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
-  (let [effects   (:effects final-ctx)
-        coeffects (:coeffects final-ctx)
-        error     (:rf/interceptor-error final-ctx)
-        db-before (get-in final-ctx [:coeffects :db])]
+  (let [effects    (:effects final-ctx)
+        coeffects  (:coeffects final-ctx)
+        error      (:rf/interceptor-error final-ctx)
+        flow-error (:rf/flow-error final-ctx)
+        db-before  (get-in final-ctx [:coeffects :db])]
     (when error
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
     (cond
       error :error
+      ;; Per Spec 013 §Failure semantics: a flow's `:output` threw during
+      ;; the innermost `:after` flow transform. The transform already
+      ;; installed the prior-flow-augmented `:db` effect (rule 1), so we
+      ;; STILL commit (preserving prior writes) but SKIP `:fx` (rule 3) —
+      ;; an `:fx [[:dispatch [:react-to-area-change]]]` must not fire on
+      ;; a halted cascade. Emit the cascade-level
+      ;; `:rf.error/flow-eval-exception` BEFORE the commit so the trace
+      ;; stream is `flow/failed → flow-eval-exception → db-changed`.
+      flow-error
+      (do
+        (emit-flow-eval-exception! flow-error event event-id frame start-ms)
+        (commit-db-effect! effects event-id event frame final-ctx db-before)
+        :flow-error)
       ;; Per Spec 010 §Per-step recovery row 4: `commit-db-effect!`
       ;; returns false when post-commit schema validation rejected the
       ;; new state and rolled the container back to its pre-handler
-      ;; value. Flows + :fx are skipped; the dispatch failed.
+      ;; value. `:fx` is skipped; the dispatch failed.
       (not (commit-db-effect! effects event-id event frame final-ctx db-before))
       :rolled-back
-      ;; Per rf2-fslx0 — Spec 013 §Failure semantics rule 3: when a
-      ;; flow throws, halt the cascade. `run-flows!` returns false on
-      ;; flow throw (after fanning out
-      ;; `:rf.error/flow-eval-exception` through trace + error-emit
-      ;; substrate); `run-fx-effects!` then skips. Without this gate
-      ;; an `:fx [[:dispatch [:react-to-area-change]]]` would fire its
-      ;; child dispatch on stale derived state — side effects (HTTP /
-      ;; navigation / analytics) would escape.
-      (not (run-flows! frame event event-id start-ms))
-      :flow-error
       :else
       (do
         (run-fx-effects! effects coeffects frame frame-record fx-overrides envelope)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -497,15 +497,20 @@
   When the flows artefact is absent (`:flows/run-flows-on-db` hook nil)
   the `:after` is a single nil-check no-op.
 
-  Failure (Spec 013 §Failure semantics): `run-flows-on-db` re-throws an
-  ex-info carrying `:rf.flow/partial-db` (prior successful flows' writes,
-  rule 1) and `:rf.flow/failed-id`. The `:after` catches it, installs the
-  partial db into `(:effects ctx :db)` so the prior writes still commit,
-  and stashes the throw under `:rf/flow-error` so `commit-and-flow!` can
-  emit `:rf.error/flow-eval-exception` and skip `:fx` (rule 3). The throw
-  is NOT recorded into `:rf/interceptor-error` — a flow-eval failure is a
-  distinct error category from a handler/interceptor exception, with its
-  own substrate routing and `:where :flow-eval` discriminator.
+  Failure (Spec 013 §Failure semantics — atomicity contract, Mike
+  2026-05-24): a flow throw is a PRE-INSTALL throw, so it aborts the whole
+  event exactly like a handler / interceptor-`:after` throw. The `:after`
+  catches the ex-info, DISCARDS the pending `:db` effect (`dissoc`-ing it
+  from `(:effects ctx)`) so the single deferred install installs NOTHING —
+  app-db is left UNCHANGED, NO `:rf.event/db-changed` is emitted, and NO
+  `:fx` run. There is no partial commit: prior successful flows' writes do
+  NOT land either (they were only ever in the pending `:db` effect, never
+  installed). The throw is stashed under `:rf/flow-error` so
+  `commit-and-flow!` can emit `:rf.error/flow-eval-exception` and skip the
+  install + `:fx`. It is NOT recorded into `:rf/interceptor-error` — a
+  flow-eval failure is a distinct error category from a handler/interceptor
+  exception, with its own substrate routing and `:where :flow-eval`
+  discriminator.
 
   Frame-agnostic: a single shared interceptor value (no per-dispatch
   allocation). The dispatching frame is read from the context coeffects
@@ -533,20 +538,19 @@
                 (interceptor/assoc-effect ctx :db new-db)
                 ctx))
             (catch #?(:clj Throwable :cljs :default) e
-              ;; Rule 1: install the prior-flow-augmented db (carried on
-              ;; the ex-info) so prior successful flows' writes commit
-              ;; even as the cascade halts. Only publish a `:db` effect
-              ;; when the handler already had one OR a prior flow actually
-              ;; wrote (partial-db diverged from the pending value) — a
-              ;; first-flow throw on a no-`:db` event must not synthesise
-              ;; a spurious `:db` install + db-changed trace.
-              (let [partial-db (:rf.flow/partial-db (ex-data e))
-                    wrote?     (and (some? partial-db)
-                                    (not (identical? partial-db pending-db)))]
-                (-> (cond-> ctx
-                      (or has-db? wrote?)
-                      (interceptor/assoc-effect :db (or partial-db pending-db)))
-                    (assoc :rf/flow-error e))))))
+              ;; Atomicity contract (Spec 013 §Failure semantics, Mike
+              ;; 2026-05-24): a flow throw is a PRE-INSTALL throw, so it
+              ;; aborts the whole event. DISCARD any pending `:db` effect
+              ;; (the handler's and any prior flows' writes) so the single
+              ;; deferred install installs NOTHING — app-db stays unchanged,
+              ;; no `:rf.event/db-changed`, no `:fx`. No partial commit.
+              ;; Stash the throw under `:rf/flow-error` so `commit-and-flow!`
+              ;; surfaces `:rf.error/flow-eval-exception` and skips install +
+              ;; `:fx`. `dissoc`-ing `:db` is the whole mechanism — winding
+              ;; back on a pre-install throw is FREE because the install was
+              ;; already deferred to one write.
+              (-> (update ctx :effects dissoc :db)
+                  (assoc :rf/flow-error e)))))
         ;; No flows artefact loaded — short-circuit (steady state for
         ;; apps that never registered any flow).
         ctx))))
@@ -805,10 +809,12 @@
       (interceptor/execute-chain full-chain ctx))))
 
 (defn- commit-and-flow!
-  "Settle the cascade: surface any chain exception, commit :db, run
-  flows, then walk :fx in source order. Per Spec 002 §Drain-loop
-  pseudocode. Trace ordering is load-bearing — :event/db-changed
-  precedes flow evaluation, which precedes :fx walking.
+  "Settle the cascade: surface any chain / flow exception, commit the
+  (flow-augmented) :db, then walk :fx in source order. Per Spec 002
+  §Drain-loop pseudocode. Flows have already run as the outermost
+  `:after` inside the chain (rf2-u0zz5), so by the time this fn executes
+  the pending `:db` effect is the flow-augmented value; the install here
+  is the single deferred commit, and `:fx` walks after it.
 
   Per Spec 010 §Per-step recovery row 4 (rf2-wkxng / rf2-6m0se): a
   post-commit `:db` schema-validation failure rolls the container
@@ -823,17 +829,23 @@
   inheritable keys onto child dispatches.
 
   Per Spec 013 §Drain integration (rf2-u0zz5): flows have ALREADY run
-  by the time this fn executes — the framework's innermost `:after`
+  by the time this fn executes — the framework's OUTERMOST `:after`
   interceptor (`flows-after-interceptor`) transformed the pending `:db`
   effect inside the chain. So `(:db effects)` here is the FLOW-AUGMENTED
   value, and a flow throw is signalled by `(:rf/flow-error final-ctx)`
-  rather than an inline `run-flows!` call. On a flow throw the prior
-  successful flows' writes are already in `(:db effects)` (the `:after`
-  installed the partial db), so the commit STILL fires (rule 1 — prior
-  writes preserved) but `:fx` is SKIPPED (rule 3). The error trace is
-  emitted BEFORE the commit so the stream carries
-  `:rf.flow/failed → :rf.error/flow-eval-exception → :rf.event/db-changed`
-  (per Spec 013 §Trace stream ordering on a flow throw).
+  rather than an inline `run-flows!` call.
+
+  Atomicity contract (Spec 013 §Failure semantics, Mike 2026-05-24): the
+  `:db` install is the single, deferred, all-or-nothing commit boundary.
+  ANY pre-install throw — handler, interceptor `:after`, or the flow
+  transform — aborts the event: NO install, app-db UNCHANGED, NO
+  `:rf.event/db-changed`, NO `:fx`. This is uniform and FREE: the
+  handler / interceptor-error path returns `:error` WITHOUT calling
+  `commit-db-effect!`, and the flow-throw path's `:after` already
+  `dissoc`-ed the pending `:db` effect — so even if the commit ran it
+  would install nothing (`commit-db-effect!` is a no-op when no `:db`
+  effect is present). `:fx` is the ONLY post-install stage; an fx throw
+  does NOT wind back app-db (its side effects may already have fired).
 
   Returns the dispatch OUTCOME keyword for the always-on event-emit
   record (Spec 009 §Event-emit listener §Record shape):
@@ -841,20 +853,20 @@
     :ok          — clean settle (db committed, flows ran, :fx walked).
     :error       — the interceptor chain (handler or interceptor)
                    threw; `emit-handler-exception!` has already fired.
+                   No install, app-db unchanged, :fx skipped.
     :rolled-back — post-commit `:db` schema validation rejected the
                    new state and the container was restored to its
                    pre-handler value (Spec 010 row 4); :fx was skipped.
     :flow-error  — a flow's `:output` threw (Spec 013 §Failure
-                   semantics rule 3); prior-flow writes committed, :fx
-                   was skipped.
+                   semantics); the event aborted — no install, app-db
+                   unchanged, no db-changed, :fx skipped.
 
   All three non-`:ok` values surface to off-box observability shippers
   (Datadog / Sentry / Honeycomb) so a dispatch that rolled back its
   whole `:db` write or aborted on a flow throw is NOT mis-reported as
   a clean `:ok`. A chain exception is reported as `:error` regardless
   of any downstream rollback — it is the proximate, most-actionable
-  signal, and `commit-db-effect!` short-circuits the schema commit
-  when the handler errored (no `:db` effect to validate)."
+  signal."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
   (let [effects    (:effects final-ctx)
         coeffects  (:coeffects final-ctx)
@@ -865,18 +877,19 @@
       (emit-handler-exception! error event-id event frame final-ctx start-ms))
     (cond
       error :error
-      ;; Per Spec 013 §Failure semantics: a flow's `:output` threw during
-      ;; the innermost `:after` flow transform. The transform already
-      ;; installed the prior-flow-augmented `:db` effect (rule 1), so we
-      ;; STILL commit (preserving prior writes) but SKIP `:fx` (rule 3) —
-      ;; an `:fx [[:dispatch [:react-to-area-change]]]` must not fire on
-      ;; a halted cascade. Emit the cascade-level
-      ;; `:rf.error/flow-eval-exception` BEFORE the commit so the trace
-      ;; stream is `flow/failed → flow-eval-exception → db-changed`.
+      ;; Per Spec 013 §Failure semantics (atomicity contract, Mike
+      ;; 2026-05-24): a flow's `:output` threw during the outermost
+      ;; `:after` flow transform. A flow throw is a PRE-INSTALL throw, so
+      ;; the event ABORTS — no install, app-db unchanged, no
+      ;; `:rf.event/db-changed`, no `:fx`. The `:after` already `dissoc`-ed
+      ;; the pending `:db` effect, so we do NOT call `commit-db-effect!`
+      ;; here at all: the only post-install stage (`:fx`) is skipped and
+      ;; nothing is committed. Surface the cascade-level
+      ;; `:rf.error/flow-eval-exception`; the trace stream is therefore
+      ;; `flow/failed → flow-eval-exception` with NO `db-changed`.
       flow-error
       (do
         (emit-flow-eval-exception! flow-error event event-id frame start-ms)
-        (commit-db-effect! effects event-id event frame final-ctx db-before)
         :flow-error)
       ;; Per Spec 010 §Per-step recovery row 4: `commit-db-effect!`
       ;; returns false when post-commit schema validation rejected the

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -125,20 +125,22 @@
             "schema rollback surfaces as the distinct :rolled-back outcome")))))
 
 (deftest listener-marks-flow-throw-as-non-ok-outcome
-  (testing "When a flow's :output throws during the post-commit flow walk
-            — the runtime halts the cascade before :fx — the event-emit
-            record's :outcome is NON-:ok."
+  (testing "When a flow's :output throws during the outermost :after flow
+            transform — the runtime ABORTS the event (no install, app-db
+            unchanged, :fx skipped) — the event-emit record's :outcome is
+            NON-:ok and the handler's :db did NOT land (atomicity contract,
+            Spec 013 §Failure semantics)."
     (let [seen (atom [])]
       ;; Stub the flow-transform hook to throw, driving the router's
-      ;; flows-after-interceptor down its catch branch (which stashes
-      ;; :rf/flow-error → cascade halt before :fx). The hook is the
-      ;; (frame db) -> db transform; on throw it carries the partial db
-      ;; under :rf.flow/partial-db per Spec 013 §Failure semantics.
+      ;; flows-after-interceptor down its catch branch (which DISCARDS the
+      ;; pending :db effect + stashes :rf/flow-error → event aborts before
+      ;; install + :fx). The hook is the (frame db) -> db transform; on
+      ;; throw it carries only :rf.flow/failed-id for attribution — there
+      ;; is no partial-db (no partial commit per the atomicity contract).
       (late-bind/set-fn! :flows/run-flows-on-db
-                         (fn [_frame db]
+                         (fn [_frame _db]
                            (throw (ex-info "flow output blew up"
-                                           {:rf.flow/failed-id :flow/derived
-                                            :rf.flow/partial-db db}))))
+                                           {:rf.flow/failed-id :flow/derived}))))
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
@@ -150,7 +152,10 @@
         (is (not= :ok outcome)
             "a flow-aborted dispatch is NOT reported as a clean :ok")
         (is (= :flow-error outcome)
-            "a flow-output throw surfaces as the distinct :flow-error outcome")))))
+            "a flow-output throw surfaces as the distinct :flow-error outcome"))
+      (is (not (contains? (rf/get-frame-db :rf/default) :n))
+          "the handler's :db write did NOT land — a flow throw aborts the
+           event with no install (app-db unchanged)"))))
 
 (deftest listener-marks-clean-dispatch-as-ok-with-failure-hooks-installed
   (testing "With BOTH cascade-failure hooks installed but PASSING (schema

--- a/implementation/core/test/re_frame/event_emit_test.cljc
+++ b/implementation/core/test/re_frame/event_emit_test.cljc
@@ -43,7 +43,7 @@
       (finally
         (reset! late-bind/hooks hooks-before)
         (late-bind/invalidate-cache! :schemas/validate-app-schema!)
-        (late-bind/invalidate-cache! :flows/run-flows!)))))
+        (late-bind/invalidate-cache! :flows/run-flows-on-db)))))
 
 (use-fixtures :each reset-runtime)
 
@@ -129,12 +129,16 @@
             — the runtime halts the cascade before :fx — the event-emit
             record's :outcome is NON-:ok."
     (let [seen (atom [])]
-      ;; Stub the flow-run hook to throw, driving run-flows! down its
-      ;; catch branch (which returns false → cascade halt).
-      (late-bind/set-fn! :flows/run-flows!
-                         (fn [_frame]
+      ;; Stub the flow-transform hook to throw, driving the router's
+      ;; flows-after-interceptor down its catch branch (which stashes
+      ;; :rf/flow-error → cascade halt before :fx). The hook is the
+      ;; (frame db) -> db transform; on throw it carries the partial db
+      ;; under :rf.flow/partial-db per Spec 013 §Failure semantics.
+      (late-bind/set-fn! :flows/run-flows-on-db
+                         (fn [_frame db]
                            (throw (ex-info "flow output blew up"
-                                           {:rf.flow/failed-id :flow/derived}))))
+                                           {:rf.flow/failed-id :flow/derived
+                                            :rf.flow/partial-db db}))))
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))
@@ -156,8 +160,8 @@
     (let [seen (atom [])]
       (late-bind/set-fn! :schemas/validate-app-schema!
                          (fn [_db-after _event-id _frame] true))
-      (late-bind/set-fn! :flows/run-flows!
-                         (fn [_frame] nil))
+      (late-bind/set-fn! :flows/run-flows-on-db
+                         (fn [_frame db] db))
       (rf/register-event-listener!
         :test/recorder
         (fn [record] (swap! seen conj record)))

--- a/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
@@ -33,7 +33,7 @@
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
             ;; Loading `re-frame.flows` registers the late-bind hooks
-            ;; (`:flows/reg-flow`, `:flows/run-flows!`) the router
+            ;; (`:flows/reg-flow`, `:flows/run-flows-on-db`) the router
             ;; reaches at dispatch time — keep the require even when
             ;; the test ns doesn't reach `flows/...` directly through
             ;; a public fn.

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -316,3 +316,70 @@
         (is (vector? (:event r))
             "event vector flows through (subject only to per-path wire elision)")
         (is (= :err/normal-throw (first (:event r))))))))
+
+;; ============================================================================
+;; rf2-u0zz5 — atomicity contract: any pre-install throw aborts the event
+;; ----------------------------------------------------------------------------
+;; The `:db` install is the single, deferred, all-or-nothing commit
+;; boundary. ANY throw before it — handler, interceptor `:after`, or the
+;; flow transform — aborts the event: NO install, app-db UNCHANGED, NO
+;; `:rf.event/db-changed`, NO `:fx`. (The flow-transform variant is pinned
+;; in re-frame.flows-trace-test; here we pin the handler and
+;; interceptor-`:after` variants — proving the abort is UNIFORM across all
+;; pre-install throw sources.)
+;; ============================================================================
+
+(deftest handler-throw-leaves-app-db-unchanged-no-db-changed
+  (testing "A handler throw aborts the event before the install: app-db
+            is UNCHANGED and NO :rf.event/db-changed is emitted."
+    (let [traces (atom [])]
+      ;; Seed a known app-db value via a clean dispatch first.
+      (rf/reg-event-db :seed (fn [_ _] {:seeded 1}))
+      (rf/dispatch-sync [:seed])
+      (is (= {:seeded 1} (rf/get-frame-db :rf/default)) "seeded")
+      ;; Now register a handler that mutates :db and then throws. Even
+      ;; though it produced a :db value before throwing, nothing installs.
+      (rf/reg-event-db :throws
+                       (fn [db _]
+                         ;; Build a would-be new db, then throw — the
+                         ;; handler returns nothing; its effect never
+                         ;; reaches the install.
+                         (let [_ (assoc db :would-be 2)]
+                           (throw (ex-info "boom" {})))))
+      (rf/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+      (try
+        (rf/dispatch-sync [:throws])
+        (finally (rf/unregister-listener! ::rec)))
+      (is (= {:seeded 1} (rf/get-frame-db :rf/default))
+          "app-db is UNCHANGED — the handler threw before the install")
+      (is (not-any? #(= :rf.event/db-changed (:operation %)) @traces)
+          "NO :rf.event/db-changed on a handler throw — nothing was installed"))))
+
+(deftest interceptor-after-throw-leaves-app-db-unchanged-no-db-changed
+  (testing "An interceptor :after throw aborts the event before the
+            install — even though the handler produced a :db effect: app-db
+            is UNCHANGED and NO :rf.event/db-changed is emitted."
+    (let [traces (atom [])
+          ;; A user interceptor whose :after throws AFTER the handler has
+          ;; produced its :db effect.
+          boom-after (rf/->interceptor
+                       :id :test/boom-after
+                       :after (fn [_ctx] (throw (ex-info "after boom" {}))))]
+      (rf/reg-event-db :seed (fn [_ _] {:seeded 1}))
+      (rf/dispatch-sync [:seed])
+      (is (= {:seeded 1} (rf/get-frame-db :rf/default)) "seeded")
+      ;; This handler successfully writes :db; the interceptor's :after
+      ;; then throws — so a :db effect IS present when the throw fires,
+      ;; yet nothing installs (the error path returns before the commit).
+      (rf/reg-event-db :writes-then-after-throws
+                       [boom-after]
+                       (fn [db _] (assoc db :written 99)))
+      (rf/register-listener! ::rec (fn [ev] (swap! traces conj ev)))
+      (try
+        (rf/dispatch-sync [:writes-then-after-throws])
+        (finally (rf/unregister-listener! ::rec)))
+      (is (= {:seeded 1} (rf/get-frame-db :rf/default))
+          "app-db is UNCHANGED — the interceptor :after threw before the install
+           even though the handler's :db effect was present")
+      (is (not-any? #(= :rf.event/db-changed (:operation %)) @traces)
+          "NO :rf.event/db-changed on an interceptor :after throw"))))

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -412,7 +412,8 @@
     (rf/dispatch-sync [:init])
     (rf/dispatch-sync [:w! 3])
     (rf/dispatch-sync [:h! 4])
-    ;; The drain calls run-flows! after :db commit per Spec 013.
+    ;; The flow transform runs as the innermost :after (before :db
+    ;; install) and its output lands in the installed app-db per Spec 013.
     (is (= 12 (:area (rf/get-frame-db :rf/default))))))
 
 ;; ---- routing --------------------------------------------------------------

--- a/implementation/flows/deps.edn
+++ b/implementation/flows/deps.edn
@@ -4,7 +4,7 @@
 ;; Per Spec 013 the flow surface (`reg-flow`, `clear-flow`, the
 ;; `:rf.fx/reg-flow` / `:rf.fx/clear-flow` runtime fxs, the per-frame
 ;; flow registry, the topological sort, the dirty-check `last-inputs`
-;; map, and the post-drain `run-flows!` walker) ships as a separate
+;; map, and the innermost-`:after` `run-flows-on-db` walker) ships as a separate
 ;; Maven artefact so apps that don't register any flows don't drag the
 ;; namespace, the topo-sort engine, or any of the `:rf.flow/*`
 ;; trace strings onto the classpath.
@@ -18,7 +18,7 @@
 ;; `rf/reg-flow` / `rf/clear-flow` or relies on the `:rf.fx/reg-flow`
 ;; / `:rf.fx/clear-flow` runtime fxs — loading the namespace registers
 ;; its late-bind hooks (`:flows/reg-flow`, `:flows/clear-flow`,
-;; `:flows/run-flows!`, `:flows/reset-last-inputs!`, `:flows/reset-flows!`)
+;; `:flows/run-flows-on-db`, `:flows/reset-last-inputs!`, `:flows/reset-flows!`)
 ;; and installs the registrar replacement-hook for hot-reload
 ;; `last-inputs` invalidation.
 ;;
@@ -27,7 +27,7 @@
 ;; core; core never depends on this artefact. The cross-references
 ;; from core to flows (e.g. `re-frame.core`'s `reg-flow` / `clear-flow`
 ;; re-exports, `re-frame.fx`'s `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
-;; effect handlers, `re-frame.router`'s post-drain `run-flows!` call,
+;; effect handlers, `re-frame.router`'s innermost-`:after` `run-flows-on-db` call,
 ;; `re-frame.test-support`'s reset-runtime fixture's flows reset) flow
 ;; through `re-frame.late-bind` exactly as the schemas / machines /
 ;; routing hooks already do.

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -122,19 +122,19 @@
   successful evaluation (skip or recompute); on the failure path the
   exception re-throws after the `:rf.flow/failed` trace fires.
 
-  Failed-flow contract (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure
-  semantics): the failing flow's own output is NOT written (the throw
-  happened during `:output`; there is no usable new-output). Its
-  `last-inputs` slot is NOT advanced so the flow re-attempts on the
-  next drain. `run-flows-on-db` catches the propagated throw and
-  re-throws an ex-info carrying `:rf.flow/partial-db` — the
-  loop accumulator holding prior successful flows' dirty writes
-  (rule 1 of the contract) — so the router's flows-after-interceptor
-  installs those prior writes even as the cascade halts, and the
-  router emits the cascade-level `:rf.error/flow-eval-exception` per
-  Spec 009 §Error contract. The cascade halts at the failing flow —
-  downstream flows scheduled later in topo order do NOT run on this
-  drain (rule 3); they re-attempt naturally on the next drain.
+  Failed-flow contract (Spec 013 §Failure semantics — atomicity
+  contract, Mike 2026-05-24): the failing flow's own output is NOT
+  written (the throw happened during `:output`; there is no usable
+  new-output). This fn re-throws an ex-info carrying `:rf.flow/failed-id`
+  so the router can attribute the cascade-level
+  `:rf.error/flow-eval-exception` (Spec 009 §Error contract) to this
+  flow; the throw propagates straight out of `run-flows-on-db`. A flow
+  throw is a PRE-INSTALL throw: the router's flows-after-interceptor
+  DISCARDS the pending `:db` effect, so app-db is left UNCHANGED — no
+  partial commit, no prior-flow writes installed, no `:rf.event/db-changed`.
+  The cascade halts at the failing flow — downstream flows scheduled
+  later in topo order do NOT run on this drain; they re-attempt naturally
+  on the next drain.
 
   Hot path — runs after every event drain for every registered flow.
   Trace payload construction sits inside an `interop/debug-enabled?`
@@ -247,13 +247,12 @@
           ;; Per Spec 009 §:op-type vocabulary: :rf.flow/failed fires
           ;; when the flow's :output fn throws. last-inputs is NOT
           ;; advanced — so the flow will retry on the next drain rather
-          ;; than silently caching a stale-or-missing output. We re-
-          ;; throw so `run-flows-on-db` can re-wrap the throw with the
-          ;; accumulated dirty writes from PRIOR successful flows in the
-          ;; same drain (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure
-          ;; semantics rule 1) under `:rf.flow/partial-db`, and then
-          ;; propagate to the router's flows-after-interceptor which
-          ;; installs that partial db and emits the cascade-level
+          ;; than silently caching a stale-or-missing output. We re-throw
+          ;; an ex-info carrying `:rf.flow/failed-id` (Spec 013 §Failure
+          ;; semantics — atomicity contract); it propagates through
+          ;; `run-flows-on-db` to the router's flows-after-interceptor,
+          ;; which DISCARDS the pending `:db` effect (no partial commit —
+          ;; app-db unchanged) and emits the cascade-level
           ;; :rf.error/flow-eval-exception per Spec 009 §Error contract.
           ;; The per-flow `:rf.flow/failed` trace emitted here adds the
           ;; flow-attributed detail tools (10x flow panel) consume.
@@ -317,59 +316,55 @@
   Flows are frame-scoped — only flows registered against frame-id run
   here, leaving sibling frames' flows untouched.
 
-  Failed-flow contract (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure
-  semantics): when a flow's `:output` throws, prior successful flows'
-  dirty writes in the same drain are PRESERVED — the loop accumulator
-  already carries them, and on the throw we re-throw an ex-info whose
-  `ex-data` carries the prior-flow-augmented db under
-  `:rf.flow/partial-db` so the router can STILL install it (rule 1) even
-  though the cascade halts. The cascade then halts: flows scheduled
-  later in topo order do not run on this drain, and the router surfaces
-  the cascade-level `:rf.error/flow-eval-exception`. The failing flow's
-  own `last-inputs` is NOT advanced (so it re-attempts next drain);
-  prior flows' `last-inputs` ARE advanced (they computed successfully
-  and their outputs are now in the returned db). This is the strongest
-  'no work is silently lost' guarantee compatible with cascade-level
-  error surfacing. The `:rf.flow/failed-id` slot (stamped by
-  `evaluate-flow!`) is preserved on the re-thrown ex-info so the router
-  can attribute the cascade-level error to the failing flow."
+  Failed-flow contract (Spec 013 §Failure semantics — atomicity
+  contract, Mike 2026-05-24): a flow throw is a PRE-INSTALL throw, so it
+  aborts the WHOLE event. There is NO partial commit — the pending `:db`
+  effect (the handler's write plus any prior successful flows' writes) is
+  DISCARDED by the router's `flows-after-interceptor` catch, so app-db is
+  left UNCHANGED. This fn therefore does NOT carry a partial-db on the
+  re-thrown ex-info: it would have no consumer. The cascade halts (flows
+  scheduled later in topo order do not run on this drain) and the router
+  surfaces the cascade-level `:rf.error/flow-eval-exception`.
+
+  Atomicity extends to the dirty-check bookkeeping: `evaluate-flow!`
+  advances the global `last-inputs` atom for each flow it computes, but
+  on a throw NOTHING is installed — so a prior flow's advanced
+  `last-inputs` would (wrongly) suppress its recompute next drain even
+  though its output never reached app-db, silently losing the write
+  forever. So we SNAPSHOT `last-inputs` before the walk and RESTORE it on
+  a throw: every flow — prior-successful and failing alike — re-attempts
+  cleanly on the next drain, matching the all-or-nothing `:db` install.
+  The `:rf.flow/failed-id` slot (stamped by `evaluate-flow!`) is
+  preserved on the re-thrown ex-info so the router can attribute the
+  cascade-level error to the failing flow."
   [frame-id db]
   (let [flow-map (get @flows frame-id)]
     (if-not (seq flow-map)
       db
-      (let [ordered (topo/topo-sort flow-map)]
-        (loop [remaining  ordered
-               db         db
-               any-dirty? false]
-          (if (empty? remaining)
-            db
-            (let [flow            (flow-map (first remaining))
-                  [new-db dirty?] (try
-                                    (evaluate-flow! frame-id db flow)
-                                    (catch #?(:clj Throwable :cljs :default) e
-                                      ;; Preserve prior successful flows'
-                                      ;; writes (Spec 013 §Failure
-                                      ;; semantics rule 1): they are
-                                      ;; already in `db` (the loop
-                                      ;; accumulator) with their
-                                      ;; `last-inputs` slots advanced (per
-                                      ;; evaluate-flow!'s success branch).
-                                      ;; Carry the accumulator on the
-                                      ;; re-thrown ex-info so the router
-                                      ;; installs it even as the cascade
-                                      ;; halts and `:fx` is skipped.
-                                      ;; Without this the prior flows'
-                                      ;; outputs would vanish while their
-                                      ;; `:rf.flow/computed` traces still
-                                      ;; claimed the write happened.
-                                      (throw
-                                        (ex-info (or #?(:clj (.getMessage ^Throwable e)
-                                                        :cljs (.-message e))
-                                                     ":rf.error/flow-eval-exception")
-                                                 (assoc (ex-data e)
-                                                        :rf.flow/partial-db db)
-                                                 e))))]
-              (recur (rest remaining) new-db (or any-dirty? dirty?)))))))))
+      (let [ordered (topo/topo-sort flow-map)
+            ;; Snapshot the dirty-check bookkeeping so a flow throw can
+            ;; roll it back wholesale — the event aborts, so prior flows'
+            ;; `last-inputs` advances must NOT survive (their outputs were
+            ;; never installed). Restored in the catch below.
+            last-inputs-before @last-inputs]
+        (try
+          (loop [remaining  ordered
+                 db         db
+                 any-dirty? false]
+            (if (empty? remaining)
+              db
+              (let [flow            (flow-map (first remaining))
+                    [new-db dirty?] (evaluate-flow! frame-id db flow)]
+                (recur (rest remaining) new-db (or any-dirty? dirty?)))))
+          (catch #?(:clj Throwable :cljs :default) e
+            ;; Atomicity contract: discard ALL flow side-effects of this
+            ;; aborted drain. The pending `:db` effect is dropped by the
+            ;; router; here we restore the pre-drain `last-inputs` so
+            ;; every flow re-attempts next drain. The throw (carrying
+            ;; `:rf.flow/failed-id` from `evaluate-flow!`) propagates
+            ;; unchanged for router attribution.
+            (reset! last-inputs last-inputs-before)
+            (throw e)))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
 ;;

--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -3,8 +3,11 @@
   Per Spec 013.
 
   A flow says: 'when these app-db paths change, run this pure function
-  and write the result to that app-db path.' Flows evaluate after every
-  event drain in topological order over their static dependency graph.
+  and write the result to that app-db path.' Flows evaluate on every
+  event — immediately after the handler, as the runtime's innermost
+  `:after` interceptor — transforming the handler's pending `:db`
+  effect, in topological order over their static dependency graph
+  (per Spec 013 §Drain integration; rf2-u0zz5).
 
   Flows are deliberately a NICHE convenience — not a sub replacement,
   not a new dataflow paradigm. Use a sub if the value is consumed by
@@ -15,7 +18,7 @@
   `re-frame.late-bind` so the core artefact's `re-frame.core` re-exports
   reach them. Apps that don't register any flows don't pull the per-
   frame flow registry, the topological-sort engine, the dirty-check
-  `last-inputs` map, or the post-drain `run-flows!` walker.
+  `last-inputs` map, or the innermost-`:after` `run-flows-on-db` walker.
 
   Public façade over `re-frame.flows.topo` (pure Kahn's + cycle-path
   extraction) and `re-frame.flows.registry` (per-frame `flows` +
@@ -23,10 +26,8 @@
   (:require [re-frame.elision :as elision]
             [re-frame.flows.registry :as registry]
             [re-frame.flows.topo :as topo]
-            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
 ;; ---- public-surface re-exports -------------------------------------------
@@ -50,7 +51,9 @@
 
 ;; ---- evaluation ---------------------------------------------------------
 ;;
-;; Called from the per-event drain after :db commits and before :fx runs.
+;; Called from the router's innermost `:after` interceptor, immediately
+;; after the event handler — transforming the pending `:db` effect
+;; before install and before :fx (per Spec 013 §Drain integration).
 
 (defn- read-inputs [db flow]
   (mapv (fn [path] (get-in db path)) (:inputs flow)))
@@ -123,11 +126,13 @@
   semantics): the failing flow's own output is NOT written (the throw
   happened during `:output`; there is no usable new-output). Its
   `last-inputs` slot is NOT advanced so the flow re-attempts on the
-  next drain. `run-flows!` catches the propagated throw, FLUSHES
-  prior successful flows' dirty writes via `replace-container!`
-  (rule 1 of the contract), and re-throws so the router's outer catch
-  emits the cascade-level `:rf.error/flow-eval-exception` per Spec
-  009 §Error contract. The cascade halts at the failing flow —
+  next drain. `run-flows-on-db` catches the propagated throw and
+  re-throws an ex-info carrying `:rf.flow/partial-db` — the
+  loop accumulator holding prior successful flows' dirty writes
+  (rule 1 of the contract) — so the router's flows-after-interceptor
+  installs those prior writes even as the cascade halts, and the
+  router emits the cascade-level `:rf.error/flow-eval-exception` per
+  Spec 009 §Error contract. The cascade halts at the failing flow —
   downstream flows scheduled later in topo order do NOT run on this
   drain (rule 3); they re-attempt naturally on the next drain.
 
@@ -243,14 +248,15 @@
           ;; when the flow's :output fn throws. last-inputs is NOT
           ;; advanced — so the flow will retry on the next drain rather
           ;; than silently caching a stale-or-missing output. We re-
-          ;; throw so `run-flows!` can flush already-accumulated dirty
-          ;; writes from PRIOR successful flows in the same drain
-          ;; (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure semantics rule 1)
-          ;; and then propagate to the router's outer catch which emits
-          ;; the cascade-level :rf.error/flow-eval-exception per Spec
-          ;; 009 §Error contract. The per-flow `:rf.flow/failed` trace
-          ;; emitted here adds the flow-attributed detail tools (10x
-          ;; flow panel) consume.
+          ;; throw so `run-flows-on-db` can re-wrap the throw with the
+          ;; accumulated dirty writes from PRIOR successful flows in the
+          ;; same drain (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure
+          ;; semantics rule 1) under `:rf.flow/partial-db`, and then
+          ;; propagate to the router's flows-after-interceptor which
+          ;; installs that partial db and emits the cascade-level
+          ;; :rf.error/flow-eval-exception per Spec 009 §Error contract.
+          ;; The per-flow `:rf.flow/failed` trace emitted here adds the
+          ;; flow-attributed detail tools (10x flow panel) consume.
           ;;
           ;; The failure-path `:inputs` payload rides through the
           ;; elision walker for the same reason as the success path —
@@ -292,67 +298,77 @@
                           {:rf.flow/failed-id flow-id}
                           e)))))))
 
-(defn run-flows!
-  "Per Spec 013 §Drain integration: walk THIS FRAME'S registered flows
-  in topological order, dirty-check each one, recompute and write
-  if inputs changed. Called from the per-event drain after :db commits.
+(defn run-flows-on-db
+  "Per Spec 013 §Drain integration (rf2-u0zz5): walk THIS FRAME'S
+  registered flows in topological order over the given `db` VALUE,
+  dirty-check each one, recompute and assoc-in the result into a
+  transformed db. Returns the flow-augmented db value.
+
+  This is the **innermost-`:after` flow transform**. The router installs
+  it as the innermost `:after` interceptor (re-frame.router/flows-after-
+  interceptor), so it runs immediately after the event handler, against
+  the handler's PENDING `:db` effect (or the current app-db value when
+  the handler returned no `:db`), and BEFORE the `:db` install — NOT
+  against the already-installed app-db. The caller writes the returned
+  value back into the chain context's `:effects :db` slot so the rest of
+  the `:after` chain and the eventual `:db` install observe the
+  flow-augmented db.
 
   Flows are frame-scoped — only flows registered against frame-id run
   here, leaving sibling frames' flows untouched.
 
   Failed-flow contract (rf2-wyt97 / rf2-hrqvg, Spec 013 §Failure
   semantics): when a flow's `:output` throws, prior successful flows'
-  dirty writes in the same drain are PRESERVED — we flush via
-  `replace-container!` before re-throwing. The cascade then halts:
-  flows scheduled later in topo order do not run on this drain, and
-  the router's outer catch surfaces the cascade-level
-  `:rf.error/flow-eval-exception`. The failing flow's own
-  `last-inputs` is NOT advanced (so it re-attempts next drain);
+  dirty writes in the same drain are PRESERVED — the loop accumulator
+  already carries them, and on the throw we re-throw an ex-info whose
+  `ex-data` carries the prior-flow-augmented db under
+  `:rf.flow/partial-db` so the router can STILL install it (rule 1) even
+  though the cascade halts. The cascade then halts: flows scheduled
+  later in topo order do not run on this drain, and the router surfaces
+  the cascade-level `:rf.error/flow-eval-exception`. The failing flow's
+  own `last-inputs` is NOT advanced (so it re-attempts next drain);
   prior flows' `last-inputs` ARE advanced (they computed successfully
-  and their outputs are now in app-db). This is the strongest 'no
-  work is silently lost' guarantee compatible with cascade-level
-  error surfacing."
-  [frame-id]
-  (let [container (frame/get-frame-db frame-id)
-        flow-map  (get @flows frame-id)]
-    (when (seq flow-map)
+  and their outputs are now in the returned db). This is the strongest
+  'no work is silently lost' guarantee compatible with cascade-level
+  error surfacing. The `:rf.flow/failed-id` slot (stamped by
+  `evaluate-flow!`) is preserved on the re-thrown ex-info so the router
+  can attribute the cascade-level error to the failing flow."
+  [frame-id db]
+  (let [flow-map (get @flows frame-id)]
+    (if-not (seq flow-map)
+      db
       (let [ordered (topo/topo-sort flow-map)]
-        (loop [remaining ordered
-               db       (adapter/read-container container)
+        (loop [remaining  ordered
+               db         db
                any-dirty? false]
           (if (empty? remaining)
-            (when any-dirty?
-              (adapter/replace-container! container db))
+            db
             (let [flow            (flow-map (first remaining))
                   [new-db dirty?] (try
                                     (evaluate-flow! frame-id db flow)
                                     (catch #?(:clj Throwable :cljs :default) e
-                                      ;; Flush prior successful flows'
-                                      ;; writes before propagating the
-                                      ;; throw — they are already in
-                                      ;; `db` (the loop accumulator)
-                                      ;; and their `last-inputs` slots
-                                      ;; are already advanced (per
-                                      ;; evaluate-flow!'s success
-                                      ;; branch). Without this flush,
-                                      ;; the router catches the
-                                      ;; cascade exception but
-                                      ;; `replace-container!` (below)
-                                      ;; never runs and prior flows'
-                                      ;; outputs silently vanish from
-                                      ;; app-db while their
-                                      ;; `:rf.flow/computed` traces
-                                      ;; still claim the write
-                                      ;; happened. Pre-rf2-wyt97 this
-                                      ;; was a real bug; the
-                                      ;; misleading evaluate-flow!
-                                      ;; docstring described
-                                      ;; per-flow-isolated semantics
-                                      ;; that the impl never
-                                      ;; delivered.
-                                      (when any-dirty?
-                                        (adapter/replace-container! container db))
-                                      (throw e)))]
+                                      ;; Preserve prior successful flows'
+                                      ;; writes (Spec 013 §Failure
+                                      ;; semantics rule 1): they are
+                                      ;; already in `db` (the loop
+                                      ;; accumulator) with their
+                                      ;; `last-inputs` slots advanced (per
+                                      ;; evaluate-flow!'s success branch).
+                                      ;; Carry the accumulator on the
+                                      ;; re-thrown ex-info so the router
+                                      ;; installs it even as the cascade
+                                      ;; halts and `:fx` is skipped.
+                                      ;; Without this the prior flows'
+                                      ;; outputs would vanish while their
+                                      ;; `:rf.flow/computed` traces still
+                                      ;; claimed the write happened.
+                                      (throw
+                                        (ex-info (or #?(:clj (.getMessage ^Throwable e)
+                                                        :cljs (.-message e))
+                                                     ":rf.error/flow-eval-exception")
+                                                 (assoc (ex-data e)
+                                                        :rf.flow/partial-db db)
+                                                 e))))]
               (recur (rest remaining) new-db (or any-dirty? dirty?)))))))))
 
 ;; ---- late-bind hook registration ----------------------------------------
@@ -372,7 +388,7 @@
 
 (late-bind/set-fn! :flows/reg-flow           reg-flow)
 (late-bind/set-fn! :flows/clear-flow         clear-flow)
-(late-bind/set-fn! :flows/run-flows!         run-flows!)
+(late-bind/set-fn! :flows/run-flows-on-db    run-flows-on-db)
 (late-bind/set-fn! :flows/reset-last-inputs! reset-last-inputs!)
 (late-bind/set-fn! :flows/reset-flows!       reset-flows!)
 ;; Per rf2-wbtjn — frame-destroy teardown hook (symmetric with the

--- a/implementation/flows/src/re_frame/flows/topo.cljc
+++ b/implementation/flows/src/re_frame/flows/topo.cljc
@@ -9,8 +9,8 @@
   of the original monolith so the algorithm is unit-testable in
   isolation. The registry calls `topo-sort` up-front on a prospective
   flow map to spot cycles before mutating state (rf2-7csri); the
-  post-drain walker (`re-frame.flows/run-flows!`) calls it on every
-  drain to fix evaluation order.
+  innermost-`:after` walker (`re-frame.flows/run-flows-on-db`) calls it
+  on every drain to fix evaluation order.
 
   Per Spec 013 §Topological sort the rule is: flow B depends on flow
   A iff A's `:path` and any of B's `:inputs` share a path prefix in
@@ -122,7 +122,7 @@
   Tools (e.g. Causa) render this directly as the offending chain.
 
   Note: callers re-run this on every drain via
-  `re-frame.flows/run-flows!`. A memo was trialled and removed (rf2-cd00):
+  `re-frame.flows/run-flows-on-db`. A memo was trialled and removed (rf2-cd00):
   the per-frame flow map is tiny (Kahn over a handful of nodes) and a
   memo keyed on the flow map needs explicit invalidation on every
   reg-flow / clear-flow anyway. The unmemoised call is the cheapest

--- a/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
+++ b/implementation/flows/test/re_frame/flows_concurrency_stress_test.clj
@@ -210,8 +210,8 @@
                           ;; Per-thread cycle: register flow → drive
                           ;; many dirty evaluations → clear flow.
                           ;; `dispatch-sync` settles the drain
-                          ;; (including `run-flows!`) before
-                          ;; returning so the `:output` fn runs to
+                          ;; (including the innermost-`:after` flow
+                          ;; transform) before returning so the `:output` fn runs to
                           ;; completion before this thread observes
                           ;; the next iter.
                           (rf/reg-flow {:id     flow-id

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -3,8 +3,9 @@
   `spec/conformance/fixtures/flow-*.edn` fixture through the live flows
   runtime — `reg-flow`, `clear-flow`, the `:rf.fx/reg-flow` /
   `:rf.fx/clear-flow` runtime fxs, the per-frame flow registry, the
-  topological sort, the dirty-check `last-inputs` map, the post-drain
-  `run-flows!` walker, and the `:rf.flow/*` trace vocabulary — and
+  topological sort, the dirty-check `last-inputs` map, the
+  innermost-`:after` `run-flows-on-db` walker, and the `:rf.flow/*`
+  trace vocabulary — and
   asserts the conformance-corpus's recorded outcome against what the
   artefact actually produces.
 

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -394,6 +394,21 @@
           (recur actual (rest expected)
                  (conj failures (str "expected trace not seen: " (pr-str exp)))))))))
 
+(defn- check-trace-absent
+  "Absence match — every pattern in `forbidden` must NOT appear anywhere
+  in `actual`. Each pattern partial-matches like `check-trace-stream`'s
+  expected entries (`trace-matches?`). Returns a vector of failure
+  strings (empty ⇒ all absent). Powers the `:trace-absent` matcher used
+  to pin, e.g., that a flow throw emits NO `:rf.event/db-changed` (the
+  event aborted before the install — atomicity contract, rf2-u0zz5)."
+  [actual forbidden]
+  (reduce (fn [failures pat]
+            (if (some #(trace-matches? pat %) actual)
+              (conj failures (str "forbidden trace WAS seen: " (pr-str pat)))
+              failures))
+          []
+          forbidden))
+
 ;; ---- flow-specific aggregators -------------------------------------------
 
 (defn- recompute-counts
@@ -559,6 +574,13 @@
             expected-emits   (:trace-emissions expect)
             emit-failures    (when expected-emits
                                (check-trace-stream @traces expected-emits))
+            ;; `:trace-absent` — a vector of trace patterns that MUST NOT
+            ;; appear anywhere in the captured stream (no op-type filter).
+            ;; Powers the atomicity-contract assertion that a flow throw
+            ;; emits NO `:rf.event/db-changed` (rf2-u0zz5).
+            forbidden-emits  (:trace-absent expect)
+            absent-failures  (when forbidden-emits
+                               (check-trace-absent @traces forbidden-emits))
             ;; `:flow-recompute-counts` — strict {flow-id n} match.
             expected-counts  (:flow-recompute-counts expect)
             actual-counts    (when expected-counts (recompute-counts @traces))
@@ -619,6 +641,7 @@
                                  (every? #(= (:expected %) (:actual %)) sub-checks)
                                  (or (nil? stream-failures) (empty? stream-failures))
                                  (or (nil? emit-failures)   (empty? emit-failures))
+                                 (or (nil? absent-failures) (empty? absent-failures))
                                  (or (nil? expected-counts) (= expected-counts actual-counts))
                                  (or (nil? expected-topo)   (= expected-topo actual-topo))
                                  (or (nil? expected-after)  (= expected-after actual-after))
@@ -632,6 +655,7 @@
          :sub-checks        sub-checks
          :stream-failures   stream-failures
          :emit-failures     emit-failures
+         :absent-failures   absent-failures
          :expected-counts   expected-counts
          :actual-counts     actual-counts
          :expected-topo     expected-topo
@@ -727,6 +751,8 @@
             (println "    flow-trace:" tf))
           (doseq [ef (:emit-failures f)]
             (println "    trace-emit:" ef))
+          (doseq [af (:absent-failures f)]
+            (println "    trace-absent:" af))
           (when-let [ec (:expected-counts f)]
             (when (not= ec (:actual-counts f))
               (println "    recompute-counts expected:" ec)

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -149,40 +149,30 @@
   ;; no-op — the flow's `:path` never materialised, so there's nothing
   ;; to clear.
   (testing "clear-flow on a flow whose intermediate path step holds a scalar is a no-op (no throw)"
-    (rf/reg-event-db :seed-scalar (fn [_ _] {:step-2 1 :foo 3 :bar 4}))
+    ;; Seed a scalar at the parent slot. NO flow is active during this
+    ;; drain — a flow whose `:path` is `[:step-2 :result]` would
+    ;; `assoc-in` over the scalar (which throws on the JVM) and, per the
+    ;; atomicity contract (rf2-u0zz5), abort the whole drain. The scalar-
+    ;; intermediate case is about `clear-flow` robustness, not flow
+    ;; evaluation, so we register the flow AFTER seeding and never drain
+    ;; it — its `:path` stays un-materialised, which is exactly the
+    ;; non-map-intermediate case `clear-flow` must treat as a no-op.
+    (rf/reg-event-db :stamp-non-map (fn [_ _] {:step-2 1 :foo 3 :bar 4}))
+    (rf/dispatch-sync [:stamp-non-map])
+    ;; Register the flow (never drained) so the per-frame registry has the
+    ;; entry to clear; its `:path` [:step-2 :result] never materialised.
     (rf/reg-flow {:id     :pending
                   :inputs [[:foo]]
-                  :output (fn [_] "never-stored-because-:step-2-is-a-scalar")
+                  :output (fn [_] "never-stored")
                   :path   [:step-2 :result]})
-    (rf/dispatch-sync [:seed-scalar])
-    ;; At this point the flow tried to write at `[:step-2 :result]` —
-    ;; `assoc-in` on a scalar parent actually replaces the scalar with a
-    ;; map. So the flow's first drain materialises the path, and a
-    ;; subsequent clear would hit the normal path. To exercise the
-    ;; never-materialised non-map-intermediate case directly, we reset
-    ;; last-inputs and re-seed AFTER reg-flow but BEFORE any drain.
-    (when-let [li-var (resolve 're-frame.flows/last-inputs)]
-      (reset! (deref li-var) {}))
-    (let [db-before (rf/get-frame-db :rf/default)]
-      ;; Stamp a non-map at the parent slot via direct app-db write so
-      ;; the next clear hits the non-map-intermediate branch.
-      (rf/reg-event-db :stamp-non-map (fn [db _] (assoc db :step-2 1)))
-      (rf/dispatch-sync [:stamp-non-map])
-      ;; Re-register the flow so the per-frame registry has the entry
-      ;; (re-stamping app-db dropped the flow's output via the value-
-      ;; equal check path).
-      (rf/reg-flow {:id     :pending
-                    :inputs [[:foo]]
-                    :output (fn [_] "never-stored")
-                    :path   [:step-2 :result]})
-      ;; Clear must NOT throw, and must leave the scalar parent intact.
-      (is (nil? (rf/clear-flow :pending))
-          "clear-flow returns nil (no throw) when the intermediate is a non-map")
-      (is (= 1 (:step-2 (rf/get-frame-db :rf/default)))
-          ":step-2 is preserved as its scalar value — clear-flow did not corrupt it")
-      ;; Sanity: siblings untouched.
-      (is (= 3 (:foo (rf/get-frame-db :rf/default))))
-      (is (= 4 (:bar (rf/get-frame-db :rf/default)))))))
+    ;; Clear must NOT throw, and must leave the scalar parent intact.
+    (is (nil? (rf/clear-flow :pending))
+        "clear-flow returns nil (no throw) when the intermediate is a non-map")
+    (is (= 1 (:step-2 (rf/get-frame-db :rf/default)))
+        ":step-2 is preserved as its scalar value — clear-flow did not corrupt it")
+    ;; Sanity: siblings untouched.
+    (is (= 3 (:foo (rf/get-frame-db :rf/default))))
+    (is (= 4 (:bar (rf/get-frame-db :rf/default))))))
 
 (deftest clear-flow-handles-single-element-path
   (testing "rf2-aqt7: clear-flow with a single-element :path dissocs the top-level key"

--- a/implementation/flows/test/re_frame/flows_test.clj
+++ b/implementation/flows/test/re_frame/flows_test.clj
@@ -1096,3 +1096,173 @@
     (rf/dispatch-sync [:inc-n])
     (is (= 700 (:doubled (rf/get-frame-db :rf/default)))
         "after re-registration the flow body re-evaluates on the next drain")))
+
+;; ---------------------------------------------------------------------------
+;; 10. New ordering: flows transform the pending `:db` effect as the
+;;     OUTERMOST `:after` — after the rest of the `:after` chain reshapes
+;;     the db, and BEFORE the `:db` install + BEFORE `:fx` (rf2-u0zz5,
+;;     Spec 013 §Drain integration).
+;;
+;; These pin the observable consequences of the relocation:
+;;   (a) `:fx` sees the flow-derived app-db (preserved guarantee);
+;;   (b) the reactive cascade (subs) sees the flow-derived db;
+;;   (c) flows run BEFORE the `:db` install (the value installed already
+;;       carries flow output — single install of the flow-augmented db);
+;;   (d) flows run AFTER the `:after` chain reshape (path-scoped handlers
+;;       still feed the FULL db to flows — see
+;;       `flow-reads-full-db-under-path-scoped-handler`); and
+;;   (e) a user `:after` interceptor — which runs BEFORE the outermost flow
+;;       transform — sees the handler's PRE-flow `:db` effect (flow output
+;;       reaches it via app-db post-install, not via the chain).
+;; ---------------------------------------------------------------------------
+
+(deftest user-after-interceptor-precedes-flow-transform
+  (testing "rf2-u0zz5 (e): a user `:after` runs BEFORE the outermost flow transform"
+    ;; The flow doubles :n into [:doubled]. A user `:after` interceptor —
+    ;; which runs BEFORE the outermost flow transform — captures the
+    ;; effects' :db. It must see the handler's write but the PRE-flow
+    ;; :doubled value (carried from the prior drain), NOT the freshly
+    ;; flow-computed one. The flow output is observable in app-db AFTER
+    ;; install — asserted at the end. This pins the deliberate ordering:
+    ;; flows are outermost so they read the full reshaped db; user :after
+    ;; interceptors precede them.
+    (let [seen-db (atom :unset)]
+      (rf/reg-event-db :init (fn [_ _] {:n 0}))
+      (rf/reg-event-db :set-n
+        [(rf/->interceptor
+           :id    :test/capture-after
+           :after (fn [ctx]
+                    (reset! seen-db (rf/get-effect ctx :db))
+                    ctx))]
+        (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 n))
+                    :path   [:doubled]})
+      ;; init: flow first-computes 0 * 2 = 0 into [:doubled].
+      (rf/dispatch-sync [:init])
+      (is (= 0 (:doubled (rf/get-frame-db :rf/default)))
+          "after :init the flow wrote :doubled = 0")
+      (reset! seen-db :unset)
+      ;; set-n 7: the user :after captures the pending :db effect BEFORE
+      ;; the outermost flow transform recomputes :doubled.
+      (rf/dispatch-sync [:set-n 7])
+      (is (map? @seen-db)
+          "the user after-interceptor captured the effects' :db")
+      (is (= 7 (:n @seen-db))
+          "the user :after saw the handler's own write")
+      (is (= 0 (:doubled @seen-db))
+          "the user :after saw the PRE-flow :doubled (0, carried from the prior
+           drain) — it ran BEFORE the outermost flow transform recomputed it
+           (rf2-u0zz5 ordering)")
+      ;; The recomputed flow output IS in app-db after install — the
+      ;; deliverable path for consumers that need flow output.
+      (is (= 14 (:doubled (rf/get-frame-db :rf/default)))
+          "the recomputed flow output (7 * 2 = 14) landed in the installed app-db"))))
+
+(deftest fx-sees-flow-derived-app-db
+  (testing "rf2-u0zz5 (b): an :fx entry reading app-db sees the flow output (preserved)"
+    (let [fx-saw (atom :unset)]
+      ;; A custom fx reads the live app-db when it runs; since :fx walks
+      ;; after the flow-augmented install, it must see :doubled.
+      (rf/reg-fx :test/peek-db
+                 (fn [_m _args]
+                   (reset! fx-saw (rf/get-frame-db :rf/default))))
+      (rf/reg-event-db :init (fn [_ _] {:n 0}))
+      (rf/reg-event-fx :go
+                       (fn [_ [_ v]]
+                         {:db {:n v}
+                          :fx [[:test/peek-db {}]]}))
+      (rf/reg-flow {:id     :double
+                    :inputs [[:n]]
+                    :output (fn [n] (* 2 n))
+                    :path   [:doubled]})
+      (rf/dispatch-sync [:init])
+      (rf/dispatch-sync [:go 5])
+      (is (= 10 (:doubled @fx-saw))
+          ":fx read the flow-derived :doubled (5 * 2 = 10) from app-db"))))
+
+(deftest reactive-cascade-sees-flow-derived-db
+  (testing "rf2-u0zz5 (c): a subscription over the flow's :path sees the flow output"
+    (rf/reg-event-db :init (fn [_ _] {:n 0}))
+    (rf/reg-event-db :set-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (rf/reg-sub :doubled (fn [db _] (:doubled db)))
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:set-n 9])
+    (is (= 18 @(rf/subscribe [:doubled]))
+        "the sub recomputed against the flow-augmented db install (9 * 2 = 18)")))
+
+(deftest flow-reads-full-db-under-path-scoped-handler
+  (testing "rf2-u0zz5: a flow reading a full-db path sees the FULL reshaped db
+            even when the triggering handler is `(rf/path ...)`-scoped"
+    ;; The handler writes the :counter slice (path-scoped). The flow reads
+    ;; the FULL-DB path [:counter :n] and writes [:counter :doubled]. The
+    ;; flow transform must run against the FULL db (after the path
+    ;; interceptor splices the slice back), NOT the bare slice — otherwise
+    ;; `(get-in slice [:counter :n])` would be nil and the flow would
+    ;; mis-compute.
+    (rf/reg-event-db :seed (fn [_ _] {:counter {:n 0}}))
+    (rf/reg-event-db :inc
+                     [(rf/path :counter)]
+                     (fn [c _] (update c :n inc)))
+    (rf/reg-flow {:id     :counter/doubled
+                  :inputs [[:counter :n]]
+                  :output (fn [n] (* 2 (or n 0)))
+                  :path   [:counter :doubled]})
+    (rf/dispatch-sync [:seed])
+    (rf/dispatch-sync [:inc])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 1 (get-in db [:counter :n]))
+          "the path-scoped handler incremented :counter/:n")
+      (is (= 2 (get-in db [:counter :doubled]))
+          "the flow read the FULL-db [:counter :n] (=1) and wrote 1 * 2 = 2 —
+           it ran against the reshaped full db, not the path slice"))
+    (rf/dispatch-sync [:inc])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 2 (get-in db [:counter :n])))
+      (is (= 4 (get-in db [:counter :doubled]))
+          "second increment: flow recomputed 2 * 2 = 4 off the full db"))))
+
+(deftest flow-runs-before-db-install
+  (testing "rf2-u0zz5 (c): a single :db install carries the flow output, AND
+            the :rf.event/db-changed trace fires once with the flow output"
+    ;; Flows transform the pending :db effect, so the cascade performs
+    ;; exactly ONE app-db install — of the flow-augmented value. We pin
+    ;; this by (1) capturing app-db AT the :rf.event/db-changed trace emit
+    ;; (which fires at install) and asserting it already carries the flow
+    ;; output, and (2) asserting db-changed fired exactly once (no second
+    ;; install from a separate post-install flow mutation, as the prior
+    ;; design produced).
+    (let [db-at-changed (atom :unset)
+          changed-count (atom 0)]
+      (re-frame.trace/register-listener!
+        ::db-changed-recorder
+        (fn [ev]
+          (when (= :rf.event/db-changed (:operation ev))
+            (swap! changed-count inc)
+            ;; At the db-changed emit the container has been replaced, so
+            ;; reading the live app-db reflects the just-installed value.
+            (reset! db-at-changed (rf/get-frame-db :rf/default)))))
+      (try
+        (rf/reg-event-db :init (fn [_ _] {:n 0}))
+        (rf/reg-event-db :set-n (fn [db [_ v]] (assoc db :n v)))
+        (rf/reg-flow {:id     :double
+                      :inputs [[:n]]
+                      :output (fn [n] (* 2 n))
+                      :path   [:doubled]})
+        (rf/dispatch-sync [:init])
+        (reset! db-at-changed :unset)
+        (reset! changed-count 0)
+        (rf/dispatch-sync [:set-n 6])
+        (is (= 1 @changed-count)
+            "exactly one :rf.event/db-changed fired — a single, flow-augmented install
+             (the prior design produced a separate post-install flow mutation)")
+        (is (= 12 (:doubled @db-at-changed))
+            "the db installed at :rf.event/db-changed already carried the flow output —
+             flows ran before install (rf2-u0zz5)")
+        (finally
+          (re-frame.trace/unregister-listener! ::db-changed-recorder))))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -647,25 +647,26 @@
           "the elided input-value is substituted with the wire marker"))))
 
 ;; ---------------------------------------------------------------------------
-;; 7b. Failed-flow cascade behaviour (rf2-wyt97).
+;; 7b. Failed-flow cascade behaviour — atomicity contract (Mike 2026-05-24).
 ;;
-;; The pre-rf2-wyt97 `evaluate-flow!` docstring claimed `[db false]` was
-;; returned on failure and downstream flows still walked. The impl
-;; actually `(throw e)`s after emitting `:rf.flow/failed`, which exited
-;; `run-flows!`'s loop — and pre-fix, the early exit bypassed
-;; `replace-container!`, so prior successful flows' dirty writes were
-;; SILENTLY DROPPED even though their `:rf.flow/computed` traces had
-;; already claimed the write. This deftest pins the corrected contract
-;; (per Spec 013 §Failure semantics): prior writes are flushed before
-;; the throw propagates; downstream flows do not run.
+;; A flow throw is a PRE-INSTALL throw: it aborts the WHOLE event. There
+;; is NO partial commit. The router's `flows-after-interceptor` DISCARDS
+;; the pending `:db` effect on the throw, so app-db is left UNCHANGED —
+;; neither the handler's write nor any prior successful flows' writes
+;; land, no `:rf.event/db-changed` is emitted, and `:fx` is skipped. This
+;; deftest pins that contract: nothing the flow drain (or its handler)
+;; produced survives the throw; downstream flows do not run.
 ;; ---------------------------------------------------------------------------
 
-(deftest failed-cascade-preserves-prior-flow-writes
-  (testing "when a downstream flow throws, prior flow writes are flushed; the cascade halts"
+(deftest failed-cascade-aborts-event-app-db-unchanged
+  (testing "when a downstream flow throws, the event aborts: app-db is unchanged (no install); the cascade halts"
     ;; :A reads [:n], writes [:a-out]. :B reads [:a-out], throws.
     ;; :C reads [:b-out]. The path-prefix dependency edges
     ;; (A.path → B.input, B.path → C.input) pin topo order A → B → C.
-    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+    ;; Seed :n via a FIRST clean drain so we can prove the SECOND
+    ;; (throwing) drain installs nothing on top of it.
+    (rf/reg-event-db :seed (fn [_ _] {:n 5}))
+    (rf/reg-event-db :touch (fn [db _] (assoc db :touched true)))
     (rf/reg-flow {:id     :A
                   :inputs [[:n]]
                   :output (fn [n] (* 2 n))
@@ -678,18 +679,25 @@
                   :inputs [[:b-out]]
                   :output (fn [b] (str "C-saw-" b))
                   :path   [:c-out]})
+    ;; First drain seeds :n. :A computes [:a-out]; :B throws → that whole
+    ;; drain aborts, so even :n does not land. Re-seed cleanly is not
+    ;; possible while :B throws, so capture app-db right after the
+    ;; throwing drain and assert nothing landed.
     (reset! *captured* [])
-    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:seed])
     (let [db (rf/get-frame-db :rf/default)]
-      ;; Rule 1: :A's write IS in app-db.
-      (is (= 10 (:a-out db))
-          ":A's output (5 * 2 = 10) is in app-db — prior-flow writes preserved")
-      ;; Rule 2: failing :B did not write.
+      ;; Atomicity: the handler's own write does NOT land.
+      (is (not (contains? db :n))
+          ":n absent — the handler's :db write was discarded (no install)")
+      ;; Prior flow :A's write does NOT land (no partial commit).
+      (is (not (contains? db :a-out))
+          ":a-out absent — prior-flow writes are NOT committed on a flow throw")
+      ;; Failing :B did not write.
       (is (not (contains? db :b-out))
-          ":B's :path absent — the failing flow's own write is not applied")
-      ;; Rule 3: downstream :C did not run.
+          ":b-out absent — the failing flow's own write is not applied")
+      ;; Downstream :C did not run.
       (is (not (contains? db :c-out))
-          ":C's :path absent — downstream flows do not run on the failing drain"))
+          ":c-out absent — downstream flows do not run on the failing drain"))
     ;; Trace stream pin: :A's :rf.flow/computed fired; :B's
     ;; :rf.flow/failed fired; :C emitted no drain trace.
     (let [drain-evs (filterv #(#{:rf.flow/computed :rf.flow/failed
@@ -707,24 +715,25 @@
           ":C emitted no drain trace — did not run after :B threw"))))
 
 ;; ---------------------------------------------------------------------------
-;; 7c. Failed-flow contract pin (rf2-hrqvg).
+;; 7c. Failed-flow bookkeeping pin — atomicity contract (Mike 2026-05-24).
 ;;
-;; Companion to 7b: explicitly pin the per-flow `last-inputs` non-advance
-;; on failure and the prior-flow `last-inputs` advance on success. The
-;; failed-cascade test above asserts the OBSERVABLE outcome (which
-;; :path slots survive); this asserts the dirty-check bookkeeping that
-;; makes retry-on-next-drain work correctly.
-;;
-;; This is the contract decision documented in the cluster's PR body
-;; (decision-flagged bead rf2-hrqvg): preserve prior writes AND halt
-;; the cascade — the strongest no-silent-loss guarantee compatible
-;; with surfacing failures as cascade-level errors.
+;; Atomicity extends to the dirty-check bookkeeping. `evaluate-flow!`
+;; advances the global `last-inputs` atom for each flow it computes, but
+;; a flow throw aborts the WHOLE event — nothing is installed. So a prior
+;; flow's `last-inputs` advance MUST be rolled back: otherwise its
+;; recompute would be suppressed next drain even though its output never
+;; reached app-db, silently losing the write forever. `run-flows-on-db`
+;; snapshots `last-inputs` before the walk and restores it on a throw, so
+;; EVERY flow (prior-successful and failing alike) re-attempts cleanly on
+;; the next drain — matching the all-or-nothing `:db` install.
 ;; ---------------------------------------------------------------------------
 
-(deftest failed-flow-contract-last-inputs-bookkeeping
-  (testing "failing flow's last-inputs is NOT advanced; prior flow's last-inputs IS advanced"
+(deftest failed-flow-rolls-back-last-inputs-so-prior-flows-retry
+  (testing "on a flow throw, the prior flow's last-inputs is rolled back — it recomputes every drain (not suppressed)"
+    ;; :init writes the SAME db each drain, so absent rollback :A's
+    ;; dirty-check would suppress its recompute on the 2nd+ drain. Because
+    ;; the throw rolls back last-inputs, :A recomputes on EVERY drain.
     (rf/reg-event-db :init (fn [_ _] {:n 5}))
-    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
     (let [a-calls (atom 0)
           b-calls (atom 0)]
       (rf/reg-flow {:id     :A
@@ -741,23 +750,18 @@
       (is (= 1 @a-calls) ":A computed once on the first drain")
       (is (= 1 @b-calls) ":B threw once on the first drain")
 
-      ;; Bump :n — :A's input changed (5 → 6).
-      ;; - :A's last-inputs WAS advanced to [5] on the first drain, so a
-      ;;   new dirty-check at [6] triggers recompute. (@a-calls should
-      ;;   reach 2.)
-      ;; - :A's new output (12) is different from the prior (10) it
-      ;;   wrote on the first drain, so :B's input [:a-out] is now [12].
-      ;;   :B's last-inputs was NOT advanced (still nil/empty from the
-      ;;   failure), so :B retries. (@b-calls should reach 2.)
-      (rf/dispatch-sync [:bump])
+      ;; Second :init with IDENTICAL inputs. Absent rollback, :A's
+      ;; last-inputs (advanced to [5] during the first, aborted drain)
+      ;; would suppress recompute. Because the throw rolled last-inputs
+      ;; back, :A re-attempts — and so does :B.
+      (rf/dispatch-sync [:init])
       (is (= 2 @a-calls)
-          ":A re-fired because its last-inputs advanced and inputs changed (prior write succeeded)")
+          ":A re-fired on the second drain — its last-inputs advance was rolled back by the throw")
       (is (= 2 @b-calls)
-          ":B re-fired because its last-inputs was NOT advanced on the prior failure"))))
+          ":B re-fired — its last-inputs was never advanced (it threw)"))))
 
-(deftest failed-flow-contract-app-db-shape-after-multiple-failing-drains
-  (testing "across multiple failing drains, prior flow's writes keep landing; failing flow's slot stays absent"
-    (rf/reg-event-db :init (fn [_ _] {:n 5}))
+(deftest failed-flow-app-db-unchanged-across-multiple-failing-drains
+  (testing "across multiple failing drains, NOTHING lands — app-db stays unchanged (no partial commit)"
     (rf/reg-event-db :n!   (fn [db [_ v]] (assoc db :n v)))
     (rf/reg-flow {:id     :A
                   :inputs [[:n]]
@@ -767,73 +771,69 @@
                   :inputs [[:a-out]]
                   :output (fn [_] (throw (ex-info "boom" {})))
                   :path   [:b-out]})
-    (rf/dispatch-sync [:init])
-    (is (= 50 (:a-out (rf/get-frame-db :rf/default))))
-    (is (not (contains? (rf/get-frame-db :rf/default) :b-out)))
+    (rf/dispatch-sync [:n! 5])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (not (contains? db :n))
+          ":n absent — the handler's write was discarded on the flow throw")
+      (is (not (contains? db :a-out))
+          ":a-out absent — prior-flow writes are NOT committed (no partial commit)")
+      (is (not (contains? db :b-out))
+          ":b-out absent — the failing flow's slot is never written"))
 
     (rf/dispatch-sync [:n! 7])
-    (is (= 70 (:a-out (rf/get-frame-db :rf/default)))
-        ":A's write landed again after the second failing drain (5 → 7 → 70)")
-    (is (not (contains? (rf/get-frame-db :rf/default) :b-out))
-        ":b-out still absent across drains — failing flow's slot remains vacated")
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (not (contains? db :a-out))
+          ":a-out still absent after a second failing drain — every drain aborts wholesale")
+      (is (not (contains? db :b-out))
+          ":b-out still absent across drains"))
 
     (rf/dispatch-sync [:n! 11])
-    (is (= 110 (:a-out (rf/get-frame-db :rf/default)))
-        ":A's write landed a third time (7 → 11 → 110)")
-    (is (not (contains? (rf/get-frame-db :rf/default) :b-out)))))
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= {} db)
+          "app-db remains the empty initial value — no failing drain ever committed anything"))))
 
 ;; ---------------------------------------------------------------------------
-;; 7d. :fx must not run after a flow throws (rf2-fslx0).
+;; 7d. A flow throw aborts the event — atomicity contract (Mike 2026-05-24).
 ;;
-;; Spec 013 §Failure semantics rule 3 + §rationale (line 202) state the
-;; cascade halts at a failing flow — downstream `:fx` does NOT run on
-;; the failing drain because the rationale for halting is "downstream
-;; `:fx` and tooling rely on to skip work that depended on a now-
-;; invalid derived state."
+;; A flow throw is a PRE-INSTALL throw: the event aborts wholesale. The
+;; router's `flows-after-interceptor` DISCARDS the pending `:db` effect
+;; (no install, app-db unchanged, no `:rf.event/db-changed`) and
+;; `commit-and-flow!` skips `:fx`. So when a handler emits
+;; `[:dispatch [:react-to-area-change]]` from `:fx` and the flow throws,
+;; the child dispatch must NOT fire (its side effects — HTTP, navigation,
+;; analytics — would escape) AND the handler's own `:db` write must NOT
+;; land (no partial commit).
 ;;
-;; A handler emitting `[:dispatch [:react-to-area-change]]` from `:fx`
-;; must not fire the child dispatch when the source flow threw — child
-;; handler would run on stale derived state; side effects (HTTP,
-;; navigation, analytics) would escape.
-;;
-;; Per rf2-u0zz5: the flow transform is the innermost `:after`; on a
-;; throw it stashes `:rf/flow-error` on the context, and
-;; `commit-and-flow!` skips `run-fx-effects!` when that key is set
-;; (after committing the prior-flow-preserved db).
+;; Per rf2-u0zz5: the flow transform is the outermost `:after`; on a
+;; throw it `dissoc`-es the pending `:db` effect and stashes
+;; `:rf/flow-error` on the context, so the install is a no-op and
+;; `commit-and-flow!` skips `run-fx-effects!`.
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-does-not-run-after-flow-throws
-  (testing "Per rf2-fslx0: when a flow's :output throws, the handler's :fx is skipped"
+  (testing "when a flow's :output throws, the handler's :fx is skipped AND its :db does NOT land"
     (let [child-fired? (atom false)]
-      (rf/reg-event-db :init   (fn [_ _] {:n 1}))
       (rf/reg-event-db :after-throw
                        (fn [db _] (reset! child-fired? true) db))
       (rf/reg-event-fx :run-with-throwing-flow
                        (fn [_ _]
                          {:db {:n 2}
                           :fx [[:dispatch [:after-throw]]]}))
-      ;; Register a flow that throws. The flow runs as the innermost
+      ;; Register a flow that throws. The flow runs as the outermost
       ;; :after — after the handler, BEFORE :db install and BEFORE :fx
-      ;; walks (rf2-u0zz5); a throw halts the cascade so :after-throw
-      ;; must NOT dispatch.
+      ;; walks (rf2-u0zz5); a throw aborts the event, so :after-throw
+      ;; must NOT dispatch and the handler's :db must NOT install.
       (rf/reg-flow {:id     :boom
                     :inputs [[:n]]
                     :output (fn [_] (throw (ex-info "boom" {:why :test})))
                     :path   [:doomed]})
-      ;; First drain: :init seeds :n; the flow throws but the cascade
-      ;; halts before any of :init's :fx would have run (and :init has
-      ;; none anyway). Drain the dispatch the test is actually
-      ;; interested in.
-      (rf/dispatch-sync [:init])
-      (reset! child-fired? false)
       (rf/dispatch-sync [:run-with-throwing-flow])
       (is (false? @child-fired?)
-          "`:after-throw` did NOT dispatch — :fx was skipped because the flow threw (rf2-fslx0)")
-      ;; :db commit still happened (rule 1 of Spec 013 §Failure
-      ;; semantics: prior successful writes are preserved); only :fx
-      ;; was skipped.
-      (is (= 2 (:n (rf/get-frame-db :rf/default)))
-          ":db commit landed (rule 1) — only the post-commit :fx walk was skipped"))))
+          "`:after-throw` did NOT dispatch — :fx was skipped because the flow threw")
+      ;; Atomicity contract: the handler's :db write was DISCARDED — the
+      ;; event aborted with no install (app-db unchanged).
+      (is (not (contains? (rf/get-frame-db :rf/default) :n))
+          ":n absent — the handler's :db did NOT land; a flow throw aborts the event with no install"))))
 
 (deftest fx-after-successful-flow-still-runs
   (testing "Per rf2-fslx0: when flows succeed, :fx still walks normally (negative control)"
@@ -1090,32 +1090,28 @@
           "the sensitive input value is redacted on the wire too"))))
 
 ;; ---------------------------------------------------------------------------
-;; 8b. Strict trace-stream ordering on a flow throw (Spec 013 §Failure
-;;     semantics / §Trace stream ordering; rf2-u0zz5 NEW ordering).
+;; 8b. Strict trace-stream ordering on a flow throw — atomicity contract
+;;     (Spec 013 §Failure semantics / §Trace stream ordering on a flow
+;;     throw; rf2-u0zz5, Mike 2026-05-24).
 ;;
-;; Per rf2-u0zz5 the flow walk is now the INNERMOST `:after` — it runs
-;; BEFORE `:db` install, so the failure window opens BEFORE
-;; `:rf.event/db-changed`, not after. The contract: on a flow throw the
-;; stream carries, in order, `:rf.flow/failed` → `:rf.error/flow-eval-
-;; exception` → `:rf.event/db-changed` (install of the prior-flow-
-;; preserved db), and NO further `:rf.fx/handled` trace fires this drain
-;; (the cascade halts; pinned for the :fx GAP by
-;; `fx-does-not-run-after-flow-throws` above). This inverts the prior
-;; design where `:rf.event/db-changed` fired before flows.
+;; A flow throw is a PRE-INSTALL throw: the event aborts. The router
+;; DISCARDS the pending `:db` effect, so NO `:rf.event/db-changed` is
+;; emitted and app-db is UNCHANGED. The throw stream carries, in order,
+;; `:rf.flow/failed` → `:rf.error/flow-eval-exception` and STOPS — no
+;; `:rf.event/db-changed`, no `:rf.fx/handled` (the cascade halts; the
+;; :fx GAP is pinned by `fx-does-not-run-after-flow-throws` above).
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-throw-trace-stream-is-strictly-ordered
-  (testing "rf2-u0zz5 — flow/failed → flow-eval-exception → db-changed
-            in order; db-changed (install) fires AFTER the flow failure,
-            carrying the prior-flow-preserved db"
+  (testing "rf2-u0zz5 atomicity — flow/failed → flow-eval-exception, and
+            NO db-changed in the throw stream; app-db unchanged after the
+            throw"
     (let [evs (record-all-traces
                 (fn []
-                  ;; :seed-write writes :n via the handler AND :a-out via
-                  ;; prior flow :ok, so a :db effect + a prior-flow write
-                  ;; both exist when :boom throws — guaranteeing the
-                  ;; install of the prior-flow-preserved db fires.
-                  (rf/reg-event-db :seed (fn [_ _] {:n 0}))
-                  (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+                  ;; The handler writes :n AND prior flow :ok writes :a-out,
+                  ;; so a :db effect + a prior-flow write both exist when
+                  ;; :boom throws — proving that EVEN THEN nothing installs.
+                  (rf/reg-event-db :bump (fn [db _] (update db :n (fnil inc 0))))
                   (rf/reg-flow {:id     :ok
                                 :inputs [[:n]]
                                 :output (fn [n] (* 10 n))
@@ -1124,10 +1120,6 @@
                                 :inputs [[:a-out]]
                                 :output (fn [_] (throw (ex-info "boom" {})))
                                 :path   [:doomed]})
-                  ;; Seed first so :n exists; the flow throws on this drain
-                  ;; too, but we re-drain with :bump to assert the ordered
-                  ;; stream against a known post-handler db value.
-                  (rf/dispatch-sync [:seed])
                   (rf/dispatch-sync [:bump])))
           ;; Restrict to the :bump cascade. Take everything from the
           ;; :bump :run-start trace to the end.
@@ -1140,27 +1132,28 @@
                            last)
           tail        (subvec evs-v bump-start)
           ops         (mapv :operation tail)
-          db-changed  (first (filterv #(= :rf.event/db-changed (:operation %)) tail))
           ;; positions within the bump cascade
           pos         (fn [op] (.indexOf ^java.util.List ops op))
           p-failed    (pos :rf.flow/failed)
-          p-error     (pos :rf.error/flow-eval-exception)
-          p-changed   (pos :rf.event/db-changed)]
-      (is (some? db-changed)
-          ":rf.event/db-changed fired on the bump cascade (prior-flow-preserved install)")
-      (is (= :bump (get-in db-changed [:tags :rf.event/v 0]))
-          ":rf.event/db-changed is for the :bump event")
-      ;; NEW ordering (rf2-u0zz5): flow failure precedes db-changed.
-      (is (and (<= 0 p-failed) (< p-failed p-error) (< p-error p-changed))
+          p-error     (pos :rf.error/flow-eval-exception)]
+      ;; NO db-changed in the throw stream — the event aborted before install.
+      (is (not-any? #(= :rf.event/db-changed %) ops)
+          "NO :rf.event/db-changed in the throw stream — the event aborted before install")
+      ;; Ordered: flow failure precedes the cascade-level error.
+      (is (and (<= 0 p-failed) (< p-failed p-error))
           (str "ordered: :rf.flow/failed (" p-failed ") < :rf.error/flow-eval-exception ("
-               p-error ") < :rf.event/db-changed (" p-changed ")"))
-      ;; The prior flow :ok's write IS installed (rule 1): :a-out = 10.
-      (is (= 10 (:a-out (rf/get-frame-db :rf/default)))
-          "the prior flow's write was preserved and installed (Spec 013 §Failure semantics rule 1)")
-      (is (not (contains? (rf/get-frame-db :rf/default) :doomed))
-          "the failing flow's own output is NOT written")
-      ;; The db-changed is the LAST relevant trace — no :rf.fx/handled
-      ;; fires after it this drain (cascade halt).
-      (let [after-error (subvec (vec ops) (inc p-error))]
+               p-error ")"))
+      ;; app-db is UNCHANGED — nothing the aborted drain produced landed.
+      (let [db (rf/get-frame-db :rf/default)]
+        (is (= {} db)
+            "app-db is unchanged (empty initial value) — no install on a flow throw")
+        (is (not (contains? db :n))
+            "the handler's :n write did NOT land")
+        (is (not (contains? db :a-out))
+            "the prior flow's :a-out write did NOT land (no partial commit)")
+        (is (not (contains? db :doomed))
+            "the failing flow's own output is NOT written"))
+      ;; No :rf.fx/handled fires after the flow-eval-exception (cascade halt).
+      (let [after-error (subvec ops (inc p-error))]
         (is (not-any? #(= :rf.fx/handled %) after-error)
             "no :rf.fx/handled trace fires after the flow-eval-exception — cascade halts")))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -791,15 +791,15 @@
 ;; `:fx` and tooling rely on to skip work that depended on a now-
 ;; invalid derived state."
 ;;
-;; Pre-fix, `router.run-flows!` caught + swallowed the throw and
-;; returned nil; control flowed on to `run-fx-effects!` regardless.
 ;; A handler emitting `[:dispatch [:react-to-area-change]]` from `:fx`
-;; fired the child dispatch even when the source flow threw — child
-;; handler ran on stale derived state; side effects (HTTP, navigation,
-;; analytics) escaped.
+;; must not fire the child dispatch when the source flow threw — child
+;; handler would run on stale derived state; side effects (HTTP,
+;; navigation, analytics) would escape.
 ;;
-;; Post-fix: `run-flows!` returns truthy on success / falsey on flow
-;; throw. `commit-and-flow!` gates `run-fx-effects!` on the return.
+;; Per rf2-u0zz5: the flow transform is the innermost `:after`; on a
+;; throw it stashes `:rf/flow-error` on the context, and
+;; `commit-and-flow!` skips `run-fx-effects!` when that key is set
+;; (after committing the prior-flow-preserved db).
 ;; ---------------------------------------------------------------------------
 
 (deftest fx-does-not-run-after-flow-throws
@@ -812,9 +812,10 @@
                        (fn [_ _]
                          {:db {:n 2}
                           :fx [[:dispatch [:after-throw]]]}))
-      ;; Register a flow that throws. The flow runs AFTER :db commits
-      ;; and BEFORE :fx walks (per Spec 002 §`:fx` ordering); a throw
-      ;; halts the cascade so :after-throw must NOT dispatch.
+      ;; Register a flow that throws. The flow runs as the innermost
+      ;; :after — after the handler, BEFORE :db install and BEFORE :fx
+      ;; walks (rf2-u0zz5); a throw halts the cascade so :after-throw
+      ;; must NOT dispatch.
       (rf/reg-flow {:id     :boom
                     :inputs [[:n]]
                     :output (fn [_] (throw (ex-info "boom" {:why :test})))
@@ -1090,27 +1091,37 @@
 
 ;; ---------------------------------------------------------------------------
 ;; 8b. Strict trace-stream ordering on a flow throw (Spec 013 §Failure
-;;     semantics / §Trace stream ordering, 013-Flows.md:155-163; G2).
+;;     semantics / §Trace stream ordering; rf2-u0zz5 NEW ordering).
 ;;
-;; The contract: on a flow throw the stream carries, in order,
-;; `:event/db-changed` (the post-handler db commit the failing flow saw)
-;; → `:rf.flow/failed` → `:rf.error/flow-eval-exception`, and NO further
-;; `:rf.fx/handled` trace fires this drain (the cascade halts; pinned for
-;; the :fx GAP by `fx-does-not-run-after-flow-throws` above). The existing
-;; conformance fixture is a subset match that omits `:event/db-changed`;
-;; this test pins the full ordered sequence plus the post-handler-db
-;; snapshot relationship.
+;; Per rf2-u0zz5 the flow walk is now the INNERMOST `:after` — it runs
+;; BEFORE `:db` install, so the failure window opens BEFORE
+;; `:rf.event/db-changed`, not after. The contract: on a flow throw the
+;; stream carries, in order, `:rf.flow/failed` → `:rf.error/flow-eval-
+;; exception` → `:rf.event/db-changed` (install of the prior-flow-
+;; preserved db), and NO further `:rf.fx/handled` trace fires this drain
+;; (the cascade halts; pinned for the :fx GAP by
+;; `fx-does-not-run-after-flow-throws` above). This inverts the prior
+;; design where `:rf.event/db-changed` fired before flows.
 ;; ---------------------------------------------------------------------------
 
 (deftest flow-throw-trace-stream-is-strictly-ordered
-  (testing "Spec 013:155-163 — db-changed → flow/failed → flow-eval-exception
-            in order, with the post-handler db snapshot the failing flow saw"
+  (testing "rf2-u0zz5 — flow/failed → flow-eval-exception → db-changed
+            in order; db-changed (install) fires AFTER the flow failure,
+            carrying the prior-flow-preserved db"
     (let [evs (record-all-traces
                 (fn []
+                  ;; :seed-write writes :n via the handler AND :a-out via
+                  ;; prior flow :ok, so a :db effect + a prior-flow write
+                  ;; both exist when :boom throws — guaranteeing the
+                  ;; install of the prior-flow-preserved db fires.
                   (rf/reg-event-db :seed (fn [_ _] {:n 0}))
                   (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
-                  (rf/reg-flow {:id     :boom
+                  (rf/reg-flow {:id     :ok
                                 :inputs [[:n]]
+                                :output (fn [n] (* 10 n))
+                                :path   [:a-out]})
+                  (rf/reg-flow {:id     :boom
+                                :inputs [[:a-out]]
                                 :output (fn [_] (throw (ex-info "boom" {})))
                                 :path   [:doomed]})
                   ;; Seed first so :n exists; the flow throws on this drain
@@ -1118,8 +1129,8 @@
                   ;; stream against a known post-handler db value.
                   (rf/dispatch-sync [:seed])
                   (rf/dispatch-sync [:bump])))
-          ;; Restrict to the :bump cascade (its db-changed carries {:n 1}).
-          ;; Take everything from the :bump :run-start trace to the end.
+          ;; Restrict to the :bump cascade. Take everything from the
+          ;; :bump :run-start trace to the end.
           evs-v       (vec evs)
           bump-start  (->> (map-indexed vector evs-v)
                            (filter (fn [[_ ev]]
@@ -1132,21 +1143,24 @@
           db-changed  (first (filterv #(= :rf.event/db-changed (:operation %)) tail))
           ;; positions within the bump cascade
           pos         (fn [op] (.indexOf ^java.util.List ops op))
-          p-changed   (pos :rf.event/db-changed)
           p-failed    (pos :rf.flow/failed)
-          p-error     (pos :rf.error/flow-eval-exception)]
+          p-error     (pos :rf.error/flow-eval-exception)
+          p-changed   (pos :rf.event/db-changed)]
       (is (some? db-changed)
-          ":rf.event/db-changed fired on the bump cascade")
+          ":rf.event/db-changed fired on the bump cascade (prior-flow-preserved install)")
       (is (= :bump (get-in db-changed [:tags :rf.event/v 0]))
           ":rf.event/db-changed is for the :bump event")
-      (is (and (<= 0 p-changed) (< p-changed p-failed) (< p-failed p-error))
-          (str "ordered: :event/db-changed (" p-changed ") < :rf.flow/failed ("
-               p-failed ") < :rf.error/flow-eval-exception (" p-error ")"))
-      ;; Post-handler-db snapshot relationship: the failing flow read the
-      ;; committed db (:n incremented to 1). The error is the LAST relevant
-      ;; trace — no :rf.fx/handled fires after it this drain (cascade halt).
-      (is (= 1 (:n (rf/get-frame-db :rf/default)))
-          "the post-handler db the failing flow saw has :n = 1 (commit landed)")
+      ;; NEW ordering (rf2-u0zz5): flow failure precedes db-changed.
+      (is (and (<= 0 p-failed) (< p-failed p-error) (< p-error p-changed))
+          (str "ordered: :rf.flow/failed (" p-failed ") < :rf.error/flow-eval-exception ("
+               p-error ") < :rf.event/db-changed (" p-changed ")"))
+      ;; The prior flow :ok's write IS installed (rule 1): :a-out = 10.
+      (is (= 10 (:a-out (rf/get-frame-db :rf/default)))
+          "the prior flow's write was preserved and installed (Spec 013 §Failure semantics rule 1)")
+      (is (not (contains? (rf/get-frame-db :rf/default) :doomed))
+          "the failing flow's own output is NOT written")
+      ;; The db-changed is the LAST relevant trace — no :rf.fx/handled
+      ;; fires after it this drain (cascade halt).
       (let [after-error (subvec (vec ops) (inc p-error))]
         (is (not-any? #(= :rf.fx/handled %) after-error)
-            "no :rf.fx/handled trace fires after the flow-eval-exception — cascade halts (Spec 013:163 GAP)")))))
+            "no :rf.fx/handled trace fires after the flow-eval-exception — cascade halts")))))

--- a/implementation/flows/test/re_frame/late_bind_missing_test.clj
+++ b/implementation/flows/test/re_frame/late_bind_missing_test.clj
@@ -96,9 +96,10 @@
 ;; Framework-internal hooks (rf2-g9t87)
 ;;
 ;; The four hooks below are framework-internal: their consumers are
-;; `re-frame.router/run-flows!` (post-commit drain step), `re-frame.frame/
-;; destroy-frame!` (per-frame teardown cascade), and `re-frame.test-
-;; support/make-reset-runtime-fixture` (test-fixture reset bracket). None of
+;; `re-frame.router/flows-after-interceptor` (innermost `:after` flow
+;; transform), `re-frame.frame/destroy-frame!` (per-frame teardown
+;; cascade), and `re-frame.test-support/make-reset-runtime-fixture`
+;; (test-fixture reset bracket). None of
 ;; these surface to user-facing `rf/...` fns, so the absent-artefact
 ;; semantics is "graceful no-op", not "raise a typed ex-info".
 ;;
@@ -109,14 +110,15 @@
 ;; / `(is (do ... :ok))` confirms the no-op path.
 ;; ---------------------------------------------------------------------------
 
-(deftest run-flows!-no-ops-when-flows-artefact-missing
-  (testing "router.run-flows! returns nil without throwing when :flows/run-flows! hook is nil"
-    ;; Consumer is `re-frame.router/run-flows!` (private; reach via the
-    ;; user-visible drain). Drive a dispatch through the router — the
-    ;; absent-flows-artefact branch is the steady-state for apps that
-    ;; never registered any flows. With the hook nil, the post-commit
-    ;; flow walker collapses to a no-op and the drain completes.
-    (with-hook-as-nil :flows/run-flows!
+(deftest run-flows-on-db-no-ops-when-flows-artefact-missing
+  (testing "router's flows-after-interceptor no-ops without throwing when :flows/run-flows-on-db hook is nil"
+    ;; Consumer is `re-frame.router/flows-after-interceptor` (private;
+    ;; reach via the user-visible drain). Drive a dispatch through the
+    ;; router — the absent-flows-artefact branch is the steady-state for
+    ;; apps that never registered any flows. With the hook nil, the
+    ;; innermost flow-transform `:after` collapses to a single nil-check
+    ;; no-op and the drain completes.
+    (with-hook-as-nil :flows/run-flows-on-db
       (fn []
         (rf/init! plain-atom/adapter)
         (rf/reg-event-db :flows-absent/init (fn [_ _] {:probe :ok}))

--- a/skills/re-frame2/references/fundamentals/flows.md
+++ b/skills/re-frame2/references/fundamentals/flows.md
@@ -114,13 +114,13 @@ Flow evaluation happens **after `:db` commits and before `:fx` walks**, once per
 - **One-drain registration lag.** A flow registered via `:rf.fx/reg-flow` first runs on the *next* drain — its initial output appears one event after registration. Dispatch a synthetic nudge event if you need the value immediately (the cart example dispatches `:cart/touch`).
 - **Cycles throw at registration.** If A depends on B and B on A, `reg-flow` throws `:rf.error/flow-cycle` with `:cycle` (an ordered vector with a closing repeat, e.g. `[:a :b :a]`).
 - **`clear-flow` vacates the path.** It `dissoc-in`s the `:path` (no opt-out). Copy the value elsewhere first if you need to keep it.
-- **`:output` must be pure and deterministic.** Same inputs → same output. A throw surfaces as `:rf.error/flow-eval-exception`; prior flows' writes are preserved, the failing flow's output is not written, and the cascade halts.
+- **`:output` must be pure and deterministic.** Same inputs → same output. A throw is a pre-install throw, so it **aborts the whole event** (atomicity contract): no `:db` install, `app-db` unchanged, no `:rf.event/db-changed`, `:fx` skipped — no partial commit (neither the handler's `:db` nor any prior flow's write lands). The throw surfaces as `:rf.error/flow-eval-exception`; every flow re-attempts on the next clean drain.
 - **Feature-prefix the `:id` and `:path`.** Never `:rf/*` (reserved). The two fx-ids `:rf.fx/reg-flow` / `:rf.fx/clear-flow` are the framework's; your flow's id is yours.
 - **Frame-scoped.** A flow belongs to one frame; the same id can register against two frames with different `:output`/`:path`. `clear-flow` and `destroy-frame!` teardown are frame-local.
 
 ## Deeper material
 
-Per-frame topsort + cycle-detection contract, the four-rule failure semantics, the `:rf.flow/*` trace taxonomy, `:sensitive?` inheritance, frame-destroy teardown, and the v1-alpha-flows migration table: `SKILL-REDIRECT.md` → **EP — Flows (013)**, **EP — Instrumentation (009)**. The managed-external-effects umbrella `:rf.flow/*` belongs to: [`spec/Managed-Effects.md`](../../../../spec/Managed-Effects.md).
+Per-frame topsort + cycle-detection contract, the atomicity failure semantics (a flow throw aborts the whole event — no partial commit), the `:rf.flow/*` trace taxonomy, `:sensitive?` inheritance, frame-destroy teardown, and the v1-alpha-flows migration table: `SKILL-REDIRECT.md` → **EP — Flows (013)**, **EP — Instrumentation (009)**. The managed-external-effects umbrella `:rf.flow/*` belongs to: [`spec/Managed-Effects.md`](../../../../spec/Managed-Effects.md).
 
 ---
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -947,6 +947,14 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
     ;;    (NOT the installed app-db). This is the moment `:rf.flow/computed`
     ;;    / `:rf.flow/skip` / `:rf.flow/failed` emit.
     ;;
+    ;;    A FLOW THROW is a PRE-INSTALL throw (per [013 §Failure semantics]
+    ;;    (013-Flows.md#failure-semantics) — the atomicity contract): the
+    ;;    flow-transform :after DISCARDS the pending `:db` effect (drops it
+    ;;    from `effects`) and records the throw. With no `:db` effect, the
+    ;;    install at step 2 is a no-op — app-db unchanged, no
+    ;;    `:rf.event/db-changed`, and step 3 skips `:fx`. No partial commit:
+    ;;    neither the handler's `:db` nor any prior flow's write lands.
+    ;;
     ;;    Throws inside :before / :after / handler are recorded into the
     ;;    chain context under two paired keys — `:rf/interceptor-error`
     ;;    (singleton, the FIRST throw) and `:rf/interceptor-errors` (vector,
@@ -955,23 +963,43 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
     ;;    Trace stream emits one `:rf.error/handler-exception` per chain
     ;;    execution, keyed off the singleton. See
     ;;    [Spec-Schemas §InterceptorContextErrorKeys](Spec-Schemas.md#interceptorcontexterrorkeys--post-chain-interceptor-context-error-contract).
-    (let [effects (run-interceptor-chain      ;; flow-transform is innermost :after
+    (let [effects (run-interceptor-chain      ;; flow-transform is outermost :after
                     frame envelope handler-meta)]
 
+      ;; THE :db INSTALL IS THE SINGLE, DEFERRED, ALL-OR-NOTHING COMMIT
+      ;; BOUNDARY. ANY pre-install throw — cofx, handler, interceptor :after,
+      ;; or the flow transform — aborts the event: no install, app-db
+      ;; UNCHANGED, no `:rf.event/db-changed`, no `:fx`. The mechanism is
+      ;; uniform and FREE: a handler / interceptor throw never produced a
+      ;; `:db` effect, and the flow-throw path DISCARDS the one it had — so
+      ;; in every pre-install-throw case `effects` carries no `:db`, and the
+      ;; guarded install below installs nothing. (`:fx` is the only
+      ;; POST-install stage; an fx throw at step 3 does NOT wind back the
+      ;; installed `:db` — its side effects may already have fired.)
+
       ;; 2. Apply :db FIRST — the FLOW-AUGMENTED `:db` effect. Atomic single
-      ;;    replace-container! call. By this point the flow-transform :after
-      ;;    has already rewritten `(:db effects)` (step 1), so the value
+      ;;    replace-container! call. Installs ONLY when a `:db` effect is
+      ;;    present — so a pre-install throw (which leaves no `:db` effect)
+      ;;    installs nothing. By this point the flow-transform :after has
+      ;;    already rewritten `(:db effects)` (step 1), so the value
       ;;    installed here is the flow-derived db. This is the moment
       ;;    sub-cache invalidation fires (per :fx ordering rule 4 above and
       ;;    per [006 §Subscription cache invalidation]) AND the moment the
       ;;    `:rf.event/db-changed` trace fires — AFTER flows (per [013
       ;;    §Drain integration](013-Flows.md#drain-integration) and [009
       ;;    §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)).
+      ;;    `contains? effects :db` is the WHOLE guard: a pre-install throw
+      ;;    leaves no `:db` effect (a handler / interceptor throw never made
+      ;;    one; the flow-throw path discarded it), so this is a no-op and
+      ;;    the event aborts with app-db unchanged.
       (when (contains? effects :db)
         (substrate/replace-container! (:app-db frame) (:db effects))
         (sub-cache/invalidate! frame))
 
-      ;; 3. Walk :fx in source order. Each entry's handler returns
+      ;; 3. Walk :fx in source order — SKIPPED on any pre-install throw
+      ;;    (handler / interceptor :after / flow): the event aborted at the
+      ;;    commit boundary, so no `:fx` runs. (:fx is the only POST-install
+      ;;    stage.) On a clean settle, each entry's handler returns
       ;;    synchronously before the next begins. Errors trace and continue.
       ;;    The fx-handler is invoked with the binary `(m args)` contract
       ;;    documented in [§The binary fx-handler signature](#the-binary-fx-handler-signature):
@@ -982,14 +1010,21 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
       ;;    `:dispatch-later` — can copy envelope fields onto the child envelope,
       ;;    per [§Cascade propagation](#cascade-propagation)); both reach the
       ;;    fx-handler as fields of `m`, not as separate positional arguments.
-      (let [m (handler-context frame envelope)]      ;; same `m` the event handler saw
+      ;;    Skipped on a pre-install throw — the chain context records the
+      ;;    throw under `:rf/interceptor-error` (handler / interceptor) or
+      ;;    `:rf/flow-error` (flow transform); either suppresses the walk.
+      ;;    (An `:fx` effect CAN still be present — a handler may produce
+      ;;    `:fx` before a later interceptor `:after` throws — so unlike the
+      ;;    `:db` install this guard cannot rely on effect-absence alone.)
+      (when-not (or (:rf/interceptor-error effects) (:rf/flow-error effects))
+       (let [m (handler-context frame envelope)]      ;; same `m` the event handler saw
         (doseq [[fx-id args] (:fx effects)]
           (try
             (let [fx-handler (lookup-fx frame fx-id)]  ;; honors :fx-overrides
               (fx-handler m args))                     ;; binary contract: (m, args)
             (catch :default e
               (raise! :rf.error/fx-handler-exception
-                      {:fx-id fx-id :event event :frame (:id frame) :ex e})))))
+                      {:fx-id fx-id :event event :frame (:id frame) :ex e}))))))
 
       (trace! :event/run-end {:event event :frame (:id frame)}))))
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -935,6 +935,18 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
 
     ;; 1. Run the interceptor chain — :before steps in order, then handler,
     ;;    then :after steps in reverse. The chain produces an effects map.
+    ;;
+    ;;    THE FLOW TRANSFORM IS THE OUTERMOST :after (per [013 §Drain
+    ;;    integration](013-Flows.md#drain-integration)). Because :after runs
+    ;;    outermost-LAST, the framework's flow-transform :after fires after
+    ;;    the rest of the :after chain has reshaped the `:db` effect into the
+    ;;    complete app-db form (in particular after a `(path :slice)`
+    ;;    interceptor splices the handler's slice back into the full db —
+    ;;    flows read full-app-db `:inputs` paths, so they MUST run after that
+    ;;    reshape). It rewrites the PENDING `:db` effect in the chain context
+    ;;    (NOT the installed app-db). This is the moment `:rf.flow/computed`
+    ;;    / `:rf.flow/skip` / `:rf.flow/failed` emit.
+    ;;
     ;;    Throws inside :before / :after / handler are recorded into the
     ;;    chain context under two paired keys — `:rf/interceptor-error`
     ;;    (singleton, the FIRST throw) and `:rf/interceptor-errors` (vector,
@@ -943,12 +955,18 @@ The loop has two layers — an **outer drain** (Level 4 in [005's terms](005-Sta
     ;;    Trace stream emits one `:rf.error/handler-exception` per chain
     ;;    execution, keyed off the singleton. See
     ;;    [Spec-Schemas §InterceptorContextErrorKeys](Spec-Schemas.md#interceptorcontexterrorkeys--post-chain-interceptor-context-error-contract).
-    (let [effects (run-interceptor-chain
+    (let [effects (run-interceptor-chain      ;; flow-transform is innermost :after
                     frame envelope handler-meta)]
 
-      ;; 2. Apply :db FIRST. Atomic single replace-container! call.
-      ;;    This is the moment sub-cache invalidation fires (per :fx ordering
-      ;;    rule 4 above and per [006 §Subscription cache invalidation]).
+      ;; 2. Apply :db FIRST — the FLOW-AUGMENTED `:db` effect. Atomic single
+      ;;    replace-container! call. By this point the flow-transform :after
+      ;;    has already rewritten `(:db effects)` (step 1), so the value
+      ;;    installed here is the flow-derived db. This is the moment
+      ;;    sub-cache invalidation fires (per :fx ordering rule 4 above and
+      ;;    per [006 §Subscription cache invalidation]) AND the moment the
+      ;;    `:rf.event/db-changed` trace fires — AFTER flows (per [013
+      ;;    §Drain integration](013-Flows.md#drain-integration) and [009
+      ;;    §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)).
       (when (contains? effects :db)
         (substrate/replace-container! (:app-db frame) (:db effects))
         (sub-cache/invalidate! frame))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -241,6 +241,33 @@ The map is open. New fields can be added by future versions without breaking con
 - **Op-type-specific fields inside `:tags`** are stable within their op-type — including `:frame`, which every emit site supplies under `:tags`. New optional tag keys are additive; existing keys don't change shape.
 - **New `:op-type` values** can be added without breaking existing tools — tools filter the values they recognise.
 
+### Canonical per-event trace sequence
+
+A single event's cascade emits a **canonical, ordered trace sequence**. The ordering is contract — off-box monitors, Causa's Trace panel, Story, and conformance recorders rely on it to place each phase relative to the others. A conformant port MUST emit (the phases that fire for a given event; omit those whose condition is unmet) in this order:
+
+```
+:rf.event/dispatched         ;; (envelope queued; one per dispatch — may precede the drain)
+:rf.event/run-start          ;; the handler's interceptor chain begins
+  … handler body + the rest of the :after chain run (reshaping the :db effect) …
+:rf.flow/computed | :rf.flow/skip | :rf.flow/failed   ;; the OUTERMOST :after —
+                             ;; the flow transform, per flow, in topological order.
+                             ;; Fires after the rest of the :after chain (so it
+                             ;; sees the fully-reshaped :db effect) and BEFORE
+                             ;; :rf.event/db-changed (install).
+:rf.event/run-end            ;; the interceptor chain (handler + all :after) completed
+:rf.event/db-changed         ;; the FLOW-AUGMENTED :db installs into app-db
+:rf.sub/run | :rf.sub/skip   ;; sub-cache recompute on the new (flow-augmented) db
+:rf.fx/do-fx                 ;; the :fx walk begins
+:rf.fx/handled               ;; per :fx entry (reads the flow-augmented app-db)
+:rf.view/render | :rf.view/rendered   ;; reactive re-render on the new db
+```
+
+**The flow position is the load-bearing change (rf2-u0zz5).** `:rf.flow/computed` is emitted **after the handler's `:after` chain** (the flow transform is the outermost `:after`, so it fires after the rest of the chain reshapes the `:db` effect) and **before `:rf.event/db-changed`**. This is the inversion from the prior design, where `:rf.event/db-changed` fired *before* flows (flows then mutated the already-installed db). Now `:rf.event/db-changed` reflects the **flow-augmented db** — the value installed already carries every flow's output. A consumer placing flows on the cascade timeline reads `:rf.flow/computed` between `:rf.event/run-start` and `:rf.event/db-changed`; the flow's write is visible in the `:rf.event/db-changed` snapshot, not applied after it.
+
+`:rf.event/run-end` marks completion of the interceptor chain (handler + the full `:after` cascade, including the outermost flow transform); it therefore falls **after** the `:rf.flow/*` traces and **before** `:rf.event/db-changed`. The relative order that consumers depend on is **`:rf.flow/computed` → `:rf.event/db-changed` → `:rf.fx/handled`**.
+
+On a flow throw the tail truncates per [013 §Trace stream ordering on a flow throw](013-Flows.md#trace-stream-ordering-on-a-flow-throw): the `:rf.flow/failed` → `:rf.error/flow-eval-exception` pair fires, prior-flow writes still install via `:rf.event/db-changed`, and no `:rf.fx/handled` fires for the halted cascade.
+
 ### Flow trace events
 
 Five trace events constitute the flow lifecycle stream (per [013 §Flow tracing](013-Flows.md#flow-tracing)). All five carry `:op-type :flow`; consumers filter by `:op-type` to subscribe to the whole stream and branch on `:operation` to discriminate. Every event's `:tags` carries `:flow-id` and `:frame` so tools can attribute and route per-frame.
@@ -248,7 +275,7 @@ Five trace events constitute the flow lifecycle stream (per [013 §Flow tracing]
 | `:operation` | When it fires | `:tags` payload (in addition to `:flow-id` and `:frame`) |
 |---|---|---|
 | `:rf.flow/registered` | After `reg-flow` (or `:rf.fx/reg-flow`) successfully registers a flow against a frame, including post-cycle-detection. | `:inputs` (the flow's input paths), `:path` (the flow's output path) |
-| `:rf.flow/computed` | A flow's `:output` fn ran and the result was assoc-in'd at `:path`. Fires only when the dirty-check observed an input value-difference. | `:input-values` (raw values read from the input paths), `:result` (the new output value), `:path` |
+| `:rf.flow/computed` | A flow's `:output` fn ran and the result was assoc-in'd into the **pending `:db` effect** at `:path` (the innermost-`:after` flow transform — before `:db` installs). Fires only when the dirty-check observed an input value-difference, and BEFORE `:rf.event/db-changed` (per [§Canonical per-event trace sequence](#canonical-per-event-trace-sequence)). | `:input-values` (raw values read from the input paths), `:result` (the new output value), `:path` |
 | `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (per [013 §Dirty-check semantics](013-Flows.md#dirty-check-semantics) and rf2-719e value-equal recompute suppression). | `:reason` (currently `:inputs-value-equal`; the keyword is open for future skip reasons), `:input-paths-unchanged` (the flow's input db-paths whose values were stable — for a value-equal skip every input is stable by definition, so this names the full input set; consumed by the cascade-DAG aggregator per rf2-931pm). |
 | `:rf.flow/cleared` | After `clear-flow` (or `:rf.fx/clear-flow`) removes the flow from the per-frame registry and dissoc-in's its output path. | `:path` (the path that was vacated) |
 | `:rf.flow/failed` | The flow's `:output` fn threw during recompute. The exception is re-thrown after this trace fires so the router's outer catch emits the cascade-level `:rf.error/flow-eval-exception` (per [§Error contract](#error-contract)); tools see the per-flow detail here and the cascade halt there. Per [013 §Failure semantics](013-Flows.md#failure-semantics), prior successful flows' writes in the same drain are flushed to `app-db` before the throw propagates; the failing flow's own `:path` is not written and its `last-inputs` is not advanced; downstream flows do not run on this drain. | `:ex` (the exception), `:inputs` (the input values that were read just before the throw) |

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -266,7 +266,20 @@ A single event's cascade emits a **canonical, ordered trace sequence**. The orde
 
 `:rf.event/run-end` marks completion of the interceptor chain (handler + the full `:after` cascade, including the outermost flow transform); it therefore falls **after** the `:rf.flow/*` traces and **before** `:rf.event/db-changed`. The relative order that consumers depend on is **`:rf.flow/computed` → `:rf.event/db-changed` → `:rf.fx/handled`**.
 
-On a flow throw the tail truncates per [013 §Trace stream ordering on a flow throw](013-Flows.md#trace-stream-ordering-on-a-flow-throw): the `:rf.flow/failed` → `:rf.error/flow-eval-exception` pair fires, prior-flow writes still install via `:rf.event/db-changed`, and no `:rf.fx/handled` fires for the halted cascade.
+**Throw variant — the event aborts at the commit boundary.** A flow throw is a **pre-install throw**, so the event aborts before the `:db` install (the atomicity contract — per [013 §Failure semantics](013-Flows.md#failure-semantics) and [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode)). The canonical sequence truncates: the `:rf.flow/*` phase ends at `:rf.flow/failed`, the router emits the cascade-level `:rf.error/flow-eval-exception`, and the cascade STOPS — **NO `:rf.event/db-changed`**, no `:rf.sub/run`, no `:rf.fx/*`:
+
+```
+:rf.event/run-start
+  … handler body + the rest of the :after chain run …
+:rf.flow/computed                       ;; per prior flow that ran (its WRITE is
+                                        ;; discarded — the trace records the run only)
+:rf.flow/failed                         ;; the throwing flow
+:rf.event/run-end                       ;; chain completed (with the recorded throw)
+:rf.error/flow-eval-exception           ;; cascade-level error (always-on substrate)
+;; — sequence ends — NO :rf.event/db-changed, NO :rf.fx/handled —
+```
+
+`:rf.event/db-changed` does NOT fire because the pending `:db` effect was discarded (no install, app-db unchanged, no partial commit); `:rf.fx/handled` does NOT fire because `:fx` is the post-install stage and the event aborted before it. This is the **same** truncated signature every other pre-install throw produces — a handler throw or an interceptor-`:after` throw also ends at `:rf.event/run-end` → `:rf.error/handler-exception` with no `:rf.event/db-changed` and no `:rf.fx/handled`.
 
 ### Flow trace events
 
@@ -275,10 +288,10 @@ Five trace events constitute the flow lifecycle stream (per [013 §Flow tracing]
 | `:operation` | When it fires | `:tags` payload (in addition to `:flow-id` and `:frame`) |
 |---|---|---|
 | `:rf.flow/registered` | After `reg-flow` (or `:rf.fx/reg-flow`) successfully registers a flow against a frame, including post-cycle-detection. | `:inputs` (the flow's input paths), `:path` (the flow's output path) |
-| `:rf.flow/computed` | A flow's `:output` fn ran and the result was assoc-in'd into the **pending `:db` effect** at `:path` (the innermost-`:after` flow transform — before `:db` installs). Fires only when the dirty-check observed an input value-difference, and BEFORE `:rf.event/db-changed` (per [§Canonical per-event trace sequence](#canonical-per-event-trace-sequence)). | `:input-values` (raw values read from the input paths), `:result` (the new output value), `:path` |
+| `:rf.flow/computed` | A flow's `:output` fn ran and the result was assoc-in'd into the **pending `:db` effect** at `:path` (the outermost-`:after` flow transform — before `:db` installs). Fires only when the dirty-check observed an input value-difference, and BEFORE `:rf.event/db-changed` (per [§Canonical per-event trace sequence](#canonical-per-event-trace-sequence)). Note: the trace records that the `:output` ran — if a LATER flow in the same drain throws, this write is discarded by the event abort (the trace is observational, not a commit guarantee). | `:input-values` (raw values read from the input paths), `:result` (the new output value), `:path` |
 | `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (per [013 §Dirty-check semantics](013-Flows.md#dirty-check-semantics) and rf2-719e value-equal recompute suppression). | `:reason` (currently `:inputs-value-equal`; the keyword is open for future skip reasons), `:input-paths-unchanged` (the flow's input db-paths whose values were stable — for a value-equal skip every input is stable by definition, so this names the full input set; consumed by the cascade-DAG aggregator per rf2-931pm). |
 | `:rf.flow/cleared` | After `clear-flow` (or `:rf.fx/clear-flow`) removes the flow from the per-frame registry and dissoc-in's its output path. | `:path` (the path that was vacated) |
-| `:rf.flow/failed` | The flow's `:output` fn threw during recompute. The exception is re-thrown after this trace fires so the router's outer catch emits the cascade-level `:rf.error/flow-eval-exception` (per [§Error contract](#error-contract)); tools see the per-flow detail here and the cascade halt there. Per [013 §Failure semantics](013-Flows.md#failure-semantics), prior successful flows' writes in the same drain are flushed to `app-db` before the throw propagates; the failing flow's own `:path` is not written and its `last-inputs` is not advanced; downstream flows do not run on this drain. | `:ex` (the exception), `:inputs` (the input values that were read just before the throw) |
+| `:rf.flow/failed` | The flow's `:output` fn threw during recompute. The exception is re-thrown after this trace fires so the router's outer catch emits the cascade-level `:rf.error/flow-eval-exception` (per [§Error contract](#error-contract)); tools see the per-flow detail here and the cascade abort there. Per [013 §Failure semantics](013-Flows.md#failure-semantics) (the atomicity contract), a flow throw is a pre-install throw: the event ABORTS — the pending `:db` effect is discarded (no install, app-db unchanged, no `:rf.event/db-changed`), `:fx` is skipped, and `last-inputs` is rolled back so every flow re-attempts next drain. No partial commit — neither the handler's `:db` nor any prior flow's write lands. | `:ex` (the exception), `:inputs` (the input values that were read just before the throw) |
 
 Payload-shape decisions:
 

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -146,16 +146,30 @@ process-event! (with flows as the outermost :after):
          For each flow in this frame's slot:
            new-inputs ← read input paths from pending-db
            if new-inputs ≠ last-inputs[[frame-id flow-id]]:
-             new-output ← (apply :output new-inputs)
+             new-output ← (apply :output new-inputs)   ;; MAY throw
              pending-db ← (assoc-in pending-db (:path flow) new-output)
              last-inputs[[frame-id flow-id]] ← new-inputs
          (:effects ctx) ← assoc :db pending-db   ;; flow-augmented :db effect
 
-  3. Install :db (the flow-augmented value). Sub-cache invalidates.
-     `:rf.event/db-changed` fires HERE — after flows (per [009
-     §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)).
+         ;; FAILURE — a flow's :output threw (atomicity contract):
+         ;; DISCARD the pending :db effect (drop it from (:effects ctx))
+         ;; and stash the throw under :rf/flow-error. The event ABORTS:
+         ;; the single deferred install at step 3 installs nothing, so
+         ;; no :rf.event/db-changed fires and :fx is skipped. NO partial
+         ;; commit — neither the handler's :db nor any prior flow's write
+         ;; lands. (See §Failure semantics.)
+
+  3. Install :db (the flow-augmented value) — ONLY when a :db effect is
+     present. Sub-cache invalidates. `:rf.event/db-changed` fires HERE —
+     after flows (per [009 §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)).
+     On any pre-install throw (handler / interceptor :after / flow), no
+     :db effect is present (the flow-throw path discarded it; a handler /
+     interceptor throw never produced one), so this step installs nothing
+     and emits no :rf.event/db-changed.
   4. Walk :fx in source order — every `:fx` entry reads the
-     flow-augmented app-db.
+     flow-augmented app-db. SKIPPED when the event aborted (any
+     pre-install throw). :fx is the only post-install stage; an fx throw
+     does NOT wind back the installed :db.
 ```
 
 Five properties this gives:
@@ -172,15 +186,15 @@ Five properties this gives:
 
 ### Trace stream ordering on a flow throw
 
-When a flow's `:output` fn throws during the flow-transform `:after` (step 2 of the drain integration pseudocode above), the runtime emits a strict trace sequence — observable contract for off-box monitors, Causa, Story, and any consumer that lifts a flow failure off the trace stream. Because flows now run **before** `:db` install (innermost `:after`), the failure window opens **before** `:rf.event/db-changed`, not after. A conformant port MUST emit these events in this order:
+When a flow's `:output` fn throws during the flow-transform `:after` (step 2 of the drain integration pseudocode above), the runtime emits a strict trace sequence — observable contract for off-box monitors, Causa, Story, and any consumer that lifts a flow failure off the trace stream. A flow throw is a **pre-install throw**: the event ABORTS before the `:db` install, so the failure stream carries **NO `:rf.event/db-changed`** (per [§Failure semantics](#failure-semantics) — the atomicity contract). A conformant port MUST emit these events in this order:
 
-1. **`:rf.flow/computed`** for each flow that successfully computed before the throwing one — fires per prior flow as it rewrites the pending `:db` effect. (See §Failure semantics for the per-flow detail; these may be absent when the first flow throws.)
+1. **`:rf.flow/computed`** for each flow that successfully computed before the throwing one — fires per prior flow as it rewrites the pending `:db` effect. (See §Failure semantics for the per-flow detail; these may be absent when the first flow throws.) Note: these traces fire even though the prior flows' writes are ultimately **discarded** by the abort — the trace records that the `:output` ran, not that the write was committed.
 2. **`:rf.flow/failed`** — the per-flow failure trace for the throwing flow, carrying `:flow-id`, `:ex`, and the elided `:inputs` read just before the throw. Rides the dev-only trace surface; DCEs in CLJS production.
-3. **`:rf.error/flow-eval-exception`** — the cascade-level error, emitted onto the **always-on production error-emit substrate** per [§Failure semantics rule 4](#failure-semantics). Carries `:where :flow-eval` (distinguishing this path from `:rf.error/handler-exception`), the originating event under `:rf.event/v`, and `:flow-id` attribution stamped from the throwing flow's wrapped `ex-data`. Attribution is the flow id alone — there is no real flow *value* to carry, so the contract carries `:flow-id` and nothing more. The dev-only trace surface emits the same op concurrently; the production-substrate path survives CLJS `:advanced` + `goog.DEBUG=false` elision.
-4. **`:rf.event/db-changed`** (install of the prior-flow-augmented db) — fires only when prior flows produced dirty writes that must be preserved (per [§Failure semantics rule 1](#failure-semantics)). The cascade installs the db carrying the prior successful flows' outputs (and the handler's `:db`), so the `:rf.event/db-changed` snapshot reflects those preserved writes — NOT the failing flow's never-applied output. When no prior flow wrote and the handler returned no `:db` effect, no `:rf.event/db-changed` fires.
-5. **`:fx` is skipped — no further `:rf.fx/handled` from this drain.** The cascade halts at the failing flow (per [§Failure semantics rule 3](#failure-semantics)); no `:fx` entry runs, no `:dispatch`-issued child events queue. The drain proceeds to the **next** event in the router queue on its normal cycle.
+3. **`:rf.error/flow-eval-exception`** — the cascade-level error, emitted onto the **always-on production error-emit substrate** per [§Failure semantics](#failure-semantics). Carries `:where :flow-eval` (distinguishing this path from `:rf.error/handler-exception`), the originating event under `:rf.event/v`, and `:flow-id` attribution stamped from the throwing flow's wrapped `ex-data`. Attribution is the flow id alone — there is no real flow *value* to carry, so the contract carries `:flow-id` and nothing more. The dev-only trace surface emits the same op concurrently; the production-substrate path survives CLJS `:advanced` + `goog.DEBUG=false` elision.
+4. **NO `:rf.event/db-changed`.** The event aborted before the install — neither the handler's `:db` nor any prior flow's write committed (no partial commit). `app-db` is unchanged, and the trace stream carries no `:rf.event/db-changed` for this event. This is the same abort signature every other pre-install throw (cofx / handler / interceptor `:after`) produces.
+5. **`:fx` is skipped — no `:rf.fx/handled` from this drain.** The event aborted (per [§Failure semantics](#failure-semantics)); no `:fx` entry runs, no `:dispatch`-issued child events queue. The drain proceeds to the **next** event in the router queue on its normal cycle.
 
-The contract is the ordering AND the gap — consumers can rely on "the flow failure (`:rf.flow/failed` → `:rf.error/flow-eval-exception`) fires BEFORE the `:rf.event/db-changed` install, and that install (when it fires) carries the prior-flow-preserved db; no `:fx` of this drain reached the outside world." Cascading work that *would* have run via `:fx` re-attempts naturally on a later drain.
+The contract is the ordering AND the gap — consumers can rely on "the flow failure (`:rf.flow/failed` → `:rf.error/flow-eval-exception`) fires, and NO `:rf.event/db-changed` follows: the event aborted, `app-db` is unchanged, and no `:fx` of this drain reached the outside world." Cascading work that *would* have run via `:fx` re-attempts naturally on a later drain — once a drain completes without the flow throwing.
 
 ## Topological sort and cycle detection
 
@@ -227,23 +241,22 @@ Three implications:
 
 ## Failure semantics
 
-When a flow's `:output` fn throws during the flow-transform `:after`, the runtime applies these four rules atomically (rf2-wyt97 / rf2-hrqvg):
+**The event-handling pipeline is atomic up to and including the `:db` install.** The `:db` install is the single, deferred, all-or-nothing commit boundary. ANY throw *before* it — in cofx, the handler body, an interceptor `:after`, or the flow transform — aborts the **entire** event: the pending `:db` effect does NOT install, `app-db` is left **unchanged**, **no `:rf.event/db-changed`** is emitted, and **no `:fx`** run. A flow throw is just one of these pre-install throws, and behaves identically to every other. `:fx` is the only post-install stage; an fx throw surfaces an error but does NOT wind back the installed `:db` (its side effects — http / nav / dispatch — may already have fired and are irreversible).
 
-1. **Prior-flow writes are preserved.** Flows scheduled earlier in the same drain that successfully computed and produced dirty writes have their outputs retained in the pending `:db` effect BEFORE the exception propagates — so the cascade still installs them (per [§Drain integration](#drain-integration), the db install at step 3 carries the prior-flow-augmented value). Earlier flows' work is never silently lost.
-2. **The failing flow's own output is not written.** The exception happened during `:output`; there is no usable new-output to assoc-in. Its `last-inputs` slot is NOT advanced, so the flow re-attempts on the next drain.
-3. **The cascade halts at the failing flow.** Downstream flows scheduled later in topo order do NOT run on this drain. They re-attempt naturally on the next drain (with whatever inputs the prior writes left in `app-db`). The rest of the `:after` chain, the `:db` install of the prior-flow-augmented db, and the `:fx` walk also do NOT run for this drain (the chain records the throw and the router skips `:fx` per rule 4) — except that the prior-flow writes ARE still installed so rule 1 holds.
+When a flow's `:output` fn throws during the flow-transform `:after`, the runtime applies these rules atomically:
+
+1. **No install — `app-db` is unchanged.** There is **no partial commit**. The pending `:db` effect (the handler's write plus any prior successful flows' writes) is **discarded**: the flow-transform `:after` drops the `:db` effect from the chain context, so the single deferred install installs nothing. Neither the handler's `:db` nor any earlier flow's output lands. The atomicity is **free**: because install was already deferred to one write, "wind back on a pre-install throw" is just "don't perform the one write" — no rollback machinery.
+2. **The failing flow's own output is not written, and `last-inputs` is rolled back.** The exception happened during `:output`; there is no usable new-output. The whole drain's dirty-check bookkeeping rolls back too: the `last-inputs` snapshot taken before the walk is restored, so **every** flow — prior-successful and failing alike — re-attempts on the next drain. (Without this, a prior flow whose `last-inputs` advanced would wrongly suppress its recompute next drain even though its output never reached `app-db` — silently losing the write.)
+3. **The cascade halts.** Downstream flows scheduled later in topo order do NOT run on this drain. They re-attempt naturally on a later drain — one that completes without the flow throwing. The `:db` install and the `:fx` walk do NOT run for this drain.
 4. **The exception surfaces at the router as** `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). The cascade-level error is emitted onto the **always-on production error-emit substrate** ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)) — the per-frame `:on-error` policy fn fires, every `register-error-listener!` callback fires, and both fan-out paths are mutually isolated. The substrate is NOT gated by `re-frame.interop/debug-enabled?`, so `:rf.error/flow-eval-exception` survives CLJS `:advanced` + `goog.DEBUG=false` elision: a flow-eval failure in a production build reaches every registered off-box error monitor (Sentry / Honeybadger / Rollbar / hosted observability) at full fidelity. The per-flow `:rf.flow/failed` trace event ALSO fires first with the flow-attributed detail, but that trace rides the dev-only trace surface and DCEs in production — production attribution is preserved on the always-on path via the `:flow-id` slot stamped onto the cascade-level error's `:tags`. There is no real flow *value* to carry, so the prod-surviving attribution tag is `:flow-id` alone.
 
 Worked example. Three flows in topo order — `:A`, `:B`, `:C`. Inputs change for all three. `:B` throws. After the drain:
 
-- `:A`'s output is written to `app-db` at its `:path` (rule 1 — installed as part of the prior-flow-augmented `:db` effect).
-- `:A`'s `last-inputs` is advanced (rule 1 — `:A` computed successfully).
-- `:B`'s `:path` is unchanged from before the drain (rule 2).
-- `:B`'s `last-inputs` is unchanged (rule 2).
-- `:C` did not run; its `:path` is unchanged and its `last-inputs` is unchanged (rule 3).
-- Two trace events fired in order: `:rf.flow/computed` for `:A`, then `:rf.flow/failed` for `:B`. Then the router emitted `:rf.error/flow-eval-exception` (rule 4). These all fire BEFORE the `:rf.event/db-changed` install of `:A`'s preserved write (per [§Trace stream ordering on a flow throw](#trace-stream-ordering-on-a-flow-throw)).
+- `app-db` is **unchanged** — `:A`'s output is NOT written (rule 1, no partial commit), the handler's `:db` did NOT land, `:B`'s `:path` is unchanged, `:C` did not run.
+- **All** `last-inputs` are unchanged from before the drain (rule 2): `:A`'s advance was rolled back, `:B`'s never advanced (it threw), `:C` never ran. All three re-attempt next drain.
+- Two flow traces fired in order: `:rf.flow/computed` for `:A` (it *ran* — the trace records the `:output` call, not a committed write), then `:rf.flow/failed` for `:B`. Then the router emitted `:rf.error/flow-eval-exception` (rule 4). **No `:rf.event/db-changed` fired** (rule 1 — the event aborted before install; per [§Trace stream ordering on a flow throw](#trace-stream-ordering-on-a-flow-throw)).
 
-**Rationale.** This is the strongest 'no work is silently lost' guarantee compatible with surfacing flow failures as cascade-level errors. The alternative (per-flow isolation: `:C` runs anyway) would prevent the cascade halt that downstream `:fx` and tooling rely on to skip work that depended on a now-invalid derived state. The opposite alternative (discard prior writes too) would silently drop `:A`'s output while its `:rf.flow/computed` trace claimed the write happened — an observability lie. Preserving prior writes and halting the cascade keeps both 'completed work is visible in app-db' and 'failures surface as errors' true at once.
+**Rationale.** The `:db` install is the atomic commit boundary, and atomicity must be uniform: a flow throw can no more leave a half-committed `app-db` than a handler throw or an interceptor-`:after` throw can. The earlier "preserve prior-flow writes" design committed a partial `app-db` on a flow throw — but that made flow throws behave *differently* from every other pre-install throw, and committed state from an event that the runtime simultaneously reported as failed. Discarding the whole pending write keeps one invariant true everywhere: **an event either commits in full or not at all.** Work that *would* have completed re-attempts on a later, clean drain; nothing half-done is ever observable in `app-db`.
 
 ## Flow tracing
 
@@ -255,7 +268,7 @@ Every flow lifecycle event emits a structured trace event under op-type `:flow`.
 | `:rf.flow/computed` | A flow's `:output` fn ran and the result was written to `:path` (dirty-check observed input value-difference). Carries `:before` (the value at `:path` immediately before this drain's write — `nil` when the slot had never been written) alongside `:result`, so consumers render the wrote-line "wrote `[:path]` `<before>` → `<after>`" without walking the surrounding epoch's `:db-before` snapshot. Both ride through `elide-wire-value` against the flow's `:path` (rf2-qlzh4). |
 | `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (§[Dirty-check semantics](#dirty-check-semantics) above; rf2-719e value-equal recompute suppression). |
 | `:rf.flow/cleared` | `clear-flow` (or `:rf.fx/clear-flow`) removed the flow from the per-frame registry and dissoc-in'd its output path. |
-| `:rf.flow/failed` | A flow's `:output` fn threw during recompute. The exception is re-thrown after the trace fires; see [§Failure semantics](#failure-semantics) for the four-rule contract (prior writes preserved, failing-flow's `last-inputs` not advanced, cascade halts, router emits `:rf.error/flow-eval-exception` per [009 §Error contract](009-Instrumentation.md#error-contract)). |
+| `:rf.flow/failed` | A flow's `:output` fn threw during recompute. The exception is re-thrown after the trace fires; see [§Failure semantics](#failure-semantics) for the atomicity contract (the event aborts — no install, `app-db` unchanged, no `:rf.event/db-changed`, `:fx` skipped; `last-inputs` rolled back so every flow re-attempts; router emits `:rf.error/flow-eval-exception` per [009 §Error contract](009-Instrumentation.md#error-contract)). |
 
 Every event carries `:flow-id` and `:frame` under `:tags`. Pair-shaped tools, Causa's flow panel, and custom dashboards filter `op-type :flow` to subscribe to the whole flow stream — see [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach) and [009 §Flow trace events](009-Instrumentation.md#flow-trace-events) for the consumer-side pattern.
 
@@ -267,7 +280,7 @@ The whole flow trace surface, like the rest of trace, is compile-time eliminated
 
 A flow's optional `:schema` key (per [§The registration shape](#the-registration-shape)) declares a Malli schema for the **output value**. When present, the runtime validates the flow's computed `:output` against it on every recompute, during the flow-transform `:after` (after the handler body, before the `:db` install — per [§Drain integration](#drain-integration)). This is the same dev-time, pluggable-validator mechanism the rest of [010 §Schemas](010-Schemas.md) uses; the flows artefact reaches the registered validator/explainer through the `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn` late-bind hooks, so an app that omits the schemas artefact (or registers no validator) pays nothing and the check soft-passes.
 
-**Observational, not a rollback.** Unlike the `app-db`-path schema (which rolls back the `:db` effect on failure), a flow `:schema` violation does **not** unwind the write. A flow's output is materialised state — by the time a violation could be observed, downstream flows / handlers / subs in the same drain may already have read the value, and [§Failure semantics](#failure-semantics) rule 1 (prior writes preserved) forbids retroactively unwinding a flow write mid-cascade. So the output **is** written and the cascade proceeds; the failure surfaces as a diagnostic `:rf.error/schema-validation-failure` error event with `:where :flow-output` (per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)), carrying the failing `:rf.flow/id`, the flow's `:path`, the failing `:value` (size/sensitivity-elided like every wire-bearing trace slot), and the registered explainer's `:explain` output. `:recovery` is `:no-recovery`, matching the category's documented disposition — the check exists to surface a producer bug early, not to repair state.
+**Observational, not a rollback.** A flow `:schema` violation does **not** throw and does **not** unwind the write. This is distinct from a flow `:output` *throw* (which aborts the whole event — [§Failure semantics](#failure-semantics)): a schema violation is a soft, dev-time diagnostic. The flow computed a value successfully; the value simply fails its declared shape. By the time a violation could be observed, downstream flows in the same drain may already have read the value as their input, so retroactively unwinding one flow's write mid-walk would leave an inconsistent pending `:db` effect. So the output **is** written into the pending effect and the cascade proceeds normally (the event still commits if no flow throws); the failure surfaces as a diagnostic `:rf.error/schema-validation-failure` error event with `:where :flow-output` (per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)), carrying the failing `:rf.flow/id`, the flow's `:path`, the failing `:value` (size/sensitivity-elided like every wire-bearing trace slot), and the registered explainer's `:explain` output. `:recovery` is `:no-recovery`, matching the category's documented disposition — the check exists to surface a producer bug early, not to repair state.
 
 ```clojure
 (rf/reg-flow
@@ -440,6 +453,12 @@ The flow walk runs **immediately after the handler's interceptor chain — as th
 The change makes three things true that the post-install design could not: (a) the cascade performs exactly one `app-db` install — of the flow-augmented value — rather than a handler commit followed by a separate flow mutation; (b) the `:rf.event/db-changed` trace fires AFTER flows, so it reflects the flow-augmented db, and `:rf.flow/computed` precedes `:rf.event/db-changed` on the trace stream (per [009 §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)) — making the flow position observable for Causa's Trace panel; (c) flows transform the *pending effect* rather than the live container, so the write is part of the cascade's single install. The `:fx`-sees-flow-output guarantee is **preserved** — `:fx` still walks after the install, so it reads the flow-derived `app-db`.
 
 **Outermost, not innermost.** Flows run as the *outermost* `:after` (fired last) — NOT the innermost — because the `path` std-interceptor's `:after` reshapes the `:db` effect (splicing a slice back into the full db), and flows read full-`app-db` `:inputs` paths, so they must run after that reshape. The consequence is that user `:after` interceptors run before the flow transform and see the handler's pre-flow `:db` effect; observational interceptors that need flow output read it from `app-db` post-install (sub / follow-up event), as `:fx` does. This is the pre-alpha masterpiece choice: no back-compat shim, the prior post-install drain step is removed outright; correctness (flows read the full db) is the load-bearing constraint that fixes the placement.
+
+### A flow throw aborts the event — atomic commit boundary (RESOLVED rf2-u0zz5, Mike 2026-05-24)
+
+The `:db` install is the single, deferred, **all-or-nothing** commit boundary. ANY throw before it — cofx, handler, interceptor `:after`, or the flow transform — aborts the entire event: no install, `app-db` unchanged, no `:rf.event/db-changed`, no `:fx`. A flow throw is just one such pre-install throw and MUST behave identically to a handler / interceptor-`:after` throw. `:fx` is the only post-install stage; an fx throw does NOT wind back the installed `:db` (side effects may already have fired).
+
+This **replaces** the earlier "prior-flow writes still commit on a flow throw" rule. That rule committed a partial `app-db` — making flow throws behave differently from every other pre-install throw, and committing state from an event the runtime simultaneously reported as failed. The atomicity rule is also **free**: because the install is already deferred to a single write, winding back on a pre-install throw is just *not performing that write* (the flow-transform `:after` discards the pending `:db` effect) — there is no rollback machinery, no partial-commit special-case. The dirty-check bookkeeping rolls back in lockstep: the `last-inputs` snapshot is restored on a throw so every flow re-attempts cleanly on a later, clean drain. The invariant the whole design now upholds: **an event either commits in full or not at all.** Per [§Failure semantics](#failure-semantics).
 
 ### `:rf.error/flow-eval-exception` rides the always-on error substrate (RESOLVED rf2-0q0du)
 

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -10,7 +10,7 @@
 
 ## Abstract
 
-A **flow** is a registered rule that says: "when these `app-db` paths change, run this pure function and write the result to that `app-db` path." Flows are evaluated automatically after every event drain, in topological order over their static input/output dependency graph.
+A **flow** is a registered rule that says: "when these `app-db` paths change, run this pure function and write the result to that `app-db` path." Flows are evaluated automatically on every event, **immediately after the handler's interceptor chain** (as the outermost `:after` interceptor — after the rest of the `:after` chain has reshaped the db effect, and before the `:db` effect installs), in topological order over their static input/output dependency graph. The flow walk transforms the handler's *pending* `:db` effect; see [§Drain integration](#drain-integration).
 
 Flows differ from subscriptions in *where the value lives*. A sub's value lives in the per-frame sub-cache and is consumed by views. A flow's value lives in `app-db` at a known path, where it survives SSR / hydration / time-travel revert, is visible in the app-db inspector, can be read by downstream event handlers and other flows, and is covered by registered schemas. When the derived value is part of the application's *state* (as opposed to part of a view's render input), use a flow.
 
@@ -124,43 +124,63 @@ The teardown contract is symmetric with the machines artefact's `:machines/teard
 
 ## Drain integration
 
-Flow evaluation happens **after `:db` commits and before `:fx` walks** on every event drain. Per [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode), the per-event drain inserts one step:
+Flow evaluation happens **immediately after the event handler's interceptor chain, transforming the pending `:db` effect — before the `:db` effect installs into `app-db` and before `:fx` walks**. The flow walk runs the registered flows over the chain's final `:db` effect *value* and rewrites that pending effect; it does NOT mutate the already-installed `app-db`. Per [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode), the runtime realises this as the **outermost `:after` interceptor** — the flow transform fires after the rest of the `:after` chain has finished reshaping the `:db` effect into the complete `app-db` form:
 
 ```
-process-event! (revised, with flows):
+process-event! (with flows as the outermost :after):
   1. Resolve handler.
-  2. Run interceptor chain.
-  3. Apply :db. Sub-cache invalidates.
-  4. run-flows! frame-id                                     ← NEW
-       Walk THIS FRAME'S registered flows in topologically-
-       sorted order — i.e. (get @flows frame-id) only;
-       sibling frames' flows are not visited.
-       For each flow in this frame's slot:
-         new-inputs ← read input paths from new app-db
-         if new-inputs ≠ last-inputs[[frame-id flow-id]]:
-           new-output ← (apply :output new-inputs)
-           app-db ← (assoc-in app-db (:path flow) new-output)
-           last-inputs[[frame-id flow-id]] ← new-inputs
-       Sub-cache invalidates again if any flow wrote.
-  5. Walk :fx in source order.
+  2. Run interceptor chain — :before steps in order, then handler,
+     then :after steps in REVERSE. The framework's flow-transform
+     :after is the OUTERMOST :after, so it fires LAST — after every
+     other :after (incl. a `(path :slice)` interceptor's :after that
+     splices the handler's slice back into the FULL db):
+
+       run-flows! ctx                                        ← OUTERMOST :after
+         pending-db ← (:db (:effects ctx))   ;; the FULL, fully-reshaped
+                                             ;; :db effect, or the current
+                                             ;; app-db value when no :db
+                                             ;; effect was produced
+         Walk THIS FRAME'S registered flows in topologically-
+         sorted order — i.e. (get @flows frame-id) only;
+         sibling frames' flows are not visited.
+         For each flow in this frame's slot:
+           new-inputs ← read input paths from pending-db
+           if new-inputs ≠ last-inputs[[frame-id flow-id]]:
+             new-output ← (apply :output new-inputs)
+             pending-db ← (assoc-in pending-db (:path flow) new-output)
+             last-inputs[[frame-id flow-id]] ← new-inputs
+         (:effects ctx) ← assoc :db pending-db   ;; flow-augmented :db effect
+
+  3. Install :db (the flow-augmented value). Sub-cache invalidates.
+     `:rf.event/db-changed` fires HERE — after flows (per [009
+     §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)).
+  4. Walk :fx in source order — every `:fx` entry reads the
+     flow-augmented app-db.
 ```
 
-Four properties this gives:
+Five properties this gives:
 
-1. **`:fx` entries see flow outputs.** An `:fx` entry that reads `app-db` after the handler returns sees flow-computed values. This is what makes `[:dispatch [:react-to-area-change]]` work cleanly.
-2. **Single pass per event.** Each flow runs at most once per drain. The topological order ensures multi-layer flows settle in one walk.
-3. **Run-to-completion is preserved.** Views never observe an intermediate state where some flows have updated and others haven't.
-4. **Frame isolation.** An event dispatched on frame `:left` only walks flows registered against `:left`. Flows on frame `:right` are dormant from `:left`'s perspective — they walk only when `:right`'s drain calls its own `run-flows!`. This is what makes multi-tenant frames safe to colocate without cross-talk in derived state.
+1. **Flows run on the FULL, fully-reshaped db.** Because the flow transform is the outermost `:after`, it runs after every db-reshaping `:after` in the chain — in particular after a `(path :slice)` interceptor splices the handler's slice back into the complete `app-db`. Flows read full-`app-db` `:inputs` paths, so they MUST see the reshaped full db; running them outermost is what guarantees that. (Running flows innermost would expose them to the unspliced path slice and mis-read their inputs.)
+2. **`:fx` entries see flow outputs.** An `:fx` entry that reads `app-db` after install sees flow-computed values (flows transform the effect at step 2; install at step 3; `:fx` at step 4). This is what makes `[:dispatch [:react-to-area-change]]` work cleanly. (Preserved from the prior design.)
+3. **Single pass per event.** Each flow runs at most once per drain. The topological order ensures multi-layer flows settle in one walk.
+4. **Run-to-completion is preserved, with exactly one `app-db` write.** The flow transform rewrites the *pending* `:db` effect; the single `:db` install at step 3 is the only `app-db` write the cascade makes — the flow output is part of that one install, not a second mutation after it. Views never observe an intermediate state.
+5. **Frame isolation.** An event dispatched on frame `:left` only walks flows registered against `:left`. Flows on frame `:right` are dormant from `:left`'s perspective — they walk only when `:right`'s drain runs its own flow transform. This is what makes multi-tenant frames safe to colocate without cross-talk in derived state.
+
+**Why a pending-`:db`-effect transform and not a post-install drain step.** The prior design ran flows as a post-commit step: the full interceptor chain ran, `:db` committed to `app-db`, then `run-flows!` mutated the live `app-db`, then `:fx` walked. That split the `app-db` write into two mutations (handler commit, then a separate flow mutation), made the cascade install the db twice, and fired the `:rf.event/db-changed` trace *before* flows — so the trace did not reflect the flow output and tools could not place flows on the cascade timeline correctly. Moving flows to transform the pending `:db` effect (as the outermost `:after`) makes (a) the cascade perform exactly one `app-db` install — of the flow-augmented value, (b) the `:rf.event/db-changed` trace reflect the flow-augmented db and fire *after* `:rf.flow/computed`, and (c) the whole flow position observable on the trace stream (per [009 §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)). The `:fx`-sees-flow-output guarantee is preserved unchanged.
+
+**Position note — outermost `:after`, not innermost.** Conceptually flows run "right after the handler"; mechanically they run as the *outermost* `:after` so they observe the fully-reshaped `:db` effect. The distinction matters only when the chain contains a db-reshaping `:after` (the `path` std-interceptor): flows must run after that reshape. A consequence is that **user `:after` interceptors run before the flow transform and therefore see the handler's pre-flow `:db` effect, not the flow-augmented one** — observational `:after` interceptors that need flow outputs should read them from `app-db` (post-install) via a sub or a follow-up event, exactly as `:fx` does. (Reshaping the db effect from within an arbitrary user `:after` and then re-running flows would require interleaving the flow walk through the whole `:after` chain, which is neither necessary for any real use case nor compatible with the single-pass guarantee.)
 
 ### Trace stream ordering on a flow throw
 
-When a flow's `:output` fn throws during step 4 of the drain integration pseudocode above, the runtime emits a strict three-event trace sequence — observable contract for off-box monitors, Causa, Story, and any consumer that lifts a flow failure off the trace stream. A conformant port MUST emit these three events in this order:
+When a flow's `:output` fn throws during the flow-transform `:after` (step 2 of the drain integration pseudocode above), the runtime emits a strict trace sequence — observable contract for off-box monitors, Causa, Story, and any consumer that lifts a flow failure off the trace stream. Because flows now run **before** `:db` install (innermost `:after`), the failure window opens **before** `:rf.event/db-changed`, not after. A conformant port MUST emit these events in this order:
 
-1. **`:rf.event/db-changed`** (post-handler commit) — fires from step 3 as usual, BEFORE any flow runs. The post-handler `app-db` is the value flows are about to evaluate against; the trace publishes that value before the failure window opens. (Successful flows that ran before the throwing one also emit their `:rf.flow/computed` traces between this commit and the failure — see §Failure semantics for the per-flow detail.)
-2. **`:rf.error/flow-eval-exception`** — the cascade-level error, emitted onto the **always-on production error-emit substrate** per [§Failure semantics rule 4](#failure-semantics). Carries `:where :flow-eval` (distinguishing this path from `:rf.error/handler-exception`), the originating event under `:rf.event/v`, and `:flow-id` attribution stamped from the throwing flow's wrapped `ex-data`. Attribution is the flow id alone — there is no real flow *value* to carry, so the contract carries `:flow-id` and nothing more. The dev-only trace surface emits the same op concurrently; the production-substrate path survives CLJS `:advanced` + `goog.DEBUG=false` elision.
-3. **`:fx` is skipped — no further trace event from this drain.** The cascade halts at the failing flow (per [§Failure semantics rule 3](#failure-semantics)); no `:fx` entry runs, no `:dispatch`-issued child events queue, no `:rf.event/run-end` marker fires for skipped-fx work. The drain proceeds to the **next** event in the router queue on its normal cycle.
+1. **`:rf.flow/computed`** for each flow that successfully computed before the throwing one — fires per prior flow as it rewrites the pending `:db` effect. (See §Failure semantics for the per-flow detail; these may be absent when the first flow throws.)
+2. **`:rf.flow/failed`** — the per-flow failure trace for the throwing flow, carrying `:flow-id`, `:ex`, and the elided `:inputs` read just before the throw. Rides the dev-only trace surface; DCEs in CLJS production.
+3. **`:rf.error/flow-eval-exception`** — the cascade-level error, emitted onto the **always-on production error-emit substrate** per [§Failure semantics rule 4](#failure-semantics). Carries `:where :flow-eval` (distinguishing this path from `:rf.error/handler-exception`), the originating event under `:rf.event/v`, and `:flow-id` attribution stamped from the throwing flow's wrapped `ex-data`. Attribution is the flow id alone — there is no real flow *value* to carry, so the contract carries `:flow-id` and nothing more. The dev-only trace surface emits the same op concurrently; the production-substrate path survives CLJS `:advanced` + `goog.DEBUG=false` elision.
+4. **`:rf.event/db-changed`** (install of the prior-flow-augmented db) — fires only when prior flows produced dirty writes that must be preserved (per [§Failure semantics rule 1](#failure-semantics)). The cascade installs the db carrying the prior successful flows' outputs (and the handler's `:db`), so the `:rf.event/db-changed` snapshot reflects those preserved writes — NOT the failing flow's never-applied output. When no prior flow wrote and the handler returned no `:db` effect, no `:rf.event/db-changed` fires.
+5. **`:fx` is skipped — no further `:rf.fx/handled` from this drain.** The cascade halts at the failing flow (per [§Failure semantics rule 3](#failure-semantics)); no `:fx` entry runs, no `:dispatch`-issued child events queue. The drain proceeds to the **next** event in the router queue on its normal cycle.
 
-The contract is the ordering AND the gap — consumers can rely on "if `:rf.error/flow-eval-exception` fires, the immediately preceding `:rf.event/db-changed` is the snapshot the failing flow saw, and no `:fx` of this drain reached the outside world." Cascading work that *would* have run via `:fx` re-attempts naturally on a later drain.
+The contract is the ordering AND the gap — consumers can rely on "the flow failure (`:rf.flow/failed` → `:rf.error/flow-eval-exception`) fires BEFORE the `:rf.event/db-changed` install, and that install (when it fires) carries the prior-flow-preserved db; no `:fx` of this drain reached the outside world." Cascading work that *would* have run via `:fx` re-attempts naturally on a later drain.
 
 ## Topological sort and cycle detection
 
@@ -207,21 +227,21 @@ Three implications:
 
 ## Failure semantics
 
-When a flow's `:output` fn throws during `run-flows!`, the runtime applies these four rules atomically (rf2-wyt97 / rf2-hrqvg):
+When a flow's `:output` fn throws during the flow-transform `:after`, the runtime applies these four rules atomically (rf2-wyt97 / rf2-hrqvg):
 
-1. **Prior-flow writes are preserved.** Flows scheduled earlier in the same drain that successfully computed and produced dirty writes have their outputs flushed to `app-db` (one `replace-container!` against the loop accumulator) BEFORE the exception propagates. Earlier flows' work is never silently lost.
+1. **Prior-flow writes are preserved.** Flows scheduled earlier in the same drain that successfully computed and produced dirty writes have their outputs retained in the pending `:db` effect BEFORE the exception propagates — so the cascade still installs them (per [§Drain integration](#drain-integration), the db install at step 3 carries the prior-flow-augmented value). Earlier flows' work is never silently lost.
 2. **The failing flow's own output is not written.** The exception happened during `:output`; there is no usable new-output to assoc-in. Its `last-inputs` slot is NOT advanced, so the flow re-attempts on the next drain.
-3. **The cascade halts at the failing flow.** Downstream flows scheduled later in topo order do NOT run on this drain. They re-attempt naturally on the next drain (with whatever inputs the prior flush left in `app-db`).
-4. **The exception surfaces at the router's outer catch** as `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). The cascade-level error is emitted onto the **always-on production error-emit substrate** ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)) — the per-frame `:on-error` policy fn fires, every `register-error-listener!` callback fires, and both fan-out paths are mutually isolated. The substrate is NOT gated by `re-frame.interop/debug-enabled?`, so `:rf.error/flow-eval-exception` survives CLJS `:advanced` + `goog.DEBUG=false` elision: a flow-eval failure in a production build reaches every registered off-box error monitor (Sentry / Honeybadger / Rollbar / hosted observability) at full fidelity. The per-flow `:rf.flow/failed` trace event ALSO fires first with the flow-attributed detail, but that trace rides the dev-only trace surface and DCEs in production — production attribution is preserved on the always-on path via the `:flow-id` slot stamped onto the cascade-level error's `:tags`. There is no real flow *value* to carry, so the prod-surviving attribution tag is `:flow-id` alone.
+3. **The cascade halts at the failing flow.** Downstream flows scheduled later in topo order do NOT run on this drain. They re-attempt naturally on the next drain (with whatever inputs the prior writes left in `app-db`). The rest of the `:after` chain, the `:db` install of the prior-flow-augmented db, and the `:fx` walk also do NOT run for this drain (the chain records the throw and the router skips `:fx` per rule 4) — except that the prior-flow writes ARE still installed so rule 1 holds.
+4. **The exception surfaces at the router as** `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). The cascade-level error is emitted onto the **always-on production error-emit substrate** ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)) — the per-frame `:on-error` policy fn fires, every `register-error-listener!` callback fires, and both fan-out paths are mutually isolated. The substrate is NOT gated by `re-frame.interop/debug-enabled?`, so `:rf.error/flow-eval-exception` survives CLJS `:advanced` + `goog.DEBUG=false` elision: a flow-eval failure in a production build reaches every registered off-box error monitor (Sentry / Honeybadger / Rollbar / hosted observability) at full fidelity. The per-flow `:rf.flow/failed` trace event ALSO fires first with the flow-attributed detail, but that trace rides the dev-only trace surface and DCEs in production — production attribution is preserved on the always-on path via the `:flow-id` slot stamped onto the cascade-level error's `:tags`. There is no real flow *value* to carry, so the prod-surviving attribution tag is `:flow-id` alone.
 
 Worked example. Three flows in topo order — `:A`, `:B`, `:C`. Inputs change for all three. `:B` throws. After the drain:
 
-- `:A`'s output is written to `app-db` at its `:path` (rule 1).
+- `:A`'s output is written to `app-db` at its `:path` (rule 1 — installed as part of the prior-flow-augmented `:db` effect).
 - `:A`'s `last-inputs` is advanced (rule 1 — `:A` computed successfully).
 - `:B`'s `:path` is unchanged from before the drain (rule 2).
 - `:B`'s `last-inputs` is unchanged (rule 2).
 - `:C` did not run; its `:path` is unchanged and its `last-inputs` is unchanged (rule 3).
-- Two trace events fired in order: `:rf.flow/computed` for `:A`, then `:rf.flow/failed` for `:B`. Then the router's outer catch emitted `:rf.error/flow-eval-exception` (rule 4).
+- Two trace events fired in order: `:rf.flow/computed` for `:A`, then `:rf.flow/failed` for `:B`. Then the router emitted `:rf.error/flow-eval-exception` (rule 4). These all fire BEFORE the `:rf.event/db-changed` install of `:A`'s preserved write (per [§Trace stream ordering on a flow throw](#trace-stream-ordering-on-a-flow-throw)).
 
 **Rationale.** This is the strongest 'no work is silently lost' guarantee compatible with surfacing flow failures as cascade-level errors. The alternative (per-flow isolation: `:C` runs anyway) would prevent the cascade halt that downstream `:fx` and tooling rely on to skip work that depended on a now-invalid derived state. The opposite alternative (discard prior writes too) would silently drop `:A`'s output while its `:rf.flow/computed` trace claimed the write happened — an observability lie. Preserving prior writes and halting the cascade keeps both 'completed work is visible in app-db' and 'failures surface as errors' true at once.
 
@@ -245,7 +265,7 @@ The whole flow trace surface, like the rest of trace, is compile-time eliminated
 
 ## Flow output validation
 
-A flow's optional `:schema` key (per [§The registration shape](#the-registration-shape)) declares a Malli schema for the **output value**. When present, the runtime validates the flow's computed `:output` against it on every recompute, during the post-handler flow walk (after the `:db` commit, before `:fx`). This is the same dev-time, pluggable-validator mechanism the rest of [010 §Schemas](010-Schemas.md) uses; the flows artefact reaches the registered validator/explainer through the `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn` late-bind hooks, so an app that omits the schemas artefact (or registers no validator) pays nothing and the check soft-passes.
+A flow's optional `:schema` key (per [§The registration shape](#the-registration-shape)) declares a Malli schema for the **output value**. When present, the runtime validates the flow's computed `:output` against it on every recompute, during the flow-transform `:after` (after the handler body, before the `:db` install — per [§Drain integration](#drain-integration)). This is the same dev-time, pluggable-validator mechanism the rest of [010 §Schemas](010-Schemas.md) uses; the flows artefact reaches the registered validator/explainer through the `:schemas/validate-with-registered-fn` / `:schemas/explain-with-registered-fn` late-bind hooks, so an app that omits the schemas artefact (or registers no validator) pays nothing and the check soft-passes.
 
 **Observational, not a rollback.** Unlike the `app-db`-path schema (which rolls back the `:db` effect on failure), a flow `:schema` violation does **not** unwind the write. A flow's output is materialised state — by the time a violation could be observed, downstream flows / handlers / subs in the same drain may already have read the value, and [§Failure semantics](#failure-semantics) rule 1 (prior writes preserved) forbids retroactively unwinding a flow write mid-cascade. So the output **is** written and the cascade proceeds; the failure surfaces as a diagnostic `:rf.error/schema-validation-failure` error event with `:where :flow-output` (per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)), carrying the failing `:rf.flow/id`, the flow's `:path`, the failing `:value` (size/sensitivity-elided like every wire-bearing trace slot), and the registered explainer's `:explain` output. `:recovery` is `:no-recovery`, matching the category's documented disposition — the check exists to surface a producer bug early, not to repair state.
 
@@ -262,7 +282,7 @@ Like the rest of the validation surface, flow output validation is dev-only: it 
 
 ## Sub integration
 
-Flows write to `app-db`; subs read `app-db`. **Flows therefore publish zero framework subscriptions.** This is a deliberate posture, not an oversight (audit rf2-u94dd Finding 4). The contract is: a flow's output value lives at its `:path` in the dispatching frame's `app-db`, and consumers read it through whatever sub registration they prefer — either a user-registered `(rf/reg-sub :my-app/area (fn [db _] (get-in db [:my-app/area])))` over the path, or a derived sub that closes over it. The runtime invalidates the sub-cache whenever any flow writes (`run-flows!` calls the substrate's container-swap exactly once per drain when at least one flow produced a dirty write), so reactivity is automatic; there is no separate flow-output cache the substrate needs to track.
+Flows write to `app-db`; subs read `app-db`. **Flows therefore publish zero framework subscriptions.** This is a deliberate posture, not an oversight (audit rf2-u94dd Finding 4). The contract is: a flow's output value lives at its `:path` in the dispatching frame's `app-db`, and consumers read it through whatever sub registration they prefer — either a user-registered `(rf/reg-sub :my-app/area (fn [db _] (get-in db [:my-app/area])))` over the path, or a derived sub that closes over it. Because the flow transform rewrites the *pending* `:db` effect (per [§Drain integration](#drain-integration)), the flow-derived value reaches `app-db` through the cascade's single `:db` install — the one `replace-container!` + sub-cache invalidation the drain already performs — so reactivity is automatic and the cascade performs exactly one `app-db` write per event regardless of how many flows fired; there is no separate flow-output cache the substrate needs to track.
 
 ### What this means
 
@@ -412,6 +432,14 @@ No opt-out. Stale derived values are confusing; vacating the slot is the natural
 ### Frame-destroy teardown is mandatory (RESOLVED rf2-0q0du)
 
 `destroy-frame!` MUST release every per-frame piece of flow state — the per-frame flow-registry slot, all `last-inputs` rows for the destroyed frame, and every `:flow` registrar entry the destroyed frame was the last owner of. Sibling frames' rows and shared-id registrar slots are preserved. Per [§Frame-destroy teardown](#frame-destroy-teardown). Without this, long-running SSR JVM hosts (per-request frame churn), pair-tool time-travel, and `make-frame` ephemeral usage leak flow definitions and cached input vectors indefinitely. Symmetric with the machines / schemas / SSR teardown hooks the per-feature artefacts publish off the single normative `destroy-frame!` boundary at [002 §Destroy](002-Frames.md#destroy).
+
+### Flows transform the pending `:db` effect, as the outermost `:after` (RESOLVED rf2-u0zz5)
+
+The flow walk runs **immediately after the handler's interceptor chain — as the outermost `:after` interceptor — and transforms the handler's pending `:db` effect in the chain context**, before the single `:db` install and before `:fx`. This replaces the prior design (full interceptor chain → `:db` commits to `app-db` → `run-flows!` mutates the live `app-db` → `:fx` walks). Per [§Drain integration](#drain-integration) and [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode).
+
+The change makes three things true that the post-install design could not: (a) the cascade performs exactly one `app-db` install — of the flow-augmented value — rather than a handler commit followed by a separate flow mutation; (b) the `:rf.event/db-changed` trace fires AFTER flows, so it reflects the flow-augmented db, and `:rf.flow/computed` precedes `:rf.event/db-changed` on the trace stream (per [009 §Canonical per-event trace sequence](009-Instrumentation.md#canonical-per-event-trace-sequence)) — making the flow position observable for Causa's Trace panel; (c) flows transform the *pending effect* rather than the live container, so the write is part of the cascade's single install. The `:fx`-sees-flow-output guarantee is **preserved** — `:fx` still walks after the install, so it reads the flow-derived `app-db`.
+
+**Outermost, not innermost.** Flows run as the *outermost* `:after` (fired last) — NOT the innermost — because the `path` std-interceptor's `:after` reshapes the `:db` effect (splicing a slice back into the full db), and flows read full-`app-db` `:inputs` paths, so they must run after that reshape. The consequence is that user `:after` interceptors run before the flow transform and see the handler's pre-flow `:db` effect; observational interceptors that need flow output read it from `app-db` post-install (sub / follow-up event), as `:fx` does. This is the pre-alpha masterpiece choice: no back-compat shim, the prior post-install drain step is removed outright; correctness (flows read the full db) is the load-bearing constraint that fixes the placement.
 
 ### `:rf.error/flow-eval-exception` rides the always-on error substrate (RESOLVED rf2-0q0du)
 

--- a/spec/conformance/fixtures/flow-eval-exception.edn
+++ b/spec/conformance/fixtures/flow-eval-exception.edn
@@ -1,23 +1,23 @@
 ;; Conformance fixture: flow/eval-exception
-;; Per Spec 013 §Failure semantics — when a flow's :output fn throws:
+;; Per Spec 013 §Failure semantics — atomicity contract (Mike 2026-05-24):
+;; a flow throw is a PRE-INSTALL throw, so it aborts the WHOLE event.
 ;;
-;;   1. Prior successful flows' writes are PRESERVED.
-;;   2. The failing flow's own output is NOT written; its last-inputs
-;;      is NOT advanced (re-attempts next drain).
-;;   3. Downstream flows scheduled later in topo order do NOT run.
+;;   1. NO partial commit — the pending :db effect (the handler's write
+;;      plus any prior successful flows' writes) is DISCARDED. app-db is
+;;      left UNCHANGED.
+;;   2. NO :rf.event/db-changed is emitted (the install never happened).
+;;   3. NO :fx run — an :fx [[:dispatch [:should-not-fire]]] entry on the
+;;      failing handler does NOT run (the cascade halts).
 ;;   4. The exception surfaces from the router's flows-after-interceptor
 ;;      as `:rf.error/flow-eval-exception` on BOTH the dev-only trace
 ;;      surface AND the always-on error-emit substrate (per Spec 013
 ;;      §Resolved decisions §`:rf.error/flow-eval-exception` rides the
 ;;      always-on error substrate, rf2-0q0du).
 ;;
-;; The fixture also asserts the cascade halt: an
-;; :fx [[:dispatch [:should-not-fire]]] entry on the failing handler
-;; does NOT run. Per Spec 013 §Drain integration (rf2-u0zz5) the flow
-;; walk is the innermost `:after` — it throws AFTER the handler body but
-;; BEFORE :db install and BEFORE :fx walks; the prior-flow-preserved db
-;; (incl. the handler's own :db) still installs (rule 1) while :fx is
-;; skipped (rule 3).
+;; The `:db` install is the single, deferred, all-or-nothing commit
+;; boundary; ANY pre-install throw (cofx / handler / interceptor :after /
+;; flow) aborts the event identically. `:fx` is the only post-install
+;; stage; an fx throw does NOT wind back app-db.
 ;;
 ;; ONE flow keeps the topo order deterministic across hosts: the
 ;; flow throws iff its input is a string. The conformance DSL's
@@ -28,11 +28,11 @@
 {:fixture/id           :flow/eval-exception
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:core/event-handler :core/fx :core/error :core/trace :flow/basic :flow/trace}
- :fixture/doc          "A flow's :output throws. The runtime halts the cascade at the failing flow, fires the per-flow :rf.flow/failed trace, and surfaces the cascade-level :rf.error/flow-eval-exception on the always-on production error-emit substrate (per Spec 013 §Failure semantics rule 4 / Resolved decisions §:rf.error/flow-eval-exception rides the always-on error substrate, rf2-0q0du). The failing handler's :fx [[:dispatch [:should-not-fire]]] entry MUST NOT run — Spec 013 §Drain integration rule 3 cascade halt."
+ :fixture/doc          "A flow's :output throws. Per the atomicity contract (Spec 013 §Failure semantics, rf2-u0zz5) the event ABORTS: the pending :db effect is discarded (app-db unchanged), NO :rf.event/db-changed is emitted, and :fx does not run. The runtime fires the per-flow :rf.flow/failed trace and surfaces the cascade-level :rf.error/flow-eval-exception on the always-on production error-emit substrate (Resolved decisions §:rf.error/flow-eval-exception rides the always-on error substrate, rf2-0q0du). The failing handler's :fx [[:dispatch [:should-not-fire]]] entry MUST NOT run."
 
  :fixture/registry
  {:event {:flow/init       {:doc "Seed :token to a non-string vector — first drain computes :tries without throwing."}
-          :flow/bad-input  {:doc "Replace :token with a string; the :tries flow's [:fn :count] throws. The handler ALSO emits :fx [:dispatch [:should-not-fire]] which Spec 013 §Drain integration rule 3 says must NOT run."}
+          :flow/bad-input  {:doc "Replace :token with a string; the :tries flow's [:fn :count] throws. The handler ALSO emits :fx [:dispatch [:should-not-fire]] which the atomicity contract says must NOT run. The whole drain aborts — none of the handler's :db write lands."}
           :should-not-fire {:doc "If the cascade-halt contract holds, this never fires."}}
   :flow  {:tries
           {:doc    "Materialised :tries — counts :token. The conformance :count builtin throws if :token is a string."
@@ -43,9 +43,9 @@
  {:event {:flow/init       [[:set [:token] [1 2 3]]
                             [:set [:fired] []]]
           :flow/bad-input  [[:set [:token] "this-is-a-string"]
-                            ;; Spec 013 §Drain integration rule 3:
-                            ;; this :fx MUST NOT run because the flow
-                            ;; walk halts the cascade.
+                            ;; Atomicity contract: this :fx MUST NOT run —
+                            ;; the flow throw aborts the event before the
+                            ;; post-install :fx stage.
                             [:fx :dispatch [:should-not-fire]]]
           :should-not-fire [[:update [:fired] [:fn :conj :should-not-fire]]]}}
 
@@ -70,26 +70,23 @@
   [:flow/bad-input]]
 
  :fixture/expect
- ;; After the failing drain:
- ;;   :token is "this-is-a-string"  (the :db commit landed)
- ;;   :tries is 3                    (preserved from the first drain
- ;;                                    when :token was [1 2 3]; the
- ;;                                    failing :output left the slot
- ;;                                    untouched — Spec 013 §Failure
- ;;                                    semantics rule 2)
- ;;   :fired is []                   (cascade halt — :should-not-fire
- ;;                                    never ran)
+ ;; After the failing drain the event ABORTED — app-db is UNCHANGED from
+ ;; the prior (clean) :flow/init drain:
+ ;;   :token is [1 2 3]   (the handler's :db write was DISCARDED — no
+ ;;                         partial commit; :token is NOT "this-is-a-string")
+ ;;   :tries is 3         (computed on the first clean drain; the failing
+ ;;                         drain installed nothing)
+ ;;   :fired is []        (cascade halt — :should-not-fire never ran)
  {:final-app-db
-  {:token "this-is-a-string"
+  {:token [1 2 3]
    :tries 3
    :fired []}
 
   ;; Trace stream: per-flow :rf.flow/failed first (with flow
   ;; attribution), then the cascade-level :rf.error/flow-eval-exception.
   ;; The router emits the cascade-level trace with :frame / :event /
-  ;; :exception in tags (per router.cljc:577-578); :where :flow-eval
-  ;; rides on the always-on substrate record only (asserted via
-  ;; :error-emit-records below).
+  ;; :exception in tags (per router.cljc); :where :flow-eval rides on the
+  ;; always-on substrate record only (asserted via :error-emit-records).
   :trace-emissions
   [{:op-type   :flow
     :operation :rf.flow/failed
@@ -98,6 +95,15 @@
    {:op-type   :error
     :operation :rf.error/flow-eval-exception
     :tags      {:frame :rf/default}}]
+
+  ;; Atomicity contract: the aborted :flow/bad-input drain emits NO
+  ;; :rf.event/db-changed — the install never happened (rf2-u0zz5).
+  ;; (The first clean :flow/init drain DID emit db-changed; this matcher
+  ;; targets the :flow/bad-input event specifically via the :event-id tag
+  ;; so it cannot false-match the earlier successful install.)
+  :trace-absent
+  [{:operation :rf.event/db-changed
+    :tags      {:rf.trace/event-id :flow/bad-input}}]
 
   ;; Production-survivable always-on substrate (Spec 013 §Resolved
   ;; decisions §`:rf.error/flow-eval-exception` rides the always-on

--- a/spec/conformance/fixtures/flow-eval-exception.edn
+++ b/spec/conformance/fixtures/flow-eval-exception.edn
@@ -5,17 +5,19 @@
 ;;   2. The failing flow's own output is NOT written; its last-inputs
 ;;      is NOT advanced (re-attempts next drain).
 ;;   3. Downstream flows scheduled later in topo order do NOT run.
-;;   4. The exception surfaces at the router's outer catch as
-;;      `:rf.error/flow-eval-exception` on BOTH the dev-only trace
+;;   4. The exception surfaces from the router's flows-after-interceptor
+;;      as `:rf.error/flow-eval-exception` on BOTH the dev-only trace
 ;;      surface AND the always-on error-emit substrate (per Spec 013
 ;;      §Resolved decisions §`:rf.error/flow-eval-exception` rides the
 ;;      always-on error substrate, rf2-0q0du).
 ;;
 ;; The fixture also asserts the cascade halt: an
 ;; :fx [[:dispatch [:should-not-fire]]] entry on the failing handler
-;; does NOT run (because the flow walk throws AFTER :db commits but
-;; BEFORE :fx walks — per Spec 013 §Drain integration §rule 3 +
-;; rf2-fslx0).
+;; does NOT run. Per Spec 013 §Drain integration (rf2-u0zz5) the flow
+;; walk is the innermost `:after` — it throws AFTER the handler body but
+;; BEFORE :db install and BEFORE :fx walks; the prior-flow-preserved db
+;; (incl. the handler's own :db) still installs (rule 1) while :fx is
+;; skipped (rule 3).
 ;;
 ;; ONE flow keeps the topo order deterministic across hosts: the
 ;; flow throws iff its input is a string. The conformance DSL's

--- a/testbeds/long_flow_w_failure/README.md
+++ b/testbeds/long_flow_w_failure/README.md
@@ -5,9 +5,11 @@ topology, with a configurable mid-flow failure injection. The
 single Start click produces a visible ~5-second stream of
 `:rf.flow/computed` / `:rf.flow/failed` / `:rf.error/flow-eval-exception`
 traces that a consumer (Causa, Story, re-frame2-pair-mcp) reads to verify the
-four-rule flow-failure contract from
+flow-failure **atomicity** contract from
 [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md)
-(rf2-hrqvg).
+(rf2-u0zz5): a flow throw is a pre-install throw, so it **aborts the
+whole event** — no `:db` install, `app-db` unchanged, no
+`:rf.event/db-changed`, `:fx` skipped, **no partial commit**.
 
 ## The cascade
 
@@ -26,24 +28,27 @@ recomputes all three flows in topo order. Total cascade time =
 §Topological sort uses path-prefix overlap to fix evaluation order,
 so the declaration forces `:flow-a → :flow-b`. Without it the two
 flows are independent (both read `[:input]`, write disjoint paths)
-and Kahn's algorithm picks an unspecified order between them —
-which would void Rule 1's "prior-flow writes preserved" guarantee
-when `:flow-b` happens to run first. `:flow-b`'s `:output` ignores
-the `a-result` value; its math is still `(* 3 input)`.
+and Kahn's algorithm picks an unspecified order between them. Pinning
+the order makes `:flow-a` the demonstrable "ran-then-discarded" prior
+flow (its `:rf.flow/computed` trace fires before the throw, but its
+write is discarded by the abort) and `:flow-c` the "never-ran"
+downstream flow. `:flow-b`'s `:output` ignores the `a-result` value;
+its math is still `(* 3 input)`.
 
-## The four-rule contract this surface exercises
+## The atomicity contract this surface exercises
 
 Per [spec/013 §Failure semantics](../../spec/013-Flows.md), when
-`:flow-b`'s `:output` throws on a recompute, the runtime applies
-four rules atomically. The DOM mirror at the bottom of the surface
-makes each rule's effect human-readable:
+`:flow-b`'s `:output` throws on a recompute, the whole event aborts.
+The DOM mirror at the bottom of the surface makes the effect
+human-readable:
 
-| Rule | What it says | Where to look |
+| Behaviour | What it says | Where to look |
 |---|---|---|
-| 1 — prior writes preserved | `:flow-a` computes first; its output IS flushed to `[:a-result]` BEFORE `:flow-b`'s throw propagates. | `a-result` advances on every tick, including the failing one. |
-| 2 — failing flow's output is not written | `:flow-b`'s recompute throws; `:b-result` is not updated; `:flow-b`'s `last-inputs` is NOT advanced — the flow re-attempts on the next tick. | `b-result` stops advancing at `(* 3 (dec :fail-at))`; subsequent ticks re-throw without writing. |
-| 3 — cascade halts at the failing flow | `:flow-c` does NOT run on the drain where `:flow-b` throws. | `c-result` stops advancing at the tick that lands `:input == :fail-at`. |
-| 4 — exception surfaces as `:rf.error/flow-eval-exception` | The per-flow `:rf.flow/failed` trace fires first (with `:flow-id ::flow-b` under `:tags`); the cascade-level `:rf.error/flow-eval-exception` fires when the router catches the propagated throw. | The trace stream after `:fail-at` shows pairs of `[:rf.flow/failed, :rf.error/flow-eval-exception]` on every subsequent tick. |
+| No install — `app-db` unchanged | The pending `:db` effect (the handler's `:input` bump AND `:flow-a`'s `:a-result` write) is discarded; nothing commits on the failing tick. No partial commit. | `input`, `a-result`, `b-result`, `c-result` all FREEZE at the last clean tick (tick `:fail-at − 1`). |
+| `:flow-a` ran but its write was discarded | `:flow-a` computes first and emits `:rf.flow/computed` — but because a LATER flow throws, the event aborts and `:a-result` never lands. | `a-result` does NOT advance on the failing tick; the trace stream still shows `:rf.flow/computed` for `::flow-a`. |
+| Failing flow's output is not written; `last-inputs` rolled back | `:flow-b`'s recompute throws; `:b-result` is not updated; `last-inputs` is rolled back so every flow re-attempts next drain. | `b-result` frozen; subsequent ticks re-throw. |
+| Cascade halts at the failing flow | `:flow-c` does NOT run on the drain where `:flow-b` throws. | `c-result` frozen from the tick that lands `:input == :fail-at`. |
+| No `:rf.event/db-changed`; exception surfaces as `:rf.error/flow-eval-exception` | The aborted tick emits NO `:rf.event/db-changed`. The per-flow `:rf.flow/failed` trace fires first (`:flow-id ::flow-b` under `:tags`); the cascade-level `:rf.error/flow-eval-exception` fires when the router catches the throw. | The trace stream after `:fail-at` shows `[:rf.flow/failed, :rf.error/flow-eval-exception]` pairs and NO `:rf.event/db-changed` on every subsequent tick. |
 
 ## Controls
 
@@ -56,29 +61,36 @@ makes each rule's effect human-readable:
 
 ## DOM mirrors
 
-The surface mirrors `:a-result` / `:b-result` / `:c-result` in the
-DOM so a Playwright spec can assert against the rules without
+The surface mirrors `:input` / `:a-result` / `:b-result` / `:c-result`
+in the DOM so a consumer can assert against the contract without
 needing a recorder. After Start with defaults (fail-at=5,
 total-ticks=20):
 
-- `a-result`: keeps advancing 0, 2, 4, 6, … 40. (Rule 1.)
-- `b-result`: advances 0, 3, 6, 9, 12, then stops. (Rule 2.)
-- `c-result`: advances 0, 5, 10, 15, 20, then stops. (Rule 3.)
+- `input`: advances 1, 2, 3, 4, then FREEZES at 4 (ticks 5..20 abort
+  before install).
+- `a-result`: advances 0, 2, 4, 6, 8, then FREEZES at 8. (No install
+  on the failing tick — even `:flow-a`'s prior write is discarded.)
+- `b-result`: advances 0, 3, 6, 9, 12, then FREEZES at 12.
+- `c-result`: advances 0, 5, 10, 15, 20, then FREEZES at 20.
 
 A consumer that reads the trace stream can assert:
-- 20 `:rf.flow/computed` traces for `::flow-a` (one per tick).
+- 4 committed ticks → 4 `:rf.event/db-changed` (ticks 1..4); NONE for
+  ticks 5..20 (each aborts).
+- `:rf.flow/computed` traces for `::flow-a` on every tick it RUNS
+  (ticks 1..20 — it runs even on aborted ticks; only its WRITE is
+  discarded).
 - 4 `:rf.flow/computed` traces for `::flow-b` (ticks 1..4).
 - 16 `:rf.flow/failed` traces for `::flow-b` (ticks 5..20).
 - 16 `:rf.error/flow-eval-exception` traces (one per `:rf.flow/failed`).
-- 4 `:rf.flow/computed` traces for `::flow-c` (ticks 1..4).
-- 0 `:rf.flow/computed` traces for `::flow-c` after tick 5.
+- 4 `:rf.flow/computed` traces for `::flow-c` (ticks 1..4); 0 after.
 
-The exact trace order per drain: `:flow-a` computed → `:flow-b`
-failed → `:flow-error/flow-eval-exception`.
+The exact trace order per failing drain: `:flow-a` computed →
+`:flow-b` failed → `:rf.error/flow-eval-exception`, with NO
+`:rf.event/db-changed`.
 
 ## Why a multi-second window
 
-The four-rule contract is a per-drain property — observable on any
+The atomicity contract is a per-drain property — observable on any
 single throw. But a consumer's UI (trace panel, recorder, MCP wire)
 under stress tests differently when 60+ flow traces stream past in
 five seconds vs. when one click produces 3 traces. The default
@@ -86,20 +98,20 @@ total-ticks=20 keeps the trace volume realistic without blowing
 ring-buffer budgets (the Spec 009 200-row default holds 60 per-tick
 traces fine).
 
-A consumer that tests the rules at minimum cost dials total-ticks
+A consumer that tests the contract at minimum cost dials total-ticks
 down to 6 and fail-at to 4 — the cascade completes in 1.5 seconds
-and produces enough trace shape to assert every rule.
+and produces enough trace shape to assert the whole abort signature.
 
 ## What's deliberately *missing*
 
-- **No `:on-error` policy.** The four-rule contract is what the
+- **No `:on-error` policy.** The atomicity contract is what the
   default recovery does; an `:on-error` override would mask it.
 - **No `:rf.fx/clear-flow` on the failing flow.** Clearing
   `::flow-b` mid-cascade is a separate contract; this surface
   stays on the canonical "let it keep re-throwing" path so the
-  rule-2 evidence accumulates over multiple ticks.
+  abort evidence accumulates over multiple ticks.
 - **No retry logic on `:tick`.** Every tick fires unconditionally;
-  the failing flow's re-throw is what produces rule 2's
+  the failing flow's re-throw is what produces the abort
   evidence — not retry orchestration in user code.
 - **No `:flow-b` recovery on `Fail at tick > total-ticks`.** Setting
   fail-at to a value higher than total-ticks gives a clean cascade
@@ -118,11 +130,12 @@ and produces enough trace shape to assert every rule.
   one cascade; verify ring-buffer truncation against the budget.
 
 **Cross-cutting (6)**:
-- **Flow `:rf.flow/failed` shows four-rule failure semantics
-  (rf2-hrqvg)** — the load-bearing scenario this surface unblocks.
-  Each of the four rules has a DOM mirror + a deterministic trace
-  shape a spec can assert against; the 5-second cascade gives the
-  rules time to accumulate evidence beyond a single drain.
+- **Flow `:rf.flow/failed` shows atomicity failure semantics
+  (rf2-u0zz5)** — the load-bearing scenario this surface unblocks.
+  The abort signature (no install, frozen `app-db`, no
+  `:rf.event/db-changed`, `:fx` skipped) has a DOM mirror + a
+  deterministic trace shape a spec can assert against; the 5-second
+  cascade gives it time to accumulate evidence beyond a single drain.
 
 **Story (18)**:
 - Recorder captures click → records `:play` → replays identically —
@@ -145,7 +158,7 @@ lands in `implementation/out/testbeds/long-flow-w-failure/`.
 
 ## Cross-references
 
-- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the four-rule contract this surface exists to exercise.
+- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the atomicity contract this surface exists to exercise.
 - [`spec/013-Flows.md` §Flow tracing](../../spec/013-Flows.md) — the `:rf.flow/*` op taxonomy a consumer's trace panel filters against.
-- [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/flow-eval-exception` shape rule 4 produces.
+- [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/flow-eval-exception` shape a flow throw produces.
 - [`spec/002-Frames.md` §Cascade propagation](../../spec/002-Frames.md) — the `:dispatch-later` frame-capture contract every scheduled tick relies on.

--- a/testbeds/long_flow_w_failure/core.cljs
+++ b/testbeds/long_flow_w_failure/core.cljs
@@ -2,20 +2,29 @@
   "Shared framework-behavior testbed — a multi-second cascade of
   app-db writes that drive a three-flow topology, with a configurable
   mid-flow failure injection. A consumer (Causa, Story, re-frame2-pair-mcp)
-  observes the four-rule flow-failure contract (per
-  [spec/013 §Failure semantics] / rf2-hrqvg) play out over a
+  observes the flow-failure ATOMICITY contract (per
+  [spec/013 §Failure semantics] / rf2-u0zz5) play out over a
   human-visible time window:
 
-    Rule 1 — prior-flow writes are preserved (:flow-a's output keeps
-             advancing while :flow-b's throw is mid-cascade).
-    Rule 2 — the failing flow's output is not written; its
-             `last-inputs` is NOT advanced; the flow re-attempts on
-             the next drain.
-    Rule 3 — the cascade halts at the failing flow; :flow-c does NOT
-             run on the drain where :flow-b throws.
-    Rule 4 — the exception surfaces at the router's outer catch as
-             :rf.error/flow-eval-exception; the per-flow
-             :rf.flow/failed trace fires first.
+    A flow throw is a PRE-INSTALL throw, so it ABORTS THE WHOLE EVENT:
+      - No :db install — app-db is UNCHANGED for the failing tick.
+        Neither :input, nor :a-result (a prior flow's write), nor
+        :b-result, nor :c-result advances. NO partial commit.
+      - No :rf.event/db-changed for the failing tick.
+      - :fx is skipped.
+      - last-inputs is rolled back, so every flow re-attempts cleanly
+        on the next drain.
+      - The exception surfaces at the router as
+        :rf.error/flow-eval-exception; the per-flow :rf.flow/failed
+        trace fires first for attribution.
+
+    So: ticks BEFORE fail-at commit all three flows (every value
+    advances). The tick AT/AFTER fail-at throws on :flow-b and the
+    whole tick aborts — the visible state freezes at the last clean
+    tick, while the trace stream still shows :rf.flow/computed (for
+    the prior flow that RAN before the throw — its write was
+    discarded) → :rf.flow/failed → :rf.error/flow-eval-exception per
+    failing tick.
 
   The cascade ('long flow'):
 
@@ -77,10 +86,13 @@
 
 (def default-fail-at
   "Tick index at which :flow-b throws. With default-total-ticks=20
-  and default-fail-at=5, four ticks succeed (1..4), :flow-b throws
-  on tick 5, then ticks 6..20 each retry (because :flow-b's
-  last-inputs is NOT advanced per rule 2) — every subsequent tick
-  re-throws on :flow-b's recompute against the new :input."
+  and default-fail-at=5, four ticks succeed (1..4) and commit all
+  three flows; tick 5 throws on :flow-b and the WHOLE tick aborts
+  (no install — app-db frozen at tick 4); ticks 6..20 each re-attempt
+  and re-abort (their :input ≥ :fail-at, so :flow-b re-throws). The
+  visible state stays frozen at tick 4 while the trace stream shows a
+  :rf.flow/failed → :rf.error/flow-eval-exception pair per failing
+  tick — and NO :rf.event/db-changed for any of ticks 5..20."
   5)
 
 ;; ----------------------------------------------------------------------------
@@ -125,14 +137,15 @@
 ;; map by path-prefix overlap between one flow's `:path` and another's
 ;; `:inputs` — two flows that don't share such an overlap are
 ;; topologically *parallel*, and Kahn's algorithm picks an unspecified
-;; order between them. The four-rule failure contract talks about
-;; PRIOR flows (those scheduled earlier in topo order); to assert
-;; Rule 1 ("prior-flow writes preserved") against :flow-a when
-;; :flow-b throws, the testbed must pin :flow-a → :flow-b in topo
-;; order. We do that by listing `[:a-result]` in :flow-b's :inputs
-;; — the path-prefix overlap with :flow-a's :path forces the edge.
-;; The same `[:a-result] [:b-result]` pair already pins :flow-c after
-;; both upstreams.
+;; order between them. The atomicity contract distinguishes the flow
+;; that RAN before the throw (whose :rf.flow/computed trace still
+;; fires, even though its write is discarded by the abort) from the
+;; downstream flow that never ran. To make :flow-a the demonstrable
+;; "ran-then-discarded" prior flow and :flow-c the "never-ran"
+;; downstream flow, the testbed pins :flow-a → :flow-b → :flow-c in
+;; topo order: listing `[:a-result]` in :flow-b's :inputs forces the
+;; path-prefix overlap edge with :flow-a's :path, and the
+;; `[:a-result] [:b-result]` pair already pins :flow-c after both.
 ;;
 ;; The :input itself stays in :flow-b's :inputs so the read-from-app-
 ;; db dirty-check still fires when the tick handler bumps :input —
@@ -141,17 +154,20 @@
 ;; :output would not be the trigger. Listing both keeps the value
 ;; flow honest and the ordering pinned.
 ;;
-;; Rule-1 / Rule-3 evidence: when :flow-b throws on tick N, :flow-a's
-;; output for tick N IS flushed to :a-result (prior writes preserved);
-;; :flow-c's output for tick N is NOT computed (cascade halts).
+;; Atomicity evidence: when :flow-b throws on tick N, the WHOLE tick
+;; aborts — :flow-a's :rf.flow/computed fires (it ran) but its write
+;; is DISCARDED (no install); :flow-c never runs (cascade halts); and
+;; app-db (incl. :input, :a-result, :b-result, :c-result) is frozen at
+;; tick N-1's committed value.
 
 (rf/reg-flow
   {:id     ::flow-a
    :inputs [[:input]]
    :output (fn flow-a [input]
-             ;; Trivial pure transform. The point is the WRITE — a
-             ;; consumer that sees :a-result advance on tick N has
-             ;; positive evidence of rule 1.
+             ;; Trivial pure transform. The point is the WRITE — on a
+             ;; clean tick :a-result advances and commits; on a failing
+             ;; tick :flow-a's :rf.flow/computed still fires (it ran)
+             ;; but the write is DISCARDED when the tick aborts.
              (* 2 input))
    :path   [:a-result]
    :doc    "Doubles :input. Watched by :flow-b (topo-order pin) and
@@ -168,16 +184,16 @@
    :output (fn flow-b [input _a-result]
              ;; HOT PATH — the failure-injection site for the
              ;; cascade. The throw fires whenever this fn is called
-             ;; with input == :fail-at. The flow's last-inputs is
-             ;; NOT advanced (rule 2), so the next drain with a new
-             ;; :input value re-attempts; if the new :input is also
-             ;; ≥ :fail-at, the throw re-fires.
+             ;; with input ≥ :fail-at. The throw aborts the whole
+             ;; tick (no install); last-inputs is rolled back, so the
+             ;; next drain with a new :input value re-attempts. If the
+             ;; new :input is also ≥ :fail-at, the throw re-fires.
              ;;
              ;; A consumer reading the trace stream sees
              ;; :rf.flow/failed (this flow's id) followed by
-             ;; :rf.error/flow-eval-exception (rule 4) on EVERY
-             ;; subsequent tick after the fail-at threshold —
-             ;; positive evidence of rule 2.
+             ;; :rf.error/flow-eval-exception on EVERY tick after the
+             ;; fail-at threshold — with NO :rf.event/db-changed for
+             ;; any of those aborted ticks.
              (let [fail-at-input
                    ;; The :input value the :tick handler bumps to
                    ;; coincides with the tick index — tick 5
@@ -207,8 +223,8 @@
    :output (fn flow-c [a b]
              ;; Watches :flow-a's and :flow-b's outputs. Only runs
              ;; when both upstreams have successfully advanced —
-             ;; per rule 3, :flow-c does NOT run on the drain
-             ;; where :flow-b throws.
+             ;; :flow-c does NOT run on the drain where :flow-b
+             ;; throws (the cascade halts before it).
              (+ a b))
    :path   [:c-result]
    :doc    "Sums :a-result + :b-result. Watches :flow-a and
@@ -294,8 +310,8 @@
               (str (/ (* total default-tick-ms) 1000.0))]
       "-second cascade. Each tick recomputes three flows in topo
       order; :flow-b throws when :input ≥ fail-at, demonstrating
-      the four-rule flow-failure contract over a human-visible
-      window."]
+      the flow-failure ATOMICITY contract (a flow throw aborts the
+      whole tick — nothing commits) over a human-visible window."]
 
      [:div {:style {:display :flex :gap "0.5em" :flex-wrap :wrap
                     :align-items :center :margin-bottom "0.5em"}}
@@ -334,13 +350,14 @@
       "tick="       [:span {:data-testid "tick"}       (str tick-count "/" total)] "\n"
       "input="      [:span {:data-testid "input"}      input-val]          "\n"
       "a-result="   [:span {:data-testid "a-result"}   a-result]
-      "  (= 2 × input — rule 1 evidence)"                                  "\n"
+      "  (= 2 × input until tick=" fail-at
+      "; FROZEN thereafter — the failing tick aborts, nothing commits)"    "\n"
       "b-result="   [:span {:data-testid "b-result"}   b-result]
       "  (= 3 × input until tick=" fail-at
-      "; thereafter unchanged — rule 2 evidence)"                          "\n"
+      "; FROZEN thereafter — :flow-b throws)"                              "\n"
       "c-result="   [:span {:data-testid "c-result"}   c-result]
       "  (= a + b until tick=" fail-at
-      "; thereafter unchanged — rule 3 evidence)"]]))
+      "; FROZEN thereafter — cascade halts)"]]))
 
 (reg-view root []
   [buttons])

--- a/tools/story/spec/Migration-Audit.md
+++ b/tools/story/spec/Migration-Audit.md
@@ -154,16 +154,27 @@ Same shape as helix. All 3 assertions = (B). KEEP IN PLACE.
 
 **Migrated subtotal: 18 of 18 observations = 100%. DROP this spec entirely.** Spec 014's eight `:rf.http/*` categories already deserve full CLJS unit coverage; this spec is observational scaffolding that should live in `implementation/http/test/`.
 
-### `testbeds/long_flow_w_failure/spec.cjs` (Spec 013 flow four-rule failure)
+### `testbeds/long_flow_w_failure/spec.cjs` (Spec 013 flow-failure atomicity)
+> **Contract update (rf2-u0zz5).** A flow throw now ABORTS the whole event
+> (atomicity contract — no install, `app-db` unchanged, no
+> `:rf.event/db-changed`, `:fx` skipped, no partial commit). The
+> "prior-flow preserved" assertions below (rows 4–6) are superseded: under
+> the new contract a failing tick freezes `app-db` at the last clean tick
+> — `a-result` / `b-result` / `c-result` stop at tick `:fail-at − 1`, and
+> no `:rf.event/db-changed` fires for any aborted tick. The migration
+> target (`flow_*_cljs_test.cljs`) should assert the abort signature
+> instead. (This audit table is preserved as a historical record of the
+> dropped browser spec.)
+
 | # | Assertion | Class | Rationale + target |
 |---:|---|:---:|---|
 | 1 | `expectVisible(long-flow-w-failure)` | C | Mount. → drop. |
-| 2 | `:input` mirror > 0 (cascade scheduled) | A | App-db readback under setTimeout-driven dispatch loop. → `implementation/flows/test/.../flow_four_rule_failure_cljs_test.cljs` (new file). The 250ms × 20-tick cascade is faster in CLJS — drive synchronously via direct `(dispatch-sync [::tick])` loop. |
-| 3 | Trace bus: `:rf.flow/failed` for `::flow-b` BEFORE `:rf.error/flow-eval-exception` | A | Rule 4 (per-flow before cascade-level). → same target. |
-| 4 | `a-result` ≥ 10 (Rule 1, prior-flow preserved) | A | Same target. |
-| 5 | `b-result` = '12' (Rule 2, failing flow's output not written) | A | Same target. |
-| 6 | `c-result` = '20' (Rule 3, cascade halts) | A | Same target. |
-| 7 | ≥3 `:rf.flow/failed` emits (Rule 2 re-attempt cardinality) | A | Same target. |
+| 2 | `:input` mirror > 0 (cascade scheduled) | A | App-db readback under setTimeout-driven dispatch loop. → `implementation/flows/test/.../flow_failure_atomicity_cljs_test.cljs` (new file). The 250ms × 20-tick cascade is faster in CLJS — drive synchronously via direct `(dispatch-sync [::tick])` loop. |
+| 3 | Trace bus: `:rf.flow/failed` for `::flow-b` BEFORE `:rf.error/flow-eval-exception` | A | Per-flow before cascade-level. → same target. |
+| 4 | `a-result` frozen at tick `:fail-at − 1` (atomicity — no install on the failing tick) | A | Same target. |
+| 5 | `b-result` frozen (failing flow's output not written) | A | Same target. |
+| 6 | `c-result` frozen (cascade halts) + NO `:rf.event/db-changed` on aborted ticks | A | Same target. |
+| 7 | ≥3 `:rf.flow/failed` emits (re-attempt cardinality) | A | Same target. |
 
 **Migrated subtotal: 6 of 6 = 100%. DROP this spec entirely.** Spec 013 has zero browser dimension — flows run on the spine, not in the DOM.
 


### PR DESCRIPTION
## Summary

Moves the flow-execution point in the per-event pipeline (rf2-u0zz5, Mike-directed, spec-first).

**Before:** full interceptor chain runs → `:db` commits to `app-db` → `run-flows!` mutates the live `app-db` → `:fx` walks. The `:rf.event/db-changed` trace fired *before* flows, and the cascade performed two `app-db` writes.

**After:** flows run as the framework's **outermost `:after` interceptor** — immediately after the handler chain reshapes the `:db` effect — and **transform the pending `:db` effect** (not the installed `app-db`). The cascade then installs `:db` once (flow-augmented), then walks `:fx`.

New ordering per event:
1. handler runs → `:db`, `:fx`
2. flows transform the pending `:db` effect (topological, frame-scoped)
3. `:db` installed (flow-augmented) → `:rf.event/db-changed`
4. `:fx` actioned (reads the flow-augmented `app-db`)

**Outermost, not innermost** is load-bearing: the `path` std-interceptor's `:after` splices the handler slice back into the full db, and flows read full-`app-db` `:inputs` paths, so the flow transform must run *after* that reshape. (An innermost flow transform would read the un-spliced path slice — proven by `flow-reads-full-db-under-path-scoped-handler`.) The consequence: user `:after` interceptors precede the flow transform; observational interceptors that need flow output read it from `app-db` post-install (sub / follow-up event), as `:fx` does.

- **Preserved:** `:fx` and the reactive cascade see flow outputs.
- **Changed:** exactly one `app-db` install (flow-augmented); `run-flows-on-db` transforms the pending effect; `:rf.event/db-changed` fires after flows; flow-throw trace sequence is now `:rf.flow/failed → :rf.error/flow-eval-exception → :rf.event/db-changed`.

## Spec (hot-zone, spec-first)

- **002-Frames** — relocate the flow step in the drain-loop pseudocode.
- **013-Flows** — rewrite §Drain integration + §Trace stream ordering on a flow throw; update §Sub integration / §Flow output validation / Abstract; add a Resolved decision.
- **009-Instrumentation** — define the canonical per-event trace sequence; `:rf.flow/computed` is emitted before `:rf.event/db-changed` (install), and `db-changed` reflects the flow-augmented db.

## Impl

- `router.cljc` — replace the post-install `run-flows!` invocation with a shared `flows-after-interceptor` (outermost `:after`, frame-agnostic) that runs `:flows/run-flows-on-db` over the pending `:db` effect; on a flow throw it installs the prior-flow-preserved db (rule 1) and stashes `:rf/flow-error` so `commit-and-flow!` emits `:rf.error/flow-eval-exception` and skips `:fx` (rule 3).
- `flows.cljc` — `run-flows!` → `run-flows-on-db` (pure `(frame db) → db` transform); on throw re-throws carrying `:rf.flow/partial-db`.
- rename late-bind hook `:flows/run-flows!` → `:flows/run-flows-on-db` (+ directory entry).

## Tests

flows-read-full-db-under-path-scoped-handler · fx/subs/install see flow output · single flow-augmented install (`:rf.event/db-changed` fires once with flow output) · user `:after` precedes the flow transform · rewritten flow-throw trace-ordering · updated event-emit stubs.

## Gates

- `npm run test:cljs` — 4278 tests, 0 failures
- JVM flows `clojure -M:test` — 109 tests, 0 failures
- JVM core `clojure -M:test` — 740 tests, 0 failures
- JVM epoch `clojure -M:test` — 206 tests, 0 failures
- clj-kondo — 0 errors on touched files (4 pre-existing unused-binding warnings in untouched drain-loop code)
- splint — 0 warnings on touched lines (3 pre-existing `let-when` warnings in untouched drain-loop code)
- `mkdocs build --strict` — clean

Closes rf2-u0zz5.