### PR TITLE
feat(re-frame2-pair-mcp): cache resolved build-id session-wide (rf2-l9ixp)

### DIFF
--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -107,6 +107,22 @@ The server auto-discovers the nREPL port from (highest precedence first):
 > `--port-file <absolute-path>` or set `SHADOW_CLJS_NREPL_PORT` if
 > discovery still fails.
 
+### Per-call build-id resolution
+
+Each tool call routes to a shadow-cljs build. The build-id is resolved
+from (highest precedence first):
+
+1. An explicit `:build` MCP arg on this call — always wins.
+2. **Session-scoped cache (rf2-l9ixp)** — populated by `discover-app`
+   on success. Run `discover-app` once at the start of a session against
+   the build you want to debug; subsequent tool calls default to that
+   build without re-passing `:build`. Removes the friction of a multi-
+   build workspace silently routing follow-up calls to `:app` (the
+   env-var fallback) and returning `:runtime-not-preloaded`. The cache
+   resets on nREPL reconnect (e.g. shadow restart, full page reload
+   destroying the runtime sentinel).
+3. `$SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.
+
 ### Path-drift probe
 
 After repo-side renames of this tool (e.g. PR #1504 `tools/pair2-mcp/`

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/nrepl.cljs
@@ -306,16 +306,23 @@
   preload has been confirmed live on this socket generation (rf2-sjpx0).
   Cleared on connect / reconnect — a full page reload destroys the CLJS
   heap (and thus the `__re_frame2_pair_runtime` marker); we re-probe
-  on the first tool call after that boundary."
+  on the first tool call after that boundary.
+
+  `:resolved-build-id` is the build-id `discover-app` last resolved
+  (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
+  default to it instead of the `SHADOW_CLJS_BUILD_ID` env-var fallback —
+  removing the pair-debug friction of re-passing the build on every call.
+  Same reconnect-invalidation lifecycle as `:probed-builds`."
   [port host]
-  (atom {:port          port
-         :host          (or host "127.0.0.1")
-         :socket        nil
-         :buf           nil
-         :pending       {}
-         :closed?       true
-         :session       nil
-         :probed-builds #{}}))
+  (atom {:port              port
+         :host              (or host "127.0.0.1")
+         :socket            nil
+         :buf               nil
+         :pending           {}
+         :closed?           true
+         :session           nil
+         :probed-builds     #{}
+         :resolved-build-id nil}))
 
 (defn attach-handlers!
   "Wire up `data` / `error` / `close` on the freshly-connected socket.
@@ -383,8 +390,12 @@
                 ;; Reset `:probed-builds` on (re)connect — a page reload
                 ;; destroys the CLJS heap and the
                 ;; `__re_frame2_pair_runtime` marker with it (rf2-sjpx0).
+                ;; Drop `:resolved-build-id` too (rf2-l9ixp) — operator may
+                ;; restart shadow against a different build between
+                ;; reconnects; a stale cache would silently mis-route.
                 (swap! conn-atom assoc :socket sock :closed? false
-                       :buf (js/Buffer.alloc 0) :probed-builds #{})
+                       :buf (js/Buffer.alloc 0)
+                       :probed-builds #{} :resolved-build-id nil)
                 (attach-handlers! conn-atom sock)
                 (resolve conn-atom)))
             (j/call sock :once "error"
@@ -394,11 +405,15 @@
 
 (defn close!
   "Close the persistent socket. Idempotent. Drops the per-socket probe
-  cache (`:probed-builds`) so a fresh connect re-probes the preload."
+  cache (`:probed-builds`) so a fresh connect re-probes the preload.
+  Also drops `:resolved-build-id` (rf2-l9ixp) — the cached default for
+  tool calls without an explicit `:build` arg — so a reconnect doesn't
+  carry a stale build-id from the previous session."
   [conn-atom]
   (when-let [^js sock (:socket @conn-atom)]
     (try (.end sock) (catch :default _ nil)))
-  (swap! conn-atom assoc :socket nil :closed? true :pending {} :probed-builds #{}))
+  (swap! conn-atom assoc :socket nil :closed? true :pending {}
+         :probed-builds #{} :resolved-build-id nil))
 
 ;; ---------------------------------------------------------------------------
 ;; Op send / receive — multiplex by request id.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/discover_app.cljs
@@ -4,7 +4,7 @@
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 (defn discover-app [conn args]
-  (let [build-id (wire/arg-build args)]
+  (let [build-id (wire/arg-build conn args)]
     (-> (probe/ensure-runtime! conn build-id)
         (.then (fn [_] (probe/runtime-health! conn build-id)))
         (.then
@@ -24,22 +24,36 @@
                              :hint "Call (rf/init!) to register :rf/default, or wait for app boot."})
 
               (:ambiguous-frame? health)
-              (wire/ok-text (assoc health :ok? true
-                                          :warning :ambiguous-frame
-                                          :note (str "Multiple frames registered: "
-                                                     (vec (:frames health))
-                                                     ". Mutating ops require --frame :foo "
-                                                     "or run `frames/select` first.")))
+              (do
+                ;; rf2-l9ixp: even on the ambiguous-frame warning the
+                ;; build-id is resolved — record it so subsequent tool
+                ;; calls (with the frame disambiguator) don't need to
+                ;; re-specify `:build`.
+                (wire/mark-resolved-build-id! conn build-id)
+                (wire/ok-text (assoc health :ok? true
+                                            :warning :ambiguous-frame
+                                            :note (str "Multiple frames registered: "
+                                                       (vec (:frames health))
+                                                       ". Mutating ops require --frame :foo "
+                                                       "or run `frames/select` first."))))
 
               (not (:coord-annotation-enabled? health))
-              (wire/ok-text (assoc health :ok? true
-                                          :warning :no-source-coord-annotation
-                                          :note (str "Neither data-rf2-source-coord nor "
-                                                     "data-rc-src is on any element. "
-                                                     "DOM->source ops will degrade. Enable "
-                                                     "(rf/configure :source-coords {:annotate-dom? true}) "
-                                                     "or use re-com with :src (at).")))
+              (do
+                (wire/mark-resolved-build-id! conn build-id)
+                (wire/ok-text (assoc health :ok? true
+                                            :warning :no-source-coord-annotation
+                                            :note (str "Neither data-rf2-source-coord nor "
+                                                       "data-rc-src is on any element. "
+                                                       "DOM->source ops will degrade. Enable "
+                                                       "(rf/configure :source-coords {:annotate-dom? true}) "
+                                                       "or use re-com with :src (at)."))))
 
               :else
-              (wire/ok-text (assoc health :ok? true :build-id build-id)))))
+              (do
+                ;; rf2-l9ixp: cache the resolved build-id session-wide so
+                ;; subsequent tool calls without an explicit `:build` arg
+                ;; default to it instead of the `SHADOW_CLJS_BUILD_ID` /
+                ;; `:app` env-var fallback. Invalidates on nREPL reconnect.
+                (wire/mark-resolved-build-id! conn build-id)
+                (wire/ok-text (assoc health :ok? true :build-id build-id))))))
         (.catch (fn [err] (probe/err->result :discover-failed err))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/dispatch.cljs
@@ -73,7 +73,7 @@
 
 (defn dispatch-tool [conn args]
   (let [event-str    (wire/arg args :event)
-        build-id     (wire/arg-build args)
+        build-id     (wire/arg-build conn args)
         sync?        (boolean (wire/arg args :sync))
         trace?       (boolean (wire/arg args :trace))
         frame        (wire/arg-keyword args :frame)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_cljs.cljs
@@ -38,8 +38,8 @@
 
 (defn eval-cljs-tool [conn args]
   (let [form      (wire/arg args :form)
-        build-id  (wire/arg-build args)
-        explicit? (wire/arg-build-explicit? args)]
+        build-id  (wire/arg-build conn args)
+        explicit? (wire/arg-build-explicit? conn args)]
     (cond
       (not @allow-eval?)
       (js/Promise.resolve

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -26,7 +26,7 @@
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 (defn get-path-tool [conn raw-args]
-  (let [build-id  (wire/arg-build raw-args)
+  (let [build-id  (wire/arg-build conn raw-args)
         frame     (some-> (wire/arg raw-args :frame) args/->frame-keyword)
         path      (args/parse-path-arg (wire/arg raw-args :path))
         ;; rf2-c2dtu — when the `--allow-sensitive-reads` boot gate is OFF,

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -161,7 +161,7 @@
          "  {:ok? false :reason :not-registered :kind :machine :id " id-edn "})")))
 
 (defn handler-meta-tool [conn args]
-  (let [build-id (wire/arg-build args)
+  (let [build-id (wire/arg-build conn args)
         kind-str (wire/arg args :kind)
         id-str   (wire/arg args :id)
         kind     (parse-kind kind-str)
@@ -228,7 +228,7 @@
     (ef/emit (ef/rt-call 'registrar-list kind))))
 
 (defn list-handlers-tool [conn args]
-  (let [build-id (wire/arg-build args)
+  (let [build-id (wire/arg-build conn args)
         kind-str (wire/arg args :kind)
         kind     (parse-kind kind-str)]
     (cond

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/list_subscriptions.cljs
@@ -46,7 +46,7 @@
       (str "(filterv #(and " (str/join " " preds) ") subs)"))))
 
 (defn list-subscriptions-tool [conn args]
-  (let [build-id (wire/arg-build args)
+  (let [build-id (wire/arg-build conn args)
         topic    (wire/arg-keyword args :topic)
         sub-id   (wire/arg args :sub-id)
         form     (ef/emit

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/precheck.cljs
@@ -113,7 +113,7 @@
   saving."
   [conn raw-args target]
   (if-let [form (precheck-form target)]
-    (let [build-id (wire/arg-build raw-args)]
+    (let [build-id (wire/arg-build conn raw-args)]
       (-> (nrepl/cljs-eval-value conn build-id form)
           (.then (fn [v]
                    (cond

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/reset_frame_db.cljs
@@ -63,7 +63,7 @@
   (if-not (writes/writes-allowed?)
     (js/Promise.resolve (writes/disabled-result "reset-frame-db"))
     (let [db-str   (wire/arg raw-args :db)
-          build-id (wire/arg-build raw-args)
+          build-id (wire/arg-build conn raw-args)
           frame    (some-> (wire/arg raw-args :frame) args/->frame-keyword)
           [tag payload] (parse-db-edn db-str)]
       (case tag

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/restore_epoch.cljs
@@ -58,7 +58,7 @@
   (if-not (writes/writes-allowed?)
     (js/Promise.resolve (writes/disabled-result "restore-epoch"))
     (let [epoch-id-str (wire/arg raw-args :epoch-id)
-          build-id     (wire/arg-build raw-args)
+          build-id     (wire/arg-build conn raw-args)
           frame        (some-> (wire/arg raw-args :frame) args/->frame-keyword)
           [tag payload] (parse-epoch-id epoch-id-str)]
       (case tag

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -20,7 +20,7 @@
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 (defn snapshot-tool [conn raw-args]
-  (let [build-id    (wire/arg-build raw-args)
+  (let [build-id    (wire/arg-build conn raw-args)
         frames      (args/parse-frames-arg (wire/arg raw-args :frames))
         include     (args/parse-include-arg (wire/arg raw-args :include))
         ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces both

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -440,7 +440,7 @@
                   (probe/err->result :subscribe-failed err))))))
 
 (defn subscribe-tool [conn raw-args extra]
-  (let [build-id           (wire/arg-build raw-args)
+  (let [build-id           (wire/arg-build conn raw-args)
         topic              (wire/arg-keyword raw-args :topic)
         filter-map         (args/parse-filter-arg (wire/arg raw-args :filter))
         max-buf-events     (wire/arg raw-args :max-buffered-events)

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
@@ -25,7 +25,7 @@
   300)
 
 (defn tail-build-tool [conn args]
-  (let [build-id (wire/arg-build args)
+  (let [build-id (wire/arg-build conn args)
         wait-ms  (or (wire/arg args :wait-ms) default-wait-ms)
         probe    (wire/arg args :probe)
         poll-ms  probe-poll-ms]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -23,7 +23,7 @@
 
 (defn trace-window-tool [conn raw-args]
   (let [ms        (or (wire/arg raw-args :ms) 1000)
-        build-id  (wire/arg-build raw-args)
+        build-id  (wire/arg-build conn raw-args)
         frame     (wire/arg-keyword raw-args :frame)
         ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces
         ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/unsubscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/unsubscribe.cljs
@@ -7,7 +7,7 @@
             [re-frame2-pair-mcp.tools.probe :as probe]))
 
 (defn unsubscribe-tool [conn args]
-  (let [build-id (wire/arg-build args)
+  (let [build-id (wire/arg-build conn args)
         sub-id   (wire/arg args :sub-id)]
     (cond
       (or (nil? sub-id) (str/blank? sub-id))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -27,7 +27,7 @@
             [re-frame2-pair-mcp.tools.raw-state :as raw-state]))
 
 (defn watch-epochs-tool [conn raw-args]
-  (let [build-id  (wire/arg-build raw-args)
+  (let [build-id  (wire/arg-build conn raw-args)
         frame     (wire/arg-keyword raw-args :frame)
         since-id  (wire/arg raw-args :since-id)
         ;; rf2-c2dtu — the `--allow-sensitive-reads` boot gate forces

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire.cljs
@@ -105,18 +105,68 @@
   [args k]
   (some-> (arg args k) keyword))
 
-(defn arg-build [args]
-  (or (arg-keyword args :build)
-      (default-build-id)))
+(defn mark-resolved-build-id!
+  "Record the build-id that `discover-app` just resolved on the conn-atom
+  (rf2-l9ixp). Subsequent tool calls without an explicit `:build` arg
+  default to this id instead of the `SHADOW_CLJS_BUILD_ID` / `:app`
+  env-var fallback. Defensive against a non-atom `conn` (test stubs)."
+  [conn build-id]
+  (when (and (some? conn) (satisfies? IDeref conn))
+    (swap! conn assoc :resolved-build-id build-id)))
+
+(defn- conn-resolved-build-id
+  "Read the session-scoped resolved-build-id cache from `conn` (rf2-l9ixp).
+  Defensive against `nil` / non-atom conn — conformance tests pass a stub
+  conn that doesn't carry the cache. Returns the cached keyword or nil."
+  [conn]
+  (when (and (some? conn) (satisfies? IDeref conn))
+    (:resolved-build-id @conn)))
+
+(defn arg-build
+  "Resolve the build-id for this tool call. Precedence (highest first):
+
+    1. Explicit `:build` MCP arg — operator override always wins
+       (no surprise from the cache).
+    2. Session-scoped resolved-build-id cache on the conn-atom — populated
+       by `discover-app` after a successful preload probe (rf2-l9ixp).
+       Removes the friction of repeating `build: foo` on every tool call
+       after a successful discover-app. Cache resets on nREPL reconnect
+       (same lifecycle as `:probed-builds`).
+    3. `SHADOW_CLJS_BUILD_ID` env var, defaulting to `:app`.
+
+  1-arity (`(arg-build args)`) is the legacy entry — used by call sites
+  that have no `conn` in scope (notably `args.cljs`'s frame/build
+  parsing). It SKIPS the conn cache and falls straight through to the
+  env-var default. Production tool dispatch threads `conn` and uses the
+  2-arity."
+  ([args] (arg-build nil args))
+  ([conn args]
+   (or (arg-keyword args :build)
+       (conn-resolved-build-id conn)
+       (default-build-id))))
 
 (defn arg-build-explicit?
-  "True iff the caller passed an explicit `:build` arg (vs. relying on
-  the `SHADOW_CLJS_BUILD_ID` / `:app` default). The eval-path build
-  resolver (rf2-ivlb3) auto-detects the running build ONLY when the
-  build is the bare default — an operator who typed `--build=foo` gets
-  `foo` honoured verbatim."
-  [args]
-  (some? (arg-keyword args :build)))
+  "True iff a deliberate build-id is available without falling back to
+  the bare `SHADOW_CLJS_BUILD_ID` / `:app` env default. The eval-path
+  build resolver (rf2-ivlb3) auto-detects the running build ONLY when
+  the build is the bare default — a deliberate choice gets honoured
+  verbatim (footgun-and-all; preflight catches typos).
+
+  Two sources count as deliberate:
+
+    - An explicit `:build` MCP arg on this call.
+    - A session-scoped resolved-build-id cached on `conn` (rf2-l9ixp) —
+      populated by a prior successful `discover-app`. Treating the cache
+      as deliberate means a subsequent eval-cljs without `:build` routes
+      to the resolved build instead of being auto-detect-rejected on a
+      multi-build workspace.
+
+  1-arity (`(arg-build-explicit? args)`) is the legacy form for callers
+  with no `conn` in scope; it sees only the per-call arg."
+  ([args] (arg-build-explicit? nil args))
+  ([conn args]
+   (or (some? (arg-keyword args :build))
+       (some? (conn-resolved-build-id conn)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-bounded marker detection (rf2-gktyn, rf2-3z0zi; lifted to

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/build_id_cache_test.cljs
@@ -1,0 +1,211 @@
+(ns re-frame2-pair-mcp.build-id-cache-test
+  "Unit tests for the session-scoped `:resolved-build-id` cache (rf2-l9ixp).
+
+  Adjacent to `probe_test.cljs`, which pins the `:probed-builds` cache
+  (rf2-sjpx0). The two caches share a lifecycle (reset on (re)connect
+  and `close!`); their semantics differ:
+
+    - `:probed-builds` is a set keyed by build-id, tracking which builds
+      have had their `__re_frame2_pair_runtime` marker confirmed live.
+    - `:resolved-build-id` is the single build-id `discover-app` last
+      resolved — the default for tool calls that don't pass `:build`.
+
+  The cache removes a 2026-05-25 pair-debug friction: after a successful
+  `discover-app` against `examples/step-deck`, every subsequent tool
+  call still needed `build: examples/step-deck` or it silently defaulted
+  to `:app` (the env-var fallback) and returned `:runtime-not-preloaded`
+  looking like a fresh discovery failure.
+
+  The fix has three pieces, exercised by the deftests below:
+
+    1. `discover-app` writes the resolved build-id into the conn-atom
+       on success.
+    2. `wire/arg-build` consults the cache before the env-var fallback
+       when no explicit `:build` arg is passed.
+    3. An explicit `:build` arg always wins (no surprise).
+    4. nREPL `connect!` / `close!` clear the cache."
+  (:require [cljs.test :refer-macros [deftest is async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.tools.discover-app :as discover-app]
+            [re-frame2-pair-mcp.tools.wire :as wire]
+            [re-frame2-pair-mcp.test-utils :as tu]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures.
+;; ---------------------------------------------------------------------------
+
+(defn- fresh-conn
+  "A conn-atom shaped like one fresh out of `connect!` — `:probed-builds`
+  cleared, `:resolved-build-id` nil. Mirrors the `probe_test/fresh-conn`
+  shape so the two caches' lifecycle assertions read the same."
+  []
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (swap! conn assoc :probed-builds #{} :resolved-build-id nil)
+    conn))
+
+(def ^:private healthy-health
+  "Canonical `(runtime/health)` payload — the shape `discover-app` reads
+  to decide which warning branch (if any) to surface. The `:ok? true`
+  branch with no warnings exercises the cache-write path."
+  {:ok?                        true
+   :debug-enabled?             true
+   :coord-annotation-enabled?  true
+   :frames                     [:rf/default]
+   :ambiguous-frame?           false})
+
+;; ---------------------------------------------------------------------------
+;; `wire/arg-build` — cache lookup precedence.
+;; ---------------------------------------------------------------------------
+
+(deftest arg-build-without-cache-uses-env-default
+  ;; Baseline: nothing in the cache, no `:build` arg → env default `:app`.
+  (let [conn (fresh-conn)
+        args (tu/args->js {})]
+    (is (= :app (wire/arg-build conn args)))))
+
+(deftest arg-build-with-cache-uses-cached-build-id
+  ;; rf2-l9ixp contract: a cached resolved-build-id is the default when
+  ;; the operator omits `:build` — overrides the `:app` env fallback.
+  (let [conn (fresh-conn)
+        args (tu/args->js {})]
+    (swap! conn assoc :resolved-build-id :examples/step-deck)
+    (is (= :examples/step-deck (wire/arg-build conn args)))))
+
+(deftest arg-build-explicit-arg-overrides-cache
+  ;; Explicit-wins rule: a `:build` MCP arg ALWAYS beats the cache.
+  ;; Operator can route a one-off call to a different build without
+  ;; clearing the session cache.
+  (let [conn (fresh-conn)
+        args (tu/args->js {:build "other-build"})]
+    (swap! conn assoc :resolved-build-id :examples/step-deck)
+    (is (= :other-build (wire/arg-build conn args))
+        "Explicit :build arg must win over the cache")))
+
+(deftest arg-build-nil-conn-falls-through-to-env-default
+  ;; Defensive: the 1-arity legacy form (and any caller passing nil
+  ;; conn) skips the cache lookup without throwing. Conformance tests
+  ;; rely on this stub-conn-friendly shape.
+  (let [args (tu/args->js {})]
+    (is (= :app (wire/arg-build nil args)))
+    (is (= :app (wire/arg-build args))
+        "1-arity legacy form must still resolve to the env default")))
+
+(deftest arg-build-explicit-predicate-treats-cache-as-deliberate
+  ;; A session-cache hit is treated as a deliberate choice — the
+  ;; eval-path resolver (rf2-ivlb3) honours it verbatim rather than
+  ;; second-guessing via auto-detect. Without this, the cache would be
+  ;; useless on a multi-build workspace.
+  (let [conn (fresh-conn)
+        args (tu/args->js {})]
+    (is (false? (wire/arg-build-explicit? conn args))
+        "Fresh conn + no arg → not explicit")
+    (swap! conn assoc :resolved-build-id :examples/step-deck)
+    (is (true? (wire/arg-build-explicit? conn args))
+        "Cache hit must count as deliberate")
+    (is (false? (wire/arg-build-explicit? nil args))
+        "1-arity legacy form (no conn) ignores the cache")))
+
+;; ---------------------------------------------------------------------------
+;; `discover-app` populates the cache on success.
+;; ---------------------------------------------------------------------------
+
+(defn- prime-probe-cache!
+  "Pre-populate `:probed-builds` so `runtime-preloaded?` short-circuits
+  without hitting the stub — the stub then sees only the
+  `(runtime/health)` round-trip and we don't need to discriminate by
+  form string."
+  [conn build-id]
+  (swap! conn update :probed-builds (fnil conj #{}) build-id))
+
+(deftest discover-app-caches-resolved-build-id-on-success
+  ;; The acceptance criterion: a successful `discover-app` records the
+  ;; build-id on the conn so subsequent tool calls don't need `:build`.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})]
+      (-> (tu/with-stubbed-eval! healthy-health
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [_result]
+              (is (= :examples/step-deck (:resolved-build-id @conn))
+                  "Successful discover-app must cache the resolved build-id")
+              (done)))))))
+
+(deftest discover-app-cache-survives-into-subsequent-arg-build-call
+  ;; End-to-end: after a discover-app run, the next call's `arg-build`
+  ;; (with no `:build` arg) routes to the same build discover-app
+  ;; resolved — the friction the bead removes.
+  (async done
+    (let [conn          (fresh-conn)
+          _             (prime-probe-cache! conn :examples/step-deck)
+          discover-args (tu/args->js {:build "examples/step-deck"})
+          tool-args     (tu/args->js {})]
+      (-> (tu/with-stubbed-eval! healthy-health
+            (fn [] (discover-app/discover-app conn discover-args)))
+          (.then
+            (fn [_]
+              (is (= :examples/step-deck (wire/arg-build conn tool-args))
+                  "Post-discover-app, omitted :build must default to the cached id")
+              (done)))))))
+
+(deftest discover-app-does-not-cache-on-precondition-failure
+  ;; `discover-app` short-circuits on precondition failures (e.g.
+  ;; `:debug-enabled? false`) without caching — the build isn't a usable
+  ;; default in that state, so subsequent tool calls should NOT silently
+  ;; route to it.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          unhealthy (assoc healthy-health :debug-enabled? false)]
+      (-> (tu/with-stubbed-eval! unhealthy
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [_]
+              (is (nil? (:resolved-build-id @conn))
+                  "Failed precondition must not populate the cache")
+              (done)))))))
+
+(deftest discover-app-caches-on-warning-branches
+  ;; The ambiguous-frame and no-source-coord-annotation branches return
+  ;; `:ok? true` with a warning — the runtime IS reachable on that
+  ;; build, just with a caveat. Cache the build-id so the operator
+  ;; doesn't have to keep re-specifying it on follow-up calls.
+  (async done
+    (let [conn (fresh-conn)
+          _    (prime-probe-cache! conn :examples/step-deck)
+          args (tu/args->js {:build "examples/step-deck"})
+          ambiguous (assoc healthy-health
+                           :frames [:rf/default :feature/sandbox]
+                           :ambiguous-frame? true)]
+      (-> (tu/with-stubbed-eval! ambiguous
+            (fn [] (discover-app/discover-app conn args)))
+          (.then
+            (fn [_]
+              (is (= :examples/step-deck (:resolved-build-id @conn))
+                  "Ambiguous-frame warning is still a discoverable build — cache it")
+              (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Cache invalidation — shared lifecycle with `:probed-builds`.
+;; ---------------------------------------------------------------------------
+
+(deftest cache-cleared-by-close
+  ;; `nrepl/close!` drops `:resolved-build-id` so a reconnect doesn't
+  ;; carry a stale build-id from the previous session — the operator
+  ;; may have restarted shadow against a different build between
+  ;; reconnects.
+  (let [conn (fresh-conn)]
+    (swap! conn assoc :resolved-build-id :examples/step-deck)
+    (nrepl/close! conn)
+    (is (nil? (:resolved-build-id @conn))
+        "close! must drop the resolved-build-id cache")))
+
+(deftest make-conn-initialises-cache-to-nil
+  ;; A fresh conn-atom has the slot present and nil — `arg-build` falls
+  ;; through to the env default cleanly, and `connect!` doesn't need to
+  ;; create the slot, just reset it.
+  (let [conn (nrepl/make-conn 0 "127.0.0.1")]
+    (is (contains? @conn :resolved-build-id))
+    (is (nil? (:resolved-build-id @conn)))))


### PR DESCRIPTION
## Friction removed

From the 2026-05-25 pair-debug session against `http://localhost:8031/counter`
(`examples/step-deck`):

