### PR TITLE
propagate(xray): move Event-panel FLOWS placement to right-after-handler (rf2-9eca7)

### DIFF
--- a/tools/xray/spec/007-UX-IA.md
+++ b/tools/xray/spec/007-UX-IA.md
@@ -9,7 +9,7 @@ event**:
 
 | Tab | Bug-class it answers |
 |---|---|
-| **Event** (`e`) | "What does this event do?" — the handling pipeline (DISPATCH → COEFFECTS → EVENT HANDLER → DB CHANGES → AFTER INTERCEPTORS → FLOWS → FX; optional sections omitted when absent) + wire-boundary diff per managed fx. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §2.) |
+| **Event** (`e`) | "What does this event do?" — the handling pipeline (DISPATCH → COEFFECTS → EVENT HANDLER → FLOWS → DB CHANGES → AFTER INTERCEPTORS → FX; optional sections omitted when absent) + wire-boundary diff per managed fx. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §2.) |
 | **app-db** (`a`) | "What changed because of this event?" — the complete app-db, sectioned by reserved `:rf/*` area, with inline diff annotations. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §4.) |
 | **Views** (`v`) | "Why did these views re-render?" — the left → right reactive-flow graph (app-db → subs → views) + hover-to-highlight on rendered DOM. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §3. Rendered tab label follows the Figma export `Views` (rf2-ad7zx); the spec's rf2-e33ad display label was `View`; key stays `:views`.) |
 | **Trace** (`t`) | "What raw events fired in this cascade?" — readable-line timeline, op-family colour bands, relative timing. (Per-panel content design: [`021-Dynamic-Panel-Designs.md`](./021-Dynamic-Panel-Designs.md) §5.) |

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -180,10 +180,13 @@ tab.
 
 ## Flows content — Event tab FLOWS section (rf2-lo37i)
 
-The pre-rewrite Flows panel is GONE. Flows surface as the **8th
-section of the Event tab** — the canonical home for per-cascade flow
-firings is [`018-Event-Spine.md`](./018-Event-Spine.md) §5.1 FLOWS
-section. For each flow that fired during the focused cascade the
+The pre-rewrite Flows panel is GONE. Flows surface as a dedicated
+**section of the Event tab placed RIGHT AFTER the HANDLER** — flows
+fire at the outermost `:after` interceptor, reshaping the pending
+`:db` before it commits, so the FLOWS section precedes EFFECTS
+RETURNED / EFFECTS HANDLERS RAN. The canonical home for per-cascade
+flow firings is [`018-Event-Spine.md`](./018-Event-Spine.md) §5.1
+FLOWS section. For each flow that fired during the focused cascade the
 FLOWS section lists, in cascade order:
 
 - `wrote <path>` — the flow's `:output` write target with the
@@ -191,9 +194,11 @@ FLOWS section lists, in cascade order:
 - `read <input-path-1> <input-path-2> …` — the flow's `:inputs`,
   shown so the reader can see which paths caused the recompute.
 
-The FLOWS section sits as a peer of EFFECTS / HANDLERS RAN / the
-returned-value slot under the per-event cascade view (see 018 §5.1
-lines 442-451 wireframe, 507-531 row contract).
+The FLOWS section sits between the HANDLER and the EFFECTS RETURNED /
+EFFECTS HANDLERS RAN sections under the per-event cascade view —
+mirroring the runtime order where flows transform the pending db
+before it commits and before any fx run (see 018 §5.1 wireframe + row
+contract).
 
 A **secondary** appearance is in the **Views tab** "Re-rendered"
 group (cross-cutting): when a flow's downstream sub appears in a

