### PR TITLE
fix(docs): retire stale 'four-rule' terminology — 4 residual sites (rf2-q8tyr)

### DIFF
--- a/testbeds/deliberate_throw/README.md
+++ b/testbeds/deliberate_throw/README.md
@@ -42,7 +42,7 @@ lets a consumer verify it discriminates.
 
 **Cross-cutting (6)**:
 - Deliberately-throwing handler surfaces structured trace in BOTH Xray + Story `:play`
-- Flow `:rf.flow/failed` shows four-rule failure semantics (rf2-hrqvg) — Button C
+- Flow `:rf.flow/failed` shows atomicity-contract failure semantics per Spec 013 §Failure semantics (rf2-hrqvg) — Button C
 - State-machine transition cascade shows `:rf.machine/*` events — Button D's pre-throw transition fires the `:rf.machine/transition` trace before the action throws
 
 **Story (18)**:
@@ -69,5 +69,5 @@ orchestrator stages `index.html` next to `main.js` and serves it under
 
 - [`spec/009-Instrumentation.md` §Error contract](../../spec/009-Instrumentation.md) — the `:rf.error/*` catalogue this surface fires four entries from.
 - [`spec/005-StateMachines.md` §Errors](../../spec/005-StateMachines.md) — the machine-action-exception contract.
-- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the four-rule flow-failure contract (rf2-hrqvg).
+- [`spec/013-Flows.md` §Failure semantics](../../spec/013-Flows.md) — the flow-failure atomicity contract (rf2-hrqvg).
 - [`spec/Spec-Schemas.md` §`:rf/epoch-record`](../../spec/Spec-Schemas.md) — the epoch-record outcome taxonomy a consumer's recorder reads.

--- a/tools/story/spec/Migration-Audit.md
+++ b/tools/story/spec/Migration-Audit.md
@@ -24,7 +24,7 @@ Classification key:
 | `testbeds/deliberate_throw/spec.cjs` | 116 | Spec 009 handler-exception trace | 4 |
 | `testbeds/drain_depth_trigger/spec.cjs` | 164 | Spec 002 drain-depth rollback + epoch record | 7 |
 | `testbeds/http_toggle/spec.cjs` | 110 | Spec 014 :rf.http/* category attribution | 6 (×3 categories = 18 obs) |
-| `testbeds/long_flow_w_failure/spec.cjs` | 172 | Spec 013 flow four-rule failure | 6 |
+| `testbeds/long_flow_w_failure/spec.cjs` | 172 | Spec 013 flow atomicity-contract failure | 6 |
 | `testbeds/non_trivial_app_db/spec.cjs` | 159 | Spec 009 event/dispatched < event/db-changed ordering | 4 |
 | ~~`testbeds/ssr_basic/spec.cjs`~~ DELETED Wave 3 (rf2-pxb7t) → `implementation/ssr/test/re_frame/ssr_hydration_test.clj` | ~~143~~ | Spec 011 hydration baseline | ~~13~~ |
 | ~~`testbeds/ssr_hydration_mismatch/spec.cjs`~~ DELETED Wave 3 (rf2-pxb7t) → `implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj` | ~~136~~ | Spec 011 :rf.ssr/hydration-mismatch | ~~9~~ |

--- a/tools/xray/spec/016-Auxiliary-Panels.md
+++ b/tools/xray/spec/016-Auxiliary-Panels.md
@@ -660,8 +660,8 @@ force continue / cancel). See
 ### Issues tab — flow cascade-halt alarm
 
 When `:rf.error/flow-eval-exception` fires, surface a high-priority
-entry listing the subsequent flows that did NOT run (the four-rule
-cascade-halt rule per Spec 013). See
+entry listing the subsequent flows that did NOT run (the cascade-halt
+clause of the atomicity contract per Spec 013 §Failure semantics). See
 [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.4 F.4.
 
 ### Issues tab — open-redirect / CRLF / trusted-shell advisories

--- a/tools/xray/spec/019-Cross-Cutting-Insight.md
+++ b/tools/xray/spec/019-Cross-Cutting-Insight.md
@@ -627,8 +627,8 @@ Erlang-Observer-for-managed-effects.
 #### F.4 — "A flow's `:output` threw and the cascade halted; what didn't run?"
 
 **Bug class:** Flow cascade-halt. When `:rf.error/flow-eval-exception`
-fires, the four-rule cascade-halt contract per Spec 013 means downstream
-flows in topological order do NOT run. Authors rarely realise this.
+fires, the atomicity contract per Spec 013 §Failure semantics means
+downstream flows in topological order do NOT run. Authors rarely realise this.
 
 **Insight Xray provides:** A high-priority **Issues entry** that lists
 the subsequent flows that did NOT run:


### PR DESCRIPTION
Tiny doc-only mop-up following PR #2098 (rf2-4gh88 cluster). The
cluster's `q2rce` sub-commit retired the obsolete **"four-rule
contract"** terminology in the 3 sites the rf2-hm4gi delta audit
cited; the cluster worker honesty-flagged that a wider grep turned up
4 more sites carrying the same stale label. This PR mops those up
with the same retirement pattern.

Spec 013 reorganised the flow-failure contract around the single
**atomicity contract** (`§Failure semantics`); the "four rules"
framing no longer maps onto any normative structure.

## Per-site changes

| File:line | Before -> After |
|---|---|
| `tools/xray/spec/016-Auxiliary-Panels.md:663` | "the four-rule cascade-halt rule per Spec 013" -> "the cascade-halt clause of the atomicity contract per Spec 013 §Failure semantics" |
| `tools/xray/spec/019-Cross-Cutting-Insight.md:630` | "the four-rule cascade-halt contract per Spec 013" -> "the atomicity contract per Spec 013 §Failure semantics" |
| `testbeds/deliberate_throw/README.md:45` | "four-rule failure semantics" -> "atomicity-contract failure semantics per Spec 013 §Failure semantics" |
| `testbeds/deliberate_throw/README.md:72` | "the four-rule flow-failure contract" -> "the flow-failure atomicity contract" (mirrors PR #2098 `testbeds/README.md:97` verbatim) |
| `tools/story/spec/Migration-Audit.md:27` | "Spec 013 flow four-rule failure" -> "Spec 013 flow atomicity-contract failure" |

## Scope

Surface-level terminology only — no semantic divergence and no
behavioural change. Sequential to PR #2098's wording precedent.

## Gates

- `mkdocs build --strict` — passes (exit 0).
- Corpus grep `git grep -i "four-rule"` on tracked files after this
  commit returns zero prose hits. The only residual matches live in
  `.beads/issues.jsonl` (historic bead bodies — narrative records,
  not normative documentation), which is correct.

Closes rf2-q8tyr.