### PR TITLE
test(integration): routing x flows + http x flows x cancellation (rf2-qm8m3)

### DIFF
--- a/implementation/http/test/re_frame/flows_http_integration_test.clj
+++ b/implementation/http/test/re_frame/flows_http_integration_test.clj
@@ -1,0 +1,327 @@
+(ns re-frame.flows-http-integration-test
+  "Integration coverage for the http × flows × cancellation composition
+  (rf2-qm8m3, second of the two gaps the rf2-hm4gi flows delta audit
+  flagged as not pinned end-to-end after rf2-vug0k's four-test cluster).
+
+  The four sibling deftests in
+  `re-frame.flows-integration-test` (under the ssr artefact's test dir)
+  pin machine-macrostep × flows, schema-rollback × flows, flow-throw ×
+  flows, SSR × flows, child-dispatch × flows, and routing × flows. This
+  file pins the LAST composition the audit listed: http × flows ×
+  cancellation.
+
+  This namespace lives in the http artefact's test tree (not the ssr
+  bundle) because http/deps.edn already pulls flows + schemas + routing
+  + ssr in as test-only deps, but the ssr artefact does NOT depend on
+  http — adding http to ssr/deps.edn just for this one cross-cut would
+  alter the canonical ssr test classpath unnecessarily. The http
+  artefact already carries the full closure (flows × http) plus the
+  managed-HTTP cancellation surface, so the test sits naturally here.
+
+  ## The atomicity contract this file pins
+  (`bd remember event-pipeline-atomicity`, Mike CONFIRMED 2026-05-24)
+
+  An event handler that drives managed-HTTP cancellation typically
+  returns:
+
+      {:db  (update db :http/in-flight dissoc :req-1)
+       :fx  [[:rf.http/managed-abort :req-1]]}
+
+  The framework's drain shape is:
+
+      handler runs → pending :db assembled (with the dissoc applied)
+        → flows transform pending :db at the outermost :after
+        → SINGLE deferred install (the :db commit boundary)
+        → :fx walks AFTER install (`:rf.http/managed-abort` fires here)
+
+  The two pinned facts:
+
+  - (cancellation happy path) A flow whose :inputs overlap the
+    `[:http/in-flight]` slot re-evals over the POST-handler db (i.e.
+    with the dissoc already applied) — the flow's derived value reflects
+    the CLEARED in-flight slot in the SAME install as the dissoc, NOT a
+    delayed eval on the next event. The `:rf.http/managed-abort` fx
+    fires after install and calls the registered abort-fn.
+
+  - (flow-throw atomicity) A flow throw on a cancellation event aborts
+    the WHOLE event PRE-install: the dissoc does NOT land (the in-flight
+    slot stays populated), `:rf.http/managed-abort` does NOT fire (fx is
+    the post-install stage that the flow-throw path skips wholesale per
+    rule a), and NO `:rf.event/db-changed` emits. This is critical: a
+    regression that let the cancel-fx fire even on a flow-throw abort
+    would issue a network abort against a request whose app-db state
+    says it's still pending — split-brain across the substrate."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.http-registry :as http-registry]
+            ;; rf2-cdmle — required only to keep the test-support
+            ;; canned-stub fx ids registered (mirrors http-managed-test's
+            ;; require closure). This file does NOT use the stubs; the
+            ;; abort path is exercised by writing directly into the
+            ;; in-flight registry with a recording abort-fn (mirrors
+            ;; routing_http_composed_corners_test.clj's pattern).
+            [re-frame.http-test-support]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- per-test reset / trace recorder -------------------------------------
+
+(def ^:dynamic ^:private *captured* nil)
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! @li-var {}))
+  (rf/init! plain-atom/adapter)
+  ;; clear-all! wiped the ns-load-time registrations of these artefacts;
+  ;; :reload re-evaluates each ns body so its registrations resurrect.
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (require 're-frame.http-managed :reload)
+  (require 're-frame.http-test-support :reload)
+  (http-managed/clear-all-in-flight!)
+  (let [captured (atom [])]
+    (binding [*captured* captured]
+      (trace/register-listener!
+        ::flows-http-recorder
+        (fn [ev] (swap! captured conj ev)))
+      (try
+        (test-fn)
+        (finally
+          (trace/unregister-listener! ::flows-http-recorder))))))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- ops
+  "All captured trace `:operation`s, in capture order."
+  []
+  (mapv :operation @*captured*))
+
+(defn- by-op
+  "Captured trace events whose `:operation` is `op`, in capture order."
+  [op]
+  (filterv #(= op (:operation %)) @*captured*))
+
+(defn- prime-in-flight!
+  "Mirror what `:rf.http/managed`'s handler does at request-issue time:
+  drop a `{:request-id :url :abort-fn}` map into the in-flight registry
+  under `request-id`. The provided `abort-fn` is the recording closure
+  the test uses to observe whether `:rf.http/managed-abort` fired."
+  [request-id abort-fn]
+  (swap! http-registry/in-flight assoc request-id
+         {:request-id request-id
+          :url        (str "/api/" (name request-id))
+          :abort-fn   abort-fn}))
+
+;; ===========================================================================
+;; 1. http × flows × cancellation — flow re-evals over the post-handler db
+;;    with the cleared in-flight slot in the SAME install as the cancel.
+;;
+;; A handler models its own in-flight bookkeeping in app-db under
+;; [:http/in-flight], parallel to the framework's side-channel registry.
+;; (Apps that want to drive sub-derived UI off in-flight state commonly
+;; mirror it into app-db so a sub can read it.) A flow over
+;; [:http/in-flight] derives a count into [:derived :pending-count].
+;;
+;; The cancel event:
+;;   1. Removes the request's slot from [:http/in-flight] in :db.
+;;   2. Emits :rf.http/managed-abort as :fx so the transport-level abort
+;;      fires.
+;;
+;; The atomicity contract this test pins: the flow's re-eval over the
+;; post-handler pending :db (with the dissoc already applied) lands the
+;; cleared count in the SAME install as the dissoc — they commit
+;; together. THEN the post-install :fx walks and fires the abort-fn.
+;; ===========================================================================
+
+(deftest cancellation-event-flow-reevals-over-cleared-in-flight-slot-atomically
+  (testing "an event that dissocs an in-flight request from app-db AND
+            emits :rf.http/managed-abort drains the flow's :after over the
+            POST-handler pending :db (cleared slot) — the cleared count
+            and the dissoc land in the SAME install; :fx walks AFTER, and
+            the abort-fn fires"
+    (let [abort-calls (atom [])
+          flow-evals  (atom [])]
+      ;; Prime the side-channel registry as if a real :rf.http/managed
+      ;; fx had issued the request — the abort-fn here records the abort
+      ;; reason the framework passes (the public managed-abort path
+      ;; calls (abort-fn :user)).
+      (prime-in-flight! :load-articles
+                        (fn [reason] (swap! abort-calls conj reason)))
+
+      ;; A flow over the app-db-mirrored in-flight map derives a pending
+      ;; count. Logging the inputs proves which pending :db each eval saw.
+      (rf/reg-flow {:id     :http/pending-count
+                    :inputs [[:http/in-flight]]
+                    :output (fn [in-flight]
+                              (swap! flow-evals conj (set (keys in-flight)))
+                              (count in-flight))
+                    :path   [:derived :pending-count]})
+
+      ;; :issue mirrors what an app handler would do alongside a real
+      ;; :rf.http/managed fx — drop a marker into app-db so subs / flows
+      ;; can read the in-flight state. (We've already primed the side-
+      ;; channel registry above; the app-db marker is the substrate the
+      ;; flow drives off.)
+      (rf/reg-event-db :http/issue
+                       (fn [db [_ request-id]]
+                         (assoc-in db [:http/in-flight request-id] true)))
+
+      ;; :cancel is the event the test exercises: dissoc app-db slot AND
+      ;; emit :rf.http/managed-abort. Both compose with the flow's
+      ;; outermost :after over the pending :db.
+      (rf/reg-event-fx :http/cancel
+                       (fn [{:keys [db]} [_ request-id]]
+                         {:db (update db :http/in-flight dissoc request-id)
+                          :fx [[:rf.http/managed-abort request-id]]}))
+
+      ;; Seed: mark :load-articles as in-flight in app-db. The flow runs
+      ;; once on this seed event and the count lands at 1.
+      (rf/dispatch-sync [:http/issue :load-articles])
+      (is (= 1 (get-in (rf/get-frame-db :rf/default) [:derived :pending-count]))
+          "precondition: flow ran on the seed event; pending count is 1")
+      (is (= [#{:load-articles}] @flow-evals)
+          "precondition: flow saw the populated in-flight slot")
+      (is (empty? @abort-calls)
+          "precondition: no abort fired yet")
+
+      ;; Dispatch the cancellation. The handler's :db is the dissoced
+      ;; pending value; the flow's :after transforms over THAT pending :db
+      ;; (cleared slot) BEFORE the single deferred install. The :fx
+      ;; (:rf.http/managed-abort) walks AFTER install.
+      (reset! *captured* [])
+      (reset! flow-evals [])
+      (rf/dispatch-sync [:http/cancel :load-articles])
+
+      ;; Post-install assertions: the cleared slot AND the cleared count
+      ;; landed together in the SAME install.
+      (is (nil? (get-in (rf/get-frame-db :rf/default)
+                        [:http/in-flight :load-articles]))
+          "the in-flight slot was cleared by the handler's :db effect")
+      (is (zero? (get-in (rf/get-frame-db :rf/default)
+                         [:derived :pending-count]))
+          "the flow's derived count reflects the CLEARED in-flight slot
+           — landed in the SAME install as the dissoc, not on the next
+           event")
+
+      ;; The flow's single eval for this dispatch saw the POST-handler
+      ;; pending :db (cleared slot), not the pre-handler one.
+      (is (= [#{}] @flow-evals)
+          "the cancellation event's single flow eval observed the CLEARED
+           in-flight map — proving the flow ran over the post-handler
+           pending :db, not the pre-handler value")
+      (let [computes (by-op :rf.flow/computed)]
+        (is (= 1 (count computes))
+            "exactly one :rf.flow/computed for the cancellation dispatch
+             — no double / missed eval")
+        (is (= [{}] (-> computes first :tags :input-values))
+            "the :rf.flow/computed trace's :input-values carries the
+             post-handler (cleared) in-flight map"))
+
+      ;; :fx walked after install — :rf.http/managed-abort looked up the
+      ;; registered abort-fn and fired it with `:user`. (The real
+      ;; abort-fn closure also calls finalise-failure! to clear the
+      ;; side-channel in-flight registry per rf2-plngk; we use a recording
+      ;; stub here so the assertion targets only the fx-firing contract,
+      ;; not the closure's downstream effects.)
+      (is (= [:user] @abort-calls)
+          ":rf.http/managed-abort fired exactly once with reason :user —
+           the post-install :fx stage walked normally for a clean cancel"))))
+
+;; ===========================================================================
+;; 2. http × flows × cancellation — atomicity under flow-throw.
+;;
+;; A flow throw on the cancellation event aborts the WHOLE event
+;; PRE-install (atomicity contract rule a): the handler's dissoc does
+;; NOT land AND the :rf.http/managed-abort fx does NOT fire. This split-
+;; brain prevention is the load-bearing claim of the contract for the
+;; cancellation surface: without it, a regression could land the
+;; transport-level abort while the app-db still says the request is
+;; in-flight (or vice-versa).
+;; ===========================================================================
+
+(deftest flow-throw-on-cancellation-event-aborts-managed-abort-fx-too
+  (testing "a flow throw on a cancellation event aborts the WHOLE event
+            PRE-install — the dissoc does NOT land (app-db's in-flight
+            slot stays populated), the :rf.http/managed-abort fx does
+            NOT fire (post-install stage skipped per atomicity contract
+            rule a), and NO :rf.event/db-changed emits"
+    (let [abort-calls (atom [])]
+      ;; Prime the side-channel registry — if the abort-fn were
+      ;; reached we'd see :user appended to @abort-calls.
+      (prime-in-flight! :load-articles
+                        (fn [reason] (swap! abort-calls conj reason)))
+
+      ;; Mirror the in-flight state into app-db. Use :issue separately
+      ;; (without the throwing flow registered) so the seed is clean.
+      (rf/reg-event-db :http/issue
+                       (fn [db [_ request-id]]
+                         (assoc-in db [:http/in-flight request-id] true)))
+      (rf/reg-event-fx :http/cancel
+                       (fn [{:keys [db]} [_ request-id]]
+                         {:db (update db :http/in-flight dissoc request-id)
+                          :fx [[:rf.http/managed-abort request-id]]}))
+
+      ;; Seed BEFORE registering the throwing flow, so the seed event
+      ;; settles cleanly.
+      (rf/dispatch-sync [:http/issue :load-articles])
+      (is (true? (get-in (rf/get-frame-db :rf/default)
+                         [:http/in-flight :load-articles]))
+          "precondition: app-db's in-flight slot is populated for
+           :load-articles before the cancel")
+      (let [baseline-db (rf/get-frame-db :rf/default)]
+
+        ;; Now register a flow over [:http/in-flight] that throws on
+        ;; every eval. It will throw on the :cancel drain.
+        (rf/reg-flow {:id     :http/boom
+                      :inputs [[:http/in-flight]]
+                      :output (fn [_]
+                                (throw (ex-info "flow boom on cancel"
+                                                {:why :test})))
+                      :path   [:derived :http-doomed]})
+
+        (reset! *captured* [])
+        (rf/dispatch-sync [:http/cancel :load-articles])
+
+        ;; The handler's :db did NOT land — pre-install throw discards
+        ;; the entire pending :db (handler dissoc + flow write alike).
+        (is (= baseline-db (rf/get-frame-db :rf/default))
+            "app-db is byte-for-byte the pre-cancel value — the handler's
+             dissoc was rolled in with the flow's pending write and
+             discarded wholesale by the flow throw")
+        (is (true? (get-in (rf/get-frame-db :rf/default)
+                           [:http/in-flight :load-articles]))
+            "app-db's in-flight slot for :load-articles is STILL populated
+             — the cancel's dissoc did NOT install")
+
+        ;; The :rf.http/managed-abort fx did NOT fire — :fx is the
+        ;; post-install stage that the flow-throw path skips wholesale.
+        (is (empty? @abort-calls)
+            ":rf.http/managed-abort did NOT fire — fx walks AFTER install,
+             and a flow throw aborts the event BEFORE install (atomicity
+             contract rule a; split-brain prevention: no transport abort
+             on a request whose app-db state still says it's pending)")
+        (is (contains? @http-managed/in-flight :load-articles)
+            "the side-channel in-flight registry STILL holds the request
+             — finalise-failure! never ran because the abort-fn was never
+             called")
+
+        ;; Trace signature: :rf.flow/failed fired but NO :rf.event/db-changed.
+        (is (seq (by-op :rf.flow/failed))
+            ":rf.flow/failed fired — the flow eval threw")
+        (is (not-any? #(= :rf.event/db-changed %) (ops))
+            "NO :rf.event/db-changed in the throw stream — the event
+             aborted before install (split-brain prevention's load-
+             bearing assertion: no install signal means no observer can
+             see a partial commit)")))))

--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -37,7 +37,16 @@
       the flow-augmented value (the flow ran before install; render reads
       the installed flow-augmented db).
     - An event whose `:fx` `:dispatch`es child events gives EACH child its
-      OWN independent flow eval, not the parent's."
+      OWN independent flow eval, not the parent's.
+    - A flow whose `:inputs` overlap the `:rf/route` slice reads the
+      POST-transition route (the slice rewrite is the handler's pending
+      `:db`; the flow at the outermost `:after` transforms that pending
+      value before install — there is no pre-transition window the flow
+      could observe). The dual atomicity assertion: a flow throw on a
+      `:rf.route/transitioned` dispatch aborts the WHOLE event — slice
+      stays on the previous route, `:on-match` `:dispatch` fxs are NOT
+      walked. Pin (rf2-qm8m3): regression coverage for the routing × flows
+      composition the rf2-hm4gi delta audit flagged."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -431,3 +440,155 @@
                (mapv #(-> % :tags :input-values) computes))
             "each compute observed its own event's input — parent saw [1],
              child saw [2] — independent evals, not a shared one")))))
+
+;; ===========================================================================
+;; 5. flow × routing (rf2-qm8m3) — a flow over the :rf/route slice reads the
+;;    POST-transition route, and a flow throw on a transition aborts the
+;;    WHOLE event (slice unchanged, :on-match :dispatch fxs skipped).
+;;
+;; `:rf.route/transitioned` is a normal event-fx: its handler returns
+;; `{:db (assoc db' :rf/route {...new-route...}) :fx [[:dispatch
+;; [:on-match]] ...]}`. The flow at the outermost `:after` transforms the
+;; pending :db (which already carries the rewritten :rf/route slice)
+;; BEFORE the single deferred install. So a flow whose :inputs overlap
+;; [:rf/route] sees the SETTLED post-transition slice, never an
+;; intermediate or pre-transition value. After install, `:fx` walks —
+;; any `[:dispatch [:on-match]]` entries fire against the flow-augmented
+;; db.
+;;
+;; The atomicity contract (`bd remember event-pipeline-atomicity` rule a):
+;; ANY pre-install throw, including a flow throw, aborts the event — no
+;; install, no db-changed, no :fx. So a flow throw on a transition event
+;; means the route slice rewrite does NOT land AND the queued `:on-match`
+;; child dispatches in :fx are NEVER walked (they sit in the post-install
+;; stage that the flow-throw path skips wholesale).
+;; ===========================================================================
+
+(deftest flow-over-route-slice-reads-settled-post-transition-route
+  (testing "a flow whose :inputs overlap [:rf/route] reads the
+            POST-transition route — the slice rewrite is the handler's
+            pending :db; the flow at the outermost :after transforms that
+            pending value, then a single deferred install commits the
+            slice + flow output together"
+    (rf/reg-route :route/article {:path   "/articles/:id"
+                                  :params [:map [:id :string]]})
+    (rf/reg-route :route/home    {:path "/"})
+    ;; A flow over the route id derives a human label into a plain app-db
+    ;; path. Logging the input it observed proves it ran on the SETTLED
+    ;; post-transition slice, not the pre-transition one.
+    (let [flow-inputs (atom [])]
+      (rf/reg-flow {:id     :route/label
+                    :inputs [[:rf/route :id]]
+                    :output (fn [route-id]
+                              (swap! flow-inputs conj route-id)
+                              (str "you are at " route-id))
+                    :path   [:derived :route-label]})
+
+      ;; Land on /home first so there is a known PRE-transition slice the
+      ;; flow could potentially observe if it ran on the wrong value.
+      (rf/dispatch-sync [:rf.route/transitioned "/"])
+      (is (= :route/home (get-in (rf/get-frame-db :rf/default) [:rf/route :id]))
+          "precondition: landed on :route/home")
+      (is (= [:route/home] @flow-inputs)
+          "precondition: flow ran once on the home slice (post-transition)")
+
+      ;; Now transition to /articles/42. The handler writes the new slice
+      ;; into pending :db; the flow's :after transforms that pending :db
+      ;; reading [:rf/route :id]; both land together at install.
+      (reset! *captured* [])
+      (reset! flow-inputs [])
+      (rf/dispatch-sync [:rf.route/transitioned "/articles/42"])
+
+      ;; The installed slice carries the new route.
+      (is (= :route/article (get-in (rf/get-frame-db :rf/default)
+                                    [:rf/route :id]))
+          "the slice landed on :route/article")
+      (is (= {:id "42"} (get-in (rf/get-frame-db :rf/default)
+                                [:rf/route :params]))
+          ":params landed alongside the route id (same install)")
+
+      ;; The flow output is in app-db AND reflects the POST-transition slice.
+      (is (= "you are at :route/article"
+             (get-in (rf/get-frame-db :rf/default) [:derived :route-label]))
+          "the flow output derived from the POST-transition route id rode
+           the same install as the slice rewrite")
+      (is (= [:route/article] @flow-inputs)
+          "the single flow eval for this transition saw the SETTLED
+           post-transition route id — not the pre-transition :route/home")
+
+      ;; Trace signature: exactly one :rf.flow/computed for the dispatched
+      ;; transition, with the post-transition route id as input.
+      (let [computes (by-op :rf.flow/computed)]
+        (is (= 1 (count computes))
+            "exactly one :rf.flow/computed trace for the transition
+             dispatch — no double / missed eval")
+        (is (= [:route/article]
+               (-> computes first :tags :input-values))
+            "the :rf.flow/computed trace's :input-values carries the
+             post-transition route id")))))
+
+(deftest flow-throw-on-route-transition-aborts-event-slice-unchanged-no-on-match-fx
+  (testing "a flow throw on a :rf.route/transitioned dispatch aborts the
+            WHOLE event — the slice rewrite does NOT land, the route stays
+            on the pre-transition value, AND the :on-match :dispatch fxs
+            in the handler's :fx are NEVER walked (post-install stage
+            skipped per the atomicity contract — rule a)"
+    (let [on-match-fired (atom 0)]
+      (rf/reg-event-db :route/load-article
+                       (fn [db _]
+                         (swap! on-match-fired inc)
+                         (assoc db :article/loaded? true)))
+      ;; :route/article carries an :on-match — :rf.route/transitioned's
+      ;; handler will return `[:dispatch [:route/load-article]]` inside :fx
+      ;; for a successful transition. The flow throw must skip that :fx.
+      (rf/reg-route :route/article
+                    {:path     "/articles/:id"
+                     :params   [:map [:id :string]]
+                     :on-match [[:route/load-article]]})
+      (rf/reg-route :route/home {:path "/"})
+
+      ;; Land on /home cleanly (no throwing flow registered yet).
+      (rf/dispatch-sync [:rf.route/transitioned "/"])
+      (is (= :route/home (get-in (rf/get-frame-db :rf/default) [:rf/route :id]))
+          "precondition: clean landing on :route/home")
+      (is (zero? @on-match-fired)
+          "precondition: :route/home has no :on-match — counter still 0")
+      (let [baseline-db (rf/get-frame-db :rf/default)]
+
+        ;; Register a flow that throws on every eval, then transition to a
+        ;; route whose :on-match would dispatch :route/load-article.
+        (rf/reg-flow {:id     :route/boom
+                      :inputs [[:rf/route :id]]
+                      :output (fn [_]
+                                (throw (ex-info "flow boom on route"
+                                                {:why :test})))
+                      :path   [:derived :route-doomed]})
+        (reset! *captured* [])
+        (rf/dispatch-sync [:rf.route/transitioned "/articles/42"])
+
+        ;; The route slice did NOT land — pre-install throw discards the
+        ;; entire pending :db (handler's slice rewrite + flow output alike).
+        (is (= baseline-db (rf/get-frame-db :rf/default))
+            "app-db is byte-for-byte the pre-transition value — the slice
+             rewrite was rolled in with the flow's pending write and
+             discarded wholesale by the flow throw")
+        (is (= :route/home (get-in (rf/get-frame-db :rf/default)
+                                   [:rf/route :id]))
+            "the :rf/route slice stayed on :route/home — the transition's
+             slice rewrite did NOT install")
+
+        ;; The :on-match :dispatch in the handler's :fx was NOT walked —
+        ;; :fx is the post-install stage that the flow-throw path skips
+        ;; wholesale (atomicity contract rule a).
+        (is (zero? @on-match-fired)
+            ":route/load-article was NOT invoked — the :on-match :dispatch
+             sat in the handler's :fx; a flow throw skips :fx entirely")
+
+        ;; Trace signature: :rf.flow/failed fired, but NO :rf.event/db-changed
+        ;; for this dispatch — the event aborted before install.
+        (is (seq (by-op :rf.flow/failed))
+            ":rf.flow/failed fired — the flow eval threw")
+        (is (not-any? #(= :rf.event/db-changed %) (ops))
+            "NO :rf.event/db-changed in the throw stream — the event
+             aborted before install (contrast: a clean transition would
+             emit one :rf.event/db-changed for the slice rewrite)")))))


### PR DESCRIPTION
Closes the last two compositions the rf2-hm4gi flows delta audit Q5 listed but rf2-vug0k (#2072) did not cover. The audit found these SOUND on correctness but lacked permanent regression tests.

## Routing x flows
`implementation/ssr/test/re_frame/flows_integration_test.clj` (two new deftests appended to the existing four-test cluster):

- **`flow-over-route-slice-reads-settled-post-transition-route`** - a flow whose `:inputs` overlap `[:rf/route :id]` reads the POST-transition route. The slice rewrite is the handler's pending `:db`; the flow at the outermost `:after` transforms that pending value, and a single deferred install commits the slice + flow output together. Asserts: installed slice, flow-derived value in app-db, single-eval count, and the `:rf.flow/computed` trace's `:input-values` carries the post-transition route id.

- **`flow-throw-on-route-transition-aborts-event-slice-unchanged-no-on-match-fx`** - a flow throw on `:rf.route/transitioned` aborts the WHOLE event. The slice rewrite does NOT install AND the `:on-match` `:dispatch` fxs in the handler's `:fx` are NEVER walked (post-install stage skipped per atomicity rule a). Asserts: byte-equality with the pre-transition db, unchanged slice, never-fired `:on-match` counter, `:rf.flow/failed` trace present, and absence of `:rf.event/db-changed`.

## HTTP x flows x cancellation
`implementation/http/test/re_frame/flows_http_integration_test.clj` (new file; `http/deps.edn` already pulls flows/schemas/routing/ssr in as test-only deps, so the file sits naturally in the http artefact's test tree without altering the ssr classpath):

- **`cancellation-event-flow-reevals-over-cleared-in-flight-slot-atomically`** - an event that dissocs the request from `[:http/in-flight]` in `:db` AND emits `:rf.http/managed-abort` drains the flow's `:after` over the POST-handler pending `:db` (cleared slot). The cleared count and the dissoc land in the SAME install; `:fx` walks AFTER and the abort-fn fires. Uses `prime-in-flight!` to write a recording abort-fn stub directly into the in-flight registry (mirrors the pattern in `routing_http_composed_corners_test.clj`).

- **`flow-throw-on-cancellation-event-aborts-managed-abort-fx-too`** - a flow throw on the cancellation event aborts the WHOLE event PRE-install: the dissoc does NOT land (app-db's in-flight slot stays populated), the `:rf.http/managed-abort` fx does NOT fire (post-install stage skipped per atomicity rule a), and NO `:rf.event/db-changed` emits. This **split-brain prevention** is the load-bearing claim for the cancellation surface - without it, a regression could land the transport abort while app-db still says the request is pending.

## Gates
- ssr JVM tests: 236/815 PASS
- http JVM tests: 265/1404 PASS
- clj-kondo: clean
- splint: clean on changed files

Bead: rf2-qm8m3.