After a successful `discover-app` against `examples/step-deck`, every
subsequent tool call still required `build: examples/step-deck`. When
forgotten, the tool defaulted to `:app` (the `SHADOW_CLJS_BUILD_ID`
env-var fallback) and returned `:reason :runtime-not-preloaded` —
indistinguishable from a fresh discovery failure rather than the
"you forgot the build arg" hint. ~30 minutes of pair-debug noise per
session before the operator internalised the pattern.

## Fix

Cache the resolved build-id on the conn-atom (alongside the existing
`:probed-builds` cache from rf2-sjpx0). Three pieces:

1. `wire/mark-resolved-build-id!` writes the slot on a successful
   `discover-app` (the `:ok? true` success branch + the two `:ok? true`
   warning branches — `:ambiguous-frame` and `:no-source-coord-annotation`
   — where the build is still reachable, just with a caveat).
   Precondition failures (`:debug-enabled? false`, `:no-frames-registered`)
   do NOT cache: the build isn't a usable default in those states.
2. `wire/arg-build` (now 1-/2-arity) consults the conn cache before the
   env-var fallback when no explicit `:build` arg is passed.
3. `wire/arg-build-explicit?` treats a cache hit as a deliberate
   choice so `eval-cljs`'s `resolve-and-preflight!` (rf2-ivlb3) honours
   it verbatim instead of falling into auto-detect (which would
   second-guess the operator's prior `discover-app` selection on
   multi-build workspaces).

