### PR TITLE
feat(re-frame2-pair-mcp): pair-debug diagnostics cluster (4 beads incl. rf2-7tgfk runtime-not-preloaded refinement)

### DIFF
--- a/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
+++ b/skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs
@@ -343,10 +343,20 @@
    :handler-fn, the :rf/machine? flag where applicable, and any extra
    keys the registrar carries (e.g. retained source forms when present).
 
-   Augments with :handler-fn-hash for use as a probe over hot-reload."
+   Augments with :handler-fn-hash for use as a probe over hot-reload.
+
+   rf2-l7vnd: the :handler-fn slot carries a raw Function. `pr-str` of a
+   Function emits `#object[Function ...]` — unreadable EDN on the MCP
+   wire, which made the tool's read-back fall to a string and the
+   handler-meta envelope misreport :unexpected-shape. The hash already
+   covers every hot-reload probing use; the raw fn ref had no surviving
+   on-the-wire consumer. Drop it before returning so the response is
+   EDN-clean by construction."
   [kind id]
   (if-let [m (rf/handler-meta kind id)]
-    (assoc m :handler-fn-hash (handler-fn-hash m))
+    (-> m
+        (assoc :handler-fn-hash (handler-fn-hash m))
+        (dissoc :handler-fn))
     {:ok? false :reason :not-registered :kind kind :id id}))
 
 (defn registrar-handler-ref

--- a/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
+++ b/skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj
@@ -1,0 +1,92 @@
+;;;; tests/runtime/registrar_describe_test.clj
+;;;;
+;;;; Babashka-runnable structural pin (rf2-l7vnd) that
+;;;; `registrar-describe` strips the raw `:handler-fn` value from its
+;;;; return before handing it to the MCP wire.
+;;;;
+;;;; Why this test exists:
+;;;;
+;;;; `re-frame.core/handler-meta` carries a `:handler-fn` slot whose
+;;;; value is a raw Function. `pr-str` of a Function emits
+;;;; `#object[Function "..."]` — unreadable EDN on the MCP wire. Before
+;;;; rf2-l7vnd the MCP server's `read-edn-safe` then fell back to the
+;;;; raw string, and the `handler-meta` tool surfaced
+;;;; `{:ok? false :reason :unexpected-shape :value "{...}"}` — a
+;;;; "failed" envelope with the actual handler data embedded as a
+;;;; string. Every operator hit this on every `handler-meta` call.
+;;;;
+;;;; The fix is to drop `:handler-fn` server-side so the wire EDN is
+;;;; clean by construction. The hash (`:handler-fn-hash`) is the
+;;;; wire-friendly substitute consumers actually use.
+;;;;
+;;;; Run: bb tests/runtime/registrar_describe_test.clj
+;;;; Exit: 0 = pass, non-zero = fail.
+
+(ns registrar-describe-test
+ (:require [clojure.java.io :as io]
+ [clojure.test :refer [deftest is run-tests]]
+ [clojure.walk :as walk]))
+
+(def ^:private runtime-cljs-path
+ (some (fn [p] (when (.exists (io/file p)) p))
+ ["preload/re_frame2_pair/runtime.cljs"
+ "skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs"
+ "../preload/re_frame2_pair/runtime.cljs"]))
+
+(when-not runtime-cljs-path
+ (binding [*out* *err*]
+ (println "ERROR: cannot locate preload/re_frame2_pair/runtime.cljs from"
+ (System/getProperty "user.dir")))
+ (System/exit 2))
+
+(defn- read-all-forms [^String src]
+ (let [pbr (java.io.PushbackReader. (java.io.StringReader. src))]
+ (loop [acc []]
+ (let [form (try (read {:read-cond :allow :features #{:cljs}} pbr)
+ (catch Exception _ ::eof))]
+ (if (= ::eof form) acc (recur (conj acc form)))))))
+
+(def ^:private all-forms
+ (read-all-forms (slurp runtime-cljs-path)))
+
+(defn- form-contains? [pred form]
+ (let [hit? (atom false)]
+ (walk/postwalk
+ (fn [node] (when (pred node) (reset! hit? true)) node)
+ form)
+ @hit?))
+
+(def ^:private registrar-describe-form
+ (some (fn [form]
+ (when (and (seq? form)
+ (= 'defn (first form))
+ (= 'registrar-describe (second form)))
+ form))
+ all-forms))
+
+(deftest registrar-describe-defn-present
+ (is (some? registrar-describe-form)
+ (str "preload/re_frame2_pair/runtime.cljs must define `registrar-describe` "
+ "(the runtime surface the MCP `handler-meta` tool calls).")))
+
+(deftest registrar-describe-dissocs-handler-fn
+ (is (form-contains? (fn [node]
+ (and (seq? node)
+ (= 'dissoc (first node))
+ (some #(= :handler-fn %) (rest node))))
+ registrar-describe-form)
+ (str "registrar-describe MUST `(dissoc :handler-fn)` before returning so the "
+ "MCP wire EDN stays readable. The raw Function ref emits "
+ "`#object[Function ...]` under pr-str, which the MCP read-edn-safe "
+ "cannot parse — surfacing `:unexpected-shape` with the real payload "
+ "buried as a string. See bead rf2-l7vnd.")))
+
+(deftest registrar-describe-still-carries-handler-fn-hash
+ (is (form-contains? (fn [node] (= :handler-fn-hash node))
+ registrar-describe-form)
+ (str "registrar-describe must still emit `:handler-fn-hash` — the wire-"
+ "friendly substitute consumers (hot-reload probing, tail-build) "
+ "actually use. Dropping it would silently break those flows.")))
+
+(let [{:keys [fail error]} (run-tests 'registrar-describe-test)]
+ (System/exit (if (zero? (+ (or fail 0) (or error 0))) 0 1)))

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -343,10 +343,25 @@ together with the load-time marker at
 `js/globalThis.__re_frame2_pair_runtime`.
 
 Every tool that needs the runtime calls `ensure-runtime!` first; the
-probe is one bencode round-trip on the persistent socket. Missing
-marker → structured `:reason :runtime-not-preloaded` error with the
-setup hint. There is no cljs-eval inject fallback (rf2-7dvg cut it
-for pre-alpha simplicity).
+probe is one bencode round-trip on the persistent socket. There is
+no cljs-eval inject fallback (rf2-7dvg cut it for pre-alpha
+simplicity).
+
+### Failure-path diagnostic ladder (rf2-7tgfk)
+
+When the probe fails, `ensure-runtime!` no longer surfaces a single
+blanket `:runtime-not-preloaded` reason. A diagnostic ladder runs on
+the failure path and reports one of four specific reasons:
+
+| `:reason`                                | Meaning |
+|------------------------------------------|---------|
+| `:nrepl-unreachable`                     | The JVM-side nREPL round-trip fails. The JVM may have stopped, or the MCP server is holding a stale socket. Restart `shadow-cljs watch`. |
+| `:build-not-running`                     | shadow-cljs's `active-builds` doesn't include the targeted build. Carries `:running-builds` so the operator can pick the right `--build=<id>`. |
+| `:no-runtime-connected`                  | The build IS running but no CLJS runtime answered the eval (cljs-eval returned blank). Open the app in a browser tab — or reload an existing tab whose WebSocket has dropped. |
+| `:runtime-loaded-but-preload-missing`    | A CLJS runtime is alive but the `__re_frame2_pair_runtime` marker is absent. The original setup hint ("add the preload to your shadow-cljs.edn") applies here. |
+
+The ladder costs one extra `jvm-eval` (active-builds enumeration) on
+the failure path; the probe cache means the success path stays free.
 
 ## Spec
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/handler_meta.cljs
@@ -55,6 +55,7 @@
   (\"where's X defined\", \"what's registered\") with a narrow surface
   the agent can rely on across runtimes and editor-config postures."
   (:require [clojure.string :as str]
+            [cljs.reader :as edn]
             [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
             [re-frame2-pair-mcp.tools.wire :as wire]
@@ -152,12 +153,18 @@
   map or a structured `:not-registered` map. Keeps the tool's response
   shape uniform across kinds.
 
+  rf2-l7vnd: `dissoc :handler-fn` for the same reason `registrar-describe`
+  drops it — a raw Function ref is unreadable on the EDN wire and made
+  the tool envelope misreport :unexpected-shape. The machine surface
+  doesn't always carry one, but the dissoc is idempotent and cheap and
+  keeps the response shape EDN-clean by construction across both kinds.
+
   The composed form is one expression so the eval is a single
   round-trip — composition is the same idiom every other tool uses."
   [id]
   (let [id-edn (pr-str id)]
     (str "(if-let [m (re-frame.core/machine-meta " id-edn ")]"
-         "  m"
+         "  (dissoc m :handler-fn)"
          "  {:ok? false :reason :not-registered :kind :machine :id " id-edn "})")))
 
 (defn handler-meta-tool [conn args]
@@ -199,17 +206,33 @@
                      ;;   - eval returned non-map: surface as
                      ;;     :unexpected-shape — should never happen
                      ;;     against a healthy runtime.
-                     (wire/ok-text
-                       (cond
-                         (not (map? v))
-                         {:ok? false :reason :unexpected-shape
-                          :kind kind :id id-val :value v}
+                     ;;
+                     ;; rf2-l7vnd defensive re-parse: if `v` is a STRING
+                     ;; that looks like a stringified map (starts with
+                     ;; `{`), one more EDN read can recover the map.
+                     ;; This guards against a runtime that ships a value
+                     ;; with an unreadable token (`#object[Function ...]`,
+                     ;; `#js {...}`, …) — `read-edn-safe` in nrepl.cljs
+                     ;; would drop back to the raw string. The runtime
+                     ;; now strips :handler-fn before returning so the
+                     ;; primary path is clean; this re-parse is the
+                     ;; belt to the runtime's braces.
+                     (let [v* (if (and (string? v)
+                                       (str/starts-with? (str/trim v) "{"))
+                                (try (edn/read-string v)
+                                     (catch :default _ v))
+                                v)]
+                       (wire/ok-text
+                         (cond
+                           (not (map? v*))
+                           {:ok? false :reason :unexpected-shape
+                            :kind kind :id id-val :value v*}
 
-                         (false? (:ok? v))
-                         (assoc v :kind kind :id id-val)
+                           (false? (:ok? v*))
+                           (assoc v* :kind kind :id id-val)
 
-                         :else
-                         (assoc v :ok? true :kind kind :id id-val)))))
+                           :else
+                           (assoc v* :ok? true :kind kind :id id-val))))))
             (.catch (fn [err] (probe/err->result :handler-meta-failed err))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -64,6 +64,76 @@
        "and make sure the directory containing re_frame2_pair/runtime.cljs "
        "is on :source-paths. See skills/re-frame2-pair/SKILL.md (§Setup)."))
 
+;; ---------------------------------------------------------------------------
+;; Diagnostic-ladder vocabulary (rf2-7tgfk).
+;;
+;; A failed preload probe used to surface ONE reason
+;; (`:runtime-not-preloaded`) whose hint always read "add the preload
+;; to your shadow-cljs.edn". In the 2026-05-25 pair-debug session that
+;; suggestion was misleading in three of the four failure modes the
+;; operator hit (~30 min of dead-end debugging). The ladder below
+;; distinguishes the cases the original single reason hid:
+;;
+;;   :nrepl-unreachable             - JVM eval round-trip fails. The
+;;                                    socket may be dead even though
+;;                                    the bash side of the world is up.
+;;   :build-not-running             - shadow's active-builds doesn't
+;;                                    include the build the tool is
+;;                                    targeting. Almost always a
+;;                                    --build typo or operator
+;;                                    targeted the wrong dev build.
+;;   :no-runtime-connected          - build IS running but cljs-eval
+;;                                    returns blank — no browser tab
+;;                                    has connected (or the tab's ws
+;;                                    is dead).
+;;   :runtime-loaded-but-preload-missing
+;;                                  - the original meaning: a CLJS
+;;                                    runtime is alive but the
+;;                                    `__re_frame2_pair_runtime` marker
+;;                                    is absent. The "add the preload"
+;;                                    hint fits ONLY this case.
+;;
+;; The ladder costs one extra `jvm-eval` (active-builds enumeration)
+;; on the failure path; ~50ms total. The probe-cache short-circuit
+;; means a healthy session pays nothing.
+;; ---------------------------------------------------------------------------
+
+(def ^:private nrepl-unreachable-hint
+  (str "The nREPL connection looks dead. Likely: the JVM running "
+       "shadow-cljs has stopped (or has been restarted, leaving the "
+       "MCP server holding a stale socket). Restart `shadow-cljs watch` "
+       "and retry; the MCP server reconnects on the next tool call."))
+
+(defn- build-not-running-hint [build-id running]
+  (cond
+    (empty? running)
+    (str "no shadow-cljs build is currently running. Start your dev "
+         "build (`shadow-cljs watch <build>`) before retrying.")
+
+    :else
+    (str "shadow-cljs is running " (vec running) " but not "
+         build-id ". Pass --build=" (first running)
+         " (or set SHADOW_CLJS_BUILD_ID) — or restart the watch worker "
+         "for " build-id " if you really mean to target it.")))
+
+(defn- no-runtime-connected-hint [build-id]
+  (str "build " build-id " is running but no CLJS runtime is currently "
+       "connected (the cljs-eval round-trip returned blank). Open the app "
+       "in a browser tab — or if a tab IS open, the WebSocket has dropped: "
+       "reload the page so the runtime reconnects."))
+
+(defn- jvm-reachable?
+  "Round-trip `1` through `jvm-eval`. Resolves to true on `:value \"1\"`,
+  false on any other shape / rejection. Used to disambiguate
+  `:nrepl-unreachable` from `:build-not-running`."
+  [conn]
+  (-> (try
+        (nrepl/jvm-eval conn "1")
+        (catch :default _ (js/Promise.resolve nil)))
+      (.then (fn [resp]
+               (= "1" (str (:value resp)))))
+      (.catch (fn [_] false))))
+
 (defn- conn-has-probed?
   "True iff `build-id` has been confirmed preloaded on the current
   socket generation. Defensive against `nil` / non-atom `conn` —
@@ -102,6 +172,104 @@
                    ok?)))
         (.catch (fn [_] false)))))
 
+;; Forward declare for diagnose-preload-failure! — running-builds is
+;; defined below alongside resolve-build! and friends; the ladder uses
+;; it on the failure path. Keeping running-builds where it is preserves
+;; the grouping with resolve-build! (both touch shadow's JVM API).
+(declare running-builds)
+
+(defn diagnose-preload-failure!
+  "Run the failure-path diagnostic ladder (rf2-7tgfk). Called only when
+  `runtime-preloaded?` returned false, so the cost is paid exactly when
+  it matters. Resolves to a map `{:reason <kw> :hint <str> ...}` whose
+  `:reason` distinguishes:
+
+    :nrepl-unreachable                     - the nREPL JVM round-trip fails.
+    :build-not-running                     - shadow's active-builds doesn't
+                                             include the targeted build.
+                                             Carries :running-builds for
+                                             the operator's next move.
+    :no-runtime-connected                  - build IS running but cljs-eval
+                                             returns blank (no browser tab
+                                             connected, or its ws is dead).
+    :runtime-loaded-but-preload-missing    - a CLJS runtime is alive but
+                                             the preload marker is absent.
+                                             The original hint applies here.
+
+  The ladder runs one extra `jvm-eval` (active-builds enumeration) plus
+  one `cljs-eval` (blank-vs-false discriminator) — ~50ms on the failure
+  path; the probe cache keeps the success path free."
+  [conn build-id]
+  (-> (jvm-reachable? conn)
+      (.then
+        (fn [nrepl-ok?]
+          (if-not nrepl-ok?
+            (js/Promise.resolve
+              {:reason :nrepl-unreachable
+               :build  build-id
+               :hint   nrepl-unreachable-hint})
+            (-> (running-builds conn)
+                (.then
+                  (fn [running]
+                    (if-not (some #(= build-id %) running)
+                      (js/Promise.resolve
+                        {:reason         :build-not-running
+                         :build          build-id
+                         :running-builds running
+                         :hint           (build-not-running-hint build-id running)})
+                      ;; Build IS running — distinguish "no runtime
+                      ;; connected" (cljs-eval returns blank/nil) from
+                      ;; "runtime present but marker absent" (cljs-eval
+                      ;; returns false). The original probe collapsed
+                      ;; both into "false"; here we re-evaluate the
+                      ;; raw form and inspect the shape.
+                      (-> (nrepl/cljs-eval-value
+                            conn build-id
+                            "(some? (and (exists? js/globalThis) (.-__re_frame2_pair_runtime js/globalThis)))")
+                          (.then
+                            (fn [v]
+                              (cond
+                                ;; blank/nil → no runtime answered the eval
+                                (nil? v)
+                                {:reason         :no-runtime-connected
+                                 :build          build-id
+                                 :running-builds running
+                                 :hint           (no-runtime-connected-hint build-id)}
+
+                                ;; false → runtime is alive but marker
+                                ;; is absent — the case the original hint
+                                ;; was written for.
+                                (false? v)
+                                {:reason :runtime-loaded-but-preload-missing
+                                 :build  build-id
+                                 :hint   preload-missing-hint}
+
+                                ;; Should not happen — a true here
+                                ;; means the probe state flipped under
+                                ;; us. Treat as missing marker.
+                                :else
+                                {:reason :runtime-loaded-but-preload-missing
+                                 :build  build-id
+                                 :hint   preload-missing-hint})))
+                          (.catch (fn [_]
+                                    ;; The discriminator eval threw —
+                                    ;; we know the build is running
+                                    ;; (active-builds confirmed it), so
+                                    ;; this is most likely a transient
+                                    ;; cljs-eval failure. Fall back to
+                                    ;; the most conservative reason.
+                                    (js/Promise.resolve
+                                      {:reason :no-runtime-connected
+                                       :build  build-id
+                                       :running-builds running
+                                       :hint   (no-runtime-connected-hint build-id)})))))))))))
+      (.catch (fn [_]
+                ;; Ladder itself threw — degrade to the original reason.
+                (js/Promise.resolve
+                  {:reason :runtime-not-preloaded
+                   :build  build-id
+                   :hint   preload-missing-hint})))))
+
 (defn runtime-health!
   "Call `(re-frame2-pair.runtime/health)`. Caller must have already
   confirmed the preload landed via `runtime-preloaded?`."
@@ -115,16 +283,26 @@
 
   After the first positive probe per `(conn, build-id)`, this resolves
   synchronously from cache — no nREPL round-trip per tool call
-  (rf2-sjpx0)."
+  (rf2-sjpx0).
+
+  rf2-7tgfk: on a failed probe the rejection no longer always reads
+  `:runtime-not-preloaded`. The diagnostic ladder
+  (`diagnose-preload-failure!`) inspects the failure mode and rejects
+  with one of four specific reasons — `:nrepl-unreachable`,
+  `:build-not-running`, `:no-runtime-connected`, or
+  `:runtime-loaded-but-preload-missing` — each with a targeted hint.
+  The original blanket `:runtime-not-preloaded` reason is reserved as
+  the degradation fallback if the ladder itself errors."
   [conn build-id]
   (-> (runtime-preloaded? conn build-id)
       (.then (fn [ok?]
                (if ok?
                  nil
-                 (js/Promise.reject
-                   (ex-info "re-frame2-pair runtime not preloaded"
-                            {:reason :runtime-not-preloaded
-                             :hint   preload-missing-hint})))))))
+                 (-> (diagnose-preload-failure! conn build-id)
+                     (.then (fn [diag]
+                              (js/Promise.reject
+                                (ex-info "re-frame2-pair runtime probe failed"
+                                         diag))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Running-build enumeration + fail-loud build resolution (rf2-ivlb3).

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/tail_build.cljs
@@ -1,5 +1,28 @@
 (ns re-frame2-pair-mcp.tools.tail-build
-  "Tool: tail-build — wait for hot-reload to land."
+  "Tool: tail-build — wait for hot-reload to land.
+
+  ## Probe-value diagnostics (rf2-36awg)
+
+  When a probe form is supplied, both the success and timeout responses
+  carry `:probe-values {:initial <v0> :final <v-last>}` — the two ends
+  of the comparison the polling loop is making. On timeout the operator
+  can therefore distinguish three failure modes from one envelope:
+
+    1. `:initial` and `:final` equal → either the probe form never
+       changes (the comparison cannot drive completion) or the
+       hot-reload genuinely didn't land (compile error / wrong build).
+    2. `:initial` nil and `:final` nil → the probe form returned nil
+       on every iteration; possibly the cljs-eval routed to a runtime
+       that hasn't loaded the target ns, or the form is bound to a
+       missing var.
+    3. `:initial` present and `:final` errored consistently →
+       `:probe-errored` envelope with `:probe-error <stringified ex>`.
+
+  Pre-rf2-36awg the timeout response carried only the misleading hint
+  \"Likely a compile error\". A pair-debug session 2026-05-25 hit the
+  case where the probe form itself was malformed and could not change;
+  with no value information returned the operator had to manually call
+  `handler-meta` to confirm the rebuild had actually landed."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.wire :as wire]))
 
@@ -23,6 +46,22 @@
   span empirical observation places shadow-cljs's bundle-swap cycle
   within after the source-file save event fires."
   300)
+
+(def ^:private timeout-note
+  "Hint surfaced on the timeout envelope. With the probe-values now
+  riding back, the operator can read the values themselves to pick
+  the actual cause from the listed candidates."
+  (str "Probe value did not change within wait-ms. "
+       "Possible causes: (a) compile error in shadow stalled the rebuild, "
+       "(b) probe form returns the same value before and after the reload, "
+       "(c) probe form errored — check :probe-values to disambiguate."))
+
+(def ^:private probe-errored-note
+  "Hint surfaced on the probe-errored envelope — the probe form raised
+  on EVERY iteration (initial fetch + every poll), so we can't even
+  measure a before/after delta. Almost always a malformed probe form
+  (typo, dotted-form host interop against a missing var, etc.)."
+  "Probe form raised an exception on every iteration. The form is likely malformed.")
 
 (defn tail-build-tool [conn args]
   (let [build-id (wire/arg-build conn args)
@@ -52,24 +91,47 @@
               (fn [before]
                 (js/Promise.
                   (fn [resolve _]
-                    (letfn [(poll []
-                              (js/setTimeout
-                                (fn []
-                                  (let [elapsed (- (js/Date.now) start)]
-                                    (if (>= elapsed wait-ms)
-                                      (resolve
-                                        (wire/ok-text {:ok? false :reason :timed-out :timed-out? true
-                                                       :note "Probe did not change within wait-ms. Likely a compile error."}))
-                                      (-> (nrepl/cljs-eval-value conn build-id probe)
-                                          (.then
-                                            (fn [now]
-                                              (if (not= now before)
-                                                (resolve (wire/ok-text {:ok? true :t (js/Date.now) :soft? false}))
-                                                (poll))))
-                                          (.catch (fn [_] (poll)))))))
-                                poll-ms))]
-                      (poll))))))
+                    ;; `latest` carries the most-recent probe value we
+                    ;; saw — initialised to `before` and overwritten on
+                    ;; every successful poll. On timeout we hand both
+                    ;; ends back to the operator under :probe-values.
+                    (let [latest (volatile! before)]
+                      (letfn [(poll []
+                                (js/setTimeout
+                                  (fn []
+                                    (let [elapsed (- (js/Date.now) start)]
+                                      (if (>= elapsed wait-ms)
+                                        (resolve
+                                          (wire/ok-text
+                                            {:ok?           false
+                                             :reason        :timed-out
+                                             :timed-out?    true
+                                             :probe-values  {:initial before
+                                                             :final   @latest}
+                                             :note          timeout-note}))
+                                        (-> (nrepl/cljs-eval-value conn build-id probe)
+                                            (.then
+                                              (fn [now]
+                                                (vreset! latest now)
+                                                (if (not= now before)
+                                                  (resolve
+                                                    (wire/ok-text
+                                                      {:ok?           true
+                                                       :t             (js/Date.now)
+                                                       :soft?         false
+                                                       :probe-values  {:initial before
+                                                                       :final   now}}))
+                                                  (poll))))
+                                            (.catch (fn [_] (poll)))))))
+                                  poll-ms))]
+                        (poll)))))))
             (.catch
               (fn [err]
-                (wire/ok-text {:ok? false :reason :probe-failed
-                               :message (.-message err)}))))))))
+                ;; Initial probe-eval threw — surface as :probe-errored
+                ;; (distinct from :timed-out, which means "polled but
+                ;; never changed"). With probe-error included the
+                ;; operator gets the underlying exception verbatim.
+                (wire/ok-text {:ok?         false
+                               :reason      :probe-errored
+                               :probe-error (.-message err)
+                               :note        probe-errored-note}))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -10,7 +10,18 @@
   Post-eval shrink pipeline lives in
   `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
   builds the eval form, awaits the runtime response, and routes the
-  epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`."
+  epoch vector through `run-wire-pipeline` with `:kind :epoch-vector`.
+
+  ## Empty-result advisory (rf2-fb4hn)
+
+  When the response would carry `:count 0` but the frame's
+  per-frame epoch-history is non-empty, an `:advisory` rides on
+  the envelope distinguishing \"nothing happened\" from \"events exist
+  but fell outside the time window\". Pre-rf2-fb4hn the operator had no
+  way to tell these apart and routinely misread \"empty window\" as
+  \"the MCP isn't capturing my events\". The advisory names the
+  history count and points to `snapshot` as the historical-inspection
+  surface."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -77,6 +88,7 @@
                             " :requested-id after-id"
                             " :head-id (some-> hist peek :epoch-id)"
                             " :next-id next-id"
+                            " :history-count (count hist)"
                             " :remaining (max 0 (- (count filtered) (count page)))}"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
@@ -104,19 +116,43 @@
                                            :ms       window-ms
                                            :until-ms until-ms
                                            :frame    sticky-frame}))
