### PR TITLE
feat(xray): resizable event-list columns (rf2-6ni62)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/config.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/config.cljc
@@ -740,7 +740,21 @@
   - `:trace-buffer/keep` (default 1000) — count of raw trace events
     to retain (mirrors `trace-bus/default-buffer-depth`).
   - `:app-db/inspector-collapse-threshold` (default 50) — branch
-    factor above which the App-db inspector collapses by default."
+    factor above which the App-db inspector collapses by default.
+
+  ## `:event-list-col-widths` (rf2-6ni62 — resizable event-list columns)
+
+  Per-column pixel widths for the L2 event list's three user-resizable
+  columns. The leading `event-id` column stays `flex: 1 1 auto` and
+  absorbs any remaining width; the trailing three carry explicit widths
+  the user drags via divider handles between cells. Persisted through
+  the same settings round-trip so widths survive reload. Floors live in
+  `event-list-col-min-widths`; defaults match the pre-resize fixed
+  widths so a fresh install reads identically to the pre-feature shell.
+
+  Header + every row read these widths via the same
+  `:rf.xray/event-list-col-widths` sub so the two surfaces never drift
+  out of column alignment."
   {:general   {:text-size              13              ; px — slider range 10–18
                :panel-position         :right-rail     ; :right-rail | :popout | :fullscreen
                :panel-width-px         default-panel-width-px ; rf2-x8h9y resize handle
@@ -773,7 +787,17 @@
                ;; so authors can preview / live in the system-token
                ;; chrome on demand. Additive to the OS detection —
                ;; both paths produce the same painted chrome.
-               :use-system-colors?      false}
+               :use-system-colors?      false
+               ;; rf2-6ni62 — L2 event-list user-resizable column
+               ;; widths in pixels. Keys match the three resizable
+               ;; columns (`event-id` is flex). Defaults mirror the
+               ;; pre-resize fixed widths so a fresh install lays out
+               ;; identically. The drag-handle dispatch path clamps to
+               ;; `event-list-col-min-widths` before the write so the
+               ;; persisted payload is always in-range.
+               :event-list-col-widths   {:source    52
+                                         :timestamp 76
+                                         :duration  60}}
    :theme     :light                                 ; :light | :dark (rf2-3f2di — light default per the authority reference)
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:retained-epochs                    200
@@ -794,6 +818,93 @@
           floor  min-panel-width-px
           ceil   (max floor max-px)]
       (long (-> px (max floor) (min ceil))))))
+
+;; ---- L2 event-list column widths (rf2-6ni62) -----------------------------
+;;
+;; The L2 event list carries four columns — `event-id` (flex), `source`,
+;; `timestamp`, `duration`. The trailing three are user-resizable via
+;; drag handles BETWEEN columns. Defaults below mirror the pre-resize
+;; fixed widths so a fresh install lays out exactly as it did before the
+;; feature. Floors keep any column from collapsing to nothing — sized
+;; from the lowercase column-label width (per-column floor, not a single
+;; 60px blanket) so the header `source` / `timestamp` / `duration`
+;; lowercase labels always read.
+;;
+;; The helpers stay CLJC-pure / JVM-testable: takes a persisted map of
+;; `{:source N :timestamp N :duration N}` (or nil / partial / malformed),
+;; returns a fully-resolved map every consumer can read against. The
+;; drag-handle dispatch path clamps to the floor BEFORE the write, so
+;; the persisted payload is always in-range; `resolve-event-list-col-
+;; widths` is defence-in-depth for legacy payloads that pre-date the
+;; clamp.
+
+(def event-list-col-default-widths
+  "Default per-column widths in pixels for the L2 event list's three
+  user-resizable columns. Keys match the column ids (`event-id` is
+  flex; never sized). Values mirror the pre-resize fixed widths
+  (rf2-pjjwh + rf2-3f2di + rf2-lnod7) so a fresh install lays out
+  identically to the pre-feature shell."
+  {:source    52
+   :timestamp 76
+   :duration  60})
+
+(def event-list-col-min-widths
+  "Per-column floors in pixels. The user cannot drag below these
+  values — sized so the lowercase header label still reads (the column
+  header carries `source` / `timestamp` / `duration` in
+  `text-transform: lowercase` `caption` weight). Larger than a blanket
+  60px floor would allow because the `source` tag column is the
+  narrowest by design; smaller is fine here because the cell only ever
+  carries 2–6 character text (`ui` / `fx` / `timer` / …)."
+  {:source    40
+   :timestamp 60
+   :duration  48})
+
+(def event-list-col-keyboard-step-px
+  "Keyboard fine step for an arrow-key press on a column divider.
+  Mirrors the panel resize handle's 8px convention but uses 10px here
+  so users can land on a column count consistent with the per-pixel
+  drag granularity (10px is one tap of the trackpad scroll wheel on
+  modern OSes)."
+  10)
+
+(def event-list-col-keyboard-coarse-multiplier
+  "Multiplier for Shift+arrow on a column divider. 10 × 3 = 30px per
+  press for coarse traversal."
+  3)
+
+(defn clamp-event-list-col-width
+  "Pure helper: clamp `px` for `col-id` to that column's floor.
+  Unknown columns (`event-id` — not user-resizable; any future
+  unsupported key) return `nil` so the caller's update path can no-op
+  on them. Non-numeric input falls back to the column's default
+  width — a malformed persisted payload never leaves the column at an
+  unusable size."
+  [col-id px]
+  (when-let [floor (get event-list-col-min-widths col-id)]
+    (let [default-px (get event-list-col-default-widths col-id)]
+      (if-not (number? px)
+        default-px
+        (long (max floor px))))))
+
+(defn resolve-event-list-col-widths
+  "Pure helper: merge `persisted` (a partial / nil / malformed map of
+  `{:source N :timestamp N :duration N}`) over the defaults, clamping
+  each known column to its floor. Always returns a fully-shaped map
+  every consumer can read against — header and row both blend their
+  `width` style off the result so the two surfaces never drift.
+
+  Unknown keys in `persisted` are silently dropped (forward-compat: a
+  future column id would land in the persisted payload but is ignored
+  by older Xrays). CLJC-pure / JVM-testable."
+  [persisted]
+  (let [persisted (when (map? persisted) persisted)]
+    (reduce-kv
+      (fn [acc col-id default-px]
+        (let [raw (get persisted col-id default-px)]
+          (assoc acc col-id (clamp-event-list-col-width col-id raw))))
+      {}
+      event-list-col-default-widths)))
 
 (defonce
   ^{:doc "Atom holding the live settings map. Seeded with

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -236,6 +236,57 @@
         {:fx [[:dispatch [:rf.xray/set-panel-width-px
                           config/default-panel-width-px]]]}))
 
