### PR TITLE
feat(machines-viz): active chrome for parallel-region containers (rf2-80rm2)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -171,6 +171,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 | **Hierarchy** | ✅ Compound parents render as a dashed container with a header-strip title; children nest via xyflow `parentNode` + `extent:"parent"`; elk lays children inside the parent box (`INCLUDE_CHILDREN`). Nesting recurses (compound-in-compound, compound-in-region). | `nodes.cljs` `compound-node`; `projection.cljc` `->elk-children` (`:parent-id` grouping), `xyflow-graph` (`parentNode`/`extent`); `layout.cljc` `parse-flat` (`:parent-id` on nested nodes). |
 | **Parallel regions — structure** | ✅ **Every** region renders as a synthetic `:region?` compound node with a **distinct dashed boundary per region** (palette rotation) + `∥` glyph + region label; states carry `:region` + `:parent-id`; edges stay region-local. | `layout.cljc` `parse-parallel`/`region-node-id`; `projection.cljc` (`type "parallel-region"`); `nodes/parallel_region_node.cljs`. |
 | **Parallel regions — active highlight** | ✅ **Closed (rf2-yoe6e / rf2-g2svr).** `highlight-ids` resolves the whole snapshot `:state` — flat keyword, compound path, **or region-map** `{region path}` — to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so a parallel snapshot's **N simultaneously-active leaves** all light up at once. A nested region value resolves to its deepest leaf. | `layout.cljc` `highlight-ids`; `projection.cljc` `xyflow-graph` (`:highlight-ids` set). |
+| **Parallel regions — active CONTAINER chrome** | ✅ **Closed (rf2-80rm2 / G4).** The region (and, for self-consistency, the compound) **container** reads as active when ANY descendant leaf is active — the projector folds the container into `:active` by walking each active leaf UP its `:parent-id` chain (reusing the G1 active set; no duplicate highlight logic). `parallel-region-node` / `compound-node` then paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so an active region reads as active at the zone level, not just the leaf inside it. **Palette delegated to Figma.** | `projection.cljc` `xyflow-graph` (`active-container-ids` parent-id walk); `nodes/parallel_region_node.cljs`; `nodes.cljs` `compound-node`. |
 | **Transition scoping** | ✅ `:on`, `:after`, `:always`, machine-level (top-level `:on`) fallback, external + internal self-transitions, vector-of-candidates forks. Self-loops render as a small loop (not a degenerate bezier); internal self-transitions render dashed + no arrowhead. | `layout.cljc` `collect-state-edges`, `collect-machine-edges`, `resolve-target-path`; `edges.cljs` (self-loop path, internal dash). |
 | **Initial** | ✅ Filled-dot `initial-marker` node + unlabelled entry edge into the initial state, at **every** compound level (xstate/SCXML semantics). | `nodes.cljs` `initial-marker`; `projection.cljc` (marker-nodes + entry-edges); `layout.cljc` `collect-nodes` (per-level `:initial?`). |
 | **Final** | ✅ Doubled border (outer ring 1px proud) + `✓` glyph inline on `state-node`. | `nodes.cljs` `state-node` (final ring + glyph). |
@@ -186,10 +187,10 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 (layout), initial, final, transition scoping, event labels,
 guards/actions, layout, and ergonomics. The high-severity **parallel
 multi-active highlight** gap (G1) is now **closed** (rf2-yoe6e /
-rf2-g2svr) and the bend-point edge-routing gap (G2) is now **closed**
-(rf2-cz8v6); the residue is two **fired-edge consistency** items the
-live-chart wiring needs and the region-ACTIVE chrome polish (G4) that
-completes the parallel-parity read.
+rf2-g2svr), the bend-point edge-routing gap (G2) is now **closed**
+(rf2-cz8v6), and the region-ACTIVE chrome polish (G4) is now **closed**
+(rf2-80rm2) — the parallel-parity read is complete; the residue is the
+two **fired-edge consistency** items the live-chart wiring needs.
 
 ## §3 — Gap analysis + deliberate divergences
 
