### PR TITLE
fix(machines-viz): compound substates render inside parent via xyflow v12 parentId (rf2-xh1lm)

### DIFF
--- a/tools/machines-viz/spec/001-Topology-Parity.md
+++ b/tools/machines-viz/spec/001-Topology-Parity.md
@@ -48,7 +48,7 @@ converter maps `position`, `width`/`height`, `shape → type`,
 `parentId` (nesting), `sourcePort`/`targetPort → sourceHandle`/
 `targetHandle`, and `edge.data.label` — **the same fields**
 `chart.projection.cljc` emits (`:position`, node `:type`,
-`parentNode`/`extent:"parent"`, `Handle` ids, `:data {:eventLabel}`).
+`parentId`/`extent:"parent"`, `Handle` ids, `:data {:eventLabel}`).
 So a large slice of parity is **already structural**; the gaps below
 are the residue that the shared primitives do not buy for free.
 
@@ -168,7 +168,7 @@ parse (`chart/layout.cljc`) + pure projection (`chart/projection.cljc`)
 
 | Concern | Status today | Where |
 |---|---|---|
-| **Hierarchy** | ✅ Compound parents render as a dashed container with a header-strip title; children nest via xyflow `parentNode` + `extent:"parent"`; elk lays children inside the parent box (`INCLUDE_CHILDREN`). Nesting recurses (compound-in-compound, compound-in-region). | `nodes.cljs` `compound-node`; `projection.cljc` `->elk-children` (`:parent-id` grouping), `xyflow-graph` (`parentNode`/`extent`); `layout.cljc` `parse-flat` (`:parent-id` on nested nodes). |
+| **Hierarchy** | ✅ Compound parents render as a dashed container with a header-strip title; children nest via xyflow `parentId` + `extent:"parent"` (rf2-xh1lm — v12 reads `parentId`, NOT the pre-v12 `parentNode`); elk lays children inside the parent box (`INCLUDE_CHILDREN`). Nesting recurses (compound-in-compound, compound-in-region). | `nodes.cljs` `compound-node`; `projection.cljc` `->elk-children` (`:parent-id` grouping), `xyflow-graph` (`parentId`/`extent`); `layout.cljc` `parse-flat` (`:parent-id` on nested nodes). |
 | **Parallel regions — structure** | ✅ **Every** region renders as a synthetic `:region?` compound node with a **distinct dashed boundary per region** (palette rotation) + `∥` glyph + region label; states carry `:region` + `:parent-id`; edges stay region-local. | `layout.cljc` `parse-parallel`/`region-node-id`; `projection.cljc` (`type "parallel-region"`); `nodes/parallel_region_node.cljs`. |
 | **Parallel regions — active highlight** | ✅ **Closed (rf2-yoe6e / rf2-g2svr).** `highlight-ids` resolves the whole snapshot `:state` — flat keyword, compound path, **or region-map** `{region path}` — to the **set** of active-leaf node-ids; `xyflow-graph` threads `:highlight-ids` and marks **every** active leaf, so a parallel snapshot's **N simultaneously-active leaves** all light up at once. A nested region value resolves to its deepest leaf. | `layout.cljc` `highlight-ids`; `projection.cljc` `xyflow-graph` (`:highlight-ids` set). |
 | **Parallel regions — active CONTAINER chrome** | ✅ **Closed (rf2-80rm2 / G4).** The region (and, for self-consistency, the compound) **container** reads as active when ANY descendant leaf is active — the projector folds the container into `:active` by walking each active leaf UP its `:parent-id` chain (reusing the G1 active set; no duplicate highlight logic). `parallel-region-node` / `compound-node` then paint active chrome (solid emphasised boundary + the `:info` active-token glow ring, the same affordance state nodes use), so an active region reads as active at the zone level, not just the leaf inside it. **Palette delegated to Figma.** | `projection.cljc` `xyflow-graph` (`active-container-ids` parent-id walk); `nodes/parallel_region_node.cljs`; `nodes.cljs` `compound-node`. |
