### PR TITLE
fix(xray): filters ribbon — reclaim layout space + 250ms anim + hide redundant top + filter (rf2-8zd80)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -818,6 +818,12 @@
       `❖ Xray` wordmark was DROPPED per A4), the `[◀ ▶ ⏭]` blue-filled
       nav cluster (A2), then the `+ filter` add-pill (A5). (rf2-pjjwh
       retired the `focus` button + focus-chip with the focus feature.)
+      The chrome `+ filter` is mutually-exclusive with the events-ribbon
+      (rf2-8zd80): when ≥1 filter is committed the events-ribbon owns the
+      `[+]` add affordance and the chrome `+ filter` collapses to zero
+      width via the `.rf-xray-filters-collapse-h` horizontal-grid track
+      (250ms, same cadence + reduced-motion seam as the events-ribbon
+      vertical collapse).
     - **RIGHT** — the Frame dropdown (`frame-switcher/frame-switcher-
       view`) + the Dynamic/Static mode dropdown (`mode-pill/mode-pill`)
       + the mute (🔇 N) / REDACTED (● N) silent-by-default indicators +
@@ -848,6 +854,12 @@
         focus          @(rf/subscribe [:rf.xray/focus])
         cascades       @(rf/subscribe [:rf.xray/filtered-cascades])
         show-ungrouped? @(rf/subscribe [:rf.xray/show-ungrouped?])
+        ;; rf2-8zd80 — the chrome `+ filter` and the events-ribbon are
+        ;; mutually-exclusive add affordances. Hide the chrome button
+        ;; when ≥1 filter is committed (the events-ribbon's own `[+]`
+        ;; takes over). Open when zero filters, closed otherwise.
+        filters        @(rf/subscribe [:rf.xray/active-filters])
+        no-filters?    (zero? (+ (count (:in filters)) (count (:out filters))))
         {:keys [at-head? at-tail? live?]}
         (nav-boundary-state {:focus           focus
                              :cascades        cascades
@@ -905,7 +917,21 @@
       ;; canonical `:rf.xray/open-edit-popup` flow), so the add behaviour
       ;; is RETAINED — only the surface changes. Muted-outline on the dark
       ;; band so it reads as a secondary chrome affordance.
-      [filter-pills/chrome-add-filter-button]]
+      ;;
+      ;; rf2-8zd80 — wrapped in a horizontal collapse track so the
+      ;; button retracts to zero width (with the same 250ms / motion-
+      ;; scale cadence as the events-ribbon vertical collapse) once the
+      ;; events-ribbon owns the add affordance via its `[+]` icon.
+      ;; `data-open` flips on the active-filters count: open when zero,
+      ;; closed when one or more. Stays mounted so the transition runs
+      ;; in both directions. The button keeps its own `data-testid` so
+      ;; tests + Playwright lassos targeting it still resolve while it
+      ;; is visible.
+      [:div {:data-testid "rf-xray-filter-add-collapse"
+             :class       "rf-xray-filters-collapse-h"
+             :data-open   (if no-filters? "true" "false")
+             :aria-hidden (if no-filters? "false" "true")}
+       [:div [filter-pills/chrome-add-filter-button]]]]
      ;; RIGHT cluster — scope selectors (Frame + Dynamic/Static) then the
      ;; silent-by-default indicators + chrome actions. Per the authority
      ;; reference chrome-ribbon right side (rf2-3f2di A5).

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -830,31 +830,76 @@
     "  background-color: rgba(255,255,255,0.12);\n"
     "  color: " (:chrome-ribbon-text tokens/tokens) ";\n"
     "}\n"