+    ;; ---- L2 event-list resizable column widths (rf2-6ni62) -------
+    ;;
+    ;; The L2 event-list carries four columns — `event-id` (flex),
+    ;; `source`, `timestamp`, `duration`. The trailing three are
+    ;; user-resizable via drag handles between cells. State lives in
+    ;; the same settings map every other persistence-bearing knob
+    ;; uses (`:general :event-list-col-widths`), so widths survive
+    ;; reload through `config/update-setting!` → localStorage.
+    ;;
+    ;; The sub resolves the persisted map over the defaults (defence-
+    ;; in-depth: a legacy / malformed payload yields a clamped, fully-
+    ;; shaped map every consumer can read against). Header and rows
+    ;; both read from the SAME sub so the two surfaces never drift
+    ;; out of column alignment — the alignment guarantee.
+    ;;
+    ;; `:rf.trace/no-emit?` mirrors `:rf.xray/set-panel-width-px`:
+    ;; drag emits one event per pixel of motion; emitting them would
+    ;; flood the trace buffer with shape no panel consumes.
+    (rf/reg-sub :rf.xray/event-list-col-widths
+      (fn [db _query]
+        (config/resolve-event-list-col-widths
+          (or (get-in db [:settings :general :event-list-col-widths])
+              (config/get-setting :general :event-list-col-widths)))))
+
+    (rf/reg-event-db :rf.xray/set-event-list-col-width
+      {:rf.trace/no-emit? true}
+      (fn [db [_ col-id px]]
+        (if-let [clamped (config/clamp-event-list-col-width col-id px)]
+          (let [persisted (or (config/get-setting :general :event-list-col-widths)
+                              config/event-list-col-default-widths)
+                next-map  (assoc persisted col-id clamped)]
+            ;; Dual-write: the atom (canonical, drives localStorage
+            ;; round-trip via `update-setting!`) and app-db (drives
+            ;; immediate reactive re-render of every header + row).
+            (config/update-setting! :general :event-list-col-widths next-map)
+            (assoc-in db [:settings :general :event-list-col-widths] next-map))
+          ;; Unknown column-id (e.g. `event-id` — flex, never sized):
+          ;; no-op. Defensive — the divider views only dispatch for
+          ;; the three resizable ids.
+          db)))
+
+    ;; Reset one column to its default — bound to a divider's
+    ;; double-click and to the Enter/Space keyboard affordance.
+    ;; Routes through the same write surface so persistence stays
+    ;; consistent.
+    (rf/reg-event-fx :rf.xray/reset-event-list-col-width
+      {:rf.trace/no-emit? true}
+      (fn [_ [_ col-id]]
+        (when-let [default-px (get config/event-list-col-default-widths col-id)]
+          {:fx [[:dispatch [:rf.xray/set-event-list-col-width col-id default-px]]]})))
+
     ;; ---- 4-layer chrome — active filter pills (rf2-xy4yb / spec/018 §7) ----
     ;;
     ;; The ribbon's filter cluster reads `:rf.xray/active-filters` —

--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -105,6 +105,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
+            [day8.re-frame2-xray.config :as config]
             [day8.re-frame2-xray.filters :as filters]
             [day8.re-frame2-xray.filters.pills :as filter-pills]
             [day8.re-frame2-xray.frame-switcher :as frame-switcher]
@@ -312,27 +313,16 @@
 ;; column width) and above `event-row` / `l2-column-header`, all later in
 ;; the file — so the symbols resolve at every use site (CLJS top-level
 ;; defs must precede use).
-(def ^:private l2-source-col-width
-  "Fixed width for the `source` column so the header label and every
-  row's origin tag align on the same left edge."
-  "52px")
-
-(def ^:private l2-time-col-min-width
-  "Min-width / right-aligned slot for the `timestamp` column — shared
-  by the header `timestamp` label and every row's absolute-time value so
-  the two right-align on the same edge. Sized (rf2-3f2di A8) to hold the
-  `HH:MM:SS.mmm` absolute clock string (`12:30:05.123`) without
-  wrapping; the prior 44px held only the relative `1s`/`now` chip."
-  "76px")
-
-(def ^:private l2-duration-col-min-width
-  "Min-width / right-aligned slot for the trailing `duration` column
-  (rf2-lnod7) — shared by the header `duration` label and every row's
-  handler-duration cell so the two right-align on the same edge. The
-  Figma EventList's fourth column; restored after the gap audit
-  (rf2-4297k) found it clipped off the live list's right edge. Sized to
-  hold `1234.5 ms` without wrapping."
-  "60px")
+;;
+;; rf2-6ni62 — the three trailing columns (`source`, `timestamp`,
+;; `duration`) are USER-RESIZABLE via drag dividers between cells.
+;; Per-column widths flow from the `:rf.xray/event-list-col-widths` sub
+;; — `l2-column-header` subscribes once and threads the resolved map
+;; through to every row; `event-row` reads its props rather than
+;; subscribing per-row (one subscribe per L2 paint, not N). The pre-
+;; rf2-6ni62 fixed-px constants below are retained as DEFAULTS in
+;; `config/event-list-col-default-widths` — a fresh install lays out
+;; identically to the pre-feature shell.
 
 (def ^:private l2-col-gap
   "Inter-column gap for both the header row and every data row. ONE
@@ -344,6 +334,200 @@
   left value sets where the gutter starts, the right where the time
   column ends. Shared so neither surface drifts."
   "6px")
