### PR TITLE
feat(machines-viz): elk bend-point edge routing around nested containers (rf2-cz8v6)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -178,7 +178,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 | **Event labels** | ✅ `event [guard] / action` composed label; `after(<ms>)`, `always`, `* (any)` wildcard segments; backplate for legibility; label is clickable when a fireable event-id + host callback are present. | `layout.cljc` `edge-label`/`event-segment`; `edges.cljs` `transition-edge`. |
 | **Guards / actions** | ✅ Guard in `[...]`, action after `/`; entry/exit state actions render as `entry / <name>` / `exit / <name>` rows under the label; state-tag pills above. | `layout.cljc` `edge-label`, `name-of`; `nodes.cljs` `state-node` (entry/exit rows, tag pills). |
 | **Layout** | ✅ elk Layered, `DOWN`/`RIGHT` direction, `INCLUDE_CHILDREN` when nested, per-container padding for header strips; async + cached pass; xyflow `fitView`. | `chart.cljs` `compute-layout!`/`default-elk-options`; `projection.cljc` `->elk-children` (per-container `layoutOptions`). |
-| **Edge routing through nesting** | ⚠️ **Partial.** Edges use `getBezierPath` (a straight-ish curve between handles); **elk bend-points are not consumed.** Deep nesting can route an edge **across** a container rather than around it. | `edges.cljs` `transition-edge` (`getBezierPath`); `layout.cljc` docstring "Edge points + bend-points — REMOVED". |
+| **Edge routing through nesting** | ✅ **Closed (rf2-cz8v6).** elk runs `ORTHOGONAL` routing with `elk.json.edgeCoords ROOT`; `compute-layout!` lifts each edge's `sections` bend-points (absolute coords) into an `{edge-id [{:x :y} …]}` map that the projector attaches to the edge `:data {:points}`. `transition-edge` then draws a smooth poly-path THROUGH the bends, so a deeply-nested transition routes **around** a container instead of cutting across it. Self-loops keep their dedicated loop path; an edge with no elk route falls back to the bezier. | `chart.cljs` `default-elk-options` (`ORTHOGONAL` + `edgeCoords ROOT`) / `elk-edge-points` / `elk-result->positions`; `projection.cljc` `xyflow-graph` (`:edge-points` → `:data {:points}`); `edges.cljs` `edge-path` (poly-path). |
 | **Simulation** | ✅ (host-side, trace-driven + hermetic sim) — live highlight off `[:rf/machines <id>]` + the Spec 009 bus; the Static-Machines Sim sub-mode is a hermetic what-if walker. Edge labels carry `:eventId` + `:onClick` so a host wires "click to send". | `projection.cljc` (`:on-edge-click`/`:eventId`); Xray `static/machines/sim.cljs` (per 003). |
 | **Interactivity / ergonomics** | ✅ xyflow pan/zoom/fit/minimap/background; density-resolved geometry + typography; node/edge click callbacks; `:after` countdown rings + `:spawn-all` join + cancellation overlays (re-frame2-native, no Stately peer). | `chart.cljs`; `visual-constants`; overlays per 003 / 000-Vision. |
 
@@ -186,10 +186,10 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 (layout), initial, final, transition scoping, event labels,
 guards/actions, layout, and ergonomics. The high-severity **parallel
 multi-active highlight** gap (G1) is now **closed** (rf2-yoe6e /
-rf2-g2svr); **one capability gap** remains (bend-point edge routing,
-G2), plus two **fired-edge consistency** items the live-chart wiring
-needs and the region-ACTIVE chrome polish (G4) that completes the
-parallel-parity read.
+rf2-g2svr) and the bend-point edge-routing gap (G2) is now **closed**
+(rf2-cz8v6); the residue is two **fired-edge consistency** items the
+live-chart wiring needs and the region-ACTIVE chrome polish (G4) that
+completes the parallel-parity read.
 
 ## §3 — Gap analysis + deliberate divergences
 
@@ -201,7 +201,7 @@ new), and the parity-bar row it serves.
 | # | Gap | Severity | Serves bar | Bead |
 |---|---|---|---|---|
 | **G1** | ✅ **CLOSED (rf2-yoe6e / rf2-g2svr).** Was: a parallel snapshot's `:state` is a region-map `{region path}` with **N active leaves**; `highlight-id` returned nil for a map, so the chart highlighted **none** (or only a degenerate single id). Now: `highlight-ids` resolves the whole `:state` (flat / compound / region-map, nested values → deepest leaf) to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so all N regions light up at once — Stately's §1.2 read. | **High** | §1.2, §1.9 | **contract:** rf2-yoe6e ✅ · **impl:** rf2-g2svr ✅ |
-| **G2** | **elk bend-point edge routing.** Edges are beziers between handles; elk's Layered bend-points (ORTHOGONAL/polyline) are discarded (§1.7). In deep nesting, edges can cut **across** a region/compound container instead of routing **around** it — the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor at real machine sizes. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 (existing, deferred polish) |
+| **G2** | ✅ **CLOSED (rf2-cz8v6).** Was: edges were beziers between handles; elk's Layered bend-points were discarded (§1.7), so in deep nesting an edge could cut **across** a region/compound container instead of routing **around** it. Now: elk runs `ORTHOGONAL` routing with `elk.json.edgeCoords ROOT`; `compute-layout!` lifts each edge's `sections` bend-points (absolute coords) into the projection (`:edge-points` → `:data {:points}`), and `edges.cljs/edge-path` draws a smooth poly-path THROUGH them — routing around non-incident containers (the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor). Self-loops keep their loop path; no-route edges fall back to the bezier; G1's active-edge highlight survives the new path. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 ✅ |
 | **G3** | **Fired-edge id consistency (live chart).** To highlight "the edge that fired this epoch" on the live chart, the host's trace→edge-id mapping MUST mint the **same** `edge-id` `chart.layout` mints. Today the helper chain needs consolidating so `extract-fired-edge-ids` emits machines-viz `edge-id`s. (The node-id scheme was already unified — rf2-m8kod.) | **Medium** | §1.3, §1.8 | **helpers:** rf2-8jzm1 (existing) · **wire:** rf2-qeemm (existing) |
 | **G4** | **Parallel-region chrome polish for the active read.** Once G1 lights up N regions, the **region container** should reflect "this region is active" (vs. structural-only chrome today) so a reader scanning N regions sees the active leaf in each at a glance — region-header active affordance + per-region active-leaf emphasis that reads as a set, not N independent highlights. | **Low–Medium** | §1.2 | **NEW — see §5 N1** |
 | **G5** | **Cross-hierarchy edge-routing option not asserted.** elk routes cross-hierarchy edges only when the option is activated on the top level (§1.7). The default elk options set `INCLUDE_CHILDREN` for nesting but do not pin the cross-hierarchy edge-routing option; an edge from a deeply-nested leaf to a top-level state may not route cleanly even after G2. | **Low** | §1.7 | **NEW — see §5 N2** (pairs with rf2-cz8v6/G2) |