-    ;; rf2-pjjwh — `filters:` (bar-2) conditional reveal animation. The
-    ;; events-ribbon is HIDDEN when there are zero filters and animates
-    ;; OPEN when the first filter is added / CLOSED when the last is
-    ;; removed. The collapse track is a CSS grid whose single row animates
-    ;; `0fr ⇄ 1fr` — the modern jank-free height collapse that doesn't need
-    ;; a fixed max-height (the bar grows to its natural height and back to
-    ;; zero with no layout jump). `min-height: 0` on the inner child lets
-    ;; the grid track collapse fully; `overflow: hidden` clips the content
-    ;; while it slides. Opacity cross-fades alongside so the bar doesn't
-    ;; pop. Runs through `--rf-xray-motion-scale` so the reduced-motion
-    ;; seam collapses it to an instant resolve.
+    ;; rf2-pjjwh + rf2-8zd80 — `filters:` (bar-2) conditional reveal
+    ;; animation. The events-ribbon is HIDDEN when there are zero filters
+    ;; and animates OPEN when the first filter is added / CLOSED when the
+    ;; last is removed. The collapse track is a CSS grid whose single row
+    ;; animates `0fr ⇄ 1fr` — the modern jank-free height collapse that
+    ;; doesn't need a fixed max-height (the bar grows to its natural
+    ;; height and back to zero with no layout jump). `min-height: 0` on
+    ;; the inner child lets the grid track collapse fully; `overflow:
+    ;; hidden` clips the content while it slides. Opacity cross-fades
+    ;; alongside so the bar doesn't pop. Runs through
+    ;; `--rf-xray-motion-scale` so the reduced-motion seam collapses it
+    ;; to an instant resolve.
+    ;;
+    ;; rf2-8zd80 — pinned both transitions to exactly 250ms (was 200ms +
+    ;; 160ms) so OPEN and CLOSE share one duration; the bar's bottom edge
+    ;; and the column flex below it now travel in lock-step.
+    ;;
+    ;; rf2-8zd80 — `min-height: 0 !important` on the inner child is
+    ;; load-bearing: the events-ribbon's inner toolbar carries an inline
+    ;; `:min-height "34px"` so the OPEN bar holds its design height (and
+    ;; grows under `flex-wrap` when pills overflow). Inline styles beat
+    ;; stylesheet rules unless `!important` wins. Without the override
+    ;; the inner stays 34px tall regardless of the parent grid track,
+    ;; the closed track can't reclaim its space, and the bar leaves a
+    ;; 34px gap where it was. The OPEN-state height comes from the
+    ;; inline `min-height` on the inner; the CLOSED-state collapse comes
+    ;; from this rule. Scoped to `[data-open=\"false\"]` so the open
+    ;; bar's 34px floor still applies.
     ".rf-xray-filters-collapse {\n"
     "  display: grid;\n"
     "  grid-template-rows: 0fr;\n"
     "  opacity: 0;\n"
-    "  transition: grid-template-rows calc(200ms * var(--rf-xray-motion-scale, 1)) ease-out,\n"
-    "              opacity calc(160ms * var(--rf-xray-motion-scale, 1)) ease-out;\n"
+    "  transition: grid-template-rows calc(250ms * var(--rf-xray-motion-scale, 1)) ease-out,\n"
+    "              opacity calc(250ms * var(--rf-xray-motion-scale, 1)) ease-out;\n"
     "}\n"
     ".rf-xray-filters-collapse[data-open=\"true\"] {\n"
     "  grid-template-rows: 1fr;\n"
     "  opacity: 1;\n"
     "}\n"
     ".rf-xray-filters-collapse > * {\n"
-    "  min-height: 0;\n"
     "  overflow: hidden;\n"
+    "}\n"
+    ".rf-xray-filters-collapse[data-open=\"false\"] > * {\n"
+    "  min-height: 0 !important;\n"
+    "}\n"
+    ;; rf2-8zd80 — horizontal sibling of the row-collapse track. Used by
+    ;; the chrome ribbon's `[+ filter]` button: when the events-ribbon
+    ;; is visible (≥1 filter), the chrome `[+ filter]` is redundant
+    ;; (the events-ribbon carries its own `[+]` icon button) and
+    ;; collapses to zero width. When the events-ribbon is hidden
+    ;; (0 filters), the chrome `[+ filter]` is the SOLE add affordance
+    ;; and expands. `grid-template-columns: 0fr ⇄ 1fr` mirrors the row
+    ;; collapse; same 250ms timing + opacity cross-fade keep the two
+    ;; tracks visually synchronised so as one bar appears the other
+    ;; affordance retracts in lock-step.
+    ".rf-xray-filters-collapse-h {\n"
+    "  display: grid;\n"
+    "  grid-template-columns: 0fr;\n"
+    "  opacity: 0;\n"
+    "  transition: grid-template-columns calc(250ms * var(--rf-xray-motion-scale, 1)) ease-out,\n"
+    "              opacity calc(250ms * var(--rf-xray-motion-scale, 1)) ease-out;\n"
+    "}\n"
+    ".rf-xray-filters-collapse-h[data-open=\"true\"] {\n"
+    "  grid-template-columns: 1fr;\n"
+    "  opacity: 1;\n"
+    "}\n"
+    ".rf-xray-filters-collapse-h > * {\n"
+    "  min-width: 0;\n"
+    "  overflow: hidden;\n"
+    "  white-space: nowrap;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -418,6 +418,75 @@
         (is (not (re-find #"Clear Filters" (text-nodes tree)))
             "no `Clear Filters` copy anywhere in the shell")))))
 
