### PR TITLE
chore(re-frame2-pair-mcp): post-merge hook warns on stale binary after pull (rf2-6jj3r)

### DIFF
--- a/scripts/git-hooks/lib/check-stale-mcp-binary.sh
+++ b/scripts/git-hooks/lib/check-stale-mcp-binary.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env sh
+# scripts/git-hooks/lib/check-stale-mcp-binary.sh
+#
+# Detection helper for the post-merge stale-MCP-binary warning (rf2-6jj3r).
+# Reads a list of newline-separated changed file paths on stdin and prints
+# a warning to stderr if any path falls inside an MCP-binary source surface
+# whose compiled artefact under `out/` is gitignored and rebuilt locally.
+#
+# This file is intentionally a pure shell library (no `set -e`, no global
+# state mutations) so the Node-side test runner under
+# `tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs` can invoke it
+# with synthetic stdin streams and assert against stdout / stderr / exit.
+#
+# Exit codes:
+#   0 — no stale binary; nothing printed.
+#   0 — stale binary detected; warning printed to stderr.
+#       (Hooks must not block `git pull`; we are advisory only.)
+#
+# Stdout: never used.
+# Stderr: warning block on detection.
+#
+# Cross-platform: POSIX sh; runs under Git Bash on Windows, macOS, Linux.
+# No bashisms (`[[`, arrays, `<<<`). Tested under `sh`, `bash`, `dash`.
+
+# Each MCP surface is declared by a label + a path-prefix gate. A change
+# to ANY file whose path starts with the prefix means the binary is now
+# stale and the operator must rebuild + bounce the MCP server.
+#
+# Adding a new MCP surface = add one stanza to `mcp_surfaces`.
+
+mcp_surfaces() {
+  # label|prefix|rebuild-cmd|bounce-hint
+  printf '%s\n' \
+    're-frame2-pair-mcp|tools/re-frame2-pair-mcp/src/|npm --prefix tools/re-frame2-pair-mcp run build|Restart Claude Code (or your MCP host) to bounce the server.' \
+    're-frame2-pair-mcp|tools/re-frame2-pair-mcp/shadow-cljs.edn|npm --prefix tools/re-frame2-pair-mcp run build|Restart Claude Code (or your MCP host) to bounce the server.' \
+    're-frame2-pair-mcp|tools/re-frame2-pair-mcp/deps.edn|npm --prefix tools/re-frame2-pair-mcp run build|Restart Claude Code (or your MCP host) to bounce the server.' \
+    're-frame2-pair-mcp|tools/re-frame2-pair-mcp/package.json|npm --prefix tools/re-frame2-pair-mcp run build|Restart Claude Code (or your MCP host) to bounce the server.'
+}
+
+# check_stale_mcp_binary
+#
+# Reads newline-separated file paths from stdin. For each MCP surface,
+# collects matching paths; if any matched, emits a single warning block
+# per surface to stderr.
+check_stale_mcp_binary() {
+  changed_paths=$(cat)
+  if [ -z "$changed_paths" ]; then
+    return 0
+  fi
+
+  any_match=0
+  # iterate surfaces; aggregate per label so multiple surface stanzas
+  # sharing a label collapse into one warning block.
+  seen_labels=""
+
+  mcp_surfaces | while IFS='|' read -r label prefix cmd bounce; do
+    matches=$(printf '%s\n' "$changed_paths" | grep -E "^${prefix}" || true)
+    if [ -z "$matches" ]; then
+      continue
+    fi
+
+    # de-dupe by label across surface stanzas
+    case " $seen_labels " in
+      *" $label "*)
+        ;;
+      *)
+        seen_labels="$seen_labels $label"
+        printf '\n' >&2
+        printf '====================================================================\n' >&2
+        printf '  %s: source changed — local binary is now stale (rf2-6jj3r)\n' "$label" >&2
+        printf '====================================================================\n' >&2
+        printf '\n' >&2
+        printf '  The compiled MCP binary under tools/re-frame2-pair-mcp/out/ is\n' >&2
+        printf '  gitignored and rebuilt locally. The just-pulled commits include\n' >&2
+        printf '  source-side changes that the running MCP server has NOT picked up.\n' >&2
+        printf '\n' >&2
+        printf '  Changed files in this pull:\n' >&2
+        ;;
+    esac
+
+    # print the matched paths under this stanza (indented)
+    printf '%s\n' "$matches" | while IFS= read -r p; do
+      [ -n "$p" ] && printf '    %s\n' "$p" >&2
+    done
+
+    any_match=1
+  done
+
+  # NB: the `while … done` ran in a subshell under POSIX sh, so any_match
+  # there is lost. Re-derive from a single match probe at the end.
+  any=$(mcp_surfaces | while IFS='|' read -r label prefix cmd bounce; do
+    printf '%s\n' "$changed_paths" | grep -E "^${prefix}" >/dev/null 2>&1 && echo y
+  done | head -n 1)
+
+  if [ "$any" = "y" ]; then
+    # print one shared remediation footer (commands are identical across
+    # current stanzas; keep it tight)
+    printf '\n' >&2
+    printf '  To refresh:\n' >&2
+    printf '    1.  npm --prefix tools/re-frame2-pair-mcp run build\n' >&2
+    printf '    2.  Restart Claude Code (or your MCP host) so the bounced\n' >&2
+    printf '        binary is exec-ed on the next tool call.\n' >&2
+    printf '\n' >&2
+    printf '  Why this warning exists: tools/re-frame2-pair-mcp/out/ is\n' >&2
+    printf '  intentionally gitignored (build artefacts rebuild per-environment).\n' >&2
+    printf '  Without this hook, pulled MCP fixes are silently inert until rebuild.\n' >&2
+    printf '====================================================================\n' >&2
+    printf '\n' >&2
+  fi
+
+  return 0
+}

