### PR TITLE
fix(xray): Handler panel — cofxs reach COEFFECTS, AFTER INTERCEPTORS shows ctx delta (rf2-9dk9y)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -224,6 +224,16 @@
          captured-cs  (when interop/debug-enabled? call-site)]
      (interceptor/->interceptor
        :id (keyword (str "cofx-" (name cofx-id)))
+       ;; Per rf2-9dk9y: tag this interceptor with `:rf/cofx-id` so
+       ;; tooling (Xray's Event lens) classifies it as a cofx injector
+       ;; and renders it under the COEFFECTS section — NOT under AFTER
+       ;; INTERCEPTORS, where it would be doubly misleading (it has no
+       ;; `:after`, and its `:before` contribution is the injected
+       ;; coeffect value, already surfaced in COEFFECTS). The tag
+       ;; preserves the cofx's fully-qualified id (the interceptor's
+       ;; own `:id` collapses to `(name cofx-id)`, losing the
+       ;; namespace).
+       :rf/cofx-id cofx-id
        :before
        (fn [ctx]
          (if-let [meta (registrar/lookup :cofx cofx-id)]

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -594,26 +594,31 @@
                           :frame      frame-id
                           :recovery   :no-recovery})))))))
 
-(def ^:private framework-coeffect-keys
+(def framework-coeffect-keys
   "Coeffect keys populated by the runtime itself (not by user-registered
-  `reg-cofx` / `inject-cofx`). Filtered OUT of the `:coeffects` stamp on
-  `:event/do-fx` per rf2-jhhqt so the Event lens's COEFFECTS section
-  shows only user-injected coeffects (mirrors the INTERCEPTORS section's
-  filter-out-framework-defaults posture).
+  `reg-cofx` / `inject-cofx`). Filtered OUT of the `:rf.event/coeffects`
+  stamp on `:rf.event/run-end` (rf2-9dk9y) so the Xray Event lens's
+  COEFFECTS section shows only user-injected coeffects (mirrors the
+  AFTER INTERCEPTORS section's filter-out-framework-defaults posture).
 
   `:db` + `:event` are populated by `assemble-initial-ctx`; `:frame` ditto.
   `:source` + `:trace-id` are envelope keys also surfaced on the cofx
   map by `assemble-initial-ctx` for handler-body convenience."
   #{:db :event :frame :source :trace-id})
 
-(defn- user-injected-coeffects
+(defn user-injected-coeffects
   "Project the user-injected subset of a coeffects map. Pure data → data.
 
   Filters out the framework-default keys per `framework-coeffect-keys`.
   Returns nil when the projection is empty (so the caller can use
-  `(when ...)` to skip the trace stamp entirely — `:event/do-fx` consumers
-  treat ABSENT `:coeffects` as 'no user-injected coeffects', distinct
-  from an empty map which would itself be a 'stamped but empty' signal)."
+  `(when ...)` to skip the trace stamp entirely — consumers treat ABSENT
+  `:rf.event/coeffects` as 'no user-injected coeffects', distinct from
+  an empty map which would itself be a 'stamped but empty' signal).
+
+  Called from `re-frame.router/emit-cascade-trailers!` to stamp the
+  per-event user-cofx subset onto `:rf.event/run-end` (rf2-9dk9y — the
+  stamp moved here from `:rf.fx/do-fx` so events that return only `:db`
+  — no `:fx` — still get a COEFFECTS row in the Xray Event lens)."
   [coeffects]
   (when (map? coeffects)
     (let [projected (reduce-kv (fn [acc k v]
@@ -666,25 +671,18 @@
                       effects shape they need via per-fx args. Absent ⇒
                       the trace marker degrades gracefully (no `:fx` /
                       `:db-present?` slots).
-    :coeffects        the handler's final coeffects map (rf2-jhhqt). The
-                      USER-INJECTED subset (everything outside
-                      `framework-coeffect-keys`) is stamped onto the
-                      `:event/do-fx` marker's `:tags` under `:coeffects`
-                      so the Xray Event lens's COEFFECTS section can
-                      render values without a second emit. The filter
-                      mirrors the INTERCEPTORS section's filter-out-
-                      framework-defaults posture; the stamp is absent
-                      entirely (not an empty map) when zero user
-                      coeffects were injected. `trace/emit!` is itself
-                      DCE-gated so prod CLJS bundles elide both the
-                      projection and the emit.
 
   The 3-arity (no `opts`) is the bare machine-exit / cascade-fx walk
-  shape; the router supplies the full opts map once per drained event."
+  shape; the router supplies the full opts map once per drained event.
+
+  Per rf2-9dk9y: the `:coeffects` stamp moved OFF this marker and
+  ONTO `:rf.event/run-end` (where it rides regardless of whether the
+  handler returned `:fx` — the prior placement silently dropped the
+  COEFFECTS row when a handler returned only `:db`)."
   ([frame-id fx-vec active-platform]
    (do-fx frame-id fx-vec active-platform nil))
   ([frame-id fx-vec active-platform
-    {:keys [overrides origin-event parent-envelope effects coeffects]}]
+    {:keys [overrides origin-event parent-envelope effects]}]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
        (handle-one-fx frame-id pair active-platform (or overrides {})
@@ -698,15 +696,7 @@
    ;; cascade rows with handler returns. The tag-map is the third
    ;; arg to `trace/emit!`; `trace/emit!` itself is DCE-gated, so
    ;; prod builds elide both the construction and the emit.
-   ;;
-   ;; Per rf2-jhhqt: additionally stamp `:coeffects` with the user-
-   ;; injected subset of the handler's coeffects map (filter out the
-   ;; framework defaults — `:db` `:event` `:frame` `:source` `:trace-id`).
-   ;; Stamp is absent entirely when zero user cofx — the Event lens
-   ;; treats absent as 'no COEFFECTS section'.
-   (let [user-cofx (user-injected-coeffects coeffects)]
-     (trace/emit! :rf.fx :rf.fx/do-fx
-                  (cond-> {:frame frame-id}
-                    (some? effects)  (assoc :rf.event/fx          (:fx effects)
-                                            :rf.event/db-present? (contains? effects :db))
-                    (some? user-cofx) (assoc :rf.event/coeffects user-cofx))))))
+   (trace/emit! :rf.fx :rf.fx/do-fx
+                (cond-> {:frame frame-id}
+                  (some? effects)  (assoc :rf.event/fx          (:fx effects)
+                                          :rf.event/db-present? (contains? effects :db))))))

--- a/implementation/core/src/re_frame/interceptor.cljc
+++ b/implementation/core/src/re_frame/interceptor.cljc
@@ -9,7 +9,8 @@
 
   The 'context' is a map with :coeffects (inputs) and :effects (outputs).
   The chain runs :before in order, then the handler, then :after in
-  reverse order.")
+  reverse order."
+  (:require [re-frame.interop :as interop]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -132,13 +133,102 @@
                         {:phase :before :id (:id interceptor) :exception e})))
       context)))
 