+;; ---- rf2-8zd80 — chrome `+ filter` ⇄ events-ribbon mutual exclusion ----
+
+(deftest chrome-add-filter-button-open-when-no-filters
+  (testing "rf2-8zd80 — with zero filters the events-ribbon is hidden,
+            so the chrome ribbon's `+ filter` button is the SOLE add
+            affordance and its horizontal collapse track is OPEN
+            (data-open=true). The button itself stays in the tree
+            (mounted) so Playwright / test lookups can resolve it."
+    (xray-setup!)
+    (trace-bus/collect-trace! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
+    (rf/with-frame :rf/xray
+      (let [tree     (shell/shell-view)
+            collapse (find-by-testid tree "rf-xray-filter-add-collapse")
+            button   (find-by-testid tree "rf-xray-filter-add")]
+        (is (some? collapse) "the horizontal collapse track is mounted")
+        (is (= "true" (:data-open (second collapse)))
+            "open when there are no filters")
+        (is (= "false" (:aria-hidden (second collapse)))
+            "aria-hidden mirrors the open state (open = visible)")
+        (is (some? button)
+            "the chrome `+ filter` button stays mounted (only the track collapses)")))))
+
+(deftest chrome-add-filter-button-collapsed-when-events-ribbon-visible
+  (testing "rf2-8zd80 — once ≥1 filter is committed the events-ribbon's
+            own `[+]` icon takes over as the add affordance, so the
+            chrome `+ filter` is REDUNDANT and its horizontal collapse
+            track flips closed (data-open=false). The events-ribbon's
+            own add button stays available throughout."
+    (xray-setup!)
+    (trace-bus/collect-trace! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/add-filter :in {:pattern :a}]))
+    (rf/with-frame :rf/xray
+      (let [tree         (shell/shell-view)
+            collapse     (find-by-testid tree "rf-xray-filter-add-collapse")
+            events-coll  (find-by-testid tree "rf-xray-events-ribbon-collapse")
+            events-add   (find-by-testid tree "rf-xray-filter-add-events")]
+        (is (= "false" (:data-open (second collapse)))
+            "chrome `+ filter` track is CLOSED when ≥1 filter")
+        (is (= "true" (:aria-hidden (second collapse)))
+            "aria-hidden flips to true when collapsed")
+        (is (= "true" (:data-open (second events-coll)))
+            "events-ribbon is OPEN (the two tracks are mutually exclusive)")
+        (is (some? events-add)
+            "the events-ribbon's own `[+]` add affordance remains available")))))
+
+(deftest chrome-add-filter-track-reopens-when-last-filter-removed
+  (testing "rf2-8zd80 — the mutual-exclusion is symmetric: removing the
+            last filter closes the events-ribbon and re-opens the chrome
+            `+ filter` track so the add affordance is never lost in either
+            transition."
+    (xray-setup!)
+    (trace-bus/collect-trace! {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                               :tags {:rf.event/v [:a] :frame :rf/default :rf.trace/dispatch-id 1}})
+    ;; add then immediately remove
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/add-filter :in {:pattern :a}])
+      (rf/dispatch-sync [:rf.xray/remove-filter :in 0]))
+    (rf/with-frame :rf/xray
+      (let [tree        (shell/shell-view)
+            collapse    (find-by-testid tree "rf-xray-filter-add-collapse")
+            events-coll (find-by-testid tree "rf-xray-events-ribbon-collapse")]
+        (is (= "true" (:data-open (second collapse)))
+            "chrome `+ filter` track re-opens after the last filter is removed")
+        (is (= "false" (:data-open (second events-coll)))
+            "events-ribbon re-closes after the last filter is removed")))))
+
 (deftest close-icon-dispatches-close-shell
   (testing "rf2-4vp5j Workstream A — the chrome ribbon `✕` dispatches the
             existing `:rf.xray/close-shell` event (landed by rf2-fq491);

--- a/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
@@ -454,6 +454,70 @@
         (is (re-find #"grid-template-rows:\s*1fr" open)
             "open state expands the grid row to 1fr")))))
 