+
+;; ---- column-divider drag state (rf2-6ni62) -----------------------------
+;;
+;; Mirrors `resize-handle.cljs` §drag-state. Each divider's pointerdown
+;; records the start-x + start-width snapshot, then attaches document-
+;; level pointermove / pointerup / pointercancel listeners so a drag
+;; faster than the per-element hit-test cadence keeps tracking the
+;; pointer (the standard split-pane recipe — without document-level
+;; capture a fast drag stalls). The `col-id` rides on the drag-state so
+;; the dispatch path knows which column to write back into.
+
+(defonce ^:private col-divider-drag-state
+  (atom nil))
+
+(defn col-divider-dragging?
+  "Test seam — true iff a column-divider drag is in progress."
+  []
+  (some? @col-divider-drag-state))
+
+(defn- col-divider-detach-listeners! []
+  (when-let [{:keys [on-move on-up on-cancel prev-cursor]} @col-divider-drag-state]
+    (when (and (exists? js/document) (.-removeEventListener js/document))
+      (try (.removeEventListener js/document "pointermove" on-move)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "pointercancel" on-cancel)
+           (catch :default _ nil)))
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor)
+            (or prev-cursor "")))
+    (reset! col-divider-drag-state nil)))
+
+(defn- col-divider-on-move [^js e]
+  (when-let [{:keys [col-id start-x start-width]} @col-divider-drag-state]
+    ;; Divider sits to the RIGHT of the column it sizes; dragging right
+    ;; widens, dragging left narrows. dx = (now-x - start-x).
+    (let [dx        (- (.-pageX e) start-x)
+          new-width (+ start-width dx)]
+      (rf/dispatch [:rf.xray/set-event-list-col-width col-id new-width]
+                   {:frame :rf/xray}))))
+
+(defn- col-divider-on-up [^js _e]
+  (col-divider-detach-listeners!))
+
+(defn- col-divider-on-cancel [^js _e]
+  (col-divider-detach-listeners!))
+
+(defn col-divider-start-drag!
+  "Begin a column-divider drag for `col-id` (`:source` /
+  `:timestamp` / `:duration`). Records the snapshot + attaches the
+  document-level move/up/cancel listeners. Exposed for the divider
+  view's `:on-pointer-down` handler AND for the test suite, which
+  drives the lifecycle without a real DOM."
+  [^js e col-id current-width]
+  (col-divider-detach-listeners!)
+  (let [start-x     (.-pageX e)
+        pointer-id  (.-pointerId e)
+        prev-cursor (when (and (exists? js/document)
+                               (.-body js/document))
+                      (-> js/document .-body .-style .-cursor))
+        on-move     col-divider-on-move
+        on-up       col-divider-on-up
+        on-cancel   col-divider-on-cancel]
+    (reset! col-divider-drag-state
+            {:col-id      col-id
+             :start-x     start-x
+             :start-width (or current-width 0)
+             :pointer-id  pointer-id
+             :on-move     on-move
+             :on-up       on-up
+             :on-cancel   on-cancel
+             :prev-cursor prev-cursor})
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor) "col-resize"))
+    (when (and (exists? js/document) (.-addEventListener js/document))
+      (try (.addEventListener js/document "pointermove" on-move)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "pointercancel" on-cancel)
+           (catch :default _ nil)))
+    (try (.preventDefault e) (catch :default _ nil))))
+
+(defn col-divider-simulate-move!
+  "Test-only: drive the document-level pointermove handler. No-op when
+  no drag is in progress."
+  [page-x]
+  (when @col-divider-drag-state
+    (col-divider-on-move #js {:pageX page-x})))
+
+(defn col-divider-simulate-up!
+  "Test-only: drive the document-level pointerup handler."
+  []
+  (when @col-divider-drag-state
+    (col-divider-on-up nil)))
+
+(defn col-divider-simulate-cancel!
+  "Test-only: drive the document-level pointercancel handler."
+  []
+  (when @col-divider-drag-state
+    (col-divider-on-cancel nil)))
+
+(defn col-divider-handle-keydown!
+  "Keyboard-navigable column-divider resize. Per spec/007-UX-IA.md
+  §Resize affordance every drag handle MUST be operable without a
+  pointer device. Mirrors the panel resize handle's bindings:
+
+    ArrowRight        +<step>px (widen the column to the LEFT)
+    ArrowLeft         -<step>px (narrow)
+    Shift+ArrowRight  +<coarse> (10 × 3 = 30px)
+    Shift+ArrowLeft   -<coarse>
+    Enter / Space     reset this column to its default
+
+  The clamp lives in the registry handler — we dispatch the desired
+  width and let `:rf.xray/set-event-list-col-width` apply the per-
+  column floor. Returns true iff the keypress was handled."
+  [^js e col-id current-width]
+  (let [key      (.-key e)
+        shift?   (.-shiftKey e)
+        step     (if shift?
+                   (* config/event-list-col-keyboard-step-px
+                      config/event-list-col-keyboard-coarse-multiplier)
+                   config/event-list-col-keyboard-step-px)
+        dispatch (fn [px]
+                   (rf/dispatch [:rf.xray/set-event-list-col-width col-id px]
+                                {:frame :rf/xray}))]
+    (case key
+      "ArrowRight"   (do (dispatch (+ current-width step)) true)
+      "ArrowLeft"    (do (dispatch (- current-width step)) true)
+      ("Enter" " ")  (do (rf/dispatch
+                           [:rf.xray/reset-event-list-col-width col-id]
+                           {:frame :rf/xray})
+                         true)
+      false)))
+
+(defn- col-divider
+  "Render a draggable divider sitting to the RIGHT of the column with
+  `col-id`. The divider is a 6px-wide vertical strip carrying the
+  `col-resize` cursor + a hover affordance defined in
+  `theme/global_styles/motion-css` (the rule paints a 1px accent stripe
+  on hover so authors can find the affordance without a hidden hit-test
+  game; the cursor change is the always-visible signal).
+
+  rf2-6ni62. The divider participates in the row's flex layout as a
+  zero-content cell with explicit width — placed BETWEEN the column
+  it sizes (to its left) and the next column. Per the alignment
+  contract the same divider widths apply to header + every row, so the
+  flex layout stays consistent across surfaces."
+  [{:keys [col-id col-px row-height]}]
+  (let [floor    (get config/event-list-col-min-widths col-id)
+        col-label (name col-id)]
+    [:div {:data-testid           (str "rf-xray-event-list-col-divider-" col-label)
+           :data-rf-xray-col-id   col-label
+           :role                  "separator"
+           :aria-orientation      "vertical"
+           :aria-label            (str "Resize " col-label " column")
+           :aria-valuemin         floor
+           :aria-valuemax         600
+           :aria-valuenow         col-px
+           :tab-index             0
+           :title                 (str "Drag to resize " col-label
+                                       " column · double-click to reset · "
+                                       "arrow keys (Shift = coarse)")
+           :on-pointer-down       (fn [^js e]
+                                    (col-divider-start-drag! e col-id col-px))
+           :on-key-down           (fn [^js e]
+                                    (when (col-divider-handle-keydown! e col-id col-px)
+                                      (try (.preventDefault e)
+                                           (catch :default _ nil))))
+           :on-double-click       (fn [^js _e]
+                                    (rf/dispatch
+                                      [:rf.xray/reset-event-list-col-width col-id]
+                                      {:frame :rf/xray}))
+           :style {:flex          "0 0 auto"
+                   :width         "5px"
+                   :align-self    "stretch"
+                   :height        (or row-height "100%")
+                   :cursor        "col-resize"
+                   :background    "transparent"
+                   ;; Disable native gestures during drag (text-select
+                   ;; on mouse, page-pan on touch).
+                   :touch-action  "none"
+                   :user-select   "none"}}]))
+
+(defn- ->px
+  "Coerce a plain number to a `\"<n>px\"` string for inline styles.
+  Accepts an already-formatted string verbatim (defence-in-depth on a
+  legacy default that snuck through as a string)."
+  [v]
+  (cond
+    (string? v) v
+    (number? v) (str v "px")
+    :else       nil))
 
 ;; ---- Relative-time chip (rf2-vbbq0 / rf2-0s2at) --------------------------
 ;;
@@ -470,24 +654,29 @@
   for call-site stability and ignored. The chip's `:title` carries the
   full ISO walltime + epoch-ms as the power-user reveal.
 
+  rf2-6ni62 — `col-px` is the user-resizable `timestamp` column width
+  (pixels). The header + every row read from the same
+  `:rf.xray/event-list-col-widths` sub so the two surfaces never drift
+  out of column alignment.
+
   Renders nothing when the cascade carries no dispatched-time stamp."
-  [cascade _now-ms]
+  [cascade _now-ms col-px]
   (when-let [then-ms (cascade-dispatched-time-ms cascade)]
     (let [label   (format-clock-time then-ms)
           tooltip (format-absolute-time then-ms)]
       [:span {:data-testid     "rf-xray-row-time-chip"
               :data-then-ms    (str then-ms)
               :title           tooltip
-              ;; rf2-ad7zx.15 — the trailing time column. Shares the
-              ;; header `timestamp` column's right-aligned min-width slot
-              ;; (`l2-time-col-min-width`) so the value right-aligns under
-              ;; the header label. Spacing from the preceding column comes
-              ;; from the row's shared flex `gap`.
+              ;; rf2-ad7zx.15 / rf2-6ni62 — the trailing time column.
+              ;; Shares the header `timestamp` column's right-aligned
+              ;; width with the same `col-px` source so the value
+              ;; right-aligns under the header label. Spacing from the
+              ;; preceding column comes from the row's shared flex `gap`.
               :style {:color         (:text-tertiary tokens)
                       :flex-shrink   0
                       :font-family   mono-stack
                       :font-size     (:caption type-scale)
-                      :min-width     l2-time-col-min-width
+                      :width         (->px col-px)
                       :text-align    "right"
                       :white-space   "nowrap"}}
        label])))
@@ -497,15 +686,20 @@
   Figma EventList's fourth column. Right-aligned handler wall-time
   (`1.2 ms`), sourced from the cascade's `:handler` trace event via
   `l2-timeline/cascade-duration-label`. Shares the header `duration`
-  column's right-aligned min-width slot (`l2-duration-col-min-width`)
-  so the value right-aligns under the header label; spacing from the
+  column's right-aligned width with the same `col-px` source so the
+  value right-aligns under the header label; spacing from the
   preceding timestamp column comes from the row's shared flex `gap`.
+
+  rf2-6ni62 — `col-px` is the user-resizable `duration` column width
+  (pixels). Header + every row read from the same
+  `:rf.xray/event-list-col-widths` sub so the two surfaces never drift
+  out of column alignment.
 
   ALWAYS renders the cell span (occupying its column width) so the
   columns stay aligned row-to-row; when the cascade carries no measured
   handler duration the cell is simply blank rather than collapsing the
   column."
-  [cascade]
+  [cascade col-px]
   (let [label (l2-timeline/cascade-duration-label cascade)]
     [:span {:data-testid   "rf-xray-row-duration"
             :data-duration (str (l2-timeline/cascade-duration-ms cascade))
@@ -513,7 +707,7 @@
                     :flex-shrink   0
                     :font-family   mono-stack
                     :font-size     (:caption type-scale)
-                    :min-width     l2-duration-col-min-width
+                    :width         (->px col-px)
                     :text-align    "right"
                     :white-space   "nowrap"}}
      label]))
@@ -1116,8 +1310,14 @@
   The menu state lives in app-db (`:row-context-menu`) so the menu
   renders at the shell-view root and floats above the L2 list's
   overflow-hidden clipping. preventDefault on the right-click
-  suppresses the browser's native menu."
-  [{:keys [cascade focused-id auto-track? now-ms]}]
+  suppresses the browser's native menu.
+
+  rf2-6ni62 — `col-widths` carries the resolved
+  `{:source N :timestamp N :duration N}` map every row reads its
+  inline column widths from. The parent (`event-list`) subscribes
+  ONCE per paint and threads the resolved map through props so each
+  row doesn't re-subscribe per render."
+  [{:keys [cascade focused-id auto-track? now-ms col-widths]}]
   (let [id          (:dispatch-id cascade)
         focused?    (= id focused-id)
         ;; rf2-ad7zx.12 — the Figma `source` column tag (origin name as
@@ -1264,17 +1464,24 @@
                      :text-align "left"
                      :min-width "0"}}
       (render-event-id-only event-vec)]
