### PR TITLE
fix(ci): gate lint + docs via always-present aggregators (rf2-aemyt)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,13 @@
 # (Settings → Pages → Build and deployment → Source). If it is still set to
 # "Deploy from a branch" the deploy-pages step below will fail.
 #
-# This workflow only triggers on docs-affecting pushes to `main`, matching
-# pull-request path filters, or via manual dispatch. The first publish is a
-# deliberate manual step (run via the Actions tab once Pages is configured) —
-# see PR description for rf2-h09k.
+# On `main`, this workflow triggers on docs-affecting pushes (the deploy job
+# publishes the site). On pull requests the trigger is UNFILTERED so the
+# `Docs required` aggregator posts a status context on EVERY PR (see
+# REQUIRED-CHECK SHAPE below); the heavy MkDocs build is re-gated job-side
+# to the docs surface. The first publish is a deliberate manual step (run
+# via the Actions tab once Pages is configured) — see PR description for
+# rf2-h09k.
 
 name: docs
 
@@ -35,19 +38,10 @@ on:
       - 'scripts/check_doc_slugs.py'
       - 'scripts/_test_fixtures/check_doc_slugs/**'
       - '.github/workflows/docs.yml'
+  # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE
+  # below). The docs surface is re-applied job-side via the `detect` job.
   pull_request:
     branches: [main]
