### PR TITLE
fix(xray-testbed): testdeck :ws/connection — use vector target [:failed] per Spec 005 §1029 (rf2-21rkg)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_machine_projection_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_machine_projection_cljs_test.cljs
@@ -1,0 +1,67 @@
+(ns day8.re-frame2-xray.testbeds.testdeck-machine-projection-cljs-test
+  "Pure-data regression guard for rf2-21rkg — the testdeck `:ws/connection`
+  machine's projection must resolve every edge `:to` to a path that exists
+  in the projected `:nodes`.
+
+  The bug: `tools/xray/testbeds/testdeck/machine.cljs` used the keyword
+  form `:target :failed` from `[:active :authenticating]`. Per Spec 005
+  §Target resolution, a keyword target resolves to a sibling of the
+  declaring state — i.e. `[:active :failed]`, which does not exist
+  (the `:failed` state lives at top-level `[:failed]`). The
+  machines-viz projector minted a `[:active :failed]` edge `:to`,
+  ELK rejected the graph with `Referenced shape does not exist:
+  active__failed`, and the Machine tab couldn't render.
+
+  The fix used the vector form `:target [:failed]` (Spec 005 §1029:
+  vector targets are unambiguous and the recommended form for
+  cross-level transitions).
+
+  This test pins the projection invariant: for the testdeck machine,
+  the set of edge `:to` paths is a SUBSET of the set of node paths.
+  A regression to the keyword form would re-mint `[:active :failed]`
+  in `:to` while `:nodes` still has `[:failed]`, and the subset
+  assertion would fail."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.set :as set]
+            [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [testdeck.machine :as testdeck]))
+
+(deftest every-edge-to-resolves-to-a-projected-node
+  (testing "rf2-21rkg — every :to path in the projected edges exists in :nodes
+            (no edge points at a non-existent state). Pins the spec-compliant
+            target form for cross-hierarchy transitions."
+    (let [{:keys [nodes edges]} (layout/parse-definition testdeck/connection-machine)
+          node-paths            (into #{} (map :path) nodes)
+          edge-to-paths         (into #{} (map :to)   edges)
+          dangling              (set/difference edge-to-paths node-paths)]
+      (is (empty? dangling)
+          (str "edge :to paths must all exist in :nodes; dangling: "
+               (pr-str dangling))))))
+
+(deftest every-edge-from-resolves-to-a-projected-node
+  (testing "symmetric guard — every :from path must also exist (would
+            catch a different shape of misuse where a substate is renamed
+            but a transition still references the old name)."
+    (let [{:keys [nodes edges]} (layout/parse-definition testdeck/connection-machine)
+          node-paths            (into #{} (map :path) nodes)
+          edge-from-paths       (into #{} (map :from) edges)
+          dangling              (set/difference edge-from-paths node-paths)]
+      (is (empty? dangling)
+          (str "edge :from paths must all exist in :nodes; dangling: "
+               (pr-str dangling))))))
+
+(deftest authenticating-failure-edge-points-at-top-level-failed
+  (testing "rf2-21rkg — the `:after`-driven failure branch from
+            [:active :authenticating] must resolve to top-level [:failed]
+            (cross-hierarchy vector target), NOT [:active :failed]
+            (the broken keyword-form resolution)."
+    (let [{:keys [edges]} (layout/parse-definition testdeck/connection-machine)
+          failure-edge    (some (fn [{:keys [from action] :as e}]
+                                  (when (and (= [:active :authenticating] from)
+                                             (= :record-error action))
+                                    e))
+                                edges)]
+      (is (some? failure-edge)
+          "the authenticating→failed `:after` edge with :record-error must project")
+      (is (= [:failed] (:to failure-edge))
+          "the failure edge resolves to top-level [:failed], not [:active :failed]"))))

--- a/tools/xray/testbeds/testdeck/machine.cljs
+++ b/tools/xray/testbeds/testdeck/machine.cljs
@@ -161,9 +161,14 @@
       {:tags  #{:ws/active :ws/authenticating}
        ;; Mock auth — branch on the user-armed failure guard. Guarded
        ;; `:after` transitions: the first whose guard passes wins.
+       ;; The failure branch crosses hierarchy ([:active :authenticating]
+       ;; → top-level [:failed]), so it uses the unambiguous vector form
+       ;; (Spec 005 §Target resolution — vector vs keyword). A keyword
+       ;; `:target :failed` would resolve relative to `:authenticating`'s
+       ;; parent `:active`, which has no `:failed` substate.
        :after {AUTHENTICATING-MS
                [{:guard :handshake-ok? :target :connected}
-                {:target :failed :action :record-error}]}}
+                {:target [:failed] :action :record-error}]}}
 
       :connected
       {:tags  #{:ws/active :ws/connected}


### PR DESCRIPTION
## The bug

The testdeck `:ws/connection` machine at
`tools/xray/testbeds/testdeck/machine.cljs:166` declared a cross-
hierarchy `:after` transition with the ambiguous keyword form:

```clojure
:authenticating
{:after {AUTHENTICATING-MS
         [{:guard :handshake-ok? :target :connected}
          {:target :failed :action :record-error}]}}   ;; <-- ambiguous
```

Per Spec 005 §Target resolution (`spec/005-StateMachines.md:1030`):

> **Keyword form — relative to the state where the transition is declared.**
> `:target :review` resolves to a sibling of the current declaring state.
> The runtime resolves the keyword against the declaring state''s
> *parent''s* `:states` map.

The declaring state is `:authenticating` at path `[:active
:authenticating]`. Its parent `:active`''s `:states` map is
`{:connecting :authenticating :connected}` — there is no `:failed`
substate there. The real `:failed` state lives at top-level
`[:failed]`.

The machines-viz projector correctly minted an edge `:to [:active
:failed]`; ELK rejected the graph with `Referenced shape does not
exist: active__failed`; the Machine tab couldn''t render.

## The fix

Use the spec-recommended vector form (Spec 005 §1029):

> **Vector form — absolute path from root.** Vector targets are
> unambiguous and the recommended form for cross-level transitions.

```clojure
{:target [:failed] :action :record-error}
```

Single line of change to the testbed; nothing in the framework / runtime
/ projector / spec touched.

## Regression guard

Added `tools/xray/test/day8/re_frame2_xray/testbeds/testdeck_machine_projection_cljs_test.cljs`,
which projects the testdeck machine via `chart.layout/parse-definition`
and pins three invariants:

1. every edge `:to` path exists in `:nodes` (no danglers);
2. every edge `:from` path exists in `:nodes` (symmetric guard);
3. the authenticating→failed `:after` branch resolves to `[:failed]`,
   not `[:active :failed]`.

A regression to the keyword form would re-mint `[:active :failed]` in
`:to` while `:nodes` still has `[:failed]`, and the subset assertion
would fail.

## Resolves rf2-o43yg via testbed fix

rf2-o43yg ("machines-viz projector doesn''t handle cross-hierarchy
keyword targets") had the premise overturned: the projector + runtime +
spec were all correct. The testbed misused the keyword form for a
cross-hierarchy target. With this PR''s fix landed, rf2-o43yg can close
as resolved-via-testbed-fix.

## Gates

- `clj-kondo --lint tools/xray/testbeds/testdeck tools/xray/test` — 0 errors, 59 warnings (all pre-existing in other files; the one new-file warning was fixed in-PR).
- `npm run test:cljs` — 4406 tests / 14076 assertions / 0 failures / 0 errors.
- `npm run test:xray-feature-gate` — 13 scenarios / 0 failures.