### PR TITLE
fix(xray): chrome polish cluster — nav button size + pill stray + + blue left-edge (3 beads incl. rf2-4yemd)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/filters/pills.cljs
@@ -51,8 +51,14 @@
 
 ;; ---- one pill ------------------------------------------------------------
 
-(defn- pill-glyph [mode]
-  (case mode :in "+" :out "×"))
+;; rf2-t2xba — the per-mode `+` / `×` LEADING glyph used to prefix the
+;; pill body has been retired. The Figma authority shows pills as
+;; `[text label] [trailing × delete button]` only — the include/exclude
+;; signal is carried by the BORDER COLOUR (green = include, red = exclude,
+;; resolved by `pill-tone` below), not by a leading glyph. The trailing
+;; remove button is also rendered as `×` (distinct role: it's the
+;; click-target that removes the pill, scoped to the remove `<button>`
+;; with its own aria-label).
 
 (defn- pill-tone [mode]
   ;; rf2-3f2di A6 — green-bordered include (`:in`) pills, red-bordered
@@ -121,7 +127,6 @@
                remove-filter event payload)"
   [{:keys [mode pill idx]}]
   (let [tone        (pill-tone mode)
-        mode-glyph  (pill-glyph mode)
         kind        (pill-kind pill)
         editable?   (= kind :event-id-pattern)
         testid      (str "rf-xray-filter-pill-" (name mode) "-" idx)
@@ -158,7 +163,10 @@
                          :font-family mono-stack
                          :font-size   (:caption type-scale)
                          :white-space "nowrap"}}
-        (str mode-glyph " " body-text " ")
+        ;; rf2-t2xba — body is label + trailing pencil only. The leading
+        ;; `+` / `×` mode glyph was retired (the border colour already
+        ;; carries the include/exclude signal).
+        (str body-text " ")
         ;; Pencil glyph per spec/018 §7 'Pill visual contract' —
         ;; visual cue that the pill body is the click-to-edit target.
         [:span {:style {:opacity 0.7}} "✎"]]
@@ -172,7 +180,9 @@
                        :font-family mono-stack
                        :font-size   (:caption type-scale)
                        :white-space "nowrap"}}
-        (str mode-glyph " " body-text)])
+        ;; rf2-t2xba — body is label only; the leading mode glyph was
+        ;; retired (border colour carries the include/exclude signal).
+        body-text])
      ;; rf2-xawwb — a VERTICAL DIVIDER sits before the `✕` (Figma-Make
      ;; surface): a 1px tone-coloured rule separating the pill body from
      ;; the remove affordance. The remove button keeps its own border-left

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -588,8 +588,13 @@
                    :cursor          "pointer"
                    :opacity         1
                    :padding         "0"