-    paths:
-      - 'docs/**'
-      - 'spec/**'
-      - 'migration/**'
-      - 'mkdocs.yml'
-      - 'mkdocs_hooks.py'
-      - 'TESTING.md'
-      - 'requirements.txt'
-      - 'scripts/check_doc_slugs.py'
-      - 'scripts/_test_fixtures/check_doc_slugs/**'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 # Allow only one concurrent Pages deployment, but do not cancel an
@@ -57,8 +51,54 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Lightweight changed-surface gate (rf2-aemyt). On a pull_request this
+  # diffs HEAD against the merge base and lights `docs_surface` only when a
+  # path that feeds the staged site changed; on push / dispatch it always
+  # lights so the build runs unconditionally (push is already path-filtered
+  # above, and a manual dispatch always wants a build). The heavy MkDocs
+  # build keys its `if:` on this output, while the always-present aggregator
+  # does not — so a docs-irrelevant PR runs only this ~5-second job plus the
+  # rollup, and the build skips.
+  detect:
+    name: Detect docs surface
+    runs-on: ubuntu-latest
+    outputs:
+      docs_surface: ${{ steps.detect.outputs.docs_surface }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      # On a PR, classify the changed-file list against the docs surface.
+      # On any non-PR event (push/dispatch) light the gate so the build
+      # always runs. Mirrors the git-diff classifier shape used by
+      # .github/scripts/report-changed-surfaces.sh in test.yml. The path
+      # set is kept in lockstep with the `push.paths` filter above.
+      - name: Classify changed files against the docs surface
+        id: detect
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "docs_surface=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event (${GITHUB_EVENT_NAME}): running MkDocs build unconditionally."
+            exit 0
+          fi
+          git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+          files="$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")"
+          docs_surface=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              docs/*|spec/*|migration/*|mkdocs.yml|mkdocs_hooks.py|TESTING.md|requirements.txt|scripts/check_doc_slugs.py|scripts/_test_fixtures/check_doc_slugs/*|.github/workflows/docs.yml)
+                docs_surface=true ;;
+            esac
+          done <<< "$files"
+          echo "docs_surface=${docs_surface}" >> "$GITHUB_OUTPUT"
+          echo "docs_surface=${docs_surface}"
+
   build:
     name: MkDocs build
+    needs: detect
+    if: needs.detect.outputs.docs_surface == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -150,3 +190,40 @@ jobs:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+
+  # ---------------------------------------------------------------------------
+  # Required-checks aggregator (rf2-aemyt).
+  #
+  # ONE stable status context — `Docs required` — that is ALWAYS present on
+  # every PR (the workflow's pull_request trigger is unfiltered) and that
+  # passes iff the MkDocs build job either passed or was surface-skipped.
+  # This is the single docs context the branch ruleset should require: a
+  # docs-irrelevant PR skips the build (no signal, OK), but the moment the
+  # build reports `failure`/`cancelled` the aggregator goes red and blocks
+  # the merge — so a broken link or a strict-mode MkDocs warning can no
+  # longer slip in on a PR that happens to touch docs paths.
+  #
+  # `if: always()` is mandatory — without it the aggregator would itself be
+  # skipped whenever the build skips, and a skipped required check never
+  # satisfies the ruleset. The pass/fail decision reads `needs.*.result`:
+  # `success` and `skipped` are acceptable; `failure` and `cancelled` are
+  # not. The `deploy` job is deliberately NOT in `needs:` — it runs only on
+  # push, never on a PR, so it carries no PR-time signal.
+  # ---------------------------------------------------------------------------
+  docs-required:
+    name: Docs required
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - build
+    steps:
+      - name: Fail if the docs build failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::A required docs.yml job reported failure or cancelled — blocking merge."
+          echo "needs results: ${{ join(needs.*.result, ', ') }}"
+          exit 1
+
+      - name: Docs build passed or was skipped
+        run: echo "The MkDocs build that ran passed (a surface-skipped build is OK)."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,17 @@ name: lint
 # template tree is excluded explicitly — those `.cljs` files carry
 # `{{placeholder}}` substitutions and are not valid Clojure (see
 # tools/deps.edn for the matching shadow-cljs exclusion rationale).
+#
+# REQUIRED-CHECK SHAPE (rf2-aemyt). The `pull_request` trigger is
+# deliberately UNFILTERED so the `Lint required` aggregator below posts a
+# status context on EVERY PR — a path-filtered workflow skips entirely on
+# an unrelated PR and emits NO context, which means a required-but-absent
+# context would sit permanently pending (the phantom trap rf2-dtvmb hit).
+# The expensive clj-kondo + Splint jobs are instead gated job-side on a
+# tiny `detect` job that diffs the PR's changed files against the lint
+# surface, so they still skip on PRs that touch no lint paths while the
+# aggregator stays present and green (all-skipped ⇒ pass). The exact
+# display name `Lint required` is the string the branch ruleset requires.
 
 on:
   push:
@@ -38,15 +49,10 @@ on:
       - 'testbeds/**'
       - '.clj-kondo/**'
       - '.github/workflows/lint.yml'
+  # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE
+  # above). The lint surface is re-applied job-side via the `detect` job.
   pull_request:
     branches: [main]
-    paths:
-      - 'implementation/**'
-      - 'tools/**'
-      - 'examples/**'
-      - 'testbeds/**'
-      - '.clj-kondo/**'
-      - '.github/workflows/lint.yml'
   # Nightly run keeps the gate honest even when no lint-surface file
   # changes (e.g. a dep bump in another tree might silently break kondo
   # via :lint-as). 03:30 UTC sits below the 04:00 UTC `expensive-tests`
@@ -60,8 +66,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Lightweight changed-surface gate (rf2-aemyt). On a pull_request this
+  # diffs HEAD against the merge base and lights `lint_surface` only when a
+  # path in the lint surface changed; on push / schedule / dispatch it
+  # always lights so the linters run unconditionally. The heavy clj-kondo +
+  # Splint jobs key their `if:` on this output, while the always-present
+  # aggregator does not — so an unrelated PR runs only this ~5-second job
+  # plus the rollup, and both linters skip.
+  detect:
+    name: Detect lint surface
+    runs-on: ubuntu-latest
+    outputs:
+      lint_surface: ${{ steps.detect.outputs.lint_surface }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      # On a PR, classify the changed-file list against the lint surface.
+      # On any non-PR event (push/schedule/dispatch) light the gate so the
+      # linters always run. Mirrors the git-diff classifier shape used by
+      # .github/scripts/report-changed-surfaces.sh in test.yml.
+      - name: Classify changed files against the lint surface
+        id: detect
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "lint_surface=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event (${GITHUB_EVENT_NAME}): running linters unconditionally."
+            exit 0
+          fi
+          git fetch --no-tags --depth=100 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+          files="$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")"
+          lint_surface=false
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              implementation/*|tools/*|examples/*|testbeds/*|.clj-kondo/*|.github/workflows/lint.yml)
+                lint_surface=true ;;
+            esac
+          done <<< "$files"
+          echo "lint_surface=${lint_surface}" >> "$GITHUB_OUTPUT"
+          echo "lint_surface=${lint_surface}"
+
   clj-kondo:
     name: clj-kondo (fail on errors, warnings informational)
+    needs: detect
+    if: needs.detect.outputs.lint_surface == 'true'
     runs-on: ubuntu-latest
     # The job runs with `--fail-level error` so an introduced ERROR
     # blocks the PR. Warnings stay informational and surface in the
@@ -129,6 +179,8 @@ jobs:
 
   splint:
     name: Splint (fail on errors, warnings informational)
+    needs: detect
+    if: needs.detect.outputs.lint_surface == 'true'
     runs-on: ubuntu-latest
     # The job runs with `--fail-on-errors` so an introduced ERROR (a
     # file Splint cannot parse) blocks the PR. Style warnings still
@@ -183,3 +235,40 @@ jobs:
             ../tools \
             ../examples \
             ../testbeds
+
+  # ---------------------------------------------------------------------------
+  # Required-checks aggregator (rf2-aemyt).
+  #
+  # ONE stable status context — `Lint required` — that is ALWAYS present on
+  # every PR (the workflow's pull_request trigger is unfiltered) and that
+  # passes iff every lint job that actually ran also passed. This is the
+  # single lint context the branch ruleset should require: a skipped
+  # surface-gated linter is OK (it contributed no signal), but the moment
+  # clj-kondo or Splint reports `failure`/`cancelled` the aggregator goes
+  # red and blocks the merge.
+  #
+  # `if: always()` is mandatory — without it the aggregator would itself be
+  # skipped whenever an upstream job skips, and a skipped required check
+  # never satisfies the ruleset. The pass/fail decision reads
+  # `needs.*.result`: `success` and `skipped` are acceptable; `failure`
+  # and `cancelled` are not. The `detect` job is included in `needs:` so a
+  # broken classifier (its own failure) is also caught.
+  # ---------------------------------------------------------------------------
+  lint-required:
+    name: Lint required
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - detect
+      - clj-kondo
+      - splint
+    steps:
+      - name: Fail if any required lint job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::A required lint.yml job reported failure or cancelled — blocking merge."
+          echo "needs results: ${{ join(needs.*.result, ', ') }}"
+          exit 1
+
+      - name: All required lint jobs passed or were skipped
+        run: echo "All lint jobs that ran passed (skipped surface-gated linters are OK)."


### PR DESCRIPTION
## What

`lint.yml` (clj-kondo + Splint) and `docs.yml` (MkDocs build) were **PR path-filtered**, so on a PR that touched none of their paths they skipped entirely and posted **no status context**. That made them impossible to require directly — a required-but-absent context sits permanently pending (the phantom trap `rf2-dtvmb` fixed for `test.yml`). Net effect today: a PR can merge with a lint error or a broken docs build, because neither workflow is enforceable.

This mirrors the `test.yml` `All required checks passed` pattern in each of the two workflows:

- **Unfilter the `pull_request` trigger** so the workflow runs on **every** PR and its aggregator always posts a context.
- **Push the path filter down to a tiny `detect` job** that diffs the PR's changed files (`origin/BASE...HEAD`, same git-diff shape as `.github/scripts/report-changed-surfaces.sh`) against the workflow's surface and emits a boolean. The heavy jobs gate their `if:` on that output, so clj-kondo / Splint / MkDocs still **skip** on PRs that touch none of their paths.
- **Add an `if: ${{ always() }}` aggregator** that `needs:` the detect + heavy jobs and **fails iff** any reports `failure`/`cancelled` (`success`/`skipped` are OK).

The `push` trigger stays path-filtered (required checks only matter for PRs). `docs.yml`'s `deploy` job stays push-only and is deliberately excluded from the aggregator's `needs:` (it never runs on a PR).

## Context names for the mayor — add to ruleset 16120663

Add these **two exact display-name contexts** (alongside the existing `All required checks passed`):

- `Lint required`
- `Docs required`

These are the job `name:` strings (GitHub matches required-status-check contexts by display name, **not** YAML job-id — the gotcha `rf2-dtvmb` hit). Do **not** require `clj-kondo`, `Splint`, or `MkDocs build` directly — they skip on unrelated PRs and would re-introduce the phantom-pending trap.

## Presence guarantee

- **This PR** touches `.github/workflows/lint.yml` + `.github/workflows/docs.yml`, so both `detect` jobs light their surface → clj-kondo, Splint, and MkDocs build all run, and `Lint required` + `Docs required` go green. (Confirmed on this PR's own checks.)
- **A PR touching neither lint nor docs paths**: both workflows still trigger (unfiltered PR trigger); each `detect` returns `false`; the heavy jobs skip; the aggregators run via `always()` and pass on all-skipped. So `Lint required` + `Docs required` are present (and green) on 100% of PRs.

## Gates

- `npx yaml-lint .github/workflows/lint.yml .github/workflows/docs.yml` → passing.
- Existing clj-kondo / Splint / MkDocs jobs unchanged in substance (only `needs:` + `if:` guards added) — they still run + must pass on a PR that touches their paths (verified on this PR, which touches both workflow files).
- CI-config only; no code tests.

Closes rf2-aemyt.