### PR TITLE
feat(re-frame2-pair-mcp): shadow HTTP API nREPL auto-discovery (rf2-umoz2)

### DIFF
--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -48,8 +48,13 @@ const EXPECTED_TOOLS = JSON.parse(
 ).names;
 
 // Force degraded mode: empty out $SHADOW_CLJS_NREPL_PORT and boot from
-// a tmpdir so the port-file probe misses. Same setup as the re-frame2-pair-mcp
-// upstream stdio-roundtrip.
+// a tmpdir so the port-file probe misses. Pre-rf2-umoz2 that was
+// sufficient; the cwd-relative file scan was the last discovery step.
+// rf2-umoz2 added a shadow HTTP probe (default port 9630) that would
+// otherwise resolve a port whenever shadow happens to be running on the
+// CI agent's loopback — so we pin --http-port to a port we know is
+// closed (port 1, IANA-reserved + never bound) which makes the probe's
+// ECONNREFUSED short-circuit deterministic on every host.
 const env = { ...process.env };
 delete env.SHADOW_CLJS_NREPL_PORT;
 
@@ -59,7 +64,7 @@ runWithWatchdog(
     clientName: 'mcp-conformance-re-frame2-pair',
     transportSpec: {
       command: process.execPath,
-      args: [SERVER],
+      args: [SERVER, '--http-port', '1'],
       cwd: os.tmpdir(),
       env,
     },

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -78,19 +78,25 @@ The server auto-discovers the nREPL port from (highest precedence first):
 1. `--port-file <path>` launch flag — an explicit, **cwd-independent**
    path to the port file. See [Launch flags](#launch-flags).
 2. `$SHADOW_CLJS_NREPL_PORT` env var.
-3. `target/shadow-cljs/nrepl.port`
-4. `.shadow-cljs/nrepl.port`
-5. `.nrepl-port`
+3. **Shadow HTTP probe (rf2-umoz2)** — `GET http://127.0.0.1:9630/api/project-info`
+   returns the live build's absolute `:project-home`; the server then
+   reads the port-file candidates resolved against that root. This is
+   the cwd-robust auto-discovery step; the HTTP port is overridable via
+   `--http-port <n>` for the rare case shadow's `:http :port` is pinned.
+4. CWD-relative scan of `target/shadow-cljs/nrepl.port`,
+   `.shadow-cljs/nrepl.port`, `.nrepl-port` — legacy fallback for
+   setups without shadow's web server (older shadow, manual nREPL boot).
 
-> **cwd caveat (rf2-3dbwh).** Steps 3–5 are bare *relative* paths,
-> resolved against the server process's current working directory
-> (`process.cwd()`). The MCP server runs as a **subprocess of the agent
-> host** (Claude Code / Cursor / Copilot), whose cwd is frequently **not**
-> your project root. When it isn't, all three file fallbacks miss
-> silently and only the env var (step 2) or `--port-file` (step 1)
-> resolve a port. If discovery fails with no obvious cause, prefer the
-> explicit escape hatches: set `SHADOW_CLJS_NREPL_PORT`, or pass
-> `--port-file <absolute-path-to-nrepl.port>`.
+> **The cwd caveat step 3 solves (rf2-3dbwh + rf2-umoz2).** Step 4 is
+> bare *relative* paths resolved against `process.cwd()`. The MCP
+> server runs as a **subprocess of the agent host** (Claude Code /
+> Cursor / Copilot), whose cwd is frequently **not** your project
+> root. Pre-rf2-umoz2 only the env var or `--port-file` worked there;
+> step 3 now closes the gap by asking shadow itself for the project
+> root. The explicit escape hatches in steps 1–2 remain the
+> deterministic overrides — pass `--port-file <absolute-path>` or set
+> `SHADOW_CLJS_NREPL_PORT` if discovery still fails (shadow not running,
+> non-default `:http :port` not surfaced via `--http-port`, etc.).
 
 ### Path-drift probe
 
@@ -153,6 +159,7 @@ your editor is the source of truth.
 | `--allow-sensitive-reads`   | OFF     | Honour caller-supplied `:include-sensitive true` and `:elision false` on direct-read tools (`snapshot` / `get-path` / `subscribe` / `trace-window` / `watch-epochs`). Default-OFF gate (rf2-c2dtu). Canonical cross-MCP flag name shared with story-mcp (rf2-2x3ql); see "sensitive-reads gate" below. |
 | `--allow-writes`            | OFF     | Enable the state-mutating tools `restore-epoch` (time-travel undo) and `reset-frame-db` (state injection). Default-OFF gate (rf2-ee38b.18); without it both return `{:ok? false :reason :rf.error/writes-disabled}` without touching the nREPL socket. `dispatch` (which drives the app's own handlers) is unaffected. See "writes gate" below. |
 | `--port-file <path>`        | —       | Explicit, **cwd-independent** path to the nREPL port file. Highest precedence in port discovery (rf2-3dbwh); see "port-file flag" below. Accepts `--port-file <path>` and `--port-file=<path>`. |
+| `--http-port <n>`           | `9630`  | Shadow's web-server port for the auto-discovery probe (rf2-umoz2). Only consulted at port-discovery step 3; setting it has no effect when `--port-file` or `SHADOW_CLJS_NREPL_PORT` is present. |
 
 #### port-file flag (rf2-3dbwh)
 

--- a/tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md
+++ b/tools/re-frame2-pair-mcp/spec/002-nREPL-Transport.md
@@ -49,15 +49,39 @@ adds the preload entry to their shadow-cljs build per
 
 ## Port discovery
 
-In order:
+In precedence order (rf2-umoz2 introduced step 3):
 
-1. `$SHADOW_CLJS_NREPL_PORT` env var.
-2. `target/shadow-cljs/nrepl.port` (shadow-cljs's standard location).
-3. `.shadow-cljs/nrepl.port`.
-4. `.nrepl-port` (generic nREPL convention).
+1. `--port-file <path>` launch flag — explicit, cwd-independent override
+   (rf2-3dbwh).
+2. `$SHADOW_CLJS_NREPL_PORT` env var.
+3. **Shadow HTTP probe** — `GET http://127.0.0.1:9630/api/project-info`
+   returns the consumer build's absolute `:project-home`; the server
+   then reads `target/shadow-cljs/nrepl.port`, `.shadow-cljs/nrepl.port`,
+   `.nrepl-port` (in that order) resolved against that root. The
+   shadow HTTP port is overridable via `--http-port <n>` (default
+   9630; rf2-umoz2).
+4. CWD-relative scan of the same three candidates — legacy fallback
+   for environments without shadow's web server.
 
 If none resolve, the server boots in degraded mode (see
 `001-Wire-Protocol.md` § Degraded boot).
+
+### Why the HTTP probe
+
+shadow-cljs's nREPL port is ephemeral (a fresh OS-assigned port on each
+`shadow-cljs watch` start) and the port file lives at a relative path
+inside the consumer project. Pre-rf2-umoz2 the server relied on
+`process.cwd()` being the project root to find that file — but agent
+hosts (Claude Code / Cursor / Copilot) spawn MCP subprocesses with a cwd
+they choose, frequently `$HOME` or the host's install dir. Shadow's own
+HTTP server (default port 9630, fixed across restarts) exposes the
+absolute project root via `/api/project-info`; that closes the loop
+without forcing every operator to hardcode `--port-file` in their MCP
+config.
+
+The probe is bounded (`probe-timeout-ms` = 500ms) and never blocks boot
+indefinitely. Probe failure (shadow not running, non-default `:http :port`,
+parse error) silently falls through to step 4.
 
 ## cljs-eval wrapper
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -38,15 +38,20 @@
   (:require [applied-science.js-interop :as j]
             [clojure.string :as str]
             [cljs.reader :as edn]
+            [re-frame2-pair-mcp.shadow-discovery :as shadow-discovery]
             ["bencode" :as bencode]
             ["net" :as net]
+            ["path" :as node-path]
             ["fs" :as fs]))
 
 ;; ---------------------------------------------------------------------------
-;; Port discovery — matches the bash-shim's read-port logic.
+;; Port discovery — five-step cascade with the shadow HTTP probe in the middle.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private port-file-candidates
+  "Standard locations shadow-cljs / generic-nREPL write the port file to,
+  relative to the project root. The cascade resolves these against three
+  different bases in three different steps — see `discover-port`."
   ["target/shadow-cljs/nrepl.port"
    ".shadow-cljs/nrepl.port"
    ".nrepl-port"])
@@ -61,9 +66,34 @@
       (when-not (js/isNaN n) n))
     (catch :default _ nil)))
 
