### PR TITLE
fix(cofx): use ctx + rf/assoc-coeffect in 5 reg-cofx bodies (rf2-gg4dz)

### DIFF
--- a/examples/reagent/realworld/auth.cljs
+++ b/examples/reagent/realworld/auth.cljs
@@ -43,10 +43,10 @@
 
 (rf/reg-cofx :auth.session/token
   {:doc "Inject the saved token (or nil) from localStorage into coeffects."}
-  (fn cofx-auth-session-token [coeffects _]
-    (assoc coeffects :auth.session/token
-           (some-> (.-localStorage js/globalThis)
-                   (.getItem "conduit/jwt")))))
+  (fn cofx-auth-session-token [ctx _]
+    (rf/assoc-coeffect ctx :auth.session/token
+                       (some-> (.-localStorage js/globalThis)
+                               (.getItem "conduit/jwt")))))
 
 ;; ============================================================================
 ;; SUPPORT EVENTS

--- a/examples/reagent/realworld/http.cljs
+++ b/examples/reagent/realworld/http.cljs
@@ -132,8 +132,8 @@
   {:doc "Inject the current wall-clock time (ms since epoch) into
          coeffects under `:realworld/now`. Use `(rf/inject-cofx
          :realworld/now)` on any handler that stamps `:loaded-at`."}
-  (fn cofx-realworld-now [coeffects]
-    (assoc coeffects :realworld/now (.getTime (js/Date.)))))
+  (fn cofx-realworld-now [ctx]
+    (rf/assoc-coeffect ctx :realworld/now (.getTime (js/Date.)))))
 
 ;; ============================================================================
 ;; FAILURE PROJECTION

--- a/examples/reagent/realworld/test/realworld/auth_test.cljs
+++ b/examples/reagent/realworld/test/realworld/auth_test.cljs
@@ -9,6 +9,7 @@
    Each test fn keeps its original signature (a plain zero-arg fn) so the
    integration runner can call them as before."
   (:require [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
             [realworld.auth]
             [realworld.test-helpers :as th])
   (:require-macros [re-frame.core :refer [with-frame]]))
@@ -35,6 +36,26 @@
     (rf/dispatch-sync [:auth/flow [:auth/logout]] {:frame f})
     (assert (= :idle (rf/compute-sub [:auth/state] (rf/get-frame-db f))))
     (assert (nil? (rf/compute-sub [:auth/user] (rf/get-frame-db f))))))
+
+(defn session-token-cofx-shape-test []
+  ;; rf2-gg4dz regression guard — the :auth.session/token cofx must
+  ;; assoc its injected value into `(:coeffects ctx)` (not the top of
+  ;; ctx). If the shape regresses, the value lands at ctx[<cofx-id>]
+  ;; and the handler's destructure binds nil — silently.
+  ;;
+  ;; Call the registered cofx handler directly with a known empty input
+  ;; ctx and assert the value lands at the conventional path. The cofx
+  ;; reads from `js/globalThis.localStorage`; node-side that is absent
+  ;; so the value is nil — but the SHAPE is what matters here:
+  ;; `:coeffects` must be present and contain the key.
+  (let [cofx-meta (registrar/handler-meta :cofx :auth.session/token)
+        handler   (:handler-fn cofx-meta)
+        result    (handler {:coeffects {}} nil)]
+    (assert (contains? (:coeffects result) :auth.session/token)
+            "cofx body must assoc its injected value under [:coeffects :auth.session/token];
+             see rf2-gg4dz")
+    (assert (nil? (get result :auth.session/token))
+            "the misshapen-cofx witness — the value must NOT land at top of ctx")))
 
 (defn login-failure-test []
   (th/reg-canned-failure! :rf.http/managed.login-failure

--- a/examples/reagent/realworld/test/realworld/tags_test.cljs
+++ b/examples/reagent/realworld/test/realworld/tags_test.cljs
@@ -64,6 +64,12 @@
       (assert (= ["intro" "demo" "clojure"]
                  (get-in snap [:data :tags])))
       (assert (= 1 (get-in snap [:data :attempt])))
+      ;; rf2-gg4dz regression guard — `:loaded-at` carries the
+      ;; `:realworld/now` cofx value into `:set-tags`. If the cofx body
+      ;; ever regresses to the wrong shape (assoc-at-top-level of ctx
+      ;; rather than into :coeffects), `now` reaches the action as nil
+      ;; and this assertion fails.
+      (assert (number? (get-in snap [:data :loaded-at])))
       ;; tag-shaped queries — these replace the slice's `:tags/loading?`
       ;; / `:tags/fetching?` derived boolean subs.
       (assert (true?  (machine-has-tag? f :tags/loaded)))

--- a/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs
@@ -41,7 +41,9 @@
   (testing "login happy path drives the auth machine to :authed and back"
     (auth-t/login-happy-path-test))
   (testing "login failure surfaces error and dismiss returns to :idle"
-    (auth-t/login-failure-test)))
+    (auth-t/login-failure-test))
+  (testing ":auth.session/token cofx assoc-shape regression guard (rf2-gg4dz)"
+    (auth-t/session-token-cofx-shape-test)))
 
 (deftest realworld-articles-feed
   (testing "global feed loads and re-loads bumping :attempt"

--- a/testbeds/schema_violation/core.cljs
+++ b/testbeds/schema_violation/core.cljs
@@ -91,10 +91,10 @@
 
 (rf/reg-cofx ::bad-counter
   {:schema pos-int?}
-  (fn [coeffects _]
+  (fn [ctx _]
     ;; HOT PATH — the injection site for :where :cofx.
     ;; Returns a value that the registered :schema will reject.
-    (assoc coeffects ::bad-counter -1)))
+    (rf/assoc-coeffect ctx ::bad-counter -1)))
 
 (rf/reg-event-fx ::violate-cofx
   [(rf/inject-cofx ::bad-counter)]

--- a/tools/story/src/re_frame/story/ui/cofx.cljc
+++ b/tools/story/src/re_frame/story/ui/cofx.cljc
@@ -66,13 +66,13 @@
   []
   (rf/reg-cofx
     :story/active-modes
-    (fn [coeffects _]
-      (assoc coeffects :story/active-modes (active-modes-snapshot))))
+    (fn [ctx _]
+      (rf/assoc-coeffect ctx :story/active-modes (active-modes-snapshot))))
 
   (rf/reg-cofx
     :story/active-args
-    (fn [coeffects _]
-      (assoc coeffects :story/active-args (active-args-snapshot))))
+    (fn [ctx _]
+      (rf/assoc-coeffect ctx :story/active-args (active-args-snapshot))))
 
   ;; Subscriptions backed by the shell-state-atom. The atom is a
   ;; Reagent ratom on CLJS, plain atom on JVM — deref participates in

