### PR TITLE
fix(xray): clean up reg-view warnings — non-DOM roots + ribbon-theme-toggle frame (rf2-uu3lp)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/shell.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/shell.cljs
@@ -874,7 +874,7 @@
      [:span {:aria-hidden "true"} "● "]
      (str "REDACTED " redacted-count)]))
 
-(defn- ribbon-theme-toggle
+(rf/reg-view ribbon-theme-toggle
   "rf2-xawwb — theme toggle (Figma-Make surface). A sun/moon icon-button
   on the chrome ribbon's right cluster that flips light ⇄ dark.
 
@@ -893,7 +893,23 @@
   The glyph follows the convention NEXT action: in DARK mode it shows
   the sun `☀` (click → go light); in LIGHT mode the moon `☾` (click →
   go dark). Muted `chrome-ribbon-text-muted` ink to sit quietly beside
-  the `⚙`/`✕` icons on the dark band."
+  the `⚙`/`✕` icons on the dark band.
+
+  ## rf2-uu3lp — `reg-view` so the subscribe routes to `:rf/xray`
+
+  The `:theme` setting lives in Xray's `:rf/xray` frame (the
+  `:rf.xray/setting` sub + `:rf.xray/settings-update` event are
+  registered against `:rf/xray` via `registry/register-xray-handlers!`).
+  A plain `defn` rendered inside the shell's `:rf/xray` frame-provider
+  would not pick up the surrounding frame (Spec 004 §Plain Reagent fns
+  / Spec 006 §Plain-fn-under-non-default-frame warning) — the subscribe
+  here would route to `:rf/default` and read the host app's app-db.
+  The dispatch ALREADY carries an explicit `{:frame :rf/xray}` arg, but
+  the subscribe was relying on React-context which the plain fn does
+  not consult. `reg-view`-registration makes the component
+  `:contextType frame-context`-aware so the subscribe resolves to
+  `:rf/xray` through the enclosing Provider — same shape as every other
+  Xray shell region (rf2-in6l2)."
   []
   (let [theme @(rf/subscribe [:rf.xray/setting :theme nil])
         dark? (= theme :dark)
@@ -2107,9 +2123,24 @@
   (rf2-o5f5f.1).
 
   Per rf2-in6l2 `reg-view`-registered for parity with every other
-  shell region."
+  shell region.
+
+  ## rf2-uu3lp — DOM-rooted via `display: contents`
+
+  The five children are stacked flex items of `shell-view`'s flex
+  column (L1 ribbon · events ribbon · L2 list · L3 tab bar · L4 detail
+  panel). A bare React Fragment root would skip the source-coord DOM
+  annotation (Spec 006 §Documented exemption: non-DOM roots) and emit
+  a one-shot warning. A wrapper `<div>` with `display: contents`
+  participates in the DOM tree (so `data-rf2-source-coord` has a home
+  and click-to-source works) while being neutralised for layout — the
+  children render as if they were direct flex items of the
+  shell-view's column. The `data-rf-xray-dynamic-chrome` attr is a
+  test-friendly handle if a future selector needs it; no production
+  code reads it today."
   []
-  [:<>
+  [:div {:data-rf-xray-dynamic-chrome ""
+         :style {:display "contents"}}
    [ribbon {}]
    [events-ribbon]
    [event-list]
@@ -2125,12 +2156,24 @@
   the swap.
 
   Per rf2-in6l2 `reg-view`-registered so the subscribe resolves to
-  `:rf/xray` via React-context."
+  `:rf/xray` via React-context.
+
+  ## rf2-uu3lp — DOM-rooted via `display: contents`
+
+  Returning the inner component head directly (`[dynamic-chrome]` /
+  `[static-shell/surface]`) would skip the source-coord DOM
+  annotation (Spec 006 §Documented exemption: component head) and
+  emit a one-shot warning. A `display: contents` wrapper lets
+  `data-rf2-source-coord` land on a real DOM node while keeping the
+  inner surface as the effective layout child of `shell-view`'s flex
+  column."
   []
   (let [mode @(rf/subscribe [:rf.xray/mode])]
-    (case mode
-      :static  [static-shell/surface]
-      [dynamic-chrome])))
+    [:div {:data-rf-xray-surface-composer ""
+           :style {:display "contents"}}
+     (case mode
+       :static  [static-shell/surface]
+       [dynamic-chrome])]))
 
 ;; ---- shell view ----------------------------------------------------------
 
@@ -2203,7 +2246,14 @@
   ;; as the modal-positioning read above — `shell-view` sits outside
   ;; its own frame-provider).
   (let [lens-mode @(rf/subscribe :rf/xray [:rf.xray/mode])]
-   [rf/frame-provider {:frame :rf/xray}
+   ;; rf2-uu3lp — the outer `<div>` IS the shell-view's root so the
+   ;; source-coord walk has a DOM node to annotate (Spec 006
+   ;; §Source-coord annotation; would otherwise warn-once because the
+   ;; previous root was the non-DOM `frame-provider` component head).
+   ;; The frame-provider sits one level inside, wrapping every
+   ;; subscribing child — React-context discipline is preserved. The
+   ;; outer `<div>` carries attrs/styles only; it never subscribes,
+   ;; so its position outside the frame is immaterial.
    [:div {:data-testid "rf-xray-shell"
           :class (str "mode-" (name (or lens-mode :dynamic)))
           ;; rf2-plajx — Xray shell root is a landmark. A 40%-
@@ -2256,6 +2306,11 @@
                             :min-width  "560px"
                             :z-index    2147483000
                             :box-shadow "rgba(0, 0, 0, 0.4) -8px 0 24px"}))}
+    ;; rf2-uu3lp — frame-provider sits INSIDE the outer `<div>` (the
+    ;; `<div>` carries the source-coord annotation as the DOM root).
+    ;; Every subscribing child below is wrapped so the `:rf/xray`
+    ;; frame flows through React-context.
+    [rf/frame-provider {:frame :rf/xray}
     ;; Left-edge horizontal resize handle (rf2-x8h9y) — only renders
     ;; in `:inline` (right-rail) mode. Position-absolute pins it to
     ;; the LEFT edge of this flex container; the outer div is

--- a/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/shell_cljs_test.cljs
@@ -211,6 +211,63 @@
             "no bottom rail")))))
 
 ;; -------------------------------------------------------------------------