@@ -203,7 +204,7 @@ new), and the parity-bar row it serves.
 | **G1** | ✅ **CLOSED (rf2-yoe6e / rf2-g2svr).** Was: a parallel snapshot's `:state` is a region-map `{region path}` with **N active leaves**; `highlight-id` returned nil for a map, so the chart highlighted **none** (or only a degenerate single id). Now: `highlight-ids` resolves the whole `:state` (flat / compound / region-map, nested values → deepest leaf) to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so all N regions light up at once — Stately's §1.2 read. | **High** | §1.2, §1.9 | **contract:** rf2-yoe6e ✅ · **impl:** rf2-g2svr ✅ |
 | **G2** | ✅ **CLOSED (rf2-cz8v6).** Was: edges were beziers between handles; elk's Layered bend-points were discarded (§1.7), so in deep nesting an edge could cut **across** a region/compound container instead of routing **around** it. Now: elk runs `ORTHOGONAL` routing with `elk.json.edgeCoords ROOT`; `compute-layout!` lifts each edge's `sections` bend-points (absolute coords) into the projection (`:edge-points` → `:data {:points}`), and `edges.cljs/edge-path` draws a smooth poly-path THROUGH them — routing around non-incident containers (the [`000-Vision.md`](000-Vision.md) §Quality-bar "no edge-crossing collapse" floor). Self-loops keep their loop path; no-route edges fall back to the bezier; G1's active-edge highlight survives the new path. | **Medium** | §1.7, §1.9 | **impl:** rf2-cz8v6 ✅ |
 | **G3** | **Fired-edge id consistency (live chart).** To highlight "the edge that fired this epoch" on the live chart, the host's trace→edge-id mapping MUST mint the **same** `edge-id` `chart.layout` mints. Today the helper chain needs consolidating so `extract-fired-edge-ids` emits machines-viz `edge-id`s. (The node-id scheme was already unified — rf2-m8kod.) | **Medium** | §1.3, §1.8 | **helpers:** rf2-8jzm1 (existing) · **wire:** rf2-qeemm (existing) |
-| **G4** | **Parallel-region chrome polish for the active read.** Once G1 lights up N regions, the **region container** should reflect "this region is active" (vs. structural-only chrome today) so a reader scanning N regions sees the active leaf in each at a glance — region-header active affordance + per-region active-leaf emphasis that reads as a set, not N independent highlights. | **Low–Medium** | §1.2 | **NEW — see §5 N1** |
+| **G4** | ✅ **CLOSED (rf2-80rm2).** Was: once G1 lit N region LEAVES, the **region CONTAINER** still read structural-only — an active region was indistinguishable from an inactive one at the zone level. Now: `xyflow-graph` folds a container (region OR compound) into `:active` when any descendant leaf is active — walked UP the `:parent-id` chain every node already carries (reuses the G1 active set; no path-prefix reimplementation). `parallel-region-node` / `compound-node` paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so each active region reads as active at a glance and the N active regions read as a set. **Palette delegated to Figma.** | **Low–Medium** | §1.2 | **impl:** rf2-80rm2 ✅ |
 | **G5** | **Cross-hierarchy edge-routing option not asserted.** elk routes cross-hierarchy edges only when the option is activated on the top level (§1.7). The default elk options set `INCLUDE_CHILDREN` for nesting but do not pin the cross-hierarchy edge-routing option; an edge from a deeply-nested leaf to a top-level state may not route cleanly even after G2. | **Low** | §1.7 | **NEW — see §5 N2** (pairs with rf2-cz8v6/G2) |
 
 ### 3.2 Deliberate non-parity divergences (intentional, NOT gaps)
@@ -270,7 +271,7 @@ not **which colour**.
 | **Initial marker** | small **filled dot** + unlabelled arrow into the initial state, at every compound level | *`accent` dot* |
 | **Compound container** | translucent box, **dashed** border, header-strip title | *`accent` 6% fill, dashed `accent`* |
 | **Parallel region container** | **distinct dashed boundary per region** (rotation so adjacent regions differ) + `∥` glyph + uppercased region label | *`region-boundary-palette` rotation* |