## Cache key + invalidation triggers

- **Key**: a single keyword `:resolved-build-id` on the conn-atom.
- **Reset triggers**:
  - `nrepl/make-conn` initialises the slot to nil.
  - `nrepl/connect!` on-connect handler clears on every (re)connect —
    matches the existing `:probed-builds` lifecycle; an operator
    restarting shadow against a different build cannot silently
    mis-route via a stale cache.
  - `nrepl/close!` clears on socket teardown.

## Explicit-wins rule

An explicit `:build` MCP arg always wins over the cache (no surprise).
Operator can route a one-off call to a different build without
clearing the session cache. Verified by
`arg-build-explicit-arg-overrides-cache`.

## Tests added

New `test/re_frame2_pair_mcp/build_id_cache_test.cljs`:

- `arg-build-without-cache-uses-env-default` — baseline.
- `arg-build-with-cache-uses-cached-build-id` — primary contract.
- `arg-build-explicit-arg-overrides-cache` — explicit-wins.
- `arg-build-nil-conn-falls-through-to-env-default` — defensive on
  the 1-arity legacy form / conformance-stub conn.
- `arg-build-explicit-predicate-treats-cache-as-deliberate` — covers
  the `arg-build-explicit?` semantics that gate the eval-path
  auto-detect.
- `discover-app-caches-resolved-build-id-on-success` — end-to-end
  write path.
- `discover-app-cache-survives-into-subsequent-arg-build-call` — the
  acceptance criterion from the bead.
- `discover-app-does-not-cache-on-precondition-failure` — `:debug-enabled?
  false` short-circuits without caching.
- `discover-app-caches-on-warning-branches` — ambiguous-frame is still
  cacheable.
- `cache-cleared-by-close` — lifecycle reset.
- `make-conn-initialises-cache-to-nil` — fresh conn slot shape.

## Gates

- `npx shadow-cljs compile server` — clean.
- `npm test` — 573 tests, 1495 assertions, 0 failures, 0 errors.
- `npm run stdio-roundtrip` — `SERVER STDIO ROUND-TRIP GREEN`.
- `clj-kondo` on changed files — 0 errors, 0 warnings (3 pre-existing
  warnings on unrelated lines).