### PR TITLE
fix(xray): unify machine node-id scheme to machines-viz injective hex-escape (rf2-m8kod)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machines/topology.cljs
@@ -61,7 +61,7 @@
        in the focused epoch.
     2. The `:state` field of the machine's live snapshot map.
     3. nil — no current-state overlay rendered."
-  (:require [clojure.string :as str]))
+  (:require [day8.re-frame2-machines-viz.chart.layout :as chart-layout]))
 
 ;; ---- state walking ------------------------------------------------------
 
@@ -81,18 +81,21 @@
     :else             nil))
 
 (defn- node-id-for-path
-  "Stable string id for a state path. Matches `chart-layout/node-id`'s
-  shape so node-ids resolve consistently across renderers."
+  "Stable string id for a state path. DELEGATES to the canonical
+  machines-viz `chart.layout/node-id` — the single source of truth for
+  the machine node-id scheme (rf2-ee38b.21 · rf2-m8kod).
+
+  Why delegate rather than re-implement: the old local body used the
+  non-injective `[^a-zA-Z0-9_] → _` collapse, which MERGED `:a/b`,
+  `:a-b`, and `:a_b` onto the same id. The Xray topology overlay and
+  the live MachineChart must address nodes identically, so any future
+  'highlight fired edges on the live chart' wiring (rf2-qeemm/B8) would
+  silently mis-target with two divergent schemes. `chart.layout/node-id`
+  is the injective hex-escape scheme (`_<hex>` per non-alnum char, `_2f`
+  namespace separator, `__` path join); using it directly keeps the two
+  renderers in lockstep by construction."
   [path]
-  (->> path
-       (map (fn [p]
-              (if (keyword? p)
-                (if-let [ns (namespace p)]
-                  (str ns "_" (name p))
-                  (name p))
-                (str p))))
-       (str/join "__")
-       (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
+  (chart-layout/node-id path))
 
 (defn- walk-states
   "Walk a `{state-id state-node}` map under `parent-path`; emit a flat

--- a/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machines/topology_cljs_test.cljs
@@ -3,6 +3,7 @@
   spec/021 §6 + §17.4). The projector is JS/React-free; tests run
   under :node-test with zero DOM harness."
   (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-machines-viz.chart.layout :as chart-layout]
             [day8.re-frame2-xray.panels.machines.topology :as topology]))
 
 (defn- toy-definition
@@ -489,3 +490,103 @@
                                     :event :submit}]}]]
       (is (= [:submitting]
              (topology/current-state-from-epoch-history history :cart))))))