-| **Parallel region (ACTIVE) — G1/G4** | region header carries an **active affordance**; **every** active leaf inside lights with the active dimension **simultaneously**; the set reads as "all active at once," not N independent picks | NEW — Figma to design the region-active treatment |
+| **Parallel region (ACTIVE) — G1/G4** | region header + boundary carry an **active affordance**; **every** active leaf inside lights with the active dimension **simultaneously**; the set reads as "all active at once," not N independent picks | ✅ shipped (rf2-80rm2): solid emphasised boundary + emphasised header tint + `info` glow ring (the state-node active token). Figma may re-key the region-active palette |
 | **Edge (resting transition)** | thin stroke + arrowhead + label backplate | *`border-default`* |
 | **Edge (active — touches active state)** | mid-weight stroke + arrow tinted to active hue | *`info`, midweight* |
 | **Edge (focused — the fired FROM→TO)** | **emphasised** stroke + **animated glow** | *`info` + `mv-chart-transition-glow`* |
@@ -335,7 +336,7 @@ project dispatch rules): `tools/xray/spec/003-Machine-Inspector.md`.
 |---|---|---|---|---|
 | A1 | **rf2-yoe6e** — spec the parallel multi-active-highlight contract | existing | **HOT** (touches 003 + machines-viz API) | Defines `highlight-ids` set semantics + region-map resolution. Serial vs any other 003 edit. |
 | A2 | **rf2-g2svr** — implement parallel multi-active highlight | existing | isolated (`chart.layout`/`chart.projection` + tests) | Set-returning resolver + projection threads the set; JVM-tested. Depends on A1. |
-| A3 | **N1 (NEW)** — `feat(machines-viz): parallel-region ACTIVE chrome (region-active affordance + simultaneous N-leaf read)` | **NEW** | isolated (`nodes/parallel_region_node.cljs` + projection flag + tests) | Closes **G4**. Region header active affordance + the "reads as a set" treatment (§4.2). **Figma owns the region-active palette.** Depends on A2. |
+| A3 | **rf2-80rm2** ✅ — `feat(machines-viz): parallel-region ACTIVE chrome (region-active affordance + simultaneous N-leaf read)` | existing | isolated (`projection.cljc` `active-container-ids` + `nodes/parallel_region_node.cljs` + `nodes.cljs` `compound-node` + JVM tests) | **Closed G4.** Container folds into `:active` via the `:parent-id` chain (reuses the G1 active set); region + compound containers paint the solid-boundary + `:info` glow active chrome (§4.2). **Figma owns the region-active palette.** |
 
 ### Phase B — edge-routing fidelity (the medium gap)
 
@@ -360,11 +361,12 @@ project dispatch rules): `tools/xray/spec/003-Machine-Inspector.md`.
 ### Proposed NEW beads (for the mayor to file)
 
 1. **N1 — `feat(machines-viz): parallel-region ACTIVE chrome`**
-   (closes **G4**). Region-header active affordance + simultaneous
-   N-active-leaf treatment that reads as one set. Isolated
-   (`nodes/parallel_region_node.cljs` + projection flag + DOM/JVM
-   tests). Depends on rf2-g2svr (A2). **Figma owns the region-active
-   palette.** P2 (it completes the parallel-parity story G1 opens).
+   ✅ **filed + closed as rf2-80rm2** (closes **G4**). Region-header +
+   boundary active affordance + simultaneous N-active-leaf treatment
+   that reads as one set. Isolated (`projection.cljc`
+   `active-container-ids` parent-id walk + `nodes/parallel_region_node.cljs`
+   + `nodes.cljs` `compound-node` + JVM tests). Depended on rf2-g2svr
+   (A2). **Figma owns the region-active palette.**
 2. **N2 — `feat(machines-viz): assert ELK cross-hierarchy edge-routing`**
    (closes **G5**). Add the top-level cross-hierarchy edge-routing
    option to `default-elk-options`; projection test pins it. Isolated

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -309,20 +309,33 @@
         vc    (chart-constants d)
         label (or (.-label d) "")
         path  (.-path d)