-                          has-more?   (some? next-cursor)
-                          remaining   (or (:remaining v) 0)]
+                          has-more?     (some? next-cursor)
+                          remaining     (or (:remaining v) 0)
+                          history-count (or (:history-count v) 0)
+                          ;; Advisory fires only when the window
+                          ;; surfaced ZERO epochs but the per-frame
+                          ;; history holds events that just fell
+                          ;; outside the time slice. Two ratchets:
+                          ;;   - count = 0 (the slot operators read
+                          ;;     to decide \"nothing happened\")
+                          ;;   - history-count > 0 (the underlying
+                          ;;     ring isn't empty — events exist).
+                          advisory      (when (and (zero? count)
+                                                   (pos? history-count))
+                                          {:reason            :window-excludes-history
+                                           :frame             sticky-frame
+                                           :epochs-in-history history-count
+                                           :window-ms         window-ms
+                                           :hint              (str history-count
+                                                                   " epochs exist in the per-frame "
+                                                                   "history but none fell inside the "
+                                                                   "last " window-ms "ms window. "
+                                                                   "Widen :ms (e.g. 60000), or use "
+                                                                   "`snapshot :include [:epochs]` to "
+                                                                   "inspect the full history.")})
+                          envelope      (cond-> {:ok?                 true
+                                                 :window-ms           window-ms
+                                                 :until-ms            until-ms
+                                                 :count               count
+                                                 :limit               limit
+                                                 :epochs-mode         mode
+                                                 :dedup               dedup?
+                                                 :epochs              value
+                                                 :has-more?           has-more?
+                                                 :estimated-remaining remaining
+                                                 :next-cursor         next-cursor}
+                                          advisory (assoc :advisory advisory))]
                       (wire/ok-text (wire/with-indicators
-                                      {:ok?                 true
-                                       :window-ms           window-ms
-                                       :until-ms            until-ms
-                                       :count               count
-                                       :limit               limit
-                                       :epochs-mode         mode
-                                       :dedup               dedup?
-                                       :epochs              value
-                                       :has-more?           has-more?
-                                       :estimated-remaining remaining
-                                       :next-cursor         next-cursor}
+                                      envelope
                                       {:dropped dropped :elided elided})))))))
             (.catch (fn [err] (probe/err->result :trace-failed err))))))))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -15,7 +15,18 @@
   Post-eval shrink pipeline lives in
   `re-frame2-pair-mcp.tools.wire-pipeline` (rf2-ae8ie). This tool body
   builds the eval form, awaits the runtime response, and routes the
