### PR TITLE
feat(machines-viz): parallel multi-active highlight — region-map current-state (rf2-yoe6e, rf2-g2svr)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -170,7 +170,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 |---|---|---|
 | **Hierarchy** | ✅ Compound parents render as a dashed container with a header-strip title; children nest via xyflow `parentNode` + `extent:"parent"`; elk lays children inside the parent box (`INCLUDE_CHILDREN`). Nesting recurses (compound-in-compound, compound-in-region). | `nodes.cljs` `compound-node`; `projection.cljc` `->elk-children` (`:parent-id` grouping), `xyflow-graph` (`parentNode`/`extent`); `layout.cljc` `parse-flat` (`:parent-id` on nested nodes). |
 | **Parallel regions — structure** | ✅ **Every** region renders as a synthetic `:region?` compound node with a **distinct dashed boundary per region** (palette rotation) + `∥` glyph + region label; states carry `:region` + `:parent-id`; edges stay region-local. | `layout.cljc` `parse-parallel`/`region-node-id`; `projection.cljc` (`type "parallel-region"`); `nodes/parallel_region_node.cljs`. |
-| **Parallel regions — active highlight** | ⚠️ **Partial.** `highlight-id` resolves a keyword **or** a vector path; it returns **nil for a region-map** `{region path}`. A parallel snapshot has **N simultaneously-active leaves** but the chart can light up **at most one**. | `layout.cljc` `highlight-id` (handles keyword/vector only); `projection.cljc` `xyflow-graph` (single `:highlight-id`). |
+| **Parallel regions — active highlight** | ✅ **Closed (rf2-yoe6e / rf2-g2svr).** `highlight-ids` resolves the whole snapshot `:state` — flat keyword, compound path, **or region-map** `{region path}` — to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so a parallel snapshot's **N simultaneously-active leaves** all light up at once. A nested region value resolves to its deepest leaf. | `layout.cljc` `highlight-ids`; `projection.cljc` `xyflow-graph` (`:highlight-ids` set). |
 | **Transition scoping** | ✅ `:on`, `:after`, `:always`, machine-level (top-level `:on`) fallback, external + internal self-transitions, vector-of-candidates forks. Self-loops render as a small loop (not a degenerate bezier); internal self-transitions render dashed + no arrowhead. | `layout.cljc` `collect-state-edges`, `collect-machine-edges`, `resolve-target-path`; `edges.cljs` (self-loop path, internal dash). |
 | **Initial** | ✅ Filled-dot `initial-marker` node + unlabelled entry edge into the initial state, at **every** compound level (xstate/SCXML semantics). | `nodes.cljs` `initial-marker`; `projection.cljc` (marker-nodes + entry-edges); `layout.cljc` `collect-nodes` (per-level `:initial?`). |
 | **Final** | ✅ Doubled border (outer ring 1px proud) + `✓` glyph inline on `state-node`. | `nodes.cljs` `state-node` (final ring + glyph). |
@@ -184,9 +184,12 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 
 **Headline:** structurally **at parity** on hierarchy, regions
 (layout), initial, final, transition scoping, event labels,
-guards/actions, layout, and ergonomics. **Two real capability gaps**
-remain (parallel multi-active highlight; bend-point edge routing), plus
-two **fired-edge consistency** items the live-chart wiring needs.
+guards/actions, layout, and ergonomics. The high-severity **parallel
+multi-active highlight** gap (G1) is now **closed** (rf2-yoe6e /
+rf2-g2svr); **one capability gap** remains (bend-point edge routing,
+G2), plus two **fired-edge consistency** items the live-chart wiring
+needs and the region-ACTIVE chrome polish (G4) that completes the
+parallel-parity read.
 
 ## §3 — Gap analysis + deliberate divergences
 
@@ -197,7 +200,7 @@ new), and the parity-bar row it serves.
 
 | # | Gap | Severity | Serves bar | Bead |
 |---|---|---|---|---|