+;; (1b) rf2-uu3lp — every shell reg-view returns a DOM-rooted tree
+;; -------------------------------------------------------------------------
+;;
+;; Before rf2-uu3lp the four shell views had non-DOM roots and the
+;; substrate emitted `:rf.warning/non-dom-root` (warn-once per id) on
+;; every step-deck testbed load:
+;;
+;;   - `shell-view`         → root was `rf/frame-provider` (fn component)
+;;   - `surface-composer`   → root was a fn-component head (`[dynamic-chrome]`)
+;;   - `dynamic-chrome`     → root was a React Fragment (`:<>`)
+;;   - `ribbon-theme-toggle` → plain `defn-` rendered under `:rf/xray`
+;;                              (frame leak: subscribe routed to `:rf/default`)
+;;
+;; This regression test asserts the FIX shape — each view's hiccup root
+;; is a keyword (DOM tag), so the source-coord wrapper has a real DOM
+;; node to annotate. `ribbon-theme-toggle` is now `reg-view`-registered
+;; so its surrounding `:rf/xray` frame-provider reaches its subscribe
+;; through React-context (no more plain-fn frame leak).
+
+(deftest shell-views-have-dom-rooted-hiccup
+  (testing "rf2-uu3lp — every shell-level reg-view returns a keyword-
+            headed (DOM) hiccup tree so the source-coord annotation
+            walk has a DOM node to land on. Non-DOM roots (function
+            components, Fragments) emit a one-shot warning per Spec
+            006 §Documented exemption — the four shell views below
+            previously triggered it."
+    (xray-setup!)
+    (rf/with-frame :rf/xray
+      (let [shell-tree (shell/shell-view)]
+        (is (vector? shell-tree) "shell-view returns a hiccup vector")
+        (is (keyword? (first shell-tree))
+            (str "shell-view root is a keyword DOM tag — was "
+                 (pr-str (first shell-tree)))))
+      (let [composer-tree (shell/surface-composer)]
+        (is (vector? composer-tree) "surface-composer returns a hiccup vector")
+        (is (keyword? (first composer-tree))
+            (str "surface-composer root is a keyword DOM tag — was "
+                 (pr-str (first composer-tree)))))
+      (let [chrome-tree (shell/dynamic-chrome)]
+        (is (vector? chrome-tree) "dynamic-chrome returns a hiccup vector")
+        (is (keyword? (first chrome-tree))
+            (str "dynamic-chrome root is a keyword DOM tag — was "
+                 (pr-str (first chrome-tree))))))))
+
+(deftest ribbon-theme-toggle-is-reg-view-registered
+  (testing "rf2-uu3lp — the theme toggle's `:theme` setting lives in
+            `:rf/xray`, so its subscribe + dispatch must route to that
+            frame. As a plain `defn` it was leaking subscribes into
+            `:rf/default`. `reg-view`-registration installs the
+            `:contextType frame-context` static so the surrounding
+            `:rf/xray` Provider reaches the component via React-context.
+            We assert the registration is present in the view registry."
+    (xray-setup!)
+    (is (some? (rf/view ::shell/ribbon-theme-toggle))
+        "ribbon-theme-toggle is registered under its namespaced id")))
+
+;; -------------------------------------------------------------------------
 ;; (2) L1 ribbon clusters
 ;; -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Four `[re-frame] warn-once` messages were emitted on every step-deck testbed page load, all from Xray's own UI (`day8.re-frame2-xray.shell.*`). This PR eliminates all four at source.