--- a/tools/xray/spec/018-Event-Spine.md
+++ b/tools/xray/spec/018-Event-Spine.md
@@ -520,9 +520,12 @@ The renderer does NOT depend on `binaryage/cljs-devtools` (that library targets 
 Shipped layout per rf2-zh2qc + rf2-jhhqt + rf2-lo37i (rf2-jhhqt swaps
 DISPATCH SITE before EVENT per Mike's Q1 verbatim and adds the COEFFECTS
 section; rf2-lo37i adds the FLOWS section as a peer surface to make the
-cascade's flow step first-class). Top-of-panel: a single-line cascade-
-outcome summary; below: eight stacked sections that read top-to-bottom
-as the developer scans.
+cascade's flow step first-class). FLOWS sits RIGHT AFTER the HANDLER —
+flows fire at the outermost `:after` interceptor, reshaping the pending
+`:db` before it commits, so the lens reads in true pipeline order
+(handler → flows → committed effects → fx-handlers). Top-of-panel: a
+single-line cascade-outcome summary; below: eight stacked sections that
+read top-to-bottom as the developer scans.
 
 ```
 ┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
@@ -544,6 +547,16 @@ as the developer scans.
 │ ▼ HANDLER                                                                            │
 │   reg-event-fx · src/cart/events.cljs:88                       [code]              │
 │                                                                                      │
+│ ▼ FLOWS  (3)                                                                         │
+│   ▸ :cart-total                wrote [:cart :total]   52.50                         │
+│                                  read  [:cart :items]                                │
+│     ↳ :tax-due       via :cart-total                                                 │
+│                                wrote [:tax :due]      5.25                          │
+│                                  read  [:cart :total]                                │
+│     ↳ :grand-total-display     via :cart-total, :tax-due                            │
+│                                wrote [:checkout :grand-total]  57.75                │
+│                                  read  [:cart :total] [:tax :due]                    │
+│                                                                                      │
 │ ▼ EFFECTS RETURNED                                                                   │
 │   :db    <… changed; see App-db tab …>                                               │
 │   :fx    [[:http/post {…}] [:dispatch [:notify "added"]]]                            │
@@ -555,16 +568,6 @@ as the developer scans.
 │   │ ▼ REQUEST  ▼ WIRE TIMING  ▼ RESPONSE  ▼ HANDLER  ▼ APP-DB SLICE      │           │
 │   └────────────────────────────────────────────────────────────────────────┘         │
 │   :dispatch    ⏱ <1ms  ✓ handled  → queued [:notify "added"]                        │
-│                                                                                      │
-│ ▼ FLOWS  (3)                                                                         │
-│   ▸ :cart-total                wrote [:cart :total]   52.50                         │
-│                                  read  [:cart :items]                                │
-│     ↳ :tax-due       via :cart-total                                                 │
-│                                wrote [:tax :due]      5.25                          │
-│                                  read  [:cart :total]                                │
-│     ↳ :grand-total-display     via :cart-total, :tax-due                            │
-│                                wrote [:checkout :grand-total]  57.75                │
-│                                  read  [:cart :total] [:tax :due]                    │
 └──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -609,26 +612,15 @@ as the developer scans.
 5. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [code]`. Per
    Q2: does NOT duplicate the event-id (already shown in §2). Reads
    `(rf/handler-meta :event id)`.
-6. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`
-   was returned. Reads `:fx` + `:db-present?` off the `:event/do-fx`
-   trace's `:tags` (rf2-twt7m Change 2). `:db` is shown as
-   `<… changed; see App-db tab …>` — the diff itself lives in the
-   App-db tab. When the focused event is `:rf.ssr/hydrated`, an
-   additional `:rf.ssr/hydration-outcome` row renders with the
-   `{:duration-ms :subs-ran :mismatches}` payload + (when mismatches
-   > 0) a `→ jump to Issues bisector` affordance.
-7. **EFFECTS HANDLERS RAN** — silent-by-default when no fx ran. One
-   row per `:rf.fx/handled` (or override / skipped / exception) trace:
-   fx-id chip + perf-tier dot + status caption. For `:dispatch` the
-   queued child event renders inline as `→ queued [:foo …]`. For
-   managed-fx surfaces (`:rf.http/*`, `:rf.ws/*`, `:rf.machine/*`,
-   `:rf.server/*`, `:rf.flow/*`) the wire-boundary `record-panel`
-   mounts INLINE beneath the row per §8.3 of the findings doc — NOT
-   in a trailing block.
-8. **FLOWS** — silent-by-default when no flows fired (rf2-lo37i —
-   peer section between the handler-driven effects and any conceptual
-   `RETURNED VALUE` slot). Reads `:rf.flow/computed` traces (op-type
-   `:flow`) from the cascade's `:other` bucket per
+6. **FLOWS** — silent-by-default when no flows fired (rf2-lo37i —
+   peer section sitting RIGHT AFTER the handler, before the
+   handler-driven effects). Flows fire automatically at the OUTERMOST
+   `:after` interceptor, immediately after the event handler returns:
+   they transform the pending `:db` effect BEFORE the single deferred
+   app-db install (the atomic commit boundary), so they precede both
+   the committed DB changes and any fx (Mike CONFIRMED 2026-05-24, `bd
+   remember --key event-pipeline-atomicity`). Reads `:rf.flow/computed`
+   traces (op-type `:flow`) from the cascade's `:other` bucket per
    [spec/013-Flows.md §Flow tracing](../../../spec/013-Flows.md#flow-tracing)
    and [spec/009-Instrumentation.md §Flow trace events](../../../spec/009-Instrumentation.md#flow-trace-events).
    One row per firing in cascade order (the framework's topo-sorted
@@ -649,6 +641,23 @@ as the developer scans.
    [spec/013-Flows.md §Dirty-check semantics](../../../spec/013-Flows.md#dirty-check-semantics))
    are NOT rendered as rows — a flow that didn't recompute did not
    touch app-db, so it stays out of the cascade-detail by default.
+7. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`
+   was returned. Reads `:fx` + `:db-present?` off the `:event/do-fx`
+   trace's `:tags` (rf2-twt7m Change 2). `:db` is shown as
+   `<… changed; see App-db tab …>` — the diff itself lives in the
+   App-db tab (and already reflects any FLOWS recomputes folded in,
+   since flows ran before the db committed). When the focused event is
+   `:rf.ssr/hydrated`, an additional `:rf.ssr/hydration-outcome` row
+   renders with the `{:duration-ms :subs-ran :mismatches}` payload +
+   (when mismatches > 0) a `→ jump to Issues bisector` affordance.
+8. **EFFECTS HANDLERS RAN** — silent-by-default when no fx ran. One
+   row per `:rf.fx/handled` (or override / skipped / exception) trace:
+   fx-id chip + perf-tier dot + status caption. For `:dispatch` the
+   queued child event renders inline as `→ queued [:foo …]`. For
+   managed-fx surfaces (`:rf.http/*`, `:rf.ws/*`, `:rf.machine/*`,
+   `:rf.server/*`, `:rf.flow/*`) the wire-boundary `record-panel`
+   mounts INLINE beneath the row per §8.3 of the findings doc — NOT
+   in a trailing block.
 
 #### Edge cases
 
@@ -664,8 +673,9 @@ as the developer scans.
   (the firing happened); the read-paths line renders the absent
   placeholder since `(rf/handler-meta :flow id)` returns nil.
 - **Handler threw** — §6 + §7 + §8 are all absent (handler never
-  returned / fx walk never started / flow walk never reached); a
-  small footer caption renders: `Handler threw — see Issues tab ⚠
+  returned, so the flow transform never ran, the db never committed,
+  and the fx walk never started — every post-handler stage is omitted);
+  a small footer caption renders: `Handler threw — see Issues tab ⚠
   for the exception detail.` This is the ONE inline cross-reference
   to another tab.
 

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -101,7 +101,7 @@ state-mutating vs state-observing.
 
 | Phase | Steps | What |
 |---|---|---|
-| **Handling** (state-mutating) | Dispatch → Coeffects → Handler → Effects → Flows recompute | The `Event` L4 panel renders the handling pipeline as a numbered vertical flow (the rendered section order — DISPATCH · COEFFECTS · EVENT HANDLER · DB CHANGES · AFTER INTERCEPTORS · FLOWS · FX — is in §2.2; optional sections are omitted when absent). |
+| **Handling** (state-mutating) | Dispatch → Coeffects → Handler → Flows recompute → Effects | The `Event` L4 panel renders the handling pipeline as a numbered vertical flow (the rendered section order — DISPATCH · COEFFECTS · EVENT HANDLER · FLOWS · DB CHANGES · AFTER INTERCEPTORS · FX — is in §2.2; optional sections are omitted when absent). Flows recompute at the outermost `:after`, reshaping the pending `:db` before it commits — so they precede DB CHANGES and FX. |
 | **Pivot** (the keystone) | — | Handling → reactive transition. The architectural inflection. App-db panel sits on this boundary. |
 | **Reactive** (state-observing) | Subs recompute → Views re-render | The `View` L4 panel renders the cascade as a left → right graph (§3). |
 
@@ -226,10 +226,14 @@ Section order (numbered; optional sections shown only when present):
      value it added to context (`+ [:now] #inst…`).
   3. **EVENT HANDLER** — the flavour (`reg-event-db` / `reg-event-fx`) as a click-to-source
      link + the **syntax-highlighted handler source** in a code block.
-  4. **DB CHANGES** — the app-db diff: `~ [path] old → new` · `+ [path] value` · `- [path]`.
-  5. **AFTER INTERCEPTORS** *(optional)* — non-standard after-interceptors: each id
+  4. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote. Flows fire at
+     the outermost `:after` interceptor, right after the handler — they reshape the pending
+     `:db` BEFORE the single deferred install (the atomic commit), so they precede DB CHANGES
+     and run long before FX.
+  5. **DB CHANGES** — the app-db diff: `~ [path] old → new` · `+ [path] value` · `- [path]`.
+     Already reflects any FLOWS recomputes (flows ran before the db committed).
+  6. **AFTER INTERCEPTORS** *(optional)* — non-standard after-interceptors: each id
      (click-to-source) + the effect it contributed (`+ [:fx :local-storage] {…}`).
-  6. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote.
   7. **FX** — the fx handlers that ran (`:dispatch → […]` · `:http-xhrio → {…}`).
 
 The cascade-id stays internal (`data-dispatch-id` on the lens root for tests/agents); not
@@ -270,19 +274,19 @@ flows, and fx):
 │   │      (fn [db _]                                                       │
 │   │        (update db :counter inc)))                                     │
 │   │                                                                       │
-│  ④  DB CHANGES                                                            │
+│  ④  FLOWS                                  (optional · shown when present) │
+│   │    :totals-flow ↗  →  [:totals] recomputed                           │
+│   │      + [:totals :sum]  42                                            │
+│   │                                                                       │
+│  ⑤  DB CHANGES                                                            │
 │   │    ~ [:counter]       1 → 2                                           │
 │   │    + [:last-updated]  #inst "2026-05-23T12:30:05"                     │
 │   │                                                                       │
-│  ⑤  AFTER INTERCEPTORS                     (optional · shown when present) │
+│  ⑥  AFTER INTERCEPTORS                     (optional · shown when present) │
 │   │    :persist-db ↗                                                      │
 │   │      + [:fx :local-storage]  {:key "app-state" :value {...}}          │
 │   │    :analytics ↗                                                       │
 │   │      + [:fx :track]          {:event "counter-inc"}                   │
-│   │                                                                       │
-│  ⑥  FLOWS                                  (optional · shown when present) │
-│   │    :totals-flow ↗  →  [:totals] recomputed                           │
-│   │      + [:totals :sum]  42                                            │
 │   │                                                                       │
 │  ⑦  FX                                                                    │
 │        :dispatch    → [:title/flow [:rf/init]]                            │
@@ -317,7 +321,7 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 
 | From | Reads |
 |---|---|
-| Focused epoch record | `:rf.event/dispatched` (step 1), `:rf.cofx/*` (step 2 — coeffect injection), `:rf.event/run-start` / `:rf.event/run-end` (step 3 — handler), `:rf.fx/do-fx` (step 4 — effects returned, carries `:rf.event/fx`), `:rf.fx/handled` per fx-id (step 5 — effects applied), `:rf.flow/computed` (step 6) — all read from the focused epoch record's `:trace-events` (one epoch = one dequeued event, §1.1) |
+| Focused epoch record | `:rf.event/dispatched` (step 1), `:rf.cofx/*` (step 2 — coeffect injection), `:rf.event/run-start` / `:rf.event/run-end` (step 3 — handler), `:rf.flow/computed` (step 4 — flows reshape the pending `:db` at the outermost `:after`, before commit), `:rf.fx/do-fx` (step 5 — the committed db diff, carries `:rf.event/fx`), `:rf.fx/handled` per fx-id (step 7 — effects applied) — all read from the focused epoch record's `:trace-events` (one epoch = one dequeued event, §1.1) |
 | Registries | Handler metadata (`reg-event-*` form file:line, optional source string when DEBUG-gated) |
 | App-db panel (bridge) | Inline diff renderer for the handler's `:db` effect — the DB CHANGES section (reuses the shared renderer §10) |
 
@@ -439,7 +443,7 @@ FLOW`), not the prior depth-first indented tree. Columns, left → right:
   edges) carries the "one sub drives N views" fact (a small `×N` may annotate it).
 
 **Cascade scope — flows are NOT in the reactive graph.** The graph is strictly **app-db → subs →
-views**. Flows mutate state — they belong to the handling pipeline (Event panel step 6) — and they
+views**. Flows mutate state — they belong to the handling pipeline (Event panel step 4) — and they
 may **feed** the cascade by writing db-paths the subs watch, but they do not appear as graph nodes.
 Quoted from the super-prompt (A.3):
 
@@ -447,7 +451,7 @@ Quoted from the super-prompt (A.3):
 > renders flows (alongside other handling steps).
 
 The L2 row's `🌊 flow-recomputed` badge surfaces flows as a cross-epoch signal; per-epoch flow
-detail lives in Event panel step 6.
+detail lives in Event panel step 4.
 
 Below the graph, two list sections record the epoch's reactive teardown (Figma design):
 
@@ -1018,7 +1022,7 @@ direction (deferred to follow-on bead). Default zoom: fit-on-mount with
 |---|---|
 | Transition edge | (no-op MVP; stretch: scroll to the dispatching event in Event panel) |
 | Guard row | Inline source-glance (DEBUG-gated source string) |
-| Action chip | Switch to **Event** panel, scroll to step 5 `:fx` row for that action |
+| Action chip | Switch to **Event** panel, scroll to step 7 `:fx` row for that action |
 | Canvas node | Set this state as the "selected" for filter-IN candidate |
 
 ### §6.5 Film-strip
@@ -1468,8 +1472,8 @@ prerequisites.
 | **Cascade aggregate** | `:rf.cascade/captured` | `{:rf.trace/dispatch-id <id> :subs-ran N :subs-skipped N :views-rendered N :flows-recomputed N}` | Optional — emitted at end-of-epoch for fast L2 badge / Reactive summary line |
 | **Dispatch-origin tag** | (on existing `:rf.event/dispatched`) | `:tags :rf.event/origin <origin-kw>` per §1.5 taxonomy (landed) | Event panel step 1 · L2 row prefix · filter pills |
 | **Handler-source string** | (on existing handler registry) | Stamp `:source-string` metadata via macro (DEBUG-gated) | Event panel step 3 inline source · §2.2 |
-| **Flow recompute** | `:rf.flow/computed` | `{:flow-id :inputs-changed [...] :rf.trace/dispatch-id <id>}` | Event panel step 6 |
-| **Flow skip** | `:rf.flow/skipped` | `{:flow-id :reason :input-unchanged :rf.trace/dispatch-id <id>}` | Event panel step 6 "dim" rows |
+| **Flow recompute** | `:rf.flow/computed` | `{:flow-id :inputs-changed [...] :rf.trace/dispatch-id <id>}` | Event panel step 4 |
+| **Flow skip** | `:rf.flow/skipped` | `{:flow-id :reason :input-unchanged :rf.trace/dispatch-id <id>}` | Event panel step 4 "dim" rows |
 | **Route phase taxonomy** | (on existing `:rf.route/*`) | Confirm `:tags :phase #{:can-leave :can-enter :on-match :settle}` is consistent | Routing panel §7 |
 
 **Per-substrate adapter work for `:rf.view/rendered`:**
@@ -1522,7 +1526,7 @@ real beads after approving this doc.
   epoch. Gates: L2 badge "cascade size", Reactive header summary line.
 
 - **rf2-?????** — *Substrate: add `:rf.flow/skipped` trace op.* Mirror
-  `:rf.sub/skipped` for flows. Gates: Event panel step 6 dim-row
+  `:rf.sub/skipped` for flows. Gates: Event panel step 4 dim-row
   rendering.
 
 - **rf2-?????** — *Substrate: focused-event-only attribution gate.*

--- a/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/diff/render.cljs
@@ -233,9 +233,10 @@
                 "(No flow's :output covers this section.)")
     :flow  (str "Flow " (pr-str (:flow-id tag))
                 " wrote here via its :output. "
-                "Per Spec 013, flows fire automatically after the handler's "
-                "effects, writing their computed value to the registered "
-                ":path.")
+                "Per Spec 013, flows fire automatically right after the "
+                "event handler — at the outermost :after interceptor — "
+                "transforming the pending :db before it commits; each "
+                "writes its computed value to the registered :path.")
     :mixed (str "Coalesced section — multiple writers contributed: "
                 (origin-tag-label tag) ". Each flow listed wrote via "
                 "its :output; the [fx :db] tag (when present) indicates "

--- a/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/app_db_diff_helpers.cljc
@@ -698,12 +698,13 @@
 ;;
 ;;   1. The event handler's `:db` effect — `[fx :db]`.
 ;;   2. A flow's `:output` fn — `[flow :flow-id]`. Per Spec 013, flows
-;;      fire automatically AFTER the handler's effects run; each flow
-;;      writes its computed result back into app-db at its registered
-;;      `:path`.
+;;      fire automatically right after the event handler — at the
+;;      outermost :after interceptor — transforming the pending `:db`
+;;      before it commits; each flow writes its computed result into
+;;      app-db at its registered `:path`.
 ;;
 ;; Without per-path attribution the developer sees "path X changed" and
-;; has to look elsewhere (the §8 FLOWS section in the Event lens) to
+;; has to look elsewhere (the FLOWS section in the Event lens) to
 ;; figure out which subset of changes came from flow recomputes. The
 ;; origin chip on each diff section closes that gap: the section header
 ;; carries `[fx :db]` or `[flow :flow-id]` next to the breadcrumb.

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -14,9 +14,9 @@
       1. DISPATCH             event vector + `FROM: <source>` (click-to-source)
       2. COEFFECTS  (opt)     user-injected coeffects + the value each added
       3. EVENT HANDLER        reg-event-* flavour + syntax-highlighted source
-      4. DB CHANGES           the app-db diff (+ SSR hydration addendum)
-      5. AFTER INTERCEPTORS (opt) non-standard after-interceptors
-      6. FLOWS      (opt)     flows that recomputed + the db path written
+      4. FLOWS      (opt)     flows that recomputed + the db path written
+      5. DB CHANGES           the app-db diff (+ SSR hydration addendum)
+      6. AFTER INTERCEPTORS (opt) non-standard after-interceptors
       7. FX                   the fx handlers that ran
 
   Steps are numbered DYNAMICALLY 1..N — an absent OPTIONAL section
@@ -490,7 +490,7 @@
               (with-meta (coeffect-row id v)
                          {:key (pr-str id)}))))))
 
-;; ---- step AFTER INTERCEPTORS (spec/021 §2.2 step 5) -------------------
+;; ---- step AFTER INTERCEPTORS (spec/021 §2.2 step 6) -------------------
 
 (defn- interceptor-row
   [{:keys [id file line] :as _interceptor}]
@@ -755,13 +755,17 @@
                      :font-size "11px"}}
        "(none)"])))
 
-;; ---- §8 FLOWS ----------------------------------------------------------
-;; rf2-lo37i — Flows fire automatically AFTER fx handlers run. Each flow's
-;; `:output` fn reads from `:inputs` paths and writes to a `:path`. Without
-;; first-class visibility here a developer cannot attribute an app-db
-;; change to the flow that caused it. Surfaced as a peer section sitting
-;; after §7 EFFECTS HANDLERS RAN — the cascade-order placement: flows are
-;; the framework's automatic step after the handler-effects complete.
+;; ---- step FLOWS (spec/021 §2.2 step 4) ---------------------------------
+;; rf2-lo37i — Flows fire automatically right after the event handler, at
+;; the OUTERMOST `:after` interceptor — they transform the pending `:db`
+;; effect BEFORE the single deferred app-db install (the atomic commit
+;; boundary), so they precede DB CHANGES and run long before FX. Each
+;; flow's `:output` fn reads from `:inputs` paths and writes to a `:path`.
+;; Without first-class visibility here a developer cannot attribute an
+;; app-db change to the flow that caused it. Surfaced as a peer section
+;; sitting between EVENT HANDLER and DB CHANGES — the cascade-order
+;; placement: flows are the framework's automatic step that reshapes the
+;; pending db before it commits.
 ;;
 ;; Per spec/013-Flows.md + spec/009-Instrumentation.md:
 ;;   `:rf.flow/computed` (op-type `:flow`) carries `:flow-id`,
@@ -885,7 +889,7 @@
       (or rows []))))
 
 (defn- flow-row
-  "One row inside the §8 FLOWS section. Shape per design:
+  "One row inside the FLOWS section. Shape per design:
 
       ▸ :flow-id              wrote [:write :path]   <result>
                               read  [:in1] [:in2]
@@ -1074,9 +1078,9 @@
                   :color       (:text-primary tokens)}}
     body]])
 
-;; ---- §2 step DB CHANGES — flat changed-paths diff list ----------------
+;; ---- step DB CHANGES — flat changed-paths diff list ------------------
 ;;
-;; Per spec/021 §2.2 step 4 (line 229) the DB CHANGES section is the
+;; Per spec/021 §2.2 step 5 the DB CHANGES section is the
 ;; app-db diff rendered as a FLAT list of changed paths ONLY:
 ;;
 ;;     ~ [path] old → new        (modified)
@@ -1197,7 +1201,7 @@
 
 (defn- db-changes-body
   "Step DB CHANGES body — the app-db diff for the focused epoch as a
-  FLAT changed-paths list (spec/021 §2.2 step 4 · spec/004 §slice-
+  FLAT changed-paths list (spec/021 §2.2 step 5 · spec/004 §slice-
   centric). One `~`/`+`/`-` row per changed path; NO untouched
   top-level keys, NO whole-tree render.
 
@@ -1279,19 +1283,23 @@
                              added.
     3. EVENT HANDLER       — flavour (`reg-event-*`, click-to-source) +
                              syntax-highlighted handler source.
-    4. DB CHANGES          — the app-db diff (+ SSR hydration-outcome
+    4. FLOWS      (opt)    — flows that recomputed + the db path each
+                             wrote. Fire at the outermost `:after`, right
+                             after the handler — they reshape the pending
+                             `:db` BEFORE it commits, so they precede DB
+                             CHANGES.
+    5. DB CHANGES          — the app-db diff (+ SSR hydration-outcome
                              addendum when the focused event hydrated).
-    5. AFTER INTERCEPTORS (opt) — non-standard after-interceptors.
-    6. FLOWS      (opt)    — flows that recomputed + the db path each
-                             wrote.
+    6. AFTER INTERCEPTORS (opt) — non-standard after-interceptors.
     7. FX                  — the fx handlers that ran.
 
   ## Handler-threw branch
 
   When the cascade carries a handler exception the handler never
-  returned, so the post-handler steps (DB CHANGES, AFTER INTERCEPTORS,
-  FLOWS, FX) are simply omitted — absence conveys the throw (spec/021
-  §2.2: no footer). Only DISPATCH / COEFFECTS? / EVENT HANDLER render.
+  returned, so the post-handler steps (FLOWS, DB CHANGES, AFTER
+  INTERCEPTORS, FX) are simply omitted — absence conveys the throw
+  (spec/021 §2.2: no footer). Only DISPATCH / COEFFECTS? / EVENT HANDLER
+  render.
 
   ## No top header (rf2-ad7zx.17)
 
@@ -1320,10 +1328,10 @@
         candidates [["dispatch"          "DISPATCH"           (dispatch-body cascade event)]
                     ["coeffects"         "COEFFECTS"          (coeffects-body cascade)]
                     ["handler"           "EVENT HANDLER"      (handler-body event-id meta)]
+                    ["flows"             "FLOWS"              (when-not threw? (flows-body cascade))]
                     ["db-changes"        "DB CHANGES"         db-changes]
                     ["after-interceptors" "AFTER INTERCEPTORS" (when-not threw?
                                                                  (after-interceptors-body user-icpts))]
-                    ["flows"             "FLOWS"              (when-not threw? (flows-body cascade))]
                     ["fx"                "FX"                 (when-not threw? (fx-body cascade))]]
         ;; Drop omitted (nil-body) steps, then number what remains 1..N
         ;; — dynamic numbering so the visible steps read contiguously.

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -14,7 +14,8 @@
        HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN.
     4. Silent-by-default — sections ABSENT (not '(none)') when their
        data is empty.
-    5. Handler threw → §6/§7 suppressed + Issues-tab footer renders.
+    5. Handler threw → every post-handler stage (FLOWS, DB CHANGES,
+       AFTER INTERCEPTORS, FX) suppressed + Issues-tab footer renders.
     6. Pure projection helpers (`user-interceptors`, `user-coeffects`,
        `cascade-outcome`, `effects-handlers-ran`, `hydration-outcome-row`).
     7. The meta-on-vector pattern (rf2-ppzid) — :key reaches every
@@ -237,8 +238,9 @@
   out the per-step `*-label` / `*-body` children testids `step-section`
   emits.
 
-  Section order: DISPATCH → COEFFECTS? → EVENT HANDLER → DB CHANGES →
-  AFTER INTERCEPTORS? → FLOWS? → FX (optional steps shown when present)."
+  Section order: DISPATCH → COEFFECTS? → EVENT HANDLER → FLOWS? →
+  DB CHANGES → AFTER INTERCEPTORS? → FX (optional steps shown when
+  present)."
   #{"rf-xray-event-detail-section-dispatch"
     "rf-xray-event-detail-section-coeffects"
     "rf-xray-event-detail-section-handler"
@@ -265,8 +267,8 @@
   (testing "rf2-ad7zx.5 — a cascade with call-site + fx + after-
             interceptors + user coeffects + a flow yields the full
             7-step numbered pipeline (spec/021 §2.2): DISPATCH,
-            COEFFECTS, EVENT HANDLER, DB CHANGES, AFTER INTERCEPTORS,
-            FLOWS, FX"
+            COEFFECTS, EVENT HANDLER, FLOWS, DB CHANGES,
+            AFTER INTERCEPTORS, FX"
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
         [(rf/->interceptor :id :auth/require-login)]
@@ -296,9 +298,9 @@
         (doseq [[id label] [["dispatch" "DISPATCH"]
                             ["coeffects" "COEFFECTS"]
                             ["handler" "EVENT HANDLER"]
+                            ["flows" "FLOWS"]
                             ["db-changes" "DB CHANGES"]
                             ["after-interceptors" "AFTER INTERCEPTORS"]
-                            ["flows" "FLOWS"]
                             ["fx" "FX"]]]
           (is (some? (find-by-testid tree (str "rf-xray-event-detail-section-" id)))
               (str "step " label " present"))
@@ -307,10 +309,11 @@
 
 (deftest event-lens-step-order-matches-spec-021-section-2-2
   (testing "rf2-ad7zx.5 — steps render top-to-bottom in spec/021 §2.2
-            order: DISPATCH → COEFFECTS → EVENT HANDLER → DB CHANGES →
-            AFTER INTERCEPTORS → FLOWS → FX (optional steps shown when
-            present). This fixture seeds no flow, so FLOWS is OMITTED —
-            absence by omission, dynamic numbering closes the gap."
+            order: DISPATCH → COEFFECTS → EVENT HANDLER → FLOWS →
+            DB CHANGES → AFTER INTERCEPTORS → FX (optional steps shown
+            when present). This fixture seeds no flow, so FLOWS is
+            OMITTED — absence by omission, dynamic numbering closes the
+            gap."
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
         [(rf/->interceptor :id :auth/require-login)]
@@ -845,9 +848,11 @@
                row-tids)
             "flow rows appear in cascade firing order")))))
 
-(deftest flows-step-sits-before-fx-step
-  (testing "rf2-ad7zx.5 — spec/021 §2.2 step order: FLOWS (step 6) sits
-            BEFORE FX (step 7) in the pipeline."
+(deftest flows-step-sits-after-handler-before-db-changes-and-fx
+  (testing "rf2-9eca7 — spec/021 §2.2 step order: FLOWS (step 4) fires at
+            the outermost :after, right after the EVENT HANDLER and
+            BEFORE DB CHANGES (the commit) + FX. Flows reshape the
+            pending :db before it installs, so they precede both."
     (rf/with-frame :rf/default
       (rf/reg-flow {:id     :a-flow
                     :inputs [[:in]] :output identity :path [:a]}))
@@ -862,21 +867,27 @@
                         (keep (fn [n]
                                 (when (and (vector? n) (map? (second n)))
                                   (let [tid (str (or (:data-testid (second n)) ""))]
-                                    (when (#{"rf-xray-event-detail-section-fx"
-                                             "rf-xray-event-detail-section-flows"}
+                                    (when (#{"rf-xray-event-detail-section-handler"
+                                             "rf-xray-event-detail-section-flows"
+                                             "rf-xray-event-detail-section-db-changes"
+                                             "rf-xray-event-detail-section-fx"}
                                             tid)
                                       tid)))))
                         (distinct)
                         (vec))]
-        (is (= ["rf-xray-event-detail-section-flows"
+        (is (= ["rf-xray-event-detail-section-handler"
+                "rf-xray-event-detail-section-flows"
+                "rf-xray-event-detail-section-db-changes"
                 "rf-xray-event-detail-section-fx"]
                tids)
-            "FLOWS appears BEFORE FX in document order")))))
+            "FLOWS appears right after EVENT HANDLER and before DB CHANGES + FX in document order")))))
 
 (deftest flows-section-absent-when-handler-threw
-  (testing "rf2-lo37i — when the handler threw, the effects walk never
-            ran, so flows never fired. The FLOWS section should be
-            absent (mirrors §6 + §7 suppression)"
+  (testing "rf2-lo37i — when the handler threw, the outermost :after
+            (and its flow transform) never ran, so flows never fired and
+            the pending :db never committed. The FLOWS section should be
+            absent (mirrors the DB CHANGES + FX suppression — every
+            post-handler stage is omitted)"
     (seed-buffer!
       (concat (cascade-evs 100 [:checkout/submit] 0
                             {:fx nil :db-present? false})

--- a/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
+++ b/tools/xray/testbeds/panel_gallery/fixtures_trace.cljs
@@ -319,24 +319,29 @@
             :event-vec [:cart/add :apple]})
        (ev {:id 2 :time 1001 :op-type :rf.event :operation :rf.event/run-end
             :source :ui :origin :app :frame :rf/default
-            :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100})
-       (ev {:id 3 :time 1002 :op-type :rf.fx :operation :rf.fx/handled
-            :source :ui :origin :app :frame :rf/default
-            :event-id :cart/add :dispatch-id 100 :fx-id :db})]
-      ;; Three flow-recomputed events — flow propagates downstream of
-      ;; the db write. Operation surface per Spec 009 §Flow trace.
-      [(ev {:id 4 :time 1003 :op-type :rf.flow/computed
+            :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100})]
+      ;; Three flow-recomputed events — flows fire at the outermost
+      ;; :after, right after the handler, transforming the pending :db
+      ;; BEFORE the single deferred install. So computed emits precede
+      ;; the :db commit (real emit order: computed → db-changed).
+      ;; Operation surface per Spec 009 §Flow trace.
+      [(ev {:id 3 :time 1002 :op-type :rf.flow/computed
             :operation :rf.flow/computed
             :source :flow :origin :app :frame :rf/default
             :dispatch-id 100 :sub-id :cart/total})
-       (ev {:id 5 :time 1004 :op-type :rf.flow/computed
+       (ev {:id 4 :time 1003 :op-type :rf.flow/computed
             :operation :rf.flow/computed
             :source :flow :origin :app :frame :rf/default
             :dispatch-id 100 :sub-id :cart/item-count})
-       (ev {:id 6 :time 1005 :op-type :rf.flow/computed
+       (ev {:id 5 :time 1004 :op-type :rf.flow/computed
             :operation :rf.flow/computed
             :source :flow :origin :app :frame :rf/default
-            :dispatch-id 100 :sub-id :cart/badge})
+            :dispatch-id 100 :sub-id :cart/badge})]
+      ;; The :db commit — the single deferred install fires AFTER the
+      ;; flows have reshaped the pending db.
+      [(ev {:id 6 :time 1005 :op-type :rf.fx :operation :rf.fx/handled
+            :source :ui :origin :app :frame :rf/default
+            :event-id :cart/add :dispatch-id 100 :fx-id :db})
        ;; Downstream render driven by the flow.
        (ev {:id 7 :time 1006 :op-type :rf.view :operation :rf.view/render
             :source :ui :origin :app :frame :rf/default :dispatch-id 100


### PR DESCRIPTION
## What

re-frame2's flows now run **right after the event handler** — at the outermost `:after` interceptor, transforming the pending `:db` effect **before** the single deferred app-db install (the atomic commit boundary) — **not** after `:fx`. This PR moves the Xray Event lens FLOWS section to match.

**Old order:** DISPATCH -> COEFFECTS -> EVENT HANDLER -> DB CHANGES -> AFTER INTERCEPTORS -> FLOWS -> FX (FLOWS after FX)
**New order:** DISPATCH -> COEFFECTS -> EVENT HANDLER -> **FLOWS** -> DB CHANGES -> AFTER INTERCEPTORS -> FX

Authoritative contract: `bd remember --key event-pipeline-atomicity` (Mike CONFIRMED 2026-05-24).

## Changed files (spec + src + fixture + tests kept consistent)

**Xray spec**
- `018-Event-Spine.md` — §5.1 8-section Event lens: ASCII mock + numbered section list (FLOWS moved to §6, right after HANDLER) + handler-threw edge case.
- `007-UX-IA.md` — Event-tab pipeline prose order.
- `021-Dynamic-Panel-Designs.md` — §2.1 handling row, §2.2 section list + dense ASCII sketch + §2.3 queries-to-step map + scattered `Event panel step N` cross-refs.
- `016-Auxiliary-Panels.md` — "Flows section" framing (now right-after-handler, not 8th-after-fx).

**Xray src**
- `panels/event_detail.cljs` — `candidates` vector (FLOWS before DB CHANGES) + docstrings + §FLOWS comment + step-number section comments.
- `diff/render.cljs` + `panels/app_db_diff_helpers.cljc` — flow-origin prose (flows reshape the pending `:db` before commit, not after fx).

**Mock fixture**
- `testbeds/panel_gallery/fixtures_trace.cljs` — `flows-buffer`: `:rf.flow/computed` now sits between run-end and the `:db` commit (real emit order: computed -> db-changed).

**Tests**
- `panels/event_detail_cljs_test.cljs` — section-order expectations, the renamed `flows-step-sits-after-handler-before-db-changes-and-fx` ordering test (now also pins FLOWS before DB CHANGES), and prose.

## Gates (all green)
- xray JVM `clojure -M:test`: 876 tests / 2941 assertions, 0 failures
- `npm run test:cljs`: 4278 tests / 13449 assertions, 0 failures
- `npm run test:xray-feature-gate:smoke`: 3 scenarios, 0 failures, 10 matrix rows
- splint: 0 new findings (15 pre-existing style warnings, none in edited regions)
- `mkdocs build --strict`: exit 0
- clj-kondo: standalone binary unavailable locally (CI-only); splint covers static-lint

Closes rf2-9eca7.