### PR TITLE
feat(xray): Trace panel per-path db-changed diff via panel-side derive (rf2-b3zw2)

### DIFF
--- a/tools/xray/spec/023-Trace-Panel.md
+++ b/tools/xray/spec/023-Trace-Panel.md
@@ -136,6 +136,10 @@ Per-op fields already on the epoch record / trace bus: views (`:rf.view/elapsed-
 - **Flow result** — `:rf.flow/computed` carries `:result` (computed value), `:before` (prior value), `:input-values`. The FLOW row renders the value + the `[:path] before → after` delta directly (no db-snapshot walk needed).
 - **Net db** — `:rf.event/db-changed` is the net installed diff (handler + flows combined). So the three contributions are distinguishable: handler-return (`:rf.event/fx` `:db`) → per-flow delta (`:rf.flow/computed` `:before`→`:result`) → net install (`:rf.event/db-changed`). No new trace fields required (rf2-u0zz5 must keep them distinct at the new emit points).
 
+### §10.1 APP-DB CHANGES — per-path diff is PANEL-SIDE DERIVED
+
+The `:rf.event/db-changed` trace event carries only `:event` + `:frame` — **no per-path diff payload on the event itself**. The per-path before→after rows the DB row presents (`+ [:path] new` / `~ [:path] old → new` / `- [:path]`) are **derived at render time** from the focused epoch record's `:db-before` / `:db-after` slots (already on every `:rf/epoch-record` per [`Spec 009`](../../../spec/009-Instrumentation.md) / [`spec/Spec-Schemas.md §:rf/epoch-record`](../../../spec/Spec-Schemas.md)). The derivation routes through the same structural-sharing engine the App-DB Diff tab and the Event-panel APP-DB CHANGES section consume (`app-db-diff-helpers/diff-paths`, [`004-App-DB-Diff.md §Changed-paths derivation`](./004-App-DB-Diff.md) — O(changed paths), not O(db size)). One engine, one shape; differences in rendering live in the view. When `db-before == db-after` the diff is `[]` and the DB row renders no per-path sub-list — the empty-diff case. Decision recorded on rf2-8q8i4 (panel-side derive, 2026-05-25); implementation tracked under rf2-b3zw2.
+
 ## §11 Implementation dependencies
 
 1. **Timing instrumentation** (Spec 009) — run-start/run-end (or elapsed-ms) on sub / cofx / fx / flow / handler trace events, so §6 durations populate beyond views.

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace.cljs
@@ -79,8 +79,10 @@
   classification, band projection, epoch-scoped feed, empty-state
   classification — lives in `trace_helpers.cljc` so the algebra runs
   under the JVM unit-test target."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [day8.re-frame2-xray.panel-registry :as panel-registry]
+            [day8.re-frame2-xray.panels.app-db-diff-format :as f]
             [day8.re-frame2-xray.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-xray.panels.event-detail :as event-detail]
             [day8.re-frame2-xray.panels.event.event-status-colour :as event-status]
@@ -122,6 +124,133 @@
       :panel-id  :trace
       :render-id (str "trace-row-" id)})])
 
+;; ---- per-path db-changed diff rows (spec/023 §APP-DB CHANGES) -----------
+;;
+;; The trace event `:rf.event/db-changed` carries only `:event` + `:frame`
+;; — no per-path diff payload (Mike-decided rf2-8q8i4 = (b), 2026-05-25:
+;; PANEL-SIDE derive). Per-path before→after rows are derived at render
+;; time from the focused epoch record's `:db-before` / `:db-after` slots
+;; by `trace_helpers/db-changed-diff-triples` (which routes through
+;; `app-db-diff-helpers/diff-paths` — the same structural-sharing engine
+;; the App-DB Diff tab + the Event-panel APP-DB CHANGES section consume,
+;; spec/004 §Changed-paths derivation). The feed projection attaches the
+;; triples to every `:rf.event/db-changed` row's `:db-diff` slot so the
+;; view stays dumb-and-pure.
+;;
+;; The row idiom mirrors the Event-panel APP-DB CHANGES section
+;; (`panels/event_detail.cljs` `db-change-row`, spec/021 §2.2 step 6
+;; mockup):
+;;
+;;     + [:path] new            (added — green)
+;;     ~ [:path] old → new      (modified — amber)
+;;     - [:path]                (removed — red — path alone)
+;;
+;; The diff helper itself (`diff-paths`) is already extracted to
+;; `app_db_diff_helpers.cljc` (shared); the render-side `db-change-row`
+;; in `event_detail.cljs` is private (`defn-`) — v1 keeps a small
+;; trace-flavoured duplicate here (denser layout, slightly different
+;; padding to fit the arc's row rhythm) per the rf2-b3zw2 brief's
+;; safer-move guidance (event_detail.cljs is post-#2114 stabilised; the
+;; lens cluster + B+ section reorder just landed). Dedupe is filed as a
+;; follow-on bead.
+
+(def ^:private diff-op->glyph
+  "Cascade diff glyph per op (spec/021 §10.3 / event_detail.cljs `op->glyph`)."
+  {:added    "+"
+   :modified "~"
+   :removed  "-"})
+
+(def ^:private diff-op->tone
+  "Glyph + path colour per op (spec/021 §10.3 / event_detail.cljs `op->tone`)."
+  {:added    :green
+   :modified :yellow
+   :removed  :red})
+
+(defn- path-suffix
+  "Stable testid suffix for a changed path — pr-str of the path vector
+  with characters that break a data-testid selector folded to `_`.
+  Mirrors event_detail.cljs's `path-suffix` so the testids read
+  consistently across the two panels."
+  [path]
+  (-> (str/join " " (map pr-str path))
+      (str/replace #"\s+" "_")))
+
+(defn- db-diff-row
+  "Render one changed-path row beneath a `:rf.event/db-changed` op row.
+  `triple` is one `app-db-diff-helpers/diff-paths` triple
+  (`{:op :path :before :after}`). Pure hiccup; no nav (the parent row's
+  click toggles the raw trace-event EDN, this sub-row is informational).
+  Shape per spec/021 §2.2 step 6 mockup:
+
+      ~ [:counter]  1 → 2
+      + [:last-updated]  #inst \"…\"
+      - [:stale]
+
+  Indented under the parent op row so the diff reads as a sub-list of
+  the db-changed event."
+  [parent-row-id {:keys [op path before after] :as _triple}]
+  (let [suffix     (path-suffix path)
+        glyph      (get diff-op->glyph op "?")
+        tone       (get tokens (get diff-op->tone op) (:text-secondary tokens))
+        path-label (f/format-edn (vec path))
+        row-test-id (str "rf-xray-trace-row-" parent-row-id
+                         "-db-diff-row-" suffix)]
+    [:div {:data-testid row-test-id
+           :data-op     (name op)
+           :on-click    (fn [e] (.stopPropagation e))
+           :style       {:display       "flex"
+                         :align-items   "baseline"
+                         :flex-wrap     "wrap"
+                         :gap           "8px"
+                         :padding       "1px 16px 1px 56px"
+                         :font-family   mono-stack
+                         :font-size     "11px"}}
+     [:span {:data-testid (str row-test-id "-glyph")
+             :style       {:flex        "0 0 12px"
+                           :color       tone
+                           :font-weight 700
+                           :text-align  "center"
+                           :user-select "none"}}
+      glyph]
+     [:span {:data-testid (str row-test-id "-path")
+             :style {:color tone}}
+      path-label]
+     (case op
+       :modified
+       [:span {:style {:display     "inline-flex"
+                       :align-items "baseline"
+                       :flex-wrap   "wrap"
+                       :gap         "6px"
+                       :min-width   0}}
+        [:span {:style {:color           (:text-tertiary tokens)
+                        :text-decoration "line-through"}}
+         (edn/inspect-inline before)]
+        [:span {:style {:color (:text-tertiary tokens)}} "→"]
+        [:span {:style {:color (:text-primary tokens)}}
+         (edn/inspect-inline after)]]
+
+       :added
+       [:span {:style {:color (:text-primary tokens) :min-width 0}}
+        (edn/inspect-inline after)]
+
+       ;; :removed — path alone (spec/021 line 229 / event_detail `db-change-row`).
+       nil)]))
+
+(defn- db-diff-rows
+  "Render the per-path diff list under a `:rf.event/db-changed` row. When
+  the diff is empty (`db-before == db-after`) renders no list — the spec
+  treats the empty diff section as the no-changes case (spec/023
+  §APP-DB CHANGES). The container carries the testid
+  `rf-xray-trace-row-<id>-db-diff` so tests can target the section
+  regardless of contents."
+  [parent-row-id triples]
+  (when (seq triples)
+    (into [:div {:data-testid (str "rf-xray-trace-row-" parent-row-id "-db-diff")
+                 :style       {:padding "2px 0 6px 0"}}]
+          (for [{:keys [path] :as triple} triples]
+            (with-meta (db-diff-row parent-row-id triple)
+                       {:key (pr-str path)})))))
+
 ;; ---- one op row (spec/023 §3) -------------------------------------------
 
 (defn- op-row
@@ -141,7 +270,7 @@
   leads with `!`, the badge + verb ride the semantic colour, and the row
   carries a tinted left rail."
   [{:keys [id operation rel-time time area area-badge verb target
-           duration-ms source-coord dispatch-id]
+           duration-ms source-coord dispatch-id db-diff]
     :as row}
    {:keys [expanded?]}]
   (let [row-test-id (str "rf-xray-trace-row-" id)
@@ -287,6 +416,13 @@
                             :white-space "nowrap"
                             :text-align  "right"}}
        (or (h/format-duration duration-ms) "—")]]
+     ;; Per-path db-changed diff rows (rf2-b3zw2 / rf2-8q8i4 = (b)) —
+     ;; only present on `:rf.event/db-changed` rows; derived panel-side
+     ;; from the focused epoch record's `:db-before` / `:db-after` by
+     ;; `trace_helpers/db-changed-diff-triples`. Empty diffs render no
+     ;; sub-list per spec/023 §APP-DB CHANGES (the empty-diff case).
+     (when (= operation :rf.event/db-changed)
+       (db-diff-rows id db-diff))
      ;; Row click → raw trace-event EDN inline (spec/023 §3).
      (when expanded? (render-payload row))]))
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/trace_helpers.cljc
@@ -54,6 +54,7 @@
   per-row payload-expand affordance is the drill-down. Show every op,
   no default narrowing (spec/023 §2 completeness-first)."
   (:require [clojure.string :as str]
+            [day8.re-frame2-xray.panels.app-db-diff-helpers :as diff-h]
             [day8.re-frame2-xray.panels.common-helpers :as common]
             [day8.re-frame2-xray.theme.tokens :as tokens]))
 
@@ -754,6 +755,58 @@
                           :empty? (empty? band-rows)}))
                      band-order)}))
 
+;; ---- per-path db-changed diff (rf2-b3zw2 / rf2-8q8i4 = (b)) -------------
+;;
+;; The trace event `:rf.event/db-changed` carries only `:event` + `:frame`
+;; (no per-path diff payload — Mike's 2026-05-25 decision rf2-8q8i4 = (b),
+;; PANEL-SIDE derive). Per spec/023 §10 the "net db" diff IS the
+;; meaningful content of a DB row, but its derivation is the panel's
+;; responsibility, not the runtime's: it comes from the focused epoch
+;; record's `:db-before` / `:db-after` slots (already on every
+;; `:rf/epoch-record` per Spec 009 / spec/Spec-Schemas.md).
+;;
+;; The cleanest place to derive it is right here in the feed projection
+;; — `project-feed-from-epoch` already holds the epoch record. We attach
+;; the diff triples onto each `:rf.event/db-changed` row's `:db-diff`
+;; slot so the view stays dumb-and-pure: it renders `:db-diff` if
+;; present, omits the per-path lines otherwise (the empty-diff case —
+;; `db-before` == `db-after` — yields `[]` and the view renders no
+;; per-path rows).
+;;
+;; The diff itself routes through `app-db-diff-helpers/diff-paths` — the
+;; SAME structural-sharing engine spec/004-App-DB-Diff.md describes and
+;; the App-DB Diff tab / Event-panel APP-DB CHANGES section both consume
+;; (spec/021 §2.2 step 6). One derivation, one engine, one shape —
+;; differences in rendering live in the view, not in re-derived data.
+
+(defn db-changed-diff-triples
+  "Derive the per-path diff for a `:rf.event/db-changed` row from the
+  focused epoch record. Routes through
+  `app-db-diff-helpers/diff-paths` — the structural-sharing engine
+  (spec/004 §Changed-paths derivation, O(changed paths) not O(db
+  size)). Returns a vector of `{:op :added/:modified/:removed
+  :path [...] :before <v> :after <v>}` triples, sorted by path-as-
+  pr-str. Returns `[]` when `db-before == db-after` (the no-changes
+  case — empty diff section per spec/023 §APP-DB CHANGES).
+
+  Pure data → data; JVM-testable."
+  [{:keys [db-before db-after] :as _epoch-record}]
+  (diff-h/diff-paths db-before db-after))
+
+(defn- attach-db-diff
+  "Attach the per-path diff triples to every `:rf.event/db-changed` row
+  in `rows`. Other rows pass through untouched. The diff is computed
+  ONCE per feed projection (cheap — pointer-equal subtrees skip via
+  structural sharing) and copied onto every db-changed row in the
+  epoch; in normal use the runtime emits at most one db-changed row
+  per epoch, but the projection is robust to none / many. Pure data."
+  [rows triples]
+  (mapv (fn [{:keys [operation] :as row}]
+          (cond-> row
+            (= operation :rf.event/db-changed)
+            (assoc :db-diff triples)))
+        rows))
+
 ;; ---- epoch-scoped feed projection (the panel reads this) ----------------
 
 (defn project-feed-from-epoch
@@ -797,7 +850,15 @@
   (let [record-present? (= :focused focus-status)
         trace-events    (when record-present?
                           (:trace-events epoch-record))
-        rows            (with-rel-times (project-rows (or trace-events [])))
+        ;; Derive the per-path db-changed diff ONCE from the epoch
+        ;; record's `:db-before` / `:db-after` (rf2-b3zw2 — panel-side
+        ;; derive, Mike-decided rf2-8q8i4 = (b)) and attach to each
+        ;; db-changed row's `:db-diff` slot.
+        db-diff         (when record-present?
+                          (db-changed-diff-triples epoch-record))
+        raw-rows        (with-rel-times (project-rows (or trace-events [])))
+        rows            (cond-> raw-rows
+                          (some? db-diff) (attach-db-diff db-diff))
         {:keys [envelope outcome bands]} (build-bands rows)
         n               (count rows)
         empty-kind      (cond

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_helpers_cljs_test.cljc
@@ -599,3 +599,128 @@
       (doseq [row (:rows feed)]
         (is (not (contains? row :row-index))
             (str "row " (:id row) " must not carry :row-index"))))))
+
+;; ---- (10) per-path db-changed diff — rf2-b3zw2 / rf2-8q8i4 = (b) --------
+;;
+;; The `:rf.event/db-changed` trace event carries no per-path diff (it
+;; only ships `:event` + `:frame`). The Trace panel derives the diff
+;; PANEL-SIDE from the focused epoch record's `:db-before` /
+;; `:db-after` slots — the rf2-8q8i4 Mike-decided shape — via
+;; `db-changed-diff-triples` (route through `app-db-diff-helpers/diff-paths`).
+;; `project-feed-from-epoch` attaches the resulting triples to every
+;; `:rf.event/db-changed` row's `:db-diff` slot so the view stays
+;; dumb-and-pure.
+
+(defn- diff-epoch
+  "A minimal epoch record carrying a non-trivial `:db-before` /
+  `:db-after` and a single `:rf.event/db-changed` row. The other rows
+  in the trail are noise the test ignores."
+  [db-before db-after]
+  {:epoch-id     71
+   :db-before    db-before
+   :db-after     db-after
+   :trace-events
+   [(ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+         :time 100 :dispatch-id 42 :tags {:rf.event/v [:counter/inc]}})
+    (ev {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+         :time 102 :dispatch-id 42})]})
+
+(deftest db-changed-diff-triples-routes-through-diff-paths
+  (testing "the helper returns the canonical diff-paths triples for the
+            epoch's :db-before / :db-after"
+    (let [triples (h/db-changed-diff-triples
+                    {:db-before {:counter 1}
+                     :db-after  {:counter 2}})]
+      (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+             triples)))))
+
+(deftest db-changed-diff-triples-empty-when-no-changes
+  (testing "db-before == db-after → empty diff (the no-changes case
+            per spec/023 §APP-DB CHANGES)"
+    (let [db      {:counter 1 :user {:name "Ada"}}
+          triples (h/db-changed-diff-triples
+                    {:db-before db :db-after db})]
+      (is (= [] triples)))))
+
+(deftest db-changed-diff-triples-nested-and-top-level-paths
+  (testing "the diff covers both top-level and nested-key changes"
+    (let [before  {:counter 1 :user {:name "Ada" :age 30}}
+          after   {:counter 2 :user {:name "Ada" :age 31}
+                   :last-seen :now}
+          triples (h/db-changed-diff-triples
+                    {:db-before before :db-after after})
+          by-path (into {} (map (juxt :path identity)) triples)]
+      (is (contains? by-path [:counter])
+          "top-level :counter shows")
+      (is (= :modified (:op (get by-path [:counter]))))
+      (is (contains? by-path [:user :age])
+          "nested [:user :age] shows")
+      (is (= :modified (:op (get by-path [:user :age]))))
+      (is (= 30 (:before (get by-path [:user :age]))))
+      (is (= 31 (:after  (get by-path [:user :age]))))
+      (is (contains? by-path [:last-seen]))
+      (is (= :added (:op (get by-path [:last-seen])))))))
+
+(deftest project-feed-attaches-db-diff-to-db-changed-rows
+  (testing "the db-changed row carries the derived diff under :db-diff;
+            other rows do NOT carry a :db-diff slot"
+    (let [feed   (h/project-feed-from-epoch
+                   (diff-epoch {:counter 1} {:counter 2 :flag true})
+                   :focused)
+          by-id  (into {} (map (juxt :id identity)) (:rows feed))
+          db-row (get by-id 2)
+          ev-row (get by-id 1)]
+      (is (contains? db-row :db-diff)
+          "the :rf.event/db-changed row carries :db-diff")
+      (let [paths (set (map :path (:db-diff db-row)))]
+        (is (= #{[:counter] [:flag]} paths)
+            "the diff covers both modified + added paths"))
+      (is (not (contains? ev-row :db-diff))
+          "the non-db-changed row carries NO :db-diff slot"))))
+
+(deftest project-feed-empty-diff-attached-as-empty-vec
+  (testing "when db-before == db-after the db-changed row still carries
+            :db-diff, but the vector is empty — the view renders no
+            per-path sub-list (spec/023 §APP-DB CHANGES — empty-diff)"
+    (let [feed  (h/project-feed-from-epoch
+                  (diff-epoch {:counter 1} {:counter 1})
+                  :focused)
+          by-id (into {} (map (juxt :id identity)) (:rows feed))]
+      (is (= [] (:db-diff (get by-id 2)))))))
+
+(deftest project-feed-no-db-changed-row-no-attachment
+  (testing "an epoch with NO :rf.event/db-changed row in :trace-events
+            (e.g. a no-op event) attaches no :db-diff to any row"
+    (let [epoch  {:epoch-id     91
+                  :db-before    {:counter 1}
+                  :db-after     {:counter 1}
+                  :trace-events
+                  [(ev {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                        :time 100 :dispatch-id 42})]}
+          feed   (h/project-feed-from-epoch epoch :focused)]
+      (doseq [row (:rows feed)]
+        (is (not (contains? row :db-diff))
+            (str "row " (:id row) " must not carry :db-diff"))))))
+
+(deftest project-feed-flow-having-and-flow-less-epoch-shapes
+  (testing "the diff projection works the same for a flow-less event
+            (handler writes :db only) and a flow-having event (flow
+            writes one path after the handler) — the diff is derived
+            from db-before/db-after which are net-of-flows on both"
+    (testing "flow-less event — handler writes [:counter] only"
+      (let [feed (h/project-feed-from-epoch
+                   (diff-epoch {:counter 1} {:counter 2})
+                   :focused)
+            db-row (some #(when (= 2 (:id %)) %) (:rows feed))]
+        (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+               (:db-diff db-row)))))
+    (testing "flow-having event — handler writes [:counter], flow
+              writes [:totals :sum]; net diff covers both"
+      (let [feed (h/project-feed-from-epoch
+                   (diff-epoch {:counter 1 :totals {:sum 1}}
+                               {:counter 2 :totals {:sum 2}})
+                   :focused)
+            db-row (some #(when (= 2 (:id %)) %) (:rows feed))
+            by-path (into {} (map (juxt :path identity)) (:db-diff db-row))]
+        (is (contains? by-path [:counter]))
+        (is (contains? by-path [:totals :sum]))))))

--- a/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/panels/trace_view_cljs_test.cljs
@@ -115,6 +115,15 @@
     :committed-at  (* 1000 epoch-id)
     :trace-events  (vec trace-events)}))
 
+(defn- mk-epoch-with-db
+  "Like `mk-epoch` but pins `:db-before` / `:db-after` so the trace
+  panel's per-path db-changed diff (rf2-b3zw2) has real snapshots to
+  derive from."
+  [epoch-id dispatch-id db-before db-after trace-events]
+  (-> (mk-epoch epoch-id dispatch-id trace-events)
+      (assoc :db-before db-before
+             :db-after  db-after)))
+
 (defn- seed-history!
   "Dispatch `:rf.xray/sync-epoch-history` to seed the per-frame ring
   buffer. Must be called inside `(rf/with-frame :rf/xray ...)`."
@@ -322,6 +331,135 @@
         (let [t (last (find-by-testid tree "rf-xray-trace-row-2-time"))]
           (is (and (string? t) (re-find #"^!" t))
               "the error row's Δt leads with ! for emphasis"))))))
+
+;; ---- (2b) per-path db-changed diff (rf2-b3zw2 / rf2-8q8i4 = (b)) -------
+;;
+;; The `:rf.event/db-changed` trace event carries only `:event` + `:frame`
+;; — no per-path diff. The Trace panel derives per-path before→after
+;; rows at render time from the focused epoch record's `:db-before` /
+;; `:db-after` (Mike-decided rf2-8q8i4 = (b), 2026-05-25 — PANEL-SIDE
+;; derive). The view renders one sub-row per changed path beneath the
+;; DB row:
+;;
+;;     + [:path] new           (added)
+;;     ~ [:path] old → new     (modified)
+;;     - [:path]               (removed — path alone)
+;;
+;; spec/023 §APP-DB CHANGES — empty diff (db-before == db-after) renders
+;; no sub-list.
+
+(defn- db-diff-row-by-suffix
+  "Walk the rendered tree for a per-path diff row under the
+  db-changed row with id `parent-row-id`; suffix is the
+  `path-suffix`-shaped string the renderer builds (e.g. `:counter` /
+  `:user_:age`)."
+  [tree parent-row-id suffix]
+  (find-by-testid tree (str "rf-xray-trace-row-" parent-row-id
+                            "-db-diff-row-" suffix)))
+
+(deftest db-changed-row-renders-per-path-diff-rows-flow-less
+  (testing "a flow-less event with a non-trivial db-changed renders one
+            per-path row beneath the DB row — modified path only"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 {:counter 1} {:counter 2}
+            [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                        :time 100 :dispatch-id 1
+                        :tags {:rf.event/v [:counter/inc]}})
+             (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-trace-row-2-db-diff"))
+            "the db-diff section renders beneath the db-changed row")
+        (let [row (db-diff-row-by-suffix tree 2 ":counter")]
+          (is (some? row)
+              "the [:counter] modified row renders")
+          (is (= "modified" (:data-op (second row))))
+          (is (= "~" (last (find-by-testid
+                             tree "rf-xray-trace-row-2-db-diff-row-:counter-glyph")))
+              "modified-row glyph reads ~"))))))
+
+(deftest db-changed-row-renders-added-and-removed-rows
+  (testing "added (`+`) and removed (`-`) per-path rows render with
+            their op tones"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 {:stale :x} {:flag true}
+            [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree    (trace/Panel)
+            added   (db-diff-row-by-suffix tree 2 ":flag")
+            removed (db-diff-row-by-suffix tree 2 ":stale")]
+        (is (some? added) "the [:flag] added row renders")
+        (is (= "added" (:data-op (second added))))
+        (is (= "+" (last (find-by-testid
+                           tree "rf-xray-trace-row-2-db-diff-row-:flag-glyph"))))
+        (is (some? removed) "the [:stale] removed row renders")
+        (is (= "removed" (:data-op (second removed))))
+        (is (= "-" (last (find-by-testid
+                           tree "rf-xray-trace-row-2-db-diff-row-:stale-glyph"))))))))
+
+(deftest db-changed-row-renders-nested-and-top-level-paths
+  (testing "top-level + nested-key diffs both surface as per-path rows"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1
+            {:counter 1 :user {:name "Ada" :age 30}}
+            {:counter 2 :user {:name "Ada" :age 31}}
+            [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (some? (db-diff-row-by-suffix tree 2 ":counter"))
+            "top-level [:counter] row renders")
+        (is (some? (db-diff-row-by-suffix tree 2 ":user_:age"))
+            "nested [:user :age] row renders")
+        ;; :user :name unchanged → no row
+        (is (nil? (db-diff-row-by-suffix tree 2 ":user_:name"))
+            "unchanged [:user :name] does NOT render")))))
+
+(deftest db-changed-row-empty-diff-renders-no-sub-list
+  (testing "db-before == db-after → empty diff → no sub-list rendered
+            (spec/023 §APP-DB CHANGES empty-diff case)"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 {:counter 1} {:counter 1}
+            [(mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (some? (find-by-testid tree "rf-xray-trace-row-2"))
+            "the db-changed row itself still renders")
+        (is (nil? (find-by-testid tree "rf-xray-trace-row-2-db-diff"))
+            "no diff sub-list when db-before == db-after")))))
+
+(deftest non-db-changed-row-renders-no-diff-section
+  (testing "an event-row that is not :rf.event/db-changed never renders
+            a per-path diff section, regardless of db-before/db-after"
+    (setup-xray-frame!)
+    (rf/with-frame :rf/xray
+      (seed-history!
+        [(mk-epoch-with-db 1 1 {:counter 1} {:counter 2}
+            [(mk-trace {:id 1 :op-type :rf.event :operation :rf.event/dispatched
+                        :time 100 :dispatch-id 1})
+             (mk-trace {:id 2 :op-type :rf.event :operation :rf.event/db-changed
+                        :time 102 :dispatch-id 1})
+             (mk-trace {:id 3 :op-type :rf.fx :operation :rf.fx/handled
+                        :time 105 :dispatch-id 1})])])
+      (focus! 1)
+      (let [tree (trace/Panel)]
+        (is (nil? (find-by-testid tree "rf-xray-trace-row-1-db-diff"))
+            "the dispatch row carries no diff section")
+        (is (nil? (find-by-testid tree "rf-xray-trace-row-3-db-diff"))
+            "the fx row carries no diff section")
+        (is (some? (find-by-testid tree "rf-xray-trace-row-2-db-diff"))
+            "only the db-changed row carries the diff section")))))
 
 ;; ---- (3) empty states ---------------------------------------------------
 


### PR DESCRIPTION
## Summary

The Trace panel now renders per-path before→after rows beneath every `:rf.event/db-changed` op row. The diff is derived **at render time** from the focused epoch record''s `:db-before` / `:db-after` slots — Mike-decided shape on `rf2-8q8i4` = **(b) panel-side derive** (2026-05-25). No change to the trace event itself, which still carries only `:event` + `:frame`.

Per-row idiom (mirrors spec/021 §2.2 step 6 / event_detail.cljs `db-change-row`):

```
+ [:path] new            (added — green)
~ [:path] old → new      (modified — amber)
- [:path]                (removed — red — path alone)
```

Sourced from `rf2-wi81e` trace-sufficiency audit S4; implementation tracked under `rf2-b3zw2`.

## Shared-helper decision: data shared, render duplicated for v1

- **Data helper (already extracted):** `app-db-diff-helpers/diff-paths` — the structural-sharing engine (spec/004 §Changed-paths derivation, O(changed paths) not O(db size)). Reused as-is; this PR adds `trace_helpers/db-changed-diff-triples` as a thin wrapper that routes the epoch record through it.
- **Render helper (duplicated for v1):** `event_detail.cljs`''s `db-change-row` is private (`defn-`); event_detail.cljs is post-`#2114` stabilised with the lens cluster + B+ section reorder just landed. Per the rf2-b3zw2 brief''s safer-move guidance, this PR keeps a small trace-flavoured duplicate renderer in `trace.cljs` (the arc row rhythm differs slightly — denser layout, different padding to fit the 5-column grid). The full dedupe will be a follow-on bead.

## Architecture

- `project-feed-from-epoch` derives the diff once per epoch and attaches the triples to every `:rf.event/db-changed` row''s `:db-diff` slot. The view stays dumb-and-pure — renders `:db-diff` when present, omits the sub-list otherwise.
- Empty diff (`db-before == db-after`) → `[]` → no sub-list rendered (spec/023 §APP-DB CHANGES empty-diff case).

## Spec clarification

`tools/xray/spec/023-Trace-Panel.md` §10 gains a new §10.1 clarifying that the per-path diff is **panel-side-derived** from the epoch record''s `:db-before` / `:db-after`, NOT on the `:rf.event/db-changed` trace event itself. One paragraph; no restructuring elsewhere.

## Tests

**Pure-data (CLJC, JVM + CLJS):**
- `db-changed-diff-triples` routes through `diff-paths` for non-trivial / empty / nested+top-level shapes.
- `project-feed-from-epoch` attaches `:db-diff` ONLY to `:rf.event/db-changed` rows; empty diffs attached as `[]`; no db-changed row → no attachment anywhere.
- Flow-less + flow-having epoch shapes both project correctly (the diff is derived from the net `db-before` / `db-after`, which are net-of-flows on both).

**CLJS view:**
- Per-path rows render beneath the DB row for flow-less + flow-having events with non-trivial changes.
- `+` / `~` / `-` glyphs + tones per op.
- Top-level + nested-key diffs both surface; unchanged sub-paths do NOT render rows.
- Empty diff → no sub-list.
- Non-db-changed rows (dispatch, fx) never carry the diff section.

## Gates (all pass)

- xray JVM `clojure -M:test` — 884 tests / 3129 assertions / 0 failures
- `npm run test:cljs` — 4385 tests / 14015 assertions / 0 failures
- `npm run test:xray-feature-gate` — 13/13 scenarios
- `npm run test:bundle-isolation` — 33 sentinels absent, 3 budgets ok
- clj-kondo + splint on changed files (the pre-existing `Math/round` splint hint in `trace_helpers.cljc:590` is untouched)
- `python -m mkdocs build --strict` — exit 0
- `python scripts/check_doc_slugs.py --verbose` — no broken links

Closes `rf2-b3zw2`.