The bead (`rf2-uu3lp`) carried Mike's diagnosis with cited line numbers; this PR follows the proposed fixes after intent-checking warning #4.

## Per-warning fix chosen

### Warning #1: `shell-view` — root was `frame_provider` (fn component) → (a) restructure

The outer `<div>` is now the shell-view's hiccup root, with `[rf/frame-provider {:frame :rf/xray} ...]` moved one level inside to wrap every subscribing child. Rationale: the existing `<div>` was already in the tree; promoting it to be the root reuses existing DOM (no new noise) and the frame-provider still pushes `:rf/xray` down via React-context to every descendant. Click-to-source now resolves to a real DOM node.

### Warning #2: `surface-composer` — root was `MetaFn` (fn-component head) → (a) `display: contents` wrapper

Wrapped in `[:div {:style {:display "contents"}}]`. Rationale: the inner `[dynamic-chrome]` / `[static-shell/surface]` is a layout participant of `shell-view`'s flex column; a regular wrapper would change layout semantics. `display: contents` neutralises the wrapper for layout while keeping it in the DOM as a source-coord anchor.

### Warning #3: `dynamic-chrome` — root was React Fragment `:<>` → (a) `display: contents` wrapper

Same rationale as #2. The five children (L1 ribbon · events-ribbon · L2 list · L3 tab-bar · L4 detail-panel) are flex items of `shell-view`'s column; the `display: contents` wrapper preserves that layout while landing source-coord.

### Warning #4: `ribbon-theme-toggle` — plain-fn frame leak → (b) `reg-view` registration

**Intent-check finding: case (b) — real bug.** The theme settings (`:rf.xray/setting` sub + `:rf.xray/settings-update` event) are registered against `:rf/xray` in `registry/register-xray-handlers!`. The toggle''s dispatch already carried an explicit `{:frame :rf/xray}` arg, but the subscribe relied on React-context — which a plain `defn-` does not consult — so the subscribe was leaking into `:rf/default` and reading the host app''s app-db rather than Xray''s.

Fix: convert from `defn-` to `rf/reg-view`. The registration installs `:contextType frame-context` so the subscribe resolves to `:rf/xray` through the enclosing Provider — same shape as every other Xray shell region (rf2-in6l2).

## Before / after

Before: four `[re-frame] warn-once` messages in console on every shell mount.

After: zero `warn-once` messages from `day8.re-frame2-xray.shell.*`. Each of the three structural views now returns a keyword-headed (DOM) hiccup tree, so the source-coord walk has a DOM node to annotate. `ribbon-theme-toggle` carries the `:contextType frame-context` static so React-context reaches it.

## Regression tests

Added to `shell_cljs_test.cljs`:

- `shell-views-have-dom-rooted-hiccup` — each of `shell-view` / `surface-composer` / `dynamic-chrome` returns a keyword-headed hiccup tree.
- `ribbon-theme-toggle-is-reg-view-registered` — `(rf/view ::shell/ribbon-theme-toggle)` resolves.

## Gates

- `clojure -M:test` (tools/xray): 877 tests / 3111 assertions, 0 failures.
- `npm run test:cljs`: 4363 tests / 13942 assertions, 0 failures (+2 new tests).
- `npm run test:xray-feature-gate`: 13 scenarios over 12 surfaces, 0 failures.
- `npm run test:bundle-isolation`: PASS (16 entries, 33 sentinels absent, 3 budgets ok).
- clj-kondo: clean (the two pre-existing info findings are unrelated to this change).
- splint: clean (the one pre-existing style warning is unrelated).

Closes rf2-uu3lp.