+(defn- read-env-port
+  "Read `$SHADOW_CLJS_NREPL_PORT` and parse as int. Returns nil when
+  unset or non-numeric. Pulled out so the precedence cascade reads
+  linearly."
+  []
+  (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
+    (let [n (js/parseInt env 10)]
+      (when-not (js/isNaN n) n))))
+
+(defn- read-port-at-base
+  "Resolve `port-file-candidates` against an absolute base directory and
+  return the first hit's parsed port — or nil. Uses `node-path/join` so
+  the candidates are platform-correct on Windows + POSIX without each
+  call site building paths by string-concat."
+  [base]
+  (when (and base (seq base))
+    (some (fn [rel] (read-port-file (node-path/join base rel)))
+          port-file-candidates)))
+
 (defn read-port-from-fs
-  "Read the nREPL port from the standard shadow-cljs / nrepl locations.
-  Returns an integer or nil.
+  "Synchronous slice of the port-discovery cascade — the explicit
+  override path + env var + cwd-relative file scan. Returns an integer
+  or nil.
+
+  Lives on as a pure-sync helper so unit tests can pin the file-system
+  precedence without driving the async HTTP probe. Production boot
+  prefers `discover-port` (async) which composes this with the shadow
+  HTTP step.
 
   ## Precedence (highest first)
 
@@ -72,22 +102,83 @@
     2. `$SHADOW_CLJS_NREPL_PORT` env var.
     3. `target/shadow-cljs/nrepl.port`  ┐
     4. `.shadow-cljs/nrepl.port`        ├ cwd-relative scan (steps 3-5).
-    5. `.nrepl-port`                    ┘
-
-  The file-scan candidates (steps 3-5) are bare relative paths resolved
-  against `process.cwd()`. An MCP server launched as a subprocess of the
-  agent host (Claude Code / Cursor / Copilot) frequently has a cwd that
-  is NOT the consumer project root — in that case the scan misses
-  silently and only the env var or `--port-file` work. `--port-file`
-  (step 1) is the cwd-independent escape hatch; see the tool README."
+    5. `.nrepl-port`                    ┘"
   ([] (read-port-from-fs nil))
   ([explicit-port-file]
    (or (when (and explicit-port-file (seq explicit-port-file))
          (read-port-file explicit-port-file))
-       (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
-         (let [n (js/parseInt env 10)]
-           (when-not (js/isNaN n) n)))
+       (read-env-port)
        (some read-port-file port-file-candidates))))
+
+(defn discover-port*
+  "Full nREPL port-discovery cascade with the shadow HTTP probe injected
+  as `shadow-probe-fn` — a `(host port) → Promise<project-home-or-nil>`
+  function. Production callers thread `shadow-discovery/discover-project-home`
+  (see [[discover-port]]); tests pass stubs to exercise each cascade
+  branch without standing up a real HTTP server.
+
+  Returns a Promise resolving to an integer port or to nil.
+
+  ## Precedence (highest first; rf2-umoz2)
+
+    1. `--port-file <path>`   explicit, cwd-independent override
+                              (rf2-3dbwh). Wins outright.
+    2. `$SHADOW_CLJS_NREPL_PORT` env var.
+    3. **Shadow HTTP probe** — `shadow-probe-fn` returns the consumer
+       project's absolute `:project-home`; we then read
+       `port-file-candidates` resolved against that root. This is the
+       cwd-robust zero-config win for the agent-host launch pattern
+       where `process.cwd()` is the host, not the project (rf2-umoz2).
+    4. CWD-relative scan of `port-file-candidates` — legacy fallback
+       for environments without the shadow HTTP API (older shadow, or
+       a manual nREPL boot bypassing shadow entirely).
+
+  ## Why steps 3 and 4 use the same candidate list
+
+  shadow-cljs writes its nREPL port to one of three known relative paths
+  inside the project root. Step 3 obtains the root from shadow itself;
+  step 4 hopes the cwd already IS the root. Sharing the candidate list
+  keeps the contract `(root, candidates) → port` symmetrical across the
+  two steps.
+
+  ## Why the HTTP probe is bounded
+
+  See `shadow-discovery/probe-timeout-ms`. The probe never blocks boot
+  for more than half a second — if shadow's web server is unreachable
+  the cascade moves on. The `--port-file` and env-var escape hatches
+  (steps 1 and 2) remain the deterministic overrides for exotic setups.
+
+  ## Why injection rather than direct call
+
+  The CLJS compiler resolves `shadow-discovery/discover-project-home` at
+  callsite-emit time; CLJS's `with-redefs` swaps the *var binding* but
+  the emitted JS for a direct multi-arity call dispatches through
+  fn-object arity slots, not through the var. Injecting the probe makes
+  the seam explicit and gives tests a clean stub-point — and the
+  production wrapper below pays nothing for the indirection (single
+  call, no allocation)."
+  [explicit-port-file http-port shadow-probe-fn]
+  (let [override (or (when (and explicit-port-file (seq explicit-port-file))
+                       (read-port-file explicit-port-file))
+                     (read-env-port))]
+    (if override
+      (js/Promise.resolve override)
+      (-> (shadow-probe-fn
+            shadow-discovery/default-host
+            (or http-port shadow-discovery/default-http-port))
+          (.then (fn [project-home]
+                   (or (read-port-at-base project-home)
+                       ;; Final fallback: cwd-relative scan.
+                       (some read-port-file port-file-candidates))))))))
+
+(defn discover-port
+  "Production entry-point for the port-discovery cascade — see
+  [[discover-port*]] for the precedence details and the design rationale.
+  Returns a Promise resolving to an integer port or to nil."
+  ([] (discover-port nil nil))
+  ([explicit-port-file http-port]
+   (discover-port* explicit-port-file http-port
+                   shadow-discovery/discover-project-home)))
 
 ;; ---------------------------------------------------------------------------
 ;; bencode framing — handle concatenated frames in one TCP packet.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -5,12 +5,14 @@
 
   ## Lifecycle
 
