### PR TITLE
feat(xray): Handler panel B+ visual order — operational ordering + two pre-commit snapshots (rf2-ynnre)

### DIFF
--- a/tools/xray/design-reference/xray_devtools_reference.cljs
+++ b/tools/xray/design-reference/xray_devtools_reference.cljs
@@ -28,9 +28,14 @@
      count pushed to the RIGHT end.
   4. **Event-list column order:** `event id` FIRST, then `source`,
      `timestamp`, `duration`.
-  5. **Handler panel** numbered lifecycle pipeline is 6 steps: 1 DISPATCH,
-     2 COEFFECTS, 3 EVENT HANDLER, 4 APP-DB CHANGES, 5 FLOWS, 6 FX. The
-     FLOWS step shows the flow(s) that recomputed + their db contribution.
+  5. **Handler panel** numbered lifecycle pipeline is 6 steps in operational
+     order (rf2-ynnre, B+): 1 DISPATCH, 2 COEFFECTS, 3 EVENT HANDLER,
+     4 FLOWS, 5 APP-DB CHANGES, 6 FX. FLOWS sits BETWEEN EVENT HANDLER and
+     APP-DB CHANGES so the panel's section rhythm tracks the operational
+     order (handler returns pending `:db` → flows reshape → atomic commit
+     → fx). Supersedes the earlier Figma-A order (HANDLER → APP-DB
+     CHANGES → FLOWS → FX), per Mike's 2026-05-25 B+ decision on
+     rf2-5t9h0.
 
   ## What this reference DELIBERATELY keeps richer than the Figma stub
 
@@ -383,8 +388,8 @@
    [tab-button active-tab :issues "Issues"]])
 
 ;; ============================================================================
-;; Handler Panel Component (rf2-xawwb — 6-step: DISPATCH / COEFFECTS /
-;; EVENT HANDLER / APP-DB CHANGES / FLOWS / FX)
+;; Handler Panel Component (rf2-ynnre B+ — 6-step operational order:
+;; DISPATCH / COEFFECTS / EVENT HANDLER / FLOWS / APP-DB CHANGES / FX)
 ;; ============================================================================
 
 (defn step-circle [n]
@@ -459,26 +464,11 @@
         "  (" [:span {:class "syntax-keyword"} "fn"] " [db _]\n"
         "    (" [:span {:class "syntax-keyword"} "update"] " db " [:span {:class "syntax-keyword"} ":counter"] " inc)))"]]]
 
-     ;; 4. APP-DB CHANGES (rf2-xawwb — renamed from `DB CHANGES`)
+     ;; 4. FLOWS (rf2-ynnre — step 4, between EVENT HANDLER and APP-DB
+     ;; CHANGES, matching operational order). Shows the flow(s) that
+     ;; recomputed + their db contribution.
      [:section {:style {:position "relative"}}
       [step-circle 4]
-      [step-label "APP-DB CHANGES"]
-      [:div {:class "devtools-mono" :style {:display "flex" :flex-direction "column" :gap "4px"}}
-       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-        [:span {:style {:color "var(--devtools-changed)"}} "~"]
-        [:span {:style {:color "var(--devtools-text-muted)"}} "[:counter]"]
-        [:span {:style {:color "var(--devtools-error)"}} "1"]
-        [:span {:style {:color "var(--devtools-text-muted)"}} "→"]
-        [:span {:style {:color "var(--devtools-success)"}} "2"]]
-       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-        [:span {:style {:color "var(--devtools-success)"}} "+"]
-        [:span {:style {:color "var(--devtools-text-muted)"}} "[:last-updated]"]
-        [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05\""]]]]
-
-     ;; 5. FLOWS (rf2-xawwb — step 5, after APP-DB CHANGES). Shows the
-     ;; flow(s) that recomputed + their db contribution.
-     [:section {:style {:position "relative"}}
-      [step-circle 5]
       [step-label "FLOWS"]
       [:div {:class "devtools-mono"}
        [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
@@ -493,10 +483,34 @@
          [:span "[:totals :sum]"]
          [:span {:style {:color "var(--devtools-success)"}} "42"]]]]]
 
