### PR TITLE
feat(xray): focused-transition lens panel + remove stale blue border-left (2 beads incl. rf2-2n34o)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs
@@ -1655,7 +1655,12 @@
   lifecycle status dot + event-id + `epoch #N` + SSR badge) is removed;
   the film-strip header is a future MVP item, not the current chrome.
 
-  The stripe (mode `:accent`) sits on the outer container per §17.1.3."
+  ## No accent stripe (rf2-cjdw3)
+
+  The 3px `:accent` border-left that previously hugged the cascade's
+  outer container has been removed — it was a stale visual affordance
+  from before the focus-feature retirement (#2091) / Figma re-skin
+  (#2089), not in the current Figma authority."
   [{:keys [dispatch-id frame event] :as cascade}]
   (let [event-id    (when (vector? event) (first event))
         meta        (when event-id (rf/handler-meta :event event-id))
@@ -1686,11 +1691,7 @@
         present    (filterv (fn [[_ _ body]] (some? body)) candidates)]
     [:div {:data-testid "rf-xray-event-detail-cascade"
            :data-dispatch-id (str dispatch-id)
-           :data-frame (str frame)
-           ;; §17.1.3 / spec/022 — Event panel header stripe is the
-           ;; single :accent (GitHub blue). No top ribbon (rf2-ad7zx.17):
-           ;; the panel leads with the numbered pipeline.
-           :style {:border-left (str "3px solid " (:accent tokens))}}
+           :data-frame (str frame)}
 
      ;; Numbered vertical-flow pipeline body. A thin vertical RAIL runs
      ;; through the CENTRE of the numbered step circles (rf2-ad7zx.17,

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector.cljs
@@ -56,7 +56,7 @@
              :as t
              :refer [tokens mono-stack sans-stack display-stack]]))
 
-;; ---- guards + actions lists --------------------------------------------
+;; ---- safe-name helper ---------------------------------------------------
 
 (defn- safe-name
   "Render `x` to a string suitable for `data-testid` suffixes. Belt-and-
@@ -71,95 +71,207 @@
     (string? x)                       x
     :else                             (str x)))
 