-| **G1** | **Parallel multi-active highlight.** A parallel snapshot's `:state` is a region-map `{region path}` with **N active leaves**; `highlight-id` returns nil for a map, so the chart highlights **none** (or only a degenerate single id). Stately lights up **every** active region at once (§1.2). This is the **single most concrete missing capability**. | **High** | §1.2, §1.9 | **contract:** rf2-yoe6e (existing) · **impl:** rf2-g2svr (existing) |
+| **G1** | ✅ **CLOSED (rf2-yoe6e / rf2-g2svr).** Was: a parallel snapshot's `:state` is a region-map `{region path}` with **N active leaves**; `highlight-id` returned nil for a map, so the chart highlighted **none** (or only a degenerate single id). Now: `highlight-ids` resolves the whole `:state` (flat / compound / region-map, nested values → deepest leaf) to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so all N regions light up at once — Stately's §1.2 read. | **High** | §1.2, §1.9 | **contract:** rf2-yoe6e ✅ · **impl:** rf2-g2svr ✅ |
 | **G2** | **elk bend-point edge routing.** Edges are beziers between handles; elk's Layered bend-points (ORTHOGONAL/polyline) are discarded (§1.7). In deep nesting, edges can cut **across** a region/compound container instead of routing **around** it — the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor at real machine sizes. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 (existing, deferred polish) |
 | **G3** | **Fired-edge id consistency (live chart).** To highlight "the edge that fired this epoch" on the live chart, the host's trace→edge-id mapping MUST mint the **same** `edge-id` `chart.layout` mints. Today the helper chain needs consolidating so `extract-fired-edge-ids` emits machines-viz `edge-id`s. (The node-id scheme was already unified — rf2-m8kod.) | **Medium** | §1.3, §1.8 | **helpers:** rf2-8jzm1 (existing) · **wire:** rf2-qeemm (existing) |
 | **G4** | **Parallel-region chrome polish for the active read.** Once G1 lights up N regions, the **region container** should reflect "this region is active" (vs. structural-only chrome today) so a reader scanning N regions sees the active leaf in each at a glance — region-header active affordance + per-region active-leaf emphasis that reads as a set, not N independent highlights. | **Low–Medium** | §1.2 | **NEW — see §5 N1** |

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -52,7 +52,7 @@ registry).
 |---|---|---|---|
 | `:machine-id` | no | `nil` | Identifies the machine. Surfaces as the chart's aria-label and on every per-node `:data` payload (read by tests + hosts). |
 | `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
-| `:current-state` | no | `nil` | The live `:state` keyword/vector for the active-state highlight. `nil` renders no highlight. |
+| `:current-state` | no | `nil` | The live snapshot `:state` value for the active-state highlight. Accepts all three Spec 005 `:state` arms: a flat keyword (`:authing`), a hierarchical path (`[:auth :authing]`), **or a parallel region-map** (`{:data :loading :form :neutral}`). For a region-map the chart lights up **every** active region leaf simultaneously (the multi-active highlight — see [§Parallel multi-active highlight](#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)). `nil` renders no highlight. |
 | `:from-highlight` | no | `nil` | Focused-event lens origin (a `:state` value). |
 | `:to-highlight` | no | `nil` | Focused-event lens landing (a `:state` value). |
 | `:sim?` | no | `nil` | Flips the highlight palette to amber for the simulator path. |
@@ -93,6 +93,61 @@ each region's bounding box via `elk.hierarchyHandling
 INCLUDE_CHILDREN`. The chart root surfaces `data-region-count`; region
 containers are excluded from `data-node-count` + the aria-label state
 count (they are zone chrome, not states).
+
+### Parallel multi-active highlight (rf2-yoe6e, rf2-g2svr)
+
+> Closes parity gap **G1** in
+> [`001-Topology-Parity.md`](001-Topology-Parity.md) §3.1 — the single
+> most concrete missing capability vs Stately. Stately lights up
+> **every** active region of a parallel state at once
+> ([§1.2 parity bar](001-Topology-Parity.md)); this contract makes
+> `MachineChart` do the same.
+
+A `{:type :parallel}` machine's snapshot `:state` is a **region-map** —
+`{region <keyword-or-path>}` — with **N simultaneously-active leaves**,
+one per region (Spec 005 §Snapshot shape, third arm). The chart marks
+**every** active leaf `:active` at once, so a reader sees the active
+state in each region simultaneously (not a single arbitrary highlight).
+
+The resolution is pure and JVM-tested, in two layers:
+
+- **`chart.layout/highlight-ids`** — the resolver. Takes the whole
+  snapshot `:state` and returns a **set of active-leaf node-ids**:
+  - flat keyword (`:authing`) → `#{(node-id [:authing])}` — singleton.
+  - hierarchical path (`[:auth :authing]`) → `#{(node-id [...])}` — the
+    singleton holding the **deepest leaf** (`node-id` of the full path).
+  - **region-map** (`{:data :loading :form :neutral}`) → the **set of N
+    leaves**. Each region value is a keyword-or-path **relative to that
+    region's own state-tree**, resolved via `node-id` of the in-region
+    path (the parse keeps a region state's in-region node-id; it does
+    not region-prefix it). A **nested region value** (a region whose
+    value is itself a vector path) resolves to its **deepest leaf**,
+    exactly as the single-compound case does.
+  - `nil` / anything else → the empty set.
+
+  It **subsumes** the single-active `chart.layout/highlight-id` — for a
+  scalar `:state`, `highlight-ids` is exactly `#{(highlight-id state)}`.
+  `highlight-id` is retained for the focused-event lens
+  (`:from-highlight` / `:to-highlight`), which is genuinely single-state.
+
+- **`chart.projection/xyflow-graph`** threads the set as the
+  `:highlight-ids` option; a node is `:active` when its id ∈ the set.
+  The scalar `:highlight-id` option remains as a convenience that folds
+  into the set as a singleton (both supplied → the union). An edge is
+  `:active` when **either** endpoint is in the active set, so each
+  region's incident edges light independently (orthogonality preserved).
+
+The chart root surfaces the full active set as `data-highlight-ids` (a
+sorted, space-joined list of node-ids); `data-highlight-id` is kept as a
+single-active convenience (the lone id when the set is a singleton, `""`
+otherwise) so flat / compound charts stay observationally identical to
+the pre-G1 single-active behaviour.
+
+**Colour delegated to Figma.** This contract fixes *which* nodes are
+active and that *all* of them light up at once; the active palette + the
+"reads as a set" region-active chrome are owned by Figma per
+[`001-Topology-Parity.md`](001-Topology-Parity.md) §4.2 (the
+region-ACTIVE chrome polish is the follow-on G4 / N1, not this bead).
 
 ### Substrate adapters (rf2-yg9he, xyflow Phase 2)
 