+     ;; rf2-6ni62 — divider sits to the RIGHT of `event id` and resizes
+     ;; the `source` column to its right. The divider widths participate
+     ;; in the flex layout on rows + header identically so the cells
+     ;; stay column-for-column aligned.
+     [col-divider {:col-id    :source
+                   :col-px    (:source col-widths)
+                   :row-height "22px"}]
      ;; rf2-ad7zx.12 + rf2-lnod7 — the `source` COLUMN (Figma EventList).
-     ;; A fixed-width cell aligned under the header's `source` label,
-     ;; carrying the dispatch-origin as a short text tag. The reference
-     ;; tags EVERY row, so the default app-code origin (`:user`, plus
-     ;; nil/unknown synthetic cascades) renders `ui` rather than a blank
-     ;; cell. rf2-pjjwh dropped the leading origin-prefix glyph — the mock
-     ;; carries the source tag as plain text only.
+     ;; A user-resizable cell (rf2-6ni62) aligned under the header's
+     ;; `source` label, carrying the dispatch-origin as a short text tag.
+     ;; The reference tags EVERY row, so the default app-code origin
+     ;; (`:user`, plus nil/unknown synthetic cascades) renders `ui` rather
+     ;; than a blank cell. rf2-pjjwh dropped the leading origin-prefix
+     ;; glyph — the mock carries the source tag as plain text only.
      [:span {:data-testid (when source-tag (str "rf-xray-row-origin-" source-tag))
              :data-rf-xray-origin source-tag
              :style {:flex-shrink 0
-                     :width l2-source-col-width
+                     :width (->px (:source col-widths))
                      :display "inline-flex"
                      :align-items "center"
                      :overflow "hidden"
@@ -1284,14 +1491,22 @@
                      :font-family sans-stack
                      :font-size (:caption type-scale)}}
       (when source-tag source-tag)]
+     ;; rf2-6ni62 — divider sits between `source` and `timestamp`.
+     [col-divider {:col-id    :timestamp
+                   :col-px    (:timestamp col-widths)
+                   :row-height "22px"}]
      ;; Timestamp column (rf2-3f2di A8) — absolute wall-clock
      ;; `HH:MM:SS.mmm`, right-aligned. The chip carries an absolute-time
      ;; `:title` tooltip as the power-user reveal.
-     (relative-time-chip cascade now-ms)
+     (relative-time-chip cascade now-ms (:timestamp col-widths))
+     ;; rf2-6ni62 — divider sits between `timestamp` and `duration`.
+     [col-divider {:col-id    :duration
+                   :col-px    (:duration col-widths)
+                   :row-height "22px"}]
      ;; Duration cell (rf2-lnod7) — the trailing `duration` column,
      ;; restoring the Figma EventList's fourth column. Handler wall-time
      ;; (`1.2 ms`), right-aligned, flush against the row's trailing edge.
-     (duration-cell cascade)]))
+     (duration-cell cascade (:duration col-widths))]))
 
 ;; ---- events ribbon (rf2-4vp5j) -----------------------------------------
 ;;
@@ -1443,8 +1658,14 @@
   lnod7 + rf2-xawwb, Figma-Make EventList). Names the FOUR columns the
   rows align to, in Figma-Make order — `event id` · `source` ·
   `timestamp` · `duration`. Caption-weight, muted, on the chrome surface
-  so it reads as chrome rather than data. Pure hiccup."
-  []
+  so it reads as chrome rather than data.
+
+  rf2-6ni62 — accepts `col-widths` (the resolved
+  `{:source N :timestamp N :duration N}` map) so the header column
+  widths read from the SAME source the rows do. Dividers between
+  columns carry the drag affordance — pointerdown begins a drag,
+  arrow keys do a fine resize, double-click resets to default."
+  [col-widths]
   (let [cell {:color       (:text-tertiary tokens)
               :font-family sans-stack
               :font-size   (:caption type-scale)
@@ -1453,12 +1674,13 @@
               :white-space "nowrap"}]
     [:div {:data-testid "rf-xray-event-list-header"
            :role        "row"
-           ;; rf2-ad7zx.15 — the header shares the EXACT column structure
-           ;; of the data rows (`event-row`): same flex `gap`, same
-           ;; horizontal `padding`, and the SAME per-column widths via the
-           ;; shared `l2-*-col-*` constants. It also carries a matching
-           ;; `1px solid transparent` border so the rows' active-row 1px
-           ;; border (content-box) never offsets the data columns 1px
+           ;; rf2-ad7zx.15 / rf2-6ni62 — the header shares the EXACT
+           ;; column structure of the data rows (`event-row`): same flex
+           ;; `gap`, same horizontal `padding`, the SAME per-column
+           ;; widths via the shared `:rf.xray/event-list-col-widths` sub,
+           ;; and the SAME dividers between cells. It also carries a
+           ;; matching `1px solid transparent` border so the rows'
+           ;; active-row 1px border never offsets the data columns 1px
            ;; right of the header. Result: event id / source / timestamp /
            ;; duration sit directly above their data columns (Figma
            ;; EventList).
@@ -1483,19 +1705,32 @@
              :style (merge cell {:flex "1 1 auto" :min-width "0"
                                  :text-align "left"})}
       "event id"]
+     ;; rf2-6ni62 — divider between `event id` (flex) and `source`.
+     [col-divider {:col-id    :source
+                   :col-px    (:source col-widths)
+                   :row-height "100%"}]
      [:span {:data-testid "rf-xray-event-list-col-source"
-             :style (merge cell {:width l2-source-col-width :flex-shrink 0})}
+             :style (merge cell {:width (->px (:source col-widths))
+                                 :flex-shrink 0})}
       "source"]
+     ;; rf2-6ni62 — divider between `source` and `timestamp`.
+     [col-divider {:col-id    :timestamp
+                   :col-px    (:timestamp col-widths)
+                   :row-height "100%"}]
      [:span {:data-testid "rf-xray-event-list-col-timestamp"
              :style (merge cell {:flex-shrink 0 :text-align "right"
-                                 :min-width l2-time-col-min-width})}
+                                 :width (->px (:timestamp col-widths))})}
       "timestamp"]
+     ;; rf2-6ni62 — divider between `timestamp` and `duration`.
+     [col-divider {:col-id    :duration
+                   :col-px    (:duration col-widths)
+                   :row-height "100%"}]
      ;; rf2-lnod7 — the fourth Figma column. Restored after the gap
      ;; audit (rf2-4297k) found the live header carried only three
      ;; columns and the duration was clipped off the right edge.
      [:span {:data-testid "rf-xray-event-list-col-duration"
              :style (merge cell {:flex-shrink 0 :text-align "right"
-                                 :min-width l2-duration-col-min-width})}
+                                 :width (->px (:duration col-widths))})}
       "duration"]]))
 
 (rf/reg-view event-list
@@ -1542,7 +1777,11 @@
   ;; mounted by the shell-view); defonce + DOM guards keep it a
   ;; no-op everywhere it matters.
   (inject-scrollbar-style!)
-  (let [cascades       @(rf/subscribe [:rf.xray/filtered-cascades])
+  (let [;; rf2-6ni62 — subscribe ONCE per L2 paint; thread the resolved
+        ;; widths map through to the header + every row so the two
+        ;; surfaces never drift out of column alignment.
+        col-widths     @(rf/subscribe [:rf.xray/event-list-col-widths])
+        cascades       @(rf/subscribe [:rf.xray/filtered-cascades])
         ;; rf2-4vp5j — the hidden-by-filters message moved UP to the
         ;; events ribbon (`events-ribbon`); the L2 list no longer renders
         ;; the banner itself. The events ribbon is the always-present
@@ -1604,7 +1843,7 @@
         ;; stack. Rendered only with rows present so the empty state
         ;; stays a clean "No events." message.
         (list
-         ^{:key "header"} [l2-column-header]
+         ^{:key "header"} [l2-column-header col-widths]
          (into ^{:key "rows"}
                [:ul {:style {:list-style "none" :margin 0 :padding 0
                             :display "flex" :flex-direction "column"
@@ -1614,7 +1853,8 @@
                 [event-row {:cascade     cascade
                             :focused-id  focused-id
                             :auto-track? auto-track?
-                            :now-ms      now-ms}]))))]]))
+                            :now-ms      now-ms
+                            :col-widths  col-widths}]))))]]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs
@@ -896,6 +896,30 @@
     "  min-width: 0;\n"
     "  overflow: hidden;\n"
     "  white-space: nowrap;\n"