+        ;; rf2-80rm2 (G4) — for self-consistency with the active-region
+        ;; chrome, a compound CONTAINER whose active descendant leaf lit it
+        ;; (the projector folds that into `:active` via the `:parent-id`
+        ;; chain) also gets active chrome: a solid (not dashed) accent border
+        ;; + the `:info` active-token glow ring — the same active affordance
+        ;; state nodes and active regions use. Minimal: only the boundary
+        ;; firms up and the glow appears; inactive compounds are unchanged.
+        active? (boolean (.-active d))
         {:keys [compound-pad-y compound-radius compound-title-px]} vc]
     (r/as-element
       [:div {:data-testid (str "rf-mv-chart-compound-" (.-id props))
              :data-node-id (.-id props)
              :data-state-path (when path (pr-str (js->clj path)))
+             :data-active (str active?)
              :style {:position         "relative"
                      :width            "100%"
                      :height           "100%"
                      :min-width        (str projection/compound-node-min-width "px")
                      :min-height       (str projection/compound-node-min-height "px")
                      :padding-top      (str compound-pad-y "px")
-                     :background       (tokens/with-alpha :accent 0.06)
-                     :border           (str "1px dashed " (:accent tokens/tokens))
+                     :background       (tokens/with-alpha :accent (if active? 0.10 0.06))
+                     :border           (str (if active? "1.5px solid " "1px dashed ")
+                                            (:accent tokens/tokens))
                      :border-radius    (str compound-radius "px")
+                     :box-shadow       (when active?
+                                         (str "0 0 0 2px "
+                                              (tokens/with-alpha :info 0.18)))
                      :pointer-events   "none"}}
        [:div {:style {:position    "absolute"
                      :top         "4px"

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -76,24 +76,47 @@
   (let [d            (.-data props)
         label        (or (.-label d) "")
         region-index (.-regionIndex d)
+        ;; rf2-80rm2 (G4) — the region CONTAINER reads active when any of
+        ;; its descendant leaves is in the active set (the projector folds
+        ;; that into `:active` via the `:parent-id` chain). An active region
+        ;; gets ACTIVE CHROME: a solid (not dashed) boundary, an emphasised
+        ;; header, and the `:info` active-token glow ring — the same
+        ;; active-token convention the state nodes use (no new palette). The
+        ;; region keeps its own rotation colour for zone identity; only the
+        ;; emphasis is added so the active region(s) read as active at the
+        ;; container level, matching Stately's active-region treatment.
+        active?      (boolean (.-active d))
         color-key    (region-boundary-color-key region-index)
         border-color (get tokens/tokens color-key)
-        body-tint    (tokens/with-alpha color-key 0.05)
-        header-tint  (tokens/with-alpha color-key 0.12)]
+        body-tint    (tokens/with-alpha color-key (if active? 0.10 0.05))
+        header-tint  (tokens/with-alpha color-key (if active? 0.20 0.12))
+        ;; Active boundary firms up (solid + heavier) so the zone reads as
+        ;; live; inactive keeps the dashed orthogonal-zone delineation.
+        border-style (if active? "solid" "dashed")
+        border-width (if active? "2px" "1.5px")]
     (r/as-element
       [:div {:data-testid    (str "rf-mv-chart-region-" (.-id props))
              :data-node-id    (.-id props)
              :data-region-id  (when-let [rid (.-regionId d)] (str rid))
              :data-region-index (when (some? region-index) (str region-index))
+             :data-active     (str active?)
              :style {:position       "relative"
                      :width          "100%"
                      :height         "100%"
                      :padding-top    "26px"
                      :background     body-tint
-                     ;; Distinct DASHED boundary per region — the
-                     ;; Stately-parity orthogonal-zone delineation.
-                     :border         (str "1.5px dashed " border-color)
+                     ;; Distinct boundary per region — the Stately-parity
+                     ;; orthogonal-zone delineation. Solid + emphasised
+                     ;; when the region is active (rf2-80rm2).
+                     :border         (str border-width " " border-style " " border-color)
                      :border-radius  "12px"
+                     ;; rf2-80rm2 (G4) — the active-region glow ring uses the
+                     ;; `:info` active token, mirroring the state-node active
+                     ;; box-shadow (`0 0 0 2px info@0.18`) so an active region
+                     ;; reads with the SAME active affordance as an active state.
+                     :box-shadow     (when active?
+                                       (str "0 0 0 2px "
+                                            (tokens/with-alpha :info 0.18)))
                      :pointer-events "none"}}
        ;; Header strip — the region label, tinted to the region colour.
        [:div {:data-testid (str "rf-mv-chart-regionhdr-" (.-id props))
@@ -106,7 +129,7 @@
                       :align-items    "center"
                       :padding        "0 10px"
                       :background     header-tint
-                      :border-bottom  (str "1px dashed " border-color)
+                      :border-bottom  (str "1px " border-style " " border-color)
                       :border-top-left-radius  "11px"
                       :border-top-right-radius "11px"
                       :font-family    sans-stack

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -209,6 +209,33 @@
         ;; union.
         active-ids (cond-> (set highlight-ids)
                      (some? highlight-id) (conj highlight-id))
+        ;; rf2-80rm2 (G4) — container ACTIVE chrome. The active set above
+        ;; holds active LEAF ids; a parallel-region (or compound) CONTAINER
+        ;; reads as active when ANY descendant leaf is active, so an active
+        ;; region's chrome (the dashed box + header) emphasises — not just
+        ;; the leaf inside it (Stately parity §1.4 of `001-Topology-Parity.md`).
+        ;;
+        ;; Reuses the G1 `active-ids` directly: walk each active leaf UP its
+        ;; `:parent-id` chain (the same id every node already carries — region
+        ;; states point at their `region-node-id`, compound substates at their
+        ;; parent's `node-id`) and collect every ancestor container id. No
+        ;; path-prefix reimplementation; no duplication of the highlight logic.
+        ;; A self-consistent compound container lights the same way a region
+        ;; does — both are containers with a `:parent-id` chain reaching them.
+        parent-of (into {} (keep (fn [n]
+                                   (when-let [p (:parent-id n)]
+                                     [(:id n) p]))
+                                 nodes))
+        active-container-ids
+        (loop [seeds  (filter active-ids (keys parent-of))
+               acc    #{}]
+          (if-let [s (first seeds)]
+            (let [p (get parent-of s)]
+              (recur (if (and p (not (contains? acc p)))
+                       (conj (rest seeds) p)
+                       (rest seeds))
+                     (cond-> acc p (conj p))))
+            acc))
         ;; rf2-lkwev — container nodes (parallel regions AND compound
         ;; parents) MUST precede their children in the xyflow nodes
         ;; array (xyflow requires a parentNode to appear before any node
@@ -218,7 +245,15 @@
         (mapv (fn [n]
                 (let [pos      (get positions (:id n) {:x 0 :y 0})
                       region?  (boolean (:region? n))
-                      active?  (contains? active-ids (:id n))
+                      ;; rf2-80rm2 (G4) — a node is active when it is an
+                      ;; active leaf (G1) OR a container reaching an active
+                      ;; leaf via the `:parent-id` chain (the active-region
+                      ;; chrome). The two sets are disjoint by construction
+                      ;; (`active-ids` is leaves, `active-container-ids` is
+                      ;; their ancestor containers), so the union is the
+                      ;; whole active surface.
+                      active?  (or (contains? active-ids (:id n))
+                                   (contains? active-container-ids (:id n)))
                       from-hi? (= (:id n) from-highlight-id)
                       to-hi?   (= (:id n) to-highlight-id)
                       base

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -385,6 +385,63 @@
           (is (= "4" (.getAttribute root "data-node-count"))
               "data-node-count excludes the region containers"))))))
 
+;; ---- parallel-region ACTIVE chrome (rf2-80rm2, G4 visual-pin) -----------
+;;
+;; G1 lights the active region LEAF; G4 lights the region CONTAINER too, so
+;; an active region reads as active at the zone level. The container surfaces
+;; the active read on its `data-active` attr (the parallel-region-node
+;; contract); this pin guards that an active region's container is `true` and
+;; an inactive region's is `false` on first commit (no elk-layout dependency).
+
+(deftest chart-parallel-active-region-container-carries-active-chrome
+  (testing "rf2-80rm2 (G4) — with one region advanced past initial, that
+            region's CONTAINER carries data-active=true while the still-
+            initial region's container is false (the active-region chrome
+            reads at the zone level, not just the leaf)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id    :test/parallel
+         :definition    parallel-machine
+         ;; :audio advances to :paused (active); :display stays at :on, its
+         ;; initial — but :on IS the active leaf of :display, so BOTH region
+         ;; containers are active. Use a region-map where only ONE region has
+         ;; a leaf in the active set to get a clean active/inactive split:
+         ;; highlight only :audio's leaf.
+         :current-state {:audio :paused}}
+        (fn [_root node]
+          ;; `clj->js` renders the keyword region-id as its bare name
+          ;; (`:audio` → "audio"), so the data-region-id attr carries the
+          ;; name without the leading colon.
+          (let [audio (.querySelector node
+                        "[data-testid^=\"rf-mv-chart-region-\"][data-region-id=\"audio\"]")
+                display (.querySelector node
+                          "[data-testid^=\"rf-mv-chart-region-\"][data-region-id=\"display\"]")]
+            (is (some? audio) ":audio region container mounted")
+            (is (some? display) ":display region container mounted")
+            (is (= "true" (.getAttribute audio "data-active"))
+                ":audio container is active (its :paused leaf is in the active set)")
+            (is (= "false" (.getAttribute display "data-active"))
+                ":display container stays inactive (no active leaf)")))))))
+
+(deftest chart-parallel-both-active-regions-light-their-containers
+  (testing "rf2-80rm2 (G4) — when BOTH regions have an active leaf, BOTH
+            region containers carry data-active=true simultaneously (the
+            N-active-at-once read at the container level)"
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id    :test/parallel
+         :definition    parallel-machine
+         :current-state {:audio :paused :display :off}}
+        (fn [_root node]
+          (let [containers (.querySelectorAll node
+                             "[data-testid^=\"rf-mv-chart-region-\"]")]
+            (is (= 2 (.-length containers)) "two region containers")
+            (is (every? #(= "true" (.getAttribute % "data-active"))
+                        (array-seq containers))
+                "both region containers read active when both regions have an active leaf")))))))
+
 ;; ---- parallel multi-active highlight (rf2-g2svr, G1) --------------------
 ;;
 ;; The parity capability: a PARALLEL machine's `:current-state` is a

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -54,6 +54,16 @@
                      :states  {:hidden  {:on {:show :shown}}
                                :shown   {:on {:hide :hidden}}}}}})
 