--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+# .git/hooks/post-merge (re-frame2-managed segment)
+#
+# Warns when a `git pull` (which invokes `git merge` and thus this hook)
+# brings down source changes for an MCP server whose compiled binary is
+# gitignored — the binary on disk is now stale.
+#
+# Installed by scripts/install-git-hooks.sh (POSIX) or .ps1 (Windows).
+# Source of truth: scripts/git-hooks/post-merge.
+#
+# The hook is ADVISORY: it never fails the merge. It prints to stderr only.
+#
+# Cross-platform: runs under Git Bash on Windows, macOS, Linux. POSIX sh.
+
+# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---
+# Managed by scripts/install-git-hooks.sh. Do not edit between markers.
+{
+  # Locate the repo root from the hook context. Git invokes hooks with the
+  # working directory set to the top of the worktree, but be defensive in
+  # case a wrapper changed cwd.
+  _rf2_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _rf2_repo_root=""
+  if [ -n "$_rf2_repo_root" ]; then
+    _rf2_lib="$_rf2_repo_root/scripts/git-hooks/lib/check-stale-mcp-binary.sh"
+    if [ -f "$_rf2_lib" ]; then
+      # ORIG_HEAD is set by `git merge` (and thus `git pull`) to the
+      # pre-merge HEAD. Compare it against the post-merge HEAD to find
+      # changed paths. If ORIG_HEAD is unset (rare — e.g. a fast-forward
+      # via plumbing that didn't update it), skip silently.
+      if git rev-parse --verify ORIG_HEAD >/dev/null 2>&1; then
+        _rf2_changed=$(git diff --name-only ORIG_HEAD HEAD 2>/dev/null)
+        if [ -n "$_rf2_changed" ]; then
+          # shellcheck source=lib/check-stale-mcp-binary.sh
+          . "$_rf2_lib"
+          printf '%s\n' "$_rf2_changed" | check_stale_mcp_binary
+        fi
+      fi
+    fi
+  fi
+  unset _rf2_repo_root _rf2_lib _rf2_changed
+} || true
+# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -1,0 +1,120 @@
+#requires -Version 5
+# scripts/install-git-hooks.ps1 — Windows-friendly mirror of
+# scripts/install-git-hooks.sh (rf2-6jj3r).
+#
+# Same behaviour: idempotent install of the re-frame2-managed segments
+# of the repo's git hooks. The hook scripts themselves are POSIX sh
+# (Git on Windows ships a `sh.exe` from the Git Bash bundle that runs
+# hooks); this installer just stages them into <gitdir>/hooks.
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1
+#   powershell -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1 -Check
+
+[CmdletBinding()]
+param(
+    [switch]$Check
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot  = (Resolve-Path (Join-Path $scriptDir '..')).Path
+$srcDir    = Join-Path $scriptDir 'git-hooks'
+$hooksDir  = (& git -C $repoRoot rev-parse --git-common-dir).Trim()
+if (-not [System.IO.Path]::IsPathRooted($hooksDir)) {
+    $hooksDir = Join-Path $repoRoot $hooksDir
+}
+$hooksDir = Join-Path $hooksDir 'hooks'
+New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+
+$beginMark = '# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+$endMark   = '# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+
+function Get-MarkerBlock {
+    param([string]$Path)
+    $lines = Get-Content -LiteralPath $Path
+    $out = New-Object System.Collections.Generic.List[string]
+    $inBlock = $false
+    foreach ($line in $lines) {
+        if ($line -eq $beginMark) { $inBlock = $true }
+        if ($inBlock) { $out.Add($line) }
+        if ($line -eq $endMark) { $inBlock = $false }
+    }
+    return ($out -join "`n")
+}
+
+function Install-Hook {
+    param([string]$HookName)
+    $src = Join-Path $srcDir $HookName
+    $dst = Join-Path $hooksDir $HookName
+
+    if (-not (Test-Path -LiteralPath $src)) {
+        Write-Error "install-git-hooks: missing source $src"
+    }
+
+    $sourceBlock = Get-MarkerBlock -Path $src
+    if ([string]::IsNullOrWhiteSpace($sourceBlock)) {
+        Write-Error "install-git-hooks: source $src has no marker block"
+    }
+
+    if (-not (Test-Path -LiteralPath $dst)) {
+        if ($Check) {
+            Write-Error "install-git-hooks: $dst missing"
+        }
+        $newContent = @(
+            '#!/usr/bin/env sh',
+            "# $HookName — managed in part by scripts/install-git-hooks.ps1",
+            '',
+            $sourceBlock
+        ) -join "`n"
+        # LF line endings: hooks must be sh-friendly even on Windows.
+        [System.IO.File]::WriteAllText($dst, $newContent + "`n", (New-Object System.Text.UTF8Encoding $false))
+        Write-Output "install-git-hooks: installed $dst"
+        return
+    }
+
+    $existing = Get-Content -LiteralPath $dst -Raw
+    if ($existing -match [regex]::Escape($beginMark)) {
+        $existingBlock = Get-MarkerBlock -Path $dst
+        if ($existingBlock -eq $sourceBlock) {
+            if (-not $Check) {
+                Write-Output "install-git-hooks: $dst up to date"
+            }
+            return
+        }
+        if ($Check) {
+            Write-Error "install-git-hooks: $dst block out of date"
+        }
+        # Strip the existing block, then append the fresh one.
+        $stripped = [regex]::Replace(
+            $existing,
+            "(?ms)" + [regex]::Escape($beginMark) + ".*?" + [regex]::Escape($endMark) + "`r?`n?",
+            ''
+        )
+        $stripped = $stripped.TrimEnd("`r","`n") + "`n"
+        $newContent = $stripped + $sourceBlock + "`n"
+        [System.IO.File]::WriteAllText($dst, $newContent, (New-Object System.Text.UTF8Encoding $false))
+        Write-Output "install-git-hooks: refreshed $dst"
+        return
+    }
+
+    # No marker yet — append.
+    if ($Check) {
+        Write-Error "install-git-hooks: $dst block missing"
+    }
+    $stripped = $existing.TrimEnd("`r","`n") + "`n`n"
+    $newContent = $stripped + $sourceBlock + "`n"
+    [System.IO.File]::WriteAllText($dst, $newContent, (New-Object System.Text.UTF8Encoding $false))
+    Write-Output "install-git-hooks: appended block to $dst"
+}
+
+try {
+    Install-Hook -HookName 'post-merge'
+}
+catch {
+    if ($Check) {
+        Write-Output "`nRun scripts/install-git-hooks.ps1 (without -Check) to install."
+    }
+    throw
+}

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env sh
+# scripts/install-git-hooks.sh — install re-frame2 repo git hooks (rf2-6jj3r).
+#
+# Idempotent. Safe to run repeatedly. Co-exists with `bd hooks install`
+# (beads-managed segments use their own BEGIN/END BEADS INTEGRATION
+# markers; this script's segments use BEGIN/END re-frame2 markers and
+# never touch beads segments).
+#
+# Today this installs only `post-merge`, which warns when a `git pull`
+# brings down MCP-source changes that invalidate the local
+# tools/re-frame2-pair-mcp/out/server.js binary. Future re-frame2 repo
+# hooks register here.
+#
+# Usage:
+#   scripts/install-git-hooks.sh           # install/refresh
+#   scripts/install-git-hooks.sh --check   # exit 0 if installed & current, 1 otherwise
+#
+# Cross-platform: POSIX sh; runs under Git Bash on Windows, macOS, Linux.
+# Windows operators who prefer PowerShell can use the sibling
+# scripts/install-git-hooks.ps1.
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+SRC_DIR="$SCRIPT_DIR/git-hooks"
+
+# git stores hooks under <gitdir>/hooks; in worktrees that's the main
+# repo's hook dir (worktrees share core.hooksPath by default), so use
+# `git rev-parse --git-common-dir` to land in the right place.
+HOOKS_DIR=$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/hooks
+mkdir -p "$HOOKS_DIR"
+
+# Marker pair (must match what the hook source files carry).
+BEGIN_MARK='# --- BEGIN re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+END_MARK='# --- END re-frame2 MCP-staleness check (rf2-6jj3r) ---'
+
+MODE="install"
+if [ $# -gt 0 ] && [ "$1" = "--check" ]; then
+  MODE="check"
+fi
+
+install_hook() {
+  hook_name="$1"
+  src="$SRC_DIR/$hook_name"
+  dst="$HOOKS_DIR/$hook_name"
+
+  if [ ! -f "$src" ]; then
+    printf 'install-git-hooks: missing source %s\n' "$src" >&2
+    return 1
+  fi
+
+  # Extract just the marker block from src (POSIX sed; portable).
+  block=$(sed -n "/$BEGIN_MARK/,/$END_MARK/p" "$src")
+  if [ -z "$block" ]; then
+    printf 'install-git-hooks: source %s has no marker block\n' "$src" >&2
+    return 1
+  fi
+
+  if [ ! -f "$dst" ]; then
+    case "$MODE" in
+      check)
+        printf 'install-git-hooks: %s missing\n' "$dst" >&2
+        return 1
+        ;;
+      install)
+        # fresh file: shebang + block.
+        {
+          printf '#!/usr/bin/env sh\n'
+          printf '# %s — managed in part by scripts/install-git-hooks.sh\n' "$hook_name"
+          printf '\n'
+          printf '%s\n' "$block"
+        } > "$dst"
+        chmod +x "$dst"
+        printf 'install-git-hooks: installed %s\n' "$dst"
+        return 0
+        ;;
+    esac
+  fi
+
+  # Existing file: replace our block in place if present, else append.
+  if grep -Fq "$BEGIN_MARK" "$dst"; then
+    # Replace block between markers.
+    current=$(sed -n "/$BEGIN_MARK/,/$END_MARK/p" "$dst")
+    if [ "$current" = "$block" ]; then
+      [ "$MODE" = "install" ] && printf 'install-git-hooks: %s up to date\n' "$dst"
+      return 0
+    fi
+    case "$MODE" in
+      check)
+        printf 'install-git-hooks: %s block out of date\n' "$dst" >&2
+        return 1
+        ;;
+      install)
+        tmp=$(mktemp "${TMPDIR:-/tmp}/rf2-hook-XXXXXX")
+        block_file=$(mktemp "${TMPDIR:-/tmp}/rf2-hook-block-XXXXXX")
+        printf '%s\n' "$block" > "$block_file"
+        # Strip the existing block (between markers, inclusive), then
+        # append the fresh block. Two passes keeps the logic clear and
+        # portable across BSD/GNU sed.
+        sed "/$BEGIN_MARK/,/$END_MARK/d" "$dst" > "$tmp"
+        cat "$block_file" >> "$tmp"
+        mv "$tmp" "$dst"
+        rm -f "$block_file"
+        chmod +x "$dst"
+        printf 'install-git-hooks: refreshed %s\n' "$dst"
+        return 0
+        ;;
+    esac
+  fi
+
+  # No marker yet — append.
+  case "$MODE" in
+    check)
+      printf 'install-git-hooks: %s block missing\n' "$dst" >&2
+      return 1
+      ;;
+    install)
+      {
+        printf '\n'
+        printf '%s\n' "$block"
+      } >> "$dst"
+      chmod +x "$dst"
+      printf 'install-git-hooks: appended block to %s\n' "$dst"
+      return 0
+      ;;
+  esac
+}
+
+rc=0
+install_hook post-merge || rc=$?
+
+if [ "$MODE" = "check" ] && [ "$rc" -ne 0 ]; then
+  printf '\nRun scripts/install-git-hooks.sh to install.\n' >&2
+fi
+
+exit "$rc"