+(def ^:private ctx-delta-segments
+  "Top-level ctx segments diffed by `compute-ctx-delta`. We compare the
+  user-meaningful contents (`:coeffects` and `:effects`) — the only
+  slots an interceptor's `:after` legitimately mutates per Spec 002
+  §The context map — and skip framework bookkeeping
+  (`:rf/interceptor-error` etc.) so the captured delta surfaces what the
+  interceptor DID, not the runtime's own scaffolding."
+  [:coeffects :effects])
+
+(defn- segment-delta
+  "Project changes between `before` and `after` for one segment map.
+  Returns `{:added {k v ...} :changed {k {:before _ :after _}} :removed
+  {k v ...}}` with each sub-map elided when empty. Returns nil when
+  the segment didn't change at all so the caller can drop the slot."
+  [before after]
+  (let [b   (or before {})
+        a   (or after {})
+        ks-b (set (keys b))
+        ks-a (set (keys a))
+        added   (reduce (fn [acc k]
+                          (if (contains? ks-b k) acc (assoc acc k (get a k))))
+                        {} ks-a)
+        removed (reduce (fn [acc k]
+                          (if (contains? ks-a k) acc (assoc acc k (get b k))))
+                        {} ks-b)
+        ;; Keys present in BOTH maps — values are compared via `=`.
+        common  (filter ks-b ks-a)
+        changed (reduce (fn [acc k]
+                          (let [vb (get b k) va (get a k)]
+                            (if (= vb va)
+                              acc
+                              (assoc acc k {:before vb :after va}))))
+                        {} common)]
+    (when (or (seq added) (seq removed) (seq changed))
+      (cond-> {}
+        (seq added)   (assoc :added added)
+        (seq changed) (assoc :changed changed)
+        (seq removed) (assoc :removed removed)))))
+
+(defn- compute-ctx-delta
+  "Project the per-`:after`-interceptor mutation surface as data. Pure
+  fn over the before/after context snapshots; idempotent and JVM-
+  portable. Returns nil when the `:after` was a no-op (returned the
+  context unchanged) so the caller can skip stashing the row entirely
+  — the Xray AFTER INTERCEPTORS section renders nothing for no-op
+  interceptors. Per rf2-9dk9y."
+  [before after]
+  (let [slots (reduce (fn [acc seg]
+                        (if-let [d (segment-delta (get before seg)
+                                                  (get after seg))]
+                          (assoc acc seg d)
+                          acc))
+                      {}
+                      ctx-delta-segments)]
+    (when (seq slots) slots)))
+
+(defn- framework-default-interceptor?
+  "True iff `interceptor` is a framework-installed scaffolding interceptor
+  whose ctx-delta should NOT be captured for the Xray AFTER INTERCEPTORS
+  surface — they are not user-meaningful interceptors. Mirrors the
+  filter the Xray panel applies on the registration-time list (`:rf/
+  default? true` plus the well-known auto-wrapper ids).
+
+  - `:rf/default?` is the substrate-side marker.
+  - `:rf/cofx-id` flags `inject-cofx` interceptors (rf2-9dk9y) —
+    their COEFFECTS contribution is rendered separately.
+
+  Pure predicate; no allocation when the interceptor carries neither
+  flag."
+  [interceptor]
+  (or (true? (:rf/default? interceptor))
+      (some? (:rf/cofx-id interceptor))))
+
 (defn- invoke-after [context interceptor]
   (if-let [f (:after interceptor)]
-    (try
-      (or (f context) context)
-      (catch #?(:clj Throwable :cljs :default) e
-        (record-error context
-                      {:phase :after :id (:id interceptor) :exception e})))
+    (let [;; Dev-only ctx-delta capture per rf2-9dk9y. The snapshot ride
+          ;; the same `interop/debug-enabled?` gate as the trace surface
+          ;; so production CLJS bundles DCE the capture. Framework
+          ;; defaults (`:rf/default?`, `:rf/cofx-id`) are skipped — they
+          ;; are not user-meaningful interceptors on the AFTER
+          ;; INTERCEPTORS surface.
+          capture? (and interop/debug-enabled?
+                        (not (framework-default-interceptor? interceptor)))
+          before   (when capture? context)]
+      (try
+        (let [after (or (f context) context)]
+          (if capture?
+            (if-let [delta (compute-ctx-delta before after)]
+              (update after :rf/icpt-after-deltas (fnil conj [])
+                      {:rf.icpt/id        (:id interceptor)
+                       :rf.icpt/ctx-delta delta})
+              after)
+            after))
+        (catch #?(:clj Throwable :cljs :default) e
+          (record-error context
+                        {:phase :after :id (:id interceptor) :exception e}))))
     context))
 
 (defn execute-chain

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -619,8 +619,8 @@
   "Walk cofx-relevant tag shapes: the cofx-injected value rides under a
   cofx-id key (per `re-frame.cofx`'s injection convention). When a
   trace event carries a `:rf.event/coeffects` slot (e.g.
-  `:rf.event/dispatched`, `:rf.fx/do-fx`), walk each cofx-id key against
-  the cofx's marks."
+  `:rf.event/dispatched`, `:rf.event/run-end` — rf2-9dk9y), walk each
+  cofx-id key against the cofx's marks."
   [tags]
   (let [cofx-map (:rf.event/coeffects tags)]
     (if-not (map? cofx-map)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -633,17 +633,18 @@
   (whether the handler returned a `:db` slot). The value of `:db`
   is NOT stamped — App-db diff traces already carry slice changes.
 
-  Per rf2-jhhqt: the handler's final coeffects map is also threaded
-  to `do-fx` (the `:coeffects` opt) so the terminating `:event/do-fx`
-  trace marker can stamp `:coeffects` with the user-injected subset
-  (the framework defaults `:db` `:event` `:frame` `:source` `:trace-id`
-  are filtered out inside `do-fx`). Powers the Event lens's COEFFECTS
-  section without a second emit.
+  Per rf2-9dk9y: the user-injected coeffects projection moved OFF the
+  `:rf.fx/do-fx` marker and ONTO `:rf.event/run-end` (see
+  `emit-cascade-trailers!`). The prior placement silently dropped the
+  COEFFECTS row whenever a handler returned only `:db` (no `:fx`) — the
+  fx walk was short-circuited so the marker never emitted. Pinning the
+  cofx stamp to the always-fires run-end emit makes the COEFFECTS
+  section render uniformly across event flavours.
 
   Per rf2-ee38b.1: the former positional do-fx arity ladder collapsed
   into a single `opts` map — this is the sole caller threading the full
   set of optionals."
-  [effects coeffects frame frame-record fx-overrides envelope]
+  [effects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
     (let [active-platform (or (-> frame-record :config :platform)
                               interop/platform)
@@ -652,8 +653,7 @@
                 {:overrides       fx-overrides
                  :origin-event    event
                  :parent-envelope envelope
-                 :effects         effects
-                 :coeffects       coeffects}))))
+                 :effects         effects}))))
 
 ;; ---- process-event* phases ------------------------------------------------
 ;;