@@ -135,11 +190,15 @@ For the supplied `:definition`, the chart shows:
   Edges are transitions, labelled with their triggering event id;
   `:after` edges read `after(<delay>)` and `:always` edges read
   `always` (per `chart.layout/edge-label`).
-- **The current state highlights.** When `:current-state` is set the
-  matching node carries a static active tint + bolder stroke; compound
-  states' active child is resolved recursively via
-  `chart.layout/highlight-id`. The highlight is a static affordance
-  (the heartbeat pulse was retired 2026-05-20 per rf2-2sez0); the only
+- **The current state highlights.** When `:current-state` is set every
+  active leaf carries a static active tint + bolder stroke. A flat /
+  compound snapshot has one active leaf; a **parallel** snapshot (a
+  region-map) has **N** simultaneously-active leaves and **every one**
+  lights up at once (see [§Parallel multi-active highlight](#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)).
+  The whole `:state` value resolves to the set of active node-ids via
+  `chart.layout/highlight-ids`; compound states' active child resolves
+  to the deepest leaf. The highlight is a static affordance (the
+  heartbeat pulse was retired 2026-05-20 per rf2-2sez0); the only
   continuous animation is the `:after` countdown rings overlay, which
   pauses when the chart is backgrounded.
 - **Focused-event lens highlights.** `:from-highlight` / `:to-highlight`

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -42,6 +42,7 @@
   contract."
   (:require ["@xyflow/react" :as xyflow]
             ["elkjs/lib/elk.bundled.js" :as elkjs]
+            [clojure.string :as str]
             [reagent.core :as r]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
@@ -391,7 +392,13 @@
           ;; the root as `data-density`.
           (let [chart-vc          (vc/chart-for-density density)
                 density-name      (name (or density :regular))
-                highlight-id      (layout/highlight-id current-state)
+                ;; rf2-g2svr (G1) — `highlight-ids` resolves the WHOLE
+                ;; `:current-state` to the SET of active leaves, so a
+                ;; PARALLEL snapshot's N simultaneously-active leaves
+                ;; (one per region) ALL light up, not just one. Flat /
+                ;; compound snapshots resolve to a singleton set (same
+                ;; result the prior scalar `highlight-id` produced).
+                highlight-ids     (layout/highlight-ids current-state)
                 from-highlight-id (layout/highlight-id from-highlight)
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
@@ -399,7 +406,7 @@
                 {:keys [nodes edges]}
                 (projection/xyflow-graph parsed
                               @positions
-                              {:highlight-id      highlight-id
+                              {:highlight-ids     highlight-ids
                                :from-highlight-id from-highlight-id
                                :to-highlight-id   to-highlight-id
                                :sim?              sim?
@@ -455,7 +462,17 @@
                    ;; re-reading the bound prop (per spec/API.md
                    ;; §Density resolution rules).
                    :data-density density-name
-                   :data-highlight-id (or highlight-id "")
+                   ;; rf2-g2svr (G1) — the FULL active set surfaces as a
+                   ;; sorted, space-joined attr so hosts + DOM tests can
+                   ;; read every active leaf (N for a parallel snapshot).
+                   ;; `data-highlight-id` is kept as the single-active
+                   ;; convenience: the lone id when the set is a
+                   ;; singleton, "" otherwise (flat/compound stay
+                   ;; observationally identical to pre-G1).
+                   :data-highlight-ids (str/join " " (sort highlight-ids))
+                   :data-highlight-id (if (= 1 (count highlight-ids))
+                                        (first highlight-ids)
+                                        "")
                    :data-from-highlight-id (or from-highlight-id "")
                    :data-to-highlight-id (or to-highlight-id "")
                    :role "application"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -549,12 +549,61 @@
     (parse-flat definition)))
 
 (defn highlight-id
-  "Resolve a snapshot `:state` value to the node-id used in the
-  positioned graph. Snapshot `:state` is either a flat keyword
-  (`:authing`) or a hierarchical path (`[:auth :authing]`)."
+  "Resolve a single-active snapshot `:state` value to the node-id used
+  in the positioned graph. Snapshot `:state` is either a flat keyword
+  (`:authing`) or a hierarchical path (`[:auth :authing]`).
+
+  This is the SINGLE-active resolver — flat + compound machines, whose
+  snapshot has exactly one active leaf. A PARALLEL machine's snapshot
+  `:state` is a region-map (N simultaneously-active leaves); use
+  `highlight-ids` for that (it subsumes this fn — the scalar value
+  resolves to a singleton set). Returns nil for a region-map (a map is
+  not a single-active state)."
   [state]
   (cond
     (nil? state)     nil
     (keyword? state) (node-id [state])
     (vector? state)  (node-id state)
     :else            nil))
+
+(defn highlight-ids
+  "Resolve a WHOLE snapshot `:state` value to the SET of active-leaf
+  node-ids — the multi-active highlight contract (rf2-yoe6e / rf2-g2svr;
+  closes parity gap G1 in `001-Topology-Parity.md`).
+
+  Spec 005 §Snapshot shape gives `:state` three arms; this fn handles
+  all three, always returning a set so a parallel machine's N
+  simultaneously-active leaves all light up at once:
+
+  - **flat keyword** (`:authing`) — single-active; `#{(node-id [:authing])}`.
+  - **hierarchical path** (`[:auth :authing]`) — single-active compound
+    leaf; `#{(node-id [:auth :authing])}` (the deepest leaf, since
+    `node-id` of the full path IS that leaf's id).
+  - **region-map** (`{:data :loading :form :neutral}`) — PARALLEL: N
+    simultaneously-active leaves. Each region's value is itself a
+    keyword-or-path **relative to that region's own state-tree**, so it
+    resolves the SAME way the parse mints region-state ids — via
+    `node-id` of the in-region path (parse-parallel does NOT region-
+    prefix a state's node-id; it tags `:region` + `:parent-id` but keeps
+    the in-region `node-id`). A nested region value (a region whose
+    value is itself a vector path) resolves to its DEEPEST leaf, exactly
+    as the single-compound case does. Returns the set of N leaf ids.
+
+  - **nil / anything else** — the empty set (no highlight).
+
+  Pure fn — JVM-runnable; the projection threads the result through
+  `xyflow-graph`'s `:highlight-ids` so EVERY active leaf is marked
+  `:active`, not just one."
+  [state]
+  (cond
+    (nil? state)     #{}
+    (keyword? state) #{(node-id [state])}
+    (vector? state)  #{(node-id state)}
+    (map? state)     (into #{}
+                           (keep (fn [[_region region-state]]
+                                   (cond
+                                     (keyword? region-state) (node-id [region-state])
+                                     (vector? region-state)  (node-id region-state)
+                                     :else                   nil)))
+                           state)
+    :else            #{}))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -128,7 +128,24 @@
 
   Options:
 
-    :highlight-id        — node-id of the active state.
+    :highlight-ids       — rf2-g2svr (closes parity gap G1). A SET of
+                           active-leaf node-ids. A node is `:active`
+                           when its id ∈ this set. A PARALLEL machine's
+                           snapshot has N simultaneously-active leaves
+                           (one per region), so passing the set lights
+                           up EVERY active region at once — the multi-
+                           active highlight Stately renders (§1.2 of
+                           `001-Topology-Parity.md`). Resolve it from a
+                           snapshot `:state` via
+                           `chart.layout/highlight-ids` (handles all
+                           three `:state` arms: flat / compound /
+                           region-map).
+    :highlight-id        — node-id of the active state (the SINGLE-
+                           active convenience). Folded into
+                           `:highlight-ids` as a singleton so flat /
+                           compound callers need not build a set; when
+                           both are supplied the union is used. Resolve
+                           it via `chart.layout/highlight-id`.
     :from-highlight-id   — node-id of the focused-event lens's
                            origin state.
     :to-highlight-id     — node-id of the focused-event lens's
@@ -164,10 +181,20 @@
                            pixel-identical to pre-rf2-k647w."
   [{:keys [nodes edges]}
    positions
-   {:keys [highlight-id from-highlight-id to-highlight-id sim?
+   {:keys [highlight-id highlight-ids from-highlight-id to-highlight-id sim?
            on-state-click on-edge-click chart]
     :or   {chart vc/chart-regular}}]
-  (let [;; rf2-lkwev — container nodes (parallel regions AND compound
+  (let [;; rf2-g2svr (G1) — the active set unifies the single-active
+        ;; (`:highlight-id`) and multi-active (`:highlight-ids`) cases.
+        ;; A PARALLEL machine's snapshot has N simultaneously-active
+        ;; leaves; `:highlight-ids` carries them all so EVERY active
+        ;; region lights up at once. The scalar `:highlight-id` folds in
+        ;; as a singleton so flat/compound callers (and the focused-edge
+        ;; logic below) need no set. A node is active when its id ∈ the
+        ;; union.
+        active-ids (cond-> (set highlight-ids)
+                     (some? highlight-id) (conj highlight-id))
+        ;; rf2-lkwev — container nodes (parallel regions AND compound
         ;; parents) MUST precede their children in the xyflow nodes
         ;; array (xyflow requires a parentNode to appear before any node
         ;; that references it). The parse already emits parents first;
@@ -176,7 +203,7 @@
         (mapv (fn [n]
                 (let [pos      (get positions (:id n) {:x 0 :y 0})
                       region?  (boolean (:region? n))
-                      active?  (= (:id n) highlight-id)
+                      active?  (contains? active-ids (:id n))
                       from-hi? (= (:id n) from-highlight-id)
                       to-hi?   (= (:id n) to-highlight-id)
                       base
@@ -220,8 +247,8 @@
 
         proj-edges
         (mapv (fn [e]
-                (let [from-active? (or (= (:source e) highlight-id)
-                                       (= (:target e) highlight-id))
+                (let [from-active? (or (contains? active-ids (:source e))
+                                       (contains? active-ids (:target e)))
                       focused?     (and (some? from-highlight-id)
                                         (some? to-highlight-id)
                                         (= (:source e) from-highlight-id)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -39,8 +39,10 @@
   green on both targets."
   (:require ["react"            :as React]
             ["react-dom/client" :as react-dom-client]
+            [clojure.string :as str]
             [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-machines-viz.adapters.react-chart :as react-chart]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.visual-constants :as vc]))
 
 ;; ---- sample machines ----------------------------------------------------
@@ -349,3 +351,49 @@
               "all four region states render")
           (is (= "4" (.getAttribute root "data-node-count"))
               "data-node-count excludes the region containers"))))))
+
+;; ---- parallel multi-active highlight (rf2-g2svr, G1) --------------------
+;;
+;; The parity capability: a PARALLEL machine's `:current-state` is a
+;; region-map, so N region leaves are active at once. The chart resolves
+;; it via `highlight-ids` and surfaces the FULL active set on the root's
+;; layout-independent `data-highlight-ids` attr (mounts on first commit).
+;; This is the browser visual-pin mirroring the JVM projection pins.
+
+(deftest chart-parallel-current-state-highlights-every-active-region
+  (testing "rf2-g2svr — a region-map :current-state lights up EVERY
+            active region leaf at once: data-highlight-ids carries BOTH
+            the :audio and :display active-leaf node-ids"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id    :test/parallel
+         :definition    parallel-machine
+         ;; both regions advanced past their initial states
+         :current-state {:audio :paused :display :off}}
+        (fn [root _node]
+          (let [ids (set (str/split (.getAttribute root "data-highlight-ids") #"\s+"))]
+            (is (contains? ids (layout/node-id [:paused]))
+                ":audio region's active leaf is in the active set")
+            (is (contains? ids (layout/node-id [:off]))
+                ":display region's active leaf is in the active set — SIMULTANEOUSLY")
+            (is (= 2 (count ids))
+                "exactly the two active region leaves, no more")
+            ;; single-active convenience attr is "" for a multi-active set
+            (is (= "" (.getAttribute root "data-highlight-id"))
+                "data-highlight-id is empty for a multi-active (parallel) set")))))))
+
+(deftest chart-flat-current-state-single-active-back-compat
+  (testing "rf2-g2svr — a flat (single-active) :current-state still
+            surfaces ONE id on both data-highlight-ids + the single-
+            active data-highlight-id convenience attr (no regression)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done
+         :current-state :loading}
+        (fn [root _node]
+          (let [loading-id (layout/node-id [:loading])]
+            (is (= loading-id (.getAttribute root "data-highlight-ids")))
+            (is (= loading-id (.getAttribute root "data-highlight-id"))
+                "single-active convenience attr carries the lone id")))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -198,6 +198,102 @@
 (deftest highlight-id-nil-for-nil-state
   (is (nil? (layout/highlight-id nil))))
 
+(deftest highlight-id-nil-for-region-map
+  (testing "rf2-g2svr — the single-active resolver returns nil for a
+            region-map (a map is not a single-active state); the
+            multi-active `highlight-ids` is the resolver for that arm"
+    (is (nil? (layout/highlight-id {:data :loading :form :neutral})))))
+
+;; ---- highlight-ids — multi-active (rf2-yoe6e / rf2-g2svr, G1) -----------
+;;
+;; Spec 005 §Snapshot shape: `:state` has three arms — flat keyword,
+;; hierarchical path, OR a region-map (PARALLEL — N simultaneously-active
+;; leaves). `highlight-ids` resolves ALL THREE to a SET of active-leaf
+;; node-ids so the chart lights up EVERY active region at once (the §1.2
+;; parity bar in 001-Topology-Parity.md). These pins are the new
+;; capability: flat→1, compound→1 leaf, region-map→N, nested→deepest leaf.
+
+(deftest highlight-ids-flat-keyword-is-singleton
+  (testing "rf2-g2svr — a flat-keyword `:state` resolves to a one-element
+            set (the single-active case, set-wrapped)"
+    (is (= #{(layout/node-id [:authing])}
+           (layout/highlight-ids :authing)))))
+
+(deftest highlight-ids-compound-path-is-singleton-leaf
+  (testing "rf2-g2svr — a hierarchical path resolves to a one-element set
+            holding the DEEPEST leaf's id (node-id of the full path)"
+    (is (= #{(layout/node-id [:authenticated :browsing])}
+           (layout/highlight-ids [:authenticated :browsing])))))
+
+(deftest highlight-ids-region-map-is-the-set-of-active-leaves
+  (testing "rf2-g2svr (THE NEW CAPABILITY) — a PARALLEL snapshot's
+            region-map resolves to the SET of N active leaves, one per
+            region. Each region value resolves the same way the parse
+            mints the region's state ids — via node-id of the in-region
+            path (parse-parallel keeps the in-region node-id; it does NOT
+            region-prefix it)."
+    (let [state {:data :loading :form :neutral :mode :active}
+          ids   (layout/highlight-ids state)]
+      (is (= 3 (count ids)) "three regions → three active leaf ids")
+      (is (= #{(layout/node-id [:loading])
+               (layout/node-id [:neutral])
+               (layout/node-id [:active])}
+             ids)))))
+
+(deftest highlight-ids-region-map-matches-parsed-region-state-ids
+  (testing "rf2-g2svr — the resolved set is exactly the set of node-ids
+            the parse minted for the active region states, so the
+            projection will mark those real nodes :active (no phantom
+            ids). Pins the resolver against the parser's actual output."
+    (let [parallel {:type :parallel
+                    :regions {:audio {:initial :muted
+                                      :states {:muted   {:on {:unmute :playing}}
+                                               :playing {:on {:mute :muted}}}}
+                              :video {:initial :hidden
+                                      :states {:hidden {:on {:show :shown}}
+                                               :shown  {:on {:hide :hidden}}}}}}
+          {:keys [nodes]} (layout/parse-definition parallel)
+          node-ids (set (map :id (remove :region? nodes)))
+          ;; both regions advanced past their initial states
+          state    {:audio :playing :video :shown}
+          ids      (layout/highlight-ids state)]
+      (is (= 2 (count ids)))
+      (is (every? #(contains? node-ids %) ids)
+          "every active id is a REAL parsed region-state node")
+      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} ids)))))
+
+(deftest highlight-ids-nested-region-value-resolves-to-deepest-leaf
+  (testing "rf2-g2svr — a region whose value is itself a vector path (a
+            compound region) resolves to the DEEPEST leaf, exactly as the
+            single-compound case does. Spec 005: a compound region's
+            value is a vector path INSIDE that region."
+    (let [state {:auth [:authenticated :dashboard] :lifecycle :idle}
+          ids   (layout/highlight-ids state)]
+      (is (= #{(layout/node-id [:authenticated :dashboard])
+               (layout/node-id [:idle])}
+             ids))
+      (is (= 2 (count ids))
+          "the compound region contributes ONE id (its deepest leaf), not
+           one-per-path-segment"))))
+
+(deftest highlight-ids-empty-for-nil
+  (testing "rf2-g2svr — nil `:state` (no highlight) → the empty set (a
+            SET, never nil — callers can always `contains?` it)"
+    (is (= #{} (layout/highlight-ids nil)))))
+
+(deftest highlight-ids-empty-for-empty-region-map
+  (testing "rf2-g2svr — an empty region-map resolves to the empty set"
+    (is (= #{} (layout/highlight-ids {})))))
+
+(deftest highlight-ids-subsumes-highlight-id-for-single-active
+  (testing "rf2-g2svr — for a single-active state, `highlight-ids` is
+            exactly `#{(highlight-id state)}` — the multi-active resolver
+            is a strict superset of the single-active one"
+    (doseq [state [:authing [:authenticated :browsing] [:a]]]
+      (is (= #{(layout/highlight-id state)}
+             (layout/highlight-ids state))
+          (str "single-active " state " agrees with the set resolver")))))
+
 ;; ---- node-id ----------------------------------------------------------
 
 (deftest node-id-is-public-fn

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -268,6 +268,104 @@
       (is (false? (:sim (:data (node-by-id no-sim hi)))))
       (is (false? (:sim (:data (node-by-id inactive (layout/node-id [:idle])))))))))
 
+;; ---- xyflow-graph multi-active highlight (rf2-g2svr, G1) ----------------
+;;
+;; A PARALLEL machine's snapshot `:state` is a region-map — N
+;; simultaneously-active leaves (one per region). `:highlight-ids` (a
+;; SET) marks EVERY active leaf `:active` so the chart lights up all
+;; regions at once (the §1.2 parity bar). The scalar `:highlight-id`
+;; stays as a single-active convenience that folds into the set.
+
+(deftest xyflow-graph-highlight-ids-marks-every-active-leaf
+  (testing "rf2-g2svr (THE PARITY CAPABILITY) — passing a SET of two
+            region-leaf ids marks BOTH region states `:active`
+            simultaneously (parallel multi-active highlight)"
+    (let [parsed     (layout/parse-definition parallel-machine)
+          playing-id (layout/node-id [:playing])
+          shown-id   (layout/node-id [:shown])
+          muted-id   (layout/node-id [:muted])
+          hidden-id  (layout/node-id [:hidden])
+          graph      (projection/xyflow-graph
+                       parsed {} {:highlight-ids #{playing-id shown-id}})]
+      (is (true? (:active (:data (node-by-id graph playing-id))))
+          ":audio region's active leaf lights up")
+      (is (true? (:active (:data (node-by-id graph shown-id))))
+          ":video region's active leaf lights up — SIMULTANEOUSLY")
+      (is (false? (:active (:data (node-by-id graph muted-id))))
+          "the inactive :audio leaf stays dark")
+      (is (false? (:active (:data (node-by-id graph hidden-id))))
+          "the inactive :video leaf stays dark"))))
+
+(deftest xyflow-graph-highlight-ids-from-snapshot-resolver
+  (testing "rf2-g2svr — end-to-end: `highlight-ids` resolves a parallel
+            region-map to the set, the projection lights every active
+            leaf. This is the live-chart path (chart.cljs calls
+            highlight-ids on :current-state)."
+    (let [parsed   (layout/parse-definition parallel-machine)
+          ;; both regions advanced past initial
+          state    {:audio :playing :video :shown}
+          ids      (layout/highlight-ids state)
+          graph    (projection/xyflow-graph parsed {} {:highlight-ids ids})
+          actives  (set (map :id (filter #(:active (:data %)) (:nodes graph))))]
+      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} actives)
+          "exactly the two active region leaves are marked active"))))
+
+(deftest xyflow-graph-scalar-highlight-id-still-works
+  (testing "rf2-g2svr — the scalar `:highlight-id` is back-compat: it
+            folds into the active set as a singleton, so flat/compound
+            callers (and existing tests) need no set"
+    (let [parsed  (layout/parse-definition idle-loading)
+          hi      (layout/node-id [:loading])
+          graph   (projection/xyflow-graph parsed {} {:highlight-id hi})
+          loading (node-by-id graph hi)
+          idle    (node-by-id graph (layout/node-id [:idle]))]
+      (is (true?  (:active (:data loading))))
+      (is (false? (:active (:data idle)))))))
+
+(deftest xyflow-graph-highlight-id-and-ids-union
+  (testing "rf2-g2svr — when BOTH `:highlight-id` and `:highlight-ids`
+            are supplied the active set is their union"
+    (let [parsed (layout/parse-definition parallel-machine)
+          a      (layout/node-id [:playing])
+          b      (layout/node-id [:shown])
+          graph  (projection/xyflow-graph
+                   parsed {} {:highlight-id a :highlight-ids #{b}})]
+      (is (true? (:active (:data (node-by-id graph a)))))
+      (is (true? (:active (:data (node-by-id graph b))))))))
+
+(deftest xyflow-graph-no-highlight-leaves-all-inactive
+  (testing "rf2-g2svr — neither `:highlight-id` nor `:highlight-ids` →
+            no state/region node is active (empty set, never
+            nil-comparison surprises). Initial-marker nodes carry no
+            `:active` key at all (they are not states), so the check
+            scopes to nodes that carry the flag."
+    (let [parsed (layout/parse-definition parallel-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          flagged (filter #(contains? (:data %) :active) (:nodes graph))]
+      (is (seq flagged) "fixture has state/region nodes carrying :active")
+      (is (every? #(false? (:active (:data %))) flagged)))))
+
+(deftest xyflow-graph-multi-active-edges-active-in-each-region
+  (testing "rf2-g2svr — with N active leaves, an edge touching ANY active
+            leaf is `:active`. Each region's self/incident edge lights up
+            independently (orthogonality preserved)."
+    (let [parsed   (layout/parse-definition parallel-machine)
+          ids      #{(layout/node-id [:playing]) (layout/node-id [:shown])}
+          graph    (projection/xyflow-graph parsed {} {:highlight-ids ids})
+          active-e (filter #(:active (:data %)) (:edges graph))
+          ;; edges incident to :playing (audio) and :shown (video)
+          regions  (set (map (fn [e]
+                               (cond
+                                 (or (= (:source e) (layout/node-id [:playing]))
+                                     (= (:target e) (layout/node-id [:playing]))) :audio
+                                 (or (= (:source e) (layout/node-id [:shown]))
+                                     (= (:target e) (layout/node-id [:shown]))) :video
+                                 :else :other))
+                             active-e))]
+      (is (seq active-e) "at least one edge is active")
+      (is (contains? regions :audio) "an :audio-region edge is active")
+      (is (contains? regions :video) "a :video-region edge is active"))))
+
 (deftest xyflow-graph-edge-active-when-endpoint-highlighted
   (testing "an edge is `:active` when EITHER endpoint is the
             highlighted node"

--- a/tools/xray/spec/003-Machine-Inspector.md
+++ b/tools/xray/spec/003-Machine-Inspector.md
@@ -579,7 +579,7 @@ Per Spec 005 and Spec 009:
 | Surface | Used for |
 |---|---|
 | `(rf/machines frame-id)` | Enumerate registered machines (drop-down in panel header). |
-| `[:rf/machines <id>]` slot in `app-db` | Read current snapshot; deref drives the live-highlight. |
+| `[:rf/machines <id>]` slot in `app-db` | Read current snapshot; deref drives the live-highlight. The host passes the snapshot's `:state` straight through as the chart's `:current-state`; for a **parallel** machine that `:state` is a region-map and the chart highlights **every** active region leaf simultaneously (parity gap G1; resolution via `chart.layout/highlight-ids` — see [machines-viz API §Parallel multi-active highlight](../../machines-viz/spec/API.md#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)). |
 | `:rf.machine/transition` traces | Build the transition-history ribbon. |
 | `:rf.machine.microstep/transition` traces | Microstep replay within an `:always`-driven cascade. |
 | `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | Drive `:after` countdown rings. |
@@ -663,7 +663,7 @@ definition→graph PARSER, not a positioner).
 | Concern | Source ns | What it does |
 |---|---|---|
 | **Component + interop glue** | `chart.cljs` (`MachineChart`) | Reagent component; mounts `[:> ReactFlow ...]`, runs the elkjs pass, holds the positions atom. |
-| **Graph parse** | `chart/layout.cljc` (`parse-definition`, `highlight-id`) | Pure CLJS data→data; JVM-runnable; definition → flat nodes + edges + per-node/per-edge metadata. Tests pin this without DOM / xyflow / elkjs. |
+| **Graph parse** | `chart/layout.cljc` (`parse-definition`, `highlight-id`, `highlight-ids`) | Pure CLJS data→data; JVM-runnable; definition → flat nodes + edges + per-node/per-edge metadata. `highlight-ids` resolves a whole snapshot `:state` (incl. a **parallel region-map**) to the **set** of active-leaf node-ids so the live highlight lights up **every** active region at once (parity gap G1; see [machines-viz API §Parallel multi-active highlight](../../machines-viz/spec/API.md#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)). Tests pin this without DOM / xyflow / elkjs. |
 | **xyflow projection** | `chart/projection.cljc` (`xyflow-graph`, `->elk-children`) | Pure projector: parsed graph + elk positions → xyflow `:nodes` / `:edges` shape with per-node/per-edge `:data` payloads (highlight flags, labels, density). |
 | **elkjs layout** | `chart.cljs` (`compute-layout!`) | Async elk.js pass over the parsed graph; merges positions back into xyflow nodes. |
 


### PR DESCRIPTION
Closes the HIGH parity gap **G1** (parity plan `tools/machines-viz/spec/001-Topology-Parity.md`): a parallel (AND) machine's snapshot `:state` is a region-map `{region kw-or-path}` with **N simultaneously-active leaves**, but `chart.layout/highlight-id` returned `nil` for a map — so the chart could light up at most one region. Stately lights up **every** active region at once (§1.2 parity bar); this makes `MachineChart` match. Beads **rf2-yoe6e** (B4, contract) + **rf2-g2svr** (B5, impl), one PR.

## Contract (B4, rf2-yoe6e)
- **machines-viz `API.md`** — `:current-state` now documents all three Spec 005 `:state` arms (flat keyword / compound path / parallel region-map); new **§Parallel multi-active highlight** defines the `highlight-ids` **set** semantics, region-value resolution (in-region `node-id`; nested value → deepest leaf), and the projection threading. Colour delegated to Figma (G4/N1 region-ACTIVE chrome is the follow-on).
- **xray `spec/003-Machine-Inspector.md`** — pointers on the graph-parse + `[:rf/machines <id>]` data-source rows.
- **`001-Topology-Parity.md`** — §2 status + §3.1 G1 flipped to **CLOSED**.

## Impl (B5, rf2-g2svr)
- **`chart/layout.cljc` `highlight-ids`** — pure resolver: whole `:state` → **set** of active-leaf node-ids. `flat→1`, `compound→1 deepest leaf`, `region-map→N`, `nested-region-value→deepest leaf`, `nil/else→#{}`. Subsumes the single-active `highlight-id` (retained for the genuinely-single focused-event lens). Resolves each region value via the canonical injective `node-id` of its in-region path (matching what `parse-parallel` mints — it keeps the in-region node-id, does not region-prefix it).
- **`chart/projection.cljc` `xyflow-graph`** — threads `:highlight-ids` (set). A node is `:active` when its id ∈ the union of `:highlight-ids` + the scalar `:highlight-id` (back-compat singleton). An edge is `:active` when **either** endpoint is in the set, so each region's edges light independently (orthogonality preserved).
- **`chart.cljs`** — live chart resolves `:current-state` via `highlight-ids`; surfaces the full active set as `data-highlight-ids` (`data-highlight-id` kept as a single-active convenience).

## Tests (pure cljc JVM + browser visual-pin)
- **layout**: flat→1, compound→1 leaf, **region-map→N (the new capability)**, region-map matches parsed region-state ids, nested-region-value→deepest leaf, empty cases, subsumes-`highlight-id`.
- **projection**: multi-active marks **every** active leaf simultaneously, end-to-end from the resolver, scalar back-compat, union, per-region edge activity.
- **chart_dom (browser)**: region-map `:current-state` lights up every region (`data-highlight-ids` carries both leaves) + flat single-active back-compat.

## Gates (all green)
- `npm run test:cljs` — 4300 tests / 13502 assertions, 0 failures.
- `npm run test:browser` — 114 tests / 323 assertions, 0 failures.
- `clojure -M:test` (machines-viz) — 211 tests / 509 assertions, 0 failures.
- clj-kondo: 0 errors, 0 new warnings on touched files. Splint: 0 errors, 0 new warnings on touched files.
- mkdocs N/A — touched specs are repo-internal tool specs (not in nav); markdown + slug-check valid.

Surface is isolated to `tools/machines-viz/` + the two spec pointers — disjoint from the other in-flight workers (xray panels, core trace, workflows).