### PR TITLE
feat(xray): external-link glyph on Handler-panel source links (rf2-xw7mj)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/event/icons.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event/icons.cljc
@@ -1,0 +1,46 @@
+(ns day8.re-frame2-xray.panels.event.icons
+  "Inline SVG glyphs used by the Event lens — small lucide-style icons
+  per the Figma authority (`tools/xray/design-reference/xray_devtools_reference.cljs`).
+
+  These exist as a shared, single-source-of-truth helper so every
+  click-to-source affordance in the Event lens renders the SAME glyph at
+  the SAME size with the SAME stroke + fill convention. Pre-rf2-xw7mj
+  the Event lens rendered the unicode `↗` arrow as the trailing
+  affordance; per the Figma authority the canonical glyph is the
+  lucide-style `external-link` SVG (open window with an outbound arrow)
+  — visually richer and more recognisably an 'open in editor' verb.
+
+  Pure data → hiccup (a static svg vector); no substrate dependency.
+  `.cljc` so the rendered tree is JVM-portable (the event-detail panel
+  tests render the tree from `clojure -M:test`).")
+
+(def ^:private external-link-svg
+  "The lucide `external-link` icon as a hiccup-shaped svg vector. 13px
+  square (the Figma authority's exact size), `viewBox 0 0 24 24` (the
+  lucide-icons coordinate system), `stroke: currentColor` so the glyph
+  inherits the surrounding link colour. `stroke-linecap` + `linejoin
+  round` mirror the lucide default so the corners + endpoints match
+  the rest of the lucide family."
+  [:svg {:width            "13"
+         :height           "13"
+         :viewBox          "0 0 24 24"
+         :fill             "none"
+         :stroke           "currentColor"
+         :stroke-width     "2"
+         :stroke-linecap   "round"
+         :stroke-linejoin  "round"
+         :aria-hidden      "true"
+         :focusable        "false"}
+   [:path     {:d "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}]
+   [:polyline {:points "15 3 21 3 21 9"}]
+   [:line     {:x1 "10" :y1 "14" :x2 "21" :y2 "3"}]])
+
+(defn external-link
+  "Render the lucide `external-link` glyph — the canonical 'open in
+  editor / open in new tab' verb on click-to-source affordances in the
+  Event lens. Inherits its colour from the enclosing link via
+  `currentColor` so the glyph reads as part of the link, not as
+  separate chrome. Always returns the same static hiccup vector — the
+  fn-form is preserved so call sites read as a component."
+  []
+  external-link-svg)

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -81,6 +81,7 @@
             [day8.re-frame2-xray.views.edn-widget.widget :as edn]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
             [day8.re-frame2-xray.panels.app-db-diff-format :as f]
+            [day8.re-frame2-xray.panels.event.icons :as icons]
             [day8.re-frame2-xray.panels.overflow-indicator :as overflow]
             [day8.re-frame2-xray.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-xray.panels.managed-fx-template :as managed-fx]
@@ -360,29 +361,44 @@
 
 (defn- coord-chip
   "Reusable 'open in editor' click-to-source affordance. Renders the
-  Figma `↗` external-link glyph; nothing when `coord` has no `:file`.
-  Dispatches `:rf.xray/open-in-editor` with the structured coord; the
-  trace-bus thereby records the click + the editor handler resolves the
-  URI through the rf2-cm93v allowlist."
+  Figma authority's `external-link` lucide SVG glyph (13px, currentColor
+  stroke, inline with the surrounding link text); nothing when `coord`
+  has no `:file`. Dispatches `:rf.xray/open-in-editor` with the
+  structured coord; the trace-bus thereby records the click + the
+  editor handler resolves the URI through the rf2-cm93v allowlist.
+
+  Per rf2-xw7mj the glyph is unified across every click-to-source site
+  in the Event lens (DISPATCH FROM, COEFFECTS rows, EVENT HANDLER
+  coord, AFTER INTERCEPTORS rows, FLOWS rows) so the affordance reads
+  as one vocabulary. The previous unicode `↗` arrow is superseded
+  here; the SVG mirrors the lucide-icons family the Figma authority
+  ships across the rest of the devtool chrome.
+
+  Accessibility: rendered as a `<button>` (so it's tab-focusable +
+  activates on Enter / Space natively); the SVG itself carries
+  `aria-hidden=\"true\"` so screen readers read the button's
+  `aria-label` (\"open in editor\") rather than walking the path
+  geometry."
   [coord testid]
   (when (and (map? coord) (seq (:file coord)))
     [:button {:data-testid testid
+              :aria-label  "open in editor"
               :title       "open in editor"
               :on-click    (fn [e]
                              (.stopPropagation e)
                              (rf/dispatch [:rf.xray/open-in-editor
                                            {:source-coord coord}]
                                           {:frame :rf/xray}))
-              :style       {:background  "transparent"
-                            :color       (:accent tokens)
-                            :border      "none"
-                            :padding     "0 4px"
-                            :margin-left "6px"
-                            :cursor      "pointer"
-                            :font-family mono-stack
-                            :font-size   "12px"
-                            :line-height 1}}
-     "↗"]))
+              :style       {:background      "transparent"
+                            :color           (:accent tokens)
+                            :border          "none"
+                            :padding         "0 4px"
+                            :margin-left     "6px"
+                            :cursor          "pointer"
+                            :display         "inline-flex"
+                            :align-items     "center"
+                            :line-height     1}}
+     (icons/external-link)]))
 
 (defn- dispatch-body
   "Step DISPATCH body — the dispatched event vector + the `FROM:
@@ -397,12 +413,13 @@
 
   The FROM row matches `EventPanel`'s dispatch presentation
   (rf2-ad7zx.17): `FROM:` then the dispatch SOURCE rendered as a single
-  accent-coloured click-to-source link (`view ↗`) — the `↗`
-  external-link glyph trails the source text and opens the call-site in
-  the editor. The prior `· origin <origin>` clutter and the standalone
-  `file:line` coord span are dropped (the mock surfaces neither); when no
-  call-site coord was captured the source renders as plain muted text
-  with no link affordance. Returns body hiccup."
+  accent-coloured click-to-source link — the lucide `external-link`
+  glyph (per the Figma authority, rf2-xw7mj) trails the source text and
+  opens the call-site in the editor. The prior `· origin <origin>`
+  clutter and the standalone `file:line` coord span are dropped (the
+  mock surfaces neither); when no call-site coord was captured the
+  source renders as plain muted text with no link affordance. Returns
+  body hiccup."
   [cascade event-vec]
   (let [coord      (dispatch-call-site cascade)
         [source _] (dispatch-source+origin cascade)
@@ -427,8 +444,9 @@
                     :overflow-x    "auto"
                     :font-weight   600}}
       (edn/inspect event-vec "event-detail/event")]