@@ -869,7 +869,6 @@
   signal."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
   (let [effects    (:effects final-ctx)
-        coeffects  (:coeffects final-ctx)
         error      (:rf/interceptor-error final-ctx)
         flow-error (:rf/flow-error final-ctx)
         db-before  (get-in final-ctx [:coeffects :db])]
@@ -899,7 +898,7 @@
       :rolled-back
       :else
       (do
-        (run-fx-effects! effects coeffects frame frame-record fx-overrides envelope)
+        (run-fx-effects! effects frame frame-record fx-overrides envelope)
         :ok))))
 
 (defn- emit-cascade-trailers!
@@ -930,26 +929,58 @@
   per-op handler duration — NOT the whole run-end − run-start cascade
   bracket (which also covers fx+subs+views). nil in production (the
   caller's read rides `interop/debug-enabled?`); the `(some? ...)` slot
-  then collapses."
-  [event-id event emit-event frame outcome start-ms handler-elapsed-ms]
-  (trace/emit! :rf.event :rf.event/run-end
-               (cond-> {:rf.trace/event-id event-id
-                        :rf.event/v        emit-event
-                        :frame             frame
-                        :rf.trace/phase    :run-end}
-                 (some? handler-elapsed-ms)
-                 (assoc :rf.event/elapsed-ms handler-elapsed-ms)))
-  ;; Sticky hook (rf2-f72pd) — always-on per-event observability fan-out
-  ;; per rf2-rirbq; survives `:advanced` + `goog.DEBUG=false`.
-  (when-let [emit-event! (late-bind/get-fn-cached :event-emit/dispatch-on-event)]
-    (let [end-ms     (interop/now-ms)
-          elapsed-ms (long (max 0 (- end-ms start-ms)))]
-      (emit-event! emit-event
-                   event-id
-                   frame
-                   end-ms
-                   outcome
-                   elapsed-ms))))
+  then collapses.
+
+  Per rf2-9dk9y two further `:tags` slots ride this emit so the Xray
+  Event lens's COEFFECTS / AFTER INTERCEPTORS sections render uniformly
+  regardless of whether the handler returned `:fx`:
+
+    `:rf.event/coeffects`    — the USER-INJECTED subset of the
+                                handler's final coeffects map (framework
+                                defaults `:db` `:event` `:frame`
+                                `:source` `:trace-id` filtered out at
+                                this boundary). Absent entirely when
+                                zero user cofx were injected.
+    `:rf.event/after-deltas` — vector of per-`:after` interceptor
+                                ctx-delta records `{:rf.icpt/id <id>
+                                :rf.icpt/ctx-delta {...}}` populated by
+                                `interceptor/execute-chain` for every
+                                user-registered `:after` that mutated
+                                the context. Absent when no user-`:after`
+                                ran. The Xray AFTER INTERCEPTORS section
+                                reads it to render an EDN-diff under
+                                each row."
+  [event-id event emit-event frame outcome start-ms handler-elapsed-ms final-ctx]
+  ;; The cofx / after-delta projections are dev-only: their cost rides
+  ;; `interop/debug-enabled?` so production CLJS bundles DCE the
+  ;; projection AND the `trace/emit!` body below (the emit itself is
+  ;; gated the same way internally).
+  (let [user-cofx    (when interop/debug-enabled?
+                       (fx/user-injected-coeffects (:coeffects final-ctx)))
+        after-deltas (when interop/debug-enabled?
+                       (not-empty (:rf/icpt-after-deltas final-ctx)))]
+    (trace/emit! :rf.event :rf.event/run-end
+                 (cond-> {:rf.trace/event-id event-id
+                          :rf.event/v        emit-event
+                          :frame             frame
+                          :rf.trace/phase    :run-end}
+                   (some? handler-elapsed-ms)
+                   (assoc :rf.event/elapsed-ms handler-elapsed-ms)
+                   (some? user-cofx)
+                   (assoc :rf.event/coeffects user-cofx)
+                   (some? after-deltas)
+                   (assoc :rf.event/after-deltas after-deltas)))
+    ;; Sticky hook (rf2-f72pd) — always-on per-event observability fan-out
+    ;; per rf2-rirbq; survives `:advanced` + `goog.DEBUG=false`.
+    (when-let [emit-event! (late-bind/get-fn-cached :event-emit/dispatch-on-event)]
+      (let [end-ms     (interop/now-ms)
+            elapsed-ms (long (max 0 (- end-ms start-ms)))]
+        (emit-event! emit-event
+                     event-id
+                     frame
+                     end-ms
+                     outcome
+                     elapsed-ms)))))
 
 (defn- run-handler-cascade!
   "Sequence the four cascade phases under the handler's
@@ -1028,7 +1059,7 @@
             outcome   (commit-and-flow! final-ctx event-id event frame
                                         frame-record fx-overrides envelope start-ms)]
         (emit-cascade-trailers! event-id event emit-event frame outcome
-                                start-ms handler-elapsed-ms)))))
+                                start-ms handler-elapsed-ms final-ctx)))))
 
 (defn- process-event*
   "Per-event drain body. Resolve handler, then sequence the four cascade

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -661,19 +661,26 @@
         (finally
           (rf/unregister-listener! ::top-level))))))
 
-;; ---- rf2-jhhqt: :coeffects stamp on :rf.fx/do-fx -------------------------
+;; ---- rf2-9dk9y: :coeffects stamp on :rf.event/run-end --------------------
 ;;
-;; Per rf2-jhhqt the user-injected subset of the handler's final
-;; coeffects map rides under `:tags :rf.event/coeffects` on :rf.fx/do-fx.
-;; Mirrors the rf2-twt7m Change 2 stamping: substrate-side filter keeps
-;; the framework defaults (:db :event :frame :source :trace-id) out so
-;; the Event lens's COEFFECTS section reads a pre-filtered map.
+;; Per rf2-9dk9y (supersedes rf2-jhhqt) the user-injected subset of the
+;; handler's final coeffects map rides under `:tags :rf.event/coeffects`
+;; on :rf.event/run-end — NOT on :rf.fx/do-fx as it used to. The prior
+;; placement silently dropped the stamp whenever a handler returned only
+;; :db (no :fx), because the do-fx walk was short-circuited and the
+;; marker never emitted. The Xray Event lens's COEFFECTS section was
+;; therefore empty for textbook reg-event-fx like `:counter/inc` that
+;; injected a cofx but returned only a :db slot. Pinning the stamp to
+;; the always-fires run-end emit makes the COEFFECTS section render
+;; uniformly across event flavours. The substrate-side filter
+;; (`fx/user-injected-coeffects`) keeps the framework defaults
+;; (:db :event :frame :source :trace-id) out at emit time.
 