+(def nested-compound-machine
+  "A two-level compound (`:outer` → `:mid` → `:leaf`) so the G4
+  active-container chain can be pinned across MORE than one level —
+  an active deep leaf must light EVERY enclosing container."
+  {:initial :outer
+   :states  {:outer {:initial :mid
+                     :states  {:mid {:initial :leaf
+                                     :states  {:leaf  {:on {:go :other}}
+                                               :other {}}}}}}})
+
 (def self-loop-machine
   "A machine with a self-transition (:idle --ping--> :idle) so the
   `:selfLoop` flag has a positive case."
@@ -306,8 +316,14 @@
           state    {:audio :playing :video :shown}
           ids      (layout/highlight-ids state)
           graph    (projection/xyflow-graph parsed {} {:highlight-ids ids})
-          actives  (set (map :id (filter #(:active (:data %)) (:nodes graph))))]
-      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} actives)
+          ;; Scope to leaf STATE nodes — rf2-80rm2 (G4) additionally marks
+          ;; the region CONTAINERS active (active-region chrome), which the
+          ;; dedicated G4 tests below pin; here we keep the G1 invariant that
+          ;; exactly the two active leaves light up among the state nodes.
+          active-states (set (map :id (filter #(and (= "state" (:type %))
+                                                    (:active (:data %)))
+                                              (:nodes graph))))]
+      (is (= #{(layout/node-id [:playing]) (layout/node-id [:shown])} active-states)
           "exactly the two active region leaves are marked active"))))
 
 (deftest xyflow-graph-scalar-highlight-id-still-works
@@ -332,6 +348,111 @@
                    parsed {} {:highlight-id a :highlight-ids #{b}})]
       (is (true? (:active (:data (node-by-id graph a)))))
       (is (true? (:active (:data (node-by-id graph b))))))))
