### PR TITLE
fix(xray): proper CLJS syntax highlighting in the Handler-panel EVENT HANDLER code block (rf2-93jp0)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -118,6 +118,14 @@
    :magenta        "#E879F9"
    :info           "#79c0ff"
 
+   ;; syntax-highlighter palette (rf2-93jp0) — mirrored from Xray's
+   ;; dark-palette so the `xray-and-machines-viz-dark-palettes-match-
+   ;; key-set` drift gate stays green. Tokens are Xray-source-highlighter
+   ;; surface; the chart itself does not read them.
+   :syntax-keyword "#ff7b72"
+   :syntax-string  "#a5d6ff"
+   :syntax-number  "#79c0ff"
+
    :red-deep       "#a83a3a"
    :white          "#ffffff"})
 
@@ -178,6 +186,16 @@
    :red            "#C84444"
    :magenta        "#B146C2"
    :info           "#0550ae"
+
+   ;; syntax-highlighter palette (rf2-93jp0) — light-palette mirror of
+   ;; Xray's syntax tokens. The light drift gate (`xray-and-machines-
+   ;; viz-light-palettes-match-values`) is shared-key equality, so
+   ;; mirroring keeps the two palettes symmetric and lets a future
+   ;; embed of machines-viz that DOES want to colour code surfaces find
+   ;; the same Figma palette under the same token name.
+   :syntax-keyword "#cf222e"
+   :syntax-string  "#0a3069"
+   :syntax-number  "#0550ae"
 
    :red-deep       "#9A3030"
    :white          "#ffffff"})

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -552,11 +552,14 @@
   "Renders the `↳ source` block under the handler flavour+coord row.
   Per Mike-direction 2026-05-21 (rf2-n4ad0) the handler source now
   routes through the canonical EDN widget's `code-block` for
-  syntax-highlighted rendering (keywords + builtins in the mode accent,
-  strings green, numbers cyan). When the substrate meta hasn't
-  yet been captured (e.g. before rf2-xgfuy lands, or in a production
-  goog.DEBUG=false build) the row renders the `<source not yet
-  captured>` placeholder per the task brief."
+  syntax-highlighted rendering. Per rf2-93jp0 the per-token palette
+  mirrors the Figma authority's `.syntax-*` classes — keywords red,
+  strings blue, numbers cool-blue, builtins on the chrome accent
+  (visually distinct from keywords), in both light and dark themes.
+  When the substrate meta hasn't yet been captured (e.g. before
+  rf2-xgfuy lands, or in a production goog.DEBUG=false build) the row
+  renders the `<source not yet captured>` placeholder per the task
+  brief."
   [meta]
   (let [src (handler-source-string meta)]
     [:div {:data-testid "rf-xray-event-detail-handler-source"

--- a/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/theme/tokens.cljc
@@ -127,6 +127,26 @@
    :magenta        "#E879F9"
    :info           "#79c0ff"   ; cool categorical blue ≠ accent (Figma syntax-number)
 
+   ;; ── syntax-highlighter palette (rf2-93jp0 · Figma `.syntax-*` block) ──
+   ;; Dedicated tokens for the in-bundle Clojure source-text highlighter
+   ;; (`views/edn_widget/widget.cljs`), mirrored 1:1 from the Figma
+   ;; authority's `.syntax-keyword` / `.syntax-string` / `.syntax-number`
+   ;; CSS classes. Catalogued as their own token family (rather than
+   ;; reusing semantic `:red`/`:green`/`:info`) so syntax hues can evolve
+   ;; independently of the semantic palette — a future "function-name"
+   ;; or "macro" hue lands here without rippling through error/success
+   ;; surfaces.
+   ;;
+   ;; The pre-rf2-93jp0 mapping reused `:accent` for BOTH `:keyword` and
+   ;; `:builtin`, so `:foo` and `reg-event-db` painted identically — a
+   ;; monochromatic look against a real editor. Splitting `:syntax-
+   ;; keyword` off (red family, per Figma) gives keywords vs builtins a
+   ;; first-class visual distinction; the builtin highlight stays on
+   ;; `:accent` (the chrome blue) and now reads as macro-call emphasis.
+   :syntax-keyword "#ff7b72"   ; Figma .dark .syntax-keyword (salmon-red)
+   :syntax-string  "#a5d6ff"   ; Figma .dark .syntax-string  (sky-blue)
+   :syntax-number  "#79c0ff"   ; Figma .dark .syntax-number  (cool-blue, = :info)
+
    ;; ── deep variants (rf2-5kfxe.4) ──
    ;; Darker variant of `:red` used as a danger-button background. The
    ;; default `:red` is the standard text-on-bg accent (high lightness
@@ -205,6 +225,22 @@
    :red            "#C84444"
    :magenta        "#B146C2"
    :info           "#0550ae"   ; cool categorical blue ≠ accent (Figma syntax-number)
+
+   ;; ── syntax-highlighter palette (rf2-93jp0 · Figma `.syntax-*` block) ──
+   ;; Light-theme mirror of the dark-palette `:syntax-*` family. Each
+   ;; hex is taken 1:1 from the Figma authority's CSS string:
+   ;;
+   ;;     .syntax-keyword { color: #cf222e; }
+   ;;     .syntax-string  { color: #0a3069; }
+   ;;     .syntax-number  { color: #0550ae; }
+   ;;
+   ;; (See `dark-palette` `:syntax-*` for the rationale — the rf2-93jp0
+   ;; split exists so keywords and builtins paint distinct hues; this
+   ;; block holds the LIGHT-theme half of that contract so the class
+   ;; toggle on the shell root resolves either palette at paint time.)
+   :syntax-keyword "#cf222e"   ; Figma .syntax-keyword (deep red)
+   :syntax-string  "#0a3069"   ; Figma .syntax-string  (deep navy)
+   :syntax-number  "#0550ae"   ; Figma .syntax-number  (Github blue, = :info)
 
    ;; ── deep variants ──
    ;; On the light canvas the danger button stays close to the

--- a/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs
@@ -346,12 +346,17 @@
 ;;
 ;;   2. **In-bundle Clojure-mode tokenizer** — `tokenize-clojure` is a
 ;;      lightweight ~140-LoC source-text lexer that emits per-token
-;;      colour classifications mapped onto the theme tokens (keywords
-;;      violet, strings green, numbers cyan, builtins violet). The
-;;      bracketed phrase in the rf2-6snc8 acceptance ("highlight.js …
-;;      or an embeddable Clojure-mode subset") explicitly authorises
-;;      this subset — and keeping the highlighter in-bundle avoids the
-;;      cost of a JS-side highlight.js dep on the dev classpath.
+;;      colour classifications mapped onto the theme tokens. Per the
+;;      rf2-93jp0 palette split, keywords paint on `:syntax-keyword`
+;;      (red family), strings on `:syntax-string` (blue family),
+;;      numbers on `:syntax-number` (cool-blue), and builtins on
+;;      `:accent` (chrome blue, macro-call emphasis) — each visually
+;;      distinct, both light and dark, mirroring the Figma authority's
+;;      `.syntax-*` CSS classes. The bracketed phrase in the rf2-6snc8
+;;      acceptance ("highlight.js … or an embeddable Clojure-mode
+;;      subset") explicitly authorises this subset — and keeping the
+;;      highlighter in-bundle avoids the cost of a JS-side highlight.js
+;;      dep on the dev classpath.
 
 (defn format-source
   "Pre-format a Clojure source string via zprint so the rendered
@@ -376,16 +381,30 @@
   "Per-token colour resolution for the in-bundle Clojure syntax
   highlighter (source-text rendering only; CLJS-value rendering goes
   through `cljs-devtools-render`). Pure data → token-keyword for the
-  token-type classification. Public for unit tests."
+  token-type classification. Public for unit tests.
+
+  ## Palette (rf2-93jp0)
+
+  Each token type maps to a dedicated `:syntax-*` token from
+  `theme/tokens.cljc` so the rendered hues match the Figma authority's
+  `.syntax-*` CSS block exactly (keyword red / string blue / number
+  cool-blue) in BOTH the light and dark theme. Keywords and builtins
+  resolve to DIFFERENT hues — keyword on `:syntax-keyword` (red family,
+  per Figma), builtin on `:accent` (the chrome blue, reading as
+  macro-call emphasis) — so a `:foo` keyword and a `reg-event-db`
+  builtin no longer paint identically against a real editor.
+
+  The fallthrough is `:text-primary`, matching a real editor where
+  plain symbols carry no special colour."
   [tok-type]
   (case tok-type
-    :keyword  :accent
-    :string   :green
-    :number   :info                   ; fixed cool-blue syntax hue, distinct from the keyword accent
+    :keyword  :syntax-keyword          ; Figma .syntax-keyword (red family)
+    :string   :syntax-string           ; Figma .syntax-string  (blue family)
+    :number   :syntax-number           ; Figma .syntax-number  (cool-blue)
     :comment  :text-tertiary
     :symbol   :text-primary
     :paren    :text-tertiary
-    :builtin  :accent
+    :builtin  :accent                  ; macro-call emphasis (chrome accent)
     :text-primary))
 
 (def clojure-builtins

--- a/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/views/edn_widget/widget_cljs_test.cljs
@@ -19,6 +19,7 @@
 
   Pure-data scope — no DOM mount; hiccup-shape assertions only."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -439,30 +440,71 @@
       (is (= "auto" (:overflow-x style))
           "overflow-x:auto keeps long handler lines scrollable in-panel"))))
 
-(deftest code-block-keyword-token-uses-accent
-  (let [out      (w/code-block {:source ":foo"})
-        spans    (walk-hiccup out)
-        accent?  (fn [n]
-                   (let [c (some-> n second :style :color)]
-                     (= c (:accent tokens))))
-        kw-span  (some #(when (and (vector? %)
-                                   (= :span (first %))
-                                   (accent? %)) %)
-                       spans)]
-    (is (some? kw-span)
-        "keyword tokens render with the mode accent colour")))
+(deftest code-block-keyword-token-uses-syntax-keyword
+  (testing "rf2-93jp0 — keyword tokens render with the Figma
+            `.syntax-keyword` red family (`:syntax-keyword`), NOT
+            `:accent`. The pre-rf2-93jp0 mapping painted keywords +
+            builtins on the same `:accent` blue (monochromatic against
+            a real editor); the split moves keywords to the dedicated
+            syntax token so `:foo` reads visibly distinct from
+            `reg-event-db`."
+    (let [out      (w/code-block {:source ":foo"})
+          spans    (walk-hiccup out)
+          kw?      (fn [n]
+                     (let [c (some-> n second :style :color)]
+                       (= c (:syntax-keyword tokens))))
+          kw-span  (some #(when (and (vector? %)
+                                     (= :span (first %))
+                                     (kw? %)) %)
+                         spans)]
+      (is (some? kw-span)
+          "keyword tokens render on the :syntax-keyword token (red)"))))
 
-(deftest code-block-string-token-uses-green
-  (let [out     (w/code-block {:source "\"hi\""})
-        spans   (walk-hiccup out)
-        green?  (fn [n]
-                  (let [c (some-> n second :style :color)]
-                    (= c (:green tokens))))
-        str-span (some #(when (and (vector? %)
-                                   (= :span (first %))
-                                   (green? %)) %)
-                       spans)]
-    (is (some? str-span))))
+(deftest code-block-string-token-uses-syntax-string
+  (testing "rf2-93jp0 — string tokens render on the dedicated
+            `:syntax-string` token (Figma `.syntax-string` blue family),
+            NOT the semantic `:green` (which carries success / changed
+            meanings elsewhere)."
+    (let [out      (w/code-block {:source "\"hi\""})
+          spans    (walk-hiccup out)
+          str?     (fn [n]
+                     (let [c (some-> n second :style :color)]
+                       (= c (:syntax-string tokens))))
+          str-span (some #(when (and (vector? %)
+                                     (= :span (first %))
+                                     (str? %)) %)
+                         spans)]
+      (is (some? str-span)
+          "string tokens render on the :syntax-string token (blue)"))))
+
+(deftest code-block-builtin-and-keyword-render-distinct-colours
+  (testing "rf2-93jp0 — `(let [x :foo] x)` paints `let` (builtin) and
+            `:foo` (keyword) on DIFFERENT colours. The headline
+            regression behind the fix — pre-fix both landed on `:accent`
+            and the editor read monochromatic."
+    (let [out          (w/code-block {:source "(let [x :foo] x)"})
+          spans        (walk-hiccup out)
+          coloured     (keep (fn [n]
+                               (when (vector? n)
+                                 (let [[tag attrs & body] n
+                                       c (some-> attrs :style :color)
+                                       lit (first body)]
+                                   (when (and (= :span tag)
+                                              (string? lit))
+                                     [lit c]))))
+                             spans)
+          builtin-colour (some (fn [[lit c]] (when (= lit "let") c)) coloured)
+          keyword-colour (some (fn [[lit c]] (when (= lit ":foo") c)) coloured)]
+      (is (some? builtin-colour)
+          "builtin `let` rendered with a colour span")
+      (is (some? keyword-colour)
+          "keyword `:foo` rendered with a colour span")
+      (is (not= builtin-colour keyword-colour)
+          "builtin and keyword must paint on distinct hues post rf2-93jp0")
+      (is (= keyword-colour (:syntax-keyword tokens))
+          "keyword colour = :syntax-keyword token")
+      (is (= builtin-colour (:accent tokens))
+          "builtin colour = :accent token (chrome blue, macro-call emphasis)"))))
 
 ;; ---- zprint pre-format ---------------------------------------------------
 
@@ -518,14 +560,46 @@
 ;; ---- highlight-clojure-token mapping -------------------------------------
 
 (deftest highlight-clojure-token-mapping
-  (is (= :accent        (w/highlight-clojure-token :keyword)))
-  (is (= :green         (w/highlight-clojure-token :string)))
-  (is (= :info          (w/highlight-clojure-token :number)))
-  (is (= :text-tertiary (w/highlight-clojure-token :comment)))
-  (is (= :text-primary  (w/highlight-clojure-token :symbol)))
-  (is (= :accent        (w/highlight-clojure-token :builtin)))
-  ;; Unknown token-type falls through to text-primary.
-  (is (= :text-primary  (w/highlight-clojure-token :unknown))))
+  (testing "rf2-93jp0 — each token type resolves to a Figma-aligned
+            syntax token; keyword and builtin paint DIFFERENT hues so
+            `:foo` and `reg-event-db` no longer read identically."
+    (is (= :syntax-keyword (w/highlight-clojure-token :keyword))
+        "keyword on the Figma `.syntax-keyword` red family")
+    (is (= :syntax-string  (w/highlight-clojure-token :string))
+        "string on the Figma `.syntax-string` blue family")
+    (is (= :syntax-number  (w/highlight-clojure-token :number))
+        "number on the Figma `.syntax-number` cool-blue")
+    (is (= :text-tertiary  (w/highlight-clojure-token :comment)))
+    (is (= :text-primary   (w/highlight-clojure-token :symbol)))
+    (is (= :text-tertiary  (w/highlight-clojure-token :paren)))
+    (is (= :accent         (w/highlight-clojure-token :builtin))
+        "builtin on the chrome accent (macro-call emphasis, distinct
+         from the keyword red)")
+    ;; Unknown token-type falls through to text-primary.
+    (is (= :text-primary   (w/highlight-clojure-token :unknown))))
+  (testing "keyword and builtin map to DIFFERENT tokens (rf2-93jp0
+            split — pre-fix they both pointed at `:accent`)"
+    (is (not= (w/highlight-clojure-token :keyword)
+              (w/highlight-clojure-token :builtin))
+        "keyword vs builtin must be visually distinct")))
+
+(deftest highlight-clojure-token-palette-resolution
+  (testing "rf2-93jp0 — every token-keyword returned by
+            `highlight-clojure-token` must actually resolve to a
+            CSS-variable string in the live `tokens` map (so the
+            `code-block` per-span `:color` lookup never falls back to
+            the `:text-primary` default for a syntax token)."
+    (doseq [tok-type [:keyword :string :number :comment
+                      :symbol :paren :builtin]]
+      (let [token-kw (w/highlight-clojure-token tok-type)
+            resolved (get tokens token-kw)]
+        (is (string? resolved)
+            (str tok-type " → " token-kw
+                 " must resolve to a CSS-variable string in `tokens`"))
+        (is (and (string? resolved)
+                 (str/starts-with? resolved "var(--rf-xray-"))
+            (str tok-type " → " token-kw
+                 " must resolve via the `var(--rf-xray-…)` indirection"))))))
 
 ;; ---- render dispatcher ---------------------------------------------------
 


### PR DESCRIPTION
## Diagnosis

All three suspected faults confirmed by inspection of
`tools/xray/src/day8/re_frame2_xray/views/edn_widget/widget.cljs`:

1. **Theme reskin contrast** — the code-block backdrop is `:bg-3`
   (`#2a2a2a` dark / `#e8e8e8` light). Mapping survived the reskin
   but…