-  1. boot: read nREPL port from the `--port-file <path>` flag, the
-     `SHADOW_CLJS_NREPL_PORT` env var, or the standard cwd-relative
-     port-files (in that precedence — see `nrepl/read-port-from-fs`).
-     Open the persistent socket lazily on first tool call (so the
-     server starts cleanly even before shadow-cljs is running — the
-     first tool that needs the socket gets a structured error).
+  1. boot: discover the nREPL port via the four-step cascade — the
+     `--port-file <path>` flag, the `SHADOW_CLJS_NREPL_PORT` env var,
+     a probe of shadow's HTTP API at port 9630 (which yields the
+     consumer project root → port-file lookup; rf2-umoz2), and finally
+     a cwd-relative port-file scan. See `nrepl/discover-port`. Open
+     the persistent socket lazily on first tool call (so the server
+     starts cleanly even before shadow-cljs is running — the first
+     tool that needs the socket gets a structured error).
   2. `initialize`: standard MCP handshake.
   3. `tools/list`: returns the full tool catalogue — see
      `tools.registry/tools` for the authoritative list (the single
@@ -53,28 +55,36 @@
 ;; Shared connection state.
 ;; ---------------------------------------------------------------------------
 
+(def ^:private port-not-found-hint
+  "Boot-failure prose for the operator. Threaded into the boot-error
+  payload and the degraded-mode hint so the same surface appears
+  whether discovery returned nil or the cascade threw."
+  (str "nREPL port not found. Start your shadow-cljs dev build "
+       "(`shadow-cljs watch <build>`), or set "
+       "SHADOW_CLJS_NREPL_PORT explicitly, or pass "
+       "`--port-file <absolute-path-to-nrepl.port>` "
+       "(the cwd-independent escape hatch)."))
+
 (defn- resolve-port
-  "Look up the nREPL port. Returns an integer or throws with a hint.
+  "Run the async port-discovery cascade — see `nrepl/discover-port` for
+  the four-step precedence (rf2-umoz2 added the shadow HTTP probe as
+  step 3). Returns a Promise resolving to an integer port or rejecting
+  with a structured `:rf.error/pair-mcp-nrepl-port-not-found` ex-info."
+  [explicit-port-file http-port]
+  (-> (nrepl/discover-port explicit-port-file http-port)
+      (.then (fn [port]
+               (if port
+                 port
+                 (throw (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
+                                 {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found
+                                  :where    'pair-mcp/resolve-port
+                                  :recovery :no-recovery
+                                  :reason   port-not-found-hint
+                                  :hint     port-not-found-hint})))))))
 
-  `explicit-port-file` (from the `--port-file <path>` launch flag) takes
-  precedence over the env var and the cwd-relative file scan — see
-  `nrepl/read-port-from-fs` and the tool README (rf2-3dbwh)."
-  [explicit-port-file]
-  (or (nrepl/read-port-from-fs explicit-port-file)
-      (throw (ex-info ":rf.error/pair-mcp-nrepl-port-not-found"
-                      {:rf.error/id :rf.error/pair-mcp-nrepl-port-not-found
-                       :where    'pair-mcp/resolve-port
-                       :recovery :no-recovery
-                       :reason   (str "nREPL port not found. Start your shadow-cljs dev build "
-                                      "(`shadow-cljs watch <build>`), or set "
-                                      "SHADOW_CLJS_NREPL_PORT explicitly, or pass "
-                                      "`--port-file <absolute-path-to-nrepl.port>` "
-                                      "(the cwd-independent escape hatch).")}))))
-
-(defn- new-conn [explicit-port-file]
-  (let [port (resolve-port explicit-port-file)]
-    (log! "nREPL port =" port)
-    (nrepl/make-conn port "127.0.0.1")))
+(defn- new-conn-for-port [port]
+  (log! "nREPL port =" port)
+  (nrepl/make-conn port "127.0.0.1"))
 
 ;; ---------------------------------------------------------------------------
 ;; MCP request handlers.
@@ -152,6 +162,34 @@
                                          :text (pr-str payload)}]
              :structuredContent (clj->js payload)}))))
 
+(defn- parse-string-value-flag
+  "Generic launch-flag pluck: returns the trailing value of `--name <v>`
+  or the inline value of `--name=<v>` for the named flag in `argv`.
+  Last occurrence wins (consistent with argv override semantics).
+  Returns nil when the flag is absent or given without a value.
+
+  Used by both `--port-file` (rf2-3dbwh) and `--http-port` (rf2-umoz2);
+  one parser, one shape — so a future string-valued flag lands here
+  without growing a per-flag micro-parser."
+  [flag-name argv]
+  (let [equals-prefix (str flag-name "=")]
+    (loop [items argv
+           found nil]
+      (if-let [item (first items)]
+        (cond
+          (str/starts-with? item equals-prefix)
+          (recur (rest items) (subs item (count equals-prefix)))
+
+          (= item flag-name)
+          (let [v (second items)]
+            (if (and v (not (str/starts-with? v "--")))
+              (recur (drop 2 items) v)
+              (recur (rest items) found)))
+
+          :else
+          (recur (rest items) found))
+        found))))
+
 (defn- parse-port-file-flag
   "Pluck the value of the `--port-file` launch flag out of `argv`.
   Accepts both the space form `--port-file <path>` and the equals form
@@ -160,24 +198,20 @@
   override semantics). Public-ish (private) — exercised via
   `parse-launch-flags` in tests."
   [argv]
