### PR TITLE
fix(xray): Machine panel views Chart + AfterRingsOverlay via reg-view to capture :rf/xray frame (rf2-m4xz1)

### DIFF
--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_after_rings.cljs
@@ -288,7 +288,7 @@
                    :epoch      (:epoch spec)}]
                  {:frame :rf/xray})))
 
-(defn AfterRingsOverlay
+(rf/reg-view AfterRingsOverlay
   "Mounts the focused machine's `:after` countdown rings over the
   xyflow chart. Subscribes to the active timers + now-ms + scrubber
   internally; projects each timer into a presentation-ready ring-spec
@@ -297,41 +297,50 @@
   rAF clock in live mode; then delegates positioning + paint to the
   machines-viz `AfterRingsOverlay`, which walks the xyflow node DOM.
 
+  rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
+  React-context frame tier carries the enclosing `:rf/xray` frame
+  through to the four subscribes inside. As a plain fn rendered under
+  `[rf/frame-provider {:frame :rf/xray}]`, the subscribes routed to
+  `:rf/default` (the host app's frame), which is a real frame-leak —
+  xray-internal slots must be read via xray's own frame. Same surgery
+  PR #2110 (rf2-uu3lp) applied to the rest of xray chrome.
+
   Accepts an optional opts map (currently unused — reserved for a
-  future per-call testid override). The legacy positioned-graph /
-  viewport-transform args are GONE (xyflow owns positions; the
-  overlay reads them off the DOM).
+  future per-call testid override). Variadic to preserve the prior
+  0-arg + 1-arg call shapes (the hiccup mount carries one arg, tests
+  call with zero or one). The legacy positioned-graph / viewport-
+  transform args are GONE (xyflow owns positions; the overlay reads
+  them off the DOM).
 
   Returns nil when the projection has no active timers (the overlay
   layer drops out so unrelated chart hover handlers aren't shadowed)."
-  ([] (AfterRingsOverlay nil))
-  ([_opts]
-   (let [timers @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
-         now    @(rf/subscribe [:rf.xray/now-ms])
-         scrub  @(rf/subscribe [:rf.xray/machine-scrubber-position])
-         ;; Kick the rAF loop iff ticking is needed (live mode + at
-         ;; least one armed timer). Cheap to call per render — the
-         ;; `:running?` sentinel collapses duplicate kicks. Per Lock #8
-         ;; this is the SINGLE per-chart clock (O(charts), not
-         ;; O(rings × charts)); the machines-viz overlay runs no clock
-         ;; of its own — it just re-measures the DOM when `:tick` bumps.
-         _      (when (rings-h/needs-ticking? timers scrub)
-                  (kick-tick!))
-         specs  (rings-h/timers->ring-specs
-                  timers chart-layout/highlight-id now)]
-     (when (seq specs)
-       [mv-after-rings/AfterRingsOverlay
-        {:ring-specs specs
-         ;; `now` is the rAF-bumped (or scrubber-pinned) instant —
-         ;; bumping it on every frame forces the overlay to re-measure
-         ;; the DOM + repaint the swept arcs (Lock #8 60Hz-when-visible
-         ;; cadence, driven by THIS ns's clock, not the overlay's).
-         :tick       now
-         :testid     "rf-xray-machine-inspector-after-rings-overlay"
-         :on-hover   (fn [node-id] (timer-hovered! specs node-id))
-         :on-leave   (fn [_node-id]
-                       (rf/dispatch [:rf.xray/timer-hover nil]
-                                    {:frame :rf/xray}))}]))))
+  [& _opts]
+  (let [timers @(rf/subscribe [:rf.xray/active-timers-for-focused-machine])
+        now    @(rf/subscribe [:rf.xray/now-ms])
+        scrub  @(rf/subscribe [:rf.xray/machine-scrubber-position])
+        ;; Kick the rAF loop iff ticking is needed (live mode + at
+        ;; least one armed timer). Cheap to call per render — the
+        ;; `:running?` sentinel collapses duplicate kicks. Per Lock #8
+        ;; this is the SINGLE per-chart clock (O(charts), not
+        ;; O(rings × charts)); the machines-viz overlay runs no clock
+        ;; of its own — it just re-measures the DOM when `:tick` bumps.
+        _      (when (rings-h/needs-ticking? timers scrub)
+                 (kick-tick!))
+        specs  (rings-h/timers->ring-specs
+                 timers chart-layout/highlight-id now)]
+    (when (seq specs)
+      [mv-after-rings/AfterRingsOverlay
+       {:ring-specs specs
+        ;; `now` is the rAF-bumped (or scrubber-pinned) instant —
+        ;; bumping it on every frame forces the overlay to re-measure
+        ;; the DOM + repaint the swept arcs (Lock #8 60Hz-when-visible
+        ;; cadence, driven by THIS ns's clock, not the overlay's).
+        :tick       now
+        :testid     "rf-xray-machine-inspector-after-rings-overlay"
+        :on-hover   (fn [node-id] (timer-hovered! specs node-id))
+        :on-leave   (fn [_node-id]
+                      (rf/dispatch [:rf.xray/timer-hover nil]
+                                   {:frame :rf/xray}))}])))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/panels/machine_canvas.cljs
@@ -233,9 +233,16 @@
 
 ;; ---- public Chart view --------------------------------------------------
 
-(defn Chart
+(rf/reg-view Chart
   "Render the interactive MachineChart inside the Dynamic Machines
   panel (or the Static Machines Topology body).
+
+  rf2-m4xz1 — registered via `reg-view` (was a plain `defn`) so the
+  React-context frame tier carries the enclosing `:rf/xray` frame
+  through to the inner view-mode-toggle subscribe. As a plain fn the
+  subscribe routed to `:rf/default` (the host app), which is a real
+  frame-leak — xray-internal slots must be read via xray's own frame.
+  Same surgery PR #2110 (rf2-uu3lp) applied to the rest of xray chrome.
 
   Args (map):
 


### PR DESCRIPTION
## Symptoms

Two `:rf.warning/plain-fn-under-non-default-frame-once` warnings fired on the Step-Deck testbed at xray mount:

1. `day8.re_frame2_xray.panels.machine_canvas.Chart` rendered under `:rf/xray`; subscribe/dispatch routed to `:rf/default`
2. `day8.re_frame2_xray.panels.machine_after_rings.AfterRingsOverlay` rendered under `:rf/xray`; subscribe/dispatch routed to `:rf/default`

## Fix shape

Both views were plain `defn`s rendered in hiccup position (`[machine-canvas/Chart {...}]`, `[after-rings/AfterRingsOverlay nil]`). Reagent strips frame context across plain fn boundaries because the returned function component carries no `:contextType`, so any `subscribe`/`dispatch` inside the body runs against `:rf/default` (the host apps frame — in this case Step-Decks) rather than `:rf/xray` (where xrays own slots live). Per `feedback-frames-are-isolated-contexts` this is a real frame-leak — xray-internal state must be read via xrays own frame, not the hosts.

Registered both via `rf/reg-view`. `reg-view` stamps `:contextType frame-context` on the wrapped fn so Reagents fn-to-class machinery hooks it up to the React frame-context tier, resolving the surrounding `[rf/frame-provider {:frame :rf/xray}]` correctly. Same surgery PR #2110 (rf2-uu3lp) applied to the rest of xray chrome — these two Machine-panel views were residue from that sweep.

`AfterRingsOverlay` was variadic (0-arg + 1-arg) prior; converted to `[& _opts]` to preserve both call shapes (the hiccup mount passes one arg, tests call with zero or one).

## Audit-grep — additional residue?

Reviewed every `defn` in `tools/xray/src/day8/re_frame2_xray/panels/` that calls `rf/subscribe` or `rf/dispatch`. Every other plain-fn helper is invoked via a Clojure call `(foo ...)` from inside a parent `reg-view`s render body (synchronous, preserves `*current-frame*`) — NOT via hiccup `[foo ...]` (a Reagent component boundary that loses context). Only `Chart` and `AfterRingsOverlay` were mounted via hiccup position, so this PR is the complete residue sweep — no additional views need conversion.

## Gates

- `clj-kondo --lint tools/xray/src tools/xray/test`: 0 errors, 96 warnings (all pre-existing in unrelated test files, none in the two changed files).
- `clojure -M:test` (tools/xray JVM): 884 tests / 3129 assertions, 0 failures / 0 errors.
- `npm run test:cljs`: 4406 tests / 14076 assertions, 0 failures / 0 errors.
- `npm run test:xray-feature-gate`: 13 scenarios, 0 failures.

## Verification

The two warnings cease at mount because the wrapped fns now resolve the surrounding `:rf/xray` frame via React context. To confirm locally: open the Step-Deck testbed with xray mounted; the two `:rf.warning/plain-fn-under-non-default-frame-once` console warnings should no longer appear, and the Machine panel chart + after-rings overlay should render identically.

## Related

- #2110 (rf2-uu3lp) — prior xray reg-view-warning sweep
- `feedback-frames-are-isolated-contexts` — the anti-pattern this instance fixed