-(deftest event-do-fx-stamps-user-injected-coeffects
+(deftest event-run-end-stamps-user-injected-coeffects-with-fx
   (testing "a handler whose chain injects user coeffects (:now etc.)
-   sees them stamped under :tags :rf.event/coeffects on :rf.fx/do-fx; the
-   framework defaults (:db :event :frame) are filtered out at the
-   substrate"
+   AND returns both :db + :fx sees them stamped under :tags
+   :rf.event/coeffects on :rf.event/run-end; the framework defaults
+   (:db :event :frame) are filtered out at the substrate"
     (rf/reg-fx :fx-test/cofx-sink (fn [_ _] :ok))
     (rf/reg-cofx :fx-test/now
       (fn [ctx]
@@ -689,34 +696,65 @@
     (let [acc (collect-traces! ::user-cofx)]
       (try
         (rf/dispatch-sync [:fx-test/uses-user-cofx])
-        (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
-              cofx  (get-in dof [:tags :rf.event/coeffects])]
-          (is (some? dof) ":rf.fx/do-fx fired")
+        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+              cofx  (get-in re [:tags :rf.event/coeffects])
+              [dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)]
+          (is (some? re) ":rf.event/run-end fired")
           (is (= {:fx-test/now    "2026-05-18T19:00:00Z"
                   :fx-test/locale :en-AU}
                  cofx)
-              "only the user-injected coeffects ride under :tags :rf.event/coeffects")
+              "only the user-injected coeffects ride under :tags :rf.event/coeffects on run-end")
           (is (not (contains? cofx :db))    "framework :db NOT stamped")
           (is (not (contains? cofx :event)) "framework :event NOT stamped")
-          (is (not (contains? cofx :frame)) "framework :frame NOT stamped"))
+          (is (not (contains? cofx :frame)) "framework :frame NOT stamped")
+          (is (not (contains? (:tags dof) :rf.event/coeffects))
+              "the stamp lives on run-end now — :rf.fx/do-fx no longer carries it"))
         (finally
           (rf/unregister-listener! ::user-cofx))))))
 
-(deftest event-do-fx-coeffects-stamp-absent-when-no-user-cofx
-  (testing "a handler with no inject-cofx has its :rf.fx/do-fx fire
-   WITHOUT a :coeffects stamp (silent-by-default — distinct from a
-   stamped empty map)"
-    (rf/reg-fx :fx-test/plain-sink (fn [_ _] :ok))
-    (rf/reg-event-fx :fx-test/no-user-cofx
-      (fn [_ _] {:db {:k 1}
-                 :fx [[:fx-test/plain-sink :go]]}))
+(deftest event-run-end-stamps-user-injected-coeffects-without-fx
+  (testing "rf2-9dk9y bug A — a reg-event-fx that injects user cofx and
+   returns only {:db ...} (no :fx) STILL surfaces its coeffects on
+   :rf.event/run-end. Was silently dropped under the prior do-fx-marker
+   stamping (do-fx was short-circuited when the handler returned no :fx,
+   so the COEFFECTS section was empty for textbook handlers like
+   :counter/inc — the cofx never reached the Xray Event lens)"
+    (rf/reg-cofx :fx-test/now
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :fx-test/now] "2026-05-18T19:00:00Z")))
+    (rf/reg-event-fx :fx-test/db-only-with-cofx
+      [(rf/inject-cofx :fx-test/now)]
+      (fn [{:keys [fx-test/now]} _]
+        {:db {:stamped-at now}}))
+    (let [acc (collect-traces! ::db-only-cofx)]
+      (try
+        (rf/dispatch-sync [:fx-test/db-only-with-cofx])
+        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+              cofx  (get-in re [:tags :rf.event/coeffects])
+              dof   (first (filterv #(= :rf.fx/do-fx (:operation %)) @acc))]
+          (is (some? re) ":rf.event/run-end fired (always — independent of :fx)")
+          (is (= {:fx-test/now "2026-05-18T19:00:00Z"} cofx)
+              "the user-injected cofx surfaces under :tags :rf.event/coeffects
+               EVEN THOUGH the handler returned no :fx — bug A's repro")
+          (is (nil? dof)
+              ":rf.fx/do-fx was correctly NOT emitted (no :fx vector); the
+               cofx stamp would have been dropped if it still rode on do-fx"))
+        (finally
+          (rf/unregister-listener! ::db-only-cofx))))))
+
+(deftest event-run-end-coeffects-stamp-absent-when-no-user-cofx
+  (testing "a handler with no inject-cofx has its :rf.event/run-end fire
+   WITHOUT a :rf.event/coeffects stamp (silent-by-default — distinct
+   from a stamped empty map)"
+    (rf/reg-event-db :fx-test/no-user-cofx
+      (fn [db _] (assoc db :k 1)))
     (let [acc (collect-traces! ::no-cofx)]
       (try
         (rf/dispatch-sync [:fx-test/no-user-cofx])
-        (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
-              tags  (:tags dof)]
-          (is (some? dof) ":rf.fx/do-fx fired")
-          (is (not (contains? tags :coeffects))
-              ":coeffects key ABSENT on :tags when no user cofx injected"))
+        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+              tags  (:tags re)]
+          (is (some? re) ":rf.event/run-end fired")
+          (is (not (contains? tags :rf.event/coeffects))
+              ":rf.event/coeffects key ABSENT on :tags when no user cofx injected"))
         (finally
           (rf/unregister-listener! ::no-cofx))))))

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -46,11 +46,21 @@
                on success-path emits. DISPATCH reads it.
     Change 3 — Framework-auto-wrapped interceptors carry
                `:rf/default? true` so AFTER INTERCEPTORS can filter them
-               out without an allowlist.
-    Change 4 — (rf2-jhhqt) `:rf.fx/do-fx` traces carry
-               `:rf.event/coeffects` on their `:tags` — the USER-INJECTED
-               subset of the handler's coeffects (framework defaults
-               filtered at the substrate). COEFFECTS reads it.
+               out without an allowlist. `inject-cofx` interceptors carry
+               `:rf/cofx-id` (rf2-9dk9y) — also filtered, since their
+               contribution renders under COEFFECTS instead.
+    Change 4 — (rf2-9dk9y, supersedes rf2-jhhqt) `:rf.event/run-end`
+               traces carry `:rf.event/coeffects` on their `:tags` — the
+               USER-INJECTED subset of the handler's coeffects (framework
+               defaults filtered at the substrate). COEFFECTS reads it.
+               Run-end always fires, so events that return only `:db`
+               (no `:fx`) still surface their user cofx.
+    Change 5 — (rf2-9dk9y) `:rf.event/run-end` traces carry
+               `:rf.event/after-deltas` on their `:tags` — a vector of
+               per-`:after`-interceptor ctx-delta records
+               `{:rf.icpt/id <id> :rf.icpt/ctx-delta {...}}`. AFTER
+               INTERCEPTORS reads it to render the +/~/- diff under each
+               row, matching APP-DB CHANGES' EDN-diff idiom.
 
   Handler-site coord + source read via `(rf/handler-meta :event id)` —
   no trace involvement; reads the registry at render time.