+    "}\n"
+    ;; rf2-6ni62 — L2 event-list column-divider hover affordance.
+    ;; The divider is a 5px-wide transparent strip between cells; the
+    ;; always-visible signal is the `cursor: col-resize` style on the
+    ;; element itself. On hover we paint a soft 1px accent stripe down
+    ;; the divider's middle so the affordance reads as draggable
+    ;; without depending on a JS pointer-move pre-flash. Mirrors the
+    ;; panel-resize-handle's always-visible accent stripe at lower
+    ;; intensity (the panel handle is the principal affordance; column
+    ;; dividers are secondary). The accent stripe routes through the
+    ;; ACTIVE-theme CSS variable so light/dark both read.
+    "[data-testid^=\"rf-xray-event-list-col-divider-\"] {\n"
+    "  transition: background-color calc(120ms * var(--rf-xray-motion-scale, 1)) ease-out;\n"
+    "}\n"
+    "[data-testid^=\"rf-xray-event-list-col-divider-\"]:hover {\n"
+    "  background: linear-gradient(\n"
+    "    to right,\n"
+    "    transparent 0,\n"
+    "    transparent 2px,\n"
+    "    color-mix(in srgb, var(--rf-xray-accent) 45%, transparent) 2px,\n"
+    "    color-mix(in srgb, var(--rf-xray-accent) 45%, transparent) 3px,\n"
+    "    transparent 3px,\n"
+    "    transparent\n"
+    "  ) !important;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/xray/test/day8/re_frame2_xray/config_test.clj
+++ b/tools/xray/test/day8/re_frame2_xray/config_test.clj
@@ -296,6 +296,134 @@
     (is (= 480 (config/get-setting :general :panel-width-px)))
     (config/reset-settings!)))
 