@@ -284,12 +284,14 @@ not **which colour**.
 
 ### 4.3 G2 / G5 — edge routing through nesting
 
-- **Consume elk bend-points (rf2-cz8v6/G2).** elk's Layered result
-  carries per-edge **bend-point sections**; the projection should pass
-  them through so `edges.cljs` can render a **polyline / piecewise
-  curve** through the bend points instead of a single bezier between
-  handles. This is what stops an edge cutting across a nested
-  container at machine sizes (§1.7).
+- ✅ **Consume elk bend-points (rf2-cz8v6/G2 — DONE).** elk's Layered
+  result carries per-edge **bend-point sections**; `compute-layout!`
+  (with `elk.edgeRouting ORTHOGONAL` + `elk.json.edgeCoords ROOT`) lifts
+  them as absolute coords into `:edge-points`, the projection threads
+  them onto each edge `:data {:points}`, and `edges.cljs/edge-path`
+  renders a **rounded poly-path** through the bend points instead of a
+  single bezier between handles. This is what stops an edge cutting
+  across a nested container at machine sizes (§1.7).
 - **Assert cross-hierarchy edge routing (rf2 NEW N2/G5).** Add the elk
   top-level cross-hierarchy edge-routing option to
   `default-elk-options` so an edge from a nested leaf to a top-level
@@ -339,7 +341,7 @@ project dispatch rules): `tools/xray/spec/003-Machine-Inspector.md`.
 
 | Step | Bead | New? | Hot-zone | Notes |
 |---|---|---|---|---|
-| B1 | **rf2-cz8v6** — elk bend-point edge routing | existing (deferred polish) | isolated (`chart.cljs` position pass + `chart.edges` polyline + tests) | Closes **G2**. Consume elk bend-point sections; render polyline through them. |
+| B1 | **rf2-cz8v6** ✅ — elk bend-point edge routing | existing | isolated (`chart.cljs` position pass + `chart.edges` polyline + tests) | **Closed G2.** elk `ORTHOGONAL` + `edgeCoords ROOT`; `compute-layout!` lifts bend-point sections; `edge-path` renders a rounded poly-path through them. |
 | B2 | **N2 (NEW)** — `feat(machines-viz): assert ELK cross-hierarchy edge-routing in default-elk-options` | **NEW** | isolated (`chart.cljs` `default-elk-options` + projection test) | Closes **G5**. Small option add; pairs with B1 (bend-points need cross-hierarchy routing enabled to matter). Land with or just before B1. |
 
 ### Phase C — fired-edge live highlight (host wiring)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -85,13 +85,33 @@
   "Canonical elk.js `layoutOptions` for the chart. Tuned for state-
   machine readability per the rf2-0yil0 audit cluster + rf2-gg7ws
   visual-quality lift (kept across the xyflow migration since the
-  layout engine itself is unchanged; only the renderer swapped)."
+  layout engine itself is unchanged; only the renderer swapped).
+
+  rf2-cz8v6 (G2 — bend-point edge routing): two routing-relevant keys.
+
+    - `elk.edgeRouting` is `ORTHOGONAL` (not `SPLINES`): the Layered
+      algorithm then computes Manhattan bend-point routes that go
+      AROUND nested/parallel containers, which the chart lifts into the
+      xyflow edge geometry (`chart.edges/transition-edge` renders a
+      smooth poly-path through them). With `SPLINES` elk emits a single
+      control-rich curve that, once collapsed to its bend points, reads
+      no better than the bezier fallback — ORTHOGONAL is what makes the
+      around-the-container routing legible at machine sizes (§1.7 of
+      `001-Topology-Parity.md`).
+    - `elk.json.edgeCoords` is `ROOT`: elk reports every edge section's
+      `startPoint` / `bendPoints` / `endPoint` relative to the ROOT
+      graph (i.e. absolute flow coordinates) rather than the default
+      per-container origin. xyflow hands the custom edge component
+      ABSOLUTE `sourceX`/`sourceY`/… so the lifted bend-points must be
+      in the same frame; `ROOT` makes elk do that rebasing for us
+      (added ELK 0.9; elkjs 0.11 wraps a newer core)."
   {"elk.algorithm"                              "layered"
    "elk.direction"                              "DOWN"
    "elk.spacing.nodeNode"                       "40"
    "elk.layered.spacing.nodeNodeBetweenLayers"  "70"
    "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
-   "elk.edgeRouting"                            "SPLINES"})
+   "elk.edgeRouting"                            "ORTHOGONAL"
+   "elk.json.edgeCoords"                        "ROOT"})
 
 (defn- ->elk-input
   "Build an elk.js JS-side input graph for the given parsed nodes +
@@ -125,38 +145,103 @@
                            :labels [{:text (:event-label e)}]})
                         edges))}))
 