-  (loop [items argv
-         found nil]
-    (if-let [item (first items)]
-      (cond
-        ;; --port-file=<path>
-        (str/starts-with? item "--port-file=")
-        (recur (rest items) (subs item (count "--port-file=")))
+  (parse-string-value-flag "--port-file" argv))
 
-        ;; --port-file <path>  (value is the next argv element)
-        (= item "--port-file")
-        (let [v (second items)]
-          (if (and v (not (str/starts-with? v "--")))
-            (recur (drop 2 items) v)
-            (recur (rest items) found)))
+(defn- parse-http-port-flag
+  "Pluck the value of the `--http-port` launch flag (rf2-umoz2) and
+  coerce to an int. Returns nil when absent / malformed.
 
-        :else
-        (recur (rest items) found))
-      found)))
+  Shadow's web server is fixed by its own `:http :port` config; the
+  default (9630) covers ~all consumers. Operators who pinned shadow's
+  HTTP port to something else surface that here without forcing a
+  re-implementation of the shadow-cljs.edn parser."
+  [argv]
+  (when-let [raw (parse-string-value-flag "--http-port" argv)]
+    (let [n (js/parseInt raw 10)]
+      (when-not (js/isNaN n) n))))
 
 (defn parse-launch-flags
   "Pluck the named launch flags out of the raw process argv. Flags today:
@@ -201,11 +235,18 @@
     --port-file <path>       — explicit, cwd-independent nREPL port-file
                                path (rf2-3dbwh). Highest precedence in the
                                port-discovery chain — see
-                               `nrepl/read-port-from-fs`. Accepts both
+                               `nrepl/discover-port`. Accepts both
                                `--port-file <path>` and `--port-file=<path>`.
+    --http-port <n>          — override shadow-cljs's HTTP server port
+                               for the auto-discovery probe (rf2-umoz2).
+                               Defaults to 9630 (shadow's standard).
+                               Only used when steps 1-2 of the cascade
+                               miss; setting it has no effect when
+                               --port-file or SHADOW_CLJS_NREPL_PORT is
+                               present.
 
   Returns `{:allow-eval? bool :allow-raw-state? bool :allow-writes? bool
-  :port-file str-or-nil}`.
+  :port-file str-or-nil :http-port int-or-nil}`.
   The internal keyword `:allow-raw-state?` is the pair-mcp
   implementation-side identifier for the gate's state; the CLI flag is the
   operator-facing name. Unknown flags are ignored — node's shadow-cljs
@@ -215,7 +256,8 @@
   {:allow-eval?      (boolean (some #{"--allow-eval"} argv))
    :allow-raw-state? (boolean (some #{"--allow-sensitive-reads"} argv))
    :allow-writes?    (boolean (some #{"--allow-writes"} argv))
-   :port-file        (parse-port-file-flag argv)})
+   :port-file        (parse-port-file-flag argv)
+   :http-port        (parse-http-port-flag argv)})
 
 (defn- apply-launch-flags!
   "Wire launch-flag state into the relevant tool gates. Called once
@@ -258,17 +300,28 @@
     (apply-resource-controls! argv)
     (when-let [pf (:port-file launch-flags)]
       (log! "nREPL port-file (--port-file):" pf))
-    (try
-      (let [conn   (new-conn (:port-file launch-flags))
-            server (boot! conn)]
-        (log! "starting stdio transport")
-        (connect-transport! server "ready — awaiting MCP frames on stdin"))
-      (catch :default e
-        (log! "boot failed:" (.-message e))
-        ;; Even on boot failure (e.g. nREPL port missing) we keep the
-        ;; process alive so the MCP client can talk to us, list tools,
-        ;; and surface a structured error from the first tool call. The
-        ;; bash-shim chain had the same semantics — the error came back
-        ;; as `{:ok? false :reason :nrepl-port-not-found}`.
-        (let [server (build-server (degraded-handler e))]
-          (connect-transport! server "ready (degraded — no nREPL port)"))))))
+    (when-let [hp (:http-port launch-flags)]
+      (log! "shadow HTTP port (--http-port):" hp))
+    ;; Port discovery is async (the shadow HTTP probe in step 3 of
+    ;; `nrepl/discover-port` is a real network call; rf2-umoz2). The
+    ;; rest of boot — stdio transport, dispatcher wiring — sequences off
+    ;; the resolved port via .then. Degraded boot fires from the .catch
+    ;; branch so a missing nREPL still yields a tools/list-discoverable
+    ;; server that surfaces a structured error on first call. Same
+    ;; observable shape as the pre-rf2-umoz2 sync boot — the await is an
+    ;; implementation detail.
+    (-> (resolve-port (:port-file launch-flags) (:http-port launch-flags))
+        (.then (fn [port]
+                 (let [conn   (new-conn-for-port port)
+                       server (boot! conn)]
+                   (log! "starting stdio transport")
+                   (connect-transport! server "ready — awaiting MCP frames on stdin"))))
+        (.catch (fn [e]
+                  (log! "boot failed:" (.-message e))
+                  ;; Even on boot failure (e.g. nREPL port missing) we keep the
+                  ;; process alive so the MCP client can talk to us, list tools,
+                  ;; and surface a structured error from the first tool call. The
+                  ;; bash-shim chain had the same semantics — the error came back
+                  ;; as `{:ok? false :reason :nrepl-port-not-found}`.
+                  (let [server (build-server (degraded-handler e))]
+                    (connect-transport! server "ready (degraded — no nREPL port)")))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/shadow_discovery.cljs
@@ -1,0 +1,168 @@
+(ns re-frame2-pair-mcp.shadow-discovery
+  "Locate the consumer project's nREPL port file via shadow-cljs's
+  built-in HTTP API — the cwd-robust auto-discovery step.
+
+  ## The cwd problem the nREPL file-scan can't solve
+
+  shadow-cljs writes its nREPL port to a relative path inside the
+  consumer project (`target/shadow-cljs/nrepl.port`,
+  `.shadow-cljs/nrepl.port`, or `.nrepl-port`). The MCP server can read
+  that file when its `process.cwd()` is the project root — but
+  `process.cwd()` is set by the spawning process, which for MCP servers
+  is the *agent host* (Claude Code / Cursor / Copilot), not the user.
+  Agent hosts pick their own cwd, frequently the host's install
+  directory or `$HOME`, so the file scan misses silently and pairing
+  breaks with `:nrepl-port-not-found`.
+
+  ## Why shadow's HTTP API closes the gap
+
+  shadow-cljs runs a web server (default port 9630) for its dashboard.
+  That server exposes `GET /api/project-info`, which returns a
+  transit-json map carrying the live build's `:project-home` (absolute
+  path to the project root). With that absolute root in hand, the
+  existing port-file candidates (`target/shadow-cljs/nrepl.port`, …)
+  become absolute paths the cwd can't perturb.
+
+  The HTTP server's port is fixed by shadow's `:http :port` config and
+  doesn't randomise across restarts (unlike the nREPL port, which is
+  ephemeral by default). 9630 is the documented default; exotic
+  configurations can pass `--http-port <n>`.
+
+  ## What this namespace does
+
+  One pure async fn: probe the shadow HTTP API, return the project root,
+  bail to nil on every error. The orchestrator in `nrepl.cljs` runs the
+  same port-file candidates against this absolute root before falling
+  back to the legacy cwd-relative scan.
+
+  ## Transit-json shape
+
+  The `/api/project-info` payload is transit-json's verbose map-as-array:
+
+      [\"^ \", \"~:project-config\", \"...\",
+              \"~:project-home\",   \"<abs-project-root>\",
+              \"~:version\",        \"3.4.10\"]
+
+  We don't pull in a transit library for one key — a JSON.parse plus a
+  linear walk for the `~:project-home` sentinel is honest about the one
+  shape we depend on. If shadow changes the wire format we want a clear
+  parser failure here, not a transit library silently doing the wrong
+  thing under an evolving spec."
+  (:require [applied-science.js-interop :as j]
+            ["http" :as http]))
+
+(def ^:const default-http-port
+  "Shadow-cljs's documented default web-server port. Overridable via the
+  `--http-port` launch flag for the (rare) consumer that pins shadow's
+  `:http :port` to something else."
+  9630)
+
+(def ^:const default-host "127.0.0.1")
+
+(def ^:const probe-timeout-ms
+  "Bound on the HTTP probe. Shadow's HTTP server is local — `connect`
+  either binds or refuses within milliseconds. If shadow's process is
+  alive but unresponsive (the only realistic stall case) we'd rather
+  fall through to the cwd-relative scan than hang the MCP boot."
+  500)
+
+(defn extract-project-home
+  "Pull `:project-home` out of a transit-json `/api/project-info` body
+  (a JSON string). Returns the absolute path string or nil.
+
+  Transit-json encodes a map as `[\"^ \" k1 v1 k2 v2 …]` with keyword
+  keys prefixed by `~:`. We walk the parsed array looking for the
+  `~:project-home` sentinel and return the next element as the value.
+
+  Public so the unit tests can pin the parser shape directly (rf2-umoz2)
+  without standing up a fake HTTP server. A defensive parser — every
+  branch where the shape disagrees collapses to nil so the caller falls
+  through cleanly."
+  [body]
+  (try
+    (let [parsed (js/JSON.parse body)]
+      (when (and (array? parsed)
+                 (= "^ " (aget parsed 0)))
+        ;; Walk index 1.. pairs; `~:project-home` is the key sentinel.
+        (loop [i 1]
+          (cond
+            (>= i (.-length parsed)) nil
+            (= "~:project-home" (aget parsed i))
+            (let [v (aget parsed (inc i))]
+              (when (string? v) v))
+            :else (recur (+ i 2))))))
+    (catch :default _ nil)))
+
+(defn fetch-project-info
+  "Issue `GET http://<host>:<http-port>/api/project-info` against shadow's
+  web server. Returns a Promise resolving to the response body (string)
+  on a 200, or rejecting on any other condition (connection refused,
+  non-200 status, body-read error, timeout). Caller is expected to
+  `.catch` and translate failures to nil — see `discover-project-home`.
+
+  Kept separate from the parsing step so tests can stub one or the
+  other in isolation."
+  [host http-port]
+  (js/Promise.
+    (fn [resolve reject]
+      (let [opts        #js {:host host
+                             :port http-port
+                             :path "/api/project-info"
+                             :method "GET"}
+            settled?    (atom false)
+            settle-once (fn [f v]
+                          (when (compare-and-set! settled? false true)
+                            (f v)))
+            ^js req     (http/request
+                          opts
+                          (fn [^js res]
+                            (let [status (.-statusCode res)]
+                              (if-not (= 200 status)
+                                (do (.resume res)
+                                    (settle-once
+                                      reject
+                                      (js/Error.
+                                        (str "shadow /api/project-info returned HTTP " status))))
+                                (let [chunks (array)]
+                                  (.setEncoding res "utf8")
+                                  (j/call res :on "data" #(.push chunks %))
+                                  (j/call res :on "end"
+                                          #(settle-once resolve (.join chunks "")))
+                                  (j/call res :on "error"
+                                          #(settle-once reject %)))))))]
+        (j/call req :on "error" #(settle-once reject %))
+        ;; Bounded probe — see `probe-timeout-ms` for rationale.
+        (j/call req :setTimeout probe-timeout-ms
+                (fn []
+                  (try (.destroy req (js/Error. "shadow HTTP probe timed out"))
+                       (catch :default _ nil))
+                  (settle-once reject (js/Error. "shadow HTTP probe timed out"))))
+        (.end req)))))
+
+(defn discover-project-home*
+  "Like [[discover-project-home]] but takes the HTTP-fetch fn as an
+  argument so tests can stub `fetch-project-info`. Production callers
+  use the 0-/2-arity wrapper below.
+
+  Returns a Promise resolving to the absolute project-home string or
+  nil. Never rejects."
+  [host http-port fetch-fn]
+  (-> (fetch-fn host http-port)
+      (.then (fn [body] (extract-project-home body)))
+      (.catch (fn [_err] nil))))
+
+(defn discover-project-home
+  "Probe shadow's HTTP API at `host:http-port` and return a Promise
+  resolving to the absolute project-home path (string) — or nil if the
+  probe fails for any reason (shadow not running, wrong port, parse
+  failure, timeout, non-200, malformed payload).
+
+  Never rejects: the caller wants a value-or-nil so it can fall through
+  to the next discovery step without a try/catch around every call site.
+
+  The cascade in `nrepl.cljs` calls `discover-project-home*` via an
+  injected probe seam (see `nrepl/discover-port*`); this 0-/2-arity
+  wrapper is the boot-time default that threads `fetch-project-info` in."
+  ([] (discover-project-home default-host default-http-port))
+  ([host http-port]
+   (discover-project-home* host http-port fetch-project-info)))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/nrepl_test.cljs
@@ -12,7 +12,8 @@
             [applied-science.js-interop :as j]
             ["bencode" :as bencode]
             ["fs" :as fs]
-            [re-frame2-pair-mcp.nrepl :as nrepl]))
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.shadow-discovery :as shadow-discovery]))
 
 (defn- decode-all
   "Wrap `nrepl/decode-all-frames` returning `[clj-vec rest-buf]`.
@@ -82,7 +83,11 @@
   "Run `body` with `fs.readFileSync` replaced by `stub-fn` (path → string,
   or throw to simulate ENOENT) and `process.env.SHADOW_CLJS_NREPL_PORT`
   set to `env-val` (nil = unset). Restores both afterwards. Returns the
-  value of `body`."
+  value of `body`.
+
+  Sync-only: the `finally` block restores the stub immediately after
+  `body` returns. The new async cascade tests use [[with-async-fs-stub!]]
+  which keeps the stub alive across Promise microtasks."
   [env-val stub-fn body]
   (let [orig-read (.-readFileSync fs)
         orig-env  (j/get-in js/process [:env env-key])]
@@ -93,6 +98,29 @@
       (finally
         (set! (.-readFileSync fs) orig-read)
         (set-env! orig-env)))))
+
+(defn- install-fs-stub!
+  "Install `stub-fn` as `fs.readFileSync` and override
+  `process.env.SHADOW_CLJS_NREPL_PORT` to `env-val` (nil = unset).
+  Returns a 0-arity restoration thunk the caller invokes once the async
+  body has settled. Pairs with the test's own `(done)` so the stub
+  lifetime spans every microtask the promise chain spawns — which the
+  sync [[with-fs-stub!]] can't guarantee for async bodies (the
+  `finally` clause fires before the `.then` callbacks).
+
+  Always pair `install-fs-stub!` with its restoration call inside the
+  final `.then` (BEFORE `(done)`) so the next test in the queue starts
+  with a pristine fs.readFileSync (rf2-umoz2). The local convention
+  here: bind the thunk in a `let`, do assertions in `.then`, call the
+  thunk, then call done."
+  [env-val stub-fn]
+  (let [orig-read (.-readFileSync fs)
+        orig-env  (j/get-in js/process [:env env-key])]
+    (set! (.-readFileSync fs) stub-fn)
+    (set-env! env-val)
+    (fn restore! []
+      (set! (.-readFileSync fs) orig-read)
+      (set-env! orig-env))))
 
 (defn- throwing-read
   "A `readFileSync` stub that always throws — simulates every candidate
@@ -142,7 +170,7 @@
       (fn [^js path]
         (let [p (str path)]
           (cond
-            (re-find #"\.shadow-cljs[\\/]nrepl\.port" p) "6002"
+            (re-find #"\.shadow-cljs[\\\\/]nrepl\.port" p) "6002"
             (re-find #"\.nrepl-port" p)                  "6003"
             :else (throw (js/Error. "ENOENT")))))
       (fn []
@@ -405,3 +433,171 @@
             (is (= 1 (count (:pending @conn)))
                 "the op is registered as pending awaiting its :done frame")
             (done)))))))
+
+;; ===========================================================================
+;; `discover-port*` async cascade (rf2-umoz2).
+;;
+;; The four-step cascade — explicit > env > shadow HTTP probe > cwd scan —
+;; promotes the cwd-bound file scan from highest-priority-after-env to a
+;; last-resort fallback. The new step 3 uses an injected `shadow-probe-fn`
+;; (production threads `shadow-discovery/discover-project-home`) so tests
+;; pass stubs without standing up a real HTTP server. See `discover-port*`
+;; for the injection rationale.
+;; ===========================================================================
+
+(defn- shadow-returns
+  "Stub builder: a discover-project-home that resolves to `home-path`."
+  [home-path]
+  (fn [_host _port] (js/Promise.resolve home-path)))
+
+(def ^:private shadow-fails
+  "Stub: discover-project-home returns nil (shadow unreachable / parse failed)."
+  (fn [_host _port] (js/Promise.resolve nil)))
+
+(deftest discover-port-explicit-port-file-short-circuits-shadow-probe
+  (testing "step 1 wins — shadow HTTP probe MUST NOT fire when --port-file resolves"
+    (async done
+      (let [probed? (atom false)
+            probe-fn (fn [_h _p]
+                       (reset! probed? true)
+                       (js/Promise.resolve "/should-not-be-used"))
+            restore! (install-fs-stub!
+                       nil (read-returning "explicit/nrepl\\.port" "9001"))]
+        (-> (nrepl/discover-port* "explicit/nrepl.port" nil probe-fn)
+            (.then (fn [v]
+                     (is (= 9001 v))
+                     (is (false? @probed?)
+                         "the HTTP probe must not be hit when step 1 resolves")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-env-var-short-circuits-shadow-probe
+  (testing "step 2 wins — env-var override skips the HTTP probe"
+    (async done
+      (let [probed? (atom false)
+            probe-fn (fn [_h _p]
+                       (reset! probed? true)
+                       (js/Promise.resolve "/should-not-be-used"))
+            restore! (install-fs-stub! "7777" throwing-read)]
+        (-> (nrepl/discover-port* nil nil probe-fn)
+            (.then (fn [v]
+                     (is (= 7777 v))
+                     (is (false? @probed?)
+                         "env override is sync — no HTTP probe needed")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-shadow-probe-yields-absolute-base
+  (testing "step 3 (rf2-umoz2) — shadow HTTP gives :project-home; candidates resolve against it"
+    (async done
+      (let [stub-fn (fn [^js path]
+                      (let [p (str path)]
+                        (cond
+                          ;; The shadow-supplied root MUST appear in the resolved path.
+                          ;; The `target/shadow-cljs/nrepl.port` candidate hits first.
+                          (and (re-find #"abs[\\\\/]proj[\\\\/]root" p)
+                               (re-find #"target[\\\\/]shadow-cljs[\\\\/]nrepl\.port" p))
+                          "6789"
+                          :else (throw (js/Error. "ENOENT")))))
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil (shadow-returns "/abs/proj/root"))
+            (.then (fn [v]
+                     (is (= 6789 v)
+                         "candidate resolved against shadow's project-home wins")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-shadow-probe-prefers-target-then-dot-shadow
+  (testing "candidate ordering preserved against the shadow-supplied base"
+    (async done
+      (let [stub-fn (fn [^js path]
+                      (let [p (str path)]
+                        ;; All three candidates exist under the shadow root; the
+                        ;; earlier one (target/shadow-cljs/nrepl.port) must win.
+                        (cond
+                          (re-find #"target[\\\\/]shadow-cljs[\\\\/]nrepl\.port" p) "5550"
+                          (re-find #"\.shadow-cljs[\\\\/]nrepl\.port" p)          "5551"
+                          (re-find #"\.nrepl-port" p)                             "5552"
+                          :else (throw (js/Error. "ENOENT")))))
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil (shadow-returns "/abs/proj/root"))
+            (.then (fn [v]
+                     (is (= 5550 v)
+                         "first candidate (target/shadow-cljs/nrepl.port) wins")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-shadow-down-falls-through-to-cwd
+  (testing "step 4 — shadow probe fails / returns nil; cascade falls through to cwd scan"
+    (async done
+      (let [restore! (install-fs-stub!
+                       nil (read-returning "target/shadow-cljs/nrepl.port" "3030"))]
+        (-> (nrepl/discover-port* nil nil shadow-fails)
+            (.then (fn [v]
+                     (is (= 3030 v)
+                         "shadow down → cwd-relative scan resolves the port")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-shadow-down-and-no-files-yields-nil
+  (testing "every step misses — cascade returns nil (degraded boot fires)"
+    (async done
+      (let [restore! (install-fs-stub! nil throwing-read)]
+        (-> (nrepl/discover-port* nil nil shadow-fails)
+            (.then (fn [v]
+                     (is (nil? v)
+                         "all four steps missed — degraded boot triggers from this")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-shadow-returned-base-but-no-port-file-falls-through
+  (testing "shadow returned a root but no port-file lives under it → cwd scan picks up the slack"
+    (async done
+      (let [stub-fn (fn [^js path]
+                      (let [p (str path)]
+                        (cond
+                          ;; No port-file under the shadow root.
+                          (re-find #"abs[\\\\/]proj[\\\\/]root" p)
+                          (throw (js/Error. "ENOENT"))
+                          ;; But a cwd-relative one does exist (manual nREPL boot
+                          ;; outside shadow's purview, say). With no node-path/join
+                          ;; prefix the candidate is the bare relative string.
+                          (= "target/shadow-cljs/nrepl.port" p) "4040"
+                          :else (throw (js/Error. "ENOENT")))))
+            restore! (install-fs-stub! nil stub-fn)]
+        (-> (nrepl/discover-port* nil nil (shadow-returns "/abs/proj/root"))
+            (.then (fn [v]
+                     (is (= 4040 v)
+                         "shadow's base had no port-file → cwd scan wins")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-http-port-arg-threads-through
+  (testing "the --http-port override is passed to the shadow probe"
+    (async done
+      (let [seen-port (atom nil)
+            probe-fn  (fn [_host port]
+                        (reset! seen-port port)
+                        (js/Promise.resolve nil))
+            restore!  (install-fs-stub! nil throwing-read)]
+        (-> (nrepl/discover-port* nil 7777 probe-fn)
+            (.then (fn [_]
+                     (is (= 7777 @seen-port)
+                         "custom --http-port reaches the probe")
+                     (restore!)
+                     (done))))))))
+
+(deftest discover-port-http-port-defaults-to-9630
+  (testing "no --http-port → the shadow probe uses the documented 9630 default"
+    (async done
+      (let [seen-port (atom nil)
+            probe-fn  (fn [_host port]
+                        (reset! seen-port port)
+                        (js/Promise.resolve nil))
+            restore!  (install-fs-stub! nil throwing-read)]
+        (-> (nrepl/discover-port* nil nil probe-fn)
+            (.then (fn [_]
+                     (is (= shadow-discovery/default-http-port @seen-port)
+                         "absent override falls back to 9630")
+                     (restore!)
+                     (done))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -161,6 +161,43 @@
         "later --port-file overrides earlier (argv override semantics)")))
 
 ;; ---------------------------------------------------------------------------
+;; --http-port (rf2-umoz2). Same parsing shape as --port-file (one shared
+;; `parse-string-value-flag` helper underneath); these tests pin the
+;; cross-cutting accept-shape (space + equals + missing-value + numeric
+;; coercion) for the new flag.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-launch-flags-http-port-defaults-nil
+  (let [flags (server/parse-launch-flags [])]
+    (is (nil? (:http-port flags))
+        "absent --http-port ⇒ :http-port nil (cascade uses 9630 default downstream)")))
+
+(deftest parse-launch-flags-http-port-space-form
+  (testing "--http-port <n> coerces to int"
+    (let [flags (server/parse-launch-flags ["--http-port" "9700"])]
+      (is (= 9700 (:http-port flags))
+          "numeric string is parsed to int"))))
+
+(deftest parse-launch-flags-http-port-equals-form
+  (testing "--http-port=<n> reads the inline value"
+    (let [flags (server/parse-launch-flags ["--http-port=9701"])]
+      (is (= 9701 (:http-port flags))))))
+
+(deftest parse-launch-flags-http-port-non-numeric-is-nil
+  (testing "garbage at --http-port collapses to nil; cascade uses the 9630 default"
+    (let [flags (server/parse-launch-flags ["--http-port" "garbage"])]
+      (is (nil? (:http-port flags))
+          "isNaN guard — never surface a NaN port"))))
+
+(deftest parse-launch-flags-http-port-rides-with-other-flags
+  (let [flags (server/parse-launch-flags
+                ["--allow-eval" "--http-port" "9702"
+                 "--port-file" "/p/nrepl.port"])]
+    (is (= 9702 (:http-port flags)))
+    (is (= "/p/nrepl.port" (:port-file flags)))
+    (is (true? (:allow-eval? flags)))))
+
+;; ---------------------------------------------------------------------------
 ;; signal-runtime! cache — fires once per (build-id, server-lifetime).
 ;; ---------------------------------------------------------------------------
 

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/shadow_discovery_test.cljs
@@ -1,0 +1,147 @@
+(ns re-frame2-pair-mcp.shadow-discovery-test
+  "Unit tests for the shadow-cljs HTTP probe (rf2-umoz2).
+
+  Two surfaces under test:
+
+    - `extract-project-home` — pure transit-json string → string|nil.
+      Driven directly from synthetic JSON bodies; no HTTP.
+    - `discover-project-home` — wraps `fetch-project-info`. We swap the
+      module-level `fetch-project-info` for a stub via the
+      `with-redefs` macro so the cascade observes the three outcomes
+      (success / non-200 / connection refused / parse failure) without
+      a real socket.
+
+  No test in this file talks to a live shadow server — the live probe
+  is exercised by hand against `http://localhost:9630/api/project-info`
+  during development and by the integration testbed at boot. CI runs
+  fully offline."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame2-pair-mcp.shadow-discovery :as sd]))
+
+;; ===========================================================================
+;; extract-project-home — transit-json parser.
+;; ===========================================================================
+
+(deftest extract-project-home-pulls-canonical-payload
+  (testing "the live shadow /api/project-info shape returns :project-home"
+    ;; Verbatim from `curl http://localhost:9630/api/project-info` on a
+    ;; running shadow-cljs instance — the contract under test.
+    (let [body (str "[\"^ \","
+                    "\"~:project-config\",\"C:\\\\Users\\\\me\\\\proj\\\\shadow-cljs.edn\","
+                    "\"~:project-home\",\"C:\\\\Users\\\\me\\\\proj\","
+                    "\"~:version\",\"3.4.10\"]")]
+      (is (= "C:\\Users\\me\\proj" (sd/extract-project-home body))))))
+
+(deftest extract-project-home-handles-posix-path
+  (let [body (str "[\"^ \","
+                  "\"~:project-config\",\"/home/me/proj/shadow-cljs.edn\","
+                  "\"~:project-home\",\"/home/me/proj\","
+                  "\"~:version\",\"3.4.10\"]")]
+    (is (= "/home/me/proj" (sd/extract-project-home body)))))
+
+(deftest extract-project-home-tolerates-key-reordering
+  (testing "the parser walks key/value pairs — key order isn't load-bearing"
+    (let [body (str "[\"^ \","
+                    "\"~:version\",\"3.4.10\","
+                    "\"~:project-home\",\"/x/y\","
+                    "\"~:project-config\",\"/x/y/shadow-cljs.edn\"]")]
+      (is (= "/x/y" (sd/extract-project-home body))))))
+
+(deftest extract-project-home-missing-key-returns-nil
+  (testing "a payload without :project-home returns nil, not throw"
+    (let [body (str "[\"^ \","
+                    "\"~:project-config\",\"/x/y/shadow-cljs.edn\","
+                    "\"~:version\",\"3.4.10\"]")]
+      (is (nil? (sd/extract-project-home body))))))
+
+(deftest extract-project-home-non-string-value-returns-nil
+  (testing "an integer / null at :project-home is rejected"
+    (is (nil? (sd/extract-project-home
+                "[\"^ \",\"~:project-home\",42]")))
+    (is (nil? (sd/extract-project-home
+                "[\"^ \",\"~:project-home\",null]")))))
+
+(deftest extract-project-home-non-map-payload-returns-nil
+  (testing "non-transit-map shapes (a bare object, a bare array, a string) → nil"
+    (is (nil? (sd/extract-project-home "{\"project-home\":\"/x\"}"))
+        "vanilla JSON object isn't the transit-map-as-array shape")
+    (is (nil? (sd/extract-project-home "[1,2,3]"))
+        "array without the \"^ \" sentinel isn't a transit map")
+    (is (nil? (sd/extract-project-home "\"hello\""))
+        "string body — no map shape at all")))
+
+(deftest extract-project-home-malformed-json-returns-nil
+  (testing "JSON parse failure must not throw — every error path collapses to nil"
+    (is (nil? (sd/extract-project-home "not-json-at-all")))
+    (is (nil? (sd/extract-project-home "")))
+    (is (nil? (sd/extract-project-home "[\"^ \", \"~:project-home\""))
+        "truncated array")))
+
+;; ===========================================================================
+;; discover-project-home* — fetch + parse composition.
+;;
+;; The HTTP-fetch fn is injected (see `discover-project-home*`); tests
+;; pass stubs. The fn under test never opens a socket in these tests;
+;; the real HTTP path is covered manually via the live-nrepl integration
+;; test and by the boot smoke (start the server with shadow up, see
+;; "nREPL port =" log line).
+;; ===========================================================================
+
+(deftest discover-project-home-success-returns-path
+  (async done
+    (let [stub-fetch (fn [_host _port]
+                       (js/Promise.resolve
+                         "[\"^ \",\"~:project-home\",\"/abs/proj\"]"))]
+      (-> (sd/discover-project-home* "127.0.0.1" 9630 stub-fetch)
+          (.then (fn [v]
+                   (is (= "/abs/proj" v))
+                   (done)))))))
+
+(deftest discover-project-home-fetch-rejection-yields-nil
+  (testing "shadow unreachable / non-200 / timeout — every reject path → nil"
+    (async done
+      (let [stub-fetch (fn [_host _port]
+                         (js/Promise.reject (js/Error. "ECONNREFUSED")))]
+        (-> (sd/discover-project-home* "127.0.0.1" 9630 stub-fetch)
+            (.then (fn [v]
+                     (is (nil? v)
+                         "rejection must surface as nil so the cascade falls through")
+                     (done))))))))
+
+(deftest discover-project-home-malformed-payload-yields-nil
+  (testing "fetch succeeded but the body wasn't the transit-map shape"
+    (async done
+      (let [stub-fetch (fn [_host _port]
+                         (js/Promise.resolve "not-the-shape-we-want"))]
+        (-> (sd/discover-project-home* "127.0.0.1" 9630 stub-fetch)
+            (.then (fn [v]
+                     (is (nil? v)
+                         "extract-project-home returned nil; cascade falls through")
+                     (done))))))))
+
+(deftest discover-project-home-missing-key-yields-nil
+  (testing "fetch succeeded, transit-shape valid, but :project-home absent"
+    (async done
+      (let [stub-fetch (fn [_host _port]
+                         (js/Promise.resolve
+                           "[\"^ \",\"~:version\",\"3.4.10\"]"))]
+        (-> (sd/discover-project-home* "127.0.0.1" 9630 stub-fetch)
+            (.then (fn [v]
+                     (is (nil? v))
+                     (done))))))))
+
+(deftest discover-project-home-args-thread-through
+  (testing "host + port supplied to the wrapper reach the fetch-fn"
+    (async done
+      (let [seen-host (atom nil)
+            seen-port (atom nil)
+            stub-fetch (fn [host port]
+                         (reset! seen-host host)
+                         (reset! seen-port port)
+                         (js/Promise.resolve
+                           "[\"^ \",\"~:project-home\",\"/x\"]"))]
+        (-> (sd/discover-project-home* "10.0.0.5" 9700 stub-fetch)
+            (.then (fn [_]
+                     (is (= "10.0.0.5" @seen-host))
+                     (is (= 9700 @seen-port))
+                     (done))))))))

--- a/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
+++ b/tools/re-frame2-pair-mcp/test/stdio-roundtrip.js
@@ -48,7 +48,11 @@ function run() {
     // Pass `--allow-eval` to opt in to the eval-cljs tool (rf2-cxx5s
     // launch-flag gate, default OFF). The roundtrip relies on
     // eval-cljs to surface the no-nREPL degraded envelope.
-    const child = spawn(process.execPath, [SERVER, '--allow-eval'], {
+    // Pin --http-port to a port that is always closed (port 1, IANA-
+    // reserved) so the rf2-umoz2 shadow HTTP probe gets a deterministic
+    // ECONNREFUSED rather than picking up shadow if it happens to be
+    // running on the test host at 9630.
+    const child = spawn(process.execPath, [SERVER, '--allow-eval', '--http-port', '1'], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: require('node:os').tmpdir(),
       env,


### PR DESCRIPTION
## What

re-frame2-pair-mcp can now auto-discover the consumer project's nREPL port by probing shadow-cljs's built-in HTTP API at `http://127.0.0.1:9630/api/project-info`. That endpoint returns the live build's `:project-home` (absolute project root) which the server then uses to resolve the standard port-file candidates — making port discovery robust to whatever cwd the agent host (Claude Code / Cursor / Copilot) chose when spawning the MCP subprocess.

Pre-rf2-umoz2 the cascade's final three steps were relative port-file paths resolved against `process.cwd()`. Agent hosts pick a cwd that is typically NOT the project root, so the scan missed silently and pairing broke with `:nrepl-port-not-found`. Operators had to hardcode `--port-file <absolute-path>` in their MCP config (a per-project ceremony bead notes acknowledged but did not fix).

## Shadow endpoint used

`GET http://127.0.0.1:9630/api/project-info` (defined in `shadow.cljs.devtools.server.web.api/project-info`). Payload is transit-json's verbose map-as-array:

```
["^ ","~:project-config","C:\\…\\shadow-cljs.edn","~:project-home","C:\\…\\implementation","~:version","3.4.10"]
```

A small JSON.parse + array-walk for the `~:project-home` sentinel pulls the absolute project root out — no transit library dependency for one key.

## Precedence cascade

Highest first; the cascade short-circuits at the first hit:

1. `--port-file <path>` — explicit, cwd-independent override (rf2-3dbwh). Wins outright.
2. `$SHADOW_CLJS_NREPL_PORT` — env-var override.
3. **Shadow HTTP probe (NEW, rf2-umoz2)** — `discover-project-home` returns the absolute root; standard port-file candidates resolve against it via `node-path/join`. Bounded to 500ms; ECONNREFUSED / non-200 / parse failure silently falls through.
4. CWD-relative port-file scan — legacy fallback for older shadow or manual nREPL boot outside shadow.

A new `--http-port <n>` flag (default 9630) lets the rare consumer with a pinned shadow `:http :port` redirect the probe.

## How the workaround `--port-file` interacts

`--port-file` remains highest precedence — step 1 of the cascade. Operators who pre-rf2-umoz2 hardcoded it in `~/.claude.json` see no behaviour change; the explicit path still wins outright and the HTTP probe never fires. The workaround is no longer required for zero-config setups but stays the deterministic escape hatch for exotic deploys (shadow running on a non-9630 HTTP port without `--http-port`, or shadow not running at all but a manual nREPL is).

## Tests

- New ns `re-frame2-pair-mcp.shadow-discovery` — transit-json parser, fetch+parse composition (success, rejection→nil, malformed→nil, missing-key→nil, args thread through).
- `nrepl.cljs` — new `discover-port*` async cascade with the HTTP probe injected as a seam so tests stub without standing up a socket. Coverage: each step short-circuits the next, shadow-down falls through to cwd, every step missing yields nil, `--http-port` arg threads through, default 9630.
- `server.cljs` — `--http-port` flag parsing: default nil, space/equals form, non-numeric→nil, rides with other flags.
- `mcp-conformance/end-to-end-re-frame2-pair.cjs` + `stdio-roundtrip.js` — both pin `--http-port 1` (IANA-reserved closed port) so the rf2-umoz2 probe gets a deterministic ECONNREFUSED on CI hosts where shadow happens to be running on 9630. "Degraded mode" assumption preserved.

Total: 536 tests pass (was 521). All clj-kondo clean. Build: `npx shadow-cljs compile server` succeeds. Live end-to-end smoke verified: `node out/server.js` booted from `/tmp` with no env/flag overrides auto-discovered nREPL port 59351 (matches `.shadow-cljs/nrepl.port`).