+;; ---- L2 event-list column widths (rf2-6ni62) -----------------------------
+;;
+;; The L2 event list's `source` / `timestamp` / `duration` columns are
+;; user-resizable via drag handles between cells. Defaults mirror the
+;; pre-resize fixed widths so a fresh install lays out identically; the
+;; floors keep any column from collapsing below its lowercase header
+;; label width. The helpers are CLJC-pure / JVM-testable — the drag-
+;; handle dispatch path clamps to the floor BEFORE the persistence
+;; write, so the persisted payload is always in-range.
+
+(deftest event-list-col-defaults-mirror-pre-resize-widths
+  (testing "rf2-6ni62 — defaults match the pre-resize fixed widths so a
+            fresh install lays out identically to the pre-feature shell"
+    (is (= {:source 52 :timestamp 76 :duration 60}
+           config/event-list-col-default-widths))))
+
+(deftest event-list-col-default-settings-include-widths-map
+  (testing "rf2-6ni62 — the default settings map carries `:general
+            :event-list-col-widths` so the persistence round-trip + the
+            sub's read never see a nil"
+    (is (= config/event-list-col-default-widths
+           (get-in config/default-settings
+                   [:general :event-list-col-widths])))))
+
+(deftest clamp-event-list-col-width-floors
+  (testing "rf2-6ni62 — clamp-event-list-col-width snaps a sub-floor
+            request to that column's floor"
+    (is (= 40 (config/clamp-event-list-col-width :source 10)))
+    (is (= 40 (config/clamp-event-list-col-width :source 40)))
+    (is (= 41 (config/clamp-event-list-col-width :source 41)))
+    (is (= 60 (config/clamp-event-list-col-width :timestamp 20)))
+    (is (= 60 (config/clamp-event-list-col-width :timestamp 60)))
+    (is (= 48 (config/clamp-event-list-col-width :duration 10)))
+    (is (= 48 (config/clamp-event-list-col-width :duration 48)))))
+
+(deftest clamp-event-list-col-width-passes-in-range
+  (testing "rf2-6ni62 — in-range values pass through verbatim"
+    (is (= 100 (config/clamp-event-list-col-width :source 100)))
+    (is (= 200 (config/clamp-event-list-col-width :timestamp 200)))
+    (is (= 150 (config/clamp-event-list-col-width :duration 150)))))
+
+(deftest clamp-event-list-col-width-unknown-col-returns-nil
+  (testing "rf2-6ni62 — unknown column ids (event-id is flex, never
+            sized; future unsupported keys) yield nil so the caller's
+            update path can no-op on them"
+    (is (nil? (config/clamp-event-list-col-width :event-id 100)))
+    (is (nil? (config/clamp-event-list-col-width :unknown 100)))
+    (is (nil? (config/clamp-event-list-col-width nil 100)))))
+
+(deftest clamp-event-list-col-width-non-numeric-falls-back-to-default
+  (testing "rf2-6ni62 — malformed persisted payload (string, nil, NaN)
+            shouldn't leave the column at an unusable size — fall back
+            to the column's default width"
+    (is (= 52 (config/clamp-event-list-col-width :source nil)))
+    (is (= 76 (config/clamp-event-list-col-width :timestamp "wide")))
+    (is (= 60 (config/clamp-event-list-col-width :duration nil)))))
+
+(deftest resolve-event-list-col-widths-from-nil
+  (testing "rf2-6ni62 — nil persisted payload resolves to the defaults"
+    (is (= config/event-list-col-default-widths
+           (config/resolve-event-list-col-widths nil)))))
+
+(deftest resolve-event-list-col-widths-from-empty
+  (testing "rf2-6ni62 — empty / non-map payload resolves to the defaults"
+    (is (= config/event-list-col-default-widths
+           (config/resolve-event-list-col-widths {})))
+    (is (= config/event-list-col-default-widths
+           (config/resolve-event-list-col-widths "not-a-map")))))
+
+(deftest resolve-event-list-col-widths-merges-partial
+  (testing "rf2-6ni62 — a partial persisted payload merges over the
+            defaults; columns the user has not touched read their
+            defaults"
+    (is (= {:source 120 :timestamp 76 :duration 60}
+           (config/resolve-event-list-col-widths {:source 120})))
+    (is (= {:source 52 :timestamp 100 :duration 60}
+           (config/resolve-event-list-col-widths {:timestamp 100})))))
+
+(deftest resolve-event-list-col-widths-clamps-each-column
+  (testing "rf2-6ni62 — a legacy / hand-edited payload with a sub-floor
+            value is clamped on read (defence-in-depth — the write path
+            clamps too, but a payload that pre-dates the clamp would
+            slip through without this read-side clamp)"
+    (is (= {:source 40 :timestamp 76 :duration 60}
+           (config/resolve-event-list-col-widths {:source 10}))
+        "sub-floor source snaps to 40")
+    (is (= {:source 52 :timestamp 60 :duration 60}
+           (config/resolve-event-list-col-widths {:timestamp 20}))
+        "sub-floor timestamp snaps to 60")
+    (is (= {:source 52 :timestamp 76 :duration 48}
+           (config/resolve-event-list-col-widths {:duration 5}))
+        "sub-floor duration snaps to 48")))
+
+(deftest resolve-event-list-col-widths-drops-unknown-keys
+  (testing "rf2-6ni62 — unknown keys in the persisted payload are
+            silently dropped (forward-compat: a future column id would
+            land in the persisted payload but is ignored by older Xrays;
+            the resolved map only carries the known shape)"
+    (let [resolved (config/resolve-event-list-col-widths
+                     {:source 100 :phantom 200 :event-id 999})]
+      (is (= {:source 100 :timestamp 76 :duration 60} resolved))
+      (is (not (contains? resolved :phantom)))
+      (is (not (contains? resolved :event-id))))))
+
+(deftest resolve-event-list-col-widths-handles-non-numeric-per-column
+  (testing "rf2-6ni62 — a per-column non-numeric value falls back to
+            that column's default; surrounding columns are unaffected"
+    (is (= {:source 52 :timestamp 76 :duration 60}
+           (config/resolve-event-list-col-widths
+             {:source "wide" :timestamp nil :duration "tall"})))))
+
+(deftest update-setting-round-trips-event-list-col-widths
+  (testing "rf2-6ni62 — the standard settings round-trip drives the
+            event-list-col-widths slot. After the round-trip get-setting
+            reads the new map."
+    (config/reset-settings!)
+    (config/update-setting! :general :event-list-col-widths
+                            {:source 120 :timestamp 90 :duration 80})
+    (is (= {:source 120 :timestamp 90 :duration 80}
+           (config/get-setting :general :event-list-col-widths)))
+    (config/reset-settings!)))
+
+(deftest event-list-col-keyboard-steps-published
+  (testing "rf2-6ni62 — fine + coarse keyboard step constants are
+            published for the divider's arrow-key handler"
+    (is (= 10 config/event-list-col-keyboard-step-px))
+    (is (= 3 config/event-list-col-keyboard-coarse-multiplier))))
+
 (deftest editor-uri-project-root-regression-rf2-5m5n2
   (testing "regression: the relative source-coord case the editor's
             OS handler used to reject ('Path does not exist') now

--- a/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/event_list_resizable_cols_cljs_test.cljs
@@ -1,0 +1,389 @@
+(ns day8.re-frame2-xray.event-list-resizable-cols-cljs-test
+  "CLJS tests for the L2 event-list's user-resizable columns (rf2-6ni62).
+
+  Asserts the alignment-guarantee design + the drag lifecycle:
+
+    1. The column-divider testids render between header cells.
+    2. Header + row column widths come from the SAME source — after a
+       `:rf.xray/set-event-list-col-width` dispatch, the header cell's
+       :width matches the row cell's :width column-for-column.
+    3. The drag lifecycle (`col-divider-start-drag!` / `simulate-move!`
+       / `simulate-up!`) dispatches the live update event.
+    4. Keyboard handler — Arrow keys + Enter route through the
+       registry events with the right shape.
+    5. The clamp-at-write-time semantics — a sub-floor dispatch lands
+       on the floor in the persisted slot.
+    6. The reset event restores the column's default width.
+
+  The drag-simulation pattern mirrors `resize_handle_cljs_test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-xray.config :as config]
+            [day8.re-frame2-xray.registry :as registry]
+            [day8.re-frame2-xray.shell :as shell]
+            [day8.re-frame2-xray.test-support :as xray-test-support]
+            [day8.re-frame2-xray.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- xray-init! []
+  (xray-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-settings!)
+  ;; Force-cleanup any stale drag-state from a previous test (the
+  ;; module-level defonce atom survives fixture reset).
+  (shell/col-divider-simulate-up!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn xray-init!}))
+
+(defn- setup! []
+  (registry/register-xray-handlers!)
+  (frame/reg-frame :rf/xray {}))
+
+;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- style-of [node]
+  (when (and (vector? node) (map? (second node)))
+    (:style (second node))))
+
+;; ---- trace-bus helpers (one cascade so the L2 list renders) -------------
+
+(defn- dispatch-trace-ev
+  "Mirrors the helper in `shell_cljs_test`. Minimal `:rf.event/dispatched`
+  trace event so the projection produces a one-cascade list."
+  [id event-vec]
+  {:id           id
+   :op-type      :rf.event
+   :operation    :rf.event/dispatched
+   :tags         {:rf.event/v          event-vec
+                  :frame               :rf/default
+                  :rf.trace/dispatch-id id}})
+
+;; ---- 1. dividers render between header cells ----------------------------
+
+(deftest column-dividers-render-between-header-cells
+  (testing "rf2-6ni62 — the L2 column header carries one divider per
+            user-resizable column (source, timestamp, duration)"
+    (setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/xray
+      (let [tree     (shell/shell-view)
+            dividers (find-all-by-testid-prefix
+                       tree "rf-xray-event-list-col-divider-")]
+        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-source"))
+            "source-column divider renders")
+        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-timestamp"))
+            "timestamp-column divider renders")
+        (is (some? (find-by-testid tree "rf-xray-event-list-col-divider-duration"))
+            "duration-column divider renders")
+        ;; Each divider appears at least once in the header + once per
+        ;; row, so we expect at minimum 6 (one row + header = 2 instances
+        ;; × 3 divider ids).
+        (is (<= 6 (count dividers))
+            "at least one divider per (header + per row) × 3 columns")))))
+
+;; ---- 2. header + row widths come from the same source -------------------
+
+(defn- timer-cascade-trace-ev [id event]
+  ;; A cascade with a dispatched-time so the row renders its time chip,
+  ;; and a :timer origin so the source column tag renders.
+  (-> (dispatch-trace-ev id event)
+      (assoc :time 1000)
+      (assoc-in [:tags :rf/dispatch-origin] :timer)))
+
+(deftest header-and-row-column-widths-stay-aligned-after-settings-write
+  (testing "rf2-6ni62 — after a settings-write changes a column's
+            width, the header cell and the row cell both read the new
+            width from the same `:rf.xray/event-list-col-widths` sub.
+            This is the alignment-guarantee design — no need to simulate
+            the full drag; assert the rendered widths match the
+            settings."
+    (setup!)
+    (trace-bus/collect-trace! (timer-cascade-trace-ev 1 [:poll/tick]))
+    ;; Set a non-default width via the production event surface.
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-event-list-col-width :timestamp 120]))
+    (rf/with-frame :rf/xray
+      (let [tree        (shell/shell-view)
+            h-timestamp (find-by-testid tree "rf-xray-event-list-col-timestamp")
+            r-time      (find-by-testid tree "rf-xray-row-time-chip")]
+        (is (some? h-timestamp) "header timestamp cell renders")
+        (is (some? r-time)      "row time chip renders")
+        (is (= "120px" (:width (style-of h-timestamp)))
+            "header carries the persisted 120px width")
+        (is (= "120px" (:width (style-of r-time)))
+            "row carries the SAME 120px width — alignment preserved")))))
+
+(deftest header-and-row-widths-default-when-settings-unwritten
+  (testing "rf2-6ni62 — with no settings write, the resolved widths
+            default to `event-list-col-default-widths`. Header + row
+            read identical widths (the alignment guarantee on the
+            silent default path)"
+    (setup!)
+    (trace-bus/collect-trace! (timer-cascade-trace-ev 1 [:poll/tick]))
+    (rf/with-frame :rf/xray
+      (let [tree     (shell/shell-view)
+            h-source (find-by-testid tree "rf-xray-event-list-col-source")
+            r-source (find-by-testid tree "rf-xray-row-origin-timer")
+            h-time   (find-by-testid tree "rf-xray-event-list-col-timestamp")
+            r-time   (find-by-testid tree "rf-xray-row-time-chip")
+            h-dur    (find-by-testid tree "rf-xray-event-list-col-duration")
+            r-dur    (find-by-testid tree "rf-xray-row-duration")]
+        (is (= "52px" (:width (style-of h-source)) (:width (style-of r-source)))
+            "source column defaults to 52px on header + row")
+        (is (= "76px" (:width (style-of h-time)) (:width (style-of r-time)))
+            "timestamp column defaults to 76px on header + row")
+        (is (= "60px" (:width (style-of h-dur)) (:width (style-of r-dur)))
+            "duration column defaults to 60px on header + row")))))
+
+;; ---- 3. drag lifecycle --------------------------------------------------
+
+(defn- stub-event [page-x]
+  #js {:pageX          page-x
+       :pointerId      1
+       :preventDefault (fn [])})
+
+(deftest start-drag-flips-state
+  (setup!)
+  (is (false? (shell/col-divider-dragging?))
+      "no drag in progress at fixture start")
+  (shell/col-divider-start-drag! (stub-event 1000) :source 52)
+  (is (true? (shell/col-divider-dragging?))
+      "start-drag! installed the global capture")
+  (shell/col-divider-simulate-up!)
+  (is (false? (shell/col-divider-dragging?))
+      "simulate-up! tore down the capture"))
+
+(deftest drag-right-widens-source-col
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-start-drag! (stub-event 1000) :source 52)
+      ;; Divider sits to the RIGHT of `event id` and sizes `source`.
+      ;; Dragging RIGHT (pageX 1080 > 1000) widens by +80 → 132.
+      (shell/col-divider-simulate-move! 1080)
+      (shell/col-divider-simulate-up!))
+    (let [width-events (filter #(= :rf.xray/set-event-list-col-width (first %))
+                               @dispatches)]
+      (is (seq width-events)
+          "set-event-list-col-width was dispatched at least once")
+      (is (some #(= [:rf.xray/set-event-list-col-width :source 132] %)
+                width-events)
+          "drag right by 80px dispatched 132 (start 52 + 80 delta)"))))
+
+(deftest drag-left-narrows-col
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-start-drag! (stub-event 1000) :timestamp 200)
+      ;; Drag LEFT by 50px (pageX 950 < 1000) → dx = -50, new = 150.
+      (shell/col-divider-simulate-move! 950)
+      (shell/col-divider-simulate-up!))
+    (let [width-events (filter #(= :rf.xray/set-event-list-col-width (first %))
+                               @dispatches)]
+      (is (some #(= [:rf.xray/set-event-list-col-width :timestamp 150] %)
+                width-events)
+          "drag left narrows: 200 - 50 = 150"))))
+
+(deftest drag-cancel-tears-down-state
+  (setup!)
+  (shell/col-divider-start-drag! (stub-event 1000) :duration 60)
+  (is (true? (shell/col-divider-dragging?)))
+  (shell/col-divider-simulate-cancel!)
+  (is (false? (shell/col-divider-dragging?))
+      "pointercancel tore down the capture cleanly"))
+
+;; ---- 4. clamp at write-time --------------------------------------------
+
+(deftest set-event-list-col-width-clamps-to-floor
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-event-list-col-width :source 10]))
+  (is (= 40 (get-in (config/get-setting :general :event-list-col-widths)
+                    [:source]))
+      "sub-floor source request clamps to its 40px floor"))
+
+(deftest set-event-list-col-width-passes-in-range
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-event-list-col-width :timestamp 110]))
+  (is (= 110 (get-in (config/get-setting :general :event-list-col-widths)
+                     [:timestamp]))
+      "in-range timestamp value persists verbatim"))
+
+(deftest set-event-list-col-width-ignores-unknown-col-id
+  (setup!)
+  (let [before (config/get-setting :general :event-list-col-widths)]
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/set-event-list-col-width :event-id 999]))
+    (is (= before (config/get-setting :general :event-list-col-widths))
+        "unknown col-id (`:event-id` — flex; never sized) is a no-op")))
+
+;; ---- 5. reset --------------------------------------------------
+
+(deftest reset-restores-default
+  (setup!)
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/set-event-list-col-width :source 200]))
+  (is (= 200 (get-in (config/get-setting :general :event-list-col-widths)
+                     [:source])))
+  (rf/with-frame :rf/xray
+    (rf/dispatch-sync [:rf.xray/reset-event-list-col-width :source]))
+  (is (= 52 (get-in (config/get-setting :general :event-list-col-widths)
+                    [:source]))
+      "reset event restored the source column to its default 52px"))
+
+;; ---- 6. keyboard navigation --------------------------------------------
+
+(defn- stub-key-event [key shift?]
+  (let [prevented? (atom false)]
+    {:event #js {:key            key
+                 :shiftKey       shift?
+                 :preventDefault (fn [] (reset! prevented? true))}
+     :prevented? prevented?}))
+
+(deftest keydown-arrow-right-widens
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowRight" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-handle-keydown! event :source 60))
+    (is (some #(= [:rf.xray/set-event-list-col-width :source 70] %)
+              @dispatches)
+        "ArrowRight adds the 10px fine step (60 + 10 = 70)")))
+
+(deftest keydown-arrow-left-narrows
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowLeft" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-handle-keydown! event :timestamp 100))
+    (is (some #(= [:rf.xray/set-event-list-col-width :timestamp 90] %)
+              @dispatches)
+        "ArrowLeft subtracts the 10px fine step (100 - 10 = 90)")))
+
+(deftest keydown-shift-arrow-uses-coarse-step
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowRight" true)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-handle-keydown! event :duration 60))
+    (is (some #(= [:rf.xray/set-event-list-col-width :duration 90] %)
+              @dispatches)
+        "Shift+ArrowRight uses the 30px coarse step (10 × 3)")))
+
+(deftest keydown-enter-resets
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Enter" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (shell/col-divider-handle-keydown! event :source 200))
+    (is (some #(= [:rf.xray/reset-event-list-col-width :source] %)
+              @dispatches)
+        "Enter dispatched the reset event for the source column")))
+
+(deftest keydown-other-keys-return-false
+  (setup!)
+  (let [{:keys [event]} (stub-key-event "x" false)]
+    (is (false? (shell/col-divider-handle-keydown! event :source 60))
+        "non-binding keys return false so the caller does not preventDefault")))
+
+;; ---- divider double-click reset -----------------------------------------
+
+(deftest divider-double-click-handler-dispatches-reset
+  (setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (rf/with-frame :rf/xray
+        (let [tree    (shell/shell-view)
+              divider (find-by-testid
+                        tree "rf-xray-event-list-col-divider-source")
+              handler (:on-double-click (second divider))]
+          (is (fn? handler)
+              "the divider carries on-double-click")
+          (handler nil))))
+    (is (some #(= [:rf.xray/reset-event-list-col-width :source] %)
+              @dispatches)
+        "double-click dispatched the source-column reset event")))
+
+;; ---- accessibility ---------------------------------------------------
+
+(deftest divider-carries-aria-attributes
+  (testing "rf2-6ni62 — each divider exposes WAI-ARIA separator with
+            role + orientation + valuemin/max/now so screenreaders + the
+            host's a11y tree announce the resize affordance correctly"
+    (setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/xray
+      (let [tree    (shell/shell-view)
+            divider (find-by-testid
+                      tree "rf-xray-event-list-col-divider-source")
+            props   (second divider)]
+        (is (= "separator" (:role props)))
+        (is (= "vertical" (:aria-orientation props)))
+        (is (string? (:aria-label props))
+            "aria-label is a non-empty string")
+        (is (= 40 (:aria-valuemin props))
+            "aria-valuemin reads the source-column floor")
+        (is (= 52 (:aria-valuenow props))
+            "aria-valuenow reads the current width (default 52px)")
+        (is (= 0 (:tab-index props))
+            "tab-index 0 puts the divider into the keyboard tab order")))))

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -277,6 +277,8 @@
    :rf.xray.static.machines/sub-mode-by-id
    ;; rf2-x8h9y — horizontal resize handle width.
    :rf.xray/panel-width-px