+(deftest motion-css-pins-filters-collapse-duration-to-250ms
+  (testing "rf2-8zd80 — both transitions on `.rf-xray-filters-collapse`
+            run at exactly 250ms so OPEN and CLOSE share one duration.
+            The previous (200ms grid-template-rows + 160ms opacity) split
+            decoupled the height collapse from the cross-fade by a frame
+            or two; pinning both to 250ms keeps the bottom edge of the
+            bar and the column flex below it travelling in lock-step."
+    (let [css  @#'gs/motion-css
+          base (re-find #"\.rf-xray-filters-collapse\s*\{[\s\S]*?\}" css)]
+      (is (some? base))
+      (when base
+        (is (re-find #"grid-template-rows\s+calc\(250ms\s*\*\s*var\(--rf-xray-motion-scale" base)
+            "grid-template-rows transition is pinned to 250ms")
+        (is (re-find #"opacity\s+calc\(250ms\s*\*\s*var\(--rf-xray-motion-scale" base)
+            "opacity transition is pinned to 250ms")
+        (is (not (re-find #"200ms|160ms" base))
+            "no residual 200ms / 160ms timing from the pre-rf2-8zd80 split")))))
+
+(deftest motion-css-closed-collapse-track-frees-min-height
+  (testing "rf2-8zd80 — the inner toolbar of the events-ribbon carries
+            an inline `min-height: 34px` so the OPEN bar holds its
+            design height (and grows under flex-wrap when pills
+            overflow). That inline min-height beats the stylesheet
+            default; without an `!important` override scoped to the
+            closed state the inner stays 34px tall regardless of the
+            parent grid track, the closed track can't reclaim its
+            space, and the bar leaves a 34px gap where it was. This
+            rule is the layout-bug fix: scoped to `data-open=\"false\"`
+            and `!important` so it lets the closed collapse fully
+            without disturbing the open height."
+    (let [css     @#'gs/motion-css
+          closed  (re-find #"\.rf-xray-filters-collapse\[data-open=\"false\"\]\s*>\s*\*\s*\{[\s\S]*?\}" css)]
+      (is (some? closed)
+          "the [data-open=\"false\"] > * rule is present")
+      (when closed
+        (is (re-find #"min-height:\s*0\s*!important" closed)
+            "closed state forces inner min-height to 0 (overriding inline)")))))
+
+(deftest motion-css-declares-horizontal-collapse-track
+  (testing "rf2-8zd80 — the chrome `+ filter` button is mutually-
+            exclusive with the events-ribbon: when ≥1 filter is
+            committed the events-ribbon's `[+]` icon owns the add
+            affordance and the chrome `+ filter` collapses to zero
+            width. The `.rf-xray-filters-collapse-h` rule is the
+            horizontal sibling of the row-collapse track —
+            `grid-template-columns: 0fr ⇄ 1fr` with the same 250ms /
+            motion-scale cadence keeps the two tracks visually
+            synchronised."
+    (let [css  @#'gs/motion-css
+          base (re-find #"\.rf-xray-filters-collapse-h\s*\{[\s\S]*?\}" css)
+          open (re-find #"\.rf-xray-filters-collapse-h\[data-open=\"true\"\]\s*\{[\s\S]*?\}" css)]
+      (is (some? base) "horizontal collapse base rule is present")
+      (is (some? open) "horizontal collapse open rule is present")
+      (when base
+        (is (re-find #"grid-template-columns:\s*0fr" base)
+            "closed state collapses the grid column to 0fr")
+        (is (re-find #"grid-template-columns\s+calc\(250ms\s*\*\s*var\(--rf-xray-motion-scale" base)
+            "grid-template-columns transition is pinned to 250ms")
+        (is (re-find #"opacity\s+calc\(250ms\s*\*\s*var\(--rf-xray-motion-scale" base)
+            "opacity transition is pinned to 250ms"))
+      (when open
+        (is (re-find #"grid-template-columns:\s*1fr" open)
+            "open state expands the grid column to 1fr")))))
+
 (deftest themes-css-publishes-root-defaults
   (testing "rf2-3f2di B2 — the :root block publishes the LIGHT palette
             as the default (flipped from dark) so any descendant that


### PR DESCRIPTION
Follow-up on #2091 (rf2-pjjwh) which made the events-filter ribbon conditional + animated. Mike observed three related issues live in step-deck.

## Three fixes

### 1. LAYOUT — events table now reclaims the freed space on collapse

**Diagnosis.** The events-ribbon inner toolbar carries an inline `:min-height "34px"` so the OPEN bar holds its 34px design height (and grows under `flex-wrap` when pills overflow). Inline styles beat stylesheet rules unless `!important` wins, so the existing `.rf-xray-filters-collapse > * { min-height: 0 }` rule never applied — the inner stayed 34px tall regardless of the parent grid track, the closed track could not reclaim its space, and the bar left a 34px gap where it had been. The grid `0fr ⇄ 1fr` transition was running on the OUTER track but the INNER refused to shrink.

**Fix.** Scope the `min-height: 0` to `[data-open="false"] > *` and make it `!important` so the closed state overrides the inline floor while the open state still honours its 34px design floor (which `flex-wrap` can grow). The grid track now collapses cleanly to 0 and the column flex below the ribbon slides up in lock-step with the animation. No other layout knobs needed — once the inner truly collapses, the existing flex-column on the shell root reflows the rest naturally.

### 2. ANIMATION — pinned both transitions to exactly 250ms

Previously `grid-template-rows` was 200ms and `opacity` was 160ms — a 2-3 frame split between the height collapse and the cross-fade. Both now run at 250ms so the bar bottom edge and the surrounding column flex travel together.

The reduced-motion seam is unchanged: `calc(250ms * var(--rf-xray-motion-scale, 1))` collapses to a near-instant resolve under `prefers-reduced-motion: reduce` (where the seam pins `--rf-xray-motion-scale: 0.001`). Verified by re-reading `themes-css` — the existing media query is intact.

### 3. CHROME `[+ filter]` hides when the events-ribbon is visible

The two add affordances are mutually exclusive: when ≥1 filter is committed the events-ribbon owns the `[+]` icon button and the chrome ribbon `[+ filter]` is redundant. Added a horizontal sibling of the row-collapse track (`.rf-xray-filters-collapse-h`, `grid-template-columns: 0fr ⇄ 1fr`) wrapping the chrome `[+ filter]`. `data-open` flips on the active-filters count: open when zero, closed otherwise. Same 250ms cadence + reduced-motion seam keep the two tracks visually synchronised — as the events-ribbon slides down, the chrome button retracts to zero width.

The button itself stays mounted (only the track collapses) so test-id lookups and Playwright lassos targeting it still resolve when it is visible, with `aria-hidden` mirroring the data-open state so AT users do not encounter a hidden button.

## Test additions

`tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs`:
- `motion-css-pins-filters-collapse-duration-to-250ms` — guards the 250ms pin against drift (also asserts NO residual 200ms/160ms).
- `motion-css-closed-collapse-track-frees-min-height` — guards the `[data-open="false"] > * { min-height: 0 !important }` override that is the root-cause fix for bug #1.
- `motion-css-declares-horizontal-collapse-track` — guards the horizontal-collapse-track shape and 250ms timing.

`tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs`:
- `chrome-add-filter-button-open-when-no-filters` — chrome track is open + visible when zero filters.
- `chrome-add-filter-button-collapsed-when-events-ribbon-visible` — once ≥1 filter is committed, the chrome track is closed and aria-hidden, while the events-ribbon `[+]` remains available.
- `chrome-add-filter-track-reopens-when-last-filter-removed` — the mutual-exclusion is symmetric.

## Gates

- xray JVM `clojure -M:test` — **863 tests / 3078 assertions, 0 failures**
- `npm run test:cljs` — **4334 tests / 13872 assertions, 0 failures**
- `npm run test:xray-feature-gate` — **13 scenarios, 0 failures**
- `npm run test:bundle-isolation` — **PASS** (uix-helix-reagent-free + bundle-isolation)
- clj-kondo + splint — not installed locally; CI workflow `lint.yml` will run them on the PR.

## Worktree boundary

All edits confined to `C:/Users/miket/code/re-frame2-worktrees/xray-filters-ribbon-layout-rf2-8zd80`; mayor checkout (`C:/Users/miket/code/re-frame2`) untouched throughout. Worker-worktree guard ran clean from the assigned worktree.

## Surface touched

- `tools/xray/src/day8/re_frame2_xray/shell.cljs` — `ribbon` reg-view: subscribe to `:rf.xray/active-filters`, wrap `chrome-add-filter-button` in the horizontal collapse track; docstring updated.
- `tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs` — `motion-css`: pinned both transitions to 250ms, scoped `min-height: 0 !important` to closed state, added horizontal-collapse-track rules.
- Plus two test files extending the existing rf2-pjjwh coverage.