2. **`:keyword` AND `:builtin` both → `:accent`** (single blue) —
   the headline fault. A `:foo` keyword and a `reg-event-db` builtin
   painted IDENTICALLY, so the EVENT HANDLER source read as
   monochromatic blue-on-text rather than a real editor where they
   are visually distinct.
3. **Most handler symbols fall to `:text-primary`** — confirmed, but
   that's actually fine (a real editor paints plain symbols as plain
   text). The visual problem was driven entirely by #2.

## Token-map change (`widget.cljs/highlight-clojure-token`)

| token type | before    | after            |
|------------|-----------|------------------|
| `:keyword` | `:accent` | `:syntax-keyword` (red, Figma) |
| `:string`  | `:green`  | `:syntax-string`  (blue, Figma) |
| `:number`  | `:info`   | `:syntax-number`  (cool-blue, Figma) |
| `:builtin` | `:accent` | `:accent` (unchanged — macro-call emphasis, now distinct from keyword red) |
| `:comment` | `:text-tertiary` | (unchanged) |
| `:symbol`  | `:text-primary`  | (unchanged) |
| `:paren`   | `:text-tertiary` | (unchanged) |

The split solves the headline regression: keyword vs builtin paint
distinct hues against the new `bg-3` backdrop, in both themes.

## New tokens added (`theme/tokens.cljc`)