+   ;; rf2-6ni62 — L2 event-list user-resizable column widths.
+   :rf.xray/event-list-col-widths
    ;; rf2-vbbq0 / rf2-0s2at — L2 row relative-time chip anchor (sub
    ;; composed off `:rf.xray/cascades` — dispatched-time of the most
    ;; recent cascade; flips on event arrival, not on a per-second tick).
@@ -460,6 +462,8 @@
    :rf.xray/palette-toggle
    :rf.xray/preview-cascade
    :rf.xray/remove-filter
+   ;; rf2-6ni62 — L2 event-list column-divider double-click reset.
+   :rf.xray/reset-event-list-col-width
    ;; rf2-x8h9y — resize-handle double-click reset.
    :rf.xray/reset-panel-width
    :rf.xray/reset-suppressed-counters
@@ -524,6 +528,8 @@
    :rf.xray.static.interceptors/set-registry-override-for-test
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.xray/set-modal-positioning
+   ;; rf2-6ni62 — L2 event-list column-divider live update event.
+   :rf.xray/set-event-list-col-width
    ;; rf2-x8h9y — resize-handle live update event.
    :rf.xray/set-panel-width-px
    ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -937,11 +937,14 @@
         (is (= (:flex (style-of h-event-id))
                (:flex (style-of r-event-id)))
             "header `event id` column and row event-id both flex-grow")
