### PR TITLE
feat(xray): Trace panel — Figma design system + 023 spec intent (rf2-l2f2g)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels.cljs
@@ -71,7 +71,7 @@
   | **event-detail** | `:rf.xray/focus` · `:rf.xray/cascades` · `:rf.xray/target-frame-db` | `:rf.xray/focus-cascade` |
   | **app-db (current-state inspector)** | `:rf.xray/app-db-state` (current-state section model over the observed frame's live app-db, sectioned by reserved `:rf/*` area — rf2-okvit) | `:rf.xray/open-segment-inspector` |
   | **reactive-panel** | `:rf.xray/reactive-data` (composite over focused cascade's `:trace-events`) | `:rf.xray/reactive-toggle-unchanged` |
-  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events`, rf2-td380) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/open-in-editor` |
+  | **trace** | `:rf.xray/trace-feed` (epoch-scoped — projects the focused epoch's `:trace-events` into the whole-epoch arc: envelope + 4 phase bands, spec/023) | `:rf.xray/toggle-trace-row-expand` · `:rf.xray/toggle-trace-band-collapse` · `:rf.xray/open-in-editor` |
   | **machine-inspector** | `:rf.xray/machine-chart-data` · `:rf.xray/active-timers-for-focused-machine` · `:rf.xray/machine-scrubber-position` | scrubber events · `:rf.xray/focus-cascade` |
   | **routing** | `:rf.xray/registered-routes` · `:rf.xray/current-route-slice` · `:rf.xray/routing-tab-data` | route-simulation events |
   | **issues-ribbon** | `:rf.xray/issues-ribbon` (composite over focused epoch's `:trace-events` — pure rows, no filtering, per spec/021 §8) | `:rf.xray/select-tab` · `:rf.xray/open-in-editor` |

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -1,215 +1,163 @@
 (ns day8.re-frame2-xray.panels.trace
-  "Trace panel — Phase 5 (rf2-argrj, parent rf2-5aw5v);
-  epoch-scoped rework (rf2-o6yqq + rf2-td380 + rf2-gkczt).
-
-  Per `tools/xray/spec/000-Vision.md` L89 (panel-inventory row) the
-  Trace panel is the raw-event ribbon — every trace event in the
-  FOCUSED EPOCH renders as one timestamped row.
+  "Trace panel — the whole-epoch trace ARC (spec/023-Trace-Panel.md).
 
   ## What this panel shows
 
-  A scrollable, relative-timestamped ribbon scoped to the spine's
-  focused epoch. Per the Figma design (rf2-ad7zx.8 — spec/021 §5.2 +
-  `design-reference/xray_devtools_reference.cljs`, the `trace-panel`
-  component) each row carries:
+  The complete trace arc of a single epoch — every trace operation the
+  substrate emits during the focused epoch, in fire order, organised by
+  the epoch's phase shape (spec/023 §1). Its contract is COMPLETENESS:
+  every op-family in the Spec-009 vocabulary surfaces.
 
-      relative-time · readable plain-language description · duration
+  The arc reads top-down:
 
-  with the op-FAMILY colour rendered as a **3px left-border band**
-  (dispatch = mode accent · db = changed · fx = warning · reactive =
-  dim · machine = chart tone) — NOT an op-type dot. Child dispatches
-  **indent** under their parent cascade (causal nesting), and the
-  post-cascade reactive aftermath **collapses** under one expandable
-  `▸ reactive aftermath (N subs, M renders)` group so the core
-  dominoes stand out.
+      ○ EPOCH OPEN   #N :event · frame · snapshotted    (the envelope)
+      ▾ ① DISPATCH
+          +0.0  EVENT     dispatched   [:counter-inc] from view↗   —
+      ▾ ② EVENT HANDLING
+          +0.1  COEFFECT  run          :now → #inst…              0.1 ms
+          +0.2  EVENT     handler ran  reg-event-db               0.2 ms
+          +0.3  FLOW      computed     :totals → [:totals]        1.5 ms
+          +1.8  DB        changed      [:counter] 1 → 2             —
+      ▾ ③ EFFECTS / FX
+          +1.9  FX        :http-xhrio  GET /api/data (queued)      —
+      ▾ ④ REACTIVE RENDERING
+          +2.6  SUB       recalculated :counter/value 1→2         0.3 ms
+          +3.1  VIEW      re-rendered  counter-display            1.8 ms
+      ● EPOCH CLOSE  outcome :ok
 
-  Clicking a row toggles its inline payload expansion (no nav);
-  clicking the reactive group toggles its children.
+  Each op is a row of five columns (spec/023 §3):
 
-  ## Epoch-scoped feed (rf2-td380)
+      Δt · area badge · what-happened · target/detail · duration
 
-  Per spec/018 §6 every L4 panel is a lens on the spine's focused
-  event, not a global ribbon. The Trace tab reads the FOCUSED EPOCH's
-  `:trace-events` — the per-frame settling epoch record's raw trace
-  slice — which folds the COMPLETE domino trail for one event: both
-  the synchronous event-side rows (dispatch-id N) AND the async
-  reactive rows (`:rf.sub/run` / `:rf.view/render`, nil dispatch-id) that
-  fire post-cascade for that settling.
+  The area badge is a NEUTRAL text badge (EVENT · COEFFECT · DB · FX ·
+  FLOW · SUB · VIEW · MACHINE · ROUTING · EPOCH · ERROR · WARNING) — no
+  per-family colour; the family identity rides a 3px left-border band
+  instead. The four phase bands are COLLAPSIBLE with sticky headers
+  (spec/023 §2 / §14); empty bands render dimmed with `(none)` so the
+  4-phase shape is always legible (spec/023 §13).
 
-  The prior shape scoped the global trace bus by `:dispatch-id`,
-  which DROPPED those async reactive rows (their dispatch-id is nil),
-  so the rendered trail was incomplete (e.g. 4 rows shown vs the
-  epoch's real 12). Reading the epoch record's `:trace-events` —
-  resolved via the shared `panels.shared.focus-resolver` against
-  `:rf.xray/focus` + `:rf.xray/epoch-history`, exactly as the
-  Issues / App-DB Diff panels do — renders the whole trail: event →
-  db-changed → subs ran → views rendered.
+  Errors / warnings are cross-cutting (spec/023 §7) — they render inline
+  at their chronological point within whatever band they occurred,
+  emphasised so failures stand out. Clicking any row expands its raw
+  trace-event EDN inline (spec/023 §3) via the shared cljs-devtools
+  browse renderer.
 
-  Per-event epochs (merged) mean the focused epoch's `:trace-events`
-  is the right scope: one epoch per event, each carrying its own
-  reactive settling.
+  ## Design system (PR #2089 · Handler panel idiom)
 
-  ## No filtering (rf2-gkczt)
+  The arc is rendered in the established Xray devtools design language —
+  the `--devtools-*` dark tokens via `theme/tokens`, the 13/12/11/10
+  type scale, mono font for the data columns, the numbered uppercase
+  band headers + thin left rail (mirroring the Handler panel's numbered
+  step-circle pipeline in `panels/event_detail.cljs`), and the
+  `+`/`~`/`-` diff idiom for DB rows.
 
-  The Trace panel surfaces the epoch-scoped rows with NO filtering
-  UI — the focused epoch IS the scope, and the per-row payload-expand
-  affordance is the drill-down. The 13-axis chip-filter rows, the
-  per-row chip affordances, and the clear-filters control are gone.
+  ## Epoch-scoped feed (spec/018 §6)
 
-  ## No header row (rf2-o6yqq)
-
-  The duplicate film-strip nav (Prev/Next), the `X / Y in view`
-  counts, and the `epoch #N · X ops` indicator are removed from this
-  panel — the L2 events list already owns spine focus navigation
-  (`:rf.xray/focus-cascade-prev` / `-next`), and the L4 tab strip is
-  the panel-name source-of-truth.
+  Every L4 panel is a lens on the spine's FOCUSED EPOCH, not a global
+  ribbon. The Trace tab reads the focused epoch record's `:trace-events`
+  via `:rf.xray/trace-feed` — resolved through the shared
+  `panels.shared.focus-resolver` against `:rf.xray/focus` +
+  `:rf.xray/epoch-history`, exactly as the Issues / App-DB Diff panels
+  do. No mock data is baked into the live panel; the arc is fed by real
+  trace data throughout.
 
   ## Empty states
 
-    :no-events     → 'No events.' (the focused epoch carries no
-                     trace events).
-    :no-focus      → defensive: no focused epoch AND no history.
-    :epoch-evicted → the focused epoch aged out of the
-                     `:epoch-history` ring buffer.
+    :no-events     → 'No events.' (focused epoch carries no trace events)
+    :no-focus      → 'Select an event to see its trace arc.' (spec/023 §14)
+    :epoch-evicted → the focused epoch aged out of the ring buffer.
 
-  ## Pure hiccup (rf2-tijr)
+  ## Pure hiccup
 
-  Same contract as every other Xray panel — pure hiccup, no
-  Reagent / UIx / Helix references. Frame isolation comes from the
-  enclosing `[rf/frame-provider {:frame :rf/xray}]` in shell.cljs.
+  Same contract as every other Xray panel — pure hiccup, no Reagent /
+  UIx / Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/xray}]` in shell.cljs.
 
   ## Helpers
 
-  All pure-data logic — row projection, epoch-scoped feed projection,
-  empty-state classification — lives in `trace_helpers.cljc` so the
-  algebra runs under the JVM unit-test target."
+  All pure-data logic — row projection, area / phase / verb / target
+  classification, band projection, epoch-scoped feed, empty-state
+  classification — lives in `trace_helpers.cljc` so the algebra runs
+  under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-xray.panels.event-detail :as event-detail]
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
-            [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
             [day8.re-frame2-xray.panels.shared.focus-resolver :as focus]
             [day8.re-frame2-xray.panels.trace-helpers :as h]
             [day8.re-frame2-xray.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]))
 
-;; ---- payload renderer ---------------------------------------------------
+;; ---- row grid template (spec/023 §3 · §14) -----------------------------
 ;;
-;; Per spec/021 §5 the per-row "expand payload" surface shows the trace
-;; event's CURRENT state — so per Mike-direction 2026-05-21 (rf2-dmso5)
-;; it renders through the EDN widget's `browse` variant, which is the
-;; re-frame-10x cljs-devtools look (type-coloured · nested · expanded).
-;; The Trace panel passes the raw trace event as `:value`.
+;; Δt · area badge · what-happened · target/detail · duration. Δt +
+;; badge + verb columns are fixed/compact; the target/detail column is
+;; the flexible one and truncates first (spec/023 §14 — usable at the
+;; ≈420px docked width, no horizontal scroll); duration right-aligns.
+
+(def ^:private row-grid-columns
+  "The 5-column grid template for an op row (spec/023 §3)."
+  "56px 64px 92px minmax(0, 1fr) auto")
+
+;; ---- payload renderer (spec/023 §3) -------------------------------------
+;;
+;; Row click → expand the full raw trace-event EDN inline via Xray's
+;; existing expandable data-inspector (the shared cljs-devtools browse
+;; renderer). Each row gets its own `:render-id` so the rendered
+;; container's testid is unique per row.
 
 (defn- render-payload
-  "Per-row payload renderer. Wires the EDN widget's current-state
-  `browse` (cljs-devtools) to the row's raw trace event. Each row gets
-  its own `:render-id` (`trace-row-<id>`) so the rendered container's
-  testid is unique per row."
+  "Per-row payload renderer — the raw `:operation` · `:tags` · timing ·
+  `:rf.trace/dispatch-id` trace-event EDN (spec/023 §3), wired through
+  the EDN widget's current-state `browse` (cljs-devtools)."
   [{:keys [id raw] :as _row}]
   [:div {:data-testid (str "rf-xray-trace-row-" id "-payload")
-         :style       {:padding "8px 16px 12px 110px"
-                       :background (:bg-1 tokens)
-                       :border-bottom (str "1px solid " (:border-subtle tokens))}}
+         :style       {:padding       "6px 16px 10px 56px"
+                       :background    (:bg-1 tokens)
+                       :border-radius "0 0 4px 4px"}}
    (edn/browse
      {:value     raw
       :panel-id  :trace
       :render-id (str "trace-row-" id)})])
 
-;; ---- row layout constants (rf2-ad7zx.8) --------------------------------
+;; ---- one op row (spec/023 §3) -------------------------------------------
 
-(def ^:private indent-px
-  "Causal-nesting indent per depth level (spec/021 §5.2 — child
-  dispatches indent under their parent cascade)."
-  20)
+(defn- op-row
+  "One op row in the arc — the five columns of spec/023 §3
+  (Δt · area badge · what-happened · target/detail · duration) with the
+  op-family colour as a 3px left-border band and the outcome tier tinting
+  the what-happened column (spec/023 §8).
 
-(defn- op-row-cells
-  "The inner grid of one op row — relative timestamp · readable
-  description · per-op duration. Per spec/021 §5.2 the Figma row is
-  `t+N.Nms · readable description · duration` with the op-family band
-  as a 3px LEFT-BORDER on the row container (not a dot). The duration
-  column shows elapsed for event/view rows; reactive point-in-time
-  emits leave it blank."
-  [{:keys [rel-time time description duration-ms] :as _row} row-test-id]
-  [:div {:data-testid (str row-test-id "-summary")
-         :style       {:display       "grid"
-                       :grid-template-columns "84px minmax(0, 1fr) auto"
-                       :gap           "12px"
-                       :align-items   "center"
-                       :padding       "6px 16px"}}
-   ;; Relative timestamp (`t+N.Nms`); absolute clock as the hover title.
-   [:span {:data-testid (str row-test-id "-time")
-           :title       (or (h/format-time time) "")
-           :style {:color (:text-tertiary tokens)
-                   :font-size "11px"
-                   :white-space "nowrap"}}
-    (or rel-time "—")]
-   ;; Readable plain-language description (the dense default line).
-   [:span {:data-testid (str row-test-id "-description")
-           :style       {:color         (:text-primary tokens)
-                         :overflow      "hidden"
-                         :text-overflow "ellipsis"
-                         :white-space   "nowrap"}
-           :title       description}
-    description]
-   ;; Per-op duration column (blank for point-in-time reactive emits).
-   [:span {:data-testid (str row-test-id "-duration")
-           :style {:color (:text-tertiary tokens)
-                   :font-size "11px"
-                   :white-space "nowrap"
-                   :text-align "right"}}
-    (or (h/format-duration duration-ms) "")]])
+  The React `:key` is the row's stable trace `:id` (via `h/row-key`) so
+  a trace push doesn't remount the viewport. The row testid keeps the
+  `rf-xray-trace-row-` prefix so the shell's scoped rounded-pill hover
+  rule (theme/global-styles) lights it.
 
-(defn- trace-row
-  "One op row in the trace ribbon.
-
-  Per rf2-z4fza: the React `:key` is the row's stable trace `:id`
-  (via `h/row-key`). The earlier shape keyed on a tuple that mixed
-  in the row's positional index inside the visible viewport — every
-  new trace push shifted every visible row's index, so every key
-  changed, and React unmounted+remounted the entire viewport on
-  EVERY push. Same discipline class as rf2-kgn0c's `v:<variant-id>`
-  cell-keying in the story workspace.
-
-  Per rf2-ad7zx.8 (spec/021 §5.2 · design-reference/xray_devtools_reference.cljs,
-  the `trace-panel` component):
-  the op-family colour is a **3px left-border band** on the row
-  container (dispatch = mode accent · db = changed · fx = warning ·
-  reactive = dim · machine = chart tone) — NOT an op-type dot. Child
-  dispatches **indent** under their parent cascade via `:depth`. The
-  row body is the readable plain-language description with a per-op
-  duration column at the right.
-
-  Per spec/021 §5.4 + rf2-7dyi8 the row-click behaviour is **inline
-  payload expansion** (NOT pivot to event-detail) — the Trace panel
-  is already scoped to the focused epoch (rf2-ycoct), so pivoting
-  would just navigate to the same cascade. Click toggles the row's
-  membership in `:rf.xray/trace-expanded-row-ids`; expanded rows
-  render the shared data-display renderer below the row inside the
-  same `<li>` so the React-key + scroll-anchoring discipline holds."
-  [{:keys [id operation source-coord dispatch-id op-family depth]
+  Row click → toggle inline raw-EDN payload expansion (spec/023 §3); no
+  nav (the panel is already scoped to the focused epoch). Error /
+  warning rows are visually emphasised inline (spec/023 §7) — the Δt
+  leads with `!`, the badge + verb ride the semantic colour, and the row
+  carries a tinted left rail."
+  [{:keys [id operation rel-time time area area-badge verb target
+           duration-ms source-coord dispatch-id]
     :as row}
    {:keys [expanded?]}]
   (let [row-test-id (str "rf-xray-trace-row-" id)
         band-colour (h/op-family-colour row)
-        depth*      (or depth 0)
-        ;; rf2-59e7k — destroy-event rows surface a 'Show cancellation
-        ;; cascade' action button. The classifier mirrors
-        ;; helpers/destroy-operations so the trace ns has no upward dep
-        ;; on the cascade view.
+        verb-colour (h/outcome-colour row)
+        severity?   (#{:error :warning} area)
+        sev-colour  (when severity?
+                      (get tokens (if (= area :error) :red :yellow)))
         destroy?    (cch/destroy-event? {:operation operation})]
     [:li {:key         (h/row-key row)
           :data-testid row-test-id
           :data-rf-xray-expanded (boolean expanded?)
-          :data-rf-xray-op-family (some-> op-family name)
-          :data-rf-xray-depth depth*
+          :data-rf-xray-area     (some-> area name)
+          :data-rf-xray-op-family (some-> (h/op-family row) name)
+          :data-rf-xray-severity (when severity? (name area))
           :on-click    (fn []
-                         ;; rf2-7dyi8 — toggle inline payload expansion
-                         ;; rather than pivoting to event-detail (spec
-                         ;; §5.4: 'Row → expand payload · Inline in
-                         ;; panel (no nav)').
                          (rf/dispatch [:rf.xray/toggle-trace-row-expand id]
                                       {:frame :rf/xray}))
           :on-context-menu (when destroy?
@@ -220,57 +168,99 @@
                                  [:rf.xray/cancellation-cascade-open
                                   {:kind :dispatch-id :id dispatch-id}]
                                  {:frame :rf/xray})))
-          :style       {:display        "flex"
-                        :align-items    "stretch"
-                        ;; op-family colour band as a 3px LEFT-BORDER.
-                        :border-left    (str "3px solid " band-colour)
-                        ;; rf2-tha26 — Figma rounded hover-pill rows
-                        ;; (the `trace-panel` component in
-                        ;; `design-reference/xray_devtools_reference.cljs`):
-                        ;; rows are discrete pills (`rounded` +
-                        ;; `space-y-0.5`) lit by a `hover:bg` fill rather
-                        ;; than flat rows divided by hairlines. Inline
-                        ;; styles can't carry a `:hover` pseudo-class, so
-                        ;; the hover fill is a scoped CSS rule in
-                        ;; theme/global-styles keyed off the row testid;
-                        ;; here we round the corners + add the 2px inter-
-                        ;; row rhythm. An expanded row keeps its tinted
-                        ;; fill so the open payload reads as one unit.
-                        :border-radius  "4px"
-                        :margin-bottom  "2px"
-                        :background     (when expanded? (:bg-1 tokens))
-                        ;; Causal-nesting indent (cascade tree).
-                        :margin-left    (str (* depth* indent-px) "px")
-                        :cursor         "pointer"
-                        :color          (:text-primary tokens)
-                        :font-family    mono-stack
-                        :font-size      "12px"
-                        :line-height    1.35}}
-     [:div {:style {:flex 1 :min-width 0}}
-      ;; Row grid + the per-row actions, held in an inner div so the
-      ;; optional payload renders as a sibling inside the same `<li>`
-      ;; without breaking the row's React-key discipline (rf2-z4fza).
-      [:div {:style {:display "flex" :align-items "center"}}
-       [:div {:style {:flex 1 :min-width 0}}
-        (op-row-cells row row-test-id)]
-       ;; Source-coord chip (when present).
+          :style       {:display       "block"
+                        ;; op-family colour band — 3px LEFT-BORDER
+                        ;; (error / warning override the band so a
+                        ;; failure stands out · spec/023 §7).
+                        :border-left   (str "3px solid "
+                                            (or sev-colour band-colour))
+                        :border-radius "4px"
+                        :margin-bottom "1px"
+                        ;; severity rows carry a faint tinted fill so the
+                        ;; failure reads while scanning (spec/023 §7).
+                        :background    (cond
+                                         expanded? (:bg-1 tokens)
+                                         (= area :error)
+                                         "color-mix(in srgb, var(--rf-xray-red) 9%, transparent)"
+                                         (= area :warning)
+                                         "color-mix(in srgb, var(--rf-xray-yellow) 9%, transparent)"
+                                         :else nil)
+                        :cursor        "pointer"
+                        :color         (:text-primary tokens)
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :line-height   1.35}}
+     [:div {:data-testid (str row-test-id "-summary")
+            :style       {:display               "grid"
+                          :grid-template-columns row-grid-columns
+                          :gap                   "10px"
+                          :align-items           "baseline"
+                          :padding               "5px 16px 5px 8px"}}
+      ;; ① Δt — ms offset from EPOCH OPEN; `!` lead for severity rows.
+      [:span {:data-testid (str row-test-id "-time")
+              :title       (or (h/format-time time) "")
+              :style       {:color       (if severity? sev-colour
+                                             (:text-tertiary tokens))
+                            :font-size   "11px"
+                            :font-weight (when severity? 700)
+                            :white-space "nowrap"
+                            :text-align  "right"}}
+       (cond
+         (and severity? rel-time) (str "!" (subs rel-time 1))
+         rel-time                 rel-time
+         :else                    "—")]
+      ;; ② area badge — neutral uppercase text badge (spec/023 §3); the
+      ;; severity tiers ride their semantic colour so a failure's family
+      ;; is unmistakeable (spec/023 §7 / §8).
+      [:span {:data-testid (str row-test-id "-badge")
+              :style       {:color          (or sev-colour (:text-tertiary tokens))
+                            :font-size      "10px"
+                            :font-weight    600
+                            :letter-spacing "0.4px"
+                            :white-space    "nowrap"}}
+       area-badge]
+      ;; ③ what-happened — the per-area verb, tinted by outcome tier.
+      [:span {:data-testid (str row-test-id "-verb")
+              :style       {:color         (if severity? sev-colour verb-colour)
+                            :white-space   "nowrap"
+                            :overflow      "hidden"
+                            :text-overflow "ellipsis"}
+              :title       verb}
+       verb]
+      ;; ④ target / detail — the op's subject; the flexible column that
+      ;; truncates first (spec/023 §14). Source-coord ↗ rides at its end.
+      [:span {:data-testid (str row-test-id "-target")
+              :style       {:display     "flex"
+                            :align-items "baseline"
+                            :gap         "8px"
+                            :min-width   0}}
+       [:span {:style {:color         (:text-secondary tokens)
+                       :overflow      "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space   "nowrap"
+                       :min-width     0}
+               :title (or target "")}
+        (or target "—")]
        (when source-coord
          [:button {:data-testid (str row-test-id "-source-coord")
+                   ;; The bare `file:line` coord rides the button's title
+                   ;; (the ↗ icon is the affordance); the open-in-editor
+                   ;; bridge reads this title verbatim.
+                   :title       source-coord
                    :on-click    (fn [e]
                                   (.stopPropagation e)
                                   (rf/dispatch [:rf.xray/open-in-editor
-                                                {:source-coord source-coord}] {:frame :rf/xray}))
-                   :style       {:background  "transparent"
-                                 :color       (:accent tokens)
-                                 :border      (str "1px solid " (:border-subtle tokens))
-                                 :padding     "1px 6px"
-                                 :margin-right "8px"
-                                 :border-radius "3px"
-                                 :cursor      "pointer"
-                                 :font-family mono-stack
-                                 :font-size   "10px"}}
-          source-coord])
-       ;; rf2-59e7k cancellation-cascade action (destroy rows only).
+                                                {:source-coord source-coord}]
+                                               {:frame :rf/xray}))
+                   :style       {:flex-shrink   0
+                                 :background    "transparent"
+                                 :color         (:accent tokens)
+                                 :border        "none"
+                                 :padding       0
+                                 :cursor        "pointer"
+                                 :font-family   mono-stack
+                                 :font-size     "11px"}}
+          "↗"])
        (when destroy?
          [:button {:data-testid (str row-test-id "-cancellation-cascade")
                    :title       "Show cancellation cascade"
@@ -280,124 +270,153 @@
                                     [:rf.xray/cancellation-cascade-open
                                      {:kind :dispatch-id :id dispatch-id}]
                                     {:frame :rf/xray}))
-                   :style       {:background  "transparent"
+                   :style       {:flex-shrink 0
+                                 :background  "transparent"
                                  :color       (or (:red tokens)
                                                   (:text-secondary tokens))
-                                 :border      (str "1px solid " (:border-subtle tokens))
-                                 :padding     "1px 6px"
-                                 :margin-right "8px"
-                                 :border-radius "3px"
+                                 :border      "none"
+                                 :padding     0
                                  :cursor      "pointer"
                                  :font-family mono-stack
-                                 :font-size   "10px"}}
-          "⟲ cascade"])]
-      ;; rf2-7dyi8 — inline payload expansion. Consumes the shared
-      ;; rf2-jgip1 data-display renderer (#1739, landed in main).
-      (when expanded? (render-payload row))]]))
+                                 :font-size   "11px"}}
+          "⟲"])]
+      ;; ⑤ duration — `N.N ms` when timed, em-dash otherwise (spec/023 §6).
+      [:span {:data-testid (str row-test-id "-duration")
+              :style       {:color       (:text-tertiary tokens)
+                            :font-size   "11px"
+                            :white-space "nowrap"
+                            :text-align  "right"}}
+       (or (h/format-duration duration-ms) "—")]]
+     ;; Row click → raw trace-event EDN inline (spec/023 §3).
+     (when expanded? (render-payload row))]))
 
-;; ---- reactive-aftermath collapse group (rf2-ad7zx.8) -------------------
+;; ---- phase band (spec/023 §2 · §13 · §14) -------------------------------
 
-(defn- reactive-group-row
-  "Render one collapsed reactive-aftermath group — the spec/021 §5.2
-  `▸ reactive aftermath (N subs, M renders)` row. Clicking toggles the
-  group open via `:rf.xray/toggle-trace-group-expand`; expanded groups
-  render their child reactive rows (subs ran · views rendered) inline
-  inside the same `<li>` so the React-key + scroll discipline holds.
-  The group rides the dim op-family band so the core dominoes stand
-  out."
-  [{:keys [id rel-time summary children depth] :as _group}
-   {:keys [expanded? expanded-row-ids]}]
-  (let [grp-test-id (str "rf-xray-trace-group-" id)
-        depth*      (or depth 0)
-        {:keys [subs renders]} summary
-        band-colour (h/op-family-colour {:op-family :reactive})]
-    [:li {:key         (str "g:" id)
-          :data-testid grp-test-id
-          :data-rf-xray-expanded (boolean expanded?)
-          :data-rf-xray-op-family "reactive"
-          :on-click    (fn []
-                         (rf/dispatch [:rf.xray/toggle-trace-group-expand id]
-                                      {:frame :rf/xray}))
-          :style       {:display       "block"
-                        :border-left   (str "3px solid " band-colour)
-                        ;; rf2-tha26 — rounded hover-pill rhythm matching
-                        ;; the op rows (the group is a trace row too).
-                        :border-radius "4px"
-                        :margin-bottom "2px"
-                        :margin-left   (str (* depth* indent-px) "px")
-                        :cursor        "pointer"
-                        :color         (:text-secondary tokens)
-                        :font-family   mono-stack
-                        :font-size     "12px"
-                        :line-height   1.35}}
-     [:div {:data-testid (str grp-test-id "-summary")
-            :style {:display "grid"
-                    :grid-template-columns "84px minmax(0, 1fr)"
-                    :gap "12px"
-                    :align-items "center"
-                    :padding "6px 16px"}}
-      [:span {:style {:color (:text-tertiary tokens)
-                      :font-size "11px"
-                      :white-space "nowrap"}}
-       (or rel-time "—")]
-      [:span {:style {:color (:text-secondary tokens)}}
-       (str (if expanded? "▾" "▸")
-            " reactive aftermath ("
-            subs " sub" (when (not= 1 subs) "s") ", "
-            renders " render" (when (not= 1 renders) "s") ")")]]
-     ;; Expanded — render the child reactive rows inline.
-     (when expanded?
-       [:div {:data-testid (str grp-test-id "-children")
-              :style {:padding-left "16px"
-                      :background (:bg-1 tokens)}}
-        (for [child children]
-          ^{:key (h/row-key child)}
-          (trace-row child
-                     {:expanded? (contains? (or expanded-row-ids #{})
-                                            (:id child))}))])]))
+(defn- band-header
+  "A collapsible phase-band header — the numbered uppercase label
+  (`① DISPATCH`, …) with a chevron + per-band op count, STICKY so the
+  current phase stays labelled while a long arc scrolls (spec/023 §14).
+  An empty band's header is dimmed (spec/023 §13)."
+  [{:keys [id label count empty?]} expanded?]
+  [:div {:data-testid (str "rf-xray-trace-band-header-" (name id))
+         :data-rf-xray-band id
+         :data-rf-xray-empty (boolean empty?)
+         :on-click    (when-not empty?
+                        (fn []
+                          (rf/dispatch [:rf.xray/toggle-trace-band-collapse id]
+                                       {:frame :rf/xray})))
+         :style       {:position       "sticky"
+                       :top            0
+                       :z-index        1
+                       :display        "flex"
+                       :align-items    "center"
+                       :gap            "8px"
+                       :padding        "6px 16px 6px 8px"
+                       :background     (:bg-2 tokens)
+                       :border-bottom  (str "1px solid " (:border-subtle tokens))
+                       :cursor         (if empty? "default" "pointer")
+                       :user-select    "none"
+                       :font-family    sans-stack
+                       :font-size      "11px"
+                       :font-weight    600
+                       :letter-spacing "0.6px"
+                       :text-transform "uppercase"
+                       :color          (if empty?
+                                         (:text-tertiary tokens)
+                                         (:text-secondary tokens))}}
+   (when-not empty?
+     [:span {:aria-hidden "true"
+             :style {:color (:text-tertiary tokens) :font-size "10px"}}
+      (if expanded? "▾" "▸")])
+   [:span label]
+   [:span {:data-testid (str "rf-xray-trace-band-count-" (name id))
+           :style {:color       (:text-tertiary tokens)
+                   :font-weight 400
+                   :font-size   "10px"
+                   :letter-spacing "0"
+                   :text-transform "none"}}
+    (if empty? "(none)" (str count))]])
 
-(defn- trace-node
-  "Render one display node — either a `:reactive-group` collapse group
-  or a plain op row. The view feeds the structural `:nodes` projection
-  (rf2-ad7zx.8) through this so the reactive-aftermath group, causal
-  nesting, and op-family bands all render from one pure-data tree."
-  [node {:keys [expanded-row-ids expanded-group-ids] :as _state}]
-  (if (= :reactive-group (:kind node))
-    (reactive-group-row node
-                        {:expanded? (contains? (or expanded-group-ids #{})
-                                               (:id node))
-                         :expanded-row-ids expanded-row-ids})
-    (trace-row node
-               {:expanded? (contains? (or expanded-row-ids #{})
-                                      (:id node))})))
+(defn- phase-band
+  "Render one phase band — its sticky numbered header + its op rows in
+  fire order (oldest-first). Empty bands render their dimmed header with
+  `(none)` and no rows (spec/023 §13); collapsed bands render the header
+  alone. A thin left rail (mirroring the Handler panel's pipeline rail)
+  runs down the band's rows so the phase reads as a distinct segment of
+  the arc (spec/023 §8)."
+  [{:keys [id rows empty?] :as band} {:keys [expanded? expanded-row-ids]}]
+  [:section {:data-testid (str "rf-xray-trace-band-" (name id))
+             :data-rf-xray-band id
+             :style {:margin-bottom "4px"}}
+   (band-header band expanded?)
+   (when (and expanded? (not empty?))
+     [:ul {:data-testid (str "rf-xray-trace-band-rows-" (name id))
+           :style {:list-style  "none"
+                   :margin      0
+                   :padding     "4px 8px 4px 8px"
+                   ;; thin left rail per the arc-segment cue (spec/023 §8).
+                   :border-left (str "1px solid " (:border-subtle tokens))
+                   :margin-left "8px"}}
+      (for [row rows]
+        ^{:key (h/row-key row)}
+        (op-row row {:expanded? (contains? (or expanded-row-ids #{})
+                                           (:id row))}))])])
 
-;; ---- footer legend ------------------------------------------------------
+;; ---- epoch envelope (spec/023 §2) ---------------------------------------
 
-(defn- footer-legend
-  "Reference footer legend (rf2-tha26 ·
-  `design-reference/xray_devtools_reference.cljs`, the `trace-panel`
-  component). Names the two reading
-  conventions of the ribbon — rows are colour-banded by op-family
-  (the 3px left border), and clicking a row expands its raw
-  `:operation` + tags payload inline. Rendered below the feed (feed
-  branch only)."
-  []
-  [:div {:data-testid "rf-xray-trace-footer-legend"
-         :style       {:margin     "16px 16px 0 16px"
-                       :padding-top "16px"
-                       :border-top (str "1px solid " (:border-default tokens))
-                       :color      (:text-tertiary tokens)
-                       :font-family sans-stack
-                       :font-size  "11px"}}
-   "colour-banded by op-family · click a row → expand raw :operation + tags"])
+(defn- envelope-row
+  "Render the EPOCH OPEN / CLOSE envelope band that brackets the arc
+  (spec/023 §2). EPOCH OPEN carries the epoch id · event · frame ·
+  `snapshotted`; EPOCH CLOSE shows the `:rf.epoch/outcome`. The marker
+  glyph (`○` open · `●` close) + the outcome tag distinguish them. The
+  envelope's `:rf.epoch/*` ops render as ordinary rows beneath the
+  marker so restore/replay lifecycle ops surface (spec/023 §2)."
+  [{:keys [kind label outcome rows expanded-row-ids]}]
+  (let [open?       (= kind :open)
+        outcome-kw  outcome
+        outcome-hex (case outcome-kw
+                      :ok      (:success tokens)
+                      :blocked (:warning tokens)
+                      :error   (:error tokens)
+                      (:text-tertiary tokens))]
+    [:div {:data-testid (str "rf-xray-trace-envelope-" (name kind))
+           :data-rf-xray-envelope kind
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :gap           "10px"
+                   :padding       "8px 16px 8px 8px"
+                   :font-family   sans-stack
+                   :font-size     "12px"
+                   :font-weight   600
+                   :letter-spacing "0.4px"
+                   :color         (:text-primary tokens)}}
+     [:span {:aria-hidden "true"
+             :style {:color     (if open? (:accent tokens) outcome-hex)
+                     :font-size "14px"}}
+      (if open? "○" "●")]
+     [:span {:style {:text-transform "uppercase" :font-size "11px"}}
+      label]
+     (when (and (not open?) outcome-kw)
+       [:span {:data-testid (str "rf-xray-trace-outcome-" (name outcome-kw))
+               :data-rf-xray-outcome outcome-kw
+               :style {:color          outcome-hex
+                       :font-family    mono-stack
+                       :font-size      "11px"
+                       :font-weight    600
+                       :letter-spacing "0"}}
+        (str "outcome " outcome-kw)])
+     (when (seq rows)
+       [:ul {:data-testid (str "rf-xray-trace-envelope-rows-" (name kind))
+             :style {:list-style "none" :margin 0 :padding 0 :flex 1 :min-width 0}}
+        (for [row rows]
+          ^{:key (h/row-key row)}
+          (op-row row {:expanded? (contains? (or expanded-row-ids #{})
+                                             (:id row))}))])]))
 
-;; ---- empty states -------------------------------------------------------
+;; ---- empty states (spec/023 §14) ----------------------------------------
 
 (defn- empty-state-message
-  "Shared terse empty-state block. `kind` drives the data-testid +
-  copy. Per rf2-td380 the Trace panel is epoch-scoped, so the empty
-  states discriminate the focus-resolver's three statuses plus the
-  'focused epoch carries no trace events' case."
+  "Shared terse empty-state block. `kind` drives the data-testid + copy."
   [kind copy]
   [:div {:data-testid (str "rf-xray-trace-empty-" (name kind))
          :style       {:padding     "24px"
@@ -405,47 +424,28 @@
                        :font-size   "13px"
                        :line-height 1.5
                        :color       (:text-secondary tokens)}}
-   [:p {:style {:margin 0
-                :color  (:text-tertiary tokens)}}
+   [:p {:style {:margin 0 :color (:text-tertiary tokens)}}
     copy]])
 
-(defn- empty-state-no-events
-  "The focused epoch carries no trace events."
-  []
+(defn- empty-state-no-events []
   (empty-state-message :no-events "No events."))
 
-(defn- empty-state-no-focus
-  "Defensive empty-state — no focused epoch AND no epoch history. Per
-  rf2-639lc the default-focus rule should always land on a real
-  cascade, so this branch should never render in practice; the terse
-  copy + testid here let us spot a regression when it does."
-  []
-  (empty-state-message :no-focus "No focused event."))
+(defn- empty-state-no-focus []
+  ;; spec/023 §14 — "Select an event to see its trace arc."
+  (empty-state-message :no-focus "Select an event to see its trace arc."))
 
-(defn- empty-state-epoch-evicted
-  "The focused epoch's record has aged out of the `:epoch-history`
-  ring buffer. Mirrors the Issues / App-DB Diff placeholder per
-  spec/021 §10.7."
-  []
+(defn- empty-state-epoch-evicted []
   (empty-state-message
     :epoch-evicted
     "This epoch has been evicted from the history buffer."))
 
-;; ---- cascade status timeline bar (rf2-b76v4) ---------------------------
+;; ---- cascade status timeline bar ----------------------------------------
 
 (defn- cascade-status-bar
-  "Render the focused cascade's lifecycle-status bar above the trace
-  ribbon. The Trace tab is cascade-scoped (rf2-ycoct) — every visible
-  row already belongs to the focused cascade — so the bar fills the
-  ribbon's full width with the canonical lifecycle colour. This is
-  the bead's 'Trace timeline bar fill' surface: ONE pure-fn-driven
-  bar that tells the user 'these rows are settled-success / errored /
-  stale / paused / in-flight' at a glance, before they scan the
-  per-row dots.
-
-  The fn consumes `event-status/event-status-colour` — the same
-  helper the L2 list rows + the Event L4 header dot consume — so the
-  whole devtool speaks ONE lifecycle vocabulary."
+  "A 3px bar above the arc filling with the focused cascade's lifecycle-
+  status colour — driven by `event-status/event-status-colour`, the same
+  fn the L2 list rows + the Event L4 header dot consume, so the whole
+  devtool speaks ONE lifecycle vocabulary."
   [{:keys [cascade focus]}]
   (let [status-state (event-status/cascade->state
                        cascade focus event-detail/cascade-outcome)
@@ -461,46 +461,31 @@
                     :paused-by-tool  "Focused cascade — paused by tool"
                     :stale           "Focused cascade — stale (replayed / RETRO)"
                     (str "Focused cascade — " (name status-kw)))
-           :style {:height        "3px"
-                   :background    status-hex
-                   :flex-shrink   0}}]))
+           :style {:height      "3px"
+                   :background  status-hex
+                   :flex-shrink 0}}]))
 
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Trace panel's root view. Subscribes to `:rf.xray/trace-feed`
-  (the epoch-scoped feed, rf2-td380) and renders the focused epoch's
-  domino-trail ribbon or an empty-state. No header row (rf2-o6yqq),
-  no filtering UI (rf2-gkczt).
-
-  ## rf2-b76v4 — cascade-status timeline bar
-
-  A 3px bar above the ribbon fills with the focused cascade's
-  lifecycle-status colour — ONE bar driven by `event-status-colour`,
-  the same fn the L2 row + Event header consume."
+  "The Trace panel's root view — the whole-epoch trace arc
+  (spec/023-Trace-Panel.md). Subscribes to `:rf.xray/trace-feed` (the
+  epoch-scoped feed) and renders the focused epoch's arc: the EPOCH OPEN
+  envelope, the four collapsible phase bands (① DISPATCH · ② EVENT
+  HANDLING · ③ EFFECTS / FX · ④ REACTIVE RENDERING) in arc order, and
+  the EPOCH CLOSE outcome. Empty bands render dimmed `(none)`
+  (spec/023 §13). No mock data — fed by real trace data throughout."
   []
-  (let [{:keys [nodes empty-kind] :as _data}
+  (let [{:keys [envelope outcome bands empty-kind] :as _data}
         @(rf/subscribe [:rf.xray/trace-feed])
-        ;; rf2-b76v4 — pull the focused cascade + focus map so the
-        ;; cascade-status timeline bar can render with the canonical
-        ;; lifecycle colour. Both subs are cheap (constant-time
-        ;; selectors over the spine slot + the cascade list).
-        cascades       @(rf/subscribe [:rf.xray/cascades])
-        focus          @(rf/subscribe [:rf.xray/focus])
-        focused-id     (:dispatch-id focus)
+        cascades        @(rf/subscribe [:rf.xray/cascades])
+        focus           @(rf/subscribe [:rf.xray/focus])
+        focused-id      (:dispatch-id focus)
         focused-cascade (when focused-id
                           (some #(when (= focused-id (:dispatch-id %)) %)
                                 cascades))
-        ;; rf2-7dyi8 — per-row inline payload expansion set; rf2-ad7zx.8
-        ;; — per-group reactive-aftermath expansion set. The node-fn
-        ;; reads both from the closure built here so it keeps the
-        ;; single-arg shape `overflow/capped-list` requires.
-        expanded-ids   @(rf/subscribe [:rf.xray/trace-expanded-row-ids])
-        expanded-groups @(rf/subscribe [:rf.xray/trace-expanded-group-ids])
-        node-with-state (fn [node]
-                          (trace-node node
-                                      {:expanded-row-ids   expanded-ids
-                                       :expanded-group-ids expanded-groups}))]
+        expanded-ids    @(rf/subscribe [:rf.xray/trace-expanded-row-ids])
+        collapsed-bands @(rf/subscribe [:rf.xray/trace-collapsed-band-ids])]
     [:section {:data-testid "rf-xray-trace"
                :style       {:height         "100%"
                              :display        "flex"
@@ -509,63 +494,74 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     ;; rf2-b76v4 — cascade-status timeline bar. Renders whenever a
-     ;; cascade is in focus — the bar reflects the focused CASCADE's
-     ;; lifecycle (sourced from `:rf.xray/cascades` + focus), which is
-     ;; orthogonal to the epoch feed's empty-kind (rf2-td380: the feed
-     ;; scopes by the focused epoch's `:trace-events`).
      (when focused-cascade
-       (cascade-status-bar {:cascade focused-cascade
-                            :focus   focus}))
+       (cascade-status-bar {:cascade focused-cascade :focus focus}))
      [:div {:style {:flex 1 :overflow "auto"}}
       (case empty-kind
         :no-events     (empty-state-no-events)
         :no-focus      (empty-state-no-focus)
         :epoch-evicted (empty-state-epoch-evicted)
-        nil            [:<>
-                        (overflow/capped-list
-                          nodes
-                          {:panel-id "trace"
-                           :ul-attrs {:data-testid "rf-xray-trace-feed"
-                                      :style       {:list-style "none"
-                                                    :margin     0
-                                                    :padding    "8px 16px 0 16px"}}
-                           :row-fn   node-with-state})
-                        (footer-legend)])]]))
+        nil
+        ;; The arc container keeps the `rf-xray-trace-feed` testid as the
+        ;; external "the arc rendered rows" contract surface. Every arc
+        ;; child carries an explicit React key (envelope-open · the four
+        ;; bands · envelope-close) so the reconciler keys the whole
+        ;; sibling list uniformly.
+        (into
+          [:div {:data-testid "rf-xray-trace-feed"
+                 :style {:padding "8px 8px 16px 8px"}}
+           ;; ○ EPOCH OPEN — the arc's opening bracket (spec/023 §2).
+           ^{:key "envelope-open"}
+           (envelope-row {:kind            :open
+                          :label           "Epoch open"
+                          :rows            (filterv #(not= :rf.epoch/outcome
+                                                           (:operation %))
+                                                    envelope)
+                          :expanded-row-ids expanded-ids})]
+          ;; ①–④ the four phase bands, in arc order (spec/023 §2 / §4),
+          ;; then the EPOCH CLOSE outcome (spec/023 §13).
+          (conj
+            (mapv (fn [{:keys [id] :as band}]
+                    ^{:key (name id)}
+                    (phase-band band
+                                {:expanded?        (not (contains?
+                                                          (or collapsed-bands #{})
+                                                          id))
+                                 :expanded-row-ids expanded-ids}))
+                  bands)
+            ^{:key "envelope-close"}
+            (envelope-row {:kind    :close
+                           :label   "Epoch close"
+                           :outcome outcome
+                           :rows    []
+                           :expanded-row-ids expanded-ids}))))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
   "Idempotent install for the Trace panel's Xray-side registrations
-  (Phase 5, rf2-argrj; epoch-scoped rework rf2-td380 + rf2-gkczt)."
+  (spec/023-Trace-Panel.md)."
   []
-  ;; ---- Trace panel — epoch-scoped feed (rf2-td380) --------------------
+  ;; ---- epoch-scoped feed (spec/018 §6) -------------------------------
   ;;
-  ;; Per spec/018 §6 every L4 panel is a lens on the spine's focused
-  ;; event, not a global ribbon. The Trace tab reads the FOCUSED
-  ;; EPOCH's `:trace-events` — the per-frame settling epoch record's
-  ;; raw trace slice, which folds the COMPLETE domino trail for one
-  ;; event (the synchronous event-side dispatch-id-N rows AND the
-  ;; async nil-dispatch-id reactive rows — `:rf.sub/run` / `:rf.view/render`
-  ;; — that fire post-cascade for that settling). The prior shape
-  ;; scoped the global trace bus by `:dispatch-id`, which dropped the
-  ;; async reactive rows; reading the epoch record renders the whole
-  ;; trail.
-  ;;
-  ;; The focused epoch record is resolved exactly as the Issues /
-  ;; App-DB Diff panels resolve theirs: join `:rf.xray/focus`
-  ;; (carrying `:epoch-id`) + `:rf.xray/epoch-history` (the
-  ;; framework's per-frame ring of `:rf/epoch-record` maps), then run
-  ;; the shared `panels.shared.focus-resolver` — which classifies the
-  ;; focus status (`:no-focus` / `:focused` / `:epoch-evicted`, with
-  ;; the rf2-h0120 head-fallback) and looks up the record.
-  ;;
-  ;; No filtering (rf2-gkczt): the focused epoch IS the scope, so the
-  ;; feed is the epoch's domino trail with no chip narrowing.
+  ;; The Trace tab reads the FOCUSED EPOCH's `:trace-events` — the
+  ;; per-frame settling epoch record's raw trace slice, which folds the
+  ;; complete domino trail for one event (the synchronous event-side
+  ;; dispatch-id-N rows AND the async nil-dispatch-id reactive rows).
+  ;; The focused epoch record is resolved exactly as the Issues / App-DB
+  ;; Diff panels resolve theirs: join `:rf.xray/focus` (carrying
+  ;; `:epoch-id`) + `:rf.xray/epoch-history`, then run the shared
+  ;; `panels.shared.focus-resolver` — which classifies the focus status
+  ;; (`:no-focus` / `:focused` / `:epoch-evicted`) and looks up the
+  ;; record. `h/project-feed-from-epoch` projects that record's
+  ;; `:trace-events` into the arc shape (envelope + 4 phase bands).
   ;;
   ;; Shape of `:rf.xray/trace-feed`:
   ;;
-  ;;     {:rows       [<row> ...]   ;; the epoch's domino trail, newest first
+  ;;     {:rows       [<row> ...]   ;; the epoch's domino trail, oldest-first
+  ;;      :envelope   [<row> ...]   ;; the EPOCH OPEN / CLOSE :rf.epoch/* ops
+  ;;      :outcome    <:ok/:blocked/:error-or-nil>
+  ;;      :bands      [{:id :label :rows :count :empty?} ...]  ;; 4 phase bands
   ;;      :total      <int>         ;; the epoch's trace-event count
   ;;      :rendered   <int>         ;; same as :total (no filtering)
   ;;      :epoch-id   <int-or-nil>  ;; the focused epoch's id
@@ -581,14 +577,10 @@
                                                     epoch-history)]
         (h/project-feed-from-epoch record focus-status))))
 
-  ;; ---- rf2-7dyi8 — per-row inline payload expansion ------------------
+  ;; ---- per-row inline payload expansion (spec/023 §3) ----------------
   ;;
-  ;; Per spec/021 §5.4 clicking a row expands its payload inline (no
-  ;; nav). The expanded set lives in app-db so the toggle survives
-  ;; sub-recomputes. The shared rf2-jgip1 renderer owns deeper-than-2
-  ;; expansion state under its own `:rf.xray/data-display-expansion`
-  ;; slot; this set gates whether the renderer is mounted for a row
-  ;; at all.
+  ;; Clicking a row expands its raw trace-event EDN inline (no nav). The
+  ;; expanded set lives in app-db so the toggle survives sub-recomputes.
 
   (rf/reg-sub :rf.xray/trace-expanded-row-ids
     (fn [db _query]
@@ -604,30 +596,31 @@
 
   (rf/reg-event-db :rf.xray/clear-trace-expand
     (fn [db _event]
-      (dissoc db :trace-expanded-row-ids :trace-expanded-group-ids)))
+      (dissoc db :trace-expanded-row-ids :trace-collapsed-band-ids)))
 
-  ;; ---- rf2-ad7zx.8 — reactive-aftermath collapse groups --------------
+  ;; ---- collapsible phase bands (spec/023 §2 · §14) -------------------
   ;;
-  ;; Per spec/021 §5.2 the post-cascade reactive emits collapse under
-  ;; one expandable `▸ reactive aftermath (N subs, M renders)` group so
-  ;; the core dominoes stand out. The expanded-group set lives in app-db
-  ;; (keyed by the group's stable `react-grp:<id>` id) so the toggle
-  ;; survives sub-recomputes, exactly as the per-row expansion set does.
+  ;; The four phase bands are collapsible (default: all expanded). The
+  ;; COLLAPSED set lives in app-db (keyed by the band id) so a band stays
+  ;; collapsed across sub-recomputes. An empty band's header is inert —
+  ;; the view only dispatches the toggle for a non-empty band.
 
-  (rf/reg-sub :rf.xray/trace-expanded-group-ids
+  (rf/reg-sub :rf.xray/trace-collapsed-band-ids
     (fn [db _query]
-      (get db :trace-expanded-group-ids #{})))
+      (get db :trace-collapsed-band-ids #{})))
 
-  (rf/reg-event-db :rf.xray/toggle-trace-group-expand
-    (fn [db [_ group-id]]
-      (let [current (get db :trace-expanded-group-ids #{})]
-        (assoc db :trace-expanded-group-ids
-               (if (contains? current group-id)
-                 (disj current group-id)
-                 (conj current group-id))))))
+  (rf/reg-event-db :rf.xray/toggle-trace-band-collapse
+    (fn [db [_ band-id]]
+      (let [current (get db :trace-collapsed-band-ids #{})]
+        (assoc db :trace-collapsed-band-ids
+               (if (contains? current band-id)
+                 (disj current band-id)
+                 (conj current band-id))))))
 
   ;; rf2-2moh1 — register the Dynamic Trace tab with the internal L4
-  ;; tab registry.
+  ;; tab registry. Flows render right after the handler (spec/023 §2 —
+  ;; the FLOW rows live in ② EVENT HANDLING), and the tab keeps its
+  ;; `t` mnemonic + order-3 placement.
   (panel-registry/reg-l4-tab!
     {:id    :trace
      :label "Trace"

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -1,101 +1,277 @@
 (ns day8.re-frame2-xray.panels.trace-helpers
-  "Pure-data helpers for Xray's Trace panel (Phase 5, rf2-argrj;
-  epoch-scoped rework rf2-td380 + rf2-gkczt).
+  "Pure-data helpers for Xray's Trace panel.
+
+  ## What this panel shows (spec/023-Trace-Panel.md)
+
+  The Trace panel renders the COMPLETE TRACE ARC of a single epoch —
+  every trace operation the substrate emits during the epoch, in fire
+  order, organised by the epoch's phase shape. Its contract is
+  COMPLETENESS: every op-family in the Spec-009 vocabulary surfaces
+  (spec/023 §1). The structural projection here turns the focused
+  epoch's `:trace-events` into:
+
+      ○ EPOCH OPEN  envelope row (epoch-lifecycle ops · :rf.epoch/*)
+      ▾ ① DISPATCH          (the event dispatched)
+      ▾ ② EVENT HANDLING    (coeffects → handler → flows → db-changed)
+      ▾ ③ EFFECTS / FX      (fx handlers · routing nav · machine timers)
+      ▾ ④ REACTIVE RENDERING (subscriptions → views)
+      ● EPOCH CLOSE outcome :ok/:blocked/:error
+
+  Each op renders as a row of five columns (spec/023 §3):
+
+      Δt · area badge · what-happened · target/detail · duration
+
+  Errors and warnings are cross-cutting — they render INLINE at their
+  chronological point in whatever band they occurred (spec/023 §7),
+  emphasised so failures stand out. Empty phase bands render dimmed
+  with `(none)` so the 4-phase shape is always legible (spec/023 §13).
 
   ## Why a separate `.cljc` ns
 
-  The panel view in `trace.cljs` paints a scrollable, timestamped
-  ribbon of the focused epoch's trace events and dispatches into the
-  Xray frame. The *logic* — projecting raw events into row shape and
-  classifying the empty state — is pure data → data. Splitting the
-  algebra into `.cljc` so it runs under the JVM unit-test target
-  (`clojure -M:test`) is required by the standing rule
-  `feedback_jvm_interop_must_work.md`.
+  The panel view in `trace.cljs` paints the arc and dispatches into the
+  Xray frame; the *logic* — projecting raw events into rows, classifying
+  each op's phase / area / verb / target, banding the rows into the arc
+  shape, and classifying the empty state — is pure data → data. The
+  algebra lives here as `.cljc` so it runs under the JVM unit-test
+  target (`clojure -M:test`) per the standing
+  `feedback_jvm_interop_must_work.md` rule.
 
-  ## Epoch-scoped feed (rf2-td380)
+  ## Epoch-scoped feed (spec/018 §6)
 
-  Per spec/018 §6 every L4 panel is a lens on the spine's focused
-  event, not a global ribbon. The Trace tab reads the FOCUSED EPOCH's
-  `:trace-events` (the per-frame settling epoch record's raw trace
-  slice — `re-frame.epoch/epoch-history` keeps oldest-first records,
-  each carrying the complete domino trail for one event: the
-  synchronous event-side dispatch-id-N events AND the async
-  nil-dispatch-id reactive events — `:rf.sub/run` / `:rf.view/render` —
-  that fire post-cascade for that settling). The prior shape scoped
-  the global trace bus by `:dispatch-id`, which DROPPED those async
-  reactive rows (they carry a nil dispatch-id), so the rendered trail
-  was incomplete (e.g. 4 rows shown vs the epoch's real 12). Reading
-  the epoch record's `:trace-events` folds both sides, so rendered
-  rows = the complete domino trail (event → db-changed → subs ran →
-  views rendered).
+  Every L4 panel is a lens on the spine's FOCUSED EPOCH, not a global
+  ribbon. The Trace tab reads the focused epoch record's `:trace-events`
+  — the per-frame settling epoch's raw trace slice — which folds the
+  complete domino trail for one event: both the synchronous event-side
+  rows (dispatch-id N) AND the async reactive rows (`:rf.sub/run` /
+  `:rf.view/render`, nil dispatch-id) that fire post-cascade. The record
+  is resolved via the shared `panels.shared.focus-resolver` against
+  `:rf.xray/focus` + `:rf.xray/epoch-history`, exactly as the Issues /
+  App-DB Diff panels resolve theirs.
 
-  ## No chip filtering (rf2-gkczt)
+  ## No chip filtering
 
-  Per Mike-direction 2026-05-22 the Trace panel surfaces the
-  epoch-scoped rows with NO filtering UI — the focused epoch IS the
-  scope, and the per-row payload-expand affordance is the drill-down.
-  The 13-axis filter vocabulary, per-axis chip enumeration, and the
-  buffer-snapshot incremental projection are gone."
+  The focused epoch IS the scope, so there is NO filtering UI — the
+  per-row payload-expand affordance is the drill-down. Show every op,
+  no default narrowing (spec/023 §2 completeness-first)."
   (:require [clojure.string :as str]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
-;; ---- op-family classification (rf2-ad7zx.8) -----------------------------
+;; ---- area-badge classification (spec/023 §3 · §5) -----------------------
 ;;
-;; The Figma Trace design (the `trace-panel` component in
-;; `design-reference/xray_devtools_reference.cljs`)
-;; bands each row with a 3px op-FAMILY-coloured left border — FIVE
-;; families, not the full op-type vocabulary:
+;; Per spec/023 §3 each row carries a NEUTRAL TEXT area badge (no
+;; per-family colour) naming the op-family. The full vocabulary
+;; (spec/023 §5 verb taxonomy + Appendix A):
 ;;
-;;     :dispatch  — the event side (`:rf.event/dispatched` / run-start /
-;;                  run-end). The single GitHub-blue accent.
-;;     :db        — `:rf.event/db-changed`. The "changed" tone.
-;;     :fx        — the effect side (`:rf.fx/*`). Warning tone.
-;;     :reactive  — the post-cascade reactive aftermath (`:rf.sub/*` /
-;;                  `:rf.view/*`). Dim tone — collapses under one group.
-;;     :machine   — `:rf.machine/*`. The machine/chart tone.
+;;     EVENT · COEFFECT · DB · FX · FLOW · SUB · VIEW · MACHINE ·
+;;     ROUTING · EPOCH · ERROR · WARNING
 ;;
-;; Plus the two severity tiers (`:error` / `:warning`) which keep their
-;; canonical semantic colours so a failure never hides under a family
-;; band. Unknown ops fall back to `:dispatch`-adjacent neutral.
+;; The badge is derived from `:op-type` + `:operation`. The two severity
+;; tiers (ERROR / WARNING) are cross-cutting — they keep their canonical
+;; semantic colour treatment in the view (spec/023 §7) so a failure
+;; never hides under a normal row.
+
+(defn area
+  "Classify a projected row (or raw event) into one of the spec/023 §3
+  AREA keywords — the neutral text badge family. Reads `:op-type` +
+  `:operation` (the operation discriminates db-changed from the rest of
+  the event family, and the epoch-lifecycle ops from anything else).
+  Pure data → keyword; JVM-testable.
+
+  Returns one of:
+    :event :coeffect :db :fx :flow :sub :view :machine :routing
+    :epoch :error :warning"
+  [{:keys [op-type operation] :as _row-or-ev}]
+  (let [op-ns (when (keyword? operation) (namespace operation))]
+    (cond
+      (= op-type :error)                 :error
+      (= op-type :warning)               :warning
+      (= operation :rf.event/db-changed) :db
+      (= op-ns "rf.epoch")               :epoch
+      (= op-ns "rf.cofx")                :coeffect
+      (= op-ns "rf.flow")                :flow
+      (= op-ns "rf.route")               :routing
+      (= op-type :rf.event)              :event
+      (= op-type :rf.fx)                 :fx
+      (= op-type :rf.sub)                :sub
+      (= op-type :rf.view)               :view
+      (= op-type :rf.machine)            :machine
+      ;; namespace fallbacks for op-types not stamped via :op-type
+      (= op-ns "rf.event")               :event
+      (= op-ns "rf.fx")                  :fx
+      (= op-ns "rf.sub")                 :sub
+      (= op-ns "rf.view")                :view
+      (#{"rf.machine" "rf.machine.microstep" "rf.machine.timer"
+         "rf.machine.spawn" "rf.machine.lifecycle"
+         "rf.machine.registrar"} op-ns)  :machine
+      :else                              :event)))
+
+(def area->badge
+  "Map an area keyword to its uppercase neutral text badge (spec/023
+  §3 / §5)."
+  {:event    "EVENT"
+   :coeffect "COEFFECT"
+   :db       "DB"
+   :fx       "FX"
+   :flow     "FLOW"
+   :sub      "SUB"
+   :view     "VIEW"
+   :machine  "MACHINE"
+   :routing  "ROUTING"
+   :epoch    "EPOCH"
+   :error    "ERROR"
+   :warning  "WARNING"})
+
+(defn area-badge
+  "The uppercase neutral text badge for a row (`EVENT`, `DB`, …) per
+  spec/023 §3. Pure data → string; JVM-testable."
+  [row-or-ev]
+  (get area->badge (area row-or-ev) "EVENT"))
+
+;; ---- phase / band placement (spec/023 §2 · §4) --------------------------
+;;
+;; Per spec/023 §4 every op-family places into the epoch envelope or one
+;; of the four phase bands, in arc order:
+;;
+;;   envelope        :rf.epoch/* (open / close / restore / replay / …)
+;;   ① DISPATCH      :rf.event/dispatched
+;;   ② EVENT HANDLING :rf.cofx/* · run-start/run-end · flows · db-changed
+;;                    · machine-as-handler transitions
+;;   ③ EFFECTS / FX  :rf.fx/* · machine timers/spawn · routing nav
+;;   ④ REACTIVE RENDERING :rf.sub/* · :rf.view/*
+;;
+;; Errors / warnings are cross-cutting (NOT a phase, spec/023 §7) — the
+;; band function leaves them out of the canonical placement and the
+;; feed projection threads them inline at their chronological point.
+
+(def band-order
+  "The canonical arc order of the four phase bands (spec/023 §2). The
+  epoch envelope brackets these and is rendered separately. Pure data."
+  [:dispatch :event-handling :effects :reactive])
+
+(def band->label
+  "Map a band keyword to its numbered uppercase header label
+  (spec/023 §2 · §9)."
+  {:dispatch       "① DISPATCH"
+   :event-handling "② EVENT HANDLING"
+   :effects        "③ EFFECTS / FX"
+   :reactive       "④ REACTIVE RENDERING"})
+
+(defn phase
+  "Classify a projected row (or raw event) into its arc phase per
+  spec/023 §4: `:envelope` · `:dispatch` · `:event-handling` ·
+  `:effects` · `:reactive`. Errors / warnings classify by the band they
+  occurred in is impossible without inline context, so they fall through
+  to `:event-handling` here — the feed projection threads them inline at
+  their chronological point regardless (spec/023 §7). Pure data →
+  keyword; JVM-testable."
+  [{:keys [operation] :as row-or-ev}]
+  (let [a (area row-or-ev)]
+    (case a
+      :epoch    :envelope
+      :coeffect :event-handling
+      :flow     :event-handling
+      :db       :event-handling
+      :sub      :reactive
+      :view     :reactive
+      :fx       :effects
+      :routing  :effects
+      :machine  :event-handling
+      :event    (if (= operation :rf.event/dispatched)
+                  :dispatch
+                  :event-handling)
+      ;; errors / warnings are cross-cutting; default placement is the
+      ;; handling band — the inline threading (spec/023 §7) does the
+      ;; real positioning.
+      :event-handling)))
+
+;; ---- outcome tier (spec/023 §8) -----------------------------------------
+;;
+;; Per spec/023 §8 the what-happened STATE must be legible at a glance
+;; with at least these tiers distinguished:
+;;
+;;   :active     created / changed / recalculated / mounted / ran
+;;   :inert      cache-hit / ran-unchanged / skipped
+;;   :gone       disposed / unmounted / cleared
+;;   :pending    queued / scheduled
+;;   :error      a failure tier (errors keep their semantic red)
+;;   :warning    a caution tier
+;;
+;; The view tints the what-happened column by tier so the arc reads its
+;; outcome shape while scanning.
+
+(defn outcome-tier
+  "Classify a row's outcome into a visual tier per spec/023 §8. Reads
+  the operation's terminal segment (`disposed`, `skip`, `cache-hit`, …).
+  Pure data → keyword; JVM-testable."
+  [{:keys [op-type operation] :as _row-or-ev}]
+  (let [op-name (when (keyword? operation) (name operation))]
+    (cond
+      (= op-type :error)   :error
+      (= op-type :warning) :warning
+      (nil? op-name)       :active
+      (re-find #"(?i)(disposed|unmounted|cleared|cancelled|stale|released|destroyed)" op-name)
+      :gone
+      (re-find #"(?i)(skip|skipped|cache-hit|unchanged|ran-unchanged)" op-name)
+      :inert
+      (re-find #"(?i)(queued|scheduled|pending|later)" op-name)
+      :pending
+      :else :active)))
+
+;; ---- op-family classification (left-border band — retained) -------------
+;;
+;; The op-FAMILY (a coarser 5-bucket grouping than the 12-area badge) is
+;; retained for the 3px op-family left-border band the view paints on
+;; each row and for the per-band rail colour. Five families plus the two
+;; severity tiers:
+;;
+;;     :dispatch  — the event side (dispatched / run-start / run-end)
+;;     :db        — :rf.event/db-changed
+;;     :fx        — the effect side (:rf.fx/* · :rf.route/*)
+;;     :reactive  — subs + views (:rf.sub/* · :rf.view/*)
+;;     :machine   — :rf.machine/*
+;;
+;; with :error / :warning preserved so a failure never hides under a
+;; family band. Unknown ops fall back to :dispatch-adjacent neutral.
 
 (defn op-family
-  "Classify a projected row (or raw event) into one of the Figma op
-  families: `:dispatch` · `:db` · `:fx` · `:reactive` · `:machine`,
-  with the `:error` / `:warning` severity tiers preserved. Reads
-  `:op-type` + `:operation` (the operation discriminates db-changed
-  from the rest of the event family). Pure data → keyword;
-  JVM-testable."
-  [{:keys [op-type operation] :as _row-or-ev}]
-  (cond
-    (= op-type :error)                 :error
-    (= op-type :warning)               :warning
-    (= operation :rf.event/db-changed) :db
-    (= op-type :rf.event)              :dispatch
-    (= op-type :rf.fx)                 :fx
-    (= op-type :rf.sub)                :reactive
-    (= op-type :rf.view)               :reactive
-    (= op-type :rf.machine)            :machine
-    :else                              :dispatch))
+  "Classify a projected row (or raw event) into one of the op families:
+  `:dispatch` · `:db` · `:fx` · `:reactive` · `:machine`, with the
+  `:error` / `:warning` severity tiers preserved. Drives the 3px
+  left-border band colour. Pure data → keyword; JVM-testable."
+  [{:keys [op-type] :as row-or-ev}]
+  (let [a (area row-or-ev)]
+    (case a
+      :error    :error
+      :warning  :warning
+      :db       :db
+      :event    :dispatch
+      :coeffect :dispatch
+      :epoch    :dispatch
+      :fx       :fx
+      :routing  :fx
+      :flow     :db
+      :sub      :reactive
+      :view     :reactive
+      :machine  :machine
+      ;; defensive fallback for an op whose area didn't resolve above.
+      (cond
+        (= op-type :rf.fx)              :fx
+        (#{:rf.sub :rf.view} op-type)   :reactive
+        (= op-type :rf.machine)         :machine
+        :else                           :dispatch))))
 
 (def op-family->token
   "Pure semantic map from op-family keyword to a `theme/tokens` token
-  keyword. The hex (CSS-var) resolution happens via
-  `op-family-colour`. Keeping the semantic mapping separate from the
-  var lookup keeps the map pure data + the palette consolidated
-  (rf2-5kfxe.4 discipline).
+  keyword. The hex (CSS-var) resolution happens via `op-family-colour`.
+  Keeping the semantic mapping separate from the var lookup keeps the
+  map pure data + the palette consolidated.
 
-  Family → token (spec/021 §5.2 · design-reference/xray_devtools_reference.cljs,
-  the `trace-panel` component):
-
-    :dispatch → :accent         (the single GitHub-blue accent)
-    :db       → :info           (the cool-blue 'changed/recompute' partner,
-                                 visually distinct from the primary
-                                 accent now that dispatch rides it)
-    :fx       → :warning        (the effect/warning tone)
-    :reactive → :dim            (dimmed / inert reactive aftermath)
-    :machine  → :green          (the machine-domain tone — Xray's
-                                 machine surfaces are green)
+    :dispatch → :accent   (the single GitHub-blue accent)
+    :db       → :info     (the cool-blue changed/recompute partner)
+    :fx       → :warning  (the effect / warning tone)
+    :reactive → :dim      (dimmed / inert reactive aftermath)
+    :machine  → :green    (the machine-domain tone)
     :error    → :red
     :warning  → :yellow"
   {:dispatch :accent
@@ -109,11 +285,63 @@
 (defn op-family-colour
   "Resolve the 3px left-border colour for a row's op family. Routes the
   family through `op-family` then `op-family->token` then
-  `theme/tokens`. Falls back to `:text-secondary` for an unknown
-  family. Pure data → CSS-var string; JVM-testable."
+  `theme/tokens`. Falls back to `:text-secondary` for an unknown family.
+  Pure data → CSS-var string; JVM-testable."
   [row-or-ev]
   (get tokens/tokens
        (get op-family->token (op-family row-or-ev) :text-secondary)))
+
+(def outcome-tier->token
+  "Map an outcome tier to its what-happened text colour token
+  (spec/023 §8). Active states read primary; inert / gone read dimmed;
+  pending rides the cool info blue; error / warning keep their semantic
+  colour."
+  {:active   :text-primary
+   :inert    :text-tertiary
+   :gone     :dim
+   :pending  :info
+   :error    :red
+   :warning  :yellow})
+
+(defn outcome-colour
+  "Resolve the what-happened text colour for a row's outcome tier
+  (spec/023 §8). Pure data → CSS-var string; JVM-testable."
+  [row-or-ev]
+  (get tokens/tokens
+       (get outcome-tier->token (outcome-tier row-or-ev) :text-primary)))
+
+;; ---- what-happened verb (spec/023 §5) -----------------------------------
+;;
+;; Per spec/023 §5 each area has a verb taxonomy — the per-row "what
+;; happened" state. We derive it from the operation's terminal segment
+;; with a small per-area override map for the readable forms (`handler
+;; ran`, `recalculated`, …).
+
+(def operation->verb
+  "Explicit verb overrides for the operations whose readable verb isn't
+  simply their terminal segment (spec/023 §5 / Appendix A). Falls
+  through to the name-based default for everything else."
+  {:rf.event/dispatched   "dispatched"
+   :rf.event/run-start    "handler ran"
+   :rf.event/run-end      "handler ran"
+   :rf.event/db-changed   "changed"
+   :rf.epoch/snapshotted  "snapshotted"
+   :rf.epoch/outcome      "outcome"
+   :rf.cofx/run           "run"
+   :rf.flow/computed      "computed"})
+
+(defn what-happened
+  "Build the per-row what-happened verb (spec/023 §5). Uses the explicit
+  override map first, then falls back to the operation's terminal name
+  segment with `/` and dots folded to spaces (`:rf.sub/run` → `run`,
+  `:rf.machine.timer/scheduled` → `scheduled`). Pure data → string;
+  JVM-testable."
+  [{:keys [operation] :as _row-or-ev}]
+  (or (get operation->verb operation)
+      (when (keyword? operation)
+        (-> (name operation)
+            (str/replace #"-" " ")))
+      "—"))
 
 ;; ---- short-description ---------------------------------------------------
 
@@ -147,20 +375,13 @@
       (str op-str " — " detail)
       op-str)))
 
-;; ---- readable plain-language description (rf2-ad7zx.8) -------------------
+;; ---- target / detail (spec/023 §3 · §5) ---------------------------------
 ;;
-;; Per spec/021 §5.1 (density note) + §5.2 (Figma readable rows) each op
-;; renders as a PLAIN-LANGUAGE line, not its raw op-type keyword:
-;;
-;;     dispatched [:counter-inc]
-;;     db changed [:counter] 1 → 2
-;;     fx :dispatch → [:title/flow [:rf/init]]
-;;     machine :title/flow idle → loading
-;;
-;; The raw `:operation` + tag-map remains the click-to-expand detail
-;; (rf2-7dyi8) — this is the single dense default line. `short-
-;; description` (above) stays the fallback for ops the readable builder
-;; doesn't recognise, so no op ever renders as a blank row.
+;; Per spec/023 §3 the target/detail column carries the op's SUBJECT:
+;; the event vector, `fx-id → arg`, `sub-id old→new`, `view-id ← cause-
+;; sub`, route id, path, etc. It is the flexible column that truncates
+;; first (spec/023 §14). We derive it per-area from the reliably-present
+;; tags; an op with no recognised subject renders an em-dash.
 
 (defn- pr-str-safe
   "pr-str that never throws (defends against un-printable trace
@@ -170,8 +391,8 @@
        (catch #?(:clj Throwable :cljs :default) _ nil)))
 
 (def ^:private tags-absent
-  "Sentinel for 'tag key absent' so a literal `nil` db value (a valid
-  app-db value) is distinguished from a missing tag."
+  "Sentinel for 'tag key absent' so a literal `nil` value is
+  distinguished from a missing tag."
   ::tags-absent)
 
 (defn- name-or-str
@@ -180,78 +401,147 @@
   [x]
   (if (keyword? x) (name x) (str x)))
 
-(defn readable-description
-  "Build the Figma plain-language row body for one trace event. Maps
-  the op family + the reliably-present tags to a human line:
+(defn target-detail
+  "Build the target/detail string for one trace event — the op's
+  subject (spec/023 §3 / §5). Per-area:
 
-    :dispatch (dispatched) → `dispatched <event-vec>`
-    :db                    → `db changed <path>? <old> → <new>?`
-    :fx                    → `fx <fx-id> → <fx-arg>?`
-    :machine               → `machine <machine-id> <from> → <to>`
-    :reactive (sub)        → `sub ran <sub-id>`
-    :reactive (view)       → `rendered <render-key>`
+    :event    → the dispatched event vector
+    :db       → `[path] old → new`
+    :fx       → `fx-id → arg`
+    :flow     → `flow-id → [path]` (or the value delta)
+    :sub      → `sub-id old → new` / `sub-id`
+    :view     → `view-id ← cause-sub` / render-key
+    :machine  → `machine-id from → to`
+    :coeffect → `cofx-id → value`
+    :routing  → route-id / fragment
+    :epoch    → epoch id · event · frame / outcome
 
-  Falls back to `short-description` for ops outside this vocabulary
-  (run-start/run-end markers, errors, registry events, …) so the row
-  is never blank. Pure data → string; JVM-testable."
-  [{:keys [operation tags] :as ev}]
-  (let [family (op-family ev)
+  Falls back to nil for an op with no recognised subject so the view
+  renders an em-dash. Pure data → string-or-nil; JVM-testable."
+  [{:keys [tags] :as ev}]
+  (let [a      (area ev)
         ev-vec (when (vector? (:rf.event/v tags)) (:rf.event/v tags))]
-    (or
-      (case family
-        :db
-        (let [path (or (:rf.db/path tags) (:path tags))
-              old  (get tags :rf.db/old tags-absent)
-              new  (get tags :rf.db/new tags-absent)]
-          (cond
-            (and (not= old tags-absent) (not= new tags-absent))
-            (str "db changed"
-                 (when path (str " " (pr-str-safe path)))
-                 " " (pr-str-safe old) " → " (pr-str-safe new))
-            path (str "db changed " (pr-str-safe path))
-            :else "db changed"))
+    (case a
+      :event
+      (when ev-vec (pr-str-safe ev-vec))
 
-        :machine
-        (let [mid  (or (:machine-id tags) (:rf/machine-id tags))
-              from (get tags :from tags-absent)
-              to   (get tags :to tags-absent)]
-          (when mid
-            (str "machine " mid
-                 (when (and (not= from tags-absent) (not= to tags-absent))
-                   (str " " (name-or-str from) " → " (name-or-str to))))))
-
-        :fx
-        (let [fx-id (or (:rf.fx/id tags) (:rf.fx/effect-id tags))]
-          (when fx-id
-            (str "fx " fx-id
-                 (when-let [arg (or (:rf.fx/arg tags) (:rf.fx/value tags))]
-                   (str " → " (pr-str-safe arg))))))
-
-        :reactive
+      :db
+      (let [path (or (:rf.db/path tags) (:path tags))
+            old  (get tags :rf.db/old tags-absent)
+            new  (get tags :rf.db/new tags-absent)]
         (cond
-          (some? (:rf.sub/id tags))
-          (str "sub ran " (:rf.sub/id tags))
-          (some? (:rf.view/render-key tags))
-          (str "rendered " (pr-str-safe (:rf.view/render-key tags)))
-          (some? (:rf.view/id tags))
-          (str "rendered " (:rf.view/id tags))
-          :else nil)
+          (and path (not= old tags-absent) (not= new tags-absent))
+          (str (pr-str-safe path) "  " (pr-str-safe old) " → " (pr-str-safe new))
+          path (pr-str-safe path)
+          :else nil))
 
-        :dispatch
-        (when (and (= operation :rf.event/dispatched) ev-vec)
-          (str "dispatched " (pr-str-safe ev-vec)))
+      :fx
+      (when-let [fx-id (or (:rf.fx/id tags) (:rf.fx/effect-id tags))]
+        (str fx-id
+             (when-let [arg (or (:rf.fx/arg tags) (:rf.fx/value tags))]
+               (str " → " (pr-str-safe arg)))))
 
-        nil)
-      ;; Fallback — the existing terse `operation — detail` line.
+      :flow
+      (let [flow-id (or (:rf.flow/id tags) (:flow-id tags))
+            path    (or (:rf.flow/path tags) (:path tags))]
+        (when flow-id
+          (str flow-id (when path (str " → " (pr-str-safe path))))))
+
+      :sub
+      (let [sub-id (:rf.sub/id tags)
+            old    (get tags :rf.sub/old tags-absent)
+            new    (get tags :rf.sub/new tags-absent)]
+        (when sub-id
+          (str sub-id
+               (when (and (not= old tags-absent) (not= new tags-absent))
+                 (str "  " (pr-str-safe old) " → " (pr-str-safe new))))))
+
+      :view
+      (let [vid   (or (:rf.view/id tags)
+                      (when-let [rk (:rf.view/render-key tags)]
+                        (pr-str-safe rk)))
+            cause (:rf.view/cause-sub tags)]
+        (when vid
+          (str vid (when cause (str " ← " cause)))))
+
+      :machine
+      (let [mid  (or (:machine-id tags) (:rf/machine-id tags))
+            from (get tags :from tags-absent)
+            to   (get tags :to tags-absent)]
+        (when mid
+          (str mid
+               (when (and (not= from tags-absent) (not= to tags-absent))
+                 (str " " (name-or-str from) " → " (name-or-str to))))))
+
+      :coeffect
+      (when-let [cofx-id (or (:rf.cofx/id tags) (:cofx-id tags))]
+        (str cofx-id
+             (when-let [v (or (:rf.cofx/value tags) (:value tags))]
+               (str " → " (pr-str-safe v)))))
+
+      :routing
+      (or (some-> (or (:rf.route/id tags) (:route-id tags)) str)
+          (some-> (:rf.route/fragment tags) str))
+
+      :epoch
+      (or (some-> (or (:rf.epoch/outcome tags) (:outcome tags)) str)
+          (when-let [eid (:epoch-id tags)] (str "#" eid)))
+
+      (:error :warning)
+      (or (:reason tags) (:exception-message tags)
+          (some-> (:rf.error/operation tags) str))
+
+      nil)))
+
+;; ---- readable plain-language description (legacy fallback) ---------------
+;;
+;; The full 5-column row (Δt · badge · verb · target/detail · duration)
+;; supersedes the single readable line as the dense default. The
+;; readable line is retained as the row's `:description` slot — used by
+;; cross-panel consumers + as the row title/hover — built from the area
+;; verb + target/detail (or the terse fallback so no op is ever blank).
+
+(defn readable-description
+  "Build a one-line plain-language description for a trace event —
+  `<verb> <target/detail>` (e.g. `dispatched [:counter/inc]`,
+  `recalculated :app/counter`). Falls back to `short-description` for
+  ops outside the recognised vocabulary so the line is never blank.
+  Pure data → string; JVM-testable.
+
+  Retained for cross-panel consumers + the row title/hover; the panel
+  itself renders the 5-column row (badge · verb · target/detail), not
+  this single line."
+  [ev]
+  (let [verb   (what-happened ev)
+        detail (target-detail ev)
+        a      (area ev)]
+    (cond
+      ;; recognised area with a subject — `verb detail`
+      (and (some? detail) (not (str/blank? detail)))
+      (case a
+        :event (str "dispatched " detail)
+        :db    (str "db changed " detail)
+        :fx    (str "fx " detail)
+        :flow  (str "flow " detail)
+        :sub   (str "sub " verb " " detail)
+        :view  (str "view " verb " " detail)
+        :machine (str "machine " detail)
+        :coeffect (str "coeffect " detail)
+        :routing (str "routing " verb " " detail)
+        :epoch (str "epoch " verb " " detail)
+        (:error :warning) (str (name a) " " detail)
+        (str verb " " detail))
+      ;; no subject — terse fallback so the row is never blank
+      :else
       (short-description ev))))
 
 ;; ---- source-coord projection --------------------------------------------
 
 (defn source-coord
   "Extract a `file:line` string from `:rf.trace/trigger-handler`'s
-  `:source-coord` slot. Per Spec 009 §Source-coord every emit inside
-  a dispatch carries this slot when handler scope is bound (per
-  rf2-3nn8 / rf2-lf84g). Pure data → string-or-nil; JVM-testable."
+  `:source-coord` slot. Per Spec 009 §Source-coord every emit inside a
+  dispatch carries this slot when handler scope is bound. Pure data →
+  string-or-nil; JVM-testable."
   [ev]
   (when-let [trigger (:rf.trace/trigger-handler ev)]
     (let [{:keys [file line]} (:source-coord trigger)]
@@ -259,45 +549,42 @@
         (cond-> file
           line (str ":" line))))))
 
-;; ---- per-row projection -------------------------------------------------
+;; ---- relative timing + duration -----------------------------------------
+;;
+;; Per spec/023 §3 each row leads with Δt — the ms offset from EPOCH
+;; OPEN — and carries a duration column (a number in ms, or `—` when the
+;; substrate supplies no timing, §6).
 
 (defn frame-of
-  "Project the event's frame routing key. Per Spec 009 §Canonical
-  per-frame routing key (rf2-shaa1) every trace event that names a
-  frame uses `:frame` under `:tags`; consumers also fall back to a
-  top-level `:frame` for events emitted before the canonical move
-  landed (defensive — the framework no longer emits the alias)."
+  "Project the event's frame routing key. Per Spec 009 every trace event
+  that names a frame uses `:frame` under `:tags`; consumers also fall
+  back to a top-level `:frame` (defensive)."
   [ev]
   (or (get-in ev [:tags :frame])
       (:frame ev)))
 
 (defn origin-of
-  "Project the dispatch-origin slot per Spec 009 §Origin tagging
-  (`:tags :rf.event/origin`). Defensive against absence — returns nil."
+  "Project the dispatch-origin slot (`:tags :rf.event/origin`).
+  Defensive against absence — returns nil."
   [ev]
   (get-in ev [:tags :rf.event/origin]))
 
 (defn duration-ms
-  "Per-op elapsed time, in ms, when the trace event reports it.
-
-  Reads (in priority order) `[:tags :elapsed-ms]` — the wall-clock
-  duration the event-emit / view-render envelopes stamp (Spec 009
-  §Record shape; `re-frame.views` for `:rf.view/rendered`) — then a
-  top-level `:elapsed-ms` fallback. Returns nil otherwise: reactive
-  point-in-time emits (`:rf.sub/run`, bare `:rf.view/render`) carry no
-  elapsed, so the view renders a timestamp rather than a duration
-  (spec/021 §5.2). Pure data → number-or-nil; JVM-testable."
+  "Per-op elapsed time, in ms, when the trace event reports it. Reads
+  `[:tags :elapsed-ms]` then a top-level `:elapsed-ms` fallback. Returns
+  nil otherwise — point-in-time emits carry no elapsed, so the duration
+  column renders `—` (spec/023 §6). Pure data → number-or-nil;
+  JVM-testable."
   [ev]
   (let [e (or (get-in ev [:tags :elapsed-ms])
               (:elapsed-ms ev))]
     (when (number? e) e)))
 
 (defn- fmt-1
-  "Format a number to EXACTLY one decimal place — `0.4`, `12.0`,
-  `0.0` — so the duration / relative-time columns read with a stable
-  rhythm (the Figma `0.4 ms` / `t+0.0ms` form). Portable: CLJS `str`
-  of a whole-number double drops the `.0`, so we round to tenths then
-  build the `<int>.<tenth>` string by hand. Pure data → string."
+  "Format a number to EXACTLY one decimal place — `0.4`, `12.0`, `0.0`.
+  Portable: CLJS `str` of a whole-number double drops the `.0`, so we
+  round to tenths then build the `<int>.<tenth>` string by hand. Pure
+  data → string."
   [n]
   (let [tenths (#?(:clj Math/round :cljs js/Math.round) (* (double n) 10.0))
         neg?   (neg? tenths)
@@ -307,13 +594,42 @@
     (str (when neg? "-") whole "." frac)))
 
 (defn format-duration
-  "Render an elapsed-ms number as a compact `N.N ms` string (matching
-  the Figma `0.4 ms` form, one decimal place). Returns nil for nil /
-  non-number input so the duration column can render empty. Pure data
-  → string-or-nil; JVM-testable."
+  "Render an elapsed-ms number as a compact `N.N ms` string (one decimal
+  place). Returns nil for nil / non-number input so the duration column
+  can render `—`. Pure data → string-or-nil; JVM-testable."
   [ms]
   (when (number? ms)
     (str (fmt-1 ms) " ms")))
+
+(defn epoch-t0
+  "The earliest `:time` across `rows` (the epoch's domino-trail origin —
+  the EPOCH OPEN moment). Returns nil when no row carries a numeric
+  `:time`. Pure."
+  [rows]
+  (let [ts (keep :time rows)]
+    (when (seq ts) (apply min ts))))
+
+(defn format-rel-time
+  "Render `t` (absolute ms) relative to `t0` as the spec/023 §3 Δt form
+  `+N.N` — the ms offset from EPOCH OPEN. An error/warning row's Δt may
+  be rendered with a `!` lead by the view (spec/023 §9); the helper
+  produces the neutral `+N.N` and the view applies emphasis. Falls back
+  to nil when either is non-numeric so the view can render an em-dash.
+  Pure data → string-or-nil; JVM-testable."
+  [t t0]
+  (when (and (number? t) (number? t0))
+    (str "+" (fmt-1 (- t t0)))))
+
+(defn with-rel-times
+  "Stamp `:rel-time` (the `+N.N` Δt string, relative to the epoch's
+  first event) onto every row. Pure data → rows; JVM-testable."
+  [rows]
+  (let [t0 (epoch-t0 rows)]
+    (mapv (fn [row]
+            (assoc row :rel-time (format-rel-time (:time row) t0)))
+          rows)))
+
+;; ---- per-row projection -------------------------------------------------
 
 (defn project-row
   "Project one raw trace event into the panel's row shape:
@@ -322,7 +638,14 @@
        :time            <ms>
        :op-type         <kw>
        :operation       <kw>
+       :area            <:event/:coeffect/:db/:fx/:flow/:sub/:view/
+                          :machine/:routing/:epoch/:error/:warning>
+       :area-badge      <string>            ;; the uppercase neutral badge
+       :phase           <:envelope/:dispatch/:event-handling/:effects/:reactive>
        :op-family       <:dispatch/:db/:fx/:reactive/:machine/:error/:warning>
+       :outcome-tier    <:active/:inert/:gone/:pending/:error/:warning>
+       :verb            <string>            ;; the what-happened verb
+       :target          <string-or-nil>     ;; the target/detail subject
        :severity        <:error/:warning/:info-or-nil>
        :source          <kw-or-nil>
        :origin          <kw-or-nil>
@@ -330,30 +653,30 @@
        :event-id        <kw-or-nil>
        :handler-id      <kw-or-nil>
        :dispatch-id     <int-or-nil>
-       :parent-dispatch-id <int-or-nil>     ;; causal-nesting parent
+       :parent-dispatch-id <int-or-nil>
        :description     <string>            ;; readable plain-language line
        :source-coord    <string-or-nil>
        :duration-ms     <num-or-nil>        ;; per-op elapsed (when present)
        :tags            <map>               ;; full tags for the detail view
        :raw             <trace-event>}
 
-  Per rf2-ad7zx.8 the `:description` is now the Figma plain-language
-  line (`readable-description`); the prior terse `operation — detail`
-  form remains its fallback. `:op-family` drives the 3px left-border
-  band and the reactive-aftermath grouping. `:duration-ms` carries the
-  op's elapsed timing when the trace event reports it (event run-end,
-  view render); reactive point-in-time emits leave it nil so the view
-  shows a timestamp, not a duration (spec/021 §5.2).
-
-  Pure data → data; JVM-testable."
+  The 5-column row (spec/023 §3) reads `:rel-time` (stamped by
+  `with-rel-times`) · `:area-badge` · `:verb` · `:target` ·
+  `:duration-ms`. `:phase` drives band placement; `:op-family` drives
+  the 3px left-border band; `:outcome-tier` drives the verb's colour
+  tint (spec/023 §8). Pure data → data; JVM-testable."
   [{:keys [id time op-type operation source tags] :as ev}]
   {:id              id
    :time            time
    :op-type         op-type
    :operation       operation
+   :area            (area ev)
+   :area-badge      (area-badge ev)
+   :phase           (phase ev)
    :op-family       (op-family ev)
-   ;; :severity is the synonym axis Spec 009 documents — set when the
-   ;; op-type is one of the three severity tiers, nil otherwise.
+   :outcome-tier    (outcome-tier ev)
+   :verb            (what-happened ev)
+   :target          (target-detail ev)
    :severity        (case op-type
                       :error   :error
                       :warning :warning
@@ -378,221 +701,104 @@
   [events]
   (mapv project-row events))
 
-;; ---- relative timing (rf2-ad7zx.8) --------------------------------------
+;; ---- band projection (spec/023 §2 · §4) ---------------------------------
 ;;
-;; Per spec/021 §5.2 the Figma row leads with a RELATIVE timestamp
-;; (`t+0.0ms`) — elapsed since the epoch's first trace event — not the
-;; absolute wall clock. Relative time scans the epoch's shape (the gaps
-;; between dominoes) at a glance, where absolute HH:MM:SS.mmm does not.
+;; Per spec/023 §2 the arc is the epoch envelope (EPOCH OPEN / CLOSE
+;; rows carrying the :rf.epoch/* ops) bracketing four collapsible phase
+;; bands, in arc order. Per spec/023 §13 EMPTY bands render dimmed with
+;; `(none)` — never hidden — so the 4-phase shape is always legible.
+;; Errors / warnings are cross-cutting (spec/023 §7) — they stay inline
+;; in whatever band they chronologically occurred (the rows keep their
+;; fire-order position within a band).
 
-(defn epoch-t0
-  "The earliest `:time` across `rows` (the epoch's domino-trail
-  origin). Returns nil when no row carries a numeric `:time`. Pure."
+(defn epoch-outcome
+  "Extract the epoch's `:rf.epoch/outcome` from its envelope rows — the
+  `:ok` / `:blocked` / `:error` outcome the EPOCH CLOSE row shows
+  (spec/023 §13). Reads the `:rf.epoch/outcome` operation's
+  `[:tags :rf.epoch/outcome]` (or `:outcome`). Returns nil when no
+  outcome op is present (the epoch is still in-flight). Pure data →
+  keyword-or-nil; JVM-testable."
   [rows]
-  (let [ts (keep :time rows)]
-    (when (seq ts) (apply min ts))))
+  (some (fn [{:keys [operation tags]}]
+          (when (= operation :rf.epoch/outcome)
+            (or (:rf.epoch/outcome tags) (:outcome tags))))
+        rows))
 
-(defn format-rel-time
-  "Render `t` (absolute ms) relative to `t0` as the Figma `t+N.Nms`
-  form. Falls back to nil when either is non-numeric so the view can
-  render an em-dash. Pure data → string-or-nil; JVM-testable."
-  [t t0]
-  (when (and (number? t) (number? t0))
-    (str "t+" (fmt-1 (- t t0)) "ms")))
+(defn build-bands
+  "Project the epoch's oldest-first rows into the spec/023 §2 arc shape:
 
-(defn with-rel-times
-  "Stamp `:rel-time` (the `t+N.Nms` string, relative to the epoch's
-  first event) onto every row. Pure data → rows; JVM-testable."
+      {:envelope [<:rf.epoch/* row> ...]   ;; EPOCH OPEN / CLOSE ops
+       :outcome  <:ok/:blocked/:error-or-nil>
+       :bands    [{:id    :dispatch
+                   :label \"① DISPATCH\"
+                   :rows  [<row> ...]       ;; in fire order, oldest-first
+                   :count <int>
+                   :empty? <bool>}          ;; → dimmed `(none)` (spec §13)
+                  ... one per band-order ...]}
+
+  Every band in `band-order` is ALWAYS present (spec/023 §13 — empty
+  bands render dimmed `(none)`, never hidden). Rows keep their fire-order
+  position WITHIN a band, so a cross-cutting error/warning row stays at
+  its chronological point in whatever band it landed (spec/023 §7).
+  Pure data → data; JVM-testable."
   [rows]
-  (let [t0 (epoch-t0 rows)]
-    (mapv (fn [row]
-            (assoc row :rel-time (format-rel-time (:time row) t0)))
-          rows)))
-
-;; ---- reactive-aftermath collapse group (rf2-ad7zx.8) --------------------
-;;
-;; Per spec/021 §5.2 the many post-cascade reactive emits (`:rf.sub/run`
-;; / `:rf.view/render`) COLLAPSE under one expandable group row —
-;; `▸ reactive aftermath (N subs, M renders)` — so the core dominoes
-;; (dispatch · db · fx · machine) stand out. A contiguous run of
-;; `:reactive`-family rows folds into ONE group node carrying the run's
-;; children; the view renders the summary and toggles the children.
-
-(defn- reactive-row?
-  "True when a projected row belongs to the reactive aftermath family."
-  [row]
-  (= :reactive (:op-family row)))
-
-(defn reactive-summary
-  "Summarise a run of reactive rows as `{:subs N :renders M}` — subs ran
-  vs views rendered. Pure data → map; JVM-testable."
-  [rows]
-  {:subs    (count (filter #(= :rf.sub (:op-type %)) rows))
-   :renders (count (filter #(= :rf.view (:op-type %)) rows))})
-
-(defn group-reactive-aftermath
-  "Fold each CONTIGUOUS run of reactive-family rows (in the given
-  oldest-first order) into a single group node:
-
-      {:kind        :reactive-group
-       :id          \"react-grp:<first-row-id>\"   ;; stable React key
-       :op-family   :reactive
-       :rel-time    <first child's rel-time>
-       :summary     {:subs N :renders M}
-       :children    [<reactive row> ...]}
-
-  Non-reactive rows pass through unchanged (each carries an implicit
-  `:kind :op` when the view reads it). Causal structure is preserved —
-  the runs are folded in place, so a reactive tail between two event-
-  side rows stays between them. Pure data → nodes; JVM-testable."
-  [rows]
-  (->> rows
-       (partition-by reactive-row?)
-       (mapcat (fn [run]
-                 (if (reactive-row? (first run))
-                   [{:kind      :reactive-group
-                     :id        (str "react-grp:" (:id (first run)))
-                     :op-family :reactive
-                     :rel-time  (:rel-time (first run))
-                     :summary   (reactive-summary run)
-                     :children  (vec run)}]
-                   run)))
-       vec))
-
-;; ---- causal nesting (rf2-ad7zx.8) ---------------------------------------
-;;
-;; Per spec/021 §5.2 child dispatches INDENT under their parent (the
-;; cascade tree) so structure is visible even in the raw view. A row's
-;; `:parent-dispatch-id` (the `:rf.trace/parent-dispatch-id` tag) names
-;; the in-flight dispatch that spawned it. We compute a per-row indent
-;; DEPTH from the dispatch lineage so the view can offset each row —
-;; the spec's `└─ dispatched [:title/loaded]` indented child.
-
-(defn nesting-depths
-  "Map each row's `:dispatch-id` → its nesting depth, walking the
-  `:parent-dispatch-id` chain. A root dispatch (no parent, or a parent
-  not present in this epoch) is depth 0; each hop down the lineage adds
-  one. Rows with no `:dispatch-id` (the reactive tail) are not keyed —
-  callers default them to 0. Pure data → map; JVM-testable."
-  [rows]
-  (let [own-ids (into #{} (keep :dispatch-id rows))
-        ;; dispatch-id → parent-dispatch-id (first row that names each)
-        parent  (reduce (fn [m {:keys [dispatch-id parent-dispatch-id]}]
-                          (cond-> m
-                            (and dispatch-id
-                                 (not (contains? m dispatch-id)))
-                            (assoc dispatch-id parent-dispatch-id)))
-                        {}
-                        rows)
-        depth   (fn depth [did seen]
-                  (let [p (get parent did)]
-                    (if (and p (contains? own-ids p) (not (contains? seen p)))
-                      (inc (depth p (conj seen did)))
-                      0)))]
-    (into {} (map (fn [did] [did (depth did #{})]) own-ids))))
-
-(defn with-nesting-depth
-  "Stamp `:depth` onto every node — the causal-nesting indent level.
-  Reads the dispatch-lineage depth map; reactive groups inherit the
-  depth of their first child (so a nested cascade's reactive tail
-  indents with it). Pure data → nodes; JVM-testable."
-  [nodes]
-  (let [op-rows (mapcat (fn [n]
-                          (if (= :reactive-group (:kind n))
-                            (:children n)
-                            [n]))
-                        nodes)
-        depths  (nesting-depths op-rows)
-        depth-of (fn [row] (get depths (:dispatch-id row) 0))]
-    (mapv (fn [n]
-            (if (= :reactive-group (:kind n))
-              (assoc n :depth (depth-of (first (:children n))))
-              (assoc n :depth (depth-of n))))
-          nodes)))
-
-(defn build-display-nodes
-  "Top-level structural projection — turn the epoch's oldest-first
-  projected rows into the Figma display node list:
-
-    1. stamp relative `t+N.Nms` times,
-    2. fold contiguous reactive runs into collapse groups,
-    3. stamp causal-nesting depth onto every node.
-
-  Returns a vector of nodes, each either an `:op` row (the projected
-  trace row, with `:rel-time` + `:depth`) or a `:reactive-group` node
-  (with `:summary` + `:children` + `:rel-time` + `:depth`). The view
-  reads `:kind` to discriminate. Oldest-first so causal nesting reads
-  top-down (parent then indented child), matching the Figma. Pure data
-  → nodes; JVM-testable."
-  [rows]
-  (-> rows
-      with-rel-times
-      group-reactive-aftermath
-      with-nesting-depth))
+  (let [by-phase (group-by :phase rows)]
+    {:envelope (vec (get by-phase :envelope []))
+     :outcome  (epoch-outcome rows)
+     :bands    (mapv (fn [band-id]
+                       (let [band-rows (vec (get by-phase band-id []))]
+                         {:id     band-id
+                          :label  (get band->label band-id)
+                          :rows   band-rows
+                          :count  (count band-rows)
+                          :empty? (empty? band-rows)}))
+                     band-order)}))
 
 ;; ---- epoch-scoped feed projection (the panel reads this) ----------------
 
 (defn project-feed-from-epoch
   "Top-level projection — produces every slot the Trace view needs,
-  scoped to the FOCUSED EPOCH's `:trace-events` (rf2-td380). Pure
-  data → data; JVM-testable.
+  scoped to the FOCUSED EPOCH's `:trace-events` (spec/018 §6). Pure data
+  → data; JVM-testable.
 
   `epoch-record` is the `:rf/epoch-record` looked up from
   `:rf.xray/epoch-history` whose `:epoch-id` matches the focused
   `:epoch-id` from `:rf.xray/focus` (resolved via the shared
-  `panels.shared.focus-resolver`). Its `:trace-events` slot carries
-  the complete domino trail for one settling — both the synchronous
+  `panels.shared.focus-resolver`). Its `:trace-events` slot carries the
+  complete domino trail for one settling — both the synchronous
   event-side rows (dispatch-id N) and the async reactive rows
   (`:rf.sub/run` / `:rf.view/render`, nil dispatch-id) — oldest-first.
 
   `focus-status` is the discriminator from
   `focus-resolver/resolve-focus-status`:
 
-    :no-focus       — no focused epoch AND no history (cold start
-                      before any cascade has settled)
-    :epoch-evicted  — focus has an :epoch-id but the matching record
-                      is gone from history (capped per :epoch-history)
-    :focused        — focus resolved to a real epoch record (either
-                      explicit pin or head-fallback per rf2-h0120)
+    :no-focus       — no focused epoch AND no history (cold start)
+    :epoch-evicted  — focus has an :epoch-id but the record is gone
+    :focused        — focus resolved to a real epoch record
 
   Returns:
 
       {:rows        [<row> ...]   ;; the epoch's domino trail, OLDEST first
-       :nodes       [<node> ...]  ;; structural display tree (rf2-ad7zx.8):
-                                  ;; reactive-aftermath collapse groups +
-                                  ;; relative times + causal-nesting depth
+       :envelope    [<row> ...]   ;; the EPOCH OPEN / CLOSE :rf.epoch/* ops
+       :outcome     <:ok/:blocked/:error-or-nil>  ;; the epoch outcome
+       :bands       [{:id :label :rows :count :empty?} ...]  ;; the 4 phase
+                                  ;; bands in arc order (spec/023 §2 / §4)
        :total       <int>         ;; the epoch's trace-event count
-       :rendered    <int>         ;; same as :total (no filtering, rf2-gkczt)
+       :rendered    <int>         ;; same as :total (no filtering)
        :epoch-id    <int-or-nil>  ;; the focused epoch's id
        :empty-kind  <:no-events / :no-focus / :epoch-evicted / nil>}
 
-  Per rf2-ad7zx.8 the rows render OLDEST-first (chronological) so the
-  Figma causal nesting reads top-down — a parent dispatch then its
-  indented `└─` child — and the reactive aftermath collapses under one
-  group between the core dominoes. `:nodes` is the structural tree the
-  view paints; `:rows` is the flat oldest-first projection (kept for
-  cross-panel consumers + tests).
-
-  `:empty-kind` discriminates the empty-state branches:
-
-      :no-focus       — spine carries no focused epoch AND history is
-                        empty (cold start, no cascades have settled).
-      :epoch-evicted  — focused epoch's record has aged out of the
-                        history ring buffer.
-      :no-events      — focused epoch carries no trace events.
-      nil             — at least one row; render the ribbon.
-
-  No `:no-matches` branch — there is no user filter to hide rows
-  (rf2-gkczt)."
+  Rows render OLDEST-first (chronological) so the arc reads top-down —
+  EPOCH OPEN → ① DISPATCH → … → ④ REACTIVE → EPOCH CLOSE. `:bands` is
+  the structural arc the view paints (one band per phase, empty bands
+  dimmed per spec/023 §13); `:rows` is the flat oldest-first projection
+  (kept for cross-panel consumers + tests). Pure data → data."
   [epoch-record focus-status]
   (let [record-present? (= :focused focus-status)
         trace-events    (when record-present?
                           (:trace-events epoch-record))
-        ;; Oldest-first (chronological) — the Figma causal nesting reads
-        ;; top-down (parent → indented child) and the reactive aftermath
-        ;; collapses between the core dominoes (rf2-ad7zx.8).
         rows            (with-rel-times (project-rows (or trace-events [])))
-        nodes           (build-display-nodes (project-rows (or trace-events [])))
+        {:keys [envelope outcome bands]} (build-bands rows)
         n               (count rows)
         empty-kind      (cond
                           (= focus-status :no-focus)      :no-focus
@@ -600,7 +806,9 @@
                           (zero? n)                       :no-events
                           :else                           nil)]
     {:rows       rows
-     :nodes      nodes
+     :envelope   envelope
+     :outcome    outcome
+     :bands      bands
      :total      n
      :rendered   n
      :epoch-id   (:epoch-id epoch-record)
@@ -611,21 +819,12 @@
 (defn row-key
   "Stable React key for one projected trace row.
 
-  Per rf2-z4fza (sibling of rf2-kgn0c — same React-key discipline):
-  the trace ribbon's earlier shape keyed each `<li>` on a tuple that
-  included the row's positional index inside the visible viewport. A
-  new trace push shifts every visible row's index down by one, which
-  changes every key, which makes React's reconciler unmount the
-  entire viewport and remount it on EVERY push — the dominant frame
-  cost under burst event rate.
-
-  The framework's `re-frame.trace` allocates a monotonically-
-  increasing `:id` per emit (`next-id!`), and the same trace event
-  is never re-projected — so `:id` is a stable, unique identity for
-  the row across the panel's lifetime. We namespace it with `t:` to
-  mirror the rf2-kgn0c discipline (`v:<variant-id>` in the story
-  workspace) so future positional fallbacks can't silently collide
-  with these keys.
+  The framework's `re-frame.trace` allocates a monotonically-increasing
+  `:id` per emit, and the same trace event is never re-projected — so
+  `:id` is a stable, unique identity across the panel's lifetime. We
+  namespace it with `t:` so future positional fallbacks can't silently
+  collide. (Keying on a positional index would change every key on every
+  trace push, forcing React to remount the whole viewport.)
 
   Pure data → string; JVM-testable."
   [{:keys [id] :as _row}]
@@ -643,34 +842,5 @@
 
 ;; Re-export the shared `HH:MM:SS.mmm` formatter so the panel surface
 ;; keeps a stable `format-time` symbol while the body lives once in
-;; `common-helpers` (alongside issues-ribbon, routes, mcp-server).
+;; `common-helpers`.
 (def format-time common/format-time-hms)
-
-(def op-type->token
-  "Pure semantic map from op-type keyword to token keyword. The hex
-  resolution happens via `op-type-colour`, which looks up
-  `theme/tokens`. Splitting the semantic mapping from the hex lookup
-  keeps the map pure-data + tokens consolidated (rf2-5kfxe.4)."
-  {:error                :red
-   :warning              :yellow
-   ;; op-family colour bands (spec/007 §Colour system). Events ride the
-   ;; single `:accent` (the spine); the sub family + info keep a fixed
-   ;; cool blue (`:info`) so the two bands stay visually distinct from
-   ;; the GitHub-blue event accent (rf2-ad7zx.13).
-   :info                 :info
-   :rf.event             :accent
-   :rf.event/db-changed  :accent
-   :rf.fx                :green
-   :rf.sub/run           :info
-   :rf.sub/create        :info
-   :rf.view/render       :magenta
-   :rf.frame             :text-secondary})
-
-(defn op-type-colour
-  "Colour swatch for an op-type. Drives the per-row dot styling.
-  Resolves the semantic token keyword through `theme/tokens`
-  (rf2-5kfxe.4) so the palette has exactly one source of truth. Falls
-  back to `:text-secondary` for unknown op-types."
-  [op-type]
-  (get tokens/tokens
-       (get op-type->token op-type :text-secondary)))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -1,6 +1,6 @@
 (ns day8.re-frame2-xray.panels.trace-helpers-cljs-test
-  "Pure-data tests for Xray's Trace panel helpers (Phase 5, rf2-argrj;
-  epoch-scoped rework rf2-td380 + rf2-gkczt).
+  "Pure-data tests for Xray's Trace panel helpers (the whole-epoch trace
+  arc — spec/023-Trace-Panel.md).
 
   ## Why the `.cljc` + `_cljs_test` naming
 
@@ -13,12 +13,18 @@
 
   ## What's under test
 
-    1. **Per-row projection** — `project-row` populates every axis
-       slot from raw trace events (Spec 009 §Filter vocabulary).
-    2. **Epoch-scoped feed** — `project-feed-from-epoch` projects the
+    1. **Per-row projection** — `project-row` populates the row shape
+       (area · area-badge · phase · verb · target · op-family ·
+       outcome-tier) from raw trace events.
+    2. **Area / phase / verb / target classification** — the spec/023
+       §3 / §4 / §5 vocabulary.
+    3. **Band projection** — `build-bands` shapes the rows into the
+       epoch envelope + 4 phase bands (spec/023 §2), with empty bands
+       always present (spec/023 §13).
+    4. **Epoch-scoped feed** — `project-feed-from-epoch` projects the
        focused epoch record's `:trace-events` into the view shape and
        classifies the empty state across the focus-resolver statuses
-       (rf2-td380)."
+       (spec/018 §6)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-xray.panels.trace-helpers :as h]
@@ -28,8 +34,7 @@
 
 (defn- ev
   "Build a Spec 009-shaped trace event for the tests. The axis slots
-  pull from both top-level slots and `:tags` — the fixture surfaces
-  every slot the projection documents."
+  pull from both top-level slots and `:tags`."
   [{:keys [id op-type operation time source origin frame event-id
            handler-id dispatch-id tags coord]
     :or {time 1000 tags {}}}]
@@ -48,7 +53,7 @@
 
 ;; ---- (1) per-row projection --------------------------------------------
 
-(deftest project-row-populates-every-axis-slot
+(deftest project-row-populates-the-row-shape
   (let [e (ev {:id 7 :op-type :rf.event :operation :rf.event/dispatched
                :time 500 :source :ui :origin :app
                :frame :rf/default :event-id :counter/inc
@@ -61,11 +66,14 @@
     (is (= 500 (:time row)))
     (is (= :rf.event (:op-type row)))
     (is (= :rf.event/dispatched (:operation row)))
+    (is (= :event (:area row)))
+    (is (= "EVENT" (:area-badge row)))
+    (is (= :dispatch (:phase row)))
+    (is (= "dispatched" (:verb row)))
+    (is (= "[:counter/inc]" (:target row)))
     (is (= :ui (:source row)))
     (is (= :app (:origin row)))
     (is (= :rf/default (:frame row)))
-    (is (= :counter/inc (:event-id row)))
-    (is (= :counter/inc-handler (:handler-id row)))
     (is (= 42 (:dispatch-id row)))
     (is (= "src/foo.cljs:12" (:source-coord row)))
     (is (= e (:raw row)))))
@@ -93,189 +101,164 @@
     (is (= [1 2 3] (mapv :id rows))
         "project-rows keeps the events' oldest-first order")))
 
-;; ---- (2) epoch-scoped feed projection — rf2-td380 ----------------------
-;;
-;; Per spec/018 §6 the Trace tab is a lens on the spine's focused event:
-;; it reads the FOCUSED EPOCH's `:trace-events` (the per-frame settling
-;; epoch record's raw trace slice — both the synchronous event-side rows
-;; AND the async nil-dispatch-id reactive rows of the complete domino
-;; trail). `project-feed-from-epoch` takes the looked-up epoch record +
-;; the focus-resolver status and produces the view shape.
+;; ---- (2) area-badge classification — spec/023 §3 / §5 ------------------
 
-(defn- domino-trail-epoch
-  "A fixture `:rf/epoch-record` whose `:trace-events` carry the COMPLETE
-  domino trail for one event — folding both the synchronous event-side
-  rows (dispatch-id N) AND the async reactive rows (`:rf.sub/run` /
-  `:rf.view/render`, nil dispatch-id) that fire post-cascade. This is the
-  exact shape the OLD dispatch-id-scoped feed dropped (it filtered to
-  the dispatch-id, losing the nil-dispatch-id reactive tail)."
-  []
-  {:epoch-id 17
-   :trace-events
-   [;; ---- synchronous event side (dispatch-id 42) ----
-    (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-         :time 100 :dispatch-id 42 :event-id :counter/inc
-         :tags {:rf.event/v [:counter/inc]}})
-    (ev {:id 2 :op-type :rf.event :operation :rf.event/run-end
-         :time 101 :dispatch-id 42})
-    (ev {:id 3 :op-type :rf.event :operation :rf.event/db-changed
-         :time 102 :dispatch-id 42})
-    (ev {:id 4 :op-type :rf.fx :operation :rf.fx/handled
-         :time 103 :dispatch-id 42})
-    ;; ---- async reactive tail (nil dispatch-id) ----
-    (ev {:id 5 :op-type :rf.sub :operation :rf.sub/run
-         :time 110 :tags {:rf.sub/id :app/counter}})
-    (ev {:id 6 :op-type :rf.sub :operation :rf.sub/run
-         :time 111 :tags {:rf.sub/id :app/derived}})
-    (ev {:id 7 :op-type :rf.view :operation :rf.view/render
-         :time 120})]})
+(deftest area-classifies-the-full-vocabulary
+  (testing "the 12-area badge vocabulary (spec/023 §3)"
+    (is (= :event    (h/area {:op-type :rf.event :operation :rf.event/dispatched})))
+    (is (= :db       (h/area {:op-type :rf.event :operation :rf.event/db-changed})))
+    (is (= :coeffect (h/area {:op-type :rf.event :operation :rf.cofx/run})))
+    (is (= :flow     (h/area {:op-type :rf.event :operation :rf.flow/computed})))
+    (is (= :fx       (h/area {:op-type :rf.fx :operation :rf.fx/handled})))
+    (is (= :sub      (h/area {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= :view     (h/area {:op-type :rf.view :operation :rf.view/render})))
+    (is (= :machine  (h/area {:op-type :rf.machine :operation :rf.machine/transition})))
+    (is (= :routing  (h/area {:op-type :rf.event :operation :rf.route/activated})))
+    (is (= :epoch    (h/area {:op-type :rf.epoch :operation :rf.epoch/snapshotted})))
+    (is (= :error    (h/area {:op-type :error :operation :rf.error/x})))
+    (is (= :warning  (h/area {:op-type :warning :operation :rf.warning/x}))))
+  (testing "namespace fallback when :op-type isn't stamped"
+    (is (= :epoch (h/area {:operation :rf.epoch/outcome})))
+    (is (= :routing (h/area {:operation :rf.route/deactivated})))
+    (is (= :machine (h/area {:operation :rf.machine.timer/scheduled}))))
+  (testing "unknown ops fall back to :event-adjacent neutral"
+    (is (= :event (h/area {:op-type :totally-made-up})))))
 
-(deftest project-feed-from-epoch-folds-the-complete-domino-trail
-  (testing "rf2-td380 headline: scoping by the focused epoch's
-            `:trace-events` renders BOTH the synchronous event-side
-            rows (dispatch-id 42) AND the async nil-dispatch-id reactive
-            tail (subs ran + view rendered) — the complete domino trail.
-            The OLD dispatch-id-scoped feed dropped the nil-dispatch-id
-            tail (3 reactive rows here), rendering 4 rows instead of 7."
-    (let [epoch (domino-trail-epoch)
-          feed  (h/project-feed-from-epoch epoch :focused)]
-      (is (= 7 (:total feed))
-          ":total = every trace event in the focused epoch")
-      (is (= 7 (:rendered feed))
-          ":rendered = :total (no filtering, rf2-gkczt)")
-      (is (= #{1 2 3 4 5 6 7} (set (map :id (:rows feed))))
-          "rows are the WHOLE trail — including the nil-dispatch-id
-           reactive rows the dispatch-id scope would have dropped")
-      (is (some #(and (nil? (:dispatch-id %)) (= :rf.sub (:op-type %)))
-                (:rows feed))
-          "the async :rf.sub/run rows (nil dispatch-id) are present")
-      (is (some #(= :rf.view (:op-type %)) (:rows feed))
-          "the async :rf.view/render row is present")
-      (is (= 17 (:epoch-id feed)))
-      (is (nil? (:empty-kind feed))))))
+(deftest area-badge-renders-uppercase-text
+  (is (= "EVENT" (h/area-badge {:op-type :rf.event :operation :rf.event/dispatched})))
+  (is (= "DB" (h/area-badge {:op-type :rf.event :operation :rf.event/db-changed})))
+  (is (= "FX" (h/area-badge {:op-type :rf.fx :operation :rf.fx/handled})))
+  (is (= "SUB" (h/area-badge {:op-type :rf.sub :operation :rf.sub/run})))
+  (is (= "MACHINE" (h/area-badge {:op-type :rf.machine :operation :rf.machine/transition})))
+  (is (= "ERROR" (h/area-badge {:op-type :error :operation :rf.error/x}))))
 
-(deftest project-feed-from-epoch-rows-oldest-first
-  (testing "rf2-ad7zx.8: rows now render OLDEST-first (chronological)
-            so the Figma causal nesting reads top-down — a parent
-            dispatch then its indented child — and the reactive
-            aftermath collapses between the core dominoes"
-    (let [epoch (domino-trail-epoch)
-          feed  (h/project-feed-from-epoch epoch :focused)]
-      (is (= [1 2 3 4 5 6 7] (mapv :id (:rows feed)))))))
-
-(deftest project-feed-from-epoch-no-events
-  (testing "a focused epoch with empty :trace-events → :no-events"
-    (let [feed (h/project-feed-from-epoch {:epoch-id 3 :trace-events []}
-                                          :focused)]
-      (is (= 0 (:total feed)))
-      (is (= 0 (:rendered feed)))
-      (is (= [] (:rows feed)))
-      (is (= 3 (:epoch-id feed)))
-      (is (= :no-events (:empty-kind feed))))))
-
-(deftest project-feed-from-epoch-no-focus
-  (testing "focus-status :no-focus → :no-focus empty-kind, no rows
-            (the record is irrelevant — there is no focused epoch)"
-    (let [feed (h/project-feed-from-epoch nil :no-focus)]
-      (is (= :no-focus (:empty-kind feed)))
-      (is (= 0 (:total feed)))
-      (is (= 0 (:rendered feed)))
-      (is (= [] (:rows feed)))
-      (is (nil? (:epoch-id feed))))))
-
-(deftest project-feed-from-epoch-epoch-evicted
-  (testing "focus-status :epoch-evicted → :epoch-evicted empty-kind,
-            no rows (the focused epoch aged out of the ring buffer)"
-    (let [feed (h/project-feed-from-epoch nil :epoch-evicted)]
-      (is (= :epoch-evicted (:empty-kind feed)))
-      (is (= 0 (:total feed)))
-      (is (= 0 (:rendered feed)))
-      (is (= [] (:rows feed))))))
-
-(deftest project-feed-from-epoch-ignores-record-unless-focused
-  (testing "rf2-td380: only :focused status reads the record's
-            :trace-events — a non-:focused status renders empty even
-            when a stray record is passed (defensive: the sub never
-            does this, but the contract is total)"
-    (let [epoch (domino-trail-epoch)]
-      (is (= 0 (:total (h/project-feed-from-epoch epoch :no-focus))))
-      (is (= 0 (:total (h/project-feed-from-epoch epoch :epoch-evicted)))))))
-
-(deftest project-feed-from-epoch-shape-keys
-  (testing "rf2-gkczt: the feed shape carries NO filtering keys —
-            :filters / :any-filter? / :distinct / :counts /
-            :active-filters / :cascade-dispatch-id are all gone"
-    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
-      (is (contains? feed :rows))
-      (is (contains? feed :total))
-      (is (contains? feed :rendered))
-      (is (contains? feed :epoch-id))
-      (is (contains? feed :empty-kind))
-      (doseq [k [:filters :any-filter? :distinct :counts
-                 :active-filters :cascade-dispatch-id]]
-        (is (not (contains? feed k))
-            (str "removed filtering key " k " must not be in the feed shape"))))))
-
-;; ---- (3) format-time ---------------------------------------------------
-
-(deftest format-time-renders-hms-with-millis
-  (testing "format-time returns nil on non-numeric input"
-    (is (nil? (h/format-time nil)))
-    (is (nil? (h/format-time "not a number"))))
-  (testing "format-time returns a HH:MM:SS.mmm-shaped string"
-    (let [s (h/format-time 12345)]
-      (is (string? s))
-      (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
-
-;; ---- (4) find-row ------------------------------------------------------
-
-(deftest find-row-by-id
-  (let [rows [{:id 1} {:id 2} {:id 3}]]
-    (is (= {:id 2} (h/find-row rows 2)))
-    (is (nil? (h/find-row rows 99)))))
-
-;; ---- (4b) op-family classification — rf2-ad7zx.8 -----------------------
-;;
-;; Per spec/021 §5.2 + design-reference/xray_devtools_reference.cljs
-;; (the trace-panel component) each
-;; row bands a 3px op-FAMILY-coloured left-border — FIVE families plus
-;; the two severity tiers — not the full op-type vocabulary.
-
-(deftest op-family-classifies-the-five-figma-families
-  (testing "dispatch family — the event side (run-start / run-end /
-            dispatched), minus db-changed"
-    (is (= :dispatch (h/op-family {:op-type :rf.event
-                                   :operation :rf.event/dispatched})))
-    (is (= :dispatch (h/op-family {:op-type :rf.event
-                                   :operation :rf.event/run-end}))))
-  (testing "db family — the db-changed operation specifically"
-    (is (= :db (h/op-family {:op-type :rf.event
-                             :operation :rf.event/db-changed}))))
-  (testing "fx family — the effect side"
-    (is (= :fx (h/op-family {:op-type :rf.fx :operation :rf.fx/handled}))))
-  (testing "reactive family — both subs and views"
-    (is (= :reactive (h/op-family {:op-type :rf.sub :operation :rf.sub/run})))
-    (is (= :reactive (h/op-family {:op-type :rf.view
-                                   :operation :rf.view/render}))))
-  (testing "machine family"
-    (is (= :machine (h/op-family {:op-type :rf.machine
-                                  :operation :rf.machine/transition}))))
-  (testing "severity tiers are preserved — a failure never hides under
-            a family band"
-    (is (= :error   (h/op-family {:op-type :error :operation :rf.error/x})))
-    (is (= :warning (h/op-family {:op-type :warning :operation :rf.warn/x}))))
-  (testing "unknown op-types fall back to :dispatch-adjacent neutral"
-    (is (= :dispatch (h/op-family {:op-type :totally-made-up})))))
-
-(deftest project-row-carries-op-family
+(deftest project-row-carries-area-badge
   (let [row (h/project-row (ev {:id 1 :op-type :rf.event
                                 :operation :rf.event/db-changed}))]
-    (is (= :db (:op-family row))
-        "project-row stamps :op-family for the left-border band")))
+    (is (= :db (:area row)))
+    (is (= "DB" (:area-badge row)))))
+
+;; ---- (3) phase / band placement — spec/023 §4 -------------------------
+
+(deftest phase-places-ops-into-arc-bands
+  (testing "envelope — the epoch-lifecycle ops"
+    (is (= :envelope (h/phase {:op-type :rf.epoch :operation :rf.epoch/snapshotted})))
+    (is (= :envelope (h/phase {:op-type :rf.epoch :operation :rf.epoch/outcome}))))
+  (testing "① DISPATCH — the event dispatched"
+    (is (= :dispatch (h/phase {:op-type :rf.event :operation :rf.event/dispatched}))))
+  (testing "② EVENT HANDLING — coeffects / handler / flows / db-changed / machine"
+    (is (= :event-handling (h/phase {:op-type :rf.event :operation :rf.cofx/run})))
+    (is (= :event-handling (h/phase {:op-type :rf.event :operation :rf.event/run-end})))
+    (is (= :event-handling (h/phase {:op-type :rf.event :operation :rf.flow/computed})))
+    (is (= :event-handling (h/phase {:op-type :rf.event :operation :rf.event/db-changed})))
+    (is (= :event-handling (h/phase {:op-type :rf.machine :operation :rf.machine/transition}))))
+  (testing "③ EFFECTS / FX — fx + routing nav"
+    (is (= :effects (h/phase {:op-type :rf.fx :operation :rf.fx/handled})))
+    (is (= :effects (h/phase {:op-type :rf.event :operation :rf.route/activated}))))
+  (testing "④ REACTIVE RENDERING — subs + views"
+    (is (= :reactive (h/phase {:op-type :rf.sub :operation :rf.sub/run})))
+    (is (= :reactive (h/phase {:op-type :rf.view :operation :rf.view/render})))))
+
+(deftest band-order-is-the-canonical-arc-order
+  (is (= [:dispatch :event-handling :effects :reactive] h/band-order)
+      "the four phase bands run in arc order (spec/023 §2)"))
+
+;; ---- (4) what-happened verb — spec/023 §5 -----------------------------
+
+(deftest what-happened-builds-the-verb
+  (testing "explicit verb overrides"
+    (is (= "dispatched" (h/what-happened {:operation :rf.event/dispatched})))
+    (is (= "handler ran" (h/what-happened {:operation :rf.event/run-end})))
+    (is (= "changed" (h/what-happened {:operation :rf.event/db-changed})))
+    (is (= "computed" (h/what-happened {:operation :rf.flow/computed})))
+    (is (= "snapshotted" (h/what-happened {:operation :rf.epoch/snapshotted}))))
+  (testing "name-based default — the operation's terminal segment"
+    (is (= "run" (h/what-happened {:operation :rf.sub/run})))
+    (is (= "scheduled" (h/what-happened {:operation :rf.machine.timer/scheduled}))))
+  (testing "dashes fold to spaces (spec/023 §5 readable forms)"
+    (is (= "skipped on platform"
+           (h/what-happened {:operation :rf.cofx/skipped-on-platform}))))
+  (testing "no operation → em-dash"
+    (is (= "—" (h/what-happened {})))))
+
+;; ---- (5) target / detail — spec/023 §3 / §5 ---------------------------
+
+(deftest target-detail-renders-the-subject
+  (testing "event → the event vector"
+    (is (= "[:counter/inc]"
+           (h/target-detail (ev {:id 1 :op-type :rf.event
+                                 :operation :rf.event/dispatched
+                                 :tags {:rf.event/v [:counter/inc]}})))))
+  (testing "db → [path] old → new"
+    (is (= "[:counter]  1 → 2"
+           (h/target-detail (ev {:id 1 :op-type :rf.event
+                                 :operation :rf.event/db-changed
+                                 :tags {:rf.db/path [:counter]
+                                        :rf.db/old 1 :rf.db/new 2}})))))
+  (testing "fx → fx-id → arg"
+    (is (= ":http-xhrio → \"GET /api\""
+           (h/target-detail (ev {:id 1 :op-type :rf.fx :operation :rf.fx/handled
+                                 :tags {:rf.fx/id :http-xhrio
+                                        :rf.fx/arg "GET /api"}})))))
+  (testing "sub → sub-id"
+    (is (= ":app/counter"
+           (h/target-detail (ev {:id 1 :op-type :rf.sub :operation :rf.sub/run
+                                 :tags {:rf.sub/id :app/counter}})))))
+  (testing "machine → machine-id from → to (states without colons)"
+    (is (= ":title/flow idle → loading"
+           (h/target-detail (ev {:id 1 :op-type :rf.machine
+                                 :operation :rf.machine/transition
+                                 :tags {:machine-id :title/flow
+                                        :from :idle :to :loading}})))))
+  (testing "flow → flow-id → path"
+    (is (= ":totals → [:totals]"
+           (h/target-detail (ev {:id 1 :op-type :rf.event :operation :rf.flow/computed
+                                 :tags {:rf.flow/id :totals
+                                        :rf.flow/path [:totals]}})))))
+  (testing "an op with no recognised subject → nil (view renders em-dash)"
+    (is (nil? (h/target-detail (ev {:id 1 :op-type :rf.event
+                                    :operation :rf.event/run-end :tags {}}))))))
+
+;; ---- (6) outcome tier — spec/023 §8 -----------------------------------
+
+(deftest outcome-tier-distinguishes-states
+  (testing "active — created / changed / recalculated / mounted / ran"
+    (is (= :active (h/outcome-tier {:operation :rf.sub/run})))
+    (is (= :active (h/outcome-tier {:operation :rf.view/render})))
+    (is (= :active (h/outcome-tier {:operation :rf.event/db-changed}))))
+  (testing "inert — cache-hit / unchanged / skipped"
+    (is (= :inert (h/outcome-tier {:operation :rf.sub/skip})))
+    (is (= :inert (h/outcome-tier {:operation :rf.view/skip}))))
+  (testing "gone — disposed / unmounted / cleared / cancelled"
+    (is (= :gone (h/outcome-tier {:operation :rf.sub/disposed})))
+    (is (= :gone (h/outcome-tier {:operation :rf.view/unmounted})))
+    (is (= :gone (h/outcome-tier {:operation :rf.flow/cleared}))))
+  (testing "error / warning keep their semantic tier"
+    (is (= :error (h/outcome-tier {:op-type :error :operation :rf.error/x})))
+    (is (= :warning (h/outcome-tier {:op-type :warning :operation :rf.warning/x})))))
+
+(deftest project-row-carries-outcome-tier-and-verb-and-target
+  (let [row (h/project-row (ev {:id 1 :op-type :rf.sub :operation :rf.sub/disposed
+                                :tags {:rf.sub/id :cart/preview}}))]
+    (is (= :gone (:outcome-tier row)))
+    (is (= "disposed" (:verb row)))
+    (is (= ":cart/preview" (:target row)))))
+
+;; ---- (7) op-family band colour — retained left-border -----------------
+
+(deftest op-family-classifies-the-band-buckets
+  (is (= :dispatch (h/op-family {:op-type :rf.event :operation :rf.event/dispatched})))
+  (is (= :db (h/op-family {:op-type :rf.event :operation :rf.event/db-changed})))
+  (is (= :fx (h/op-family {:op-type :rf.fx :operation :rf.fx/handled})))
+  (is (= :reactive (h/op-family {:op-type :rf.sub :operation :rf.sub/run})))
+  (is (= :reactive (h/op-family {:op-type :rf.view :operation :rf.view/render})))
+  (is (= :machine (h/op-family {:op-type :rf.machine :operation :rf.machine/transition})))
+  (is (= :error (h/op-family {:op-type :error :operation :rf.error/x})))
+  (is (= :warning (h/op-family {:op-type :warning :operation :rf.warning/x}))))
 
 (deftest op-family-colour-maps-each-family-to-a-distinct-token
-  ;; Post rf2-on4cm the colours are CSS-variable strings (`tokens/tokens`).
-  ;; Compare against the var-map so the test pins the indirection.
+  ;; Colours are CSS-variable strings (`tokens/tokens`); compare against
+  ;; the var-map so the test pins the indirection.
   (is (= (:accent tokens/tokens)
          (h/op-family-colour {:op-type :rf.event :operation :rf.event/dispatched})))
   (is (= (:info tokens/tokens)
@@ -288,7 +271,7 @@
          (h/op-family-colour {:op-type :rf.machine :operation :rf.machine/transition})))
   (is (= (:red tokens/tokens)
          (h/op-family-colour {:op-type :error :operation :rf.error/x})))
-  (testing "the five op-family bands resolve to distinct colours"
+  (testing "the five band families resolve to distinct colours"
     (let [bands (mapv (fn [[ot op]] (h/op-family-colour {:op-type ot :operation op}))
                       [[:rf.event :rf.event/dispatched]
                        [:rf.event :rf.event/db-changed]
@@ -298,43 +281,223 @@
       (is (= 5 (count (distinct bands)))
           "dispatch / db / fx / reactive / machine bands are all distinct"))))
 
-;; ---- (4c) readable plain-language description — rf2-ad7zx.8 ------------
+(deftest outcome-colour-tints-the-verb-column
+  (is (= (:text-primary tokens/tokens)
+         (h/outcome-colour {:operation :rf.sub/run})))
+  (is (= (:text-tertiary tokens/tokens)
+         (h/outcome-colour {:operation :rf.sub/skip})))
+  (is (= (:dim tokens/tokens)
+         (h/outcome-colour {:operation :rf.sub/disposed})))
+  (is (= (:red tokens/tokens)
+         (h/outcome-colour {:op-type :error :operation :rf.error/x}))))
 
-(deftest readable-description-figma-plain-language
-  (testing "dispatch → 'dispatched <event-vec>'"
-    (is (= "dispatched [:counter/inc]"
-           (h/readable-description
-             (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                  :tags {:rf.event/v [:counter/inc]}})))))
-  (testing "machine → 'machine <id> <from> → <to>' (states without colons)"
-    (is (= "machine :title/flow idle → loading"
-           (h/readable-description
-             (ev {:id 1 :op-type :rf.machine :operation :rf.machine/transition
-                  :tags {:machine-id :title/flow :from :idle :to :loading}})))))
-  (testing "sub → 'sub ran <id>'"
-    (is (= "sub ran :app/counter"
-           (h/readable-description
-             (ev {:id 1 :op-type :rf.sub :operation :rf.sub/run
-                  :tags {:rf.sub/id :app/counter}})))))
-  (testing "fx → 'fx <id>'"
-    (is (= "fx :dispatch"
-           (h/readable-description
-             (ev {:id 1 :op-type :rf.fx :operation :rf.fx/handled
-                  :tags {:rf.fx/id :dispatch}})))))
-  (testing "unknown op falls back to short-description (never blank)"
-    (is (= ":rf.event/run-end"
-           (h/readable-description
-             (ev {:id 1 :op-type :rf.event :operation :rf.event/run-end
-                  :tags {}}))))))
+;; ---- (8) band projection — spec/023 §2 / §13 --------------------------
 
-;; ---- (4d) duration — rf2-ad7zx.8 --------------------------------------
+(defn- domino-trail-epoch
+  "A fixture `:rf/epoch-record` whose `:trace-events` carry the COMPLETE
+  domino trail for one event — folding both the synchronous event-side
+  rows (dispatch-id N) AND the async reactive rows (`:rf.sub/run` /
+  `:rf.view/render`, nil dispatch-id), plus the epoch envelope ops."
+  []
+  {:epoch-id 17
+   :trace-events
+   [;; ---- envelope ----
+    (ev {:id 0 :op-type :rf.epoch :operation :rf.epoch/snapshotted :time 99})
+    ;; ---- ① DISPATCH ----
+    (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+         :time 100 :dispatch-id 42 :event-id :counter/inc
+         :tags {:rf.event/v [:counter/inc]}})
+    ;; ---- ② EVENT HANDLING ----
+    (ev {:id 2 :op-type :rf.event :operation :rf.event/run-end
+         :time 101 :dispatch-id 42})
+    (ev {:id 3 :op-type :rf.event :operation :rf.event/db-changed
+         :time 102 :dispatch-id 42})
+    ;; ---- ③ EFFECTS / FX ----
+    (ev {:id 4 :op-type :rf.fx :operation :rf.fx/handled
+         :time 103 :dispatch-id 42})
+    ;; ---- ④ REACTIVE RENDERING ----
+    (ev {:id 5 :op-type :rf.sub :operation :rf.sub/run
+         :time 110 :tags {:rf.sub/id :app/counter}})
+    (ev {:id 6 :op-type :rf.sub :operation :rf.sub/run
+         :time 111 :tags {:rf.sub/id :app/derived}})
+    (ev {:id 7 :op-type :rf.view :operation :rf.view/render :time 120})
+    ;; ---- close ----
+    (ev {:id 8 :op-type :rf.epoch :operation :rf.epoch/outcome
+         :time 121 :tags {:rf.epoch/outcome :ok}})]})
+
+(deftest build-bands-shapes-the-arc
+  (testing "the rows shape into the epoch envelope + 4 phase bands in
+            arc order (spec/023 §2 / §4)"
+    (let [rows  (h/with-rel-times (h/project-rows (:trace-events (domino-trail-epoch))))
+          {:keys [envelope outcome bands]} (h/build-bands rows)]
+      (testing "envelope carries the :rf.epoch/* ops"
+        (is (= #{0 8} (set (map :id envelope)))))
+      (testing "outcome is read from the :rf.epoch/outcome op"
+        (is (= :ok outcome)))
+      (testing "every band in band-order is present (spec/023 §13)"
+        (is (= [:dispatch :event-handling :effects :reactive]
+               (mapv :id bands))))
+      (let [by-id (into {} (map (juxt :id identity) bands))]
+        (is (= [1] (mapv :id (:rows (:dispatch by-id))))
+            "① DISPATCH — the dispatched row")
+        (is (= [2 3] (mapv :id (:rows (:event-handling by-id))))
+            "② EVENT HANDLING — run-end + db-changed in fire order")
+        (is (= [4] (mapv :id (:rows (:effects by-id))))
+            "③ EFFECTS / FX — the fx row")
+        (is (= [5 6 7] (mapv :id (:rows (:reactive by-id))))
+            "④ REACTIVE RENDERING — the subs + view in fire order")))))
+
+(deftest build-bands-empty-bands-always-present
+  (testing "a no-op event (only ② populated) keeps ③④ present + empty
+            (spec/023 §13 — empty bands render dimmed `(none)`, never
+            hidden)"
+    (let [rows  (h/with-rel-times
+                  (h/project-rows
+                    [(ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                          :time 100})
+                     (ev {:id 2 :op-type :rf.event :operation :rf.event/run-end
+                          :time 101})]))
+          {:keys [bands]} (h/build-bands rows)
+          by-id (into {} (map (juxt :id identity) bands))]
+      (is (= 4 (count bands)) "all four bands present")
+      (is (false? (:empty? (:dispatch by-id))))
+      (is (false? (:empty? (:event-handling by-id))))
+      (is (true? (:empty? (:effects by-id))) "③ EFFECTS empty for a no-op")
+      (is (true? (:empty? (:reactive by-id))) "④ REACTIVE empty for a no-op")
+      (is (zero? (:count (:effects by-id))))
+      (is (= 1 (:count (:dispatch by-id)))))))
+
+(deftest epoch-outcome-reads-the-outcome-op
+  (is (= :ok (h/epoch-outcome
+               (h/project-rows
+                 [(ev {:id 1 :op-type :rf.epoch :operation :rf.epoch/outcome
+                       :tags {:rf.epoch/outcome :ok}})]))))
+  (is (= :blocked (h/epoch-outcome
+                    (h/project-rows
+                      [(ev {:id 1 :op-type :rf.epoch :operation :rf.epoch/outcome
+                            :tags {:rf.epoch/outcome :blocked}})]))))
+  (testing "no outcome op → nil (epoch still in-flight)"
+    (is (nil? (h/epoch-outcome
+                (h/project-rows
+                  [(ev {:id 1 :op-type :rf.event
+                        :operation :rf.event/dispatched})]))))))
+
+;; ---- (9) epoch-scoped feed projection — spec/018 §6 -------------------
+
+(deftest project-feed-from-epoch-folds-the-complete-domino-trail
+  (testing "scoping by the focused epoch's `:trace-events` renders the
+            WHOLE arc — both the synchronous event-side rows AND the
+            async nil-dispatch-id reactive tail (subs ran + view
+            rendered) + the envelope ops"
+    (let [epoch (domino-trail-epoch)
+          feed  (h/project-feed-from-epoch epoch :focused)]
+      (is (= 9 (:total feed))
+          ":total = every trace event in the focused epoch")
+      (is (= 9 (:rendered feed))
+          ":rendered = :total (no filtering)")
+      (is (= #{0 1 2 3 4 5 6 7 8} (set (map :id (:rows feed))))
+          "rows are the WHOLE trail — including the nil-dispatch-id
+           reactive rows and the envelope ops")
+      (is (some #(and (nil? (:dispatch-id %)) (= :rf.sub (:op-type %)))
+                (:rows feed))
+          "the async :rf.sub/run rows (nil dispatch-id) are present")
+      (is (some #(= :rf.view (:op-type %)) (:rows feed))
+          "the async :rf.view/render row is present")
+      (is (= 17 (:epoch-id feed)))
+      (is (= :ok (:outcome feed)) "the epoch outcome is exposed")
+      (is (nil? (:empty-kind feed))))))
+
+(deftest project-feed-from-epoch-rows-oldest-first
+  (testing "rows render OLDEST-first (chronological) so the arc reads
+            top-down — EPOCH OPEN → ① DISPATCH → … → ④ REACTIVE"
+    (let [epoch (domino-trail-epoch)
+          feed  (h/project-feed-from-epoch epoch :focused)]
+      (is (= [0 1 2 3 4 5 6 7 8] (mapv :id (:rows feed)))))))
+
+(deftest project-feed-from-epoch-exposes-bands
+  (testing "the feed carries the structural arc the view paints —
+            envelope + 4 phase bands + outcome (spec/023 §2)"
+    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
+      (is (contains? feed :envelope))
+      (is (contains? feed :bands))
+      (is (contains? feed :outcome))
+      (is (= [:dispatch :event-handling :effects :reactive]
+             (mapv :id (:bands feed))))
+      (is (= #{0 8} (set (map :id (:envelope feed)))))
+      (is (= :ok (:outcome feed))))))
+
+(deftest project-feed-from-epoch-no-events
+  (testing "a focused epoch with empty :trace-events → :no-events"
+    (let [feed (h/project-feed-from-epoch {:epoch-id 3 :trace-events []}
+                                          :focused)]
+      (is (zero? (:total feed)))
+      (is (zero? (:rendered feed)))
+      (is (= [] (:rows feed)))
+      (is (= 3 (:epoch-id feed)))
+      (is (= :no-events (:empty-kind feed)))
+      (testing "even an empty epoch still exposes all four bands (empty)"
+        (is (= 4 (count (:bands feed))))
+        (is (every? :empty? (:bands feed)))))))
+
+(deftest project-feed-from-epoch-no-focus
+  (testing "focus-status :no-focus → :no-focus empty-kind, no rows"
+    (let [feed (h/project-feed-from-epoch nil :no-focus)]
+      (is (= :no-focus (:empty-kind feed)))
+      (is (zero? (:total feed)))
+      (is (zero? (:rendered feed)))
+      (is (= [] (:rows feed)))
+      (is (nil? (:epoch-id feed))))))
+
+(deftest project-feed-from-epoch-epoch-evicted
+  (testing "focus-status :epoch-evicted → :epoch-evicted empty-kind"
+    (let [feed (h/project-feed-from-epoch nil :epoch-evicted)]
+      (is (= :epoch-evicted (:empty-kind feed)))
+      (is (zero? (:total feed)))
+      (is (zero? (:rendered feed)))
+      (is (= [] (:rows feed))))))
+
+(deftest project-feed-from-epoch-ignores-record-unless-focused
+  (testing "only :focused status reads the record's :trace-events"
+    (let [epoch (domino-trail-epoch)]
+      (is (zero? (:total (h/project-feed-from-epoch epoch :no-focus))))
+      (is (zero? (:total (h/project-feed-from-epoch epoch :epoch-evicted)))))))
+
+(deftest project-feed-from-epoch-shape-keys
+  (testing "the feed shape carries NO filtering keys"
+    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
+      (is (contains? feed :rows))
+      (is (contains? feed :total))
+      (is (contains? feed :rendered))
+      (is (contains? feed :epoch-id))
+      (is (contains? feed :empty-kind))
+      (is (contains? feed :bands))
+      (is (contains? feed :envelope))
+      (is (contains? feed :outcome))
+      (doseq [k [:filters :any-filter? :distinct :counts
+                 :active-filters :cascade-dispatch-id]]
+        (is (not (contains? feed k))
+            (str "removed filtering key " k " must not be in the feed shape"))))))
+
+;; ---- (10) relative timing + duration — spec/023 §3 / §6 ---------------
+
+(deftest relative-time-figma-form
+  (testing "epoch-t0 is the earliest row time (EPOCH OPEN)"
+    (is (= 100 (h/epoch-t0 [{:time 300} {:time 100} {:time 200}])))
+    (is (nil? (h/epoch-t0 [{:time nil} {:time nil}]))))
+  (testing "format-rel-time renders the Δt '+N.N' offset"
+    (is (= "+0.0" (h/format-rel-time 100 100)))
+    (is (= "+2.0" (h/format-rel-time 102 100)))
+    (is (nil? (h/format-rel-time nil 100))))
+  (testing "with-rel-times stamps :rel-time on every row"
+    (let [rows (h/with-rel-times [{:time 100} {:time 103}])]
+      (is (= ["+0.0" "+3.0"] (mapv :rel-time rows))))))
 
 (deftest duration-ms-reads-elapsed
   (testing "duration-ms pulls :elapsed-ms from tags"
     (is (= 0.4 (h/duration-ms (ev {:id 1 :op-type :rf.view
                                    :operation :rf.view/render
                                    :tags {:elapsed-ms 0.4}})))))
-  (testing "reactive point-in-time emits carry no elapsed → nil"
+  (testing "point-in-time emits carry no elapsed → nil (renders —)"
     (is (nil? (h/duration-ms (ev {:id 1 :op-type :rf.sub
                                   :operation :rf.sub/run
                                   :tags {:rf.sub/id :x}}))))))
@@ -345,127 +508,25 @@
   (is (nil? (h/format-duration nil)))
   (is (nil? (h/format-duration "nope"))))
 
-;; ---- (4e) relative timing — rf2-ad7zx.8 -------------------------------
+;; ---- (11) format-time --------------------------------------------------
 
-(deftest relative-time-figma-form
-  (testing "epoch-t0 is the earliest row time"
-    (is (= 100 (h/epoch-t0 [{:time 300} {:time 100} {:time 200}])))
-    (is (nil? (h/epoch-t0 [{:time nil} {:time nil}]))))
-  (testing "format-rel-time renders 't+N.Nms' relative to t0"
-    (is (= "t+0.0ms" (h/format-rel-time 100 100)))
-    (is (= "t+2.0ms" (h/format-rel-time 102 100)))
-    (is (nil? (h/format-rel-time nil 100))))
-  (testing "with-rel-times stamps :rel-time on every row"
-    (let [rows (h/with-rel-times [{:time 100} {:time 103}])]
-      (is (= ["t+0.0ms" "t+3.0ms"] (mapv :rel-time rows))))))
+(deftest format-time-renders-hms-with-millis
+  (testing "format-time returns nil on non-numeric input"
+    (is (nil? (h/format-time nil)))
+    (is (nil? (h/format-time "not a number"))))
+  (testing "format-time returns a HH:MM:SS.mmm-shaped string"
+    (let [s (h/format-time 12345)]
+      (is (string? s))
+      (is (re-find #"^\d{2}:\d{2}:\d{2}\.\d{3}$" s)))))
 
-;; ---- (4f) reactive-aftermath collapse group — rf2-ad7zx.8 -------------
+;; ---- (12) find-row -----------------------------------------------------
 
-(deftest reactive-aftermath-collapses-to-one-group
-  (testing "a contiguous run of reactive rows folds into one group node
-            carrying the (N subs, M renders) summary + the children"
-    (let [rows  (h/project-rows (:trace-events (domino-trail-epoch)))
-          nodes (h/group-reactive-aftermath rows)
-          groups (filter #(= :reactive-group (:kind %)) nodes)]
-      (is (= 1 (count groups))
-          "the trailing 2 subs + 1 render fold into ONE group")
-      (let [g (first groups)]
-        (is (= {:subs 2 :renders 1} (:summary g))
-            "summary counts subs ran vs views rendered")
-        (is (= 3 (count (:children g)))
-            "the group carries its 3 child reactive rows")
-        (is (= :reactive (:op-family g)))
-        (is (string? (:id g))))
-      (testing "the core dominoes (dispatch/db/fx) stay as flat op rows"
-        (is (= 4 (count (remove #(= :reactive-group (:kind %)) nodes)))
-            "4 event-side rows remain ungrouped")))))
+(deftest find-row-by-id
+  (let [rows [{:id 1} {:id 2} {:id 3}]]
+    (is (= {:id 2} (h/find-row rows 2)))
+    (is (nil? (h/find-row rows 99)))))
 
-(deftest reactive-runs-fold-in-place-preserving-causal-structure
-  (testing "a reactive run BETWEEN two event-side rows stays between
-            them — the fold is per-contiguous-run, not a global sweep"
-    (let [rows  [{:id 1 :op-type :rf.event :op-family :dispatch}
-                 {:id 2 :op-type :rf.sub   :op-family :reactive}
-                 {:id 3 :op-type :rf.event :op-family :dispatch}
-                 {:id 4 :op-type :rf.sub   :op-family :reactive}
-                 {:id 5 :op-type :rf.view  :op-family :reactive}]
-          nodes (h/group-reactive-aftermath rows)]
-      (is (= [:op :reactive-group :op :reactive-group]
-             (mapv #(or (:kind %) :op) nodes))
-          "two separate reactive runs → two separate groups, in place"))))
-
-;; ---- (4g) causal nesting — rf2-ad7zx.8 --------------------------------
-
-(deftest causal-nesting-indents-child-dispatches
-  (testing "a child dispatch (parent-dispatch-id → an in-epoch dispatch)
-            gets depth 1; the root dispatch is depth 0"
-    (let [rows  [{:dispatch-id 1 :parent-dispatch-id nil}
-                 {:dispatch-id 2 :parent-dispatch-id 1}
-                 {:dispatch-id 3 :parent-dispatch-id 2}]
-          depths (h/nesting-depths rows)]
-      (is (= 0 (get depths 1)))
-      (is (= 1 (get depths 2)))
-      (is (= 2 (get depths 3)))))
-  (testing "a parent not present in this epoch ⇒ the child is a root
-            (depth 0) — the lineage walk only counts in-epoch hops"
-    (let [depths (h/nesting-depths [{:dispatch-id 5 :parent-dispatch-id 99}])]
-      (is (= 0 (get depths 5)))))
-  (testing "with-nesting-depth stamps :depth onto op nodes"
-    (let [nodes (h/with-nesting-depth
-                  [{:kind :op :dispatch-id 1 :parent-dispatch-id nil}
-                   {:kind :op :dispatch-id 2 :parent-dispatch-id 1}])]
-      (is (= [0 1] (mapv :depth nodes))))))
-
-(deftest build-display-nodes-end-to-end
-  (testing "build-display-nodes folds rel-times + reactive group +
-            nesting depth in one pass; oldest-first ordering"
-    (let [rows  (h/project-rows (:trace-events (domino-trail-epoch)))
-          nodes (h/build-display-nodes rows)]
-      ;; 4 event-side op rows + 1 reactive group = 5 nodes.
-      (is (= 5 (count nodes)))
-      (is (= 1 (count (filter #(= :reactive-group (:kind %)) nodes))))
-      (is (every? #(contains? % :depth) nodes)
-          "every node carries a causal-nesting :depth")
-      (is (every? (fn [n]
-                    (if (= :reactive-group (:kind n))
-                      (some? (:rel-time n))
-                      (contains? n :rel-time)))
-                  nodes)
-          "every node carries a relative time"))))
-
-;; ---- (4h) feed exposes :nodes — rf2-ad7zx.8 ---------------------------
-
-(deftest project-feed-from-epoch-exposes-structural-nodes
-  (testing "the feed carries the structural :nodes tree the Figma view
-            paints (reactive group + nesting + bands) AND the flat
-            oldest-first :rows"
-    (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
-      (is (contains? feed :nodes))
-      (is (= 5 (count (:nodes feed)))
-          "4 event-side op rows + 1 reactive-aftermath group")
-      (is (= 1 (count (filter #(= :reactive-group (:kind %)) (:nodes feed)))))
-      (testing "rows are OLDEST-first now (Figma reads top-down for
-                causal nesting), with rel-times stamped"
-        (is (= [1 2 3 4 5 6 7] (mapv :id (:rows feed))))
-        (is (every? #(contains? % :rel-time) (:rows feed)))))))
-
-;; ---- (5) op-type-colour ------------------------------------------------
-
-(deftest op-type-colour-mapping
-  ;; Post rf2-on4cm `op-type-colour` returns CSS-variable strings —
-  ;; the active theme class on the shell root decides whether the dark
-  ;; or light hex resolves at paint time. Compare against the var-map
-  ;; (`tokens/tokens`) so the test pins the indirection rather than a
-  ;; specific palette's hex.
-  (is (= (:red    tokens/tokens)  (h/op-type-colour :error)))
-  (is (= (:yellow tokens/tokens)  (h/op-type-colour :warning)))
-  (is (= (:info tokens/tokens) (h/op-type-colour :info)))
-  (is (= (:accent tokens/tokens) (h/op-type-colour :rf.event)))
-  (is (= (:green  tokens/tokens)  (h/op-type-colour :rf.fx)))
-  (is (= (:magenta tokens/tokens) (h/op-type-colour :rf.view/render)))
-  ;; Defensive fallback.
-  (is (= (:text-secondary tokens/tokens) (h/op-type-colour :totally-unknown))))
-
-;; ---- (6) source-coord -------------------------------------------------
+;; ---- (13) source-coord -------------------------------------------------
 
 (deftest source-coord-projection
   (testing "source-coord pulls file:line from :rf.trace/trigger-handler"
@@ -482,7 +543,26 @@
              {:id 1 :op-type :rf.event
               :rf.trace/trigger-handler {:source-coord {:file "src/foo.cljs"}}})))))
 
-;; ---- (7) short-description --------------------------------------------
+;; ---- (14) readable-description (legacy cross-panel line) ---------------
+
+(deftest readable-description-never-blank
+  (testing "dispatch → 'dispatched <event-vec>'"
+    (is (= "dispatched [:counter/inc]"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                  :tags {:rf.event/v [:counter/inc]}})))))
+  (testing "sub → 'sub ran <id>'"
+    (is (= "sub run :app/counter"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.sub :operation :rf.sub/run
+                  :tags {:rf.sub/id :app/counter}})))))
+  (testing "unknown op falls back to short-description (never blank)"
+    (is (= ":rf.event/run-end"
+           (h/readable-description
+             (ev {:id 1 :op-type :rf.event :operation :rf.event/run-end
+                  :tags {}}))))))
+
+;; ---- (15) short-description --------------------------------------------
 
 (deftest short-description-priority-order
   (testing "event vector is preferred"
@@ -495,60 +575,26 @@
                  (h/short-description
                    (ev {:id 1 :op-type :error :operation :rf.error/x
                         :tags {:reason "because"}})))))
-  (testing "exception-message is used when no reason"
-    (is (re-find #"boom"
-                 (h/short-description
-                   (ev {:id 1 :op-type :error :operation :rf.error/x
-                        :tags {:exception-message "boom"}})))))
-  (testing "sub-id is used for sub events"
-    (is (re-find #"app/counter"
-                 (h/short-description
-                   (ev {:id 1 :op-type :rf.sub :operation :rf.sub/run
-                        :tags {:rf.sub/id :app/counter}})))))
   (testing "fallback is the operation keyword alone"
     (is (= ":rf.event/dispatched"
            (h/short-description
              (ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                   :tags {}}))))))
 
-;; ---- (8) row-key — rf2-z4fza (sibling of rf2-kgn0c) -------------------
-;;
-;; Per rf2-z4fza: the trace ribbon's React `:key` must be a stable
-;; per-trace-event identity (the framework's monotonic `:id`). The
-;; earlier shape mixed in the row's positional index inside the
-;; visible viewport, so every new trace push shifted every key and
-;; React remounted the entire viewport — the dominant frame cost
-;; under burst event rate. Same discipline class as rf2-kgn0c's
-;; `v:<variant-id>` keys in the story workspace.
+;; ---- (16) row-key — stable per-trace-event identity --------------------
 
 (deftest row-key-uses-stable-trace-id
-  (testing "row-key reads only :id — the framework's monotonic trace
-            id is stable per emit, so the key is stable across pushes"
+  (testing "row-key reads only :id — stable per emit"
     (is (= "t:7" (h/row-key {:id 7})))
     (is (= "t:42" (h/row-key {:id 42}))))
   (testing "row-key is unique per distinct trace id"
-    (let [ids   (range 1 200)
-          keys  (mapv #(h/row-key {:id %}) ids)]
-      (is (= (count ids) (count (distinct keys)))
-          "every trace id maps to a unique React key"))))
-
-(deftest row-key-ignores-row-index-and-position
-  (testing "rf2-z4fza acceptance: row-key MUST NOT consume :row-index
-            (the slot is gone from rows; any future regression that
-            re-adds it would silently destabilise keys)"
-    (let [row-a (h/project-row {:id 5 :op-type :rf.event :operation :rf.event/dispatched
-                                :time 100})
-          row-b (assoc row-a :row-index 0)
-          row-c (assoc row-a :row-index 99)]
-      (is (= (h/row-key row-a) (h/row-key row-b))
-          "row-key with :row-index 0 equals row-key without :row-index")
-      (is (= (h/row-key row-a) (h/row-key row-c))
-          "row-key with :row-index 99 equals row-key without :row-index"))))
+    (let [ids  (range 1 200)
+          keys (mapv #(h/row-key {:id %}) ids)]
+      (is (= (count ids) (count (distinct keys)))))))
 
 (deftest project-feed-from-epoch-rows-carry-no-row-index-slot
-  (testing "rf2-z4fza acceptance: rows MUST NOT carry a :row-index slot
-            — its mere presence on the row was a footgun inviting
-            positional React keys"
+  (testing "rows MUST NOT carry a :row-index slot (a footgun inviting
+            positional React keys)"
     (let [feed (h/project-feed-from-epoch (domino-trail-epoch) :focused)]
       (doseq [row (:rows feed)]
         (is (not (contains? row :row-index))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -1,46 +1,45 @@
 (ns day8.re-frame2-xray.panels.trace-view-cljs-test
-  "CLJS-side wiring + view tests for Xray's Trace panel
-  (Phase 5, rf2-argrj; epoch-scoped rework rf2-o6yqq + rf2-td380 +
-  rf2-gkczt).
+  "CLJS-side wiring + view tests for Xray's Trace panel — the whole-epoch
+  trace ARC (spec/023-Trace-Panel.md).
 
   ## What's under test (in addition to the pure-data tests in
   `trace_helpers_cljs_test.cljc`)
 
-    1. **Registry wires the composite sub** under
-       `:rf.xray/trace-feed` (the epoch-scoped feed).
+    1. **Registry wires the composite sub** under `:rf.xray/trace-feed`
+       (the epoch-scoped feed) + the row-expand / band-collapse events.
 
-    2. **Render contract** — the section + feed + data-testid wiring
-       matches the production view tree. The top header row (counts /
-       epoch-indicator / film-strip) is GONE (rf2-o6yqq); the
-       chip-filter rows + clear-filters control are GONE (rf2-gkczt).
+    2. **Render contract** — the arc tree (epoch envelope + 4 phase
+       bands + the 5-column rows) matches the production view; the prior
+       top header / chip-filter UI stays gone.
 
-    3. **Focused-epoch scope** (spec/018 §6 + rf2-td380) — the panel
-       surfaces the focused epoch record's `:trace-events` (the
-       complete domino trail, including the async nil-dispatch-id
-       reactive rows); refocusing changes the rendered feed.
+    3. **Focused-epoch scope** (spec/018 §6) — the panel surfaces the
+       focused epoch record's `:trace-events` (the complete arc);
+       refocusing changes the rendered feed.
 
     4. **Empty states** — `:no-events`, `:no-focus`, `:epoch-evicted`
        each render their distinct container.
 
-    5. **Row interactions** — clicking a row toggles inline payload
-       expansion; clicking the source-coord chip fires :open-in-editor
-       and does NOT also toggle.
+    5. **Row interactions** — clicking a row toggles inline raw-EDN
+       payload expansion; clicking the source-coord ↗ fires
+       :open-in-editor and does NOT also toggle.
 
-    6. **React-key stability** (rf2-z4fza) — rows keyed on the stable
-       trace id.
+    6. **Phase bands** — every band renders (empty bands dimmed
+       `(none)`); collapsing a band hides its rows.
+
+    7. **React-key stability** — rows keyed on the stable trace id.
 
   ## Pure hiccup
 
-  Same approach as `issues_ribbon_view_cljs_test.cljs` — walk the
-  view's hiccup tree by `data-testid` rather than mounting to the DOM.
+  Same approach as `issues_ribbon_view_cljs_test.cljs` — walk the view's
+  hiccup tree by `data-testid` rather than mounting to the DOM.
 
   ## Seeding
 
   The Trace panel is epoch-scoped: it reads the focused epoch record's
-  `:trace-events`, NOT the global trace bus. So trace events are seeded
-  by attaching them to a `:rf/epoch-record`'s `:trace-events` slot and
-  syncing the per-frame ring via `:rf.xray/sync-epoch-history`, then
-  focusing via `:rf.xray/focus-cascade`."
+  `:trace-events`. Trace events are seeded by attaching them to a
+  `:rf/epoch-record`'s `:trace-events` slot and syncing the per-frame
+  ring via `:rf.xray/sync-epoch-history`, then focusing via
+  `:rf.xray/focus-cascade`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -60,17 +59,19 @@
      :init-fn xray-test-support/reset-all!}))
 
 ;; ---- hiccup walkers ----------------------------------------------------
-;; Thin aliases over re-frame.test-helpers so the local call sites read
-;; identically to before.
 
-(def ^:private find-by-testid           th/find-by-testid)
-(def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
+(def ^:private find-by-testid th/find-by-testid)
 
 (defn- hiccup-seq
   "Expands fn components via the framework walker, then yields
   depth-first nodes."
   [tree]
   (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
+
+(defn- node-attrs
+  "The attribute map of the rendered node with the given data-testid."
+  [tree testid]
+  (some-> (find-by-testid tree testid) second))
 
 (defn- setup-xray-frame! []
   (registry/register-xray-handlers!)
@@ -80,14 +81,14 @@
 ;; `:trace-events` slot.
 (defn- mk-trace
   [{:keys [id time op-type operation source origin frame
-           event-id handler-id dispatch-id reason]
-    :or   {time 1000}}]
+           event-id handler-id dispatch-id reason tags]
+    :or   {time 1000 tags {}}}]
   {:id        id
    :time      time
    :op-type   op-type
    :operation operation
    :source    source
-   :tags      (cond-> {}
+   :tags      (cond-> tags
                 origin      (assoc :rf.event/origin origin)
                 frame       (assoc :frame frame)
                 event-id    (assoc :rf.trace/event-id event-id)
@@ -98,9 +99,8 @@
 
 (defn- mk-epoch
   "Build a minimal `:rf/epoch-record` carrying the supplied
-  `trace-events`. `dispatch-id` defaults to (10 + epoch-id) so the
-  spine resolver pairs the record with `:rf.xray/focus-cascade
-  <dispatch-id>` deterministically."
+  `trace-events`. `dispatch-id` defaults to (10 + epoch-id) so the spine
+  resolver pairs the record with `:rf.xray/focus-cascade <dispatch-id>`."
   ([epoch-id trace-events]
    (mk-epoch epoch-id (+ 10 epoch-id) trace-events))
   ([epoch-id dispatch-id trace-events]
@@ -122,53 +122,49 @@
   (rf/dispatch-sync [:rf.xray/sync-epoch-history (vec records)]))
 
 (defn- focus!
-  "Pin focus to the cascade with the given `dispatch-id`. Per
-  `spine/focus-cascade-reducer` the spine resolves the matching
-  `:epoch-id` from `:epoch-history`."
+  "Pin focus to the cascade with the given `dispatch-id`."
   [dispatch-id]
   (rf/dispatch-sync [:rf.xray/focus-cascade dispatch-id nil]))
 
 ;; ---- (1) registry wiring ------------------------------------------------
 
 (deftest registry-installs-trace-handlers
-  (testing "register-xray-handlers! installs the epoch-scoped
-            composite sub + the row-expand events"
+  (testing "register-xray-handlers! installs the epoch-scoped composite
+            sub + the row-expand + band-collapse events"
     (registry/register-xray-handlers!)
     (is (some? (registrar/handler :sub :rf.xray/trace-feed))
         ":rf.xray/trace-feed sub registered")
     (is (some? (registrar/handler :sub :rf.xray/trace-expanded-row-ids))
         ":rf.xray/trace-expanded-row-ids sub registered")
+    (is (some? (registrar/handler :sub :rf.xray/trace-collapsed-band-ids))
+        ":rf.xray/trace-collapsed-band-ids sub registered")
     (is (some? (registrar/handler :event :rf.xray/toggle-trace-row-expand))
-        ":rf.xray/toggle-trace-row-expand event registered")))
+        ":rf.xray/toggle-trace-row-expand event registered")
+    (is (some? (registrar/handler :event :rf.xray/toggle-trace-band-collapse))
+        ":rf.xray/toggle-trace-band-collapse event registered")))
 
 (deftest filter-handlers-are-gone
-  (testing "rf2-gkczt: the chip-filter subs + events MUST NOT register"
+  (testing "the chip-filter subs + events MUST NOT register"
     (registry/register-xray-handlers!)
-    (is (nil? (registrar/handler :sub :rf.xray/trace-filters))
-        ":rf.xray/trace-filters sub is gone")
-    (is (nil? (registrar/handler :sub :rf.xray/trace-feed-state))
-        ":rf.xray/trace-feed-state buffer-snapshot sub is gone (rf2-td380)")
-    (is (nil? (registrar/handler :event :rf.xray/set-trace-filter))
-        ":rf.xray/set-trace-filter event is gone")
-    (is (nil? (registrar/handler :event :rf.xray/clear-trace-filters))
-        ":rf.xray/clear-trace-filters event is gone")))
+    (is (nil? (registrar/handler :sub :rf.xray/trace-filters)))
+    (is (nil? (registrar/handler :sub :rf.xray/trace-feed-state)))
+    (is (nil? (registrar/handler :event :rf.xray/set-trace-filter)))
+    (is (nil? (registrar/handler :event :rf.xray/clear-trace-filters)))))
 
 (deftest trace-feed-defaults-no-focus
-  (testing "rf2-td380: with no focus + no epoch history the composite
-            returns an empty feed with :no-focus (cold start — the
-            focus-resolver classifies nil-focus + empty-history as
-            :no-focus)"
+  (testing "with no focus + no epoch history the composite returns an
+            empty feed with :no-focus"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])]
         (is (= [] (:rows feed)))
-        (is (= 0 (:total feed)))
-        (is (= 0 (:rendered feed)))
+        (is (zero? (:total feed)))
+        (is (zero? (:rendered feed)))
         (is (= :no-focus (:empty-kind feed)))))))
 
 (deftest trace-feed-projects-focused-epoch-events-into-rows
-  (testing "rf2-td380: with a focused epoch the composite returns one
-            row per trace event in that epoch's :trace-events"
+  (testing "with a focused epoch the composite returns one row per trace
+            event in that epoch's :trace-events"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -195,116 +191,162 @@
         (is (some? (find-by-testid tree "rf-xray-trace"))
             "panel container present")))))
 
-(deftest top-header-row-is-gone
-  (testing "rf2-o6yqq: the top header row — counts, epoch-indicator,
-            film-strip nav — is removed from the Trace panel"
+(deftest top-header-and-chip-filter-ui-are-gone
+  (testing "the top header row + chip-filter UI stay removed"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 42
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :dispatch-id 42})])])
+                               :dispatch-id 42 :source :ui})])])
       (focus! 42)
       (let [tree (trace/Panel)]
-        (is (nil? (find-by-testid tree "rf-xray-trace-counts"))
-            "counts span is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-epoch-indicator"))
-            "epoch indicator is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-film-strip"))
-            "film-strip wrapper is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-film-strip-prev"))
-            "film-strip prev button is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-film-strip-next"))
-            "film-strip next button is gone")))))
+        (is (nil? (find-by-testid tree "rf-xray-trace-counts")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-epoch-indicator")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-film-strip")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-axis-row-op-type")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-clear-filters")))))))
 
-(deftest chip-filter-ui-is-gone
-  (testing "rf2-gkczt: the chip-filter rows, per-row chip affordances,
-            and clear-filters control are removed"
+(deftest arc-renders-envelope-bands-and-rows
+  (testing "spec/023 §2: a focused epoch renders the EPOCH OPEN/CLOSE
+            envelope, the four phase bands in arc order, and the op rows
+            in their bands"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
-        [(mk-epoch 1 42
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :dispatch-id 42 :source :ui})
-                    (mk-trace {:id 2 :op-type :error :operation :rf.error/x
-                               :dispatch-id 42 :source :timer})])])
-      (focus! 42)
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 0 :op-type :rf.epoch :operation :rf.epoch/snapshotted
+                               :time 99})
+                    (mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :rf.fx :operation :rf.fx/handled
+                               :time 103 :dispatch-id 1})
+                    (mk-trace {:id 3 :op-type :rf.sub :operation :rf.sub/run :time 110})
+                    (mk-trace {:id 8 :op-type :rf.epoch :operation :rf.epoch/outcome
+                               :time 121 :tags {:rf.epoch/outcome :ok}})])])
+      (focus! 1)
       (let [tree (trace/Panel)]
-        (is (nil? (find-by-testid tree "rf-xray-trace-axis-row-op-type"))
-            "op-type chip row is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-axis-row-source"))
-            "source chip row is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-clear-filters"))
-            "clear-filters control is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-1-source-chip"))
-            "per-row source chip is gone")
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-1-row-chips"))
-            "per-row chip cell is gone")))))
+        (is (some? (find-by-testid tree "rf-xray-trace-feed")) "arc container present")
+        (is (some? (find-by-testid tree "rf-xray-trace-envelope-open"))
+            "EPOCH OPEN envelope present")
+        (is (some? (find-by-testid tree "rf-xray-trace-envelope-close"))
+            "EPOCH CLOSE envelope present")
+        (is (some? (find-by-testid tree "rf-xray-trace-outcome-ok"))
+            "the :ok outcome renders on the close envelope")
+        (testing "all four phase bands render"
+          (is (some? (find-by-testid tree "rf-xray-trace-band-dispatch")))
+          (is (some? (find-by-testid tree "rf-xray-trace-band-event-handling")))
+          (is (some? (find-by-testid tree "rf-xray-trace-band-effects")))
+          (is (some? (find-by-testid tree "rf-xray-trace-band-reactive")))
+          (is (some? (find-by-testid tree "rf-xray-trace-band-header-dispatch"))))
+        (testing "the op rows land in their bands"
+          (is (some? (find-by-testid tree "rf-xray-trace-row-1"))
+              "the dispatch row renders")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
+              "the fx row renders")
+          (is (some? (find-by-testid tree "rf-xray-trace-row-3"))
+              "the reactive sub row renders"))))))
 
-(deftest feed-list-renders-when-focused-epoch-has-events
-  (testing "rf2-td380 + rf2-ad7zx.8: with a focused epoch the panel
-            renders the <ul> feed; the core dominoes (dispatch/fx) are
-            top-level op rows and the reactive aftermath (the
-            nil-dispatch-id :rf.sub/run) collapses under one group
-            (spec/021 §5.2)"
+(deftest op-row-renders-the-five-columns
+  (testing "spec/023 §3: each op row carries Δt · area badge ·
+            what-happened · target/detail · duration"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 1000 :dispatch-id 1
+                               :tags {:rf.event/v [:counter/inc]}})
+                    (-> (mk-trace {:id 2 :op-type :rf.view :operation :rf.view/render
+                                   :time 1002})
+                        (assoc-in [:tags :elapsed-ms] 0.4))])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (= "+0.0" (last (find-by-testid tree "rf-xray-trace-row-1-time")))
+            "Δt column reads +0.0 relative to the epoch origin")
+        (is (= "EVENT" (last (find-by-testid tree "rf-xray-trace-row-1-badge")))
+            "area badge column reads the neutral EVENT badge")
+        (is (= "dispatched" (last (find-by-testid tree "rf-xray-trace-row-1-verb")))
+            "what-happened column reads the verb")
+        (is (some? (find-by-testid tree "rf-xray-trace-row-1-target"))
+            "target/detail column present")
+        (is (= "0.4 ms" (last (find-by-testid tree "rf-xray-trace-row-2-duration")))
+            "duration column reads the view's elapsed ms")
+        (is (= "—" (last (find-by-testid tree "rf-xray-trace-row-1-duration")))
+            "an untimed op renders an em-dash duration")))))
+
+(deftest op-row-carries-op-family-left-border-and-area-attr
+  (testing "spec/023 §3: rows band by op-family 3px left-border + carry
+            data attrs for area + op-family"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 1})
-                    (mk-trace {:id 2 :op-type :rf.fx :operation :rf.fx/handled
+                    (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
                                :dispatch-id 1})
-                    (mk-trace {:id 3 :op-type :rf.sub :operation :rf.sub/run})])])  ; nil dispatch-id
+                    (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+                               :dispatch-id 1})])])
       (focus! 1)
-      (let [tree (trace/Panel)
-            rows (find-all-by-testid-prefix tree "rf-xray-trace-row-")]
-        (is (some? (find-by-testid tree "rf-xray-trace-feed"))
-            "feed <ul> present")
-        (is (some? (find-by-testid tree "rf-xray-trace-row-1"))
-            "the dispatch op row is a top-level row")
+      (let [tree (trace/Panel)]
+        (is (= "event" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-1"))))
+        (is (= "db" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-2"))))
+        (is (= "fx" (:data-rf-xray-area (node-attrs tree "rf-xray-trace-row-3"))))
+        (is (= "dispatch" (:data-rf-xray-op-family
+                            (node-attrs tree "rf-xray-trace-row-1"))))
+        (let [border (get-in (node-attrs tree "rf-xray-trace-row-1")
+                             [:style :border-left])]
+          (is (and (string? border) (re-find #"^3px solid " border))
+              "the op-family band is a 3px left-border on the row"))))))
+
+(deftest error-rows-are-emphasised-inline
+  (testing "spec/023 §7: an error op renders inline at its chronological
+            point, emphasised (severity attr + Δt leads with !)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch 1 1
+                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :time 100 :dispatch-id 1})
+                    (mk-trace {:id 2 :op-type :error :operation :rf.error/fx-handler-exception
+                               :time 105 :reason "boom"})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
-            "the fx op row is a top-level row")
-        ;; The async nil-dispatch-id :rf.sub/run folds into the reactive
-        ;; aftermath collapse group — NOT a top-level row (rf2-ad7zx.8).
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-3"))
-            "the reactive sub row is collapsed (not a top-level row)")
-        (is (some? (find-by-testid tree "rf-xray-trace-group-react-grp:3"))
-            "a reactive-aftermath collapse group renders for the sub run")
-        (is (>= (count rows) 2)
-            "the two core-domino op rows render")))))
+            "the error row renders inline (not hidden)")
+        (is (= "error" (:data-rf-xray-severity (node-attrs tree "rf-xray-trace-row-2")))
+            "the error row carries the severity attr")
+        (is (= "ERROR" (last (find-by-testid tree "rf-xray-trace-row-2-badge")))
+            "the error row's badge reads ERROR")
+        (let [t (last (find-by-testid tree "rf-xray-trace-row-2-time"))]
+          (is (and (string? t) (re-find #"^!" t))
+              "the error row's Δt leads with ! for emphasis"))))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 
 (deftest empty-state-no-events-renders-for-empty-epoch
-  (testing "with a focused epoch carrying no trace events the panel
-            renders the :no-events empty-state"
+  (testing "a focused epoch carrying no trace events → :no-events"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history! [(mk-epoch 1 11 [])])
       (focus! 11)
       (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-empty-no-events"))
-            ":no-events empty-state container present")
+        (is (some? (find-by-testid tree "rf-xray-trace-empty-no-events")))
         (is (nil? (find-by-testid tree "rf-xray-trace-feed"))
-            "no feed list when focused epoch carries no events")))))
+            "no arc when focused epoch carries no events")))))
 
 (deftest empty-state-no-focus-renders
-  (testing "rf2-td380: with no focus + no history the panel renders the
-            :no-focus empty-state (cold start — the focus-resolver
-            classifies nil-focus + empty-history as :no-focus)"
+  (testing "with no focus + no history → :no-focus empty-state"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-empty-no-focus"))
-            "cold-start :no-focus empty-state present")
-        (is (nil? (find-by-testid tree "rf-xray-trace-feed"))
-            "no feed list at cold start")))))
+        (is (some? (find-by-testid tree "rf-xray-trace-empty-no-focus")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-feed")))))))
 
 (deftest empty-state-epoch-evicted-renders
-  (testing "rf2-td380: when focus pins an :epoch-id no longer in
-            :epoch-history the panel paints the evicted-epoch
-            placeholder (mirrors the Issues panel, spec/021 §10.7)"
+  (testing "when focus pins an :epoch-id no longer in :epoch-history →
+            the evicted-epoch placeholder"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history! [(mk-epoch 1 11 [])])
@@ -312,50 +354,41 @@
         [:day8.re-frame2-xray.panels.trace-view-cljs-test/seed-evicted-focus])
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])
             tree (trace/Panel)]
-        (is (= :epoch-evicted (:empty-kind feed))
-            "composite signals :epoch-evicted when no record matches focus")
-        (is (some? (find-by-testid tree "rf-xray-trace-empty-epoch-evicted"))
-            "canonical placeholder container rendered")
-        (is (nil? (find-by-testid tree "rf-xray-trace-feed"))
-            "no feed list when the focused epoch has been evicted")))))
+        (is (= :epoch-evicted (:empty-kind feed)))
+        (is (some? (find-by-testid tree "rf-xray-trace-empty-epoch-evicted")))
+        (is (nil? (find-by-testid tree "rf-xray-trace-feed")))))))
 
 ;; ---- (4) focused-epoch scope (refocus) ----------------------------------
 
 (deftest trace-feed-rescopes-on-refocus
-  (testing "rf2-td380: focusing a different epoch re-renders with that
-            epoch's :trace-events"
+  (testing "focusing a different epoch re-renders with that epoch's
+            :trace-events"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 100
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 100})
-                    (mk-trace {:id 2 :op-type :rf.fx :operation :rf.fx/handled})])  ; nil dispatch-id reactive
+                    (mk-trace {:id 2 :op-type :rf.fx :operation :rf.fx/handled})])
          (mk-epoch 2 200
                    [(mk-trace {:id 3 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 200})
                     (mk-trace {:id 4 :op-type :rf.sub :operation :rf.sub/run})
                     (mk-trace {:id 5 :op-type :rf.view :operation :rf.view/render})])])
-      ;; Focus epoch 1 (cascade 100).
       (focus! 100)
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])]
-        (is (= #{1 2} (set (map :id (:rows feed))))
-            "epoch 1's rows — including the nil-dispatch-id reactive row 2")
+        (is (= #{1 2} (set (map :id (:rows feed)))))
         (is (= 1 (:epoch-id feed))))
-      ;; Refocus to epoch 2 (cascade 200).
       (focus! 200)
       (let [feed @(rf/subscribe [:rf.xray/trace-feed])]
-        (is (= #{3 4 5} (set (map :id (:rows feed))))
-            "epoch 2's rows — the whole domino trail (event + sub + view)")
+        (is (= #{3 4 5} (set (map :id (:rows feed)))))
         (is (= 2 (:epoch-id feed)))))))
 
 ;; ---- (5) row interactions -----------------------------------------------
 
 (deftest row-click-toggles-inline-payload-expansion
-  (testing "rf2-7dyi8 — clicking a row dispatches
-            :rf.xray/toggle-trace-row-expand with the row's :id rather
-            than pivoting to event-detail. Per spec/021 §5.4 the Trace
-            panel surfaces row payloads inline; no nav."
+  (testing "spec/023 §3 — clicking a row dispatches
+            :rf.xray/toggle-trace-row-expand with the row's :id; no nav"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -378,30 +411,24 @@
         (is (not-any? #(and (vector? %)
                             (= :rf.xray/select-dispatch-id (first %)))
                       @dispatches)
-            "the legacy pivot is gone — no select-dispatch-id fired")))))
+            "no legacy pivot fired")))))
 
 (deftest toggle-trace-row-expand-event-mutates-set
-  (testing "rf2-7dyi8 — :rf.xray/toggle-trace-row-expand toggles row
-            membership in :trace-expanded-row-ids set."
+  (testing ":rf.xray/toggle-trace-row-expand toggles row membership"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 11])
-      (is (= #{11} @(rf/subscribe [:rf.xray/trace-expanded-row-ids]))
-          "first toggle adds the id")
+      (is (= #{11} @(rf/subscribe [:rf.xray/trace-expanded-row-ids])))
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 22])
-      (is (= #{11 22} @(rf/subscribe [:rf.xray/trace-expanded-row-ids]))
-          "second toggle on a different id appends")
+      (is (= #{11 22} @(rf/subscribe [:rf.xray/trace-expanded-row-ids])))
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 11])
-      (is (= #{22} @(rf/subscribe [:rf.xray/trace-expanded-row-ids]))
-          "toggling an already-expanded row removes it")
+      (is (= #{22} @(rf/subscribe [:rf.xray/trace-expanded-row-ids])))
       (rf/dispatch-sync [:rf.xray/clear-trace-expand])
-      (is (= #{} @(rf/subscribe [:rf.xray/trace-expanded-row-ids]))
-          ":rf.xray/clear-trace-expand drops every expanded id"))))
+      (is (= #{} @(rf/subscribe [:rf.xray/trace-expanded-row-ids]))))))
 
-(deftest expanded-row-renders-cljs-devtools-payload
-  (testing "rf2-7dyi8 + rf2-dmso5 — when a row's :id is in the expanded
-            set, the current-state cljs-devtools browse renderer mounts
-            below the row (Trace payloads are current-state)."
+(deftest expanded-row-renders-raw-edn-payload
+  (testing "spec/023 §3 — when a row's :id is in the expanded set, the
+            raw trace-event EDN renders below the row via cljs-devtools"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -409,24 +436,20 @@
                    [(mk-trace {:id 13 :op-type :rf.event :operation :rf.event/dispatched
                                :dispatch-id 1 :source :ui :origin :app})])])
       (focus! 1)
-      ;; Pre-expansion — no payload.
       (let [tree (trace/Panel)]
         (is (nil? (find-by-testid tree "rf-xray-trace-row-13-payload"))
-            "payload block absent when row is not in expanded set"))
-      ;; Toggle expand → payload renders.
+            "payload absent when row not expanded"))
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 13])
-      (let [tree    (trace/Panel)
-            payload (find-by-testid tree "rf-xray-trace-row-13-payload")]
-        (is (some? payload) "payload block renders when row is expanded")
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-trace-row-13-payload"))
+            "payload renders when row expanded")
         (is (some? (find-by-testid tree
                                    "rf-xray-edn-widget-browse-trace-trace-row-13"))
             "cljs-devtools browse mounted with per-row render-id")))))
 
 (deftest source-coord-click-fires-open-in-editor
-  (testing "clicking the source-coord chip fires :rf.xray/open-in-editor;
-            stopPropagation prevents the row's expand-toggle from also
-            firing (rf2-7dyi8 — the row click toggles inline expansion
-            now, the source-coord button bubbles must not toggle it)"
+  (testing "clicking the source-coord ↗ fires :rf.xray/open-in-editor;
+            stopPropagation prevents the row's expand-toggle from firing"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
@@ -444,7 +467,7 @@
           (let [tree    (trace/Panel)
                 node    (find-by-testid tree "rf-xray-trace-row-9-source-coord")
                 handler (:on-click (second node))]
-            (is (some? node) "source-coord chip rendered")
+            (is (some? node) "source-coord ↗ rendered")
             (when handler
               (handler #js {:stopPropagation #(reset! stop-evt true)}))))
         (is (some (fn [ev]
@@ -453,244 +476,103 @@
                          (= {:source-coord "core.cljs:42"} (second ev))))
                   @dispatches)
             ":rf.xray/open-in-editor fired with the projected coord")
-        (is @stop-evt "stopPropagation was called so the row's pivot
-                       handler doesn't also fire")))))
+        (is @stop-evt "stopPropagation was called")))))
 
-;; ---- (5b) Figma structural surfaces — rf2-ad7zx.8 ----------------------
+;; ---- (6) phase bands — spec/023 §13 / §14 -----------------------------
 
-(defn- node-attrs
-  "The attribute map of the rendered <li> with the given data-testid."
-  [tree testid]
-  (some-> (find-by-testid tree testid) second))
-
-(deftest op-rows-band-by-op-family-left-border
-  (testing "rf2-ad7zx.8: each op row carries a 3px op-family LEFT-BORDER
-            (not an op-type dot) and a data-rf-xray-op-family attr"
+(deftest empty-band-renders-dimmed-none
+  (testing "spec/023 §13: a no-op event keeps ③④ present with a `(none)`
+            count, never hidden"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :dispatch-id 1})
-                    (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
-                               :dispatch-id 1})
-                    (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
-                               :dispatch-id 1})])])
+                               :time 100 :dispatch-id 1})])])
       (focus! 1)
       (let [tree (trace/Panel)]
-        ;; The legacy op-type dot is gone.
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-1-op-type-dot"))
-            "op-type dot is removed (rf2-ad7zx.8)")
-        (is (= "dispatch" (:data-rf-xray-op-family
-                            (node-attrs tree "rf-xray-trace-row-1")))
-            "dispatch row carries the dispatch op-family")
-        (is (= "db" (:data-rf-xray-op-family
-                      (node-attrs tree "rf-xray-trace-row-2")))
-            "db-changed row carries the db op-family")
-        (is (= "fx" (:data-rf-xray-op-family
-                      (node-attrs tree "rf-xray-trace-row-3")))
-            "fx row carries the fx op-family")
-        (let [border (get-in (node-attrs tree "rf-xray-trace-row-1")
-                             [:style :border-left])]
-          (is (and (string? border) (re-find #"^3px solid " border))
-              "the op-family band is a 3px left-border on the row"))))))
+        (is (some? (find-by-testid tree "rf-xray-trace-band-effects"))
+            "③ EFFECTS band present even when empty")
+        (is (= "(none)" (last (find-by-testid tree "rf-xray-trace-band-count-effects")))
+            "an empty band's count reads (none)")
+        (is (true? (:data-rf-xray-empty
+                     (node-attrs tree "rf-xray-trace-band-header-effects")))
+            "the empty band header carries the empty attr")))))
 
-(deftest op-rows-render-relative-time-and-duration-columns
-  (testing "rf2-ad7zx.8: rows lead with a relative t+N.Nms time and
-            carry a duration column (elapsed for event/view rows)"
+(deftest collapsing-a-band-hides-its-rows
+  (testing "spec/023 §2 / §14: collapsing a band hides its rows; the
+            header stays"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 1000 :dispatch-id 1})
-                    (-> (mk-trace {:id 2 :op-type :rf.view :operation :rf.view/render
-                                   :time 1002})
-                        (assoc-in [:tags :elapsed-ms] 0.4))])])
+                               :time 100 :dispatch-id 1})])])
       (focus! 1)
+      ;; expanded by default — the dispatch row + its band rows ul render
       (let [tree (trace/Panel)]
-        (is (= "t+0.0ms" (->> (find-by-testid tree "rf-xray-trace-row-1-time")
-                              last))
-            "first row reads t+0.0ms relative to the epoch origin")
-        ;; The view-render row carries its elapsed duration; it folds into
-        ;; the reactive group, so expand the group to read its child cell.
-        (rf/dispatch-sync [:rf.xray/toggle-trace-group-expand "react-grp:2"])
-        (let [tree (trace/Panel)
-              dur  (->> (find-by-testid tree "rf-xray-trace-row-2-duration")
-                       last)]
-          (is (= "0.4 ms" dur)
-              "the view-render row shows its 0.4 ms elapsed duration"))))))
+        (is (some? (find-by-testid tree "rf-xray-trace-band-rows-dispatch")))
+        (is (some? (find-by-testid tree "rf-xray-trace-row-1"))))
+      ;; collapse the dispatch band → rows hidden, header remains
+      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :dispatch])
+      (let [tree (trace/Panel)]
+        (is (nil? (find-by-testid tree "rf-xray-trace-band-rows-dispatch"))
+            "collapsed band hides its rows ul")
+        (is (nil? (find-by-testid tree "rf-xray-trace-row-1"))
+            "the band's row is hidden when collapsed")
+        (is (some? (find-by-testid tree "rf-xray-trace-band-header-dispatch"))
+            "the band header stays so the phase is still labelled")))))
 
-(deftest reactive-aftermath-group-renders-and-toggles
-  (testing "rf2-ad7zx.8: the reactive aftermath collapses under one
-            expandable group; toggling it renders the child reactive
-            rows inline"
+(deftest band-header-click-fires-toggle-event
+  (testing "spec/023 §2: clicking a non-empty band header dispatches
+            :rf.xray/toggle-trace-band-collapse with the band id"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 100 :dispatch-id 1})
-                    (mk-trace {:id 2 :op-type :rf.sub :operation :rf.sub/run :time 110})
-                    (mk-trace {:id 3 :op-type :rf.sub :operation :rf.sub/run :time 111})
-                    (mk-trace {:id 4 :op-type :rf.view :operation :rf.view/render :time 120})])])
-      (focus! 1)
-      ;; Collapsed by default — the group renders, children do not.
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-group-react-grp:2"))
-            "reactive-aftermath group renders")
-        (is (nil? (find-by-testid tree "rf-xray-trace-row-2"))
-            "child reactive rows are collapsed by default"))
-      ;; Expand the group → children render.
-      (rf/dispatch-sync [:rf.xray/toggle-trace-group-expand "react-grp:2"])
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-group-react-grp:2-children"))
-            "expanded group renders its children container")
-        (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
-            "a child reactive row renders when the group is expanded")))))
-
-(deftest reactive-group-click-fires-toggle-event
-  (testing "rf2-ad7zx.8: clicking the reactive group dispatches
-            :rf.xray/toggle-trace-group-expand with the group's id"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :time 100 :dispatch-id 1})
-                    (mk-trace {:id 2 :op-type :rf.sub :operation :rf.sub/run :time 110})])])
+                               :time 100 :dispatch-id 1})])])
       (focus! 1)
       (let [dispatches (atom [])]
         (with-redefs [rf/dispatch* (fn
                                      ([ev]    (swap! dispatches conj ev) nil)
                                      ([ev _o] (swap! dispatches conj ev) nil))]
           (let [tree    (trace/Panel)
-                grp     (find-by-testid tree "rf-xray-trace-group-react-grp:2")
-                handler (:on-click (second grp))]
-            (is (some? grp) "reactive group node present")
+                header  (find-by-testid tree "rf-xray-trace-band-header-dispatch")
+                handler (:on-click (second header))]
+            (is (some? header))
+            (is (some? handler) "non-empty band header carries on-click")
             (when handler (handler))))
-        (is (some #(= [:rf.xray/toggle-trace-group-expand "react-grp:2"] %)
+        (is (some #(= [:rf.xray/toggle-trace-band-collapse :dispatch] %)
                   @dispatches)
-            "group click fires the toggle event with the group id")))))
+            "band header click fires the toggle with the band id")))))
 
-(deftest toggle-trace-group-expand-event-mutates-set
-  (testing "rf2-ad7zx.8: :rf.xray/toggle-trace-group-expand toggles
-            membership in :trace-expanded-group-ids"
+(deftest toggle-trace-band-collapse-event-mutates-set
+  (testing ":rf.xray/toggle-trace-band-collapse toggles membership"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      (rf/dispatch-sync [:rf.xray/toggle-trace-group-expand "react-grp:5"])
-      (is (= #{"react-grp:5"}
-             @(rf/subscribe [:rf.xray/trace-expanded-group-ids]))
-          "first toggle adds the group id")
-      (rf/dispatch-sync [:rf.xray/toggle-trace-group-expand "react-grp:5"])
-      (is (= #{} @(rf/subscribe [:rf.xray/trace-expanded-group-ids]))
-          "toggling again removes it"))))
+      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :effects])
+      (is (= #{:effects} @(rf/subscribe [:rf.xray/trace-collapsed-band-ids])))
+      (rf/dispatch-sync [:rf.xray/toggle-trace-band-collapse :effects])
+      (is (= #{} @(rf/subscribe [:rf.xray/trace-collapsed-band-ids]))))))
 
-(deftest child-dispatch-rows-indent-via-depth
-  (testing "rf2-ad7zx.8: a child dispatch (parent-dispatch-id → a parent
-            in the same epoch) renders with a causal-nesting depth attr
-            and a margin-left indent"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(-> (mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                                   :time 100 :dispatch-id 1}))
-                    ;; child dispatch — parent-dispatch-id points at 1
-                    (-> (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/dispatched
-                                   :time 110 :dispatch-id 2})
-                        (assoc-in [:tags :rf.trace/parent-dispatch-id] 1))])])
-      (focus! 1)
-      (let [tree    (trace/Panel)
-            parent  (node-attrs tree "rf-xray-trace-row-1")
-            child   (node-attrs tree "rf-xray-trace-row-2")]
-        (is (= 0 (:data-rf-xray-depth parent)) "root dispatch is depth 0")
-        (is (= 1 (:data-rf-xray-depth child))  "child dispatch is depth 1")
-        (is (= "0px" (get-in parent [:style :margin-left]))
-            "root row has no indent")
-        (is (not= "0px" (get-in child [:style :margin-left]))
-            "child row is indented under its parent (cascade tree)")))))
-
-;; ---- (5c) Figma fidelity — rf2-tha26 -----------------------------------
-
-(deftest footer-legend-renders-below-the-feed
-  (testing "rf2-tha26 — the Figma footer legend renders below the feed
-            naming the row reading conventions (colour-banded by op-family
-            · click a row → expand raw :operation + tags)"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :dispatch-id 1})])])
-      (focus! 1)
-      (let [tree   (trace/Panel)
-            legend (find-by-testid tree "rf-xray-trace-footer-legend")]
-        (is (some? legend) "footer legend renders in the feed branch")
-        (is (= "colour-banded by op-family · click a row → expand raw :operation + tags"
-               (last legend))
-            "footer legend carries the reference copy")))))
-
-(deftest footer-legend-absent-in-empty-states
-  (testing "rf2-tha26 — the footer legend is scoped to the feed branch; it
-            does NOT render when the panel shows an empty-state"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      ;; Focused epoch with no trace events → :no-events empty-state.
-      (seed-history! [(mk-epoch 1 11 [])])
-      (focus! 11)
-      (let [tree (trace/Panel)]
-        (is (some? (find-by-testid tree "rf-xray-trace-empty-no-events"))
-            "empty-state renders")
-        (is (nil? (find-by-testid tree "rf-xray-trace-footer-legend"))
-            "footer legend absent in the empty-state branch")))))
-
-(deftest op-rows-are-rounded-pills-not-flat-divided
-  (testing "rf2-tha26 — Figma rounded hover-pill rows: each op row carries
-            a border-radius (rounded) + inter-row rhythm and DROPS the
-            flat hairline `border-bottom` divider; the op-family 3px
-            left-border is preserved"
-    (setup-xray-frame!)
-    (rf/with-frame :rf/xray
-      (seed-history!
-        [(mk-epoch 1 1
-                   [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
-                               :dispatch-id 1})])])
-      (focus! 1)
-      (let [tree* (trace/Panel)
-            attrs (node-attrs tree* "rf-xray-trace-row-1")
-            style (:style attrs)]
-        (is (= "4px" (:border-radius style)) "row is a rounded pill")
-        (is (nil? (:border-bottom style))
-            "the flat hairline divider is gone (pills, not divided rows)")
-        (let [bl (:border-left style)]
-          (is (and (string? bl) (re-find #"^3px solid " bl))
-              "the op-family 3px left-border band is preserved"))))))
-
-;; ---- (6) frame isolation ------------------------------------------------
+;; ---- (7) frame isolation ------------------------------------------------
 
 (deftest trace-expand-state-does-not-leak-into-default-frame
   (testing "the panel's expand state lives on :rf/xray, never :rf/default"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/toggle-trace-row-expand 5]))
-    (let [xray-db   (frame/frame-app-db-value :rf/xray)
+    (let [xray-db    (frame/frame-app-db-value :rf/xray)
           default-db (frame/frame-app-db-value :rf/default)]
-      (is (= #{5} (:trace-expanded-row-ids xray-db))
-          "expand set lands on Xray")
-      (is (nil? (:trace-expanded-row-ids default-db))
-          "expand set did NOT leak into :rf/default"))))
+      (is (= #{5} (:trace-expanded-row-ids xray-db)))
+      (is (nil? (:trace-expanded-row-ids default-db))))))
 
-;; ---- (7) React-key stability across the feed — rf2-z4fza ---------------
-;;
-;; Sibling of rf2-kgn0c (same React-key discipline class). The rendered
-;; `<li>` for any row keys on the stable trace `:id` (`t:<id>`), not a
-;; positional index — so React's reconciler reuses DOM nodes instead of
-;; remounting the viewport.
+;; ---- (8) React-key stability across the feed ---------------------------
 
 (defn- row-li-by-id
   "Walk the rendered tree and return the `<li>` whose data-testid is
-  `rf-xray-trace-row-<id>`. Returns nil when the row isn't rendered."
+  `rf-xray-trace-row-<id>`."
   [tree id]
   (let [testid (str "rf-xray-trace-row-" id)]
     (some (fn [node]
@@ -702,15 +584,10 @@
           (hiccup-seq tree))))
 
 (deftest trace-row-react-keys-are-stable-trace-ids
-  (testing "rf2-z4fza — the rendered <li> :key is the stable trace id
-            (`t:<id>`), distinct per row and free of any positional
-            component"
+  (testing "the rendered <li> :key is the stable trace id (`t:<id>`),
+            distinct per row and free of any positional component"
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
-      ;; All three are core-domino op rows (event/fx/db-changed) so they
-      ;; render as top-level rows — the reactive aftermath collapses into
-      ;; a group (rf2-ad7zx.8), so this test uses non-reactive rows to
-      ;; exercise the per-row key discipline directly.
       (seed-history!
         [(mk-epoch 1 1
                    [(mk-trace {:id 11 :op-type :rf.event :operation :rf.event/dispatched
@@ -724,20 +601,15 @@
             k11  (:key (second (row-li-by-id tree 11)))
             k22  (:key (second (row-li-by-id tree 22)))
             k33  (:key (second (row-li-by-id tree 33)))]
-        (is (= "t:11" k11)
-            "row 11 keyed on stable trace id alone (no positional prefix)")
+        (is (= "t:11" k11))
         (is (= "t:22" k22))
         (is (= "t:33" k33))
-        (is (= 3 (count (distinct [k11 k22 k33])))
-            "all row keys distinct")))))
+        (is (= 3 (count (distinct [k11 k22 k33]))))))))
 
 ;; ---- evicted-focus helper ----------------------------------------------
 
 ;; A test-only event that pins :focus to an :epoch-id that's not in
-;; history — exercises the :epoch-evicted classifier path. Production
-;; only reaches this state when the framework's `:epoch-history`
-;; setting caps the buffer and older epochs roll off; in tests we
-;; synthesise the same in-memory shape directly.
+;; history — exercises the :epoch-evicted classifier path.
 (rf/reg-event-db
   :day8.re-frame2-xray.panels.trace-view-cljs-test/seed-evicted-focus
   (fn [db _event]

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -327,15 +327,18 @@
    ;; rf2-7hwwe — `:after` countdown ring hover slot (rich tooltip lifecycle).
    :rf.xray/timer-hover
    :rf.xray/trace-buffer
-   ;; rf2-7dyi8 — per-row inline payload expansion state (spec/021 §5.4).
+   ;; rf2-l2f2g — per-row inline raw-EDN payload expansion state
+   ;; (spec/023-Trace-Panel.md §3 — row click → raw EDN).
    :rf.xray/trace-expanded-row-ids
-   ;; rf2-ad7zx.8 — per-group reactive-aftermath collapse state
-   ;; (spec/021 §5.2 — collapsible reactive aftermath group).
-   :rf.xray/trace-expanded-group-ids
+   ;; rf2-l2f2g — per-band collapse state (spec/023 §2 / §14 —
+   ;; collapsible phase bands; default all-expanded, this set tracks the
+   ;; COLLAPSED bands).
+   :rf.xray/trace-collapsed-band-ids
    ;; rf2-td380 — epoch-scoped feed (reads the focused epoch record's
    ;; `:trace-events` directly). The `:rf.xray/trace-feed-state`
    ;; buffer snapshot + `:rf.xray/trace-filters` chip-filter slot were
-   ;; removed with rf2-td380 + rf2-gkczt.
+   ;; removed with rf2-td380 + rf2-gkczt. The feed now projects the arc
+   ;; shape (envelope + 4 phase bands) per spec/023 (rf2-l2f2g).
    :rf.xray/trace-feed
    ;; Reactive panel (rf2-wyvf2 · spec/021 §3 · renamed from Views per
    ;; §11.5; tab key stays `:views`, display label rebases). Reads the
@@ -587,12 +590,12 @@
    :rf.xray/timer-hover
    :rf.xray/timer-tick
    :rf.xray/toggle-live-pause
-   ;; rf2-7dyi8 — toggle the inline payload expansion for one trace row
-   ;; (per spec/021 §5.4 — Row → expand payload · Inline in panel).
+   ;; rf2-l2f2g — toggle the inline raw-EDN payload expansion for one
+   ;; trace row (spec/023-Trace-Panel.md §3 — Row click → raw EDN).
    :rf.xray/toggle-trace-row-expand
-   ;; rf2-ad7zx.8 — toggle one reactive-aftermath collapse group open
-   ;; (per spec/021 §5.2 — ▸ reactive aftermath (N subs, M renders)).
-   :rf.xray/toggle-trace-group-expand
+   ;; rf2-l2f2g — toggle one phase band's collapse state (spec/023 §2 /
+   ;; §14 — the four phase bands are collapsible).
+   :rf.xray/toggle-trace-band-collapse
    ;; Reactive panel events (rf2-wyvf2 · spec/021 §3 · renamed from
    ;; Views per §11.5; tab key stays `:views`).
    :rf.xray/reactive-set-unchanged

--- a/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/var_resolution_cljs_test.cljs
@@ -144,14 +144,32 @@
         (is (re-find #"^var\(--rf-xray-" v)
             (str "severity-colour " severity " resolves to a CSS variable"))))))
 
-(deftest op-type-colour-returns-css-variable-string
-  (testing "rf2-on4cm — `trace-helpers/op-type-colour` returns the
-            per-row Trace dot colour as a CSS variable."
-    (doseq [op-type [:error :warning :info :rf.event :rf.fx :rf.view/render]]
-      (let [v (trace-h/op-type-colour op-type)]
+(deftest trace-band-colour-returns-css-variable-string
+  (testing "rf2-on4cm / rf2-l2f2g — `trace-helpers/op-family-colour`
+            returns the per-row Trace op-family 3px left-border band
+            colour as a CSS variable (spec/023 §8)."
+    (doseq [[op-type op] [[:rf.event :rf.event/dispatched]
+                          [:rf.event :rf.event/db-changed]
+                          [:rf.fx :rf.fx/handled]
+                          [:rf.sub :rf.sub/run]
+                          [:rf.machine :rf.machine/transition]
+                          [:error :rf.error/x]
+                          [:warning :rf.warning/x]]]
+      (let [v (trace-h/op-family-colour {:op-type op-type :operation op})]
         (is (string? v))
         (is (re-find #"^var\(--rf-xray-" v)
-            (str "op-type-colour " op-type " resolves to a CSS variable"))))))
+            (str "op-family-colour " op-type " resolves to a CSS variable"))))))
+
+(deftest trace-outcome-colour-returns-css-variable-string
+  (testing "rf2-l2f2g — `trace-helpers/outcome-colour` tints the
+            what-happened column by outcome tier and resolves to a CSS
+            variable (spec/023 §8)."
+    (doseq [op [:rf.sub/run :rf.sub/skip :rf.sub/disposed :rf.error/x]]
+      (let [v (trace-h/outcome-colour {:op-type (if (= op :rf.error/x) :error :rf.sub)
+                                       :operation op})]
+        (is (string? v))
+        (is (re-find #"^var\(--rf-xray-" v)
+            (str "outcome-colour " op " resolves to a CSS variable"))))))
 
 (deftest event-status-colour-returns-css-variable-string
   (testing "rf2-on4cm — the lifecycle-status helper consumed by the


### PR DESCRIPTION
Reworks the Xray **Trace panel** into the whole-epoch **trace arc** described by `tools/xray/spec/023-Trace-Panel.md`, rendered in the established Xray devtools design system. There is no Trace-specific Figma mock (the authority file stubs Trace as a placeholder), so this combines the live `--devtools-*` design language with the 023 content/structure intent.

## Design-system elements applied
- **Tokens + type scale**: dark `--devtools-*` tokens via `theme/tokens` (no new theme edits), mono font for the data columns, sans for chrome/labels, 13/12/11/10 scale.
- **Handler-panel idiom** (`panels/event_detail.cljs`): numbered uppercase band headers (`① DISPATCH` …) on a thin left rail, mirroring the Event panel's numbered step-circle pipeline; the `+`/`~`/`-` diff vocabulary informs the DB row target rendering.
- **Rounded-pill rows** keep the `rf-xray-trace-row-` testid prefix so the shell's existing scoped hover-fill CSS rule (theme/global-styles, an in-flight file) keeps lighting them — no theme edit needed.

## 023 intent pulled in
- Whole-epoch arc: **EPOCH OPEN / CLOSE envelope** bracketing the **four collapsible phase bands** in canonical arc order (① DISPATCH · ② EVENT HANDLING — flows right after the handler · ③ EFFECTS / FX · ④ REACTIVE RENDERING).
- **5-column rows**: Δt · neutral text **area badge** · what-happened verb · target/detail · duration (§3), with the full area vocabulary (EVENT · COEFFECT · DB · FX · FLOW · SUB · VIEW · MACHINE · ROUTING · EPOCH · ERROR · WARNING, §5).
- **Op-family 3px left-border band** + **outcome-tier tint** on the verb column (§8); **empty bands render dimmed `(none)`**, never hidden (§13); **errors/warnings inline + emphasised** (`!` Δt, semantic colour, tinted rail, §7).
- **Row click → raw trace-event EDN** inline via the shared cljs-devtools browse renderer (§3); sticky band headers (§14); source-coord `↗` open-in-editor.
- **EPOCH CLOSE outcome** (`:ok`/`:blocked`/`:error`) surfaced from `:rf.epoch/outcome` (§13).

### Deliberately left
- Cross-panel `↗` jump map (§15) and child/nested-epoch `↗` linking (§12) are interaction-wiring follow-ons, not visual; left for a later bead.
- Per-op timing for cofx/fx/flow/handler (§6) is a Spec-009 instrumentation dependency upstream of this panel — rows render `—` until it lands; views already show elapsed.

## Real-data wiring retained
The panel stays fed by real trace data: `:rf.xray/trace-feed` resolves the focused epoch record via the shared `focus-resolver` over `:rf.xray/focus` + `:rf.xray/epoch-history` and projects its `:trace-events` into the arc (`build-bands`). No mock data is baked into the live panel. All new helpers (area / phase / what-happened / target-detail / outcome-tier / build-bands / epoch-outcome) are pure-data and JVM-testable.

## In-flight files avoided
No edits to `shell.cljs`, `filters/`, `frame_switcher.cljs`, `theme/global_styles.cljs`, or `theme/tokens.cljc` (the a086719e / rf2-pjjwh surface). Machine panel untouched. Changes are panel-local (`panels/trace.cljs` + `trace_helpers.cljc`) plus test/catalogue updates and one panel-doc-comment line in `panels.cljs`.

## Gates
- xray JVM `clojure -M:test`: 882 tests, 0 failures.
- `npm run test:cljs`: 4354 tests, 0 failures, 0 warnings.
- `npm run test:xray-feature-gate`: 13/13 scenarios pass.
- `npm run test:browser`: 119 tests, 0 failures.
- `npm run test:bundle-isolation`: PASS.
- clj-kondo: 0 errors on changed files (remaining warnings pre-existing). splint: 0 new (only the pre-existing `Math/round` reader-conditional interop in `fmt-1`).
- mkdocs not run — no committed doc/spec files touched.