+
+;; ---- xyflow-graph active-region CONTAINER chrome (rf2-80rm2, G4) ---------
+;;
+;; G1 lit the active LEAF; G4 lights the active region/compound CONTAINER
+;; so the zone itself reads as active (Stately parity §1.4). The projector
+;; folds a container into `:active` when ANY descendant leaf is in the
+;; active set — walked up the `:parent-id` chain every node already carries
+;; (no path-prefix reimplementation, no duplicate highlight logic). The
+;; container components (parallel-region-node / compound-node) then paint
+;; the active chrome; these JVM pins guard the projection half.
+
+(deftest xyflow-graph-active-leaf-lights-its-region-container
+  (testing "rf2-80rm2 (THE G4 CAPABILITY) — an active region LEAF marks its
+            parallel-region CONTAINER `:active`, so the zone (not just the
+            leaf inside it) reads as active"
+    (let [parsed     (layout/parse-definition parallel-machine)
+          playing-id (layout/node-id [:playing])
+          audio-id   (layout/region-node-id :audio)
+          graph      (projection/xyflow-graph
+                       parsed {} {:highlight-ids #{playing-id}})
+          audio      (node-by-id graph audio-id)]
+      (is (= "parallel-region" (:type audio)) "fixture sanity: audio is a region")
+      (is (true? (:active (:data audio)))
+          "the :audio region container lights because its :playing leaf is active"))))
+
+(deftest xyflow-graph-inactive-region-container-stays-inactive
+  (testing "rf2-80rm2 — a region whose leaf is NOT in the active set keeps
+            its container `:active false` (only the active region(s) get
+            chrome — orthogonality of the active read)"
+    (let [parsed     (layout/parse-definition parallel-machine)
+          playing-id (layout/node-id [:playing])     ; :audio leaf, active
+          audio-id   (layout/region-node-id :audio)
+          video-id   (layout/region-node-id :video)
+          graph      (projection/xyflow-graph
+                       parsed {} {:highlight-ids #{playing-id}})]
+      (is (true?  (:active (:data (node-by-id graph audio-id))))
+          "the active region container lights")
+      (is (false? (:active (:data (node-by-id graph video-id))))
+          "the region with no active leaf stays inactive"))))
+
+(deftest xyflow-graph-both-region-containers-active-when-both-have-active-leaf
+  (testing "rf2-80rm2 — a parallel snapshot with an active leaf in EVERY
+            region lights EVERY region container simultaneously (the
+            multi-active read at the container level)"
+    (let [parsed   (layout/parse-definition parallel-machine)
+          state    {:audio :playing :video :shown}
+          ids      (layout/highlight-ids state)
+          graph    (projection/xyflow-graph parsed {} {:highlight-ids ids})
+          audio    (node-by-id graph (layout/region-node-id :audio))
+          video    (node-by-id graph (layout/region-node-id :video))]
+      (is (true? (:active (:data audio))) ":audio container active")
+      (is (true? (:active (:data video))) ":video container active"))))
+
+(deftest xyflow-graph-compound-container-active-with-active-descendant
+  (testing "rf2-80rm2 — self-consistency: a compound (non-parallel)
+            container also gets active chrome when an active descendant
+            leaf lit it (the same `:parent-id`-chain mechanic)"
+    (let [parsed      (layout/parse-definition compound-machine)
+          browsing-id (layout/node-id [:authenticated :browsing])
+          authed-id   (layout/node-id [:authenticated])
+          graph       (projection/xyflow-graph
+                        parsed {} {:highlight-ids #{browsing-id}})
+          authed      (node-by-id graph authed-id)]
+      (is (= "compound" (:type authed)) "fixture sanity: authenticated is compound")
+      (is (true? (:active (:data authed)))
+          "the compound container lights because its :browsing leaf is active"))))
+
+(deftest xyflow-graph-active-chain-lights-every-enclosing-container
+  (testing "rf2-80rm2 — a deep active leaf lights EVERY enclosing
+            container up the `:parent-id` chain (more than one level)"
+    (let [parsed   (layout/parse-definition nested-compound-machine)
+          leaf-id  (layout/node-id [:outer :mid :leaf])
+          mid-id   (layout/node-id [:outer :mid])
+          outer-id (layout/node-id [:outer])
+          other-id (layout/node-id [:outer :mid :other])
+          graph    (projection/xyflow-graph
+                     parsed {} {:highlight-ids #{leaf-id}})]
+      (is (true? (:active (:data (node-by-id graph leaf-id))))
+          "the active leaf itself stays active (G1 unchanged)")
+      (is (true? (:active (:data (node-by-id graph mid-id))))
+          "the immediate compound parent lights")
+      (is (true? (:active (:data (node-by-id graph outer-id))))
+          "the grandparent compound lights too (chain walks all the way up)")
+      (is (false? (:active (:data (node-by-id graph other-id))))
+          "an inactive sibling leaf stays dark"))))
+
+(deftest xyflow-graph-flat-machine-unaffected-by-container-chrome
+  (testing "rf2-80rm2 — a flat machine has no containers, so the active
+            set is exactly the active leaf(s); no spurious node lights"
+    (let [parsed   (layout/parse-definition idle-loading)
+          hi       (layout/node-id [:loading])
+          graph    (projection/xyflow-graph parsed {} {:highlight-id hi})
+          flagged  (filter #(contains? (:data %) :active) (:nodes graph))
+          actives  (set (map :id (filter #(:active (:data %)) flagged)))]
+      (is (= #{hi} actives)
+          "exactly the highlighted leaf is active — no container chrome leaks"))))
+
+(deftest xyflow-graph-inactive-compound-container-stays-inactive
+  (testing "rf2-80rm2 — a compound with NO active descendant keeps its
+            container `:active false` (no highlight → no chrome)"
+    (let [parsed (layout/parse-definition compound-machine)
+          graph  (projection/xyflow-graph parsed {} {})
+          authed (node-by-id graph (layout/node-id [:authenticated]))]
+      (is (false? (:active (:data authed)))
+          "no highlight → the compound container is inactive"))))
 
 (deftest xyflow-graph-no-highlight-leaves-all-inactive
   (testing "rf2-g2svr — neither `:highlight-id` nor `:highlight-ids` →


### PR DESCRIPTION
## What

Closes parity gap **G4** in `tools/machines-viz/spec/001-Topology-Parity.md` (flipped to ✅ in this PR — §2 table, §3.1 gap table, §4.2 visual-dimensions row, §5 roadmap A3 + the NEW-beads N1 entry).

G1 (rf2-g2svr) lit the active region **LEAF**; G4 lights the active region/compound **CONTAINER** so the zone itself reads as active (Stately §1.2/§1.4) — previously an active region was indistinguishable from an inactive one at the container level.

## How

**`chart/projection.cljc`** — `xyflow-graph` folds a container (parallel-region OR, for self-consistency, compound) into `:active` when ANY descendant leaf is active. It **reuses the G1 active set directly**: walks each active leaf UP its `:parent-id` chain (the id every node already carries — region states point at their `region-node-id`, compound substates at their parent's `node-id`) and collects the ancestor container ids. No path-prefix reimplementation, no duplicate highlight logic. The **edge-projection path is untouched** to ease the rebase of B8 (rf2-qeemm), which follows on the edge surface.

**`chart/nodes/parallel_region_node.cljs`** — an active region paints active chrome: a solid (not dashed) emphasised boundary, emphasised header tint, and the `:info` active-token glow ring — the **same active affordance state nodes use** (no new palette; colour delegated to Figma). The region keeps its rotation colour for zone identity.

**`chart/nodes.cljs` `compound-node`** — for self-consistency, a compound container with an active descendant gets the matching minimal treatment (solid accent border + `:info` glow). **Choice: yes, compounds light too** — both are containers reached by the same `:parent-id` chain, so the read is uniform.

## Tests

- **JVM projection pins** (`projection_cljs_test.cljc`): region container active when its leaf is active; inactive region stays inactive; both-region-active; compound container active with active descendant; a deep leaf lights **every** enclosing container up the chain; flat machine unaffected (no spurious container chrome); no-highlight leaves all inactive.
- **Browser DOM visual-pins** (`chart_dom_cljs_test.cljs`): the rendered region container carries `data-active=true/false` correctly (single-active split + both-active).

## Gate results

- machines-viz JVM (`clojure -M:test`): **223 tests / 534 assertions, 0 failures, 0 errors**
- `npm run test:cljs`: **4330 tests, 0 failures, 0 errors**
- `npm run test:browser`: **117 tests / 330 assertions, 0 failures, 0 errors**
- clj-kondo (changed files): **0 errors, 0 warnings**
- splint (changed files): **0 errors** (1 pre-existing style warning, not introduced here)