@@ -250,7 +250,7 @@ The contract (rf2-yoe6e) + impl (rf2-g2svr):
     its node-id and return the **set of N leaves**. Region-scoped
     paths resolve **within** the region (a region's `path` is relative
     to that region's own state-tree; the node-id is minted under the
-    region's `parentNode`).
+    region's `parentId`).
 - **Projection threads a set.** `xyflow-graph` accepts
   `:highlight-ids` (set) alongside / superseding the scalar
   `:highlight-id`; a node is `:active` when its id ∈ the set. The

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -88,8 +88,10 @@ with `:region` + `:parent-id`, and flags the result `:parallel? true`.
 `type: "parallel-region"` xyflow node (rendered by
 `chart.nodes.parallel-region-node` with a distinct dashed boundary +
 header label whose colour rotates per region index) and assigns each
-state a `parentNode`/`:extent "parent"` so xyflow's sub-flow mechanic
-nests the states inside the zone; elkjs lays the states out inside
+state a `parentId`/`:extent "parent"` so xyflow's sub-flow mechanic
+nests the states inside the zone (rf2-xh1lm — xyflow v12 reads
+`parentId`, NOT the pre-v12 `parentNode`, which is silently ignored);
+elkjs lays the states out inside
 each region's bounding box via `elk.hierarchyHandling
 INCLUDE_CHILDREN`. The chart root surfaces `data-region-count`; region
 containers are excluded from `data-node-count` + the aria-label state
@@ -109,6 +111,38 @@ against the FULL measured extent overflow the smaller fallback and
 visually escape the container. Leaf (non-container) state nodes carry
 NO `:style`; xyflow sizes them from the rendered DOM
 (`state-node-min-{width,height}`).
+
+### Sub-flow nesting — `:parentId` (NOT `:parentNode`) (rf2-xh1lm)
+
+Every nested xyflow node (region substate, compound substate, the
+initial-marker glyph that pairs with a nested initial state) MUST emit
+`:parentId <container-node-id>` + `:extent "parent"` on the projected
+node. The container's `:position` is root-absolute (from ELK's root
+frame); the child's `:position` is parent-relative (from ELK's nested
+walk). xyflow's `adoptUserNodes` then adopts the child against the
+parent's measured box and reports a `positionAbsolute` of `parent.x +
+child.x`, so the rendered DOM sits inside the container.
+
+This is **`:parentId`, not `:parentNode`**. xyflow v12 renamed the
+sub-flow key from the pre-v12 `parentNode` to `parentId`
+(`@xyflow/system` `types/nodes.d.ts` `NodeBase.parentId`; the v12
+`adoptUserNodes` walk reads `userNode.parentId` exclusively).
+**A `:parentNode` slot is silently ignored** — no warning, no
+deprecation notice; the node is treated as root-level and its
+`:position` is read as ABSOLUTE flow coordinates. With ELK's
+parent-relative coords, that puts an `:active__connecting` child at
+root `(14, 34)` instead of inside `:active` at root `(36, 274)` — the
+exact symptom rf2-xh1lm fixed (substates rendered top-left of canvas
+while the empty `:active` container sat bottom-right).
+
+The projection test corpus guards this two ways: every assertion uses
+`:parentId` (`xyflow-graph-region-children-wire-parent-id`,
+`xyflow-graph-compound-children-wire-parent-id`,
+`xyflow-graph-emits-compound-substate-initial-marker`), and a dedicated
+regression test (`xyflow-graph-region-children-do-not-emit-pre-v12-parent-node`)
+asserts the `:parentNode` key MUST NOT appear on any projected node —
+catching a re-introduction at the projector level rather than waiting
+for a downstream visual-regression catch.
 
 ### Parallel multi-active highlight (rf2-yoe6e, rf2-g2svr)
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -223,7 +223,8 @@
   Walks nested elk children (rf2-lkwev — parallel machines nest each
   region's states under the region container). elkjs reports a child's
   `x`/`y` RELATIVE to its parent container, which is exactly what
-  xyflow's parentNode sub-flow wants — so we record each node's
+  xyflow's `parentId` sub-flow wants (rf2-xh1lm — xyflow v12 reads
+  `parentId`, not the pre-v12 `parentNode`) — so we record each node's
   position AS elkjs gives it, no re-basing. Region containers get
   their root-relative position + the size elkjs computed for the zone.
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -62,9 +62,10 @@
   the `chart.nodes/parallel-region-node` paints with a distinct
   dashed boundary (Stately parity). Every state inside a region
   carries `:region <region-id>` + `:parent-id <region-node-id>` so
-  the chart projector can hand xyflow a `parentNode`/sub-flow
-  grouping; edges stay region-local (a transition declared inside a
-  region never crosses into a sibling region — orthogonality).
+  the chart projector can hand xyflow a `parentId`/sub-flow grouping
+  (rf2-xh1lm — v12 reads `parentId`); edges stay region-local (a
+  transition declared inside a region never crosses into a sibling
+  region — orthogonality).
 
   Region node-ids are prefixed `region__<region-id>` so they never
   collide with a real state's `node-id`.
@@ -440,9 +441,11 @@
                                    ;; A node nested inside a compound parent
                                    ;; carries `:parent-id` (the parent's
                                    ;; node-id) so the projector wires xyflow's
-                                   ;; parentNode sub-flow — the SAME mechanic
-                                   ;; that nests parallel-region states. Top-
-                                   ;; level states (path length 1) carry none.
+                                   ;; `parentId` sub-flow (rf2-xh1lm — v12
+                                   ;; reads `parentId`, not `parentNode`) —
+                                   ;; the SAME mechanic that nests parallel-
+                                   ;; region states. Top-level states (path
+                                   ;; length 1) carry none.
                                    (> (count path) 1)
                                    (assoc :parent-id (node-id (pop path))))]
                         (assoc n' :id (node-id path))))
@@ -491,9 +494,10 @@
   all but the first). Each region becomes a synthetic `:region?`
   compound node whose `node-id` is `region-node-id`; each region's
   states carry `:region <region-id>` + `:parent-id <region-node-id>`
-  so the chart projector can hand xyflow a `parentNode`/sub-flow
-  grouping. Region order is preserved (regions are an ordered map in
-  practice; we keep insertion order via `:regions`)."
+  so the chart projector can hand xyflow a `parentId`/sub-flow
+  grouping (rf2-xh1lm — v12 reads `parentId`). Region order is
+  preserved (regions are an ordered map in practice; we keep
+  insertion order via `:regions`)."
   [definition]
   (let [regions (:regions definition)
         per-region
@@ -502,7 +506,8 @@
             (let [rid       (region-node-id region-id)
                   parsed    (parse-flat region-def)
                   ;; Tag every state node with its region + parent so
-                  ;; the projector emits xyflow parentNode grouping.
+                  ;; the projector emits xyflow `parentId` grouping
+                  ;; (rf2-xh1lm — v12 reads `parentId`).
                   tagged-nodes
                   (mapv (fn [n]
                           (assoc n
@@ -536,7 +541,8 @@
   parallel-region rendering; supersedes the Phase 1 first-region-only
   projection). Each region surfaces a synthetic `:region?` compound
   node and its states carry `:region` + `:parent-id` for xyflow
-  parentNode grouping; the result also carries `:parallel? true`."
+  `parentId` grouping (rf2-xh1lm — v12 reads `parentId`); the result
+  also carries `:parallel? true`."
   [definition]
   (cond
     (nil? definition)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes.cljs
@@ -19,7 +19,7 @@
       :path :active? :final? :tags :on-click ...}` and renders
       accordingly.
     - `compound-node` — compound parent with a header strip and a
-      large body containing nested children (xyflow's `parentNode`
+      large body containing nested children (xyflow's `parentId`
       mechanic handles the hierarchical layout; this node renders
       the outer container chrome).
     - `initial-marker` — a small glyph node paired with the initial
@@ -301,7 +301,7 @@
   translucent boxed background with a header strip carrying the
   compound state's label.
 
-  xyflow's `parentNode` mechanic places child state nodes inside
+  xyflow's `parentId` mechanic places child state nodes inside
   this container; this component only renders the surrounding
   chrome."
   [^js props]

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/nodes/parallel_region_node.cljs
@@ -16,11 +16,12 @@
   `chart.layout/parse-parallel` mints a synthetic `:region?` compound
   node per region; `chart.projection/xyflow-graph` projects it as a
   `type: \"parallel-region\"` xyflow node and assigns every state in
-  the region a `parentNode` pointing at the region node (xyflow's
-  sub-flow mechanic). This component renders the region's CHROME — a
-  large translucent box with a dashed border + the region label in
+  the region a `parentId` pointing at the region node (xyflow's
+  sub-flow mechanic — rf2-xh1lm: xyflow v12 reads `parentId`, NOT the
+  pre-v12 `parentNode`). This component renders the region's CHROME —
+  a large translucent box with a dashed border + the region label in
   the header strip. The child state nodes sit inside via xyflow's
-  parentNode positioning; this component only paints the surround.
+  `parentId` positioning; this component only paints the surround.
 
   ## Distinct boundary per region
 
@@ -70,7 +71,7 @@
 
   Renders a translucent zone with a distinct dashed boundary (the
   region's rotation colour) + a header strip carrying the region
-  label. xyflow's parentNode mechanic places the region's child state
+  label. xyflow's `parentId` mechanic places the region's child state
   nodes inside; this component renders only the surrounding chrome."
   [^js props]
   (let [d            (.-data props)

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/projection.cljc
@@ -80,7 +80,8 @@
   Nesting is keyed on `:parent-id`: parallel-region states (rf2-lkwev)
   AND compound substates carry it, so BOTH nest UNDER their container
   and elkjs lays them out inside the container's bounding box (xyflow's
-  parentNode sub-flow then renders them inside the dashed boundary).
+  `parentId` sub-flow then renders them inside the dashed boundary —
+  rf2-xh1lm: xyflow v12 reads `parentId`, NOT the pre-v12 `parentNode`).
   Nesting recurses — a compound inside a region, or a compound inside a
   compound, lays out correctly. Each container (region OR compound) gets
   its own `elk.algorithm`/`elk.padding` so the header strip has room and
@@ -257,8 +258,11 @@
             acc))
         ;; rf2-lkwev — container nodes (parallel regions AND compound
         ;; parents) MUST precede their children in the xyflow nodes
-        ;; array (xyflow requires a parentNode to appear before any node
-        ;; that references it). The parse already emits parents first;
+        ;; array (xyflow requires a parentId target to appear before any
+        ;; node that references it; the v12 `adoptUserNodes` walk warns
+        ;; otherwise — `Parent node ${parentId} not found. Please make
+        ;; sure that parent nodes are in front of their child nodes in
+        ;; the nodes array.`). The parse already emits parents first;
         ;; sort defensively so the parent-before-child invariant holds.
         proj-nodes
         (mapv (fn [n]
@@ -323,9 +327,21 @@
                     (assoc :style {:width  (:width pos)
                                    :height (:height pos)})
 
+                    ;; rf2-xh1lm — xyflow v12 reads `parentId` (NOT
+                    ;; `parentNode`, the pre-v12 name retained only in
+                    ;; xyflow's CHANGELOG). Without `parentId` xyflow
+                    ;; does NOT recognise the child as nested: it
+                    ;; interprets `:position` as ABSOLUTE flow coords
+                    ;; and ignores `:extent "parent"` clamping, so an
+                    ;; ELK parent-relative child (e.g. `{:x 14 :y 34}`
+                    ;; under an `:active` container at `{:x 22 :y 240}`)
+                    ;; renders at root `(14, 34)` — visually OUTSIDE
+                    ;; the parent. Emit `:parentId` so xyflow's
+                    ;; `adoptUserNodes` path adopts the child + uses
+                    ;; the parent's absolute origin as the offset.
                     (and (not region?) (:parent-id n))
-                    (assoc :parentNode (:parent-id n)
-                           :extent     "parent"))))
+                    (assoc :parentId (:parent-id n)
+                           :extent   "parent"))))
               (sort-by #(if (or (:region? %) (:compound? %)) 0 1) nodes))
 
         proj-edges
@@ -417,7 +433,7 @@
         ;; `:initial?` state via an unlabelled entry edge. xstate/SCXML
         ;; semantics: every compound level shows its own initial marker.
         ;; The marker shares the state's xyflow coordinate frame (same
-        ;; parentNode for region/compound children) so it sits just left
+        ;; `:parentId` for region/compound children) so it sits just left
         ;; of the state inside its container.
         initial-nodes (filter :initial? nodes)
         marker-nodes