Three new entries in `dark-palette` AND `light-palette`, mirroring
the Figma authority (`causa_devtools.cljs` `.syntax-*` CSS) 1:1:

| token             | dark      | light     | Figma source        |
|-------------------|-----------|-----------|---------------------|
| `:syntax-keyword` | `#ff7b72` | `#cf222e` | `.syntax-keyword`   |
| `:syntax-string`  | `#a5d6ff` | `#0a3069` | `.syntax-string`    |
| `:syntax-number`  | `#79c0ff` | `#0550ae` | `.syntax-number`    |

Catalogued as their own family rather than reusing semantic `:red` /
`:green` / `:info` so syntax hues can evolve independently. The
`themes-css` emitter walks the palette automatically — the new
`--rf-xray-syntax-*` CSS variables publish to `:root` /
`.rf-xray-theme-{dark,light}` with no emitter change.

Mirrored the same three tokens into
`tools/machines-viz/.../theme/tokens.cljc` so the
`xray-and-machines-viz-{dark,light}-palettes-match-{key-set,values}`
drift gates stay green.

## Tests

Updated `widget_cljs_test.cljs`:
- `highlight-clojure-token-mapping` — pinned new per-type mapping +
  keyword≠builtin distinctness invariant.
- `highlight-clojure-token-palette-resolution` (new) — every token
  the highlighter returns must resolve to `var(--rf-xray-…)` in
  `tokens` (no silent `:text-primary` fallback).