+(defn elk-edge-points
+  "rf2-cz8v6 (G2) — lift one elk edge's routed bend-points into a flat
+  `[{:x :y} …]` vector of absolute (flow) coordinates.
+
+  An elk edge carries one or more `sections`; each section has a
+  `startPoint`, an `endPoint`, and an optional `bendPoints` array. We
+  chain them into start → bend… → end. With `elk.json.edgeCoords ROOT`
+  set on the layout (`default-elk-options`) every coordinate is already
+  root-relative — i.e. the same absolute frame xyflow hands the custom
+  edge component as `sourceX`/`sourceY`/… — so no re-basing is needed.
+
+  Returns nil when the edge has no usable section (elk gave no route),
+  so the projector can fall back to the bezier path. A degenerate
+  one-or-zero-point result is treated as no route (nothing to route
+  through)."
+  [^js edge]
+  (let [sections (or (.-sections edge) #js [])
+        pts      (->> (areduce sections i acc []
+                        (let [^js s  (aget sections i)
+                              ^js sp (.-startPoint s)
+                              ^js ep (.-endPoint s)
+                              bp     (or (.-bendPoints s) #js [])]
+                          (-> acc
+                              (cond-> sp (conj {:x (.-x sp) :y (.-y sp)}))
+                              (into (map (fn [^js p] {:x (.-x p) :y (.-y p)})) bp)
+                              (cond-> ep (conj {:x (.-x ep) :y (.-y ep)})))))
+                      ;; Collapse consecutive duplicate points (a
+                      ;; section's endPoint can repeat the next section's
+                      ;; startPoint) so the rendered path has no zero-
+                      ;; length segments.
+                      (dedupe))]
+    (when (> (count pts) 1)
+      (vec pts))))
+
 (defn- elk-result->positions
-  "Adapter: elk.js JS result → `{node-id {:x :y :width :height}}` map.
+  "Adapter: elk.js JS result → `{:positions {node-id {:x :y :width
+  :height}} :edge-points {edge-id [{:x :y} …]}}`.
+
   Used by `xyflow-graph` to merge xyflow-side node objects with
-  elk-laid-out positions.
+  elk-laid-out positions, and (rf2-cz8v6 / G2) to route edges through
+  elk's computed bend-points.
+
+  ## Positions
 
   Walks nested elk children (rf2-lkwev — parallel machines nest each
   region's states under the region container). elkjs reports a child's
   `x`/`y` RELATIVE to its parent container, which is exactly what
   xyflow's parentNode sub-flow wants — so we record each node's
   position AS elkjs gives it, no re-basing. Region containers get
-  their root-relative position + the size elkjs computed for the zone."
+  their root-relative position + the size elkjs computed for the zone.
+
+  ## Edge points (rf2-cz8v6 / G2)
+
+  elk attaches each edge's routed `sections` to whichever node it lays
+  the edge out under (the LCA of its endpoints). We walk EVERY node's
+  `edges` array so cross-hierarchy edges (laid out at a container or at
+  the root) are all collected. Each edge's points are lifted via
+  `elk-edge-points`; with `edgeCoords ROOT` they are already absolute,
+  so a deeply-nested transition's route is in the same frame as a flat
+  one. Edges with no route (no sections) are simply absent from the
+  map — the projector / edge component then falls back to the bezier
+  path."
   [elk-result]
-  (let [acc (atom {})]
-    (letfn [(walk! [^js node]
+  (let [positions   (atom {})
+        edge-points (atom {})]
+    (letfn [(collect-edges! [^js node]
+              (let [edges (or (.-edges node) #js [])
+                    n     (alength edges)]
+                (dotimes [i n]
+                  (let [e   (aget edges i)
+                        pts (elk-edge-points e)]
+                    (when pts
+                      (swap! edge-points assoc (.-id e) pts))))))
+            (walk! [^js node]
+              (collect-edges! node)
               (let [children (or (.-children node) #js [])
                     n        (alength children)]
                 (dotimes [i n]
                   (let [c (aget children i)]
-                    (swap! acc assoc (.-id c)
+                    (swap! positions assoc (.-id c)
                            {:x      (or (.-x c) 0)
                             :y      (or (.-y c) 0)
                             :width  (or (.-width c) projection/state-node-min-width)
                             :height (or (.-height c) projection/state-node-min-height)})
                     (walk! c)))))]
       (walk! elk-result))
-    @acc))
+    {:positions   @positions
+     :edge-points @edge-points}))
 
 (defn compute-layout!
   "Run elk.js layout on `parsed` (the output of
-  `chart.layout/parse-definition`); call `done-fn` with a map of
-  `{node-id {:x :y :width :height}}` when ready (or with `nil` on
-  failure). The async path is idiomatic xyflow + elkjs:
+  `chart.layout/parse-definition`); call `done-fn` with a map
+  `{:positions {node-id {:x :y :width :height}} :edge-points {edge-id
+  [{:x :y} …]}}` when ready (or with `nil` on failure). The
+  `:edge-points` half (rf2-cz8v6 / G2) carries elk's routed bend-points
+  so the chart routes edges AROUND nested containers instead of cutting
+  across them. The async path is idiomatic xyflow + elkjs:
 
     1. `(->elk-input parsed direction layout-options)` builds a JS
        graph.
@@ -316,7 +401,13 @@
     :testid            — root wrapper `data-testid`; defaults to
                          `\"rf-mv-chart\"` so tests + hosts find it."
   [_initial-props]
-  (let [positions     (r/atom {})
+  (let [;; rf2-cz8v6 (G2) — the layout atom now holds BOTH the node
+        ;; positions and elk's routed edge bend-points
+        ;; (`{:positions {…} :edge-points {…}}`) so the projector can
+        ;; route edges around nested containers. Starts empty (no
+        ;; positions, no routes) — the pre-layout render falls back to
+        ;; origin + bezier until the async elk pass resolves.
+        layout-state  (r/atom {:positions {} :edge-points {}})
         layout-key    (r/atom nil)]
     (fn [{:keys [machine-id definition current-state from-highlight to-highlight
                  sim? on-state-click on-edge-click read-only?
@@ -349,9 +440,9 @@
                    (not= this-key @layout-key))
           (reset! layout-key this-key)
           (compute-layout! parsed direction layout-options
-                           (fn [poss]
-                             (when poss
-                               (reset! positions poss)))))
+                           (fn [result]
+                             (when result
+                               (reset! layout-state result)))))
         (cond
           (nil? definition)
           [:div {:data-testid (str testid "-no-definition")
@@ -403,15 +494,20 @@
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
                 edge-callback     (when-not read-only? on-edge-click)
+                {:keys [positions edge-points]} @layout-state
                 {:keys [nodes edges]}
                 (projection/xyflow-graph parsed
-                              @positions
+                              positions
                               {:highlight-ids     highlight-ids
                                :from-highlight-id from-highlight-id
                                :to-highlight-id   to-highlight-id
                                :sim?              sim?
                                :on-state-click    callback
                                :on-edge-click     edge-callback
+                               ;; rf2-cz8v6 (G2) — elk's routed bend-
+                               ;; points; the projector attaches each
+                               ;; edge's route to its :data {:points}.
+                               :edge-points       edge-points
                                :chart             chart-vc})
                 aria-label (str "State machine"
                                 (when machine-id

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/edges.cljs
@@ -50,6 +50,118 @@
 (def ^:private BaseEdge        (.-BaseEdge xyflow))
 (def ^:private EdgeLabelRenderer (.-EdgeLabelRenderer xyflow))
 
+;; ---- elk bend-point routing (rf2-cz8v6, G2) ----------------------------
+;;
+;; When elk hands us a multi-point route (start → bend… → end, in
+;; absolute flow coords), we render the edge ALONG it instead of a
+;; single bezier between handles. This is what stops a deeply-nested
+;; transition cutting ACROSS a region/compound container — the route
+;; goes AROUND it (§1.7 of `001-Topology-Parity.md`).
+
+(def ^:private corner-radius
+  "Max rounding applied at each bend (px). Kept small so the route
+  stays visibly orthogonal (it reads as elk's Manhattan routing) while
+  softening the hard corners to match the chart's bezier aesthetic."
+  8)
+
+(defn- poly-path
+  "Build an SVG path string that runs THROUGH `pts` (a JS array of
+  `#js {:x :y}` points) with small rounded corners at each interior
+  bend. `pts` has ≥ 2 entries (the projector / layout filter degenerate
+  routes out). Mirrors the rounded-orthogonal look of a hand-routed
+  statechart edge without depending on a layout-engine path string."
+  [pts]
+  (let [n (alength pts)]
+    (if (<= n 2)
+      ;; A straight start→end run — no interior bend to round.
+      (let [a (aget pts 0) b (aget pts (dec n))]
+        (str "M " (.-x a) "," (.-y a) " L " (.-x b) "," (.-y b)))
+      (let [sb   (js/Array.)
+            p0   (aget pts 0)]
+        (.push sb (str "M " (.-x p0) "," (.-y p0)))
+        ;; For each interior point, draw a line up TO a point shy of the
+        ;; corner, then a quadratic curve THROUGH the corner to a point
+        ;; just past it — rounding the bend.
+        (dotimes [i (- n 2)]
+          (let [prev (aget pts i)
+                cur  (aget pts (inc i))
+                nxt  (aget pts (+ i 2))
+                dx1  (- (.-x cur) (.-x prev))
+                dy1  (- (.-y cur) (.-y prev))
+                dx2  (- (.-x nxt) (.-x cur))
+                dy2  (- (.-y nxt) (.-y cur))
+                len1 (js/Math.hypot dx1 dy1)
+                len2 (js/Math.hypot dx2 dy2)
+                ;; clamp the rounding to half of the shorter incident
+                ;; segment so adjacent corners never overlap.
+                r    (js/Math.min corner-radius (/ len1 2) (/ len2 2))
+                ;; entry point: r before the corner along the incoming seg
+                ex   (if (pos? len1) (- (.-x cur) (* (/ dx1 len1) r)) (.-x cur))
+                ey   (if (pos? len1) (- (.-y cur) (* (/ dy1 len1) r)) (.-y cur))
+                ;; exit point: r after the corner along the outgoing seg
+                xx   (if (pos? len2) (+ (.-x cur) (* (/ dx2 len2) r)) (.-x cur))
+                xy   (if (pos? len2) (+ (.-y cur) (* (/ dy2 len2) r)) (.-y cur))]
+            (.push sb (str "L " ex "," ey))
+            (.push sb (str "Q " (.-x cur) "," (.-y cur) " " xx "," xy))))
+        (let [last-pt (aget pts (dec n))]
+          (.push sb (str "L " (.-x last-pt) "," (.-y last-pt))))
+        (.join sb " ")))))
+
+(defn- path-midpoint
+  "The label anchor for a routed edge: the midpoint of the path's
+  middle segment (so the label sits ON the route, not floating at the
+  bezier midpoint). `pts` is the JS points array (≥ 2)."
+  [pts]
+  (let [n (alength pts)
+        i (quot n 2)
+        a (aget pts (max 0 (dec i)))
+        b (aget pts i)]
+    [(/ (+ (.-x a) (.-x b)) 2)
+     (/ (+ (.-y a) (.-y b)) 2)]))
+
+(defn edge-path
+  "Pure path-selection for a transition edge — the single source of
+  truth `transition-edge` renders + the test suite pins (rf2-cz8v6).
+
+  Returns `{:d <svg-path-string> :label-x <px> :label-y <px> :routed?
+  <bool>}`. Path selection, in priority order:
+
+    1. `self-loop?`  → a small loop off the node's edge (NOT routed —
+       self-loops keep their dedicated path even if elk emitted bends).
+    2. elk route     → when `points` is a JS array of ≥ 2 `#js {:x :y}`,
+       a smooth poly-path THROUGH the bends so the edge goes AROUND
+       nested containers (`:routed? true`).
+    3. bezier        → `getBezierPath` between the handles (`:routed?
+       false`) — the no-bend-point fallback."
+  [{:keys [src-x src-y tgt-x tgt-y src-pos tgt-pos self-loop? points]}]
+  (let [routed? (and (not self-loop?)
+                     (some? points)
+                     (> (alength points) 1))]
+    (cond
+      self-loop?
+      (let [r 30]
+        {:d (str "M " src-x "," src-y
+                 " C " (+ src-x r) "," (- src-y r)
+                 " "  (+ src-x r) "," (+ src-y r)
+                 " "  src-x       "," src-y)
+         :label-x (+ src-x r 4)
+         :label-y src-y
+         :routed? false})
+
+      routed?
+      (let [[lx ly] (path-midpoint points)]
+        {:d (poly-path points) :label-x lx :label-y ly :routed? true})
+
+      :else
+      (let [bz (get-bezier-path
+                 #js {:sourceX        src-x
+                      :sourceY        src-y
+                      :sourcePosition src-pos
+                      :targetX        tgt-x
+                      :targetY        tgt-y
+                      :targetPosition tgt-pos})]
+        {:d (aget bz 0) :label-x (aget bz 1) :label-y (aget bz 2) :routed? false}))))
+
 ;; ---- helpers ------------------------------------------------------------
 ;;
 ;; rf2-k647w — edge typography (label font-size + backplate opacity)
@@ -125,27 +237,20 @@
         ;; Render it WITHOUT the re-entry arrowhead + with a dashed loop
         ;; so it reads as "no exit/entry re-trigger" (Stately parity).
         internal?  (boolean (.-internal d))
+        ;; rf2-cz8v6 (G2) — elk's routed bend-points (absolute coords),
+        ;; a JS array of `#js {:x :y}`. Present only when elk computed a
+        ;; multi-point route; nil for a simple edge (bezier fallback)
+        ;; and for self-loops (which keep their dedicated loop path).
+        points     (.-points d)
         {:keys [edge-label-px edge-label-backplate-opacity]} vc
-        ;; A self-transition (source == target) renders as a small loop
-        ;; off the node's edge instead of xyflow's degenerate near-zero
-        ;; bezier. Everything else uses `getBezierPath`, which returns
-        ;; [path-string label-x label-y offset-x offset-y] (aget'd).
-        [path label-x label-y]
-        (if self-loop?
-          (let [r 30]
-            [(str "M " src-x "," src-y
-                  " C " (+ src-x r) "," (- src-y r)
-                  " "  (+ src-x r) "," (+ src-y r)
-                  " "  src-x       "," src-y)
-             (+ src-x r 4) src-y])
-          (let [bz (get-bezier-path
-                     #js {:sourceX        src-x
-                          :sourceY        src-y
-                          :sourcePosition src-pos
-                          :targetX        tgt-x
-                          :targetY        tgt-y
-                          :targetPosition tgt-pos})]
-            [(aget bz 0) (aget bz 1) (aget bz 2)]))
+        ;; rf2-cz8v6 (G2) — path selection lives in the pure `edge-path`
+        ;; helper (self-loop → elk route → bezier), so the test suite
+        ;; pins the SAME geometry the renderer paints.
+        {path :d label-x :label-x label-y :label-y routed? :routed?}
+        (edge-path {:src-x src-x :src-y src-y
+                    :tgt-x tgt-x :tgt-y tgt-y
+                    :src-pos src-pos :tgt-pos tgt-pos
+                    :self-loop? self-loop? :points points})
         stroke  (edge-stroke {:active? active? :focused? focused?})
         stroke-w (edge-stroke-width {:active? active? :focused? focused? :chart vc})]
     (r/as-element
@@ -171,6 +276,10 @@
                ;; DOM suite + a host can distinguish self-transition kind
                ;; + inherited fallbacks.
                :data-internal (str internal?)
+               ;; rf2-cz8v6 (G2) — surface whether this edge rendered
+               ;; along elk's bend-point route (true) or fell back to
+               ;; the bezier (false), so the DOM suite can pin routing.
+               :data-routed (str routed?)
                :data-machine-level (str (boolean (.-machineLevel d)))
                ;; rf2-u422r — clickable edges surface their fireable
                ;; event-id so a host (Xray on-chart sim) + tests can

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -166,6 +166,21 @@
                            `:always`) carry the callback too but a nil
                            `:eventId`; the host filters those out. nil
                            omits the wiring entirely (no-op edge labels).
+    :edge-points         — rf2-cz8v6 (closes parity gap G2). A map
+                           `{edge-id [{:x :y} …]}` of elk's routed
+                           bend-points (absolute / flow coordinates;
+                           `chart`'s `compute-layout!` sets
+                           `elk.json.edgeCoords ROOT` so they share
+                           xyflow's frame). When an edge has an entry,
+                           its route is attached to the edge `:data` as
+                           `:points`, and `chart.edges/transition-edge`
+                           draws a smooth poly-path THROUGH those points
+                           — routing AROUND nested/parallel containers
+                           rather than cutting across them (§1.7 of
+                           `001-Topology-Parity.md`). An edge with no
+                           entry (or a self-loop, which keeps its
+                           dedicated loop path) falls back to the bezier
+                           between handles. Defaults to `{}`.
     :chart               — rf2-k647w. The resolved visual-constants
                            map for the active `:density`
                            (`visual-constants/chart-for-density`).
@@ -182,8 +197,8 @@
   [{:keys [nodes edges]}
    positions
    {:keys [highlight-id highlight-ids from-highlight-id to-highlight-id sim?
-           on-state-click on-edge-click chart]
-    :or   {chart vc/chart-regular}}]
+           on-state-click on-edge-click edge-points chart]
+    :or   {chart vc/chart-regular edge-points {}}}]
   (let [;; rf2-g2svr (G1) — the active set unifies the single-active
         ;; (`:highlight-id`) and multi-active (`:highlight-ids`) cases.
         ;; A PARALLEL machine's snapshot has N simultaneously-active
@@ -270,7 +285,13 @@
                                         (not (:always? e))
                                         (keyword? (:event e))
                                         (not= :* (:event e)))
-                      event-id     (when fireable? (:event e))]
+                      event-id     (when fireable? (:event e))
+                      ;; rf2-cz8v6 (G2) — elk's routed bend-points for
+                      ;; this edge (absolute coords). Self-loops keep
+                      ;; their dedicated loop path, so they never carry
+                      ;; points even if elk emitted a degenerate route.
+                      points       (when-not self-loop?
+                                     (get edge-points (:id e)))]
                   {:id     (:id e)
                    :source (:source e)
                    :target (:target e)
@@ -286,6 +307,13 @@
                             :guard      (layout/name-of (:guard e))
                             :action     (layout/name-of (:action e))
                             :selfLoop   self-loop?
+                            ;; rf2-cz8v6 (G2) — elk's routed bend-points
+                            ;; (a `[{:x :y} …]` vector in absolute /
+                            ;; flow coords) when elk computed a route;
+                            ;; the edge component draws a smooth poly-
+                            ;; path THROUGH them (around nested
+                            ;; containers). nil → the bezier fallback.
+                            :points       points
                             ;; rf2-ee38b.21 — an internal self-transition
                             ;; (omit :target) runs only :action; the
                             ;; renderer draws it as a self-loop with no
@@ -340,6 +368,11 @@
                  :data        {:eventLabel "" :entry true
                                :active false :focused false :afterMs nil
                                :guard nil :action nil :selfLoop false
+                               ;; rf2-cz8v6 (G2) — entry edges keep the
+                               ;; bezier (a short marker→state hop never
+                               ;; crosses a container); :points nil so
+                               ;; the every-edge :data shape stays whole.
+                               :points nil
                                :internal false :machineLevel false
                                :eventId nil :fromPath nil :toPath nil
                                :onClick on-edge-click :chart chart}})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -164,6 +164,39 @@
           (is (= "3" (.getAttribute root "data-edge-count"))
               "data-edge-count reflects the transition count"))))))
 
