### PR TITLE
fix(xray-spec): 023-Trace-Panel Appendix-A op-list hygiene (rf2-b1jkm)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -78,8 +78,8 @@ Errors & warnings are cross-cutting — see §7. Child epochs spawned by a `:dis
 | FLOW | computed · cleared · failed · skipped |
 | SUB | created · recalculated · ran-unchanged · cache-hit · disposed |
 | VIEW | mounted · re-rendered · skipped · unmounted |
-| MACHINE | created · transition · action-ran · guard-evaluated · after · spawned · spawn-cancelled · spawn-timed-out · timer-scheduled · timer-fired · timer-stale · timer-cancelled · timer-skipped-on-server · done · finished · event-received · system-id-bound · system-id-released · destroyed |
-| ROUTING | navigated · activated · deactivated · cleared · fragment-changed · url-changed · navigation-blocked · not-found |
+| MACHINE | created · transition · action-ran · guard-evaluated · after · spawned · spawn-cancelled · timer-scheduled · timer-fired · timer-stale · timer-cancelled · timer-skipped-on-server · done · finished · event-received · system-id-bound · system-id-released · destroyed (a `:spawn` wall-clock guard fires as `timer-fired` on the `:spawn`-bearing state's `:after` — the retired `spawn-timed-out` op, per Spec-009 / rf2-3y3y) |
+| ROUTING | activated · deactivated · cleared · fragment-changed · navigation-blocked (no-match surfaces as the `WARNING :rf.warning/no-not-found-route` row, not a positive ROUTING op; a URL change is the dispatched event `:rf.event/dispatched [:rf.route/handle-url-change …]`, an EVENT row) |
 | EPOCH | snapshotted · restored · db-replaced · replay-conflict · reset |
 
 Registration ops (`:rf.flow/registered`, `:rf.route/registered`, `:rf.fx/reg-flow`, `:rf.machine.registrar/*`) are boot-time / out-of-epoch and are normally absent from a per-epoch arc.
@@ -186,7 +186,7 @@ This is **interaction wiring, not visual** — Figma need only render a generic 
 ▾ ② EVENT HANDLING   COEFFECT current-route · handler ran · DB [:rf/route] (or [:rf/pending-navigation])
               ROUTING deactivated :app/home · ROUTING activated :app/settings
               — or — ROUTING navigation-blocked  (:can-leave)        → outcome :blocked
-▾ ③ EFFECTS   FX :rf.nav/push-url /settings · ROUTING url-changed ↗ child epoch #N
+▾ ③ EFFECTS   FX :rf.nav/push-url /settings   ↗ child epoch #N (the URL change re-enters as EVENT :rf.route/handle-url-change)
 ▾ ④ REACTIVE  SUB :route/current recalculated · VIEW route-outlet re-rendered
 ● EPOCH CLOSE outcome :ok | :blocked
 ```
@@ -240,14 +240,14 @@ Every Spec-009 trace operation → its row. `dur?` = number once timing instrume
 | `:rf.flow/computed` | ② | FLOW | computed | flow-id → path | dur? |
 | `:rf.flow/cleared` · `failed` · `skip` | ② | FLOW | cleared / failed / skipped | flow-id | — |
 | `:rf.route/activated` · `deactivated` · `cleared` · `fragment-changed` | ③ | ROUTING | activated / deactivated / cleared / fragment-changed | route-id / fragment | — |
-| `:rf.route/handle-url-change` | ③ | ROUTING | url-changed | url | — (↗ child) |
 | `:rf.route/navigation-blocked` | ② / ③ | ROUTING | navigation-blocked | route-id (guard) | — (→ outcome :blocked) |
-| `:rf.route/not-found` | ③ | ROUTING | not-found | url | — |
+| `:rf.warning/no-not-found-route` | inline (its phase) | WARNING | no-not-found-route | url (unmatched, no `:rf.route/not-found` route registered) | — |
+| `:rf.event/dispatched [:rf.route/handle-url-change …]` | ① | EVENT | dispatched | url (the URL-change EVENT — **not** a standalone trace op; it rides the `:rf.event/dispatched` row above) | — (↗ child) |
 | `:rf.machine.timer/scheduled` | ③ | MACHINE | timer-scheduled | delay · state | — (↗ future epoch) |
 | `:rf.machine.timer/fired` | own epoch | MACHINE | timer-fired | delay · state | — |
 | `:rf.machine.timer/stale-after` · `cancelled-on-resolution` | ③ | MACHINE | timer-stale / timer-cancelled | state | — |
 | `:rf.machine.timer/skipped-on-server` | ③ | MACHINE | timer-skipped-on-server | state | — |
-| `:rf.machine.spawn/*` · `spawn-all/*` (spawned / cancelled-on-join / timed-out) | ③ | MACHINE | spawned / spawn-cancelled / spawn-timed-out | invoke-id | — (↗ child) |
+| `:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*` | ③ | MACHINE | spawned / spawn-cancelled / spawn-all-started/completed/failed | invoke-id | — (↗ child) |
 | `:rf.machine/after` · `done` · `finished` | ② / ③ | MACHINE | after / done / finished | delay / output | — |
 | `:rf.sub/create` | ④ | SUB | created | sub-id | — |
 | `:rf.sub/run`+`computed` (value-changed? ✓) | ④ | SUB | recalculated | sub-id  old → new | dur? |


### PR DESCRIPTION
Panel-spec hygiene on the Trace-panel doc (`tools/xray/spec/023-Trace-Panel.md`) — the Figma-handoff target. Reconciles Appendix A (and the §5 verb taxonomy + §16 worked routing shape) against the live Spec-009 emit catalogue, per trace-sufficiency audit rf2-wi81e S5. Docs-only; no impl change.

## Op entries corrected

1. **`:rf.machine.spawn/timed-out` retired** (per rf2-3y3y; Spec 009 ~L141). The `:timeout-ms` slot on `:spawn` / `:spawn-all` was dropped in favour of a state-level `:after`; the "wall-clock guard fired" semantic now surfaces as `:rf.machine.timer/fired` on the `:spawn`-bearing state's `:after`. Removed `spawn-timed-out` from the §5 MACHINE verb list and rewrote the Appendix-A spawn matrix row to the accurate live ops (`:rf.machine/spawned` · `:rf.machine.spawn/cancelled-on-join-resolution` · `:rf.machine.spawn-all/*`), with a clarifying note.

2. **`:rf.route/handle-url-change` is a dispatched EVENT, not a standalone trace op.** It surfaces as `:rf.event/dispatched [:rf.route/handle-url-change …]` (confirmed: no `:rf.route/handle-url-change` operation exists in the Spec-009 `:rf.route/*` op vocabulary; it is the runtime event referenced by `:rf.error/no-such-handler :kind :route`). Replaced the bogus standalone ROUTING op row in Appendix A with an EVENT row; fixed the §5 ROUTING verb list and the §16 worked routing shape (the `↗ child epoch` now correctly rides the `:rf.nav/push-url` fx, with the URL re-entering as the EVENT).

3. **`:rf.route/not-found` is a registered route-id, not a positive trace op.** An unmatched URL surfaces as the warning `:rf.warning/no-not-found-route` (Spec 009 L1434) and/or `:rf.error/no-such-handler :kind :route`; `:rf.route/not-found` itself is the `:rf/route :id` value the app registers a view for. Replaced the bogus ROUTING op row in Appendix A with the `:rf.warning/no-not-found-route` warning row.

Each entry verified against `spec/009-Instrumentation.md` (the `:op-type`/`:operation` vocabulary, L125-213 and the error/warning contract L1330-1448) and `spec/012-Routing.md` (Route-not-found / handle-url-change semantics). The matrix structure is unchanged — only stale/incorrect op entries were corrected.

## Gates

- `python scripts/check_doc_slugs.py` — clean (exit 0); all intra-repo links + anchor slugs resolve. This is the authoritative link/anchor gate for the doc (it lives under `tools/xray/spec/`, outside the mkdocs nav).
- `python -m mkdocs build --strict` — clean (exit 0).

Closes rf2-b1jkm.