### PR TITLE
fix(xray/test): restore semantic intent of namespace prefix collision fixture (rf2-hr2uy)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/trace_bus_self_noise_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/trace_bus_self_noise_cljs_test.cljc
@@ -227,11 +227,11 @@
       (is (false? (trace-bus/xray-internal-event-id? 42))))
     (testing "namespace prefix collision guard"
       ;; A keyword whose namespace STARTS with `rf.xray` but is not
-      ;; exactly `rf.xray` (e.g. `:rf.causal/x`, `:rf.causal-link/y`)
+      ;; exactly `rf.xray` (e.g. `:rf.xray-test/x`, `:rf.xray-foo/y`)
       ;; must NOT match. The contract is namespace equality, not
       ;; prefix matching.
-      (is (false? (trace-bus/xray-internal-event-id? :rf.causal/x)))
-      (is (false? (trace-bus/xray-internal-event-id? :rf.causal-link/y))))))
+      (is (false? (trace-bus/xray-internal-event-id? :rf.xray-test/x)))
+      (is (false? (trace-bus/xray-internal-event-id? :rf.xray-foo/y))))))
 
 (deftest xray-internal-cascade?-event-vector-head
   (testing "true iff the cascade's :event vector's head is xray-internal"


### PR DESCRIPTION
Causa→Xray rename leftover. The "namespace prefix collision guard" sub-test at `tools/xray/test/day8/re_frame2_xray/trace_bus_self_noise_cljs_test.cljc:228-234` was originally written when the predicate at `tools/xray/src/day8/re_frame2_xray/trace_bus.cljc:282-284` checked for the `rf.causa` namespace; its fixture inputs `:rf.causal/x` and `:rf.causal-link/y` were chosen specifically because they START with `rf.causa` but aren't EXACTLY `rf.causa`, exercising the prefix-collision-equality-not-substring contract. After the rename the predicate now equality-checks `"rf.xray"`, so the old fixture inputs no longer test the contract — they pass trivially because they don't start with `rf.xray` at all. This change updates the fixture keywords to `:rf.xray-test/x` and `:rf.xray-foo/y` (namespaces that START with `rf.xray` but aren't exactly `rf.xray`) and refreshes the surrounding comment, restoring the test's docstring intent. Implementation untouched.