--- a/tools/story/test/re_frame/story/ui/cofx_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/cofx_cljs_test.cljs
@@ -1,0 +1,41 @@
+(ns re-frame.story.ui.cofx-cljs-test
+  "Regression guard for rf2-gg4dz — the `:story/active-modes` and
+  `:story/active-args` cofx bodies must inject their value under
+  `[:coeffects <cofx-id>]`. If the body regresses to the wrong shape
+  (assoc-at-top-level of ctx) the consuming event handler binds nil
+  silently and the chrome's mode/arg awareness disappears.
+
+  Both cofx bodies are 2-arity (take `ctx` plus an `inject-cofx`-passed
+  value). The shape contract is identical to the 1-arity form."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story.ui.cofx :as ui-cofx]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (ui-cofx/install-canonical-cofx!))}))
+
+(deftest story-active-modes-cofx-shape
+  (testing ":story/active-modes cofx body assoc's into [:coeffects :story/active-modes]"
+    (let [meta    (rf/handler-meta :cofx :story/active-modes)
+          handler (:handler-fn meta)
+          result  (handler {:coeffects {}} nil)]
+      (is (contains? (:coeffects result) :story/active-modes)
+          "value lands at [:coeffects :story/active-modes] (canonical slot)")
+      (is (vector? (get-in result [:coeffects :story/active-modes]))
+          "the snapshot is a vector (default empty)")
+      (is (nil? (get result :story/active-modes))
+          "the misshapen-cofx witness — value must NOT land at top of ctx"))))
+
+(deftest story-active-args-cofx-shape
+  (testing ":story/active-args cofx body assoc's into [:coeffects :story/active-args]"
+    (let [meta    (rf/handler-meta :cofx :story/active-args)
+          handler (:handler-fn meta)
+          result  (handler {:coeffects {}} nil)]
+      (is (contains? (:coeffects result) :story/active-args)
+          "value lands at [:coeffects :story/active-args] (canonical slot)")
+      (is (nil? (get result :story/active-args))
+          "the misshapen-cofx witness — value must NOT land at top of ctx"))))

--- a/tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_cofx_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_cofx_cljs_test.cljs
@@ -1,0 +1,65 @@
+(ns day8.re-frame2-xray.testbeds.testdeck-cofx-cljs-test
+  "Regression guard for rf2-gg4dz — the testdeck `:testdeck/now` cofx
+  must inject its value under `[:coeffects :testdeck/now]` so the
+  `:counter/inc` handler's destructure of `:testdeck/now` binds the
+  injected wall-clock time (not nil). If the cofx body ever regresses to
+  the wrong shape (assoc at the top of ctx rather than into `:coeffects`)
+  the handler binds nil and `[:counter :last-clicked]` stays nil
+  silently — no error fires.
+
+  This test installs the cofx ad-hoc using the SAME body shape the
+  testbed source carries, then exercises it both ways:
+    1. Direct call against the registered handler — asserts the value
+       lands at `[:coeffects :testdeck/now]` (the canonical slot).
+    2. End-to-end `dispatch-sync` of an event using `inject-cofx` —
+       asserts the handler's `:testdeck/now` destructure binds the
+       injected value.
+
+  We do NOT `:require` `testdeck.counter` at ns-load time — the
+  testbed's `:counter/inc` registration is a per-process side effect
+  that collides with the identically-named event in the
+  `counter-with-stories` testbed, and the per-test registrar fixture
+  cannot roll back a load-time registration. The body shape pinned
+  here mirrors `tools/xray/testbeds/testdeck/counter.cljs`; drift
+  between the two is the regression rf2-gg4dz documents."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+(deftest testdeck-now-cofx-direct-shape-witness
+  (testing "calling the registered cofx handler directly puts the value
+            under [:coeffects :testdeck/now], NOT at the top of ctx"
+    (rf/reg-cofx :testdeck/now
+      (fn [ctx]
+        (rf/assoc-coeffect ctx :testdeck/now (.getTime (js/Date.)))))
+    (let [meta    (rf/handler-meta :cofx :testdeck/now)
+          handler (:handler-fn meta)
+          result  (handler {:coeffects {}})]
+      (is (number? (get-in result [:coeffects :testdeck/now]))
+          "value lands at [:coeffects :testdeck/now] (the canonical slot)")
+      (is (nil? (get result :testdeck/now))
+          "the misshapen-cofx witness — value must NOT land at top of ctx
+           (the bug-shape pre-rf2-gg4dz)"))))
+
+(deftest testdeck-now-cofx-reaches-handler-via-dispatch
+  (testing "an event handler using `(rf/inject-cofx :testdeck/now)`
+            observes the injected value under its `:testdeck/now`
+            destructure. End-to-end pin of the cofx-injection contract
+            the testdeck counter's `:counter/inc` handler relies on."
+    (rf/reg-cofx :testdeck/now
+      (fn [ctx]
+        (rf/assoc-coeffect ctx :testdeck/now 1234567890)))
+    (rf/reg-event-fx ::tick
+      [(rf/inject-cofx :testdeck/now)]
+      (fn [{:keys [db testdeck/now]} _]
+        {:db (assoc db ::last-tick now)}))
+    (rf/dispatch-sync [::tick])
+    (let [db (rf/get-frame-db :rf/default)]
+      (is (= 1234567890 (::last-tick db))
+          "handler's `:testdeck/now` destructure binds the cofx-injected
+           value; nil here means the cofx body regressed (rf2-gg4dz)"))))

--- a/tools/xray/testbeds/testdeck/counter.cljs
+++ b/tools/xray/testbeds/testdeck/counter.cljs
@@ -53,8 +53,8 @@
 (rf/reg-cofx :testdeck/now
   {:doc "Inject the current wall-clock time (ms since epoch) into
          coeffects under `:testdeck/now`."}
-  (fn cofx-testdeck-now [coeffects]
-    (assoc coeffects :testdeck/now (.getTime (js/Date.)))))
+  (fn cofx-testdeck-now [ctx]
+    (rf/assoc-coeffect ctx :testdeck/now (.getTime (js/Date.)))))
 
 ;; ============================================================================
 ;; APP-DB SLICE


### PR DESCRIPTION
## Summary

Five `reg-cofx` bodies in the corpus used the wrong arg shape: they
took the interceptor context as their first arg but treated it as the
coeffects map and `assoc`-ed at the top level, so the injected value
landed at `ctx[<cofx-id>]` instead of `ctx[:coeffects][<cofx-id>]`.
Event handlers reading the cofx via `:keys [<cofx-id>]`-style
destructure bound `nil` — no error fired (the cofx returns a
"valid" context shape), so the bug was silent.

This PR fixes all five sites, plus a sixth discovered during the
sweep, and uses the idiomatic `rf/assoc-coeffect` helper per the
canonical doc example at `implementation/core/src/re_frame/cofx.cljc:118-120`.

## Chain to #2097

This is the underlying cofx-body bug that #2097 (rf2-9dk9y) bumped
into — that PR fixed the Xray panel's display of cofxs so the test
case (`:testdeck/now` on `:counter/inc`) showed correctly. This PR
makes the value actually reach the handler.

## Sweep result

The bead listed five sites; a `git grep` for `reg-cofx` confirmed
each one is broken as described and surfaced a sixth:

| # | Site | Cofx id | Arity |
|---|---|---|---|
| 1 | `tools/xray/testbeds/testdeck/counter.cljs:56` | `:testdeck/now` | 1 |
| 2 | `tools/story/src/re_frame/story/ui/cofx.cljc:69` | `:story/active-modes` | 2 |
| 3 | `tools/story/src/re_frame/story/ui/cofx.cljc:74` | `:story/active-args` | 2 |
| 4 | `examples/reagent/realworld/http.cljs:135` | `:realworld/now` | 1 |
| 5 | `examples/reagent/realworld/auth.cljs:46` | `:auth.session/token` | 2 |
| 6 | `testbeds/schema_violation/core.cljs:94` | `::bad-counter` | 2 |

Site 6 was discovered during the sweep — it deliberately injects `-1`
so the registered `:schema pos-int?` rejects the value. The wrong-shape
masked itself: the validator read `(:coeffects ctx)`, found nil
(because the cofx assoc-ed at the top of ctx), and rejected nil as
not-pos-int. With the fix, -1 reaches the validator under the canonical
slot and is rejected as a correctly-negative integer; the failure trace
shape is unchanged (still `:where :cofx`, `:recovery :no-recovery`)
but the `:value` tag now carries `-1` instead of `nil` — clearer
diagnostics.

`examples/reagent/todomvc/db.cljs` (`:todo.storage/todos`) was confirmed
correct and used as the working template.

## Per-site fix shape

Pre-rf2-gg4dz:
```clojure
(rf/reg-cofx :testdeck/now
  (fn cofx-testdeck-now [coeffects]
    (assoc coeffects :testdeck/now (.getTime (js/Date.)))))
```

Post-rf2-gg4dz:
```clojure
(rf/reg-cofx :testdeck/now
  (fn cofx-testdeck-now [ctx]
    (rf/assoc-coeffect ctx :testdeck/now (.getTime (js/Date.)))))
```

Arg rename `coeffects → ctx` is mandatory — the old name was the source
of the confusion. The 2-arity sites preserve their second `value` arg
unchanged; only the first-arg name and the assoc target change.

## Test strengthening

Per the bead's "Why this isn't caught by tests" — these cofxs return a
valid-shaped context so no test that merely runs the handler catches
the bug; a value-assertion on the cofx-derived field is required.

- `tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_cofx_cljs_test.cljs`
  (new) — direct-call shape witness AND end-to-end `dispatch-sync` of
  an event using `inject-cofx`. Both pin the canonical
  `[:coeffects :testdeck/now]` slot. The test installs the cofx
  ad-hoc rather than `:require`-ing `testdeck.counter` (whose
  `:counter/inc` registration collides with the identically-named
  event in the `counter-with-stories` testbed across the test process).

- `tools/story/test/re_frame/story/ui/cofx_cljs_test.cljs` (new) —
  direct-call shape witnesses for `:story/active-modes` and
  `:story/active-args`.

- `examples/reagent/realworld/test/realworld/auth_test.cljs` —
  added `session-token-cofx-shape-test` that pins the shape contract
  on the registered handler.

- `examples/reagent/realworld/test/realworld/tags_test.cljs` —
  strengthened `tags-machine-load-test` to assert `[:data :loaded-at]`
  is a number after `:tags/load` resolves, pinning that the
  `:realworld/now` cofx-value reaches the machine's `:set-tags` action.

- `implementation/adapters/reagent/test/re_frame/realworld_cljs_test.cljs` —
  wires the new auth shape test into the cross-suite runner.

## Acceptance verification

Per the bead's acceptance criterion: after the testdeck fix, the next
`:counter/inc` dispatch on the step-deck testbed populates
`[:counter :last-clicked]`. The dispatch-via-`inject-cofx` test in
`testdeck_cofx_cljs_test.cljs` pins this in headless form.

## Gates

- `npm run test:cljs` (node-runtime CLJS sweep): 4372 tests, 0 failures
- `npm run test:bundle-isolation`: PASS (16 artefact entries; 33
  sentinels absent; reagent-free for uix/helix)
- `npm run test:xray-feature-gate` (nightly-full): 13/13 scenarios pass
- `scripts/test-jvm-implementation.sh`: all artefacts pass (core,
  schemas, machines, routing, flows, http, ssr, ssr-ring, epoch)
- `scripts/test-jvm-tools.sh`: all artefacts pass (story, story-mcp,
  mcp-base, mcp-conformance/wire-vocab)
- `clj-kondo`: 0 errors, 0 warnings on every changed file

## Commit structure

Four sequenced commits, one per scope:

1. `fix(testdeck): use ctx + rf/assoc-coeffect in :testdeck/now cofx (rf2-gg4dz)`
2. `fix(story): use ctx + rf/assoc-coeffect in :story/active-modes + :story/active-args cofx (rf2-gg4dz)`
3. `fix(realworld): use ctx + rf/assoc-coeffect in :realworld/now + :auth.session/token cofx (rf2-gg4dz)`
4. `fix(schema-violation testbed): use ctx + rf/assoc-coeffect in ::bad-counter cofx (rf2-gg4dz)`