-                   :width           "22px"
-                   :height          "22px"
+                   ;; rf2-xrn3l — Figma authority specifies 21px square nav
+                   ;; buttons (chevron-left / chevron-right / chevrons-right
+                   ;; in the chrome ribbon's left cluster). The prior 22px
+                   ;; was a 1-px drift from the authority — corrected here
+                   ;; to match the Figma export.
+                   :width           "21px"
+                   :height          "21px"
                    :display         "inline-flex"
                    :align-items     "center"
                    :justify-content "center"

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -884,16 +884,13 @@
                    :background       (:chrome-ribbon-bg tokens)
                    :color            (:chrome-ribbon-text tokens)
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
-                   ;; rf2-o5f5f.1 — mode-signal mechanism #2: a 2-px
-                   ;; left-edge stripe in the single `:accent` (GitHub
-                   ;; blue — the Figma export carries one accent;
-                   ;; rf2-ad7zx.13). Painted on the ribbon so it lines up
-                   ;; with the top-of-shell edge regardless of the L2
-                   ;; resize-handle. The stripe-hex helper resolves the
-                   ;; `:accent` token through the current palette (light
-                   ;; vs dark via CSS custom properties).
-                   :border-left      (str "2px solid "
-                                          (static-shell/stripe-hex-for-mode :dynamic))
+                   ;; rf2-4yemd — the rf2-o5f5f.1 mode-signal mechanism #2
+                   ;; (a 2-px `:accent` left-edge stripe) was retired. The
+                   ;; Figma authority chrome ribbon has NO left-edge accent
+                   ;; — Dynamic mode signals through the mode-pill alone.
+                   ;; Removing the stripe also resolves the visual `blue
+                   ;; left edge on the chrome ribbon` reported by Mike
+                   ;; 2026-05-24.
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
      ;; LEFT cluster — `Events` label · nav · add(+). Per the authority

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -540,8 +540,6 @@
     ;; its own palette (Canvas / CanvasText / Highlight / …), which
     ;; collapses every author-encoded signal across the Xray chrome:
     ;;
-    ;;   - L1 ribbon stripe (the single GitHub-blue accent on the left
-    ;;     edge)
     ;;   - L2 row focused border (accent)
     ;;   - L2 row status accent (the 2px inset box-shadow on the
     ;;     trailing edge — box-shadow itself is also dropped in HCM)
@@ -593,12 +591,11 @@
     "  [data-testid=\"rf-xray-palette-backdrop\"] *:focus-visible {\n"
     "    outline-color: Highlight !important;\n"
     "  }\n"
-    ;; L1 ribbon stripe (single GitHub-blue accent) → Highlight.
-    ;; The 2px left border is the operator's chrome-edge accent signal;
-    ;; preserve it as the user's selected-emphasis hue.
-    "  [data-testid=\"rf-xray-ribbon\"] {\n"
-    "    border-left-color: Highlight !important;\n"
-    "  }\n"
+    ;; rf2-4yemd — the L1 ribbon left-edge stripe was retired
+    ;; (rf2-o5f5f.1 mode-signal mechanism #2 dropped to match the Figma
+    ;; authority chrome). The HCM `border-left-color` rule on
+    ;; `rf-xray-ribbon` that recoloured it to `Highlight` has been
+    ;; removed alongside — nothing left to recolour.
     ;; L2 focused event row — `aria-pressed=\"true\"` rides on the
     ;; focused row's `<li>`. The 1px solid mode-accent border becomes a
     ;; Highlight outline (outline composes over the existing border
@@ -700,9 +697,8 @@
     "[data-testid=\"rf-xray-static-shell\"][data-rf-force-colors=\"active\"] *:focus-visible {\n"
     "  outline-color: Highlight !important;\n"
     "}\n"
-    "[data-rf-force-colors=\"active\"] [data-testid=\"rf-xray-ribbon\"] {\n"
-    "  border-left-color: Highlight !important;\n"
-    "}\n"
+    ;; rf2-4yemd — parallel removal of the operator-opt-in HCM rule that
+    ;; recoloured the (now-retired) L1 ribbon left-edge stripe.
     "[data-rf-force-colors=\"active\"] [data-testid^=\"rf-xray-event-row-\"][aria-pressed=\"true\"] {\n"
     "  outline: 2px solid Highlight !important;\n"
     "  outline-offset: -1px !important;\n"

--- a/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/filters/pills_cljs_test.cljs
@@ -117,6 +117,32 @@
     (is (re-find #":auth/\*" (text-nodes pill))
         "pill renders the pattern")))
 
+(deftest pill-body-has-no-leading-mode-glyph
+  (testing "rf2-t2xba — the Figma authority pill is `[label] [trailing ×]`;
+            the prior `+` (include) / `×` (exclude) LEADING glyph prefix on
+            the pill BODY was a drift, retired here. The border colour
+            carries the include/exclude signal. The body must NOT start
+            with `+` or `×`; the trailing remove-button is its own element
+            (`-remove` testid) and is unaffected."
+    (xray-setup!)
+    (let [tree    (pills/pills-view
+                    {:filters {:in  [{:pattern ":auth/*"}]
+                               :out [{:pattern ":mouse-move"}]}})
+          in-body (find-by-testid tree "rf-xray-filter-pill-in-0-body")
+          out-body (find-by-testid tree "rf-xray-filter-pill-out-0-body")
+          in-text  (text-nodes in-body)
+          out-text (text-nodes out-body)]
+      (is (some? in-body))
+      (is (some? out-body))
+      (is (not (re-find #"^\s*\+" in-text))
+          "include pill body does NOT start with `+`")
+      (is (not (re-find #"^\s*×" out-text))
+          "exclude pill body does NOT start with `×`")
+      (is (re-find #":auth/\*" in-text)
+          "include pill still shows the pattern label")
+      (is (re-find #":mouse-move" out-text)
+          "exclude pill still shows the pattern label"))))
+
 (deftest pills-use-green-include-red-exclude-borders
   (testing "rf2-3f2di A6 — include (`:in`) pills are GREEN-bordered
             (`:success` = reference --devtools-success) and exclude

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -319,6 +319,22 @@
         (is (not (re-find #"❖" (text-nodes ribbon)))
             "no diamond `❖` glyph anywhere in the chrome ribbon")))))
 
+(deftest chrome-ribbon-has-no-left-edge-stripe
+  (testing "rf2-4yemd — the chrome ribbon must NOT paint a left-edge
+            accent stripe. The prior `rf2-o5f5f.1 mode-signal mechanism
+            #2` (a 2-px `:accent` `border-left`) was retired to match the
+            Figma authority chrome (no left-edge accent on the ribbon);
+            this is also the fix for the `blue left edge on chrome ribbon`
+            observed live 2026-05-24."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (let [ribbon (shell/ribbon nil)
+            root   (find-by-testid ribbon "rf-xray-ribbon")
+            style  (:style (second root))]
+        (is (some? root))
+        (is (nil? (:border-left style))
+            "chrome ribbon root has no :border-left in its inline style")))))
+
 (deftest events-ribbon-carries-warning-and-committed-pills
   (testing "rf2-3f2di A5/A6 — reconciled to the authority reference
             events-ribbon (bar-2). It carries the `N events filtered out`

--- a/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/theme/global_styles_cljs_test.cljs
@@ -265,14 +265,16 @@
       (is (re-find #"outline-color:\s*Highlight" css)
           "focus-visible outline-color is Highlight inside the block"))))
 
-(deftest motion-css-forced-colors-maps-ribbon-stripe-to-highlight
-  (testing "rf2-wxepo — the L1 ribbon's 2px left-edge mode stripe
-            (runtime violet / static cyan) maps to `Highlight` so the
-            mode signal is preserved under HCM."
+(deftest motion-css-has-no-ribbon-border-left-color-rule
+  (testing "rf2-4yemd — the chrome ribbon's left-edge mode stripe
+            (rf2-o5f5f.1 mechanism #2) was retired to match the Figma
+            authority. The HCM `border-left-color` rule on
+            `rf-xray-ribbon` that re-coloured the stripe to `Highlight`
+            was retired alongside it — nothing left to recolour."
     (let [css @#'gs/motion-css]
-      (is (re-find #"\[data-testid=\"rf-xray-ribbon\"\]\s*\{[^}]*border-left-color:\s*Highlight"
-                   css)
-          "ribbon border-left-color is Highlight"))))
+      (is (not (re-find #"\[data-testid=\"rf-xray-ribbon\"\]\s*\{[^}]*border-left-color"
+                        css))
+          "no `border-left-color` rule scoped to `[data-testid=\"rf-xray-ribbon\"]`"))))
 
 (deftest motion-css-forced-colors-distinguishes-status-accents
   (testing "rf2-wxepo — the four lifecycle-status accents map onto


### PR DESCRIPTION
@
Three-bead xray-shell polish cluster (Shape-2; smallest commits first).

## Per-bead

### rf2-xrn3l — `shell.cljs/ribbon-nav-cluster`
Chrome-ribbon nav buttons (chevron-left / chevron-right / chevrons-right)
rendered at 22px square; Figma authority specifies 21px. Single change:
the `btn-style` `:width` / `:height` slot in
`ribbon-nav-cluster` flipped 22 → 21. Cited by the rf2-s9ez3 Figma-
mapping audit.

### rf2-t2xba — `filters/pills.cljs/pill`
Filter pills carried a leading `+` (include) / `×` (exclude) glyph
prepended to the pill body. The Figma authority pill is `[label]
[trailing × delete]` only — the include/exclude signal is carried by the
border colour (green / red). The per-mode `pill-glyph` fn and its
`mode-glyph` let-binding were retired; both the editable
(keyword-pattern) body and the typed-predicate body emit the label
only. The trailing pencil glyph + the trailing `×` remove button + its
`aria-label` are unchanged. New regression in
`tools/xray/test/.../filters/pills_cljs_test.cljs` asserts neither IN
nor OUT pill body starts with the retired glyph.

### rf2-4yemd — `shell.cljs/ribbon` + `theme/global_styles.cljs`
**Root cause:** the chrome ribbon root inline style carried
`:border-left "2px solid <accent>"` — the `rf2-o5f5f.1 mode-signal
mechanism #2` introduced when Dynamic/Static modes shipped. The
authority chrome reconciliation (rf2-3f2di / rf2-xawwb) did not bring
that stripe back; Dynamic mode now signals through the mode-pill alone.
The stripe is the spurious blue LEFT edge Mike observed live 2026-05-24.

**Fix:**
- drop the `:border-left` declaration from the chrome ribbon root in
  `shell.cljs/ribbon`
- drop the now-dead HCM rules in `theme/global_styles.cljs` that
  recoloured the (no-longer-painted) stripe to `Highlight` (both the
  `@media (forced-colors: active)` block and the
  `[data-rf-force-colors="active"]` operator-opt-in block)
- update the HCM signal inventory comment to drop the L1-stripe item
- new regression in `shell_cljs_test` asserts the chrome ribbon root
  has no `:border-left` in its inline style; the existing global-styles
  HCM test for the ribbon stripe is inverted to assert the rule is gone

## Gates
- `npm run test:cljs` (CLJS unit, 4341 tests / 13890 assertions): pass
- `clojure -M:test` (xray JVM, 863 tests / 3078 assertions): pass
- `npm run test:xray-feature-gate` (nightly-full 13 scenarios): pass
- `npm run test:bundle-isolation`: pass
@