### PR TITLE
fix(machines-viz): compound containers receive :style {:width :height} from ELK (mirror region path) (rf2-a64bi)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -95,6 +95,21 @@ INCLUDE_CHILDREN`. The chart root surfaces `data-region-count`; region
 containers are excluded from `data-node-count` + the aria-label state
 count (they are zone chrome, not states).
 
+### Container sizing — `:style {:width :height}` from ELK (rf2-a64bi)
+
+BOTH region containers (above) AND compound containers receive a
+`:style {:width :height}` slot on their projected xyflow node, sourced
+from elk's measured `{:x :y :width :height}` position entry. Container
+renderers (`parallel-region-node`, `compound-node`) fill their box with
+`width:100% height:100%`, so the projector MUST hand xyflow the box elk
+measured — otherwise xyflow falls back to
+`compound-node-min-{width,height}` (220×120, the renderer's minimum DOM
+size), and substates whose parent-relative coordinates elk computed
+against the FULL measured extent overflow the smaller fallback and
+visually escape the container. Leaf (non-container) state nodes carry
+NO `:style`; xyflow sizes them from the rendered DOM
+(`state-node-min-{width,height}`).
+
 ### Parallel multi-active highlight (rf2-yoe6e, rf2-g2svr)
 
 > Closes parity gap **G1** in

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -306,9 +306,23 @@
                                                   :regionIndex (:region-index n)))
                        :draggable false
                        :selectable false}]
+                  ;; rf2-a64bi — BOTH region AND compound containers receive
+                  ;; `:style {:width :height}` from elk's measured position.
+                  ;; The parallel-region renderer (`parallel_region_node`)
+                  ;; AND the compound renderer (`compound_node`) both fill
+                  ;; their box with `width:100% height:100%`, so xyflow must
+                  ;; allocate the box elk measured — otherwise it falls back
+                  ;; to `compound-node-min-{width,height}` (220×120), and
+                  ;; substates whose parent-relative coords elk computed
+                  ;; against the FULL measured extent overflow the smaller
+                  ;; fallback box and visually escape the container. The
+                  ;; asymmetry (region styled, compound not) was the bug;
+                  ;; mirroring the region path here keeps containment.
                   (cond-> base
-                    region? (assoc :style {:width  (:width pos)
-                                           :height (:height pos)})
+                    (or region? (:compound? n))
+                    (assoc :style {:width  (:width pos)
+                                   :height (:height pos)})
+
                     (and (not region?) (:parent-id n))
                     (assoc :parentNode (:parent-id n)
                            :extent     "parent"))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -570,6 +570,63 @@
           region    (node-by-id graph rid)]
       (is (= {:width 320 :height 180} (:style region))))))
 
+(deftest xyflow-graph-compound-style-from-measured-position
+  (testing "rf2-a64bi — a compound container's `:style {:width :height}`
+            comes from its measured position entry, the SAME way a region
+            container's does. The compound renderer fills its box with
+            `width:100% height:100%`, so without the styled box xyflow
+            falls back to `compound-node-min-{width,height}` (220×120)
+            and substates whose parent-relative elk coords were computed
+            against the FULL measured extent overflow + visually escape
+            the container."
+    (let [parsed    (layout/parse-definition compound-machine)
+          cid       (layout/node-id [:authenticated])
+          positions {cid {:x 0 :y 0 :width 328 :height 156}}
+          graph     (projection/xyflow-graph parsed positions {})
+          compound  (node-by-id graph cid)]
+      (is (= "compound" (:type compound)) "fixture sanity: authenticated is compound")
+      (is (= {:width 328 :height 156} (:style compound))))))
+
+(deftest xyflow-graph-compound-style-coexists-with-parent-relative-substates
+  (testing "rf2-a64bi — when a compound has substates, the compound's
+            `:style {:width :height}` matches elk's bounding box AND each
+            substate carries `:parentNode` + `:extent \"parent\"` with a
+            parent-relative `:position`. The two together are the
+            containment contract: xyflow allocates the measured box, then
+            clamps the parent-relative substates inside it."
+    (let [parsed    (layout/parse-definition compound-machine)
+          cid       (layout/node-id [:authenticated])
+          browsing  (layout/node-id [:authenticated :browsing])
+          paying    (layout/node-id [:authenticated :paying])
+          positions {cid      {:x 0   :y 0  :width 328 :height 156}
+                     browsing {:x 14  :y 34 :width 140 :height 44}
+                     paying   {:x 174 :y 34 :width 140 :height 44}}
+          graph     (projection/xyflow-graph parsed positions {})
+          compound  (node-by-id graph cid)
+          b         (node-by-id graph browsing)
+          p         (node-by-id graph paying)]
+      (is (= {:width 328 :height 156} (:style compound))
+          "compound gets elk's measured box as :style")
+      (is (= cid (:parentNode b)) ":browsing nests under :authenticated")
+      (is (= cid (:parentNode p)) ":paying nests under :authenticated")
+      (is (= "parent" (:extent b)))
+      (is (= "parent" (:extent p)))
+      (is (= {:x 14 :y 34} (:position b))
+          "substate :position is parent-relative (passed through verbatim)")
+      (is (= {:x 174 :y 34} (:position p))))))
+
+(deftest xyflow-graph-leaf-state-has-no-style
+  (testing "rf2-a64bi — a leaf (non-container) state carries NO `:style`
+            even with a measured size in the positions map; xyflow sizes
+            leaf nodes from the rendered DOM (`state-node-min-{width,height}`)
+            rather than a projector-supplied box."
+    (let [parsed    (layout/parse-definition idle-loading)
+          idle-id   (layout/node-id [:idle])
+          positions {idle-id {:x 0 :y 0 :width 200 :height 60}}
+          graph     (projection/xyflow-graph parsed positions {})
+          idle      (node-by-id graph idle-id)]
+      (is (nil? (:style idle))))))
+
 (deftest xyflow-graph-position-defaults-to-origin
   (testing "a node with no entry in the positions map defaults to
             {:x 0 :y 0} (the pre-layout placeholder)"


### PR DESCRIPTION
@-