@@ -217,13 +227,25 @@
 
 (defn user-interceptors
   "Filter `interceptors` (the chain on `(rf/handler-meta :event id)
-  :interceptors`) down to the user-visible ones — drop any flagged
-  `:rf/default? true`, plus the known auto-wrapper ids as a belt-and-
-  braces fallback. Pure fn; JVM-testable."
+  :interceptors`) down to the user-visible AFTER INTERCEPTORS surface —
+  drop:
+
+    - any flagged `:rf/default? true` (the substrate-side marker for
+      framework-auto-wrapped interceptors, per rf2-twt7m Change 3);
+    - any flagged `:rf/cofx-id` (per rf2-9dk9y — the `inject-cofx`
+      interceptor's contribution is rendered under COEFFECTS, not
+      AFTER INTERCEPTORS, so it would be doubly misleading to surface
+      it here — it has no `:after` and its `:before` injection is
+      already shown one section up);
+    - the known framework auto-wrapper ids as a belt-and-braces
+      fallback for older registrations that pre-date the flag.
+
+  Pure fn; JVM-testable."
   [interceptors]
   (vec
     (remove (fn [i]
               (or (true? (:rf/default? i))
+                  (some? (:rf/cofx-id i))
                   (contains? default-interceptor-id? (:id i))))
             (or interceptors []))))
 