--- a/skills/re-frame2-pair/references/mcp-transport.md
+++ b/skills/re-frame2-pair/references/mcp-transport.md
@@ -36,6 +36,31 @@ The server auto-discovers the nREPL port from (in order):
 3. `.shadow-cljs/nrepl.port`
 4. `.nrepl-port`
 
+## Stale-binary post-merge hook (rf2-6jj3r)
+
+When you work inside the re-frame2 source repo (rather than against a
+globally-installed npm release), the MCP binary lives at
+`tools/re-frame2-pair-mcp/out/server.js` and is rebuilt locally —
+`out/` is `.gitignore`d. After `git pull` brings down MCP source-side
+changes, the binary on disk is now stale; the running MCP server is
+still exec-ing the previous build. Symptoms are confusing
+(stale-fix-still-not-fixed; `:nrepl-port-not-found` after a port
+discovery improvement merged; …).
+
+Install the repo's git hooks once per clone so `git pull` warns when
+this happens:
+
+```bash
+scripts/install-git-hooks.sh
+# or, on Windows:
+powershell -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1
+```
+
+The hook is idempotent, advisory (it never blocks a pull), and prints
+the exact rebuild command + bounce hint when MCP source / build config
+changed in the pulled commits. Re-run to refresh after upstream hook
+edits.
+
 ## MCP tool reference (args)
 
 | MCP tool       | Args |

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -363,7 +363,31 @@ npm run stdio-roundtrip
 
 # Live-nREPL integration test (requires an nREPL running on $NREPL_TEST_PORT)
 NREPL_TEST_PORT=17777 node test/live-nrepl.js