-     ;; FROM: <source> ↗ — the dispatch-origin as a single
-     ;; click-to-source link (EventPanel shape; rf2-ad7zx.17).
+     ;; FROM: <source> + external-link chip — the dispatch-origin as a
+     ;; single click-to-source link (EventPanel shape; rf2-ad7zx.17 +
+     ;; rf2-xw7mj for the unified lucide glyph).
      [:div {:data-testid "rf-xray-event-detail-dispatch-caption"
             :style {:display "flex"
                     :align-items "center"
@@ -438,7 +456,8 @@
                     :font-size "11px"}}
       "FROM:"
       (if linked?
-        ;; Accent-coloured source link + trailing ↗ (the coord-chip).
+        ;; Accent-coloured source link + trailing external-link chip
+        ;; (the coord-chip, rf2-xw7mj).
         [:span {:data-testid "rf-xray-event-detail-dispatch-from"
                 :style {:display "inline-flex"
                         :align-items "center"
@@ -489,16 +508,29 @@
       m)))
 
 (defn- coeffect-row
+  "One COEFFECTS row: `<id>  <chip?>  <value>`. Per rf2-xw7mj the
+  cofx-id renders alongside an `external-link` click-to-source chip
+  whenever the registered `reg-cofx` carries a captured source-coord
+  (`(rf/handler-meta :cofx id)`); the chip is omitted when the registry
+  lookup yields no `:file` (e.g. framework-default cofx or one
+  registered without coord capture). Matches the Figma authority's
+  click-to-source treatment for COEFFECTS coeffect-name links."
   [id value]
-  (let [suffix (interceptor-testid-suffix id)]
+  (let [suffix     (interceptor-testid-suffix id)
+        cofx-meta  (when (keyword? id) (rf/handler-meta :cofx id))
+        coord      (when (and cofx-meta (string? (:file cofx-meta)))
+                     {:file (:file cofx-meta) :line (:line cofx-meta)})]
     [:div {:data-testid (str "rf-xray-event-detail-coeffect-row-" suffix)
            :style {:display "flex"
                    :align-items "flex-start"
                    :padding "2px 0"}}
-     [:span {:style {:color (:accent tokens)
-                     :min-width "180px"
+     [:span {:style {:display      "inline-flex"
+                     :align-items  "center"
+                     :color        (:accent tokens)
+                     :min-width    "180px"
                      :margin-right "12px"}}
-      (pr-str id)]
+      (pr-str id)
+      (coord-chip coord (str "rf-xray-event-detail-coeffect-open-chip-" suffix))]
      [:span {:style {:color (:text-primary tokens)
                      :min-width 0
                      :flex 1
@@ -1050,9 +1082,19 @@
       ▸ :flow-id              wrote [:write :path]   <result>
                               read  [:in1] [:in2]
       ↳ :chained-flow         wrote [:other :path]   <result>
-                              read  [:in :read :the-upstream :wrote]"
+                              read  [:in :read :the-upstream :wrote]
+
+  Per rf2-xw7mj the flow-id renders alongside an `external-link`
+  click-to-source chip whenever the registered `reg-flow` carries a
+  captured source-coord (`(rf/handler-meta :flow id)`); the chip is
+  omitted when the registry lookup yields no `:file` (e.g. the flow
+  has been cleared mid-session). Matches the Figma authority's
+  click-to-source treatment for FLOWS flow-id links."
   [{:keys [flow-id write-path result read-paths via? via-flow-ids trace-id]}]
-  (let [suffix (interceptor-testid-suffix flow-id)]
+  (let [suffix     (interceptor-testid-suffix flow-id)
+        flow-meta  (when (keyword? flow-id) (rf/handler-meta :flow flow-id))
+        coord      (when (and flow-meta (string? (:file flow-meta)))
+                     {:file (:file flow-meta) :line (:line flow-meta)})]
     [:div {:data-testid (str "rf-xray-event-detail-flow-row-" suffix)
            :data-via    (str via?)
            :style {:padding     "4px 0"
@@ -1070,10 +1112,13 @@
                       :font-size   "12px"}}
        (if via? "↳" "▸")]
       [:span {:data-testid (str "rf-xray-event-detail-flow-row-id-" suffix)
-              :style {:color       (:accent tokens)
+              :style {:display     "inline-flex"
+                      :align-items "center"
+                      :color       (:accent tokens)
                       :font-weight 600
                       :min-width   "160px"}}
-       (pr-str flow-id)]
+       (pr-str flow-id)
+       (coord-chip coord (str "rf-xray-event-detail-flow-open-chip-" suffix))]
       (when via?
         [:span {:data-testid (str "rf-xray-event-detail-flow-row-via-" suffix)
                 :style {:color       (:text-tertiary tokens)

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -29,6 +29,7 @@
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-xray.config :as config]
@@ -768,6 +769,46 @@
                                     "rf-xray-event-detail-flow-row-read-cart-total"))
             "'read' line renders")))))
 
+(deftest flow-row-renders-external-link-chip-when-flow-has-source-coord
+  (testing "rf2-xw7mj — when the registered flow carries a captured
+            source-coord on its handler-meta, the FLOWS row renders the
+            unified `external-link` click-to-source chip beside the
+            flow-id. When the registry lookup yields no :file (e.g. the
+            flow was cleared mid-session) the chip is omitted."
+    ;; Direct registrar writes — bypass the macro so the meta we install
+    ;; is exactly what the lookup path sees. `reg-flow` itself stores
+    ;; the flow under `:flow` registry kind; we mirror that shape here.
+    (registrar/register! :flow :rf2-xw7mj/registered-flow
+                         {:handler-fn (fn [_] 0)
+                          :inputs     [[:cart :items]]
+                          :path       [:cart :total]
+                          :file "src/flows.cljc" :line 23})
+    (registrar/register! :flow :rf2-xw7mj/anonymous-flow
+                         {:handler-fn (fn [_] 0)
+                          :inputs     [[:cart :items]]
+                          :path       [:cart :sum]})
+    (seed-buffer!
+      (concat (cascade-evs 100 [:cart/add-item] 0)
+              [(flow-computed-ev 100 50 :rf2-xw7mj/registered-flow
+                                  {:write-path   [:cart :total]
+                                   :input-values [[:apple]]
+                                   :result       1})
+               (flow-computed-ev 100 51 :rf2-xw7mj/anonymous-flow
+                                  {:write-path   [:cart :sum]
+                                   :input-values [[:apple]]
+                                   :result       1})]))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid
+                     tree
+                     "rf-xray-event-detail-flow-open-chip-rf2-xw7mj/registered-flow"))
+            "chip rendered for flow with captured source-coord")
+        (is (nil? (find-by-testid
+                    tree
+                    "rf-xray-event-detail-flow-open-chip-rf2-xw7mj/anonymous-flow"))
+            "no chip when the flow's handler-meta has no :file")))))
+
 (deftest flows-section-renders-input-paths-from-registry
   (testing "rf2-lo37i — `:rf.flow/computed` does not carry input PATHS
             (only :input-values). The render-time lookup via
@@ -1043,6 +1084,37 @@
             ":now row rendered")
         (is (some? (find-by-testid tree "rf-xray-event-detail-coeffect-row-local-storage"))
             ":local-storage row rendered")))))
+
+(deftest coeffect-row-renders-external-link-chip-when-cofx-has-source-coord
+  (testing "rf2-xw7mj — when the registered cofx carries a captured
+            source-coord on its handler-meta, the COEFFECTS row renders
+            the unified `external-link` click-to-source chip beside the
+            cofx id. When the registry lookup yields no :file the chip
+            is omitted (no chip for framework-default cofx, framework-
+            internal coords, etc.)."
+    ;; Direct registrar writes — bypass the macro so the meta we install
+    ;; is exactly what the lookup path sees (a `:file`/`:line` pair for
+    ;; the registered cofx; a coord-free entry for the anonymous one).
+    (registrar/register! :cofx :rf2-xw7mj/registered-cofx
+                         {:handler-fn (fn [ctx] ctx)
+                          :file "src/cofx.cljc" :line 17})
+    (registrar/register! :cofx :rf2-xw7mj/anonymous-cofx
+                         {:handler-fn (fn [ctx] ctx)})
+    (seed-buffer!
+      (cascade-evs 100 [:cart/restore] 0
+                   {:coeffects {:rf2-xw7mj/registered-cofx :present
+                                :rf2-xw7mj/anonymous-cofx  :no-coord}}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid
+                     tree
+                     "rf-xray-event-detail-coeffect-open-chip-rf2-xw7mj/registered-cofx"))
+            "chip rendered for cofx with captured source-coord")
+        (is (nil? (find-by-testid
+                    tree
+                    "rf-xray-event-detail-coeffect-open-chip-rf2-xw7mj/anonymous-cofx"))
+            "no chip when the cofx's handler-meta has no :file")))))
 
 (deftest coeffects-section-renders-qualified-keyword-ids
   (testing "qualified-keyword cofx ids (e.g. :auth/token, :env/build)


### PR DESCRIPTION
Per the rf2-s9ez3 Figma-mapping audit, unify the click-to-source link affordance in the Event lens around the lucide `external-link` SVG glyph documented in the Figma authority (`C:\Users\miket\OneDrive\Desktop\causa_devtools (1).cljs`, the `external-link` defn at L123-127 + its uses around L368-419). The prior unicode `↗` arrow is superseded; the SVG is visually richer + visibly an "open in editor" verb, consistent with the rest of the lucide-family chrome.

## Per-site list of click-to-source links unified

All sites route through the shared `coord-chip` helper, so the SVG swap covers them all in one place:

- **DISPATCH FROM** — already chip via `coord-chip`; SVG swap.
- **EVENT HANDLER coord row** — already chip via `coord-chip`; SVG swap.
- **AFTER INTERCEPTORS row** — already chip via `coord-chip`; SVG swap.
- **COEFFECTS cofx-id row** — NEW chip; `(rf/handler-meta :cofx id)` resolves `:file`/`:line`; chip omitted when the registry entry has no `:file` (framework-default cofx, registrations without coord capture).
- **FLOWS flow-id row** — NEW chip; `(rf/handler-meta :flow id)` resolves `:file`/`:line`; chip omitted when the flow has been cleared mid-session.

## Glyph helper location

`tools/xray/src/day8/re_frame2_xray/panels/event/icons.cljc` — small shared `.cljc` helper (the `panels/event/` subdir already houses event-lens specific helpers like `event_status_colour.cljc`). The `external-link` fn returns the lucide `external-link` SVG as a hiccup vector: 13px square, `viewBox 0 0 24 24`, `stroke: currentColor` (inherits the surrounding link colour), `stroke-linecap`/`linejoin: round` matching the lucide family.

## Accessibility notes

- Each chip is a `<button>` (tab-focusable; activates on Enter / Space natively).
- The `<button>` carries `aria-label="open in editor"` + a matching `title` tooltip.
- The inner SVG carries `aria-hidden="true"` + `focusable="false"` so screen readers read the button's label rather than walking the path geometry, and the SVG itself never becomes a separate focus stop.
- `currentColor` stroke ensures the glyph inherits the link colour in both themes (light + dark).

## Source-coord plumbing — unchanged

The `:rf.xray/open-in-editor` dispatch, the rf2-cm93v editor-URI allowlist, the structured source-coord shape (`{:file :line :column :ns}`) are all unchanged. The chip's testid scheme is unchanged (`rf-xray-event-detail-{dispatch,handler,interceptor,coeffect,flow}-open-chip[-suffix]`). Every existing assertion on chip testids continues to pass.

## Gates

- `clojure -M:test` from `tools/xray/`: 863 tests / 3078 assertions / 0 failures.
- `npm run test:cljs` from `implementation/`: 4343 tests / 13894 assertions / 0 failures (two new CLJS asserts for COEFFECTS + FLOWS chip presence/absence axes).
- `npm run test:xray-feature-gate`: 13 scenarios / 0 failures.
- `npm run test:bundle-isolation`: PASS (uix + helix + reagent bundles checked).
- `clj-kondo` on changed files: 0 new findings (one pre-existing `do-fx-trace` unused-private-var warning surfaces — not introduced here).