### PR TITLE
feat(xray): adopt Figma-Make surface design — dark chrome/tabs ribbons + theme toggle + Handler-panel FLOWS (rf2-xawwb)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -79,6 +79,19 @@
    :bg-3           "#2a2a2a"
    :bg-active      "#2a2a2a"
 
+   ;; chrome ribbon (rf2-xawwb · Figma-Make surface) — mirrored from
+   ;; Xray's dark-palette to satisfy the `xray-and-machines-viz-dark-
+   ;; palettes-match-key-set` drift gate. These are Xray-chrome tokens
+   ;; (the chart itself doesn't read them) but the gate requires an exact
+   ;; key-set mirror, so they're published here at the same values.
+   :chrome-ribbon-bg              "#0d1117"
+   :chrome-ribbon-text            "#e6edf3"
+   :chrome-ribbon-text-muted      "#8b949e"
+   :chrome-ribbon-tab-active      "#2a2a2a"
+   :chrome-ribbon-tab-active-text "#e6edf3"
+   :active-bg                     "#1f6feb"
+   :active-text                   "#ffffff"
+
    :border-subtle  "#2a2a2a"
    :border-default "#373737"
 
@@ -127,6 +140,18 @@
    :bg-2           "#ffffff"
    :bg-3           "#e8e8e8"
    :bg-active      "#e8e8e8"
+
+   ;; chrome ribbon (rf2-xawwb · Figma-Make surface) — mirrored from
+   ;; Xray's light-palette so the two palettes stay symmetric (the dark
+   ;; drift gate is key-set equality; the light gate checks shared-key
+   ;; values agree). Xray-chrome tokens; the chart doesn't read them.
+   :chrome-ribbon-bg              "#2a2a2a"
+   :chrome-ribbon-text            "#ffffff"
+   :chrome-ribbon-text-muted      "#b0b0b0"
+   :chrome-ribbon-tab-active      "#ffffff"
+   :chrome-ribbon-tab-active-text "#24292f"
+   :active-bg                     "#0969da"
+   :active-text                   "#ffffff"
 
    :border-subtle  "#e8e8e8"
    :border-default "#d1d1d1"

--- a/tools/xray/design-reference/xray_devtools_reference.cljs
+++ b/tools/xray/design-reference/xray_devtools_reference.cljs
@@ -1,5 +1,49 @@
 (ns xray.devtools
-  "Xray DevTools - Single-file Reagent implementation"
+  "Xray DevTools — authoritative SURFACE reference (rf2-xawwb).
+
+  This file is a self-contained, loadable Reagent render of the
+  AUTHORITATIVE Xray surface design produced by Figma Make. It is a
+  REFERENCE ARTEFACT, not the implementation — the live shell
+  (`tools/xray/src/day8/re_frame2_xray/shell.cljs` + the per-panel
+  views) carries the real subscriptions, filters, frame-switching,
+  keybindings, settings, share modal, resize handles, etc. This file
+  exists so a human (or agent) can see the TARGET LOOK at a glance and
+  diff the live chrome against it.
+
+  ## rf2-xawwb — the Figma-Make surface deltas recorded here
+
+  1. **Chrome ribbon → DARK.** The top chrome ribbon paints the dark
+     `--devtools-chrome-ribbon-bg` band with white
+     `--devtools-chrome-ribbon-text` ink in BOTH themes. Label reads
+     `Event History` (was `Events`). The filter affordance is a `+ filter`
+     TEXT button. A sun/moon THEME TOGGLE flips light ⇄ dark.
+  2. **Dark tabs ribbon.** The tab strip is a dark band carrying
+     ROUNDED-TOP tab buttons (`border-radius 4px 4px 0 0`; active = light
+     `--devtools-chrome-ribbon-tab-active` fill, inactive = translucent),
+     prefixed with a `↳ for selected event` contextual label. The first
+     tab is `Handler` (was `Event`).
+  3. **Events ribbon reorg.** LEFT → RIGHT: a `↳ filters:` label + an
+     add-filter `+` button; the green/red filter pills (each with a
+     vertical divider before the `✕`); then the `N events filtered out`
+     count pushed to the RIGHT end.
+  4. **Event-list column order:** `event id` FIRST, then `source`,
+     `timestamp`, `duration`.
+  5. **Handler panel** numbered lifecycle pipeline is 6 steps: 1 DISPATCH,
+     2 COEFFECTS, 3 EVENT HANDLER, 4 APP-DB CHANGES, 5 FLOWS, 6 FX. The
+     FLOWS step shows the flow(s) that recomputed + their db contribution.
+
+  ## What this reference DELIBERATELY keeps richer than the Figma stub
+
+  The Figma export stubs the `app-db` panel. This reference RETAINS the
+  earlier richer `app-db-panel` section (APP STATE / MACHINE / ROUTE
+  cards) rather than the stub — the live App-db panel is the contractual
+  surface and the reference documents its shape.
+
+  ## Out of scope (WIP)
+
+  The Machine panel design is a work-in-progress (Mike). This reference
+  carries NO Machine-panel design — the Machine TAB exists in the tab
+  bar (one label) but its body is a placeholder here."
   (:require [reagent.core :as r]
             [reagent.dom :as rdom]))
 
@@ -19,9 +63,17 @@
 
   /* Developer tool colors */
   --devtools-chrome-bg: #f5f5f5;
+  /* rf2-xawwb — dark chrome ribbon band (DARK even under the light theme) */
+  --devtools-chrome-ribbon-bg: #2a2a2a;
+  --devtools-chrome-ribbon-text: #ffffff;
+  --devtools-chrome-ribbon-text-muted: #b0b0b0;
+  --devtools-chrome-ribbon-tab-active: #ffffff;
+  --devtools-chrome-ribbon-tab-active-text: #24292f;
   --devtools-border: #d1d1d1;
   --devtools-hover: #e8e8e8;
   --devtools-active: #0969da;
+  --devtools-active-bg: #0969da;
+  --devtools-active-text: #ffffff;
   --devtools-text: #24292f;
   --devtools-text-muted: #656d76;
   --devtools-changed: #0969da;
@@ -33,9 +85,16 @@
 
 .dark {
   --devtools-chrome-bg: #1c1c1c;
+  --devtools-chrome-ribbon-bg: #0d1117;
+  --devtools-chrome-ribbon-text: #e6edf3;
+  --devtools-chrome-ribbon-text-muted: #8b949e;
+  --devtools-chrome-ribbon-tab-active: #2a2a2a;
+  --devtools-chrome-ribbon-tab-active-text: #e6edf3;
   --devtools-border: #373737;
   --devtools-hover: #2a2a2a;
   --devtools-active: #539bf5;
+  --devtools-active-bg: #1f6feb;
+  --devtools-active-text: #ffffff;
   --devtools-text: #e6edf3;
   --devtools-text-muted: #8b949e;
   --devtools-changed: #539bf5;
@@ -51,25 +110,10 @@
 }
 
 /* Type scale utilities */
-.devtools-body {
-  font-size: var(--devtools-body);
-  line-height: 1.4;
-}
-
-.devtools-body-tight {
-  font-size: var(--devtools-body-tight);
-  line-height: 1.3;
-}
-
-.devtools-caption {
-  font-size: var(--devtools-caption);
-  line-height: 1.3;
-}
-
-.devtools-micro {
-  font-size: var(--devtools-micro);
-  line-height: 1.2;
-}
+.devtools-body { font-size: var(--devtools-body); line-height: 1.4; }
+.devtools-body-tight { font-size: var(--devtools-body-tight); line-height: 1.3; }
+.devtools-caption { font-size: var(--devtools-caption); line-height: 1.3; }
+.devtools-micro { font-size: var(--devtools-micro); line-height: 1.2; }
 
 /* Syntax highlighting for code */
 .syntax-keyword { color: #cf222e; }
@@ -97,10 +141,6 @@
   [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
    [:path {:d "M13 17l5-5-5-5M6 17l5-5-5-5"}]])
 
-(defn plus []
-  [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
-   [:path {:d "M12 5v14M5 12h14"}]])
-
 (defn chevron-down []
   [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
    [:path {:d "M6 9l6 6 6-6"}]])
@@ -108,220 +148,174 @@
 (defn settings-icon []
   [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
    [:circle {:cx "12" :cy "12" :r "3"}]
-   [:path {:d "M12 1v6m0 6v6M5.64 5.64l4.24 4.24m4.24 4.24l4.24 4.24M1 12h6m6 0h6M5.64 18.36l4.24-4.24m4.24-4.24l4.24-4.24"}]])
+   [:path {:d "M12 1v6m0 6v6m5.196-15.804l-4.242 4.242m-5.908 5.908l-4.242 4.242m15.804-10.392l-4.242 4.242m-5.908 5.908l-4.242 4.242"}]])
 
 (defn x-icon []
   [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
    [:path {:d "M18 6L6 18M6 6l12 12"}]])
 
+(defn moon []
+  [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
+   [:path {:d "M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"}]])
+
+(defn sun []
+  [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
+   [:circle {:cx "12" :cy "12" :r "5"}]
+   [:path {:d "M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"}]])
+
+(defn corner-down-right []
+  [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
+   [:polyline {:points "15 10 20 15 15 20"}]
+   [:path {:d "M4 4v7a4 4 0 0 0 4 4h12"}]])
+
 (defn external-link []
   [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
-   [:path {:d "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"}]])
+   [:path {:d "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}]
+   [:polyline {:points "15 3 21 3 21 9"}]
+   [:line {:x1 "10" :y1 "14" :x2 "21" :y2 "3"}]])
 
 ;; ============================================================================
-;; Chrome Ribbon Component
+;; Chrome Ribbon Component (rf2-xawwb — DARK band + Event History + theme toggle)
 ;; ============================================================================
 
-(defn chrome-ribbon []
-  (let [selected-frame "Main"]
-    [:div {:style {:height "34px"
-                   :padding "0 12px"
-                   :display "flex"
-                   :align-items "center"
-                   :justify-content "space-between"
-                   :border-bottom "1px solid var(--devtools-border)"
-                   :background "var(--devtools-chrome-bg)"}}
-     ;; Left: Events navigation and Filters
-     [:div {:style {:display "flex" :align-items "center" :gap "13px"}}
-      [:span {:class "devtools-body" :style {:color "var(--devtools-text)" :font-weight "500"}} "Events"]
+(defn chrome-ribbon [is-dark toggle-theme]
+  [:div {:style {:height "34px"
+                 :padding "0 12px"
+                 :display "flex"
+                 :align-items "center"
+                 :justify-content "space-between"
+                 :border-bottom "1px solid var(--devtools-border)"
+                 :background "var(--devtools-chrome-ribbon-bg)"}}
 
-      ;; Navigation buttons
-      [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-       [:button {:style {:padding "8px"
-                         :border-radius "4px"
-                         :background "var(--devtools-active)"
-                         :color "white"
-                         :border "none"
-                         :cursor "pointer"
-                         :opacity "0.9"}
-                 :on-mouse-enter #(set! (.. % -target -style -opacity) "1")
-                 :on-mouse-leave #(set! (.. % -target -style -opacity) "0.9")}
-        [chevron-left]]
-       [:button {:style {:padding "8px"
-                         :border-radius "4px"
-                         :background "var(--devtools-active)"
-                         :color "white"
-                         :border "none"
-                         :cursor "pointer"
-                         :opacity "0.9"}
-                 :on-mouse-enter #(set! (.. % -target -style -opacity) "1")
-                 :on-mouse-leave #(set! (.. % -target -style -opacity) "0.9")}
-        [chevron-right]]
-       [:button {:style {:padding "8px"
-                         :border-radius "4px"
-                         :background "var(--devtools-active)"
-                         :color "white"
-                         :border "none"
-                         :cursor "pointer"
-                         :opacity "0.9"}
-                 :on-mouse-enter #(set! (.. % -target -style -opacity) "1")
-                 :on-mouse-leave #(set! (.. % -target -style -opacity) "0.9")}
-        [chevrons-right]]]
+   ;; Left side — `Event History` label + nav cluster + `+ filter`
+   [:div {:style {:display "flex" :align-items "center" :gap "13px"}}
+    [:span {:class "devtools-body" :style {:color "var(--devtools-chrome-ribbon-text)" :font-weight "500"}}
+     "Event History"]
 
-      [:span {:class "devtools-body" :style {:color "var(--devtools-text-muted)"}} "Filters:"]
+    ;; Navigation buttons (blue --devtools-active-bg fill, white icon)
+    [:div {:style {:display "flex" :gap "8px"}}
+     (for [[k icon] [["prev" chevron-left] ["next" chevron-right] ["head" chevrons-right]]]
+       ^{:key k}
+       [:button {:style {:width "21px" :height "21px" :border-radius "4px"
+                         :background "var(--devtools-active-bg)" :color "var(--devtools-active-text)"
+                         :border "none" :cursor "pointer" :display "flex"
+                         :align-items "center" :justify-content "center"}}
+        [icon]])]
 
-      [:button {:style {:padding "8px"
-                        :border-radius "4px"
-                        :background "transparent"
-                        :border "none"
-                        :cursor "pointer"
-                        :color "var(--devtools-text-muted)"}
-                :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-       [plus]]]
+    ;; rf2-xawwb — `+ filter` TEXT button (replaces the prior plus-icon).
+    [:button {:class "devtools-caption"
+              :style {:height "21px" :padding "0 8px" :border-radius "4px"
+                      :border "1px solid var(--devtools-chrome-ribbon-text-muted)"
+                      :background "transparent" :color "var(--devtools-chrome-ribbon-text-muted)"
+                      :cursor "pointer"}}
+     "+ filter"]]
 
-     ;; Right: Dropdowns and action buttons
-     [:div {:style {:display "flex" :align-items "center" :gap "13px"}}
-      [:button {:class "devtools-body-tight"
-                :style {:display "flex"
-                        :align-items "center"
-                        :gap "8px"
-                        :padding "8px"
-                        :border-radius "4px"
-                        :background "transparent"
-                        :border "none"
-                        :cursor "pointer"
-                        :color "var(--devtools-text)"
-                        :width "89px"
-                        :justify-content "space-between"}
-                :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-       [:span selected-frame]
-       [chevron-down]]
+   ;; Right side — Frame + Mode dropdowns, theme toggle, settings, close
+   [:div {:style {:display "flex" :align-items "center" :gap "13px"}}
+    [:button {:class "devtools-body-tight"
+              :style {:display "flex" :align-items "center" :gap "8px" :padding "8px"
+                      :border-radius "4px" :background "transparent" :border "none"
+                      :color "var(--devtools-chrome-ribbon-text)" :cursor "pointer"
+                      :width "89px" :justify-content "space-between"}}
+     [:span "Main"]
+     [chevron-down]]
 
-      [:button {:class "devtools-body-tight"
-                :style {:display "flex"
-                        :align-items "center"
-                        :gap "8px"
-                        :padding "8px"
-                        :border-radius "4px"
-                        :background "transparent"
-                        :border "none"
-                        :cursor "pointer"
-                        :color "var(--devtools-text)"
-                        :width "144px"
-                        :justify-content "space-between"}
-                :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-       [:span "Dynamic"]
-       [chevron-down]]
+    [:button {:class "devtools-body-tight"
+              :style {:display "flex" :align-items "center" :gap "8px" :padding "8px"
+                      :border-radius "4px" :background "transparent" :border "none"
+                      :color "var(--devtools-chrome-ribbon-text)" :cursor "pointer"
+                      :width "144px" :justify-content "space-between"}}
+     [:span "Dynamic"]
+     [chevron-down]]
 
-      [:button {:style {:padding "8px"
-                        :border-radius "4px"
-                        :background "transparent"
-                        :border "none"
-                        :cursor "pointer"
-                        :color "var(--devtools-text-muted)"}
-                :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-       [settings-icon]]
+    ;; rf2-xawwb — sun/moon THEME TOGGLE. In the live shell this flips the
+    ;; existing `:theme` setting (toggling `rf-xray-theme-light/dark` on
+    ;; the shell + <html> root); here it toggles the local `dark` class so
+    ;; the reference previews both palettes.
+    [:button {:style {:padding "8px" :border-radius "4px" :background "transparent"
+                      :border "none" :color "var(--devtools-chrome-ribbon-text-muted)"
+                      :cursor "pointer" :display "flex" :align-items "center" :justify-content "center"}
+              :on-click toggle-theme}
+     (if @is-dark [sun] [moon])]
 
-      [:button {:style {:padding "8px"
-                        :border-radius "4px"
-                        :background "transparent"
-                        :border "none"
-                        :cursor "pointer"
-                        :color "var(--devtools-text-muted)"}
-                :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-       [x-icon]]]]))
+    [:button {:style {:padding "8px" :border-radius "4px" :background "transparent"
+                      :border "none" :color "var(--devtools-chrome-ribbon-text-muted)"
+                      :cursor "pointer" :display "flex" :align-items "center" :justify-content "center"}}
+     [settings-icon]]
+
+    [:button {:style {:padding "8px" :border-radius "4px" :background "transparent"
+                      :border "none" :color "var(--devtools-chrome-ribbon-text-muted)"
+                      :cursor "pointer" :display "flex" :align-items "center" :justify-content "center"}}
+     [x-icon]]]])
 
 ;; ============================================================================
-;; Events Ribbon Component
+;; Events Ribbon Component (rf2-xawwb — filters: label + add(+) left, count right)
 ;; ============================================================================
+
+(defn filter-pill [label tone]
+  [:div {:class "devtools-micro"
+         :style {:display "flex" :align-items "center" :overflow "hidden"
+                 :border-radius "4px" :border (str "1px solid " tone)
+                 :height "21px" :color tone}}
+   [:span {:style {:padding "0 8px"}} label]
+   ;; rf2-xawwb — VERTICAL DIVIDER before the ✕.
+   [:div {:style {:width "1px" :height "13px" :background tone}}]
+   [:button {:style {:width "21px" :height "21px" :border "none" :background "transparent"
+                     :color "inherit" :cursor "pointer" :display "flex"
+                     :align-items "center" :justify-content "center"}}
+    [x-icon]]])
 
 (defn events-ribbon []
-  (let [include-filters ["view" "fx"]
-        exclude-filters ["timer"]
-        filtered-out-count 12]
-    [:div {:style {:height "34px"
-                   :padding "0 12px"
-                   :display "flex"
-                   :align-items "center"
-                   :gap "13px"
-                   :border-bottom "1px solid var(--devtools-border)"
-                   :background "var(--devtools-chrome-bg)"}}
-     [:span {:class "devtools-caption" :style {:color "var(--devtools-warning)" :font-weight "500"}}
-      (str filtered-out-count " events filtered out")]
+  [:div {:style {:height "34px" :padding-left "34px" :padding-right "12px"
+                 :display "flex" :align-items "center" :gap "13px"
+                 :border-bottom "1px solid var(--devtools-border)"
+                 :background "var(--devtools-chrome-bg)"}}
 
-     ;; Include filter pills
-     (for [filter include-filters]
-       ^{:key (str "include-" filter)}
-       [:div {:class "devtools-micro"
-              :style {:padding "2px 8px"
-                      :border-radius "4px"
-                      :border "1px solid var(--devtools-success)"
-                      :background "transparent"
-                      :color "var(--devtools-success)"
-                      :display "flex"
-                      :align-items "center"
-                      :gap "8px"}}
-        [:span filter]
-        [:button {:style {:background "transparent"
-                          :border "none"
-                          :cursor "pointer"
-                          :color "inherit"
-                          :padding "0"
-                          :display "flex"
-                          :align-items "center"}
-                  :on-mouse-enter #(set! (.. % -target -style -opacity) "0.75")
-                  :on-mouse-leave #(set! (.. % -target -style -opacity) "1")}
-         [x-icon]]])
+   ;; LEFT — `↳ filters:` label + add-filter (+) button
+   [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+    [:span {:class "devtools-caption" :style {:color "var(--devtools-text-muted)"
+                                              :display "flex" :align-items "center" :gap "8px"}}
+     [corner-down-right]
+     "filters:"]
 
-     ;; Exclude filter pills
-     (for [filter exclude-filters]
-       ^{:key (str "exclude-" filter)}
-       [:div {:class "devtools-micro"
-              :style {:padding "2px 8px"
-                      :border-radius "4px"
-                      :border "1px solid var(--devtools-error)"
-                      :background "transparent"
-                      :color "var(--devtools-error)"
-                      :display "flex"
-                      :align-items "center"
-                      :gap "8px"}}
-        [:span filter]
-        [:button {:style {:background "transparent"
-                          :border "none"
-                          :cursor "pointer"
-                          :color "inherit"
-                          :padding "0"
-                          :display "flex"
-                          :align-items "center"}
-                  :on-mouse-enter #(set! (.. % -target -style -opacity) "0.75")
-                  :on-mouse-leave #(set! (.. % -target -style -opacity) "1")}
-         [x-icon]]])]))
+    [:button {:style {:width "21px" :height "21px" :border-radius "4px"
+                      :border "1px solid var(--devtools-border)" :background "transparent"
+                      :color "var(--devtools-text-muted)" :cursor "pointer"
+                      :display "flex" :align-items "center" :justify-content "center"}}
+     [:svg {:width "13" :height "13" :viewBox "0 0 24 24" :fill "none" :stroke "currentColor" :stroke-width "2"}
+      [:path {:d "M12 5v14m-7-7h14"}]]]]
+
+   ;; Filter pills — green-bordered INCLUDE, red-bordered EXCLUDE.
+   [filter-pill "view" "var(--devtools-success)"]
+   [filter-pill "fx" "var(--devtools-success)"]
+   [filter-pill "timer" "var(--devtools-error)"]
+
+   ;; RIGHT — `N events filtered out` count pushed to the trailing edge.
+   [:span {:class "devtools-caption" :style {:color "var(--devtools-warning)" :font-weight "500"
+                                             :margin-left "auto"}}
+    "12 events filtered out"]])
 
 ;; ============================================================================
-;; Event List Component
+;; Event List Component (rf2-xawwb — event-id FIRST, then source)
 ;; ============================================================================
 
 (defn event-list []
   (let [height (r/atom 144)
-        mock-events [{:source "fx" :event-id ":title/flow" :timestamp "12:30:05.123" :duration "1.2 ms"}
-                     {:source "view" :event-id ":counter-inc" :timestamp "12:30:06.456" :duration "0.4 ms" :active? true}
-                     {:source "timer" :event-id ":poll/tick" :timestamp "12:30:07.001" :duration "0.2 ms"}
-                     {:source "view" :event-id ":user/profile" :timestamp "12:30:07.892" :duration "0.6 ms"}
-                     {:source "machine" :event-id ":title/loaded" :timestamp "12:30:08.234" :duration "0.3 ms"}
-                     {:source "view" :event-id ":form/submit" :timestamp "12:30:09.456" :duration "1.8 ms"}]]
+        ;; rf2-xawwb — column order is event-id FIRST, then source.
+        mock-events [{:event-id ":title/flow"  :source "fx"     :timestamp "12:30:05.123" :duration "1.2 ms"}
+                     {:event-id ":counter-inc" :source "view"   :timestamp "12:30:06.456" :duration "0.4 ms" :active? true}
+                     {:event-id ":poll/tick"   :source "timer"  :timestamp "12:30:07.001" :duration "0.2 ms"}
+                     {:event-id ":user/profile" :source "view"  :timestamp "12:30:07.892" :duration "0.6 ms"}
+                     {:event-id ":title/loaded" :source "machine" :timestamp "12:30:08.234" :duration "0.3 ms"}
+                     {:event-id ":form/submit" :source "view"   :timestamp "12:30:09.456" :duration "1.8 ms"}]]
     (fn []
       [:div {:style {:border-bottom "1px solid var(--devtools-border)" :position "relative"}}
        [:div {:style {:height (str @height "px") :overflow "auto"}}
         [:table {:class "devtools-body" :style {:width "100%" :border-collapse "collapse"}}
          [:thead {:style {:position "sticky" :top "0" :background "var(--devtools-chrome-bg)" :border-bottom "1px solid var(--devtools-border)"}}
           [:tr {:class "devtools-caption" :style {:color "var(--devtools-text-muted)"}}
-           [:th {:style {:text-align "left" :padding "8px 13px" :font-weight "500"}} "source"]
            [:th {:style {:text-align "left" :padding "8px 13px" :font-weight "500"}} "event id"]
+           [:th {:style {:text-align "left" :padding "8px 13px" :font-weight "500"}} "source"]
            [:th {:style {:text-align "left" :padding "8px 13px" :font-weight "500"}} "timestamp"]
            [:th {:style {:text-align "left" :padding "8px 13px" :font-weight "500"}} "duration"]]]
          [:tbody
@@ -329,140 +323,133 @@
             ^{:key idx}
             [:tr {:style {:border-bottom "1px solid var(--devtools-border)"
                           :background (when (:active? event) "var(--devtools-hover)")
-                          :cursor "pointer"}
-                  :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-hover)")
-                  :on-mouse-leave #(set! (.. % -target -style -background) (when (:active? event) "var(--devtools-hover)"))}
-             [:td {:style {:padding "4px 13px" :color "var(--devtools-text-muted)"}} (:source event)]
+                          :cursor "pointer"}}
              [:td {:class "devtools-mono" :style {:padding "4px 13px" :color "var(--devtools-text)"}} (:event-id event)]
+             [:td {:style {:padding "4px 13px" :color "var(--devtools-text-muted)"}} (:source event)]
              [:td {:class "devtools-mono" :style {:padding "4px 13px" :color "var(--devtools-text-muted)"}} (:timestamp event)]
              [:td {:class "devtools-mono" :style {:padding "4px 13px" :color "var(--devtools-text-muted)"}} (:duration event)]])]]]
 
        ;; Resize handle
-       [:div {:style {:position "absolute"
-                      :bottom "0"
-                      :left "0"
-                      :right "0"
-                      :height "4px"
-                      :cursor "ns-resize"
-                      :background "transparent"}
-              :on-mouse-enter #(set! (.. % -target -style -background) "var(--devtools-active)")
-              :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}]])))
+       [:div {:style {:position "absolute" :bottom "0" :left "0" :right "0"
+                      :height "4px" :cursor "ns-resize" :background "transparent"}}]])))
 
 ;; ============================================================================
-;; Event Panel Component
+;; Tabs Ribbon Component (rf2-xawwb — DARK band, rounded-top tabs, Handler tab)
 ;; ============================================================================
 
-(defn event-panel []
+(defn tab-button [active-tab tab-id label]
+  (let [is-active (= @active-tab tab-id)]
+    [:button {:class "devtools-body"
+              :style {:padding "3px 16px" :border-radius "4px 4px 0 0" :border "none"
+                      :background (if is-active "var(--devtools-chrome-ribbon-tab-active)" "rgba(255,255,255,0.12)")
+                      :color (if is-active "var(--devtools-chrome-ribbon-tab-active-text)" "var(--devtools-chrome-ribbon-text-muted)")
+                      :cursor "pointer" :transition "all 0.2s"}
+              :on-click #(reset! active-tab tab-id)}
+     label]))
+
+(defn tabs-ribbon [active-tab]
+  [:div {:style {:height "34px" :padding "0 12px" :display "flex" :align-items "flex-end" :gap "3px"
+                 :border-bottom "1px solid var(--devtools-border)"
+                 :background "var(--devtools-chrome-ribbon-bg)"}}
+
+   ;; rf2-xawwb — `↳ for selected event` contextual label.
+   [:span {:class "devtools-caption" :style {:color "var(--devtools-chrome-ribbon-text-muted)"
+                                             :margin-right "13px" :display "flex"
+                                             :align-items "center" :gap "8px" :align-self "center"}}
+    [corner-down-right]
+    "for selected event"]
+
+   ;; rf2-xawwb — first tab is `Handler` (was `Event`). Machine TAB stays
+   ;; (one label); its panel body design is WIP and out of scope here.
+   [tab-button active-tab :handler "Handler"]
+   [tab-button active-tab :app-db "app-db"]
+   [tab-button active-tab :views "Views"]
+   [tab-button active-tab :trace "Trace"]
+   [tab-button active-tab :machine "Machine"]
+   [tab-button active-tab :routes "Routes"]
+   [tab-button active-tab :issues "Issues"]])
+
+;; ============================================================================
+;; Handler Panel Component (rf2-xawwb — 6-step: DISPATCH / COEFFECTS /
+;; EVENT HANDLER / APP-DB CHANGES / FLOWS / FX)
+;; ============================================================================
+
+(defn step-circle [n]
+  [:div {:class "devtools-caption"
+         :style {:position "absolute" :width "21px" :height "21px" :border-radius "50%"
+                 :background "var(--devtools-text-muted)" :color "var(--devtools-chrome-bg)"
+                 :display "flex" :align-items "center" :justify-content "center"
+                 :font-weight "600" :left "-44px" :top "0" :z-index "10"}}
+   (str n)])
+
+(defn step-label [title]
+  [:h3 {:class "devtools-caption" :style {:text-transform "uppercase" :letter-spacing "0.05em"
+                                          :color "var(--devtools-text-muted)" :margin-bottom "8px"}}
+   title])
+
+(defn handler-panel []
   [:div {:class "devtools-body" :style {:padding "21px" :overflow "auto" :color "var(--devtools-text)"}}
-   [:div {:style {:margin-left "55px" :position "relative"}}
+   [:div {:style {:position "relative" :margin-left "55px"}}
     ;; Vertical pipeline line
-    [:div {:style {:position "absolute"
-                   :width "2px"
-                   :background "var(--devtools-border)"
-                   :left "-34px"
-                   :top "13px"
-                   :bottom "0"}}]
+    [:div {:style {:position "absolute" :width "2px" :background "var(--devtools-border)"
+                   :left "-34px" :top "13px" :bottom "0"}}]
 
     [:div {:style {:display "flex" :flex-direction "column" :gap "21px"}}
      ;; 1. DISPATCH
      [:section {:style {:position "relative"}}
-      [:div {:style {:position "absolute"
-                     :width "21px"
-                     :height "21px"
-                     :border-radius "50%"
-                     :background "var(--devtools-text-muted)"
-                     :color "white"
-                     :display "flex"
-                     :align-items "center"
-                     :justify-content "center"
-                     :left "-44px"
-                     :top "0"
-                     :font-size "11px"
-                     :font-weight "600"}} "1"]
-      [:h3 {:class "devtools-caption" :style {:text-transform "uppercase" :letter-spacing "0.05em" :color "var(--devtools-text-muted)" :margin-bottom "8px"}}
-       "DISPATCH"]
+      [step-circle 1]
+      [step-label "DISPATCH"]
       [:div {:class "devtools-mono" :style {:background "var(--devtools-hover)" :padding "13px" :border-radius "4px"}}
        "[:counter-inc]"]
-      [:div {:class "devtools-caption" :style {:margin-top "8px" :color "var(--devtools-text-muted)" :display "flex" :align-items "center" :gap "8px"}}
+      [:div {:class "devtools-caption" :style {:margin-top "8px" :color "var(--devtools-text-muted)"
+                                               :display "flex" :align-items "center" :gap "8px"}}
        "FROM:"
-       [:a {:href "#" :style {:color "var(--devtools-active)" :text-decoration "none" :display "flex" :align-items "center" :gap "4px"}
-            :on-mouse-enter #(set! (.. % -target -style -text-decoration) "underline")
-            :on-mouse-leave #(set! (.. % -target -style -text-decoration) "none")}
+       [:a {:href "#" :style {:color "var(--devtools-active)" :text-decoration "none"
+                              :display "flex" :align-items "center" :gap "4px"}}
         "view" [external-link]]]]
 
-     ;; 2. COEFFECTS
+     ;; 2. COEFFECTS — may show MULTIPLE coeffects.
      [:section {:style {:position "relative"}}
-      [:div {:style {:position "absolute"
-                     :width "21px"
-                     :height "21px"
-                     :border-radius "50%"
-                     :background "var(--devtools-text-muted)"
-                     :color "white"
-                     :display "flex"
-                     :align-items "center"
-                     :justify-content "center"
-                     :left "-44px"
-                     :top "0"
-                     :font-size "11px"
-                     :font-weight "600"}} "2"]
-      [:h3 {:class "devtools-caption" :style {:text-transform "uppercase" :letter-spacing "0.05em" :color "var(--devtools-text-muted)" :margin-bottom "8px"}}
-       "COEFFECTS"]
+      [step-circle 2]
+      [step-label "COEFFECTS"]
       [:div {:style {:display "flex" :flex-direction "column" :gap "13px"}}
        [:div
-        [:div {:style {:display "flex" :align-items "center" :gap "4px" :margin-bottom "8px"}}
-         [:a {:class "devtools-mono" :href "#" :style {:color "var(--devtools-active)" :text-decoration "none" :display "flex" :align-items "center" :gap "4px"}
-              :on-mouse-enter #(set! (.. % -target -style -text-decoration) "underline")
-              :on-mouse-leave #(set! (.. % -target -style -text-decoration) "none")}
-          ":now" [external-link]]]
-        [:div {:class "devtools-mono"}
-         [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-          [:span {:style {:color "var(--devtools-success)"}} "+"]
-          [:span {:style {:color "var(--devtools-text-muted)"}} "[:now]"]
-          [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05.123Z\""]]]]]]
+        [:a {:class "devtools-mono" :href "#" :style {:color "var(--devtools-active)" :text-decoration "none"
+                                                      :display "flex" :align-items "center" :gap "4px" :margin-bottom "3px"}}
+         ":now" [external-link]]
+        [:div {:class "devtools-mono" :style {:display "flex" :align-items "center" :gap "8px"}}
+         [:span {:style {:color "var(--devtools-success)"}} "+"]
+         [:span {:style {:color "var(--devtools-text-muted)"}} "[:now]"]
+         [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05.123Z\""]]]
+       [:div
+        [:a {:class "devtools-mono" :href "#" :style {:color "var(--devtools-active)" :text-decoration "none"
+                                                      :display "flex" :align-items "center" :gap "4px" :margin-bottom "3px"}}
+         ":session" [external-link]]
+        [:div {:class "devtools-mono" :style {:display "flex" :align-items "center" :gap "8px"}}
+         [:span {:style {:color "var(--devtools-success)"}} "+"]
+         [:span {:style {:color "var(--devtools-text-muted)"}} "[:session]"]
+         [:span {:style {:color "var(--devtools-success)"}} "{:user-id 42, :token \"...\"}"]]]]]
 
      ;; 3. EVENT HANDLER
      [:section {:style {:position "relative"}}
-      [:div {:style {:position "absolute"
-                     :width "21px"
-                     :height "21px"
-                     :border-radius "50%"
-                     :background "var(--devtools-text-muted)"
-                     :color "white"
-                     :display "flex"
-                     :align-items "center"
-                     :justify-content "center"
-                     :left "-44px"
-                     :top "0"
-                     :font-size "11px"
-                     :font-weight "600"}} "3"]
-      [:a {:class "devtools-caption" :href "#" :style {:text-transform "uppercase" :letter-spacing "0.05em" :color "var(--devtools-active)" :text-decoration "none" :display "inline-flex" :align-items "center" :gap "4px" :margin-bottom "8px"}
-           :on-mouse-enter #(set! (.. % -target -style -text-decoration) "underline")
-           :on-mouse-leave #(set! (.. % -target -style -text-decoration) "none")}
+      [step-circle 3]
+      [:a {:class "devtools-caption" :href "#" :style {:text-transform "uppercase" :letter-spacing "0.05em"
+                                                       :color "var(--devtools-active)" :text-decoration "none"
+                                                       :display "inline-flex" :align-items "center" :gap "4px"
+                                                       :margin-bottom "8px"}}
        "EVENT HANDLER" [external-link]]
-      [:div {:class "devtools-mono" :style {:background "var(--devtools-hover)" :padding "13px" :border-radius "4px" :overflow-x "auto"}}
-       [:pre {:style {:font-size "13px"}}
+      [:div {:class "devtools-mono" :style {:background "var(--devtools-hover)" :padding "13px"
+                                            :border-radius "4px" :overflow-x "auto"}}
+       [:pre {:style {:margin "0"}}
         [:span {:class "syntax-keyword"} "(rf/reg-event-db "] [:span {:class "syntax-keyword"} ":counter-inc"] "\n"
         "  [" [:span {:class "syntax-keyword"} ":rf/db"] "]\n"
         "  (" [:span {:class "syntax-keyword"} "fn"] " [db _]\n"
         "    (" [:span {:class "syntax-keyword"} "update"] " db " [:span {:class "syntax-keyword"} ":counter"] " inc)))"]]]
 
-     ;; 4. DB CHANGES
+     ;; 4. APP-DB CHANGES (rf2-xawwb — renamed from `DB CHANGES`)
      [:section {:style {:position "relative"}}
-      [:div {:style {:position "absolute"
-                     :width "21px"
-                     :height "21px"
-                     :border-radius "50%"
-                     :background "var(--devtools-text-muted)"
-                     :color "white"
-                     :display "flex"
-                     :align-items "center"
-                     :justify-content "center"
-                     :left "-44px"
-                     :top "0"
-                     :font-size "11px"
-                     :font-weight "600"}} "4"]
-      [:h3 {:class "devtools-caption" :style {:text-transform "uppercase" :letter-spacing "0.05em" :color "var(--devtools-text-muted)" :margin-bottom "8px"}}
-       "DB CHANGES"]
+      [step-circle 4]
+      [step-label "APP-DB CHANGES"]
       [:div {:class "devtools-mono" :style {:display "flex" :flex-direction "column" :gap "4px"}}
        [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
         [:span {:style {:color "var(--devtools-changed)"}} "~"]
@@ -475,33 +462,38 @@
         [:span {:style {:color "var(--devtools-text-muted)"}} "[:last-updated]"]
         [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05\""]]]]
 
-     ;; 5. FX
+     ;; 5. FLOWS (rf2-xawwb — step 5, after APP-DB CHANGES). Shows the
+     ;; flow(s) that recomputed + their db contribution.
      [:section {:style {:position "relative"}}
-      [:div {:style {:position "absolute"
-                     :width "21px"
-                     :height "21px"
-                     :border-radius "50%"
-                     :background "var(--devtools-text-muted)"
-                     :color "white"
-                     :display "flex"
-                     :align-items "center"
-                     :justify-content "center"
-                     :left "-44px"
-                     :top "0"
-                     :font-size "11px"
-                     :font-weight "600"}} "5"]
-      [:h3 {:class "devtools-caption" :style {:text-transform "uppercase" :letter-spacing "0.05em" :color "var(--devtools-text-muted)" :margin-bottom "8px"}}
-       "FX"]
+      [step-circle 5]
+      [step-label "FLOWS"]
+      [:div {:class "devtools-mono"}
+       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+        [:a {:href "#" :style {:color "var(--devtools-active)" :text-decoration "none"
+                               :display "flex" :align-items "center" :gap "4px"}}
+         ":totals-flow" [external-link]]
+        [:span {:style {:color "var(--devtools-text-muted)"}} "→"]
+        [:span {:style {:color "var(--devtools-text)"}} "[:totals] recomputed"]]
+       [:div {:style {:margin-left "21px" :margin-top "3px" :color "var(--devtools-text-muted)"}}
+        [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+         [:span {:style {:color "var(--devtools-success)"}} "+"]
+         [:span "[:totals :sum]"]
+         [:span {:style {:color "var(--devtools-success)"}} "42"]]]]]
+
+     ;; 6. FX
+     [:section {:style {:position "relative"}}
+      [step-circle 6]
+      [step-label "FX"]
       [:div {:class "devtools-mono" :style {:display "flex" :flex-direction "column" :gap "4px"}}
-       [:div {:style {:display "flex" :align-items "flex-start" :gap "8px"}}
+       [:div {:style {:display "flex" :gap "8px"}}
         [:span {:style {:color "var(--devtools-text-muted)"}} ":dispatch"]
         [:span {:style {:color "var(--devtools-text)"}} "→ [:title/flow [:rf/init]]"]]
-       [:div {:style {:display "flex" :align-items "flex-start" :gap "8px"}}
+       [:div {:style {:display "flex" :gap "8px"}}
         [:span {:style {:color "var(--devtools-text-muted)"}} ":http-xhrio"]
         [:span {:style {:color "var(--devtools-text)"}} "→ {:method :get, :uri \"/api/data\"}"]]]]]]])
 
 ;; ============================================================================
-;; App-DB Panel Component (simplified)
+;; App-DB Panel Component (RETAINED — richer than the Figma stub)
 ;; ============================================================================
 
 (defn app-db-panel []
@@ -528,19 +520,31 @@
     [:div {:class "devtools-mono" :style {:background "var(--devtools-hover)" :padding "13px" :border-radius "4px" :color "var(--devtools-text)"}}
      "{:id :home, :params {}}"]]])
 
+(defn placeholder-panel [name]
+  [:div {:class "devtools-body" :style {:padding "21px" :color "var(--devtools-text-muted)"}}
+   [:p (str name " panel content here")]])
+
 ;; ============================================================================
 ;; Main App Component
 ;; ============================================================================
 
 (defn main-app []
-  (let [active-tab (r/atom "event")]
+  (let [active-tab (r/atom :handler)
+        is-dark    (r/atom false)
+        toggle-theme #(do
+                        (swap! is-dark not)
+                        (if @is-dark
+                          (.add (.-classList js/document.documentElement) "dark")
+                          (.remove (.-classList js/document.documentElement) "dark")))]
     (fn []
-      [:div {:style {:height "100vh" :display "flex" :flex-direction "column" :background "var(--background)" :color "var(--devtools-text)" :font-family "system-ui, -apple-system, sans-serif"}}
+      [:div {:style {:height "100vh" :display "flex" :flex-direction "column"
+                     :background "var(--devtools-chrome-bg)" :color "var(--devtools-text)"
+                     :font-family "system-ui, -apple-system, sans-serif"}}
        ;; CSS injection
        [:style devtools-css]
 
-       ;; Region 1: Chrome Ribbon
-       [chrome-ribbon]
+       ;; Region 1: Chrome Ribbon (DARK)
+       [chrome-ribbon is-dark toggle-theme]
 
        ;; Region 2: Events Ribbon
        [events-ribbon]
@@ -548,51 +552,15 @@
        ;; Region 3: Event List
        [event-list]
 
-       ;; Region 4 & 5: Tabs and Panel Content
+       ;; Region 4 & 5: Tabs Ribbon (DARK) and Panel Content
        [:div {:style {:flex "1" :display "flex" :flex-direction "column" :overflow "hidden"}}
-        ;; Tab Strip
-        [:div {:style {:height "34px"
-                       :padding "0 12px"
-                       :display "flex"
-                       :align-items "center"
-                       :gap "0"
-                       :border-bottom "1px solid var(--devtools-border)"
-                       :background "var(--devtools-chrome-bg)"
-                       :flex-shrink "0"}}
-         (for [tab [{:value "event" :label "Event"}
-                    {:value "app-db" :label "app-db"}
-                    {:value "views" :label "Views"}
-                    {:value "trace" :label "Trace"}
-                    {:value "machine" :label "Machine"}
-                    {:value "routes" :label "Routes"}
-                    {:value "issues" :label "Issues"}]]
-           ^{:key (:value tab)}
-           [:button {:class "devtools-body"
-                     :style {:padding "0 16px"
-                             :height "100%"
-                             :border "none"
-                             :border-bottom (if (= @active-tab (:value tab))
-                                              "2px solid var(--devtools-active)"
-                                              "2px solid transparent")
-                             :background "transparent"
-                             :color (if (= @active-tab (:value tab))
-                                      "var(--devtools-text)"
-                                      "var(--devtools-text-muted)")
-                             :cursor "pointer"
-                             :transition "all 0.2s"}
-                     :on-click #(reset! active-tab (:value tab))
-                     :on-mouse-enter #(when (not= @active-tab (:value tab))
-                                        (set! (.. % -target -style -background) "var(--devtools-hover)"))
-                     :on-mouse-leave #(set! (.. % -target -style -background) "transparent")}
-            (:label tab)])]
-
-        ;; Tab Content
+        [tabs-ribbon active-tab]
         [:div {:style {:flex "1" :overflow "hidden"}}
          (case @active-tab
-           "event" [event-panel]
-           "app-db" [app-db-panel]
-           [:div {:class "devtools-body" :style {:padding "21px" :color "var(--devtools-text-muted)"}}
-            (str "Panel: " @active-tab " (not yet implemented)")])]]])))
+           :handler [handler-panel]
+           :app-db  [app-db-panel]
+           ;; Machine panel design is WIP (out of scope) — placeholder.
+           [placeholder-panel (name @active-tab)])]]])))
 
 ;; ============================================================================
 ;; Application Mount
@@ -601,9 +569,6 @@
 (defn ^:export init []
   (rdom/render [main-app]
                (.getElementById js/document "app")))
-
-;; Auto-initialize on load
-(init)
 
 ;; For hot-reload during development
 (defn ^:dev/after-load reload []

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -173,6 +173,11 @@
                        :font-size   (:caption type-scale)
                        :white-space "nowrap"}}
         (str mode-glyph " " body-text)])
+     ;; rf2-xawwb — a VERTICAL DIVIDER sits before the `✕` (Figma-Make
+     ;; surface): a 1px tone-coloured rule separating the pill body from
+     ;; the remove affordance. The remove button keeps its own border-left
+     ;; as the divider so it round-trips through the same tone; the explicit
+     ;; padding gives the `✕` a square hit-area that reads against the rule.
      [:button {:data-testid  (str testid "-remove")
                :on-click     #(rf/dispatch
                                 [:rf.xray/remove-filter mode idx]
@@ -183,8 +188,8 @@
                        :border        "none"
                        :color         tone
                        :cursor        "pointer"
-                       :padding       "0 2px"
-                       :margin-left   "2px"
+                       :padding       "0 4px 0 6px"
+                       :margin-left   "4px"
                        :font-family   sans-stack
                        :font-size     (:caption type-scale)
                        :line-height   "1"

--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -229,6 +229,68 @@
                           :white-space   "nowrap"}}
    "[ + ]"])
 
+(defn chrome-add-filter-button
+  "rf2-xawwb — the chrome-ribbon `+ filter` TEXT button (Figma-Make
+  surface). Replaces the prior `Filters:` label + plus-icon affordance
+  on bar-1 with a single outlined text button. Opens the SAME edit
+  popup as `add-pill` (`:rf.xray/open-edit-popup {:source :add :mode
+  :in}`) — only the surface changes; the add behaviour is retained.
+
+  Outlined on the dark chrome band: a muted `chrome-ribbon-text-muted`
+  border + ink so it reads as a secondary chrome affordance against the
+  near-black ribbon."
+  []
+  [:button {:data-testid "rf-xray-filter-add"
+            :on-click    #(rf/dispatch
+                            [:rf.xray/open-edit-popup
+                             {:source :add :mode :in}]
+                            {:frame :rf/xray})
+            :aria-label  "Add filter pill"
+            :title       "Add filter pill"
+            :style       {:background    "transparent"
+                          :border        (str "1px solid "
+                                              (:chrome-ribbon-text-muted tokens))
+                          :color         (:chrome-ribbon-text-muted tokens)
+                          :cursor        "pointer"
+                          :padding       "2px 8px"
+                          :border-radius "4px"
+                          :font-family   sans-stack
+                          :font-size     (:caption type-scale)
+                          :white-space   "nowrap"}}
+   "+ filter"])
+
+(defn events-add-filter-button
+  "rf2-xawwb — the events-ribbon add-filter `+` ICON button (Figma-Make
+  surface). Sits after the `filters:` contextual label on bar-2, before
+  the committed pills. Opens the SAME edit popup as `add-pill`; the add
+  behaviour is retained. A square bordered `+` icon-button on the light
+  data canvas (the events ribbon stays on `bg-2`, not the dark chrome
+  band)."
+  []
+  [:button {:data-testid "rf-xray-filter-add-events"
+            :on-click    #(rf/dispatch
+                            [:rf.xray/open-edit-popup
+                             {:source :add :mode :in}]
+                            {:frame :rf/xray})
+            :aria-label  "Add filter pill"
+            :title       "Add filter pill"
+            :style       {:background      "transparent"
+                          :border          (str "1px solid "
+                                                (:border-default tokens))
+                          :color           (:text-secondary tokens)
+                          :cursor          "pointer"
+                          :width           "21px"
+                          :height          "21px"
+                          :padding         "0"
+                          :border-radius   "4px"
+                          :display         "inline-flex"
+                          :align-items     "center"
+                          :justify-content "center"
+                          :font-family     sans-stack
+                          :font-size       (:body type-scale)
+                          :line-height     "1"}}
+   [:span {:aria-hidden "true"} "+"]])
+
 ;; ---- cluster -------------------------------------------------------------
 
 (defn- counts-tooltip

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -14,16 +14,20 @@
       1. DISPATCH             event vector + `FROM: <source>` (click-to-source)
       2. COEFFECTS  (opt)     user-injected coeffects + the value each added
       3. EVENT HANDLER        reg-event-* flavour + syntax-highlighted source
-      4. FLOWS      (opt)     flows that recomputed + the db path written
-      5. DB CHANGES           the app-db diff (+ SSR hydration addendum)
+      4. APP-DB CHANGES       the app-db diff (+ SSR hydration addendum)
+      5. FLOWS      (opt)     flows that recomputed + the db path written
       6. AFTER INTERCEPTORS (opt) non-standard after-interceptors
       7. FX                   the fx handlers that ran
+
+  rf2-xawwb — the Figma-Make surface numbers APP-DB CHANGES as step 4 and
+  FLOWS as step 5 (supersedes rf2-9eca7 / #2070, which placed FLOWS
+  before DB CHANGES).
 
   Steps are numbered DYNAMICALLY 1..N — an absent OPTIONAL section
   (COEFFECTS / AFTER INTERCEPTORS / FLOWS) consumes no number; absence is
   conveyed by OMISSION, not an empty-state line. There is **no outcome
   badge** and **no `db committed` footer** (the prior superseded shape):
-  a throwing handler simply omits DB CHANGES and the later steps —
+  a throwing handler simply omits APP-DB CHANGES and the later steps —
   absence conveys the throw.
 
   Per `EventPanel` there is **no top header/ribbon** (rf2-ad7zx.17):
@@ -755,17 +759,22 @@
                      :font-size "11px"}}
        "(none)"])))
 
-;; ---- step FLOWS (spec/021 §2.2 step 4) ---------------------------------
+;; ---- step FLOWS (Figma-Make surface step 5 · rf2-xawwb) ----------------
 ;; rf2-lo37i — Flows fire automatically right after the event handler, at
 ;; the OUTERMOST `:after` interceptor — they transform the pending `:db`
 ;; effect BEFORE the single deferred app-db install (the atomic commit
-;; boundary), so they precede DB CHANGES and run long before FX. Each
-;; flow's `:output` fn reads from `:inputs` paths and writes to a `:path`.
-;; Without first-class visibility here a developer cannot attribute an
-;; app-db change to the flow that caused it. Surfaced as a peer section
-;; sitting between EVENT HANDLER and DB CHANGES — the cascade-order
-;; placement: flows are the framework's automatic step that reshapes the
-;; pending db before it commits.
+;; boundary), and run long before FX. Each flow's `:output` fn reads from
+;; `:inputs` paths and writes to a `:path`. Without first-class
+;; visibility here a developer cannot attribute an app-db change to the
+;; flow that caused it.
+;;
+;; rf2-xawwb — the Figma-Make surface PRESENTS FLOWS as step 5, AFTER the
+;; APP-DB CHANGES diff (step 4): the diff leads, and the FLOWS section
+;; then attributes the flow-driven slots within it. (This supersedes the
+;; rf2-9eca7 / #2070 presentation order that placed FLOWS before DB
+;; CHANGES. The underlying framework TIMING is unchanged — flows still
+;; reshape the pending db before commit; only the panel's visual ordering
+;; changes to match the authoritative surface.)
 ;;
 ;; Per spec/013-Flows.md + spec/009-Instrumentation.md:
 ;;   `:rf.flow/computed` (op-type `:flow`) carries `:flow-id`,
@@ -1275,7 +1284,8 @@
   number. There is NO outcome badge and NO `db committed` footer; absence
   of a step is conveyed by omission.
 
-  Step order (numbered; optional steps shown only when present):
+  Step order (numbered; optional steps shown only when present) — the
+  Figma-Make surface order (rf2-xawwb):
 
     1. DISPATCH            — the event vector + `FROM: <source>`
                              (click-to-source).
@@ -1283,20 +1293,27 @@
                              added.
     3. EVENT HANDLER       — flavour (`reg-event-*`, click-to-source) +
                              syntax-highlighted handler source.
-    4. FLOWS      (opt)    — flows that recomputed + the db path each
-                             wrote. Fire at the outermost `:after`, right
-                             after the handler — they reshape the pending
-                             `:db` BEFORE it commits, so they precede DB
-                             CHANGES.
-    5. DB CHANGES          — the app-db diff (+ SSR hydration-outcome
+    4. APP-DB CHANGES      — the app-db diff (+ SSR hydration-outcome
                              addendum when the focused event hydrated).
+    5. FLOWS      (opt)    — flows that recomputed + the db path each
+                             wrote. (Framework-timing note: flows fire at
+                             the outermost `:after` and reshape the
+                             pending `:db` BEFORE it commits; the
+                             Figma-Make surface PRESENTS them after the
+                             APP-DB CHANGES diff so the diff leads and the
+                             flow attribution reads as the explanation of
+                             the flow-driven slots within it.)
     6. AFTER INTERCEPTORS (opt) — non-standard after-interceptors.
     7. FX                  — the fx handlers that ran.
+
+  rf2-xawwb — supersedes the rf2-9eca7 (#2070) placement of FLOWS BEFORE
+  DB CHANGES; the Figma-Make surface numbers APP-DB CHANGES as step 4 and
+  FLOWS as step 5.
 
   ## Handler-threw branch
 
   When the cascade carries a handler exception the handler never
-  returned, so the post-handler steps (FLOWS, DB CHANGES, AFTER
+  returned, so the post-handler steps (APP-DB CHANGES, FLOWS, AFTER
   INTERCEPTORS, FX) are simply omitted — absence conveys the throw
   (spec/021 §2.2: no footer). Only DISPATCH / COEFFECTS? / EVENT HANDLER
   render.
@@ -1328,8 +1345,8 @@
         candidates [["dispatch"          "DISPATCH"           (dispatch-body cascade event)]
                     ["coeffects"         "COEFFECTS"          (coeffects-body cascade)]
                     ["handler"           "EVENT HANDLER"      (handler-body event-id meta)]
+                    ["db-changes"        "APP-DB CHANGES"     db-changes]
                     ["flows"             "FLOWS"              (when-not threw? (flows-body cascade))]
-                    ["db-changes"        "DB CHANGES"         db-changes]
                     ["after-interceptors" "AFTER INTERCEPTORS" (when-not threw?
                                                                  (after-interceptors-body user-icpts))]
                     ["fx"                "FX"                 (when-not threw? (fx-body cascade))]]

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -1553,10 +1553,15 @@
   ;; rf2-2moh1 — register the Dynamic Event tab with the internal L4
   ;; tab registry. The runtime shell's L3 tab bar + L4 detail panel
   ;; pick the entry up by `tabs-for-mode :dynamic`.
+  ;; rf2-xawwb — the Figma-Make tabs ribbon renames the first tab
+  ;; `Event` → `Handler` (it answers "what did this event's HANDLER
+  ;; do?"). The tab `:id` stays `:event` so every existing
+  ;; `:rf.xray/select-tab :event` dispatch, testid, sub, and registry
+  ;; lookup keeps resolving — only the visible label + mnemonic change.
   (panel-registry/reg-l4-tab!
     {:id    :event
-     :label "Event"
-     :mnem  "e"
+     :label "Handler"
+     :mnem  "h"
      :modes #{:dynamic}
      :order 0
      :panel Panel}))

--- a/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/settings/view.cljs
@@ -776,7 +776,7 @@
             ["Ctrl+click" "Copy cascade-id"]]}
    {:group "Tab bar (L3)"
     :rows  [["1-6"             "Switch tab by index"]
-            ["e"               "Event tab"]
+            ["h"               "Handler tab"]
             ["a"               "App-db tab"]
             ["v"               "Views tab"]
             ["t"               "Trace tab"]

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -374,7 +374,8 @@
 ;; Layout (left → right), matching the Figma EventList columns plus Xray's
 ;; leading focus gutter (a Xray affordance the mock didn't carry):
 ;;
-;;   [gutter 14px] gap [source 52px] gap [event id flex-1] gap [time →right]
+;;   [gutter 14px] gap [event id flex-1] gap [source 52px] gap [time →right]
+;;   (rf2-xawwb — event-id leads, source follows, per the Figma-Make surface)
 ;;
 ;; Both surfaces use the SAME flex container gap + horizontal padding, and
 ;; a matching `1px solid transparent` border so the row's focused/ungrouped
@@ -1701,6 +1702,29 @@
               gutter-click (assoc :on-click gutter-click))
       (or focus-marker
           [:span {:style {:color glyph-col}} glyph])]
+     ;; rf2-xawwb — column order is `event id` FIRST, then `source`
+     ;; (Figma-Make surface). The bare event-id keyword leads the row as
+     ;; the primary read; the source tag follows as secondary context.
+     ;; Round-3 rf2-cmtkw — minimal default row renders ONLY the bare
+     ;; event-id keyword (e.g. `:cart/add-item`). The full event vector
+     ;; with args moves to the row's hover tooltip + the L4 Handler tab
+     ;; detail. The event-id column is LEFT-aligned (Figma `text-left`) so
+     ;; the keyword sits flush under the header's `event id` label.
+     [:span {:data-testid "rf-xray-row-event-id"
+             :style {:flex "1 1 auto" :overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :text-align "left"
+                     :min-width "0"}}
+      (if ungrouped?
+        ;; rf2-r9lyy — the :ungrouped pseudo-cascade has no event
+        ;; vector by construction. Render a clear muted label instead
+        ;; of the defence-in-depth `<no event>` fallback so the user
+        ;; understands they're looking at the bucket of events outside
+        ;; any dispatch.
+        [:span {:style {:color      (:text-tertiary tokens)
+                        :font-style "italic"}}
+         ":ungrouped (pseudo-cascade)"]
+        (render-event-id-only event-vec))]
      ;; rf2-ad7zx.12 + rf2-lnod7 — the `source` COLUMN, reconciled to the
      ;; Figma EventList. A fixed-width cell aligned under the header's
      ;; `source` label, carrying the dispatch-origin as a short text tag
@@ -1710,9 +1734,9 @@
      ;; (rf2-4297k) flagged the pre-rf2-lnod7 blank ui-origin column.
      ;; `:ungrouped` rows still render an empty spacer cell (no dispatch
      ;; envelope, no origin to surface) while occupying the column width
-     ;; so the `event id` column stays left-aligned across rows. The
-     ;; `:title` carries the closed-enum value as a hover affordance
-     ;; (rf2-gf58j origin glyphs preserved as the leading mark).
+     ;; so the columns stay aligned across rows. The `:title` carries the
+     ;; closed-enum value as a hover affordance (rf2-gf58j origin glyphs
+     ;; preserved as the leading mark).
      [:span {:data-testid (when (and source-tag (not ungrouped?))
                             (str "rf-xray-row-origin-" source-tag))
              :data-rf-xray-origin (when (and source-tag (not ungrouped?))
@@ -1733,30 +1757,6 @@
         (list
          (when origin-prefix ^{:key "g"} [:span {:aria-hidden "true"} origin-prefix])
          ^{:key "t"} [:span source-tag]))]
-     ;; Round-3 rf2-cmtkw — minimal default row renders ONLY the
-     ;; bare event-id keyword (e.g. `:cart/add-item`). The full event
-     ;; vector with args moves to the row's hover tooltip + the L4
-     ;; Event tab detail (the panel that owns the room for it).
-     ;; Earlier rf2-htik0 Bug 3 inline-rendered the truncated full
-     ;; vector here — superseded by the Round-3 minimal-row contract.
-     ;; rf2-cplj8 — the event-id column is explicitly LEFT-aligned (Figma
-     ;; EventList `text-left`) so the keyword sits flush at the column's
-     ;; left edge under the header's `event id` label.
-     [:span {:data-testid "rf-xray-row-event-id"
-             :style {:flex "1 1 auto" :overflow "hidden"
-                     :text-overflow "ellipsis"
-                     :text-align "left"
-                     :min-width "0"}}
-      (if ungrouped?
-        ;; rf2-r9lyy — the :ungrouped pseudo-cascade has no event
-        ;; vector by construction. Render a clear muted label instead
-        ;; of the defence-in-depth `<no event>` fallback so the user
-        ;; understands they're looking at the bucket of events outside
-        ;; any dispatch.
-        [:span {:style {:color      (:text-tertiary tokens)
-                        :font-style "italic"}}
-         ":ungrouped (pseudo-cascade)"]
-        (render-event-id-only event-vec))]
      (when (seq badges)
        ;; rf2-gf58j — activity-badge cluster sourced from
        ;; `panels.l2-timeline/activity-badges`. Render order matches
@@ -1927,26 +1927,21 @@
         (when any-active?
           [clear-filters-button])])]))
 
-;; rf2-ad7zx.12 + rf2-lnod7 — the L2 list's column-header row, reconciled
-;; to the Figma EventList (the `event-list` component in
-;; `design-reference/xray_devtools_reference.cljs`).
-;; The Figma mock renders a sticky header naming the FOUR columns the
-;; rows align to: `source` · `event id` · `timestamp` · `duration`. The
-;; header was MISSING pre-Figma (the list was a bare row stack), which
-;; is the gap Mike flagged ("does not match the Figma mock"); the gap
-;; audit (rf2-4297k) then found the `duration` column clipped off the
-;; right edge — only three columns rendered. The column widths mirror
-;; the row layout below: a fixed leading FOCUS gutter (14px, unlabeled —
-;; it is a Xray affordance the mock didn't have), a fixed `source` tag
-;; column, the flexible `event id` column, then the right-aligned
-;; `timestamp` chip and `duration` cells.
+;; rf2-ad7zx.12 + rf2-lnod7 + rf2-xawwb — the L2 list's column-header row,
+;; reconciled to the Figma-Make EventList. The header names the FOUR
+;; columns the rows align to, in Figma-Make order: `event id` · `source`
+;; · `timestamp` · `duration` (event-id leads; source follows). The
+;; column widths mirror the row layout below: a fixed leading FOCUS
+;; gutter (14px, unlabeled — a Xray affordance the mock didn't have),
+;; the flexible `event id` column, a fixed `source` tag column, then the
+;; right-aligned `timestamp` chip and `duration` cells.
 
 (defn- l2-column-header
   "Sticky column-header row for the L2 event list (rf2-ad7zx.12 + rf2-
-  lnod7, Figma EventList). Names the FOUR columns the rows align to —
-  `source` · `event id` · `timestamp` · `duration`. Caption-weight,
-  muted, on the chrome surface so it reads as chrome rather than data.
-  Pure hiccup."
+  lnod7 + rf2-xawwb, Figma-Make EventList). Names the FOUR columns the
+  rows align to, in Figma-Make order — `event id` · `source` ·
+  `timestamp` · `duration`. Caption-weight, muted, on the chrome surface
+  so it reads as chrome rather than data. Pure hiccup."
   []
   (let [cell {:color       (:text-tertiary tokens)
               :font-family sans-stack
@@ -1979,17 +1974,17 @@
      ;; (the gutter itself is a Xray affordance, unlabeled in the header).
      [:span {:aria-hidden "true"
              :style {:width l2-gutter-col-width :flex-shrink 0}}]
-     [:span {:data-testid "rf-xray-event-list-col-source"
-             :style (merge cell {:width l2-source-col-width :flex-shrink 0})}
-      "source"]
-     ;; rf2-cplj8 — the `event id` column is explicitly LEFT-aligned (Figma
-     ;; EventList renders every body cell `text-left`). The label sits flush
-     ;; at the column's left edge directly above the row's left-aligned
-     ;; event-id keyword, rather than drifting toward centre.
+     ;; rf2-xawwb — column order is `event id` FIRST, then `source`
+     ;; (Figma-Make surface). The event-id is the primary read; source is
+     ;; secondary context, so the id leads. The `event id` column is
+     ;; LEFT-aligned (the row's keyword sits flush under this label).
      [:span {:data-testid "rf-xray-event-list-col-event-id"
              :style (merge cell {:flex "1 1 auto" :min-width "0"
                                  :text-align "left"})}
       "event id"]
+     [:span {:data-testid "rf-xray-event-list-col-source"
+             :style (merge cell {:width l2-source-col-width :flex-shrink 0})}
+      "source"]
      [:span {:data-testid "rf-xray-event-list-col-timestamp"
              :style (merge cell {:flex-shrink 0 :text-align "right"
                                  :min-width l2-time-col-min-width})}

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -1851,22 +1851,24 @@
    "Clear Filters"])
 
 (rf/reg-view events-ribbon
-  "L1.5 **events ribbon** (bar-2) — reconciled to the authoritative
-  reference events-ribbon (`tools/xray/design-reference/xray_devtools_
-  reference.cljs`, rf2-3f2di A5/A6). The second stratum below the chrome
-  ribbon. LEFT → RIGHT:
+  "L1.5 **events ribbon** (bar-2) — reconciled to the Figma-Make surface
+  (rf2-xawwb). The second stratum below the chrome ribbon. LEFT → RIGHT:
 
-    - the `N events filtered out` warning text (when N > 0), in the
-      `:warning` colour;
+    - the `↳ filters:` contextual label (corner-down-right glyph);
+    - the add-filter `+` ICON button
+      (`filter-pills/events-add-filter-button`) — opens the edit popup;
     - the committed green-bordered IN pills + red-bordered OUT pills
-      (`filter-pills/pills-view`, A6);
-    - FAR RIGHT (only when a filter is active): the `Clear Filters`
-      button (Xray wiring — one-click reset of every pill + mute).
+      (`filter-pills/pills-view`), each with a vertical divider before
+      its `✕`;
+    - pushed to the FAR RIGHT (via `margin-left: auto`): the `N events
+      filtered out` warning text (when N > 0, `:warning` colour) +
+      (only when a filter is active) the `Clear Filters` button.
 
-  The nav cluster, focus button, focus-chip, and the add(+) affordance
-  moved UP to the chrome ribbon (bar-1) per the reference's chrome-ribbon
-  / events-ribbon split (rf2-3f2di A5). This bar now carries ONLY the
-  filtered-out warning + the committed pills + the reset action.
+  rf2-xawwb supersedes the rf2-3f2di A5/A6 layout (warning LED the bar):
+  the Figma-Make surface leads with the `filters:` label + add(+) and
+  pushes the filtered-out count to the trailing edge. The nav cluster,
+  focus button, focus-chip, and the chrome add affordance live UP on the
+  chrome ribbon (bar-1).
 
   Visibility (rf2-4vp5j Decision 3, preserved):
     - the bar renders its background/hairline always (it is a fixed
@@ -1895,20 +1897,35 @@
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
-     ;; rf2-3f2di A5 — the `N events filtered out` warning leads the
-     ;; bar-2 cluster (reference events-ribbon left side), ahead of the
-     ;; pills. Renders only when N > 0.
-     (filters-hidden-message hidden-summary)
+     ;; rf2-xawwb — `↳ filters:` contextual label leads the events ribbon
+     ;; (Figma-Make surface), followed by the add-filter (+) ICON button,
+     ;; then the committed pills. The corner-down-right glyph mirrors the
+     ;; tabs ribbon's `for selected event` label idiom.
+     [:span {:data-testid "rf-xray-events-ribbon-filters-label"
+             :style {:display      "inline-flex"
+                     :align-items  "center"
+                     :gap          "6px"
+                     :color        (:text-secondary tokens)
+                     :font-family  sans-stack
+                     :font-size    (:caption type-scale)
+                     :white-space  "nowrap"}}
+      [:span {:aria-hidden "true"} "↳"]
+      "filters:"]
+     [filter-pills/events-add-filter-button]
      ;; rf2-3f2di A6 — the committed green/red filter pills.
      [ribbon-filter-pills {:filters filters}]
-     ;; rf2-4vp5j Decision 3 — Clear Filters on the far right, only when
-     ;; a filter is active. `margin-left: auto` pushes it to the trailing
-     ;; edge regardless of pill count.
-     (when any-active?
+     ;; rf2-xawwb — the `N events filtered out` warning is pushed to the
+     ;; RIGHT end (Figma-Make surface), alongside Clear Filters. The
+     ;; `margin-left: auto` on this trailing cluster shoves both to the
+     ;; trailing edge regardless of pill count. The warning renders only
+     ;; when N > 0; Clear Filters only when a filter is active.
+     (when (or (:visible? hidden-summary) any-active?)
        [:div {:data-testid "rf-xray-events-ribbon-actions"
-              :style {:display "flex" :align-items "center" :gap "8px"
+              :style {:display "flex" :align-items "center" :gap "12px"
                       :margin-left "auto"}}
-        [clear-filters-button]])]))
+        (filters-hidden-message hidden-summary)
+        (when any-active?
+          [clear-filters-button])])]))
 
 ;; rf2-ad7zx.12 + rf2-lnod7 — the L2 list's column-header row, reconciled
 ;; to the Figma EventList (the `event-list` component in

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -2118,30 +2118,25 @@
 ;; ---- L3 tab bar ----------------------------------------------------------
 
 (defn- tab-button
-  "One tab in the L3 tab bar — an UNDERLINE tab per the authoritative
-  reference (`tools/xray/design-reference/xray_devtools_reference.cljs`,
-  the `main-app` tab-strip, rf2-3f2di A1), NOT a radio glyph and NOT a
-  filled-accent pill. Each tab is a borderless button on a transparent
-  background:
+  "One tab in the L3 tab bar — a ROUNDED-TOP folder tab on the DARK tabs
+  ribbon (rf2-xawwb · Figma-Make surface). Each tab is a borderless
+  button with `border-radius: 4px 4px 0 0`:
 
-  - the ACTIVE tab carries a 2px `border-bottom` in `:accent` and the
-    NORMAL text colour (`:text-primary` = the reference
-    `text-[var(--devtools-text)]`) — the underline, not a filled fill,
-    is the selected signal;
-  - INACTIVE tabs are transparent with a 2px TRANSPARENT bottom border
-    (so the active underline never shifts the row by 2px) and NEUTRAL
-    muted ink (`:text-tertiary` = the reference `--devtools-text-muted`,
-    the `text-muted-foreground` of the reference Tabs).
+  - the ACTIVE tab carries a LIGHT `chrome-ribbon-tab-active` fill with
+    dark `chrome-ribbon-tab-active-text` ink — the lit fill reads as a
+    folder tab lifting out of the dark band onto the panel below;
+  - INACTIVE tabs carry a faint translucent-white fill
+    (`rgba(255,255,255,0.12)`) with muted-white `chrome-ribbon-text-muted`
+    ink, so they recede into the dark band.
 
-  The subtle `:hover` background fill lives in
+  The subtle `:hover` lift for inactive tabs lives in
   `theme/global-styles/motion-css` (keyed off the `rf-xray-tab-*`
   testid, since inline styles can't carry a `:hover` pseudo-class). The
-  mnemonic letter is exposed via the `title` attribute. The decorative
-  `●/○` radio glyph is GONE — the underline + text colour carry the
-  selected signal.
+  mnemonic letter is exposed via the `title` attribute.
 
-  rf2-3f2di — the prior rf2-ad7zx.16 filled-accent pill (bg `:accent`,
-  white text) is superseded by the reference's underline treatment.
+  rf2-xawwb — supersedes the rf2-3f2di underline treatment (a 2px
+  `:accent` bottom border on a transparent bar) with the Figma-Make
+  rounded-top tabs on the dark band.
 
   `aria-label` wraps the visible label as `Xray <tab-label> tab` so the
   button's accessible name never collides with host-app role queries
@@ -2169,38 +2164,30 @@
               :on-click      #(rf/dispatch [:rf.xray/select-tab id] {:frame :rf/xray})
               :title         (str label " (" mnem ")")
               :aria-label    (str "Xray " label " tab")
-              :style {;; rf2-3f2di A1 — UNDERLINE tab per the authority
-                      ;; reference. ACTIVE → transparent bg, normal text
-                      ;; ink, 2px `:accent` bottom border (the underline);
-                      ;; INACTIVE → transparent bg, neutral muted ink, 2px
-                      ;; TRANSPARENT bottom border (so the active
-                      ;; underline never shifts the row 2px). The `:hover`
-                      ;; fill for inactive tabs is applied via the scoped
-                      ;; CSS rule in motion-css.
-                      :background    "transparent"
+              :style {;; rf2-xawwb — ROUNDED-TOP tab on the dark tabs
+                      ;; ribbon (Figma-Make surface). ACTIVE → light
+                      ;; `chrome-ribbon-tab-active` fill + dark
+                      ;; `chrome-ribbon-tab-active-text` ink (the tab
+                      ;; "lifts" onto the panel below); INACTIVE →
+                      ;; translucent white fill + muted-white ink. Both
+                      ;; carry `border-radius: 4px 4px 0 0` so the top
+                      ;; corners round like folder tabs. The `:hover` lift
+                      ;; for inactive tabs is the scoped rule in motion-css.
+                      :background    (if active?
+                                       (:chrome-ribbon-tab-active tokens)
+                                       "rgba(255,255,255,0.12)")
                       :border        "none"
-                      ;; The selected signal is the 2px accent underline
-                      ;; (reference `main-app` tab-strip:
-                      ;; `border-bottom: 2px solid var(--devtools-active)`
-                      ;; when active, `2px solid transparent` otherwise).
-                      :border-bottom (if active?
-                                       (str "2px solid " (:accent tokens))
-                                       "2px solid transparent")
-                      ;; ACTIVE → normal text ink (reference
-                      ;; `text-[var(--devtools-text)]` = `:text-primary`);
-                      ;; INACTIVE → neutral muted ink (`:text-tertiary` =
-                      ;; reference `--devtools-text-muted`).
+                      :border-radius "4px 4px 0 0"
                       :color         (if active?
-                                       (:text-primary tokens)
-                                       (:text-tertiary tokens))
+                                       (:chrome-ribbon-tab-active-text tokens)
+                                       (:chrome-ribbon-text-muted tokens))
                       :cursor        "pointer"
-                      :padding       "0 16px"       ; reference `px-4`, full-height
-                      :height        "100%"
+                      :padding       "4px 16px"     ; rounded-top tab pad
                       :font-family   sans-stack
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
                       :white-space   "nowrap"
-                      :transition    "border-color 120ms ease-out, color 120ms ease-out"}}
+                      :transition    "background-color 120ms ease-out, color 120ms ease-out"}}
      label]))
 
 (rf/reg-view tab-bar
@@ -2225,18 +2212,37 @@
     [:div {:data-testid "rf-xray-tab-bar"
            :role        "tablist"
            :aria-label  "Xray panel tabs"
-           ;; rf2-3f2di A1 — `align-items: stretch` + `gap: 0` so the
-           ;; full-height underline tabs (reference `main-app` tab-strip)
-           ;; sit flush and their 2px accent bottom-border lands on the
-           ;; bar's bottom edge. Height matches the 34px ribbon rhythm.
+           ;; rf2-xawwb — DARK tabs ribbon (Figma-Make surface). The tab
+           ;; strip becomes a dark band carrying rounded-top tab buttons.
+           ;; `align-items: flex-end` so each rounded-top tab sits flush
+           ;; on the bar's bottom edge (the active tab's light fill reads
+           ;; as a folder-tab lifting onto the panel below). `gap: 3px`
+           ;; gives the rounded tabs breathing room. Prefixed with the
+           ;; `for selected event` contextual label.
            :style {:display       "flex"
-                   :align-items   "stretch"
-                   :gap           "0"
+                   :align-items   "flex-end"
+                   :gap           "3px"
                    :height        "34px"
                    :padding       "0 12px"
-                   :background    (:bg-1 tokens)
+                   :background    (:chrome-ribbon-bg tokens)
                    :border-top    (str "1px solid " (:border-subtle tokens))
                    :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     ;; rf2-xawwb — `↳ for selected event` contextual label (Figma-Make
+     ;; tabs ribbon): the corner-down-right glyph + muted-white text on
+     ;; the dark band, signalling that the tabs below project the
+     ;; CURRENTLY-SELECTED L2 event.
+     [:span {:data-testid "rf-xray-tab-bar-context-label"
+             :style {:display      "inline-flex"
+                     :align-items  "center"
+                     :gap          "6px"
+                     :align-self   "center"
+                     :margin-right "10px"
+                     :color        (:chrome-ribbon-text-muted tokens)
+                     :font-family  sans-stack
+                     :font-size    (:caption type-scale)
+                     :white-space  "nowrap"}}
+      [:span {:aria-hidden "true"} "↳"]
+      "for selected event"]
      ;; rf2-2moh1 — iterate `dynamic-tabs` (registry-derived) rather
      ;; than a literal vector. Tab order follows each entry's `:order`.
      (for [{:keys [id] :as tab} (dynamic-tabs)]

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -656,12 +656,13 @@
   so the disabled glyph dimmed the wrong button.)"
   [{:keys [at-head? at-tail? live?]}]
   (let [head-disabled? (boolean (and at-head? live?))
-        ;; rf2-3f2di A2 — filled `:accent` buttons (reference chrome-
-        ;; ribbon): blue bg, white icon, 4px radius, hover opacity lift
-        ;; (the `:hover` rule lives in `theme/global-styles/motion-css`).
-        btn-style {:background      (:accent tokens)
+        ;; rf2-3f2di A2 / rf2-xawwb — filled nav buttons (Figma-Make chrome-
+        ;; ribbon): blue `active-bg` fill, white `active-text` icon, 4px
+        ;; radius, hover opacity lift (the `:hover` rule lives in
+        ;; `theme/global-styles/motion-css`).
+        btn-style {:background      (:active-bg tokens)
                    :border          "none"
-                   :color           (:white tokens)
+                   :color           (:active-text tokens)
                    :cursor          "pointer"
                    :opacity         1
                    :padding         "0"
@@ -804,10 +805,13 @@
               :style {:display         "inline-flex"
                       :align-items     "center"
                       :gap             "4px"
-                      :background      (:accent tokens)
+                      ;; rf2-xawwb — blue `active-bg` fill / white
+                      ;; `active-text` ink to match the Figma-Make chrome
+                      ;; nav buttons on the dark band.
+                      :background      (:active-bg tokens)
                       :border          "none"
                       :border-radius   "4px"
-                      :color           (:white tokens)
+                      :color           (:active-text tokens)
                       :cursor          (if disabled? "not-allowed" "pointer")
                       :opacity         (if disabled? 0.5 1)
                       :padding         "2px 8px"
@@ -903,6 +907,50 @@
                                :line-height   "1"}}
         "✕"]])))                  ;; ✕
 
+(defn- ribbon-theme-toggle
+  "rf2-xawwb — theme toggle (Figma-Make surface). A sun/moon icon-button
+  on the chrome ribbon's right cluster that flips light ⇄ dark.
+
+  ## Integrates the EXISTING theme mechanism (no parallel state)
+
+  Xray already owns a `:theme` setting (`config.cljc`, default `:light`)
+  read via `[:rf.xray/setting :theme nil]` and written via
+  `[:rf.xray/settings-update :theme nil <kw>]`, whose handler calls
+  `settings/effects/apply-theme!` to toggle the `rf-xray-theme-light` /
+  `rf-xray-theme-dark` class on the shell + `<html>` root. This button
+  dispatches through that SAME event — it does NOT toggle a bare `dark`
+  class on `document.documentElement` (the Figma stub's approach) nor
+  introduce a second theme atom. The settings popup's theme radio and
+  this toggle therefore stay in lockstep.
+
+  The glyph follows the convention NEXT action: in DARK mode it shows
+  the sun `☀` (click → go light); in LIGHT mode the moon `☾` (click →
+  go dark). Muted `chrome-ribbon-text-muted` ink to sit quietly beside
+  the `⚙`/`✕` icons on the dark band."
+  []
+  (let [theme @(rf/subscribe [:rf.xray/setting :theme nil])
+        dark? (= theme :dark)
+        next  (if dark? :light :dark)]
+    [:button {:data-testid "rf-xray-theme-toggle"
+              :title       (if dark? "Switch to light theme" "Switch to dark theme")
+              :aria-label  (if dark? "Switch to light theme" "Switch to dark theme")
+              :on-click    #(rf/dispatch [:rf.xray/settings-update :theme nil next]
+                                         {:frame :rf/xray})
+              :style       {:background      "transparent"
+                            :border          "none"
+                            :border-radius   "4px"
+                            :color           (:chrome-ribbon-text-muted tokens)
+                            :cursor          "pointer"
+                            :font-size       "14px"
+                            :line-height     "1"
+                            :display         "inline-flex"
+                            :align-items     "center"
+                            :justify-content "center"
+                            :width           "22px"
+                            :height          "22px"
+                            :padding         "0"}}
+     [:span {:aria-hidden "true"} (if dark? "☀" "☾")]]))
+
 (defn- ribbon-right-icons
   "Right-icons cluster — `⚙` settings · `✕` close. Per spec/018 §3
   Right-icon behaviour the pop-out (`⛶`) slot is reserved for the
@@ -933,7 +981,10 @@
   (let [icon-style {:background      "transparent"
                     :border          "none"
                     :border-radius   "4px"
-                    :color           (:text-tertiary tokens)
+                    ;; rf2-xawwb — muted-white ink on the dark chrome band
+                    ;; (Figma-Make surface) so the settings/close glyphs
+                    ;; read against the near-black ribbon in both themes.
+                    :color           (:chrome-ribbon-text-muted tokens)
                     :cursor          "pointer"
                     :font-size       "14px"
                     :line-height     "1"
@@ -1056,7 +1107,13 @@
                    :gap              "12px"
                    :height           (:top-strip-height layout)
                    :padding          "0 12px"
-                   :background       (:bg-1 tokens)
+                   ;; rf2-xawwb — DARK chrome band (Figma-Make surface).
+                   ;; The chrome ribbon paints the dedicated dark-chrome
+                   ;; token in BOTH themes; chrome text reads the white
+                   ;; `chrome-ribbon-text` token so it stays legible on the
+                   ;; near-black band.
+                   :background       (:chrome-ribbon-bg tokens)
+                   :color            (:chrome-ribbon-text tokens)
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
                    ;; rf2-o5f5f.1 — mode-signal mechanism #2: a 2-px
                    ;; left-edge stripe in the single `:accent` (GitHub
@@ -1077,14 +1134,15 @@
      [:div {:data-testid "rf-xray-ribbon-selectors"
             :style {:display "flex" :align-items "center" :gap "13px"
                     :flex-wrap "wrap"}}
-      ;; rf2-3f2di A4 — `Events` label leads the left cluster (reference
-      ;; chrome-ribbon left side: `text-[var(--devtools-text)] font-medium`).
+      ;; rf2-xawwb — `Event History` label leads the left cluster (Figma-
+      ;; Make surface renamed `Events` → `Event History`). White ink on the
+      ;; dark chrome band (`chrome-ribbon-text`).
       [:span {:data-testid "rf-xray-ribbon-events-label"
-              :style {:color       (:text-primary tokens)
+              :style {:color       (:chrome-ribbon-text tokens)
                       :font-family sans-stack
                       :font-weight 500
                       :white-space "nowrap"}}
-       "Events"]
+       "Event History"]
       ;; rf2-3f2di A2/A5 — blue-filled nav cluster, promoted to bar-1.
       [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail? :live? live?}]
       ;; Xray spine controls — the always-present blue `focus` button
@@ -1093,15 +1151,14 @@
       ;; cluster because they are spine navigation, not scope selectors.
       [ribbon-focus-button {:focused-cascade focused-cascade}]
       [ribbon-focus-chip {:focus-set focus-set}]
-      ;; rf2-3f2di A5 — `Filters:` label + the add(+) affordance (the
-      ;; committed pills live on bar-2). Reference chrome-ribbon left
-      ;; side: `Filters:` muted label then the `+` add button.
-      [:span {:data-testid "rf-xray-ribbon-filters-label"
-              :style {:color       (:text-secondary tokens)
-                      :font-family sans-stack
-                      :white-space "nowrap"}}
-       "Filters:"]
-      [filter-pills/add-pill]]
+      ;; rf2-xawwb — `+ filter` text button (Figma-Make chrome-ribbon).
+      ;; Replaces the prior `Filters:` label + plus-icon affordance with a
+      ;; single outlined `+ filter` text button. Opens the same edit
+      ;; popup (`filter-pills/chrome-add-filter-button` delegates to the
+      ;; canonical `:rf.xray/open-edit-popup` flow), so the add behaviour
+      ;; is RETAINED — only the surface changes. Muted-outline on the dark
+      ;; band so it reads as a secondary chrome affordance.
+      [filter-pills/chrome-add-filter-button]]
      ;; RIGHT cluster — scope selectors (Frame + Dynamic/Static) then the
      ;; silent-by-default indicators + chrome actions. Per the authority
      ;; reference chrome-ribbon right side (rf2-3f2di A5).
@@ -1123,6 +1180,9 @@
       ;; manager modal.
       [spine-filters/ribbon-mute-indicator muted-count]
       [ribbon-redacted-indicator redacted-count]
+      ;; rf2-xawwb — theme toggle (sun/moon) sits before the settings/close
+      ;; icons per the Figma-Make chrome-ribbon right cluster.
+      [ribbon-theme-toggle]
       [ribbon-right-icons]]]))
 
 ;; ---- L2 event list -------------------------------------------------------

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -798,18 +798,16 @@
     "    rgba(236, 72, 153, 0.30) 0 6px,\n"
     "    rgba(236, 72, 153, 0.10) 6px 12px) !important;\n"
     "}\n"
-    ;; rf2-ad7zx.16 — L3 tab-bar hover. The Figma button-bar
-    ;; (the `tabs` component + the main layout's TabsList in
-    ;; `design-reference/xray_devtools_reference.cljs`) gives
-    ;; inactive tabs a subtle `hover:bg-[var(--devtools-hover)]` fill;
-    ;; the active tab keeps its filled `:accent` background. Inline
-    ;; styles can't carry a `:hover` pseudo-class, so the hover lift is a
-    ;; scoped CSS rule keyed off the `rf-xray-tab-*` testid. The
-    ;; `[aria-selected="false"]` predicate scopes it to inactive tabs so
-    ;; hovering the active tab doesn't override its accent fill.
+    ;; rf2-xawwb — L3 tabs-ribbon hover (Figma-Make dark tabs ribbon).
+    ;; Inactive rounded-top tabs sit on the DARK chrome band with a faint
+    ;; translucent-white fill; on hover the fill brightens and the ink
+    ;; lifts to full white. Keyed off the `rf-xray-tab-*` testid + the
+    ;; `[aria-selected="false"]` predicate so hovering the active (light-
+    ;; filled) tab doesn't override its fill. Inline styles can't carry a
+    ;; `:hover` pseudo-class, hence the scoped rule.
     "[data-testid^=\"rf-xray-tab-\"][aria-selected=\"false\"]:hover {\n"
-    "  background-color: " (:hover tokens/tokens) ";\n"
-    "  color: " (:text-primary tokens/tokens) ";\n"
+    "  background-color: rgba(255,255,255,0.22);\n"
+    "  color: " (:chrome-ribbon-text tokens/tokens) ";\n"
     "}\n"
     ;; rf2-tha26 — Trace-panel rounded hover-pill rows. The Figma
     ;; `design-reference/xray_devtools_reference.cljs` (the `trace-panel`
@@ -830,20 +828,23 @@
     "li[data-testid^=\"rf-xray-trace-group-\"]:hover {\n"
     "  background-color: " (:hover tokens/tokens) ";\n"
     "}\n"
-    ;; rf2-cplj8 — borderless chrome icon-buttons hover. The Figma
-    ;; ChromeRibbon + EventsRibbon render the settings/close icons and
-    ;; the nav chevrons as `p-1 rounded hover:bg-[var(--devtools-hover)]`
-    ;; borderless buttons. Inline styles can't carry `:hover`, so the
-    ;; fill lift is a scoped CSS rule keyed off each button's testid. The
-    ;; `:not([disabled])` predicate keeps a disabled (inert) nav chevron
-    ;; from lighting up on hover.
+    ;; rf2-cplj8 / rf2-xawwb — borderless chrome icon-buttons hover. The
+    ;; settings / close / theme-toggle icons + the blue-filled nav
+    ;; chevrons live on the DARK chrome band (Figma-Make surface), so the
+    ;; hover lift is a faint translucent-white wash that keeps the white
+    ;; ink legible (NOT the `:hover`/`:text-primary` pair, which would
+    ;; turn the glyph dark on the near-black band). Inline styles can't
+    ;; carry `:hover`, so the fill is a scoped rule keyed off each
+    ;; button's testid. The `:not([disabled])` predicate keeps a disabled
+    ;; (inert) nav chevron from lighting up on hover.
     "[data-testid=\"rf-xray-icon-settings\"]:hover,\n"
     "[data-testid=\"rf-xray-icon-close\"]:hover,\n"
+    "[data-testid=\"rf-xray-theme-toggle\"]:hover,\n"
     "[data-testid=\"rf-xray-nav-prev\"]:not([disabled]):hover,\n"
     "[data-testid=\"rf-xray-nav-next\"]:not([disabled]):hover,\n"
     "[data-testid=\"rf-xray-nav-head\"]:not([disabled]):hover {\n"
-    "  background-color: " (:hover tokens/tokens) ";\n"
-    "  color: " (:text-primary tokens/tokens) ";\n"
+    "  background-color: rgba(255,255,255,0.12);\n"
+    "  color: " (:chrome-ribbon-text tokens/tokens) ";\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -73,6 +73,20 @@
    :bg-3           "#2a2a2a"   ; popovers / strip (= Figma --devtools-hover)
    :bg-active      "#2a2a2a"
 
+   ;; ── chrome ribbon (rf2-xawwb · Figma-Make surface) ──
+   ;; The chrome ribbon + tabs ribbon read a DEDICATED dark-chrome
+   ;; band that is dark in BOTH themes — the Figma-Make surface paints
+   ;; the top chrome bar and the tab strip on a near-black band with
+   ;; white text, so the data canvas below pops. These map to the
+   ;; Figma `--devtools-chrome-ribbon-*` + `--devtools-active-*` vars.
+   :chrome-ribbon-bg              "#0d1117"   ; Figma --devtools-chrome-ribbon-bg (dark)
+   :chrome-ribbon-text            "#e6edf3"   ; Figma --devtools-chrome-ribbon-text
+   :chrome-ribbon-text-muted      "#8b949e"   ; Figma --devtools-chrome-ribbon-text-muted
+   :chrome-ribbon-tab-active      "#2a2a2a"   ; active tab fill on the dark band
+   :chrome-ribbon-tab-active-text "#e6edf3"   ; active tab ink
+   :active-bg                     "#1f6feb"   ; Figma --devtools-active-bg (nav buttons)
+   :active-text                   "#ffffff"   ; Figma --devtools-active-text
+
    ;; ── borders ──
    :border-subtle  "#2a2a2a"
    :border-default "#373737"   ; Figma --devtools-border
@@ -148,6 +162,21 @@
    :bg-2           "#ffffff"   ; panel surface
    :bg-3           "#e8e8e8"   ; popovers / strip (= Figma --devtools-hover)
    :bg-active      "#e8e8e8"
+
+   ;; ── chrome ribbon (rf2-xawwb · Figma-Make surface) ──
+   ;; Dark chrome band even under the LIGHT theme — the Figma-Make
+   ;; surface keeps the top chrome ribbon + tab strip dark (#2a2a2a)
+   ;; with white text in light mode, so the chrome reads as a distinct
+   ;; band above the light data canvas. The active tab fills WHITE on
+   ;; the light surface (the tab "lifts" out of the dark band onto the
+   ;; light panel below).
+   :chrome-ribbon-bg              "#2a2a2a"   ; Figma --devtools-chrome-ribbon-bg (light)
+   :chrome-ribbon-text            "#ffffff"   ; Figma --devtools-chrome-ribbon-text
+   :chrome-ribbon-text-muted      "#b0b0b0"   ; Figma --devtools-chrome-ribbon-text-muted
+   :chrome-ribbon-tab-active      "#ffffff"   ; active tab fill (lifts onto light canvas)
+   :chrome-ribbon-tab-active-text "#24292f"   ; active tab ink
+   :active-bg                     "#0969da"   ; Figma --devtools-active-bg (nav buttons)
+   :active-text                   "#ffffff"   ; Figma --devtools-active-text
 
    ;; ── borders ── (light mid-greys)
    :border-subtle  "#e8e8e8"

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -238,9 +238,9 @@
   out the per-step `*-label` / `*-body` children testids `step-section`
   emits.
 
-  Section order: DISPATCH → COEFFECTS? → EVENT HANDLER → FLOWS? →
-  DB CHANGES → AFTER INTERCEPTORS? → FX (optional steps shown when
-  present)."
+  Section order (rf2-xawwb Figma-Make surface): DISPATCH → COEFFECTS? →
+  EVENT HANDLER → APP-DB CHANGES → FLOWS? → AFTER INTERCEPTORS? → FX
+  (optional steps shown when present)."
   #{"rf-xray-event-detail-section-dispatch"
     "rf-xray-event-detail-section-coeffects"
     "rf-xray-event-detail-section-handler"
@@ -264,10 +264,10 @@
        (vec)))
 
 (deftest event-lens-renders-all-seven-steps-when-fully-populated
-  (testing "rf2-ad7zx.5 — a cascade with call-site + fx + after-
+  (testing "rf2-xawwb — a cascade with call-site + fx + after-
             interceptors + user coeffects + a flow yields the full
-            7-step numbered pipeline (spec/021 §2.2): DISPATCH,
-            COEFFECTS, EVENT HANDLER, FLOWS, DB CHANGES,
+            7-step numbered pipeline (Figma-Make surface order): DISPATCH,
+            COEFFECTS, EVENT HANDLER, APP-DB CHANGES, FLOWS,
             AFTER INTERCEPTORS, FX"
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
@@ -298,8 +298,8 @@
         (doseq [[id label] [["dispatch" "DISPATCH"]
                             ["coeffects" "COEFFECTS"]
                             ["handler" "EVENT HANDLER"]
+                            ["db-changes" "APP-DB CHANGES"]
                             ["flows" "FLOWS"]
-                            ["db-changes" "DB CHANGES"]
                             ["after-interceptors" "AFTER INTERCEPTORS"]
                             ["fx" "FX"]]]
           (is (some? (find-by-testid tree (str "rf-xray-event-detail-section-" id)))
@@ -848,11 +848,14 @@
                row-tids)
             "flow rows appear in cascade firing order")))))
 
-(deftest flows-step-sits-after-handler-before-db-changes-and-fx
-  (testing "rf2-9eca7 — spec/021 §2.2 step order: FLOWS (step 4) fires at
-            the outermost :after, right after the EVENT HANDLER and
-            BEFORE DB CHANGES (the commit) + FX. Flows reshape the
-            pending :db before it installs, so they precede both."
+(deftest flows-step-sits-after-db-changes-before-fx
+  (testing "rf2-xawwb — Figma-Make surface step order: EVENT HANDLER →
+            APP-DB CHANGES (step 4) → FLOWS (step 5) → FX. The APP-DB
+            CHANGES diff leads and the FLOWS section then attributes the
+            flow-driven slots within it. (Supersedes rf2-9eca7 / #2070,
+            which placed FLOWS before DB CHANGES. The framework TIMING is
+            unchanged — flows still reshape the pending db before commit;
+            only the panel's visual ordering changes.)"
     (rf/with-frame :rf/default
       (rf/reg-flow {:id     :a-flow
                     :inputs [[:in]] :output identity :path [:a]}))
@@ -876,11 +879,11 @@
                         (distinct)
                         (vec))]
         (is (= ["rf-xray-event-detail-section-handler"
-                "rf-xray-event-detail-section-flows"
                 "rf-xray-event-detail-section-db-changes"
+                "rf-xray-event-detail-section-flows"
                 "rf-xray-event-detail-section-fx"]
                tids)
-            "FLOWS appears right after EVENT HANDLER and before DB CHANGES + FX in document order")))))
+            "APP-DB CHANGES precedes FLOWS, both after EVENT HANDLER and before FX (rf2-xawwb)")))))
 
 (deftest flows-section-absent-when-handler-threw
   (testing "rf2-lo37i — when the handler threw, the outermost :after

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -279,13 +279,13 @@
             "`Events` label leads the chrome ribbon")
         (is (nil? (find-by-testid ribbon "rf-xray-ribbon-logo"))
             "the `❖ Xray` wordmark is GONE (A4)")
-        ;; A2/A5 — the nav cluster + add(+) now live in the chrome ribbon.
+        ;; A2/A5 — the nav cluster + add affordance now live in the chrome
+        ;; ribbon. rf2-xawwb — the prior `Filters:` label + plus-icon is
+        ;; replaced by the single `+ filter` text button (same testid).
         (is (some? (find-by-testid ribbon "rf-xray-ribbon-nav"))
             "nav cluster IS in the chrome ribbon (A5)")
-        (is (some? (find-by-testid ribbon "rf-xray-ribbon-filters-label"))
-            "`Filters:` label in the chrome ribbon (A5)")
         (is (some? (find-by-testid ribbon "rf-xray-filter-add"))
-            "the add(+) affordance is in the chrome ribbon (A5)")
+            "the `+ filter` add affordance is in the chrome ribbon (rf2-xawwb)")
         ;; right cluster — scope selectors + icons.
         (is (or (find-by-testid ribbon "rf-xray-ribbon-frame")
                 (find-by-testid ribbon "rf-xray-ribbon-frame-picker"))
@@ -300,19 +300,20 @@
             "committed filter pills are NOT in the chrome ribbon")))))
 
 (deftest chrome-ribbon-leads-with-events-label-not-logo
-  (testing "rf2-3f2di A4 — the chrome ribbon's LEFT cluster opens with an
-            `Events` label per the authority reference chrome-ribbon; the
-            `❖ Xray` wordmark was DROPPED. The label renders inside the
-            left cluster, ahead of the nav cluster."
+  (testing "rf2-xawwb — the chrome ribbon's LEFT cluster opens with an
+            `Event History` label (Figma-Make surface renamed `Events` →
+            `Event History`); the `❖ Xray` wordmark was DROPPED. The
+            label renders inside the left cluster, ahead of the nav
+            cluster."
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [ribbon    (shell/ribbon nil)
             selectors (find-by-testid ribbon "rf-xray-ribbon-selectors")
             label     (find-by-testid ribbon "rf-xray-ribbon-events-label")]
-        (is (some? label) "the `Events` label renders in the chrome ribbon")
+        (is (some? label) "the `Event History` label renders in the chrome ribbon")
         (is (some? selectors) "the left cluster is present")
-        (is (re-find #"Events" (text-nodes label))
-            "the label text reads `Events`")
+        (is (re-find #"Event History" (text-nodes label))
+            "the label text reads `Event History` (rf2-xawwb)")
         (is (nil? (find-by-testid ribbon "rf-xray-ribbon-logo"))
             "the `❖ Xray` wordmark is gone (A4)")
         (is (not (re-find #"❖" (text-nodes ribbon)))
@@ -538,18 +539,21 @@
                 (str "after select-tab :machines, tab " tab-id
                      " aria-selected reflects the new active tab"))))))))
 
-(deftest tab-bar-is-underline-not-pill-or-radios
-  (testing "rf2-3f2di A1 — the L3 tab strip renders as UNDERLINE tabs per
-            the authority reference (`main-app` tab-strip), NOT a filled-
-            accent pill and NOT radio-circle glyphs. Each tab is a
-            borderless transparent button; the ACTIVE tab carries a 2px
-            `:accent` bottom border + NORMAL text ink; inactive tabs are
-            transparent with a 2px TRANSPARENT bottom border + neutral
-            muted ink."
+(deftest tab-bar-is-rounded-top-dark-tabs
+  (testing "rf2-xawwb — the L3 tab strip renders as ROUNDED-TOP folder
+            tabs on the DARK tabs ribbon (Figma-Make surface), NOT
+            underline tabs and NOT radio-circle glyphs. Each tab is a
+            borderless `<button>` with `border-radius 4px 4px 0 0`; the
+            ACTIVE tab carries the light `:chrome-ribbon-tab-active` fill +
+            dark `:chrome-ribbon-tab-active-text` ink; inactive tabs carry
+            a faint translucent-white fill + muted-white ink."
     (xray-setup!)
     (rf/with-frame :rf/xray
-      (let [tree (shell/shell-view)
-            accent-underline (str "2px solid " (:accent tokens))]
+      (let [tree            (shell/shell-view)
+            active-fill     (:chrome-ribbon-tab-active tokens)
+            active-ink      (:chrome-ribbon-tab-active-text tokens)
+            inactive-ink    (:chrome-ribbon-text-muted tokens)
+            rounded-top     "4px 4px 0 0"]
         ;; (a) NO radio-circle glyphs anywhere in the tab strip.
         (doseq [tab-id expected-tab-ids]
           (let [btn  (find-by-testid tree (str "rf-xray-tab-" (name tab-id)))
@@ -557,51 +561,45 @@
             (is (some? btn) (str "tab button for " tab-id " present"))
             (is (not (re-find #"[◉○●]" txt))
                 (str "tab " tab-id " carries no radio-circle glyph"))))
-        ;; (b) Every tab is a borderless transparent button — NOT a
-        ;; filled pill. No border-radius (the underline, not a rounded
-        ;; fill, is the shape).
+        ;; (b) Every tab is a `<button>` with rounded-TOP corners (folder
+        ;; tab), not the prior square underline tab.
         (doseq [tab-id expected-tab-ids]
           (let [btn   (find-by-testid tree (str "rf-xray-tab-" (name tab-id)))
                 style (:style (second btn))]
             (is (= :button (first btn))
                 (str "tab " tab-id " is a <button>"))
-            (is (= "transparent" (:background style))
-                (str "tab " tab-id " background is transparent (no filled pill)"))
-            (is (nil? (:border-radius style))
-                (str "tab " tab-id " carries no border-radius (underline, not pill)"))))
-        ;; (c) The ACTIVE tab (default :event) carries the 2px accent
-        ;; underline + normal text ink — NOT a filled accent bg / white text.
+            (is (= rounded-top (:border-radius style))
+                (str "tab " tab-id " has rounded-top corners (4px 4px 0 0)"))))
+        ;; (c) The ACTIVE tab (default :event) carries the light fill + dark
+        ;; ink (the folder tab lifting onto the panel below).
         (let [active (find-by-testid tree "rf-xray-tab-event")
               style  (:style (second active))]
-          (is (= accent-underline (:border-bottom style))
-              "active tab has a 2px :accent bottom border (the underline)")
-          (is (= (:text-primary tokens) (:color style))
-              "active tab text is the normal :text-primary ink")
-          (is (not= (:accent tokens) (:background style))
-              "active tab background is NOT a filled :accent pill"))
-        ;; (d) INACTIVE tabs are transparent with a TRANSPARENT 2px bottom
-        ;; border + NEUTRAL muted ink.
+          (is (= active-fill (:background style))
+              "active tab background is the light :chrome-ribbon-tab-active fill")
+          (is (= active-ink (:color style))
+              "active tab ink is the dark :chrome-ribbon-tab-active-text"))
+        ;; (d) INACTIVE tabs carry a translucent-white fill + muted-white ink.
         (doseq [tab-id (remove #{:event} expected-tab-ids)]
           (let [btn   (find-by-testid tree (str "rf-xray-tab-" (name tab-id)))
                 style (:style (second btn))]
-            (is (= "2px solid transparent" (:border-bottom style))
-                (str "inactive tab " tab-id " bottom border is transparent"))
-            (is (= (:text-tertiary tokens) (:color style))
-                (str "inactive tab " tab-id " text is neutral muted ink"))))))
-    ;; (e) After switching the active tab, the underline follows the new
-    ;; selection (and the old tab reverts to a transparent underline).
+            (is (= "rgba(255,255,255,0.12)" (:background style))
+                (str "inactive tab " tab-id " has the translucent-white fill"))
+            (is (= inactive-ink (:color style))
+                (str "inactive tab " tab-id " text is muted-white ink"))))))
+    ;; (e) After switching the active tab, the light fill follows the new
+    ;; selection (and the old tab reverts to the translucent fill).
     (select-tab! :machines)
     (rf/with-frame :rf/xray
-      (let [tree   (shell/shell-view)
-            accent-underline (str "2px solid " (:accent tokens))
-            mach   (:style (second (find-by-testid tree "rf-xray-tab-machines")))
-            event  (:style (second (find-by-testid tree "rf-xray-tab-event")))]
-        (is (= accent-underline (:border-bottom mach))
-            "newly-active :machines tab gains the accent underline")
-        (is (= (:text-primary tokens) (:color mach))
-            "newly-active :machines tab text is the normal ink")
-        (is (= "2px solid transparent" (:border-bottom event))
-            "previously-active :event tab reverts to a transparent underline")))))
+      (let [tree        (shell/shell-view)
+            active-fill (:chrome-ribbon-tab-active tokens)
+            mach        (:style (second (find-by-testid tree "rf-xray-tab-machines")))
+            event       (:style (second (find-by-testid tree "rf-xray-tab-event")))]
+        (is (= active-fill (:background mach))
+            "newly-active :machines tab gains the light fill")
+        (is (= (:chrome-ribbon-tab-active-text tokens) (:color mach))
+            "newly-active :machines tab ink is the dark active-text")
+        (is (= "rgba(255,255,255,0.12)" (:background event))
+            "previously-active :event tab reverts to the translucent fill")))))
 
 (deftest tab-click-dispatches-select-tab
   (testing "spec/018 §5 — clicking a tab fires :rf.xray/select-tab"
@@ -2300,25 +2298,26 @@
 ;;   (3) event-list event-id column → explicitly LEFT-aligned (header +
 ;;       row); the selected/active row → subtle :hover fill, NOT a 1px
 ;;       blue ring; the `timestamp` column → absolute HH:MM:SS.mmm (A8).
-;;   (4) tabs → UNDERLINE (2px accent bottom-border + normal ink for the
-;;       active tab), NOT a filled pill (A1; covered by
-;;       `tab-bar-is-underline-not-pill-or-radios` above).
+;;   (4) tabs → ROUNDED-TOP folder tabs on the dark tabs ribbon (light
+;;       fill + dark ink for the active tab), NOT a filled pill nor an
+;;       underline (rf2-xawwb; covered by
+;;       `tab-bar-is-rounded-top-dark-tabs` above).
 ;; -------------------------------------------------------------------------
 
 (deftest chrome-events-label-uses-neutral-ink-not-accent
-  (testing "rf2-3f2di A4 — the `Events` label (which replaced the dropped
-            `❖ Xray` wordmark) renders in the NEUTRAL chrome text colour
-            (:text-primary = reference --devtools-text), NOT the :accent
-            blue. The single accent is reserved for active/selected
-            affordances."
+  (testing "rf2-xawwb — the `Event History` label (which replaced the
+            dropped `❖ Xray` wordmark) renders in the white
+            chrome-ribbon text colour (:chrome-ribbon-text), legible on
+            the dark chrome band, NOT the :accent blue. The single accent
+            is reserved for active/selected affordances."
     (xray-setup!)
     (rf/with-frame :rf/xray
       (let [ribbon (shell/ribbon nil)
             label  (find-by-testid ribbon "rf-xray-ribbon-events-label")
             style  (:style (second label))]
-        (is (some? label) "the `Events` label renders")
-        (is (= (:text-primary tokens) (:color style))
-            "the label ink is the neutral :text-primary token")
+        (is (some? label) "the `Event History` label renders")
+        (is (= (:chrome-ribbon-text tokens) (:color style))
+            "the label ink is the white :chrome-ribbon-text token")
         (is (not= (:accent tokens) (:color style))
             "the label ink is NOT the :accent blue")))))
 

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -1398,13 +1398,13 @@
             "⏭ ENABLED — paused-at-head, pressing it resumes LIVE")))))
 
 (deftest ribbon-nav-disabled-button-has-inert-styling
-  (testing "rf2-x5tro + rf2-3f2di A2 — a disabled nav button READS as
-            inert, not just cursor: not-allowed. With the blue-filled
-            treatment (reference chrome-ribbon) the inert signal is a
-            strong opacity drop (the filled blue fades) + not-allowed
-            cursor. The button keeps its filled :accent base + white icon
-            + borderless box; only the opacity recedes. Asserted on ⏭ at
-            head + live."
+  (testing "rf2-x5tro + rf2-xawwb — a disabled nav button READS as inert,
+            not just cursor: not-allowed. With the blue-filled treatment
+            (Figma-Make chrome-ribbon) the inert signal is a strong
+            opacity drop (the filled blue fades) + not-allowed cursor. The
+            button keeps its filled :active-bg base + white :active-text
+            icon + borderless box; only the opacity recedes. Asserted on
+            ⏭ at head + live."
     (xray-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
     (rf/with-frame :rf/xray
@@ -1416,11 +1416,11 @@
         (is (true? (:disabled (second head)))
             "⏭ disabled at head + live (single event, fresh focus)")
         ;; The proper inert appearance — filled but faded.
-        (is (= (:accent tokens) (:background style))
-            "disabled nav button keeps the filled :accent base")
+        (is (= (:active-bg tokens) (:background style))
+            "disabled nav button keeps the filled :active-bg base")
         (is (= "none" (:border style))
             "disabled nav button has NO border box — borderless filled style")
-        (is (= (:white tokens) (:color style))
+        (is (= (:active-text tokens) (:color style))
             "disabled icon stays white (the opacity drop carries the fade)")
         (is (= 0.4 (:opacity style))
             "disabled opacity reduced so the filled blue recedes")
@@ -2350,15 +2350,15 @@
                 (str label " icon-button has NO border box"))
             (is (= "transparent" (:background style))
                 (str label " icon-button is transparent (hover fill via CSS)"))
-            (is (= (:text-tertiary tokens) (:color style))
-                (str label " icon-button uses muted :text-tertiary ink"))))))))
+            (is (= (:chrome-ribbon-text-muted tokens) (:color style))
+                (str label " icon-button uses muted-white :chrome-ribbon-text-muted ink (dark band, rf2-xawwb)"))))))))
 
 (deftest chrome-ribbon-nav-buttons-are-blue-filled
-  (testing "rf2-3f2di A2 — the chrome-ribbon nav cluster renders FILLED
-            `:accent` buttons (reference chrome-ribbon: blue bg, white
-            icon), NOT borderless icon-buttons and NOT bordered triangles.
-            The active (enabled) button carries `background: :accent` +
-            white icon + `border: none`."
+  (testing "rf2-xawwb — the chrome-ribbon nav cluster renders FILLED
+            `:active-bg` buttons (Figma-Make chrome-ribbon: blue bg, white
+            `:active-text` icon), NOT borderless icon-buttons and NOT
+            bordered triangles. The active (enabled) button carries
+            `background: :active-bg` + white icon + `border: none`."
     (xray-setup!)
     ;; Two events + focus the middle so prev/next are ENABLED (active style).
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
@@ -2374,18 +2374,18 @@
             (is (some? btn) (str tid " present"))
             (is (= "none" (:border style))
                 (str tid " is borderless (no 1px border box)"))
-            (is (= (:accent tokens) (:background style))
-                (str tid " background is the filled :accent (blue)"))
-            (is (= (:white tokens) (:color style))
-                (str tid " icon is white"))))
+            (is (= (:active-bg tokens) (:background style))
+                (str tid " background is the filled :active-bg (blue)"))
+            (is (= (:active-text tokens) (:color style))
+                (str tid " icon is white :active-text"))))
         ;; the nav cluster lives in the chrome ribbon (bar-1) now.
         (is (some? (find-by-testid (find-by-testid tree "rf-xray-ribbon")
                                    "rf-xray-ribbon-nav"))
             "the nav cluster is mounted inside the chrome ribbon (A5)")))))
 
 (deftest chrome-ribbon-carries-blue-focus-button
-  (testing "rf2-3f2di A5 — the always-present blue `focus` button is a
-            filled :accent button with white text + the `focus` label,
+  (testing "rf2-xawwb — the always-present blue `focus` button is a filled
+            :active-bg button with white :active-text + the `focus` label,
             now sitting in the CHROME ribbon left cluster (it moved up
             with the nav cluster). Distinct from the focus-CHIP (which
             only appears when a focus-set is active)."
@@ -2396,10 +2396,10 @@
             btn    (find-by-testid tree "rf-xray-focus-button")
             style  (:style (second btn))]
         (is (some? btn) "the blue focus button renders (always present)")
-        (is (= (:accent tokens) (:background style))
-            "focus button background is the filled :accent (blue)")
-        (is (= (:white tokens) (:color style))
-            "focus button text is white")
+        (is (= (:active-bg tokens) (:background style))
+            "focus button background is the filled :active-bg (blue)")
+        (is (= (:active-text tokens) (:color style))
+            "focus button text is white :active-text")
         (is (re-find #"focus" (text-nodes btn))
             "the button carries the `focus` label")
         ;; It lives in the chrome ribbon (bar-1) now, not the events ribbon.


### PR DESCRIPTION
@
Re-skins the xray devtools chrome to the authoritative Figma-Make surface. Restyle-in-place: all existing subscriptions, filter/frame/keybinding/settings/share/resize wiring is RETAINED — only markup + tokens change. The Machine panel content/design is untouched (WIP per Mike); only its tab label is restyled like every other tab.

## Deltas applied

1. **Dark chrome ribbon + theme toggle** (`shell.cljs` `ribbon` / `ribbon-nav-cluster` / `ribbon-focus-button` / `ribbon-right-icons` / new `ribbon-theme-toggle`; `filters/pills.cljs` `chrome-add-filter-button`; `theme/tokens.cljc`). Ribbon paints the dark `chrome-ribbon-bg` band with white `chrome-ribbon-text` in both themes; `Events` → `Event History`; the plus-icon + `Filters:` label collapse to a `+ filter` text button; nav/focus buttons use `active-bg`/`active-text`; a sun/moon toggle dispatches the EXISTING `[:rf.xray/settings-update :theme nil …]` event (integrates the live theme mechanism — does NOT toggle a bare `dark` class or invent a parallel atom).
2. **Dark rounded-top tabs ribbon** (`shell.cljs` `tab-button` / `tab-bar`; `theme/global_styles.cljs` hover rules). Dark band, rounded-top tabs (active = light `chrome-ribbon-tab-active` fill, inactive = translucent), `↳ for selected event` label, first tab `Event` → `Handler` (tab `:id` stays `:event` so all dispatches/testids/subs/registry lookups keep resolving).
3. **Events-ribbon reorg** (`shell.cljs` `events-ribbon`; `filters/pills.cljs` `events-add-filter-button` + pill `×` divider). `↳ filters:` label + add `+` button lead; `N events filtered out` count pushed to the right; each pill carries a vertical divider before its `✕`.
4. **Event-list column order** (`shell.cljs` `l2-column-header` + `event-row`): `event id` FIRST, then `source`, `timestamp`, `duration`.
5. **Handler panel 6-step order** (`panels/event_detail.cljs` `event-lens` candidates): 1 DISPATCH, 2 COEFFECTS, 3 EVENT HANDLER, 4 **APP-DB CHANGES** (renamed from `DB CHANGES`), 5 **FLOWS**, 6 FX. Reconciled with PR #2070 (rf2-9eca7): FLOWS was placed before DB CHANGES; the Figma-Make surface numbers APP-DB CHANGES step 4 and FLOWS step 5. Framework timing note retained in docstrings (flows still reshape the pending db before commit; only the visual order changed).
6. **Tokens** (`theme/tokens.cljc`): added `chrome-ribbon-bg/-text/-text-muted/-tab-active/-tab-active-text`, `active-bg`, `active-text` to both palettes; auto-flow through the `var(--rf-xray-…)` map + `themes-css`.

Design-reference (`design-reference/xray_devtools_reference.cljs`) updated to record the new authoritative surface; the richer `app-db-panel` section is RETAINED (Figma stubs it); NO Machine-panel design added.

## Retained (so nothing regressed)

FLOWS step still reads REAL `:rf.flow/computed` trace data (`flows-fired`/`flow-row`) — no mock values hardcoded into the live panel; the live rendering is richer than the Figma stub. COEFFECTS still renders multiple coeffects. The L2 focus gutter (Xray affordance, not in Figma) is kept ahead of the columns. The optional AFTER INTERCEPTORS step (Xray addition) is kept. frame-switcher / mode-pill / focus-chip are self-contained bordered chips, legible on the dark band, left untouched.

## Machine panel

Confirmed untouched: `machine_canvas.cljs`, `machine_inspector*`, `machine_after_rings*`, `panels/machines/**`, `chart/**` — no edits. The Machine TAB stays in the bar (label only).

## Gates

- xray JVM `clojure -M:test`: 876 tests / 0 failures
- machines-viz JVM `clojure -M:test`: 230 / 0 (palette drift-gate mirror added)
- `npm run test:cljs`: 4350 / 0
- `npm run test:xray-feature-gate`: 13 scenarios / 0 failures (exit 0)
- `npm run test:bundle-isolation`: PASS (exit 0)
- `npm run test:browser`: 119 / 0
- clj-kondo: 0 errors; splint: 0 NEW warnings (10 pre-existing == baseline)

Note: machines-viz `theme/tokens.cljc` got the 7 new chrome tokens mirrored (Xray-chrome tokens, not chart colours) purely to satisfy the `xray-and-machines-viz-dark-palettes-match-key-set` drift CI gate.
@