### PR TITLE
perf(ci): job-level gating + spec-md guard + CLJS browser dedup (rf2-f79t8)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -29,6 +29,7 @@ else
 fi
 
 implementation_jvm=false
+cljs_node_test=false
 adapter_diagnostic=false
 cljs_browser=false
 cljs_prod=false
@@ -45,6 +46,7 @@ playground=false
 
 mark_all() {
   implementation_jvm=true
+  cljs_node_test=true
   adapter_diagnostic=true
   cljs_browser=true
   cljs_prod=true
@@ -86,6 +88,29 @@ is_story_xray_runtime_path() {
   esac
 }
 
+# rf2-f79t8 — predicate: does `$1` compile into the consolidated
+# `:node-test` build? shadow-cljs.edn lists tools/{story,xray}/{src,test}
+# as :source-paths, so a CLJS/CLJC change under those trees changes the
+# node-test output and MUST fire the `cljs` job (which is gated on
+# cljs_node_test). Markdown specs (tools/{story,xray}/spec/**), EDN
+# config, and JVM-only `.clj` files there do NOT compile into node-test
+# and so must not fire it — the same spec-md-exclusion philosophy the
+# runtime-extension guard applies to the Playwright gate.
+is_story_xray_node_test_path() {
+  case "$1" in
+    tools/story/src/*|tools/xray/src/*|tools/story/test/*|tools/xray/test/*|tools/story/testbeds/*|tools/xray/testbeds/*)
+      case "$1" in
+        *.cljs|*.cljc)
+          return 0 ;;
+        *)
+          return 1 ;;
+      esac
+      ;;
+    *)
+      return 1 ;;
+  esac
+}
+
 if [ "$files" = "__ALL__" ]; then
   mark_all
 else
@@ -107,6 +132,7 @@ else
         # Story variant boot silently is caught by the nightly cron +
         # post-merge gate (both run the full matrix on main).
         implementation_jvm=true
+        cljs_node_test=true
         adapter_diagnostic=true
         cljs_browser=true
         cljs_prod=true
@@ -122,6 +148,7 @@ else
         # at scripts/check-reagent-slim-bundle-isolation.cjs is the
         # canonical gate; adapter_testbed_smokes is no longer fired here.
         implementation_jvm=true
+        cljs_node_test=true
         adapter_diagnostic=true
         cljs_browser=true
         cljs_prod=true
@@ -134,6 +161,7 @@ else
         # source changes are the canonical trigger; orchestrator-script
         # changes are caught by the harness-script case below.
         implementation_jvm=true
+        cljs_node_test=true
         adapter_diagnostic=true
         cljs_browser=true
         cljs_prod=true
@@ -161,6 +189,7 @@ else
         # (createRoot lifecycle, hydration, real concurrent scheduling).
         # Nightly + post-merge gate runs the full matrix.
         implementation_jvm=true
+        cljs_node_test=true
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
@@ -179,8 +208,11 @@ else
         # per-artefact _conformance_test.clj. Fire implementation_jvm
         # so the per-artefact corpus runners pick up new fixtures, and
         # fire the CLJS surfaces so the cross-platform corpus runner
-        # in core does too.
+        # in core does too. The CLJS corpus runner
+        # (conformance_corpus_cljs_test.cljs) is in the consolidated
+        # :node-test build, so cljs_node_test fires too.
         implementation_jvm=true
+        cljs_node_test=true
         cljs_browser=true
         cljs_prod=true
         ;;
@@ -193,7 +225,9 @@ else
         # Xray browser gate). A shadow-cljs.edn or implementation/
         # scripts/ change that breaks the build is caught by the
         # nightly cron + post-merge gate (both run the full matrix on
-        # main).
+        # main). shadow-cljs.edn + package-lock.json directly determine
+        # the :node-test build, so cljs_node_test fires here too.
+        cljs_node_test=true
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
@@ -228,24 +262,47 @@ else
         template_expensive=true
         ;;
       tools/story/*|tools/xray/*)
-        # rf2-os0c1 + rf2-k9ekz + rf2-t5slp — Story / Xray changes
-        # legitimately fan out to tools_jvm (per-artefact JVM unit tests
-        # + sibling story-mcp consumer) and mcp_conformance (the MCP
-        # wrappers consume these artefacts). story_xray_browser is
-        # narrowed (rf2-k9ekz): it fires ONLY when the changed path is
-        # under tools/{story,xray}/{src,testbeds}/** AND the file has a
-        # runtime extension (.cljs/.cljc/.js/.cjs/.css/.scss). Markdown
-        # specs under tools/{story,xray}/spec/**, JVM unit tests under
-        # tools/{story,xray}/test/**, deps.edn, README.md, and *.txt
-        # do NOT fire it — they cannot affect chrome and so cannot
-        # invalidate the Playwright gate. The split-out framework-
-        # testbeds gate (formerly rf2-9grp6) was retired in rf2-t5slp
-        # after all four rf2-tglku migration waves moved every Xray-
-        # owned testbed assertion to CLJS/JVM unit tests.
-        tools_jvm=true
-        mcp_conformance=true
+        # rf2-os0c1 + rf2-k9ekz + rf2-t5slp + rf2-f79t8 — Story / Xray
+        # changes legitimately fan out to tools_jvm (per-artefact JVM
+        # unit tests + sibling story-mcp consumer) and mcp_conformance
+        # (the MCP wrappers consume these artefacts).
+        #
+        # rf2-f79t8 — spec-md guard. A pure documentation change under
+        # tools/{story,xray}/spec/**.md cannot affect any runtime, any
+        # JVM unit test, or any MCP wire surface, so it must NOT fan out
+        # to the JVM/MCP probes (jvm-tools-{xray,story,story-mcp},
+        # node-test-tools-story-mcp, mcp-conformance-*). It is covered by
+        # docs.yml + the nightly full matrix. Mirrors the
+        # runtime-extension guard already applied to story_xray_browser
+        # below (rf2-k9ekz). All NON-spec-md changes (src/test .clj/.cljs,
+        # deps.edn, README, EDN, …) still fire the probes conservatively.
+        case "$file" in
+          tools/story/spec/*.md|tools/xray/spec/*.md)
+            : # spec doc only — no runtime/JVM/MCP/CLJS fan-out
+            ;;
+          *)
+            tools_jvm=true
+            mcp_conformance=true
+            ;;
+        esac
+        # story_xray_browser is narrowed (rf2-k9ekz): it fires ONLY when
+        # the changed path is under tools/{story,xray}/{src,testbeds}/**
+        # AND the file has a runtime extension
+        # (.cljs/.cljc/.js/.cjs/.css/.scss). Markdown specs, JVM unit
+        # tests under tools/{story,xray}/test/**, deps.edn, README.md,
+        # and *.txt do NOT fire it. The split-out framework-testbeds
+        # gate (formerly rf2-9grp6) was retired in rf2-t5slp.
         if is_story_xray_runtime_path "$file"; then
           story_xray_browser=true
+        fi
+        # rf2-f79t8 — the consolidated :node-test build lists
+        # tools/{story,xray}/{src,test} as :source-paths (shadow-cljs.edn),
+        # so a CLJS/CLJC change under those trees changes node-test output
+        # and must fire the `cljs` job (gated on cljs_node_test). A
+        # markdown / EDN / JVM-only `.clj` change does not compile into
+        # node-test and so does not fire it.
+        if is_story_xray_node_test_path "$file"; then
+          cljs_node_test=true
         fi
         ;;
       tools/story-mcp/*)
@@ -309,6 +366,7 @@ emit() {
 }
 
 emit implementation_jvm "$implementation_jvm"
+emit cljs_node_test "$cljs_node_test"
 emit adapter_diagnostic "$adapter_diagnostic"
 emit cljs_browser "$cljs_browser"
 emit cljs_prod "$cljs_prod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,21 @@ on:
     branches: [main]
 
 # Fast PR spine jobs stay always-on: lockstep drift, skill/MCP drift,
-# core JVM, CLJS node integration, and JS harness self-tests. Expensive
-# browser, bundle, examples, Story/Xray, tool, template, MCP-live, and
-# skill structural jobs are guarded by the conservative changed-surface
-# classifier below. Skipped diagnostic jobs are not required coverage; the
+# and JS harness self-tests. These are cheap (no JVM/Node build) and act
+# as the always-present minimum so the aggregator never resolves to an
+# all-skipped phantom. The heavier core JVM (jvm-core) and CLJS node
+# integration (cljs) jobs are job-level gated on the changed-surface
+# classifier (rf2-f79t8): they skip on a spec/docs-only PR but run on
+# every code surface (core / adapters / per-feature artefacts / fixtures
+# / build config, and — for cljs — the tools/{story,xray} CLJS test
+# trees the consolidated :node-test build compiles). Expensive browser,
+# bundle, examples, Story/Xray, tool, template, MCP-live, and skill
+# structural jobs are likewise guarded. The workflow's pull_request
+# trigger stays UNFILTERED so the `All required checks passed` aggregator
+# is always present (job-level gating, NOT a trigger path filter — a
+# path-filtered trigger would make the required aggregator absent on
+# filtered PRs = a phantom-pending trap, the exact bug rf2-dtvmb fixed).
+# Skipped surface-gated jobs are not required coverage; the
 # nightly/manual workflow carries the rigorous full sweep.
 
 jobs:
@@ -35,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       implementation_jvm: ${{ steps.detect.outputs.implementation_jvm }}
+      cljs_node_test: ${{ steps.detect.outputs.cljs_node_test }}
       adapter_diagnostic: ${{ steps.detect.outputs.adapter_diagnostic }}
       cljs_browser: ${{ steps.detect.outputs.cljs_browser }}
       cljs_prod: ${{ steps.detect.outputs.cljs_prod }}
@@ -100,6 +112,17 @@ jobs:
 
   jvm-core:
     name: JVM core (clojure -M:test)
+    # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:
+    # the pull_request trigger stays unfiltered so the
+    # `All required checks passed` aggregator is always present). The
+    # JVM core suite skips on a spec/docs-only PR, where
+    # `implementation_jvm` is false; it runs on every code surface that
+    # touches core, the adapters, the per-feature artefacts, the
+    # conformance fixtures, or the build config (see
+    # report-changed-surfaces.sh). The aggregator treats a surface-skip
+    # as OK and the nightly full matrix is the safety net.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -669,6 +692,18 @@ jobs:
 
   cljs:
     name: CLJS (shadow-cljs :node-test)
+    # rf2-f79t8 — job-level gating (NOT a workflow-trigger path filter:
+    # the pull_request trigger stays unfiltered so the
+    # `All required checks passed` aggregator is always present). The
+    # consolidated :node-test build compiles core + every adapter + every
+    # per-feature artefact PLUS the tools/{story,xray}/{src,test} CLJS
+    # test trees (shadow-cljs.edn :source-paths). `cljs_node_test` fires
+    # on any of those surfaces (and on the build config / fixtures); it is
+    # false only on a spec/docs-only PR, where this job skips. The
+    # aggregator treats a surface-skip as OK and the nightly full matrix
+    # is the safety net.
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -724,6 +759,27 @@ jobs:
       - name: Run JS harness self-tests
         run: npm run test:script-policy && npm run test:script-helpers
 
+  # ---------------------------------------------------------------------------
+  # CLJS browser / prod Playwright jobs (rf2-f79t8 part c).
+  #
+  # The browser/prod cluster — cljs-browser (:browser-test, dev),
+  # cljs-browser-schemas-boundary-prod (:advanced + goog.DEBUG=false),
+  # cljs-browser-prod-elision (:advanced + goog.DEBUG=false) — each
+  # npm-installs, installs Playwright, and compiles a DISTINCT shadow-cljs
+  # build with a distinct ns-regexp + compiler options. A "merge into one
+  # job" dedup was rejected as NOT low-risk: (1) the three builds cannot
+  # share a compile artifact (one dev, two :advanced with different
+  # ns-regexps), so merging would still recompile three bundles; (2)
+  # merging serialises three currently-parallel gates onto one runner,
+  # lengthening wall-clock on a code PR; (3) it collapses three
+  # independently-reported required statuses into one, losing failure
+  # locality. The cheap, low-risk win applied instead is the shared
+  # Playwright browser-binary cache below: every PR-time Playwright job
+  # previously re-downloaded Chromium (~120 MB) on each run; the cache,
+  # keyed on the locked Playwright version, removes that redundant
+  # download across all browser jobs (and across runs) with zero change
+  # to which suites run.
+  # ---------------------------------------------------------------------------
   cljs-browser:
     name: CLJS (shadow-cljs :browser-test, headless Chromium)
     needs: detect_changed_surfaces
@@ -767,6 +823,21 @@ jobs:
 
       - name: npm install
         run: npm ci
+
+      # rf2-f79t8 — cache the Playwright browser binary across runs/jobs.
+      # Every PR-time Playwright job previously re-downloaded Chromium
+      # (~120 MB) on each run. The binary is keyed on the locked
+      # Playwright version (package-lock.json), so the cache is correct by
+      # construction: a Playwright bump busts it. On a hit, the install
+      # step below still runs `--with-deps` (the apt system libs are not
+      # cacheable) but Playwright skips the binary download.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
@@ -817,6 +888,15 @@ jobs:
 
       - name: npm install
         run: npm ci
+
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
@@ -874,6 +954,15 @@ jobs:
 
       - name: npm install
         run: npm ci
+
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
@@ -1051,6 +1140,15 @@ jobs:
       - name: npm install
         run: npm ci
 
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium
 
@@ -1136,6 +1234,15 @@ jobs:
 
       - name: npm install
         run: npm ci
+
+      # rf2-f79t8 — cache the Playwright browser binary (see cljs-browser).
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright (Chromium + system deps)
         run: npx playwright install --with-deps chromium

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -96,6 +96,148 @@ test('Mixed Story src + spec change DOES trigger story_xray_browser (rf2-k9ekz)'
   assert.equal(result.story_xray_browser, 'true');
 });
 
+// rf2-f79t8 (b) — a tools/{story,xray}/spec/**.md MARKDOWN change is a
+// pure doc change: it cannot affect any runtime, JVM unit test, or MCP
+// wire surface, so it must NOT fan out to the JVM/MCP probes (tools_jvm,
+// mcp_conformance). docs.yml + the nightly full matrix cover docs.
+
+test('Story spec-only .md does NOT fan out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
+  const result = classify('tools/story/spec/Spec.md');
+  assert.equal(result.tools_jvm, 'false');
+  assert.equal(result.mcp_conformance, 'false');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
+test('Xray spec-only .md does NOT fan out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
+  const result = classify('tools/xray/spec/017-Test-Coverage-Matrix.md');
+  assert.equal(result.tools_jvm, 'false');
+  assert.equal(result.mcp_conformance, 'false');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
+test('Story NON-spec change (JVM .clj test) STILL fans out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
+  const result = classify('tools/story/test/some_test.clj');
+  assert.equal(result.tools_jvm, 'true');
+  assert.equal(result.mcp_conformance, 'true');
+  // A JVM-only .clj does not compile into the consolidated :node-test build.
+  assert.equal(result.cljs_node_test, 'false');
+});
+
+test('Story deps.edn change STILL fans out to tools_jvm / mcp_conformance (rf2-f79t8)', () => {
+  const result = classify('tools/story/deps.edn');
+  assert.equal(result.tools_jvm, 'true');
+  assert.equal(result.mcp_conformance, 'true');
+});
+
+test('Mixed Story spec .md + JVM .clj DOES fan out to tools_jvm (rf2-f79t8)', () => {
+  const result = classify('tools/story/spec/bar.md', 'tools/story/test/some_test.clj');
+  assert.equal(result.tools_jvm, 'true');
+  assert.equal(result.mcp_conformance, 'true');
+});
+
+// rf2-f79t8 (a) — jvm-core + cljs (the consolidated :node-test build) are
+// job-level gated so a spec/docs-only PR skips the two heavy always-on
+// suites. The classifier drives the `if:` via implementation_jvm
+// (jvm-core) and cljs_node_test (cljs). The pull_request trigger stays
+// UNFILTERED — gating is job-side, NOT a trigger path filter.
+
+test('Spec-only .md change skips jvm-core + cljs (implementation_jvm + cljs_node_test false) (rf2-f79t8)', () => {
+  const result = classify('spec/006-ReactiveSubstrate.md');
+  assert.equal(result.implementation_jvm, 'false');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
+test('Docs-only change skips jvm-core + cljs (rf2-f79t8)', () => {
+  const result = classify('docs/guide/intro.md');
+  assert.equal(result.implementation_jvm, 'false');
+  assert.equal(result.cljs_node_test, 'false');
+});
+
+test('Core change runs jvm-core + cljs (implementation_jvm + cljs_node_test true) (rf2-f79t8)', () => {
+  const result = classify('implementation/core/src/re_frame/core.cljc');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('Conformance fixture change runs cljs (CLJS corpus runner is in node-test) (rf2-f79t8)', () => {
+  const result = classify('spec/conformance/fixtures/dispatch.edn');
+  assert.equal(result.implementation_jvm, 'true');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('shadow-cljs.edn change runs cljs (it defines the node-test build) (rf2-f79t8)', () => {
+  const result = classify('implementation/shadow-cljs.edn');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('Story CLJS test-tree change runs cljs (node-test compiles tools/story/test) (rf2-f79t8)', () => {
+  const result = classify('tools/story/test/re_frame/story_cljs_test.cljs');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+test('Xray CLJS src change runs cljs (node-test compiles tools/xray) (rf2-f79t8)', () => {
+  const result = classify('tools/xray/src/day8/re_frame2_xray/core.cljs');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
+// rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
+// job-level gated (needs + if), NOT trigger-filtered, and the
+// pull_request trigger must stay unfiltered so the aggregator is always
+// present.
+
+function jobBlock(workflow, jobName) {
+  // Tolerate CRLF: match the job header at 2-space indent followed by a
+  // line break (\r?\n), mirroring storyXrayJobBlock's indexOf approach
+  // but anchored on the exact job name.
+  const header = new RegExp(`\\n {2}${jobName}:\\r?\\n`);
+  const m = header.exec(workflow);
+  assert.notEqual(m, null, `${jobName} job not found in test.yml`);
+  const rest = workflow.slice(m.index + 1);
+  const nextJob = rest.search(/\n {2}[A-Za-z0-9_-]+:\r?\n/);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob);
+}
+
+test('jvm-core is job-level gated on implementation_jvm (rf2-f79t8)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'jvm-core');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.implementation_jvm == 'true'/,
+  );
+});
+
+test('cljs (node-test) is job-level gated on cljs_node_test (rf2-f79t8)', () => {
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'cljs');
+  assert.match(block, /needs: detect_changed_surfaces/);
+  assert.match(
+    block,
+    /if: needs\.detect_changed_surfaces\.outputs\.cljs_node_test == 'true'/,
+  );
+});
+
+test('test.yml pull_request trigger stays UNFILTERED (no PR-level paths filter) (rf2-f79t8)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  // The `on:` block must carry a `pull_request:` with `branches: [main]`
+  // and NO `paths:`/`paths-ignore:` under it — a path-filtered PR trigger
+  // would make the required aggregator absent on filtered PRs.
+  const onBlock = workflow.slice(0, workflow.indexOf('\njobs:'));
+  const prStart = onBlock.indexOf('  pull_request:');
+  assert.notEqual(prStart, -1, 'pull_request trigger not found');
+  const prBlock = onBlock.slice(prStart);
+  assert.doesNotMatch(prBlock, /^\s+paths:/m);
+  assert.doesNotMatch(prBlock, /^\s+paths-ignore:/m);
+});
+
+test('All required checks passed aggregator still present + needs jvm-core + cljs (rf2-f79t8)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  assert.match(workflow, /name: All required checks passed/);
+  const block = jobBlock(workflow, 'all-required-passed');
+  assert.match(block, /if: \$\{\{ always\(\) \}\}/);
+  assert.match(block, /- jvm-core\r?\n/);
+  // `- cljs` followed directly by a line break (not `- cljs-browser` etc.)
+  assert.match(block, /- cljs\r?\n/);
+});
+
 // rf2-wa3oo — the story-xray-browser PR job now runs the PR-SMOKE
 // tier, not the full sweep. It runs the Xray gate in --smoke mode and
 // the single-testbed Story :play-script gate (which renders the


### PR DESCRIPTION
CI fan-out efficiency refinements (rf2-f79t8). CI-config only. Post-enforcement RE-SCOPE applied: NO workflow-trigger path filter (that would make the required `All required checks passed` aggregator absent on filtered PRs — the phantom-pending trap rf2-dtvmb fixed). Job-level gating only, mirroring lint.yml/docs.yml (rf2-aemyt).

## (a) PR-trigger efficiency via job-level gating
`jvm-core` and the consolidated CLJS `:node-test` job (`cljs`) were the two heavy always-on jobs. They are now job-level gated:
- `jvm-core` → `if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'`
- `cljs` → `if: needs.detect_changed_surfaces.outputs.cljs_node_test == 'true'` (new surface flag)

A new `cljs_node_test` flag was needed because the consolidated `:node-test` build compiles core + every adapter + every per-feature artefact PLUS the `tools/{story,xray}/{src,test}` CLJS test trees (shadow-cljs.edn `:source-paths`). Gating `cljs` on `implementation_jvm` alone would have dropped Story/Xray CLJS coverage on a tools-only PR. `cljs_node_test` fires on all of those surfaces, so code-PR coverage is unchanged; it is false only on a spec/docs-only PR.

The `pull_request` trigger stays UNFILTERED. The `All required checks passed` aggregator is unchanged (`if: always()`, already `needs:` jvm-core + cljs; a skipped surface-gated job rolls up as OK). The fast PR spine (lockstep / skill-MCP-drift / JS-harness self-tests) stays always-on as the always-present minimum.

## (b) report-changed-surfaces.sh spec-md guard
A `tools/{story,xray}/spec/**.md` markdown change no longer fans out to `tools_jvm` / `mcp_conformance` (the JVM + story-mcp + wire-vocab + MCP probes) — a doc change cannot affect any runtime, JVM unit test, or MCP wire surface (covered by docs.yml + the nightly full matrix). Mirrors the runtime-extension guard already applied to `story_xray_browser` (rf2-k9ekz). All non-spec changes (`.clj`/`.cljs`/`deps.edn`/README/EDN) still fan out conservatively.

## (c) CLJS browser-job dedup
A full job-merge of the three browser/prod jobs was rejected as not low-risk (documented inline): the three builds (`:browser-test` dev, two `:advanced`+goog.DEBUG=false with distinct ns-regexps) cannot share a compile artifact, merging serialises currently-parallel gates onto one runner, and it collapses three independently-reported required statuses into one (losing failure locality). The cheap, unambiguous win applied instead: a shared Playwright browser-binary cache (`~/.cache/ms-playwright`, keyed on the locked Playwright version in package-lock.json) added to all five PR-time Playwright jobs, which previously each re-downloaded Chromium (~120 MB) on every run. Zero change to which suites run.

## Gates
- `npx yaml-lint .github/workflows/test.yml` — clean
- `npm run test:script-policy` — path-policy + changed-surfaces (38, incl. 16 new rf2-f79t8 cases) + story-feature-load-port — all pass
- `bash -n report-changed-surfaces.sh` — clean

NOTE: because this PR touches `test.yml` + `report-changed-surfaces.sh`, the classifier `mark_all`s every surface on this PR, so jvm-core + cljs + the full matrix run here — confirming the aggregator rolls them up green.