@@ -450,16 +472,19 @@
 
 (defn user-coeffects
   "Project the user-injected coeffects map off the cascade's
-  `:event/do-fx` trace (rf2-jhhqt — substrate Change 4 stamps the
-  user-injected subset on `:tags :rf.event/coeffects`). Pure fn; JVM-testable.
+  `:rf.event/run-end` trace (rf2-9dk9y — the substrate stamps the user-
+  injected subset on `:tags :rf.event/coeffects` of run-end so it rides
+  uniformly across event flavours; the prior placement on `:rf.fx/do-fx`
+  silently dropped the stamp whenever a handler returned only `:db` and
+  no `:fx`, because do-fx was never invoked). Pure fn; JVM-testable.
 
-  Returns the map (preserving id → value pairs) or nil when the
-  cascade carries no coeffects stamp / the stamp is empty. The
-  substrate filters the framework defaults (`:db` `:event` `:frame`
-  `:source` `:trace-id`) at emit-time so this fn is a thin reader —
-  it does NOT re-filter."
-  [cascade]
-  (let [m (some-> (do-fx-trace cascade) :tags :rf.event/coeffects)]
+  Returns the map (preserving id → value pairs) or nil when the cascade
+  carries no coeffects stamp / the stamp is empty. The substrate
+  filters the framework defaults (`:db` `:event` `:frame` `:source`
+  `:trace-id`) at emit-time so this fn is a thin reader — it does NOT
+  re-filter."
+  [{:keys [handler] :as _cascade}]
+  (let [m (some-> handler :tags :rf.event/coeffects)]
     (when (and (map? m) (seq m))
       m)))
 
@@ -496,43 +521,162 @@
 
 ;; ---- step AFTER INTERCEPTORS (spec/021 §2.2 step 6) -------------------
 
+(defn after-deltas-by-id
+  "Project the per-`:after` ctx-delta records off the cascade's
+  `:rf.event/run-end` trace (rf2-9dk9y) into a `{:rf.icpt/id → delta}`
+  lookup map. Returns `{}` when the trace carries no after-deltas (no
+  user `:after` ran, or every `:after` was a no-op). Pure fn;
+  JVM-testable."
+  [{:keys [handler] :as _cascade}]
+  (let [rows (some-> handler :tags :rf.event/after-deltas)]
+    (if (sequential? rows)
+      (reduce (fn [acc {:keys [rf.icpt/id rf.icpt/ctx-delta]}]
+                (cond-> acc
+                  (and (some? id) (some? ctx-delta))
+                  (assoc id ctx-delta)))
+              {}
+              rows)
+      {})))
+
+(def ^:private ctx-delta-op->glyph
+  "EDN-diff glyph idiom mirrors APP-DB CHANGES: `+` added, `~` changed,
+  `-` removed."
+  {:added   "+"
+   :changed "~"
+   :removed "-"})
+
+(def ^:private ctx-delta-op->colour-key
+  "Token key per op — same green/yellow/red palette APP-DB CHANGES uses
+  (`app-db-diff-format/op->border`) so the two sections read as one
+  visual idiom."
+  {:added   :green
+   :changed :yellow
+   :removed :red})
+
+(defn- ctx-delta-row
+  "One `[<glyph>] [<segment>/<key>] [<value>]` row for the after-delta
+  block. `segment` is `:coeffects` or `:effects`; `op` is `:added`,
+  `:changed`, or `:removed`; `value` is the post-state for added /
+  the pre-state for removed / the `{:before _ :after _}` pair for
+  changed (pre-formatted by `format-changed-value`)."
+  [segment op k display-value testid-suffix]
+  (let [glyph    (ctx-delta-op->glyph op)
+        colour   (get tokens (ctx-delta-op->colour-key op))]
+    [:div {:data-testid (str "rf-xray-event-detail-icpt-delta-row-" testid-suffix)
+           :style {:display "flex"
+                   :align-items "flex-start"
+                   :padding "1px 0 1px 24px"
+                   :font-family mono-stack
+                   :font-size "11px"}}
+     [:span {:style {:color colour
+                     :font-weight 700
+                     :margin-right "8px"
+                     :min-width "10px"}}
+      glyph]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :margin-right "8px"
+                     :min-width "0"}}
+      (str (name segment) "/" (pr-str k))]
+     [:span {:style {:color (:text-primary tokens)
+                     :min-width "0"
+                     :flex 1
+                     :word-break "break-word"}}
+      display-value]]))
+
+(defn- format-changed-value
+  "Pretty-print a `{:before _ :after _}` change pair as
+  `<before> → <after>` using the same EDN formatter App-DB diff rows
+  use, so the value column reads consistently with that section."
+  [{:keys [before after]}]
+  (str (f/format-display-edn before) " → " (f/format-display-edn after)))
+
+(defn- ctx-delta-block
+  "Render the ctx-delta data captured for one `:after` interceptor as a
+  block of rows (one per added/changed/removed key per ctx-segment).
+  Returns nil when `delta` is nil so the caller can omit the block
+  entirely (per spec/021 §2.2 — absence by omission). Per rf2-9dk9y."
+  [delta icpt-suffix]
+  (when (seq delta)
+    (let [segments  [:coeffects :effects]
+          per-seg   (fn [seg]
+                      (let [seg-delta (get delta seg)
+                            added     (sort (keys (:added seg-delta)))
+                            changed   (sort (keys (:changed seg-delta)))
+                            removed   (sort (keys (:removed seg-delta)))]
+                        (concat
+                          (for [k added]
+                            (ctx-delta-row seg :added k
+                                           (f/format-display-edn
+                                             (get-in seg-delta [:added k]))
+                                           (str icpt-suffix "-" (name seg) "-added-"
+                                                (interceptor-testid-suffix k))))
+                          (for [k changed]
+                            (ctx-delta-row seg :changed k
+                                           (format-changed-value
+                                             (get-in seg-delta [:changed k]))
+                                           (str icpt-suffix "-" (name seg) "-changed-"
+                                                (interceptor-testid-suffix k))))
+                          (for [k removed]
+                            (ctx-delta-row seg :removed k
+                                           (f/format-display-edn
+                                             (get-in seg-delta [:removed k]))
+                                           (str icpt-suffix "-" (name seg) "-removed-"
+                                                (interceptor-testid-suffix k)))))))
+          rows      (mapcat per-seg segments)]
+      (when (seq rows)
+        (into [:div {:data-testid (str "rf-xray-event-detail-icpt-delta-" icpt-suffix)
+                     :style {:padding "2px 0 4px 0"}}]
+              (map-indexed
+                (fn [i row] (with-meta row {:key (str i)}))
+                rows))))))
+
 (defn- interceptor-row
-  [{:keys [id file line] :as _interceptor}]
+  [{:keys [id file line] :as _interceptor} delta]
   (let [coord   (when (string? file) {:file file :line line})
         display (format-coord-display coord)
         suffix  (interceptor-testid-suffix id)]
     [:div {:data-testid (str "rf-xray-event-detail-interceptor-row-" suffix)
-           :style {:display "flex"
-                   :align-items "center"
-                   :padding "2px 0"}}
-     [:span {:style {:color (:accent tokens)
-                     :margin-right "12px"
-                     :min-width "180px"}}
-      (pr-str id)]
-     (if display
-       [:span {:style {:color (:text-secondary tokens)}}
-        display]
-       [:span {:style {:color (:text-tertiary tokens)
-                       :font-style "italic"
-                       :font-size "11px"}}
-        "rf2 std-interceptor"])
-     (coord-chip coord
-                 (str "rf-xray-event-detail-interceptor-open-chip-" suffix))]))
+           :style {:padding "2px 0"}}
+     [:div {:style {:display "flex"
+                    :align-items "center"}}
+      [:span {:style {:color (:accent tokens)
+                      :margin-right "12px"
+                      :min-width "180px"}}
+       (pr-str id)]
+      (if display
+        [:span {:style {:color (:text-secondary tokens)}}
+         display]
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-style "italic"
+                        :font-size "11px"}}
+         "rf2 std-interceptor"])
+      (coord-chip coord
+                  (str "rf-xray-event-detail-interceptor-open-chip-" suffix))]
+     ;; Per rf2-9dk9y: render the per-:after ctx-delta block below the
+     ;; row when the substrate captured one — using the EDN-diff
+     ;; +/~/- idiom shared with APP-DB CHANGES. Absent (`nil` delta)
+     ;; when the :after was a no-op, or when this interceptor has no
+     ;; :after fn — the row then reads as 'ran, no ctx mutation' /
+     ;; ':before-only' respectively.
+     (ctx-delta-block delta suffix)]))
 
 (defn- after-interceptors-body
   "Step AFTER INTERCEPTORS body — one row per non-standard interceptor.
   Returns nil when the user has no non-standard interceptors; the
   OPTIONAL step is then omitted entirely (spec/021 §2.2 — absence by
   omission). Pre-computed via `user-interceptors` (test-level helper)
-  before invoking this fn. Returns body hiccup otherwise."
-  [user-icpts]
+  before invoking this fn. `id->delta` is the per-id ctx-delta lookup
+  (`after-deltas-by-id`) — looked up per row to render what each
+  `:after` added / changed / removed in `:rf/ctx`. Returns body hiccup
+  otherwise."
+  [user-icpts id->delta]
   (when (seq user-icpts)
     (into [:div]
           ;; Per rf2-ppzid: `^{:key ...}` reader-meta on a fn CALL FORM
           ;; (a list) is lost — `with-meta` on the fn return preserves
           ;; the key correctly.
           (for [icpt user-icpts]
-            (with-meta (interceptor-row icpt)
+            (with-meta (interceptor-row icpt (get id->delta (:id icpt)))
                        {:key (pr-str (:id icpt))})))))
 
 ;; ---- step EVENT HANDLER (spec/021 §2.2 step 3) ------------------------
@@ -1330,10 +1474,11 @@
 
   The stripe (mode `:accent`) sits on the outer container per §17.1.3."
   [{:keys [dispatch-id frame event] :as cascade}]
-  (let [event-id   (when (vector? event) (first event))
-        meta       (when event-id (rf/handler-meta :event event-id))
-        user-icpts (user-interceptors (:interceptors meta))
-        threw?     (has-handler-exception? cascade)
+  (let [event-id    (when (vector? event) (first event))
+        meta        (when event-id (rf/handler-meta :event event-id))
+        user-icpts  (user-interceptors (:interceptors meta))
+        id->delta   (after-deltas-by-id cascade)
+        threw?      (has-handler-exception? cascade)
         ;; Build the DB CHANGES body — the app-db diff, with the SSR
         ;; hydration-outcome addendum appended when present.
         db-changes (when-not threw?
@@ -1351,7 +1496,7 @@
                     ["db-changes"        "APP-DB CHANGES"     db-changes]
                     ["flows"             "FLOWS"              (when-not threw? (flows-body cascade))]
                     ["after-interceptors" "AFTER INTERCEPTORS" (when-not threw?
-                                                                 (after-interceptors-body user-icpts))]
+                                                                 (after-interceptors-body user-icpts id->delta))]
                     ["fx"                "FX"                 (when-not threw? (fx-body cascade))]]
         ;; Drop omitted (nil-body) steps, then number what remains 1..N
         ;; — dynamic numbering so the visible steps read contiguously.

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -67,10 +67,15 @@
     - Stamps `:source` + `:origin` (also top-level — `build-event`'s
       success-path hoist).
     - Stamps `:fx` + `:db-present?` on the `:rf.fx/do-fx` trace's
-      `:tags` (rf2-twt7m Change 2) so EFFECTS RETURNED has data."
+      `:tags` (rf2-twt7m Change 2) so EFFECTS RETURNED has data.
+    - Stamps `:rf.event/coeffects` + `:rf.event/after-deltas` on the
+      `:rf.event/run-end` trace's `:tags` (rf2-9dk9y — supersedes the
+      prior do-fx-marker placement) so COEFFECTS + AFTER INTERCEPTORS
+      surfaces have data."
   ([dispatch-id event-vec id-base]
    (cascade-evs dispatch-id event-vec id-base nil))
-  ([dispatch-id event-vec id-base {:keys [frame-id call-site source origin fx db-present? coeffects]
+  ([dispatch-id event-vec id-base {:keys [frame-id call-site source origin fx db-present?
+                                          coeffects after-deltas]
                                     :or   {fx          [[:db nil] [:dispatch [:bar]]]
                                            db-present? true
                                            source      :ui
@@ -86,13 +91,14 @@
              frame-id (assoc :frame frame-id))}
     {:id (+ id-base 3) :op-type :rf.event :operation :rf.event/run-end
      :tags (cond-> {:rf.trace/dispatch-id dispatch-id :rf.trace/phase :run-end :duration-ms 11}
-             frame-id (assoc :frame frame-id))}
+             frame-id        (assoc :frame frame-id)
+             (seq coeffects) (assoc :rf.event/coeffects coeffects)
+             (seq after-deltas) (assoc :rf.event/after-deltas after-deltas))}
     {:id (+ id-base 4) :op-type :rf.fx :operation :rf.fx/do-fx
      :tags (cond-> {:rf.trace/dispatch-id dispatch-id}
              frame-id    (assoc :frame frame-id)
              fx          (assoc :rf.event/fx fx)
-             db-present? (assoc :rf.event/db-present? true)
-             (seq coeffects) (assoc :rf.event/coeffects coeffects))}
+             db-present? (assoc :rf.event/db-present? true))}
     {:id (+ id-base 5) :op-type :rf.fx :operation :rf.fx/handled
      :tags (cond-> {:rf.trace/dispatch-id dispatch-id :rf.fx/id :db :duration-ms 1}
              frame-id (assoc :frame frame-id))}
@@ -514,6 +520,57 @@
                                     "rf-xray-event-detail-interceptor-row-auth/require-login")))
         (is (some? (find-by-testid tree
                                     "rf-xray-event-detail-interceptor-row-auth/log-action")))))))