-(defn- guards-list
-  "Render the per-transition Guards section. Empty list = no surface
-  (silent-by-default per rf2-g3ghh)."
-  [guards]
-  (when (seq guards)
-    [:div {:data-testid "rf-xray-machine-focused-event-guards"
-           :style {:padding "8px 12px"
-                   :background (:bg-1 tokens)
-                   :border-top (str "1px solid " (:border-subtle tokens))}}
-     [:div {:style {:color (:text-tertiary tokens)
-                    :font-family sans-stack
-                    :font-size "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :margin-bottom "4px"}}
-      "Guards"]
-     (into [:ul {:style {:list-style "none"
-                         :margin 0
-                         :padding 0
-                         :font-family mono-stack
-                         :font-size "11px"
-                         :color (:text-primary tokens)}}]
-           (for [{:keys [guard-id input outcome]} guards]
-             ^{:key (str guard-id)}
-             [:li {:data-testid (str "rf-xray-machine-focused-event-guard-"
-                                     (safe-name guard-id))
-                   :style {:display "flex"
-                           :align-items "center"
-                           :gap "8px"
-                           :padding "2px 0"}}
-              [:span {:style {:color (case outcome
-                                       :pass (:green tokens)
-                                       :fail (:red tokens)
-                                       (:text-tertiary tokens))
-                              :font-weight 600}}
-               (case outcome :pass "✓" :fail "✗" "?")]
-              [:span (str guard-id)]
-              (when input
-                [:span {:style {:color (:text-tertiary tokens)}}
-                 (pr-str input)])]))]))
+;; ---- focused-transition lens (rf2-2n34o · spec/003 §Focused-transition lens) -----
+;;
+;; The lens is the above-chart forensic block specified in
+;; spec/003-Machine-Inspector.md §Focused-transition lens (rf2-99rhe).
+;; It renders the EXACT shape:
+;;
+;;   Target Machine Instance: :title/flow-instance-42
+;;   TRANSITION
+;;     idle → loading
+;;   GUARDS RUN
+;;     :token?
+;;       (fn [data] (get-in data [:session :token]))
+;;       → return true
+;;   ACTIONS RUN
+;;     :fetch!
+;;       (fn [data] {:fx [[:dispatch [:loading/complete]]]})
+;;       → :fx :dispatch → [:loading/complete]
+;;
+;; Data sources (all available post-rf2-ypu5i, rf2-99rhe, rf2-8og3k):
+;;   - target instance id + from→to: `:rf.machine/transition` tags
+;;   - guard id + return: `:rf.machine/guard-evaluated` tags
+;;   - guard / action fn-source: `(rf/handler-meta :machine-guard / :machine-action ...)`
+;;   - action id + `:fx` output: `:rf.machine/action-ran` tags `:outcome`
+;;
+;; Dynamic-mode constraint (rf2-8og3k): the lens binds to EXACTLY ONE
+;; instance — the first transition record in trace order (the upstream
+;; projection already sorts cascade-document-order, so `first` is the
+;; tiebreaker). When no machine transitioned, the panel renders only the
+;; verbatim empty-state placeholder (see `blank-state`).
 
-(defn- actions-list
-  "Render the per-transition Actions section. Empty list = no surface."
-  [actions]
-  (when (seq actions)
-    [:div {:data-testid "rf-xray-machine-focused-event-actions"
-           :style {:padding "8px 12px"
-                   :background (:bg-1 tokens)
-                   :border-top (str "1px solid " (:border-subtle tokens))}}
-     [:div {:style {:color (:text-tertiary tokens)
-                    :font-family sans-stack
-                    :font-size "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :margin-bottom "4px"}}
-      "Actions"]
-     (into [:ul {:style {:list-style "none"
-                         :margin 0
-                         :padding 0
-                         :font-family mono-stack
-                         :font-size "11px"
-                         :color (:text-primary tokens)}}]
-           (for [{:keys [action-id input outcome]} actions]
-             ^{:key (str action-id)}
-             [:li {:data-testid (str "rf-xray-machine-focused-event-action-"
-                                     (safe-name action-id))
-                   :style {:display "flex"
-                           :align-items "center"
-                           :gap "8px"
-                           :padding "2px 0"}}
-              [:span {:style {:color (case outcome
-                                       :ok   (:green tokens)
-                                       :fail (:red tokens)
-                                       (:text-tertiary tokens))
-                              :font-weight 600}}
-               (case outcome :ok "✓" :fail "✗" "•")]
-              [:span (str action-id)]
-              (when input
-                [:span {:style {:color (:text-tertiary tokens)}}
-                 (pr-str input)])]))]))
+(defn- fn-source-line
+  "Render the captured fn-source string under a guard / action id, or a
+  muted fallback when production-elision dropped it (Spec 005
+  §`reg-machine` / `reg-machine*`: programmatic registrations carry no
+  source). The string is intentionally rendered raw — no syntax
+  highlighting at v1, matching the spec's plain monospace treatment."
+  [source]
+  [:div {:style {:padding-left "16px"
+                 :color (if source (:text-secondary tokens) (:text-tertiary tokens))
+                 :font-style (when-not source "italic")
+                 :font-family mono-stack
+                 :font-size "11px"
+                 :line-height 1.5
+                 :white-space "pre-wrap"
+                 :word-break "break-word"}}
+   (or source "(fn source unavailable)")])
+
+(defn- dispatch-vectors-from-fx
+  "Extract `[:dispatch <event>]` entries from an action's returned
+  `{:fx [...]}` map. Returns a vector of event-vectors (possibly empty).
+  Tolerates `nil`, non-map outcomes, or :fx vectors carrying non-dispatch
+  fx entries (those are skipped)."
+  [outcome]
+  (let [fx (when (map? outcome) (:fx outcome))]
+    (->> (or fx [])
+         (keep (fn [entry]
+                 (when (and (vector? entry)
+                            (= :dispatch (first entry)))
+                   (second entry))))
+         vec)))
+
+(defn- lens-guard-block
+  "Render one guard's block inside the lens GUARDS RUN section:
+
+       :guard-id
+         (fn source)
+         → return <pass|fail>"
+  [machine-id {:keys [guard-id outcome]}]
+  (let [m       (try (rf/handler-meta :machine-guard [machine-id guard-id])
+                     (catch :default _ nil))
+        source  (:rf.handler/source m)
+        return  (case outcome
+                  :pass "true"
+                  :fail "false"
+                  (when (some? outcome) (pr-str outcome)))]
+    [:div {:data-testid (str "rf-xray-machine-lens-guard-"
+                             (safe-name guard-id))
+           :data-guard-id (str guard-id)
+           :data-outcome (when outcome (name outcome))
+           :style {:font-family mono-stack
+                   :font-size "12px"
+                   :color (:text-primary tokens)
+                   :margin "2px 0"}}
+     [:div {:style {:padding-left "16px"
+                    :color (:magenta tokens)}}
+      (str guard-id)]
+     (fn-source-line source)
+     (when return
+       [:div {:style {:padding-left "16px"
+                      :color (:info tokens)}}
+        (str "→ return " return)])]))
+
+(defn- lens-action-block
+  "Render one action's block inside the lens ACTIONS RUN section:
+
+       :action-id
+         (fn source)
+         → :fx :dispatch → [<dispatch-vec>]
+
+  The trailing dispatch lines surface child-cascade `:dispatch` entries
+  pulled from the action's returned `{:fx [...]}` map. When no `:fx
+  :dispatch` fired, the arrow line is suppressed."
+  [machine-id {:keys [action-id outcome]}]
+  (let [m         (try (rf/handler-meta :machine-action [machine-id action-id])
+                       (catch :default _ nil))
+        source    (:rf.handler/source m)
+        dispatches (dispatch-vectors-from-fx outcome)]
+    [:div {:data-testid (str "rf-xray-machine-lens-action-"
+                             (safe-name action-id))
+           :data-action-id (str action-id)
+           :data-dispatch-count (str (count dispatches))
+           :style {:font-family mono-stack
+                   :font-size "12px"
+                   :color (:text-primary tokens)
+                   :margin "2px 0"}}
+     [:div {:style {:padding-left "16px"
+                    :color (:magenta tokens)}}
+      (str action-id)]
+     (fn-source-line source)
+     (into [:<>]
+           (for [[idx ev] (map-indexed vector dispatches)]
+             ^{:key idx}
+             [:div {:data-testid (str "rf-xray-machine-lens-action-dispatch-"
+                                      (safe-name action-id) "-" idx)
+                    :style {:padding-left "16px"
+                            :color (:info tokens)}}
+              (str "→ :fx :dispatch → " (pr-str ev))]))]))
+
+(defn- focused-transition-lens
+  "The above-chart forensic lens per spec/003 §Focused-transition lens.
+  Reads `record` (the focused transition, picked via
+  `h/pick-focused-transition` — see Dynamic-mode rule, rf2-8og3k) and
+  renders the Target Machine Instance / TRANSITION / GUARDS RUN /
+  ACTIONS RUN block in the normative order. Pure hiccup — fn-source is
+  resolved via `rf/handler-meta` which is a pure registrar lookup."
+  [{:keys [machine-id from-state to-state guards actions]}]
+  [:div {:data-testid "rf-xray-machine-focused-transition-lens"
+         :data-machine-id (str machine-id)
+         :data-guard-count (str (count guards))
+         :data-action-count (str (count actions))
+         :style {:padding "12px 14px"
+                 :background (:bg-1 tokens)
+                 :border-bottom (str "1px solid " (:border-subtle tokens))
+                 :font-family mono-stack
+                 :font-size "12px"
+                 :color (:text-primary tokens)
+                 :line-height 1.55}}
+   [:div {:data-testid "rf-xray-machine-lens-target-instance"
+          :style {:margin-bottom "6px"}}
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "Target Machine Instance: "]
+    [:span {:style {:color (:magenta tokens)}}
+     (h/format-machine-id machine-id)]]
+   [:div {:data-testid "rf-xray-machine-lens-transition"
+          :style {:margin "4px 0"}}
+    [:div {:style {:color (:text-tertiary tokens)
+                   :text-transform "uppercase"
+                   :font-size "10px"
+                   :letter-spacing "0.5px"}}
+     "Transition"]
+    [:div {:style {:padding-left "16px"}}
+     [:span {:style {:color (:text-secondary tokens)}}
+      (h/format-state from-state)]
+     [:span {:style {:color (:accent tokens) :margin "0 6px"}} "→"]
+     [:span {:style {:color (:text-primary tokens) :font-weight 600}}
+      (h/format-state to-state)]]]
+   (when (seq guards)
+     [:div {:data-testid "rf-xray-machine-lens-guards-run"
+            :style {:margin "4px 0"}}
+      [:div {:style {:color (:text-tertiary tokens)
+                     :text-transform "uppercase"
+                     :font-size "10px"
+                     :letter-spacing "0.5px"}}
+       "Guards Run"]
+      (into [:div]
+            (for [g guards]
+              ^{:key (str (:guard-id g))}
+              (lens-guard-block machine-id g)))])
+   (when (seq actions)
+     [:div {:data-testid "rf-xray-machine-lens-actions-run"
+            :style {:margin "4px 0"}}
+      [:div {:style {:color (:text-tertiary tokens)
+                     :text-transform "uppercase"
+                     :font-size "10px"
+                     :letter-spacing "0.5px"}}
+       "Actions Run"]
+      (into [:div]
+            (for [a actions]
+              ^{:key (str (:action-id a))}
+              (lens-action-block machine-id a)))])])
 
 ;; ---- per-machine focused-event section ---------------------------------
 
 (defn- focused-event-section
-  "Render one section per transitioned machine. Header → chart →
-  guards → actions → cancellation cascade (inline) → after-rings
-  overlay (on the chart)."
+  "Render one section per transitioned machine. Lens (above the chart,
+  rf2-2n34o) → header → chart → cancellation cascade (inline) →
+  after-rings overlay (on the chart). Guards / actions detail lives
+  in the lens, not in a separate strip below the chart."
   [{:keys [machine-id from-state to-state on-event event microstep?
-           definition guards actions fired-edge-ids]}]
+           definition fired-edge-ids]
+    :as record}]
   ;; rf2-gpzb4 (2026-05-21 xyflow migration) — the host-side ELK
   ;; layout dance (layout-or-fallback / ensure-elk! / compute-layout!)
   ;; is GONE. xyflow + elkjs now own positioning end-to-end inside
@@ -225,6 +337,11 @@
                         :font-size "11px"
                         :margin-left "auto"}}
          (h/format-event event)])]
+     ;; rf2-2n34o — focused-transition lens, ABOVE the chart per
+     ;; spec/003 §Focused-transition lens. The lens is the panel's
+     ;; forensic above-chart block; the chart below shows the same
+     ;; transition's topology.
+     (focused-transition-lens record)
      (cond
        (nil? definition)
        [:div {:data-testid "rf-xray-machine-focused-event-no-definition"
@@ -312,8 +429,11 @@
                                         :path       path}]
                                       {:frame :rf/xray}))
               :show-after-rings?  true}]])))
-     (guards-list guards)
-     (actions-list actions)
+     ;; rf2-2n34o — guards/actions detail lives in the
+     ;; `focused-transition-lens` ABOVE the chart (per spec/003
+     ;; §Focused-transition lens). The redundant ✓/✗ status strips
+     ;; that used to render below the chart are gone — single source of
+     ;; truth for the forensic block.
      ;; rf2-59e7k — Cancellation cascade inline (per machine). The
      ;; SidePanel reg-view short-circuits to nil when the focused
      ;; machine has no cancellation in the trace window, so the mount
@@ -369,58 +489,70 @@
 
 (defn- focused-event-view
   "Top-level focused-event lens. Reads the
-  `:rf.xray/machine-transitions-for-focused-event` composite sub.
-  Returns nil when no machine transitioned in the focused event's
-  cascade — the panel renders the blank state in that case."
+  `:rf.xray/machine-transitions-for-focused-event` composite sub and
+  binds the panel to **exactly one** machine instance per the
+  Dynamic-mode single-instance rule (rf2-8og3k): the first transition
+  record in trace order. Returns nil when no machine transitioned in
+  the focused event's cascade — the panel renders the empty-state
+  placeholder in that case (see `blank-state`)."
   []
   (let [records @(rf/subscribe
-                   [:rf.xray/machine-transitions-for-focused-event])]
-    (when (seq records)
-      (into [:div {:data-testid "rf-xray-machine-focused-event"
-                   :data-section-count (count records)
-                   ;; rf2-zdfbm — fill the focused-event host so each
-                   ;; per-machine section (`flex 1`) can grow its topology
-                   ;; chart into the panel's available height.
-                   :style {:display "flex"
-                           :flex-direction "column"
-                           :flex 1
-                           :min-height 0}}]
-            (for [rec records]
-              (with-meta (focused-event-section rec)
-                {:key (str (:machine-id rec) "-"
-                           (:id rec) "-"
-                           (:from-state rec) "-"
-                           (:to-state rec))}))))))
+                   [:rf.xray/machine-transitions-for-focused-event])
+        ;; Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
+        ;; single-instance, event-driven, rf2-8og3k): pick the first
+        ;; transition by trace order. The upstream projection already
+        ;; sorts cascade-document-order, so `first` is the tiebreaker.
+        record  (h/pick-focused-transition records)]
+    (when record
+      [:div {:data-testid "rf-xray-machine-focused-event"
+             ;; The host carries the count of records the cascade
+             ;; transitioned (1..N) but only the focused instance
+             ;; renders — pinned so tests can assert the rule (one
+             ;; section even when N > 1).
+             :data-section-count "1"
+             :data-cascade-transition-count (str (count records))
+             ;; rf2-zdfbm — fill the focused-event host so the section
+             ;; (`flex 1`) can grow its topology chart into the panel's
+             ;; available height.
+             :style {:display "flex"
+                     :flex-direction "column"
+                     :flex 1
+                     :min-height 0}}
+       (with-meta (focused-event-section record)
+         {:key (str (:machine-id record) "-"
+                    (:id record) "-"
+                    (:from-state record) "-"
+                    (:to-state record))})])))
 
 (defn- blank-state
   "Rendered when the focused event has no machine activity in its
-  cascade. The Dynamic Machines panel is **event-driven only** (Mike's
-  2026-05-19 redesign, panel docstring §4-15): it is silent-by-default
-  (rf2-g3ghh) when the focused event triggered no machine transition.
+  cascade. Per spec/003 §Empty state — focused event does not target a
+  state machine (rf2-8og3k) the panel renders ONLY the verbatim
+  placeholder text — no chart, no lens, no history ribbon, no machine
+  name, no instance picker, no hint. Just the single line:
 
-  This is a TRULY BLANK affordance — not a topology render. The earlier
-  rf2-t5wp9 (#1757) variant rendered one per-machine topology section
-  here, which contradicted the event-driven-only contract and produced
-  the inverted visibility bug (rf2-zdfbm): content surfaced on
-  non-machine events, drowning the panel's lens job. The most-recent-
-  known-state topology view belongs to the future Static Machines
-  surface (rf2-r4nao), not the Dynamic lens."
+      This event does not target a state machine
+
+  Visual treatment: centered in the panel viewport, body weight,
+  muted-foreground colour token per 007-UX-IA (matching the quiet
+  empty-state pattern other Xray panels use)."
   []
   [:div {:data-testid "rf-xray-machine-inspector-blank"
          :style {:padding "16px"
                  :color (:text-tertiary tokens)
                  :font-family sans-stack
-                 :font-size "13px"
+                 :font-size "14px"
                  :flex 1
                  :display "flex"
                  :flex-direction "column"
                  :align-items "center"
                  :justify-content "center"
                  :text-align "center"}}
-   [:p {:style {:margin "0 0 6px 0" :font-size "14px"}}
-    "No machine activity in the focused event."]
-   [:p {:style {:margin 0 :font-size "12px" :color (:text-tertiary tokens)}}
-    "Select an event that triggered a transition to inspect machines."]])
+   [:p {:data-testid "rf-xray-machine-inspector-blank-message"
+        :style {:margin 0
+                :font-weight 600
+                :color (:text-tertiary tokens)}}
+    h/empty-state-text]])
 
 ;; ---- empty state (no machines registered at all) -----------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_inspector_helpers.cljc
@@ -641,3 +641,36 @@
           ;; silent on what is really a buffer-eviction event.
           (peek history))
       :else (peek history))))
+
+;; ---- Dynamic-mode single-instance rule (rf2-8og3k, impl rf2-2n34o) ------
+;;
+;; Per spec/003-Machine-Inspector.md §Dynamic mode — single-instance,
+;; event-driven (rf2-8og3k): the Dynamic Machines panel binds to EXACTLY
+;; ONE machine instance per focused event, or to NONE. When the focused
+;; event's cascade transitioned multiple instances, the rule picks the
+;; FIRST transition trace by trace order (earliest `:rf.trace/at`;
+;; ties broken by trace-emission sequence within the same epoch).
+;;
+;; `project-focused-event-transitions` already sorts the records
+;; cascade-document-order (oldest-first by `:id` or `:time`), so the
+;; tiebreaker is satisfied by `first`. This helper exists to name the
+;; rule at the call site — the spec text "first by trace order" lands
+;; here, not buried in a `(first records)` call.
+
+(defn pick-focused-transition
+  "Pick the focused transition record per the Dynamic-mode single-
+  instance rule (spec/003 §Dynamic mode — single-instance, event-driven,
+  rf2-8og3k). Returns the FIRST record in trace order (which is what the
+  upstream projection already produces — this helper names the rule),
+  or nil when no machine transitioned in the focused event's cascade.
+
+  Pure fn — JVM-runnable."
+  [transition-records]
+  (first transition-records))
+
+(def empty-state-text
+  "The Dynamic Machines panel's empty-state placeholder text, rendered
+  verbatim per spec/003 §Empty state — focused event does not target a
+  state machine (rf2-8og3k). The string is the entire empty-state
+  content — no chart, no lens, no history ribbon."
+  "This event does not target a state machine")

--- a/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/event_detail_cljs_test.cljs
@@ -1573,12 +1573,13 @@
         (is (empty? label-strings)
             "no 'cascade #NNN' label appears anywhere in the rendered lens")))))
 
-(deftest cascade-container-carries-accent-stripe-per-section-17
-  (testing "rf2-zv9r9 / rf2-ad7zx — per spec/021 §17.1.3 + spec/022 the
-            Event panel identity stripe is the mode :accent (the single
-            GitHub blue). Rendered as a 3px left border on the outer
-            cascade container — it survives the top-ribbon removal
-            (rf2-ad7zx.17)."
+(deftest cascade-container-has-no-accent-stripe-rf2-cjdw3
+  (testing "rf2-cjdw3 — the 3px :accent border-left that previously
+            hugged the cascade root is GONE. It was a stale visual
+            affordance from before the focus-feature retirement
+            (#2091) / Figma re-skin (#2089), not in the current Figma
+            authority. The cascade container still mounts; just the
+            inline border-left is dropped."
     (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/xray
       (rf/dispatch-sync [:rf.xray/select-dispatch-id 100])
@@ -1586,10 +1587,8 @@
             cascade (find-by-testid tree "rf-xray-event-detail-cascade")
             border (get-in cascade [1 :style :border-left])]
         (is (some? cascade) "cascade container present")
-        (is (and (string? border)
-                 (str/includes? border "3px")
-                 (str/includes? border "solid"))
-            "stripe is a 3px solid left border")))))
+        (is (nil? border)
+            "no inline border-left on the cascade root (rf2-cjdw3)")))))
 
 ;; ---- (13) handler-source slot (rf2-xgfuy DEBUG-stamp consumer) --------
 

--- a/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/machine_inspector_view_cljs_test.cljs
@@ -15,6 +15,7 @@
   Same approach as every other Xray view test — walk the rendered
   hiccup tree by `data-testid` rather than mounting to the DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -308,9 +309,15 @@
         (is (= "idle"    (:data-from-highlight-id (second chart))))
         (is (= "authing" (:data-to-highlight-id   (second chart))))))))
 
-(deftest focused-event-lens-renders-multi-machine-cascade
-  (testing "a cascade triggering transitions across multiple machines
-            yields one section per machine, document-order"
+(deftest focused-event-lens-binds-to-first-machine-in-trace-order-rf2-8og3k
+  (testing "Dynamic-mode single-instance rule (spec/003 §Dynamic mode —
+            single-instance, event-driven, rf2-8og3k): when the focused
+            event's cascade transitioned multiple machine instances, the
+            panel binds to EXACTLY ONE — the first transition trace in
+            trace order (earliest `:rf.trace/at`; ties broken by
+            trace-emission sequence within the same epoch). The host
+            still records the cascade transition count so callers can
+            distinguish 'one transition' from 'first of N'."
     (setup-xray-frame!)
     (rf/with-frame :rf/xray
       (override-machines!    [:auth/login :checkout/flow :session/clock])
@@ -337,13 +344,200 @@
                    :event      [:tick] :rf.trace/dispatch-id "d-1"}}]}])
       (focus-epoch! 7)
       (let [tree     (machine-inspector/Panel)
+            host     (find-by-testid tree "rf-xray-machine-focused-event")
             sections (find-all-by-testid-prefix
                        tree "rf-xray-machine-focused-event-section-")]
-        (is (= 3 (count sections))
-            "three sections — one per transitioned machine")
-        (is (= [":auth/login" ":checkout/flow" ":session/clock"]
+        (is (some? host) "focused-event host mounts")
+        (is (= "1" (:data-section-count (second host)))
+            "exactly one section rendered (Dynamic-mode single-instance)")
+        (is (= "3" (:data-cascade-transition-count (second host)))
+            "cascade transition count is preserved on the host")
+        (is (= 1 (count sections))
+            "exactly one machine section — the trace-order tiebreaker winner")
+        (is (= [":auth/login"]
                (mapv #(:data-machine-id (second %)) sections))
-            "sections appear in cascade document order")))))
+            "the first-by-trace-order machine wins (lowest :id wins)")))))
+
+;; ---- (4b) focused-transition lens (rf2-2n34o · spec/003 §Focused-transition lens) -----
+
+(defn- register-machine-guard-meta! [machine-id guard-id source]
+  ;; Bypass `reg-machine` — register the handler-meta entry directly so
+  ;; the lens has data to render under JVM/Node tests without booting
+  ;; the `reg-machine` macro pipeline.
+  (registrar/register!
+    :machine-guard [machine-id guard-id]
+    {:rf/guard-id        guard-id
+     :rf/machine-id      machine-id
+     :rf.handler/source  source
+     :handler-fn         (fn [_] true)}))
+
+(defn- register-machine-action-meta! [machine-id action-id source]
+  (registrar/register!
+    :machine-action [machine-id action-id]
+    {:rf/action-id       action-id
+     :rf/machine-id      machine-id
+     :rf.handler/source  source
+     :handler-fn         (fn [_] nil)}))
+
+(deftest blank-state-renders-verbatim-empty-state-text-rf2-8og3k
+  (testing "spec/003 §Empty state — focused event does not target a state
+            machine (rf2-8og3k): the panel renders ONLY the verbatim
+            placeholder string when the focused event triggered no
+            transitions. No chart, no lens, no history ribbon — just
+            that one line."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (let [tree    (machine-inspector/Panel)
+            blank   (find-by-testid tree "rf-xray-machine-inspector-blank")
+            message (find-by-testid tree "rf-xray-machine-inspector-blank-message")]
+        (is (some? blank)  "blank-state container present")
+        (is (some? message) "verbatim message container present")
+        ;; The verbatim string per spec/003 §Empty state.
+        (is (= "This event does not target a state machine"
+               (last message))
+            "the empty-state surface renders the verbatim spec text")
+        ;; No lens, no chart, no history ribbon in the empty state.
+        (is (nil? (find-by-testid
+                    tree "rf-xray-machine-focused-transition-lens"))
+            "no lens in the empty state")
+        (is (nil? (find-by-testid tree "rf-xray-machine-focused-event-chart"))
+            "no chart in the empty state")))))
+
+(deftest lens-renders-target-instance-and-transition-rf2-2n34o
+  (testing "spec/003 §Focused-transition lens — rendered shape: the lens
+            block sits above the chart and carries Target Machine
+            Instance: + TRANSITION (from → to) lines."
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree   (machine-inspector/Panel)
+            lens   (find-by-testid tree "rf-xray-machine-focused-transition-lens")
+            target (find-by-testid tree "rf-xray-machine-lens-target-instance")
+            transition (find-by-testid tree "rf-xray-machine-lens-transition")]
+        (is (some? lens)        "the focused-transition lens mounts above the chart")
+        (is (= ":auth/login" (:data-machine-id (second lens))))
+        (is (some? target)      "Target Machine Instance: line present")
+        (is (some? transition)  "TRANSITION line present")))))
+
+(deftest lens-renders-guard-source-and-return-rf2-2n34o
+  (testing "spec/003 §Focused-transition lens — GUARDS RUN: id + fn-source
+            (from `rf/handler-meta :machine-guard`) + return value
+            rendered. The trace's `:rf.machine/guard-evaluated` event
+            carries the outcome :pass / :fail; the lens prints
+            `→ return true` / `→ return false`."
+    (setup-xray-frame!)
+    (register-machine-guard-meta! :auth/login :token?
+      "(fn [data] (get-in data [:session :token]))")
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
+           {:id 2 :time 11 :operation :rf.machine/guard-evaluated
+            :tags {:machine-id :auth/login :guard-id :token? :outcome :pass}}]}])
+      (focus-epoch! 1)
+      (let [tree    (machine-inspector/Panel)
+            guard   (find-by-testid tree "rf-xray-machine-lens-guard-token?")
+            guards-run (find-by-testid tree "rf-xray-machine-lens-guards-run")
+            hiccup-strs (->> guard flatten (filter string?) (str/join " "))]
+        (is (some? guards-run) "GUARDS RUN section present")
+        (is (some? guard) "guard block rendered for :token?")
+        (is (= "pass" (:data-outcome (second guard))))
+        (is (str/includes? hiccup-strs ":token?")
+            "guard id rendered")
+        (is (str/includes?
+              hiccup-strs "(fn [data] (get-in data [:session :token]))")
+            "guard fn-source rendered from handler-meta")
+        (is (str/includes? hiccup-strs "→ return true")
+            "return value rendered as `→ return true`")))))
+
+(deftest lens-renders-action-source-and-dispatch-follow-on-rf2-2n34o
+  (testing "spec/003 §Focused-transition lens — ACTIONS RUN: id + fn-source
+            + `:fx :dispatch → [<event>]` follow-on rendered. The action's
+            `:outcome` slot on the trace carries the returned `{:fx [...]}`
+            map; the lens extracts the `:dispatch` entries."
+    (setup-xray-frame!)
+    (register-machine-action-meta! :auth/login :fetch!
+      "(fn [data] {:fx [[:dispatch [:loading/complete]]]})")
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
+           {:id 2 :time 11 :operation :rf.machine/action-ran
+            :tags {:machine-id :auth/login
+                   :action-id :fetch!
+                   :outcome   {:fx [[:dispatch [:loading/complete]]]}}}]}])
+      (focus-epoch! 1)
+      (let [tree        (machine-inspector/Panel)
+            actions-run (find-by-testid tree "rf-xray-machine-lens-actions-run")
+            action      (find-by-testid tree "rf-xray-machine-lens-action-fetch!")
+            dispatch    (find-by-testid
+                          tree "rf-xray-machine-lens-action-dispatch-fetch!-0")
+            hiccup-strs (->> action flatten (filter string?) (str/join " "))]
+        (is (some? actions-run) "ACTIONS RUN section present")
+        (is (some? action) "action block rendered for :fetch!")
+        (is (= "1" (:data-dispatch-count (second action))))
+        (is (some? dispatch) "downstream :dispatch line rendered")
+        (is (str/includes? hiccup-strs ":fetch!"))
+        (is (str/includes?
+              hiccup-strs "(fn [data] {:fx [[:dispatch [:loading/complete]]]})")
+            "action fn-source rendered from handler-meta")
+        (is (str/includes?
+              hiccup-strs ":fx :dispatch → [:loading/complete]")
+            "downstream dispatch event rendered after `→ :fx :dispatch →`")))))
+
+(deftest lens-falls-back-to-placeholder-when-source-absent-rf2-2n34o
+  (testing "spec/003 §Focused-transition lens — when no handler-meta is
+            registered (programmatic `reg-machine*` path, or production-
+            elided), the lens renders a muted '(fn source unavailable)'
+            line instead of crashing."
+    (setup-xray-frame!)
+    ;; No register-machine-guard-meta! call — handler-meta returns nil.
+    (rf/with-frame :rf/xray
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :rf.trace/dispatch-id "d-1"}}
+           {:id 2 :time 11 :operation :rf.machine/guard-evaluated
+            :tags {:machine-id :auth/login :guard-id :token? :outcome :pass}}]}])
+      (focus-epoch! 1)
+      (let [tree  (machine-inspector/Panel)
+            guard (find-by-testid tree "rf-xray-machine-lens-guard-token?")
+            hiccup-strs (->> guard flatten (filter string?) (str/join " "))]
+        (is (some? guard) "guard block rendered without crashing")
+        (is (str/includes? hiccup-strs "(fn source unavailable)")
+            "muted fallback rendered when handler-meta is absent")))))
 
 ;; ---- (5) per-machine prev/next nav -------------------------------------
 


### PR DESCRIPTION
Shape-2 cluster — 2 beads, single PR, sequenced commits.

## Per-bead summary

- **rf2-cjdw3 (P3 fix)** — removes the 3px `:accent` (GitHub-blue) `border-left` on the cascade root container in `panels/event_detail.cljs`. Stale visual affordance from before the focus-feature retirement (#2091) / Figma re-skin (#2089); not in the current Figma authority. Mike observed live 2026-05-25. Companion test pinning the stripe is inverted to assert the border is now absent.

- **rf2-2n34o (P2 feat)** — implements the focused-transition lens panel specified in `tools/xray/spec/003-Machine-Inspector.md` §Focused-transition lens (rf2-99rhe), with the Dynamic-mode single-instance constraint from rf2-8og3k, using the core-side data path landed under rf2-ypu5i (`:rf/guard-id` + `:rf/action-id` + reg-machine handler-meta source).

## rf2-cjdw3 root cause

`tools/xray/src/day8/re_frame2_xray/panels/event_detail.cljs` carried this on the cascade outer container:

    :style {:border-left (str "3px solid " (:accent tokens))}

A stale identity-stripe (`§17.1.3` predecessor) that survived the spec/021 redraw. Removing the inline style drops the blue vertical line on the Handler tab without affecting structural reads — the pipeline body inside the cascade owns its own padding + rail.

## rf2-2n34o data sources

All confirmed available post-#2106 / #2107 / #2108:

- Target instance + from→to: `:rf.machine/transition` `:tags`.
- Guard id + return: `:rf.machine/guard-evaluated` `:tags {:guard-id … :outcome :pass|:fail}`.
- Action id + `:fx` output: `:rf.machine/action-ran` `:tags {:action-id … :outcome <fx-map>}`.
- Guard / action fn-source: `(rf/handler-meta :machine-guard [<machine-id> <guard-id>])` and the `:machine-action` sibling, returning `:rf.handler/source` per Spec 005 §`:machine-guard` / `:machine-action` handler-meta surfaces.
- Downstream `:dispatch [...]`: extracted from the action's returned `{:fx [[:dispatch …]]}` map (carried as `:outcome`).

## Dynamic-mode constraint (rf2-8og3k)

The panel now binds to EXACTLY ONE machine instance per focused event, or to NONE. When the focused event's cascade transitioned multiple machines, the rule picks the FIRST transition trace in trace order (earliest `:rf.trace/at`; ties broken by trace-emission sequence within the same epoch). `h/pick-focused-transition` names this rule at the call site.

## Verbatim empty state

When the focused event triggers no transition, the panel renders ONLY this line — no chart, no lens, no history ribbon, no machine name, no instance picker, no hint:

    This event does not target a state machine

Body weight, muted-foreground token per `007-UX-IA`, centered in the panel viewport.

## Gates run

- `clojure -M:test` from `tools/xray/` — 877 tests / 3111 assertions / 0 failures / 0 errors.
- `npm run test:cljs` — 4373 tests / 13979 assertions / 0 failures / 0 errors.
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures.
- `npm run test:bundle-isolation` — pass.
- `clj-kondo` — no errors on changed files; pre-existing warnings unchanged.
- `splint` on changed files — pre-existing warnings only; no new ones from this PR.

## Test coverage (new)

- `cascade-container-has-no-accent-stripe-rf2-cjdw3` — inverts the pre-PR stripe test.
- `blank-state-renders-verbatim-empty-state-text-rf2-8og3k` — pins the verbatim "This event does not target a state machine" line + the no-chart / no-lens invariant.
- `lens-renders-target-instance-and-transition-rf2-2n34o` — the above-chart lens mounts and carries Target Machine Instance + TRANSITION lines.
- `lens-renders-guard-source-and-return-rf2-2n34o` — guard id + fn-source (via `handler-meta`) + return value rendering.
- `lens-renders-action-source-and-dispatch-follow-on-rf2-2n34o` — action id + fn-source + the `:fx :dispatch → [...]` line.
- `lens-falls-back-to-placeholder-when-source-absent-rf2-2n34o` — muted "(fn source unavailable)" fallback for programmatic / production-elided registrations.
- `focused-event-lens-binds-to-first-machine-in-trace-order-rf2-8og3k` — supersedes the pre-rule multi-machine-cascade test.