- `code-block-keyword-token-uses-syntax-keyword` (rename + retarget),
  `code-block-string-token-uses-syntax-string` (rename + retarget),
  `code-block-builtin-and-keyword-render-distinct-colours` (new) —
  hiccup-level assertions: a `(let [x :foo] x)` source paints `let`
  and `:foo` on different colours.

## Gate results

| Gate | Result |
|------|--------|
| xray JVM (`clojure -M:test` from `tools/xray/`) | 863 tests / 3078 assertions, 0 failures |
| machines-viz JVM (`clojure -M:test`) | 230 tests / 551 assertions, 0 failures |
| `npm run test:cljs` | 4328 tests / 13850 assertions, 0 failures |
| `npm run test:xray-feature-gate` | 13 scenarios, 0 failures |
| `npm run test:bundle-isolation` | PASS — 33 internal sentinels absent; uix/helix/reagent bundles clean |
| `mkdocs build --strict` | N/A (no docs/spec touched) |

## Before / after

Before: the EVENT HANDLER source in the Event panel painted
keywords + builtins on the same chrome-blue accent, so a handler
body like `(reg-event-db :counter/inc (fn [db _] (update db :n inc)))`
read as plain text peppered with same-coloured blue tokens.

After: `:counter/inc` paints red (`:syntax-keyword`), `reg-event-db`
and `update` paint blue (`:accent` — chrome blue, macro-call
emphasis), `:n` paints red, and the body symbols (`db`, `_`, `n`)
stay on `:text-primary`. Visually, the block now reads with the
same hue distribution a real CLJS editor produces, in both light
and dark themes.