+
+;; ---- rf2-m8kod: node-id scheme parity with machines-viz ----------------
+;;
+;; The Xray topology overlay and the live MachineChart MUST address nodes
+;; with the SAME string ids — otherwise any future "highlight fired edges
+;; on the live chart" wiring (rf2-qeemm/B8) silently mis-targets. The old
+;; Xray-local `node-id-for-path` used the non-injective `[^a-zA-Z0-9_] → _`
+;; collapse, which MERGED `:a/b`, `:a-b`, `:a_b` onto one id; it now
+;; delegates to the canonical injective hex-escape scheme
+;; `chart.layout/node-id`. These tests pin that the two schemes agree id-
+;; for-id (driven through the public `project` API, which uses the private
+;; `node-id-for-path` for every node `:id`) AND that the collision triples
+;; mint DISTINCT ids.
+
+(defn- machine-from-state-ids
+  "Build a flat single-level machine whose top-level state-ids are
+  `state-ids`, so projecting it exercises `node-id-for-path` over each
+  `[state-id]` path. The first state is the `:initial`."
+  [state-ids]
+  {:initial (first state-ids)
+   :states  (into {} (map (fn [id] [id {}]) state-ids))})
+
+(deftest node-id-parity-flat-paths
+  (testing "every projected node :id matches chart-layout/node-id for its path"
+    (let [state-ids [:empty :populated :logged-in :rate-limited
+                     :a/b :a-b :a_b :foo.bar/baz :x+y :state?]
+          out       (topology/project
+                      {:definition (machine-from-state-ids state-ids)})
+          ;; project carries the source path on :data :path — pair it
+          ;; with the minted :id so we can compare against the canonical fn.
+          id-by-path (into {} (map (juxt #(-> % :data :path) :id)
+                                   (:nodes out)))]
+      (doseq [id state-ids]
+        (let [path [id]]
+          (is (= (chart-layout/node-id path) (get id-by-path path))
+              (str "node-id parity for path " (pr-str path))))))))
+
+(deftest node-id-parity-nested-paths
+  (testing "compound (nested-vector) paths match chart-layout/node-id"
+    (let [def {:initial :unauth
+               :states  {:unauth {:on {:login :authed}}
+                         :authed {:initial :browsing
+                                  :states  {:browsing {:on {:checkout :rate-limited}}
+                                            :rate-limited {:on {:retry :browsing}}}}}}
+          out (topology/project {:definition def})
+          id-by-path (into {} (map (juxt #(-> % :data :path) :id)
+                                   (:nodes out)))]
+      (doseq [[path id] id-by-path]
+        (is (= (chart-layout/node-id path) id)
+            (str "nested node-id parity for path " (pr-str path)))))))
+
+(deftest node-id-collision-triples-mint-distinct-ids
+  (testing ":a/b vs :a-b vs :a_b project to THREE distinct node ids"
+    (let [state-ids [:a/b :a-b :a_b]
+          out       (topology/project
+                      {:definition (machine-from-state-ids state-ids)})
+          ids       (mapv :id (:nodes out))]
+      (is (= 3 (count (:nodes out)))
+          "all three states survive (no id-collision drop)")
+      (is (= 3 (count (set ids)))
+          "the three ids are pairwise distinct (injective scheme)")
+      ;; And the canonical scheme is itself injective for the triple.
+      (is (apply distinct?
+                 [(chart-layout/node-id [:a/b])
+                  (chart-layout/node-id [:a-b])
+                  (chart-layout/node-id [:a_b])])
+          "canonical scheme is itself injective for the triple"))))
+
+(deftest edge-ids-built-from-canonical-node-ids
+  (testing "topology edge :source / :target are the canonical node ids"
+    (let [def {:initial :a-b
+               :states  {:a-b {:on {:go :a/b}}
+                         :a/b {}}}
+          out (topology/project {:definition def})
+          e   (first (:edges out))]
+      (is (= (chart-layout/node-id [:a-b]) (:source e))
+          "edge :source uses the canonical from-node id")
+      (is (= (chart-layout/node-id [:a/b]) (:target e))
+          "edge :target uses the canonical to-node id")
+      ;; The collision triple no longer fuses source + target into one id.
+      (is (not= (:source e) (:target e))
+          ":a-b and :a/b stay distinct across an edge"))))
+
+(deftest extract-fired-edge-ids-uses-canonical-node-ids
+  (testing "fired-edge-id composite agrees with the projected edge :id"
+    (let [def    {:initial :rate-limited
+                  :states  {:rate-limited {:on {:retry :logged-in}}
+                            :logged-in    {}}}
+          graph  (topology/project {:definition def})
+          retry-id (some (fn [e] (when (= "retry" (:label e)) (:id e)))
+                         (:edges graph))
+          events [{:operation :rf.machine/transition
+                   :tags      {:machine-id :sess}
+                   :from      [:rate-limited] :to [:logged-in]
+                   :event     :retry}]
+          fired  (topology/extract-fired-edge-ids events :sess)]
+      (is (string? retry-id))
+      (is (= #{retry-id} fired)
+          "the fired-edge composite (built from node-id-for-path) matches
+           the projected edge id — so live-chart highlight wiring lands"))))


### PR DESCRIPTION
## What

Unifies the two divergent machine node-id schemes (epic rf2-tt1lt B3, research rf2-ox50v).

The Xray topology projector (`tools/xray/.../panels/machines/topology.cljs`) carried its own `node-id-for-path` using the **OLD non-injective** `[^a-zA-Z0-9_] -> _` collapse, which MERGES `:a/b`, `:a-b`, and `:a_b` onto the same id. machines-viz's `chart.layout/node-id` is the canonical **injective hex-escape** scheme (rf2-ee38b.21): every non-alnum char becomes `_<hex>`, namespace separator `_2f`, segments joined `__`.

The collision is latent today (the Xray-local edge-ids feed only an emptiness-check + a data-attribute, not the live chart), but it would **silently mis-target** any future "highlight fired edges on the live chart" wiring (rf2-qeemm/B8): the overlay and the live MachineChart must address nodes identically.

## Fix

- `node-id-for-path` now **DELEGATES** to `chart.layout/node-id` — single source of truth. Xray already deps on machines-viz, and sibling panels (`machine_inspector`, `machine_after_rings`) already require its `chart.layout`.
- The edge-id composites and `extract-fired-edge-ids` build from `node-id-for-path`, so they inherit the canonical scheme by construction.
- Dropped the now-unused `clojure.string` require.

## Parity test battery

- Every projected node id matches `chart.layout/node-id` for flat + nested paths (incl. `+ ? . /` special chars).
- The collision triple `:a/b` / `:a-b` / `:a_b` mints **three DISTINCT** ids (no node-drop).
- Edge `:source`/`:target` use the canonical node ids; `:a-b` and `:a/b` stay distinct across an edge.
- The `extract-fired-edge-ids` composite agrees with the projected edge `:id` (so live-chart highlight wiring lands).

## Gates

- `npm run test:cljs` — 4283 tests, 0 failures
- `tools/xray clojure -M:test` — 876 tests / 2941 assertions, 0 failures (incl. 5 new parity tests)
- clj-kondo (touched files) — 0 errors, 0 warnings
- splint (touched files) — 0 errors, 0 new warnings (3 pre-existing warnings, none in new code)

Refs rf2-m8kod.