### PR TITLE
fix(xray/design-ref): mirror-vs-authority drift cleanup (2 beads incl. rf2-68yxk syntax-comment)

### DIFF
--- a/tools/xray/design-reference/xray_devtools_reference.cljs
+++ b/tools/xray/design-reference/xray_devtools_reference.cljs
@@ -133,9 +133,7 @@
 .syntax-string { color: #0a3069; }
 .dark .syntax-string { color: #a5d6ff; }
 .syntax-number { color: #0550ae; }
-.dark .syntax-number { color: #79c0ff; }
-.syntax-comment { color: #6e7781; font-style: italic; }
-.dark .syntax-comment { color: #8b949e; }")
+.dark .syntax-number { color: #79c0ff; }")
 
 ;; ============================================================================
 ;; SVG Icons (simplified - replace with your icon library)

--- a/tools/xray/design-reference/xray_devtools_reference.cljs
+++ b/tools/xray/design-reference/xray_devtools_reference.cljs
@@ -39,6 +39,18 @@
   cards) rather than the stub — the live App-db panel is the contractual
   surface and the reference documents its shape.
 
+  ## What this reference DELIBERATELY diverges from the Figma authority
+
+  - **Inactive-tab background opacity = 0.12 (NOT the authority's 0.2)**
+    — see `tab-button` below. The Figma authority paints inactive tabs
+    at `rgba(255,255,255,0.2)`; both this mirror and the live shell
+    (`tools/xray/src/day8/re_frame2_xray/shell.cljs`) use 0.12 instead.
+    The quieter inactive fill lets the active tab POP in the rhythm
+    of the dark tabs ribbon; 0.2 made the inactive tabs read as
+    competing siblings rather than backgrounded options. This is a
+    deliberate, contractual divergence from the authority — codified
+    here (rf2-2kw7f) so a future audit doesn't re-raise it as drift.
+
   ## Out of scope (WIP)
 
   The Machine panel design is a work-in-progress (Mike). This reference
@@ -339,6 +351,9 @@
 
 (defn tab-button [active-tab tab-id label]
   (let [is-active (= @active-tab tab-id)]
+    ;; rf2-2kw7f — inactive fill is rgba(...,0.12), NOT the Figma
+    ;; authority's 0.2. Deliberate; see the docstring (§What this
+    ;; reference DELIBERATELY diverges from the Figma authority).
     [:button {:class "devtools-body"
               :style {:padding "3px 16px" :border-radius "4px 4px 0 0" :border "none"
                       :background (if is-active "var(--devtools-chrome-ribbon-tab-active)" "rgba(255,255,255,0.12)")


### PR DESCRIPTION
Two small drifts between the committed design-reference mirror (`tools/xray/design-reference/xray_devtools_reference.cljs`) and the Figma authority file, both surfaced by the rf2-s9ez3 figma-mapping audit. Single surface, bundled as one PR. Sequenced commits, smallest cleanup first.

- **rf2-2kw7f (doc):** Codify the inactive-tab background opacity divergence (mirror + live shell at `rgba(255,255,255,0.12)`; Figma authority at `0.2`). New docstring section `## What this reference DELIBERATELY diverges from the Figma authority` + inline comment at the `tab-button` rgba site. No behaviour change.
- **rf2-68yxk (fix):** Drop the spurious `.syntax-comment` light + `.dark .syntax-comment` rules from the mirror — they exist in neither the Figma authority nor the live runtime (tokens carry only `:syntax-keyword/-string/-number`; the EDN widget classifier has no `:comment` row). Mirror now matches the authority 1:1.

### Gates
- xray JVM `clojure -M:test` from `tools/xray/`: **863 tests / 3078 assertions / 0 failures, 0 errors** (run after each commit + once more after rebase on origin/main).
- File parses cleanly via `clojure.core/read` (26 forms).
- clj-kondo + Splint covered by the `lint` CI workflow.

### Out of scope
Option (b) of rf2-68yxk — plumbing a `:syntax-comment` token through `theme/tokens.cljc` + the machines-viz drift gate + the widget classifier so the live actually paints comments — is deferred (smaller change is option (a), preferred per the bead description).