+
+# Stale-binary post-merge hook tests (rf2-6jj3r)
+npm run test:post-merge-hook
 ```
+
+### Stale-binary post-merge hook (rf2-6jj3r)
+
+`out/server.js` is gitignored and rebuilt locally. After
+`git pull` brings down MCP source changes, the binary on disk is
+stale until you re-run `npm run build` AND bounce the MCP server in
+your host (typically by restarting Claude Code). To get a stderr
+warning automatically on every pull, install the repo's git hooks
+once per clone (from the repo root):
+
+```bash
+scripts/install-git-hooks.sh
+# or, on Windows / PowerShell:
+powershell -ExecutionPolicy Bypass -File scripts/install-git-hooks.ps1
+```
+
+Both installers are idempotent. The hook is advisory only — it never
+blocks `git pull`. Source lives at
+[`scripts/git-hooks/post-merge`](../../scripts/git-hooks/post-merge);
+the testable detection helper lives at
+[`scripts/git-hooks/lib/check-stale-mcp-binary.sh`](../../scripts/git-hooks/lib/check-stale-mcp-binary.sh).
 
 ## Implementation language
 

--- a/tools/re-frame2-pair-mcp/package.json
+++ b/tools/re-frame2-pair-mcp/package.json
@@ -21,6 +21,7 @@
     "stdio-roundtrip": "node test/stdio-roundtrip.js",
     "probe-mcp-path": "node bin/probe-mcp-path.cjs",
     "test:probe-mcp-path": "node test/probe-mcp-path-test.cjs",
+    "test:post-merge-hook": "node test/post-merge-hook-test.cjs",
     "test:roots-discovery-live": "node test/roots-discovery-live.js"
   },
   "dependencies": {

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -131,6 +131,30 @@ return shape. The real `~/.claude.json` is never read.
 
 Run with: `npm run test:probe-mcp-path` (or `node test/probe-mcp-path-test.cjs`).
 
+#### `post-merge-hook-test.cjs` — stale-binary post-merge hook (rf2-6jj3r)
+
+Unit + smoke tests for the repo's `post-merge` git hook (source lives
+under `scripts/git-hooks/`). The hook is pure POSIX sh (no CLJS source
+of truth), so its tests sit here as a `.cjs` sibling for the same
+reason as `probe-mcp-path-test.cjs`.
+
+Two layers:
+
+- **Unit** — dot-sources `scripts/git-hooks/lib/check-stale-mcp-binary.sh`
+  and pipes synthetic lists of changed file paths through
+  `check_stale_mcp_binary`. Asserts warning text appears only for
+  paths that fall inside an MCP source surface (the `src/` tree, the
+  build-config files `shadow-cljs.edn` / `deps.edn` / `package.json`)
+  and is silent otherwise.
+- **Smoke** — spins up a tiny temp git repo, stages the hook's
+  detection library at the expected relative path, sets `ORIG_HEAD`
+  to a prior commit, and runs `scripts/git-hooks/post-merge`
+  end-to-end. Asserts the warning fires for a real cross-MCP diff and
+  is silent for an unrelated diff.
+
+Run with: `npm run test:post-merge-hook` (or
+`node test/post-merge-hook-test.cjs`).
+
 ## Adding a new test — decision tree
 
 ```