-        ;; TIMESTAMP / time column — header label min-width == chip min-width,
-        ;; both right-aligned, so the timestamp header sits over the chip
-        (is (= (:min-width (style-of h-timestamp))
-               (:min-width (style-of r-time)))
-            "header `timestamp` min-width == row time-chip min-width")
+        ;; TIMESTAMP / time column — header label width == chip width,
+        ;; both right-aligned, so the timestamp header sits over the chip.
+        ;; rf2-6ni62 moved this column to an explicit `:width` (user-
+        ;; resizable, no longer a min-width slot); header + row both read
+        ;; from the same `:rf.xray/event-list-col-widths` sub.
+        (is (= (:width (style-of h-timestamp))
+               (:width (style-of r-time)))
+            "header `timestamp` width == row time-chip width")
         (is (= "right"
                (:text-align (style-of h-timestamp))
                (:text-align (style-of r-time)))
@@ -1027,9 +1030,12 @@
             "the duration value reads the handler wall-time as `1.2 ms`")))))
 
 (deftest event-list-duration-column-aligns-header-and-row
-  (testing "rf2-lnod7 — the header `duration` label and the row's
-            duration cell share the SAME right-aligned min-width slot so
-            the value sits directly under the header label."
+  (testing "rf2-lnod7 / rf2-6ni62 — the header `duration` label and the
+            row's duration cell share the SAME width source so the value
+            sits directly under the header label. rf2-6ni62 promoted the
+            column to a user-resizable explicit `:width` (no longer the
+            min-width slot); header + row both read from the same
+            `:rf.xray/event-list-col-widths` sub so they never drift."
     (xray-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:poll/tick]))
     (trace-bus/collect-trace! (run-end-trace-ev 1 0.4))
@@ -1039,9 +1045,9 @@
             r-duration (find-by-testid tree "rf-xray-row-duration")]
         (is (some? h-duration) "header duration column renders")
         (is (some? r-duration) "row duration cell renders")
-        (is (= (:min-width (style-of h-duration))
-               (:min-width (style-of r-duration)))
-            "header `duration` min-width == row duration-cell min-width")
+        (is (= (:width (style-of h-duration))
+               (:width (style-of r-duration)))
+            "header `duration` width == row duration-cell width")
         (is (= "right"
                (:text-align (style-of h-duration))
                (:text-align (style-of r-duration)))


### PR DESCRIPTION
## Summary

The L2 event-list's `source` / `timestamp` / `duration` columns are now user-resizable via drag handles between cells. The leading `event id` column stays `flex: 1 1 auto` and absorbs remaining width. Mike-requested 2026-05-24 (live observation) — until this PR users had no way to widen a column when an event id or value clipped under the fixed widths.

## Persistence

Widths live in app-db at `[:settings :general :event-list-col-widths]` carrying `{:source N :timestamp N :duration N}`. The write path routes through `config/update-setting!` so the map round-trips through localStorage under the existing settings key (`re-frame2.xray.settings.v1`) — widths survive reload via the same mechanism every other persistence-bearing knob uses.

`:rf.xray/set-event-list-col-width [col-id px]` is the live update event (`:rf.trace/no-emit?` to keep drag-cadence dispatches out of the trace buffer); `:rf.xray/reset-event-list-col-width [col-id]` restores one column to its default. Both routes through `config/clamp-event-list-col-width` so the persisted payload is always in-range.

Defaults mirror the pre-resize fixed widths (source 52, timestamp 76, duration 60) — a fresh install lays out identically. Floors are per-column (source 40, timestamp 60, duration 48) — sized so the lowercase header label still reads.

## Drag implementation

Mirrors the established `resize-handle.cljs` pattern. Each divider's pointerdown records a `{:col-id :start-x :start-width}` snapshot, then attaches document-level pointermove / pointerup / pointercancel listeners on `js/document` (NOT on the divider element) so a drag faster than the per-element hit-test cadence keeps tracking the pointer — the standard split-pane recipe used by Chrome devtools, VS Code's panel boundary, etc. Body cursor flips to col-resize globally during the drag so the operation reads as continuous even when the cursor crosses the column being resized. Pointercancel tears the capture down cleanly so a system-preempted gesture (mobile system gesture override) never strands listeners.

Pointer events unify mouse + touch + pen so the same handler covers laptop trackpads, desktop mice, and tablet / phone touch screens without branching.

## Accessibility

- Each divider exposes WAI-ARIA `separator` with `aria-orientation=vertical` + `aria-valuemin` / `aria-valuemax` / `aria-valuenow` so screenreaders announce the resize affordance correctly.
- Keyboard handle: `ArrowLeft` / `ArrowRight` do a 10px fine resize; `Shift+ArrowLeft` / `ArrowRight` do a 30px coarse resize; `Enter` / `Space` reset the column to its default.
- Double-click on a divider resets that column to its default (the pointer-equivalent of Enter/Space).
- Hover affordance (a soft 1px accent stripe down the divider's middle) lives in CSS at `theme/global_styles/motion-css` so it paints reliably without a re-render. The 120ms transition scales through `--rf-xray-motion-scale` so the `prefers-reduced-motion: reduce` seam (+ the rf2-ybjkx user override) collapses it.
- `tab-index=0` puts every divider in the keyboard tab order.

## Alignment-guarantee design

The header (`l2-column-header`) and every row (`event-row`) read column widths from the SAME `:rf.xray/event-list-col-widths` sub. The `event-list` view subscribes ONCE per L2 paint and threads the resolved widths through to both surfaces so the two never drift out of column alignment.

Verified by a CLJS unit test that dispatches the live update event and asserts the rendered `:width` on header + row are byte-identical:

```clj
(rf/dispatch-sync [:rf.xray/set-event-list-col-width :timestamp 120])
;; →
(is (= "120px" (:width (style-of h-timestamp)) (:width (style-of r-time))))
```

A second test asserts the silent-default path — without any settings write, header + row both read the defaults (52 / 76 / 60).

## Files

- `tools/xray/src/day8/re_frame2_xray/config.cljc` — defaults + floors + clamp + resolve helpers + settings-map default slot. CLJC-pure / JVM-testable.
- `tools/xray/src/day8/re_frame2_xray/registry.cljs` — `:rf.xray/event-list-col-widths` sub + `:rf.xray/set-event-list-col-width` / `:rf.xray/reset-event-list-col-width` events. `:rf.trace/no-emit?` mirrors the panel-resize handler.
- `tools/xray/src/day8/re_frame2_xray/shell.cljs` — divider view + drag state + start-drag + keyboard handler + the alignment-guarantee threading from `event-list` → `l2-column-header` + `event-row`. `relative-time-chip` and `duration-cell` now accept `col-px` from the caller so they read the user-resizable width rather than the deleted constant.
- `tools/xray/src/day8/re_frame2_xray/theme/global_styles.cljs` — divider hover stripe (CSS, motion-scale-aware).

## Tests

- 14 new JVM tests in `config_test.clj` covering the pure helpers (clamp + resolve from persisted-or-default, floor / unknown-col / partial-map / non-numeric paths).
- New CLJS unit test `event_list_resizable_cols_cljs_test` covering divider render, header/row alignment after a settings-write (the alignment-guarantee design), drag lifecycle, clamp at write-time, reset, keyboard navigation, double-click handler, and ARIA attributes.
- Pre-existing `shell_cljs_test` alignment assertions updated from `:min-width` → `:width` (the column is now explicit-width, not a min-width slot).
- `registry_cljs_test` contract list extended with the two new events + the new sub.

## Gates

- xray JVM: `clojure -M:test` — Ran 877 tests, 3111 assertions, 0 failures, 0 errors.
- CLJS: `npm run test:cljs` — Ran 4359 tests, 13931 assertions, 0 failures, 0 errors.
- Xray feature gate: `npm run test:xray-feature-gate` — 13 scenarios, 0 failures.
- Bundle isolation: `npm run test:bundle-isolation` — PASS, all sentinels absent.
- clj-kondo: only pre-existing infos / warnings; nothing new introduced.
- splint: only pre-existing style warnings; nothing new introduced.