-     ;; 6. FX
+     ;; 5. APP-DB CHANGES (rf2-ynnre — step 5, after FLOWS, matching
+     ;; operational order). Carries the `committed diff` caption to
+     ;; clarify it's the post-flow t4 observable.
+     [:section {:style {:position "relative"}}
+      [step-circle 5]
+      [step-label "APP-DB CHANGES"]
+      [:div {:class "devtools-caption" :style {:color "var(--devtools-text-muted)"
+                                               :font-style "italic" :margin-bottom "4px"}}
+       "committed diff (post-flow · atomic install boundary)"]
+      [:div {:class "devtools-mono" :style {:display "flex" :flex-direction "column" :gap "4px"}}
+       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+        [:span {:style {:color "var(--devtools-changed)"}} "~"]
+        [:span {:style {:color "var(--devtools-text-muted)"}} "[:counter]"]
+        [:span {:style {:color "var(--devtools-error)"}} "1"]
+        [:span {:style {:color "var(--devtools-text-muted)"}} "→"]
+        [:span {:style {:color "var(--devtools-success)"}} "2"]]
+       [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+        [:span {:style {:color "var(--devtools-success)"}} "+"]
+        [:span {:style {:color "var(--devtools-text-muted)"}} "[:last-updated]"]
+        [:span {:style {:color "var(--devtools-success)"}} "#inst \"2026-05-23T12:30:05\""]]]]
+
+     ;; 6. FX (rf2-ynnre — carries the post-commit · irreversible caption)
      [:section {:style {:position "relative"}}
       [step-circle 6]
       [step-label "FX"]
+      [:div {:class "devtools-caption" :style {:color "var(--devtools-text-muted)"
+                                               :font-style "italic" :margin-bottom "4px"}}
+       "post-commit · irreversible (fx throws don't wind app-db back)"]
       [:div {:class "devtools-mono" :style {:display "flex" :flex-direction "column" :gap "4px"}}
        [:div {:style {:display "flex" :gap "8px"}}
         [:span {:style {:color "var(--devtools-text-muted)"}} ":dispatch"]

--- a/tools/xray/spec/021-Dynamic-Panel-Designs.md
+++ b/tools/xray/spec/021-Dynamic-Panel-Designs.md
@@ -101,7 +101,7 @@ state-mutating vs state-observing.
 
 | Phase | Steps | What |
 |---|---|---|
-| **Handling** (state-mutating) | Dispatch → Coeffects → Handler → Flows recompute → Effects | The `Event` L4 panel renders the handling pipeline as a numbered vertical flow (the rendered section order — DISPATCH · COEFFECTS · EVENT HANDLER · FLOWS · DB CHANGES · AFTER INTERCEPTORS · FX — is in §2.2; optional sections are omitted when absent). Flows recompute at the outermost `:after`, reshaping the pending `:db` before it commits — so they precede DB CHANGES and FX. |
+| **Handling** (state-mutating) | Dispatch → Coeffects → Handler → Flows recompute → Effects | The `Event` L4 panel renders the handling pipeline as a numbered vertical flow (the rendered section order — DISPATCH · COEFFECTS · EVENT HANDLER · FLOWS · AFTER INTERCEPTORS · APP-DB CHANGES · FX — is in §2.2; optional sections are omitted when absent). Flows recompute at the outermost `:after`, reshaping the pending `:db` before it commits — so they precede APP-DB CHANGES and FX. |
 | **Pivot** (the keystone) | — | Handling → reactive transition. The architectural inflection. App-db panel sits on this boundary. |
 | **Reactive** (state-observing) | Subs recompute → Views re-render | The `View` L4 panel renders the cascade as a left → right graph (§3). |
 
@@ -198,11 +198,17 @@ default density on a 1080p screen (the dense case in §2.2 lands at ~40
 lines including the rail). Per-section collapse stays available via header
 click for the operator who wants to focus, but is opt-out, not default.
 
-### §2.2 Layout — numbered vertical-flow pipeline (Figma design — rf2-ad7zx)
+### §2.2 Layout — numbered vertical-flow pipeline (operational order · rf2-ynnre B+)
 
-> Reconciled to the Figma design (`tools/xray/design-reference/xray_devtools_reference.cljs`,
-> the `event-panel` component), the later iteration. The prior chevron/bare-label/`EFFECTS
-> RETURNED+APPLIED` shape and the brief's outcome-badge proposal are **superseded**.
+> **Operational order — supersedes Figma-A** (rf2-ynnre, Mike's 2026-05-25 decision on
+> rf2-5t9h0 = B+). The Figma-A order (HANDLER → APP-DB CHANGES → FLOWS → FX) was drawn
+> BEFORE the atomicity contract was pinned (Mike 2026-05-24, [`013-Flows.md §Failure
+> semantics`](../../../spec/013-Flows.md#failure-semantics)) and read
+> "result-then-attribution". B+ swaps to operational order — the panel's section rhythm
+> now teaches the contract for free: handler returns pending `:db` → flows reshape it
+> (pre-commit) → atomic install → fx (post-commit, irreversible). The prior
+> chevron/bare-label/`EFFECTS RETURNED+APPLIED` shape and the brief's outcome-badge
+> proposal remain **superseded**.
 
 The Event panel expresses its top-to-bottom one-way pipeline as a **thin vertical line down
 the panel's left edge** with a small **numbered step circle** (`1`, `2`, …) at each section.
@@ -213,9 +219,9 @@ muted (`var(--text-secondary)`); the numbered circles + the rail carry the order
 
 The **mode-accent stripe** (the single GitHub-blue accent, both modes) sits at the panel's edge.
 
-Optional sections (COEFFECTS, AFTER INTERCEPTORS, FLOWS) are **shown only when present** —
+Optional sections (COEFFECTS, FLOWS, AFTER INTERCEPTORS) are **shown only when present** —
 absence is conveyed by omission, not an empty-state line. A throwing handler therefore simply
-has no DB CHANGES / later sections; there is **no outcome badge** and **no "db committed"
+has no APP-DB CHANGES / later sections; there is **no outcome badge** and **no "db committed"
 footer**.
 
 Section order (numbered; optional sections shown only when present):
@@ -225,16 +231,32 @@ Section order (numbered; optional sections shown only when present):
   2. **COEFFECTS** *(optional)* — user-injected coeffects: each id (click-to-source) + the
      value it added to context (`+ [:now] #inst…`).
   3. **EVENT HANDLER** — the flavour (`reg-event-db` / `reg-event-fx`) as a click-to-source
-     link + the **syntax-highlighted handler source** in a code block.
-  4. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote. Flows fire at
-     the outermost `:after` interceptor, right after the handler — they reshape the pending
-     `:db` BEFORE the single deferred install (the atomic commit), so they precede DB CHANGES
-     and run long before FX.
-  5. **DB CHANGES** — the app-db diff: `~ [path] old → new` · `+ [path] value` · `- [path]`.
-     Already reflects any FLOWS recomputes (flows ran before the db committed).
-  6. **AFTER INTERCEPTORS** *(optional)* — non-standard after-interceptors: each id
+     link + the **syntax-highlighted handler source** in a code block + a **returned
+     effects sub-block** (the t1 pre-commit observable: pending `:db` slot presence + each
+     entry of the returned `:fx` vector). The pending `:db` value itself is not yet on the
+     trace surface today — the row cross-refs APP-DB CHANGES below for the committed value
+     (which EQUALS the pending value when no flows fired). A CORE follow-on can later
+     capture the t1-pending-`:db` snapshot for the flow-having case so the full t1→t2
+     reshape renders inline under FLOWS.
+  4. **FLOWS** *(optional)* — flows that recomputed + the db path they wrote (the t1→t2
+     reshape · pre-commit). Flows fire at the outermost `:after` interceptor, right after
+     the handler and any user `:after` interceptors — they reshape the pending `:db` BEFORE
+     the single deferred install (the atomic commit), so they precede APP-DB CHANGES and run
+     long before FX. **Hidden entirely when no flows fired this event** (the common case);
+     the flow-less panel reads as the simpler HANDLER → APP-DB CHANGES → FX shape.
+  5. **AFTER INTERCEPTORS** *(optional)* — non-standard after-interceptors: each id
      (click-to-source) + the effect it contributed (`+ [:fx :local-storage] {…}`).
-  7. **FX** — the fx handlers that ran (`:dispatch → […]` · `:http-xhrio → {…}`).
+  6. **APP-DB CHANGES** — the **COMMITTED diff at t4** (the atomic install boundary). Carries
+     a `committed diff (post-flow · atomic install boundary)` caption to keep users from
+     reading the section as "what the handler returned" (the handler's pending effects map
+     lives one step up). The diff: `~ [path] old → new` · `+ [path] value` · `- [path]`.
+     When flows fired, includes the flow-driven slot mutations; when none fired, this
+     equals the handler's pending `:db` diff.
+  7. **FX** — the fx handlers that ran (`:dispatch → […]` · `:http-xhrio → {…}`). Carries
+     a `post-commit · irreversible (fx throws don't wind app-db back)` caption — the
+     atomic install boundary at t4 has crossed, side effects (http / nav / dispatch) may
+     already have fired, and an fx-throw surfaces an error but leaves app-db committed
+     (per [`013-Flows.md §Failure semantics`](../../../spec/013-Flows.md#failure-semantics)).
 
 The cascade-id stays internal (`data-dispatch-id` on the lens root for tests/agents); not
 shown. The sections form a one-way pipeline — **linear numbered flow, not a flat list.**
@@ -273,22 +295,28 @@ flows, and fx):
 │   │      [:rf/db]                                                         │
 │   │      (fn [db _]                                                       │
 │   │        (update db :counter inc)))                                     │
+│   │    ↳ returned effects (pre-commit)                                    │
+│   │       :db   pending — see APP-DB CHANGES below for committed diff     │
+│   │       :fx   1 entry — see FX below for what ran                       │
+│   │             [:dispatch [:title/flow [:rf/init]]]                      │
 │   │                                                                       │
 │  ④  FLOWS                                  (optional · shown when present) │
 │   │    :totals-flow ↗  →  [:totals] recomputed                           │
 │   │      + [:totals :sum]  42                                            │
 │   │                                                                       │
-│  ⑤  DB CHANGES                                                            │
-│   │    ~ [:counter]       1 → 2                                           │
-│   │    + [:last-updated]  #inst "2026-05-23T12:30:05"                     │
-│   │                                                                       │
-│  ⑥  AFTER INTERCEPTORS                     (optional · shown when present) │
+│  ⑤  AFTER INTERCEPTORS                     (optional · shown when present) │
 │   │    :persist-db ↗                                                      │
 │   │      + [:fx :local-storage]  {:key "app-state" :value {...}}          │
 │   │    :analytics ↗                                                       │
 │   │      + [:fx :track]          {:event "counter-inc"}                   │
 │   │                                                                       │
+│  ⑥  APP-DB CHANGES                                                        │
+│   │    committed diff (post-flow · atomic install boundary)               │
+│   │    ~ [:counter]       1 → 2                                           │
+│   │    + [:last-updated]  #inst "2026-05-23T12:30:05"                     │
+│   │                                                                       │
 │  ⑦  FX                                                                    │
+│        post-commit · irreversible (fx throws don't wind app-db back)      │
 │        :dispatch    → [:title/flow [:rf/init]]                            │
 │        :http-xhrio  → {:method :get, :uri "/api/data"}                    │
 └──────────────────────────────────────────────────────────────────────────┘
@@ -308,11 +336,15 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 │   │                                                                       │
 │  ②  EVENT HANDLER ↗                                                       │
 │   │    (rf/reg-event-db :poll/tick …)        ← syntax-highlighted         │
+│   │    ↳ returned effects (pre-commit)                                    │
+│   │       :db   pending — see APP-DB CHANGES below for committed diff     │
 │   │                                                                       │
-│  ③  DB CHANGES                                                            │
+│  ③  APP-DB CHANGES                                                        │
+│   │    committed diff (post-flow · atomic install boundary)               │
 │   │    ~ [:poll :n]  41 → 42                                              │
 │   │                                                                       │
 │  ④  FX                                                                    │
+│        post-commit · irreversible (fx throws don't wind app-db back)      │
 │        (none)                                                             │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
@@ -321,9 +353,9 @@ the optional sections are simply omitted, so the visible steps renumber `①②�
 
 | From | Reads |
 |---|---|
-| Focused epoch record | `:rf.event/dispatched` (step 1), `:rf.cofx/*` (step 2 — coeffect injection), `:rf.event/run-start` / `:rf.event/run-end` (step 3 — handler), `:rf.flow/computed` (step 4 — flows reshape the pending `:db` at the outermost `:after`, before commit), `:rf.fx/do-fx` (step 5 — the committed db diff, carries `:rf.event/fx`), `:rf.fx/handled` per fx-id (step 7 — effects applied) — all read from the focused epoch record's `:trace-events` (one epoch = one dequeued event, §1.1) |
+| Focused epoch record | `:rf.event/dispatched` (step 1), `:rf.cofx/*` (step 2 — coeffect injection), `:rf.event/run-start` / `:rf.event/run-end` (step 3 — handler), `:rf.fx/do-fx` (step 3 — also feeds the returned-effects sub-block under the handler, via `:rf.event/fx` + `:rf.event/db-present?`), `:rf.flow/computed` (step 4 — flows reshape the pending `:db` at the outermost `:after`, before commit), `:rf.event/db-changed` (step 6 — the committed diff), `:rf.fx/handled` per fx-id (step 7 — effects applied) — all read from the focused epoch record's `:trace-events` (one epoch = one dequeued event, §1.1) |
 | Registries | Handler metadata (`reg-event-*` form file:line, optional source string when DEBUG-gated) |
-| App-db panel (bridge) | Inline diff renderer for the handler's `:db` effect — the DB CHANGES section (reuses the shared renderer §10) |
+| App-db panel (bridge) | Inline diff renderer for the committed `:db` — the APP-DB CHANGES section (reuses the shared renderer §10) |
 
 ### §2.4 Cross-panel navigation
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -2,26 +2,34 @@
   "Event panel — the L4 default-tab panel. Answers \"what did this event
   DO?\" by rendering the focused epoch's end-to-end mutation pipeline.
 
-  ## Numbered vertical-flow pipeline (spec/021 §2.2 · Figma design)
+  ## Numbered vertical-flow pipeline (spec/021 §2.2 · operational order)
 
-  Reconciled to the Figma design under rf2-ad7zx.5
-  (`tools/xray/design-reference/xray_devtools_reference.cljs`, the
-  `event-panel` component +
-  `tools/xray/spec/021-Dynamic-Panel-Designs.md` §2.2). The handling
-  perspective is a top-to-bottom ONE-WAY pipeline drawn as a thin left
-  RAIL with a NUMBERED STEP CIRCLE at each section. Sections, in order:
+  Per spec/021 §2.2 (B+ order, decided 2026-05-25 under rf2-5t9h0 / impl
+  rf2-ynnre) the panel renders sections in the framework's OPERATIONAL
+  order — what happens, in the order it happens — so the visual rhythm
+  teaches the atomicity contract (flows reshape the pending `:db`
+  BEFORE the single deferred install; FX runs AFTER the commit). The
+  handling perspective is a top-to-bottom ONE-WAY pipeline drawn as a
+  thin left RAIL with a NUMBERED STEP CIRCLE at each section. Sections,
+  in order:
 
       1. DISPATCH             event vector + `FROM: <source>` (click-to-source)
       2. COEFFECTS  (opt)     user-injected coeffects + the value each added
       3. EVENT HANDLER        reg-event-* flavour + syntax-highlighted source
-      4. APP-DB CHANGES       the app-db diff (+ SSR hydration addendum)
-      5. FLOWS      (opt)     flows that recomputed + the db path written
-      6. AFTER INTERCEPTORS (opt) non-standard after-interceptors
-      7. FX                   the fx handlers that ran
+                              + the returned effects map (t1 pending — :db
+                              slot present? :fx vector entries)
+      4. FLOWS      (opt)     flows that recomputed + the db path written
+                              (t1→t2 reshape · pre-commit)
+      5. AFTER INTERCEPTORS (opt) non-standard after-interceptors
+      6. APP-DB CHANGES       the COMMITTED diff (t4 · post-flow · atomic
+                              install boundary; + SSR hydration addendum)
+      7. FX                   the fx handlers that ran (post-commit · irreversible)
 
-  rf2-xawwb — the Figma-Make surface numbers APP-DB CHANGES as step 4 and
-  FLOWS as step 5 (supersedes rf2-9eca7 / #2070, which placed FLOWS
-  before DB CHANGES).
+  rf2-ynnre — supersedes the earlier rf2-xawwb / Figma-A order
+  (HANDLER → APP-DB CHANGES → FLOWS → FX), which displayed the result
+  before the attribution. The atomicity contract was pinned 2026-05-24
+  (spec/013-Flows.md §Failure semantics) AFTER the Figma was drawn; B+
+  brings the panel into line with it.
 
   Steps are numbered DYNAMICALLY 1..N — an absent OPTIONAL section
   (COEFFECTS / AFTER INTERCEPTORS / FLOWS) consumes no number; absence is
@@ -763,12 +771,89 @@
                        :color       (:text-tertiary tokens)}}
         "<source not yet captured>"])]))
 
+(defn- handler-returned-effects-block
+  "Renders the `↳ returned effects` sub-block under the handler source.
+  This is the t1 observable — the effects map the event handler RETURNED,
+  PRE-flow-transform and PRE-commit. Per rf2-ynnre (B+ visual order) the
+  HANDLER step surfaces this map so the panel reads in operational order
+  — what did the handler return, what did flows then reshape, what was
+  ultimately committed.
+
+  Today the trace surface captures `:fx` (the returned fx vector, off
+  `:rf.fx/do-fx :tags :rf.event/fx`) and `:db-present?` (a boolean, off
+  the same trace's `:tags :rf.event/db-present?`), but NOT the pending
+  `:db` value itself. The pending `:db` is `nil` for handlers that
+  returned no `:db` slot; otherwise its committed value reads naturally
+  one step down in APP-DB CHANGES (when no flows fired the t4 committed
+  diff EQUALS the t1 pending diff). A CORE follow-on can later capture
+  the t1-pending-`:db` snapshot for the flow-having case — until then
+  this block shows what is observable.
+
+  Returns nil when neither `:db` was returned nor any `:fx` (the rare
+  noop event); the absence-by-omission rule applies inside the section
+  body too — no empty `(none)` placeholder."
+  [cascade]
+  (let [do-fx-tags (some-> (do-fx-trace cascade) :tags)
+        db-pres?   (:rf.event/db-present? do-fx-tags)
+        fx-vec     (:rf.event/fx do-fx-tags)]
+    (when (or db-pres? (seq fx-vec))
+      [:div {:data-testid "rf-xray-event-detail-handler-returned-effects"
+             :style {:margin-top "8px"
+                     :padding "6px 0 0 16px"
+                     :border-top (str "1px dashed " (:border-subtle tokens))}}
+       [:div {:data-testid "rf-xray-event-detail-handler-returned-effects-caption"
+              :style {:color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :margin-bottom "4px"}}
+        "↳ returned effects (pre-commit)"]
+       (when db-pres?
+         [:div {:data-testid "rf-xray-event-detail-handler-returned-db"
+                :style {:display "flex"
+                        :align-items "baseline"
+                        :gap "8px"
+                        :padding "1px 0"
+                        :font-family mono-stack
+                        :font-size "11px"}}
+          [:span {:style {:color (:accent tokens)
+                          :min-width "32px"}} ":db"]
+          [:span {:style {:color (:text-tertiary tokens)
+                          :font-style "italic"}}
+           "pending — see APP-DB CHANGES below for the committed diff"]])
+       (when (seq fx-vec)
+         (into [:div {:data-testid "rf-xray-event-detail-handler-returned-fx"
+                      :style {:padding "1px 0"
+                              :font-family mono-stack
+                              :font-size "11px"}}
+                [:div {:style {:display "flex"
+                               :align-items "baseline"
+                               :gap "8px"}}
+                 [:span {:style {:color (:accent tokens)
+                                 :min-width "32px"}} ":fx"]
+                 [:span {:style {:color (:text-tertiary tokens)}}
+                  (str (count fx-vec) " entr"
+                       (if (= 1 (count fx-vec)) "y" "ies")
+                       " — see FX below for what ran")]]]
+               (map-indexed
+                 (fn [i pair]
+                   (let [[fx-id _] (when (vector? pair) pair)]
+                     (with-meta
+                       [:div {:data-testid (str "rf-xray-event-detail-handler-returned-fx-row-"
+                                                 (interceptor-testid-suffix fx-id))
+                              :style {:padding "1px 0 1px 40px"
+                                      :color (:text-secondary tokens)}}
+                        (pr-str pair)]
+                       {:key (str i)})))
+                 fx-vec)))])))
+
 (defn- handler-body
   "Step EVENT HANDLER body — `reg-event-<kind>` flavour + source coord
   (a click-to-source link), then the syntax-highlighted handler source
   (`:rf.handler/source` meta, DEBUG-gated · rf2-xgfuy; placeholder when
-  absent). Per spec/021 §2.2 step 3. Returns body hiccup."
-  [event-id meta]
+  absent), then the t1 RETURNED EFFECTS sub-block (rf2-ynnre — what the
+  handler RETURNED, pre-flow-transform and pre-commit). Per spec/021 §2.2
+  step 3. Returns body hiccup."
+  [event-id meta cascade]
   (let [kind   (:event/kind meta)
         coord  (when (string? (:file meta))
                  {:file (:file meta) :line (:line meta)})
@@ -799,7 +884,8 @@
            (str "no registration found for " (pr-str event-id))
            "no handler registered")])
       (coord-chip coord "rf-xray-event-detail-handler-open-chip")]
-     (handler-source-line meta)]))
+     (handler-source-line meta)
+     (handler-returned-effects-block cascade)]))
 
 ;; ---- hydration outcome (SSR addendum) --------------------------------
 
@@ -913,32 +999,52 @@
               :style {:margin "6px 0 4px 16px"}}
         (managed-fx/record-panel managed-fx-record)])]))
 
+(defn- fx-post-commit-caption
+  "Tiny inline caption at the top of the FX section body — `post-commit ·
+  irreversible`. Per rf2-ynnre (B+ visual order) FX is the only stage
+  AFTER the atomic `:db` install: an fx throw surfaces an error but does
+  NOT wind app-db back, and side effects (http / nav / dispatch) may
+  already have fired. The caption makes the commit boundary legible at
+  the panel so users see where ordering atomicity ends and irreversible
+  effects begin. Cross-ref `spec/013-Flows.md §Failure semantics`."
+  []
+  [:div {:data-testid "rf-xray-event-detail-fx-post-commit-caption"
+         :style {:color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "11px"
+                 :font-style "italic"
+                 :margin-bottom "4px"}}
+   "post-commit · irreversible (fx throws don't wind app-db back)"])
+
 (defn- fx-body
-  "Step FX body — one row per `:rf.fx/handled` fx-handler that ran.
-  Inline-mounts the managed-fx record beneath its causing fx-handler row
-  per §8.3 (colocation). Per spec/021 §2.2 step 7 FX is a REQUIRED step
-  (always shown — `(none)` when no fx handlers ran, per the sparse-case
-  mockup), unlike the optional COEFFECTS / AFTER INTERCEPTORS / FLOWS
-  steps. Returns body hiccup."
+  "Step FX body — a small `post-commit · irreversible` caption (rf2-ynnre
+  — clarifies the commit boundary), then one row per `:rf.fx/handled`
+  fx-handler that ran. Inline-mounts the managed-fx record beneath its
+  causing fx-handler row per §8.3 (colocation). Per spec/021 §2.2 step 7
+  FX is a REQUIRED step (always shown — `(none)` when no fx handlers
+  ran, per the sparse-case mockup), unlike the optional COEFFECTS /
+  AFTER INTERCEPTORS / FLOWS steps. Returns body hiccup."
   [cascade]
   (let [rows    (effects-handlers-ran cascade)
         records (managed-fx-h/cascade->managed-fx-records cascade)]
-    (if (seq rows)
-      (into [:div]
-            ;; Per rf2-ppzid — `with-meta` on the fn return, not
-            ;; `^{:key ...}` on the call form.
-            (for [{:keys [id] :as row} rows]
-              (with-meta
-                (fx-handler-row row (managed-fx-record-for-row records id))
-                {:key id})))
-      [:div {:data-testid "rf-xray-event-detail-fx-none"
-             :style {:color (:text-tertiary tokens)
-                     :font-style "italic"
-                     :font-family sans-stack
-                     :font-size "11px"}}
-       "(none)"])))
+    [:div
+     (fx-post-commit-caption)
+     (if (seq rows)
+       (into [:div]
+             ;; Per rf2-ppzid — `with-meta` on the fn return, not
+             ;; `^{:key ...}` on the call form.
+             (for [{:keys [id] :as row} rows]
+               (with-meta
+                 (fx-handler-row row (managed-fx-record-for-row records id))
+                 {:key id})))
+       [:div {:data-testid "rf-xray-event-detail-fx-none"
+              :style {:color (:text-tertiary tokens)
+                      :font-style "italic"
+                      :font-family sans-stack
+                      :font-size "11px"}}
+        "(none)"])]))
 
-;; ---- step FLOWS (Figma-Make surface step 5 · rf2-xawwb) ----------------
+;; ---- step FLOWS (spec/021 §2.2 step 4 · rf2-ynnre — operational order) -
 ;; rf2-lo37i — Flows fire automatically right after the event handler, at
 ;; the OUTERMOST `:after` interceptor — they transform the pending `:db`
 ;; effect BEFORE the single deferred app-db install (the atomic commit
@@ -947,13 +1053,15 @@
 ;; visibility here a developer cannot attribute an app-db change to the
 ;; flow that caused it.
 ;;
-;; rf2-xawwb — the Figma-Make surface PRESENTS FLOWS as step 5, AFTER the
-;; APP-DB CHANGES diff (step 4): the diff leads, and the FLOWS section
-;; then attributes the flow-driven slots within it. (This supersedes the
-;; rf2-9eca7 / #2070 presentation order that placed FLOWS before DB
-;; CHANGES. The underlying framework TIMING is unchanged — flows still
-;; reshape the pending db before commit; only the panel's visual ordering
-;; changes to match the authoritative surface.)
+;; rf2-ynnre — FLOWS sits at step 4, BETWEEN EVENT HANDLER (step 3) and
+;; APP-DB CHANGES (step 6 — the committed diff). The visual order tracks
+;; the framework's operational order (handler returns pending `:db` →
+;; flows reshape it → atomic install → fx), so the panel's section
+;; rhythm teaches the atomicity contract for free. (Supersedes rf2-xawwb
+;; / Figma-A which placed FLOWS AFTER APP-DB CHANGES — diff-leads-
+;; attribution-follows; that order pre-dated Mike's 2026-05-24 atomicity
+;; pin under spec/013-Flows.md §Failure semantics.) The framework
+;; TIMING is unchanged; only the panel's display order changes.
 ;;
 ;; Per spec/013-Flows.md + spec/009-Instrumentation.md:
 ;;   `:rf.flow/computed` (op-type `:flow`) carries `:flow-id`,
@@ -1279,10 +1387,11 @@
                   :color       (:text-primary tokens)}}
     body]])
 
-;; ---- step DB CHANGES — flat changed-paths diff list ------------------
+;; ---- step APP-DB CHANGES — flat changed-paths diff list ---------------
 ;;
-;; Per spec/021 §2.2 step 5 the DB CHANGES section is the
-;; app-db diff rendered as a FLAT list of changed paths ONLY:
+;; Per spec/021 §2.2 step 6 (rf2-ynnre — operational order) the APP-DB
+;; CHANGES section is the COMMITTED app-db diff at t4 (the atomic
+;; install boundary) rendered as a FLAT list of changed paths ONLY:
 ;;
 ;;     ~ [path] old → new        (modified)
 ;;     + [path] value            (added)
@@ -1400,11 +1509,32 @@
        ;; :removed — path alone (spec/021 line 229: `- [path]`).
        nil)]))
 
+(defn- db-changes-committed-caption
+  "Tiny inline caption at the top of the APP-DB CHANGES section body —
+  `committed diff (post-flow)`. Per rf2-ynnre (B+ visual order) this
+  section IS the COMMITTED diff at t4 — the single atomic `:db` install
+  boundary. When flows fired, the diff equals
+  `(pre-event-db → post-flow-pending-db)` = `(pre-event-db →
+  post-event-committed-db)`; when no flows fired, it equals the
+  handler's pending `:db` diff (t1 = t4). The caption keeps users from
+  reading the section as 'what the handler returned' — the handler's
+  returned effects map lives one step up in EVENT HANDLER. Cross-ref
+  `spec/013-Flows.md §Failure semantics` (the atomic-install contract)."
+  []
+  [:div {:data-testid "rf-xray-event-detail-db-changes-committed-caption"
+         :style {:color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "11px"
+                 :font-style "italic"
+                 :margin-bottom "4px"}}
+   "committed diff (post-flow · atomic install boundary)"])
+
 (defn- db-changes-body
-  "Step DB CHANGES body — the app-db diff for the focused epoch as a
-  FLAT changed-paths list (spec/021 §2.2 step 5 · spec/004 §slice-
-  centric). One `~`/`+`/`-` row per changed path; NO untouched
-  top-level keys, NO whole-tree render.
+  "Step APP-DB CHANGES body — a tiny `committed diff` caption (rf2-ynnre
+  — clarifies the commit-boundary framing) then the app-db diff for the
+  focused epoch as a FLAT changed-paths list (spec/021 §2.2 step 6 ·
+  spec/004 §slice-centric). One `~`/`+`/`-` row per changed path; NO
+  untouched top-level keys, NO whole-tree render.
 
   Per spec/021 §2.2 this step is the app-db diff ALONE — the prior
   combined `:db + :fx` shape (and the `db now committed for epoch #N`
@@ -1431,35 +1561,37 @@
         db-after  (:db-after record)
         had-snap? (or (some? db-before) (some? db-after))
         evicted?  (db-fx-evicted? record dispatch-id)]
-    (cond
-      evicted?
-      [:div {:data-testid "rf-xray-event-detail-db-changes-evicted"
-             :style {:padding "6px 0"
-                     :color (:text-tertiary tokens)
-                     :font-style "italic"
-                     :font-family sans-stack
-                     :font-size "12px"}}
-       "Epoch evicted from buffer — increase :epoch-history to retain more."]
+    [:div
+     (db-changes-committed-caption)
+     (cond
+       evicted?
+       [:div {:data-testid "rf-xray-event-detail-db-changes-evicted"
+              :style {:padding "6px 0"
+                      :color (:text-tertiary tokens)
+                      :font-style "italic"
+                      :font-family sans-stack
+                      :font-size "12px"}}
+        "Epoch evicted from buffer — increase :epoch-history to retain more."]
 
-      ;; The focused epoch carried db snapshots AND the structural diff
-      ;; found changed paths — render the flat list (changed paths only).
-      (and (some? record) had-snap? (seq triples))
-      [:div {:data-testid "rf-xray-event-detail-db-diff"
-             :style {:padding     "4px 0"
-                     :font-family mono-stack
-                     :font-size   "12px"}}
-       (into [:div]
-             (for [{:keys [path] :as triple} triples]
-               (with-meta (db-change-row triple)
-                          {:key (pr-str path)})))]
+       ;; The focused epoch carried db snapshots AND the structural diff
+       ;; found changed paths — render the flat list (changed paths only).
+       (and (some? record) had-snap? (seq triples))
+       [:div {:data-testid "rf-xray-event-detail-db-diff"
+              :style {:padding     "4px 0"
+                      :font-family mono-stack
+                      :font-size   "12px"}}
+        (into [:div]
+              (for [{:keys [path] :as triple} triples]
+                (with-meta (db-change-row triple)
+                           {:key (pr-str path)})))]
 
-      :else
-      [:div {:data-testid "rf-xray-event-detail-db-changes-empty"
-             :style {:color (:text-tertiary tokens)
-                     :font-style "italic"
-                     :font-family sans-stack
-                     :font-size "12px"}}
-       "no app-db change this epoch"])))
+       :else
+       [:div {:data-testid "rf-xray-event-detail-db-changes-empty"
+              :style {:color (:text-tertiary tokens)
+                      :font-style "italic"
+                      :font-family sans-stack
+                      :font-size "12px"}}
+        "no app-db change this epoch"])]))
 
 ;; ---- the lens (numbered vertical-flow pipeline · spec/021 §2.2) --------
 
@@ -1477,30 +1609,36 @@
   of a step is conveyed by omission.
 
   Step order (numbered; optional steps shown only when present) — the
-  Figma-Make surface order (rf2-xawwb):
+  OPERATIONAL order (rf2-ynnre, supersedes rf2-xawwb's Figma-A):
 
     1. DISPATCH            — the event vector + `FROM: <source>`
                              (click-to-source).
     2. COEFFECTS  (opt)    — user-injected coeffects + the value each
                              added.
     3. EVENT HANDLER       — flavour (`reg-event-*`, click-to-source) +
-                             syntax-highlighted handler source.
-    4. APP-DB CHANGES      — the app-db diff (+ SSR hydration-outcome
-                             addendum when the focused event hydrated).
-    5. FLOWS      (opt)    — flows that recomputed + the db path each
-                             wrote. (Framework-timing note: flows fire at
-                             the outermost `:after` and reshape the
-                             pending `:db` BEFORE it commits; the
-                             Figma-Make surface PRESENTS them after the
-                             APP-DB CHANGES diff so the diff leads and the
-                             flow attribution reads as the explanation of
-                             the flow-driven slots within it.)
-    6. AFTER INTERCEPTORS (opt) — non-standard after-interceptors.
-    7. FX                  — the fx handlers that ran.
+                             syntax-highlighted handler source +
+                             returned effects map (t1 — pending `:db`
+                             presence + `:fx` vector entries).
+    4. FLOWS      (opt)    — flows that recomputed + the db path each
+                             wrote (t1→t2 reshape · pre-commit). Flows
+                             fire at the outermost `:after` and reshape
+                             the pending `:db` BEFORE it commits.
+    5. AFTER INTERCEPTORS (opt) — non-standard after-interceptors.
+    6. APP-DB CHANGES      — the COMMITTED diff at t4 (post-flow, atomic
+                             install boundary). When flows fired,
+                             includes the flow-driven slot mutations;
+                             when none fired this equals the handler's
+                             pending `:db` diff. + SSR hydration-outcome
+                             addendum when the focused event hydrated.
+    7. FX                  — the fx handlers that ran. Post-commit ·
+                             irreversible: fx throws do NOT wind app-db
+                             back (`spec/013-Flows.md §Failure semantics`).
 
-  rf2-xawwb — supersedes the rf2-9eca7 (#2070) placement of FLOWS BEFORE
-  DB CHANGES; the Figma-Make surface numbers APP-DB CHANGES as step 4 and
-  FLOWS as step 5.
+  rf2-ynnre — supersedes rf2-xawwb's Figma-A order (HANDLER → APP-DB
+  CHANGES → FLOWS → FX, which read 'result-then-attribution'). Mike
+  voted B+ on 2026-05-25 (rf2-5t9h0): swap to operational order. The
+  framework timing is unchanged; only the panel's visual ordering
+  changes so the section rhythm teaches the atomicity contract.
 
   ## Handler-threw branch
 
@@ -1537,11 +1675,11 @@
         ;; on the threw branch.
         candidates [["dispatch"          "DISPATCH"           (dispatch-body cascade event)]
                     ["coeffects"         "COEFFECTS"          (coeffects-body cascade)]
-                    ["handler"           "EVENT HANDLER"      (handler-body event-id meta)]
-                    ["db-changes"        "APP-DB CHANGES"     db-changes]
+                    ["handler"           "EVENT HANDLER"      (handler-body event-id meta cascade)]
                     ["flows"             "FLOWS"              (when-not threw? (flows-body cascade))]
                     ["after-interceptors" "AFTER INTERCEPTORS" (when-not threw?
                                                                  (after-interceptors-body user-icpts id->delta))]
+                    ["db-changes"        "APP-DB CHANGES"     db-changes]
                     ["fx"                "FX"                 (when-not threw? (fx-body cascade))]]
         ;; Drop omitted (nil-body) steps, then number what remains 1..N
         ;; — dynamic numbering so the visible steps read contiguously.
@@ -1646,7 +1784,7 @@
 
 (rf/reg-view Panel
   "The Event lens panel's root view. Subscribes to
-  `:rf.xray/event-detail` and renders either the 6-section
+  `:rf.xray/event-detail` and renders either the 7-section
   `event-lens` (when a cascade is focused) or the cascade-list empty
   state (when not)."
   []

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -240,13 +240,13 @@
 ;; ---- (2) numbered-pipeline steps render in spec order ------------------
 
 (def ^:private ^:const section-root-testids
-  "The numbered-pipeline step ROOT testids (spec/021 §2.2 · Figma
-  reconcile rf2-ad7zx.5). Used by `section-testids-in-order` to filter
-  out the per-step `*-label` / `*-body` children testids `step-section`
+  "The numbered-pipeline step ROOT testids (spec/021 §2.2 · operational
+  order rf2-ynnre). Used by `section-testids-in-order` to filter out
+  the per-step `*-label` / `*-body` children testids `step-section`
   emits.
 
-  Section order (rf2-xawwb Figma-Make surface): DISPATCH → COEFFECTS? →
-  EVENT HANDLER → APP-DB CHANGES → FLOWS? → AFTER INTERCEPTORS? → FX
+  Section order (rf2-ynnre — operational): DISPATCH → COEFFECTS? →
+  EVENT HANDLER → FLOWS? → AFTER INTERCEPTORS? → APP-DB CHANGES → FX
   (optional steps shown when present)."
   #{"rf-xray-event-detail-section-dispatch"
     "rf-xray-event-detail-section-coeffects"
@@ -271,11 +271,11 @@
        (vec)))
 
 (deftest event-lens-renders-all-seven-steps-when-fully-populated
-  (testing "rf2-xawwb — a cascade with call-site + fx + after-
+  (testing "rf2-ynnre — a cascade with call-site + fx + after-
             interceptors + user coeffects + a flow yields the full
-            7-step numbered pipeline (Figma-Make surface order): DISPATCH,
-            COEFFECTS, EVENT HANDLER, APP-DB CHANGES, FLOWS,
-            AFTER INTERCEPTORS, FX"
+            7-step numbered pipeline (operational order): DISPATCH,
+            COEFFECTS, EVENT HANDLER, FLOWS, AFTER INTERCEPTORS,
+            APP-DB CHANGES, FX"
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
         [(rf/->interceptor :id :auth/require-login)]
@@ -305,9 +305,9 @@
         (doseq [[id label] [["dispatch" "DISPATCH"]
                             ["coeffects" "COEFFECTS"]
                             ["handler" "EVENT HANDLER"]
-                            ["db-changes" "APP-DB CHANGES"]
                             ["flows" "FLOWS"]
                             ["after-interceptors" "AFTER INTERCEPTORS"]
+                            ["db-changes" "APP-DB CHANGES"]
                             ["fx" "FX"]]]
           (is (some? (find-by-testid tree (str "rf-xray-event-detail-section-" id)))
               (str "step " label " present"))
@@ -315,12 +315,12 @@
               (str "step " label " carries a numbered step circle")))))))
 
 (deftest event-lens-step-order-matches-spec-021-section-2-2
-  (testing "rf2-ad7zx.5 — steps render top-to-bottom in spec/021 §2.2
-            order: DISPATCH → COEFFECTS → EVENT HANDLER → FLOWS →
-            DB CHANGES → AFTER INTERCEPTORS → FX (optional steps shown
-            when present). This fixture seeds no flow, so FLOWS is
-            OMITTED — absence by omission, dynamic numbering closes the
-            gap."
+  (testing "rf2-ynnre — steps render top-to-bottom in spec/021 §2.2
+            operational order: DISPATCH → COEFFECTS → EVENT HANDLER →
+            FLOWS → AFTER INTERCEPTORS → APP-DB CHANGES → FX (optional
+            steps shown when present). This fixture seeds no flow, so
+            FLOWS is OMITTED — absence by omission, dynamic numbering
+            closes the gap."
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
         [(rf/->interceptor :id :auth/require-login)]
@@ -338,11 +338,11 @@
         (is (= ["rf-xray-event-detail-section-dispatch"
                 "rf-xray-event-detail-section-coeffects"
                 "rf-xray-event-detail-section-handler"
-                "rf-xray-event-detail-section-db-changes"
                 "rf-xray-event-detail-section-after-interceptors"
+                "rf-xray-event-detail-section-db-changes"
                 "rf-xray-event-detail-section-fx"]
                order)
-            "step testids appear in spec/021 §2.2 order (FLOWS omitted)")))))
+            "step testids appear in spec/021 §2.2 operational order (FLOWS omitted)")))))
 
 (deftest event-lens-dynamic-step-numbering-renumbers-on-omission
   (testing "rf2-ad7zx.5 — step numbers are assigned DYNAMICALLY 1..N
@@ -946,14 +946,16 @@
                row-tids)
             "flow rows appear in cascade firing order")))))
 
-(deftest flows-step-sits-after-db-changes-before-fx
-  (testing "rf2-xawwb — Figma-Make surface step order: EVENT HANDLER →
-            APP-DB CHANGES (step 4) → FLOWS (step 5) → FX. The APP-DB
-            CHANGES diff leads and the FLOWS section then attributes the
-            flow-driven slots within it. (Supersedes rf2-9eca7 / #2070,
-            which placed FLOWS before DB CHANGES. The framework TIMING is
-            unchanged — flows still reshape the pending db before commit;
-            only the panel's visual ordering changes.)"
+(deftest flows-step-sits-between-event-handler-and-db-changes-when-fired
+  (testing "rf2-ynnre — operational step order: EVENT HANDLER → FLOWS
+            (when fired) → APP-DB CHANGES → FX. FLOWS sits BETWEEN the
+            handler and the committed diff because in operational time
+            flows reshape the pending `:db` BEFORE the atomic install.
+            The visual order teaches the atomicity contract for free.
+            (Supersedes rf2-xawwb's Figma-A order which placed FLOWS
+            AFTER APP-DB CHANGES — diff-leads-attribution-follows.
+            Framework timing is unchanged; only the panel's display
+            order changes per Mike's 2026-05-25 B+ decision rf2-5t9h0.)"
     (rf/with-frame :rf/default
       (rf/reg-flow {:id     :a-flow
                     :inputs [[:in]] :output identity :path [:a]}))
@@ -977,11 +979,114 @@
                         (distinct)
                         (vec))]
         (is (= ["rf-xray-event-detail-section-handler"
-                "rf-xray-event-detail-section-db-changes"
                 "rf-xray-event-detail-section-flows"
+                "rf-xray-event-detail-section-db-changes"
                 "rf-xray-event-detail-section-fx"]
                tids)
-            "APP-DB CHANGES precedes FLOWS, both after EVENT HANDLER and before FX (rf2-xawwb)")))))
+            "FLOWS sits between EVENT HANDLER and APP-DB CHANGES (rf2-ynnre operational order)")))))
+
+(deftest flows-step-hidden-when-no-flows-fired
+  (testing "rf2-ynnre — when zero flows fired this event, the FLOWS
+            section is OMITTED entirely (no empty placeholder text).
+            Mirrors the conditional-show rule that already applies to
+            COEFFECTS and AFTER INTERCEPTORS. The flow-less case is
+            the common case; the panel reads as the simpler B shape
+            (HANDLER → APP-DB CHANGES → FX) for those events."
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :poll/tick (fn [db _] db)))
+    (seed-buffer! (cascade-evs 100 [:poll/tick] 0))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-xray-event-detail-section-flows"))
+            "FLOWS section omitted when no flows fired")))))
+
+(deftest handler-step-shows-returned-effects-block-with-pending-db-and-fx
+  (testing "rf2-ynnre — the EVENT HANDLER step's body carries a t1
+            'returned effects' sub-block showing the handler's pending
+            `:db` slot + `:fx` vector entries (pre-commit observable).
+            The pending `:db` value is not in trace today so the block
+            shows the slot's PRESENCE + a cross-ref pointer to APP-DB
+            CHANGES for the committed value (which equals the pending
+            value when no flows fired)."
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :widget/poke (fn [_ _] {})))
+    (seed-buffer!
+      (cascade-evs 100 [:widget/poke {:id 1}] 0
+                   {:fx [[:dispatch [:bar]] [:dispatch-later {:ms 50 :dispatch [:tick]}]]
+                    :db-present? true}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree
+                                    "rf-xray-event-detail-handler-returned-effects"))
+            "returned-effects sub-block renders inside EVENT HANDLER")
+        (is (some? (find-by-testid tree
+                                    "rf-xray-event-detail-handler-returned-db"))
+            "pending `:db` slot row renders when handler returned `:db`")
+        (is (some? (find-by-testid tree
+                                    "rf-xray-event-detail-handler-returned-fx"))
+            "`:fx` vector summary renders when handler returned `:fx`")
+        ;; The block reads as a sub-block of HANDLER, not a separate step.
+        (is (nil? (find-by-testid tree
+                                   "rf-xray-event-detail-section-returned-effects"))
+            "returned-effects is a sub-block of HANDLER (NOT a separate step)")))))
+
+(deftest handler-step-returned-effects-block-absent-on-noop-handler
+  (testing "rf2-ynnre — when the handler returned NEITHER `:db` NOR `:fx`
+            (a noop event) the returned-effects sub-block is omitted
+            entirely (absence by omission)"
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :noop (fn [_ _] {})))
+    (seed-buffer!
+      (cascade-evs 100 [:noop] 0
+                   {:fx []
+                    :db-present? false}))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree
+                                   "rf-xray-event-detail-handler-returned-effects"))
+            "returned-effects sub-block omitted on noop handler")))))
+
+(deftest db-changes-step-carries-committed-diff-caption
+  (testing "rf2-ynnre — the APP-DB CHANGES section's body carries the
+            'committed diff (post-flow · atomic install boundary)'
+            caption so users don't read the section as 'what the handler
+            did' — it's the t4 committed observable. Cross-refs
+            spec/013-Flows.md §Failure semantics (atomic-install
+            contract)."
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :counter/inc (fn [db _] db)))
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            cap  (find-by-testid tree
+                                  "rf-xray-event-detail-db-changes-committed-caption")
+            text (->> (hiccup-seq cap) (filter string?) (apply str))]
+        (is (some? cap) "committed-diff caption renders")
+        (is (re-find #"committed" text) "caption mentions `committed`")
+        (is (re-find #"post-flow" text) "caption mentions `post-flow`")))))
+
+(deftest fx-step-carries-post-commit-irreversible-caption
+  (testing "rf2-ynnre — the FX section's body carries the 'post-commit ·
+            irreversible' caption so the panel's section rhythm shows
+            the atomic commit boundary clearly: fx throws do NOT wind
+            app-db back. Cross-refs spec/013-Flows.md §Failure
+            semantics."
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :counter/inc (fn [db _] db)))
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/xray
+      (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            cap  (find-by-testid tree
+                                  "rf-xray-event-detail-fx-post-commit-caption")
+            text (->> (hiccup-seq cap) (filter string?) (apply str))]
+        (is (some? cap) "post-commit caption renders")
+        (is (re-find #"post-commit" text) "caption mentions `post-commit`")
+        (is (re-find #"irreversible" text) "caption mentions `irreversible`")))))
 
 (deftest flows-section-absent-when-handler-threw
   (testing "rf2-lo37i — when the handler threw, the outermost :after


### PR DESCRIPTION
Implements bead **rf2-ynnre**. Mike-decided rf2-5t9h0 = B+ on 2026-05-25: swap the Event lens panel from the Figma-A `result-then-attribution` order to the framework's actual operational order, so the panel's section rhythm teaches the atomicity contract for free.

## Section order: before vs after

Before (Figma-A, rf2-xawwb):
```
DISPATCH · COEFFECTS? · EVENT HANDLER · APP-DB CHANGES · FLOWS? · AFTER INTERCEPTORS? · FX
```

After (operational, rf2-ynnre B+):
```
DISPATCH · COEFFECTS? · EVENT HANDLER · FLOWS? · AFTER INTERCEPTORS? · APP-DB CHANGES · FX
```

The framework timing is unchanged; only the panel's display order changes so the rhythm matches: handler returns pending `:db` → flows reshape it (pre-commit) → atomic install → fx (post-commit, irreversible).

## t1 / t2 / t4 observability findings

Three distinct observables matter for the B+ shape:

| Observable | Status | Decision |
|---|---|---|
| **t1** — handler''s returned effects map (incl. pending `:db`) | Partial: `:rf.fx/do-fx :tags` carry `:rf.event/fx` + `:rf.event/db-present?`. Pending `:db` *value* is NOT in trace today (deliberate: the full db can be huge — see `fx.cljc:691-702` rationale). | **Reused existing trace.** EVENT HANDLER now shows a `returned effects (pre-commit)` sub-block: pending `:db` slot presence (with cross-ref to APP-DB CHANGES for the committed value) + the returned `:fx` vector entries. Rich t1 view (full pending `:db`) deferred to follow-on bead **rf2-ta0y7** (CORE-side trace surface decision needed — memory cost tradeoffs documented on the bead). |
| **t2** — post-flow pending `:db` (t1→t2 reshape) | Per-flow `:rf.flow/computed :before`/`:result` already capture each flow''s slot contribution (rf2-qlzh4). | **Already observable.** Per-flow rendering in FLOWS section preserves the per-flow t1→t2 detail. A single unified `t1→t2` diff view ships with rf2-ta0y7. |
| **t4** — committed diff | Already rendered as the APP-DB CHANGES section. | **Reframed.** Section now carries a `committed diff (post-flow · atomic install boundary)` caption clarifying it''s the t4 observable, not "what the handler did". |

## Other changes

- **FLOWS now conditional**: hidden when no flows fired this event (the common case). Mirrors the COEFFECTS / AFTER INTERCEPTORS conditional-show pattern. Flow-less events read as the simpler HANDLER → APP-DB CHANGES → FX shape Mike noted (the "B" reading for those events).
- **FX `post-commit · irreversible` annotation**: small inline caption at the top of the FX section body so the commit boundary is legible at the panel. Cross-refs `spec/013-Flows.md §Failure semantics`.

## Conditional-show rule

Every section conditional on "did this op-family contribute this event?". The pattern was already in place for COEFFECTS / AFTER INTERCEPTORS; this PR extends it to FLOWS. Empty section → hidden (absence by omission), no placeholder text.

## spec/021 update

`tools/xray/spec/021-Dynamic-Panel-Designs.md §2.2` normatively updated:
- Section header relabelled `Layout — numbered vertical-flow pipeline (operational order · rf2-ynnre B+)`.
- New normative blockquote noting Mike''s 2026-05-25 B+ decision + that the Figma-A order pre-dated Mike''s 2026-05-24 atomicity pin (`spec/013-Flows.md §Failure semantics`).
- Numbered list updated to operational order (FLOWS at 4, AFTER INTERCEPTORS at 5, APP-DB CHANGES at 6).
- Dense + sparse ASCII sketches updated to the new order + the new captions.
- §1 phase table + §2.3 queries table updated accordingly.
- Design-reference (`tools/xray/design-reference/xray_devtools_reference.cljs`) mirrored: handler-panel section reordered + the two new captions added in-line.

## Files

- `tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs` — candidates vector reordered; new `handler-returned-effects-block` defn; new `db-changes-committed-caption` defn; new `fx-post-commit-caption` defn; section-comment + docstring updates.
- `tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs` — reversed `flows-step-sits-after-db-changes-before-fx` to `flows-step-sits-between-event-handler-and-db-changes-when-fired`; updated `event-lens-renders-all-seven-steps-when-fully-populated` + `event-lens-step-order-matches-spec-021-section-2-2` to operational order; new tests `flows-step-hidden-when-no-flows-fired`, `handler-step-shows-returned-effects-block-with-pending-db-and-fx`, `handler-step-returned-effects-block-absent-on-noop-handler`, `db-changes-step-carries-committed-diff-caption`, `fx-step-carries-post-commit-irreversible-caption`.
- `tools/xray/spec/021-Dynamic-Panel-Designs.md` — §2.2 normatively updated as above + §1 phase table + §2.3 queries table.
- `tools/xray/design-reference/xray_devtools_reference.cljs` — handler-panel section reordered + captions added.

## Filed follow-ons

- **rf2-ta0y7** — `feat(core): capture t1 pending :db snapshot on a CORE trace so Xray Handler panel can render the t1 effects-map value + t1→t2 flow reshape diff` (P3). The rich t1 view; deliberately deferred from this PR to keep the visual change clean.

## Gates

- `tools/xray` JVM: 877 tests · 3111 assertions · 0 failures
- `npm run test:cljs`: 4368 tests · 13954 assertions · 0 failures
- `npm run test:xray-feature-gate`: 13 scenarios · 0 failures
- `npm run test:bundle-isolation`: PASS (16 artefact entries, 33 sentinels absent)
- `clj-kondo`: 0 errors, 0 warnings on changed files
- `splint`: no new warnings (4 pre-existing carried over)
- `mkdocs build --strict`: exit 0