--- a/tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs
+++ b/tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * Unit + smoke tests for the post-merge stale-MCP-binary hook (rf2-6jj3r).
+ *
+ * Two layers, both POSIX-portable so they run under Git Bash on Windows
+ * and native sh on macOS / Linux:
+ *
+ *   1.  **Unit** — invokes `scripts/git-hooks/lib/check-stale-mcp-binary.sh`
+ *       with synthetic stdin streams (lists of changed paths). Asserts the
+ *       warning text appears only when the inputs intersect the MCP source
+ *       surface and is silent otherwise. No git state is touched.
+ *
+ *   2.  **Smoke** — simulates `git pull` having just landed by setting
+ *       `ORIG_HEAD` to an arbitrary prior commit and running the hook
+ *       script directly. Asserts the warning fires for a real diff that
+ *       crosses an MCP source path, and is silent for a diff that doesn't.
+ *
+ * The probe-mcp-path-test.cjs sibling carries the .cjs precedent — the
+ * hook itself is a sh/Node-side artefact with no CLJS source of truth,
+ * so its tests live as .cjs siblings rather than under
+ * `re_frame2_pair_mcp/*_test.cljs`.
+ *
+ * Run with: node test/post-merge-hook-test.cjs
+ * Exit 0 = all-pass, 1 = any failure.
+ */
+
+'use strict';
+
+const fs       = require('fs');
+const os       = require('os');
+const path     = require('path');
+const child    = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const LIB_PATH  = path.join(REPO_ROOT, 'scripts', 'git-hooks', 'lib', 'check-stale-mcp-binary.sh');
+const HOOK_PATH = path.join(REPO_ROOT, 'scripts', 'git-hooks', 'post-merge');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assert(cond, label) {
+  if (cond) {
+    passed += 1;
+  } else {
+    failed += 1;
+    failures.push(label);
+  }
+}
+
+// Run a small POSIX-sh program with stdin. Returns {stdout, stderr, code}.
+function runSh(script, stdin) {
+  const res = child.spawnSync('sh', ['-c', script], {
+    input: stdin || '',
+    encoding: 'utf8',
+  });
+  return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status };
+}
+
+function runShFile(file, args, stdin, env) {
+  const res = child.spawnSync('sh', [file].concat(args || []), {
+    input: stdin || '',
+    encoding: 'utf8',
+    env: Object.assign({}, process.env, env || {}),
+  });
+  return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status };
+}
+
+// --- LAYER 1: unit tests for check-stale-mcp-binary.sh ---
+
+function runDetector(changedPaths) {
+  // dot-source the lib then call the function with stdin piped in.
+  const script = '. ' + JSON.stringify(LIB_PATH) + ' && check_stale_mcp_binary';
+  return runSh(script, changedPaths);
+}
+
+// Case A: MCP source changed → warning fires.
+{
+  const r = runDetector(
+    'tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs\n' +
+    'docs/guide/26-config.md\n'
+  );
+  assert(r.code === 0,                                                  'A: exit 0');
+  assert(r.stdout === '',                                               'A: no stdout');
+  assert(/re-frame2-pair-mcp: source changed/.test(r.stderr),           'A: warning header');
+  assert(/server\.cljs/.test(r.stderr),                                 'A: lists the changed file');
+  assert(/npm --prefix tools\/re-frame2-pair-mcp run build/.test(r.stderr),
+                                                                        'A: prints rebuild command');
+  assert(/Restart Claude Code/.test(r.stderr),                          'A: prints bounce hint');
+}
+
+// Case B: only non-MCP paths → silent.
+{
+  const r = runDetector(
+    'docs/guide/26-config.md\n' +
+    'tools/xray/src/foo.cljs\n' +
+    'implementation/core/src/re_frame/views.cljs\n'
+  );
+  assert(r.code === 0,        'B: exit 0');
+  assert(r.stdout === '',     'B: no stdout');
+  assert(r.stderr === '',     'B: no warning');
+}
+
+// Case C: empty stdin → silent.
+{
+  const r = runDetector('');
+  assert(r.code === 0,        'C: exit 0');
+  assert(r.stderr === '',     'C: no warning on empty input');
+}
+
+// Case D: shadow-cljs.edn touched → warns.
+{
+  const r = runDetector('tools/re-frame2-pair-mcp/shadow-cljs.edn\n');
+  assert(r.code === 0,                                                  'D: exit 0');
+  assert(/source changed/.test(r.stderr),                               'D: warning fires for shadow-cljs.edn');
+  assert(/shadow-cljs\.edn/.test(r.stderr),                             'D: lists the changed file');
+}
+
+// Case E: deps.edn touched → warns.
+{
+  const r = runDetector('tools/re-frame2-pair-mcp/deps.edn\n');
+  assert(r.code === 0,                            'E: exit 0');
+  assert(/source changed/.test(r.stderr),         'E: warning fires for deps.edn');
+}
+
+// Case F: package.json touched → warns.
+{
+  const r = runDetector('tools/re-frame2-pair-mcp/package.json\n');
+  assert(r.code === 0,                            'F: exit 0');
+  assert(/source changed/.test(r.stderr),         'F: warning fires for package.json');
+}
+
+// Case G: README under MCP dir → silent (out-of-scope path).
+{
+  const r = runDetector('tools/re-frame2-pair-mcp/README.md\n');
+  assert(r.code === 0,        'G: exit 0');
+  assert(r.stderr === '',     'G: README change must not trigger');
+}
+
+// Case H: test/ under MCP dir → silent (test-only edits don't restage the binary).
+{
+  const r = runDetector('tools/re-frame2-pair-mcp/test/stdio-roundtrip.js\n');
+  assert(r.code === 0,        'H: exit 0');
+  assert(r.stderr === '',     'H: test-only edit must not trigger');
+}
+
+// Case I: multiple MCP source files → one warning block, lists all.
+{
+  const r = runDetector(
+    'tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs\n' +
+    'tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs\n'
+  );
+  assert(r.code === 0,                                              'I: exit 0');
+  const headerCount = (r.stderr.match(/source changed/g) || []).length;
+  assert(headerCount === 1,                                         'I: single header for multiple source files');
+  assert(/server\.cljs/.test(r.stderr) && /tools\.cljs/.test(r.stderr),
+                                                                    'I: both files listed');
+}
+
+// Case J: prefix collision guard — `tools/re-frame2-pair-mcp-fake/src/foo.cljs`
+//        must NOT trigger (the prefix gate ends with a `/`).
+{
+  const r = runDetector('tools/re-frame2-pair-mcp-fake/src/foo.cljs\n');
+  assert(r.code === 0,        'J: exit 0');
+  assert(r.stderr === '',     'J: lookalike prefix must not trigger');
+}
+
+// --- LAYER 2: smoke test of the hook against a synthetic ORIG_HEAD ---
+
+// Build a tiny disposable git repo and run the hook against simulated
+// pre/post pull states. This proves the hook's wiring (rev-parse ORIG_HEAD,
+// diff --name-only, lib resolution) works end-to-end without touching the
+// surrounding repo's HEAD.
+
+function mkTempRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rf2-post-merge-hook-test-'));
+  // We need git operations and a worktree that LOOKS like the re-frame2
+  // repo to the hook (it `rev-parse --show-toplevel`s then reads
+  // scripts/git-hooks/lib/check-stale-mcp-binary.sh relative to that).
+  // Strategy: init a temp repo, then SYMLINK / copy the hook's lib into
+  // it at the expected relative path.
+  child.spawnSync('git', ['init', '-q', dir], { stdio: 'inherit' });
+  child.spawnSync('git', ['-C', dir, 'config', 'user.email', 't@t'], { stdio: 'inherit' });
+  child.spawnSync('git', ['-C', dir, 'config', 'user.name',  't'  ], { stdio: 'inherit' });
+  child.spawnSync('git', ['-C', dir, 'config', 'commit.gpgsign', 'false'], { stdio: 'inherit' });
+
+  // Bring the lib in at the same relative path the hook reads.
+  const libDest = path.join(dir, 'scripts', 'git-hooks', 'lib', 'check-stale-mcp-binary.sh');
+  fs.mkdirSync(path.dirname(libDest), { recursive: true });
+  fs.copyFileSync(LIB_PATH, libDest);
+  return dir;
+}
+
+function gitIn(dir, args, input) {
+  return child.spawnSync('git', ['-C', dir].concat(args), {
+    encoding: 'utf8', input: input || '',
+  });
+}
+
+function writeFile(dir, rel, content) {
+  const fp = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content);
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) { /* ignore */ }
+}
+
+// Smoke A: real diff that crosses MCP source → hook warns.
+{
+  const dir = mkTempRepo();
+  try {
+    // Pre-pull commit: a non-MCP file.
+    writeFile(dir, 'README.md', 'r0\n');
+    gitIn(dir, ['add', '.']);
+    gitIn(dir, ['commit', '-qm', 'r0']);
+
+    // Capture pre-pull head into ORIG_HEAD via plumbing — git writes
+    // ORIG_HEAD on real merges; we set it directly here.
+    const origHead = gitIn(dir, ['rev-parse', 'HEAD']).stdout.trim();
+    fs.writeFileSync(path.join(dir, '.git', 'ORIG_HEAD'), origHead + '\n');
+
+    // Post-pull commit: MCP source changed.
+    writeFile(dir, 'tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs',
+              '(ns re-frame2-pair-mcp.server)\n');
+    gitIn(dir, ['add', '.']);
+    gitIn(dir, ['commit', '-qm', 'mcp-fix']);
+
+    const r = runShFile(HOOK_PATH, [], '', { GIT_WORK_TREE: dir, GIT_DIR: path.join(dir, '.git') });
+    // Hook prints to stderr from the dir-relative repo root; we ran it
+    // with GIT_DIR/GIT_WORK_TREE so rev-parse --show-toplevel resolves
+    // inside the temp repo and finds the lib we staged there.
+    assert(r.code === 0,                                              'Smoke A: hook exit 0');
+    assert(/re-frame2-pair-mcp: source changed/.test(r.stderr),       'Smoke A: warning fires on real diff');
+    assert(/server\.cljs/.test(r.stderr),                             'Smoke A: warning names the file');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Smoke B: real diff that does NOT cross MCP source → hook silent.
+{
+  const dir = mkTempRepo();
+  try {
+    writeFile(dir, 'README.md', 'r0\n');
+    gitIn(dir, ['add', '.']);
+    gitIn(dir, ['commit', '-qm', 'r0']);
+
+    const origHead = gitIn(dir, ['rev-parse', 'HEAD']).stdout.trim();
+    fs.writeFileSync(path.join(dir, '.git', 'ORIG_HEAD'), origHead + '\n');
+
+    writeFile(dir, 'docs/guide/26-config.md', 'docs change\n');
+    gitIn(dir, ['add', '.']);
+    gitIn(dir, ['commit', '-qm', 'docs-only']);
+
+    const r = runShFile(HOOK_PATH, [], '', { GIT_WORK_TREE: dir, GIT_DIR: path.join(dir, '.git') });
+    assert(r.code === 0,                                              'Smoke B: hook exit 0');
+    assert(r.stderr === '',                                           'Smoke B: hook silent on docs-only diff');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// Smoke C: no ORIG_HEAD set → hook silent (no false positives on
+// unusual merge / rebase flows where ORIG_HEAD isn't written).
+{
+  const dir = mkTempRepo();
+  try {
+    writeFile(dir, 'README.md', 'r0\n');
+    gitIn(dir, ['add', '.']);
+    gitIn(dir, ['commit', '-qm', 'r0']);
+
+    // Deliberately do NOT write .git/ORIG_HEAD.
+    const r = runShFile(HOOK_PATH, [], '', { GIT_WORK_TREE: dir, GIT_DIR: path.join(dir, '.git') });
+    assert(r.code === 0,        'Smoke C: hook exit 0');
+    assert(r.stderr === '',     'Smoke C: hook silent without ORIG_HEAD');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// --- summary ---
+
+const total = passed + failed;
+process.stdout.write(`post-merge-hook-test: ${passed}/${total} passed\n`);
+if (failed > 0) {
+  process.stderr.write('\nFailures:\n');
+  for (const f of failures) {
+    process.stderr.write('  - ' + f + '\n');
+  }
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## What

A `post-merge` git hook that prints a clear stderr warning when a `git pull` brings down source-side changes for the re-frame2-pair MCP server — whose compiled binary `tools/re-frame2-pair-mcp/out/server.js` is gitignored and rebuilt locally. Without this hook, pulled MCP fixes are silently inert until the operator manually rebuilds and bounces the MCP server.

Originally surfaced in the pair-debug session 2026-05-25 after rf2-umoz2 (#2105) + rf2-3grub (#2109) merged but the binary on disk hadn't been rebuilt; tool calls failed with stale-fix symptoms.

## Approach (A from the bead's four options)

Mike's recommendation in the bead is **A: warning hook**, not B (auto-build → JVM cold-start tax on every pull), C (in-server staleness check → too much logic inside the MCP for marginal gain), or D (docs only → status quo).

The hook is **advisory** — never blocks `git pull`. It diffs `ORIG_HEAD..HEAD` (set by `git merge`, which is what `git pull` invokes), matches against the MCP-source surface, and prints to stderr if any path falls inside it.

## Files

| Path | What |
|---|---|
| `scripts/git-hooks/post-merge` | The hook — POSIX sh, marker-delimited block. |
| `scripts/git-hooks/lib/check-stale-mcp-binary.sh` | Testable detection helper. Adding a new MCP surface = one stanza here. |
| `scripts/install-git-hooks.sh` | POSIX installer. |
| `scripts/install-git-hooks.ps1` | Windows / PowerShell installer (same behaviour). |
| `tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs` | 34 assertions — unit (lib in isolation) + smoke (hook end-to-end against a temp git repo). |

## Install mechanism

Both `scripts/install-git-hooks.sh` (POSIX, runnable under Git Bash on Windows) and `scripts/install-git-hooks.ps1` (PowerShell on Windows) install into `<git-common-dir>/hooks/post-merge` with BEGIN/END re-frame2 markers around our block.

Both installers are **idempotent** and **block-aware**:

- Fresh install — writes shebang + block.
- Re-install when block exists — replaces between markers in place.
- File exists with other content (e.g. `bd hooks install` has written its `BEADS INTEGRATION` block) — appends our block, leaving the beads block untouched. Verified live by running `bd hooks install` → `scripts/install-git-hooks.sh` → re-running both; both blocks coexist, both fire on `post-merge`.
- `--check` / `-Check` mode — exits 0 when the installed block matches the source, non-zero otherwise; suitable for a CI preflight if Mike wants to wire one later.

Worktrees share `core.hooksPath` via `git rev-parse --git-common-dir`, so installing from any worktree lands the hook in the right place.

## Cross-platform notes

- The hook itself is **POSIX sh** with no bashisms (`[` not `[[`, no arrays, no `<<<`); runs identically under Git Bash on Windows, native sh on macOS, dash on Linux.
- `*.sh text eol=lf` already in `.gitattributes` — LF endings stable across platforms.
- The installer wears two hats (sh + PowerShell) so operators on Windows who don't have Git Bash open can install from PS too.
- The Node test runner spawns `sh -c …` for the unit layer and `sh <hook>` for the smoke layer; both rely only on Git's bundled `sh.exe` on Windows.

## Tests

`tools/re-frame2-pair-mcp/test/post-merge-hook-test.cjs` — wired as `npm run test:post-merge-hook` in the MCP package. 34 assertions:

- **Unit (cases A-J)** — pipe synthetic newline-separated diff inputs through the detection helper; assert warning vs silence across: MCP src (`server.cljs`), shadow-cljs.edn, deps.edn, package.json (warn); README, test/, docs, xray src, empty input, prefix collision (`tools/re-frame2-pair-mcp-fake/…`) (silent); plus multi-file aggregation (one header block, both files listed).
- **Smoke (cases A-C)** — spin up a tiny temp git repo, copy the lib in at the expected relative path, set `.git/ORIG_HEAD`, run the hook end-to-end:
  - A — real diff crossing MCP source → warning fires, names the file.
  - B — docs-only diff → silent.
  - C — no ORIG_HEAD → silent (defensive for unusual merge / rebase flows).

The test file follows the existing `probe-mcp-path-test.cjs` precedent for pure-Node tests with no CLJS source of truth (documented in `tools/re-frame2-pair-mcp/test/README.md`).

## Live verification

- `ORIG_HEAD=HEAD~10` (covers MCP src changes across rf2-umoz2 + rf2-3grub + rf2-rzex9): hook fires with the warning block, lists `nrepl.cljs`, `roots_discovery.cljs`, `server.cljs`, `package.json`, prints the rebuild command + bounce hint.
- `ORIG_HEAD=HEAD~1` (diff is `.beads/issues.jsonl` only): hook silent.
- Idempotency: `sh scripts/install-git-hooks.sh && sh scripts/install-git-hooks.sh --check` → both exit 0; second install reports `up to date`.

## Docs

- `tools/re-frame2-pair-mcp/README.md` — new "Stale-binary post-merge hook" subsection under Development.
- `tools/re-frame2-pair-mcp/test/README.md` — new entry in the test-layering decision tree.
- `skills/re-frame2-pair/references/mcp-transport.md` — install instructions next to the MCP-server install steps.

Bead: rf2-6jj3r.