+;; ---- edge routing fallback (rf2-cz8v6, G2) ------------------------------
+;;
+;; Before the async elkjs pass resolves, edges carry no bend-points, so
+;; the edge component renders the bezier fallback (`data-routed=false`).
+;; The routed path (`data-routed=true`) only appears after layout —
+;; which the synchronous runner cannot await (see the ns docstring) — so
+;; the routed geometry itself is pinned at the cheap layer:
+;; `edges-cljs-test` (the pure `edge-path` helper) +
+;; `projection-cljs-test` (the `:edge-points` → `:data {:points}`
+;; threading). This DOM pin guards the LIVE fallback render.
+
+(deftest chart-edge-label-renders-bezier-fallback-before-layout
+  (testing "rf2-cz8v6 — on first commit (pre-elk-layout) an edge label
+            renders with data-routed=\"false\": no bend-points yet, so
+            the edge takes the bezier fallback path. (The routed path
+            arrives after the async layout the runner can't await; the
+            poly-path geometry is pinned in edges-cljs-test.)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/flow :definition idle-loading-done}
+        (fn [_root node]
+          (let [labels (.querySelectorAll node "[data-testid^=\"rf-mv-chart-edge-\"]")]
+            ;; edge labels mount via EdgeLabelRenderer on the first commit
+            ;; (they do not depend on positions for existence).
+            (when (pos? (.-length labels))
+              (let [el (aget labels 0)]
+                (is (= "false" (.getAttribute el "data-routed"))
+                    "pre-layout edge falls back to the bezier path")))
+            ;; Always assert at least the structural invariant so the
+            ;; test is meaningful even if labels race the commit.
+            (is (number? (.-length labels)))))))))
+
 ;; ---- final-state affordance ---------------------------------------------
 
 (deftest chart-marks-final-states

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/edges_cljs_test.cljs
@@ -1,0 +1,162 @@
+(ns day8.re-frame2-machines-viz.chart.edges-cljs-test
+  "CLJS tests for the MachineChart edge path-selection (rf2-cz8v6, G2).
+
+  `chart.edges/edge-path` is the pure source-of-truth for the SVG path a
+  transition edge renders: self-loop → elk bend-point route → bezier
+  fallback. The renderer (`transition-edge`) calls it, so pinning the
+  helper pins the rendered geometry without racing the async elkjs
+  layout pass (the full-mount DOM suite can't await elk).
+
+  The ns requires `chart.edges`, which `:require`s `@xyflow/react` — a
+  pure-JS module that loads fine under Node (only its React-DOM
+  COMPONENTS need a browser; `getBezierPath` is pure math). So this runs
+  under the `:node-test` build (`cljs-test$` ns-regexp) — it is NOT a
+  `-dom-cljs-test` (no DOM mount), and the JVM `clojure -M:test` runner
+  skips it (it scans .clj/.cljc only, never .cljs)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [day8.re-frame2-machines-viz.chart :as chart]
+            [day8.re-frame2-machines-viz.chart.edges :as edges]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(defn- pt [x y] #js {:x x :y y})
+
+(def ^:private base-coords
+  "Source/target handle coords + handle positions shared by the cases."
+  {:src-x 0 :src-y 0 :tgt-x 100 :tgt-y 200
+   :src-pos "bottom" :tgt-pos "top"})
+
+;; ---- elk-edge-points: JS elk section → absolute point vector -----------
+;;
+;; `chart/elk-edge-points` is the JS-interop lift that turns one elk
+;; edge's `sections` (start → bend… → end) into the `[{:x :y} …]` vector
+;; the projector carries. It walks real elk JS objects, so it lives in
+;; chart.cljs (which `:require`s elkjs — loads under Node); these pins
+;; exercise it against synthetic section objects shaped exactly like
+;; elk's output.
+
+(defn- ->section
+  "Build a synthetic elk edge `section` JS object."
+  [start bends end]
+  #js {:startPoint start
+       :bendPoints  (apply array bends)
+       :endPoint    end})
+
+(defn- ->edge [sections]
+  #js {:sections (apply array sections)})
+
+(deftest elk-edge-points-chains-start-bends-end
+  (testing "rf2-cz8v6 — a single-section edge lifts to start → bend… →
+            end as a CLJS vector of {:x :y} maps (absolute coords)"
+    (let [edge (->edge [(->section (pt 0 0) [(pt 0 50) (pt 80 50)] (pt 80 100))])]
+      (is (= [{:x 0 :y 0} {:x 0 :y 50} {:x 80 :y 50} {:x 80 :y 100}]
+             (chart/elk-edge-points edge))))))
+
+(deftest elk-edge-points-collapses-duplicate-seam-points
+  (testing "rf2-cz8v6 — across two sections the first's endPoint can
+            repeat the next's startPoint; consecutive duplicates collapse
+            so the path has no zero-length segment"
+    (let [edge (->edge [(->section (pt 0 0) [] (pt 0 50))
+                        (->section (pt 0 50) [] (pt 60 50))])]
+      (is (= [{:x 0 :y 0} {:x 0 :y 50} {:x 60 :y 50}]
+             (chart/elk-edge-points edge))
+          "the shared (0,50) seam point appears once"))))
+
+(deftest elk-edge-points-nil-without-sections
+  (testing "rf2-cz8v6 — an edge elk gave no route (no sections) lifts to
+            nil so the projector falls back to the bezier"
+    (is (nil? (chart/elk-edge-points #js {})))
+    (is (nil? (chart/elk-edge-points #js {:sections #js []})))))
+
+(deftest elk-edge-points-nil-for-degenerate-single-point
+  (testing "rf2-cz8v6 — a section that collapses to one point is not a
+            real route (nothing to route THROUGH) → nil"
+    (let [edge (->edge [(->section (pt 5 5) [] (pt 5 5))])]
+      (is (nil? (chart/elk-edge-points edge))))))
+
+;; ---- elk-route case (the G2 capability) --------------------------------
+
+(deftest edge-path-routes-through-bend-points
+  (testing "rf2-cz8v6 — when elk supplies a multi-point route, the path
+            runs THROUGH every bend (the path string mentions each
+            interior bend's coords), NOT a straight/bezier shortcut"
+    (let [;; an L-shaped route around a container corner:
+          ;; (0,0) → (0,120) → (160,120) → (160,200)
+          points (array (pt 0 0) (pt 0 120) (pt 160 120) (pt 160 200))
+          {:keys [d routed?]} (edges/edge-path
+                                (assoc base-coords
+                                       :self-loop? false :points points))]
+      (is (true? routed?) "a multi-point route is :routed?")
+      (is (str/starts-with? d "M 0,0")
+          "the path starts at the route's first point")
+      ;; the corner-rounding emits the bend vertices as quadratic control
+      ;; points, so each interior bend's coords appear verbatim in the `d`.
+      (is (str/includes? d "120") "the path bends at the y=120 corner row")
+      (is (str/includes? d "160") "the path bends at the x=160 corner column")
+      (is (str/ends-with? d "160,200")
+          "the path ends at the route's last point")
+      ;; a bezier shortcut would be a single C command; a routed path is
+      ;; a poly-path of L/Q segments.
+      (is (str/includes? d "Q") "rounded corners use quadratic segments")
+      (is (not (str/includes? d "C"))
+          "a routed path is NOT a single bezier curve"))))
+
+(deftest edge-path-routed-label-sits-on-the-route
+  (testing "rf2-cz8v6 — a routed edge's label anchors on the route
+            (the midpoint of its middle segment), not at a bezier
+            midpoint floating away from the bends"
+    (let [points (array (pt 0 0) (pt 0 100) (pt 100 100) (pt 100 200))
+          {:keys [label-x label-y routed?]}
+          (edges/edge-path (assoc base-coords :self-loop? false :points points))]
+      (is (true? routed?))
+      ;; middle segment is (0,100)→(100,100): midpoint (50,100).
+      (is (= 50 label-x))
+      (is (= 100 label-y)))))
+
+(deftest edge-path-two-point-route-is-a-straight-line
+  (testing "rf2-cz8v6 — a degenerate two-point route (no interior bend)
+            renders a straight M…L… line, still flagged :routed?"
+    (let [points (array (pt 10 10) (pt 90 90))
+          {:keys [d routed?]}
+          (edges/edge-path (assoc base-coords :self-loop? false :points points))]
+      (is (true? routed?))
+      (is (= "M 10,10 L 90,90" d)))))
+
+;; ---- bezier fallback (the no-bend-point case) --------------------------
+
+(deftest edge-path-falls-back-to-bezier-without-points
+  (testing "rf2-cz8v6 — a simple edge with NO elk points falls back to
+            the bezier path (xyflow `getBezierPath` → a single C curve),
+            and is NOT flagged :routed?"
+    (let [{:keys [d routed?]}
+          (edges/edge-path (assoc base-coords :self-loop? false :points nil))]
+      (is (false? routed?) "no points → not routed (bezier fallback)")
+      (is (string? d))
+      (is (str/includes? d "C")
+          "the bezier fallback is a cubic curve (C command)"))))
+
+(deftest edge-path-empty-points-falls-back-to-bezier
+  (testing "rf2-cz8v6 — a single-point (or empty) route is not a real
+            route; the edge falls back to the bezier"
+    (let [{:keys [routed?]}
+          (edges/edge-path (assoc base-coords :self-loop? false
+                                  :points (array (pt 5 5))))]
+      (is (false? routed?) "a one-point route is too degenerate to route"))))
+
+;; ---- self-loop (unchanged) ---------------------------------------------
+
+(deftest edge-path-self-loop-keeps-its-loop-path
+  (testing "rf2-cz8v6 — a self-loop keeps its dedicated small-loop path
+            and is NEVER routed, even if elk emitted bend-points for it"
+    (let [{:keys [d routed?]}
+          (edges/edge-path (assoc base-coords
+                                  :self-loop? true
+                                  ;; elk route present but must be ignored
+                                  :points (array (pt 0 0) (pt 9 9) (pt 18 0))))]
+      (is (false? routed?) "self-loops are never routed")
+      ;; the loop path is the shipped cubic loop off the source handle.
+      (is (str/starts-with? d "M 0,0") "loop starts at the source handle")
+      (is (str/includes? d "C") "the self-loop is a cubic loop")
+      (is (not (str/includes? d "Q"))
+          "the self-loop is NOT the routed poly-path"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -796,3 +796,94 @@
       (is (= "on-leave" (:exit (:data a))))
       (is (nil? (:entry (:data b))) "a state with no entry carries nil")
       (is (nil? (:exit (:data b)))))))
+
+;; ---- elk bend-point edge routing (rf2-cz8v6, G2) -----------------------
+;;
+;; elk computes multi-point edge routes (start → bend… → end) that go
+;; AROUND nested/parallel containers. `chart.cljs/compute-layout!` lifts
+;; them into an `{edge-id [{:x :y} …]}` map (absolute coords via
+;; `elk.json.edgeCoords ROOT`); the projector attaches each edge's route
+;; to its `:data {:points}` so `chart.edges/transition-edge` can draw a
+;; poly-path THROUGH the bends instead of a bezier shortcut that may cut
+;; across a container (§1.7 of `001-Topology-Parity.md`). These pins
+;; guard the projection half at the cheap JVM layer.
+
+(deftest xyflow-graph-attaches-edge-points-to-matching-edge
+  (testing "rf2-cz8v6 (THE G2 CAPABILITY) — an edge whose id has an
+            entry in :edge-points carries that route on its
+            `:data {:points}` so the edge renders THROUGH the bend
+            points (not a straight/bezier shortcut)"
+    (let [parsed   (layout/parse-definition idle-loading)
+          ;; the idle→loading :start edge
+          start    (->> (:edges parsed)
+                        (filter #(= (:source %) (layout/node-id [:idle])))
+                        first)
+          route    [{:x 0 :y 0} {:x 0 :y 50} {:x 80 :y 50} {:x 80 :y 100}]
+          graph    (projection/xyflow-graph
+                     parsed {} {:edge-points {(:id start) route}})
+          start-e  (edge-by-id graph (:id start))]
+      (is (some? start-e))
+      (is (= route (:points (:data start-e)))
+          "elk's routed bend-points ride on the edge data"))))
+
+(deftest xyflow-graph-edge-without-route-falls-back-to-nil-points
+  (testing "rf2-cz8v6 — a simple edge with no :edge-points entry carries
+            `:points nil`, so the edge component falls back to the
+            bezier path (the no-bend-point case)"
+    (let [parsed (layout/parse-definition idle-loading)
+          ;; supply a route for ONE edge only; every other edge is bare
+          start  (->> (:edges parsed)
+                      (filter #(= (:source %) (layout/node-id [:idle])))
+                      first)
+          graph  (projection/xyflow-graph
+                   parsed {} {:edge-points {(:id start) [{:x 0 :y 0} {:x 9 :y 9}]}})
+          others (remove #(= (:id %) (:id start))
+                         (remove #(:entry (:data %)) (:edges graph)))]
+      (is (seq others) "fixture has more than one transition edge")
+      (is (every? #(nil? (:points (:data %))) others)
+          "edges with no route entry carry nil points (bezier fallback)"))))
+
+(deftest xyflow-graph-no-edge-points-leaves-all-points-nil
+  (testing "rf2-cz8v6 — omitting :edge-points entirely (the pre-layout
+            render, before elk resolves) leaves EVERY edge's :points nil
+            so the whole chart falls back to beziers"
+    (let [parsed (layout/parse-definition idle-loading)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (is (seq (:edges graph)))
+      (is (every? #(nil? (:points (:data %))) (:edges graph))
+          "no edge-points map → no routed edges"))))
+
+(deftest xyflow-graph-self-loop-never-carries-points
+  (testing "rf2-cz8v6 — a self-loop keeps its dedicated loop path: even
+            when elk emits a route for the self-edge id, the projector
+            drops it so :points stays nil (self-loops unchanged)"
+    (let [parsed (layout/parse-definition self-loop-machine)
+          self   (->> (:edges parsed)
+                      (filter #(= (:source %) (:target %)))
+                      first)
+          graph  (projection/xyflow-graph
+                   parsed {} {:edge-points {(:id self) [{:x 0 :y 0} {:x 5 :y 5}]}})
+          self-e (edge-by-id graph (:id self))]
+      (is (some? self) "fixture has a self-transition")
+      (is (true? (:selfLoop (:data self-e))))
+      (is (nil? (:points (:data self-e)))
+          "a self-loop never carries elk points (it keeps its loop path)"))))
+
+(deftest xyflow-graph-routed-edge-keeps-active-highlight
+  (testing "rf2-cz8v6 — G1's active-edge styling survives routing: an
+            edge that BOTH has a route AND touches the highlighted node
+            is `:active` (highlighted) AND carries its `:points`"
+    (let [parsed  (layout/parse-definition idle-loading)
+          hi      (layout/node-id [:loading])
+          start   (->> (:edges parsed)
+                       (filter #(= (:source %) (layout/node-id [:idle])))
+                       first)
+          route   [{:x 0 :y 0} {:x 0 :y 40} {:x 60 :y 40}]
+          graph   (projection/xyflow-graph
+                    parsed {} {:highlight-id hi
+                               :edge-points  {(:id start) route}})
+          start-e (edge-by-id graph (:id start))]
+      (is (true? (:active (:data start-e)))
+          "the idle→loading edge still highlights (target is active)")
+      (is (= route (:points (:data start-e)))
+          "and still carries its elk route — highlight + routing coexist"))))


### PR DESCRIPTION
## What

Closes parity gap **G2** in `tools/machines-viz/spec/001-Topology-Parity.md` (flipped to ✅ in this PR).

ELK computes multi-point edge routes (bend-points) that go **around** nested/parallel compound containers, but the chart discarded them — edges rendered as beziers and, on deep nesting, an edge could cut **across** a container (vs Stately/ELK's clean orthogonal routing). This lifts ELK's bend-points into the xyflow edge geometry.

## How

- **`chart.cljs`** — `default-elk-options` now uses `elk.edgeRouting ORTHOGONAL` (Manhattan routes around containers) + `elk.json.edgeCoords ROOT` (sections reported in absolute/flow coords, the same frame xyflow hands the custom edge component). New `elk-edge-points` lifts each edge's `sections` (`start → bend… → end`) into a `[{:x :y} …]` vector, collapsing duplicate seam points. `elk-result->positions` now returns `{:positions :edge-points}` and walks **every** node's `edges` array so cross-hierarchy routes are collected. The layout atom carries both halves.
- **`projection.cljc`** — `xyflow-graph` takes `:edge-points` and attaches each edge's route to `:data {:points}`. Self-loops never carry points (they keep their dedicated loop path); entry-marker edges keep the bezier.
- **`edges.cljs`** — a pure `edge-path` helper is the single source of truth: self-loop → ELK poly-path (rounded-corner route **through** the bends) → bezier fallback. `transition-edge` renders it and surfaces `data-routed`. G1's `highlight-ids` active-edge styling is intact — an active edge still highlights along the new path.

Coordinate space: ELK node x/y are parent-relative (unchanged handling); edge points are made root-relative via `edgeCoords ROOT`, matching xyflow's absolute `sourceX`/`targetX`/… frame, so a deeply-nested transition's route is in the same space as a flat one.

## Tests

- **projection (`.cljc`, JVM)** — route → `:data {:points}`; a no-route edge → `nil` (bezier fallback); no `:edge-points` map → all nil; a self-loop never carries points; highlight + routing coexist.
- **edges (`.cljs`, node)** — `edge-path` geometry: poly-path runs through the bends (not a straight/bezier shortcut), label sits on the route, two-point route is a straight line, bezier fallback without points, self-loop keeps its loop path; `elk-edge-points` over synthetic ELK JS sections (chain, seam-dedupe, nil cases).
- **chart-dom (`.cljs`, browser)** — live edge falls back to the bezier (`data-routed="false"`) on first commit (pre-async-layout; the routed geometry is pinned at the cheap layer since the runner can't await elk).

## Gates (all green)

- clj-kondo: **errors: 0** (no new warnings in changed files)
- splint: **0 errors** (no new style warnings in changed files)
- `clojure -M:test` (machines-viz): **216 tests / 520 assertions, 0 failures, 0 errors**
- `npm run test:cljs` (node): **4316 / 13539, 0 failures, 0 errors**
- `npm run test:browser`: **115 / 324, 0 failures, 0 errors**

## Spec

G2 flipped to ✅ in `001-Topology-Parity.md` (§2 table row, §3.1 gap table, §4.3 design bullet, Phase B B1 roadmap row, and the §2 headline). G5 (cross-hierarchy edge-routing assertion, N2) remains a separate bead.