-  matches vector through `run-wire-pipeline` with `:kind :epoch-vector`."
+  matches vector through `run-wire-pipeline` with `:kind :epoch-vector`.
+
+  ## Empty-result advisory (rf2-fb4hn)
+
+  When the response would carry `:count 0` but the frame's per-frame
+  epoch-history is non-empty, an `:advisory` rides on the envelope
+  distinguishing two cases:
+
+    - `:no-events-since-id` — caller passed `:since-id` and no new
+      epochs landed after it. Calmly says \"nothing new\".
+    - `:pred-excludes-history` — the predicate filtered every epoch
+      out. Says the history exists; the pred is the gate."
   (:require [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.tools.args :as args]
             [re-frame2-pair-mcp.tools.eval-form :as ef]
@@ -58,19 +69,31 @@
                                                    (or pred-map {})
                                                    (ef/rt-raw "%")))
                               " (:epochs r))")
+            history-call (if sticky-frame
+                           (ef/rt-call 'epoch-history sticky-frame)
+                           (ef/rt-call 'epoch-history))
             form (ef/emit
                    (ef/rt-let
-                     ['r       epochs-since-call
-                      'matches (ef/rt-raw matches-form)
-                      'page    (ef/rt-raw (str "(vec (take " limit " matches))"))
-                      'next-id (ef/rt-raw
-                                 "(when (< (count page) (count matches)) (:epoch-id (last page)))")]
+                     ['r             epochs-since-call
+                      'matches       (ef/rt-raw matches-form)
+                      'page          (ef/rt-raw (str "(vec (take " limit " matches))"))
+                      'next-id       (ef/rt-raw
+                                       "(when (< (count page) (count matches)) (:epoch-id (last page)))")
+                      ;; rf2-fb4hn: history-count surfaces the
+                      ;; per-frame ring depth so the tool can advise
+                      ;; on the \"empty matches but non-empty history\"
+                      ;; case the operator typically misreads as
+                      ;; pre-attach invisibility.
+                      'history-count (ef/rt-raw (str "(count " (ef/emit history-call) ")"))
+                      'since-count   (ef/rt-raw "(count (:epochs r))")]
                      (ef/rt-raw
                        (str "{:matches page"
                             " :id-aged-out? (:id-aged-out? r)"
                             " :requested-id (:requested-id r)"
                             " :head-id (:head-id r)"
                             " :next-id next-id"
+                            " :history-count history-count"
+                            " :since-count since-count"
                             " :remaining (max 0 (- (count matches) (count page)))}"))))]
         (-> (probe/ensure-runtime! conn build-id)
             (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
@@ -90,19 +113,61 @@
                                                  :mode   mode
                                                  :dedup? dedup?})
                           {:keys [dropped elided count]} indicators
-                          next-id     (:next-id v)
-                          next-cursor (cursor/encode-cursor
-                                        (when next-id
-                                          {:v        1
-                                           :after-id next-id
-                                           :ms       nil
-                                           :until-ms nil
-                                           :frame    sticky-frame}))
-                          remaining   (or (:remaining v) 0)
-                          base        (cond-> {:ok?          true
-                                               :head-id      (:head-id v)
-                                               :id-aged-out? (boolean aged-out?)}
-                                        (:requested-id v) (assoc :requested-id (:requested-id v)))]
+                          next-id       (:next-id v)
+                          next-cursor   (cursor/encode-cursor
+                                          (when next-id
+                                            {:v        1
+                                             :after-id next-id
+                                             :ms       nil
+                                             :until-ms nil
+                                             :frame    sticky-frame}))
+                          remaining     (or (:remaining v) 0)
+                          history-count (or (:history-count v) 0)
+                          since-count   (or (:since-count v) 0)
+                          ;; rf2-fb4hn: two distinct empty-result
+                          ;; explainers, picked by the runtime data:
+                          ;;
+                          ;;   - since-count = 0 + history-count > 0
+                          ;;     → caller's :since-id is at (or past)
+                          ;;     the head; calmly say \"nothing new
+                          ;;     yet\".
+                          ;;
+                          ;;   - since-count > 0 + count = 0
+                          ;;     → events landed since the id but the
+                          ;;     :pred filtered them all out — point
+                          ;;     at the predicate, not the buffer.
+                          advisory
+                          (cond
+                            (and (zero? count)
+                                 (zero? since-count)
+                                 (pos? history-count))
+                            {:reason            :no-events-since-id
+                             :frame             sticky-frame
+                             :epochs-in-history history-count
+                             :requested-id      effective-after
+                             :hint              (str "Per-frame history holds "
+                                                     history-count
+                                                     " epochs but none have landed since the "
+                                                     "supplied :since-id. Dispatch an event "
+                                                     "to advance the head, or omit :since-id "
+                                                     "to see the full ring.")}
+
+                            (and (zero? count)
+                                 (pos? since-count))
+                            {:reason            :pred-excludes-history
+                             :frame             sticky-frame
+                             :epochs-in-history history-count
+                             :epochs-since-id   since-count
+                             :hint              (str since-count
+                                                     " epochs landed since the requested id but "
+                                                     "the :pred filter excluded all of them. "
+                                                     "Drop / widen :pred, or use trace-window for "
+                                                     "an unfiltered view.")})
+                          base          (cond-> {:ok?          true
+                                                 :head-id      (:head-id v)
+                                                 :id-aged-out? (boolean aged-out?)}
+                                          (:requested-id v) (assoc :requested-id (:requested-id v))
+                                          advisory          (assoc :advisory advisory))]
                       (wire/ok-text (wire/with-indicators
                                       (assoc base
                                              :matches             value

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/conformance_test.cljs
@@ -142,20 +142,51 @@
   raw-state fixtures to verify the gate forces
   `:rf.size/include-sensitive? false` server-side (the walker-option
   namespaced keyword, NOT the wire-key — the wire-key is the
-  unqualified `:include-sensitive` post-rf2-ihq4d)."
-  [eval-script forms-seen body-fn]
-  (let [orig nrepl/cljs-eval-value
-        stub (fn
-               ([_conn _build-id form-str]
-                (swap! forms-seen conj form-str)
-                (js/Promise.resolve (run-eval-script eval-script form-str)))
-               ([_conn _build-id form-str _opts]
-                (swap! forms-seen conj form-str)
-                (js/Promise.resolve (run-eval-script eval-script form-str))))]
-    (set! nrepl/cljs-eval-value stub)
-    (-> (js/Promise.resolve nil)
-        (.then (fn [_] (body-fn)))
-        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+  unqualified `:include-sensitive` post-rf2-ihq4d).
+
+  rf2-7tgfk: also stubs `nrepl/jvm-eval` so the preload-failure
+  diagnostic ladder doesn't short-circuit to `:nrepl-unreachable` on
+  every preload-missing fixture. The default JVM stub:
+    - returns `{:value \"1\"}` for the `1` health-probe so
+      `jvm-reachable?` resolves true.
+    - returns `{:value \"[:app]\"}` for `active-builds` so the
+      ladder treats `:app` as a running build.
+  Together these mean a fixture scripting the cljs probe form to
+  `false` lands on `:runtime-loaded-but-preload-missing` — the case
+  the original hint was for. Fixtures wanting the other ladder
+  rungs (`:build-not-running`, `:no-runtime-connected`,
+  `:nrepl-unreachable`) override via the new `:fixture/jvm-eval-script`
+  slot."
+  ([eval-script forms-seen body-fn]
+   (with-stubbed-eval! eval-script forms-seen nil body-fn))
+  ([eval-script forms-seen jvm-eval-script body-fn]
+   (let [orig-cljs nrepl/cljs-eval-value
+         orig-jvm  nrepl/jvm-eval
+         cljs-stub (fn
+                     ([_conn _build-id form-str]
+                      (swap! forms-seen conj form-str)
+                      (js/Promise.resolve (run-eval-script eval-script form-str)))
+                     ([_conn _build-id form-str _opts]
+                      (swap! forms-seen conj form-str)
+                      (js/Promise.resolve (run-eval-script eval-script form-str))))
+         default-jvm-script
+         ;; First-match wins; this is the failure-path default the
+         ;; rf2-7tgfk diagnostic ladder relies on.
+         [["active-builds" {:value "[:app]"}]
+          [:default        {:value "1"}]]
+         effective-jvm-script (or jvm-eval-script default-jvm-script)
+         jvm-stub (fn
+                    ([_conn form-str]
+                     (js/Promise.resolve (run-eval-script effective-jvm-script form-str)))
+                    ([_conn form-str _opts]
+                     (js/Promise.resolve (run-eval-script effective-jvm-script form-str))))]
+     (set! nrepl/cljs-eval-value cljs-stub)
+     (set! nrepl/jvm-eval         jvm-stub)
+     (-> (js/Promise.resolve nil)
+         (.then (fn [_] (body-fn)))
+         (.finally (fn []
+                     (set! nrepl/cljs-eval-value orig-cljs)
+                     (set! nrepl/jvm-eval         orig-jvm)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Wire-shape matchers — partial / submap matching against the parsed EDN
@@ -305,14 +336,14 @@
      :edn-submap {:ok? true :build-id :app}}}
 
    {:fixture/id    :discover-app/preload-missing
-    :fixture/doc   "discover-app surfaces :runtime-not-preloaded when the global marker is absent."
+    :fixture/doc   "discover-app surfaces :runtime-loaded-but-preload-missing when the marker is absent (rf2-7tgfk — the specific rung of the diagnostic ladder)."
     :fixture/tool  "discover-app"
     :fixture/args  {}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  false]
      [:default                    nil]]
     :fixture/expect
-    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+    {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
 
    ;; ---------- eval-cljs --------------------------------------------------
    ;; The launch-flag gate (rf2-cxx5s, cascade from rf2-czv3p) ships
@@ -395,14 +426,14 @@
      :reason :missing-event}}
 
    {:fixture/id    :dispatch/preload-missing
-    :fixture/doc   "dispatch surfaces :runtime-not-preloaded when probe fails."
+    :fixture/doc   "dispatch surfaces :runtime-loaded-but-preload-missing when the marker is absent (rf2-7tgfk diagnostic ladder)."
     :fixture/tool  "dispatch"
     :fixture/args  {:event "[:counter/inc]"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  false]
      [:default                    nil]]
     :fixture/expect
-    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+    {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
 
    ;; ---------- restore-epoch (rf2-ee38b.18 — gated write) ----------------
    ;; The --allow-writes gate ships DEFAULT-OFF. The disabled fixture pins
@@ -546,14 +577,14 @@
     {:isError? false}}
 
    {:fixture/id    :snapshot/preload-missing
-    :fixture/doc   "snapshot surfaces :runtime-not-preloaded when probe fails."
+    :fixture/doc   "snapshot surfaces :runtime-loaded-but-preload-missing when the marker is absent (rf2-7tgfk diagnostic ladder)."
     :fixture/tool  "snapshot"
     :fixture/args  {:frames "all"}
     :fixture/eval-script
     [["__re_frame2_pair_runtime"  false]
      [:default                    nil]]
     :fixture/expect
-    {:edn-submap {:ok? false :reason :runtime-not-preloaded}}}
+    {:edn-submap {:ok? false :reason :runtime-loaded-but-preload-missing}}}
 
    ;; ---------- get-path ---------------------------------------------------
    {:fixture/id    :get-path/happy

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/handler_meta_test.cljs
@@ -20,6 +20,7 @@
        structured `:reason` slots an agent can read."
   (:require [cljs.test :refer-macros [deftest is testing async]]
             [applied-science.js-interop :as j]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
             [re-frame2-pair-mcp.test-utils :as tu]
             [re-frame2-pair-mcp.tools :as tools]
             [re-frame2-pair-mcp.tools.handler-meta :as hm]))
@@ -191,3 +192,130 @@
           rl-enum (-> (find-descriptor "list-handlers") :inputSchema :properties :kind :enum set)]
       (is (= hm-enum rl-enum)
           "drift here would make agents learn two vocabularies for one concept"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-l7vnd regression — handler-meta returns :ok? true with the real
+;; data as top-level keys; the bug shape was :ok? false :reason
+;; :unexpected-shape with the actual map embedded as an EDN string.
+;;
+;; Pre-rf2-l7vnd path the runtime emitted a map containing
+;; `:handler-fn <Function>`; `pr-str` rendered that as
+;; `#object[Function ...]`; nrepl's `read-edn-safe` couldn't parse it
+;; back; the tool body fell into `(not (map? v))` and stuffed the raw
+;; string under `:value`. Two complementary defences pin the fix:
+;;
+;;   - Runtime side (skills/re-frame2-pair/preload/...): dissoc'd
+;;     :handler-fn before returning. Pinned structurally by the
+;;     babashka test `registrar_describe_test.clj`.
+;;
+;;   - MCP tool side (here): defensive re-parse so a future runtime
+;;     slip emitting a stringified map still surfaces as :ok? true.
+;; ---------------------------------------------------------------------------
+
+(defn- with-canned-eval!
+  "Stub `nrepl/cljs-eval-value` to resolve every call with `v`. The
+  probe call (first eval, `__re_frame2_pair_runtime` form) gets the
+  same response so we MUST hand back `true` from the first call. The
+  trick: gate by call-count, so call 1 returns true (probe), call 2
+  returns the canned value (actual handler-meta eval)."
+  [canned-handler-value body-fn]
+  (let [orig nrepl/cljs-eval-value
+        ;; conn cache makes the probe round-trip skipped after the
+        ;; first call. To be safe across tests, we always return
+        ;; `true` for forms that contain the probe sentinel and the
+        ;; canned value otherwise.
+        stub (fn
+               ([_conn _build-id form-str]
+                (js/Promise.resolve
+                  (if (re-find #"__re_frame2_pair_runtime" form-str)
+                    true
+                    canned-handler-value)))
+               ([_conn _build-id form-str _opts]
+                (js/Promise.resolve
+                  (if (re-find #"__re_frame2_pair_runtime" form-str)
+                    true
+                    canned-handler-value))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(deftest handler-meta-returns-ok-true-with-real-keys
+  (testing "registered handler → :ok? true with the metadata as top-level keys"
+    (async done
+      (let [canned {:ns 'testdeck.counter
+                    :file "testdeck/counter.cljs"
+                    :line 82
+                    :handler-fn-hash 1140207590}]
+        (-> (with-canned-eval! canned
+              (fn []
+                (-> (hm/handler-meta-tool nil (args-js {:kind "event" :id ":counter/inc"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (not (is-error? result))
+                                   "the response MUST NOT carry :isError true — bug shape")
+                               (is (true? (:ok? edn))
+                                   "the response MUST carry :ok? true, not :ok? false :reason :unexpected-shape")
+                               (is (= :event (:kind edn)))
+                               (is (= :counter/inc (:id edn)))
+                               (is (= 'testdeck.counter (:ns edn))
+                                   "real metadata keys must appear at the top level, not buried under :value")
+                               (is (= 82 (:line edn)))
+                               (is (= 1140207590 (:handler-fn-hash edn))
+                                   "handler-fn-hash is the wire-friendly substitute for :handler-fn")
+                               (is (not (contains? edn :value))
+                                   "the bug shape stuffed the map under :value as a string — must not recur"))
+                             (done))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+
+(deftest handler-meta-defensive-reparse-of-stringified-map
+  (testing "if a runtime emits a stringified map, the tool still recovers :ok? true"
+    ;; This pins the MCP-side defensive re-parse — should a future
+    ;; runtime slip emit `#object[...]` again, the tool tries one more
+    ;; EDN read of the raw string before falling to :unexpected-shape.
+    (async done
+      (let [stringified-map "{:ns testdeck.counter, :line 99, :handler-fn-hash 42}"]
+        (-> (with-canned-eval! stringified-map
+              (fn []
+                (-> (hm/handler-meta-tool nil (args-js {:kind "event" :id ":counter/inc"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (true? (:ok? edn))
+                                   "defensive re-parse: stringified map recovered as :ok? true")
+                               (is (= 99 (:line edn))
+                                   "the recovered map's keys must be top-level"))
+                             (done))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+
+(deftest handler-meta-not-registered-passes-through
+  (testing "the runtime's :not-registered envelope still passes through unchanged"
+    (async done
+      (let [canned {:ok? false :reason :not-registered :kind :event :id :no/such}]
+        (-> (with-canned-eval! canned
+              (fn []
+                (-> (hm/handler-meta-tool nil (args-js {:kind "event" :id ":no/such"}))
+                    (.then (fn [result]
+                             (let [edn (extract-edn result)]
+                               (is (false? (:ok? edn)))
+                               (is (= :not-registered (:reason edn))))
+                             (done))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+
+(deftest handler-meta-genuinely-unparseable-still-fails
+  (testing "a non-map non-recoverable value still surfaces :unexpected-shape"
+    (async done
+      ;; A plain integer back from the runtime is genuinely the wrong
+      ;; shape — not a map, not a stringified map. The tool MUST still
+      ;; surface :unexpected-shape so the bug envelope keeps doing its job
+      ;; for actual shape errors.
+      (-> (with-canned-eval! 42
+            (fn []
+              (-> (hm/handler-meta-tool nil (args-js {:kind "event" :id ":anything"}))
+                  (.then (fn [result]
+                           (let [edn (extract-edn result)]
+                             (is (false? (:ok? edn)))
+                             (is (= :unexpected-shape (:reason edn)))
+                             (is (= 42 (:value edn))
+                                 "the offending value rides on :value for forensics"))
+                           (done))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/probe_test.cljs
@@ -35,20 +35,42 @@
   "Install a stub `cljs-eval-value` that resolves to `canned-value` on
   every call, counting invocations into `call-count*`. Run `body-fn`
   (returning a Promise) and restore in `.finally` so cleanup outlives
-  async resolution. Mirror of `conformance_test/with-stubbed-eval!`."
+  async resolution. Mirror of `conformance_test/with-stubbed-eval!`.
+
+  rf2-7tgfk: also stubs `nrepl/jvm-eval` minimally so the preload-
+  failure diagnostic ladder runs to the `:runtime-loaded-but-preload-
+  missing` rung (the one that mirrors the OLD `:runtime-not-preloaded`
+  semantics — runtime alive, marker absent). Without the JVM stub the
+  ladder would short-circuit on `:nrepl-unreachable` for every
+  negative cljs probe."
   [canned-value call-count* body-fn]
-  (let [orig nrepl/cljs-eval-value
-        stub (fn
-               ([_conn _build-id _form-str]
-                (swap! call-count* inc)
-                (js/Promise.resolve canned-value))
-               ([_conn _build-id _form-str _opts]
-                (swap! call-count* inc)
-                (js/Promise.resolve canned-value)))]
-    (set! nrepl/cljs-eval-value stub)
+  (let [orig-cljs nrepl/cljs-eval-value
+        orig-jvm  nrepl/jvm-eval
+        cljs-stub (fn
+                    ([_conn _build-id _form-str]
+                     (swap! call-count* inc)
+                     (js/Promise.resolve canned-value))
+                    ([_conn _build-id _form-str _opts]
+                     (swap! call-count* inc)
+                     (js/Promise.resolve canned-value)))
+        jvm-stub  (fn
+                    ([_conn form-str]
+                     (js/Promise.resolve
+                       (if (re-find #"active-builds" form-str)
+                         {:value "[:app]"}
+                         {:value "1"})))
+                    ([_conn form-str _opts]
+                     (js/Promise.resolve
+                       (if (re-find #"active-builds" form-str)
+                         {:value "[:app]"}
+                         {:value "1"}))))]
+    (set! nrepl/cljs-eval-value cljs-stub)
+    (set! nrepl/jvm-eval         jvm-stub)
     (-> (js/Promise.resolve nil)
         (.then (fn [_] (body-fn)))
-        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+        (.finally (fn []
+                    (set! nrepl/cljs-eval-value orig-cljs)
+                    (set! nrepl/jvm-eval         orig-jvm))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Conn fixture — a real conn-atom (not a stubbed one). The probe
@@ -202,8 +224,17 @@
           (.then (fn [_] (done)))))))
 
 (deftest ensure-runtime-rejects-on-missing-preload
-  ;; Negative path still surfaces the structured ex-info — cache only
+  ;; Negative path surfaces a structured ex-info — cache only
   ;; affects positive-result hot path.
+  ;;
+  ;; rf2-7tgfk: the rejection reason is now
+  ;; `:runtime-loaded-but-preload-missing` (the specific rung of the
+  ;; diagnostic ladder for the case where the JVM is reachable, the
+  ;; build is running, a CLJS runtime is connected, and ONLY the
+  ;; marker is absent). The probe-test stub returns `false` for the
+  ;; marker query (runtime alive, marker absent) → the ladder lands
+  ;; on this rung. Pre-rf2-7tgfk a single `:runtime-not-preloaded`
+  ;; reason covered every failure mode regardless of root cause.
   (async done
     (let [conn  (fresh-conn)
           calls (atom 0)]
@@ -214,7 +245,96 @@
                            (is false "ensure-runtime! must reject when preload missing")))
                   (.catch (fn [err]
                             (let [data (ex-data err)]
-                              (is (= :runtime-not-preloaded (:reason data)))
-                              (is (string? (:hint data))))))
+                              (is (= :runtime-loaded-but-preload-missing (:reason data)))
+                              (is (string? (:hint data)))
+                              (is (= :app (:build data))
+                                  "rejection carries the build id for the operator's next move"))))
                   (.then (fn [_] nil)))))
           (.then (fn [_] (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Diagnostic ladder — rf2-7tgfk. Pin each rung end-to-end.
+;; ---------------------------------------------------------------------------
+
+(defn- with-tri-stub!
+  "Stub harness with finer control over both `cljs-eval-value` and
+  `jvm-eval`. Used to drive each rung of the diagnostic ladder. Both
+  are a fn `(fn [form-str] -> canned)` so the test can branch on the
+  form being eval'd."
+  [cljs-fn jvm-fn body-fn]
+  (let [orig-cljs nrepl/cljs-eval-value
+        orig-jvm  nrepl/jvm-eval
+        cljs-stub (fn
+                    ([_conn _build-id form-str]      (js/Promise.resolve (cljs-fn form-str)))
+                    ([_conn _build-id form-str _opts] (js/Promise.resolve (cljs-fn form-str))))
+        jvm-stub  (fn
+                    ([_conn form-str]      (js/Promise.resolve (jvm-fn form-str)))
+                    ([_conn form-str _opts] (js/Promise.resolve (jvm-fn form-str))))]
+    (set! nrepl/cljs-eval-value cljs-stub)
+    (set! nrepl/jvm-eval         jvm-stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn []
+                    (set! nrepl/cljs-eval-value orig-cljs)
+                    (set! nrepl/jvm-eval         orig-jvm))))))
+
+(defn- assert-ladder-rejects-with-reason
+  "Drive `ensure-runtime!` to the rejection path and assert the rung's
+  reason + hint pattern. Centralises the deeply-nested Promise chain
+  shape so each rung test reads as data."
+  [conn expected-reason hint-pattern done extra-assertions]
+  (-> (probe/ensure-runtime! conn :app)
+      (.then  (fn [_] (is false "must reject") (done)))
+      (.catch (fn [err]
+                (let [data (ex-data err)]
+                  (is (= expected-reason (:reason data)))
+                  (is (re-find hint-pattern (:hint data)))
+                  (when extra-assertions (extra-assertions data))
+                  (done))))))
+
+(deftest diagnose-rung-nrepl-unreachable
+  (testing "JVM eval returns garbage (not \"1\") → :nrepl-unreachable"
+    (async done
+      (with-tri-stub! (fn [_] false)
+                      (fn [_] {:value "dead"})
+        (fn []
+          (assert-ladder-rejects-with-reason
+            (fresh-conn) :nrepl-unreachable #"nREPL" done nil))))))
+
+(deftest diagnose-rung-build-not-running
+  (testing "build is not in active-builds → :build-not-running with :running-builds"
+    (async done
+      (with-tri-stub! (fn [_] false)
+                      (fn [form-str]
+                        (if (re-find #"active-builds" form-str)
+                          {:value "[:other]"}
+                          {:value "1"}))
+        (fn []
+          (assert-ladder-rejects-with-reason
+            (fresh-conn) :build-not-running #":other" done
+            (fn [data]
+              (is (= [:other] (:running-builds data))))))))))
+
+(deftest diagnose-rung-no-runtime-connected
+  (testing "build is running but cljs-eval returns blank/nil → :no-runtime-connected"
+    (async done
+      (with-tri-stub! (fn [_] nil)
+                      (fn [form-str]
+                        (if (re-find #"active-builds" form-str)
+                          {:value "[:app]"}
+                          {:value "1"}))
+        (fn []
+          (assert-ladder-rejects-with-reason
+            (fresh-conn) :no-runtime-connected #"no CLJS runtime" done nil))))))
+
+(deftest diagnose-rung-runtime-loaded-but-preload-missing
+  (testing "cljs eval returns false → :runtime-loaded-but-preload-missing"
+    (async done
+      (with-tri-stub! (fn [_] false)
+                      (fn [form-str]
+                        (if (re-find #"active-builds" form-str)
+                          {:value "[:app]"}
+                          {:value "1"}))
+        (fn []
+          (assert-ladder-rejects-with-reason
+            (fresh-conn) :runtime-loaded-but-preload-missing #"preload" done nil))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/tail_build_test.cljs
@@ -1,0 +1,151 @@
+(ns re-frame2-pair-mcp.tail-build-test
+  "Unit tests for the `tail-build` MCP tool — specifically the
+  probe-value diagnostics added in rf2-36awg.
+
+  Pre-rf2-36awg the tool returned `{:ok? true :soft? false}` on success
+  and `{:ok? false :reason :timed-out :note \"...likely a compile
+  error.\"}` on timeout. Neither response carried the probe values
+  themselves, so the operator could not tell:
+
+    - Did the probe form evaluate at all?
+    - Did the probe return the same value before / after the reload?
+    - Did the probe form raise on every iteration?
+
+  These tests pin the new envelope shape so the diagnostic stays
+  visible across refactors of the polling loop."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.tail-build :as tail]))
+
+;; ---------------------------------------------------------------------------
+;; Stub harness — `cljs-eval-value` is the only nREPL surface tail-build
+;; touches. We script it with a seq of values; each call shifts the head.
+;; ---------------------------------------------------------------------------
+
+(defn- with-scripted-eval!
+  "Install a stub `cljs-eval-value` that resolves successive calls to
+  the head of `script*` (an atom holding a vector of values; each call
+  shifts the head; an empty queue falls back to the last value so a
+  short script can drive arbitrary polling). Run `body-fn` (returning
+  a Promise) and restore in `.finally`."
+  [script* body-fn]
+  (let [orig nrepl/cljs-eval-value
+        stub (fn
+               ([_conn _build-id _form-str]
+                (let [s @script*
+                      v (if (seq s) (first s) (peek (or (:tail @script*) [])))]
+                  (when (seq s) (swap! script* subvec 1))
+                  (js/Promise.resolve v)))
+               ([_conn _build-id _form-str _opts]
+                (let [s @script*
+                      v (if (seq s) (first s) (peek (or (:tail @script*) [])))]
+                  (when (seq s) (swap! script* subvec 1))
+                  (js/Promise.resolve v))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+(defn- with-rejecting-eval!
+  "Install a stub `cljs-eval-value` that REJECTS every call with an
+  Error carrying `err-msg`. Used to drive the `:probe-errored` path —
+  the probe form raised on the initial evaluation, so we never even
+  enter the polling loop."
+  [err-msg body-fn]
+  (let [orig nrepl/cljs-eval-value
+        stub (fn
+               ([_conn _build-id _form-str]
+                (js/Promise.reject (js/Error. err-msg)))
+               ([_conn _build-id _form-str _opts]
+                (js/Promise.reject (js/Error. err-msg))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+;; ---------------------------------------------------------------------------
+;; Soft delay — no probe supplied; envelope is unchanged from pre-rf2-36awg.
+;; ---------------------------------------------------------------------------
+
+(deftest no-probe-soft-resolves
+  (testing "tail-build with no probe resolves with :soft? true and no probe-values"
+    (async done
+      (-> (tail/tail-build-tool nil (tu/args->js {}))
+          (.then (fn [result]
+                   (let [edn (tu/extract-edn result)]
+                     (is (true? (:ok? edn)))
+                     (is (true? (:soft? edn)))
+                     (is (not (contains? edn :probe-values))
+                         "no probe → no probe-values slot"))
+                   (done)))))))
+
+;; ---------------------------------------------------------------------------
+;; Probe changes — success envelope carries :probe-values {:initial :final}.
+;; ---------------------------------------------------------------------------
+
+(deftest probe-changes-carries-initial-and-final
+  (testing "successful tail-build returns probe-values with distinct initial/final"
+    (async done
+      (let [script (atom [0 1])] ; first call → 0 (initial), second → 1 (changed)
+        (-> (with-scripted-eval! script
+              (fn []
+                (-> (tail/tail-build-tool nil (tu/args->js {:probe "(some-form)" :wait-ms 1000}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (true? (:ok? edn)))
+                               (is (false? (:soft? edn)))
+                               (is (= {:initial 0 :final 1} (:probe-values edn))
+                                   "success envelope carries both ends of the comparison"))
+                             (done))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Probe never changes — timeout envelope carries :probe-values with
+;; initial = final, plus the new :note hint.
+;; ---------------------------------------------------------------------------
+
+(deftest probe-stuck-timeout-carries-equal-initial-and-final
+  (testing "tail-build that times out exposes initial = final under :probe-values"
+    (async done
+      (let [;; Every call returns 42 → before == now forever → poll loop
+            ;; runs until wait-ms elapses.
+            script (atom [42 42 42 42 42 42 42 42 42 42 42 42 42 42 42])]
+        (-> (with-scripted-eval! script
+              (fn []
+                (-> (tail/tail-build-tool nil (tu/args->js {:probe "(some-stuck-form)"
+                                                            :wait-ms 250}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (false? (:ok? edn)))
+                               (is (= :timed-out (:reason edn)))
+                               (is (= {:initial 42 :final 42} (:probe-values edn))
+                                   "timeout envelope shows the comparison failed to drift")
+                               (is (string? (:note edn)))
+                               (is (re-find #"probe form returns the same value"
+                                            (:note edn))
+                                   "new hint distinguishes value-stuck from compile-error"))
+                             (done))))))
+            (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Probe raises on initial eval — :probe-errored envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest probe-rejects-initial-surfaces-probe-errored
+  (testing "tail-build with a probe that throws returns :probe-errored, not :timed-out"
+    (async done
+      (-> (with-rejecting-eval! "Unable to resolve symbol: zorp"
+            (fn []
+              (-> (tail/tail-build-tool nil (tu/args->js {:probe "(zorp)"
+                                                          :wait-ms 250}))
+                  (.then (fn [result]
+                           (let [edn (tu/extract-edn result)]
+                             (is (false? (:ok? edn)))
+                             (is (= :probe-errored (:reason edn))
+                                 "errored initial eval is its own reason, not :timed-out")
+                             (is (re-find #"zorp" (:probe-error edn))
+                                 "underlying nREPL error message rides on :probe-error")
+                             (is (string? (:note edn))))
+                           (done))))))
+          (.catch (fn [e] (is false (str "rejected: " (.-message e))) (done)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/trace_window_test.cljs
@@ -1,0 +1,126 @@
+(ns re-frame2-pair-mcp.trace-window-test
+  "Unit tests for the `trace-window` MCP tool — specifically the
+  empty-result advisory added in rf2-fb4hn.
+
+  Pre-rf2-fb4hn the tool returned `:count 0` with no explanation when
+  the time window excluded every event in the per-frame ring. Operators
+  routinely misread this as \"events aren't being captured\" when in
+  fact events existed but fell outside `:ms`. The advisory distinguishes
+  \"genuinely empty history\" from \"window excludes the history\"."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.trace-window :as tw]))
+
+;; ---------------------------------------------------------------------------
+;; Stub harness — `cljs-eval-value` is scripted by form-keyword
+;; substring: a sequence of [substring response] pairs picks the first
+;; pair whose substring appears in the eval form (probe forms contain
+;; `__re_frame2_pair_runtime`; trace-window's slice form contains
+;; `epoch-history`). A `:default` sentinel is the fall-through.
+;; ---------------------------------------------------------------------------
+
+(defn- with-substr-eval!
+  [script body-fn]
+  (let [orig nrepl/cljs-eval-value
+        match (fn [form-str]
+                (some (fn [[k v]]
+                        (when (or (= k :default)
+                                  (and (string? k) (re-find (re-pattern k) form-str)))
+                          v))
+                      script))
+        stub (fn
+               ([_conn _build-id form-str]
+                (js/Promise.resolve (match form-str)))
+               ([_conn _build-id form-str _opts]
+                (js/Promise.resolve (match form-str))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty window + empty history → NO advisory.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-history-no-advisory
+  (testing "trace-window with empty history returns count 0 + no advisory"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:epochs         []
+                                                  :id-aged-out?   false
+                                                  :requested-id   nil
+                                                  :head-id        nil
+                                                  :next-id        nil
+                                                  :history-count  0
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (tw/trace-window-tool nil (tu/args->js {:ms 1000}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (true? (:ok? edn)))
+                               (is (= 0 (:count edn)))
+                               (is (not (contains? edn :advisory))
+                                   "genuine empty: history empty → no advisory")
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty window + non-empty history → ADVISORY with epochs-in-history.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-window-non-empty-history-surfaces-advisory
+  (testing "trace-window with no events in window but 9 in history → :advisory"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:epochs         []
+                                                  :id-aged-out?   false
+                                                  :requested-id   nil
+                                                  :head-id        :epoch-9
+                                                  :next-id        nil
+                                                  :history-count  9
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (tw/trace-window-tool nil (tu/args->js {:ms 1000 :frame "step-deck"}))
+                    (.then (fn [result]
+                             (let [edn      (tu/extract-edn result)
+                                   advisory (:advisory edn)]
+                               (is (true? (:ok? edn)))
+                               (is (= 0 (:count edn)))
+                               (is (some? advisory)
+                                   "advisory should fire: 0 matches but 9 in history")
+                               (is (= :window-excludes-history (:reason advisory)))
+                               (is (= 9 (:epochs-in-history advisory)))
+                               (is (= 1000 (:window-ms advisory)))
+                               (is (= :step-deck (:frame advisory)))
+                               (is (re-find #"9 epochs exist" (:hint advisory)))
+                               (is (re-find #"snapshot" (:hint advisory))
+                                   "hint points operators to snapshot for historical inspection")
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Non-empty window → NO advisory (the happy path).
+;; ---------------------------------------------------------------------------
+
+(deftest non-empty-window-no-advisory
+  (testing "trace-window with matches in window → no advisory regardless of history"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:epochs         [{:epoch-id :e1 :committed-at 100}]
+                                                  :id-aged-out?   false
+                                                  :requested-id   nil
+                                                  :head-id        :e1
+                                                  :next-id        nil
+                                                  :history-count  20
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (tw/trace-window-tool nil (tu/args->js {:ms 60000}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (true? (:ok? edn)))
+                               (is (= 1 (:count edn)))
+                               (is (not (contains? edn :advisory))
+                                   "advisory should NOT fire when count > 0")
+                               (done))))))))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/watch_epochs_test.cljs
@@ -1,0 +1,154 @@
+(ns re-frame2-pair-mcp.watch-epochs-test
+  "Unit tests for the `watch-epochs` MCP tool — specifically the
+  empty-result advisory added in rf2-fb4hn.
+
+  watch-epochs returns matches that landed AFTER a :since-id AND
+  satisfy an optional :pred. When matches is empty the operator wants
+  to know which gate filtered the result:
+
+    - The :since-id is at (or past) the head — calmly \"nothing new\".
+    - Events landed since the id, but the :pred excluded them all —
+      point at the predicate.
+    - Genuinely empty history — no advisory.
+
+  Pre-rf2-fb4hn these three cases all looked identical (empty matches +
+  no further detail), feeding a misread that the listener wasn't
+  capturing events."
+  (:require [cljs.test :refer-macros [deftest is testing async]]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.watch-epochs :as we]))
+
+(defn- with-substr-eval!
+  [script body-fn]
+  (let [orig nrepl/cljs-eval-value
+        match (fn [form-str]
+                (some (fn [[k v]]
+                        (when (or (= k :default)
+                                  (and (string? k) (re-find (re-pattern k) form-str)))
+                          v))
+                      script))
+        stub (fn
+               ([_conn _build-id form-str]
+                (js/Promise.resolve (match form-str)))
+               ([_conn _build-id form-str _opts]
+                (js/Promise.resolve (match form-str))))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_] (body-fn)))
+        (.finally (fn [] (set! nrepl/cljs-eval-value orig))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty matches + empty history → no advisory.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-history-no-advisory
+  (testing "watch-epochs with truly empty per-frame ring → no advisory"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:matches        []
+                                                  :id-aged-out?   false
+                                                  :requested-id   nil
+                                                  :head-id        nil
+                                                  :next-id        nil
+                                                  :history-count  0
+                                                  :since-count    0
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (we/watch-epochs-tool nil (tu/args->js {}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (true? (:ok? edn)))
+                               (is (= 0 (:count edn)))
+                               (is (not (contains? edn :advisory)))
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty matches + history non-empty + since-count = 0 → :no-events-since-id.
+;; ---------------------------------------------------------------------------
+
+(deftest history-non-empty-but-nothing-since-id
+  (testing "watch-epochs at head of ring → :no-events-since-id advisory"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:matches        []
+                                                  :id-aged-out?   false
+                                                  :requested-id   :epoch-9
+                                                  :head-id        :epoch-9
+                                                  :next-id        nil
+                                                  :history-count  9
+                                                  :since-count    0
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (we/watch-epochs-tool nil (tu/args->js {:since-id ":epoch-9"
+                                                            :frame "step-deck"}))
+                    (.then (fn [result]
+                             (let [edn      (tu/extract-edn result)
+                                   advisory (:advisory edn)]
+                               (is (some? advisory))
+                               (is (= :no-events-since-id (:reason advisory)))
+                               (is (= 9 (:epochs-in-history advisory)))
+                               (is (= :step-deck (:frame advisory)))
+                               (is (re-find #"none have landed since" (:hint advisory)))
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Empty matches + since-count > 0 → :pred-excludes-history.
+;; ---------------------------------------------------------------------------
+
+(deftest pred-filters-all-events-since-id
+  (testing "watch-epochs with :pred excluding every event → :pred-excludes-history"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:matches        []
+                                                  :id-aged-out?   false
+                                                  :requested-id   :epoch-3
+                                                  :head-id        :epoch-9
+                                                  :next-id        nil
+                                                  :history-count  9
+                                                  :since-count    6
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (we/watch-epochs-tool
+                      nil
+                      (tu/args->js {:since-id ":epoch-3"
+                                    :pred #js {:event-id ":no/match"}}))
+                    (.then (fn [result]
+                             (let [edn      (tu/extract-edn result)
+                                   advisory (:advisory edn)]
+                               (is (some? advisory))
+                               (is (= :pred-excludes-history (:reason advisory)))
+                               (is (= 9 (:epochs-in-history advisory)))
+                               (is (= 6 (:epochs-since-id advisory)))
+                               (is (re-find #":pred filter excluded"
+                                            (:hint advisory)))
+                               (done))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Non-empty matches → no advisory.
+;; ---------------------------------------------------------------------------
+
+(deftest non-empty-matches-no-advisory
+  (testing "watch-epochs with matches → no advisory"
+    (async done
+      (let [script [["__re_frame2_pair_runtime" true]
+                    [:default                    {:matches        [{:epoch-id :e1}]
+                                                  :id-aged-out?   false
+                                                  :requested-id   nil
+                                                  :head-id        :e1
+                                                  :next-id        nil
+                                                  :history-count  5
+                                                  :since-count    5
+                                                  :remaining      0}]]]
+        (-> (with-substr-eval! script
+              (fn []
+                (-> (we/watch-epochs-tool nil (tu/args->js {}))
+                    (.then (fn [result]
+                             (let [edn (tu/extract-edn result)]
+                               (is (true? (:ok? edn)))
+                               (is (= 1 (:count edn)))
+                               (is (not (contains? edn :advisory)))
+                               (done))))))))))))


### PR DESCRIPTION
Shape-2 cluster of 4 MCP pair-debug diagnostic improvements surfaced from the 2026-05-25 pair-debug session against `localhost:8031`. Smallest cleanup first, biggest fix last.

## Per-bead changes

**rf2-36awg (commit 1) — `tail-build` carries probe values for diagnosis.**
Both success and timeout envelopes now include `:probe-values {:initial <v0> :final <v-last>}` — the two ends of the polling comparison. On timeout the operator can disambiguate compile-didn''t-land vs probe-form-returns-same-value vs probe-errored. New `:reason :probe-errored` covers the case where the probe form raises on every iteration; the previous blanket "Likely a compile error" hint is replaced with a hint that points at the probe-values themselves.

**rf2-fb4hn (commit 2) — empty-result advisory on `trace-window` + `watch-epochs`.**
When matches=0 but the per-frame epoch-history is non-empty, both tools now surface a structured `:advisory` slot:
- `trace-window` → `:reason :window-excludes-history` with `:epochs-in-history` + `:window-ms` + a hint pointing at `snapshot :include [:epochs]` for historical inspection.
- `watch-epochs` → either `:no-events-since-id` (caller is at the head — nothing new) or `:pred-excludes-history` (events landed but the predicate filtered them all).
Operators in the pair-debug session repeatedly misread "empty matches" as "events aren''t being captured"; the advisory closes that gap.

**rf2-l7vnd (commit 3) — `handler-meta` returns `:ok? true` with real metadata.**
Real bug. `re-frame.core/handler-meta` carries a `:handler-fn` slot whose value is a raw Function. `pr-str` of a Function emits `#object[Function ...]` — unreadable EDN on the MCP wire, so `read-edn-safe` fell back to the raw string and the tool surfaced a `:unexpected-shape` failure envelope with the actual map embedded as `:value "{...}"`. Every `handler-meta` call hit this. Two defences:
- Runtime side: `registrar-describe` and the `:machine` form `dissoc :handler-fn` before returning (the wire-friendly `:handler-fn-hash` is the substitute consumers actually use).
- MCP tool side: defensive re-parse — if the value comes back as a stringified map, attempt one more `edn/read-string` before falling to `:unexpected-shape`.

**rf2-7tgfk (commit 4) — `:runtime-not-preloaded` refined into a 4-way diagnostic ladder.**
Pre-rf2-7tgfk every failed preload probe returned a blanket `:runtime-not-preloaded` reason with a hint that always read "add the preload to your shadow-cljs.edn". In the 2026-05-25 session that hint was misleading in 3 of the 4 failure modes the operator actually hit (~30 min of dead-end exploration).

`ensure-runtime!` now runs a diagnostic ladder on the failure path and rejects with one of four specific reasons, each carrying a targeted hint:

| `:reason`                                | Failure mode |
|------------------------------------------|--------------|
| `:nrepl-unreachable`                     | JVM-side eval round-trip fails — stale socket / dead JVM. Restart `shadow-cljs watch`. |
| `:build-not-running`                     | shadow''s `active-builds` doesn''t include the targeted build; `:running-builds` names the actual ones. |
| `:no-runtime-connected`                  | Build IS running but cljs-eval returns blank — no browser tab, or its ws is dead. |
| `:runtime-loaded-but-preload-missing`    | Runtime alive, marker absent — the case the original blanket reason was for. Original "add the preload" hint reserved for this rung. |

Cost: one extra `jvm-eval` (active-builds) on the failure path; ~50ms. The probe cache means the success path stays free. `:runtime-not-preloaded` is retained only as the degradation fallback if the ladder itself errors.

## Tests + gates

- `npm test` → 592 tests, 1567 assertions, 0 failures.
- `npm run stdio-roundtrip` → SERVER STDIO ROUND-TRIP GREEN.
- `npx shadow-cljs compile server` → 0 warnings; production binary at `out/server.js` rebuilt and ready for the rf2-6jj3r post-merge hook.
- `clj-kondo` over changed files → 0 new warnings (pre-existing warnings unchanged).
- New tests: 4 ladder rung tests (probe_test), 4 advisory tests across trace-window + watch-epochs, 4 handler-meta regression tests, 4 tail-build probe-value tests, plus a babashka structural pin for `registrar-describe` (skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj).
- 3 conformance fixtures (discover-app / dispatch / snapshot preload-missing) updated to expect `:runtime-loaded-but-preload-missing` — the ladder rung that mirrors the old blanket-reason semantics.

## Files touched

- `tools/re-frame2-pair-mcp/src/.../tail_build.cljs`
- `tools/re-frame2-pair-mcp/src/.../trace_window.cljs`
- `tools/re-frame2-pair-mcp/src/.../watch_epochs.cljs`
- `tools/re-frame2-pair-mcp/src/.../handler_meta.cljs`
- `tools/re-frame2-pair-mcp/src/.../probe.cljs`
- `tools/re-frame2-pair-mcp/test/...` (new suites + conformance + probe extensions)
- `tools/re-frame2-pair-mcp/README.md` (§"Failure-path diagnostic ladder")
- `skills/re-frame2-pair/preload/re_frame2_pair/runtime.cljs` (`registrar-describe` dissoc :handler-fn)
- `skills/re-frame2-pair/tests/runtime/registrar_describe_test.clj` (new bb structural pin)