### PR TITLE
fix(machines-viz): surface ELK layout errors instead of swallowing (rf2-4lyvh)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -44,7 +44,10 @@
             ["elkjs/lib/elk.bundled.js" :as elkjs]
             [clojure.string :as str]
             [reagent.core :as r]
+            [re-frame.interop :as interop]
+            [re-frame.trace :as trace]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [day8.re-frame2-machines-viz.chart.layout-error :as layout-error]
             [day8.re-frame2-machines-viz.chart.projection :as projection]
             [day8.re-frame2-machines-viz.chart.nodes :as nodes]
             [day8.re-frame2-machines-viz.chart.edges :as edges]
@@ -262,33 +265,113 @@
     {:positions   @positions
      :edge-points @edge-points}))
 
+;; ---- error reporting (rf2-4lyvh) ----------------------------------------
+;;
+;; Before rf2-4lyvh, compute-layout! had two bare `(catch :default _ nil)`
+;; clauses (one sync around `.layout`, one async on the rejection branch)
+;; that discarded ELK errors entirely. The downstream `(when result ...)`
+;; guard in MachineChart then silently no-op'd, leaving `layout-state` at
+;; its initial `{:positions {} :edge-points {}}` — every node renders at
+;; the default origin, all stacked. The operator saw nothing in the
+;; console. The fix surfaces ELK failures three ways:
+;;
+;;   1. A `:rf.error/machines-viz-elk-layout-failed` trace event lands on
+;;      the bus so tools (Xray Issues panel, off-box monitors) that
+;;      subscribe to `:rf.error/*` see the failure.
+;;   2. `js/console.error` (gated on `interop/debug-enabled?` so the path
+;;      is elision-safe in production bundles) so an operator opening
+;;      DevTools sees something immediately.
+;;   3. The callback receives a result-map shape carrying `:layout-error`
+;;      instead of `nil`; the projector renders a banner on the chart
+;;      area so the failure is visible IN the panel, not just in console.
+;;
+;; The pure data side (input summary + error→data adapter + result-map
+;; builder) lives in `chart.layout-error` so the .cljc test corpus can
+;; pin every shape without loading elkjs / xyflow. The side-effect side
+;; (trace emit + dev-only console.error + the elkjs interop indirection)
+;; stays here next to the .layout call.
+
+(defn ^:private report-layout-error!
+  "Surface an ELK layout failure: emit the canonical error trace + a
+  console.error in dev builds. Returns nothing — the caller still has to
+  build the result-map shape that gets handed to `done-fn`. Split out so
+  the side-effect surface (trace + console) is in one place + unit-
+  testable via `with-redefs` on the trace fn."
+  [error parsed direction layout-options machine-id]
+  (let [summary (layout-error/input-summary parsed direction layout-options)
+        err     (layout-error/error->data error)]
+    (trace/emit-error! :rf.error/machines-viz-elk-layout-failed
+                       {:elk-error     err
+                        :machine-id    machine-id
+                        :input-summary summary})
+    (when interop/debug-enabled?
+      (js/console.error "[machines-viz] ELK layout failed:" error
+                        (pr-str (assoc summary :machine-id machine-id))))))
+
+(defn invoke-elk-layout!
+  "Indirection over `(.layout elk-instance input)`. Lives at the
+  public surface (not `^:private`) ONLY as a test seam: the
+  `compute-layout!` error-path tests (rf2-4lyvh) rebind this via
+  `set!` to stub elkjs's behaviour (sync throw / async reject / async
+  resolve) without reaching into the `defonce` elk instance. The
+  `defonce` is intentional — we want one elk instance per process —
+  and reaching into its internals from a test is fragile.
+
+  No production code outside this ns should call this fn; treat it
+  as private-by-convention. Returns whatever elkjs returns: a Promise
+  on success; may throw synchronously on a malformed input (rare,
+  but observed in the wild)."
+  [^js input]
+  (.layout elk-instance input))
+
 (defn compute-layout!
   "Run elk.js layout on `parsed` (the output of
   `chart.layout/parse-definition`); call `done-fn` with a map
   `{:positions {node-id {:x :y :width :height}} :edge-points {edge-id
-  [{:x :y} …]}}` when ready (or with `nil` on failure). The
-  `:edge-points` half (rf2-cz8v6 / G2) carries elk's routed bend-points
-  so the chart routes edges AROUND nested containers instead of cutting
-  across them. The async path is idiomatic xyflow + elkjs:
+  [{:x :y} …]}}` on success.
+
+  On failure (rf2-4lyvh) the callback receives the SAME map shape with
+  empty `:positions` + `:edge-points` AND an extra `:layout-error
+  {:error … :input-summary …}` slot — the existing `(when result ...)`
+  guard at the callsite is preserved, the projector can read
+  `:layout-error` to render an in-panel indicator instead of silently
+  rendering every node stacked at origin. The failure also fires a
+  `:rf.error/machines-viz-elk-layout-failed` trace event + (in dev
+  builds, gated on `interop/debug-enabled?`) a `js/console.error`.
+
+  The `:edge-points` half (rf2-cz8v6 / G2) carries elk's routed bend-
+  points so the chart routes edges AROUND nested containers instead of
+  cutting across them. The async path is idiomatic xyflow + elkjs:
 
     1. `(->elk-input parsed direction layout-options)` builds a JS
        graph.
     2. `.layout` returns a Promise.
     3. Resolve → `elk-result->positions` → callback.
-    4. Reject → callback with nil; caller may render a 'laying out…'
-       placeholder."
+    4. Reject → callback with the layout-error result-map (above).
+
+  Optional `:machine-id` is threaded onto the error trace's `:tags` so
+  consumers (Xray Issues panel) can attribute the failure to a specific
+  machine; nil when called without a machine id (e.g. unit tests)."
   ([parsed done-fn]
-   (compute-layout! parsed :tb nil done-fn))
+   (compute-layout! parsed :tb nil nil done-fn))
   ([parsed direction layout-options done-fn]
-   (let [input (->elk-input parsed direction layout-options)
-         p     (try (.layout elk-instance input)
-                    (catch :default _ nil))]
-     (if (and p (.-then p))
+   (compute-layout! parsed direction layout-options nil done-fn))
+  ([parsed direction layout-options machine-id done-fn]
+   (let [input  (->elk-input parsed direction layout-options)
+         handle (fn handle-error [e]
+                  (report-layout-error! e parsed direction layout-options
+                                        machine-id)
+                  (done-fn (layout-error/layout-error-result
+                             e parsed direction layout-options)))
+         p      (try (invoke-elk-layout! input)
+                     (catch :default e
+                       (handle e)
+                       nil))]
+     (when (and p (.-then p))
        (-> p
            (.then (fn [result]
                     (done-fn (elk-result->positions result))))
-           (.catch (fn [_e] (done-fn nil))))
-       (done-fn nil)))))
+           (.catch (fn [e] (handle e))))))))
 
 ;; ---- graph projection (parsed + positions → xyflow nodes/edges) ---------
 ;;
@@ -481,7 +564,7 @@
         (when (and (seq (:nodes parsed))
                    (not= this-key @layout-key))
           (reset! layout-key this-key)
-          (compute-layout! parsed direction layout-options
+          (compute-layout! parsed direction layout-options machine-id
                            (fn [result]
                              (when result
                                (reset! layout-state result)))))
@@ -536,7 +619,7 @@
                 to-highlight-id   (layout/highlight-id to-highlight)
                 callback          (when-not read-only? on-state-click)
                 edge-callback     (when-not read-only? on-edge-click)
-                {:keys [positions edge-points]} @layout-state
+                {:keys [positions edge-points layout-error]} @layout-state
                 {:keys [nodes edges]}
                 (projection/xyflow-graph parsed
                               positions
@@ -622,6 +705,12 @@
                    ;; DOM tests can read every traversed arm at the chart
                    ;; root (mirrors `data-highlight-ids`). "" when none.
                    :data-fired-edge-ids (str/join " " (sort (set fired-edge-ids)))
+                   ;; rf2-4lyvh — surface ELK layout-failure as a root
+                   ;; data-attr so DOM tests + hosts can pin the failure
+                   ;; without inspecting the banner DOM. "true" / "false";
+                   ;; the visible banner below carries the human-readable
+                   ;; message.
+                   :data-layout-error (if layout-error "true" "false")
                    :role "application"
                    :aria-label aria-label
                    :style {:position "relative"
@@ -705,4 +794,40 @@
                         (seq (:steps cancellation-cascade)))
                [overlay-cascade/CancellationCascadeOverlay
                 {:cascade-spec cancellation-cascade
-                 :tick         overlay-tick}])]))))))
+                 :tick         overlay-tick}])
+             ;; rf2-4lyvh — ELK layout-failure indicator. When
+             ;; `compute-layout!` surfaces a `:layout-error` slot the
+             ;; chart would otherwise render every node stacked at
+             ;; origin (no positions). Paint a small banner over the
+             ;; canvas so the operator sees the failure IN the panel,
+             ;; not just in the trace bus or DevTools console. The full
+             ;; structured failure lives on the `:rf.error/machines-
+             ;; viz-elk-layout-failed` trace event (tools/Xray Issues
+             ;; panel surfaces it from there); this banner is the dev-
+             ;; tool affordance for the operator running the live app.
+             (when layout-error
+               [:div {:data-testid (str testid "-layout-error-banner")
+                      :role "status"
+                      :aria-live "polite"
+                      :style {:position      "absolute"
+                              :top           "8px"
+                              :left          "8px"
+                              :right         "8px"
+                              :z-index       10
+                              :padding       "8px 12px"
+                              :font-family   tokens/sans-stack
+                              :font-size     "12px"
+                              :line-height   1.4
+                              :color         (:text-primary tokens/tokens)
+                              :background    (tokens/with-alpha :error 0.15)
+                              :border        (str "1px solid "
+                                                  (:error tokens/tokens))
+                              :border-radius "4px"}}
+                [:strong {:style {:color (:error tokens/tokens)
+                                  :margin-right "6px"}}
+                 "Layout failed."]
+                [:span (or (get-in layout-error [:error :message])
+                           "ELK threw an unknown error.")]
+                [:span {:style {:color (:text-tertiary tokens/tokens)
+                                :margin-left "6px"}}
+                 "See console / Issues panel."]])]))))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout_error.cljc
@@ -1,0 +1,101 @@
+(ns day8.re-frame2-machines-viz.chart.layout-error
+  "rf2-4lyvh — pure helpers for the ELK layout-failure surface.
+
+  Before rf2-4lyvh, `chart/compute-layout!` swallowed both the sync
+  `(catch :default _ nil)` around `(.layout elk-instance input)` AND
+  the async `(.catch (fn [_e] (done-fn nil)))` on the returned promise.
+  The downstream `(when result ...)` guard at the callsite then no-
+  op'd, leaving `layout-state` at its initial empty shape; every
+  rendered node fell back to (0, 0). Operators saw stacked boxes with
+  no diagnostic.
+
+  This namespace owns the pure side of the fix — the input-summary,
+  the JS-error → CLJS-data adapter, and the result-map builder the
+  `done-fn` callback receives on failure. The side-effects (trace
+  emit + dev-only `console.error`) stay in `chart.cljs` next to the
+  elkjs interop; this ns is split out so the .cljc test corpus can
+  pin the data shape without loading xyflow / elkjs (mirroring the
+  rf2-0gmwp split that moved the pure projector into
+  `chart.projection`).
+
+  ## Shapes
+
+    - `(input-summary parsed direction layout-options)`
+        → `{:node-count :edge-count :region-count :parallel?
+            :direction :layout-option-ks}` — counts + the layout
+        option KEY-SET (values omitted — caller-supplied + may drift).
+        Suitable as an error-trace `:tags` payload.
+
+    - `(error->data err)`
+        → `{:message <str>}` (and `:name <str>` when present).
+        Adapter for any thrown value (JS error, string, or nil) into
+        a CLJS map fit for an error trace. We deliberately do NOT
+        include `:stack` — stacks are long, environment-specific, and
+        bloat the bus.
+
+    - `(layout-error-result err parsed direction layout-options)`
+        → `{:positions {} :edge-points {}
+            :layout-error {:error <error-data>
+                           :input-summary <summary>}}`
+        The callback result-map handed to `done-fn` on failure. The
+        existing `(when result ...)` guard at the chart callsite still
+        gates on truthiness (the map is non-nil, so the reset! still
+        runs); the projector reads `:layout-error` to paint the in-
+        panel indicator banner.
+
+  Every fn here is pure, JVM-runnable through `.cljc`, and free of
+  framework state."
+  (:require [clojure.string :as str]))
+
+(defn input-summary
+  "Build a SAFE, error-tag-suitable summary of the `(parsed,
+  direction, layout-options)` input that fed a failing layout pass.
+  Carries counts + direction + the layout-option KEY-SET (values
+  omitted — caller-supplied + may drift) so a tool reading the error
+  trace sees enough to diagnose without the projector's full graph on
+  the wire. Pure fn."
+  [parsed direction layout-options]
+  {:node-count       (count (:nodes parsed))
+   :edge-count       (count (:edges parsed))
+   :region-count     (count (filter :region? (:nodes parsed)))
+   :parallel?        (boolean (:parallel? parsed))
+   :direction        direction
+   :layout-option-ks (vec (sort (keys (or layout-options {}))))})
+
+(defn error->data
+  "Adapter: turn a thrown value into a CLJS map fit for an error
+  trace's `:tags`.
+
+    - nil → `{:message \"unknown error\"}`
+    - string → `{:message <the-string>}`
+    - JS `Error` (CLJS) — reads `.message` + `.name`
+    - JVM `Throwable` — reads `.getMessage` + `.getName` of its
+      class (cljc consumers exercise the JVM branch in unit tests)
+
+  Deliberately omits `:stack` — stacks are long, environment-
+  specific, and bloat the trace bus."
+  [e]
+  (cond
+    (nil? e)    {:message "unknown error"}
+    (string? e) {:message e}
+    :else       #?(:cljs (let [msg (some-> ^js e .-message)
+                               nm  (some-> ^js e .-name)]
+                           (cond-> {:message (or msg "unknown error")}
+                             (not (str/blank? nm)) (assoc :name nm)))
+                   :clj  (let [msg (when (instance? Throwable e)
+                                     (.getMessage ^Throwable e))
+                               nm  (when e (.getName (class e)))]
+                           (cond-> {:message (or msg "unknown error")}
+                             (not (str/blank? nm)) (assoc :name nm))))))
+
+(defn layout-error-result
+  "Build the result-map the layout callback receives on ELK failure.
+  Empty `:positions` + `:edge-points` (the projector still renders,
+  every node at default origin — same as a pre-layout commit) plus
+  `:layout-error` so the chart can paint the in-panel indicator
+  banner. Pure fn."
+  [error parsed direction layout-options]
+  {:positions    {}
+   :edge-points  {}
+   :layout-error {:error         (error->data error)
+                  :input-summary (input-summary parsed direction layout-options)}})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/compute_layout_error_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/compute_layout_error_cljs_test.cljs
@@ -1,0 +1,241 @@
+(ns day8.re-frame2-machines-viz.chart.compute-layout-error-cljs-test
+  "rf2-4lyvh — pins for the `chart/compute-layout!` ELK error path.
+
+  ## What this guards
+
+  Before rf2-4lyvh, `compute-layout!` had two `(catch :default _ nil)`
+  clauses that discarded ELK errors entirely; the downstream
+  `(when result ...)` guard in MachineChart then no-op'd, leaving
+  every node at the default origin (stacked boxes; no console output;
+  no diagnostic). The fix surfaces ELK failures THREE ways — the bus
+  (`:rf.error/machines-viz-elk-layout-failed`), a dev-only
+  `console.error`, AND a `:layout-error` slot on the callback result-
+  map so the chart can render an in-panel banner.
+
+  This suite pins:
+
+    1. SYNC ELK throw → callback receives the layout-error result-map
+       (positions/edge-points empty + `:layout-error` slot present).
+    2. ASYNC ELK reject → same callback shape arrives.
+    3. The canonical `:rf.error/machines-viz-elk-layout-failed` trace
+       event fires (op-type `:error`, the right operation, the right
+       tag shape including machine-id) — and ONLY once per failure.
+    4. NEGATIVE: a successful layout does NOT emit the error trace
+       AND the callback receives a result without `:layout-error`.
+
+  ## Why this is a `-cljs-test` (node), not a DOM test
+
+  `compute-layout!` is JS-interop-heavy but the elkjs Promise + the
+  trace bus are both Node-runnable. We rebind the private
+  `chart/invoke-elk-layout!` (an indirection added precisely so tests
+  can substitute the elkjs call) + `re-frame.trace/emit-error!` so
+  the suite never reaches the real elkjs runtime. No DOM needed."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [day8.re-frame2-machines-viz.chart :as chart]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(def ^:private sample-parsed
+  "Minimal `parse-definition` shape sufficient for `compute-layout!`'s
+  `->elk-input` projection. Two flat states, one transition."
+  {:nodes [{:id "idle"} {:id "loading"}]
+   :edges [{:id "idle->loading"
+            :source "idle"
+            :target "loading"
+            :event-label "start"}]
+   :parallel? false})
+
+(defn- silence-console!
+  "Stub `js/console.error` to a no-op for the duration of `f`. The
+  failure path under test deliberately calls `console.error` (dev-
+  build operator affordance per rf2-4lyvh), so the test would
+  otherwise spam the test runner's stdout with stack traces that
+  read as failures. Returns the value of `(f)`."
+  [f]
+  (let [orig (.-error js/console)]
+    (set! (.-error js/console) (fn [& _args] nil))
+    (try (f)
+         (finally (set! (.-error js/console) orig)))))
+
+(defn- capture-trace-emits
+  "Run `f` with `trace/emit-error!` rebound to capture the (operation,
+  tags) calls into the returned atom, AND with `js/console.error`
+  silenced. Returns the atom."
+  [f]
+  (let [captured (atom [])]
+    (silence-console!
+      (fn []
+        (with-redefs [trace/emit-error! (fn [op tags]
+                                          (swap! captured conj [op tags]))]
+          (f captured))))
+    captured))
+
+;; ---- sync ELK throw ----------------------------------------------------
+
+(deftest compute-layout-sync-throw-delivers-error-result
+  (testing "When elkjs throws synchronously, `done-fn` receives the
+            canonical layout-error result-map (empty positions/edge-
+            points + :layout-error slot). The downstream `(when result
+            ...)` guard sees a TRUTHY map, so the chart reset!s
+            layout-state and paints the banner instead of silently
+            no-op'ing."
+    (let [result-promise (atom nil)]
+      (silence-console!
+        (fn []
+          (with-redefs [chart/invoke-elk-layout!
+                        (fn [_input]
+                          (throw (js/Error. "elk: malformed input")))
+                        trace/emit-error! (fn [_op _tags] nil)]
+            (chart/compute-layout! sample-parsed :tb nil :test/machine
+                                   (fn [r] (reset! result-promise r))))))
+      (let [r @result-promise]
+        (is (map? r) "callback was called with a non-nil map")
+        (is (= {} (:positions r)) "empty positions on failure")
+        (is (= {} (:edge-points r)) "empty edge-points on failure")
+        (is (some? (:layout-error r))
+            ":layout-error slot carries the failure")
+        (is (= "elk: malformed input"
+               (get-in r [:layout-error :error :message]))
+            ":layout-error :error :message carries the ELK error")
+        (is (= 2 (get-in r [:layout-error :input-summary :node-count]))
+            ":layout-error :input-summary carries the input counts")))))
+
+;; ---- async ELK reject --------------------------------------------------
+
+(deftest compute-layout-async-reject-delivers-error-result
+  (testing "When elkjs returns a rejected Promise, the .catch handler
+            invokes `done-fn` with the same layout-error result-map
+            shape the sync branch produces. `set!`-based stubbing
+            (not `with-redefs`) so the stubs survive the async
+            microtask boundary the rejection rides."
+    (async done
+      (let [orig-elk     chart/invoke-elk-layout!
+            orig-emit    trace/emit-error!
+            orig-console (.-error js/console)]
+        (set! (.-error js/console) (fn [& _args] nil))
+        (set! chart/invoke-elk-layout!
+              (fn [_input] (js/Promise.reject (js/Error. "elk: rejected"))))
+        (set! trace/emit-error! (fn [_op _tags] nil))
+        (chart/compute-layout!
+          sample-parsed :tb nil :test/machine
+          (fn [r]
+            (is (map? r))
+            (is (= {} (:positions r)))
+            (is (some? (:layout-error r)))
+            (is (= "elk: rejected"
+                   (get-in r [:layout-error :error :message])))
+            (set! chart/invoke-elk-layout! orig-elk)
+            (set! trace/emit-error! orig-emit)
+            (set! (.-error js/console) orig-console)
+            (done)))))))
+
+;; ---- trace event emit --------------------------------------------------
+
+(deftest compute-layout-sync-throw-emits-rf-error-trace
+  (testing "On sync ELK failure, `trace/emit-error!` fires ONCE with
+            operation = :rf.error/machines-viz-elk-layout-failed,
+            tags = {:elk-error … :machine-id … :input-summary …}.
+            This is the contract tools (Xray Issues panel, off-box
+            monitors) read off the bus."
+    (let [captured (capture-trace-emits
+                     (fn [_]
+                       (with-redefs [chart/invoke-elk-layout!
+                                     (fn [_input]
+                                       (throw (js/Error. "boom")))]
+                         (chart/compute-layout! sample-parsed :tb nil
+                                                :test/machine
+                                                (fn [_r] nil)))))
+          emits    @captured]
+      (is (= 1 (count emits))
+          "exactly one error trace event per failure (no double-emit)")
+      (let [[op tags] (first emits)]
+        (is (= :rf.error/machines-viz-elk-layout-failed op)
+            "canonical operation keyword")
+        (is (= :test/machine (:machine-id tags))
+            ":machine-id carries through onto the trace tags")
+        (is (= "boom" (get-in tags [:elk-error :message]))
+            ":elk-error :message carries the ELK error message")
+        (is (= 2 (get-in tags [:input-summary :node-count]))
+            ":input-summary carries node-count")
+        (is (= :tb (get-in tags [:input-summary :direction]))
+            ":input-summary carries direction")
+        (is (not (contains? tags :layout-options))
+            "raw caller-supplied layout-options are NOT on the trace
+            (only the key-set, on :input-summary)")))))
+
+(deftest compute-layout-async-reject-emits-rf-error-trace
+  (testing "On async ELK rejection, the same `:rf.error/machines-viz-
+            elk-layout-failed` event fires (op-type :error).
+
+            `with-redefs` is synchronous-scoped — it unwinds at body
+            exit, which arrives BEFORE the rejected-promise microtask
+            runs. So we install the stubs via `set!` (CLJS's mutable
+            Var rebind), exercise the async path, then restore the
+            originals inside `done-fn`. Asserts run before `(done)`
+            so cljs.test's async machinery sees them."
+    (async done
+      (let [captured     (atom [])
+            orig-elk     chart/invoke-elk-layout!
+            orig-emit    trace/emit-error!
+            orig-console (.-error js/console)]
+        (set! (.-error js/console) (fn [& _args] nil))
+        (set! chart/invoke-elk-layout!
+              (fn [_input] (js/Promise.reject (js/Error. "async-boom"))))
+        (set! trace/emit-error!
+              (fn [op tags] (swap! captured conj [op tags])))
+        (chart/compute-layout!
+          sample-parsed :tb nil :test/machine
+          (fn [_r]
+            (let [emits @captured]
+              (is (= 1 (count emits))
+                  "one emit on async reject")
+              (let [[op tags] (first emits)]
+                (is (= :rf.error/machines-viz-elk-layout-failed op))
+                (is (= "async-boom"
+                       (get-in tags [:elk-error :message])))
+                (is (= :test/machine (:machine-id tags)))))
+            ;; Restore — async tests must clean up their globals so
+            ;; following tests start from a clean slate.
+            (set! chart/invoke-elk-layout! orig-elk)
+            (set! trace/emit-error! orig-emit)
+            (set! (.-error js/console) orig-console)
+            (done)))))))
+
+;; ---- negative: happy path keeps existing contract ---------------------
+
+(deftest compute-layout-happy-path-does-not-emit-error-trace
+  (testing "When elkjs resolves cleanly, NO `:rf.error/*` trace fires
+            AND the callback receives a result WITHOUT :layout-error.
+            Guards against an over-eager emit that would put the
+            Issues panel in a red state on every render. Async path
+            via `set!` (see the rationale on the reject test above)."
+    (async done
+      (let [captured  (atom [])
+            orig-elk  chart/invoke-elk-layout!
+            orig-emit trace/emit-error!
+            ;; Build a minimally-shaped elk JS result (.children +
+            ;; .edges) so `elk-result->positions` walks it without
+            ;; throwing — we don't care about positions here, only
+            ;; that the success branch runs.
+            ok-result #js {:id "root"
+                           :children #js [#js {:id "idle" :x 0 :y 0
+                                               :width 100 :height 50
+                                               :children #js []}
+                                          #js {:id "loading" :x 0 :y 60
+                                               :width 100 :height 50
+                                               :children #js []}]
+                           :edges #js []}]
+        (set! chart/invoke-elk-layout! (fn [_input] (js/Promise.resolve ok-result)))
+        (set! trace/emit-error! (fn [op tags] (swap! captured conj [op tags])))
+        (chart/compute-layout!
+          sample-parsed :tb nil :test/machine
+          (fn [r]
+            (is (map? r))
+            (is (nil? (:layout-error r))
+                "happy path → no :layout-error")
+            (is (zero? (count @captured))
+                "happy path → no :rf.error/* emits")
+            (set! chart/invoke-elk-layout! orig-elk)
+            (set! trace/emit-error! orig-emit)
+            (done)))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_error_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_error_cljs_test.cljc
@@ -1,0 +1,148 @@
+(ns day8.re-frame2-machines-viz.chart.layout-error-cljs-test
+  "rf2-4lyvh — pure-data tests for the ELK layout-failure surface.
+
+  Pins the shapes the `chart.layout-error` ns produces:
+
+    1. `input-summary` carries counts + direction + the layout-option
+       KEY-SET (values omitted by design) and stays JVM-runnable.
+    2. `error->data` handles the three thrown-value classes
+       (nil, string, native error) without leaking environment-
+       specific fields onto the trace bus.
+    3. `layout-error-result` carries the empty-positions shape PLUS
+       the `:layout-error` slot the chart projector reads to paint
+       the in-panel indicator banner. Equality-pinned end-to-end so
+       a refactor that drops the slot fails here.
+
+  These pins guard the SHAPE consumers (Xray Issues panel; the
+  chart's banner) read. `chart-cljs-test` (browser-only, sibling) is
+  the place to wire a DOM-level pin for the banner itself; the data
+  shape it reads must not drift, which is what this suite enforces.
+
+  Cljc — the ns has no JS-interop touchpoints (it lives in
+  `chart.layout-error` precisely so the JVM corpus can exercise it
+  without loading elkjs/xyflow). Filename ends `-cljs-test` so the
+  `:node-test` shadow build's `cljs-test$` regexp picks it up."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-machines-viz.chart.layout-error :as layout-error]))
+
+;; ---- input-summary -----------------------------------------------------
+
+(deftest input-summary-counts-flat-machine
+  (testing "input-summary returns node/edge counts + region-count 0
+            + parallel? false for a flat machine"
+    (let [parsed   {:nodes [{:id :idle}
+                            {:id :loading}
+                            {:id :done}]
+                    :edges [{:id :idle->loading}
+                            {:id :loading->done}]
+                    :parallel? false}
+          summary  (layout-error/input-summary parsed :tb nil)]
+      (is (= 3 (:node-count summary)) "node-count counts every node")
+      (is (= 2 (:edge-count summary)) "edge-count counts every edge")
+      (is (zero? (:region-count summary)) "no :region? nodes → region-count 0")
+      (is (false? (:parallel? summary)) "flat machine → parallel? false")
+      (is (= :tb (:direction summary)) "direction passes through")
+      (is (= [] (:layout-option-ks summary))
+          "nil layout-options → empty key-set vec"))))
+
+(deftest input-summary-counts-parallel-machine
+  (testing "input-summary counts region nodes separately + reports
+            parallel? true for a parallel machine"
+    (let [parsed  {:nodes [{:id :audio   :region? true}
+                           {:id :display :region? true}
+                           {:id :playing}
+                           {:id :paused}
+                           {:id :on}
+                           {:id :off}]
+                   :edges [{:id :a} {:id :b}]
+                   :parallel? true}
+          summary (layout-error/input-summary parsed :lr nil)]
+      (is (= 6 (:node-count summary))
+          "node-count includes synthetic region containers")
+      (is (= 2 (:region-count summary))
+          "region-count filters :region? nodes only")
+      (is (true? (:parallel? summary)))
+      (is (= :lr (:direction summary))))))
+
+(deftest input-summary-layout-option-keys-only
+  (testing "input-summary surfaces the option KEY-SET (not values)
+            so caller-supplied option values do not bleed onto the
+            trace bus"
+    (let [parsed  {:nodes [] :edges []}
+          opts    {"elk.algorithm" "layered"
+                   "elk.direction" "DOWN"
+                   "elk.spacing.nodeNode" "40"}
+          summary (layout-error/input-summary parsed :tb opts)]
+      (is (= ["elk.algorithm" "elk.direction" "elk.spacing.nodeNode"]
+             (:layout-option-ks summary))
+          "key-set is sorted + value-free")
+      (is (not (contains? summary :layout-options))
+          "no `:layout-options` slot — values must not leak"))))
+
+;; ---- error->data -------------------------------------------------------
+
+(deftest error->data-handles-nil
+  (testing "error->data on nil returns the placeholder message"
+    (is (= {:message "unknown error"}
+           (layout-error/error->data nil)))))
+
+(deftest error->data-handles-string
+  (testing "error->data on a raw string returns it as :message
+            (no name field — strings carry no class info)"
+    (is (= {:message "elk: not a graph"}
+           (layout-error/error->data "elk: not a graph")))))
+
+(deftest error->data-handles-native-error
+  (testing "error->data on a native Error / Throwable returns
+            :message + :name. The native-error branch is cljs/clj-
+            split inside the fn; this pin exercises whichever runtime
+            the test compiles to."
+    (let [e   #?(:cljs (js/Error. "boom")
+                 :clj  (RuntimeException. "boom"))
+          out (layout-error/error->data e)]
+      (is (= "boom" (:message out)))
+      (is (some? (:name out)) ":name field carries the error class"))))
+
+(deftest error->data-omits-stack
+  (testing "error->data never carries :stack — stacks are long,
+            environment-specific, and bloat the trace bus. Pin the
+            negative so a refactor that adds :stack fails here."
+    (let [e   #?(:cljs (js/Error. "boom")
+                 :clj  (RuntimeException. "boom"))
+          out (layout-error/error->data e)]
+      (is (not (contains? out :stack))))))
+
+;; ---- layout-error-result -----------------------------------------------
+
+(deftest layout-error-result-shape
+  (testing "layout-error-result returns the canonical callback shape:
+            empty positions + empty edge-points + :layout-error
+            {:error :input-summary}. The (when result ...) guard at
+            the chart callsite needs a TRUTHY map so the reset! still
+            runs; that's what makes the banner appear instead of the
+            silent no-op."
+    (let [parsed  {:nodes [{:id :a}] :edges []}
+          err     #?(:cljs (js/Error. "bad input")
+                     :clj  (RuntimeException. "bad input"))
+          result  (layout-error/layout-error-result err parsed :tb nil)]
+      (is (map? result) "result is a map (so `when result` reset!s)")
+      (is (= {} (:positions result)) "positions empty on failure")
+      (is (= {} (:edge-points result)) "edge-points empty on failure")
+      (is (some? (:layout-error result)) ":layout-error slot present")
+      (is (= "bad input"
+             (get-in result [:layout-error :error :message]))
+          ":layout-error :error carries the error data")
+      (is (= 1 (get-in result [:layout-error :input-summary :node-count]))
+          ":layout-error :input-summary carries the parsed-graph summary"))))
+
+(deftest layout-error-result-includes-direction-and-options-keys
+  (testing "layout-error-result threads (direction, layout-option-ks)
+            through onto :input-summary so the trace consumer can
+            attribute the failure to a specific direction / option
+            combination."
+    (let [parsed  {:nodes [] :edges []}
+          opts    {"elk.algorithm" "layered"}
+          result  (layout-error/layout-error-result "boom" parsed :lr opts)]
+      (is (= :lr (get-in result [:layout-error :input-summary :direction])))
+      (is (= ["elk.algorithm"]
+             (get-in result [:layout-error :input-summary :layout-option-ks]))))))


### PR DESCRIPTION
## Root cause

`tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs` —
`compute-layout!` (L283–291 pre-fix) had two `catch` clauses that
discarded the ELK error wholesale:

```clj
(let [input (->elk-input parsed direction layout-options)
      p     (try (.layout elk-instance input)
                 (catch :default _ nil))]              ;; sync swallow
  (if (and p (.-then p))
    (-> p
        (.then (fn [result] (done-fn (elk-result->positions result))))
        (.catch (fn [_e] (done-fn nil))))               ;; async swallow
    (done-fn nil)))
```

`done-fn` arrived with `nil`. The chart callsite (L484–487 pre-fix)
gated on `(when result ...)` and silently skipped the `reset!`,
leaving `layout-state` at its initial `{:positions {} :edge-points {}}`.
The projector then rendered every node at default origin — stacked
boxes, no console error, no in-panel hint, no `:rf.error/*` on the bus.

## Fix — three error surfaces

1. **Trace event** — `:rf.error/machines-viz-elk-layout-failed`
   fires on both sync throw and async reject. Tags:

   ```clj
   {:elk-error     {:message <str> :name <str-opt>}
    :machine-id    <kw-or-nil>
    :input-summary {:node-count :edge-count :region-count
                    :parallel? :direction :layout-option-ks}}
   ```

   `:layout-option-ks` carries only the KEY-SET (sorted vec) — option
   values are caller-supplied and may drift, so they stay off the bus.

2. **Dev-only `console.error`** — `(when interop/debug-enabled?
   (js/console.error ...))` so an operator opening DevTools sees the
   failure immediately on the running app. Gated so it elides in
   production bundles.

3. **In-panel banner** — `compute-layout!`'s callback now receives
   a result-map shape `{:positions {} :edge-points {} :layout-error
   {:error … :input-summary …}}` on failure instead of `nil`. The
   existing `(when result ...)` guard is PRESERVED — the map is
   truthy, the `reset!` still fires — but `layout-state` now carries
   the failure flag. The chart paints a small banner over the canvas:
   `"Layout failed. <error message>. See console / Issues panel."`
   The root surfaces `data-layout-error="true"` / `"false"` so DOM
   tests can pin the failure without inspecting the banner DOM.

## Callback-shape choice

Option B from the bead — result-map carrying `:layout-error` —
because it preserves the existing `(when result ...)` callsite guard
verbatim and the projector can read the slot off the destructure
without any control-flow refactor. The (result, error) two-arg form
would have rippled through every (current and future) `compute-
layout!` caller for a single new error path.

## Module split

Pure-data helpers (`input-summary`, `error->data`,
`layout-error-result`) moved into a new `chart.layout-error` cljc
namespace so the `.cljc` test corpus exercises them without loading
elkjs/xyflow — mirrors the `rf2-0gmwp` split that moved the pure
projector into `chart.projection`. Side effects (trace emit +
console.error + the new `invoke-elk-layout!` test seam) stay in
`chart.cljs` next to the `.layout` call.

`compute-layout!` gains an optional `machine-id` arity so the trace
event can attribute the failure to a specific machine; the chart
threads its `:machine-id` prop through. The original 4-arg arity
(no machine-id) is retained for callers that lack one (unit tests).

## Tests

- `tools/machines-viz/test/.../chart/layout_error_cljs_test.cljc` —
  pure-data pins (runs under both `node-test` and JVM `clojure -M:test`):
  - `input-summary` for flat + parallel machines, plus the
    layout-option key-set carries only keys, never values.
  - `error->data` for nil / string / native error; pins the
    `:stack` omission as a negative invariant so a refactor that
    starts shipping stacks fails here.
  - `layout-error-result` shape end-to-end (empty positions, the
    `:layout-error` slot, the direction + option-key threading).

- `tools/machines-viz/test/.../chart/compute_layout_error_cljs_test.cljs`
  — `compute-layout!` integration (node, no DOM):
  - Sync throw → `done-fn` receives the layout-error result-map;
    `:rf.error/machines-viz-elk-layout-failed` fires once with the
    right tags + machine-id.
  - Async reject → same callback shape; same trace event (the async
    path uses `set!`-based stubbing because `with-redefs` unwinds
    before the rejected-promise microtask runs).
  - Negative — happy path emits no `:rf.error/*` and the callback
    receives a result-map WITHOUT `:layout-error`.

## Gates

- `tools/machines-viz` JVM `clojure -M:test` — 239 tests, 0 failures.
- `implementation` `npm run test:cljs` — 4387 tests, 0 failures.
- `clj-kondo` on changed files — clean.
- `splint` over `tools/machines-viz/{src,test}` — 0 errors (style
  warnings unchanged from baseline).

No committed docs touched; `mkdocs build --strict` not required.

Refs rf2-4lyvh.