+
+(deftest after-interceptors-step-omits-cofx-interceptors
+  (testing "rf2-9dk9y bug B — a chain consisting ONLY of inject-cofx
+            interceptors must not surface an AFTER INTERCEPTORS section.
+            Their contribution belongs to COEFFECTS; surfacing them here
+            (the prior misclassification Mike observed live) would render
+            an empty-bodied row since cofx wrappers have no :after."
+    (rf/with-frame :rf/default
+      (rf/reg-cofx :testdeck/now (fn [ctx] (assoc-in ctx [:coeffects :testdeck/now] 0)))
+      (rf/reg-event-fx :counter/inc
+        [(rf/inject-cofx :testdeck/now)]
+        (fn [_ _] {:db {:k 1}})))
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0
+                                {:coeffects {:testdeck/now 1716000000000}}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-xray-event-detail-section-after-interceptors"))
+            "AFTER INTERCEPTORS omitted — the cofx interceptor is filtered out
+             so the otherwise-empty user-chain leaves the section absent")
+        (is (some? (find-by-testid tree "rf-xray-event-detail-section-coeffects"))
+            "COEFFECTS section IS present (the cofx renders there instead)")))))
+
+(deftest after-interceptors-rows-render-ctx-delta-from-handler-stamp
+  (testing "rf2-9dk9y bug B — each AFTER INTERCEPTORS row carries an
+            EDN-diff block showing what its :after added / changed /
+            removed in :rf/ctx. Read off :tags :rf.event/after-deltas
+            on the cascade's :handler (run-end) trace."
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :auth/login
+        [(rf/->interceptor :id :auth/require-login :after identity)
+         (rf/->interceptor :id :auth/log-action    :after identity)]
+        (fn [_ _] {})))
+    (seed-buffer!
+      (cascade-evs 100 [:auth/login] 0
+                   {:after-deltas
+                    [{:rf.icpt/id        :auth/require-login
+                      :rf.icpt/ctx-delta {:coeffects {:added {:user/id 42}}}}
+                     {:rf.icpt/id        :auth/log-action
+                      :rf.icpt/ctx-delta {:effects {:changed
+                                                    {:db {:before {:k 1}
+                                                          :after  {:k 2}}}}}}]}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree
+                                    "rf-xray-event-detail-icpt-delta-auth/require-login"))
+            "delta block renders for the first interceptor")
+        (is (some? (find-by-testid tree
+                                    "rf-xray-event-detail-icpt-delta-auth/log-action"))
+            "delta block renders for the second interceptor")))))
 
 ;; ---- (6) EVENT HANDLER step --------------------------------------------
 
@@ -1000,18 +1057,40 @@
         (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-auth/token")))
         (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-env/build")))))))
 
-(deftest user-coeffects-helper-projects-stamp-from-do-fx
-  (testing "user-coeffects reads :tags :coeffects off the cascade's :fx
-            (do-fx) trace; returns nil when the stamp is absent / empty"
+(deftest user-coeffects-helper-projects-stamp-from-run-end
+  (testing "rf2-9dk9y — user-coeffects reads :tags :rf.event/coeffects
+            off the cascade's :handler (run-end) trace; returns nil when
+            the stamp is absent / empty. The stamp moved off :rf.fx/do-fx
+            because do-fx doesn't fire for handlers that return only :db
+            (no :fx) — bug A's repro"
     (is (= {:now "2026-05-18"}
            (event-detail/user-coeffects
-             {:fx {:tags {:rf.event/coeffects {:now "2026-05-18"}}}})))
-    (is (nil? (event-detail/user-coeffects {:fx {:tags {}}}))
+             {:handler {:tags {:rf.event/coeffects {:now "2026-05-18"}}}})))
+    (is (nil? (event-detail/user-coeffects {:handler {:tags {}}}))
         "absent stamp → nil")
-    (is (nil? (event-detail/user-coeffects {:fx {:tags {:rf.event/coeffects {}}}}))
+    (is (nil? (event-detail/user-coeffects {:handler {:tags {:rf.event/coeffects {}}}}))
         "empty stamp → nil (silent-by-default)")
-    (is (nil? (event-detail/user-coeffects {:fx nil}))
-        "no do-fx trace → nil")))
+    (is (nil? (event-detail/user-coeffects {:handler nil}))
+        "no run-end trace → nil")))
+
+(deftest user-coeffects-survives-handlers-that-return-only-db
+  (testing "rf2-9dk9y bug A regression — a synthetic cascade for a handler
+            that returned only {:db ...} (no :fx) still surfaces its
+            user-injected cofx under COEFFECTS. Before the fix, the stamp
+            rode on :rf.fx/do-fx and was therefore silently dropped when
+            do-fx never fired."
+    (seed-buffer!
+      (cascade-evs 100 [:counter/inc] 0
+                   {:fx nil
+                    :db-present? true
+                    :coeffects {:testdeck/now 1716000000000}}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-event-detail-section-coeffects"))
+            "COEFFECTS section renders even though :fx was nil")
+        (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-testdeck/now"))
+            "the user-injected cofx surfaces as a row")))))
 
 ;; ---- (9) handler-threw — omits post-handler steps, NO footer ----------
 