@@ -431,9 +447,11 @@
                            :data      {:targetPath (:path n) :chart chart}
                            :draggable false
                            :selectable false}
+                    ;; rf2-xh1lm — see compound substate :parentId
+                    ;; comment above. xyflow v12 reads `parentId`.
                     (:parent-id n)
-                    (assoc :parentNode (:parent-id n)
-                           :extent     "parent"))))
+                    (assoc :parentId (:parent-id n)
+                           :extent   "parent"))))
               initial-nodes)
         entry-edges
         (mapv (fn [n]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/chart_dom_cljs_test.cljs
@@ -385,6 +385,76 @@
           (is (= "4" (.getAttribute root "data-node-count"))
               "data-node-count excludes the region containers"))))))
 
+;; ---- compound substate parent linkage (rf2-xh1lm visual-pin) -----------
+;;
+;; xyflow v12 reads `userNode.parentId` (NOT the pre-v12 `parentNode`) and
+;; populates its `parentLookup` from it. A node whose id is the parentId
+;; of any other node gets the CSS class `parent` on its
+;; `.react-flow__node` wrapper (`adoptUserNodes` → store
+;; `parentLookup.has(id)` → `isParent: true` → `parent` class). Without
+;; that class no child is adopted; children render at root + visually
+;; escape the container (the bug rf2-xh1lm fixed: substates rendered
+;; top-left of canvas while the empty `:active` container sat
+;; bottom-right). This DOM pin is layout-independent — the `.parent`
+;; class lands on first commit, before the async elkjs layout pass —
+;; so the synchronous browser-test runner can assert it without
+;; awaiting elk.
+
+(def ^:private compound-machine
+  "A compound machine: :authenticated contains 2 substates (rf2-xh1lm
+  regression fixture). Mirrors the `:ws/connection` shape that broke
+  pre-fix: a single compound parent + nested substates."
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(deftest chart-compound-container-gets-xyflow-parent-class
+  (testing "rf2-xh1lm — xyflow adopts compound substates via `parentId`,
+            which causes the parent node to receive the CSS class
+            `parent` (the on-DOM marker that `parentLookup.has(id)` is
+            true). Pre-fix the projector emitted `:parentNode` (silently
+            ignored by v12) so no child was ever adopted and the parent
+            never got the class — substates rendered at root and escaped
+            their container. Mounts the compound fixture and asserts the
+            `:authenticated` container wrapper carries `.parent`."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/compound :definition compound-machine}
+        (fn [_root node]
+          (let [authed-id (layout/node-id [:authenticated])
+                ;; xyflow's outer wrapper carries `data-id` + the
+                ;; `parent` class when any child claims it via parentId.
+                wrapper   (.querySelector node
+                            (str ".react-flow__node[data-id=\"" authed-id "\"]"))]
+            (is (some? wrapper)
+                ":authenticated xyflow wrapper mounts")
+            (is (.. wrapper -classList (contains "parent"))
+                "the compound wrapper carries .parent — xyflow's parentLookup adopted at least one child via :parentId (rf2-xh1lm)")))))))
+
+(deftest chart-region-container-gets-xyflow-parent-class
+  (testing "rf2-xh1lm + rf2-lkwev — the same `.parent` adoption applies
+            to parallel-region containers. Pre-fix BOTH compound AND
+            region substates were unadopted (the projector emitted
+            `:parentNode` for both); the bead screenshot only captured
+            the compound symptom but the region path was equally broken.
+            This pin guards the region adoption too."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises this")
+      (with-mounted-chart
+        {:machine-id :test/parallel :definition parallel-machine}
+        (fn [_root node]
+          (doseq [region-id (map layout/region-node-id [:audio :display])]
+            (let [wrapper (.querySelector node
+                            (str ".react-flow__node[data-id=\"" region-id "\"]"))]
+              (is (some? wrapper)
+                  (str "region " region-id " xyflow wrapper mounts"))
+              (is (.. wrapper -classList (contains "parent"))
+                  (str "region " region-id " carries .parent — its child states were adopted via :parentId")))))))))
+
 ;; ---- parallel-region ACTIVE chrome (rf2-80rm2, G4 visual-pin) -----------
 ;;
 ;; G1 lights the active region LEAF; G4 lights the region CONTAINER too, so

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -54,8 +54,9 @@
 
 (deftest parse-definition-wires-compound-parent-id
   (testing "rf2-54s5a — compound substates carry :parent-id (the
-            parent's node-id) for xyflow parentNode nesting; top-level
-            states carry none"
+            parent's node-id) for xyflow `:parentId` nesting (rf2-xh1lm
+            — v12 reads `parentId`, not the pre-v12 `parentNode`);
+            top-level states carry none"
     (let [{:keys [nodes]} (layout/parse-definition compound-machine)
           browsing (first (filter #(= [:authenticated :browsing] (:path %)) nodes))
           unauth   (first (filter #(= [:unauth] (:path %)) nodes))]
@@ -146,8 +147,8 @@
 
 (deftest parse-definition-tags-region-states-with-parent
   (testing "rf2-lkwev — every state inside a region carries :region +
-            :parent-id so the chart projector emits xyflow parentNode
-            sub-flow grouping"
+            :parent-id so the chart projector emits xyflow `:parentId`
+            sub-flow grouping (rf2-xh1lm — v12 reads `parentId`)"
     (let [parallel {:type :parallel
                     :regions {:r1 {:initial :a :states {:a {} :b {}}}
                               :r2 {:initial :x :states {:x {} :y {}}}}}

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/projection_cljs_test.cljc
@@ -44,7 +44,7 @@
 
 (def parallel-machine
   "Two-region parallel machine — exercises the region container
-  node-type, the parentNode/extent sub-flow wiring, and the
+  node-type, the parentId/extent sub-flow wiring, and the
   parent-before-child sort."
   {:type    :parallel
    :regions {:audio {:initial :muted
@@ -182,44 +182,62 @@
           region (node-by-id graph (layout/region-node-id :audio))]
       (is (= "parallel-region" (:type region))))))
 
-;; ---- xyflow-graph parentNode / extent sub-flow wiring (G1) --------------
+;; ---- xyflow-graph parentId / extent sub-flow wiring (G1) ---------------
+;;
+;; rf2-xh1lm — xyflow v12 reads `parentId` (NOT `parentNode`, the pre-v12
+;; name). The projector must emit `:parentId` so xyflow's
+;; `adoptUserNodes` walks the parent lookup and treats `:position` as
+;; parent-relative; emitting `:parentNode` instead is silently ignored
+;; (the previous shape — substates rendered at root + visually escaped
+;; the parent container).
 
-(deftest xyflow-graph-region-children-wire-parent-node
-  (testing "rf2-lkwev — every state inside a region carries
-            `:parentNode` (the region container id) + `:extent
-            \"parent\"` so xyflow's sub-flow nests + clamps it; the
-            region container itself carries NEITHER"
+(deftest xyflow-graph-region-children-wire-parent-id
+  (testing "rf2-lkwev + rf2-xh1lm — every state inside a region carries
+            `:parentId` (the region container id) + `:extent \"parent\"`
+            so xyflow v12's sub-flow nests + clamps it; the region
+            container itself carries NEITHER"
     (let [parsed (layout/parse-definition parallel-machine)
           graph  (projection/xyflow-graph parsed {} {})
           region (node-by-id graph (layout/region-node-id :audio))
           muted  (node-by-id graph (layout/node-id [:muted]))]
-      (is (= (layout/region-node-id :audio) (:parentNode muted)))
+      (is (= (layout/region-node-id :audio) (:parentId muted)))
       (is (= "parent" (:extent muted)))
-      (is (nil? (:parentNode region)) "region container is not nested")
+      (is (nil? (:parentId region)) "region container is not nested")
       (is (nil? (:extent region))))))
 
-(deftest xyflow-graph-flat-state-has-no-parent-node
-  (testing "a state in a non-parallel machine carries no parentNode /
+(deftest xyflow-graph-region-children-do-not-emit-pre-v12-parent-node
+  (testing "rf2-xh1lm — the projector emits the v12 `:parentId` shape
+            ONLY; the pre-v12 `:parentNode` key MUST NOT appear (xyflow
+            v12 silently ignores it, hiding the bug behind a green test
+            suite — the regression mode this guards)"
+    (let [parsed (layout/parse-definition parallel-machine)
+          graph  (projection/xyflow-graph parsed {} {})]
+      (doseq [n (:nodes graph)]
+        (is (not (contains? n :parentNode))
+            (str "node " (:id n) " must not carry the dead :parentNode key"))))))
+
+(deftest xyflow-graph-flat-state-has-no-parent-id
+  (testing "a state in a non-parallel machine carries no parentId /
             extent — those wire ONLY for region children"
     (let [parsed (layout/parse-definition idle-loading)
           graph  (projection/xyflow-graph parsed {} {})
           idle   (node-by-id graph (layout/node-id [:idle]))]
-      (is (nil? (:parentNode idle)))
+      (is (nil? (:parentId idle)))
       (is (nil? (:extent idle))))))
 
 ;; ---- xyflow-graph parent-before-child sort (G1) ------------------------
 
 (deftest xyflow-graph-sorts-regions-before-children
-  (testing "rf2-lkwev — xyflow requires a parentNode to appear in the
-            nodes array BEFORE any node that references it. Every
-            region container must precede its first child in the
-            projected order."
+  (testing "rf2-lkwev — xyflow requires a parentId target to appear in
+            the nodes array BEFORE any node that references it (v12's
+            `adoptUserNodes` warns otherwise). Every region container
+            must precede its first child in the projected order."
     (let [parsed   (layout/parse-definition parallel-machine)
           graph    (projection/xyflow-graph parsed {} {})
           ids      (mapv :id (:nodes graph))
           index-of (fn [id] (.indexOf ids id))]
       (doseq [n (:nodes graph)
-              :let [parent (:parentNode n)]
+              :let [parent (:parentId n)]
               :when parent]
         (is (< (index-of parent) (index-of (:id n)))
             (str "parent " parent " must precede child " (:id n)))))))
@@ -234,7 +252,7 @@
           ids      (mapv :id (:nodes graph))
           index-of (fn [id] (.indexOf ids id))]
       (doseq [n (:nodes graph)
-              :let [parent (:parentNode n)]
+              :let [parent (:parentId n)]
               :when parent]
         (is (< (index-of parent) (index-of (:id n))))))))
 
@@ -588,12 +606,14 @@
       (is (= {:width 328 :height 156} (:style compound))))))
 
 (deftest xyflow-graph-compound-style-coexists-with-parent-relative-substates
-  (testing "rf2-a64bi — when a compound has substates, the compound's
-            `:style {:width :height}` matches elk's bounding box AND each
-            substate carries `:parentNode` + `:extent \"parent\"` with a
-            parent-relative `:position`. The two together are the
-            containment contract: xyflow allocates the measured box, then
-            clamps the parent-relative substates inside it."
+  (testing "rf2-a64bi + rf2-xh1lm — when a compound has substates, the
+            compound's `:style {:width :height}` matches elk's bounding
+            box AND each substate carries `:parentId` (xyflow v12's
+            sub-flow key, NOT the pre-v12 `:parentNode`) + `:extent
+            \"parent\"` with a parent-relative `:position`. The two
+            together are the containment contract: xyflow adopts the
+            child against the parent's measured box, then clamps the
+            parent-relative substates inside it."
     (let [parsed    (layout/parse-definition compound-machine)
           cid       (layout/node-id [:authenticated])
           browsing  (layout/node-id [:authenticated :browsing])
@@ -607,8 +627,11 @@
           p         (node-by-id graph paying)]
       (is (= {:width 328 :height 156} (:style compound))
           "compound gets elk's measured box as :style")
-      (is (= cid (:parentNode b)) ":browsing nests under :authenticated")
-      (is (= cid (:parentNode p)) ":paying nests under :authenticated")
+      (is (= cid (:parentId b)) ":browsing nests under :authenticated")
+      (is (= cid (:parentId p)) ":paying nests under :authenticated")
+      (is (not (contains? b :parentNode))
+          "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear")
+      (is (not (contains? p :parentNode)))
       (is (= "parent" (:extent b)))
       (is (= "parent" (:extent p)))
       (is (= {:x 14 :y 34} (:position b))
@@ -857,15 +880,17 @@
       (is (false? (:initial (:data loading)))))))
 
 (deftest xyflow-graph-emits-compound-substate-initial-marker
-  (testing "rf2-54s5a — a compound parent's :initial substate also
-            gets a marker (xstate per-level initial semantics) sharing
-            the compound's coordinate frame"
+  (testing "rf2-54s5a + rf2-xh1lm — a compound parent's :initial substate
+            also gets a marker (xstate per-level initial semantics) sharing
+            the compound's coordinate frame via xyflow v12's `:parentId`"
     (let [parsed      (layout/parse-definition compound-machine)
           graph       (projection/xyflow-graph parsed {} {})
           browsing-id (layout/node-id [:authenticated :browsing])
           marker      (node-by-id graph (str "initial__" browsing-id))]
       (is (some? marker) "the compound's initial substate gets a marker")
-      (is (= (layout/node-id [:authenticated]) (:parentNode marker))))))
+      (is (= (layout/node-id [:authenticated]) (:parentId marker)))
+      (is (not (contains? marker :parentNode))
+          "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear"))))
 
 (deftest xyflow-graph-flags-self-transition
   (testing "rf2-54s5a — a source==target edge carries :data {:selfLoop true}"
@@ -877,14 +902,18 @@
       (is (true?  (:selfLoop (:data self))))
       (is (false? (:selfLoop (:data non-self)))))))
 
-(deftest xyflow-graph-compound-children-wire-parent-node
-  (testing "rf2-54s5a — compound substates nest via xyflow parentNode
-            (same mechanic as parallel-region children)"
+(deftest xyflow-graph-compound-children-wire-parent-id
+  (testing "rf2-54s5a + rf2-xh1lm — compound substates nest via xyflow
+            v12's `:parentId` (same mechanic as parallel-region children;
+            the pre-v12 `:parentNode` key is silently ignored by v12 so
+            the projector MUST NOT emit it)"
     (let [parsed   (layout/parse-definition compound-machine)
           graph    (projection/xyflow-graph parsed {} {})
           browsing (node-by-id graph (layout/node-id [:authenticated :browsing]))]
-      (is (= (layout/node-id [:authenticated]) (:parentNode browsing)))
-      (is (= "parent" (:extent browsing))))))
+      (is (= (layout/node-id [:authenticated]) (:parentId browsing)))
+      (is (= "parent" (:extent browsing)))
+      (is (not (contains? browsing :parentNode))
+          "rf2-xh1lm — the pre-v12 :parentNode key MUST NOT appear"))))
 
 (deftest elk-children-nests-compound-substates
   (testing "rf2-54s5a — a compound parent nests its substates as elk


### PR DESCRIPTION
## Symptom

PR #2124 (rf2-a64bi) sized the `:active` container correctly, but its 3
substates (`connecting` / `authenticating` / `connected`) still rendered
top-right of the canvas while `:active` itself sat empty bottom-left.
Projection-correctness did not imply render-correctness — the bead noted
"the assertion shape doesn't match what users see."

## Empirical investigation

The bead verified the projector + ELK were both already correct:

- `chart.projection` emits the expected `:parentNode` + `:extent "parent"`
  + parent-relative `:position` on each substate.
- ELK gives parent-relative coords for nested children (verified via a
  Node + elkjs probe against the live `->elk-input` shape).

So the gap was in the projector → xyflow handoff. Reading the live xyflow
v12 source (`implementation/node_modules/@xyflow/react/dist/esm/index.mjs`
+ `@xyflow/system/dist/esm/index.js`) confirmed:

- xyflow v12 reads `userNode.parentId` **exclusively**. The pre-v12
  `parentNode` key is silently ignored — no warning, no fallback.
  Every reference in the v12 system bundle uses `parentId`; `parentNode`
  appears only as a local variable name
  (`const parentNode = nodeLookup.get(parentId)`).
- `NodeBase.parentId?: string;`
  (`@xyflow/system/dist/esm/types/nodes.d.ts:42`).
- `adoptUserNodes` walks `if (userNode.parentId)` to populate
  `parentLookup`; without `parentId`, no child is adopted.
- When `parentLookup.has(id)` is true, xyflow adds the CSS class
  `parent` to the parent's `.react-flow__node` wrapper
  (`isParent: s.parentLookup.has(id)` → `parent: isParent`).

The projector was emitting `:parentNode` for **every** nested node
(compound substates AND parallel-region substates AND the initial-marker
glyph paired with nested initials). v12 ignored the slot, the parent's
`parentLookup` stayed empty, ELK's parent-relative coords were rendered
as ABSOLUTE flow coords, and the child landed at root `(14, 34)` instead
of inside `:active` at root `(36, 274)` — the exact screenshot symptom.

## Root cause

The projector emits the pre-v12 xyflow sub-flow key. `@xyflow/react`
12.4.2 ignores it.

Mike's hypothesis (xyflow only honours `:parentNode` for
`type "parallel-region"`, not `"compound"`) was directionally correct
(xyflow isn't honouring the slot) but the root cause was deeper: **the
key name itself is wrong for v12**. BOTH compound and region substates
were equally broken; the parallel-region "works" claim was untested
(the rf2-lkwev DOM pin only asserts container mount + `data-active`,
not visual containment).

## Fix shape

- `chart.projection.cljc` emits `:parentId` instead of `:parentNode` on
  the two sub-flow paths (compound substates + initial-marker glyph).
  `:extent "parent"` unchanged.
- All `:parentNode` assertions in `projection-cljs-test` +
  `layout-cljs-test` re-pointed at `:parentId`, plus regression-guards
  (`xyflow-graph-region-children-do-not-emit-pre-v12-parent-node` +
  per-test `(is (not (contains? n :parentNode)))`) so a re-introduction
  is caught at the unit level rather than waiting for a downstream
  visual catch (the failure mode rf2-a64bi suffered).
- `chart_dom_cljs_test.cljs` adds two browser-side pins
  (`chart-compound-container-gets-xyflow-parent-class`,
  `chart-region-container-gets-xyflow-parent-class`) that mount the
  compound + parallel fixtures and assert each container's xyflow
  wrapper carries the `.parent` CSS class. xyflow only adds `.parent`
  when at least one child was adopted via `parentId` — the live DOM
  marker for adoption working end-to-end. Layout-independent so it
  runs without awaiting the elk Promise.

## Spec coverage

`tools/machines-viz/spec/API.md` gets a new
`### Sub-flow nesting — :parentId (NOT :parentNode) (rf2-xh1lm)` section
documenting the v12 contract + the regression-guard shape.
`001-Topology-Parity.md` Hierarchy row updated. All doc comments
mentioning `parentNode` in `src/` + `spec/` + tests re-anchored on
`parentId` with an explicit rf2-xh1lm cross-ref.

## Cross-refs

- Builds on #2124 (rf2-a64bi container sizing) — same surface, lower-
  layer cause. Container size + child adoption are the two halves of
  the containment contract; rf2-a64bi shipped the size half against an
  unobservable bug, rf2-xh1lm ships the adoption half against an
  observable one.
- Closes the rf2-21rkg → rf2-o43yg → rf2-a64bi → rf2-xh1lm lineage on
  the `:ws/connection` compound substate render.

## Gates

- `clj-kondo --lint tools/machines-viz/{src,test}` — 0 errors, no new
  warnings (4 pre-existing warnings unchanged).
- `npm run test:cljs` — Ran 4412 tests containing 14101 assertions,
  0 failures, 0 errors (up from 4409 — 3 new projection regression-
  guard tests).
- `npm run test:browser` — Ran 118 tests containing 334 assertions,
  0 failures, 0 errors (up from 115 — 3 new DOM pins on the
  `:parent` class adoption marker).

## Live verification

```bash
cd implementation && npx shadow-cljs watch examples/step-deck
# open the testdeck, navigate to the :ws/connection chart —
# the 3 substates (connecting / authenticating / connected) now sit
# visually INSIDE the dashed :active container, not stacked top-right
# of canvas. The empty :active bottom-left is gone.
```