@@ -1070,6 +1149,42 @@
                  {:id :user-icpt :before identity}]
           user  (event-detail/user-interceptors chain)]
       (is (= [:user-icpt] (map :id user))))))
+
+(deftest user-interceptors-filters-cofx-interceptors
+  (testing "rf2-9dk9y bug B — interceptors carrying :rf/cofx-id
+            (`inject-cofx`) are filtered from AFTER INTERCEPTORS so their
+            contribution is rendered under COEFFECTS only (the prior
+            behaviour leaked the cofx interceptor into AFTER INTERCEPTORS,
+            misclassifying it and rendering it without any ctx delta
+            since it has no :after)"
+    (let [chain [{:id :cofx-now :rf/cofx-id :testdeck/now :before identity}
+                 {:id :cofx-jwt :rf/cofx-id :auth/jwt    :before identity}
+                 {:id :auth/require-login :before identity :after identity}
+                 {:id :rf/db-handler :rf/default? true :before identity}]
+          user  (event-detail/user-interceptors chain)]
+      (is (= [:auth/require-login] (map :id user))
+          "only the genuine user `:after`-bearing interceptor remains; the
+           cofx wrappers + the framework default are both filtered out"))))
+
+(deftest after-deltas-by-id-projects-handler-tag
+  (testing "rf2-9dk9y — after-deltas-by-id flattens the
+            :rf.event/after-deltas vector off the cascade's :handler
+            (run-end) trace into a {:rf.icpt/id → ctx-delta} lookup map"
+    (is (= {:auth/require-login {:coeffects {:added {:user/id 42}}}
+            :auth/log-action    {:effects   {:changed {:db {:before {:k 1}
+                                                            :after  {:k 2}}}}}}
+           (event-detail/after-deltas-by-id
+             {:handler
+              {:tags {:rf.event/after-deltas
+                      [{:rf.icpt/id :auth/require-login
+                        :rf.icpt/ctx-delta {:coeffects {:added {:user/id 42}}}}
+                       {:rf.icpt/id :auth/log-action
+                        :rf.icpt/ctx-delta {:effects {:changed {:db {:before {:k 1}
+                                                                     :after  {:k 2}}}}}}]}}})))
+    (is (= {} (event-detail/after-deltas-by-id {:handler nil}))
+        "no run-end trace → {}")
+    (is (= {} (event-detail/after-deltas-by-id {:handler {:tags {}}}))
+        "no :rf.event/after-deltas tag → {}")))
 
 (deftest cascade-outcome-projection-shape-is-stable
   (testing "cascade-outcome returns the documented keys"


### PR DESCRIPTION
## Diagnosis

Two related Handler-panel bugs Mike observed live in the step-deck app (2026-05-24).

### Bug A — COEFFECTS empty for cofx-injecting handlers that return only `:db`

`:counter/inc` is a textbook `reg-event-fx` with `(inject-cofx :testdeck/now)` that returns `{:db ...}` and no `:fx`. The user-injected coeffects stamp was being applied to `:rf.fx/do-fx` (rf2-jhhqt) — but `router/run-fx-effects!` short-circuits via `(when-let [fx-vec (:fx effects)] ...)` when the handler returns no `:fx`. **The do-fx walk never ran, the marker never emitted, the stamp was silently dropped.** COEFFECTS panel empty.

`extract-coeffects` in the export module had already been written to read from the handler (run-end) trace — but the substrate never stamped it there. The reader was right; the emitter was wrong.

### Bug B — `inject-cofx` interceptors misclassified into AFTER INTERCEPTORS

The xray panel's `user-interceptors` filter dropped anything carrying `:rf/default? true` (substrate-side marker for framework auto-wrappers) plus three known auto-wrapper ids. The `inject-cofx` interceptor (id e.g. `:cofx-now`) had neither marker, so it leaked into the AFTER INTERCEPTORS list. It has no `:after` — and nothing was rendering each interceptor's ctx-delta anyway — so it surfaced as an empty unhelpful row.

## Fix shape

**A.** Move the user-injected coeffects stamp from `:rf.fx/do-fx` to `:rf.event/run-end`. Run-end always fires (once per event), so the stamp now rides regardless of whether the handler returned `:fx`. Substrate filter (`fx/user-injected-coeffects`) unchanged — framework defaults (`:db :event :frame :source :trace-id`) filtered at emit-time. Dev-only via the same `interop/debug-enabled?` gate the trace surface already uses.

**B-1.** Mark the `inject-cofx` interceptor with `:rf/cofx-id <cofx-id>`. The xray panel's `user-interceptors` filter excludes anything carrying that key — the cofx renders under COEFFECTS, full stop.

**B-2.** Capture per-`:after` ctx-delta data in `re-frame.interceptor/execute-chain`: each `:after` invocation snapshots before+after, computes added/changed/removed on `:coeffects` + `:effects`, and stashes a `{:rf.icpt/id ... :rf.icpt/ctx-delta {...}}` row under `:rf/icpt-after-deltas` on the running ctx (dev-only, framework defaults skipped). `emit-cascade-trailers!` lifts the vector onto `:rf.event/run-end`'s `:tags :rf.event/after-deltas`. Panel renders the `+`/`~`/`-` EDN-diff under each interceptor row using the same green/yellow/red palette as APP-DB CHANGES.

## Tests added

- `core/test/re_frame/fx_test.clj` — 3 deftests replace the rf2-jhhqt do-fx-marker tests:
  - `event-run-end-stamps-user-injected-coeffects-with-fx` (the previous shape, retargeted to run-end);
  - `event-run-end-stamps-user-injected-coeffects-without-fx` (**bug A regression** — handler returns only `:db`, cofx still surfaces, and do-fx is asserted NOT emitted);
  - `event-run-end-coeffects-stamp-absent-when-no-user-cofx` (silent-by-default).
- `tools/xray/test/.../event_detail_cljs_test.cljs`:
  - `user-coeffects-helper-projects-stamp-from-run-end` (reader test, run-end source);
  - `user-coeffects-survives-handlers-that-return-only-db` (**bug A regression** at the panel layer);
  - `user-interceptors-filters-cofx-interceptors` (**bug B-1 regression**);
  - `after-interceptors-step-omits-cofx-interceptors` (panel-render bug B-1 regression);
  - `after-interceptors-rows-render-ctx-delta-from-handler-stamp` (**bug B-2 regression**);
  - `after-deltas-by-id-projects-handler-tag` (projection helper).

## Gate results

- core JVM `clojure -M:test`: 749 tests, 3531 assertions, 0 failures.
- xray JVM `clojure -M:test`: 863 tests, 3078 assertions, 0 failures.
- `npm run test:cljs`: 4333 tests, 13860 assertions, 0 failures.
- `npm run test:xray-feature-gate`: 13 scenarios, 0 failures.
- `npm run test:bundle-isolation`: PASS.
- Splint on changed files: no new warnings (existing style warnings predate this PR).
